### PR TITLE
feat(dashboard): opt-in per-session project directory

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5913,6 +5913,8 @@
           "enabled": true
         },
         "default_project": "",
+        "new_project_per_session": false,
+        "session_project_root": "",
         "theme_mode": "",
         "sso_login_flags": "",
         "theme_color": "",
@@ -6498,6 +6500,34 @@
       "tags": [],
       "label": "Default Project",
       "help": "Directory path used as the project for new chat tabs. Empty = workspace dir.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": ""
+    },
+    {
+      "path": "dashboard.new_project_per_session",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "New Project Per Session",
+      "help": "Give each new chat session its own project directory instead of sharing one. Off by default: until it is turned on, new sessions resolve their project exactly as before.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
+      "path": "dashboard.session_project_root",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Session Project Root",
+      "help": "Directory that holds the per-session project directories created when 'New Project Per Session' is on. Must already exist. Empty = a '.sessions' folder inside the workspace directory, created for you. Config-file only, like 'Default Project' -- no dashboard-writable setting takes a path.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": ""

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -34,7 +34,7 @@ from urllib.parse import urlsplit as _urlsplit  # noqa: F401 - compatibility fac
 # FROZEN pre-split alias snapshot (test_loader_reexports_historical_snapshot_by_identity),
 # so new resolution helpers are reached through the module, not re-exported.
 import kiro_crew.config.resolution as _resolution
-from kiro_crew import __version__, model_registry, platform_compat, windows_acl
+from kiro_crew import __version__, model_registry, pinned_fs, platform_compat, windows_acl
 from kiro_crew.agent_sdk.capabilities import MODEL_NAMESPACE_ACP, capabilities_for
 
 # Leaf module (stdlib + platform_compat only) — no import cycle with config.
@@ -1576,6 +1576,363 @@ def default_project_dir(workspace: str | None = None) -> str:
     except Exception:
         pass
     return ""
+
+
+#: Container the per-session directories live in when no root is configured.
+#: A FIXED name, never derived from a session key, and dot-prefixed so it cannot
+#: collide with a project file: the session name becomes the directory name, so
+#: creating those directly in the workspace root lets a session called
+#: ``package.json`` put a DIRECTORY on that path and every later write of the
+#: real file fails with ``IsADirectoryError``. One level of indirection removes
+#: the whole class -- inside the container the only neighbours a session name can
+#: collide with are other session names, which exclusive creation already
+#: refuses.
+_SESSION_DIR_CONTAINER = ".sessions"
+
+
+def _pinned_dir_create(
+    parent: str, name: str, *, exclusive: bool, linked_ancestor: str | None
+) -> int:
+    """Create ``name`` directly under ``parent`` and return ITS descriptor, or raise.
+
+    The descriptor is the point, not a convenience. Re-opening the child by
+    pathname after creating it hands a sibling process -- and in this product an
+    agent is such a process, running as the same user -- a window to swap the new
+    directory for a link to ANOTHER session's directory. The refusals that follow
+    the create then validate whatever the name now means, and a link aimed at a
+    sibling inside the same parent passes every one of them, so the new session
+    adopts that session's files. Everything downstream therefore validates the
+    descriptor this returns; the name is never resolved again.
+
+    The ONE create routine for both directories this module makes -- the
+    container and a session's own directory -- so their protection is identical
+    by construction rather than by two call sites remembering the same rules. A
+    second, softer create is how a fixed container reintroduced the very class
+    the hardened session create had closed: ``mkdir(exist_ok=True)`` follows a
+    symlink planted at the name, and everything below then resolves through it.
+
+    *parent* must be resolved by the CALLER, once, before this runs, and
+    *linked_ancestor* must be the ancestor shape observed at that same moment
+    (``None`` where the platform can walk components instead). Both are the
+    caller's because both have to predate the window this closes.
+
+    ``exclusive`` refuses a name that already exists. Without it an existing
+    directory is accepted, but only after an ``O_NOFOLLOW`` open proves it is a
+    real directory and not a link -- accepting the name is not the same as
+    accepting whatever currently answers to it.
+
+    The caller owns the returned descriptor and must ``os.close`` it. Raises
+    :class:`pinned_fs.PinnedPathRefusal` for a swapped or linked component,
+    ``FileExistsError`` for a refused existing name, and ``OSError`` for an
+    ordinary failure. Callers turn all three into "no per-session directory".
+    """
+    if pinned_fs.supports_pinned_walk() and os.mkdir in os.supports_dir_fd:
+        # POSIX: one `openat` per component of the already-resolved parent, each
+        # with `O_NOFOLLOW`, so a component swapped since the caller resolved it
+        # is refused, and the child is created against the descriptor that walk
+        # produced rather than against a path.
+        parent_fd = pinned_fs.pin_parent(parent, what="per-session project root")
+        try:
+            try:
+                os.mkdir(name, 0o700, dir_fd=parent_fd)
+            except FileExistsError:
+                if exclusive:
+                    raise
+            # Opened relative to the pinned parent with `O_NOFOLLOW`, so this
+            # refuses a link or a non-directory at the name -- which is both what
+            # proves an accepted existing name is a real directory, and what makes
+            # the descriptor a witness the caller can validate instead of the name.
+            return os.open(name, pinned_fs.dir_flags(), dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+    # Windows: no `O_DIRECTORY` and no `dir_fd`, and naming those flags raises
+    # `AttributeError`. Holding the parent open without `FILE_SHARE_DELETE`
+    # forbids renaming or deleting it and everything above it, and refuses a
+    # reparse point at its own name; re-reading the ancestor shape while that pin
+    # is HELD is what catches a swap that landed before it. Order is the
+    # property: the same check before the pin leaves the window open.
+    parent_pin = platform_compat.pin_directory(parent)
+    try:
+        if platform_compat.first_linked_ancestor(parent) != linked_ancestor:
+            raise pinned_fs.PinnedPathRefusal("an ancestor changed shape mid-call")
+        child = os.path.join(parent, name)
+        if platform_compat.is_link_or_junction(child):
+            raise pinned_fs.PinnedPathRefusal("a link sits at the directory's own name")
+        try:
+            os.mkdir(child, 0o700)
+        except FileExistsError:
+            if exclusive:
+                raise
+        # `pin_directory` refuses a reparse point at the name and, while held,
+        # forbids renaming or deleting what it opened -- so this descriptor is the
+        # same witness the POSIX branch returns, reached by the mechanism this
+        # platform has.
+        return platform_compat.pin_directory(child)
+    finally:
+        os.close(parent_pin)
+
+
+def _validated_dir_from_fd(fd: int, *, expected_parent: str) -> str:
+    """The path of the directory ``fd`` HOLDS, validated, or ``""``.
+
+    The single place a created directory turns back into a path, and it asks the
+    kernel which path the open inode has rather than asking the filesystem what a
+    name currently means. That distinction is the whole point: between creating a
+    directory and validating it, a process running as this user -- an agent, in
+    this product -- can replace the name with a link to ANOTHER session's
+    directory, and a link aimed at a sibling under the same parent satisfies a
+    containment check on the re-resolved name. Validating the descriptor instead
+    cannot be redirected, because a descriptor has no name left to swap.
+
+    Fails closed on every arm. ``fd_real_path`` returns ``None`` rather than
+    falling back to a mutable pathname when the kernel cannot answer, and a
+    non-directory, a sensitive location, or a parent other than
+    *expected_parent* all yield ``""`` -- the caller's "no per-session
+    directory".
+    """
+    from kiro_crew.security import is_sensitive_path  # circular import
+
+    resolved = pinned_fs.fd_real_path(fd)
+    if not resolved:
+        return ""
+    if not _stat.S_ISDIR(os.fstat(fd).st_mode):
+        return ""
+    if is_sensitive_path(resolved):
+        return ""
+    if os.path.dirname(resolved) != expected_parent:
+        return ""
+    return resolved
+
+
+def _default_session_root(workspace: str | None) -> str:
+    """The container under the workspace default, created if absent.
+
+    Returns ``""`` when the workspace directory is unusable or the container
+    cannot be made, which the caller reads as "no per-session directory" -- the
+    same degrade the rest of this path takes.
+
+    Created here rather than required to pre-exist, unlike a CONFIGURED root: a
+    configured root that does not exist is a typo, and creating it would scatter
+    directories wherever the typo pointed, but this path is a fixed name under a
+    directory that already validated, so there is nothing to guess at. Created
+    through the same pinned routine the session directories use, and owner-only,
+    because a container that can be redirected redirects everything under it.
+    """
+    ws = default_project_dir(workspace)
+    if not ws:
+        return ""
+    try:
+        can_pin = pinned_fs.supports_pinned_walk() and os.mkdir in os.supports_dir_fd
+        linked = None if can_pin else platform_compat.first_linked_ancestor(ws)
+        fd = _pinned_dir_create(ws, _SESSION_DIR_CONTAINER, exclusive=False, linked_ancestor=linked)
+        try:
+            return _validated_dir_from_fd(fd, expected_parent=ws)
+        finally:
+            os.close(fd)
+    except Exception:
+        logger.debug("per-session container unavailable under %r", ws, exc_info=True)
+        return ""
+
+
+def session_project_dir(session_key: str, root: str = "", workspace: str | None = None) -> str:
+    """Resolve a per-session project directory for ``session_key``.
+
+    Returns the realpath of a directory under ``root`` -- creating only that one
+    directory -- or ``""`` when no such directory can be offered. A caller must
+    read ``""`` as "no per-session directory", NOT as an error: every failure
+    mode here (a root that is missing, not a directory, or sensitive; a
+    derived name that would escape the root; an ``OSError`` from the ``mkdir``)
+    has to leave the session openable on the shared default. That is the posture
+    the configured-default branch in ``chat_handlers`` already takes for an
+    ineligible path -- degrade rather than wedge a new slot.
+
+    ``root`` empty falls back to a fixed container inside the workspace the
+    session already resolves to, rather than to the workspace directory itself:
+    the session name becomes the directory name, so creating them at that top
+    level lets a session called ``package.json`` squat a DIRECTORY on that path.
+    A CONFIGURED root must ALREADY EXIST, matching how
+    ``dashboard.default_project`` is treated: a typo then disables the feature
+    instead of scattering directories across the filesystem. The container is the
+    one directory this function will create for itself, because its name is fixed
+    rather than guessed at.
+
+    Two properties are load-bearing rather than incidental:
+
+    * The containment assertion is not decorative. :func:`_safe_dir_name` is a
+      *sanitizer*, not a validator -- it maps separators to ``_`` but does not
+      reject ``..`` -- so the joined path is checked against the resolved root
+      instead of the derived name being trusted. This is the immediate-child
+      form of the containment check ``api_workspaces_create`` applies with
+      ``is_relative_to``, tightened because a session directory is always
+      exactly one level down; it also rejects an existing ``name`` that is a
+      symlink pointing out of the root. ``mkdir`` is called without ``parents``
+      so nothing above the root's own children can be created regardless.
+    * The derivation is DETERMINISTIC in ``session_key``, but NOTHING depends on
+      that for restore. ``slot.project`` is persisted on the transcript's
+      metadata line (``chat_persistence`` writes it, ``history`` owns the field)
+      and is rehydrated from there, so a restored session is served from
+      metadata and never reaches this function. Determinism is therefore only a
+      naming choice and is explicitly NOT relied on to re-find a directory.
+    * Consequently the directory is created EXCLUSIVELY, and an existing one is
+      never adopted. Since a restored session comes back from metadata, a
+      candidate that already exists belongs to some EARLIER session whose key
+      was reused -- handing it over would give a fresh session that session's
+      files. Refusing, and letting the caller fall back to the shared default,
+      is the entire point.
+
+    Blocking file IO (``mkdir``): call via ``asyncio.to_thread`` from async
+    paths, as the sibling project-resolution in ``chat_handlers`` does.
+    """
+    from kiro_crew.security import is_sensitive_path  # circular import
+
+    if not isinstance(session_key, str) or not session_key:
+        # Explicit, rather than letting a bad key reach `_safe_dir_name` and
+        # raise into the broad `except` below. That masking is not theoretical:
+        # it turned a caller passing the request body's `name` -- which is None
+        # on the dashboard's own new-chat path -- into a silent no-op where the
+        # opt-in appeared to do nothing at all.
+        #
+        # Measured: removing this guard reddens nothing, because the broad
+        # `except` returns the same `""`. It is kept anyway, to make a caller
+        # error explicit AT THE BOUNDARY instead of incidental to a catch-all,
+        # and so it still holds if that `except` is ever narrowed.
+        return ""
+
+    try:
+        base = (
+            os.path.realpath(os.path.expanduser(root)) if root else _default_session_root(workspace)
+        )
+        if not base or not os.path.isdir(base) or is_sensitive_path(base):
+            # `isdir` is redundant with the `mkdir` below, which fails anyway on a
+            # missing or non-directory root because it is called without
+            # `parents` -- deleting it reddens nothing. It stays for two reasons:
+            # it states the documented "root must already exist" contract at the
+            # point the contract applies, and it does not depend on which OSError
+            # subclass a given platform raises for that mkdir.
+            return ""
+        name = _safe_dir_name(session_key)
+        if not name or name in (".", ".."):
+            return ""
+        base_resolved = Path(base).resolve()
+        candidate = base_resolved / name
+        # Whether this platform can create relative to a directory descriptor.
+        # POSIX has `openat` behind it; Windows has neither `O_DIRECTORY` nor
+        # `dir_fd`, and naming those flags there raises `AttributeError`. Probed
+        # rather than branched on the platform name, and probed HERE because the
+        # branch that cannot pin needs a sample taken before the window opens.
+        can_pin = pinned_fs.supports_pinned_walk() and os.mkdir in os.supports_dir_fd
+        # The shape of the ancestor chain as validation sees it, for the branch
+        # that has no per-component walk to refuse a change with. A junction the
+        # user's own layout already contains -- a redirected profile, a mapped
+        # drive -- is legitimate and must keep working, so what matters is not
+        # whether a linked ancestor EXISTS but whether the answer changes while
+        # this function runs. Sampled root-first by the helper, so the probe
+        # itself never traverses a link.
+        linked_ancestor = None if can_pin else platform_compat.first_linked_ancestor(base_resolved)
+        # The two containment assertions are a deliberate PAIR, and BOTH are now
+        # measurably unobservable - deleting either or both reddens nothing. That
+        # is a property of the other guards rather than of the tests, and it was
+        # measured, not assumed: `_safe_dir_name` cannot emit a path separator
+        # (it maps `/`, `\` and `:` to `_`), so the join is an immediate child by
+        # construction, and `mkdir` does NOT follow a symlink at the final
+        # component - dangling or not it raises `FileExistsError`, which the
+        # exclusive create already refuses.
+        #
+        # They stay as depth against a change to either of those two facts: a
+        # sanitizer that starts passing separators through, or a move away from
+        # exclusive creation, would make them load-bearing again with no other
+        # signal. The first refuses before any side effect; the second re-checks
+        # after the mkdir. `_set_project` guards its own path the same way,
+        # checking both the pre-resolution and the post-realpath form.
+        if candidate.resolve().parent != base_resolved:
+            return ""
+        if is_sensitive_path(str(candidate)):
+            # BEFORE the mkdir, not only after it. The post-`mkdir` check below
+            # rejects a sensitive result but cannot undo the side effect, and
+            # nothing here deletes - so creating first would leave a DIRECTORY
+            # squatting on a path that is supposed to hold a file. For a
+            # governance leaf such as `<data_home>/security_policy.json` that is
+            # unbounded: policy loading expects a file, and a directory in its
+            # place blocks it. The key is caller-steerable (a supplied name
+            # becomes the slot key), so the name reaching this line is not
+            # necessarily a minted one, and `is_sensitive_path` matches a path
+            # that does not exist yet - which is exactly the case that matters.
+            return ""
+        # Create the child through a PINNED PARENT, never by re-resolving the
+        # root's path. A path-based `mkdir` resolves every component afresh, so a
+        # root -- or any directory above it -- that an attacker replaces between
+        # the validation and the create redirects the create to wherever the
+        # replacement points, under a name the caller steers (the session key
+        # becomes the directory name). The refusals below reject the RESULT, but
+        # nothing here deletes, so the escaped directory would already exist.
+        #
+        # Both branches use the mechanism the repo already has rather than a
+        # bespoke open, and neither is a weaker substitute for the other -- the
+        # platforms close the window by different means:
+        #
+        # * POSIX: `pin_parent` does one `openat` per component of the ALREADY
+        #   RESOLVED root, each with `O_NOFOLLOW`, and the final component is the
+        #   root itself -- so a root swapped for a link and an ANCESTOR swapped
+        #   for a link are both refused, and `name` is then created relative to
+        #   the descriptor that walk produced. A single `O_NOFOLLOW` open of the
+        #   root does NOT cover this: it guards the last component only, and a
+        #   swapped ancestor is followed silently. Checking the result afterwards
+        #   cannot see it either, since re-resolving the path traverses the
+        #   swapped ancestor and so agrees with itself. `base_resolved` is passed
+        #   as-is and never re-resolved here, which is `pin_parent`'s stated
+        #   contract: resolving inside the walk re-follows whatever an ancestor
+        #   points at by then and makes the walk useless.
+        # * Windows: it has neither `O_DIRECTORY` nor `dir_fd`, and naming those
+        #   flags there raises `AttributeError`, so it takes the pin-and-verify
+        #   branch. `pin_directory` opens the root without `FILE_SHARE_DELETE`,
+        #   and a directory held by such a handle -- along with every directory
+        #   above it -- can be neither renamed nor deleted while the handle
+        #   lives; that open also refuses to follow a reparse point at the root's
+        #   own name. Those two together leave one gap, an ancestor swapped
+        #   BEFORE the pin, which the ancestor-shape re-read closes.
+        #
+        # `name` is a single component by construction (`_safe_dir_name` maps
+        # `/`, `\` and `:` to `_`), which is what makes it safe to create
+        # relative to a pinned directory at all. `0o700` on both branches: POSIX
+        # masks it with the umask, and on Windows the DACL governs access instead
+        # of the mode bits.
+        try:
+            child_fd = _pinned_dir_create(
+                str(base_resolved), name, exclusive=True, linked_ancestor=linked_ancestor
+            )
+        except (FileExistsError, pinned_fs.PinnedPathRefusal):
+            # NEVER adopt an existing directory, and never write through a
+            # component that changed under us. A restored session is served its
+            # project from the transcript metadata line and does not reach this
+            # function, so a path that already exists here belongs to an EARLIER
+            # session whose key was reused -- a closed session plus a same-second
+            # restart can reproduce a minted key. Adopting it would leak that
+            # session's files into a fresh one, so refuse and let the caller fall
+            # back to the shared default. Exclusive creation is also what makes
+            # this safe without a delete path: nothing is ever cleared or reused.
+            #
+            # Both refusals collapse to the same answer deliberately: the caller's
+            # contract is "no per-session directory", and it has nothing different
+            # to do for a reused key than for a swapped ancestor.
+            return ""
+        # Validated through the descriptor the create returned, never by
+        # re-resolving `candidate`. Re-opening the name here is what let a
+        # same-user process swap the new directory for a link to a SIBLING
+        # session's directory: that link resolves to a real directory, under the
+        # right parent, in a non-sensitive place, so every check below passed and
+        # the new session adopted the other one's files -- the exact adoption the
+        # exclusive create exists to refuse, reached one step later.
+        try:
+            return _validated_dir_from_fd(child_fd, expected_parent=str(base_resolved))
+        finally:
+            os.close(child_fd)
+    except Exception:
+        # Same breadth as `default_project_dir` above, for the same reason: this
+        # runs on the slot-creation path, so an unexpected failure has to become
+        # "no per-session directory" rather than an exception that stops a
+        # session from opening.
+        logger.debug("per-session project dir unavailable for %r", session_key, exc_info=True)
+        return ""
 
 
 def env_path() -> Path:
@@ -3404,6 +3761,10 @@ class KiroCrewConfig:
                     key_present="tailscale" in dashboard_data,
                 ),
                 restore_sessions=dashboard_data.get("restore_sessions", False),
+                new_project_per_session=_safe_bool(
+                    dashboard_data.get("new_project_per_session"), False
+                ),
+                session_project_root=dashboard_data.get("session_project_root", ""),
                 qr_session_until_restart=_safe_bool(
                     dashboard_data.get("qr_session_until_restart"), True
                 ),

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -2789,6 +2789,26 @@ class DashboardConfig:
             "Directory path used as the project for new chat tabs. Empty = workspace dir.",
         ),
     )
