### PR TITLE
fix(session-directive): preserve the tail marker, not the last sentinel substring

### DIFF
--- a/src/kiro_crew/session_directive.py
+++ b/src/kiro_crew/session_directive.py
@@ -224,6 +224,29 @@ def tag_refusal(text: str) -> str:
     return f"{text}\n{_REFUSAL_SENTINEL}"
 
 
+def _bounded_marker_payload(full: str, probe: int) -> str | None:
+    """The marker LINE starting at *probe* (sentinel included), or ``None`` when
+    the line is too long to be a marker.
+
+    The bound is :data:`MAX_TOOL_RESULT_CHARS`, and it is a semantic bar, not a
+    shortcut, for three independent reasons: :func:`encode` refuses any directive
+    over :data:`MAX_DIRECTIVE_CHARS` (far below it), a tail this long fails
+    :func:`preserve_tail_marker`'s own room check so it could never be
+    re-attached, and the transport cuts every frame to the same budget so no
+    consumer ever reads a marker line past it. A longer line is model-authored
+    bytes wearing the sentinel, and treating it as bytes is what keeps this walk
+    O(occurrences): the frame is unbounded, so per-occurrence work must not
+    scale with the frame.
+    """
+    limit = probe + MAX_TOOL_RESULT_CHARS
+    end = full.find("\n", probe, limit)
+    if end < 0:
+        if len(full) > limit:
+            return None
+        end = len(full)
+    return full[probe:end]
+
+
 def preserve_tail_marker(full: str, truncated: str) -> str:
     """Re-attach a tail-anchored marker that truncating *full* into *truncated* cut.
 
@@ -237,15 +260,19 @@ def preserve_tail_marker(full: str, truncated: str) -> str:
     same reason: a control token that decides how a frame is interpreted must not
     be a casualty of a length cut applied to the frame's prose.
 
-    The marker is located by walking sentinel occurrences from the RIGHT and
-    accepting the first whose tail actually reads (:func:`peek` for the directive
-    sentinel; exact tail anchoring for the refusal tag, which :func:`tag_refusal`
-    appends as the final line). ``rfind`` alone picked the last occurrence of the
-    sentinel *substring* -- and the payload is model-authored, JSON string
-    escaping leaves ``[`` alone, so a directive whose own arguments carry the
-    sentinel bytes embeds a later occurrence inside the payload. Preserving from
-    there re-attached a tail that began mid-payload, unreadable to every
-    consumer: the helper built to save the marker was what corrupted it (#8962).
+    The marker is located by scanning sentinel occurrences left to right and
+    keeping the RIGHTMOST whose own line actually reads (:func:`peek` for the
+    directive sentinel; exact tail anchoring for the refusal tag, which
+    :func:`tag_refusal` appends as the final line). ``rfind`` alone picked the
+    last occurrence of the sentinel *substring* -- and the payload is
+    model-authored, JSON string escaping leaves ``[`` alone, so a directive whose
+    own arguments carry the sentinel bytes embeds a later occurrence inside the
+    payload. Preserving from there re-attached a tail that began mid-payload,
+    unreadable to every consumer: the helper built to save the marker was what
+    corrupted it (#8962). Each occurrence is judged on a BOUNDED line
+    (:func:`_bounded_marker_payload`), never on a suffix of the frame: ``full``
+    is unbounded, so per-occurrence suffix slices are O(N*L) -- an event-loop
+    stall reachable by one command that repeats the sentinel bytes.
     Occurrences reading as genuinely DIFFERENT markers are refused outright --
     the ambiguity bar ``_repair_escaped_marker`` already holds, kept here so a
     length cut cannot launder a two-marker frame into a clean one. When nothing
@@ -255,14 +282,13 @@ def preserve_tail_marker(full: str, truncated: str) -> str:
     for sentinel in (_SENTINEL, _REFUSAL_SENTINEL):
         if sentinel is _SENTINEL:
             idx, lines = -1, set()
-            probe = full.rfind(sentinel)
+            probe = full.find(sentinel)
             while probe >= 0:
-                tail = full[probe:]
-                if peek(tail) is not None:
-                    if idx < 0:
-                        idx = probe
-                    lines.add(tail.split("\n", 1)[0])
-                probe = full.rfind(sentinel, 0, probe)
+                line = _bounded_marker_payload(full, probe)
+                if line is not None and peek(line) is not None:
+                    idx = probe
+                    lines.add(line)
+                probe = full.find(sentinel, probe + 1)
             if len(lines) > 1:
                 return truncated
         else:

--- a/src/kiro_crew/session_directive.py
+++ b/src/kiro_crew/session_directive.py
@@ -236,9 +236,39 @@ def preserve_tail_marker(full: str, truncated: str) -> str:
     Mirrors the MCP App render marker's re-injection at the same seam, for the
     same reason: a control token that decides how a frame is interpreted must not
     be a casualty of a length cut applied to the frame's prose.
+
+    The marker is located by walking sentinel occurrences from the RIGHT and
+    accepting the first whose tail actually reads (:func:`peek` for the directive
+    sentinel; exact tail anchoring for the refusal tag, which :func:`tag_refusal`
+    appends as the final line). ``rfind`` alone picked the last occurrence of the
+    sentinel *substring* -- and the payload is model-authored, JSON string
+    escaping leaves ``[`` alone, so a directive whose own arguments carry the
+    sentinel bytes embeds a later occurrence inside the payload. Preserving from
+    there re-attached a tail that began mid-payload, unreadable to every
+    consumer: the helper built to save the marker was what corrupted it (#8962).
+    Occurrences reading as genuinely DIFFERENT markers are refused outright --
+    the ambiguity bar ``_repair_escaped_marker`` already holds, kept here so a
+    length cut cannot launder a two-marker frame into a clean one. When nothing
+    reads, nothing is re-attached: a garbage tail protects no consumer and costs
+    the prose the cut had kept.
     """
     for sentinel in (_SENTINEL, _REFUSAL_SENTINEL):
