### PR TITLE
fix(dashboard): stop rewind's commit undoing mid-boundary writes

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -542,15 +542,24 @@ the four where `rewind` does not yet, so nobody reads them as already shared:
   forward, so an arrived row can never be stamped *earlier* than the edited one —
   but it can be stamped **identically**, because on a coarse clock (Windows ticks
   in ~15.6 ms steps) both appends read the same instant, and list order is what
-  separates that tie. Its question map is intersected rather than adopted, so a card retired
-  by either the edit or an arrived row stays retired. A carried row reaches disk
+  separates that tie. Its question map is **retired in place** rather than adopted or
+  intersected: the commit deletes exactly the ids the edit retired, so a card answered
+  during the boundary stays retired (the answer pops it from the live dict) and a card
+  raised during the boundary survives (an intersection against the frozen copy would
+  erase it). A carried row reaches disk
   the ordinary way — the commit sets `_dirty`, so the next periodic flush writes
   the merged window — and deliberately **not** through a second guarded save
   after the commit: no await may sit between the commit and the dispatch release
   (see the next bullet), so that write is not available without paying a worse
-  failure. **`rewind` still replaces wholesale**, so the same injected-row loss is
-  open there and on the other rewrite-save callers (`regenerate`, `fork`); closing
-  it belongs with the shared boundary contract rather than one endpoint.
+  failure. **`rewind` now applies the same delta commit**: it carries arrived rows in
+  both the window and the pending queue, drops a row the client already drained rather
+  than requeueing it, and retires question ids in place. The identity sets keep the
+  pre-await rows RETAINED, because an `id()` is only an identity while something holds
+  a reference and a cap trim would otherwise let a freed row's address be reused by an
+  arrival. The other rewrite-save callers (`regenerate`, `fork`) are **deliberately
+  still open** to the injected-row loss; closing them belongs with the shared boundary
+  contract rather than one endpoint, and the fixed subset is exactly `rewind` and
+  `edit-resend`.
 - **The commit and the dispatch release are separated by no await.** Once the
   live slot has adopted the truncated window, the reserved dispatch is armed and
   only `dispatch_ready.set()` in the handler's `finally` is left to run. An await

--- a/src/kiro_crew/dashboard/chat_regenerate.py
+++ b/src/kiro_crew/dashboard/chat_regenerate.py
@@ -448,8 +448,21 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
         # commit because every pre-await row stays referenced throughout -- the
         # prefix by ``prospective_slot.messages``, the discarded suffix by the
         # live ``slot.messages``.
-        pre_await_row_ids = {id(row) for row in slot.messages}
-        pre_await_pending_ids = {id(row) for row in slot._pending}
+        # RETAINED lists, not just the id sets. An ``id()`` is an integer that
+        # says nothing about the object's lifetime, and nothing else here keeps
+        # the pre-await rows alive: the window trims at the cap
+        # (``_MAX_SLOT_MESSAGES``) and a low-index edit pins nothing ahead of
+        # ``index`` (at index 0 the prospective copy is empty), so a leading row
+        # can be freed while the awaits below run and CPython can hand its id to a
+        # newly appended arrival. The commit would then read that arrival as "not
+        # new" and drop it -- the exact loss this snapshot exists to prevent.
+        # Holding the rows keeps every id unique to the object that minted it.
+        # ``meta.mid`` is not an alternative identity: ``append`` skips it for
+        # restored rows (``mint_mid=False``) and for the wire-only roles.
+        pre_await_rows = list(slot.messages)
+        pre_await_row_ids = {id(row) for row in pre_await_rows}
+        pre_await_pending = list(slot._pending)
+        pre_await_pending_ids = {id(row) for row in pre_await_pending}
 
         # Reserve the slot BEFORE the awaits below. ``slot.running`` derives
         # from ``slot.task``, and the send path is not serialized on
@@ -503,20 +516,135 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
             # Durably clear the native conversation BEFORE the history rewrite,
             # mirroring rewind. A failure here leaves the original branch intact
             # and dispatches no replacement turn.
+            def _sel_native_destroyed(reason: str, *, native_cleared: str = "1") -> None:
+                """Record a destroyed native context that never reached a commit.
+
+                ``discard_conversation`` plus ``aflush`` are irreversible: past
+                that point the provider-side conversation is gone whether or not
+                this request goes on to succeed. SEL already carries this
+                endpoint's denials and its successful commits, so without this
+                record the ONE outcome that destroyed context WITHOUT committing
+                anything is the only one missing from the audit trail -- and it
+                is the only one that cannot be reconstructed from the others,
+                because in the trail it is indistinguishable from a denial that
+                touched nothing.
+
+                ``native_cleared`` is a THREE-valued field, not a flag, because
+                the teardown has three outcomes and only two of them are facts:
+                it happened, it did not, or the check that would have told us
+                raised. ``"unknown"`` is what the third writes. A boolean here
+                forced the one case the audit exists for to be spelled as one of
+                the other two, and an audit that goes quiet on the outcome it
+                could not determine is worse than none: its silence reads as
+                nothing to report.
+                """
+                sel().log_api_access(
+                    caller=request_app or "dashboard",
+                    operation="chat.edit_resend",
+                    outcome="error",
+                    source="dashboard",
+                    resources=f"slot={slot.key},native_cleared={native_cleared}",
+                    error=reason,
+                )
+
             if state.sessions is not None:
