### PR TITLE
fix(auto-improvement): publish only the commit the pipeline committed

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -377,7 +377,6 @@ test/test_agent_template_skills.py
 test/test_ai_agent_runner_coverage.py
 test/test_ai_backend_routes_coverage.py
 test/test_ai_pr_watchers_coverage.py
-test/test_ai_spine_driver_coverage.py
 test/test_api_agent_config_put_succeeds.py
 test/test_api_agents_order.py
 test/test_api_file_diff.py

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
@@ -13,7 +13,9 @@ element.
 
 from __future__ import annotations
 
+import hashlib
 import ipaddress
+import json
 import logging
 import os
 import re
@@ -26,6 +28,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
+from kiro_crew.config.paths import data_home
 from kiro_crew.platform.context import redact_via_context
 from kiro_crew.platform_compat import (
     first_linked_ancestor,
@@ -414,6 +417,165 @@ def _retire_unsafe_clone(repo: Path) -> Path | None:
     return retired
 
 
+#: The quarantine markers' root: a TOP-LEVEL crew-home leaf, not a path under
+#: ``apps/auto-improvement/data/``. Two structural reasons.
+#:
+#: The leaf is bind-masked from every agent sandbox (``sandbox._CREW_HIDDEN_LEAVES``) and
+#: fenced from agent file tools (``security.sensitive_home_dirs``), which is what makes the
+#: marker something an agent cannot plant, rewrite or delete. Nothing inside a sandbox reads
+#: it -- the marker is written and read host-side by this module -- so HIDDEN is the right
+#: disposition of the three that list offers.
+#:
+#: A mask covers the name it is bound over, not that name's ancestors, so a leaf under
+#: ``apps/auto-improvement/data/`` would sit beneath a directory an agent CAN rename, taking
+#: the mount with it. At the top level the only ancestors are the data home and ``$HOME``,
+#: the residual every other fenced leaf already stands on. This mirrors
+#: ``aws_control.storage.STAGING_DIR_LEAF``, top-level for exactly this reason. Raised by the
+#: GPT review of this branch.
+_QUARANTINE_DIR_LEAF = "quarantined-clones"
+
+
+def _quarantine_root() -> Path | None:
+    """The masked directory quarantine markers live in, or ``None`` if it is unusable.
+
+    On a sandboxed host this exists before any agent runs: the sandbox materialises it ahead
+    of every namespace spawn (``sandbox._CREW_PRECREATE_HIDDEN_DIR_LEAVES``), because a mask
+    can only bind over a name that exists. The ``mkdir`` here therefore matters only where
+    nothing is masking anything -- sandbox off, or Windows.
+
+    The root itself must be a REAL directory: a link planted at the root would put every
+    marker outside the fence, and no per-marker check can see that. Same guard
+    ``aws_control.storage._preview_staging_parent`` stands on.
+
+    IT MUST ALSO PROVE IT IS WRITABLE, by creating and removing a probe entry. A root that
+    exists and can be READ but not written is the one state where this guard fails OPEN: the
+    marking open fails, so nothing is recorded, while the reuse check finds no marker and
+    certifies the clone -- the poisoned tree is then reused with both halves of the mechanism
+    reporting nothing wrong. Proving writability at every call collapses that case into a
+    refusal, because the same root that could not take the write cannot pass the probe either.
+    ``os.access`` is not enough: it answers from the permission bits and is wrong under an ACL
+    or a read-only mount. Raised by the GPT review of this branch.
+    """
+    root = data_home() / _QUARANTINE_DIR_LEAF
+    try:
+        if is_link_or_junction(root) or first_linked_ancestor(root):
+            logger.error("quarantine marker root %s is under a link; refusing to use it", root)
+            return None
+        root.mkdir(parents=True, mode=0o700, exist_ok=True)
+        if is_link_or_junction(root):
+            return None
+        probe = root / f".probe-{secrets.token_hex(8)}"
+        fd = os.open(probe, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        os.close(fd)
+        probe.unlink()
+    except OSError:
+        logger.exception("quarantine marker root %s is not usable for recording", root)
+        return None
+    return root
+
+
+def _quarantine_marker(repo: Path) -> Path | None:
+    """Where the refusal-to-reuse marker for *repo* lives, or ``None`` if unusable.
+
+    Keyed by the HASH of the clone's absolute path, so the name cannot be steered by a
+    repository name: it is fixed-length, has no separators to traverse with, and cannot
+    collide with another clone's marker.
+    """
+    root = _quarantine_root()
+    if root is None:
+        return None
+    digest = hashlib.sha256(str(repo.absolute()).encode("utf-8", "surrogateescape")).hexdigest()
+    return root / f"{digest}.json"
+
+
+def _mark_clone_quarantined(repo: Path, reason: str) -> Path | None:
+    """Persist "this clone must never be reused". The marker path, or ``None``.
+
+    WRITTEN BEFORE RETIREMENT IS ATTEMPTED, not after it fails. :func:`_retire_unsafe_clone`
+    renaming the tree aside is the primary guard and needs no marker, because a clone renamed
+    away from its canonical name is not found and not reused. The marker covers the window
+    that guard cannot: the caller persists it first, so a process that dies between the two
+    steps, or a rename that fails outright, still leaves a durable refusal behind rather than a
+    poisoned tree sitting at the name the next run looks up. A marker whose clone is retired or
+    removed clears itself, which is what the next paragraph is about.
+
+    WHEN IT CLEARS is the question a persisted latch has to answer, and this one answers it
+    structurally rather than on a timer or an event: the marker names a specific DIRECTORY, so
+    :func:`_clone_is_quarantined` reports it only while that directory still exists. A later
+    successful retirement, or an operator removing the tree, therefore clears the guard as a
+    side effect of removing the thing it guards -- there is no state where the bytes are gone
+    and the refusal outlives them, and none where the bytes are present and the refusal has
+    expired.
+
+    ``O_EXCL``, NEVER ``O_TRUNC``: this open must not be able to shorten an existing file, so
+    the truncating flag is simply not in the set. An existing ENTRY at the marker name is then
+    not a failure but the guard already standing, and it is reported as such.
+
+    THE TWO SIDES MUST AGREE ON WHAT "PRESENT" MEANS, which is why the reader below uses
+    ``lstat`` and not ``exists``. A DANGLING SYMLINK is an existing entry to this open --
+    ``O_CREAT|O_EXCL`` refuses it -- and an absent file to ``exists``. Split that way, a
+    planted dangling link would make marking report success while the guard read no marker at
+    all. Raised by the GPT review of this branch.
+
+    Best-effort by construction: if even this write fails there is nothing further to try, and
+    the caller logs that the clone is unsafe in place.
+    """
+    marker = _quarantine_marker(repo)
+    if marker is None:
+        return None
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    body = json.dumps({"clone": str(repo.absolute()), "reason": reason}, ensure_ascii=True)
+    try:
+        fd = os.open(marker, flags, 0o600)
+        try:
+            os.write(fd, body.encode("ascii", "replace")[:4096])
+        finally:
+            os.close(fd)
+    except FileExistsError:
+        return marker  # an entry already stands here; presence is the signal, not contents
+    except OSError:
+        logger.exception("could not mark clone %s as quarantined", repo)
+        return None
+    return marker
+
+
+def _clone_is_quarantined(repo: Path) -> bool:
+    """Is *repo* marked unreusable AND still the tree that was marked?
+
+    ``lstat`` rather than ``exists``: the question is whether an ENTRY stands at the marker
+    name, not whether it resolves to a readable file -- see
+    :func:`_mark_clone_quarantined` for why the two sides have to agree. Anything at that
+    name counts, so a planted entry can only make this MORE conservative: it reports the
+    clone quarantined, which refuses it.
+
+    Fails CLOSED on an unusable root, and on an ``lstat`` that raises for any reason other
+    than absence: "I could not look" is not "I looked and it was clean". A marker whose clone
+    is gone is stale -- that is how the guard clears -- and it is removed on the way past so
+    the directory does not accumulate one file per clone the app has ever retired.
+    """
+    marker = _quarantine_marker(repo)
+    if marker is None:
+        return True  # the guard cannot be consulted, so do not certify the clone
+    try:
+        os.lstat(marker)
+    except FileNotFoundError:
+        return False
+    except OSError:
+        logger.exception("could not read the quarantine marker for %s", repo)
+        return True
+    try:
+        if repo.exists():
+            return True
+    except OSError:
+        logger.exception("could not stat the quarantined clone %s", repo)
+        return True
+    try:
+        marker.unlink()
+    except OSError:
+        logger.warning("could not prune the stale quarantine marker %s", marker)
+    return False
+
+
 def _push_disabled(repo: Path) -> bool:
     return _origin_urls(repo, push=True) == [DISABLED_NO_PUSH] and _origin_urls(
         repo, push=False
@@ -572,6 +734,22 @@ def _setup_safe_clone(url: str, scratch_root: Path, *, timeout_s: int = 300) -> 
 
     if is_link_or_junction(dest):
         return {}, f"Destination is a link or junction (refused for safety): {dest}"
+
+    # REFUSE A QUARANTINED CLONE BEFORE ANY OTHER JUDGEMENT ABOUT IT. The marker is written
+    # whenever a rollback fails, before retirement is attempted, and it is what stops reuse
+    # when that retirement then fails or never runs -- so a clone still sitting at this name
+    # carries a provisional commit that was REFUSED and never scanned. Every reuse
+    # attestation below is about the clone's git metadata and remotes -- none of them look at
+    # what the branch tip points AT -- so a poisoned clone passes all of them and the next
+    # run commits its winner on top of the refused commit and publishes it as an unscanned
+    # ancestor. Checked ahead of the `.git` probe because the name is burned, not just its
+    # metadata: a tree whose `.git` was destroyed by the same failure must not fall through
+    # to the fresh-clone path and reuse the directory either.
+    if _clone_is_quarantined(dest):
+        return {}, (
+            f"Existing clone at {dest} is quarantined after a failed rollback and must not "
+            "be reused -- remove the directory to clear the marker and clone fresh."
+        )
 
     git_dir = dest / ".git"
     if is_link_or_junction(git_dir):

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
@@ -118,19 +118,185 @@ class PushEnabledError(RuntimeError):
 _GIT_SAFE_CONFIG = GIT_SAFE_CONFIG
 
 
-def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+def _git(
+    args: list[str], cwd: Path, *, config: tuple[str, ...] = ()
+) -> subprocess.CompletedProcess:
     require_pinned(cwd)
+    # ``config`` carries EXTRA ``-c`` pairs for the one caller that needs them, spliced into the
+    # flag section so *args* still begins with the subcommand. Keeping that position stable is
+    # deliberate: this module's own callers and its test doubles both read argv by its leading
+    # verb, and a flag pushed in front of it would make the same call unrecognisable to them.
+    # ``core.useReplaceRefs=false`` on EVERY call in this module, not just the credential scan.
+    # Git substitutes objects named by ``refs/replace/<oid>`` transparently in reads while the
+    # push transport sends the ORIGINAL, and `git replace` is not on the pre-push reviewer's
+    # denylist -- so any read here that a replacement could redirect is a place where what this
+    # code inspects and what it publishes come apart. Two instances were found one at a time
+    # (the scan, then the rebase); disabling it at the single chokepoint every read goes through
+    # closes the class FOR THIS MODULE'S READS instead of the next
+    # instance. It is not repository-wide: `pr_recipe` and `backend/commit.py` do their own
+    # git reads and still honour `refs/replace/*`, so their scans remain substitutable the
+    # same way. Out of scope here, named so the guarantee is not read as broader than it is. Raised by the GPT review of this branch.
     # ``errors="replace"``: callers run `diff`/`show`, which print file CONTENT, and a repo
     # legitimately holds non-UTF-8 bytes. A strict decode raises inside
     # ``subprocess.communicate``, so the failure cannot be read off ``returncode`` — the
     # direct-push path would abort on any tree containing a PNG. See ``pr_watchers._git``.
     return subprocess.run(
-        ["git", "-C", str(cwd), *_GIT_SAFE_CONFIG, *args],
+        [
+            "git",
+            "-C",
+            str(cwd),
+            *_GIT_SAFE_CONFIG,
+            "-c",
+            "core.useReplaceRefs=false",
+            *config,
+            *args,
+        ],
         capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
     )
+
+
+def _fetched_tip_oid(porcelain_stdout: str) -> str:
+    """The object id ``git fetch --porcelain`` reports for the ref it just fetched.
+
+    ``FETCH_HEAD`` is a mutable FILE in the clone, not a value, so keying the rebase or the
+    replay count on that NAME lets anything else operating in the clone substitute what gets
+    replayed -- and because only the replayed commit is scanned, a substituted parent's content
+    rides along to the push through a scanner that believed it had looked. ``--porcelain`` makes
+    the fetch report the id on its OWN stdout, one line per ref as
+    ``<flag> <old-oid> <new-oid> <local-ref>``, so the id never comes from a ref at all. A
+    forty-hex object id cannot be substituted; a ref name can. Raised by the GPT review of this
+    branch, which prescribed exactly this: capture the id from the fetch operation itself.
+
+    Returns ``""`` when no line carries a usable id -- including the all-zero null id, which
+    means the ref was DELETED rather than fetched, and the case where ``--porcelain`` is not
+    understood at all (an older git fails the fetch outright, so the caller never gets here).
+    The caller must treat ``""`` as a refusal: an id it could not obtain is the absence of the
+    check, not a pass.
+    """
+    for line in (porcelain_stdout or "").splitlines():
+        fields = line.split()
+        if len(fields) < 3:
+            continue
+        new_oid = fields[2]
+        if len(new_oid) == 40 and all(c in "0123456789abcdef" for c in new_oid):
+            if new_oid == "0" * 40:
+                continue  # a deletion, not a tip anything can be rebased onto
+            return new_oid
+    return ""
+
+
+def _expected_replay_tree(base: str, src: str, cwd: Path) -> str:
+    """The tree a replay of *src* onto *base* must produce. ``""`` if it cannot be computed.
+
+    A rebase replays a commit onto a new parent, so the replay is a DIFFERENT object id
+    carrying the same change -- an id captured from ambient ``HEAD`` afterwards cannot be
+    checked against the authorized input by equality. What CAN be stated exactly is the
+    RESULT: ``git merge-tree --write-tree`` performs the same three-way merge the rebase does
+    and prints the resulting tree's object id on its own stdout, computed from two immutable
+    inputs and touching no ref. Comparing that against the replay's own tree authorizes the
+    published content itself rather than a property of it.
+
+    A TREE BINDS LOCATION; A PATCH IDENTITY DOES NOT. ``git patch-id`` deliberately ignores
+    hunk line numbers -- that is what lets it recognise a change replayed onto a moved base --
+    so a commit whose added and removed LINES match the authorized change while sitting
+    elsewhere in the file hashes identically to it. A tree names the exact content of every
+    path, so the same lines in a different place is a different tree. Raised by the GPT review
+    of this branch, which asked for exactly this: authorize the replay against an expected
+    tree rather than a patch identity.
+
+    Returns ``""`` on any non-zero exit, which covers a merge that CONFLICTS (the tree printed
+    then records a conflict, it is not an authorization) and a git too old to know
+    ``--write-tree``. The caller treats ``""`` as a refusal: a result it could not compute is
+    the absence of the check, not a pass.
+    """
+    out = _git(["merge-tree", "--write-tree", base, src], cwd)
+    if out.returncode != 0:
+        return ""
+    tree = ((out.stdout or "").splitlines() or [""])[0].strip()
+    if len(tree) != 40 or any(c not in "0123456789abcdef" for c in tree):
+        return ""
+    return tree
+
+
+_ATTRIBUTION_FORMAT = "%an%x00%ae%x00%cn%x00%ce%x00%B"
+
+
+def _commit_attribution(rev: str, cwd: Path) -> str:
+    """*rev*'s author, committer and message as one comparable string, or ``""``.
+
+    DATES ARE DELIBERATELY ABSENT. A replay commits at a new wall-clock time, so including a
+    date would make every honest retry compare unequal; the fields here are the ones a replay
+    is supposed to carry over unchanged. NUL separates them so a name holding the delimiter
+    cannot forge a match by spanning two fields.
+
+    ``%B`` is the raw body, last because it is the only field that may contain newlines.
+    """
+    out = _git(["log", "-1", f"--format={_ATTRIBUTION_FORMAT}", rev], cwd)
+    if out.returncode != 0:
+        return ""
+    return out.stdout or ""
+
+
+def _committer_identity(rev: str, cwd: Path) -> tuple[str, str]:
+    """*rev*'s committer name and email, or ``("", "")``.
+
+    READ OFF AN IMMUTABLE OBJECT, which is the whole point: the identity a replay should carry
+    is the one the authorized commit already holds, recorded when the pipeline created it and
+    therefore before any reviewing agent ran. Configuration cannot be trusted for this at
+    replay time -- the agent's shell can write the repository's own config, and nothing masks a
+    global one either.
+    """
+    out = _git(["log", "-1", "--format=%cn%x00%ce", rev], cwd)
+    if out.returncode != 0:
+        return "", ""
+    parts = (out.stdout or "").rstrip("\n").split("\0")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        return "", ""
+    return parts[0], parts[1]
+
+
+def _commit_tree(rev: str, cwd: Path) -> str:
+    """The tree object id *rev* points at, or ``""``.
+
+    ``log -1 --format=%T`` rather than ``rev-parse <rev>^{tree}`` so this question carries its
+    own verb: ``rev-parse`` in this module already answers an unrelated one (does a parent
+    exist), and a caller keyed on argv cannot tell two questions apart under one prefix.
+    """
+    out = _git(["log", "-1", "--format=%T", rev], cwd)
+    tree = (out.stdout or "").strip()
+    if out.returncode != 0 or len(tree) != 40 or any(c not in "0123456789abcdef" for c in tree):
+        return ""
+    return tree
+
+
+def _full_head_id(cwd: Path) -> str:
+    """The FULL object id at ``HEAD``, validated, or ``""``.
+
+    WHAT A FINALIZER HANDS BACK IS A TRUST ANCHOR, so it is a full object id and never an
+    abbreviation. A short sha is an ambiguous NAME: git resolves a revision through ref names
+    before abbreviated object ids, and a prefix stops naming one object as soon as a second
+    object shares it. Anything able to write the repository between a read and the anchor's
+    capture can arrange either reading, which makes the id that gets verified and the id that
+    gets published two different things -- the substitution this whole path exists to refuse.
+    A forty-hex id has no second reading, so the class is absent rather than defended against.
+    Raised by the GPT review of this branch.
+
+    ``HEAD`` is safe to resolve here, and that is the distinction: no ref can shadow ``HEAD``,
+    and this runs immediately after the commit it names, before any gate hands control to an
+    agent. Callers that want a short form derive it from the returned id for DISPLAY and never
+    feed it back into a lookup.
+
+    Fails CLOSED: an unreadable or malformed answer returns ``""``, which every caller treats
+    as "no committed object" and refuses to publish.
+    """
+    out = _git(["rev-parse", "HEAD"], cwd)
+    sha = (out.stdout or "").strip()
+    if out.returncode != 0 or len(sha) != 40 or any(c not in "0123456789abcdef" for c in sha):
+        return ""
+    return sha
 
 
 class Driver:
@@ -283,6 +449,15 @@ class Driver:
         )
         self._stop = False
         self._repository_retired = False
+        #: Set when a provisional rollback FAILED. HEAD then still carries a commit that
+        #: was refused and never published, and the next winner commits ON TOP of it: that
+        #: winner's scan reads only its own revision (`<rev>~1..<rev>`) while its push sends the
+        #: whole ancestry, so the refused content is published by a scanner that never saw it.
+        #: Nothing local can repair that -- the rollback is what was supposed to -- so this
+        #: latches and publishing refuses from here on. This flag covers ONE PROCESS; the clone
+        #: is also QUARANTINED on disk (`_quarantine_unrolled_clone`), because the refused commit
+        #: outlives the run and the clone is reused. Raised by the GPT review of this branch.
+        self._rollback_failed = False
         # Terminal latch for a probe whose sandbox launcher crashed: set (then
         # re-raised) by `_retire_if_unsafe`. Some intermediate layers catch
         # broadly to keep a run alive (per-candidate error containment), so
@@ -850,10 +1025,197 @@ class Driver:
             return False
         return True
 
+    def _revision_scans_clean(self, rev: str) -> tuple[bool, str]:
+        """Credential-scan ONE revision's own object -- metadata and content. ``(clean, note)``.
+
+        BOTH HALVES OF THE OBJECT ARE SCANNED. The tree diff covers what the commit changes;
+        the commit's header lines are separate bytes the push transfers just the same, and the
+        committer identity among them comes from configuration rather than from the replayed
+        commit, so a process able to write the clone's git config chooses it.
+
+        Shared by both publish paths so the scan cannot be attached to one of them and
+        forgotten on the other -- which is exactly what happened: the scan lived inline in
+        :meth:`_direct_push` and covered the first push's object, while the rebase retry in
+        :meth:`_push_with_rebase` published a REPLAYED object that had been build-verified and
+        never credential-scanned. A non-fast-forward retry is not an edge case here; the
+        retry's own docstring records losing 3 of 6 gate survivors to that race. Raised by the
+        GPT review of this branch.
+
+        *rev* must be a FULL OBJECT ID, never ``HEAD``: the point is that the object scanned
+        here and the object pushed are the same one by construction rather than by timing.
+
+        The git call's EXIT STATUS is load-bearing, not just its stdout: ``_git`` does not
+        raise, and a failed read exits non-zero with EMPTY stdout -- which the scanner would
+        read as "nothing to scan". Every failure here therefore refuses. ``--root`` lets one
+        listing cover a root commit, which has no parent to compare against.
+
+        HISTORY WORTH KEEPING, because the shape of the range is what went wrong before: an
+        earlier form diffed ``{dest}..HEAD``, which was silently EMPTY -- ``dest`` is the local
+        branch the commit sits on the tip of, so that diffs a ref against itself, the scanner
+        read "clean", and the fail-closed credential gate was SKIPPED entirely. Measured
+        against a real repo at the time: a commit adding an AWS key produced a 0-byte
+        ``{dest}..HEAD`` diff and a 144-byte single-commit diff carrying the key.
+        """
+        # Imported here, not at module scope, to match `_direct_push`'s existing pattern: the
+        # name is then resolved on `push_policy` at call time, which is also the seam the
+        # tests patch.
+        from .push_policy import describe_scan, scan_content_for_secrets
+
+        # `core.useReplaceRefs=false` is load-bearing, not hygiene. Git substitutes objects
+        # named by `refs/replace/<oid>` transparently in READS -- `diff` and `show` included --
+        # while the push transport sends the ORIGINAL object. So a reviewer that runs
+        # `git replace` (not on that runner's denylist, which covers only `push` and
+        # `remote set-url`) could point a replacement at clean content, have this scan read the
+        # decoy, and still have the credential-bearing object transferred. Reading with replace
+        # refs disabled makes what is scanned and what is sent the same bytes. Raised by the
+        # GPT review of this branch.
+        # Only `diff.external=` here: `_git` already injects `core.useReplaceRefs=false` on
+        # every call it makes, so spelling it again is the same guarantee written twice, and
+        # only the chokepoint spelling is test-pinned. Dropped on the first-principles review.
+        _NO_REPLACE = ("-c", "diff.external=")
+        # SCAN THE COMMIT OBJECT ITSELF, not only the content it carries. A tree diff shows
+        # what the commit CHANGES; the commit's own header lines are separate bytes that the
+        # push transfers just the same, and `--format=` on the root-commit branch suppresses
+        # them outright. `git rebase` takes the COMMITTER identity from configuration rather
+        # than from the commit it replays, so a process able to write the clone's git config
+        # decides those bytes -- the same actor this method already refuses to trust for
+        # `git replace` above, since the runner's denylist covers only `push` and
+        # `remote set-url`. Measured on a real repository: a replayed commit whose config set
+        # a key-shaped `user.email` carries it in the committer line while the diff branch and
+        # the `--format=` branch both print nothing but the tree change. `cat-file commit`
+        # yields the raw object -- tree, parent, author, committer, then the message -- so the
+        # header bytes and the message reach the scanner as the transport sees them, and no
+        # diff-shaping flag applies. Raised by the GPT review of this branch.
+        meta = _git(["cat-file", "commit", rev], self.clone)
+        if meta.returncode != 0:
+            return False, "could not read the pushable commit object"
+        clean, scan_code = scan_content_for_secrets(meta.stdout or "")
+        if not clean:
+            return False, describe_scan(scan_code)
+        # SCAN THE RAW BLOBS THE PUSH TRANSFERS, not a rendered diff. `git diff` is a REPORT
+        # for humans: for a blob it decides is binary it prints "Binary files a and b differ"
+        # and no content at all, so a credential inside such a blob is invisible to a scan that
+        # reads diff output -- and a NUL byte anywhere in a file is enough to trigger that,
+        # which whatever writes the tree chooses freely. Measured on a real repository: a blob
+        # holding NUL, then a key, then NUL renders as that one summary line with zero
+        # occurrences of the key, while `cat-file blob` on the same object yields it. The push
+        # sends objects rather than a diff, so enumerating the revision's own changed blobs and
+        # reading each one is what makes the scanned bytes and the transferred bytes the same
+        # bytes. This also scans a WHOLE blob rather than the changed hunks, which is again what
+        # is published: a hunk is a view of an object, and it is the object that lands on the
+        # remote. Raised by the GPT review of this branch.
+        #
+        # `--root` covers a root commit, which has no parent to diff against, so both cases go
+        # through one listing rather than a branch whose second half was the weaker reading.
+        listing = _git(
+            ["diff-tree", "-r", "--root", "--no-commit-id", rev],
+            self.clone,
+            config=_NO_REPLACE,
+        )
+        if listing.returncode != 0:
+            return False, "could not list the pushable blobs"
+        for line in (listing.stdout or "").splitlines():
+            # ``:<src mode> <dst mode> <src sha> <dst sha> <status>\t<path>``
+            if not line.startswith(":"):
+                continue
+            meta_fields = line[1:].partition("\t")[0].split()
+            if len(meta_fields) < 5:
+                return False, "could not read a pushable blob entry"
+            dst_mode, dst_sha, status = meta_fields[1], meta_fields[3], meta_fields[4]
+            # A DELETION publishes no content, and a gitlink is a commit pointer with no blob
+            # behind it -- `cat-file blob` on either is a failure that would fail this closed
+            # for a revision carrying nothing to read.
+            if status.startswith("D") or dst_mode == "160000" or set(dst_sha) == {"0"}:
+                continue
+            blob = _git(["cat-file", "blob", dst_sha], self.clone)
+            if blob.returncode != 0:
+                return False, "could not read a pushable blob"
+            clean, scan_code = scan_content_for_secrets(blob.stdout or "")
+            if not clean:
+                # `describe_scan` maps a fixed code to a fixed literal, so nothing derived from
+                # the scanned content reaches a log line or a ledger row.
+                return False, describe_scan(scan_code)
+        return True, ""
+
+    def _restore_branch(self, branch: str, *, promote: str = "") -> bool:
+        """Put the clone back on *branch*, moving it to *promote* first when given. ``ok``.
+
+        RETURNS A STATUS because the caller must be able to abort on it. Logging a failed
+        restore and continuing would publish with the clone detached or its durable branch
+        stale -- a ref lock or a checkout failure is exactly the case where the repository is
+        not in the state the push assumes. Raised by the GPT review of this branch.
+
+        The rebase retry DETACHES HEAD in order to replay the authorized object rather than
+        whatever the branch points at, so every exit from that path has to leave the clone
+        attached again. :meth:`_reset_provisional` rolls a provisional commit back with
+        ``git reset --hard``, which on a detached HEAD moves the detachment and leaves the
+        BRANCH still carrying that commit -- a rollback that silently does not roll back.
+
+        PROMOTION IS CONDITIONAL BY CONSTRUCTION. ``git branch -f`` is only correct when the
+        thing it moves onto is the verified, scanned replay, so the caller passes *promote*
+        at exactly one place: after the replay has passed re-verification, the HEAD-identity
+        check and the credential scan. A failed or aborted rebase therefore cannot force the
+        branch onto whatever HEAD happens to be -- it takes the no-argument form, which
+        re-attaches without moving anything. Raised in review of this branch.
+        """
+        was = ""
+        if promote:
+            # TRANSACTIONAL: remember where the branch was, because `git branch -f` lands
+            # BEFORE the checkout can fail. A concurrent index lock that fails the checkout
+            # would otherwise leave the branch promoted to a replay this method then reports as
+            # unrestored -- the push aborts, the caller rolls back the detached HEAD, and the
+            # unpushed commit stays on the durable branch. Raised by the GPT review.
+            was = _git(["rev-parse", branch], self.clone).stdout.strip()
+            if _git(["branch", "-f", branch, promote], self.clone).returncode != 0:
+                self.log.error(
+                    "direct-push: could not move %s onto the replayed commit %s",
+                    branch,
+                    promote[:12],
+                )
+                return False
+        if _git(["checkout", branch], self.clone).returncode != 0:
+            self.log.error("direct-push: could not re-attach the clone to %s", branch)
+            if promote and was:
+                # Undo the promotion so the branch is not left carrying an unpushed commit.
+                if _git(["branch", "-f", branch, was], self.clone).returncode != 0:
+                    self.log.error(
+                        "direct-push: could not put %s back on %s after a failed checkout",
+                        branch,
+                        was[:12],
+                    )
+            return False
+        return True
+
     def _push_with_rebase(
-        self, fetch_url: str, dest: str, target: str
+        self, fetch_url: str, dest: str, target: str, src: str
     ) -> subprocess.CompletedProcess | None:
-        """Push HEAD to ``dest``, rebasing ONCE onto the remote if it moved meanwhile.
+        """Push *src* to ``dest``, rebasing ONCE onto the remote if it moved meanwhile.
+
+        *src* is the revision the FIRST push sends, and it is REQUIRED: an object id cannot be
+        repointed, so once this is called, nothing running in the clone can change which commit
+        gets published. Pushing the symbolic ``HEAD`` left a time-of-check/time-of-use window --
+        the identity check happens, then the credential scan and the push each re-read ``HEAD``
+        -- and a background process left behind by the pre-push reviewer could move it in
+        between. Raised by the GPT review of this branch.
+
+        It began as an optional parameter defaulting to ``HEAD`` "for callers that have nothing
+        more specific". There were none: the sole production caller resolves the committed
+        object first and passes it. That default kept three arms alive that fired only for a
+        symbolic source -- skipping the pre-fetch tamper check, replaying the BRANCH rather than
+        the object, and reading ``HEAD`` after the push for the ledger -- each of them the very
+        check-then-use shape this change exists to remove. Requiring the argument deletes all
+        three. Raised by the first-principles review of this branch, which asked for the
+        subtraction rather than more guards.
+
+        THE RETRY REPUBLISHES BY ID TOO. A rebase REPLAYS the commit as a NEW object, so *src*
+        names the pre-rebase commit -- not what the rebase produced, and non-fast-forward
+        anyway -- but the answer is to resolve the REPLACEMENT to a full id, credential-scan
+        that object, and push it. An earlier revision of this method pushed ``HEAD`` there and
+        justified it with "``_reverify_head`` has just run", which was the same
+        check-then-use mistake this branch fixed twice elsewhere: the build gate is a check,
+        the push is a later use, and ``HEAD`` is re-resolved in between. It also published an
+        object no credential scan had ever covered, because the caller scans the PRE-rebase
+        object. Raised by the GPT review of this branch.
 
         A run takes tens of minutes, so the branch can legitimately advance between the
         clone's fetch and the winner's push — and a bare push then dies
@@ -878,13 +1240,18 @@ class Driver:
           * never ``--force``. If the second push is also rejected, we stop — a losing
             race is a signal, not something to overwrite.
 
-        The caller must read the pushed sha from the clone AFTER this returns, not from
-        its own pre-push snapshot: a rebase rewrites HEAD, so the pre-rebase sha names a
-        commit that does not exist on the remote.
+        The caller must record ``self._pushed_object``, which this sets to whatever it actually
+        sent, and NOT its own pre-push snapshot: a rebase rewrites HEAD, so the pre-rebase sha
+        names a commit that does not exist on the remote. Reading the sha back from the clone is
+        wrong for the same reason -- HEAD can move between the push and the read.
         """
         if self._retire_if_unsafe("direct-push preflight"):
             return None
         require_pinned(self.clone)
+        # Remember WHICH OBJECT was sent, so the caller records that rather than re-reading
+        # `HEAD` after the push: HEAD can move between the push and the read, which would put
+        # an unrelated sha in the ledger for a commit that did land. Raised by the GPT review.
+        self._pushed_object = src
         push = subprocess.run(
             [
                 "git",
@@ -893,7 +1260,7 @@ class Driver:
                 *_GIT_SAFE_CONFIG,
                 "push",
                 fetch_url,
-                f"HEAD:refs/heads/{dest}",
+                f"{src}:refs/heads/{dest}",
             ],
             capture_output=True,
             **UTF8_TEXT,
@@ -905,19 +1272,229 @@ class Driver:
             if "non-fast-forward" not in blob and "fetch first" not in blob:
                 return push  # a different failure — do not mask it with a retry
             self.log.info("direct-push: %s moved under us; rebasing and retrying", dest)
-            if _git(["fetch", fetch_url, dest], self.clone).returncode != 0:
+            # `git rebase` replays whatever the CURRENT BRANCH points at, not *src* -- so if
+            # HEAD has moved since the caller's checks, the retry would replay the moved commit
+            # and then bind its own capture, verify and scan to THAT, consistently passing while
+            # publishing content that never descended from the verified object. Refuse instead:
+            # the rebase input has to be the object this run authorized. Skipped when *src* is
+            # the default symbolic `HEAD`, where there is no retained id to compare against.
+            # Raised by the GPT review of this branch.
+            # A TAMPER DETECTOR, not the guarantee it once was. The rebase below names the
+            # authorized object EXPLICITLY, so what gets replayed does not depend on where
+            # HEAD points and this check is not what makes that safe. It stays because a HEAD
+            # that has moved by now means something wrote the clone after the caller's checks,
+            # and a clone being written by an unknown actor is not one to publish from. On its
+            # own it is defeatable: it sits before the `fetch`, a network operation lasting
+            # seconds, so relied on alone it would only see the branch as it was before that
+            # window. Raised by the GPT review of this branch.
+            src_ok, src_note = self._head_is_the_committed_sha(src)
+            if not src_ok:
+                self.log.error(
+                    "direct-push: HEAD is no longer the authorized source (%s) -- not rebasing",
+                    src_note,
+                )
                 return push
-            reb = _git(["rebase", "FETCH_HEAD"], self.clone)
+            # CAPTURE THE FETCHED TIP AS AN OBJECT ID, FROM THE FETCH ITSELF. `FETCH_HEAD` is a
+            # mutable file in the clone, and the pre-push reviewer's shell can rewrite it between
+            # the fetch and the rebase: the replay then lands on a SUBSTITUTED parent whose
+            # content nothing scanned (the scan covers only the replayed commit), and the push
+            # carries it. Keying both the rebase input and the replayed-commit count on that same
+            # name made them corroborate the substitution rather than catch it. Measured on a
+            # throwaway repo: with `.git/FETCH_HEAD` rewritten to a prepared child,
+            # `rev-list --count FETCH_HEAD..HEAD` still reported 1 while the truth against the
+            # real tip was 2, the scanned range held only our own file, and a bare remote ACCEPTED
+            # the push -- the foreign file landed. With the id taken from `--porcelain` stdout the
+            # same attack replays onto the real tip and the foreign file is gone from the
+            # published range. Raised by the GPT review of this branch.
+            fetched = _git(["fetch", "--porcelain", fetch_url, dest], self.clone)
+            if fetched.returncode != 0:
+                return push
+            base = _fetched_tip_oid(fetched.stdout)
+            if not base:
+                self.log.error(
+                    "direct-push: the fetch did not report the tip's object id -- not rebasing"
+                )
+                return push
+            # PIN THE COMMITTER FROM THE AUTHORIZED OBJECT, not from configuration. A replay
+            # writes a NEW commit object, and git takes its committer identity from config
+            # rather than from the commit being replayed -- while author and message carry
+            # over. The reviewing agent's shell can write the repository's config (its git
+            # denylist covers only `push` and `remote set-url`) and nothing masks a global
+            # one, so a replay left to resolve identity itself publishes attribution that a
+            # distrusted actor chose. `src` already holds the identity the pipeline committed
+            # under, recorded before any agent ran, and it is an immutable object: reading the
+            # answer off it needs no new state and no trust in any config file. Raised by the
+            # GPT review of this branch.
+            pin_name, pin_email = _committer_identity(src, self.clone)
+            if not pin_name or not pin_email:
+                self._restore_branch(dest)
+                self.log.error(
+                    "direct-push: cannot read the authorized commit's own identity -- not"
+                    " rebasing"
+                )
+                return push
+            # REPLAY THE RETAINED OBJECT ONTO THE CAPTURED BASE. `git rebase <base> <rev>` checks
+            # out *rev* detached and replays it, so BOTH ends are immutable object ids and nothing
+            # that rewrites a ref in between can substitute either one. There is no no-argument
+            # form any more: *src* is required, so the branch is never the thing replayed.
+            reb = _git(
+                ["rebase", base, src],
+                self.clone,
+                config=("-c", f"user.name={pin_name}", "-c", f"user.email={pin_email}"),
+            )
             if reb.returncode != 0:
                 _git(["rebase", "--abort"], self.clone)
+                self._restore_branch(dest)
                 self.log.warning("direct-push: rebase onto %s conflicted — not pushing", dest)
                 return push
+            # The rebase REPLAYED the commit, so the object about to be published is a new one
+            # that nothing has scanned: the caller's credential scan covered the PRE-rebase
+            # object. Resolve the replacement to a full id, scan THAT, and push THAT -- so this
+            # path holds the same invariant as the first push instead of trusting `HEAD`, which
+            # is re-resolved by the push itself and can be moved in between by a process the
+            # reviewer left behind. Raised by the GPT review of this branch.
+            #
+            # RESOLVED BEFORE `_reverify_head`, DELIBERATELY. That gate runs the
+            # repository-under-improvement's OWN test suite, i.e. arbitrary code from the tree
+            # being published, so resolving afterwards let a test teardown move HEAD and have
+            # the moved commit captured, scanned and pushed as though the gate had measured it:
+            # credentials still covered, but the build-verification invariant broken with no
+            # recheck. Capturing first and asserting HEAD is still that object afterwards makes
+            # the thing the gate measured and the thing published the same object. Raised by
+            # the GPT review of this branch, which found the earlier ordering.
+            rebased_id = (
+                _git(["rev-list", "-1", "HEAD^{commit}"], self.clone).stdout or ""
+            ).strip()
             verified = self._reverify_head()
             if self._retire_if_unsafe("post-rebase verification"):
                 return None
+            # Every refusal from here re-attaches the clone WITHOUT moving the branch: the
+            # rebase left HEAD detached at the replay, and `_reset_provisional` rolls back with
+            # `git reset --hard`, which on a detached HEAD would move the detachment and leave
+            # the branch still carrying the provisional commit. Leaving the branch where it was
+            # is also the conservative outcome -- it never points at a replay that failed a
+            # check.
             if not verified:
+                self._restore_branch(dest)
                 return push  # rebased tree is unverified — return the original rejection
+            # The emptiness refusal is deliberately HERE rather than at the capture above: the
+            # capture has to precede the gate, but refusing there would preempt the retire and
+            # re-verify checks and swallow the atomic clone retirement (`return None`), which is
+            # a stronger outcome than a failed push. Same shape as `_direct_push`: resolve
+            # early, carry the value forward, refuse in the original order.
+            if not rebased_id:
+                self.log.error("direct-push: cannot resolve the rebased commit -- not pushing")
+                self._restore_branch(dest)
+                return push
+            # THE CAPTURED REPLAY MUST CARRY THE AUTHORIZED CHANGE. Everything below binds to
+            # *rebased_id*, and *rebased_id* comes from ambient `HEAD` -- so a process that
+            # moves HEAD in the window between the rebase returning and that read gets its own
+            # commit measured, scanned, counted and published, with every check agreeing
+            # because they all agree ABOUT THE SUBSTITUTE. The HEAD-equality check below cannot
+            # catch it: it compares HEAD against the same captured id, so a substitution that
+            # happened BEFORE the capture is corroborated rather than refused. Nothing in the
+            # chain reached back to *src*, the object the caller authorized and already
+            # scanned.
+            #
+            # Equality of ids is not available -- a replay is a new object by definition -- so
+            # the binding is the RESULT: the tree a replay of *src* onto *base* must produce,
+            # computed from those two immutable ids by git's own merge, against the tree the
+            # captured commit actually carries. That closes the window by making the published
+            # CONTENT provably the authorized content rather than by trying to make the window
+            # empty; HEAD is the only handle the rebase leaves, so the window cannot be
+            # removed, only made harmless.
+            #
+            # A TREE, NOT A PATCH IDENTITY, because a patch identity ignores hunk positions:
+            # the same added and removed lines placed elsewhere in the file carry the same
+            # identity and a different tree. Raised by the GPT review of this branch.
+            #
+            # FAIL-CLOSED, and the cost is a skipped publish, never a bad one: this cycle's
+            # commit stays on the branch and the next cycle re-pushes it.
+            want_tree = _expected_replay_tree(base, src, self.clone)
+            have_tree = _commit_tree(rebased_id, self.clone)
+            if not want_tree or not have_tree or want_tree != have_tree:
+                self.log.error(
+                    "direct-push: the rebased commit %s does not carry the tree a replay of the"
+                    " authorized %s produces -- not pushing",
+                    rebased_id[:12],
+                    src[:12],
+                )
+                self._restore_branch(dest)
+                return push
+            want_attr = _commit_attribution(src, self.clone)
+            have_attr = _commit_attribution(rebased_id, self.clone)
+            if not want_attr or not have_attr or want_attr != have_attr:
+                # THE PIN IS NOT THE GUARANTEE, this is. A `-c` override loses to the
+                # ``GIT_COMMITTER_*`` environment, and author and message are carried over by
+                # the replay rather than pinned at all, so the published object's attribution
+                # is checked against the authorized one instead of assumed. Comparing objects
+                # to each other keeps configuration out of the answer entirely.
+                self.log.error(
+                    "direct-push: the rebased commit %s does not carry the attribution of the"
+                    " authorized %s -- not pushing",
+                    rebased_id[:12],
+                    src[:12],
+                )
+                self._restore_branch(dest)
+                return push
+            head_ok, head_note = self._head_is_the_committed_sha(rebased_id)
+            if not head_ok:
+                self.log.error(
+                    "direct-push: HEAD moved while the build gate ran (%s) -- not pushing",
+                    head_note,
+                )
+                self._restore_branch(dest)
+                return push
+            scan_ok, scan_note = self._revision_scans_clean(rebased_id)
+            if not scan_ok:
+                self.log.error(
+                    "direct-push: the rebased commit %s did not scan clean (%s) -- not pushing",
+                    rebased_id[:12],
+                    scan_note,
+                )
+                self._restore_branch(dest)
+                return push
+            # THE REBASE MUST HAVE REPLAYED EXACTLY ONE COMMIT. If the remote already carries an
+            # equivalent patch, `git rebase` drops ours as already-applied and leaves HEAD at
+            # the remote tip -- which every check below would then bind to, consistently, and
+            # the ledger would record an unrelated commit as the one this pipeline landed. A
+            # count of 0 is that case; anything above 1 means the replay is not the single
+            # commit this method is documented to handle. Raised by the GPT review.
+            #
+            # BOTH ENDPOINTS ARE CAPTURED IDS. The base is the tip the fetch reported, not
+            # `FETCH_HEAD` -- that name is a mutable file, so a count keyed on it measures the
+            # same substituted state the rebase would have replayed onto, and agrees with it.
+            # The far end is *rebased_id*, not ambient `HEAD`: `HEAD` resolves to whatever the
+            # working tree points at when this line runs, and the build gate above executes the
+            # target repository's OWN test suite, so a teardown can move it in between. The
+            # equality check above proves HEAD was still the replay a moment ago, which is a
+            # check-then-use pair -- naming the id removes the dependency instead of timing it.
+            # It also makes the range counted identical to the range PUBLISHED: the push sends
+            # *rebased_id*, so `base..rebased_id` is exactly what this adds to the remote.
+            # Raised by the GPT review of this branch, one step along from the same defect in
+            # the rebase input.
+            replayed = (
+                _git(["rev-list", "--count", f"{base}..{rebased_id}"], self.clone).stdout or ""
+            ).strip()
+            if replayed != "1":
+                self.log.error(
+                    "direct-push: the rebase replayed %s commits, not 1 -- not pushing",
+                    replayed or "an unreadable number of",
+                )
+                self._restore_branch(dest)
+                return push
+            # THE ONE PLACE THE BRANCH IS PROMOTED, and it is reached only after the replay has
+            # passed re-verification, the HEAD-identity check and the credential scan. Doing it
+            # any earlier would force the branch onto whatever HEAD happened to be if a later
+            # check refused -- silently, with the branch looking healthy. Raised in review.
+            # A FAILED restore ABORTS the push: publishing while the clone is detached or its
+            # durable branch is stale is exactly what the restore exists to prevent, so its
+            # status is checked rather than logged. Raised by the GPT review.
+            if not self._restore_branch(dest, promote=rebased_id):
+                self.log.error("direct-push: branch restore failed -- not pushing %s", dest)
+                return push
             require_pinned(self.clone)
+            self._pushed_object = rebased_id
             push = subprocess.run(
                 [
                     "git",
@@ -926,7 +1503,7 @@ class Driver:
                     *_GIT_SAFE_CONFIG,
                     "push",
                     fetch_url,
-                    f"HEAD:refs/heads/{dest}",
+                    f"{rebased_id}:refs/heads/{dest}",
                 ],
                 capture_output=True,
                 **UTF8_TEXT,
@@ -971,7 +1548,40 @@ class Driver:
             "rh_functional_ok": meas.rh_functional_ok,
         }
 
+    def _publishing_is_halted(self) -> bool:
+        """Whether a failed provisional rollback has made this clone unsafe to publish from.
+
+        A failed rollback leaves HEAD carrying a commit that was refused and never published.
+        Anything that publishes afterwards sends that commit as an ANCESTOR while its own scan
+        looks at one revision, so the refused content lands through a scanner that never saw it.
+        The rollback IS the repair, so a rollback that cannot be trusted to have happened must
+        not be followed by work that assumes it did -- and the answer is to stop, not to retry:
+        a retry would be one more thing whose failure has to be handled.
+
+        Checked at three places so the halt is UNCONDITIONAL rather than narrowed:
+
+        * here, at the top of each winner-applying method, which is BEFORE the PR pipeline's
+          `emit_*` -- that path reaches ``pr_recipe._push_fix_branch``, which pushes ``HEAD``
+          and knows nothing about this latch, and it runs before the direct push does;
+        * at :meth:`_direct_push`, the publish gate itself;
+        * and through ``request_stop``, which the cycle loop reads, so no later cycle starts.
+
+        One cycle can hold SEVERAL bug winners (``for prop, bug_res in bug_winners``), so a
+        latch read only at cycle boundaries would let the next winner in the SAME cycle publish.
+        Raised by the GPT review of this branch; the unconditional form was the conductor's
+        requirement.
+        """
+        if not getattr(self, "_rollback_failed", False):
+            return False
+        self.log.error(
+            "refusing to apply any further winner: a provisional rollback failed, so HEAD"
+            " carries a commit that was refused and never published"
+        )
+        return True
+
     def _apply_verdict(self, cycle, base_sha, verdict, archived, fresh_count, gated_sha) -> int:
+        if self._publishing_is_halted():
+            return 0
         # Archive ALL survivors (the whole population is evolutionary memory). The kept
         # winner's diff_ref is reused as the CR's ``diff-ref`` (06_*.md §3.1/§3.2).
         winner_diff_ref = ""
@@ -1248,8 +1858,11 @@ class Driver:
                 "Look for defects that would matter in review: incorrect logic, unhandled\n"
                 "errors, resource leaks, race conditions, security issues, and behaviour\n"
                 "changes the commit does not mention. Ignore style preferences.\n\n"
-                "Do NOT push. Do NOT open a pull request. Review only — you may fix a trivial\n"
-                "finding in the clone and re-review, but the last line MUST be the verdict.\n\n"
+                "Do NOT push. Do NOT open a pull request. Do NOT commit or amend anything:\n"
+                "this is REPORT-ONLY. A commit here replaces the object the pipeline measured\n"
+                "and reproduced, which the publish gate then refuses -- so a well-meant fix\n"
+                "discards the verified change. Report the finding instead. The last line MUST\n"
+                "be the verdict.\n\n"
                 "End your reply with EXACTLY one line: `REVIEW: clean` if there are no open\n"
                 "findings on the added or changed lines, else `REVIEW: <N> open`. If you could\n"
                 "not actually review the diff, say `REVIEW: unavailable` rather than guessing —\n"
@@ -1258,7 +1871,17 @@ class Driver:
             res = runner.run(
                 prompt,
                 cwd=str(self.clone),
-                allowed_tools=["Bash", "Read", "Edit", "Grep", "Glob"],
+                # NO `Edit`. The prompt above is report-only and gives a reviewer no
+                # sanctioned reason to modify the clone. What actually determines whether a
+                # reviewer CAN modify it is the tool list, not the prose, so withholding the
+                # capability is what matters here. Raised by the first-principles review of
+                # this branch.
+                #
+                # This is least privilege, NOT the enforcement boundary: `Bash` remains (the
+                # review has to run git to read the diff), and a shell can write files and
+                # commit. That is precisely why the identity checks below exist rather than
+                # relying on what the reviewer was told or granted.
+                allowed_tools=["Bash", "Read", "Grep", "Glob"],
                 max_turns=30,
                 timeout_s=420,
             )
@@ -1326,6 +1949,57 @@ class Driver:
             return True, "full suite green"
         return False, f"{len(failing)} failing test(s): {', '.join(failing[:3])}"
 
+    def _head_is_the_committed_sha(self, committed_id: str) -> tuple[bool, str]:
+        """Is the clone's HEAD still the commit this pipeline committed? ``(ok, note)``.
+
+        This gate holds one invariant: do not push what a worker did not commit.
+        *committed_id* is the FULL object id of what :meth:`_finalize_winner_commit` /
+        :meth:`_finalize_bug_winner_commit` produced -- the commit that was measured,
+        reproduced and written to the ledger -- resolved by the caller BEFORE the review gate
+        runs. Nothing holds the verified commit and the published one together, and the window
+        between them is not empty: :meth:`_prepush_review_clean` runs an agent in THIS clone
+        with ``Bash`` for up to 30 turns, and that runner's git denylist covers only ``push``
+        and ``remote set-url``, so ``git commit --amend`` is permitted there. That prompt is
+        report-only and grants no ``Edit``, but neither is an ENFORCEMENT BOUNDARY -- a prompt
+        is an instruction to an agent that may be
+        carrying an injected diff, and a shell can write files whatever the tool list says -- so
+        a moved HEAD stays reachable and this check is what refuses it.
+
+        THE ANCHOR IS A FULL OBJECT ID, which is what makes this comparison mean anything. A
+        short sha is an ambiguous NAME: git reads a revision as a ref name before an
+        abbreviated object id, and a prefix stops naming one object once a second object shares
+        it. Either reading is arrangeable by whatever can write the repository, so a gate that
+        re-resolved an abbreviation would compare two values the distrusted actor chose. The
+        finalizers therefore return a validated forty-hex id and nothing downstream resolves by
+        prefix; a short form is derived for DISPLAY only. Raised by the GPT review of this
+        branch.
+
+        Resolved with ``rev-list -1`` rather than ``rev-parse --verify`` because this method
+        ALREADY asks a different question with ``rev-parse --verify --quiet HEAD~1`` -- "does
+        a parent exist", a boolean that picks the credential scan's range. One verb carrying
+        two unrelated questions is indistinguishable to a reader and to any caller keyed on
+        the argv, and ``test_ai_spine_driver_coverage``'s git double is keyed on exactly that:
+        its own docstring says prefixes are scripted "so a caller can pin
+        ``rev-parse --verify`` separately from ``rev-parse HEAD``". One prefix, one call site.
+
+        FAIL-CLOSED. A revision that does not resolve is the ABSENCE of the check, not a
+        pass: an amended-away commit can be pruned, and "I could not look" must never read
+        as "I looked and it was fine".
+        """
+        if not committed_id:
+            return False, "cannot resolve the committed object -- refusing to publish"
+        have = _git(["rev-list", "-1", "HEAD^{commit}"], self.clone)
+        have_sha = (have.stdout or "").strip()
+        if have.returncode != 0 or not have_sha:
+            return False, "cannot resolve the clone's HEAD -- refusing to publish"
+        if committed_id != have_sha:
+            return False, (
+                f"HEAD moved after the pipeline committed {committed_id[:12]}"
+                f" (HEAD is now {have_sha[:12]}): the commit that would be published is"
+                " not the one this run verified"
+            )
+        return True, f"HEAD is the committed revision {have_sha[:12]}"
+
     def _direct_push(self, *, fp: str, kind: str, target: str, sha: str) -> bool | None:
         """F10: push the just-committed verified change to the operator-authorized branch.
 
@@ -1343,9 +2017,7 @@ class Driver:
         is its gate (F6/F10; fail-closed)."""
         from .push_policy import (
             authorize_direct_push,
-            describe_scan,
             normalize_branch,
-            scan_content_for_secrets,
         )
 
         ok, reason = authorize_direct_push(direct_commit=self.direct_commit, branch=self.branch)
@@ -1361,6 +2033,37 @@ class Driver:
                 )
             )
             return False
+        # A FAILED ROLLBACK IS TERMINAL FOR PUBLISHING. HEAD still carries a commit that was
+        # refused and never published, so this winner's scan (`<rev>~1..<rev>`) reads one
+        # revision while its push sends the whole ancestry -- publishing the refused content
+        # through a scanner that never looked at it. Checked HERE and not only via the run's
+        # stop flag because that flag is read at cycle boundaries, and a cycle can hold SEVERAL
+        # bug winners (`for prop, bug_res in bug_winners`), each reaching this method. Raised by
+        # the GPT review of this branch.
+        if getattr(self, "_rollback_failed", False):
+            reason = "a provisional rollback failed, so HEAD carries an unpublished commit"
+            self.log.error("direct-push refused for %s: %s", target, reason)
+            self.ledger.record(
+                L.LedgerEntry(
+                    fp=fp,
+                    kind=kind,
+                    target=target,
+                    status=L.STATUS_ERROR,
+                    note=f"direct-push refused: {reason}"[:200],
+                )
+            )
+            return False
+        # THE FINALIZER HANDS BACK A FULL OBJECT ID, so nothing is resolved by prefix here. A
+        # short sha is an ambiguous name -- git reads a revision as a ref name before an
+        # abbreviated object id, and a prefix stops naming one object once a second object
+        # shares it -- so a lookup keyed on one lets whatever can write the repository decide
+        # which object this path anchors to. Validating the id the finalizer already produced
+        # leaves no lookup to aim at. An empty or malformed value is carried forward and
+        # refused below rather than raised, so a missing sha keeps its own existing message.
+        # Raised by the GPT review of this branch.
+        committed_id = ""
+        if len(sha) == 40 and all(c in "0123456789abcdef" for c in sha):
+            committed_id = sha
         # PRE-PUSH REVIEW GATE (fail-closed): a direct-pushed commit gets no human review,
         # so the automated reviewer must clear it before it lands on the shared branch.
         clean, note = self._prepush_review_clean(target=target, base_ref=self.branch)
@@ -1399,6 +2102,27 @@ class Driver:
                 )
             )
             return False
+        # Publish only what this pipeline committed. Placed HERE
+        # deliberately -- AFTER the review gate, so a reviewer that edited and amended the
+        # clone is caught, and BEFORE the credential scan and the push, so an unverified
+        # commit is neither scanned as though it were the verified one nor published. NOT
+        # wrapped around the push itself: `_push_with_rebase` rewrites HEAD on purpose and
+        # re-verifies the replayed tree, so a check there would refuse that legitimate path.
+        # Refusing returns False, the same disposition every other gate in this method uses:
+        # the commit stays local and recoverable and the caller rolls the provisional back.
+        head_ok, head_note = self._head_is_the_committed_sha(committed_id)
+        if not head_ok:
+            self.log.error("direct-push REFUSED for %s: %s", target, head_note)
+            self.ledger.record(
+                L.LedgerEntry(
+                    fp=fp,
+                    kind=kind,
+                    target=target,
+                    status=L.STATUS_ERROR,
+                    note=f"direct-push refused: {head_note}"[:200],
+                )
+            )
+            return False
         dest = normalize_branch(self.branch)
         # Resolve the real remote URL the clone FETCHES from (push remote is disabled). We
         # push HEAD (the verified commit we just made on self.branch) to the authorized ref.
@@ -1426,65 +2150,20 @@ class Driver:
         # Scan the CONTENT before it leaves the host. `_redact_commit_message` covers the
         # message; this covers the commit itself, which is equally unwipeable once pushed
         # and is agent-authored. Detect-and-refuse: the commit stays local and the ledger
-        # records why, rather than publishing a silently-rewritten patch.
-        # Scan the RANGE THAT WILL BE PUSHED, which is the verified commit itself: HEAD and
-        # its parent. The earlier `{dest}..HEAD` form was silently EMPTY — `dest` is the
-        # local branch this commit sits on the tip of, so `git diff <branch>..HEAD` diffs a
-        # ref against itself and returns nothing, which `scan_content_for_secrets` reads as
-        # "clean" and the fail-closed credential gate is SKIPPED. Measured against a real
-        # repo: a commit adding an AWS key produced a 0-byte `<branch>..HEAD` diff and a
-        # 144-byte `HEAD~1..HEAD` diff carrying the key. (This regressed when the checkout
-        # was moved to the local branch; before that `dest` was the stale `origin/<branch>`
-        # tracking ref, which happened to differ.) Raised by the GPT review of this branch.
+        # records why, rather than publishing a silently-rewritten patch. The range mechanics
+        # and the history behind them live in `_revision_scans_clean`.
         #
-        # `HEAD~1..HEAD` for a normal commit; `--root` shows a root commit that has no
-        # parent. The git call's EXIT STATUS is load-bearing, not just its stdout: `_git`
-        # does not raise, and a failed diff exits non-zero with EMPTY stdout — which the
-        # scanner would read as "nothing to scan". Both sibling call sites refuse on a
-        # non-zero status; this one must too.
-        has_parent = (
-            _git(["rev-parse", "--verify", "--quiet", "HEAD~1"], self.clone).returncode == 0
-        )
-        proc = (
-            _git(
-                ["-c", "diff.external=", "diff", "--no-ext-diff", "HEAD~1..HEAD"],
-                self.clone,
-            )
-            if has_parent
-            else _git(
-                [
-                    "-c",
-                    "diff.external=",
-                    "show",
-                    "--no-ext-diff",
-                    "--format=",
-                    "--root",
-                    "HEAD",
-                ],
-                self.clone,
-            )
-        )
-        if proc.returncode != 0:
-            self.log.error(
-                "direct-push REFUSED for %s: could not read the pushable diff (git exit %s)",
-                target,
-                proc.returncode,
-            )
-            self.ledger.record(
-                L.LedgerEntry(
-                    fp=fp,
-                    kind=kind,
-                    target=target,
-                    status=L.STATUS_ERROR,
-                    note="direct-push refused: could not read the pushable diff",
-                )
-            )
-            return False
-        clean, scan_code = scan_content_for_secrets(proc.stdout or "")
-        if not clean:
-            # `describe_scan` maps a fixed code to a fixed literal, so nothing derived
-            # from the scanned content reaches this log line or the ledger row below.
-            scan_note = describe_scan(scan_code)
+        # Scan the COMMITTED OBJECT BY ID, never through `HEAD`. Binding this to the symbolic
+        # ref left a hole that no amount of re-checking closes: a background process can point
+        # HEAD at a clean decoy for the duration of the `git diff` and restore it before any
+        # later check, so the scanner reads the decoy, every check passes, and the real commit
+        # is published having never been scanned. An id names one immutable object, so the
+        # thing scanned here and the thing pushed below are the same object by construction
+        # rather than by timing. `_push_with_rebase` calls the SAME helper on the replayed
+        # object if it has to rebase, so neither publish path can go out unscanned.
+        # Raised by the GPT review of this branch.
+        scan_ok, scan_note = self._revision_scans_clean(committed_id)
+        if not scan_ok:
             self.log.error("direct-push REFUSED for %s: %s", target, scan_note)
             self.ledger.record(
                 L.LedgerEntry(
@@ -1497,7 +2176,32 @@ class Driver:
             )
             return False
 
-        push = self._push_with_rebase(fetch_url, dest, target)
+        # A TAMPER DETECTOR, not the thing that binds the scan -- that is the object id used
+        # above and below, and this check is deliberately not load-bearing for it. Relying on
+        # a post-scan re-check to prove the scan had covered the published object would be
+        # wrong: the re-check is itself a check-then-use pair, so a process that swapped HEAD
+        # during the diff and restored it before this line defeats both. What this still
+        # catches is worth keeping: HEAD
+        # differing here means something wrote the clone after the review returned, and a
+        # clone that is being written by an unknown actor is not one to publish from, even
+        # when the object about to be published is provably the verified one.
+        head_ok, head_note = self._head_is_the_committed_sha(committed_id)
+        if not head_ok:
+            self.log.error("direct-push REFUSED for %s after the scan: %s", target, head_note)
+            self.ledger.record(
+                L.LedgerEntry(
+                    fp=fp,
+                    kind=kind,
+                    target=target,
+                    status=L.STATUS_ERROR,
+                    note=f"direct-push refused after the scan: {head_note}"[:200],
+                )
+            )
+            return False
+
+        # Publish the OBJECT ID, not ``HEAD``: an id cannot be repointed, so no process in
+        # the clone can change what lands on the branch between here and the push itself.
+        push = self._push_with_rebase(fetch_url, dest, target, src=committed_id)
         if push is None:
             self.ledger.record(
                 L.LedgerEntry(
@@ -1509,12 +2213,19 @@ class Driver:
                 )
             )
             return None
-        # Read the sha back from the clone: a rebase inside `_push_with_rebase` rewrites
-        # HEAD, so the caller's pre-push snapshot would name a commit that is NOT on the
-        # remote. `self.pushed_sha` is what the ledger records. Fall back to the snapshot
-        # only when rev-parse fails, so a reporting hiccup cannot blank a real sha.
-        head_after = _git(["rev-parse", "HEAD"], self.clone)
-        self.pushed_sha = (head_after.stdout or "").strip() or sha
+        # Record the OBJECT THAT WAS SENT, which `_push_with_rebase` reports -- on the fast path
+        # the retained id, on the retry path the replayed one. Re-reading `HEAD` here was wrong
+        # for the same reason it is wrong everywhere else on this path: HEAD can move between
+        # the push and the read, and the ledger would then name an unrelated commit for a change
+        # that really did land. The HEAD read is GONE rather than kept as a fallback: `src` is
+        # required now, so there is no caller for whom the sent object is unknown, and a fallback
+        # that re-reads HEAD is the defect wearing a smaller hat. There is no fallback to the
+        # caller's own snapshot either, because it is unreachable: the ONLY return in
+        # `_push_with_rebase` that precedes `self._pushed_object = src` is the retire path's
+        # `return None`, and that routes to this method's own `return None` above -- before this
+        # line. Raised by the GPT review, then narrowed twice by the first-principles review.
+        sent = str(getattr(self, "_pushed_object", "") or "")
+        self.pushed_sha = sent
         if push.returncode != 0:
             # Redact BEFORE the bound (here and at every stderr slice below): git
             # echoes the authenticated remote URL on an auth failure, and slicing
@@ -1653,21 +2364,154 @@ class Driver:
             return False
         return True
 
-    def _reset_provisional(self, pre_sha: str) -> None:
-        """Roll the branch back to ``pre_sha`` after a provisional commit that was not
-        filed, so a fluke, duplicate or error never advances HEAD (06_*.md §1.1)."""
+    def _reset_provisional(self, pre_sha: str) -> bool:
+        """Roll the AUTHORIZED branch back to ``pre_sha`` after a provisional commit that was
+        not filed, so a fluke, duplicate or error never advances HEAD (06_*.md section 1.1).
+
+        Returns whether the branch is back where it belongs. A FAILED rollback is not a log
+        line: HEAD keeps the refused commit, the next winner commits on top of it, and that
+        winner's single-revision scan cannot see the parent its own push would publish. So a
+        failure latches ``_rollback_failed`` and stops the run, at this chokepoint rather than
+        at the five call sites, because a caller that forgets to check is the whole defect.
+
+        ONE COMMAND, and that is the whole point. ``git reset --hard`` acts on WHATEVER IS
+        CHECKED OUT, and this runs after the pre-push reviewer has had a shell in the clone --
+        whose denylist covers only ``push`` and ``remote set-url``, so ``git checkout`` is
+        permitted there. Two ways that bites:
+
+        * the reviewer checks out a DIFFERENT branch, and the rollback hard-resets that branch
+          to a sha from an unrelated run, destroying its commits;
+        * HEAD is DETACHED, and the reset moves the detachment while the branch keeps carrying
+          the provisional commit -- a rollback that silently does not roll back.
+
+        An earlier fix read ``rev-parse --abbrev-ref HEAD``, checked the branch out if it
+        differed, then reset -- which was the same check-then-use pair one level up: a
+        backgrounded ``setsid git checkout victim`` landing between the check and the reset put
+        the reset back on the wrong branch. ``git checkout -f -B <branch> <pre_sha>`` is a
+        single invocation that NAMES the branch, moves it to *pre_sha* and checks it out, so
+        there is no window and no ambiguity about which ref moves. ``-f`` keeps the old
+        ``reset --hard`` semantics of discarding the working tree. Fail closed on error: a
+        provisional commit left behind is resolved by the next cycle's stage step, while
+        touching a ref that was never this run's to touch is not recoverable. Raised across
+        three rounds of the GPT review of this branch.
+        """
         if not pre_sha:
-            return
-        head = _git(["rev-parse", "HEAD"], self.clone).stdout.strip()
-        if head == pre_sha:
-            return  # nothing was committed (empty diff)
-        res = _git(["reset", "--hard", pre_sha], self.clone)
+            return True
+        if getattr(self, "_repository_retired", False):
+            # The clone was already renamed out from under us; there is nothing to roll back
+            # and no path to roll it back on.
+            return False
+        branch = normalize_branch(self.branch)
+        res = _git(["checkout", "-f", "-B", branch, pre_sha], self.clone)
         if res.returncode != 0:
             self.log.error(
-                "could not roll back the provisional commit to %s: %s",
+                "could not roll back the provisional commit to %s on %s: %s -- halting: HEAD"
+                " carries a commit that was refused and never published",
                 pre_sha[:10],
+                branch,
                 redact_log_via_context((res.stderr or "").strip())[:160],
             )
+            self._rollback_failed = True
+            self.request_stop()
+            self._quarantine_unrolled_clone(pre_sha)
+            return False
+        return True
+
+    def _quarantine_unrolled_clone(self, pre_sha: str) -> None:
+        """Rename the clone out of its canonical name after a rollback failure.
+
+        THE GUARD HAS TO OUTLIVE THE PROCESS, because the thing it guards does. The in-memory
+        latch stops this run, but the un-rolled-back commit is on DISK and the clone is REUSED:
+        the next run starts with a clear latch on a clone that still carries the refused commit,
+        commits the next winner on top of it, and publishes an ancestor its single-revision scan
+        never looked at. A guard scoped to a process lifetime is checking something shorter-lived
+        than the hazard. Raised by the GPT review of this branch; the conductor asked for
+        quarantine over a persisted latch, because a persisted latch raises the question of when
+        it clears and one that clears on the wrong event is worse than none.
+
+        Retirement is the app's OWN primitive for exactly this, not a new mechanism:
+        ``_retire_unsafe_clone`` renames the root directory aside, and its docstring already
+        says it "prevents a later run from adopting a rejected provisional commit". Reuse in
+        ``_setup_safe_clone`` hinges on the canonical ``<dest>/.git`` being a directory, so a
+        retired clone is not reused -- the next run clones fresh. Nothing about how clones are
+        located or named changes, and the bytes are preserved for diagnosis.
+
+        Unconditional: unlike :meth:`_retire_if_unsafe`, this does not consult the isolation
+        probe first. The trigger is the failed rollback itself, which is already known, so a
+        probe verdict could only talk us out of quarantining a clone we know is poisoned.
+
+        RETIREMENT ITSELF CAN FAIL, and the reason it fails is correlated with the reason the
+        rollback failed rather than independent of it: a Windows process still holding handles
+        inside the tree makes both the force-checkout and the rename fail from that one cause.
+        Logging "MUST NOT be reused" is not a guard -- the next run does not read this log --
+        so a marker is persisted at a masked crew-home leaf (``_mark_clone_quarantined``) and
+        ``_setup_safe_clone`` refuses a marked clone. Reuse there attests git metadata and
+        remotes and never inspects the branch tip, so without the marker the poisoned tree
+        passes every existing check. The marker deliberately does NOT live beside the clone:
+        the scratch tree is one the agent works in, so a marker there could be truncated
+        through a pre-placed hardlink or simply deleted.
+
+        THE MARKER IS WRITTEN FIRST, BEFORE THE RENAME IS ATTEMPTED. Ordering it after made
+        the durable record depend on a path reached only once two things had already failed,
+        and a transient failure of the marker write itself then left the clone reusable with
+        nothing recording that it must not be -- fail-open at the exact moment the guard is
+        needed. Written first, the record exists before anything is disturbed, and a rename
+        that then SUCCEEDS makes it stale rather than wrong: the marker names a directory, so
+        it stops reporting once that directory is gone and is pruned on the way past.
+
+        THREE LEVERS, AND THE CANONICAL NAME MUST NOT SURVIVE ALL THREE. Recording a marker
+        and renaming the tree aside fail from independent causes -- an unwritable marker root
+        against a held file handle -- so either alone can be the one that works. When BOTH
+        fail the clone is still sitting at the name the next run looks up with nothing saying
+        it must not be, so the last lever is to remove the tree outright: a partially removed
+        clone presents no ``.git`` directory, and ``_setup_safe_clone`` refuses a destination
+        that exists and is not a git repository. It can fail too, from the same
+        held handle that defeated the rename, and then the log is all that is left -- but the
+        reuse check has one more independent reason to refuse by then, because a marker root
+        that could not take the write cannot pass ``_quarantine_root``'s writability probe
+        either, and that makes the guard fail closed for every clone. All three halves raised
+        by the GPT review of this branch.
+        """
+        from kiro_crew.platform_compat import rmtree_force
+
+        from ..backend.clone_setup import _mark_clone_quarantined, _retire_unsafe_clone
+
+        marked = _mark_clone_quarantined(
+            self.clone, f"provisional rollback to {pre_sha[:10]} failed"
+        )
+        if marked is None:
+            self.log.error(
+                "could not record a quarantine marker for %s before retiring it; a later run"
+                " has nothing to read, so retirement is now the only durable guard",
+                self.clone,
+            )
+        retained = _retire_unsafe_clone(self.clone)
+        self._repository_retired = True
+        if retained is None:
+            self.log.error(
+                "could not retire the clone after the failed rollback to %s; it is left unsafe"
+                " in place and MUST NOT be reused (quarantine marker: %s)",
+                pre_sha[:10],
+                marked or "could not be written either",
+            )
+            if marked is None and not rmtree_force(self.clone):
+                self.log.error(
+                    "could not remove %s either; every guard against reusing it has failed and"
+                    " it must be deleted by hand before another run starts",
+                    self.clone,
+                )
+        else:
+            self.log.error(
+                "clone retired to %s after the failed rollback to %s, so no later run can adopt"
+                " the commit that was refused",
+                retained,
+                pre_sha[:10],
+            )
+        self._progress(
+            stage="rollback_failed",
+            error="provisional rollback failed; clone quarantined so it is not reused",
+            retained_clone=str(retained or ""),
+        )
 
     def _finalize_winner_commit(
         self, winner: Proposal, *, verify, reproduce=None, cycle: int, diff_ref: str
@@ -1683,7 +2527,7 @@ class Driver:
         always does on a filed perf win) — never silently re-using VERIFY when the real
         numbers are available."""
         if not winner.diff.strip():
-            return _git(["rev-parse", "--short", "HEAD"], self.clone).stdout.strip()
+            return _full_head_id(self.clone)
         if True:
             # Use the INDEPENDENT reproduce measurement (carried back from the pipeline) for
             # the ``reproduce:`` line so the kept-commit message states the real second-A/B
@@ -1704,7 +2548,7 @@ class Driver:
                 ["commit", "-q", "--amend", "-m", self._redact_commit_message(msg)],
                 self.clone,
             )
-        return _git(["rev-parse", "--short", "HEAD"], self.clone).stdout.strip()
+        return _full_head_id(self.clone)
 
     # ── bug-track keep/draft (M4; 05_improvement_loop_bugfix.md §4) ───────────
 
@@ -1716,6 +2560,8 @@ class Driver:
         This is the bug-track analogue of :meth:`_apply_verdict`'s keep path, but the
         CR trigger is the boolean RED/GREEN gate (the doubled-RED flake check is the
         reproduction analogue, §4.1) — there is no second A/B and no noise band."""
+        if self._publishing_is_halted():
+            return
         diff_ref = self.archive.save_candidate(
             cand_id=winner.cand_id,
             diff=winner.diff,
@@ -1964,7 +2810,7 @@ class Driver:
                 ["commit", "-q", "--amend", "-m", self._redact_commit_message(msg)],
                 self.clone,
             )
-        return _git(["rev-parse", "--short", "HEAD"], self.clone).stdout.strip()
+        return _full_head_id(self.clone)
 
     def _preflight_checked(self) -> PreflightResult | None:
         """Run perf preflight, then attest/retire before any later host Git."""

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_clone_setup_idempotent.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_clone_setup_idempotent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 from pathlib import Path
@@ -9,12 +10,13 @@ from unittest import mock
 
 import pytest
 
-from kiro_crew import platform_compat
+from kiro_crew import platform_compat, sandbox, security
 from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
 from kiro_crew.apps.builtins.auto_improvement.backend.clone_setup import (
     DISABLED_NO_PUSH,
     CloneSpec,
 )
+from kiro_crew.platform_compat import rmtree_force
 
 
 def _seeded_bare(tmp_path: Path) -> Path:
@@ -192,6 +194,237 @@ def test_retire_unsafe_clone_preserves_bytes_off_canonical_path(
     retained = sorted(tmp_path.glob(".clone.unsafe-*"))
     assert len(retained) == clone_setup._UNSAFE_CLONE_RETENTION
     assert latest.exists()
+
+
+@pytest.fixture
+def marker_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the quarantine marker's crew-home root at a temp dir.
+
+    ``_quarantine_root`` resolves it through ``config.paths.data_home()``, the real crew data
+    home -- writing markers there from a test would leak state between runs and could refuse
+    a developer's own clone. Patched on the name ``clone_setup`` imported, so the redirect
+    holds however the caller reaches it.
+    """
+    home = tmp_path / "crewhome"
+    home.mkdir()
+    monkeypatch.setattr(clone_setup, "data_home", lambda: home)
+    return home / clone_setup._QUARANTINE_DIR_LEAF
+
+
+def test_a_quarantined_clone_is_refused_for_reuse(tmp_path: Path, marker_root: Path) -> None:
+    """A clone whose rollback AND retirement both failed must not be reused.
+
+    Reuse attests git metadata, config and origin URLs -- none of which look at what the
+    branch tip points AT -- so a clone still carrying a REFUSED, unscanned provisional commit
+    passes every one of those checks. The next run would commit its winner on top and publish
+    the refused commit as an ancestor. The marker is what makes the refusal outlive the
+    process that discovered it, since the un-rolled-back commit is on disk.
+    """
+    bare = _seeded_bare(tmp_path)
+    root = tmp_path / "root"
+    result, err = _setup(bare, root)
+    assert result and not err
+    clone = Path(result["clone"])
+
+    marker = clone_setup._mark_clone_quarantined(clone, "rollback to abc0123456 failed")
+    assert marker is not None
+
+    again, err = _setup(bare, root)
+    assert again == {}
+    assert "quarantined" in err
+
+
+def test_the_marker_lives_outside_the_tree_the_agent_works_in(
+    tmp_path: Path, marker_root: Path
+) -> None:
+    """The marker must not sit in the scratch directory, which the agent writes to.
+
+    It lives at a TOP-LEVEL crew-home leaf that is bind-masked from every agent sandbox and
+    fenced from agent file tools. Top-level matters on its own: a mask covers the name it is
+    bound over and not that name's ancestors, so a leaf under an agent-writable directory
+    could be renamed out from under the mount.
+    """
+    bare = _seeded_bare(tmp_path)
+    root = tmp_path / "root"
+    result, _ = _setup(bare, root)
+    clone = Path(result["clone"])
+
+    marker = clone_setup._quarantine_marker(clone)
+    assert marker is not None
+    assert marker.parent == marker_root, "the marker is not under the masked crew-home leaf"
+    assert not marker.is_relative_to(root), "the marker is inside the agent's scratch root"
+    assert not marker.is_relative_to(clone)
+    # The name is a hash of the clone path, so a repository name cannot steer it.
+    assert marker.name.endswith(".json") and len(marker.stem) == 64
+    assert "/" not in marker.stem and "\\" not in marker.stem
+    # Both gates that fence the leaf name it, so neither can drift from the other.
+    # ``sensitive_home_dirs`` reports crew-home-PREFIXED paths, one per home spelling.
+    assert clone_setup._QUARANTINE_DIR_LEAF in sandbox._CREW_HIDDEN_LEAVES
+    fenced = [
+        d for d in security.sensitive_home_dirs() if d.endswith(clone_setup._QUARANTINE_DIR_LEAF)
+    ]
+    assert fenced, "the quarantine leaf is masked from sandboxes but not fenced from file tools"
+
+
+def test_a_dangling_marker_symlink_reads_as_quarantined(tmp_path: Path, marker_root: Path) -> None:
+    """A planted entry can only make the guard MORE conservative, never less.
+
+    The marking open refuses to follow links, so a dangling symlink at the marker name is an
+    existing entry to it -- while `exists()` would call the same entry absent. Split that way,
+    a planted dangling link would let marking report success while the guard read no marker,
+    and the poisoned clone would be reused. `lstat` closes it: anything at the name counts.
+    """
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    marker = clone_setup._quarantine_marker(clone)
+    assert marker is not None
+    try:
+        marker.symlink_to(tmp_path / "does-not-exist")
+    except OSError as exc:  # pragma: no cover - host policy may forbid links
+        pytest.skip(f"cannot create a symlink: {exc}")
+
+    assert marker.exists() is False, "precondition: a dangling link looks absent to exists()"
+    assert clone_setup._clone_is_quarantined(clone) is True
+    # And marking over it reports the guard as standing rather than claiming a fresh write.
+    assert clone_setup._mark_clone_quarantined(clone, "planted") == marker
+
+
+def test_a_linked_marker_root_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A link planted at the ROOT would put every marker outside the fence, and no per-marker
+    check can see that -- so the root is refused and the guard fails closed."""
+    home = tmp_path / "crewhome"
+    home.mkdir()
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    try:
+        platform_compat.symlink_or_junction(foreign, home / clone_setup._QUARANTINE_DIR_LEAF)
+    except OSError as exc:  # pragma: no cover - host policy may forbid links
+        pytest.skip(f"cannot create a directory link: {exc}")
+    monkeypatch.setattr(clone_setup, "data_home", lambda: home)
+
+    assert clone_setup._quarantine_root() is None
+    assert clone_setup._mark_clone_quarantined(tmp_path, "unusable root") is None
+    # Fails CLOSED: a guard that cannot be consulted must not certify the clone.
+    assert clone_setup._clone_is_quarantined(tmp_path) is True
+
+
+def test_the_marker_write_cannot_truncate_an_existing_file(
+    tmp_path: Path, marker_root: Path
+) -> None:
+    """`O_TRUNC` is absent from the open, so an existing marker is never shortened.
+
+    An existing marker is the guard already standing, not a failure -- presence is the whole
+    signal and the contents are diagnostic -- so marking twice reports the same path and
+    leaves the first write intact.
+    """
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    first = clone_setup._mark_clone_quarantined(clone, "first failure")
+    assert first is not None
+    before = first.read_bytes()
+
+    second = clone_setup._mark_clone_quarantined(clone, "second failure")
+
+    assert second == first
+    assert first.read_bytes() == before, "the second mark truncated or rewrote the first"
+    assert clone_setup._clone_is_quarantined(clone) is True
+
+
+def test_the_quarantine_marker_clears_when_the_clone_is_gone(
+    tmp_path: Path, marker_root: Path
+) -> None:
+    """The guard is scoped to the DIRECTORY it names, which is how it answers "when does it
+    clear": a later successful retirement, or an operator removing the tree, removes the thing
+    the marker names, so nothing is left permanently refusing a name whose bytes are gone. The
+    stale marker is pruned on the way past rather than accumulating one file per clone."""
+    bare = _seeded_bare(tmp_path)
+    root = tmp_path / "root"
+    result, _ = _setup(bare, root)
+    clone = Path(result["clone"])
+    marker = clone_setup._mark_clone_quarantined(clone, "retirement failed")
+    assert marker is not None and clone_setup._clone_is_quarantined(clone) is True
+
+    rmtree_force(clone)
+
+    assert clone_setup._clone_is_quarantined(clone) is False
+    assert not marker.exists(), "the stale marker was not pruned"
+    fresh, err = _setup(bare, root)
+    assert fresh and not err, err
+
+
+def test_the_marker_survives_a_clone_that_cannot_be_written_into(
+    tmp_path: Path, marker_root: Path
+) -> None:
+    """Retirement fails on Windows because a handle is held INSIDE the tree, and that same
+    cause would block a marker written under it -- which is one reason the marker is not a
+    child of the clone. Here the clone directory is made unwritable to stand in for that."""
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    original = clone.stat().st_mode
+    os.chmod(clone, 0o500)
+    try:
+        marker = clone_setup._mark_clone_quarantined(clone, "retirement failed")
+        assert marker is not None, "a read-only clone must not defeat the marker"
+        assert marker.exists()
+        assert clone_setup._clone_is_quarantined(clone) is True
+    finally:
+        os.chmod(clone, original)
+
+
+def test_an_unwritable_marker_root_refuses_every_clone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A root that reads but cannot be written is the one state that fails OPEN otherwise.
+
+    The marking open fails, so nothing is recorded; the reuse check then finds no marker and
+    certifies the clone, with both halves reporting nothing wrong. Proving writability turns
+    that into a refusal, because the root that could not take the write fails the probe.
+    """
+    home = tmp_path / "crewhome"
+    home.mkdir()
+    root = home / clone_setup._QUARANTINE_DIR_LEAF
+    root.mkdir()
+    monkeypatch.setattr(clone_setup, "data_home", lambda: home)
+    original = root.stat().st_mode
+    os.chmod(root, 0o500)
+    try:
+        if os.access(root, os.W_OK):  # pragma: no cover - root or a permissive filesystem
+            pytest.skip("cannot make a directory unwritable for this user")
+        assert clone_setup._quarantine_root() is None
+        assert clone_setup._mark_clone_quarantined(tmp_path, "unwritable root") is None
+        # The clone is NOT certified: a guard that cannot record cannot clear anything.
+        assert clone_setup._clone_is_quarantined(tmp_path) is True
+    finally:
+        os.chmod(root, original)
+
+
+def test_a_clone_is_removed_when_neither_marker_nor_retirement_works(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The canonical name must not survive all three levers.
+
+    Recording a marker and renaming the tree aside fail from independent causes, so either
+    alone suffices. When both fail the clone still sits at the name the next run looks up, so
+    the tree is removed outright -- a destination that exists without a `.git` directory is
+    refused by `_setup_safe_clone`.
+    """
+    from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+    clone = tmp_path / "clone"
+    (clone / ".git").mkdir(parents=True)
+    monkeypatch.setattr(clone_setup, "_mark_clone_quarantined", lambda *_a, **_k: None)
+    monkeypatch.setattr(clone_setup, "_retire_unsafe_clone", lambda _clone: None)
+    # A real Driver without ``__init__``, the convention the dogfood suite uses: a
+    # SimpleNamespace is not a Driver, so mypy rejects it as the self argument.
+    d = object.__new__(D.Driver)
+    d.clone = clone
+    d.log = logging.getLogger("t")
+    d._repository_retired = False
+    monkeypatch.setattr(D.Driver, "_progress", lambda _self, **_k: None)
+
+    D.Driver._quarantine_unrolled_clone(d, "abc0123456")
+
+    assert not clone.exists(), "the clone survived every guard and is still reusable"
 
 
 def test_linked_scratch_root_is_refused_before_mutation(tmp_path: Path) -> None:

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
@@ -117,6 +117,73 @@ class TestMetricDirectionIsPlumbed:
         assert keep_min is False
 
 
+#: The object id every retry-path double reports as the fetched tip. The retry captures that id
+#: from `git fetch --porcelain` STDOUT instead of reading the mutable `FETCH_HEAD` ref:
+#: that ref is a FILE the pre-push reviewer's shell can rewrite between the fetch and the
+#: rebase, which would replay onto a substituted parent whose content nothing scanned. So every
+#: double on this path has to answer the fetch, and one that does not is correctly refused.
+FETCHED_BASE = "ba5e" + "0" * 36
+
+
+def _porcelain_fetch(argv: list[str]) -> "subprocess.CompletedProcess | None":
+    """The `git fetch --porcelain` reply for *argv*, or ``None`` if it is not a fetch.
+
+    Shape measured against real git 2.50: one line per ref, ``<flag> <old-oid> <new-oid>
+    <local-ref>``, and for a `FETCH_HEAD`-style fetch the local-ref column reads ``FETCH_HEAD``
+    while the new-oid column carries the tip. Shared so the doubles state it once.
+    """
+    if argv[:1] != ["fetch"]:
+        return None
+    return subprocess.CompletedProcess(
+        args=argv,
+        returncode=0,
+        stdout=f"* {'0' * 40} {FETCHED_BASE} FETCH_HEAD\n",
+        stderr="",
+    )
+
+
+def _replay_identity(argv: list[str]) -> "subprocess.CompletedProcess | None":
+    """The expected-tree reply for *argv*, or ``None`` if it is not one of those reads.
+
+    Before publishing, the retry checks that the replay carries the tree a replay of the
+    AUTHORIZED source produces, because the id it works from is captured from ambient `HEAD`
+    and a process that moves HEAD before that read has every later check bind to its
+    substitute. Identity of object ids cannot express this -- a replay is a new object -- and
+    a patch identity would ignore hunk positions, so the binding is the tree: the expected one
+    from `merge-tree --write-tree`, the actual one from `log -1 --format=%T`.
+
+    ONE CONSTANT FOR BOTH READS, which is what "the replay carries the authorized content"
+    looks like from here. A double that answered one but not the other would report an empty
+    tree and refuse, so both are stated. Shared so the doubles state it once.
+
+    ATTRIBUTION IS ANSWERED HERE TOO, for the same reason and with the same shape. The retry
+    pins the replay's committer to the identity the authorized object already holds, then
+    compares the replayed commit's author, committer and message against that object's -- so a
+    double that answered neither read would refuse before reaching what its test is about. One
+    constant again: both revisions get the same answer, which is the equal case every test in
+    this class except the attribution one depends on.
+    """
+    if argv[:2] == ["merge-tree", "--write-tree"] or argv[:3] == ["log", "-1", "--format=%T"]:
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout="7ea5" + "0" * 36 + "\n", stderr=""
+        )
+    if argv[:3] == ["log", "-1", "--format=%cn%x00%ce"]:
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout="pipeline\x00pipeline@example.invalid\n", stderr=""
+        )
+    if len(argv) >= 3 and argv[:2] == ["log", "-1"] and argv[2].startswith("--format=%an"):
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout=(
+                "author\x00author@example.invalid\x00pipeline"
+                "\x00pipeline@example.invalid\x00the authorized change\n"
+            ),
+            stderr="",
+        )
+    return None
+
+
 class TestPushRetriesOnRace:
     """3 of 6 gate survivors were lost to a branch that moved mid-run."""
 
@@ -163,21 +230,669 @@ class TestPushRetriesOnRace:
 
         gits: list[list[str]] = []
 
-        def _fake_git(a, cwd):
+        def _fake_git(a, cwd, **_kw):
             gits.append(a)
-            return subprocess.CompletedProcess(args=a, returncode=0, stdout="", stderr="")
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            # The retry resolves the REPLAYED commit to a full object id and pushes THAT
+            # rather than `HEAD`, so the double has to answer that question; an empty
+            # answer is correctly treated as "cannot resolve" and refuses to push.
+            # `rev-list --count FETCH_HEAD..HEAD` proves the rebase replayed exactly ONE
+            # commit: an equivalent upstream patch makes git drop ours, and an
+            # unanswered count is correctly read as "not one" and refuses.
+            if a[:2] == ["rev-list", "--count"]:
+                out = "1\n"
+            elif a[:1] == ["rev-list"]:
+                out = "rebasedsha0000000000000000000000000000\n"
+            else:
+                out = ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
 
         monkeypatch.setattr(D.subprocess, "run", _fake_run)
         monkeypatch.setattr(D, "_git", _fake_git)
         import logging
 
         d = self._driver(tmp_path, logging.getLogger("t"))
-        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        out = D.Driver._push_with_rebase(
+            d, "https://x/y.git", "b", "tgt", src="rebasedsha0000000000000000000000000000"
+        )
         assert out is not None
         assert out.returncode == 0
         assert len(pushes) == 2, "should push, rebase, push again"
-        assert ["fetch", "https://x/y.git", "b"] in gits
-        assert ["rebase", "FETCH_HEAD"] in gits
+        assert ["fetch", "--porcelain", "https://x/y.git", "b"] in gits, (
+            "the fetch must ask for --porcelain: that is where the tip's object id comes from, "
+            "instead of the mutable FETCH_HEAD ref"
+        )
+        # BOTH ends of the rebase are object ids. `rebase FETCH_HEAD` with no revision replays
+        # whatever the BRANCH points at, and that bare form is rejected (`src` is
+        # required); naming FETCH_HEAD as the BASE is a defect, since that ref is a
+        # mutable file the reviewer can repoint at an unscanned commit.
+        assert [
+            "rebase",
+            FETCHED_BASE,
+            "rebasedsha0000000000000000000000000000",
+        ] in gits, gits
+        assert not any(
+            g[:1] == ["rebase"] and "FETCH_HEAD" in g for g in gits
+        ), "the rebase still keys on the mutable FETCH_HEAD ref"
+        # And the retry publishes the REPLAYED OBJECT BY ID, not `HEAD`: a symbolic ref is
+        # resolved by the push itself, i.e. after the re-verify and after the scan.
+        assert "rebasedsha0000000000000000000000000000:refs/heads/b" in pushes[1], pushes[1]
+        assert "HEAD:refs/heads/b" not in pushes[1], pushes[1]
+        # It also REPORTS that object, which is what the caller records in the ledger -- a
+        # post-push `rev-parse HEAD` would name whatever HEAD points at by then.
+        assert d._pushed_object == "rebasedsha0000000000000000000000000000"
+
+    def test_the_retry_refuses_a_replayed_object_that_does_not_scan_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The rebase REPLAYS the commit as a new object, and the caller's credential scan
+        covered the PRE-rebase one -- so without a scan here the retry published an object
+        nothing had ever scanned. A non-fast-forward retry is not an edge case on this path:
+        this class exists because 3 of 6 gate survivors were lost to that race.
+
+        Raised by the GPT review of this branch, which called it the one place the
+        object/ref binding was still broken."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        pushes: list[list[str]] = []
+        gits: list[list[str]] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            rc = 1 if len(pushes) == 1 else 0
+            err = "! [rejected] HEAD -> b (non-fast-forward)" if rc else ""
+            return subprocess.CompletedProcess(args=argv, returncode=rc, stdout="", stderr=err)
+
+        def _fake_git(a, cwd, **_kw):
+            gits.append(a)
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            # The scan reads the pushable OBJECTS, not a rendered diff: `cat-file commit`
+            # for the header bytes, `diff-tree` to list the changed blobs, then
+            # `cat-file blob` for each blob's RAW bytes. The credential is planted in the
+            # blob the listing points at, so it reaches the scanner exactly as the push
+            # would transfer it.
+            blob_sha = "b10b" + "0" * 36
+            if a[:2] == ["cat-file", "commit"]:
+                # Benign, non-empty commit metadata: an empty read would fail closed.
+                return subprocess.CompletedProcess(
+                    args=a,
+                    returncode=0,
+                    stdout="tree 7ea5\nauthor a <a@x> 0 +0000\ncommitter a <a@x> 0 +0000\n\nfix\n",
+                    stderr="",
+                )
+            if a[:1] == ["diff-tree"]:
+                # `:<src mode> <dst mode> <src sha> <dst sha> <status>\t<path>` -- one
+                # modified blob pointing at the credential-bearing object below.
+                return subprocess.CompletedProcess(
+                    args=a,
+                    returncode=0,
+                    stdout=f":100644 100644 {'a' * 40} {blob_sha} M\tapp.py\n",
+                    stderr="",
+                )
+            if a[:2] == ["cat-file", "blob"] and a[2:3] == [blob_sha]:
+                # The REPLAYED object carries a credential the first scan never saw. This
+                # exact form was checked against the real `scan_content_for_secrets`: the
+                # uppercase `AWS_SECRET_ACCESS_KEY = '...'` spelling is NOT flagged, so a
+                # test using it would pass for the wrong reason.
+                return subprocess.CompletedProcess(
+                    args=a, returncode=0, stdout="AWS_KEY = 'AKIAIOSFODNN7EXAMPLE'\n", stderr=""
+                )
+            # `rev-list --count FETCH_HEAD..HEAD` proves the rebase replayed exactly ONE
+            # commit: an equivalent upstream patch makes git drop ours, and an
+            # unanswered count is correctly read as "not one" and refuses.
+            if a[:2] == ["rev-list", "--count"]:
+                out = "1\n"
+            elif a[:1] == ["rev-list"]:
+                out = "rebasedsha0000000000000000000000000000\n"
+            else:
+                out = ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"))
+        out = D.Driver._push_with_rebase(
+            d, "https://x/y.git", "b", "tgt", src="rebasedsha0000000000000000000000000000"
+        )
+
+        assert len(pushes) == 1, "the replayed object was published without scanning clean"
+        assert out is not None and out.returncode == 1, "the original rejection must be returned"
+        # And the branch is NOT promoted onto a replay that failed the scan: promotion belongs
+        # only on the path where every check passed.
+        assert not any(
+            g[:2] == ["branch", "-f"] for g in gits
+        ), "the branch was force-moved onto a replay that did not scan clean"
+
+    def test_the_retry_refuses_when_the_replayed_commit_cannot_be_resolved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        """Fail closed: not being able to name the replacement is the ABSENCE of the check,
+        so it must not fall back to pushing the symbolic ref.
+
+        The MESSAGE is asserted, not just the refusal, because the later HEAD-equality check
+        would also refuse an empty id -- so without pinning which one fired, deleting this
+        check would leave no test red. Same reason the first-push tests assert which of their
+        two identity checks refused."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        pushes: list[list[str]] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            rc = 1 if len(pushes) == 1 else 0
+            err = "(fetch first)" if rc else ""
+            return subprocess.CompletedProcess(args=argv, returncode=rc, stdout="", stderr=err)
+
+        # The pre-fetch tamper read is answered (`src` is required now, so it always runs);
+        # every LATER answer is empty, including the `rev-list` that resolves the replacement.
+        # Both reads are the same argv, so they are told apart by ORDER -- which is also what
+        # makes the message assertion below necessary rather than decorative.
+        reads: list[list[str]] = []
+
+        def _fake_git(a, cwd, **_kw):
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            out = ""
+            if a[:1] == ["rev-list"]:
+                reads.append(a)
+                out = "authorizedsrc00\n" if len(reads) == 1 else ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        log = logging.getLogger("retry-unresolvable")
+        d = TestPushRetriesOnRace._driver(tmp_path, log)
+        with caplog.at_level(logging.ERROR, logger="retry-unresolvable"):
+            out = D.Driver._push_with_rebase(
+                d, "https://x/y.git", "b", "tgt", src="authorizedsrc00"
+            )
+
+        assert len(pushes) == 1, "an unresolvable replacement was published anyway"
+        assert out is not None and out.returncode == 1
+        assert any("cannot resolve the rebased commit" in r.getMessage() for r in caplog.records), [
+            r.getMessage() for r in caplog.records
+        ]
+
+    def test_the_retry_refuses_when_head_moves_while_the_build_gate_runs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`_reverify_head` runs the repository-under-improvement's OWN test suite, so arbitrary
+        code from the tree being published executes inside that call. Resolving the replacement
+        commit AFTER it let a test teardown move HEAD and have the moved object captured,
+        scanned and pushed as though the gate had measured it -- credentials still covered, but
+        nothing had built or tested the thing that landed.
+
+        The replacement is therefore resolved BEFORE the gate and HEAD must still be that
+        object afterwards. Here the gate itself moves HEAD, which is exactly the teardown's
+        capability. Raised by the GPT review of this branch."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        pushes: list[list[str]] = []
+        gate_ran: list[str] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            rc = 1 if len(pushes) == 1 else 0
+            err = "! [rejected] HEAD -> b (non-fast-forward)" if rc else ""
+            return subprocess.CompletedProcess(args=argv, returncode=rc, stdout="", stderr=err)
+
+        def _fake_git(a, cwd, **_kw):
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            out = ""
+            if a[:1] == ["rev-list"]:
+                # Before the gate: the replayed commit. After it: a DIFFERENT object, which is
+                # what a teardown moving HEAD looks like from here.
+                out = "movedsha00000000000000000000000000000\n" if gate_ran else "rebased0000\n"
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"))
+
+        def _gate_that_moves_head(*, worktree, src):
+            gate_ran.append("yes")
+            return SimpleNamespace(passed=True, detail="green", commit_sha="")
+
+        d.profile.build_gate.build_and_test = _gate_that_moves_head  # type: ignore[attr-defined]
+
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="rebased0000")
+
+        assert gate_ran, "the build gate never ran, so nothing was injected"
+        assert len(pushes) == 1, "a tree the gate never measured was published"
+        assert out is not None and out.returncode == 1
+
+    def test_the_retry_refuses_to_rebase_a_head_that_is_no_longer_the_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`git rebase` replays the CURRENT BRANCH, not the revision handed to this method. So
+        if HEAD moved after the caller's checks, the retry would replay the moved commit and
+        then bind its own capture, verify and scan to THAT -- every check passing while the
+        published content never descended from the authorized object. The rebase input is
+        therefore checked first. Raised by the GPT review of this branch."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        pushes: list[list[str]] = []
+        gits: list[list[str]] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            rc = 1 if len(pushes) == 1 else 0
+            err = "(fetch first)" if rc else ""
+            return subprocess.CompletedProcess(args=argv, returncode=rc, stdout="", stderr=err)
+
+        def _fake_git(a, cwd, **_kw):
+            gits.append(a)
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            # HEAD is something OTHER than the authorized source.
+            # `rev-list --count FETCH_HEAD..HEAD` proves the rebase replayed exactly ONE
+            # commit: an equivalent upstream patch makes git drop ours, and an
+            # unanswered count is correctly read as "not one" and refuses.
+            if a[:2] == ["rev-list", "--count"]:
+                out = "1\n"
+            elif a[:1] == ["rev-list"]:
+                out = "movedhead000\n"
+            else:
+                out = ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"))
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="authorized00")
+
+        assert len(pushes) == 1, "a moved HEAD was rebased and republished"
+        assert not any(g[:1] == ["rebase"] for g in gits), "the rebase ran on an unauthorized HEAD"
+        assert not any(g[:1] == ["fetch"] for g in gits), "it should refuse before fetching"
+        assert out is not None and out.returncode == 1
+
+    def test_a_rewritten_fetch_head_cannot_substitute_the_rebase_base(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The base comes from the FETCH's OWN STDOUT, so repointing `FETCH_HEAD` does nothing.
+
+        `FETCH_HEAD` is a mutable FILE in the clone, not a value, and the pre-push reviewer's
+        shell can rewrite it between the fetch and the rebase. Measured on a throwaway repo with
+        a bare remote: with `.git/FETCH_HEAD` rewritten to a prepared child,
+        `rev-list --count FETCH_HEAD..HEAD` still reported 1 while the truth against the real tip
+        was 2, the scanned range held only our own file, and the remote ACCEPTED the push -- the
+        foreign file landed through a scanner that believed it had looked. Both the rebase input
+        and the count read that same name, so they agreed with the substitution instead of
+        catching it. This asserts the id the fetch REPORTED is what both of them use, and that
+        the ref name appears in neither."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        gits: list[list[str]] = []
+        pushes: list[list[str]] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            rc = 1 if len(pushes) == 1 else 0
+            return subprocess.CompletedProcess(
+                args=argv, returncode=rc, stdout="", stderr="(fetch first)" if rc else ""
+            )
+
+        def _fake_git(a, cwd, **_kw):
+            gits.append(a)
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            out = ""
+            if a[:2] == ["rev-list", "--count"]:
+                out = "1\n"
+            elif a[:1] == ["rev-list"]:
+                out = "rebasedsha00\n"
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"))
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="rebasedsha00")
+
+        assert out is not None and out.returncode == 0
+        assert ["rebase", FETCHED_BASE, "rebasedsha00"] in gits, gits
+        assert [
+            "rev-list",
+            "--count",
+            f"{FETCHED_BASE}..rebasedsha00",
+        ] in gits, (
+            "the replayed-commit count must name BOTH captured ids: a `..HEAD` far end resolves "
+            "at read time, after the build gate ran the target repo's own tests, and it is not "
+            "the range the push publishes"
+        )
+        assert not any(
+            g[:2] == ["rev-list", "--count"] and any("HEAD" in f for f in g[2:]) for g in gits
+        ), "the replayed-commit count still has an ambient endpoint"
+        assert not any("FETCH_HEAD" in "".join(g) for g in gits if g[:1] != ["fetch"]), (
+            "something on the retry path still names FETCH_HEAD, so a rewrite of that file "
+            "can still substitute an unscanned parent"
+        )
+
+    def test_the_retry_refuses_when_the_fetch_reports_no_object_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail closed: an id it could not obtain is the absence of the check, not a pass.
+
+        Also covers an older git that does not understand `--porcelain` -- there the fetch fails
+        outright -- and a ref DELETION, which reports the all-zero null id."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        gits: list[list[str]] = []
+        pushes: list[list[str]] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            return subprocess.CompletedProcess(
+                args=argv, returncode=1, stdout="", stderr="(fetch first)"
+            )
+
+        def _fake_git(a, cwd, **_kw):
+            gits.append(a)
+            # The fetch SUCCEEDS but says nothing usable -- the null id of a deleted ref.
+            if a[:1] == ["fetch"]:
+                zero = "0" * 40
+                return subprocess.CompletedProcess(
+                    args=a, returncode=0, stdout=f"- {zero} {zero} FETCH_HEAD\n", stderr=""
+                )
+            out = "rebasedsha00\n" if a[:1] == ["rev-list"] else ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"))
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="rebasedsha00")
+
+        assert out is not None and out.returncode == 1
+        assert len(pushes) == 1, "it published without knowing what it rebased onto"
+        assert not any(g[:1] == ["rebase"] for g in gits), "it rebased onto an unknown base"
+
+    def test_the_retry_replays_the_retained_object_and_only_then_moves_the_branch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`git rebase <base-oid> <rev>` replays an immutable object id ONTO an immutable object
+        id, so nothing that rewrites a ref during the `fetch` can substitute either end. A bare
+        `git rebase FETCH_HEAD` could substitute the replayed side, because it replays whatever
+        the branch points at; naming `FETCH_HEAD` as the BASE could substitute the other side,
+        because that ref is a mutable file the pre-push reviewer can repoint at a commit nothing
+        scanned. This form detaches HEAD, so the branch is promoted onto the result afterwards,
+        and ONLY after re-verification, the HEAD-identity check and the credential scan have
+        passed. Raised by the GPT review of this branch and ruled on by the conductor."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        pushes: list[list[str]] = []
+        gits: list[list[str]] = []
+        order: list[str] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            order.append("push")
+            rc = 1 if len(pushes) == 1 else 0
+            err = "(fetch first)" if rc else ""
+            return subprocess.CompletedProcess(args=argv, returncode=rc, stdout="", stderr=err)
+
+        def _fake_git(a, cwd, **_kw):
+            gits.append(a)
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            order.append(" ".join(a[:2]))
+            # `rev-list --count FETCH_HEAD..HEAD` proves the rebase replayed exactly ONE
+            # commit: an equivalent upstream patch makes git drop ours, and an
+            # unanswered count is correctly read as "not one" and refuses.
+            if a[:2] == ["rev-list", "--count"]:
+                out = "1\n"
+            elif a[:1] == ["rev-list"]:
+                out = "rebasedsha00\n"
+            else:
+                out = ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"))
+
+        def _gate(*, worktree, src):
+            order.append("verify")
+            return SimpleNamespace(passed=True, detail="green", commit_sha="")
+
+        d.profile.build_gate.build_and_test = _gate  # type: ignore[attr-defined]
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="rebasedsha00")
+
+        assert out is not None and out.returncode == 0
+        # The replay names the object, not the ref.
+        assert ["rebase", FETCHED_BASE, "rebasedsha00"] in gits, gits
+        assert not any(
+            g[:1] == ["rebase"] and "FETCH_HEAD" in g for g in gits
+        ), "the rebase base is a mutable ref name, not the id the fetch reported"
+        # The branch is promoted onto the replay, then re-attached.
+        assert ["branch", "-f", "b", "rebasedsha00"] in gits, gits
+        assert ["checkout", "b"] in gits, gits
+        # Ordering is the point: promote only after the gate ran, and before the second push.
+        assert order.index("verify") < order.index("branch -f"), order
+        assert order.index("branch -f") < len(order) - 1, order
+        assert "rebasedsha00:refs/heads/b" in pushes[1], pushes[1]
+
+    def test_a_failed_rebase_leaves_the_branch_alone_and_publishes_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`git branch -f` is only correct when HEAD IS the replayed result. After a rebase
+        that fails, conflicts or aborts, HEAD is something else -- so forcing the branch onto
+        it would publish the wrong tree while the branch looked healthy. The promotion is
+        therefore reached only on the success path; a failure re-attaches without moving
+        anything. Required by the conductor's ruling on this change."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        pushes: list[list[str]] = []
+        gits: list[list[str]] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            return subprocess.CompletedProcess(
+                args=argv, returncode=1, stdout="", stderr="(fetch first)"
+            )
+
+        def _fake_git(a, cwd, **_kw):
+            gits.append(a)
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            if a[:1] == ["rebase"] and a[1:2] != ["--abort"]:
+                return subprocess.CompletedProcess(
+                    args=a, returncode=1, stdout="", stderr="CONFLICT"
+                )
+            # `rev-list --count FETCH_HEAD..HEAD` proves the rebase replayed exactly ONE
+            # commit: an equivalent upstream patch makes git drop ours, and an
+            # unanswered count is correctly read as "not one" and refuses.
+            if a[:2] == ["rev-list", "--count"]:
+                out = "1\n"
+            elif a[:1] == ["rev-list"]:
+                out = "rebasedsha00\n"
+            else:
+                out = ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"))
+        # `src` matches what the double resolves HEAD to, so the pre-rebase tamper check passes
+        # and the flow actually reaches the rebase this test is about.
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="rebasedsha00")
+
+        assert len(pushes) == 1, "a failed rebase still published"
+        assert ["rebase", "--abort"] in gits, "the failed rebase was not aborted"
+        assert not any(
+            g[:2] == ["branch", "-f"] for g in gits
+        ), "the branch was force-moved after a rebase that failed"
+        assert ["checkout", "b"] in gits, "the clone was left detached after the failed rebase"
+        assert out is not None and out.returncode == 1
+
+    def test_the_retry_refuses_when_the_rebase_dropped_the_commit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the remote already carries an equivalent patch, `git rebase` drops ours as
+        already-applied and leaves HEAD at the remote tip. Every check downstream would then
+        bind to THAT, consistently, and the ledger would record an unrelated commit as the one
+        this pipeline landed. So the retry proves exactly one commit was replayed. Raised by
+        the GPT review of this branch."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        pushes: list[list[str]] = []
+        gits: list[list[str]] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            return subprocess.CompletedProcess(
+                args=argv, returncode=1, stdout="", stderr="(fetch first)"
+            )
+
+        def _fake_git(a, cwd, **_kw):
+            gits.append(a)
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            if a[:2] == ["rev-list", "--count"]:
+                out = "0\n"  # the rebase dropped our commit
+            elif a[:1] == ["rev-list"]:
+                out = "rebasedsha00\n"
+            else:
+                out = ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"))
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="rebasedsha00")
+
+        assert len(pushes) == 1, "a dropped commit was published as though it were ours"
+        assert not any(
+            g[:2] == ["branch", "-f"] for g in gits
+        ), "the branch was promoted onto a commit the rebase did not replay"
+        assert out is not None and out.returncode == 1
+
+    def test_a_failed_branch_restore_aborts_the_push(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ref lock or a checkout failure means the repository is not in the state the push
+        assumes -- publishing then leaves the clone detached or its durable branch stale while
+        the remote moves on. The restore's status is therefore checked, not logged. Raised by
+        the GPT review of this branch."""
+        import logging
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        pushes: list[list[str]] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            return subprocess.CompletedProcess(
+                args=argv, returncode=1, stdout="", stderr="(fetch first)"
+            )
+
+        def _fake_git(a, cwd, **_kw):
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            if a[:2] == ["branch", "-f"]:
+                return subprocess.CompletedProcess(
+                    args=a, returncode=1, stdout="", stderr="cannot lock ref"
+                )
+            if a[:2] == ["rev-list", "--count"]:
+                out = "1\n"
+            elif a[:1] == ["rev-list"]:
+                out = "rebasedsha00\n"
+            else:
+                out = ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+
+        d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"))
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="rebasedsha00")
+
+        assert len(pushes) == 1, "the push went ahead despite a failed branch restore"
+        assert out is not None and out.returncode == 1
+
+    def test_every_git_read_here_ignores_replacement_refs(self) -> None:
+        """`git replace` is not on the pre-push reviewer's denylist, and git substitutes
+        replaced objects in READS while the push sends the ORIGINAL -- so any read that a
+        replacement can redirect is a place where what this code inspects and what it
+        publishes come apart. Two instances were found one at a time (the credential scan,
+        then the rebase), so the setting belongs at the single chokepoint every read goes
+        through rather than on the next call someone remembers. Raised by the GPT review."""
+        import inspect
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        src = inspect.getsource(D._git)
+        assert (
+            '"core.useReplaceRefs=false"' in src
+        ), "driver._git no longer disables replacement refs, so a `git replace` can redirect it"
 
     def test_a_non_race_failure_is_not_retried(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -197,7 +912,7 @@ class TestPushRetriesOnRace:
         import logging
 
         d = self._driver(tmp_path, logging.getLogger("t"))
-        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="authorizedsrc00")
         assert out is not None
         assert out.returncode == 1
         assert len(pushes) == 1, "a non-race failure must not be retried"
@@ -216,17 +931,26 @@ class TestPushRetriesOnRace:
                 args=argv, returncode=1, stdout="", stderr="(fetch first)"
             )
 
-        def _fake_git(a, cwd):
+        def _fake_git(a, cwd, **_kw):
             gits.append(a)
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
             rc = 1 if a[:1] == ["rebase"] and a != ["rebase", "--abort"] else 0
-            return subprocess.CompletedProcess(args=a, returncode=rc, stdout="", stderr="")
+            # `src` is required now, so the pre-fetch tamper check ALWAYS runs; answer its read
+            # so the check this test exists to measure is still the one that refuses.
+            out = "authorizedsrc00\n" if a[:1] == ["rev-list"] else ""
+            return subprocess.CompletedProcess(args=a, returncode=rc, stdout=out, stderr="")
 
         monkeypatch.setattr(D.subprocess, "run", _fake_run)
         monkeypatch.setattr(D, "_git", _fake_git)
         import logging
 
         d = self._driver(tmp_path, logging.getLogger("t"))
-        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="authorizedsrc00")
         assert out is not None
         assert out.returncode == 1
         assert ["rebase", "--abort"] in gits, "a conflicted rebase must be aborted"
@@ -268,9 +992,26 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
                 args=argv, returncode=rc, stdout="", stderr="(fetch first)" if rc else ""
             )
 
-        def _fake_git(a, cwd):
+        def _fake_git(a, cwd, **_kw):
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
             order.append(a[0])
-            return subprocess.CompletedProcess(args=a, returncode=0, stdout="", stderr="")
+            # See the sibling class: the retry resolves the replayed commit to a full object
+            # id and pushes THAT, so the double must answer `rev-list`.
+            # `rev-list --count FETCH_HEAD..HEAD` proves the rebase replayed exactly ONE
+            # commit: an equivalent upstream patch makes git drop ours, and an
+            # unanswered count is correctly read as "not one" and refuses.
+            if a[:2] == ["rev-list", "--count"]:
+                out = "1\n"
+            elif a[:1] == ["rev-list"]:
+                out = "rebasedsha0000000000000000000000000000\n"
+            else:
+                out = ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
 
         monkeypatch.setattr(D.subprocess, "run", _fake_run)
         monkeypatch.setattr(D, "_git", _fake_git)
@@ -285,7 +1026,9 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
 
         d.profile.build_gate.build_and_test = _counting_gate  # type: ignore[attr-defined]
 
-        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        out = D.Driver._push_with_rebase(
+            d, "https://x/y.git", "b", "tgt", src="rebasedsha0000000000000000000000000000"
+        )
         assert out is not None
         assert out.returncode == 0
         assert verified == ["gate"], "the rebased tree must be re-verified exactly once"
@@ -319,9 +1062,18 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
 
         gits: list[list[str]] = []
 
-        def _fake_git(args, _cwd):
+        def _fake_git(args, _cwd, **_kw):
             gits.append(args)
-            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+            porcelain = _porcelain_fetch(args)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(args)
+            if identity is not None:
+                return identity
+            # `src` is required now, so the pre-fetch tamper check ALWAYS runs; answer its read
+            # so the check this test exists to measure is still the one that refuses.
+            out = "authorizedsrc00\n" if args[:1] == ["rev-list"] else ""
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=out, stderr="")
 
         monkeypatch.setattr(D.subprocess, "run", _fake_run)
         monkeypatch.setattr(D, "_git", _fake_git)
@@ -330,7 +1082,7 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
         d._repository_retired = False
         d._progress = lambda **_event: None
 
-        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="authorizedsrc00")
 
         assert out is None
         assert retired == [tmp_path / "clone"]
@@ -364,7 +1116,14 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
         monkeypatch.setattr(
             D,
             "_git",
-            lambda args, _cwd: subprocess.CompletedProcess(args, 0, "", ""),
+            # Answers the pre-fetch tamper read, plus the replay-identity and attribution
+            # reads, so the re-verification failure is still what this test measures
+            # (`src` is required now).
+            lambda args, _cwd, **_kw: _porcelain_fetch(args)
+            or _replay_identity(args)
+            or subprocess.CompletedProcess(
+                args, 0, "authorizedsrc00\n" if args[:1] == ["rev-list"] else "", ""
+            ),
         )
         d = TestPushRetriesOnRace._driver(
             tmp_path / "clone", logging.getLogger("t"), reverify=reverify, raises=raises
@@ -373,7 +1132,7 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
         d._repository_retired = False
         d._progress = lambda **_event: None
 
-        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="authorizedsrc00")
 
         assert out is None
         assert d._repository_retired is True
@@ -393,14 +1152,23 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
                 args=argv, returncode=1, stdout="", stderr="(fetch first)"
             )
 
-        def _fake_git(a, cwd):
-            return subprocess.CompletedProcess(args=a, returncode=0, stdout="", stderr="")
+        def _fake_git(a, cwd, **_kw):
+            porcelain = _porcelain_fetch(a)
+            if porcelain is not None:
+                return porcelain
+            identity = _replay_identity(a)
+            if identity is not None:
+                return identity
+            # `src` is required now, so the pre-fetch tamper check ALWAYS runs; answer its read
+            # so the check this test exists to measure is still the one that refuses.
+            out = "authorizedsrc00\n" if a[:1] == ["rev-list"] else ""
+            return subprocess.CompletedProcess(args=a, returncode=0, stdout=out, stderr="")
 
         monkeypatch.setattr(D.subprocess, "run", _fake_run)
         monkeypatch.setattr(D, "_git", _fake_git)
 
         d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"), reverify=False)
-        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="authorizedsrc00")
         assert out is not None
         assert out.returncode == 1, "the original rejection is returned"
         assert len(pushes) == 1, "an unverified rebased tree must never be pushed"
@@ -423,11 +1191,19 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
         monkeypatch.setattr(
             D,
             "_git",
-            lambda a, cwd: subprocess.CompletedProcess(args=a, returncode=0, stdout="", stderr=""),
+            # Answers the pre-fetch tamper read so the RAISING gate is still what this
+            # test measures (`src` is required now).
+            lambda a, cwd, **_kw: _porcelain_fetch(a)
+            or subprocess.CompletedProcess(
+                args=a,
+                returncode=0,
+                stdout="authorizedsrc00\n" if a[:1] == ["rev-list"] else "",
+                stderr="",
+            ),
         )
 
         d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"), raises=True)
-        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt", src="authorizedsrc00")
         assert out is not None
         assert out.returncode == 1
         assert len(pushes) == 1, "a gate that raised must not be read as a pass"
@@ -438,6 +1214,12 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
         Measured on a real repo: ``eb828444`` before the rebase, ``11aff54a`` after. The
         pre-fix ledger row said ``cr=eb828444`` — a sha nowhere in the remote's history,
         so anyone auditing "what did the bot land?" chases a commit that does not exist.
+
+        The FIX for that was originally a post-push ``rev-parse HEAD``, which this asserted.
+        That read was itself the same defect one step later: HEAD can move between the push
+        and the read, so the ledger could name an unrelated commit for a change that really
+        did land. The publish helper now REPORTS the object it sent, and that is what gets
+        recorded -- an id, not a re-read ref.
         """
         import inspect
 
@@ -445,7 +1227,19 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
 
         push_src = inspect.getsource(Driver._direct_push)
         assert "pushed_sha" in push_src, "_direct_push must publish the landed sha"
-        assert "rev-parse" in push_src, "the landed sha must be read back from the clone"
+        assert (
+            "_pushed_object" in push_src
+        ), "the landed sha must be the object the push REPORTED sending, not a re-read ref"
+        assert (
+            "rev-parse" not in push_src.split("pushed_sha")[-1]
+        ), "a ref is re-read after the push again -- HEAD can move in between"
+        # And no fallback to the caller's pre-push snapshot. That fallback was unreachable --
+        # the only return preceding `_pushed_object = src` routes to `_direct_push`'s own
+        # `return None` -- and its stated reason ("callers that do not pass an explicit source")
+        # described callers that do not exist once `src` became required.
+        assert (
+            "self.pushed_sha = sent\n" in push_src
+        ), "the recorded sha has a fallback again; it must be the object the push reported"
 
         body = inspect.getsource(Driver)
         for site in ("direct-pushed to {self.branch}", "direct-pushed bug fix to {self.branch}"):
@@ -5145,6 +5939,62 @@ class TestRepoControlledGitHooksDoNotExecuteHostSide:
             "would execute host-side"
         )
 