-        idx = full.rfind(sentinel)
+        if sentinel is _SENTINEL:
+            idx, lines = -1, set()
+            probe = full.rfind(sentinel)
+            while probe >= 0:
+                tail = full[probe:]
+                if peek(tail) is not None:
+                    if idx < 0:
+                        idx = probe
+                    lines.add(tail.split("\n", 1)[0])
+                probe = full.rfind(sentinel, 0, probe)
+            if len(lines) > 1:
+                return truncated
+        else:
+            # The genuine refusal tag is tail-anchored by construction; an
+            # embedded occurrence mid-prose is bytes, not a tag.
+            idx = len(full) - len(sentinel) if full.endswith(sentinel) else -1
         if idx < 0:
             continue
         tail = full[idx:]

--- a/test/test_tail_marker_picks_the_marker_8962.py
+++ b/test/test_tail_marker_picks_the_marker_8962.py
@@ -1,0 +1,125 @@
+"""#8962: ``preserve_tail_marker`` must re-attach the MARKER, not the last
+occurrence of the sentinel *substring*.
+
+The marker's payload is model-authored (``monitor_start``'s ``message``,
+``autonudge_stop``'s ``reason``) and JSON string escaping leaves ``[`` alone, so
+a directive whose own arguments carry the literal sentinel bytes places a later
+occurrence of the sentinel INSIDE the payload. ``rfind`` selected that embedded
+occurrence, the preserved "tail" began mid-payload, and the re-attached frame
+was unreadable: the helper that exists to protect the marker was the thing that
+corrupted it, and the effect (a monitor loop, a project switch) was silently
+dropped while the model was told it had been made.
+
+The fix walks sentinel occurrences from the right and accepts the first whose
+tail actually READS (``peek`` for the directive sentinel; exact tail anchoring
+for the refusal tag, which :func:`tag_refusal` appends as the final line). Two
+occurrences reading as genuinely DIFFERENT markers are refused outright -- the
+same ambiguity bar ``_repair_escaped_marker`` holds, so this seam cannot be
+used to launder a two-marker frame into a clean one.
+"""
+
+from __future__ import annotations
+
+from kiro_crew import session_directive
+
+MAX = session_directive.MAX_TOOL_RESULT_CHARS
+SENTINEL = session_directive.SENTINEL
+
+
+def _cut_dropping_the_tail(full: str) -> str:
+    """The transport's naive length cut, sized so the marker line is lost."""
+    cut = full[:MAX]
+    assert not full == cut, "precondition: a real truncation occurred"
+    return cut
+
+
+class TestTheMarkerWinsOverEmbeddedSentinelBytes:
+    def test_a_directive_whose_message_carries_the_sentinel_round_trips(self):
+        """THE #8962 attack: sentinel bytes inside ``args`` must not divert the
+        re-attach to a mid-payload tail."""
+        args = {"message": f"alert when {SENTINEL} shows up in the output"}
+        directive = session_directive.encode("monitor_start", args, "Monitoring armed")
+        assert directive.count(SENTINEL) == 2, "precondition: payload embeds the sentinel"
+        full = "y" * MAX + "\n" + directive
+        cut = _cut_dropping_the_tail(full)
+        assert session_directive.peek(cut) is None, "precondition: the cut drops the marker"
+
+        kept = session_directive.preserve_tail_marker(full, cut)
+
+        got = session_directive.peek(kept)
+        assert got is not None, "the re-attached frame must be readable"
+        kind, got_args = got
+        assert kind == "monitor_start"
+        assert got_args == args, "the payload must survive byte-for-byte"
+        assert len(kept) <= MAX
+
+    def test_a_well_formed_frame_is_preserved_exactly_as_before(self):
+        """Control: no embedded sentinel, the walk lands on the same occurrence
+        ``rfind`` always chose."""
+        directive = session_directive.encode("autonudge_stop", {"reason": "goal met"}, "stopping")
+        full = "y" * MAX + "\n" + directive
+        cut = _cut_dropping_the_tail(full)
+
+        kept = session_directive.preserve_tail_marker(full, cut)
+
+        assert session_directive.decode(kept, "autonudge_stop") == {"reason": "goal met"}
+        assert len(kept) <= MAX
+
+    def test_two_copies_of_the_same_marker_are_not_ambiguous(self):
+        """A backend that duplicates the frame raises the occurrence count
+        without naming two directives -- ``_repair_escaped_marker`` resolves that
+        case rather than refusing, and this seam must agree."""
+        directive = session_directive.encode("autonudge_stop", {"reason": "done"}, "stopping")
+        marker_line = directive.split("\n", 1)[1]
+        full = "y" * MAX + "\n" + marker_line + "\n" + marker_line
+        cut = _cut_dropping_the_tail(full)
+
+        kept = session_directive.preserve_tail_marker(full, cut)
+
+        assert session_directive.peek(kept) == ("autonudge_stop", {"reason": "done"})
+
+
+class TestAmbiguityIsRefusedNotLaundered:
+    def test_two_different_readable_markers_are_left_cut(self):
+        """The pin the issue asks for: a frame naming two genuinely different
+        directives must not have one of them picked and re-attached --
+        ``_repair_escaped_marker`` refuses that frame when it arrives whole, and
+        a length cut must not become the way around that refusal."""
+        a = session_directive.encode("autonudge_stop", {"reason": "a"}, "ha")
+        b = session_directive.encode("monitor_start", {"message": "b"}, "hb")
+        full = "y" * MAX + "\n" + a + "\n" + b
+        cut = _cut_dropping_the_tail(full)
+
+        kept = session_directive.preserve_tail_marker(full, cut)
+
+        assert kept == cut, "ambiguous frames are refused, not resolved"
+
+
+class TestNothingReadableMeansNothingReattached:
+    def test_prose_mentioning_the_sentinel_is_not_promoted_to_a_marker(self):
+        """Sentinel bytes with no readable marker anywhere (a file read, a doc
+        quoting the constant) used to get a garbage tail re-attached at the cost
+        of the prose the cut had kept. Nothing a consumer could read is being
+        protected, so the cut stands."""
+        full = "y" * MAX + "\n note: " + SENTINEL + "zzz is the marker prefix"
+        cut = _cut_dropping_the_tail(full)
+
+        kept = session_directive.preserve_tail_marker(full, cut)
+
+        assert kept == cut
+
+    def test_a_refusal_tag_survives_embedded_directive_bytes_in_its_prose(self):
+        """A tagged refusal whose prose carries directive-sentinel bytes must
+        fall through the (unreadable) directive occurrences and still get its
+        tail-anchored tag back -- losing it re-creates the lost-marker class
+        the tag exists to prevent."""
+        refusal = session_directive.tag_refusal(f"Error: field {SENTINEL}zzz was rejected")
+        full = "y" * MAX + "\n" + refusal
+        cut = _cut_dropping_the_tail(full)
+        assert not session_directive.is_refusal(cut), "precondition: the cut drops the tag"
+
+        kept = session_directive.preserve_tail_marker(full, cut)
+
+        assert session_directive.is_refusal(kept)
+        assert session_directive.peek(kept) is None, "the prose bytes must not read as a directive"
+        assert len(kept) <= MAX