+    new_project_per_session: bool = field(
+        default=False,
+        metadata=_meta(
+            "New Project Per Session",
+            "Give each new chat session its own project directory instead of "
+            "sharing one. Off by default: until it is turned on, new sessions "
+            "resolve their project exactly as before.",
+        ),
+    )
+    session_project_root: str = field(
+        default="",
+        metadata=_meta(
+            "Session Project Root",
+            "Directory that holds the per-session project directories created "
+            "when 'New Project Per Session' is on. Must already exist. "
+            "Empty = a '.sessions' folder inside the workspace directory, "
+            "created for you. Config-file only, like "
+            "'Default Project' -- no dashboard-writable setting takes a path.",
+        ),
+    )
     theme_mode: str = field(
         default="",
         metadata=_meta(

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -37,6 +37,7 @@ from kiro_crew.config.loader import (
     default_project_dir,
     published_autocompact_pct,
     resolve_agent_bindings,
+    session_project_dir,
 )
 from kiro_crew.dashboard import remote_mirror
 from kiro_crew.dashboard.channel_slots import channel_slot_name, note_slot_closed
@@ -221,6 +222,129 @@ def _sweep_stale_permissions(slot: "_ChatSlot") -> None:
         )
 
 
+async def _apply_per_session_project(slot, cfg, workspace: str) -> bool:
+    """Give ``slot`` its own project directory when the opt-in is on.
+
+    Called from ONE path: the create endpoint, and only for a slot that endpoint
+    just minted. A reopen of an existing slot is excluded at the call site, where
+    the reason is recorded: such a slot can already have a live provider whose
+    cwd this cannot change. The message-send endpoint also
+    auto-creates slots, but deliberately does NOT call this - an auto-created
+    slot's workspace is ``"default"`` there, and resolving the real one from the
+    requested agent's bindings needs the final project directory, which needs the
+    workspace: a circular dependency traced in the send handler's own comment. So
+    a session first created by a send to an unknown name falls back to the shared
+    default rather than getting a directory under the wrong workspace root.
+
+    No-ops unless the slot has no project yet, so an explicit project, a
+    folder-inherited one, and a metadata-restored one are all left alone. Any
+    failure resolving or creating the directory yields ``""`` and leaves the
+    project unset for the caller's normal fallback chain - the same
+    degrade-rather-than-wedge posture the configured-default branch takes for an
+    ineligible path.
+
+    Reuse is prevented inside ``session_project_dir`` rather than by a predicate
+    here: it creates the directory EXCLUSIVELY, so an existing path is refused
+    instead of adopted. That covers every reusable-key case at once - a
+    caller-supplied name, a channel key, or a minted key reproduced by a closed
+    session plus a same-second restart - without either call site classifying
+    keys. An earlier revision gated on ``_slot_index_from_key``, which only
+    checks that the second segment is a digit and never validates the trailing
+    timestamp, so ``worker-1-stable`` passed an "auto-minted only" test while
+    being entirely reusable.
+
+    Note what does NOT justify any of this: ``slot.project`` IS persisted, on the
+    transcript's metadata line, and is rehydrated from there. A restored session
+    is served from metadata and never re-derives, which is exactly why refusing
+    an existing directory is safe.
+
+    Config is read with ``getattr`` and the dataclass defaults, NOT bare
+    attribute access. Measured: 36 sites across 19 test files patch
+    ``KiroCrewConfig.load`` with a minimal ``dashboard=SimpleNamespace(...)``
+    carrying only the fields the surrounding code reads, so a bare read of a
+    newly added field raises ``AttributeError`` inside the request handler and
+    becomes a 500. That says ``cfg.dashboard`` arriving here is routinely a
+    partial stand-in - the same reason the ``cfg`` guard exists. A missing field
+    defaulting to OFF is the documented default, so this is correct behaviour
+    rather than a mask.
+
+    Returns True ONLY when this call assigned ``slot.project``, and the caller
+    must force a durable save when it does. Assignment alone is in-memory: the
+    caller's own save is conditional on other supplied metadata, and an ordinary
+    create supplies none of it -- the dashboard's own new-chat request carries no
+    folder, no pinned title and no peer key -- so the assignment lands with
+    nothing persisting it, and a crash before the next periodic flush loses the
+    association while the directory, and whatever the session wrote into it, stay
+    on disk with nothing pointing at them. Every other exit returns False,
+    including a follower that found the project already assigned and the
+    compare-and-set losing to a concurrent writer: each of those has an owner
+    that handles its own persistence, and reporting True would attribute their
+    value to this call.
+
+    The transaction is serialised per slot on ``slot._project_init_lock``, so a
+    duplicate create reuses the winner's directory instead of deriving a second
+    one -- see the lock's own comment in ``state.py`` for what deriving twice
+    costs.
+    """
+    if slot.project or not cfg:
+        return False
+    # Guard the WHOLE access chain, not just the leaf fields. Hardening
+    # `new_project_per_session` alone still left `cfg.dashboard` itself bare, and
+    # the send path sees config stand-ins with no `dashboard` attribute at all -
+    # which raised `AttributeError` inside the handler and became a 500 on an
+    # endpoint whose contract is to fail closed with 400/409.
+    dash = getattr(cfg, "dashboard", None)
+    if dash is None or not getattr(dash, "new_project_per_session", False):
+        return False
+    # Serialise the whole transaction on this slot. Two creates naming one slot
+    # key -- a double submit, a client retry -- otherwise both pass the check
+    # above and both derive: the loser's exclusive create meets the winner's
+    # directory, gets nothing back, and returns False, at which point the
+    # caller's fallback chain puts the slot on the SHARED default. If that
+    # fallback commits before the winner's assignment, the compare-and-set below
+    # correctly declines to overwrite it, and the outcome is a slot on the shared
+    # directory with the winner's private one orphaned -- isolation silently lost
+    # in the ordinary duplicate-request case, which is the opposite of what the
+    # opt-in promises. Holding the lock makes the follower wait and then find the
+    # project already assigned, so it reuses the winner's directory by no-oping.
+    #
+    # The re-check inside is not redundant with the one above: the value that
+    # matters is the one final when the lock is held, and for the follower that
+    # is the winner's committed assignment.
+    async with slot._project_init_lock:
+        if slot.project:
+            return False
+        # `slot.key`, NOT any caller-supplied name: the dashboard's own new-chat
+        # path sends no name at all, so a name-derived directory would be missing
+        # on the exact flow the setting exists for. `slot.key` is always present.
+        per_session = await asyncio.to_thread(
+            session_project_dir,
+            slot.key,
+            getattr(dash, "session_project_root", ""),
+            workspace,
+        )
+        if not per_session:
+            return False
+        conflict = await asyncio.to_thread(voice_runtime_workspace_conflict, per_session)
+        if conflict is not None:
+            return False
+        # Compare-and-set at the commit point, NOT a bare assignment. The lock
+        # above serialises this helper against ITSELF, but a concurrent project
+        # POST does not take it, and this still awaits twice (the derivation and
+        # the conflict scan), so an explicit selection can land while we wait.
+        # Committing unconditionally would clobber that selection with a derived
+        # default - the weaker value overwriting the stronger one. So re-read the
+        # field and write ONLY if it is still the empty value we derived from; if
+        # a concurrent writer filled it, yield and leave their selection
+        # standing. This is the root of the whole class of ordering bugs in this
+        # feature's call sites: trust the value that is final at commit time, not
+        # the one captured before the await.
+        if not slot.project:
+            slot.project = per_session
+            return True
+        return False
+
+
 async def api_chat(request: web.Request) -> web.StreamResponse:
     """POST /api/chat — send message to a slot, stream response via SSE."""
     state: DashboardState = request.app["state"]
@@ -377,6 +501,28 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
     denied = deny_non_owner_remote_operation(request, slot, "chat_send")
     if denied is not None:
         return denied
+    # This endpoint also creates slots, but the per-session project is
+    # deliberately NOT derived here, and the reason is an ordering constraint in
+    # the code below rather than caution.
+    #
+    # The derivation needs the session's WORKSPACE. An auto-created slot has not
+    # got a meaningful one - `get_or_create_slot` above is called with no
+    # workspace, so it is `"default"` regardless of the agent the request names -
+    # and the real workspace comes from that agent's bindings. But
+    # `resolve_agent_bindings` (below) documents that the project directory it is
+    # given "must be the same directory Kiro Crew passes as the kiro-cli cwd",
+    # because passing a directory the session does not run in reintroduces the
+    # silent agent-substitution bug that lookup exists to prevent. So bindings
+    # need the final project, and deriving the project needs the bindings'
+    # workspace: circular.
+    #
+    # Deriving here anyway - which an earlier revision did - put the directory
+    # under the DEFAULT workspace root whenever the root is unconfigured and the
+    # request named a non-default agent, and persisted that wrong location on the
+    # transcript's metadata line. Not deriving degrades to the shared default,
+    # which is exactly today's behaviour and the point of the opt-in being off by
+    # default. A session created through the create endpoint, where the workspace
+    # is resolved before the derivation, is unaffected.
     # The member-pin refusal sits AFTER the app-ownership 404s (a 409 here
     # for an app would be an existence oracle for slots it may not see) and
     # BEFORE the _human_seen attendance mark, so a denied request leaves the
@@ -2736,6 +2882,41 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
         # it and continue to use the project endpoint for scope changes.
         if folder_project and folder_applied and not slot.project:
             slot.project = folder_project
+        # Opt-in: give each new session its own project directory so
+        # unrelated concurrent work stops sharing one. Default OFF, so until a
+        # user turns it on the fallback chain below is reached exactly as
+        # before. A folder-linked slot keeps the project it just inherited
+        # above -- that inheritance is server-owned and explicit, so it
+        # outranks a derived default.
+        #
+        # The reasoning lives on `_apply_per_session_project`. This is its only
+        # caller: the message-send path also creates slots but deliberately does
+        # not derive (see the circular-dependency note there).
+        #
+        # GATED ON `is_new_slot`, and that gate is load-bearing rather than a
+        # scope preference. This endpoint also serves a REOPEN of a slot that
+        # already exists, and such a slot may already have a live provider
+        # running in the shared directory. Assigning a project here changes only
+        # in-memory metadata: the provider keeps the cwd it started with, so the
+        # session would advertise a private directory while its files continue
+        # landing in the shared one -- isolation reported but not delivered, and
+        # the mixed files are not recoverable afterwards. The dedicated
+        # workspace-switch handler tears the live session down for exactly this
+        # reason (`_reset_slot_session_or_warn`), which is a correct thing to do
+        # on an explicit switch and the wrong thing to do on a reopen that the
+        # user did not ask to restart. A newly minted slot has no provider yet --
+        # `schedule_eager_spawn` runs at the end of this handler, after the
+        # project is final -- so on that path the cwd and the metadata agree by
+        # construction. An existing projectless slot keeps the shared default,
+        # which is this feature's documented degrade posture.
+        #
+        # The return value feeds the durable save below. A derived directory is
+        # only reachable again through the persisted assignment -- nothing
+        # re-derives it -- so the save has to be forced by the assignment
+        # itself, not left to whatever metadata the request happened to carry.
+        per_session_project_applied = False
+        if is_new_slot:
+            per_session_project_applied = await _apply_per_session_project(slot, cfg, workspace)
         # Default project to workspace directory so file search works out of the box
         if not slot.project:
             cfg_proj = cfg.dashboard.default_project if cfg else ""
@@ -2755,7 +2936,26 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
                 cfg_proj = resolved if eligible else ""
             else:
                 cfg_proj = ""
-            slot.project = cfg_proj or default_project_dir(workspace)
+            # Commit under the same per-slot lock the derivation takes, because
+            # the lock's job is deciding THIS SLOT's project and the fallback is
+            # the other half of that decision. Two overlapping creates on one key
+            # split into a winner that mints the slot and a follower that does
+            # not, and only the winner runs the derivation. Committing here
+            # unlocked lets the follower read the field during the winner's await
+            # window, find it empty, and install the shared default; the winner's
+            # compare-and-set then correctly declines to overwrite, so the slot
+            # runs in the shared directory while the private one it exclusively
+            # created is orphaned. Waiting makes the follower observe the
+            # winner's choice instead of racing it.
+            #
+            # The value is computed above, OUTSIDE the lock: it depends on config
+            # and the workspace, never on the slot, so two callers compute the
+            # same answer and only the commit needs ordering. The re-read inside
+            # is the authoritative one, since the field can be filled while this
+            # coroutine waits.
+            async with slot._project_init_lock:
+                if not slot.project:
+                    slot.project = cfg_proj or default_project_dir(workspace)
         _sync_dashboard_slots(state)
         # Persist INSIDE the suspension, ahead of the coalesced broadcast, the
         # same ordering `session_control.py`'s create span uses ("the whole
@@ -2787,7 +2987,14 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
         # A pinned title must persist too (not just a folder move): without the
         # write, a restart rehydrates the previous title with a refreshable
         # "auto" origin and the background refresh may rewrite the pin.
-        if folder_id or title or remote_slot_key:
+
+        # A per-session project directory assigned above persists on the same
+        # write, and is the reason this condition is not just the three supplied
+        # metadata fields. An ordinary create sends none of them -- the
+        # dashboard's own new-chat request carries no folder, title or peer
+        # key -- and that is exactly the request that assigns a directory and
+        # would otherwise save nothing.
+        if folder_id or title or remote_slot_key or per_session_project_applied:
             # The create/recreate request has been authorized against this
             # transcript.  Do not let a rebind while the off-loop write waits on
             # the history lock redirect its newly supplied metadata to another

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3355,6 +3355,7 @@ class _ChatSlot:
         "_fork_lock",
         "_model_pick_lock",
         "_remote_pick_lock",
+        "_project_init_lock",
         "_tab_id",
         "_channel_window_mtime",
         "_disk_older_count",
@@ -3896,6 +3897,24 @@ class _ChatSlot:
         # await, so it gets its own lock rather than blocking every window edit
         # on the tunnel's round-trip.
         self._remote_pick_lock: asyncio.Lock = asyncio.Lock()
+        # Serialises DECIDING this slot's project directory -- both halves: the
+        # per-session derivation (derive -> exclusive create -> conflict scan ->
+        # assign) and the shared-default fallback that runs when no derivation
+        # happened. Two overlapping creates on one slot key split into a winner
+        # that mints the slot and a follower that does not, and only the winner
+        # derives. Without this, the follower installs the shared default during
+        # the winner's await window, the winner's compare-and-set then declines
+        # to overwrite it, and the slot runs in the shared directory while the
+        # private one the winner exclusively created is orphaned -- a duplicate
+        # submit silently costing the isolation the opt-in exists for. Every
+        # writer waits instead, so a follower observes the decision already made
+        # rather than racing it.
+        #
+        # Deliberately NOT ``slot._lock``, for the reason its siblings above
+        # give: that lock guards message-window edits, and this transaction
+        # suspends on a thread hop for the create and another for the
+        # workspace-conflict scan.
+        self._project_init_lock: asyncio.Lock = asyncio.Lock()
         self._tab_id: str = ""  # permanent tab identity for cross-restart session chaining
         # Transcript mtime the in-memory window was last brought up to date
         # against. Only meaningful for a slot bound to a channel session, whose

--- a/test/test_session_project_dir.py
+++ b/test/test_session_project_dir.py
@@ -1,0 +1,990 @@
+"""Tests for the opt-in per-session project directory.
+
+`session_project_dir` runs on the slot-creation path, so its contract is as much
+about what it REFUSES as what it returns: every rejection has to come back as
+``""`` (the caller's "no per-session directory") rather than as an exception,
+because an exception there stops a session from opening.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import stat
+import tempfile
+import time
+import unittest.mock
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig, session_project_dir
+from kiro_crew.config.sections import DashboardConfig
+
+
+def _load_from_dict(data: object) -> KiroCrewConfig:
+    """Write *data* to a temp config file and load via ``KiroCrewConfig.load()``.
+
+    Same mechanism as ``test_config_loader._load_from_dict`` -- loading through
+    the real entry point is what makes the parse wiring observable.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(data, f)
+        tmp = Path(f.name)
+    try:
+        with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+            return KiroCrewConfig.load()
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+class TestSessionProjectDirHappyPath:
+    def test_creates_directory_under_root_and_returns_realpath(self, tmp_path):
+        root = tmp_path / "sessions"
+        root.mkdir()
+
+        got = session_project_dir("chat-7", str(root))
+
+        assert got == os.path.realpath(str(root / "chat-7"))
+        assert Path(got).is_dir()
+
+    def test_an_existing_directory_is_refused_not_adopted(self, tmp_path):
+        """A second derivation of one key must REFUSE, not hand over the first.
+
+        `slot.project` is persisted on the transcript's metadata line and
+        rehydrated from there, so a restored session is served from metadata and
+        never re-derives. A path that already exists here therefore belongs to an
+        EARLIER session whose key was reused, and adopting it would leak that
+        session's files into a fresh one.
+        """
+        root = tmp_path / "sessions"
+        root.mkdir()
+
+        first = session_project_dir("chat-7", str(root))
+        second = session_project_dir("chat-7", str(root))
+
+        assert first == os.path.realpath(str(root / "chat-7"))
+        assert second == "", "an existing directory must never be adopted"
+        assert [p.name for p in root.iterdir()] == ["chat-7"]
+
+    def test_a_sensitive_candidate_is_refused_before_the_directory_exists(
+        self, tmp_path, monkeypatch
+    ):
+        """A sensitive candidate must be rejected BEFORE `mkdir`, not after.
+
+        The post-`mkdir` sensitive check cannot undo a side effect, and nothing
+        here deletes, so creating first leaves a DIRECTORY squatting on a path
+        meant to hold a file. For a governance leaf such as
+        `<data_home>/security_policy.json` that blocks policy loading outright.
+
+        The load-bearing assertion is the second one: returning `""` was already
+        true before the fix, because the post-check caught it. What was wrong was
+        that the directory existed by then.
+        """
+        import kiro_crew.security as security
+
+        root = tmp_path / "sessions"
+        root.mkdir()
+        target = os.path.realpath(str(root / "security_policy.json"))
+        real = security.is_sensitive_path
+        monkeypatch.setattr(
+            security,
+            "is_sensitive_path",
+            lambda p: os.path.realpath(str(p)) == target or real(p),
+        )
+
+        assert session_project_dir("security_policy.json", str(root)) == ""
+        assert list(root.iterdir()) == [], "created the sensitive path before rejecting it"
+
+    def test_a_pre_existing_directory_is_never_handed_over(self, tmp_path):
+        """Same refusal when the directory was not created by this function."""
+        root = tmp_path / "sessions"
+        root.mkdir()
+        stale = root / "chat-9"
+        stale.mkdir()
+        (stale / "previous-session-notes.md").write_text("secret", encoding="utf-8")
+
+        assert session_project_dir("chat-9", str(root)) == ""
+        # And the earlier session's file is untouched: nothing here deletes.
+        assert (stale / "previous-session-notes.md").read_text(encoding="utf-8") == "secret"
+
+    def test_distinct_keys_get_distinct_directories(self, tmp_path):
+        root = tmp_path / "sessions"
+        root.mkdir()
+
+        a = session_project_dir("chat-1", str(root))
+        b = session_project_dir("chat-2", str(root))
+
+        assert a != b
+        assert sorted(p.name for p in root.iterdir()) == ["chat-1", "chat-2"]
+
+
+class TestSessionProjectDirRefusals:
+    def test_parent_traversal_key_is_refused(self, tmp_path):
+        """`_safe_dir_name` is a sanitizer, not a validator.
+
+        It maps separators to ``_`` but does NOT reject ``..``, so the
+        containment assertion is what actually stops an escape. Without it this
+        would resolve to the root's parent.
+        """
+        root = tmp_path / "sessions"
+        root.mkdir()
+
+        assert session_project_dir("..", str(root)) == ""
+        assert session_project_dir(".", str(root)) == ""
+
+    def test_separators_in_key_stay_one_level_down(self, tmp_path):
+        root = tmp_path / "sessions"
+        root.mkdir()
+
+        got = session_project_dir("a/b:c d", str(root))
+
+        assert got == os.path.realpath(str(root / "a_b_c_d"))
+        assert Path(got).parent == root.resolve()
+
+    def test_missing_root_returns_empty(self, tmp_path):
+        assert session_project_dir("chat-7", str(tmp_path / "absent")) == ""
+
+    @pytest.mark.parametrize("bad_key", [None, "", 0, 17, b"chat-7"])
+    def test_a_key_that_is_not_a_non_empty_string_returns_empty(self, bad_key, tmp_path):
+        """Pins the guard that a caller bug must not reach `_safe_dir_name`.
+
+        A `None` key reaching the broad `except` reports the caller's mistake as
+        "no per-session directory" -- indistinguishable from the feature being
+        off. The guard makes it explicit, and this test fails
+        if anyone removes it AND the broad except is ever narrowed.
+        """
+        root = tmp_path / "sessions"
+        root.mkdir()
+
+        assert session_project_dir(bad_key, str(root)) == ""
+        assert list(root.iterdir()) == []
+
+    def test_root_that_is_a_file_returns_empty(self, tmp_path):
+        f = tmp_path / "not-a-dir"
+        f.write_text("x", encoding="utf-8")
+
+        assert session_project_dir("chat-7", str(f)) == ""
+
+    def test_symlink_child_pointing_outside_root_is_refused(self, tmp_path):
+        """An existing child that is a symlink out of the root must not be used."""
+        root = tmp_path / "sessions"
+        root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (root / "chat-7").symlink_to(outside, target_is_directory=True)
+
+        assert session_project_dir("chat-7", str(root)) == ""
+
+    def test_dangling_symlink_child_cannot_create_outside_the_root(self, tmp_path):
+        """A symlink to a MISSING target outside the root must create nothing.
+
+        Measured, and not what I first assumed: `mkdir` does NOT follow a symlink
+        at the final component. Dangling or not, it raises `FileExistsError`, so
+        exclusive creation is what refuses this - the containment assertions are
+        not what this test exercises. It is kept because the property it pins is a
+        security property worth stating outright: no directory appears outside
+        the configured root. The second assertion is the load-bearing one.
+        """
+        root = tmp_path / "sessions"
+        root.mkdir()
+        outside = tmp_path / "outside"  # deliberately NOT created
+        (root / "chat-7").symlink_to(outside, target_is_directory=True)
+
+        assert session_project_dir("chat-7", str(root)) == ""
+        assert not outside.exists(), "followed a dangling symlink and created outside the root"
+
+    def test_root_swapped_for_a_symlink_after_validation_creates_nothing_outside(self, tmp_path):
+        """The ROOT going symlink mid-call must not redirect the create.
+
+        The child is created relative to a descriptor opened on the root that
+        passed validation, so the create cannot be steered by a later change to
+        what that PATH resolves to. Without that, the create re-resolves the root
+        at call time: an attacker who can replace the root directory -- it is
+        writable by the gateway's own user, and the caller steers the child's
+        name through the session key -- gets a directory of their choosing
+        created wherever the replacement symlink points.
+
+        The swap is timed off the last validation call before the create, which
+        is the sensitive-path check on the candidate, so the interleaving is
+        deterministic rather than a race the test hopes to hit.
+        """
+        import kiro_crew.security as security
+
+        root = tmp_path / "sessions"
+        root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        real_check = security.is_sensitive_path
+        swapped = []
+
+        def _swap_root_then_check(path: str) -> bool:
+            # Runs for the root first, then for the candidate. Swap on the
+            # candidate call: validation of the root is done by then, so this is
+            # the window the fix has to close.
+            if str(path).startswith(str(root / "chat-9")) and not swapped:
+                swapped.append(True)
+                root.rmdir()
+                root.symlink_to(outside, target_is_directory=True)
+            return real_check(path)
+
+        with unittest.mock.patch.object(security, "is_sensitive_path", _swap_root_then_check):
+            result = session_project_dir("chat-9", str(root))
+
+        assert swapped, "the swap never ran, so this test proves nothing"
+        assert result == ""
+        assert list(outside.iterdir()) == [], "created a directory outside the configured root"
+
+    def test_an_ancestor_swapped_for_a_symlink_creates_nothing_outside(self, tmp_path):
+        """An ANCESTOR of the root going symlink mid-call must be refused too.
+
+        Distinct from the test above, and the reason a single `O_NOFOLLOW` open of
+        the root is not enough: that flag guards the LAST component only, so a
+        directory ABOVE the root swapped for a link is followed silently and the
+        open then pins the link's target. Re-resolving the root afterwards to
+        check it cannot see this either -- that resolution walks the swapped
+        ancestor as well, so it agrees with itself and the escape looks contained.
+
+        Closed by walking the already-resolved root one component at a time, each
+        open carrying `O_NOFOLLOW`, so the swapped ancestor is refused at the
+        component it sits on.
+        """
+        import kiro_crew.security as security
+
+        tree = tmp_path / "tree"
+        (tree / "sessions").mkdir(parents=True)
+        outside = tmp_path / "outside"
+        (outside / "sessions").mkdir(parents=True)
+        root = tree / "sessions"
+        real_check = security.is_sensitive_path
+        swapped = []
+
+        def _swap_ancestor_then_check(path: str) -> bool:
+            # Swap `tree`, the root's PARENT, once the root itself has passed
+            # validation -- the window a leaf-only guard leaves open.
+            if str(path).startswith(str(root / "chat-11")) and not swapped:
+                swapped.append(True)
+                (tree / "sessions").rmdir()
+                tree.rmdir()
+                tree.symlink_to(outside, target_is_directory=True)
+            return real_check(path)
+
+        with unittest.mock.patch.object(security, "is_sensitive_path", _swap_ancestor_then_check):
+            result = session_project_dir("chat-11", str(root))
+
+        assert swapped, "the swap never ran, so this test proves nothing"
+        assert result == ""
+        assert list((outside / "sessions").iterdir()) == [], "created through a swapped ancestor"
+
+    def test_the_directory_is_still_created_without_the_posix_open_flags(
+        self, tmp_path, monkeypatch
+    ):
+        """Windows has no `O_DIRECTORY`/`O_NOFOLLOW`, and must still get a directory.
+
+        Naming either flag on Windows raises `AttributeError`, and this function's
+        catch-all turns that into `""` -- so an earlier revision silently disabled
+        the whole opt-in on every Windows session while looking correct on POSIX.
+        Every assertion in this file passed, because they all run on POSIX.
+
+        Simulated the way the repo's other Windows tests do it, by DELETING the
+        two attributes rather than by faking a capability flag: deleting them is
+        what reproduces the `AttributeError`, and a test that only cleared
+        `os.supports_dir_fd` would have passed against the broken code. What the
+        non-pinned branch does on real Windows is hold the root open in a share
+        mode that forbids renaming or deleting it, or anything above it, which is
+        why creating by name there is safe; on POSIX the same call degrades to an
+        ordinary directory open, so what this pins is the part that was broken --
+        that the feature still produces a directory at all.
+        """
+        monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+        monkeypatch.setattr(os, "supports_dir_fd", set())
+        root = tmp_path / "sessions"
+        root.mkdir()
+
+        result = session_project_dir("chat-13", str(root))
+
+        assert result == os.path.realpath(str(root / "chat-13"))
+        assert Path(result).is_dir()
+
+    def test_an_ancestor_swap_is_refused_without_the_posix_open_flags(self, tmp_path, monkeypatch):
+        """The non-pinned branch must refuse an ancestor swap, not just create safely.
+
+        The branch taken where a platform cannot create relative to a descriptor
+        needs its REFUSALS tested, not only its happy path. Holding the root open
+        stops it being renamed from that moment on and refuses a reparse point at
+        its own name, but an ancestor swapped before the pin is traversed, so the
+        pin lands on whatever that ancestor points at -- the same escape the
+        component walk refuses on POSIX, arriving by a different route. Pinning
+        the happy path alone leaves it open, and on POSIX nothing exercises this
+        branch at all.
+
+        Same swap and same timing as the POSIX ancestor test, with the two flags
+        deleted so the platform capability reports False.
+        """
+        import kiro_crew.security as security
+
+        monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+        monkeypatch.setattr(os, "supports_dir_fd", set())
+        tree = tmp_path / "tree"
+        (tree / "sessions").mkdir(parents=True)
+        outside = tmp_path / "outside"
+        (outside / "sessions").mkdir(parents=True)
+        root = tree / "sessions"
+        real_check = security.is_sensitive_path
+        swapped = []
+
+        def _swap_ancestor_then_check(path: str) -> bool:
+            if str(path).startswith(str(root / "chat-15")) and not swapped:
+                swapped.append(True)
+                (tree / "sessions").rmdir()
+                tree.rmdir()
+                tree.symlink_to(outside, target_is_directory=True)
+            return real_check(path)
+
+        with unittest.mock.patch.object(security, "is_sensitive_path", _swap_ancestor_then_check):
+            result = session_project_dir("chat-15", str(root))
+
+        assert swapped, "the swap never ran, so this test proves nothing"
+        assert result == ""
+        assert list((outside / "sessions").iterdir()) == [], "created through a swapped ancestor"
+
+    def test_a_sibling_swap_after_creation_cannot_be_adopted(self, tmp_path):
+        """Swapping the new directory for a SIBLING's link must not be adopted.
+
+        The exclusive create refuses an existing directory so a fresh session
+        never inherits another session's files. Turning the created directory
+        back into a path by re-resolving its NAME reopens that adoption one step
+        later: a process running as this user replaces the new child with a link
+        to a sibling under the same parent, and that link is a real directory, in
+        a non-sensitive place, with the right parent -- so every containment check
+        passes and the session is handed the sibling's files.
+
+        The link points at a SIBLING deliberately. A containment check catches a
+        target outside the parent; a sibling INSIDE it is what the check cannot
+        see, and it is the shape that leaks another session's work.
+
+        The swap is timed off the create's own return, which is the window the
+        attack has and the only point both a descriptor-validating and a
+        name-resolving version pass through. Hooking a later call instead lets the
+        name be resolved before the swap lands, and the test then passes against
+        the defect it is meant to catch.
+        """
+        from kiro_crew.config import loader as config_loader
+
+        root = tmp_path / "sessions"
+        root.mkdir()
+        victim = root / "chat-victim"
+        victim.mkdir()
+        (victim / "victim-notes.md").write_text("secret", encoding="utf-8")
+        real_create = config_loader._pinned_dir_create
+        swapped = []
+        blocked = []
+
+        def _create_then_swap(parent, name, **kw):
+            fd = real_create(parent, name, **kw)
+            # Stand-in for a same-user process acting the instant the directory
+            # exists: drop the new child and put a link to a sibling in its place.
+            target = Path(parent) / name
+            try:
+                target.rmdir()
+            except OSError:
+                # Windows opens the created directory in a share mode that
+                # forbids deleting it, so the substitution cannot even begin
+                # while the descriptor is held. That is a stronger outcome than
+                # detecting it, and asserting it here is the honest way to cover
+                # this branch instead of skipping the platform.
+                blocked.append(True)
+                return fd
+            target.symlink_to(victim, target_is_directory=True)
+            swapped.append(True)
+            return fd
+
+        with unittest.mock.patch.object(config_loader, "_pinned_dir_create", _create_then_swap):
+            result = session_project_dir("chat-21", str(root))
+
+        assert swapped or blocked, "the hook never ran, so this test proves nothing"
+        if swapped:
+            assert result != os.path.realpath(str(victim)), "adopted a sibling session's directory"
+        else:
+            assert result == os.path.realpath(str(root / "chat-21"))
+        assert (victim / "victim-notes.md").read_text(encoding="utf-8") == "secret"
+
+    @pytest.mark.skipif(
+        os.name != "posix" or os.geteuid() == 0,
+        reason="POSIX-only: root ignores directory permissions, and os.geteuid is absent on Windows",
+    )
+    def test_unwritable_root_degrades_to_empty(self, tmp_path):
+        """A permissions failure must degrade, not raise.
+
+        The caller treats "" as "use the shared default", so this is the path
+        that keeps a session openable on a read-only or full disk.
+        """
+        root = tmp_path / "sessions"
+        root.mkdir()
+        original_mode = stat.S_IMODE(root.stat().st_mode)
+        os.chmod(root, stat.S_IRUSR | stat.S_IXUSR)
+        try:
+            assert session_project_dir("chat-7", str(root)) == ""
+        finally:
+            # Restore what pytest created rather than a hardcoded mode: a literal
+            # here is both less correct and flagged by the insecure-file-permissions
+            # SAST rule.
+            os.chmod(root, original_mode)
+
+
+class TestSessionProjectDirRootFallback:
+    def test_empty_root_falls_back_to_a_container_inside_the_workspace(self, tmp_path, monkeypatch):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        monkeypatch.setattr(
+            "kiro_crew.config.loader.default_project_dir",
+            lambda workspace=None: str(ws),
+        )
+
+        got = session_project_dir("chat-7", "")
+
+        assert got == os.path.realpath(str(ws / ".sessions" / "chat-7"))
+        assert sorted(p.name for p in ws.iterdir()) == [".sessions"]
+
+    def test_a_session_name_cannot_squat_a_project_file_in_the_workspace(
+        self, tmp_path, monkeypatch
+    ):
+        """A session named after a real file must not take that file's path.
+
+        The session name becomes the directory name, and with no configured root
+        the base is the workspace the session already resolves to. Creating there
+        directly means `POST /api/chat/slots {"name": "package.json"}` puts a
+        DIRECTORY on `<workspace>/package.json`, and every later write of the real
+        file fails with `IsADirectoryError` -- caller-steerable, silent, and it
+        breaks a file the session did not own.
+
+        The container is what removes the class: inside it the only names a
+        session can collide with are other session names, which exclusive
+        creation already refuses.
+        """
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        monkeypatch.setattr(
+            "kiro_crew.config.loader.default_project_dir",
+            lambda workspace=None: str(ws),
+        )
+
+        got = session_project_dir("package.json", "")
+
+        assert got == os.path.realpath(str(ws / ".sessions" / "package.json"))
+        assert not (ws / "package.json").exists(), "squatted a project file's path"
+        # The path the session name was after is still free for the real file.
+        (ws / "package.json").write_text("{}", encoding="utf-8")
+        assert (ws / "package.json").is_file()
+
+    def test_a_symlinked_container_is_refused_not_followed(self, tmp_path, monkeypatch):
+        """A link planted at the container's name must not redirect everything.
+
+        The container is created rather than required to pre-exist, and a create
+        that tolerates an existing name follows a symlink sitting there, so every
+        session directory lands wherever it points. Accepting the NAME is not the
+        same as accepting whatever currently answers to it, so the container goes
+        through the same pinned create and an `O_NOFOLLOW` open proves what is
+        there.
+
+        The link points INSIDE the workspace deliberately. A containment check on
+        the resolved path refuses a target outside and would mask this, but a
+        redirect to a sibling directory passes containment while still putting the
+        session's files somewhere the user did not choose -- so that case is what
+        separates a pinned create from a checked one.
+        """
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        sibling = ws / "notes"
+        sibling.mkdir()
+        (ws / ".sessions").symlink_to(sibling, target_is_directory=True)
+        monkeypatch.setattr(
+            "kiro_crew.config.loader.default_project_dir",
+            lambda workspace=None: str(ws),
+        )
+
+        got = session_project_dir("chat-17", "")
+
+        assert got == ""
+        assert list(sibling.iterdir()) == [], "created through a symlinked container"
+
+    def test_an_existing_real_container_is_reused(self, tmp_path, monkeypatch):
+        """Refusing a link must not also refuse the ordinary second session."""
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        (ws / ".sessions").mkdir()
+        monkeypatch.setattr(
+            "kiro_crew.config.loader.default_project_dir",
+            lambda workspace=None: str(ws),
+        )
+
+        first = session_project_dir("chat-18", "")
+        second = session_project_dir("chat-19", "")
+
+        assert first == os.path.realpath(str(ws / ".sessions" / "chat-18"))
+        assert second == os.path.realpath(str(ws / ".sessions" / "chat-19"))
+
+    def test_empty_root_with_no_workspace_dir_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            "kiro_crew.config.loader.default_project_dir",
+            lambda workspace=None: "",
+        )
+
+        assert session_project_dir("chat-7", "") == ""
+
+
+class TestNamelessCreateThroughTheHandler:
+    """The flow the setting exists for, driven through the real create handler.
+
+    The dashboard's own "New chat" path sends no name, so the handler's local
+    `name` is None there. An earlier revision derived the directory from that
+    `name`, which meant the opt-in silently did nothing on precisely this path
+    while looking correct on a named create. A unit test of the helper cannot
+    catch that -- only driving the handler can, because the defect was in which
+    argument the call site passed.
+    """
+
+    @staticmethod
+    async def _create(
+        tmp_path,
+        monkeypatch,
+        body,
+        preseed=None,
+        cfg_override=None,
+        reopen=False,
+        after_create=None,
+    ):
+        """POST to the real create handler with the setting on. Returns (state, root).
+
+        ``preseed`` names a directory to create under the root BEFORE the POST,
+        standing in for a session that was closed and whose key a later create
+        reproduces. ``cfg_override`` replaces the config object entirely, for
+        exercising a PARTIAL config whose dashboard lacks the new fields.
+        ``reopen`` POSTs the same body twice. In between it clears every slot's
+        project AND empties the root, so the second request is a reopen of an
+        existing slot that has no directory of its own -- the shape a session
+        first materialized by the send path leaves behind, and the only shape
+        where the derivation would actually run. Leaving the first create's
+        directory in place instead would let the never-adopt rule refuse the
+        second derivation for a different reason and hide whether the gate works.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+        from chat_test_helpers import _make_ready_kiro_prerequisite
+
+        from kiro_crew.config.loader import KiroCrewConfig
+        from kiro_crew.dashboard.chat import api_chat_slot_create
+        from kiro_crew.dashboard.state import DashboardState
+        from kiro_crew.history import ConversationLog
+
+        root = tmp_path / "session-roots"
+        root.mkdir()
+        if preseed:
+            stale = root / preseed
+            stale.mkdir()
+            (stale / "previous-session-notes.md").write_text("secret", encoding="utf-8")
+        cfg = cfg_override or KiroCrewConfig(
+            dashboard=DashboardConfig(
+                new_project_per_session=True,
+                session_project_root=str(root),
+            )
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load",
+            classmethod(lambda cls: cfg),
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+
+        sessions = MagicMock(count=0)
+        sessions.remove = AsyncMock()
+        sessions.recycle_background = AsyncMock()
+        sessions.get_pid = MagicMock(return_value=None)
+        state = DashboardState(
+            sessions=sessions,
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            start_time=0.0,
+            conversation_log=ConversationLog(base_dir=tmp_path),
+        )
+        state.kiro_prerequisite_service = _make_ready_kiro_prerequisite()
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots", api_chat_slot_create)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/chat/slots", json=body)
+            assert resp.status == 200, f"slot create returned {resp.status}, not 200"
+            if after_create is not None:
+                # Handed the OPEN client so a test can drive a second request
+                # against the same live state, which is what a reopen is.
+                await after_create(state, root, client)
+            if reopen:
+                for existing in state._slots.values():
+                    existing.project = ""
+                for made in root.iterdir():
+                    shutil.rmtree(made)
+                resp = await client.post("/api/chat/slots", json=body)
+                assert resp.status == 200, f"slot reopen returned {resp.status}, not 200"
+        return state, root
+
+    @pytest.mark.asyncio
+    async def test_a_create_with_no_name_still_gets_its_own_directory(self, tmp_path, monkeypatch):
+        state, root = await self._create(tmp_path, monkeypatch, {})
+
+        assert len(state._slots) == 1
+        slot = next(iter(state._slots.values()))
+        # The directory must be named from the MINTED key, and must actually be
+        # the slot's project rather than the shared workspace default.
+        assert slot.project == os.path.realpath(str(root / slot.key))
+        assert Path(slot.project).is_dir()
+        assert Path(slot.project).parent == root.resolve()
+
+    @pytest.mark.asyncio
+    async def test_a_concurrent_explicit_selection_during_the_await_is_not_clobbered(
+        self, tmp_path, monkeypatch
+    ):
+        """The helper must yield to a project set by a concurrent writer.
+
+        The helper awaits twice and does not hold a lock across them, so a
+        project POST can set an explicit selection while it waits. Committing the
+        derived directory unconditionally would replace that selection with the
+        weaker default. Simulated by having the conflict-scan await set
+        `slot.project` mid-flight, standing in for the concurrent writer; the
+        commit must then see a non-empty field and leave it alone.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard import chat_handlers
+
+        root = tmp_path / "sessions"
+        root.mkdir()
+        slot = SimpleNamespace(
+            project="",
+            key="chat-1-1788689331",
+            workspace="default",
+            _project_init_lock=asyncio.Lock(),
+        )
+        explicit = "/some/explicit/project"
+
+        def _scan_sets_project(_path):
+            # Stand-in for a concurrent project POST landing during the await.
+            slot.project = explicit
+            return None
+
+        monkeypatch.setattr(chat_handlers, "voice_runtime_workspace_conflict", _scan_sets_project)
+        cfg = SimpleNamespace(
+            dashboard=SimpleNamespace(new_project_per_session=True, session_project_root=str(root))
+        )
+
+        await chat_handlers._apply_per_session_project(slot, cfg, "default")
+
+        assert slot.project == explicit, "clobbered a concurrent explicit selection"
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_creates_for_one_slot_derive_only_once(self, tmp_path):
+        """A duplicate create must REUSE the winner's directory, not derive again.
+
+        Two creates naming one slot key -- a double submit, a client retry -- both
+        pass the "no project yet" check unless something serialises them, and both
+        derive. The loser's
+        exclusive create meets the winner's directory and gets nothing back, so it
+        returns False and its caller falls through to the SHARED default; if that
+        fallback commits first, the compare-and-set correctly declines to
+        overwrite it and the slot ends on the shared directory with the winner's
+        private one orphaned. A duplicate request silently costs the isolation the
+        opt-in exists for.
+
+        Pinned on the DERIVATION COUNT rather than the final project, because the
+        final project looks identical either way in this unit -- the orphaning
+        needs the caller's fallback to interleave. Exactly one derivation is the
+        property that makes the follower a reuser instead of a second creator.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.config import loader as config_loader
+        from kiro_crew.dashboard import chat_handlers
+
+        root = tmp_path / "sessions"
+        root.mkdir()
+        slot = SimpleNamespace(
+            project="",
+            key="chat-9-1788689331",
+            workspace="default",
+            _project_init_lock=asyncio.Lock(),
+        )
+        cfg = SimpleNamespace(
+            dashboard=SimpleNamespace(new_project_per_session=True, session_project_root=str(root))
+        )
+        calls = []
+        real_derive = config_loader.session_project_dir
+
+        def _counting_derive(session_key, root_arg="", workspace=None):
+            # Slow enough that a second caller reaches the helper before the first
+            # commits, so the interleaving is forced rather than hoped for.
+            calls.append(session_key)
+            time.sleep(0.05)
+            return real_derive(session_key, root_arg, workspace)
+
+        with unittest.mock.patch.object(chat_handlers, "session_project_dir", _counting_derive):
+            results = await asyncio.gather(
+                chat_handlers._apply_per_session_project(slot, cfg, "default"),
+                chat_handlers._apply_per_session_project(slot, cfg, "default"),
+            )
+
+        assert len(calls) == 1, f"derived {len(calls)} times; the follower re-derived"
+        assert sorted(results) == [False, True], "both calls claimed the assignment"
+        assert slot.project == os.path.realpath(str(root / slot.key))
+        assert [p.name for p in root.iterdir()] == [slot.key], "left an orphaned directory"
+
+        """The send path must NOT derive, and must say why at the call site.
+
+        Deriving there is circular: it needs the session's workspace, which for an
+        auto-created slot comes from the requested agent's bindings, but
+        `resolve_agent_bindings` requires the project directory it is given to be
+        the one the session actually runs in. An earlier revision derived anyway
+        and put the directory under the DEFAULT workspace root whenever the root
+        was unconfigured and the request named a non-default agent.
+
+        Pinned structurally because the harm is a wrong LOCATION chosen from stale
+        inputs, which a status-code test cannot see. The reasoning is required to
+        stay next to the code so a later reader does not "fix" the gap by
+        reintroducing the bug.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_handlers
+
+        send_src = inspect.getsource(chat_handlers.api_chat)
+        assert "_apply_per_session_project" not in send_src, "the send path derives again"
+        assert "circular" in send_src, "the reason for not deriving is not recorded"
+        # The create endpoint, which does have a resolved workspace, must apply it.
+        create_src = inspect.getsource(chat_handlers.api_chat_slot_create)
+        assert "_apply_per_session_project" in create_src
+
+    @pytest.mark.asyncio
+    async def test_a_config_without_a_dashboard_attribute_is_tolerated(self):
+        """The whole access chain must be guarded, not just the leaf fields.
+
+        Measured regression: hardening `new_project_per_session` alone left
+        `cfg.dashboard` itself bare, and the send path sees config stand-ins with
+        no `dashboard` attribute at all. That raised `AttributeError` inside the
+        request handler and surfaced as a 500 on an endpoint contracted to fail
+        closed with 400/409 - five tests across two files caught it, none of them
+        in this file.
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.chat_handlers import _apply_per_session_project
+
+        slot = SimpleNamespace(project="", key="chat-1-1788689331", workspace="default")
+        # No `dashboard` attribute at all, and no exception may escape.
+        await _apply_per_session_project(slot, SimpleNamespace(default_agent="x"), "default")
+
+        assert slot.project == ""
+
+    @pytest.mark.asyncio
+    async def test_a_partial_config_object_does_not_break_slot_create(self, tmp_path, monkeypatch):
+        """A config whose dashboard lacks the new fields must still create a slot.
+
+        This is a regression pin for a real 500. `cfg.dashboard` reaching this
+        handler is routinely a PARTIAL stand-in - 36 sites across 19 test files
+        patch `KiroCrewConfig.load` with a minimal
+        `dashboard=SimpleNamespace(default_project="")` - so reading a newly
+        added field by bare attribute access raised `AttributeError` inside the
+        request handler and returned 500 from `/api/chat/slots`. Three CI shards
+        caught it while every test in this file passed, because this file always
+        built a COMPLETE config.
+
+        The pin is the response status, not the absence of an exception: the
+        observable failure was a 500, and `_create` asserts 200.
+        """
+        from types import SimpleNamespace
+
+        partial = SimpleNamespace(
+            default_agent="local-only-crew",
+            dashboard=SimpleNamespace(default_project=""),
+        )
+        state, root = await self._create(tmp_path, monkeypatch, {}, cfg_override=partial)
+
+        # And a missing field must read as OFF, not as "on with a bad root".
+        assert list(root.iterdir()) == [], "a missing field must default the feature OFF"
+        slot = next(iter(state._slots.values()))
+        assert slot.project != os.path.realpath(str(root / slot.key))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("supplied_name", ["reused-name", "worker-1-stable"])
+    async def test_a_create_whose_directory_already_exists_falls_back(
+        self, supplied_name, tmp_path, monkeypatch
+    ):
+        """The blocking case: a reused key must not inherit the old directory.
+
+        Driven through the handler because that is where the harm lands. The
+        directory is pre-seeded with a file, standing in for a session that was
+        closed and whose key a later create reproduces. `slot.project` must NOT
+        become that directory, and the earlier file must survive - nothing in
+        this change deletes.
+
+        `worker-1-stable` is parametrized deliberately: an earlier revision gated
+        on the key's SHAPE via `_slot_index_from_key`, which only checks that the
+        second segment is a digit, so that name passed an "auto-minted only"
+        guard while being entirely reusable. Refusing an existing directory
+        covers it without classifying keys at all.
+        """
+        state, root = await self._create(
+            tmp_path, monkeypatch, {"name": supplied_name}, preseed=supplied_name
+        )
+
+        slot = state._slots[supplied_name]
+        stale = root / supplied_name
+        assert slot.project != os.path.realpath(str(stale)), "adopted a reused key's directory"
+        assert (stale / "previous-session-notes.md").read_text(encoding="utf-8") == "secret"
+
+    @pytest.mark.asyncio
+    async def test_the_assignment_is_saved_even_with_no_other_metadata(self, tmp_path, monkeypatch):
+        """A derived directory must be durable at the moment it is assigned.
+
+        The handler's durable save was conditional on the metadata the REQUEST
+        supplied -- a folder, a pinned title, a peer binding -- and a plain
+        create or reopen supplies none of those. So the assignment lived only in
+        memory: a crash before the next periodic flush lost it, while the
+        directory and anything the session had written into it stayed on disk
+        with nothing pointing at it. Nothing re-derives the directory (a restored
+        session is served its project from metadata), so the assignment IS the
+        only record of the association.
+
+        Asserted on the forced save rather than on file contents because the
+        defect is that the write never happens, and `force=True` is what
+        distinguishes it from the dirty-flag flush that may or may not follow.
+        """
+        from unittest.mock import AsyncMock
+
+        from kiro_crew.dashboard import chat_handlers
+
+        saves = AsyncMock(return_value=True)
+        monkeypatch.setattr(chat_handlers, "save_slot_off_loop", saves)
+
+        state, root = await self._create(tmp_path, monkeypatch, {})
+
+        slot = next(iter(state._slots.values()))
+        assert slot.project == os.path.realpath(str(root / slot.key))
+        assert saves.await_count == 1, "the assignment was never persisted"
+        assert saves.await_args.kwargs["force"] is True
+        assert saves.await_args.args[1] is slot
+
+    @pytest.mark.asyncio
+    async def test_a_reopen_of_an_existing_slot_derives_nothing(self, tmp_path, monkeypatch):
+        """Only a slot this request MINTS may be given a directory.
+
+        This endpoint also serves a reopen, and a slot that already exists can
+        have a live provider running in the shared directory. Assigning a project
+        there changes in-memory metadata only: the provider keeps the cwd it
+        started with, so the session advertises a private directory while its
+        files keep landing in the shared one. Isolation is reported and not
+        delivered, and the mixed files cannot be sorted out afterwards.
+
+        The second POST reopens the slot with its project cleared and no
+        directory of its own, which is what a session first materialized by the
+        send path looks like -- that path deliberately does not derive. That is
+        the only precondition where the derivation would run at all: leave the
+        first create's directory in place and the never-adopt rule refuses for a
+        different reason, which proves nothing about the gate.
+        """
+        state, root = await self._create(tmp_path, monkeypatch, {"name": "reopened"}, reopen=True)
+
+        slot = state._slots["reopened"]
+        assert list(root.iterdir()) == [], "the reopen derived a directory"
+        assert slot.project != os.path.realpath(str(root / "reopened")), "reopen assigned a project"
+
+    @pytest.mark.asyncio
+    async def test_the_shared_fallback_waits_for_an_in_flight_project_decision(
+        self, tmp_path, monkeypatch
+    ):
+        """The handler must not commit the shared default past a held decision.
+
+        Two overlapping creates on one name split into a winner that mints the
+        slot and a follower that finds it existing. Only the winner derives -- the
+        follower is excluded so it cannot reassign a project under a live
+        provider -- which takes the follower straight to the shared fallback. A
+        fallback that commits while the winner's derivation is in flight wins the
+        field, the winner's compare-and-set then correctly declines to overwrite
+        it, and the slot runs in the shared directory with the private one it
+        exclusively created orphaned.
+
+        Driven by holding `_project_init_lock` with the project cleared, which is
+        exactly the state a follower observes mid-derivation, and then issuing the
+        follower's own request. Held that way the request must not finish; once
+        the decision lands and the lock frees, it must accept that decision
+        instead of replacing it. Two concurrent POSTs cannot express this -- over
+        HTTP they observably serialise, so such a test passes whether or not the
+        fallback locks anything.
+        """
+        outcome = {}
+
+        async def _follower(state, root, client):
+            slot = state._slots["raced"]
+            derived = slot.project
+            assert derived == os.path.realpath(str(root / "raced"))
+            async with slot._project_init_lock:
+                slot.project = ""
+                task = asyncio.create_task(client.post("/api/chat/slots", json={"name": "raced"}))
+                await asyncio.sleep(0.2)
+                outcome["finished_while_held"] = task.done()
+                # The winner's commit, landing while the follower waits.
+                slot.project = derived
+            resp = await task
+            assert resp.status == 200
+            outcome["project"] = slot.project
+            outcome["derived"] = derived
+
+        await self._create(tmp_path, monkeypatch, {"name": "raced"}, after_create=_follower)
+
+        assert outcome["finished_while_held"] is False, "committed past a held project decision"
+        assert outcome["project"] == outcome["derived"], "shared default replaced the derivation"
+
+
+class TestOffByDefault:
+    def test_toggle_defaults_to_false(self):
+        """Installing this change must alter nothing until a user opts in."""
+        assert DashboardConfig().new_project_per_session is False
+
+    def test_root_defaults_to_empty(self):
+        assert DashboardConfig().session_project_root == ""
+
+    def test_config_that_never_mentions_the_keys_parses_to_the_old_behaviour(self):
+        cfg = _load_from_dict({"dashboard": {}})
+
+        assert cfg.dashboard.new_project_per_session is False
+        assert cfg.dashboard.session_project_root == ""
+
+    def test_config_that_sets_the_keys_is_actually_read(self, tmp_path):
+        """Pins the loader wiring, which the default-only test cannot.
+
+        A test that only asserts False-when-absent passes even if the parse were
+        never wired at all, because the dataclass default is already False. This
+        one fails unless `_load_resolved` reads both keys.
+        """
+        cfg = _load_from_dict(
+            {
+                "dashboard": {
+                    "new_project_per_session": True,
+                    "session_project_root": str(tmp_path / "roots"),
+                }
+            }
+        )
+
+        assert cfg.dashboard.new_project_per_session is True
+        assert cfg.dashboard.session_project_root == str(tmp_path / "roots")
+
+    def test_non_boolean_toggle_degrades_to_false(self):
+        """`_safe_bool` keeps a hand-edited config from raising on load."""
+        cfg = _load_from_dict({"dashboard": {"new_project_per_session": "yes please"}})
+
+        assert cfg.dashboard.new_project_per_session is False


### PR DESCRIPTION
# What is the problem?

Every new chat session lands in the same shared project directory. A user running
several unrelated pieces of work concurrently gets their notes, scratch files and
session context mixed together, because nothing about session creation is
per-session: the project a new slot resolves to comes from
`dashboard.default_project`, else from the workspace directory.

The only workaround today is to open a session and manually repoint it at another
directory through the project endpoint, every single time.

# Why this issue matters to the user

The reporter's case is the common one, not an edge case: concurrent unrelated
activities. Manual repointing is easy to forget and easy to get wrong, and the
failure is silent - you do not find out that two pieces of work shared a
directory until their files are already interleaved. Forgetting it once is enough
to lose the separation for that session's whole lifetime.

# How our fix solves it

THIS DEFAULTS OFF. `dashboard.new_project_per_session` is `False`, so installing
this change alters nothing: a config that never mentions the key resolves a new
session's project through exactly the same chain as before.

Chaining from the symptom to the root cause:

- Symptom: unrelated sessions share files.
- Because: a new slot's project is resolved from global config, so every new
  session resolves to the same directory.
- Because: there was no per-session directory in that resolution at all. A slot
  carries two identities - `slot.workspace` (a NAME, derived from the agent
  binding, whose name-to-directory mapping is global) and `slot.project` (a real
  directory) - and only the second is per-session.
- So: the fix adds a derivation keyed on `slot.project`, which is already
  per-session, already has a validated setter, and is already what becomes the
  agent's cwd.

**Why the config keys are project-named rather than workspace-named.** The request
says "workspace", but in this codebase a workspace is a distinct concept with its
own name-to-directory mapping and its own memory and knowledge base. This change
sets `slot.project`. Naming the keys after what they actually set avoids shipping a
name that would need a compatibility alias later, and a config key is one of the
few things here that is genuinely expensive to rename once it is in user config
files.

Answering the four questions this change has to answer, all from existing code
rather than invented:

**WHERE the directory goes.** Under an existing configured root, never anywhere
new. `dashboard.session_project_root` names it; empty falls back to a `.sessions`
folder inside the workspace directory the session already resolves to, created
through the same pinned routine the session directories use. It is one level down
rather than the workspace directory itself because the session name becomes the
directory name, so creating at that top level lets a session called
`package.json` put a directory on that path. A CONFIGURED root must ALREADY
EXIST, matching how `dashboard.default_project` is treated in
the sibling branch, so a typo disables the feature instead of scattering
directories. Nothing is written outside the root: the derived path is asserted to
be an immediate child of the resolved root, and `mkdir` is called without
`parents`.

**HOW it is named, and why an existing directory is never taken over.** From
`slot.key` - the MINTED key, not the request body's `name` - via the existing
`_safe_dir_name`. Two properties matter, and the second is the one that makes the
feature safe:

- `_safe_dir_name` is a sanitizer, not a validator. It maps separators to `_` but
  does not reject `..`, so the containment assertion is what stops an escape, not
  the name.
- The directory is created EXCLUSIVELY. `slot.project` is persisted on the
  transcript's metadata line and rehydrated from there, so a restored session is
  served from metadata and never re-derives. A candidate path that already exists
  therefore belongs to an EARLIER session whose key was reused - a caller-supplied
  name, a channel key, or a minted key reproduced by a closed session plus a
  same-second restart - and adopting it would hand a fresh session that session's
  files. It is refused, and the caller falls back to the shared default.

Exclusive creation is also what lets this ship with NO delete path: nothing is
cleared, reused, or overwritten.

**WHAT happens when creation FAILS.** The session still opens, degraded. Every
failure mode - a root that is empty, missing, not a directory or sensitive; a name
that would escape the root; an existing candidate; an `OSError` from the `mkdir` on
a read-only or full disk - returns `""`, which the caller reads as "no per-session
directory" and falls through to the shared default. This is not a new posture: the
sibling configured-default branch already skips an ineligible path to fall back
"instead of wedging every new slot".

**WHO cleans up.** Nobody, and that is a real cost this PR names rather than
solves. A directory per session is unbounded growth. This change deliberately
contains NO delete path - a reaper written in the same change as a create path is
how data loss ships - so cleanup is proposed below instead.

Deliberate deviations from the issue's literal request, each with its reason:

- No Settings UI toggle. A new label needs a new i18n key, and
  `catalogParity.test.ts` requires every locale (14 of them). I will not fabricate
  translations for 13 languages, and `en.json` is generated and must not be
  hand-edited (`website/docs/i18n-catalog.md`). The setting is config-file only for
  now, exactly like its closest sibling `dashboard.default_project`, which also
  ships with no UI control.
- The root is config-file only rather than a Settings directory picker. Measured:
  every key the dashboard config PUT accepts is a bool, an int or a small enum, and
  that handler's write branch does no path handling at all. This change does not
  make itself the first dashboard-writable path setting.
- No memory or knowledge-base isolation. That is the open product question the
  reporter flagged, and it lives on `slot.workspace`, which is agent-derived -
  repointing it per session would collide with agent bindings. The reporter's own
  view was that shared memory is the safer default.

`config-baseline.json` is regenerated because the repo commits a schema snapshot
and asserts byte-parity with its generator, so adding two config fields invalidates
it. That is a consequence of the change, which is why the diff touches a fifth
file.

## What review changed, and one thing I got wrong twice

Four rounds of blocking findings, all inside this diff:

1. The handler derived the directory from the request body's `name`. The
   dashboard's own new-chat path sends no name, so `name` was `None`,
   `_safe_dir_name(None)` raised, the broad `except` swallowed it, and with the
   toggle ON behaviour was identical to OFF on the primary path. Now derives from
   `slot.key`.
2. `os.geteuid()` was evaluated at collection time, which aborts the whole shard on
   Windows where the attribute does not exist. Guarded with `os.name != "posix"`.
   Separately, SAST flagged a hardcoded `0o700`; the test now captures and restores
   the mode pytest created, which removes the finding and is more correct.
3. A reused key could inherit a deleted session's files. I gated on the key's SHAPE
   via `_slot_index_from_key`, which only checks that the second segment is a digit
   and never validates the trailing timestamp - so `worker-1-stable` passed an
   "auto-minted only" test while being entirely reusable. That is relying on what a
   predicate is called instead of reading what it validates.
4. The real fix, and the correction of my own error. I claimed `slot.project` is not
   persisted, having checked `open_slots.json` (which carries session keys only) and
   concluded a global absence. It is persisted - on the transcript's metadata line,
   rehydrated in `chat_persistence`, with `project` in `history`'s owned-field list.
   I verified one persistence mechanism and treated that as verifying the
   inference. Because restore comes from metadata rather than re-derivation,
   refusing an existing directory is safe, and exclusive creation replaces the
   key-classifying gate entirely - covering every reusable-key case without this
   call site classifying keys at all.
5. A 500 from this endpoint, found by CI and not by my own tests. Reading the new
   field by bare attribute access raised `AttributeError` inside the request
   handler, so `POST /api/chat/slots` returned 500 whenever `cfg.dashboard` was a
   partial stand-in. Measured: 36 sites across 19 test files patch
   `KiroCrewConfig.load` with a minimal `dashboard=SimpleNamespace(...)` carrying
   only the fields the surrounding code reads. That is why the read now uses
   `getattr` with the dataclass defaults, and why the fix belongs in the handler
   rather than in 19 test doubles - a missing field reading as OFF is the
   documented default. I had attributed this red to a flaky event-loop class for
   three board cycles; see the harvest below.
6. A sensitive path was CREATED before being validated. `is_sensitive_path` was
   applied to the root before the `mkdir` and to the result after it, but never to
   the candidate before it - so a session key of `security_policy.json` under the
   data home minted a DIRECTORY on a governance trust root, and the post-check then
   returned `""` having already done the damage. Nothing here deletes, so the
   directory would stay and block policy loading. I had applied the
   pre-check/post-check reasoning to containment only, never to sensitivity. Now
   rejected before the `mkdir`; verified that `is_sensitive_path` matches the path
   while it still does not exist, which is the case that matters. This is also
   downstream of dropping the key-shape gate in round 4: a caller-supplied name
   becomes the slot key, so the name reaching that line is caller-steerable, and I
   widened who could steer it without re-examining the guards that depend on it.
7. I tried to apply the setting on the second creation path and reverted it, which
   is the most useful thing in this history. `POST /api/chat` also creates a slot,
   so the setting applied on the create endpoint and not on a send to an unknown
   slot. Adding it there produced two defects in two rounds. First it broke six
   fail-closed tests: `test_slot_create_default_agent` patches
   `KiroCrewConfig.load` to raise `OSError`, and my unguarded `await` propagated it
   as a 500 from an endpoint contracted to answer 400/409 - and separately, the
   round-5 hardening of `new_project_per_session` had left `cfg.dashboard` itself
   bare, which the send path exposed because it sees config stand-ins with no
   `dashboard` attribute at all. I had fixed the leaf and assumed the chain. Then,
   with those fixed, the reviewer found the derivation was using the wrong
   workspace: an auto-created slot's workspace is `"default"` regardless of the
   agent the request names, so with an unconfigured root the directory landed under
   the default workspace's tree and that wrong location persisted.
8. That last defect is not fixable there, and the reason is a documented invariant
   rather than my judgement. Deriving needs the workspace; for an auto-created slot
   the workspace comes from the requested agent's bindings; but
   `resolve_agent_bindings` requires the project directory it is given to be "the
   same directory Kiro Crew passes as the kiro-cli cwd", because passing a
   directory the session does not run in reintroduces the silent
   agent-substitution bug that lookup exists to prevent. Bindings need the final
   project, and the project needs the bindings' workspace. So the send path now
   deliberately does NOT derive, with that reasoning at the call site and a test
   pinning both the absence and the reason. It degrades to the shared default,
   which is today's behaviour. The create endpoint, where the workspace is resolved
   before the derivation, is unaffected.
9. The commit was a bare assignment past two awaits. `_apply_per_session_project`
   awaits the derivation and the conflict scan without holding a lock across them,
   so a concurrent project POST could set an explicit selection while it waited,
   and the unconditional `slot.project = per_session` at the end would overwrite
   that selection with the derived default - the weaker value clobbering the
   stronger. Now a compare-and-set: re-read the field after the awaits and commit
   only if it is still the empty value the derivation started from; a concurrent
   writer wins. This is the ROOT of the whole class - findings 1, 5, 7 and this one
   are all a value trusted at commit time that was only valid before an await - and
   unlike the earlier per-instance fixes it closes the class at the commit point.

Two blocking findings I am not acting on, each with the measurement rather than a
preference. The first is the send path above: the choice was between a directory
under the wrong workspace root and the setting not applying there, and the second
degrades to current behaviour while the first persists a wrong location.

The second is preserving the per-session project across agent and workspace
switches. The workspace-switch handler refuses outright once a session has messages
- `if slot.total_messages > 0` returns 409 "Cannot change workspace after messages
have been sent. Open a new session instead." - so the switch is only reachable on a
session that has written nothing, and there are no files to re-share. The residual is
an empty orphaned directory and the setting no longer applying after a switch: disk
cost and incompleteness rather than the data loss the finding is anchored to.
Re-deriving under the new workspace is also a design decision about what a workspace
switch MEANS, and belongs in its own change. Both are filed as follow-ups below.

# What tests we did

`test/test_session_project_dir.py`, 30 tests, run as
`python3 -m pytest -n0 test/test_session_project_dir.py`: 30 passed. black, isort
and flake8 clean on all four Python files changed. mypy reports 2 errors, both in
`transcribe.py`, a file this change does not touch.

Three handler-level tests drive the real `api_chat_slot_create`, because several of
the findings above were in what the call site passed or read, which no unit test of
the helper can see: a nameless create must get its own directory named from the
minted key; a create whose directory already exists must NOT adopt it - parametrized
over `reused-name` and `worker-1-stable`, the second being the name that defeated the
earlier gate, with a pre-seeded file asserted to survive; and a create with a PARTIAL
config must still return 200 with the feature reading as OFF.

Two further tests cover what those cannot. One asserts structurally that the send
path does NOT derive and that the reason is recorded at the call site, so a later
reader does not close the apparent gap by reintroducing the wrong-workspace bug; it
also asserts the create endpoint still does apply it. The other calls the helper
directly with a config object that has no `dashboard` attribute, the shape that
turned into a 500 in finding 7.

Mutation-verified, classified by reading the runner's own failure line:

| mutation | result |
| --- | --- |
| revert `getattr` to bare attribute access | reddens the partial-config test with `assert 500 == 200`, and reproduces the original CI failure |
| revert exclusive create to `exist_ok=True` | reddens 4 tests, including both handler cases, on the adopted path |
| revert `slot.key` to `name` | reddens the nameless test, `assert '' == '.../chat-1-...'` |
| non-deterministic name | reddens 7 tests on real assertions |
| remove `except` degradation | reddens with `PermissionError`, the correct observable for a guard whose absence crashes |
| drop the config parse line | reddens `assert '' == '.../roots'` |
| flip the default to `True` | reddens `assert True is False` |
| delete the PRE-`mkdir` sensitive check | reddens `assert [PosixPath('.../security_policy.json')] == []` |
| make the send path derive again | reddens the deliberately-does-not-derive test |
| bare `cfg.dashboard` instead of the guarded chain | reddens with the exact `AttributeError`, and reproduces the CI regression |
| bare commit instead of compare-and-set | reddens the concurrent-selection test with the clobbered path |
| delete either or BOTH containment sites | reddens NOTHING - see the survivors below |

Three survivors are disclosed rather than hidden, because each says something about
the code:

- Deleting EITHER containment site, or BOTH, reddens nothing. I previously claimed
  deleting both surfaced an escape; that was wrong, and measuring it is what showed
  why. `_safe_dir_name` cannot emit a path separator (it maps `/`, `\` and `:` to
  `_`), so the join is an immediate child by construction; and `mkdir` does NOT
  follow a symlink at the final component - dangling or not it raises
  `FileExistsError`, which exclusive creation already refuses. So containment is
  now depth against a change to either of those facts, not an active guard. It stays
  because a sanitizer that starts passing separators through, or a move away from
  exclusive creation, would make it load-bearing again with no other signal.
- Deleting the `isdir(base)` guard reddens nothing, because `mkdir` without
  `parents` fails on a missing or non-directory root anyway.
- Deleting the non-string key guard reddens nothing, because the broad `except`
  returns the same `""`.

All three share one cause worth stating plainly: the broad `except Exception` is the
backstop that makes individual guards unobservable, and it is also what let finding
1 above ship as a silent no-op. It is kept because the sibling `default_project_dir`
uses the same breadth for the same reason, and because a session must open even on
an unanticipated failure - but every guard it masks now carries a comment recording
that it was measured unobservable, so a later reader neither deletes it as dead nor
trusts it as pinned.

On the CI reds, split by measurement rather than by guess. `Backend Tests (3.12, 3)`
and `(Windows) (3)` were MINE: the 500 above, established by reverting only my three
source files and re-running the named test class (3 failed with my change, 3 passed
without, 190 pass in that whole file now). `Backend Tests (3.12, 4)` is NOT mine:
its failure is `test_snapshot.py::TestNotificationCopyWhenNoLiveFileExists`
asserting a concurrency ordering, it does not reproduce serially, and it passes
25/25 both with my change and with my change reverted - so nothing in this diff
moves it. I am not fixing that one here.

# Any other suggestions on the work

- **Cleanup is owed and is proposed, not implemented.** The reporter's own
  suggestion was to ask on session delete with a Yes / No / Never answer, and he
  called the zip-to-archive idea scope creep himself. Any reaper should be its own
  change, so a delete path is never introduced alongside a create path. Note that
  exclusive creation means a stale directory is never silently reused, so the cost
  of not having a reaper is disk growth rather than cross-session leakage.
- The Settings toggle is a clean follow-up once the 14 locale strings can be
  produced properly. No backend change is needed beyond adding the key to the
  dashboard config GET and PUT.
- A per-session workspace that also isolates memory and the knowledge base is a
  larger, separate decision about `slot.workspace` and agent bindings.
- Applying the setting to sessions auto-created by a send to an unknown slot needs the
  workspace-versus-bindings circularity broken first - most likely by having that
  endpoint resolve the workspace explicitly before the slot is used, rather than
  relying on `get_or_create_slot`'s default. Worth doing, but not as a side effect of
  this change.
- What a per-session project should do across an agent or workspace switch is its own
  decision, and is the one blocking finding I declined above. Today a workspace
  switch repoints the project at the new workspace's directory, which is defensible;
  the switch is also refused with a 409 once the session has messages. Worth settling
  deliberately rather than inside this change.
- #8265 asks for a dashboard UI to create, update and delete workspaces. Different
  mechanism, but adjacent, and whoever builds that UI is the natural owner of the
  toggle above.

## Pattern harvest

Rule candidate: a call inserted into a long handler must sit after every input it
reads is FINAL, and "final" is found by locating where each input is last assigned -
not by reading the surrounding lines. My insertion read a workspace that the handler
never assigns and a config the handler deliberately loads late and tolerantly. Two
separate defects, one ordering cause.

Rule candidate: when adding a call into a shared request handler, derive the
regression surface from the ROUTE rather than from which files look related. I picked
two files that had failed recently, both passed, and CI then failed six tests in
three files I had not run. Grepping the route name across the test tree produced 28
files in one command - that list is the sweep, and it is cheap enough that guessing
was never worth it.

Rule candidate: when hardening an attribute read against partial stand-ins, guard the
whole chain, not the leaf. I replaced `cfg.dashboard.new_field` with
`getattr(cfg.dashboard, "new_field", default)` and left `cfg.dashboard` itself bare,
so the same class of `AttributeError` came back one level up on a different call path.
A helper reached from more than one entry point sees more shapes of its arguments than
any single call site does.

Rule candidate: when a function validates a path and then creates it, every
validation must run BEFORE the side effect, not merely somewhere in the function. I
had a pre-check/post-check pair for containment and only a post-check for
sensitivity, so the sensitive path was created and then rejected - and with no delete
path, rejecting after the fact leaves the damage in place. List the checks against
the single line that mutates the filesystem and ask of each one which side of it it
falls on.

Rule candidate: before calling a CI red flaky or inherited, read WHICH test failed
and check whether it exercises a surface this change touches. I dismissed a failing
shard as a flaky event-loop class for three board cycles; its annotation named a 500
on `/api/chat/slots`, the exact endpoint being modified. The evidence I had cited was
real but about different files, so it never bore on this failure. "Does not reproduce
serially" is only evidence once it is the failing test that was re-run.

Rule candidate: checking one persistence mechanism does not establish that a field
is unpersisted. `open_slots.json` carrying only session keys was true and did not
support "slot.project is not persisted" - the per-slot fields ride the transcript
metadata line. Before building on an absence, enumerate the write sites for the
field (grep every assignment and every serializer) rather than reading the one store
you happened to open.

Rule candidate: a broad `except` on a resolution helper converts caller errors into
its own "unavailable" return value, so a wrong argument at the call site ships as a
silent no-op and every guard inside the helper stops being observable to mutation.
When a helper degrades by returning a sentinel, validate the caller's argument at the
boundary and test the call site through its real entry point.

Refs #8432

