### PR TITLE
fix(dashboard): release the composer drag suppression when the resize handle leaves mid-drag

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -2082,6 +2082,26 @@ function ChatInput({
     return () => document.removeEventListener('keydown', onSlashFocus)
   }, [typedCommandMenus, composerCollapsed, expandComposer, composerControl])
 
+  // Teardown keyed to the HANDLE's lifecycle, not the component's: the handle
+  // leaves the tree on its own mid-drag (the pointer type flipping coarse swaps
+  // it for the plain spacer; the approval ghost swap unmounts the strip) and
+  // pointer capture dies with the element — the terminal lostpointercapture
+  // then fires on a DETACHED node, which React's root listener never sees, so
+  // onEnd never arrives. React invokes callback refs with null on unmount
+  // (component unmount included), making this the one teardown path that
+  // covers every exit. onEnd keeps the normal path; whichever runs first wins,
+  // the `dragging` flag makes the loser a no-op.
+  const releaseDragSuppression = useCallback(() => {
+    if (!dragging.current) return
+    dragging.current = false
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+    if (wrapperRef.current) wrapperRef.current.style.contain = ''
+  }, [])
+  const resizeHandleLifecycleRef = useCallback((node: HTMLDivElement | null) => {
+    if (node === null) releaseDragSuppression()
+  }, [releaseDragSuppression])
+
   const inputResize = usePointerDrag({
     threshold: 0,
     onStart: (e) => {
@@ -2110,27 +2130,21 @@ function ChatInput({
       wrapperRef.current.style.height = h + 'px'
     },
     onEnd: () => {
-      if (!dragging.current || !wrapperRef.current) return
-      dragging.current = false
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-      wrapperRef.current.style.contain = ''
+      if (!dragging.current) return
+      // Restore the page-wide suppression BEFORE anything that can bail: the
+      // wrapper ref going null must never strand body.cursor/userSelect.
+      releaseDragSuppression()
+      const el = wrapperRef.current
+      if (!el) return // suppression released; nothing to measure or commit
       // Commit final height to React state
-      const finalH = wrapperRef.current.offsetHeight
+      const finalH = el.offsetHeight
       setManualHeight(finalH)
       safeSetItem(INPUT_HEIGHT_LS_KEY, String(Math.round(finalH)))
     },
   })
-  // Unmount guard: onEnd can't fire if the composer unmounts mid-drag
-  // (setPointerCapture dies with the element), so restore the global body styles
-  // here to avoid leaving the resize cursor / text-selection lock stuck.
-  useEffect(() => () => {
-    if (dragging.current) {
-      dragging.current = false
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-    }
-  }, [])
+  // (Component-unmount teardown is covered by resizeHandleLifecycleRef above:
+  // React fires callback refs with null on unmount at every level, so a
+  // separate unmount-only effect guard would be a dead duplicate here.)
 
 
 
@@ -3364,6 +3378,7 @@ function ChatInput({
       {!showGhost && (isTouch || composerCollapsed
         ? <div aria-hidden="true" data-testid="composer-top-gap" className="h-[6px] shrink-0" />
         : <div
+        ref={resizeHandleLifecycleRef}
         aria-hidden="true"
         data-testid="composer-resize-handle"
         className="flex items-center justify-center h-[6px] cursor-row-resize group/drag"

--- a/website/src/test/ChatInput.dragTeardownLeak.test.tsx
+++ b/website/src/test/ChatInput.dragTeardownLeak.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, act } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import ChatInput from '../components/ChatInput'
+
+/**
+ * The composer resize handle can leave the tree on its own, mid-drag, while
+ * ChatInput itself stays mounted: `showGhost` flips on for the approval ghost
+ * swap, and the pointer type going coarse swaps the handle for a plain spacer.
+ * Pointer capture dies with the element, so the terminal `lostpointercapture`
+ * fires on a DETACHED node — React's root listener never sees it, and no
+ * onEnd is ever delivered for the drag that was live at that moment.
+ *
+ * The globals set in onStart (page-wide `row-resize` cursor, text-selection
+ * suppression on <body>) then stay stuck until the next drag or a full
+ * component unmount — the old teardown guard was keyed to COMPONENT unmount
+ * only, which is exactly the case that does not happen here.
+ *
+ * The teardown must therefore be keyed to the HANDLE's lifecycle (which also
+ * covers component unmount one level up), and onEnd itself must restore the
+ * globals even when the wrapper ref is already gone — whichever path runs
+ * first wins; the other must be a no-op.
+ */
+
+const defaultProps = {
+  value: '',
+  onChange: vi.fn(),
+  onSend: vi.fn(),
+}
+
+const COARSE = '(pointer: coarse)'
+const NO_HOVER = '(hover: none)'
+
+/**
+ * Mutable, REACTIVE matchMedia stub: `useIsTouchDevice` subscribes via
+ * addEventListener('change'), so flipping the answer must also notify the
+ * captured listeners or the component never re-renders. (The fixed-answer stub
+ * in ChatInput.resizeHandleTouch.test.tsx deliberately drops listeners; this
+ * suite is ABOUT the flip, so it keeps them.)
+ */
+function stubReactivePointer() {
+  const original = window.matchMedia
+  const matches: Record<string, boolean> = { [COARSE]: false, [NO_HOVER]: false }
+  const listeners = new Set<() => void>()
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      get matches() { return matches[query] ?? false },
+      media: query,
+      addEventListener: (_: string, cb: () => void) => { listeners.add(cb) },
+      removeEventListener: (_: string, cb: () => void) => { listeners.delete(cb) },
+      dispatchEvent: () => false,
+    }),
+  })
+  return {
+    flipToTouch() {
+      matches[COARSE] = true
+      matches[NO_HOVER] = true
+      listeners.forEach(cb => cb())
+    },
+    flipToMouse() {
+      matches[COARSE] = false
+      matches[NO_HOVER] = false
+      listeners.forEach(cb => cb())
+    },
+    restore() {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true, configurable: true, value: original,
+      })
+    },
+  }
+}
+
+let pointer: ReturnType<typeof stubReactivePointer>
+
+beforeEach(() => {
+  localStorage.clear()
+  document.body.style.cursor = ''
+  document.body.style.userSelect = ''
+  pointer = stubReactivePointer()
+})
+afterEach(() => { pointer.restore() })
+
+const handle = () => screen.getByTestId('composer-resize-handle')
+
+describe('ChatInput drag teardown when the handle leaves mid-drag', () => {
+  it('restores the body suppression when the handle unmounts mid-drag (component stays mounted)', () => {
+    renderWithProviders(<ChatInput {...defaultProps} value="test" />)
+
+    fireEvent.pointerDown(handle(), { clientX: 100, clientY: 200 })
+    expect(document.body.style.cursor).toBe('row-resize')
+    expect(document.body.style.userSelect).toBe('none')
+
+    // Pointer type goes coarse mid-drag: the handle is swapped for the plain
+    // 6px spacer while ChatInput stays mounted. No pointerup/lostpointercapture
+    // can reach React once the element is detached — teardown must not depend
+    // on one arriving.
+    act(() => { pointer.flipToTouch() })
+    expect(screen.queryByTestId('composer-resize-handle')).toBeNull()
+
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+    // And no phantom height commit: the drag never ended over the wrapper.
+    expect(localStorage.getItem('mc-input-height')).toBeNull()
+  })
+
+  it('a drag after the handle returns starts and ends clean (no stale dragging state)', () => {
+    renderWithProviders(<ChatInput {...defaultProps} value="test" />)
+
+    // Leak scenario first, so any stale `dragging` flag from it would poison
+    // the next gesture.
+    fireEvent.pointerDown(handle(), { clientX: 100, clientY: 200 })
+    act(() => { pointer.flipToTouch() })
+    act(() => { pointer.flipToMouse() })
+
+    // Fresh gesture on the re-mounted handle must behave like a first drag.
+    fireEvent.pointerDown(handle(), { clientX: 100, clientY: 250 })
+    expect(document.body.style.cursor).toBe('row-resize')
+    fireEvent.pointerUp(handle(), { clientX: 100, clientY: 240 })
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+    // The completed drag commits its height (jsdom measures 0 — the value is
+    // irrelevant here; the WRITE is what proves onEnd ran its commit branch).
+    expect(localStorage.getItem('mc-input-height')).not.toBeNull()
+  })
+
+  it('handle swap with no drag live is a no-op on body styles', () => {
+    renderWithProviders(<ChatInput {...defaultProps} value="test" />)
+    document.body.style.cursor = 'progress' // sentinel: teardown must not clobber others' state
+    act(() => { pointer.flipToTouch() })
+    expect(document.body.style.cursor).toBe('progress')
+    document.body.style.cursor = ''
+  })
+
+  it('still restores the body suppression on full component unmount mid-drag', () => {
+    // The old guard covered exactly this; the handle-lifecycle teardown that
+    // replaces it must keep the guarantee — effect cleanups run on unmount too.
+    const { unmount } = renderWithProviders(<ChatInput {...defaultProps} value="test" />)
+    fireEvent.pointerDown(handle(), { clientX: 100, clientY: 200 })
+    expect(document.body.style.cursor).toBe('row-resize')
+    unmount()
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+})


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** the change attaches a callback ref to an existing element and reorders drag teardown logic; a ref attribute is not rendered DOM, so no pixel on any surface changes.

## Problem / Motivation

The composer resize handle can leave the tree on its own while `ChatInput` stays mounted: the pointer type flipping to coarse swaps it for the plain spacer, and the approval ghost swap unmounts the handle strip. Pointer capture dies with the element, so the terminal `lostpointercapture` fires on a detached node that React's root listener never sees, and no `onEnd` is delivered for the live drag. The page-wide `row-resize` cursor and the body-wide text-selection suppression set at drag start then stay stuck until the component unmounts or a later drag happens to clean them up.

This is the consumer-side follow-up that #8904's own Pattern harvest named as out of scope there: "`ChatInput`'s drag `onEnd` early-returns without clearing the suppression when its wrapper ref is null while still mounted." That early-return is the second, latent stranding path this PR closes alongside the primary handle-swap one.

## Why it matters

Same user pain family as #8271, on the dashboard's primary surface: a stuck arrow/`row-resize` cursor and unselectable text page-wide, with no visible cause and self-healing behavior that makes it nearly impossible to report. #8904 fixed the shared hook's capture-loss termination; this consumer can still strand its own globals whenever the handle element itself leaves mid-drag, because in that case the hook's events have no attached target left to fire on at all.

## What changed (motivation → approach → change)

- Observed symptom: mid-drag, the handle unmounts (coarse-pointer flip or ghost swap); the drag never ends; `body.cursor` stays `row-resize` and `body.userSelect` stays `none` while `ChatInput` remains mounted.
- Root cause: every teardown path was keyed to the wrong lifecycle. The `lostpointercapture` end rides the handle element, which is gone; the cleanup `useEffect` fires only on component unmount, which has not happened; and `onEnd`'s compound guard (`!dragging || !wrapper`) could bail before restoring the globals whenever the wrapper ref nulled first.
- Change: key the teardown to the handle's lifecycle. A callback ref on the handle releases the suppression (cursor, userSelect, wrapper `contain`, dragging flag) when the element unmounts for any reason; React fires callback refs with `null` on component unmount too, so the old effect guard is subsumed rather than duplicated. `onEnd` now releases the suppression before anything that can bail and gates only the height commit on the wrapper's existence. The release callback is `useCallback` with empty deps (refs and globals only), so its identity is stable for the component lifetime and the ref never fires spuriously mid-drag on re-render. Whichever path runs first wins; the dragging flag makes the loser a no-op.
- Alternative considered and rejected: patching each swap site (the coarse-pointer flip, the ghost swap) to end the drag before removing the handle. That fixes the two known causes but not the class; any future conditional render of the handle would reintroduce the leak. Keying teardown to the element whose existence actually gates capture covers all of them, and also closes the wrapper-null bail that per-site patches would not touch.

## Tests

New `website/src/test/ChatInput.dragTeardownLeak.test.tsx` (4 tests):

- attack: the mid-drag handle swap restores both body styles and commits no phantom height (fails before this change);
- recovery: a fresh drag after the handle returns starts and ends clean, with no stale dragging state;
- benign: a handle swap with no drag live leaves foreign body styles untouched;
- control: full component unmount mid-drag still restores the suppression (the old guarantee, kept).

Reproducer output, before (tests added, source at base):

```
FAIL src/test/ChatInput.dragTeardownLeak.test.tsx > ChatInput drag teardown when the handle leaves mid-drag > restores the body suppression when the handle unmounts mid-drag (component stays mounted)
AssertionError: expected 'row-resize' to be '' // Object.is equality
Test Files  1 failed (1) · Tests  1 failed | 3 passed (4)
```

The one failure is the handle-swap attack; critically, the full-unmount control passes at base, so the suite discriminates exactly the claimed gap: the old guard covered component unmount and only the mid-drag handle swap leaked. After the fix: `4 passed`. Drag-seam neighbor suites: 34 files, 485 tests, all passing.

## Manual verification

jsdom does not model real pointer-capture bookkeeping, so the tests prove the lifecycle contract: when the handle element leaves the tree, React fires its callback ref with `null` and the suppression is released. That callback-ref-on-unmount behavior is React's documented semantics, the same mechanism the component already relies on for the wrapper ref. The visual result (cursor and selection restored the instant the handle disappears) follows directly.

## Related Issues

Addresses #8271 (already fixed at the hook layer by #8904; this completes the consumer-side follow-up that PR's Pattern harvest explicitly deferred).

## Pattern harvest

Rule candidate: review-prompt
Pattern: teardown for a gesture must be keyed to the lifecycle of the element that owns the gesture's events, not the component's. If pointer capture (or any element-attached listener) gates delivery of the "end" signal, a conditional render of that element is a silent teardown bypass. Review prompt: for every element that can be conditionally unmounted while its owner stays mounted, check what gesture state or global side effects die stranded with it; a callback ref that releases on `null` covers every unmount cause at once, including the component's own.

The adjacent hook-side hardening named in #8904 remains intentionally out of scope for this one-topic fix: `usePointerDrag` swallows `setPointerCapture` failure, so an uncaptured drag whose `pointerup` lands outside the handle never terminates; a window-listener fallback would close it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: behavioral fix within one component's drag teardown; the contract is documented at the changed seam
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

I confirm this contribution is my own work, derived from the public repository and public web-platform documentation, and I license it under the project's existing license terms.