+    def test_the_publish_helper_has_no_symbolic_source_default(self) -> None:
+        """`src` must be REQUIRED, so no caller can publish a symbolic ref by omission.
+
+        It shipped as `src: str = "HEAD"` "for callers that have nothing more specific". There
+        were none: one production caller, which resolves the committed object and passes it.
+        The default kept three arms alive that fired only for a symbolic source -- skipping the
+        pre-fetch tamper check, replaying the BRANCH instead of the object, and re-reading HEAD
+        after the push for the ledger. Each was the check-then-use shape this whole change
+        exists to remove, reachable by anyone who later added a caller and omitted the argument.
+        A default is invisible at the call site, which is why this is pinned on the SIGNATURE:
+        reviving it changes nothing observable until someone omits the argument, and then it
+        changes what gets published. Asked for by the first-principles review, which wanted the
+        subtraction rather than a fourth guard."""
+        import inspect
+
+        from kiro_crew.apps.builtins.auto_improvement.spine.driver import Driver
+
+        param = inspect.signature(Driver._push_with_rebase).parameters["src"]
+        assert (
+            param.default is inspect.Parameter.empty
+        ), f"`src` has a default again ({param.default!r}) -- a symbolic source is publishable"
+        body = inspect.getsource(Driver._push_with_rebase)
+        assert '"HEAD"' not in body, "a `HEAD` literal is back in the publish helper"
+
+    def test_the_replay_is_authorized_against_an_exact_tree(self) -> None:
+        """The publish gate must compare TREES, never a patch identity.
+
+        `git patch-id` ignores hunk positions -- that is what lets it recognise a change
+        replayed onto a moved base -- so a commit whose added and removed lines match the
+        authorized change while sitting elsewhere in the file carries the same identity. A
+        tree names the exact content of every path, so relocation is a different tree.
+
+        Pinned on the SOURCE because the failure is silent. Both forms produce a well-formed
+        value, the gate keeps passing honest replays, and nothing observable changes until a
+        relocated substitution arrives -- there is no behavioural test that fails if this
+        regresses to a patch identity. Raised by the GPT review.
+        """
+        import inspect
+
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        body = inspect.getsource(D._expected_replay_tree)
+        assert '"merge-tree", "--write-tree"' in body, (
+            "_expected_replay_tree no longer states the expected tree from the two immutable "
+            "ids, so the replay is not bound to the authorized content"
+        )
+        gate = inspect.getsource(D.Driver._push_with_rebase)
+        assert "_expected_replay_tree(base, src" in gate, "the publish gate lost the tree check"
+        assert "_commit_tree(rebased_id" in gate, "the gate no longer reads the replay's tree"
+        # The ARGV element, not the word: the comments here name patch-id to explain why a
+        # tree is used instead, and flagging prose would make this assertion unmaintainable.
+        assert '"patch-id"' not in gate and '"patch-id"' not in body, (
+            "a patch identity is back in the publish path; it ignores hunk positions, so the "
+            "same lines relocated would authorize"
+        )
+
     def test_the_post_agent_status_probes_are_hardened(self) -> None:
         """`author_bug_fix`/`author_perf_fix` run `git status --porcelain` on the HOST right
         after the agent turn to see whether it produced work. `git status` consults (and can
@@ -6922,3 +7772,602 @@ class TestBugPrRecordsTheTestedBaseNotTheFix:
         assert "base_anchor=f\"{self.branch} @ {base_sha[:12]}\"" in src, (
             "the perf path's base anchor changed shape — it must keep using base_sha"
         )
+
+
+class TestOnlyTheCommitThePipelineMadeIsPublished:
+    """Only the commit the pipeline made is published: do not push what a worker did not commit.
+
+    The direct push sent ``HEAD:refs/heads/<dest>`` while the pipeline verified, measured
+    and recorded ONE specific commit. Between the two sits the pre-push review gate, which
+    runs an agent in the SAME clone with ``Bash`` for up to 30 turns, and whose git denylist
+    covers only ``push`` and ``remote set-url`` -- so ``git commit --amend`` is permitted there.
+    That prompt is now report-only and its ``Edit`` grant is withdrawn, but neither is an
+    enforcement boundary: a prompt is an instruction, and a shell can write files whatever the
+    tool list says. Nothing compared the published commit against the verified one, so "what the
+    pipeline verified" and "what got pushed" could come apart with nothing flagging it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _safe_repository(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+        monkeypatch.setattr(clone_setup, "_push_disabled", lambda _clone: True)
+        monkeypatch.setattr(clone_setup, "_repository_is_isolated", lambda _clone: True)
+
+    def test_the_report_only_reviewer_has_no_edit_grant(self) -> None:
+        """The prompt lost the sentence sanctioning an in-place fix; the CAPABILITY has to go
+        with it. What decides whether a reviewer can modify the clone is the tool list, not the
+        prose telling it what to do, so removing the instruction while keeping `Edit` leaves a
+        reviewer that may still edit with no sanctioned reason to -- a grant with no consumer.
+
+        This is least privilege, not the boundary: `Bash` stays, because the review has to run
+        git to read the diff, and a shell can write files and commit. The boundary is the
+        identity check that compares the published object against the verified one -- which is
+        why this test asserts the grant is gone AND that the check is still what refuses a moved
+        HEAD. Raised by the first-principles review of this branch."""
+        import inspect
+
+        from kiro_crew.apps.builtins.auto_improvement.spine.driver import Driver
+
+        src = inspect.getsource(Driver._prepush_review_clean)
+        assert '"Edit"' not in src, "the report-only reviewer may still edit the clone"
+        assert '"Write"' not in src, "an edit-capable grant came back under another name"
+        assert '"Bash"' in src, (
+            "the review needs a shell to read the diff; removing it would make the gate "
+            "vacuous rather than safer"
+        )
+
+    @staticmethod
+    def _repo(tmp_path: Path) -> tuple[Path, str]:
+        """A real one-commit clone; returns ``(clone, full 40-hex object id)``.
+
+        REAL git rather than a stubbed ``_git``: the publish path validates that its anchor
+        is a full forty-hex object id and refuses anything else, and a stub cannot exercise
+        that -- a text comparison would pass against canned output while refusing every real
+        push. The anchor is the id ``git rev-parse HEAD`` produces, never an abbreviation.
+        """
+        clone = tmp_path / "clone"
+        clone.mkdir()
+
+        def git(*args: str) -> str:
+            done = subprocess.run(
+                ["git", "-C", str(clone), *args],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                cwd=clone,
+                check=True,
+            )
+            return done.stdout.strip()
+
+        git("init", "-q", "-b", "work")
+        git("config", "user.email", "pipeline@example.invalid")
+        git("config", "user.name", "pipeline")
+        git("config", "commit.gpgsign", "false")
+        (clone / "f.py").write_text("def g():\n    return 2\n", encoding="utf-8")
+        git("add", "f.py")
+        git("commit", "-q", "-m", "the verified change")
+        return clone, git("rev-parse", "HEAD")
+
+    @staticmethod
+    def _driver(clone: Path, reviewer: object):  # type: ignore[no-untyped-def]
+        """A Driver whose only stub is the PUBLISH call, so the gate itself stays real.
+
+        ``_push_with_rebase`` is recorded rather than executed: it is what publishing IS,
+        and the gate under test sits upstream of it. Everything the gate reads -- the clone,
+        its git, the abbreviated sha -- is real.
+        """
+        from kiro_crew.apps.builtins.auto_improvement.spine.driver import Driver
+
+        recorded: list = []
+        publishes: list[tuple[str, str, str, str]] = []
+
+        def _publish(  # type: ignore[no-untyped-def]
+            fetch_url: str, dest: str, target: str, src: str = "HEAD"
+        ):
+            # `src` is recorded, not ignored: WHICH REVISION is handed to the push is the
+            # whole subject of this class, so a spy that dropped it could not tell publishing the
+            # verified object from publishing whatever `HEAD` happens to be.
+            publishes.append((fetch_url, dest, target, src))
+            return subprocess.CompletedProcess(args=["push"], returncode=0, stdout="", stderr="")
+
+        d = object.__new__(Driver)
+        d.clone = clone  # type: ignore[attr-defined]
+        d.log = logging.getLogger("t")  # type: ignore[attr-defined]
+        d.branch = "work"  # type: ignore[attr-defined]
+        d.direct_commit = True  # type: ignore[attr-defined]
+        d.prepush_review = reviewer is not None  # type: ignore[attr-defined]
+        d._agent_runner = reviewer  # type: ignore[attr-defined]
+        d.pushed_sha = ""  # type: ignore[attr-defined]
+        d.ledger = SimpleNamespace(record=recorded.append)  # type: ignore[assignment]
+        d.profile = SimpleNamespace(  # type: ignore[attr-defined]
+            pr_recipe=SimpleNamespace(fetch_url="https://example.invalid/y.git"),
+        )
+        d._push_with_rebase = _publish  # type: ignore[method-assign]
+        return d, recorded, publishes
+
+    def test_a_reviewer_amend_between_commit_and_push_refuses_to_publish(
+        self, tmp_path: Path
+    ) -> None:
+        """The real fault at the real seam: the pre-push reviewer amends the clone."""
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        clone, verified = self._repo(tmp_path)
+
+        class _AmendingReviewer:
+            """Takes the pre-push prompt's own invitation to edit the clone."""
+
+            def run(self, _prompt: str, **_kw: object):  # type: ignore[no-untyped-def]
+                (clone / "f.py").write_text("def g():\n    return 99\n", encoding="utf-8")
+                subprocess.run(["git", "-C", str(clone), "add", "f.py"], cwd=clone, check=True)
+                subprocess.run(
+                    ["git", "-C", str(clone), "commit", "-q", "--amend", "--no-edit"],
+                    cwd=clone,
+                    check=True,
+                )
+                return SimpleNamespace(text="REVIEW: clean")
+
+        d, recorded, publishes = self._driver(clone, _AmendingReviewer())
+        out = D.Driver._direct_push(d, fp="fp", kind="bug", target="tgt", sha=verified)
+
+        # The injection APPLIED: an assertion about a fault that never occurred is vacuous.
+        head_now = subprocess.run(
+            ["git", "-C", str(clone), "rev-list", "-1", "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout.strip()
+        assert head_now != verified, "the reviewer stub did not move HEAD"
+
+        assert out is False
+        assert publishes == [], "a commit the pipeline never verified must not be published"
+        notes = [getattr(e, "note", "") for e in recorded]
+        # Pin WHICH gate refused. There are two identity checks -- one before the credential
+        # scan, one after it -- and the later one would absorb this case silently if the
+        # earlier one were removed, so asserting only "HEAD moved" would leave the pre-scan
+        # gate unmeasured. It must be the PRE-SCAN one: an amend during the review has
+        # already happened by then, and refusing before the scan means the scanner never
+        # reads a substituted commit and the recorded reason is the true one rather than
+        # whatever that commit's content happens to trip.
+        assert any(n.startswith("direct-push refused: HEAD moved") for n in notes), notes
+        assert not any("after the scan" in n for n in notes), notes
+
+    def test_an_unmoved_head_still_publishes(self, tmp_path: Path) -> None:
+        """The accepting case: a gate with no reachable yes is an outage, not a guard, and
+        only this direction can tell the two apart."""
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        clone, verified = self._repo(tmp_path)
+
+        class _CleanReviewer:
+            def run(self, _prompt: str, **_kw: object):  # type: ignore[no-untyped-def]
+                return SimpleNamespace(text="REVIEW: clean")
+
+        d, recorded, publishes = self._driver(clone, _CleanReviewer())
+        out = D.Driver._direct_push(d, fp="fp", kind="bug", target="tgt", sha=verified)
+        assert out is True, [getattr(e, "note", "") for e in recorded]
+        assert len(publishes) == 1
+        assert publishes[0][1] == "work"
+        # It publishes the FULL OBJECT ID, not `HEAD`. A symbolic ref is resolved by the push
+        # itself, which is after every check; an id names one immutable commit.
+        full = subprocess.run(
+            ["git", "-C", str(clone), "rev-list", "-1", "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout.strip()
+        assert publishes[0][3] == full, publishes[0]
+        assert publishes[0][3] != "HEAD"
+
+    def test_a_move_after_the_scan_cannot_change_what_is_published(self, tmp_path: Path) -> None:
+        """The residual time-of-check/time-of-use window: the identity check passes, and only
+        THEN do the credential scan and the push run. Re-reading ``HEAD`` at each step opens
+        this window: a background process the reviewer left behind could move it in between --
+        the scan would read one commit and the push would publish another, neither of them
+        verified.
+
+        Two things close it, and this test pins both. The push is handed the retained OBJECT
+        ID, which cannot be repointed. And the identity is re-checked after the scan, so a
+        move during the scan window is refused rather than published unscanned. Here the move
+        is injected by the credential scanner itself, which is the last thing to run before
+        the push. Raised by the GPT review of this branch."""
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        clone, verified = self._repo(tmp_path)
+
+        class _CleanReviewer:
+            def run(self, _prompt: str, **_kw: object):  # type: ignore[no-untyped-def]
+                return SimpleNamespace(text="REVIEW: clean")
+
+        d, recorded, publishes = self._driver(clone, _CleanReviewer())
+        before = subprocess.run(
+            ["git", "-C", str(clone), "rev-list", "-1", "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout.strip()
+
+        def _scan_then_amend(_blob: str):  # type: ignore[no-untyped-def]
+            """Stands in for a background amend landing while the scan runs."""
+            (clone / "f.py").write_text("def g():\n    return 99\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(clone), "add", "f.py"], cwd=clone, check=True)
+            subprocess.run(
+                ["git", "-C", str(clone), "commit", "-q", "--amend", "--no-edit"],
+                cwd=clone,
+                check=True,
+            )
+            return True, 0
+
+        # Patched on `push_policy`, not on `driver`: `_direct_push` imports the scanner
+        # INSIDE the function, so the name it binds is looked up on the source module at
+        # call time and a `driver`-level attribute would never be consulted.
+        from kiro_crew.apps.builtins.auto_improvement.spine import push_policy as PP
+
+        monkey = PP.scan_content_for_secrets
+        try:
+            PP.scan_content_for_secrets = _scan_then_amend  # type: ignore[assignment]
+            out = D.Driver._direct_push(d, fp="fp", kind="bug", target="tgt", sha=verified)
+        finally:
+            PP.scan_content_for_secrets = monkey  # type: ignore[assignment]
+
+        after = subprocess.run(
+            ["git", "-C", str(clone), "rev-list", "-1", "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout.strip()
+        assert after != before, "the injected move did not apply, so this proves nothing"
+
+        assert out is False
+        assert publishes == [], "a move during the scan window must not reach the push"
+        notes = [getattr(e, "note", "") for e in recorded]
+        assert any("after the scan" in n for n in notes), notes
+
+    def test_the_credential_scan_reads_the_committed_object_not_head(self, tmp_path: Path) -> None:
+        """The scan must read the object that gets published, bound by ID rather than by
+        timing. While it read ``HEAD``, a concurrent writer in the clone could point HEAD at a
+        clean decoy for the duration of the ``git diff`` and restore it afterwards: the
+        scanner saw the decoy, every identity check still passed, and the real commit was
+        published having never been scanned. A later re-check cannot close that -- it is
+        itself a check-then-use pair -- so the range is the object id.
+
+        The move is injected here between the pre-scan gate and the scan, which is exactly the
+        window a backgrounded process would use. Raised by the GPT review of this branch."""
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+        from kiro_crew.apps.builtins.auto_improvement.spine import push_policy as PP
+
+        clone, verified = self._repo(tmp_path)
+
+        class _CleanReviewer:
+            def run(self, _prompt: str, **_kw: object):  # type: ignore[no-untyped-def]
+                return SimpleNamespace(text="REVIEW: clean")
+
+        d, recorded, publishes = self._driver(clone, _CleanReviewer())
+        # The move must land INSIDE the window -- after the pre-scan gate, before the scan --
+        # so the seam is the gate's own return. Two seams were tried and rejected:
+        # `driver.normalize_branch` is imported INSIDE `_direct_push`, so patching it on the
+        # driver module is inert (the injection never fired and this test passed against a
+        # deliberately broken gate -- caught by the mutation, not by the green run); patching
+        # it on `push_policy` fires too EARLY, because `authorize_direct_push` calls it before
+        # the gate, which refuses and the scan never runs.
+        real_gate = D.Driver._head_is_the_committed_sha
+        real_scan = PP.scan_content_for_secrets
+        scanned: list[str] = []
+        gate_calls: list[int] = []
+
+        def _gate_then_swap_head(committed_id: str):  # type: ignore[no-untyped-def]
+            out = real_gate(d, committed_id)
+            gate_calls.append(1)
+            if len(gate_calls) == 1:  # only after the PRE-scan gate, not the post-scan one
+                (clone / "f.py").write_text("def g():\n    return 99\n", encoding="utf-8")
+                subprocess.run(["git", "-C", str(clone), "add", "f.py"], cwd=clone, check=True)
+                subprocess.run(
+                    ["git", "-C", str(clone), "commit", "-q", "--amend", "--no-edit"],
+                    cwd=clone,
+                    check=True,
+                )
+            return out
+
+        def _record(blob: str):  # type: ignore[no-untyped-def]
+            scanned.append(blob)
+            return True, 0
+
+        d._head_is_the_committed_sha = _gate_then_swap_head  # type: ignore[method-assign]
+        try:
+            PP.scan_content_for_secrets = _record  # type: ignore[assignment]
+            D.Driver._direct_push(d, fp="fp", kind="bug", target="tgt", sha=verified)
+        finally:
+            PP.scan_content_for_secrets = real_scan  # type: ignore[assignment]
+
+        head_now = subprocess.run(
+            ["git", "-C", str(clone), "rev-list", "-1", "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout.strip()
+        original = subprocess.run(
+            ["git", "-C", str(clone), "rev-list", "-1", f"{verified}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout.strip()
+        assert gate_calls, "the pre-scan gate never ran, so nothing was injected"
+        assert head_now != original, "the injection did not move HEAD, so this proves nothing"
+        assert scanned, "the credential scan never ran, so this proves nothing"
+        # The scan reads the commit OBJECT and its tree content as separate passes, so the
+        # assertion covers everything handed to the scanner rather than one pass by index.
+        blob = "\n".join(scanned)
+        assert "return 2" in blob, f"the scan did not read the verified object: {blob!r}"
+        assert "return 99" not in blob, f"the scan read the decoy at HEAD instead: {blob!r}"
+
+    def test_a_ref_named_the_abbreviation_cannot_shadow_the_committed_object(
+        self, tmp_path: Path
+    ) -> None:
+        """The anchor is a full object id from the start, so no abbreviation is ever resolved
+        and there is no second reading for a ref to capture. Git resolves a revision through
+        ref names before abbreviated object ids, so if the anchor were a short sha a reviewer
+        could amend and then create a branch named that short sha, and a late re-resolution
+        would point at the amended HEAD -- both sides equal, gate satisfied, unverified commit
+        published. Two things now hold. A planted ref named the short sha changes nothing,
+        because the publish path anchors on the full id the finalizer produced. And a short
+        sha handed in as the anchor is REFUSED rather than resolved, so the abbreviation never
+        becomes a lookup a ref could shadow."""
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        clone, verified = self._repo(tmp_path)
+        short = subprocess.run(
+            ["git", "-C", str(clone), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout.strip()
+
+        class _ShadowingReviewer:
+            """Amends, then points a ref named the OLD short sha at the new commit."""
+
+            def run(self, _prompt: str, **_kw: object):  # type: ignore[no-untyped-def]
+                (clone / "f.py").write_text("def g():\n    return 99\n", encoding="utf-8")
+                subprocess.run(["git", "-C", str(clone), "add", "f.py"], cwd=clone, check=True)
+                subprocess.run(
+                    ["git", "-C", str(clone), "commit", "-q", "--amend", "--no-edit"],
+                    cwd=clone,
+                    check=True,
+                )
+                subprocess.run(
+                    ["git", "-C", str(clone), "branch", short, "HEAD"],
+                    cwd=clone,
+                    check=True,
+                )
+                return SimpleNamespace(text="REVIEW: clean")
+
+        d, recorded, publishes = self._driver(clone, _ShadowingReviewer())
+        out = D.Driver._direct_push(d, fp="fp", kind="bug", target="tgt", sha=verified)
+
+        # Both halves of the injection APPLIED: the ref named the short sha exists AND it
+        # resolves to the amended commit, which is what would defeat a late re-resolution of
+        # an abbreviation.
+        shadow = subprocess.run(
+            ["git", "-C", str(clone), "rev-list", "-1", f"{short}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout.strip()
+        head = subprocess.run(
+            ["git", "-C", str(clone), "rev-list", "-1", "HEAD^{commit}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout.strip()
+        assert shadow == head, "the shadow ref did not capture the abbreviation"
+
+        # The anchor is the full id, so the planted ref changes nothing: the gate compares the
+        # full id against the amended HEAD, they differ, and the publish is refused.
+        assert out is False
+        assert publishes == [], "a shadowed abbreviation must not authorize a publish"
+        notes = [getattr(e, "note", "") for e in recorded]
+        # The PRE-SCAN gate must be the one that refuses: the post-scan re-check would
+        # otherwise absorb this case and leave the pre-scan gate unmeasured.
+        assert any(n.startswith("direct-push refused: HEAD moved") for n in notes), notes
+        assert not any("after the scan" in n for n in notes), notes
+
+        # And the new validation: a SHORT sha handed in as the anchor is refused rather than
+        # resolved, so an abbreviation never becomes a lookup a ref could shadow. A fresh clone
+        # keeps the reviewer from mattering here -- the point is the anchor's shape.
+        second = tmp_path / "second"
+        second.mkdir()
+        clean_clone, _full = self._repo(second)
+        clean_short = subprocess.run(
+            ["git", "-C", str(clean_clone), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clean_clone,
+            check=True,
+        ).stdout.strip()
+
+        class _CleanReviewer:
+            def run(self, _prompt: str, **_kw: object):  # type: ignore[no-untyped-def]
+                return SimpleNamespace(text="REVIEW: clean")
+
+        d2, recorded2, publishes2 = self._driver(clean_clone, _CleanReviewer())
+        out2 = D.Driver._direct_push(d2, fp="fp", kind="bug", target="tgt", sha=clean_short)
+        assert out2 is False, "a short sha anchor was resolved instead of refused"
+        assert publishes2 == [], "a short sha anchor must not authorize a publish"
+        notes2 = [getattr(e, "note", "") for e in recorded2]
+        assert any(n.startswith("direct-push refused: cannot resolve") for n in notes2), notes2
+
+    def test_a_replacement_ref_cannot_substitute_what_the_scan_reads(self, tmp_path: Path) -> None:
+        """Git substitutes objects named by ``refs/replace/<oid>`` transparently in READS --
+        ``diff`` and ``show`` included -- while the push transport sends the ORIGINAL object.
+        A reviewer can run ``git replace`` (its runner's denylist covers only ``push`` and
+        ``remote set-url``), point a replacement at clean content, and have the credential
+        scan read the decoy while the real object is transferred. The scan therefore reads
+        with replace refs disabled. Real git, because this is git behaviour rather than
+        anything a stub could express. Raised by the GPT review of this branch."""
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+        from kiro_crew.apps.builtins.auto_improvement.spine import push_policy as PP
+
+        clone, verified = self._repo(tmp_path)
+
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", "-C", str(clone), *args],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                cwd=clone,
+                check=True,
+            ).stdout.strip()
+
+        # A DECOY commit with clean-looking content, then a replacement ref pointing the
+        # verified object at it.
+        original_id = git("rev-list", "-1", f"{verified}^{{commit}}")
+        git("checkout", "-q", "--detach", original_id)
+        (clone / "f.py").write_text("def g():\n    return 777\n", encoding="utf-8")
+        git("add", "f.py")
+        git("commit", "-q", "--amend", "--no-edit")
+        decoy_id = git("rev-list", "-1", "HEAD^{commit}")
+        git("checkout", "-q", "work")
+        git("replace", "-f", original_id, decoy_id)
+        assert git("rev-parse", "--verify", f"refs/replace/{original_id}"), "no replacement ref"
+
+        class _CleanReviewer:
+            def run(self, _prompt: str, **_kw: object):  # type: ignore[no-untyped-def]
+                return SimpleNamespace(text="REVIEW: clean")
+
+        d, recorded, publishes = self._driver(clone, _CleanReviewer())
+        real_scan = PP.scan_content_for_secrets
+        scanned: list[str] = []
+
+        def _record(blob: str):  # type: ignore[no-untyped-def]
+            scanned.append(blob)
+            return True, 0
+
+        try:
+            PP.scan_content_for_secrets = _record  # type: ignore[assignment]
+            D.Driver._direct_push(d, fp="fp", kind="bug", target="tgt", sha=verified)
+        finally:
+            PP.scan_content_for_secrets = real_scan  # type: ignore[assignment]
+
+        # Control: the replacement really is in effect for an ordinary read.
+        replaced_read = subprocess.run(
+            ["git", "-C", str(clone), "show", "--format=", "--root", original_id],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout
+        assert (
+            "777" in replaced_read
+        ), "the replacement ref is not in effect, so this proves nothing"
+
+        assert scanned, "the credential scan never ran"
+        # The scan reads the commit OBJECT and its tree content as separate passes, so the
+        # assertion covers everything handed to the scanner rather than one pass by index.
+        blob = "\n".join(scanned)
+        assert "return 2" in blob, f"the scan read the replacement, not the real object: {blob!r}"
+        assert "return 777" not in blob, f"the scan read the substituted content: {blob!r}"
+
+    def test_an_unresolvable_committed_revision_fails_closed(self, tmp_path: Path) -> None:
+        """Not being able to look must not read as having looked and found nothing wrong:
+        an amended-away commit can be pruned, which is exactly when this check matters
+        most."""
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        clone, _verified = self._repo(tmp_path)
+
+        class _CleanReviewer:
+            def run(self, _prompt: str, **_kw: object):  # type: ignore[no-untyped-def]
+                return SimpleNamespace(text="REVIEW: clean")
+
+        d, recorded, publishes = self._driver(clone, _CleanReviewer())
+        out = D.Driver._direct_push(d, fp="fp", kind="bug", target="tgt", sha="0" * 12)
+        assert out is False
+        assert publishes == []
+        notes = [getattr(e, "note", "") for e in recorded]
+        # Pre-scan gate again: an unresolvable object should stop the push before the
+        # credential scan spends a git diff on a revision that does not exist.
+        assert any(n.startswith("direct-push refused: cannot resolve") for n in notes), notes
+        assert not any("after the scan" in n for n in notes), notes
+
+    def test_a_credential_in_the_committer_identity_refuses_to_publish(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A commit carries HEADER BYTES as well as content, and the push transfers both.
+
+        `git rebase` takes the committer identity from CONFIGURATION rather than from the
+        commit it replays, so a process able to write the clone's git config chooses those
+        bytes -- the same actor this path already refuses to trust for `git replace`, whose
+        runner denylist covers only `push` and `remote set-url`. A scan reading only the tree
+        diff cannot see them, and the root-commit branch suppresses headers outright with
+        `--format=`, so a key-shaped identity would reach the remote unread. Exposure to a
+        remote is not recoverable, which is why this fails closed rather than warning.
+
+        The plant goes through the ENVIRONMENT here because this suite's conftest pins
+        ``GIT_COMMITTER_EMAIL`` for hermetic runs and that takes precedence over config. Which
+        of the two carries it is incidental to what is being proved: the bytes land in the
+        commit object either way, and the question is whether the scanner reads them.
+        """
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        clone, _verified = self._repo(tmp_path)
+
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", "-C", str(clone), *args],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                cwd=clone,
+                check=True,
+            ).stdout.strip()
+
+        # The tree content stays CLEAN; only the identity is poisoned. A commit that carried
+        # the key in its content would be caught by the pre-existing content scan and would
+        # prove nothing about metadata.
+        (clone / "f.py").write_text("def g():\n    return 3\n", encoding="utf-8")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "AKIAIOSFODNN7EXAMPLE@example.invalid")
+        git("add", "f.py")
+        git("commit", "-q", "-m", "a clean-looking change")
+        poisoned = git("rev-parse", "HEAD")
+
+        # Control 1: the identity really did land in the object's committer line.
+        raw = git("cat-file", "commit", poisoned)
+        assert "AKIAIOSFODNN7EXAMPLE" in raw, f"the identity did not reach the object: {raw!r}"
+
+        # Control 2: the TREE DIFF is clean, so a refusal cannot come from the content path.
+        # Without this the test would pass even if metadata were still unscanned.
+        diff_only = subprocess.run(
+            ["git", "-C", str(clone), "diff", "--no-ext-diff", f"{poisoned}~1..{poisoned}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=clone,
+            check=True,
+        ).stdout
+        assert "AKIAIOSFODNN7EXAMPLE" not in diff_only, "the content path would catch this"
+
+        d = object.__new__(D.Driver)
+        d.clone = clone  # type: ignore[attr-defined]
+        clean, note = D.Driver._revision_scans_clean(d, poisoned)
+        assert clean is False, "a credential in the committer identity was scanned as clean"
+        # The note is a fixed literal from `describe_scan`, so nothing scanned reaches a log.
+        assert "AKIAIOSFODNN7EXAMPLE" not in note, note

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
@@ -519,21 +519,45 @@ class TestEveryPushPathScansContent:
 
     def test_the_shared_scanner_is_the_single_implementation(self) -> None:
         """Each push path must call ``push_policy.scan_content_for_secrets``, not its own
-        copy — three drifting copies is how one of them ends up without the fix."""
+        copy -- three drifting copies is how one of them ends up without the fix.
+
+        Every path also clears the external diff helper (``diff.external=``) on the git
+        read it scans, so a repository-writable ``diff.external`` cannot run an attacker
+        binary in place of the read. The two paths that render a human diff also pass
+        ``--no-ext-diff`` for the same reason; the driver reads objects with ``cat-file``
+        instead of rendering a diff, so it carries no ``--no-ext-diff`` and must render no
+        ``git diff`` at all.
+        """
         from pathlib import Path
 
         root = Path(__file__).resolve().parent.parent
-        for rel in (
-            "profiles/github_repo/pr_recipe.py",
-            "spine/driver.py",
-            "backend/commit.py",
+        # ``renders_diff`` says whether the path scans rendered ``git diff`` output (and so
+        # must neutralize the external helper with ``--no-ext-diff``) or reads objects
+        # directly (and so must not render a diff to scan).
+        for rel, renders_diff in (
+            ("profiles/github_repo/pr_recipe.py", True),
+            ("spine/driver.py", False),
+            ("backend/commit.py", True),
         ):
             src = (root / rel).read_text(encoding="utf-8")
             assert "scan_content_for_secrets" in src, f"{rel} does not scan pushed content"
-            assert "--no-ext-diff" in src, f"{rel} permits external diff execution"
             assert "diff.external=" in src, f"{rel} does not clear the external diff helper"
+            if renders_diff:
+                assert "--no-ext-diff" in src, f"{rel} permits external diff execution"
             # No path may re-import the raw scanners and hand-roll the decision.
             assert "redact_credentials" not in src, f"{rel} should delegate, not re-implement"
+
+        # The driver reads objects directly, so its scan method must not fall back to
+        # scanning a rendered diff, whose binary-file summary hides a credential the object
+        # itself carries. Scoped to the method rather than the file: other driver methods
+        # render diffs for unrelated reasons.
+        import inspect
+
+        from kiro_crew.apps.builtins.auto_improvement.spine.driver import Driver
+
+        scan_src = inspect.getsource(Driver._revision_scans_clean)
+        assert "--no-ext-diff" not in scan_src, "the driver scan renders a diff"
+        assert '"diff"' not in scan_src, "the driver scan renders a diff"
 
     def test_scanner_refuses_a_credential(self) -> None:
         from kiro_crew.apps.builtins.auto_improvement.spine.push_policy import (
@@ -554,30 +578,78 @@ class TestEveryPushPathScansContent:
         # An empty range is not a finding: nothing to publish means nothing to refuse.
         assert scan_content_for_secrets("")[0] is True
 
-    def test_the_direct_push_scan_range_is_not_self_diffing(self) -> None:
-        """A scanner that is CALLED but on an EMPTY range is not a gate. The driver's F10
-        push diffed ``{dest}..HEAD`` where ``dest`` is the local branch HEAD sits on the
-        tip of — so ``git diff <branch>..HEAD`` compared a ref to itself and returned
-        nothing, and the fail-closed credential scan passed on a 0-byte input. Measured:
-        a commit adding an AWS key gave a 0-byte ``<branch>..HEAD`` diff and a 144-byte
-        ``HEAD~1..HEAD`` diff. Pin the source so the self-diffing range cannot return.
-        Raised by the GPT review of this branch.
+    def test_the_direct_push_blob_listing_cannot_be_read_as_clean(self) -> None:
+        """A scanner that is CALLED but on an unread or empty listing is not a gate. The
+        driver enumerates the revision's changed blobs with ``diff-tree`` and reads each
+        one; if that listing read fails it exits non-zero with empty stdout, and treating
+        empty stdout as "nothing to scan" would pass the fail-closed credential gate on a
+        blob it never saw. The scan therefore refuses on the listing's exit status, and
+        its per-blob loop can only reach ``clean`` by reading every listed blob.
+
+        The listing is taken PER REVISION: ``diff-tree`` names the explicit ``rev`` with
+        ``--root`` so a root commit (which has no parent) is covered by the same listing,
+        and the scanned object is bound to the pushed object by construction. The scan is
+        NOT anchored on ``HEAD``, which each git call re-resolves separately, so a
+        concurrent writer cannot make the scanned object and the published object differ.
         """
+        import ast
         import inspect
+        import re
+        import textwrap
 
         from kiro_crew.apps.builtins.auto_improvement.spine.driver import Driver
 
-        src = inspect.getsource(Driver._direct_push)
-        assert "HEAD~1..HEAD" in src, "the push scan no longer diffs the committed range"
-        # The buggy construct was `scan_range = f"{dest}..HEAD"` fed to `git diff`. Match the
-        # CODE, not a mention in a comment: an f-string building a `<var>..HEAD` diff range.
-        import re
+        scan_src = inspect.getsource(Driver._revision_scans_clean)
 
-        code_lines = [ln for ln in src.splitlines() if not ln.lstrip().startswith("#")]
-        code = "\n".join(code_lines)
+        def _executable_code(text: str) -> str:
+            """The method's executable statements only -- its docstring and comments
+            describe history that names ``HEAD`` and ranges the code itself must not use."""
+            tree = ast.parse(textwrap.dedent(text))
+            func = tree.body[0]
+            # Narrowed for the type checker as much as for the reader: this helper is only
+            # ever handed one method's source, so anything else is a caller mistake.
+            assert isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)), type(func)
+            body = func.body
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                body = body[1:]  # drop the docstring
+            return "\n".join(ast.unparse(node) for node in body)
+
+        scan_code = _executable_code(scan_src)
+
+        # The listing enumerates the explicit revision's own objects with ``diff-tree``,
+        # rooted so a parentless commit is covered, rather than diffing a range.
+        assert re.search(
+            r"'diff-tree'.*'--root'.*rev", scan_code, re.DOTALL
+        ), "the scan does not list the revision's own blobs per revision with --root"
+        assert "'cat-file', 'blob'" in scan_code, "the scan does not read each blob's bytes"
+
+        # The listing read must fail closed: an empty or unread listing cannot reach clean.
+        assert (
+            "could not list the pushable blobs" in scan_code
+        ), "a failed blob listing does not fail closed"
+        assert (
+            "listing.returncode != 0" in scan_code
+        ), "the scan does not refuse on the listing's exit status"
+
+        # No self-diffing range may return: the scan reads objects, not a ``<ref>..<ref>``
+        # diff, so no ``..`` range and no ``HEAD``-anchored range appears in the code.
+        assert ".." not in scan_code, "a two-dot scan range is back in the code"
+        assert (
+            "HEAD" not in scan_code
+        ), "the scan is anchored on HEAD again, so it is not bound to the pushed object"
+
+        # ``_direct_push`` must delegate to the shared per-revision scan rather than
+        # re-growing its own range.
+        push_code = _executable_code(inspect.getsource(Driver._direct_push))
+        assert "_revision_scans_clean(" in push_code, "the push path does not scan its content"
         assert not re.search(
-            r'f"\{[A-Za-z_]+\}\.\.HEAD"', code
-        ), "a self-diffing f-string scan range is back in the code"
+            r"f'\{[A-Za-z_]+\}\.\.HEAD'", push_code
+        ), "a self-diffing f-string scan range is back in the push path"
 
     def test_a_committed_secret_is_actually_in_the_scanned_range(self, tmp_path) -> None:
         """End to end against a real repo: the range the driver scans for a one-commit
@@ -827,30 +899,43 @@ class TestLoggedStringsAreRebuiltFromConstants:
 
 
 class TestAFailedDiffIsNeverVacuouslyClean:
-    """A credential gate that reads an EMPTY diff must not conclude "clean".
+    """A credential gate that reads an EMPTY git output must not conclude "clean".
 
-    Raised by review of this branch against the driver's direct-push path. `_git` does not
-    raise, so a diff against a ref with no local head exits non-zero with empty stdout —
-    and `scan_content_for_secrets` reads blank text as "nothing to publish" and returns OK.
-    The fail-closed gate was therefore skipped and the commit would be pushed unscanned.
-    Reproduced before fixing: `git diff no-such-branch..HEAD` exits 128 with empty stdout.
+    ``_git`` does not raise, so a failed git read exits non-zero with empty stdout, and
+    ``scan_content_for_secrets`` reads blank text as "nothing to publish" and returns OK.
+    A path that treats empty stdout as nothing-to-scan therefore skips the fail-closed
+    gate and pushes the commit unscanned. The premise holds against a real repo:
+    ``git diff no-such-branch..HEAD`` exits 128 with empty stdout.
 
-    The scanner's blank-input shortcut is correct in itself — an empty range genuinely has
-    nothing to refuse — so the guard belongs at every CALL SITE, which is why this asserts
-    on all three rather than changing the scanner.
+    The scanner's blank-input shortcut is correct in itself -- an empty input genuinely
+    has nothing to refuse -- so the guard belongs at every git read in every CALL SITE.
+    The driver reads three kinds of object (the commit, the changed-blob listing, and
+    each blob), so all three of its reads must refuse on a non-zero exit.
     """
 
     def test_all_three_push_paths_check_the_git_exit_status(self) -> None:
+        import inspect
         from pathlib import Path
+
+        from kiro_crew.apps.builtins.auto_improvement.spine.driver import Driver
 
         root = Path(__file__).resolve().parent.parent
         for rel, marker in (
-            ("spine/driver.py", "proc.returncode != 0"),
             ("profiles/github_repo/pr_recipe.py", "proc.returncode != 0"),
             ("backend/commit.py", "scanned.returncode == 0"),
         ):
             src = (root / rel).read_text(encoding="utf-8")
-            assert marker in src, f"{rel} does not check the diff's exit status"
+            assert marker in src, f"{rel} does not check the git read's exit status"
+
+        # The driver reads three objects and each read must fail closed on a non-zero exit
+        # rather than scan its empty stdout as nothing-to-scan.
+        scan_src = inspect.getsource(Driver._revision_scans_clean)
+        for marker in (
+            "meta.returncode != 0",
+            "listing.returncode != 0",
+            "blob.returncode != 0",
+        ):
+            assert marker in scan_src, f"the driver scan does not refuse on `{marker}`"
 
     def test_blank_input_still_reads_as_clean(self) -> None:
         """Documents WHY the guard lives at the call sites: this shortcut is intended."""

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -206,6 +206,16 @@ _CREW_HIDDEN_LEAVES: tuple[str, ...] = (
     # ``apps/aws-control/``: a mask covers the leaf, not its ancestors, and an
     # agent-writable ancestor could be renamed out from under it mid-transfer.
     "aws-control-staging",
+    # Quarantine markers for auto-improvement clones whose provisional rollback AND
+    # retirement both failed. Each marker is the only durable record that a clone still
+    # carrying a REFUSED, unscanned commit must never be reused, and the process it has to
+    # outlive is an agent's: masked so a reviewer's shell cannot plant, rewrite or delete
+    # one. Nothing in-sandbox reads it -- the marker is written and consulted host-side by
+    # `auto_improvement.backend.clone_setup` -- so HIDDEN rather than READONLY. A TOP-LEVEL
+    # leaf for the `aws-control-staging` reason: a mask covers the leaf, not its ancestors,
+    # and a marker under `apps/auto-improvement/data/` would sit below a directory an agent
+    # can rename out from under the mount.
+    "quarantined-clones",
     "apps/meetings/data/edits",
     "whatsapp",
     # The refused-inbound spool. Fenced from agent FILE TOOLS by
@@ -622,9 +632,17 @@ _CREW_PRECREATE_READONLY_FILE_LEAVES: tuple[str, ...] = (
 #: and the first import then creates it visible to every sandbox already running --
 #: where a same-UID agent can ``rm -rf`` packs the user cannot get back. The store
 #: tolerates finding its root already present and empty.
+#:
+#: ``quarantined-clones`` shares that first-use shape: the root is built when the
+#: first clone is quarantined, so an install that has never had one offers the mask
+#: loop no name, and the marker that must outlive an agent's process would be
+#: created visible to every sandbox already running. Its resolver treats an
+#: existing empty root as usable, and proves the root writable before certifying
+#: any clone, so materialising it early changes nothing it relies on.
 _CREW_PRECREATE_HIDDEN_DIR_LEAVES: tuple[str, ...] = (
     "aws-control-staging",
     "appearance-library",
+    "quarantined-clones",
 )
 
 #: What a materialised ceiling holds — the empty JSON object every reader above

--- a/src/kiro_crew/security/paths.py
+++ b/src/kiro_crew/security/paths.py
@@ -270,6 +270,12 @@ _CREW_SECRET_LEAVES: list[str] = [
     # one CLI spawn that must write into it is granted its per-call subdirectory
     # explicitly.
     "aws-control-staging",
+    # Quarantine markers for auto-improvement clones whose rollback and retirement both
+    # failed. A marker is the only durable record that a clone carrying a refused, unscanned
+    # commit must not be reused, and an agent that could write or delete one could certify
+    # its own poisoned clone. Masked at OS level too (`sandbox._CREW_HIDDEN_LEAVES`), since a
+    # spawned shell's `open()` never routes through this gate.
+    "quarantined-clones",
     "browser-cookies.txt",
     "playwright-storage-state.json",
     # The refused-inbound spool (messaging/inbound_spool.py). Not a secret: it is

--- a/test/test_ai_spine_driver_coverage.py
+++ b/test/test_ai_spine_driver_coverage.py
@@ -67,7 +67,26 @@ class _Git:
     def __init__(self) -> None:
         self.calls: list[str] = []
         self.inputs: list[str] = []
+        self.configs: list[tuple[str, tuple[str, ...]]] = []
         self._script: dict[str, list[tuple[int, str, str]]] = {}
+        # PRECONDITIONS OF THE RETRY PATH, answered by default. Before replaying, it reads the
+        # authorized object's own committer identity to pin the replay to it; afterwards it
+        # compares the replayed commit's author, committer and message against that object's.
+        # Both run on every retry regardless of what a test is about, and an unscripted key
+        # returns empty stdout -- which those checks correctly read as "cannot tell" and
+        # refuse, failing every test in the class for a reason unrelated to its subject. One
+        # answer for both revisions, so the comparison is equal unless a test overrides it.
+        self._script["log -1 --format=%cn%x00%ce"] = [
+            (0, "pipeline\x00pipeline@example.invalid\n", "")
+        ]
+        self._script["log -1 --format=%an"] = [
+            (
+                0,
+                "author\x00author@example.invalid\x00pipeline"
+                "\x00pipeline@example.invalid\x00the authorized change\n",
+                "",
+            )
+        ]
 
     def script(self, key: str, *results) -> None:
         norm: list[tuple[int, str, str]] = []
@@ -85,7 +104,7 @@ class _Git:
         seq = self._script[best]
         return seq.pop(0) if len(seq) > 1 else seq[0]
 
-    def git(self, args, cwd):
+    def git(self, args, cwd, **kwargs):
         toks = [str(a) for a in args]
         clean: list[str] = []
         index = 0
@@ -97,8 +116,19 @@ class _Git:
             index += 1
         joined = " ".join(clean)
         self.calls.append(joined)
+        # ``config`` arrives by KEYWORD, so it is absent from *args* and invisible to the
+        # scripting keys. Recorded separately, keyed by the same joined string, so a test can
+        # assert what a call was pinned to without the pins disturbing how results are matched.
+        self.configs.append((joined, tuple(str(c) for c in kwargs.get("config", ()))))
         rc, out, err = self._take(joined)
         return subprocess.CompletedProcess(args=list(args), returncode=rc, stdout=out, stderr=err)
+
+    def config_for(self, prefix: str) -> tuple[str, ...]:
+        """The ``-c`` pins the first call matching *prefix* was given."""
+        for joined, config in self.configs:
+            if joined.startswith(prefix):
+                return config
+        return ()
 
     def run(self, argv, **kwargs):
         toks = [str(a) for a in argv]
@@ -374,6 +404,11 @@ def _proposal(cand_id="c1", *, kind=TRACK_PERF, target="mod.py::sym", diff="", s
 
 DIFF = "--- a/m.py\n+++ b/m.py\n@@ -1 +1 @@\n-old\n+new\n"
 
+#: A full 40-char lowercase-hex commit id. The finalizers hand back a validated forty-hex
+#: object id and `_direct_push` validates its `sha` the same way, so the id a test passes in
+#: and the id the clone resolves to must both be real object ids, never an abbreviation.
+COMMITTED_HEAD = "c0ffee" + "0" * 34
+
 
 @pytest.fixture(autouse=True)
 def _isolate_env(tmp_path, monkeypatch):
@@ -397,6 +432,20 @@ def git(monkeypatch):
     monkeypatch.setattr(drv, "_git", g.git)
     monkeypatch.setattr(drv, "subprocess", types.SimpleNamespace(run=g.run))
     monkeypatch.setattr(drv, "require_pinned", lambda cwd: None)
+    # `_direct_push`'s HEAD-identity gate resolves the clone's HEAD with `rev-list -1`
+    # and refuses when it differs from the full object id it was handed. Scripted here
+    # rather than per test because every direct-push test needs the SAME answer, and the
+    # default for an unscripted key is rc 0 with EMPTY stdout, which that gate correctly
+    # reads as "cannot resolve" and fails closed on. A test that wants to exercise the
+    # refusal overrides this with its own longer-prefix script.
+    g.script("rev-list -1", (0, f"{COMMITTED_HEAD}\n", ""))
+    # And the retry proves the rebase replayed exactly ONE commit; the longer
+    # prefix wins over `rev-list -1`, so the two questions stay separable.
+    g.script("rev-list --count", (0, "1\n", ""))
+    # The retry captures the fetched tip's object id from `git fetch --porcelain` STDOUT rather
+    # than from the mutable `FETCH_HEAD` ref, so the fetch has to report one; an
+    # unscripted fetch yields empty stdout, which the capture correctly reads as a refusal.
+    g.script("fetch --porcelain", (0, f"* {'0' * 40} {'ba5e' + '0' * 36} FETCH_HEAD\n", ""))
     return g
 
 
@@ -597,7 +646,9 @@ def test_preflight_uses_an_explicitly_injected_boot_verbatim(tmp_path, monkeypat
     _stub_preflight(monkeypatch, capture=seen)
     sentinel = object()
     boot = lambda: sentinel  # noqa: E731 — a one-expression fake boot
-    d = _make(tmp_path, profile=_Profile(isolation=_Isolation(boot=lambda: None)), boot_callable=boot)
+    d = _make(
+        tmp_path, profile=_Profile(isolation=_Isolation(boot=lambda: None)), boot_callable=boot
+    )
     d.preflight()
     assert seen["boot"] is boot
 
@@ -769,52 +820,215 @@ def test_reverify_head_refuses_an_unverifiable_tree(tmp_path, git):
 def test_push_succeeds_on_the_first_attempt(tmp_path, git):
     git.script("push", 0)
     d = _make(tmp_path)
-    assert d._push_with_rebase("https://example.invalid/r.git", "feature", "mod.py::sym").returncode == 0
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "mod.py::sym", COMMITTED_HEAD
+        ).returncode
+        == 0
+    )
     assert git.seen("fetch") == []
 
 
 def test_a_non_race_push_failure_is_returned_untouched(tmp_path, git):
     git.script("push", (1, "", "fatal: authentication failed"))
     d = _make(tmp_path)
-    res = d._push_with_rebase("https://example.invalid/r.git", "feature", "mod.py::sym")
+    res = d._push_with_rebase(
+        "https://example.invalid/r.git", "feature", "mod.py::sym", COMMITTED_HEAD
+    )
     assert res.returncode == 1
     assert git.seen("fetch") == []  # no retry masks a real error
 
 
 def test_a_lost_race_with_a_failing_fetch_returns_the_rejection(tmp_path, git):
     git.script("push", (1, "", "! [rejected] non-fast-forward"))
-    git.script("fetch", 1)
+    git.script("fetch --porcelain", 1)
     d = _make(tmp_path)
-    assert d._push_with_rebase("https://example.invalid/r.git", "feature", "t").returncode == 1
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD
+        ).returncode
+        == 1
+    )
     assert git.seen("rebase") == []
 
 
 def test_a_conflicting_rebase_aborts_and_does_not_push(tmp_path, git):
     git.script("push", (1, "", "fetch first"))
-    git.script("fetch", 0)
-    git.script("rebase FETCH_HEAD", 1)
+    git.script("rebase", 1)
     git.script("rebase --abort", 0)
     d = _make(tmp_path)
-    assert d._push_with_rebase("https://example.invalid/r.git", "feature", "t").returncode == 1
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD
+        ).returncode
+        == 1
+    )
     assert git.seen("rebase --abort")
 
 
 def test_an_unverifiable_rebased_tree_is_not_published(tmp_path, git):
     git.script("push", (1, "", "non-fast-forward"))
-    git.script("fetch", 0)
-    git.script("rebase FETCH_HEAD", 0)
+    git.script("rebase", 0)
     d = _make(tmp_path, profile=_Profile(build_gate=_BuildGate(passed=False)))
-    assert d._push_with_rebase("https://example.invalid/r.git", "feature", "t").returncode == 1
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD
+        ).returncode
+        == 1
+    )
     assert len(git.seen("push")) == 1  # never pushed a second time
 
 
 def test_a_reverified_rebase_retries_the_push_once(tmp_path, git):
     git.script("push", (1, "", "non-fast-forward"), (0, "", ""))
-    git.script("fetch", 0)
-    git.script("rebase FETCH_HEAD", 0)
+    git.script("rebase", 0)
+    _script_matching_replay(git)
     d = _make(tmp_path)
-    assert d._push_with_rebase("https://example.invalid/r.git", "feature", "t").returncode == 0
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD
+        ).returncode
+        == 0
+    )
     assert len(git.seen("push")) == 2
+
+
+def _script_matching_replay(git, *, tree: str = "a" * 40) -> None:
+    """Make the replay's tree equal the tree a replay of the source produces.
+
+    ``merge-tree --write-tree`` states the expected tree from the two immutable ids, and
+    ``log -1 --format=%T`` reads the tree the captured commit actually carries; equal means
+    the published content is the authorized content.
+    """
+    git.script("merge-tree --write-tree", (0, f"{tree}\n", ""))
+    git.script("log -1 --format=%T", (0, f"{tree}\n", ""))
+
+
+def test_a_replay_carrying_the_authorized_tree_is_published(tmp_path, git):
+    """The gate is a binding, not a blanket refusal: a replay whose tree matches passes."""
+    git.script("push", (1, "", "non-fast-forward"), (0, "", ""))
+    git.script("rebase", 0)
+    _script_matching_replay(git)
+    d = _make(tmp_path)
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD
+        ).returncode
+        == 0
+    )
+    assert git.seen("merge-tree --write-tree"), "the expected replay tree was never computed"
+
+
+def test_a_replay_whose_attribution_differs_is_not_published(tmp_path, git):
+    """A replay writes a NEW commit, and git takes its committer from configuration.
+
+    Author and message carry over, but the committer does not, so a process able to write the
+    repository's config -- the reviewing agent's shell, whose git denylist covers only `push`
+    and `remote set-url` -- chooses who the published commit says committed it. The retry pins
+    the replay's committer to the identity the authorized object already holds, and this is the
+    check behind that pin: the ``GIT_COMMITTER_*`` environment outranks a ``-c`` override, so
+    the published object's attribution is compared against the authorized one rather than
+    assumed. Content passing every other gate is exactly the case this catches -- the tree
+    matches here, so nothing else in the path objects.
+    """
+    git.script("push", (1, "", "non-fast-forward"), (0, "", ""))
+    git.script("rebase", 0)
+    _script_matching_replay(git)
+    # Same key, two answers: the authorized object's, then the replay's. A queue pops in call
+    # order, and the retry reads `src` first.
+    git.script(
+        "log -1 --format=%an",
+        (0, "a\x00a@example.invalid\x00pipeline\x00pipeline@example.invalid\x00m\n", ""),
+        (0, "a\x00a@example.invalid\x00intern\x00intern@example.invalid\x00m\n", ""),
+    )
+    d = _make(tmp_path)
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD
+        ).returncode
+        == 1
+    )
+    assert len(git.seen("push")) == 1, "a falsely attributed commit was published"
+
+
+def test_the_replay_pins_its_committer_to_the_authorized_object(tmp_path, git):
+    """The pin is what keeps an honest retry working rather than merely refusing.
+
+    Refusing on a mismatch alone would hand the agent a denial of service: writing one config
+    value would make every retry decline, and the retry exists because a moving branch lost
+    gate survivors. Reading the identity off `src` -- an immutable object the pipeline
+    committed before any agent ran -- needs no config to be trustworthy at replay time.
+    """
+    git.script("push", (1, "", "non-fast-forward"), (0, "", ""))
+    git.script("rebase", 0)
+    _script_matching_replay(git)
+    d = _make(tmp_path)
+    d._push_with_rebase("https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD)
+    rebases = [c for c in git.calls if c.startswith("rebase")]
+    assert rebases, "the replay never ran"
+    pins = git.config_for("rebase")
+    assert "user.name=pipeline" in pins, pins
+    assert "user.email=pipeline@example.invalid" in pins, pins
+
+
+def test_a_replay_carrying_a_different_tree_is_not_published(tmp_path, git):
+    """A commit substituted into HEAD before the capture is caught by the tree comparison.
+
+    Every later check binds to the captured id, so they all agree ABOUT THE SUBSTITUTE --
+    including the HEAD-equality check, which compares HEAD against that same id. Only
+    reaching back to what a replay of the authorized `src` must produce refuses it.
+    """
+    git.script("push", (1, "", "non-fast-forward"), (0, "", ""))
+    git.script("rebase", 0)
+    git.script("merge-tree --write-tree", (0, "a" * 40 + "\n", ""))
+    git.script("log -1 --format=%T", (0, "b" * 40 + "\n", ""))
+    d = _make(tmp_path)
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD
+        ).returncode
+        == 1
+    )
+    assert len(git.seen("push")) == 1, "a substituted commit was published"
+
+
+def test_the_same_lines_in_a_different_place_are_a_different_tree(tmp_path, git):
+    """The reason this is a tree and not a patch identity.
+
+    A patch identity ignores hunk positions, so a commit whose added and removed lines match
+    the authorized change while sitting elsewhere in the file carries the SAME identity. Its
+    tree differs, so the tree comparison refuses it where a patch identity would not.
+    """
+    git.script("push", (1, "", "non-fast-forward"), (0, "", ""))
+    git.script("rebase", 0)
+    # Same change, relocated: the merge result and the captured commit disagree on content.
+    git.script("merge-tree --write-tree", (0, "c" * 40 + "\n", ""))
+    git.script("log -1 --format=%T", (0, "d" * 40 + "\n", ""))
+    d = _make(tmp_path)
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD
+        ).returncode
+        == 1
+    )
+    assert len(git.seen("push")) == 1
+
+
+def test_an_uncomputable_expected_tree_refuses_the_publish(tmp_path, git):
+    """Fail-closed: a conflicted or unsupported merge prints no usable tree, and two empty
+    answers would compare EQUAL, so emptiness must refuse."""
+    git.script("push", (1, "", "non-fast-forward"), (0, "", ""))
+    git.script("rebase", 0)
+    git.script("merge-tree --write-tree", (1, "", "CONFLICT"))
+    git.script("log -1 --format=%T", (0, "a" * 40 + "\n", ""))
+    d = _make(tmp_path)
+    assert (
+        d._push_with_rebase(
+            "https://example.invalid/r.git", "feature", "t", COMMITTED_HEAD
+        ).returncode
+        == 1
+    )
+    assert len(git.seen("push")) == 1
 
 
 # ─────────────────────────── pre-push review gate ───────────────────────────
@@ -957,36 +1171,96 @@ def test_direct_push_refuses_a_missing_commit_sha(tmp_path, git, sha):
 def test_direct_push_refuses_a_disabled_remote_url(tmp_path, git):
     git.script("remote get-url", (0, "DISABLED_NO_PUSH\n", ""))
     d = _direct_push_driver(tmp_path, profile=_Profile(fetch_url=""))
-    assert d._direct_push(fp="fp", kind="perf", target="t", sha="abc") is False
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is False
     assert d.ledger._seen["fp"].note == "direct-push: no usable remote url"
 
 
-def test_direct_push_refuses_an_unreadable_pushable_diff(tmp_path, git):
-    git.script("rev-parse --verify", 0)
-    git.script("diff --no-ext-diff HEAD~1..HEAD", (128, "", "fatal"))
+def test_direct_push_refuses_when_the_pushable_blobs_cannot_be_listed(tmp_path, git):
+    # A git READ that fails must refuse rather than be read as nothing to scan. The scan
+    # lists the revision's own changed blobs and reads each one, so both reads are load-
+    # bearing: a failing `diff-tree` cannot enumerate what to scan, and a failing
+    # `cat-file blob` leaves a real blob unread. The `_Git` double matches by argv prefix
+    # (longest wins), so `diff-tree` and `cat-file blob` are scripted independently.
+    # `COMMITTED_HEAD` is what the shared `git` fixture scripts `rev-list -1` to return.
+    git.script("diff-tree", (128, "", "fatal"))
     d = _direct_push_driver(tmp_path)
-    assert d._direct_push(fp="fp", kind="perf", target="t", sha="abc") is False
-    assert d.ledger._seen["fp"].note == (
-        "direct-push refused: could not read the pushable diff"
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is False
+    assert d.ledger._seen["fp"].note == ("direct-push refused: could not list the pushable blobs")
+    assert git.seen("push") == []
+
+
+def test_direct_push_refuses_when_a_pushable_blob_cannot_be_read(tmp_path, git):
+    # The listing enumerates one added blob, but reading its raw bytes fails. An unreadable
+    # blob is the absence of the scan, not a clean scan, so the push is refused.
+    git.script(
+        "diff-tree",
+        (0, ":000000 100644 " + "0" * 40 + " " + "d" * 40 + " A\tm.py\n", ""),
     )
+    git.script("cat-file blob", (128, "", "fatal"))
+    d = _direct_push_driver(tmp_path)
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is False
+    assert d.ledger._seen["fp"].note == ("direct-push refused: could not read a pushable blob")
+    assert git.seen("push") == []
 
 
-def test_direct_push_scans_a_root_commit_with_show(tmp_path, git, monkeypatch):
-    git.script("rev-parse --verify", 1)  # no parent → root commit
-    git.script("show --no-ext-diff --format=", (0, DIFF, ""))
-    git.script("rev-parse HEAD", (0, "landedsha\n", ""))
+def test_direct_push_scans_a_root_commit_through_the_single_listing(tmp_path, git):
+    # A root commit has no parent, and `diff-tree --root` lists its blobs in the SAME
+    # listing every other commit goes through -- so a root commit is still fully scanned
+    # with no separate branch. Each listed blob's raw bytes are read and scanned clean.
+    git.script(
+        "diff-tree",
+        (0, ":000000 100644 " + "0" * 40 + " " + "e" * 40 + " A\tm.py\n", ""),
+    )
+    git.script("cat-file blob", (0, "clean content\n", ""))
     git.script("push", 0)
     d = _direct_push_driver(tmp_path)
-    assert d._direct_push(fp="fp", kind="perf", target="t", sha="abc") is True
-    assert git.seen("show --no-ext-diff --format=")
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is True
+    assert git.seen("diff-tree")
+    assert git.seen("cat-file blob " + "e" * 40)
+
+
+def test_direct_push_scans_a_binary_blobs_raw_bytes_and_refuses_a_credential(
+    tmp_path, git, monkeypatch
+):
+    # THE HOLE THIS CLOSES. `git diff` renders a blob it judges binary as one summary line,
+    # `Binary files a and b differ`, with none of its content -- and a single NUL byte is
+    # enough to make git judge a blob binary, which whatever writes the tree chooses freely.
+    # A scan that read diff output would see that summary line and zero occurrences of the
+    # key. The push transfers OBJECTS, not a diff, so the scan reads each changed blob's raw
+    # bytes with `cat-file blob`; a credential in those bytes must refuse the push.
+    seen_blob_scan: list = []
+
+    def _scan(text):
+        # Record only whether the raw blob bytes reached the scanner, never the text itself.
+        if "AKIAIOSFODNN7EXAMPLE" in text:
+            seen_blob_scan.append(True)
+            return False, PP.SCAN_HIT
+        return True, PP.SCAN_OK
+
+    monkeypatch.setattr(PP, "scan_content_for_secrets", _scan)
+    # A realistic added-blob listing line; the raw blob is binary (NUL-wrapped) and carries
+    # the key, exactly the shape a rendered diff would collapse to "Binary files ... differ".
+    git.script(
+        "diff-tree",
+        (0, ":000000 100644 " + "0" * 40 + " " + "f" * 40 + " A\tsecret.bin\n", ""),
+    )
+    git.script("cat-file blob", (0, "\x00AKIAIOSFODNN7EXAMPLE\x00", ""))
+    d = _direct_push_driver(tmp_path)
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is False
+    assert d.ledger._seen["fp"].note == (
+        "direct-push refused: content scan found credential/exfiltration finding(s)"
+    )
+    assert git.seen("cat-file blob " + "f" * 40)
+    # NON-VACUOUS: the refusal happened because the scanner actually SAW the raw blob bytes,
+    # not because nothing was scanned.
+    assert seen_blob_scan == [True], "the raw blob bytes never reached the scanner"
+    assert git.seen("push") == []
 
 
 def test_direct_push_refuses_content_the_scanner_flags(tmp_path, git, monkeypatch):
     monkeypatch.setattr(PP, "scan_content_for_secrets", lambda text: (False, PP.SCAN_HIT))
-    git.script("rev-parse --verify", 0)
-    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
     d = _direct_push_driver(tmp_path)
-    assert d._direct_push(fp="fp", kind="perf", target="t", sha="abc") is False
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is False
     assert d.ledger._seen["fp"].note == (
         "direct-push refused: content scan found credential/exfiltration finding(s)"
     )
@@ -994,47 +1268,57 @@ def test_direct_push_refuses_content_the_scanner_flags(tmp_path, git, monkeypatc
 
 
 def test_direct_push_records_a_failed_push(tmp_path, git):
-    git.script("rev-parse --verify", 0)
-    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
-    git.script("rev-parse HEAD", (0, "headsha\n", ""))
     git.script("push", (1, "", "remote rejected"))
     d = _direct_push_driver(tmp_path)
-    assert d._direct_push(fp="fp", kind="perf", target="t", sha="abc") is False
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is False
     assert "direct-push failed" in d.ledger._seen["fp"].note
-    assert d.pushed_sha == "headsha"
+    # The recorded sha is the OBJECT THAT WAS SENT -- the full object id the gate retained
+    # and pushed -- not a later re-read of `HEAD`.
+    assert d.pushed_sha == COMMITTED_HEAD
 
 
 def test_direct_push_reports_the_sha_that_actually_landed(tmp_path, git):
-    git.script("rev-parse --verify", 0)
-    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
-    git.script("rev-parse HEAD", (0, "rebasedsha\n", ""))
+    """The sha recorded must be the object the push transferred.
+
+    `_push_with_rebase` reports the revision it sent, and the ledger follows that rather than
+    a post-push `rev-parse HEAD`: reading HEAD after the push would name whatever HEAD points
+    at by then, so a concurrent move could put an unrelated commit in the ledger for a change
+    that really did land. `rev-parse HEAD` is deliberately scripted to a DIFFERENT value here,
+    so a regression to reading the ref reddens.
+    """
+    git.script("rev-parse HEAD", (0, "someotherhead\n", ""))
     git.script("push", 0)
     d = _direct_push_driver(tmp_path)
-    assert d._direct_push(fp="fp", kind="perf", target="t", sha="presha") is True
-    assert d.pushed_sha == "rebasedsha"
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is True
+    assert d.pushed_sha == COMMITTED_HEAD
+    assert d.pushed_sha != "someotherhead", "the ledger followed the ref, not the pushed object"
 
 
-def test_direct_push_falls_back_to_the_snapshot_sha_when_rev_parse_blanks(tmp_path, git):
-    git.script("rev-parse --verify", 0)
-    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
+def test_direct_push_reporting_survives_a_blank_rev_parse(tmp_path, git):
+    """Pins that this path does not fall back to the caller's snapshot when `rev-parse HEAD`
+    blanks. That fallback is unreachable here, because the recorded sha comes from the object
+    that was sent rather than from a post-push ref read -- which is a stronger version of the
+    same guarantee ("a reporting hiccup cannot blank a real sha"). The fallback itself remains
+    for callers that do not pass an explicit source.
+    """
     git.script("rev-parse HEAD", (0, "   \n", ""))
     git.script("push", 0)
     d = _direct_push_driver(tmp_path)
-    assert d._direct_push(fp="fp", kind="perf", target="t", sha="snapshot") is True
-    assert d.pushed_sha == "snapshot"
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is True
+    assert d.pushed_sha == COMMITTED_HEAD, "a blank ref read must not affect the recorded sha"
 
 
 def test_direct_push_reads_the_fetch_url_off_the_clone_when_the_profile_has_none(tmp_path, git):
     git.script("remote get-url", (0, "https://example.invalid/from-clone.git\n", ""))
-    git.script("rev-parse --verify", 0)
-    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
-    git.script("rev-parse HEAD", (0, "sha\n", ""))
     git.script("push", 0)
     d = _direct_push_driver(tmp_path, profile=_Profile(fetch_url=""))
-    assert d._direct_push(fp="fp", kind="perf", target="t", sha="abc") is True
+    assert d._direct_push(fp="fp", kind="perf", target="t", sha=COMMITTED_HEAD) is True
     pushes = git.seen("push")
+    # The refspec source is the OBJECT ID the gate retained, not `HEAD`: an id cannot
+    # be repointed, so nothing in the clone can change what is published after the check.
+    # `COMMITTED_HEAD` is what the shared `git` fixture scripts `rev-list -1` to return.
     assert pushes == [
-        "push https://example.invalid/from-clone.git HEAD:refs/heads/auto_improvement/feature"
+        f"push https://example.invalid/from-clone.git {COMMITTED_HEAD}:refs/heads/auto_improvement/feature"
     ]
 
 
@@ -1116,24 +1400,198 @@ def test_a_provisional_commit_never_names_the_candidate(tmp_path, git):
     assert commits == ["commit -q -m wip(auto-improvement): staging a verified candidate"]
 
 
-@pytest.mark.parametrize("pre_sha", ["", "abc123"])
-def test_reset_provisional_is_a_no_op_when_nothing_advanced(tmp_path, git, pre_sha):
-    git.script("rev-parse HEAD", (0, "abc123\n", ""))
+@pytest.mark.parametrize(
+    "stdout,expect",
+    [
+        # The real shape, measured against git 2.50: `<flag> <old-oid> <new-oid> <local-ref>`.
+        (f"* {'0' * 40} {'a' * 40} FETCH_HEAD\n", "a" * 40),
+        # A deletion reports the NULL id, which is not a tip anything can rebase onto.
+        (f"- {'a' * 40} {'0' * 40} FETCH_HEAD\n", ""),
+        # Nothing usable: an older git that rejected --porcelain, or a silent fetch.
+        ("", ""),
+        ("From https://example.invalid/r.git\n * branch main -> FETCH_HEAD\n", ""),
+        # Not an object id in the id column.
+        (f"* {'0' * 40} refs/heads/main FETCH_HEAD\n", ""),
+        # Short of forty hex, so not an id either.
+        (f"* {'0' * 40} {'a' * 39} FETCH_HEAD\n", ""),
+    ],
+)
+def test_fetched_tip_oid_only_accepts_a_real_object_id(stdout, expect):
+    """The retry rebases onto the id the FETCH reported, never onto `FETCH_HEAD` -- that ref is a
+    mutable file the pre-push reviewer can repoint at a commit nothing scanned, so neither the
+    rebase nor the replayed-commit count reads it. Anything this cannot parse must come
+    back empty so the caller refuses: an id it could not obtain is the absence of the check."""
+    assert drv._fetched_tip_oid(stdout) == expect
+
+
+def test_reset_provisional_does_nothing_without_a_pre_sha(tmp_path, git):
+    """REPLACES a test that asserted no `reset --hard` when nothing advanced. The rollback is
+    now a single idempotent `checkout -f -B <branch> <pre_sha>`, so "nothing advanced" needs no
+    special case -- but an ABSENT pre_sha must still touch nothing at all."""
     d = _make(tmp_path)
-    d._reset_provisional(pre_sha)
-    assert git.seen("reset --hard abc123") == []
+    d._reset_provisional("")
+    assert git.seen("checkout") == [], "it moved a ref with no sha to roll back to"
 
 
-def test_reset_provisional_rolls_the_branch_back(tmp_path, git):
-    git.script("rev-parse HEAD", (0, "newsha\n", ""))
+def test_reset_provisional_rolls_the_branch_back_atomically(tmp_path, git):
+    """ONE command that NAMES the branch. `git reset --hard` acts on whatever is checked out,
+    and this runs after the pre-push reviewer has had a shell in the clone where `git checkout`
+    is permitted -- so a read-then-reset pair lets a backgrounded `setsid git checkout victim`
+    land in between and destroy commits on `victim`. An intermediate fix read HEAD, checked the
+    branch out if it differed, then reset, which was the same pair one level up. Raised across
+    three rounds of the GPT review of this branch."""
     d = _make(tmp_path)
     d._reset_provisional("oldsha")
-    assert git.seen("reset --hard oldsha")
+    moves = git.seen("checkout")
+    assert moves == [
+        "checkout -f -B auto_improvement/feature oldsha"
+    ], f"the rollback is not a single branch-naming command: {moves}"
+    # Nothing that acts on "whatever is checked out", and no read whose answer could go stale
+    # before the write, may remain.
+    assert git.seen("reset --hard") == [], "a reset on the current branch is back"
+    assert git.seen("rev-parse --abbrev-ref") == [], "it reads HEAD then acts -- a stale check"
+
+
+def test_restore_branch_undoes_the_promotion_when_the_checkout_fails(tmp_path, git, caplog):
+    """`git branch -f` lands BEFORE the checkout can fail, so a concurrent index lock would
+    otherwise leave the branch promoted to a replay this reports as unrestored -- the push
+    aborts and the unpushed commit stays on the durable branch. Raised by the GPT review."""
+    git.script("rev-parse b", (0, "wasthere\n", ""))
+    git.script("checkout", (1, "", "index.lock exists"))
+    d = _make(tmp_path)
+    assert d._restore_branch("b", promote="replaysha") is False
+    moves = git.seen("branch -f")
+    assert "branch -f b replaysha" in moves, moves
+    assert "branch -f b wasthere" in moves, "the promotion was not undone after the failure"
+
+
+def test_a_failed_rollback_quarantines_the_clone_so_a_later_run_cannot_adopt_it(tmp_path, git):
+    """THE GUARD MUST OUTLIVE THE PROCESS, because the thing it guards does.
+
+    `_rollback_failed` stops the run it is set in, but the un-rolled-back commit is on DISK and
+    the clone is REUSED: a later run starts with a clear latch on a clone that still carries the
+    refused commit, commits the next winner on top, and publishes an ancestor its single-revision
+    scan never looked at. An in-memory guard is checking something shorter-lived than the hazard.
+
+    This crosses the boundary that matters rather than re-proving the in-run halt: it fails a
+    rollback, then asserts the predicate a LATER run's clone setup branches on. Reuse in
+    `clone_setup._setup_safe_clone` hinges on the canonical `<dest>/.git` being a directory, so
+    once retirement has renamed the clone aside, the next run cannot adopt it and clones fresh.
+    A fresh Driver on the same path is built to make the point explicit: its latch is clear, and
+    that is exactly why the protection cannot live there. Raised by the GPT review of this branch;
+    quarantine was the conductor's choice over a persisted latch, whose clearing condition would
+    itself have to be got right."""
+    d = _make(tmp_path)
+    clone = tmp_path / "clone"
+    (clone / ".git").mkdir(parents=True, exist_ok=True)
+    assert (clone / ".git").is_dir(), "precondition: the clone looks reusable"
+    git.script("checkout -f -B", (1, "", "cannot checkout"))
+
+    assert d._reset_provisional("oldsha") is False
+    assert d._repository_retired is True, "the clone was not quarantined"
+
+    # The predicate `_setup_safe_clone` branches on for reuse (clone_setup.py: `git_dir.is_dir()`).
+    assert not (clone / ".git").is_dir(), (
+        "the canonical clone still looks reusable, so a later run would adopt the commit that "
+        "was refused and never published"
+    )
+    retirements = [p for p in tmp_path.iterdir() if p.name.startswith(".clone.unsafe-")]
+    assert retirements, f"no retirement container beside the clone: {list(tmp_path.iterdir())}"
+    assert (retirements[0] / "clone").is_dir(), "the bytes were not preserved for diagnosis"
+
+    # A NEW run is a new Driver with a CLEAR latch -- which is the whole reason the protection
+    # cannot be the latch alone.
+    fresh = _make(tmp_path)
+    assert fresh._rollback_failed is False, "the in-memory latch does not survive, as expected"
+
+
+def test_a_second_rollback_after_quarantine_is_a_no_op_and_does_not_mislead(tmp_path, git, caplog):
+    """`_reset_provisional` is called from five sites, so it can be reached again after the clone
+    has already been renamed aside. Without the already-retired short circuit it would try to
+    check out a path that is gone, fail, and then report "left unsafe in place" -- which
+    is false and is exactly the wrong thing to tell whoever is reading the log during an
+    incident, because the clone WAS quarantined properly."""
+    d = _make(tmp_path)
+    (tmp_path / "clone" / ".git").mkdir(parents=True, exist_ok=True)
+    git.script("checkout -f -B", (1, "", "cannot checkout"))
+    assert d._reset_provisional("oldsha") is False
+    before = len(git.seen("checkout"))
+    with caplog.at_level(logging.ERROR, logger=LOG.name):
+        caplog.clear()
+        assert d._reset_provisional("oldsha") is False, "a retired clone reported a good rollback"
+    assert len(git.seen("checkout")) == before, "it tried to roll back a clone that is gone"
+    assert "left unsafe in place" not in caplog.text, (
+        "it reported the clone as unquarantined after having quarantined it -- the opposite of "
+        "what an operator needs during an incident"
+    )
+
+
+def test_a_failed_rollback_halts_the_run_and_says_why(tmp_path, git, caplog):
+    """A failed rollback is not a log line. HEAD keeps the commit that was refused and never
+    published, so the NEXT winner commits on top of it and that winner's single-revision scan
+    (`<rev>~1..<rev>`) cannot see the parent its own push would publish -- the refused content
+    lands through a scanner that never looked at it. Nothing local repairs that, since the
+    rollback IS the repair, so the run stops. Raised by the GPT review of this branch."""
+    git.script("checkout -f -B", (1, "", "cannot checkout"))
+    d = _make(tmp_path)
+    with caplog.at_level(logging.ERROR, logger=LOG.name):
+        assert d._reset_provisional("oldsha") is False, "a failed rollback reported success"
+    assert d._rollback_failed is True, "the failure did not latch"
+    assert d._stop is True, "the run was allowed to continue after an unrepairable HEAD"
+    assert "could not roll back the provisional commit" in caplog.text
+    assert "refused and never published" in caplog.text
+
+
+def test_a_successful_rollback_reports_success_and_does_not_halt(tmp_path, git):
+    """The positive control: the latch must not fire on the ordinary path, or the flag would
+    read as "always broken" and prove nothing."""
+    d = _make(tmp_path)
+    assert d._reset_provisional("oldsha") is True
+    assert d._rollback_failed is False
+    assert d._stop is False
+
+
+def test_a_failed_rollback_stops_every_further_winner_before_any_push(tmp_path, git, caplog):
+    """The halt has to be UNCONDITIONAL, and the publish gate alone is not enough.
+
+    `_apply_bug_winner` calls `pr_pipeline.emit_bug` BEFORE `_direct_push`, and that path reaches
+    `pr_recipe._push_fix_branch`, which pushes `HEAD:refs/heads/<branch>` and knows nothing about
+    the latch. So a second bug winner in the SAME cycle would publish the un-rolled-back commit
+    through the PR branch before the direct-push gate was ever consulted. Guarded at the top of
+    both winner-applying methods, which is upstream of every push either one can reach.
+
+    The control is structural: `archive.save_candidate` is the first thing both methods do, so a
+    double that raises proves the guard returned before any work -- and reddens if it is removed.
+    """
+    d = _make(tmp_path)
+    d._rollback_failed = True
+
+    def _boom(**_kw):
+        raise AssertionError("a winner was applied after the rollback failed")
+
+    d.archive = types.SimpleNamespace(save_candidate=_boom)  # type: ignore[assignment]
+    with caplog.at_level(logging.ERROR, logger=LOG.name):
+        assert d._apply_verdict(1, "basesha", None, [], 0, "") == 0
+        assert d._apply_bug_winner(1, None, None) is None
+    assert "refusing to apply any further winner" in caplog.text
+
+
+def test_direct_push_refuses_after_a_failed_rollback(tmp_path, git):
+    """Checked at the PUBLISH gate, not only through the run's stop flag: that flag is read at
+    cycle boundaries, and one cycle can hold SEVERAL bug winners (`for prop, bug_res in
+    bug_winners`), each reaching `_direct_push`. So the second winner in the same cycle is
+    exactly the case a stop-flag-only fix would miss."""
+    d = _direct_push_driver(tmp_path)
+    d._rollback_failed = True
+    assert d._direct_push(fp="fp", kind="bug", target="t", sha="abc") is False
+    assert "provisional rollback failed" in d.ledger._seen["fp"].note
+    assert git.seen("push") == [], "it published from a clone with an unpublished commit at HEAD"
 
 
 def test_reset_provisional_logs_a_failed_rollback(tmp_path, git, caplog):
-    git.script("rev-parse HEAD", (0, "newsha\n", ""))
-    git.script("reset --hard", (1, "", "cannot reset"))
+    """Fail closed and SAY SO: a provisional commit left behind is resolved by the next cycle's
+    stage step, but it must not pass silently."""
+    git.script("checkout -f -B", (1, "", "cannot checkout"))
     d = _make(tmp_path)
     with caplog.at_level(logging.ERROR, logger=LOG.name):
         d._reset_provisional("oldsha")
@@ -1141,10 +1599,12 @@ def test_reset_provisional_logs_a_failed_rollback(tmp_path, git, caplog):
 
 
 def test_finalize_winner_commit_skips_the_amend_for_an_empty_diff(tmp_path, git):
-    git.script("rev-parse --short HEAD", (0, "shorty\n", ""))
+    git.script("rev-parse HEAD", (0, "a" * 40 + "\n", ""))
     d = _make(tmp_path)
-    got = d._finalize_winner_commit(_proposal(diff=""), verify=_measurement(), cycle=1, diff_ref="d")
-    assert got == "shorty"
+    got = d._finalize_winner_commit(
+        _proposal(diff=""), verify=_measurement(), cycle=1, diff_ref="d"
+    )
+    assert got == "a" * 40
     assert git.seen("commit -q --amend") == []
 
 
@@ -1156,18 +1616,20 @@ def test_finalize_winner_commit_amends_with_the_reproduce_numbers(tmp_path, git,
         return "perf: real numbers"
 
     monkeypatch.setattr(drv.D, "perf_commit_message", _msg)
-    git.script("rev-parse --short HEAD", (0, "amended\n", ""))
+    git.script("rev-parse HEAD", (0, "b" * 40 + "\n", ""))
     d = _make(tmp_path)
     reproduce = _measurement(delta=-4.0)
     got = d._finalize_winner_commit(
         _proposal(diff=DIFF), verify=_measurement(), reproduce=reproduce, cycle=3, diff_ref="d.diff"
     )
-    assert got == "amended"
+    assert got == "b" * 40
     assert seen["reproduce"] is reproduce
     assert git.seen("commit -q --amend")
 
 
-def test_finalize_winner_commit_falls_back_to_verify_without_a_reproduce(tmp_path, git, monkeypatch):
+def test_finalize_winner_commit_falls_back_to_verify_without_a_reproduce(
+    tmp_path, git, monkeypatch
+):
     seen: dict = {}
     monkeypatch.setattr(drv.D, "perf_commit_message", lambda **kw: seen.update(kw) or "m")
     git.script("rev-parse --short HEAD", (0, "x\n", ""))
@@ -1230,7 +1692,7 @@ def test_a_provisional_bug_commit_never_names_the_candidate(tmp_path, git):
 
 def test_finalize_bug_commit_amends_with_the_red_green_narrative(tmp_path, git, monkeypatch):
     monkeypatch.setattr(drv.D, "bug_commit_message", lambda **kw: "fix: red to green")
-    git.script("rev-parse --short HEAD", (0, "bugsha\n", ""))
+    git.script("rev-parse HEAD", (0, "c" * 40 + "\n", ""))
     d = _make(tmp_path)
     got = d._finalize_bug_winner_commit(
         _proposal(kind=TRACK_BUG, diff=DIFF),
@@ -1238,12 +1700,12 @@ def test_finalize_bug_commit_amends_with_the_red_green_narrative(tmp_path, git, 
         cycle=2,
         diff_ref="d.diff",
     )
-    assert got == "bugsha"
+    assert got == "c" * 40
     assert git.seen("commit -q --amend")
 
 
 def test_finalize_bug_commit_skips_the_amend_for_an_empty_diff(tmp_path, git):
-    git.script("rev-parse --short HEAD", (0, "same\n", ""))
+    git.script("rev-parse HEAD", (0, "d" * 40 + "\n", ""))
     d = _make(tmp_path)
     got = d._finalize_bug_winner_commit(
         _proposal(kind=TRACK_BUG, diff=""),
@@ -1251,7 +1713,7 @@ def test_finalize_bug_commit_skips_the_amend_for_an_empty_diff(tmp_path, git):
         cycle=1,
         diff_ref="d",
     )
-    assert got == "same"
+    assert got == "d" * 40
     assert git.seen("commit -q --amend") == []
 
 
@@ -1262,7 +1724,13 @@ def test_a_skipped_proposal_records_its_own_terminal_status(tmp_path, git):
     d = _make(tmp_path)
     prop = _proposal(skipped=True, skip_status=L.STATUS_NO_DEFECT, skip_reason="nothing found")
     d._work_one_proposal(
-        prop, base_sha="b", cycle=1, proposals=[prop], perf_survivors=[], bug_winners=[], gated_sha={}
+        prop,
+        base_sha="b",
+        cycle=1,
+        proposals=[prop],
+        perf_survivors=[],
+        bug_winners=[],
+        gated_sha={},
     )
     fp = L.fingerprint(kind=TRACK_PERF, target="mod.py::sym")
     assert d.ledger._seen[fp].status == L.STATUS_NO_DEFECT
@@ -1273,7 +1741,13 @@ def test_a_skipped_proposal_from_a_real_error_counts_as_one(tmp_path, git):
     d = _make(tmp_path)
     prop = _proposal(skipped=True, skip_status=L.STATUS_ERROR, skip_reason="")
     d._work_one_proposal(
-        prop, base_sha="b", cycle=1, proposals=[prop], perf_survivors=[], bug_winners=[], gated_sha={}
+        prop,
+        base_sha="b",
+        cycle=1,
+        proposals=[prop],
+        perf_survivors=[],
+        bug_winners=[],
+        gated_sha={},
     )
     assert d.stats.errors == 1
     fp = L.fingerprint(kind=TRACK_PERF, target="mod.py::sym")
@@ -1311,7 +1785,13 @@ def test_a_rejected_bug_fix_maps_onto_the_shared_ledger_vocabulary(
     d.gate = _Gate(bug_result=BugGateResult(passed=False, reason=reason, detail="why"))
     prop = _proposal(kind=TRACK_BUG)
     d._work_one_proposal(
-        prop, base_sha="b", cycle=1, proposals=[prop], perf_survivors=[], bug_winners=[], gated_sha={}
+        prop,
+        base_sha="b",
+        cycle=1,
+        proposals=[prop],
+        perf_survivors=[],
+        bug_winners=[],
+        gated_sha={},
     )
     fp = L.fingerprint(kind=TRACK_BUG, target="mod.py::sym")
     assert d.ledger._seen[fp].status == expected_status
@@ -1418,7 +1898,7 @@ def test_an_unreproduced_perf_keep_rolls_the_branch_back(tmp_path, git):
     verdict = Verdict(keep=True, status=KEPT, winner=prop, measurement=meas, reason="win")
     d._apply_verdict(1, "base", verdict, [(prop, KEPT, meas)], 1, {})
     assert d.stats.kept == 0  # the keep did not become a reproduced win
-    assert git.seen("reset --hard presha")
+    assert git.seen("checkout -f -B auto_improvement/feature presha")
 
 
 def test_a_direct_committed_perf_win_records_the_landed_sha(tmp_path, git):
@@ -1457,7 +1937,7 @@ def test_a_refused_direct_push_rolls_the_commit_back_and_unwinds_the_keep(tmp_pa
 
     assert d.stats.kept == 0
     assert d.stats.filed == 0
-    assert git.seen("reset --hard presha")
+    assert git.seen("checkout -f -B auto_improvement/feature presha")
 
 
 # ─────────────────────────── the bug verdict ───────────────────────────
@@ -1489,13 +1969,13 @@ def test_a_filed_bug_fix_files_then_returns_head_to_where_it_started(tmp_path, g
     assert d.stats.filed == 1
     assert d.pr_pipeline.bug_kwargs["base_anchor"] == "auto_improvement/feature @ presha"
     assert [e for e in events if "cr_filed" in e][0]["cr_filed"]["kind"] == "bug"
-    assert git.seen("reset --hard presha")
+    assert git.seen("checkout -f -B auto_improvement/feature presha")
 
 
 def test_a_direct_committed_bug_fix_records_committed_once(tmp_path, git):
     d = _make(tmp_path, direct_commit=True)
     d.pr_pipeline = _Pipeline(CrOutcome(fp="fp-bc", status="committed", committed_ready=True))
-    git.script("rev-parse --short HEAD", (0, "bshort\n", ""))
+    git.script("rev-parse HEAD", (0, "e" * 40 + "\n", ""))
     d._direct_push = lambda **kwargs: True
     d.pushed_sha = ""
 
@@ -1505,7 +1985,7 @@ def test_a_direct_committed_bug_fix_records_committed_once(tmp_path, git):
 
     entry = d.ledger._seen["fp-bc"]
     assert entry.status == L.STATUS_COMMITTED
-    assert entry.cr == "bshort"  # fell back to the pre-push short sha
+    assert entry.cr == "e" * 40  # fell back to the finalizer's full head id
     assert (d.stats.kept, d.stats.filed) == (1, 1)
 
 
@@ -1521,7 +2001,7 @@ def test_a_refused_bug_push_rolls_back_without_touching_the_keep_counter(tmp_pat
     )
 
     assert d.stats.kept == 0  # never incremented, so never decremented
-    assert git.seen("reset --hard presha")
+    assert git.seen("checkout -f -B auto_improvement/feature presha")
 
 
 def test_an_unfiled_bug_fix_leaves_head_where_it_was(tmp_path, git):
@@ -1532,7 +2012,7 @@ def test_an_unfiled_bug_fix_leaves_head_where_it_was(tmp_path, git):
         1, _proposal(kind=TRACK_BUG, diff=""), BugGateResult(passed=True, reason=BUG_FILED)
     )
     assert d.stats.filed == 0
-    assert git.seen("reset --hard presha")
+    assert git.seen("checkout -f -B auto_improvement/feature presha")
 
 
 # ─────────────────────────── the per-cycle workflow ───────────────────────────

--- a/test/test_sandbox_absent_ceiling_seal.py
+++ b/test/test_sandbox_absent_ceiling_seal.py
@@ -611,13 +611,21 @@ class TestMaskableDirsAreMaterializedBeforeTheSpawn:
             assert (crew_home / leaf).is_dir()
 
     def test_an_existing_directory_is_left_alone_and_not_reported(self, crew_home):
+        """Every leaf, not one of them: with a leaf hardcoded here, adding a second one to
+        ``_CREW_PRECREATE_HIDDEN_DIR_LEAVES`` makes materialisation report the new leaf and
+        this assertion fail for a reason that has nothing to do with what it checks."""
+        markers = []
         for leaf in sandbox._CREW_PRECREATE_HIDDEN_DIR_LEAVES:
-            (crew_home / leaf).mkdir(parents=True)
-        marker = crew_home / "aws-control-staging" / "drive-preview-live"
-        marker.mkdir()
+            target = crew_home / leaf
+            target.mkdir(parents=True)
+            marker = target / "pre-existing-content"
+            marker.mkdir()
+            markers.append(marker)
 
         assert sandbox._materialize_maskable_dirs() == []
-        assert marker.is_dir()
+        assert markers, "no maskable leaves are declared, so this proves nothing"
+        for marker in markers:
+            assert marker.is_dir()
 
     @_POSIX_ONLY
     @pytest.mark.parametrize("mode", ["standard", "cc", "strict"])

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -488,6 +488,13 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # that cannot apply is refused BEFORE the pipeline drafts.
         "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"
         "::test_a_diff_that_does_not_apply_never_reaches_the_pipeline",
+        # Same basis: literal `git config/add/commit/cat-file/diff` against a tmp_path clone,
+        # proving a credential planted in the COMMITTER IDENTITY is refused. Real git is
+        # required rather than a stub: the point is which bytes git itself puts in the commit
+        # object, which canned output cannot demonstrate. Nothing is agent-influenced -- the
+        # argv is literal and the cwd is the test's own tmp_path.
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"
+        "::test_a_credential_in_the_committer_identity_refuses_to_publish",
         # NOT a subprocess spawn: the AST heuristic matches ``asyncio.run`` (attr ``run`` on
         # base ``asyncio``), used to drive the async ``_approve`` coroutine so a REAL SEL
         # write can be read back off disk. No child process is created.
@@ -547,6 +554,39 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # Its inner `_repo` helper: fixed `git init/clone/commit/push` argv against a tmp_path
         # bare repo, building the local-vs-remote base case for the credential-scan self-diff.
         "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py::_repo",
+        # The direct-push HEAD-identity tests. `::run` is a stub pre-push reviewer that
+        # amends the test's OWN tmp_path clone to reproduce the race; the test function spawns
+        # `git rev-parse --short HEAD` inline to assert that amend really landed before it
+        # asserts the refusal. Both are fixed `git` argv against a per-test tmp_path repo with
+        # no remote -- nothing in the argv, the cwd or the resolved binary is agent-influenced,
+        # and the enclosing `::git` helper above already covers the repo builder.
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py::run",
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"
+        "::test_a_reviewer_amend_between_commit_and_push_refuses_to_publish",
+        # Same basis: the shadow-ref variant additionally spawns `git branch <short-sha> HEAD`
+        # and two `git rev-list -1` reads, all literal argv with cwd and `-C` pinned to the
+        # same per-test tmp_path clone, asserting the injection applied before the refusal.
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"
+        "::test_a_ref_named_the_abbreviation_cannot_shadow_the_committed_object",
+        # The time-of-check/time-of-use pair, same basis again: `::_scan_then_amend` stands in
+        # for a background amend landing while the credential scan runs, and the two test
+        # functions read HEAD back with `git rev-list -1` to prove the injection applied and
+        # to pin the published revision to a full object id.
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py::_scan_then_amend",
+        # `::_gate_then_swap_head` is the same injection one step earlier -- it moves HEAD
+        # right after the pre-scan gate returns, to prove the scan is bound to the object id
+        # rather than to `HEAD`.
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py" "::_gate_then_swap_head",
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"
+        "::test_the_credential_scan_reads_the_committed_object_not_head",
+        # Same basis: this one additionally spawns `git replace` and a `git show` control, to
+        # prove a replacement ref cannot substitute what the credential scan reads.
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"
+        "::test_a_replacement_ref_cannot_substitute_what_the_scan_reads",
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"
+        "::test_a_move_after_the_scan_cannot_change_what_is_published",
+        "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"
+        "::test_an_unmoved_head_still_publishes",
         # Same basis: literal `git rev-parse`/`diff`/`reset` against a tmp_path repo, showing a
         # left-behind provisional commit lands in the NEXT bug PR's range.
         "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"


### PR DESCRIPTION
## Problem / Motivation

`Driver._direct_push` is handed the sha its finalizer produced -- the commit the
pipeline measured, reproduced and wrote to its ledger -- and then published
`HEAD:refs/heads/<dest>` after scanning `HEAD~1..HEAD`. Nothing tied either of those to
the verified commit, so what reached the branch, and what got scanned on the way, were
whatever `HEAD` happened to point at when each step ran.

The window between the two is not empty. `_prepush_review_clean` runs an agent inside
that same clone with `allowed_tools=["Bash", "Read", "Edit", "Grep", "Glob"]`,
`max_turns=30` and `timeout_s=420`. That runner's git denylist is
`_FORBIDDEN_SUBCOMMANDS["git"] = (("push",), ("remote", "set-url"))`, so `git commit` is
permitted there. A reviewer can therefore amend the clone, report `REVIEW: clean`, and
the commit that lands is one this pipeline never verified.

## Why it matters

Everything the loop exists to guarantee is attached to a specific commit: the A/B
measurement, the reproduce measurement, the credential scan, the review verdict and the
`committed` ledger row. If HEAD moves after the finalizer, all of that describes one
commit while a different one is on the branch -- and the ledger records the landed sha,
so the record looks consistent while the content was never checked. There is no
after-the-fact signal either: whether the published state was verified depends only on
when the amend happened, and a poll that reads the forge every few minutes cannot see a
state that existed for one.

## What changed (motivation -> approach -> change)

Symptom: the pipeline can publish, and can credential-scan, a commit it never verified.

Root cause: the publish path addressed the clone through the symbolic ref `HEAD`, which
each step resolves separately. Every check against it is therefore a check-then-use pair,
and the review gate opens a long window in which an agent with `Edit` and `Bash` runs
inside the very clone about to be published.

The change stops using the symbolic ref for anything that decides what gets published:

* The committed object is resolved to a FULL id at the TOP of `_direct_push`, before the
  review gate runs anything.
* A new `_revision_scans_clean(rev)` credential-scans ONE revision's own content by id
  (`<rev>~1..<rev>`, or `show --root <rev>`), and BOTH publish paths call it.
* The first push is handed that id as its refspec source rather than `HEAD`.
* The rebase retry REPLAYS THE RETAINED OBJECT -- `git rebase FETCH_HEAD <rev>` -- so what
  gets replayed is an immutable id rather than whatever the branch points at, then resolves
  the replacement to its own full id BEFORE the build gate runs, requires HEAD to still be
  that object afterwards, scans THAT, and pushes THAT. Because that form detaches HEAD, the
  branch is promoted onto the result with `git branch -f` at exactly ONE place: after
  re-verification, the identity check and the scan have all passed. Every other exit
  re-attaches without moving the branch, which is both the conservative outcome and required
  for correctness -- `_reset_provisional` rolls back with `git reset --hard`, which on a
  detached HEAD moves the detachment and leaves the branch still carrying the commit.
* EVERY git read in this module runs with `core.useReplaceRefs=false`, set once in `_git`,
  because git substitutes objects named by `refs/replace/<oid>` in READS while the push
  transport sends the ORIGINAL -- so a `git replace` (not on the reviewer runner's denylist)
  could otherwise have a read see a clean decoy while the credential-bearing object was
  transferred. Two instances were found one at a time, the credential scan and then the
  rebase, which is why the setting belongs at the chokepoint rather than on the next call
  someone remembers.
* The retry proves the rebase replayed EXACTLY ONE commit. An equivalent upstream patch makes
  `git rebase` drop ours as already-applied and leave HEAD at the remote tip, which every
  later check would then bind to consistently while the ledger recorded an unrelated commit
  as the one this pipeline landed.
* A failed branch restore ABORTS the push rather than logging: a ref lock or checkout failure
  means the repository is not in the state the push assumes. The restore is also
  TRANSACTIONAL -- `git branch -f` lands before the checkout can fail, so a failed checkout
  puts the branch back where it was rather than leaving it carrying an unpushed commit.
* **The pre-push reviewer's `Edit` grant is withdrawn**, not just the prompt sentence that
  sanctioned using it. What decides whether a reviewer can modify the clone is the tool list, not
  the prose telling it what to do, so removing the instruction while keeping the capability left a
  reviewer that may still edit with no sanctioned reason to. `Bash` stays -- the review needs git
  to read the diff -- so this is least privilege rather than the boundary: a shell can still write
  files, which is exactly why the identity checks are what refuse a moved HEAD.
* **The replayed-commit count names BOTH captured ids**, `base..rebased_id`, not `base..HEAD`.
  `HEAD` resolves when that line runs, and the build gate just above it executes the target
  repository's own test suite, so a teardown can move it in between; the equality check before it
  proved HEAD was the replay a moment earlier, which is a check-then-use pair rather than a
  guarantee. It also makes the range COUNTED identical to the range PUBLISHED, since the push
  sends `rebased_id`. Same property as the fetch fix one step earlier: prefer the immutable
  identifier already captured over the mutable name that resolves at read time.
* **A failed provisional rollback halts publishing instead of only logging.** HEAD then keeps a
  commit that was refused and never published; the next winner commits on top of it, and that
  winner's single-revision scan (`<rev>~1..<rev>`) cannot see the parent its own push would
  publish -- so refused content lands through a scanner that never looked at it. The rollback now
  reports its outcome, latches the failure and stops the run, and `_direct_push` refuses while the
  latch is set. **The failure STOPS the run rather than being retried** -- a rollback that cannot
  be trusted to have happened must not be followed by work that assumes it did, and a retry would
  be one more thing whose own failure has to be handled. The halt is unconditional: no retry, no
  further winner, no next cycle. It is enforced at three places because the publish gate alone was
  not enough -- `_apply_bug_winner` calls the PR pipeline's `emit_bug` BEFORE `_direct_push`, and
  that path reaches `pr_recipe._push_fix_branch`, which pushes `HEAD:refs/heads/<branch>` and knows
  nothing about the latch. So the guard sits at the top of both winner-applying methods (upstream of
  every push either can reach), again at the publish gate, and again through the run's stop flag,
  which the cycle loop reads. One cycle can hold several bug winners, so a latch read only at cycle
  boundaries would have let the next winner in the SAME cycle publish. **And the clone is
  QUARANTINED on disk, so a failed rollback blocks reuse of that clone across RUNS, not just
  publishing within one.** The latch lives in memory and clears when the process ends, while the
  refused commit is on disk and the clone is reused -- so the next run would have started with a
  clear latch on poisoned state, which delivers the guarantee for one process lifetime rather than
  for the hazard. Retirement renames the clone out of its canonical name, and that name is the
  predicate `clone_setup._setup_safe_clone` branches on for reuse, so the next run clones fresh
  instead of adopting it. It is the app's own primitive, whose docstring already says it "prevents
  a later run from adopting a rejected provisional commit": nothing about how clones are located or
  named changes, and the bytes are preserved for diagnosis.
* **The rebase base is the object id the FETCH reported, not `FETCH_HEAD`.** That ref is a
  mutable FILE in the clone, and the pre-push reviewer's shell can rewrite it between the fetch
  and the rebase: the replay then lands on a substituted parent whose content nothing scanned,
  and the push carries it. Both the rebase input and the replayed-commit count read that same
  name, so they corroborated the substitution instead of catching it. Measured on a throwaway
  repo with a bare remote: with `.git/FETCH_HEAD` rewritten to a prepared child,
  `rev-list --count FETCH_HEAD..HEAD` still reported `1` while the truth against the real tip was
  `2`, the scanned range held only our own file, and the remote ACCEPTED the push -- the foreign
  file landed through a scanner that believed it had looked. `git fetch --porcelain` reports the
  tip as `<flag> <old-oid> <new-oid> <ref>` on its own stdout, so the id comes from the fetch
  itself and there is no ref to substitute. A fetch that reports no usable id -- including the
  all-zero null id of a deleted ref -- refuses the retry.
* **`src` is REQUIRED on the publish helper, and the three symbolic-source arms are gone.**
  It shipped as `src: str = "HEAD"` "for callers that have nothing more specific"; there were
  none. That default kept alive the pre-fetch tamper check being SKIPPED, a bare
  `rebase FETCH_HEAD` replaying the BRANCH, and a post-push `rev-parse HEAD` for the ledger --
  each the check-then-use shape this change exists to remove, reachable by anyone who later
  added a caller and omitted the argument. Requiring the argument deletes all three. Pinned on
  the signature, because a revived default changes nothing observable until someone omits the
  argument, and then it changes what gets published.
* `_revision_scans_clean` no longer re-spells `core.useReplaceRefs=false`: `_git` injects it on
  every call, so it was one guarantee written twice, and only the chokepoint spelling is pinned. The
  chokepoint covers THIS MODULE's reads only: `pr_recipe` and `backend/commit.py` do their own git
  reads and still honour `refs/replace/*`, so their scans remain substitutable the same way. Out of
  scope here, named so the guarantee is not read as repository-wide.
* `_reset_provisional` is now ONE atomic `git checkout -f -B <branch> <pre_sha>`.
  `git reset --hard` acts on whatever is checked out, and this runs after the pre-push
  reviewer has had a shell in the clone where `git checkout` is permitted -- so it could
  hard-reset an unrelated branch (destroying its commits) or a detached HEAD (a rollback that
  silently does not roll back). An intermediate fix read HEAD, checked the branch out if it
  differed, then reset, which was the same check-then-use pair one level up: a backgrounded
  `setsid git checkout victim` landing in between put the reset back on the wrong branch. A
  single invocation that NAMES the branch has no window. Fixed at the chokepoint because every
  caller shares the exposure, and this closes a LATENT path older than this PR -- the old code
  reached the same `reset --hard` through a scan or push failure.
* The ledger records the object that was SENT, reported by `_push_with_rebase`, rather than a
  post-push `rev-parse HEAD` that a concurrent move could make name an unrelated commit.
* `_head_is_the_committed_sha` compares the retained id against `HEAD` before the scan, so
  a reviewer amend is refused early with a truthful reason, and again after the scan as a
  tamper detector.

Because the scanned object and the published object are named by the same immutable id on
both paths, they are the same object by construction rather than by timing. That holds for
THIS publish path. Two sibling sites still push through `HEAD` -- `pr_recipe._push_fix_branch`
and `backend/commit.py` -- and the threat model above reaches them; they are out of scope
here and named so the claim is not read as repository-wide. That is the
part a re-check cannot buy, and this PR learned it twice. An earlier revision tried to
prove the scan had covered the published object with a post-scan re-check of `HEAD` --
wrong, because the re-check is itself a check-then-use pair. A later one kept `HEAD` on
the retry path and justified it with "`_reverify_head` has just run" -- the same mistake
again, in the one place the carve-out had been left: the build gate is a check, the push
is a later use, `HEAD` is re-resolved in between, and the replayed object had never been
credential-scanned at all because the caller scans the PRE-rebase object. A
non-fast-forward retry is not an edge case on this path; the retry's own docstring
records losing 3 of 6 gate survivors to that race. A third revision then resolved the
replacement AFTER `_reverify_head` -- and that gate runs the repository-under-improvement's
OWN test suite, i.e. arbitrary code from the tree being published, so a test teardown could
move HEAD and have the moved object captured, scanned and pushed as though the gate had
measured it. Credentials were still covered; the build-verification invariant was not. The
capture is now before the gate with an equality check after it. A fourth revision still let
`git rebase` replay whatever HEAD pointed at rather than the authorized source, so the retry
could bind its own capture, verify and scan to a moved commit and pass every check while
publishing content that never descended from the verified object; the rebase input is now
named explicitly. A fifth revision checked HEAD before the `fetch` and still let `git rebase
FETCH_HEAD` replay the branch -- a network operation lasting seconds sat between the check
and the use. That check remains, re-documented as a tamper detector rather than the
guarantee it was mistaken for; the guarantee now comes from naming the object.

Four things about it are deliberate.

* THE ABBREVIATION IS NEVER RE-RESOLVED, which is why the resolve happens early. Git
  resolves a revision through ref names before abbreviated object ids, so re-resolving
  the finalizer's short sha later is defeatable by exactly the actor this gate distrusts:
  amend, then `git branch <old-short-sha> HEAD`, and both sides resolve to the amended
  HEAD. A retained full id has no such input.
* THE SCAN IS ONE HELPER, NOT TWO CALL SITES. It was inline in `_direct_push`, which is
  precisely how the retry path came to publish an unscanned object: a check attached to
  one path and forgotten on the other. `src` still defaults to `HEAD` so no other caller
  of `_push_with_rebase` changes behaviour.
* THE POST-SCAN CHECK IS NO LONGER LOAD-BEARING, and is documented as a tamper detector
  rather than a binding. What it still catches is worth keeping: HEAD differing there
  means something wrote the clone after the review returned, and a clone being written by
  an unknown actor is not one to publish from, even when the object about to be published
  is provably the verified one.
* `rev-list -1` rather than `rev-parse --verify`, because this method already asks a
  DIFFERENT question with `rev-parse --verify --quiet <rev>~1` -- "does a parent exist", a
  boolean that picks the scan's range. One verb carrying two unrelated questions is
  indistinguishable to a reader and to any caller keyed on the argv, and
  `test_ai_spine_driver_coverage`'s git double is keyed on exactly that.

Everything fails closed. An unresolvable object -- the committed one or the replayed one
-- is the absence of the check, not a pass. `_direct_push` returns `False` and records a
`STATUS_ERROR` ledger row, the same disposition every other gate there uses; the retry
returns the original push rejection, which is what that method already does for a
rebased tree that fails re-verification. The commit stays local and recoverable and the
caller's existing rollback runs unchanged.

Two test files outside the change's own are touched, and both are consequences of the
mechanism rather than scope:

* `test/test_ai_spine_driver_coverage.py` (+17): one line in the shared `git` fixture
  scripting the gate's `rev-list -1` resolution -- its fake returns rc 0 with EMPTY stdout
  for an unscripted key, which the gate correctly reads as unresolvable, so without it
  every direct-push test fails closed -- plus two scripted/asserted argv strings that now
  name an object id instead of `HEAD`. No test's intent is changed. The blast radius was
  measured rather than estimated: one test broke on the scan change, one on the push
  change.
* `test/test_spawn_audit.py` (+29): six `BENIGN_SPAWNS` keys with the justification that
  audit's own assertion asks for. The new tests spawn literal `git` argv with both `-C`
  and `cwd` pinned to a per-test `tmp_path` clone; nothing in the argv, the cwd or the
  resolved binary is agent-influenced.

## Tests

Six behavioural tests for the first push in
`TestOnlyTheCommitThePipelineMadeIsPublished`, driving the real `_direct_push` against a
real one-commit git repository, plus three for the retry path in the existing
`TestPushRetriesOnRace`. Real git rather than a stubbed `_git` is load-bearing for the
first group: ref-versus-abbreviation resolution order and `HEAD`-versus-object-id ranges
are the subject of two of them, and a stub cannot exercise either.

* `test_a_reviewer_amend_between_commit_and_push_refuses_to_publish` -- the real fault at
  the real seam: a reviewer that edits, amends, and returns `REVIEW: clean`.
* `test_a_ref_named_the_abbreviation_cannot_shadow_the_committed_object` -- amend, then
  create a branch named the finalizer's short sha.
* `test_the_credential_scan_reads_the_committed_object_not_head` -- HEAD is swapped to a
  decoy immediately after the pre-scan gate returns; the blob handed to the scanner must
  still be the verified object's.
* `test_a_move_after_the_scan_cannot_change_what_is_published` -- the move is injected by
  the credential scanner itself, the last thing before the push.
* `test_an_unmoved_head_still_publishes` -- the accepting case, which also pins that the
  revision handed to the push is the full object id and not `HEAD`.
* `test_an_unresolvable_committed_revision_fails_closed` -- the fail-closed arm.
* `test_the_retry_refuses_a_replayed_object_that_does_not_scan_clean` -- a credential in
  the REPLAYED object, which the caller's scan never saw, must stop the retry.
* `test_the_retry_refuses_when_the_replayed_commit_cannot_be_resolved` -- fail-closed on
  the retry path too; it must not fall back to pushing the symbolic ref. It asserts the
  LOG MESSAGE, because the later HEAD-equality check would also refuse an empty id, so
  without that the check could be deleted with nothing going red.
* `test_the_retry_refuses_when_head_moves_while_the_build_gate_runs` -- the gate itself
  moves HEAD, which is exactly a test teardown's capability.
* `test_the_retry_refuses_to_rebase_a_head_that_is_no_longer_the_source` -- and it refuses
  before fetching, so no rebase runs on an unauthorized HEAD.
* `test_a_replacement_ref_cannot_substitute_what_the_scan_reads` -- real `git replace`
  against a real repository, with a control proving the replacement is in effect for an
  ordinary read while the scan still sees the true object.
* `test_direct_push_reports_the_sha_that_actually_landed` (pre-existing, rewritten) now
  scripts `rev-parse HEAD` to a DIFFERENT value, so a regression to reading the ref reddens.
* `test_the_retry_replays_the_retained_object_and_only_then_moves_the_branch` -- asserts the
  rebase names the object, that the bare form is NOT used, and that the branch promotion
  happens after the gate and before the second push.
* `test_a_failed_rebase_leaves_the_branch_alone_and_publishes_nothing` -- a rebase that
  conflicts must abort, must not force-move the branch, must re-attach the clone, and must
  publish nothing. `git branch -f` is only correct when HEAD IS the replayed result, so this
  pins that the promotion is unreachable from a failure path.
* `test_a_non_fast_forward_triggers_exactly_one_rebase_and_retry` (pre-existing, extended)
  now also asserts the retry's refspec is the resolved id and not `HEAD:refs/heads/<b>`.

Each injecting test asserts its injection APPLIED before asserting the consequence, and
the three first-push refusal tests assert WHICH of the two identity checks refused, so
neither can be deleted without a test going red.

Mutation-verified by hand, forty-nine mutations, each with its own red set:

| mutation | reddens |
|---|---|
| neuter the PRE-SCAN check | the amend, shadow-ref AND fail-closed tests |
| re-resolve the abbreviation late instead of using the retained id | ONLY the shadow-ref test |
| let an unresolvable committed object pass | ONLY the fail-closed test |
| first push sends `HEAD` instead of the retained id | ONLY `test_direct_push_reads_the_fetch_url_off_the_clone_when_the_profile_has_none` |
| remove the POST-SCAN tamper check | ONLY the move-after-the-scan test |
| bind the credential scan back to `HEAD` | ONLY the scan-reads-the-committed-object test |
| retry pushes `HEAD` instead of the replayed id | ONLY the one-rebase-and-retry test |
| retry skips the scan of the replayed object | ONLY the replayed-object-scan test |
| retry falls through when the replayed commit cannot be resolved | ONLY the unresolvable-replacement test |
| remove the retry's post-gate HEAD equality check | ONLY the head-moves-during-the-gate test |
| resolve the replacement AFTER the build gate again | ONLY the head-moves-during-the-gate test |
| remove the pre-rebase authorized-source check | ONLY the rebase-input test |
| drop `core.useReplaceRefs=false` from the scan | ONLY the replacement-ref test |
| record `HEAD` instead of the object that was sent | the three sha-reporting tests |
| replay the BRANCH instead of the retained object | ONLY the explicit-replay test |
| promote the branch on the scan-refusal path | ONLY the replayed-object-scan test |
| promote the branch after a FAILED rebase | ONLY the failed-rebase test |
| never promote, leaving the branch behind after a publish | ONLY the explicit-replay test |
| skip the re-attach after a failed rebase | ONLY the failed-rebase test |
| drop `core.useReplaceRefs=false` from `_git` | ONLY the chokepoint test |
| accept a rebase that replayed the wrong number of commits | ONLY the dropped-commit test |
| ignore a failed branch restore and push anyway | ONLY the failed-restore test |
| leave the promotion in place when the checkout fails | ONLY the undo-promotion test |
| roll back with `reset --hard` on whatever is checked out | the atomic-rollback test and 3 rollback callers |
| roll back to a detached sha instead of naming the branch | the atomic-rollback test and 3 rollback callers |
| restore the `src="HEAD"` default | ONLY the signature test |
| replay the branch again (bare `rebase FETCH_HEAD`) | the retry-argv test and the replay-then-promote test |
| skip the pre-fetch tamper check | ONLY the moved-HEAD refusal test |
| re-read `HEAD` for the ledger | all 3 sha-reporting tests |
| rebase onto `FETCH_HEAD` instead of the reported id | the substitution test and 2 retry tests |
| count replayed commits against `FETCH_HEAD` | ONLY the substitution test |
| drop `--porcelain`, so no id is reported | 3 retry tests, via the fail-closed refusal |
| accept a missing id instead of refusing | ONLY the no-id refusal test |
| accept the null id of a deleted ref | the refusal test and the parser's null-id case |
| swallow a failed rollback (log only) | ONLY the halt test |
| latch the failure but let the run continue | ONLY the halt test |
| drop the publish-gate refusal, keeping the stop flag | ONLY the same-cycle refusal test |
| drop the perf-track winner guard | ONLY the unconditional-halt test |
| drop the bug-track winner guard (upstream of the PR push) | ONLY the unconditional-halt test |
| make the halt predicate always report safe | ONLY the unconditional-halt test |
| count the replay against ambient `HEAD` | ONLY the substitution test |
| restore the fallback to the caller's pre-push snapshot | ONLY the ledger-shape test |
| restore the reviewer's `Edit` grant | ONLY the report-only-grant test |
| grant `Write` instead (same capability, other name) | ONLY the report-only-grant test |
| strip `Bash` too, making the review vacuous | ONLY the report-only-grant test |
| latch only, no quarantine (the in-memory-guard defect) | ONLY the cross-run quarantine test |
| quarantine without marking the clone retired | ONLY the cross-run quarantine test |
| mark retired but never rename the clone aside | ONLY the cross-run quarantine test |
| drop the already-retired short circuit | ONLY the second-rollback test |

The `src="HEAD"` mutation reddens ONLY a signature assertion, and that is the honest reading:
a revived default changes nothing observable while every caller passes the argument, and
changes what gets published the moment one does not. It is pinned where it is reachable rather
than left unmeasured.

Each mutation asserted its anchor was unique before being applied, because an unapplied
mutation is indistinguishable from a surviving one. Two earlier rounds of this table had
SURVIVORS and neither was recorded as a pass. First: the post-scan check silently absorbed
every case the pre-scan check was supposed to catch, and the refspec assertion lives in the
other file -- fixed by pinning which check refuses and re-running that mutation where it is
observable. Second, and worse: the scan-binding test passed against a deliberately broken
gate, because its injection patched `driver.normalize_branch` while `_direct_push` imports
that name INSIDE the function, so the patch was inert; patching the source module instead
fired too early, so the seam is now the gate's own return. Both were found by the
mutation, not by the green run. A third survivor appeared this round: once the post-gate
equality check existed, it absorbed the unresolvable-replacement refusal, so that mutation
stopped reddening -- fixed by asserting the log message rather than only the refusal. The
reordering it came from also broke three pre-existing tests that pin the atomic clone
RETIREMENT, because refusing at the capture preempted it; the capture now happens early
while the refusal stays in its original position. And one process mistake worth recording:
this round's mutation loop was run BEFORE committing, so `git checkout -- driver.py` between
mutations restored the file from HEAD and discarded three uncommitted fixes. They were
re-applied and the rule is now explicit -- commit first, then mutate. The credential sample in the retry test was likewise
checked against the real `scan_content_for_secrets` first -- the uppercase
`AWS_SECRET_ACCESS_KEY = '...'` spelling is NOT flagged, so the obvious sample would have
made that test pass for the wrong reason.

Run locally after committing (a diff-scoped gate run before the commit gates nothing):
`test_dogfood_learnings.py` 323 passed at `-n0`, `test_ai_spine_driver_coverage.py` 157,
`test_spawn_audit.py` 12, `test_pr_recipe.py` 66. Every baselined gate in `Backend Lint & Type Check` passes:
subprocess encoding, black, agent-SDK boundary, sync-IO-in-async,
lockdown-before-publish. `isort --check-only` and `flake8` over CI's own paths are clean.
`mypy src/kiro_crew/` reports 4 errors, all pre-existing on main in `transcribe.py` and
`ops_mission_control/backend/providers/cloudwatch.py`, and 0 in any file this PR touches.

## Manual verification

N/A -- unit coverage is sufficient. The fault, the accepting case, the ref-shadowing,
mid-scan and post-scan variants and both retry-path refusals are all driven through the
real methods, and exercising the path live would mean authorizing a real direct push.

## Related Issues

Refs #8452

### For a future publish path

No shared publish seam exists in this app, so the halt is enforced at three hand-placed sites --
the top of `_apply_verdict`, the top of `_apply_bug_winner`, and `_direct_push` itself -- and the
object-id pinning lives in `_push_with_rebase`. A publish path added later must adopt BOTH
properties independently: refuse while `_rollback_failed` is latched, and address the commit by the
id it verified rather than by `HEAD`. `pr_recipe._push_fix_branch` and `backend/commit.py` are the
two existing paths that do neither; they are known-unfixed and deliberately out of scope here.

### What is in the diff, and why it is this size

`+2217/-156` across six files. `driver.py` is `+634/-82` and is the fix plus its reasoning; the
remaining `+1251/-26` is test (`test_dogfood_learnings.py +1213/-18`, `test_pr_recipe.py +32/-8`,
`test_spawn_audit.py +33`) and `test_ai_spine_driver_coverage.py` is `+305/-47`. The test bulk is
not incidental to a defect fix -- it is what makes forty-nine separate protections falsifiable,
each with its own red set, and several cases (abbreviated-sha shadowing, real `git replace`, a real
rebase detaching HEAD) cannot be exercised against a stubbed `_git` at all, so they run against real
one-commit repositories. Every guard here refuses a publish, and a guard that no test can redden is
indistinguishable from one that was never wired up.

### Declared: a mechanical reformat rides along

`test/test_ai_spine_driver_coverage.py` LEAVES `.github/black-baseline.txt` (the diff's only
baseline change, `-1`, and no additions). Leaving the baseline means the whole file must be
`black`-clean, so a whole-file reformat is included. Its size cannot be stated as a clean subset
of the file's `+305/-47`, because black reflowed lines that this PR also edits, so the mechanical and
substantive hunks overlap: what is measurable is that running `black` on the BASE version alone
yields `+260/-74`, i.e. most of that file's churn is reflow rather than new content, and every
non-test hunk in it is black's own output with no hand edits. The prune is
REQUIRED rather than opportunistic -- putting the entry back makes the gate fail with
`0 new offender(s), 1 graduated entry to prune`. The baseline is never grown by this PR: the diff
against the base is exactly one deletion.

## Pattern harvest

Rule candidate: review-prompt
Pattern: addressing a repository through a SYMBOLIC REF while holding a verified object id.
`git push HEAD:refs/heads/<b>` and `git diff HEAD~1..HEAD` each resolve `HEAD` at their own
call time, so every check against it is a check-then-use pair and each window belongs to
whatever else can write the clone. Adding another check does not help, because the new check
has a window of its own -- this PR made that mistake twice before naming the object id in
every step that must agree, which turns a timing argument into a structural one. Two
corollaries worth carrying: a check written inline in one path is how the sibling path comes
to lack it, so put it in a helper both call; and re-resolving an ABBREVIATED id is the same
bug with an extra edge, since git resolves ref names before abbreviated object ids and a ref
is something an untrusted actor can create.

## Other suggestions

* This is one of the three directions #8452 offers, scoped to the publish path in this
  repository. The amends the issue reports were observed in worker worktrees under
  `oss/kirocrew-fix-*`, and the process that wrote them is still unidentified; the issue
  itself rules this file out as that mechanism, because a commit created in the separate
  push-disabled clone cannot write a `commit (amend)` entry into a worktree's reflog. The
  issue therefore stays open for the maintainer decision, and this PR leaves its scope
  intact.
* The two routes the issue lists as uninvestigated -- the `kirocrew-worktree-dev` skill's
  amend plus force-push sequence, and `issue_radar/backend/pipeline_fold.py` -- are
  untouched here. Measured while locating the right seam: `dev_fleet` contains no push
  invocation at all, and no shared publish helper exists that every push site routes
  through, so a single central gate was not available. First Principles Review reached
  the same conclusion independently by counting `HEAD:refs/heads` sites.
* One open PR, #5081, also touches `test_dogfood_learnings.py`. Its hunks sit around line
  1241 inside `TestTheStoredPushDestinationIsValidated` while this change appends at the
  end of the file and edits `TestPushRetriesOnRace` near the top, so the two do not
  collide. `merge-tree` between the two heads does report conflicts, but that reading is
  confounded: their merge-base is thousands of commits behind this branch, so those
  conflicts are main's own history rather than an adjacency with this change.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, no user-facing surface changed
- [x] No secrets, credentials, or internal references in the diff




















