### PR TITLE
fix(mcp-gateway): refuse a junctioned spill dir on both spill paths

### DIFF
--- a/src/kiro_crew/mcp_gateway/spill.py
+++ b/src/kiro_crew/mcp_gateway/spill.py
@@ -50,15 +50,21 @@ def _sanitize_server_name(name: str) -> str:
 def cleanup_old_spill_files() -> int:
     """Delete spill files older than 24h. Returns count deleted. Best-effort.
 
-    Symlink-hardened: ``is_dir()``/``is_file()``/``stat()`` all FOLLOW
-    symlinks, so an agent that swapped the spill dir (or planted a link
-    inside it) could otherwise aim this sweep at an arbitrary directory and
-    have the gateway delete 24h-old files there (confused deputy). The dir
-    itself and every entry are checked with lstat semantics; links are
-    skipped, never followed.
+    Link-hardened: ``is_dir()``/``is_file()``/``stat()`` all FOLLOW links, so
+    an agent that swapped the spill dir (or planted a link inside it) could
+    otherwise aim this sweep at an arbitrary directory and have the gateway
+    delete 24h-old files there (confused deputy). The dir itself and every
+    entry are checked with lstat semantics; links are skipped, never followed.
+
+    The directory-level check runs through ``is_link_or_junction`` rather than
+    ``is_symlink()``. A Windows junction is not a symlink: ``is_symlink()``
+    answers False for one and ``is_dir()`` answers True, so the guard admitted
+    it and the sweep iterated the junction's TARGET. The per-entry
+    ``S_ISREG`` screen below does not cover that -- it skips links INSIDE the
+    directory, whereas a junction is the directory itself.
     """
     spill_dir = _spill_dir()
-    if spill_dir.is_symlink() or not spill_dir.is_dir():
+    if platform_compat.is_link_or_junction(spill_dir) or not spill_dir.is_dir():
         return 0
     now = time.time()
     deleted = 0