-                try:
+                # Shielded and drained for the same reason the history save below
+                # is: ``discard_conversation`` pops the session and calls
+                # ``clear_sid`` BEFORE its own remaining awaits
+                # (``to_thread(unlink)``, ``provider.shutdown()``,
+                # ``release_subagent_runtime``), so the destruction is already
+                # true while those run. A client disconnect landing there would
+                # otherwise propagate past every handler below with the context
+                # gone and nothing recorded. The shield does not make the teardown
+                # slower -- it was always going to run to completion -- it only
+                # keeps this handler alive long enough to learn the outcome.
+                discard_task = asyncio.ensure_future(
                     # ``skip_if_busy``: an inbound channel turn holds the session
                     # semaphore while ``slot.running`` reads False, so the idle
                     # check above cannot see it -- an unconditional discard would
                     # tear down its provider mid-reply.
-                    discarded = await state.sessions.discard_conversation(
-                        session_key, skip_if_busy=True
-                    )
+                    state.sessions.discard_conversation(session_key, skip_if_busy=True)
+                )
+                try:
+                    discarded = await asyncio.shield(discard_task)
+                except asyncio.CancelledError:
+                    # Drain to learn whether the teardown actually happened. The
+                    # outcome is THREE-valued and the code says so: it destroyed
+                    # (record it), it refused because the session was busy and
+                    # destroyed nothing (record nothing), or we could not find out
+                    # (record the unknown). Collapsing the third into
+                    # ``destroyed = False`` asserted a fact this branch does not
+                    # have, and suppressed the audit event on the one path most
+                    # likely to need it.
+                    #
+                    # Bounded re-shield rather than a single ``await``, exactly as
+                    # the history-rewrite drain below does: this await is itself a
+                    # cancellation point, so one further cancel -- a gateway
+                    # shutdown reaching a handler already unwinding from a client
+                    # disconnect -- would abandon the drain and lose the record.
+                    for _ in range(_SAVE_DRAIN_ATTEMPTS):
+                        if discard_task.done():
+                            break
+                        try:
+                            await asyncio.shield(discard_task)
+                        except asyncio.CancelledError:
+                            continue
+                        except Exception:
+                            break
+                    if discard_task.done() and not discard_task.cancelled():
+                        discard_exc = discard_task.exception()
+                        if discard_exc is not None:
+                            # Recorded, not swallowed: the trail gets the
+                            # undetermined outcome and the log gets the cause. The
+                            # catch above stays broad on purpose --
+                            # ``provider.shutdown()`` is provider transport and its
+                            # failure modes are not enumerable from here, and
+                            # letting an arbitrary error out of a
+                            # ``CancelledError`` handler would REPLACE the client's
+                            # cancellation with an unrelated exception. It narrows
+                            # where it matters: ``Exception`` leaves
+                            # ``CancelledError``, ``KeyboardInterrupt`` and
+                            # ``SystemExit`` free to surface.
+                            logger.warning(
+                                "edit-resend: the discard for %s raised while draining "
+                                "a cancellation, so whether the native context was "
+                                "torn down is undetermined",
+                                session_key,
+                                exc_info=discard_exc,
+                            )
+                            _sel_native_destroyed(
+                                "discard_cancelled_outcome_unknown", native_cleared="unknown"
+                            )
+                        elif discard_task.result():
+                            _sel_native_destroyed("discard_cancelled")
+                    else:
+                        logger.warning(
+                            "edit-resend: the discard for %s did not settle within %d "
+                            "cancellation(s), so whether the native context was torn "
+                            "down is undetermined",
+                            session_key,
+                            _SAVE_DRAIN_ATTEMPTS,
+                        )
+                        _sel_native_destroyed(
+                            "discard_cancelled_outcome_unknown", native_cleared="unknown"
+                        )
+                    raise
                 except Exception:
                     logger.warning(
                         "edit-resend: failed to discard ACP conversation for %s",
                         session_key,
                         exc_info=True,
+                    )
+                    # The raise can land on either side of this teardown's own
+                    # destruction point: ``discard_conversation`` pops the session
+                    # and calls ``clear_sid`` before its remaining awaits, so a
+                    # failure inside it proves nothing either way. Record the
+                    # undetermined outcome rather than nothing -- a silent exit
+                    # here is indistinguishable in the trail from a refusal that
+                    # touched no state, which is exactly the confusion the audit
+                    # exists to remove.
+                    _sel_native_destroyed(
+                        "discard_failed_outcome_unknown", native_cleared="unknown"
                     )
                     state.push_slots_update()
                     return web.json_response(
@@ -541,12 +669,25 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
                     # exit before that write would resurrect the discarded
                     # conversation on restart.
                     await state.sessions.aflush()
+                except asyncio.CancelledError:
+                    # ``discarded`` is already True here, so the native context
+                    # IS gone -- and ``CancelledError`` derives from
+                    # BaseException, so the handler below cannot absorb it. A
+                    # client disconnect landing on this await would otherwise
+                    # leave the destruction with no record at all, which is the
+                    # one outcome this audit exists for. Record, then let the
+                    # cancellation propagate untouched.
+                    _sel_native_destroyed("sid_flush_cancelled")
+                    raise
                 except Exception:
                     logger.warning(
                         "edit-resend: failed to flush the cleared resume sid for %s",
                         session_key,
                         exc_info=True,
                     )
+                    # The in-memory discard already happened, so the native
+                    # context is gone even though its sid clear is not durable.
+                    _sel_native_destroyed("sid_flush_failed")
                     state.push_slots_update()
                     return web.json_response(
                         {
@@ -631,23 +772,30 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
                 arrived_pending = [
                     row for row in slot._pending if id(row) not in pre_await_pending_ids
                 ]
-                # A card retired by EITHER the edit or an arrived row stays
-                # retired -- tightest-wins, so the commit can never resurrect one
-                # whose answer channel is already gone -- and only a card still
-                # live is announced.
-                surviving_questions = {
-                    cid: rec
-                    for cid, rec in prospective_slot._question_pending.items()
-                    if cid in slot._question_pending
-                }
+                # Both containers are edited IN PLACE rather than replaced, and
+                # the reason is one rule: a copy frozen before the awaits cannot
+                # carry any write that landed during them. Answering a card pops
+                # the id from the LIVE dict (``clear_pending``), and ``drain()``
+                # does ``slot._pending.clear()`` on the LIVE list, so assigning
+                # either frozen copy back resurrects an answered card or requeues
+                # an already-delivered row. Deleting exactly what the edit
+                # retired, and dropping only rows the edit's own snapshot has
+                # since lost, leaves every concurrent write standing --
+                # ``mark_pending`` is the only writer that ADDS a card, so a card
+                # that arrived mid-boundary survives too. Announce only the ids
+                # actually removed.
                 announce_retired = [
                     question_id
                     for question_id in retired_question_ids
-                    if question_id in slot._question_pending
+                    if slot._question_pending.pop(question_id, None) is not None
                 ]
                 slot.messages = prospective_slot.messages + arrived_rows
-                slot._pending = prospective_slot._pending + arrived_pending
-                slot._question_pending = surviving_questions
+                delivered_pending_ids = pre_await_pending_ids - {id(row) for row in slot._pending}
+                slot._pending[:] = [
+                    row
+                    for row in prospective_slot._pending + arrived_pending
+                    if id(row) not in delivered_pending_ids
+                ]
                 slot.invalidate_source_links()
                 slot._dirty = True
                 slot._resumed_count = 0
@@ -778,9 +926,19 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
                         "committed live state and dispatching the edited prompt",
                         slot.key,
                     )
+                else:
+                    # The native context is already gone and nothing was
+                    # committed against it: either the rewrite did not land, or
+                    # it landed on a slot that moved. This is the same
+                    # destroyed-without-a-commit outcome as the 503 paths below,
+                    # and it is the one exit where the client is not even told --
+                    # the cancellation propagates instead of a response, so the
+                    # SEL record is the ONLY place it can be attributed from.
+                    _sel_native_destroyed("request_cancelled")
                 raise
             except Exception:
                 logger.warning("edit-resend: failed to persist", exc_info=True)
+                _sel_native_destroyed("history_save_exception")
                 state.push_slots_update()
                 return web.json_response(
                     {
@@ -799,6 +957,7 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
                     "edit-resend: history save refused for %s (concurrent delete or rebind)",
                     slot.key,
                 )
+                _sel_native_destroyed("history_save_refused")
                 state.push_slots_update()
                 return web.json_response(
                     {
@@ -814,6 +973,7 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
             # awaits above. No await between these checks and the mutations
             # below, so the decision cannot go stale.
             if not _commit_target_intact():
+                _sel_native_destroyed("commit_target_moved")
                 state.push_slots_update()
                 return web.json_response(
                     {

--- a/src/kiro_crew/dashboard/chat_rewind.py
+++ b/src/kiro_crew/dashboard/chat_rewind.py
@@ -41,6 +41,17 @@ from kiro_crew.session_map import _kiro_sessions_dir
 
 logger = logging.getLogger(__name__)
 
+# How many times the cancellation path re-shields the in-flight native discard
+# before giving up on learning its outcome. Each retry absorbs ONE further
+# cancellation (a gateway shutdown landing on a handler already unwinding from a
+# client disconnect), so this bounds a cancel storm rather than a duration -- the
+# teardown itself always runs to completion. A single ``await`` on the task is
+# defeated by exactly one more cancellation, which would leave an irreversible
+# teardown unrecorded; giving up after the bound records the outcome as
+# undetermined rather than assuming one. ``chat_regenerate`` carries the same
+# reasoning for its history-rewrite drain (``_SAVE_DRAIN_ATTEMPTS``).
+_DISCARD_DRAIN_ATTEMPTS = 8
+
 
 async def _delete_orphan_kiro_session(session_id: str) -> None:
     """Delete the orphaned kiro-cli session JSONL file, best-effort.
@@ -281,6 +292,31 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
         # refuses a valid cursor (``since < base``) or repeats rows. The save has
         # no contract on this one, so it travels only to the commit.
         pre_await_disk_older_durable_count = slot._disk_older_durable_count
+        # Row identities on the LIVE slot at the boundary. A workflow or cron
+        # completion appends WITHOUT taking ``slot._lock`` (``workflow_inject``
+        # calls ``append_and_surface`` straight on the event loop), so a
+        # wholesale replace at the commit drops the injected row -- and the
+        # rewrite cannot put it back, because a rewrite deliberately skips the
+        # cross-process-append scan (``collect_foreign=not rewrite`` in
+        # ``chat_persistence``). Keeping it in the window is what makes the next
+        # ORDINARY flush re-persist it. Identity rather than a length: an
+        # ``append`` at the window cap trims the front, so a positional slice
+        # would either re-adopt trimmed rows or miss the arrived one.
+        # RETAINED lists, not just the id sets. An ``id()`` is an integer that
+        # says nothing about the object's lifetime, and nothing else here keeps
+        # the pre-await rows alive: the window trims at the cap
+        # (``_MAX_SLOT_MESSAGES``) and a low-index edit pins nothing ahead of
+        # ``index`` (at index 0 the prospective copy is empty), so a leading row
+        # can be freed while the awaits below run and CPython can hand its id to a
+        # newly appended arrival. The commit would then read that arrival as "not
+        # new" and drop it -- the exact loss this snapshot exists to prevent.
+        # Holding the rows keeps every id unique to the object that minted it.
+        # ``meta.mid`` is not an alternative identity: ``append`` skips it for
+        # restored rows (``mint_mid=False``) and for the wire-only roles.
+        pre_await_rows = list(slot.messages)
+        pre_await_row_ids = {id(row) for row in pre_await_rows}
+        pre_await_pending = list(slot._pending)
+        pre_await_pending_ids = {id(row) for row in pre_await_pending}
         retired_question_ids = [
             question_id
             for question_id in slot._question_pending
@@ -332,26 +368,139 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
 
         task.add_done_callback(_on_done)
 
+        def _sel_native_destroyed(reason: str, *, native_cleared: str = "1") -> None:
+            """Record a destroyed native context that never reached a commit.
+
+            ``discard_conversation`` plus ``aflush`` are irreversible: past that
+            point the provider-side conversation is gone whether or not this
+            request goes on to succeed. SEL already carries this endpoint's
+            denials and its successful commits, so without this record the ONE
+            outcome that destroyed context WITHOUT committing anything is the
+            only one missing from the audit trail -- and it is the only one that
+            cannot be reconstructed from the others, because in the trail it is
+            indistinguishable from a denial that touched nothing.
+
+            ``native_cleared`` is a THREE-valued field, not a flag, because the
+            teardown has three outcomes and only two of them are facts: it
+            happened, it did not, or the check that would have told us raised.
+            ``"unknown"`` is what the third writes. A boolean here forced the one
+            case the audit exists for to be spelled as one of the other two, and
+            an audit that goes quiet on the outcome it could not determine is
+            worse than none: its silence reads as nothing to report.
+            """
+            sel().log_api_access(
+                caller=request_app or "dashboard",
+                operation="chat.rewind",
+                outcome="error",
+                source="dashboard",
+                resources=f"slot={slot.key},native_cleared={native_cleared}",
+                error=reason,
+            )
+
         # Durably clear the native resume sid before committing the edited
         # history. A failure leaves the original branch intact and dispatches
         # no replacement turn.
         try:
             if state.sessions is not None:
-                try:
+                # Shielded and drained for the same reason the history save below
+                # is: ``discard_conversation`` pops the session and calls
+                # ``clear_sid`` BEFORE its own remaining awaits
+                # (``to_thread(unlink)``, ``provider.shutdown()``,
+                # ``release_subagent_runtime``), so the destruction is already
+                # true while those run. A client disconnect landing there would
+                # otherwise propagate past every handler below with the context
+                # gone and nothing recorded. The shield does not make the teardown
+                # slower -- it was always going to run to completion -- it only
+                # keeps this handler alive long enough to learn the outcome.
+                discard_task = asyncio.ensure_future(
                     # ``skip_if_busy``: an inbound channel turn (a Slack reply
                     # on the linked session) holds the session semaphore while
                     # ``slot.running`` reads False, so the idle check above
                     # cannot see it -- an unconditional discard would tear
                     # down its provider mid-reply. The refusal is atomic with
                     # the busy probe inside the lifecycle service.
-                    discarded = await state.sessions.discard_conversation(
-                        session_key, skip_if_busy=True
-                    )
+                    state.sessions.discard_conversation(session_key, skip_if_busy=True)
+                )
+                try:
+                    discarded = await asyncio.shield(discard_task)
+                except asyncio.CancelledError:
+                    # Drain to learn whether the teardown actually happened. The
+                    # outcome is THREE-valued and the code says so: it destroyed
+                    # (record it), it refused because the session was busy and
+                    # destroyed nothing (record nothing), or we could not find out
+                    # (record the unknown). Collapsing the third into
+                    # ``destroyed = False`` asserted a fact this branch does not
+                    # have, and suppressed the audit event on the one path most
+                    # likely to need it.
+                    #
+                    # Bounded re-shield rather than a single ``await``: this await
+                    # is itself a cancellation point, so one further cancel -- a
+                    # gateway shutdown reaching a handler already unwinding from a
+                    # client disconnect -- would abandon the drain and lose the
+                    # record. Each pass absorbs one more.
+                    for _ in range(_DISCARD_DRAIN_ATTEMPTS):
+                        if discard_task.done():
+                            break
+                        try:
+                            await asyncio.shield(discard_task)
+                        except asyncio.CancelledError:
+                            continue
+                        except Exception:
+                            break
+                    if discard_task.done() and not discard_task.cancelled():
+                        discard_exc = discard_task.exception()
+                        if discard_exc is not None:
+                            # Recorded, not swallowed: the trail gets the
+                            # undetermined outcome and the log gets the cause. The
+                            # catch above stays broad on purpose --
+                            # ``provider.shutdown()`` is provider transport and its
+                            # failure modes are not enumerable from here, and
+                            # letting an arbitrary error out of a
+                            # ``CancelledError`` handler would REPLACE the client's
+                            # cancellation with an unrelated exception. It narrows
+                            # where it matters: ``Exception`` leaves
+                            # ``CancelledError``, ``KeyboardInterrupt`` and
+                            # ``SystemExit`` free to surface.
+                            logger.warning(
+                                "rewind: the discard for %s raised while draining a "
+                                "cancellation, so whether the native context was "
+                                "torn down is undetermined",
+                                session_key,
+                                exc_info=discard_exc,
+                            )
+                            _sel_native_destroyed(
+                                "discard_cancelled_outcome_unknown", native_cleared="unknown"
+                            )
+                        elif discard_task.result():
+                            _sel_native_destroyed("discard_cancelled")
+                    else:
+                        logger.warning(
+                            "rewind: the discard for %s did not settle within %d "
+                            "cancellation(s), so whether the native context was torn "
+                            "down is undetermined",
+                            session_key,
+                            _DISCARD_DRAIN_ATTEMPTS,
+                        )
+                        _sel_native_destroyed(
+                            "discard_cancelled_outcome_unknown", native_cleared="unknown"
+                        )
+                    raise
                 except Exception:
                     logger.warning(
                         "rewind: failed to discard ACP conversation for %s",
                         session_key,
                         exc_info=True,
+                    )
+                    # The raise can land on either side of this teardown's own
+                    # destruction point: ``discard_conversation`` pops the session
+                    # and calls ``clear_sid`` before its remaining awaits, so a
+                    # failure inside it proves nothing either way. Record the
+                    # undetermined outcome rather than nothing -- a silent exit
+                    # here is indistinguishable in the trail from a refusal that
+                    # touched no state, which is exactly the confusion the audit
+                    # exists to remove.
+                    _sel_native_destroyed(
+                        "discard_failed_outcome_unknown", native_cleared="unknown"
                     )
                     state.push_slots_update()
                     return web.json_response(
@@ -379,12 +528,25 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                     # semantics for its other callers (chat_runner, channel
                     # handlers), which tolerate the debounce.
                     await state.sessions.aflush()
+                except asyncio.CancelledError:
+                    # ``discarded`` is already True here, so the native context
+                    # IS gone -- and ``CancelledError`` derives from
+                    # BaseException, so the handler below cannot absorb it. A
+                    # client disconnect landing on this await would otherwise
+                    # leave the destruction with no record at all, which is the
+                    # one outcome this audit exists for. Record, then let the
+                    # cancellation propagate untouched.
+                    _sel_native_destroyed("sid_flush_cancelled")
+                    raise
                 except Exception:
                     logger.warning(
                         "rewind: failed to flush the cleared resume sid for %s",
                         session_key,
                         exc_info=True,
                     )
+                    # The in-memory discard already happened, so the native
+                    # context is gone even though its sid clear is not durable.
+                    _sel_native_destroyed("sid_flush_failed")
                     state.push_slots_update()
                     return web.json_response(
                         {
@@ -402,15 +564,63 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                 is the only thing that keeps live state matching it. No await
                 inside, so it is atomic on the event loop.
                 """
-                slot.messages = prospective_slot.messages
+                # Carry the rows that landed on the LIVE slot while the
+                # boundaries were pending -- see ``pre_await_row_ids``. Appending
+                # them AFTER the prospective window is the correct order and not
+                # merely a convenient one: ``monotonic_transcript_ts`` only ever
+                # moves a row forward, so an arrived row can never be stamped
+                # EARLIER than the edited one. It can be stamped IDENTICALLY --
+                # on a coarse clock (Windows ticks in ~15.6 ms steps) both
+                # appends read the same instant -- and list order is what
+                # separates that tie, which is why the merge order matters rather
+                # than a re-sort.
+                arrived_rows = [row for row in slot.messages if id(row) not in pre_await_row_ids]
+                arrived_pending = [
+                    row for row in slot._pending if id(row) not in pre_await_pending_ids
+                ]
+                # The question set is RETIRED IN PLACE rather than replaced with
+                # the frozen copy, and the difference is the whole fix. Answering
+                # a card mutates the live dict -- ``clear_pending`` pops the id
+                # from ``slot._question_pending`` on the slot it resolved from
+                # ``state._slots``. Assigning the prospective copy here would
+                # swap out the very dict that pop wrote to, so a BLOCKING card
+                # answered inside the awaits above came back with its answer
+                # channel already gone: a card rendered as awaiting input against
+                # a round-trip that has completed. Deleting exactly the ids the
+                # edit retired leaves every other in-place write standing, which
+                # makes the answer authoritative by construction -- nothing here
+                # carries a competing copy of the container, so no later edit to
+                # this commit can forget to reconcile it. ``mark_pending`` is the
+                # only writer that adds an id, so a card that ARRIVED during the
+                # boundary survives too. Announce only the ids actually removed.
+                announce_retired = [
+                    question_id
+                    for question_id in retired_question_ids
+                    if slot._question_pending.pop(question_id, None) is not None
+                ]
+                slot.messages = prospective_slot.messages + arrived_rows
                 # Remove only the entries captured in the pre-await snapshot:
                 # an entry queued while the boundaries were pending belongs to
                 # the NEW timeline and must survive for the teardown drain.
                 slot._queue[:] = [
                     entry for entry in slot._queue if entry["id"] not in discarded_queue_ids
                 ]
-                slot._pending = prospective_slot._pending
-                slot._question_pending = prospective_slot._question_pending
+                # ``_pending`` is edited in place for the same reason the question
+                # set is: ``drain()`` does ``slot._pending.clear()``, so a client
+                # that drains mid-boundary has already DELIVERED those rows.
+                # ``prospective_slot._pending`` was frozen before the awaits and
+                # still holds them, so replacing the list would queue delivered
+                # rows for re-delivery. A pre-await row therefore survives only
+                # if it is still live; the edit's own row and anything that
+                # arrived are kept unconditionally. Order is unchanged --
+                # pre-await rows, then the edit, then arrivals -- which is the
+                # same monotonic argument as the window above.
+                delivered_pending_ids = pre_await_pending_ids - {id(row) for row in slot._pending}
+                slot._pending[:] = [
+                    row
+                    for row in prospective_slot._pending + arrived_pending
+                    if id(row) not in delivered_pending_ids
+                ]
                 slot.invalidate_source_links()
                 slot._dirty = True
                 slot._resumed_count = 0
@@ -458,9 +668,9 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                     slot.event.set()
                 else:
                     slot.event.clear()
-                if retired_question_ids and callable(slot._on_question_retired):
+                if announce_retired and callable(slot._on_question_retired):
                     try:
-                        slot._on_question_retired(slot.key, retired_question_ids)  # type: ignore[operator]
+                        slot._on_question_retired(slot.key, announce_retired)  # type: ignore[operator]
                     except Exception:
                         logger.debug(
                             "rewind: question-retirement announcement failed for slot %s",
@@ -517,9 +727,19 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                         "committed live state and dispatching the edited prompt",
                         slot.key,
                     )
+                else:
+                    # The native context is already gone and nothing was
+                    # committed against it: either the rewrite did not land, or
+                    # it landed on a slot that moved. This is the same
+                    # destroyed-without-a-commit outcome as the 503 paths below,
+                    # and it is the one exit where the client is not even told --
+                    # the cancellation propagates instead of a response, so the
+                    # SEL record is the ONLY place it can be attributed from.
+                    _sel_native_destroyed("request_cancelled")
                 raise
             except Exception:
                 logger.warning("rewind: failed to persist truncated history", exc_info=True)
+                _sel_native_destroyed("history_save_exception")
                 state.push_slots_update()
                 return web.json_response(
                     {
@@ -538,6 +758,7 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                     "rewind: history save refused for %s (concurrent delete or rebind)",
                     slot.key,
                 )
+                _sel_native_destroyed("history_save_refused")
                 state.push_slots_update()
                 return web.json_response(
                     {
@@ -562,6 +783,7 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                     "persistence; refusing the commit",
                     slot.key,
                 )
+                _sel_native_destroyed("commit_target_moved")
                 state.push_slots_update()
                 return web.json_response(
                     {

--- a/test/test_chat_regenerate_cov80.py
+++ b/test/test_chat_regenerate_cov80.py
@@ -1517,6 +1517,78 @@ async def test_edit_resend_commit_does_not_resurrect_a_card_retired_meanwhile(st
     assert announced == [("s1", ["q1", "q2"])]
 
 
+@pytest.mark.asyncio
+async def test_edit_resend_commit_keeps_a_blocking_card_answered_meanwhile(state) -> None:
+    """An answer landing mid-boundary must not be undone by the commit.
+
+    Answering pops the id from the LIVE dict, so a commit that assigned the
+    frozen pre-await copy back would restore the card with its answer channel
+    already gone. A BLOCKING card is the shape that reaches this: an append never
+    retires one, so the edit's own ``user`` row cannot be what cleared it.
+    """
+    slot = state.get_or_create_slot("s1")
+    slot.append("user", "first")
+    slot.append("assistant", "answer")
+    slot.drain()
+    state.mark_question_pending("s1", blocking=True, card_id="ask-1")
+    assert "ask-1" in slot._question_pending
+    observed: dict = {}
+
+    async def _discard(key, **kwargs):
+        observed["cleared"] = state.clear_question_pending("s1", card_id="ask-1")
+        return True
+
+    state.sessions.discard_conversation = AsyncMock(side_effect=_discard)
+
+    with patch("kiro_crew.dashboard.chat_regenerate._run_chat", new=AsyncMock()):
+        async with _client(state) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/edit-resend", json={"index": 0, "content": "edited"}
+            )
+            assert resp.status == 200
+            await asyncio.sleep(0)
+
+    assert observed["cleared"] is True
+    assert "ask-1" not in slot._question_pending, (
+        "the commit resurrected a card that was answered during the boundary, "
+        "so the slot awaits input against a completed round-trip"
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_resend_commit_keeps_a_card_that_arrived_meanwhile(state) -> None:
+    """A card marked mid-boundary must survive the commit.
+
+    ``post_question_card`` is addressed by slot key, so a card can be marked on a
+    slot whose turn is being replaced. It is in the LIVE dict and not in the
+    frozen pre-await copy, so any commit keyed on that copy erases it -- and the
+    client has already been shown it.
+    """
+    slot = state.get_or_create_slot("s1")
+    slot.append("user", "first")
+    slot.append("assistant", "answer")
+    slot.drain()
+
+    async def _discard(key, **kwargs):
+        state.mark_question_pending("s1", blocking=True, card_id="ask-late")
+        return True
+
+    state.sessions.discard_conversation = AsyncMock(side_effect=_discard)
+
+    with patch("kiro_crew.dashboard.chat_regenerate._run_chat", new=AsyncMock()):
+        async with _client(state) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/edit-resend", json={"index": 0, "content": "edited"}
+            )
+            assert resp.status == 200
+            await asyncio.sleep(0)
+
+    assert "ask-late" in slot._question_pending, (
+        "the commit erased a card that was raised during the boundary, so the "
+        "client renders a card the server no longer believes is pending"
+    )
+
+
 # ── edit-resend: the commit re-checks the transcript it was authorized against ──
 
 

--- a/test/test_dashboard_chat_rewind.py
+++ b/test/test_dashboard_chat_rewind.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import gc
 import json
 import threading
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,6 +15,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from chat_test_helpers import _make_app, _make_state
 
 from kiro_crew.dashboard import chat_persistence
+from kiro_crew.dashboard.state import append_and_surface
 
 
 @pytest.fixture(autouse=True)
@@ -607,6 +611,621 @@ class TestRewindSlot:
             slot.task.cancel()
 
     @pytest.mark.asyncio
+    async def test_rewind_commit_keeps_a_row_that_arrived_during_the_boundaries(self, tmp_path):
+        """A workflow row landing mid-boundary must survive the commit.
+
+        ``workflow_inject`` appends straight on the event loop without taking
+        ``slot._lock``, so a row can land between the pre-await snapshot and the
+        commit. A wholesale replace drops it, and the rewrite above cannot put it
+        back because a rewrite deliberately skips the cross-process-append scan
+        -- keeping it in the live window is what makes the next ORDINARY flush
+        re-persist it.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        async def _arriving_discard(key, **kwargs):
+            # Runs inside the awaited boundary, through the real append door
+            # a workflow completion uses -- not a hand-built row.
+            append_and_surface(state, slot, "assistant", "workflow finished", "msg msg-a")
+            return True
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_arriving_discard)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 200
+
+        contents = [row.get("content") for row in slot.messages]
+        assert "workflow finished" in contents
+        # AFTER the edited row: ``monotonic_transcript_ts`` only ever moves a row
+        # forward, so an arrived row must never be ordered before the edit. On a
+        # coarse clock both appends can read the SAME instant, and list order is
+        # what separates that tie.
+        assert contents.index("workflow finished") > contents.index("edited first question")
+        # Retention must not resurrect the truncated suffix.
+        assert "second question" not in contents
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_commit_keeps_a_pending_row_that_arrived_during_the_boundaries(
+        self, tmp_path
+    ):
+        """The arrived row must survive in the un-drained buffer too.
+
+        ``_pending`` is what an open client's stream reader drains, so a row
+        dropped there never reaches the screen even when it is in the window.
+        The prospective copy froze ``_pending`` BEFORE the arrival, so the same
+        wholesale replace loses it one field over.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        async def _arriving_discard(key, **kwargs):
+            append_and_surface(state, slot, "assistant", "workflow finished", "msg msg-a")
+            return True
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_arriving_discard)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 200
+
+        pending_contents = [row.get("content") for row in slot._pending]
+        assert "workflow finished" in pending_contents
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_commit_keeps_a_blocking_card_answered_during_the_boundaries(
+        self, tmp_path
+    ):
+        """An answer that lands mid-boundary must not be undone by the commit.
+
+        Answering retires the card by MUTATING the live dict --
+        ``clear_question_pending`` pops the id from ``slot._question_pending``.
+        Assigning the frozen prospective copy at commit time swaps that dict out,
+        so the card comes back with its answer channel already gone: rendered as
+        awaiting input against a round-trip that has completed. A BLOCKING card
+        is the shape that reaches this, because an append never retires one --
+        ``_QUESTION_RETIRING_ROLES`` fires only on the non-blocking records.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        state.sessions._session_map.get = MagicMock(return_value="")
+        state.mark_question_pending(slot.key, blocking=True, card_id="ask-1")
+        assert "ask-1" in slot._question_pending
+        observed: dict = {}
+
+        async def _answering_discard(key, **kwargs):
+            # Runs inside the awaited boundary, through the same door the
+            # question round-trip uses when the user answers.
+            observed["cleared"] = state.clear_question_pending(slot.key, card_id="ask-1")
+            # Axis-isolating precondition: the card is blocking, so the edit's
+            # own ``user`` append cannot be what retired it.
+            observed["blocking"] = True
+            return True
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_answering_discard)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 200
+
+        assert observed["cleared"] is True
+        assert "ask-1" not in slot._question_pending, (
+            "the commit resurrected a card that was answered during the boundary, "
+            "so the slot awaits input against a completed round-trip"
+        )
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_commit_does_not_requeue_a_row_drained_during_the_boundaries(
+        self, tmp_path
+    ):
+        """A row already delivered mid-boundary must not be queued again.
+
+        ``drain()`` does ``slot._pending.clear()`` on the LIVE list, so once a
+        client has drained, those rows are gone from the buffer because they
+        reached the client. ``prospective_slot._pending`` was frozen before the
+        awaits and still holds them, so replacing the list would hand the client
+        the same rows a second time.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        state.sessions._session_map.get = MagicMock(return_value="")
+        # The fixture drains, so seed one undelivered row through the real append
+        # door. It is a PRE-AWAIT row, which is the only kind a drain can strand.
+        append_and_surface(state, slot, "assistant", "streamed but not yet read", "msg msg-a")
+        assert slot._pending, "the fixture must leave rows in the buffer to drain"
+        observed: dict = {}
+
+        async def _draining_discard(key, **kwargs):
+            # Runs inside the awaited boundary, through the same door a client's
+            # stream reader uses.
+            observed["delivered"] = [row.get("content") for row in slot.drain()]
+            return True
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_draining_discard)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 200
+
+        assert observed["delivered"], "the drain delivered nothing, so this test proved nothing"
+        buffered = [row.get("content") for row in slot._pending]
+        for content in observed["delivered"]:
+            assert content not in buffered, (
+                "the commit requeued a row the client had already been given, "
+                "so an open client is handed it twice"
+            )
+        # The edit's own row still has to reach the client.
+        assert "edited first question" in buffered
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_retains_the_pre_await_rows_so_their_ids_cannot_recycle(self, tmp_path):
+        """The arrival snapshot must hold the rows, not just their ``id()`` values.
+
+        ``id()`` is an integer that says nothing about lifetime. The window trims
+        at ``_MAX_SLOT_MESSAGES`` and a low-index edit pins nothing ahead of
+        ``index`` -- at index 0 the prospective copy is empty -- so a leading row
+        can be freed mid-boundary and CPython can hand its id to a newly appended
+        arrival, which the commit would then read as "not new" and drop.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        state.sessions._session_map.get = MagicMock(return_value="")
+        observed: dict = {}
+
+        async def _trimming_discard(key, **kwargs):
+            # Stands in for the cap trim: the leading row leaves the live window
+            # while the boundary is open. Rows are plain dicts so they cannot be
+            # weak-referenced; ask the collector instead which lists still hold
+            # this one. At index 0 the prospective copy is empty and the fixture
+            # drained ``_pending``, so the endpoint's own retained snapshot is the
+            # only list that can appear here.
+            row = slot.messages[0]
+            del slot.messages[0]
+            observed["retaining_lists"] = [
+                holder
+                for holder in gc.get_referrers(row)
+                if isinstance(holder, list) and holder is not slot.messages
+            ]
+            append_and_surface(state, slot, "assistant", "workflow finished", "msg msg-a")
+            return True
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_trimming_discard)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 200
+
+        assert observed["retaining_lists"], (
+            "no list holds the trimmed row while the boundary is open, so it is "
+            "freed and its id() can be reused by an arrival the commit then drops"
+        )
+        # The behavioural half: the arrival still lands.
+        assert "workflow finished" in [row.get("content") for row in slot.messages]
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_records_a_sel_event_when_the_native_context_is_destroyed(
+        self, tmp_path, monkeypatch
+    ):
+        """A 503 after the native discard must leave an attributable SEL record.
+
+        Once ``discard_conversation`` and ``aflush`` succeed the native session
+        is unrecoverable. SEL carries this endpoint's denials and its successful
+        commits, so without a record here the one outcome that destroyed context
+        WITHOUT committing anything is indistinguishable in the audit trail from
+        a denial that touched nothing.
+        """
+        events: list[dict] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        def _fail_save(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_rewind._save_slot_to_history", _fail_save)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "rewind_save_failed"
+
+        destroyed = [
+            event for event in events if "native_cleared=1" in str(event.get("resources", ""))
+        ]
+        assert len(destroyed) == 1
+        record = destroyed[0]
+        assert record["operation"] == "chat.rewind"
+        assert record["outcome"] == "error"
+        assert record["error"] == "history_save_exception"
+        # Without the slot the record cannot be attributed to a conversation.
+        assert f"slot={slot.key}" in record["resources"]
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_cancelled_on_the_sid_flush_still_records_the_destruction(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation on the sid flush must still leave a SEL record.
+
+        ``discard_conversation`` has already returned True at this point, so the
+        native context IS gone. ``CancelledError`` derives from BaseException, so
+        the ``except Exception`` beside it cannot absorb it -- without its own
+        handler the destruction propagates with no record and no response, which
+        is the one outcome the audit exists for.
+        """
+        events: list[dict] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        state.sessions._session_map.get = MagicMock(return_value="")
+        observed: dict = {}
+
+        async def _discarded(key, **kwargs):
+            observed["discarded"] = True
+            return True
+
+        async def _cancelled_flush():
+            raise asyncio.CancelledError()
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_discarded)
+        state.sessions.aflush = AsyncMock(side_effect=_cancelled_flush)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            with contextlib.suppress(Exception):
+                await client.post(
+                    "/api/chat/slots/src/rewind",
+                    json={"at_message_index": 0, "content": "edited first question"},
+                )
+
+        # The precondition: the destruction really happened before the cancel.
+        assert observed.get("discarded") is True
+        destroyed = [
+            event for event in events if "native_cleared=1" in str(event.get("resources", ""))
+        ]
+        assert len(destroyed) == 1, (
+            "a cancellation on the sid flush left the destroyed native context "
+            "with no SEL record, so the outcome is unattributable"
+        )
+        assert destroyed[0]["error"] == "sid_flush_cancelled"
+        assert destroyed[0]["outcome"] == "error"
+        assert f"slot={slot.key}" in destroyed[0]["resources"]
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_cancelled_inside_the_discard_still_records_the_destruction(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation inside the discard's own awaits must be recorded.
+
+        ``discard_conversation`` pops the session and calls ``clear_sid`` before
+        its remaining awaits (``to_thread(unlink)``, ``provider.shutdown()``,
+        ``release_subagent_runtime``), so the destruction is already true while
+        those run. An unshielded await here would let a client disconnect
+        propagate past every later handler with the context gone and no record.
+        """
+        events: list[dict] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        observed: dict = {}
+        handler: dict = {}
+
+        def _capture_handler_task(*_args, **_kwargs):
+            # Called on the handler's own stack before the discard, so this is
+            # the task that will be awaiting the shield.
+            handler["task"] = asyncio.current_task()
+            return ""
+
+        state.sessions._session_map.get = MagicMock(side_effect=_capture_handler_task)
+
+        async def _teardown_then_cancel(key, **kwargs):
+            # Stands in for the position after ``clear_sid``: the destruction has
+            # happened and the remaining awaits are still running when the client
+            # disconnects. Cancel the handler, then yield so the cancellation is
+            # delivered to its shielded await while this teardown is in flight.
+            observed["entered"] = True
+            handler["task"].cancel()
+            await asyncio.sleep(0)
+            return True
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_teardown_then_cancel)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            with contextlib.suppress(Exception):
+                await client.post(
+                    "/api/chat/slots/src/rewind",
+                    json={"at_message_index": 0, "content": "edited first question"},
+                )
+
+        assert observed.get("entered") is True
+        assert handler.get("task") is not None
+        destroyed = [
+            event for event in events if "native_cleared=1" in str(event.get("resources", ""))
+        ]
+        assert len(destroyed) == 1, (
+            "a cancellation inside the discard left the destroyed native context "
+            "with no SEL record, so the outcome is unattributable"
+        )
+        assert destroyed[0]["error"] == "discard_cancelled"
+        assert destroyed[0]["outcome"] == "error"
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_cancelled_discard_that_refused_records_no_destruction(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancelled discard that REFUSED must not be recorded as a destruction.
+
+        ``skip_if_busy`` returns False without tearing anything down, so the
+        drain has to distinguish "cancelled after destroying" from "cancelled
+        after refusing". Recording the refusal would put a destruction that never
+        happened into the audit trail.
+        """
+        events: list[dict] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        async def _refusing_discard(key, **kwargs):
+            return False
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_refusing_discard)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 409
+
+        destroyed = [
+            event for event in events if "native_cleared=1" in str(event.get("resources", ""))
+        ]
+        assert destroyed == [], (
+            "a discard that refused was recorded as a destruction, so the audit "
+            "trail claims a teardown that never happened"
+        )
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_cancelled_discard_that_raises_records_an_unknown_outcome(
+        self, tmp_path, monkeypatch
+    ):
+        """A drain that raises must record the UNKNOWN outcome, not silence.
+
+        Three outcomes are possible and only two are facts: the teardown happened,
+        it refused and destroyed nothing, or the drained call raised and nothing
+        here can tell which. Spelling the third as ``destroyed = False`` asserted
+        the second, so the audit went quiet on exactly the case it exists for --
+        and silence in a trail reads as nothing to report.
+        """
+        events: list[dict] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        observed: dict = {}
+        handler: dict = {}
+
+        def _capture_handler_task(*_args, **_kwargs):
+            handler["task"] = asyncio.current_task()
+            return ""
+
+        state.sessions._session_map.get = MagicMock(side_effect=_capture_handler_task)
+
+        async def _teardown_then_cancel_then_raise(key, **kwargs):
+            # Cancel the handler, yield so the cancellation reaches its shielded
+            # await, then fail the way a provider shutdown can fail after the
+            # pop and ``clear_sid`` have already run.
+            observed["entered"] = True
+            handler["task"].cancel()
+            await asyncio.sleep(0)
+            raise RuntimeError("provider shutdown transport closed")
+
+        state.sessions.discard_conversation = AsyncMock(
+            side_effect=_teardown_then_cancel_then_raise
+        )
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            with contextlib.suppress(Exception):
+                await client.post(
+                    "/api/chat/slots/src/rewind",
+                    json={"at_message_index": 0, "content": "edited first question"},
+                )
+
+        assert observed.get("entered") is True
+        unknown = [
+            event for event in events if "native_cleared=unknown" in str(event.get("resources", ""))
+        ]
+        assert len(unknown) == 1, (
+            "a discard that raised while draining a cancellation left no audit "
+            "record, so an undetermined teardown is indistinguishable from one "
+            "that never happened"
+        )
+        assert unknown[0]["error"] == "discard_cancelled_outcome_unknown"
+        assert unknown[0]["outcome"] == "error"
+        # It must NOT claim a destruction it cannot prove.
+        claimed = [
+            event for event in events if "native_cleared=1" in str(event.get("resources", ""))
+        ]
+        assert claimed == [], "an undetermined teardown was recorded as a definite destruction"
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_second_cancellation_on_the_drain_still_records(
+        self, tmp_path, monkeypatch
+    ):
+        """A second cancellation must not abandon the drain and lose the record.
+
+        The drain's own ``await`` is a cancellation point, so a single one is
+        defeated by exactly one more cancel -- a gateway shutdown reaching a
+        handler already unwinding from a client disconnect. The bounded re-shield
+        absorbs one per pass, which is the same shape the history-rewrite drain
+        uses.
+        """
+        events: list[dict] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        observed: dict = {}
+        handler: dict = {}
+
+        def _capture_handler_task(*_args, **_kwargs):
+            handler["task"] = asyncio.current_task()
+            return ""
+
+        state.sessions._session_map.get = MagicMock(side_effect=_capture_handler_task)
+
+        async def _cancel_twice_then_destroy(key, **kwargs):
+            # First cancel reaches the shielded await; the second reaches the
+            # drain itself. Only then does the teardown report success.
+            observed["cancels"] = 0
+            handler["task"].cancel()
+            await asyncio.sleep(0)
+            handler["task"].cancel()
+            observed["cancels"] = 2
+            await asyncio.sleep(0)
+            return True
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_cancel_twice_then_destroy)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            with contextlib.suppress(Exception):
+                await client.post(
+                    "/api/chat/slots/src/rewind",
+                    json={"at_message_index": 0, "content": "edited first question"},
+                )
+
+        assert observed.get("cancels") == 2, "the second cancellation never landed"
+        recorded = [
+            event for event in events if "native_cleared" in str(event.get("resources", ""))
+        ]
+        assert len(recorded) == 1, (
+            "a second cancellation on the drain abandoned it, so an irreversible "
+            "teardown left no audit record at all"
+        )
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_discard_failure_records_an_unknown_outcome(self, tmp_path, monkeypatch):
+        """An ordinary discard failure must record the UNDETERMINED outcome.
+
+        ``discard_conversation`` pops the session and calls ``clear_sid`` before
+        its remaining awaits, so a raise from inside it proves nothing either way.
+        Returning 503 with no record leaves that exit indistinguishable in the
+        trail from a refusal that touched no state.
+        """
+        events: list[dict] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        original_messages = list(slot.messages)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        async def _raising_discard(key, **kwargs):
+            raise RuntimeError("provider shutdown transport closed")
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_raising_discard)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "rewind_prepare_failed"
+
+        unknown = [
+            event for event in events if "native_cleared=unknown" in str(event.get("resources", ""))
+        ]
+        assert len(unknown) == 1, (
+            "an ordinary discard failure left no audit record, so a possibly "
+            "destroyed native context is indistinguishable from a refusal"
+        )
+        assert unknown[0]["error"] == "discard_failed_outcome_unknown"
+        assert unknown[0]["outcome"] == "error"
+        # It must NOT claim a destruction it cannot prove.
+        claimed = [
+            event for event in events if "native_cleared=1" in str(event.get("resources", ""))
+        ]
+        assert claimed == [], "an undetermined teardown was recorded as a definite destruction"
+        # The 503 leaves the original branch intact.
+        assert slot.messages == original_messages
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
     async def test_rewind_refuses_while_a_channel_turn_holds_the_session(self, tmp_path):
         """A busy session (inbound channel reply in flight) must 409, not discard.
 
@@ -691,6 +1310,77 @@ class TestRewindSlot:
             await asyncio.sleep(0.02)
         _mock_run_chat.assert_awaited_once()
         assert _mock_run_chat.await_args.args[2] == "edited first question"
+
+    @pytest.mark.asyncio
+    async def test_rewind_cancelled_without_a_landed_rewrite_still_records_the_destruction(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation that commits nothing must still leave a SEL record.
+
+        This is the one exit where the client is never told: the cancellation
+        propagates instead of a response, so an already-destroyed native context
+        can only be attributed from SEL. The sibling 503 paths all carry the
+        record; before this, the cancellation path did not.
+        """
+        events: list[dict] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind.sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        original_messages = list(slot.messages)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        save_started = threading.Event()
+        release = threading.Event()
+
+        def _gated_refused_save(*_args, **_kwargs):
+            # Same gate as the landed-rewrite test, with the save REFUSING: the
+            # native discard has already happened, so nothing can be committed.
+            save_started.set()
+            release.wait()
+            return False
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind._save_slot_to_history", _gated_refused_save
+        )
+
+        from aiohttp.test_utils import make_mocked_request
+
+        from kiro_crew.dashboard.chat_rewind import api_chat_slot_rewind
+
+        app = _make_app(state)
+        fake_request = make_mocked_request(
+            "POST", "/api/chat/slots/src/rewind", match_info={"slot": "src"}, app=app
+        )
+        fake_request["app"] = ""
+
+        async def _json():
+            return {"at_message_index": 0, "content": "edited first question"}
+
+        fake_request.json = _json  # type: ignore[method-assign]
+        handler_task = asyncio.create_task(api_chat_slot_rewind(fake_request))
+        await asyncio.wait_for(asyncio.to_thread(save_started.wait), timeout=2)
+        handler_task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await handler_task
+
+        # Nothing was committed -- the precondition that makes this the
+        # destroyed-without-a-commit outcome rather than the landed one.
+        assert slot.messages == original_messages
+        destroyed = [
+            event for event in events if "native_cleared=1" in str(event.get("resources", ""))
+        ]
+        assert len(destroyed) == 1
+        record = destroyed[0]
+        assert record["operation"] == "chat.rewind"
+        assert record["outcome"] == "error"
+        assert record["error"] == "request_cancelled"
+        assert f"slot={slot.key}" in record["resources"]
+        if slot.task:
+            slot.task.cancel()
 
     @pytest.mark.asyncio
     async def test_rewind_middle_user_message_keeps_prior_turns(self, tmp_path):


### PR DESCRIPTION
## Problem / Motivation

`rewind` and `edit-resend` are the two edit context-boundary endpoints, and they run the same transaction: freeze a prospective window, destroy the native conversation, rewrite persisted history, then adopt the prepared state on the live slot. Anything that writes to the live slot while those boundaries are pending is racing the commit. Two of those writes were being thrown away, and a third outcome was leaving no record. Measured at main `7dd090fb62e858cc1d752e404deae44913d48de1`, and re-verified on the rebase onto `56f67aa43f00f9484c346a8d1669b39102a63c78`.

1. **A row that arrives mid-boundary is silently erased.** `rewind`'s commit did `slot.messages = prospective_slot.messages` -- a wholesale replace. A workflow or cron completion appends straight on the event loop without taking `slot._lock` (`workflow_inject` -> `append_and_surface`), so a row can land between the pre-await snapshot and the commit. The replace drops it, and the rewrite cannot put it back because a rewrite deliberately skips the cross-process-append scan (`collect_foreign=not rewrite`). The same loss happens one field over in `slot._pending`, which is what an open client's stream reader drains.

2. **A row already delivered mid-boundary is queued again.** `_pending` is the un-drained buffer an open client's stream reader empties, and `drain()` does `slot._pending.clear()` on the live list. The commit did `slot._pending = prospective_slot._pending + arrived_pending`, and that frozen copy still holds every row the drain delivered -- so a client that read mid-boundary is handed the same rows a second time.

3. **An answered question card comes back.** Answering a card mutates the live dict: `clear_question_pending` pops the id from `slot._question_pending`. The commit did `slot._question_pending = prospective_slot._question_pending`, which replaces that whole dict with a copy frozen before any await -- so the pop is undone. A **blocking** card is the shape that reaches this, because an append never retires one: `state.py` retires on `_QUESTION_RETIRING_ROLES = {"user", "nudge"}` and only `if not rec.get("blocking")`. The user sees a card asking for an answer they already gave, and the slot reports `needs_input` against a round-trip that has completed.

4. **A failure after the native discard left no audit record.** Once the native session is torn down it is unrecoverable. SEL carried this endpoint's denials and its successful commits, but not this outcome -- so in the trail, "destroyed the user's conversation context and then failed" was indistinguishable from a denial that touched nothing. True of both endpoints, and true of seven exits rather than the four that are obvious: the four 503 returns plus a cancellation landing on any of the three awaits that run with destruction already done. None of those three is reachable by an `except Exception`, because `CancelledError` derives from BaseException, and they are the worst of the seven because the client is never told at all -- the cancellation propagates instead of a response, so SEL is the only place the outcome can be attributed from.

## Why it matters

(1) is silent data loss in a user-visible path: the arrived row is gone from the window, and because it never returns to the window no later flush re-persists it either. (2) is the mirror -- nothing is lost, something is duplicated, and the client sees a row it has already been shown. (3) is worse than either, because it strands consent. A blocking card is a question that gated what happened next. Bringing it back either asks the user twice for one decision, or leaves the session waiting on a question nobody knows is pending -- with the answer channel already gone, no later round-trip can retire it. (4) is the one that cannot be recovered after the fact: the destruction is irreversible and, without a record, unattributable.

## What changed (motivation -> approach -> change)

The four defects above lose to one thing: the commit replaces a whole container with one frozen before the boundary. So there is one rule -- **a commit edits the live container by the delta the transaction owns; it never assigns a frozen copy over it** -- and it is now applied to all three fields, in **both** endpoints.

- **Arrival retention.** `pre_await_row_ids` / `pre_await_pending_ids` are captured beside the existing `pre_await_disk_older_count`, in the same synchronous stretch as the snapshot. The window becomes `prospective_slot.messages + arrived_rows`. Identity rather than a length, because an `append` at the window cap trims the front and a positional slice would re-adopt trimmed rows or miss the arrived one. Arrivals go *after* the prospective window: `monotonic_transcript_ts` only ever moves a row forward, so an arrived row must never sort before the edit, and on a coarse clock (Windows ticks in ~15.6 ms steps) both appends can read the same instant -- list order is what separates that tie.

  Identity by `id()` needs the objects kept alive, and that is a correctness requirement rather than a detail. An `id()` is an integer that says nothing about lifetime, and at a low-index edit nothing else pins the leading rows -- at index 0 the prospective copy is empty. A cap trim during the awaits would free a leading row, CPython could hand its address to a newly appended arrival, and the commit would read that arrival as "not new" and drop it. So the snapshot retains the lists (`pre_await_rows`, `pre_await_pending`) and derives the id sets from them. `meta.mid` is not usable as the identity instead: `append` skips it for restored rows (`mint_mid=False`) and for the wire-only roles, so it is not present on every row.

- **`_pending` is edited, not replaced.** A pre-await row survives only if it is still live, so a row the drain already delivered is dropped instead of requeued; the edit's own row and anything that arrived are kept unconditionally. Order is unchanged -- pre-await rows, then the edit, then arrivals -- which is the same monotonic argument as the window.

  ```python
  delivered_pending_ids = pre_await_pending_ids - {id(row) for row in slot._pending}
  slot._pending[:] = [
      row
      for row in prospective_slot._pending + arrived_pending
      if id(row) not in delivered_pending_ids
  ]
  ```

- **The answer is made authoritative by construction.** The commit stops assigning `_question_pending` at all. It deletes exactly the ids the edit retired, in place, and announces only the ids it actually removed:

  ```python
  announce_retired = [
      question_id
      for question_id in retired_question_ids
      if slot._question_pending.pop(question_id, None) is not None
  ]
  ```

  A census of every `_question_pending` write site in `src/kiro_crew` returns eight, and exactly one **adds** an id: `mark_pending`. So once an answer has popped a card, nothing in the commit can bring it back -- the commit no longer carries a competing copy of the container, which means there is no reconciliation for a later edit to this function to forget. It also leaves a card that *arrived* mid-boundary alone. `edit-resend` used to keep a `prospective INTERSECT live` set here, which retired an answered card correctly but erased an arrived one, because the intersection is keyed on the frozen copy. That set is deleted and both endpoints now retire in place.

```mermaid
flowchart LR
  subgraph Before
    A1["answer pops id from live dict"]:::ctx --> B1["commit assigns frozen copy"]:::removed --> C1["card is back, unanswerable"]:::removed
  end
  subgraph After
    A2["answer pops id from live dict"]:::ctx --> B2["commit pops only the edit's ids"]:::added --> C2["card stays answered"]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
```

Legend: green = added by this change, red = removed by it, blue = unchanged.

*The commit used to hand the slot a dict copied before the answer existed; now it edits the dict the answer wrote to, so the answer wins.*

- **SEL on post-discard failure.** A local `_sel_native_destroyed(reason)` in each endpoint, called before every exit that leaves destroyed context uncommitted. `outcome="error"`, `resources` carrying `slot=<key>,native_cleared=1`, and a distinct reason per site. The spelling is not invented: `outcome="error"` is settled 98 times across `src/kiro_crew/dashboard/`.

  **Every exit in the destroyed-context window, and what `native_cleared` ends up as.** The window opens at the first instruction inside `discard_conversation` that changes state and closes at the commit. Both endpoints are identical; the reasons are prefixed per endpoint in the log.

  | # | exit | what is known | `native_cleared` |
  |---|---|---|---|
  | 1 | discard cancelled, drain settles with a raise | nothing either way | `unknown` |
  | 2 | discard cancelled, drain settles True | it happened | `1` |
  | 3 | discard cancelled, drain settles False | provably nothing -- `skip_if_busy` returns before the pop | *no record* |
  | 4 | discard cancelled, never settles within 8 passes | nothing either way | `unknown` |
  | 5 | discard raises ordinarily, 503 `*_prepare_failed` | nothing either way -- the raise can land on either side of the pop | `unknown` |
  | 6 | discard returns False, 409 `*_session_busy` | provably nothing -- refusal precedes the pop | *no record* |
  | 7 | `aflush()` cancelled | it happened -- the discard already returned True | `1` |
  | 8 | `aflush()` raises, 503 `*_prepare_failed` | it happened | `1` |
  | 9 | save cancelled and the rewrite did not land | it happened | `1` |
  | 10 | save raises, 503 `*_save_failed` | it happened | `1` |
  | 11 | save refuses, 503 `*_save_failed` | it happened | `1` |
  | 12 | commit target moved, 503 `*_slot_rebound` | it happened | `1` |
  | 13 | success -- the commit runs | it happened and was committed | *no record; the success is audited separately* |

  Rows 3 and 6 are where `unknown` would be the **wrong** word, and they are the reason the field is three-valued rather than two: `discard_conversation` evaluates `if skip_if_busy and ... semaphore.locked(): return False` **before** `owner._sessions.pop(...)`, so a refusal is positive knowledge that nothing was torn down. Writing `unknown` there would discard a fact. Rows 1, 4 and 5 are the opposite: genuinely nothing is known, and the field says so instead of picking whichever of the two facts is cheaper. Rows 5 and 12's ordinary-failure siblings were the last two exits to write nothing at all; both now write, which closes the enumeration.

  The broad `except Exception` around the drain is deliberate and the code says why. `provider.shutdown()` is provider transport and its failure modes are not enumerable from a caller, and letting an arbitrary error escape a `CancelledError` handler would replace the client's cancellation with an unrelated exception on a teardown path. It narrows where it matters -- `CancelledError`, `KeyboardInterrupt` and `SystemExit` still surface -- and the breadth is harmless now that it no longer manufactures a false state.

  The drain is a **bounded re-shield**, not a single `await`, because that await is itself a cancellation point: one further cancel would abandon it and lose the record. Eight passes, matching `_SAVE_DRAIN_ATTEMPTS`, whose comment in this file names the same hazard. The settled task is inspected rather than the await's value.

  One direction stays open and it is a callee's contract, not a branch: `discard_conversation` never reports whether it passed its own destruction point, which is why rows 1, 4 and 5 can only say `unknown` rather than the truth. Folded into #8988 with a census of all eight call sites.

  **Two other rewrite-save callers are deliberately not closed**: `regenerate` and `fork` have the same injected-row exposure and are untouched by this change. The spec now says so, so the fixed subset -- exactly `rewind` and `edit-resend` -- is discoverable rather than inferred.

**Disclosed: all three cancellation paths were added in review, and each reviewer was right.** The first revision covered only the four 503 returns. Opus flagged the history save. GPT then flagged `aflush()`. On the next round GPT flagged the discard itself, and its adjudication is what corrected the reasoning here: I had argued in a disposition that a cancelled discard destroys nothing and so should not be recorded, which is wrong -- `session_lifecycle.py` pops the session and calls `clear_sid` before three further awaits, so destruction is already true while those run. The table above replaces that claim.

**Subtracted in review: two extra commit-time identity axes, and the measurement is why.** An earlier revision added a `_commit_target_intact()` predicate to `rewind` carrying three axes -- the routing key main already checked, plus `state._slots.get(name) is slot` and `slot.task is task`. A review finding on the object-identity axis is correct and its consequence is larger than the axis: every one of those axes is evaluated *after* `await asyncio.shield(save_task)` has already rewritten the shared history file, so no axis at that point in the sequence can protect the file. A same-name close-and-recreate keeps the same history key, the save's routing guard passes it, and the replacement conversation's transcript is truncated with **no archive and no recovery** -- the 503 tells the client to retry the rewind, not to restore the other conversation. Adding or dropping a commit-time axis does not move that by a single instruction. Closing it means pre-write validation inside `_save_slot_to_history`, which is a shared write path serving both endpoints and a second, larger purpose than this change. So the two added axes are dropped and main's own commit-time routing check is restored verbatim at both call sites. **Nothing that exists on main is removed** -- this declines to add, it does not delete a protection. The corruption is filed as #8988 with the remedy shape.

**The sibling is fixed rather than declared, because the reviewers were right that a declaration was not enough.** An earlier revision fixed `rewind` only and named `edit-resend`'s intersect as out of scope. Design Review and First Principles Review each landed on the same objection from opposite ends: the PR derives a rule and then leaves a live violation of it, in a file the diff already opens, when the fix is the same six lines. So `surviving_questions` is deleted, `edit-resend` retires in place, and the two endpoints now spell one job one way instead of two. This makes the diff wider by one function and the *concept* narrower by one special case.

**`slot.total_messages` is also not taken.** `edit-resend` increments this lifetime counter for the edited row; `rewind` does not, and `prospective_slot.append` bumps only the shallow copy's int. That looks like a real defect, is not reachable from any gap above, and would not be tested by anything here.

## Tests

Thirteen new tests in `test/test_dashboard_chat_rewind.py` and two in `test/test_chat_regenerate_cov80.py`, all driving the real endpoint through `TestClient` with the racing event injected inside the awaited boundary via `discard_conversation`'s side effect -- the harness both files already use.

| Test | Locks in |
|---|---|
| `..._keeps_a_row_that_arrived_during_the_boundaries` | the arrived row survives, sits *after* the edited row, and the truncated suffix is not resurrected |
| `..._keeps_a_pending_row_that_arrived_during_the_boundaries` | the same row survives in `_pending` |
| `..._keeps_a_blocking_card_answered_during_the_boundaries` | a blocking card answered inside the boundary stays retired through the commit |
| `..._does_not_requeue_a_row_drained_during_the_boundaries` | a row the client already drained is not handed to it twice, while the edit's own row still arrives |
| `..._records_a_sel_event_when_the_native_context_is_destroyed` | one SEL record, `outcome="error"`, `native_cleared=1`, naming the slot and the reason |
| `..._cancelled_without_a_landed_rewrite_still_records_the_destruction` | the post-save cancellation exit records the destruction, asserting the no-commit precondition so it cannot pass via the landed branch |
| `..._retains_the_pre_await_rows_so_their_ids_cannot_recycle` | a row trimmed mid-boundary is still held by a list, asked of `gc.get_referrers` because rows are plain dicts and cannot be weak-referenced, plus the behavioural half that the arrival still lands |
| `..._cancelled_on_the_sid_flush_still_records_the_destruction` | the `aflush` cancellation records it too, asserting the discard returned True first so the destruction really happened |
| `..._cancelled_inside_the_discard_still_records_the_destruction` | a cancellation delivered while the discard's own awaits are in flight records `discard_cancelled`; the handler task is captured on its own stack so the cancellation lands deterministically |
| `..._cancelled_discard_that_refused_records_no_destruction` | a `skip_if_busy` refusal destroyed nothing and must leave no record, so the drain cannot simply record on every cancellation |
| `..._cancelled_discard_that_raises_records_an_unknown_outcome` | a drain that raises records exactly one `native_cleared=unknown` **and zero** `native_cleared=1`, so it cannot be satisfied by over-claiming in either direction |
| `..._second_cancellation_on_the_drain_still_records` | cancelling the handler twice -- once onto the shielded await, once onto the drain -- still leaves exactly one record; asserts the second cancel landed so it cannot pass on the first alone |
| `..._discard_failure_records_an_unknown_outcome` | an ordinary discard raise records exactly one `native_cleared=unknown` **and zero** `native_cleared=1`, and leaves the original branch intact |
| `test_edit_resend_commit_keeps_a_blocking_card_answered_meanwhile` | the sibling endpoint keeps an answered card retired |
| `test_edit_resend_commit_keeps_a_card_that_arrived_meanwhile` | the sibling endpoint keeps a card raised during its own boundary -- the erasure the deleted intersect caused |

Each test asserts its own precondition so it cannot pass vacuously: the arrival tests append through `append_and_surface`, the real door a workflow completion uses; the drain test asserts the drain delivered something and seeds the buffer through that same door, since the fixture drains; and the card tests assert the clear returned `True` and use a **blocking** card, which is the axis-isolating condition -- a non-blocking card would be retired by the edit's own `user` append and the test would never touch the race.

Proved rather than asserted: `prepare-pr`'s `prove.py --base main` reverts the production hunks in a throwaway worktree while keeping the test hunks, re-runs the changed test files, and reports `PROVEN: an assertion failed with the bug reintroduced`. Individual fixes were also mutation-checked by hand -- restoring `destroyed = False`, and dropping the retained row list -- each reddening its own test on its own assertion message, which is what separates a test from a decoration.

An existing test is the control that the deleted intersect lost no coverage: `test_edit_resend_commit_does_not_resurrect_a_card_retired_meanwhile` pins the case the intersect was written for -- an arrived `user` row retiring every non-blocking card, with no second announcement from the commit -- and it passes unchanged against the in-place retire.

Gates run individually rather than through a wrapper, on the changed files: `black --target-version py310 --check` clean, `isort --check-only` clean, `flake8` clean, `mypy src/kiro_crew/dashboard/chat_rewind.py` reporting only two pre-existing errors in `src/kiro_crew/transcribe.py:1337` reached transitively (identical count on an unmodified sibling, so not from this diff). Suites at `-n0`, one file at a time: `test_dashboard_chat_rewind.py` 51 passed (38 before), `test_chat_regenerate_cov80.py` 66 (64 before), `test_chat_regenerate_refusal_codes.py` 3, plus every spec that reads the symbols this diff touches -- `test_slot_needs_input_status.py` 30, `test_ask_question_roundtrip.py` 63, `test_chat_slot_facade_contract.py` 5, `test_steer_requeue.py` 52.

## Manual verification

N/A -- unit coverage sufficient. All four defects are concurrency-shaped and reachable only by interleaving an event with an awaited boundary, which the tests drive directly and deterministically; the SEL record is asserted from the recorded call rather than from a log.

## Related Issues

Closes #8975
Refs #8419
Refs #8988

## Pattern harvest

The defect class is a commit that adopts prepared state by **replacing a container** rather than editing it. Every field lost this way lost the same way: `messages`, `_pending`, and `_question_pending` were each assigned a copy frozen before an await, so any in-place write that landed during the await was discarded without a trace. Replacement is the easy thing to write and it is silently destructive exactly in proportion to how long the boundary is open. The tell is a plain assignment of one object's field to another object's field inside a commit that follows an `await`.

Rule candidate: review-prompt
Pattern: inside a post-await commit, `live.field = frozen_copy.field` discards every concurrent in-place write to `live.field` -- prefer editing the live container by the delta the transaction owns.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- `docs/system-specs/modules/session.md` reconciled: its "Edit rewind context boundary" bullets described the pre-fix behaviour
- [x] No secrets, credentials, or internal references in the diff