--- a/test/test_tail_marker_picks_the_marker_8962.py
+++ b/test/test_tail_marker_picks_the_marker_8962.py
@@ -123,3 +123,87 @@ class TestNothingReadableMeansNothingReattached:
         assert session_directive.is_refusal(kept)
         assert session_directive.peek(kept) is None, "the prose bytes must not read as a directive"
         assert len(kept) <= MAX
+
+
+class TestRepeatedSentinelBytesStayLinear:
+    """The locate walk must pay a BOUNDED cost per occurrence, never a suffix of
+    the frame. ``full`` is an unbounded, model-authored tool-result join (the
+    per-part cut is deliberately gone at the dispatch seam), and the sentinel is
+    a public constant -- one command whose output repeats it puts tens of
+    thousands of occurrences in a multi-megabyte frame. A per-occurrence
+    ``full[probe:]`` slice makes that O(N*L): an event-loop stall and a watchdog
+    restart, reachable without a single valid marker.
+    """
+
+    def test_a_frame_dense_with_sentinel_bytes_parses_in_bounded_time(self):
+        """Attack shape from review: repeated sentinel bytes, no readable marker
+        until the genuine one at the tail. Quadratic locate stalls for minutes;
+        the bounded walk finishes with a wide margin under the ceiling."""
+        import time
+
+        directive = session_directive.encode("autonudge_stop", {"reason": "goal met"}, "stopping")
+        # ~1.3 MB of prose carrying ~32,000 sentinel occurrences on one line --
+        # the review's own attack shape. Each occurrence's "line" is the giant
+        # remainder, so a suffix-slicing walk pays ~40 GB of copies (measured
+        # ~27s here; the ceiling below under-states it 5x on purpose). The
+        # noise sits BEYOND the cut, keeping the kept head sentinel-free prose:
+        # the walk runs over ``full`` either way, and a sentinel-free head is
+        # what lets the round-trip assert stay byte-exact. The fixed walk stays
+        # ~milliseconds (lesson: CI fixture cost must not become the test's own
+        # failure mode).
+        noise = (SENTINEL + "x" * 32) * 32000
+        full = "y" * MAX + "\n" + noise + "\n" + directive
+        cut = _cut_dropping_the_tail(full)
+
+        start = time.monotonic()
+        kept = session_directive.preserve_tail_marker(full, cut)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 5.0, f"locate walk took {elapsed:.1f}s -- quadratic cost is back"
+        assert session_directive.decode(kept, "autonudge_stop") == {"reason": "goal met"}
+
+    def test_sentinel_dense_frame_with_no_marker_at_all_is_also_bounded(self):
+        """Same attack without any genuine marker: the walk still visits every
+        occurrence (the ambiguity bar requires it), so the bound must hold on
+        the pure-noise path too, and the cut must stand untouched."""
+        import time
+
+        noise = (SENTINEL + "x" * 32) * 32000
+        full = "y" * MAX + "\n" + noise + "\nplain tail, no marker"
+        cut = _cut_dropping_the_tail(full)
+
+        start = time.monotonic()
+        kept = session_directive.preserve_tail_marker(full, cut)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 5.0, f"locate walk took {elapsed:.1f}s -- quadratic cost is back"
+        assert kept == cut
+
+
+class TestAMarkerLineWiderThanAFrameIsBytes:
+    def test_an_over_budget_marker_line_cannot_divert_the_reattach(self):
+        """A sentinel line longer than MAX_TOOL_RESULT_CHARS cannot be a marker
+        three ways at once: ``encode`` refuses anything over MAX_DIRECTIVE_CHARS,
+        the room check could never re-attach it, and the transport cut means no
+        consumer ever reads it whole. The bounded walk treats it as the bytes it
+        is, and the genuine, encodable marker still wins."""
+        directive = session_directive.encode("autonudge_stop", {"reason": "goal met"}, "stopping")
+        huge_args = '{"kind":"monitor_start","args":{"message":"' + "m" * (MAX * 2) + '"}}'
+        full = "y" * MAX + "\n" + SENTINEL + huge_args + "\n" + directive
+        cut = _cut_dropping_the_tail(full)
+
+        kept = session_directive.preserve_tail_marker(full, cut)
+
+        assert session_directive.decode(kept, "autonudge_stop") == {"reason": "goal met"}
+        assert len(kept) <= MAX
+
+    def test_an_over_budget_line_alone_leaves_the_cut_standing(self):
+        """The over-budget line as the ONLY sentinel content: nothing readable
+        within the frame budget, so nothing is re-attached."""
+        huge_args = '{"kind":"monitor_start","args":{"message":"' + "m" * (MAX * 2) + '"}}'
+        full = "y" * MAX + "\n" + SENTINEL + huge_args
+        cut = _cut_dropping_the_tail(full)
+
+        kept = session_directive.preserve_tail_marker(full, cut)
+
+        assert kept == cut