@@ -126,10 +132,16 @@ def maybe_spill_response(
         filename = f"{safe_server}-{request_id}-{timestamp}.json"
 
         spill_dir = _spill_dir()
-        # Never operate through a symlinked spill dir (agent-swappable): an
-        # attacker-planted link would redirect the write outside the data home.
-        if spill_dir.is_symlink():
-            logger.warning("spill dir is a symlink — refusing to spill")
+        # Never operate through a LINKED spill dir (agent-swappable): an
+        # attacker-planted link would redirect the write outside the data home,
+        # and what lands there is a full tool response -- exactly the payload
+        # that may carry secrets. Junctions count: one is not a symlink, so
+        # ``is_symlink()`` alone left this open on Windows. The O_EXCL/
+        # O_NOFOLLOW open below does not cover it either -- those constrain the
+        # FINAL component, not the directory the path resolves through, and
+        # ``os.O_NOFOLLOW`` does not exist on Windows at all.
+        if platform_compat.is_link_or_junction(spill_dir):
+            logger.warning("spill dir is a symlink or junction — refusing to spill")
             return line
         # Not a bare mkdir(mode=0o700): that is umask-masked, is ignored for
         # an already-existing directory, and is inert on Windows -- yet this

--- a/test/test_mcp_gateway_oversize.py
+++ b/test/test_mcp_gateway_oversize.py
@@ -16,6 +16,9 @@ import os
 import time
 from unittest.mock import patch
 
+import pytest
+
+from conftest import make_dir_link
 from kiro_crew import platform_compat as pc
 from kiro_crew.mcp_gateway.spill import (
     cleanup_old_spill_files,
@@ -74,6 +77,39 @@ class TestSpillToFile:
         assert len(spill_files) == 1
         spill_content = json.loads(spill_files[0].read_bytes())
         assert spill_content["result"]["content"][0]["text"] == big_text
+
+    def test_spill_refuses_a_linked_spill_dir(self, tmp_path):
+        """The WRITE path refuses a linked spill dir too.
+
+        Sibling of the cleanup guard, same directory and same blind spot. This
+        function's own comment says why it matters: "an attacker-planted link
+        would redirect the write outside the data home". What gets written is a
+        full tool response -- precisely the payload that may carry secrets.
+
+        ``O_EXCL``/``O_NOFOLLOW`` on the open do not cover it: they constrain
+        the FINAL path component, not the directory the path resolves through,
+        and ``os.O_NOFOLLOW`` does not exist on Windows -- the only platform
+        that has junctions.
+        """
+        victim_dir = tmp_path / "victim"
+        victim_dir.mkdir()
+
+        spill_dir = tmp_path / "mcp_spill"
+        make_dir_link(spill_dir, victim_dir)
+
+        big_text = "S" * 500_000
+        msg = {
+            "jsonrpc": "2.0",
+            "id": "req-7",
+            "result": {"content": [{"type": "text", "text": big_text}]},
+        }
+        line = json.dumps(msg, separators=(",", ":")).encode("utf-8") + b"\n"
+
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            result = maybe_spill_response(line, "test-mcp", 256 * 1024)
+
+        assert list(victim_dir.iterdir()) == [], "spilled a payload outside the data home"
+        assert result == line, "a refused spill must forward the original line unmodified"
 
     def test_spill_preserves_id(self, tmp_path):
         """Spilled response preserves the original JSON-RPC id."""
@@ -361,3 +397,50 @@ class TestSpillCleanup:
 
         assert deleted == 0
         assert fresh_file.exists()
+
+    def test_cleanup_refuses_a_linked_spill_dir(self, tmp_path):
+        """A linked spill dir is refused, so the sweep never runs through it.
+
+        ``is_symlink()`` answers False for a Windows junction, so the dir-level
+        guard admitted one and the sweep iterated the junction's TARGET,
+        calling ``unlink()`` on every 24h-old regular file there. That is
+        exactly the confused deputy this function's docstring says it hardened
+        against, reached by a link kind its check cannot see. The per-entry
+        ``lstat``/``S_ISREG`` screen does not help: it guards links INSIDE the
+        directory, while here the directory itself is the link.
+        """
+        victim_dir = tmp_path / "victim"
+        victim_dir.mkdir()
+        precious = victim_dir / "precious.json"
+        precious.write_text("precious")
+        old_time = time.time() - (25 * 3600)
+        os.utime(precious, (old_time, old_time))
+
+        spill_dir = tmp_path / "mcp_spill"
+        make_dir_link(spill_dir, victim_dir)
+
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            deleted = cleanup_old_spill_files()
+
+        assert deleted == 0
+        assert precious.exists(), "cleanup deleted a file outside the spill dir"
+
+    @pytest.mark.skipif(not pc.IS_WINDOWS, reason="junctions are Windows-only")
+    def test_make_dir_link_yields_a_junction_on_windows(self, tmp_path):
+        """Guard the guard: the seam above must produce a JUNCTION, not a symlink.
+
+        What a junction *is* -- a directory that ``is_symlink()`` misses and
+        ``is_link_or_junction`` catches -- is already pinned by
+        ``test_junction_is_recognised_and_removable``. The property that is
+        NOT pinned anywhere else, and that the two containment tests above
+        depend on, is that this particular seam yields one: were
+        ``make_dir_link`` ever to hand back a symlink on Windows, both would
+        pass against the ORIGINAL ``is_symlink()`` guard and prove nothing.
+        """
+        target = tmp_path / "target"
+        target.mkdir()
+        link = tmp_path / "link"
+        make_dir_link(link, target)
+
+        assert link.is_dir()
+        assert not link.is_symlink()


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/mcp_gateway/spill.py` guards its spill directory in **two**
places, and both tested only `spill_dir.is_symlink()`.

A Windows junction is a directory reparse point, not a symlink: `is_symlink()`
answers `False` for one while `is_dir()` answers `True`. So both guards admitted
a junction and both then operated **through** it.

**1. The cleanup path** — `cleanup_old_spill_files()`:

```python
if spill_dir.is_symlink() or not spill_dir.is_dir():
    return 0
```

The 24h sweep iterated the junction's *target* and called `entry.unlink()` on
every 24h-old regular file there. Its docstring names this exact threat:

> an agent that swapped the spill dir (or planted a link inside it) could
> otherwise aim this sweep at an arbitrary directory and have the gateway
> delete 24h-old files there (confused deputy)

The per-entry screen does not compensate — `lstat`/`S_ISREG` skips links
**inside** the directory, while here the directory itself is the link and the
entries reached through it are ordinary regular files.

**2. The write path** — `maybe_spill_response()`:

```python
# Never operate through a symlinked spill dir (agent-swappable): an
# attacker-planted link would redirect the write outside the data home.
if spill_dir.is_symlink():
```

The spilled payload was written into the junction's target. What lands there is
a full tool response — exactly the content that may carry secrets. The
`O_EXCL`/`O_NOFOLLOW` open below it does not cover this: those constrain the
**final** path component, not the directory the path resolves through, and
`os.O_NOFOLLOW` does not exist on Windows at all — the only platform that has
junctions.

Both were measured end to end on Windows against the unpatched tree: the sweep
reported `deleted == 1` with the victim's file gone, and the write path left a
spill file inside the victim directory.

## Why it matters

One root cause, two consequences, both outside the data home and both performed
by the gateway rather than by whatever planted the link — the confused deputy
these guards were written to prevent, reached through a link kind neither could
see:

- **deletion** of arbitrary 24h-old files in an attacker-chosen directory;
- **disclosure** — a tool response, which is the payload most likely to carry
  secrets, written to an attacker-chosen directory.

Neither needs user action. `gatewayd.py:496` schedules `cleanup_old_spill_files`
on the maintenance executor at gateway startup, and the write path runs on any
oversized tool result.

The worst part is that the protection reads as present. Each site has an
explicit link check and a comment describing this attack, so a reviewer
concludes the path is hardened — while on Windows neither is.

## What changed (motivation → approach → change)

**Observed symptom** — with the spill directory replaced by a junction, the
startup sweep deletes files in the junction's target, and an oversized tool
result is written there.

**Root cause** — `Path.is_symlink()` is `False` for a Windows junction while
`is_dir()` is `True`, so the directory-level check passes at both sites. Every
downstream defence is scoped to something else: `S_ISREG` to directory
*entries*, `O_EXCL`/`O_NOFOLLOW` to the *final* component.

**Change** — route both checks through `platform_compat.is_link_or_junction`,
which this module already imports:

```python
if platform_compat.is_link_or_junction(spill_dir) or not spill_dir.is_dir():  # cleanup
if platform_compat.is_link_or_junction(spill_dir):                            # write
```

That helper tries `os.path.islink` first and only then tests for a junction, so
symlink behaviour is byte-identical and each change strictly widens what the
guard refuses. Two production lines, plus comments recording which link kinds
are covered and why the downstream defences are not substitutes.

`grep -n 'is_symlink()' src/kiro_crew/mcp_gateway/spill.py` now returns only
prose — no live call site remains.

**Deliberately not changed.** `platform_compat.first_linked_ancestor` documents
an adjacent gap — a link in an *ancestor* of the path, e.g. a junctioned
`config_dir()`. That is outside the threat these comments model ("swapped the
spill dir, or planted a link inside it") and outside what was measured, so it is
named here rather than folded in.

## Tests

- **`TestSpillCleanup::test_cleanup_refuses_a_linked_spill_dir`** — plants a
  25h-old file in the link target; asserts cleanup returns `0` **and** that the
  file still exists. The second assertion is the load-bearing one: a count of 0
  alone would also be satisfied by a sweep that found nothing.
- **`TestSpillToFile::test_spill_refuses_a_linked_spill_dir`** — sends an
  oversized tool result through `maybe_spill_response`; asserts the link target
  is still **empty** and that the original line is forwarded unmodified.
- **`test_make_dir_link_yields_a_junction_on_windows`** — guards the guard.
  What a junction *is* is already pinned by
  `test_junction_is_recognised_and_removable`, so this asserts only the property
  that is pinned nowhere else and that the two tests above depend on: that this
  seam yields a junction rather than a symlink. Were `make_dir_link` ever to
  hand back a symlink on Windows, both would pass against the *original* guards
  and prove nothing.

**Red-before / green-after**, measured on Windows with the tests in place and
`spill.py` reverted to `origin/main`:

```
E  assert [WindowsPath('.../test-mcp-req-7-1757...json')] == []
   AssertionError: spilled a payload outside the data home
E  assert 1 == 0
FAILED ...::TestSpillToFile::test_spill_refuses_a_linked_spill_dir
FAILED ...::TestSpillCleanup::test_cleanup_refuses_a_linked_spill_dir
2 failed, 1 passed
```

After the fix: `292 passed, 1 skipped` across `test_mcp_gateway_oversize.py` +
`test_mcp_gateway_backend_coverage.py` (the skip is the pre-existing
`windows-expected-failures.txt` entry, not new).

**Platform honesty.** `make_dir_link` creates a junction on Windows and a
symlink on POSIX. The original checks already refused symlinks, so on Linux CI
the two containment tests are no-regression checks rather than red-befores —
only Windows exercises the fix. The third test exists so that distinction is
pinned in the suite rather than living only in this description.

Gates run locally: `flake8` clean, `isort --check-only` clean, `mypy` reports
nothing for `spill.py`, and `scripts/check_black_formatting.py` passes scoped to
`origin/main...HEAD` — both touched files were already in the 1166-file
known-unformatted baseline, so no new offender and no unrelated reformatting.

## Manual verification

N/A — unit coverage sufficient: both behaviours are filesystem-level guards, and
the tests create a real junction and assert on a real deletion and a real write,
so there is no integration surface the automated tests cannot reach.

## Related Issues

None. Found while auditing link-containment guards; no existing issue covers
this file.

## Pattern harvest

Rule candidate: `semgrep`

Pattern: a link-containment guard that tests only `is_symlink()` /
`os.path.islink()` before acting on a path — a Windows junction is invisible to
both and passes as an ordinary directory, so the guard silently does not hold
there. Any such site that then walks, reads, hashes, writes or unlinks through
the path should go through `platform_compat.is_link_or_junction`.

Two corollaries this PR is direct evidence for:

- **Sweep the whole file, not the hit.** The same `spill_dir` was guarded twice
  with the same blind spot; fixing only the site that surfaced first would have
  left the disclosure half live.
- **Depth does not save you.** A per-entry `S_ISREG` screen and an
  `O_EXCL`/`O_NOFOLLOW` open both sat downstream of these guards and neither
  helped, because each is scoped to a component rather than to the directory the
  path resolves through.

The inverse is not a defect: `shutil.rmtree` refuses a junction on its own, so
an `rmtree`-based site is already safe.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
