### PR TITLE
fix(test): scope the notification-copy ordering triggers to the destination open

### DIFF
--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -2361,6 +2361,7 @@ class TestNotificationCopyWhenNoLiveFileExists(_NotificationCopyFixtures):
         note = {"ts": "2026-09-05T00:00:00Z", "msg": "LIVE-NOTE", "kind": "agent"}
         ran_during_copy = threading.Event()
         submitted: list[object] = []
+        dst = str(home / "notifications.jsonl")
         real_open = os.open
 
         def append_note() -> None:
@@ -2369,7 +2370,16 @@ class TestNotificationCopyWhenNoLiveFileExists(_NotificationCopyFixtures):
 
         def opening(path, flags, *args, **kwargs):
             fd = real_open(path, flags, *args, **kwargs)
-            if flags & os.O_CREAT and not submitted:
+            # Scoped to the copy's own destination open, not to "the first O_CREAT
+            # seen anywhere": this hook patches `os.open` PROCESS-WIDE, and on a
+            # loaded CI shard the first creating open can belong to another thread
+            # entirely (issue #8893 -- both ordering tests in this class fired on
+            # shard 4 for PRs whose diffs never touch this path). A foreign trigger
+            # submits the append while the worker is still FREE, and the assertion
+            # then reads a real ordering guarantee as broken. The destination is the
+            # one open the copy performs while it occupies the worker, so it is the
+            # only trigger that measures the serialisation.
+            if flags & os.O_CREAT and os.fspath(path) == dst and not submitted:
                 submitted.append(pool.submit(append_note))
                 # A FREE worker runs this in microseconds; a worker the copy is running
                 # on cannot run it at all until the copy returns.
@@ -2460,6 +2470,7 @@ class TestNotificationCopyWhenNoLiveFileExists(_NotificationCopyFixtures):
         note = {"ts": "2026-09-05T00:00:00Z", "msg": "LIVE-NOTE", "kind": "agent"}
         ran_during_copy = threading.Event()
         fired: list[int] = []
+        dst = str(home / "notifications.jsonl")
         real_open = os.open
 
         def append_note() -> None:
@@ -2468,7 +2479,14 @@ class TestNotificationCopyWhenNoLiveFileExists(_NotificationCopyFixtures):
 
         def opening(path, flags, *args, **kwargs):
             fd = real_open(path, flags, *args, **kwargs)
-            if flags & os.O_CREAT and not fired:
+            # Same scoping as the READER test above, same reason (issue #8893): the
+            # hook patches `os.open` PROCESS-WIDE, and on a loaded shard the first
+            # O_CREAT can come from a foreign thread while the notification worker is
+            # still FREE -- the append then runs immediately and the assertion reads
+            # the ordering guarantee as broken. Only the copy's own destination open
+            # happens while the copy occupies the worker, so it is the only trigger
+            # that measures the serialisation this test is about.
+            if flags & os.O_CREAT and os.fspath(path) == dst and not fired:
                 fired.append(1)
                 # The delivery sink's own route on a fresh gateway: it ACQUIRES the
                 # executor, creating it if the copy did not.
@@ -2489,6 +2507,99 @@ class TestNotificationCopyWhenNoLiveFileExists(_NotificationCopyFixtures):
         assert any(
             r.get("msg") == "LIVE-NOTE" for r in rows
         ), f"the live notification was dropped by the positional cap ({len(rows)} rows)"