### PR DESCRIPTION
## Problem / Motivation

`preserve_tail_marker` re-attaches a tail-anchored directive/refusal marker that the transport's length cut removed. It located the marker with `full.rfind(sentinel)` — the last occurrence of the sentinel *substring*, which is not necessarily the marker. The marker's payload is model-authored (`monitor_start`'s `message`, `autonudge_stop`'s `reason`, a `suggest_followup` item's `prompt`) and JSON string escaping does not escape `[`, so a directive whose own arguments contain the literal sentinel bytes embeds a later occurrence *inside* the payload. `rfind` selected that embedded occurrence, the preserved "tail" began mid-payload, and the re-attached frame was unreadable by `peek`/`decode`.

The failure is the silent kind: the model is told the request was made, the consumer reads no directive, and nothing reports that the two disagree — a monitor loop that was never armed, a project switch that never happened.

## Why it matters

The helper exists to protect the marker from the length cut; on this input it is the thing that corrupts it. The effect is a dropped control token rather than a security boundary (the applied payload is always the gateway-parked, tool-validated record, and a forged marker finds no record) — but a silently dropped `monitor_start` is an agent that believes it is watching something it is not.

## What changed (motivation → approach → change)

Walk sentinel occurrences from the right and accept the first whose tail actually **reads**, instead of trusting the rightmost substring match:

- **Directive sentinel:** the tail must `peek` (yield a selector). An occurrence embedded in a JSON string never does — what follows it is the remainder of a string literal, not a parseable marker line — so the walk steps left and lands on the genuine marker.
- **Refusal sentinel:** the genuine tag is tail-anchored by construction (`tag_refusal` appends it as the final line), so acceptance is exact tail anchoring (`full.endswith(sentinel)`). An embedded occurrence mid-prose is bytes, not a tag.
- **Ambiguity is refused, not resolved:** occurrences reading as genuinely *different* markers return the truncated frame unchanged — the same bar `_repair_escaped_marker` holds for multi-marker envelopes, kept here so a length cut cannot launder a two-marker frame into a clean single-marker one. Identical duplicates still resolve (matching that helper's tolerance for backends that copy the result text into two fields).
- **Nothing readable, nothing re-attached:** sentinel bytes with no readable marker anywhere (a file read quoting the constant) previously got a garbage tail re-attached at the cost of the prose the cut had kept. No consumer could read that tail, so the cut now stands.
- **Per-occurrence work is bounded** (`_bounded_marker_payload`): extracting a candidate marker line reads at most `MAX_TOOL_RESULT_CHARS` bytes past the occurrence. The bound is a semantic bar, not a shortcut: `encode` refuses directives far below it, a tail that long fails `preserve_tail_marker`'s own room check so it could never be re-attached, and the transport cuts every frame to the same budget so no consumer ever reads a marker line past it. A longer line is model-authored bytes wearing the sentinel; treating it as bytes keeps the walk O(occurrences) on an unbounded frame. Declared consequence: an over-budget "marker" line can neither divert the walk nor win the re-attach.

Behaviour for every well-formed frame is unchanged: the rightmost readable occurrence is exactly the occurrence `rfind` chose whenever the frame was unambiguous.

## Tests

`test/test_tail_marker_picks_the_marker_8962.py` — ten pins: six semantic (attack pins fail before the fix: round-trip corruption, ambiguity laundering, garbage promotion; controls pass before and after) and four bounding (dense-frame attacks fail against the first commit's unbounded walk; over-budget-line controls pin the declared consequence):

- **Attack (the #8962 round-trip pin):** a `monitor_start` whose `message` carries the literal sentinel survives the cut-and-reattach seam and `peek`s back byte-for-byte.
- **Control:** a well-formed frame without embedded sentinel bytes is preserved exactly as before.
- **Duplicate tolerance:** two copies of the *same* marker are not ambiguous (backend-copy shape).
- **Ambiguity pin:** a frame carrying two genuinely different readable markers is left cut — refused, not picked — so this seam cannot bypass `_repair_escaped_marker`'s refusal.
- **No-promotion pin:** prose mentioning the sentinel with no readable marker is left as the cut made it.
- **Refusal fall-through:** a tagged refusal whose prose embeds directive-sentinel bytes still gets its tail-anchored tag back.
- **Bounded-walk attack (x2):** a sentinel-dense multi-MB frame, with and without a genuine marker, parses within a hard time budget.
- **Over-budget line pins (x2):** a sentinel line longer than `MAX_TOOL_RESULT_CHARS` cannot divert the re-attach toward itself, and alone it leaves the cut standing.

Full gate run (10 targeted + 21 seam-neighbor suites = 1006 tests, mypy, flake8, isort, black baseline, docs lint) green at the submitted sha.

## Manual verification

Ran the six-pin suite at the pristine base commit before applying the fix: the three attack pins fail there with the predicted shapes — the round-trip pin fails on "the re-attached frame must be readable" (mid-payload tail), the ambiguity pin on a marker being picked, the no-promotion pin on a garbage tail re-attach — and the three controls pass, so the suite convicts the defect rather than the environment. Same suite is 6/6 green on the fixed tree.

The fix round repeats the ritual for the four bounding pins: with the first commit's walk restored, both dense-frame attacks fail on the time budget (19.7s and 20.2s against a 5.0s ceiling, "quadratic cost is back") and pass bounded after; 10/10 green at the submitted sha.

## Screenshots / video

<!-- no-visual-delta --> Transport-seam string handling only; no rendered surface changes.

## Related Issues

Part of #8962. Surfaced on #8899 by review of that PR's new call sites, but reachable on `main` through the pre-existing `_build_tool_result_event` path; sibling of the #8886 deep-nesting crash on the same seam.

## Pattern harvest

The class is "a guard that locates a control token by *substring search* over text that interpolates model-authored content": the search finds the attacker-positioned copy, not the token. Adjacent members checked: `peek`/`decode`/`strip_marker` use `find` (leftmost) — the *leftmost* occurrence in a genuine `encode` frame is always the real marker since the payload follows it, so they do not share the defect; `_repair_escaped_marker` already anchors acceptance to `peek` ("acceptance is the test, not the shape"), which is the pattern this fix extends to the truncation seam. Two further same-class members sit outside this module and are registered rather than fixed here: `constants.py:292` (`rfind` on `[STEERING`/`[OPTIONS`) and `messaging/renderer.py:462` (`rfind` on `[OPTIONS`) both locate control tokens by substring position over text that can interpolate model-authored content; each deserves its own reproducer against its own consumer semantics. A third residual member registered rather than fixed here: prose *before* the marker carrying sentinel bytes can shadow a re-attached marker from `peek`'s leftmost read on the delivered frame — a distinct, narrower shape (model-echoed sentinel in the human confirmation line) that deserves its own reproducer rather than a rider on this fix.

Rule candidate: locate control tokens by parse acceptance, never by substring position — the rightmost/leftmost occurrence of a sentinel in mixed trusted/untrusted text is attacker-positionable.

## Checklist

- [x] Tests added/updated and passing locally
- [x] Lint/format/docs gates green
- [x] No unrelated changes

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's contribution license agreement.