+
+    def test_the_ordering_trigger_ignores_a_foreign_O_CREAT_open(self, tmp_path, monkeypatch):
+        """The loaded-shard condition itself, kept as a test (issue #8893).
+
+        Both ordering tests in this class patch ``os.open`` PROCESS-WIDE, and both
+        fired on a contended CI shard for PRs that never touch this path: some other
+        thread's ``O_CREAT`` open arrived first, the append was submitted while the
+        notification worker was still FREE, and it ran immediately -- the assertion
+        then read a scheduling accident as a broken ordering guarantee. The fix is
+        the destination-path scope on the trigger, and this test is that condition
+        made deterministic: a churn thread is CONFIRMED to have done a creating open
+        before the merge even starts, so under the old first-O_CREAT-anywhere shape
+        the trigger is GUARANTEED foreign and the test fails every run, not one CI
+        run in a thousand. Under the scoped shape the churn is invisible, however
+        the scheduler interleaves it, and the ordering measurement is captured
+        INSIDE the trigger -- the wait's return value, taken while the copy still
+        holds the worker -- where the append's legitimate post-copy run cannot
+        race it: the trigger fired on the destination, the worker stayed held,
+        the note survived.
+        """
+        from kiro_crew.dashboard import state as dashboard_state
+
+        snap, home = self._snap(
+            tmp_path,
+            b"".join(
+                b'{"ts":"2026-01-%02dT00:00:00Z","msg":"archive-%d","kind":"agent"}\n'
+                % ((i % 28) + 1, i)
+                for i in range(dashboard_state._MAX_PERSISTED_NOTIFICATIONS)
+            ),
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        monkeypatch.setattr(dashboard_state, "_notification_io_pool", None)
+        note = {"ts": "2026-09-05T00:00:00Z", "msg": "LIVE-NOTE", "kind": "agent"}
+        ran_during_copy = threading.Event()
+        ran_while_worker_held: list[bool] = []
+        fired: list[str] = []
+        dst = str(home / "notifications.jsonl")
+        real_open = os.open
+
+        def append_note() -> None:
+            dashboard_state._persist_notification(note)
+            ran_during_copy.set()
+
+        def opening(path, flags, *args, **kwargs):
+            fd = real_open(path, flags, *args, **kwargs)
+            if flags & os.O_CREAT and os.fspath(path) == dst and not fired:
+                fired.append(os.fspath(path))
+                dashboard_state._notification_io_executor().submit(append_note)
+                # The measurement is the WAIT'S RETURN VALUE, captured here. A free
+                # worker runs the queued append in microseconds and the wait returns
+                # True; the worker this copy occupies cannot run it at all, so the
+                # wait times out False. Re-reading the EVENT after the merge returns
+                # would race the append's legitimate post-copy run instead (the
+                # churner join below hands the worker exactly that window).
+                ran_while_worker_held.append(ran_during_copy.wait(timeout=1.0))
+            return fd
+
+        monkeypatch.setattr(os, "open", opening)
+
+        noise_dir = tmp_path / "foreign-o-creat"
+        noise_dir.mkdir()
+        stop = threading.Event()
+        churned_once = threading.Event()
+
+        def churn() -> None:
+            i = 0
+            while not stop.is_set():
+                p = noise_dir / f"scratch-{i}.tmp"
+                fd = os.open(str(p), os.O_CREAT | os.O_WRONLY, 0o600)
+                os.close(fd)
+                p.unlink(missing_ok=True)
+                churned_once.set()
+                i += 1
+
+        churner = threading.Thread(target=churn, name="foreign-o-creat", daemon=True)
+        churner.start()
+        try:
+            assert churned_once.wait(timeout=5.0), "the churn thread never opened a file"
+            self._merge(snap, home)
+        finally:
+            stop.set()
+            churner.join(timeout=5.0)
+
+        assert fired == [dst], f"the trigger fired on the wrong open(s): {fired}"
+        assert ran_while_worker_held == [False], (
+            "the append ran while the copy occupied the worker: a foreign trigger "
+            "submitted it while the worker was still free, or the ordering broke"
+        )
+        dashboard_state._notification_io_executor().submit(lambda: None).result()
+        rows = dashboard_state._load_notifications()
+        assert any(
+            r.get("msg") == "LIVE-NOTE" for r in rows
+        ), f"the live notification was dropped ({len(rows)} rows)"
 
     def test_an_import_failure_that_is_not_ImportError_is_not_swallowed(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Problem / Motivation

Two ordering tests in `TestNotificationCopyWhenNoLiveFileExists` (`test/test_snapshot.py`) failed on a loaded `Backend Tests (3.12, 4)` shard for PR #8887, whose diff never touches the snapshot/notification path:

```
AssertionError: the append ran while the copy was still writing, so the two are concurrent rather than ordered
AssertionError: a delivery on a fresh gateway ran concurrently with the copy: 'no pool' was read as 'no writer'
```

The class passes locally on the same commit. A second occurrence fired on shard 4 for PR #8896 (run 34014923783) while the same test passed 5/5 locally at that PR's exact sha — and a third on the very next round of the same PR (run 34017247801, `test_a_FRESH_gateway_still_orders_the_copy_against_a_delivery` again, taking the Coverage Gate down with it via the missing shard upload). Three firings across three unrelated diffs in under 24 hours: the failure follows shard load, not the diff.

## Why it matters

Every PR in the repo runs these tests; a scheduling-dependent trigger turns busy CI days into false-negative red boards and burns contributor CI rounds on failures their diffs cannot cause. The class is one day old (#8576), so this is its first hardening pass — left alone, it becomes a standing flake with a growing rerun tax.

## What changed (motivation → approach → change)

- **Symptom**: ordering assertions fail only on contended shards, for unrelated diffs.
- **Root cause** (confirmed with a deterministic reproducer, hypothesis from the auto-triage comment on #8893): both tests patch `os.open` **process-wide** and fire their delivery trigger on the *first* `O_CREAT` open observed anywhere (`if flags & os.O_CREAT and not fired`). Locally that first open is the copy's own destination — taken while the copy occupies the single notification worker, so the queued append cannot run and the bounded wait times out exactly as intended. On a loaded shard, the first creating open can come from a foreign thread while the worker is still **free**: the append runs immediately, `ran_during_copy` sets, and the assertion reads a scheduling accident as a broken ordering guarantee.
- **Change**: scope both triggers to the copy's own destination open (`os.fspath(path) == dst`). The destination is opened by full path at a single site (`snapshot.py::_install_notifications`, `os.open(dst_path, O_CREAT|O_EXCL|...)`), and it is the one open the copy performs while it holds the worker — so it is the only trigger that measures the serialisation these tests exist to prove. Per the issue's ask and the testing conventions: no retry, no sleep — the foreign-trigger case is removed, not tolerated.

## Tests

- `test_the_ordering_trigger_ignores_a_foreign_O_CREAT_open` (new): keeps the loaded-shard condition as a deterministic test. A churn thread is *confirmed* to have completed a creating open before the merge starts, so under the old first-`O_CREAT`-anywhere shape the trigger is guaranteed foreign and the test fails every run (reproduced before the fix: the churn open fires the trigger and the pin fails deterministically). Under the scoped shape the churn is invisible however the scheduler interleaves it; asserts the trigger fired on exactly the destination, the worker-held measurement stayed false (captured inside the trigger from the wait's return value, where the append's legitimate post-copy run cannot race it), and the note survived. Soaked 20/20 solo runs; an event-re-read variant of the same assertion failed the identical soak, which is what forced the in-trigger capture.
- `test_a_note_delivered_during_the_copy_survives_the_READER` and `test_a_FRESH_gateway_still_orders_the_copy_against_a_delivery` (updated): destination-scoped triggers; their assertions — including the `assert fired` proved-something guard — are unchanged.
- Full file green: 130 passed. Seam neighbors (`test_dashboard.py`, `test_notification_phase5.py`): 68 passed.

## Manual verification

N/A — unit coverage sufficient: the flake condition itself is now a deterministic in-suite test, and the affected surface is test-only (no production code changed).

## Related Issues

Fixes #8893

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a process-wide patch of a filesystem/syscall entry point must scope its trigger to the specific path or descriptor under test — 'the first call observed' is a scheduling assertion on loaded runners, not a behavioral one". Flag new tests that monkeypatch `os.open`/`builtins.open` and branch on flags alone without binding to the path they mean.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Per the template placeholder (CLA text pending): offered under the same terms as my prior merged contributions to this repository (#8835).
