### PR TITLE
fix(dashboard): key the slot switch lock on the session, not the slot

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -5476,24 +5476,33 @@ class _CommitToken(str):
 # by the SESSION the switch handlers probe and reset rather than by the
 # transcript.
 #
-# LOCK ORDER — the one place it is written down. Session lock, then
-# ``slot._lock``, then ``slot._model_pick_lock``. Every switch handler
-# acquires them in that order and nothing acquires them in the opposite one,
-# so two aliases contending on one session cannot cycle. Unrelated slots
-# resolve to DIFFERENT keys and so take different locks: this serializes
-# aliases of one session, never one slot against another session's switch.
-# A WeakValueDictionary so a session's lock is collected once no request
-# holds it.
+# LOCK ORDER — the one place it is written down. ``slot._lock``, then the
+# session lock, then ``slot._model_pick_lock``. Every switch handler acquires
+# them in that order and nothing acquires them in the opposite one, so two
+# aliases contending on one session cannot cycle: a holder of the session lock
+# already holds its own ``slot._lock`` and never waits for another slot's.
+# Unrelated slots resolve to DIFFERENT keys and so take different locks: this
+# serializes aliases of ONE session, never one slot against another session's
+# switch. A WeakValueDictionary so a session's lock is collected once no
+# request holds it.
 #
-# The lock KEY is resolved BEFORE ``slot._lock`` — the only order in which
-# one request can wait for another's whole transaction — while each handler
-# goes on resolving the key it PROBES AND RESETS inside its own lock, so no
-# existing in-lock guarantee moves. If a rebind lands between those two
-# reads this serializes on the previous session; that is the residual
-# ``_autocompact_txn_locks`` documents in the same words ("a rebind
-# mid-request is handled by the expected_history_key pin and the post-persist
-# reauthorization, not by the lock key"), and every handler here already
-# re-checks ``effective_session_key(slot) != session_key`` after its awaits.
+# WHY THE SESSION LOCK IS ENTERED SECOND, THROUGH AN ExitStack. Its key is
+# ``effective_session_key(slot)``, and that value is only trustworthy once
+# ``slot._lock`` is held: a channel/cron rebind can land while a request
+# queues, which is why every handler deliberately resolves the key INSIDE its
+# lock (pinned by
+# ``test_binding_that_lands_while_queued_on_the_lock_is_the_one_switched`` --
+# the binding that lands is the one switched). Keying the session lock on any
+# EARLIER read would be unsound in exactly that case: the handler would hold
+# the lock for the PREVIOUS session while probing and resetting the new one,
+# so a concurrent alias switch on the new session would not be serialized
+# against it -- and the handlers' post-await re-checks cannot catch it,
+# because they compare ``effective_session_key(slot) != session_key`` and
+# session_key would already BE the new key. Entering the lock after the
+# in-lock read makes the lock key and the acted-on key THE SAME VALUE BY
+# CONSTRUCTION, so there is no window to guard and no new decision point to
+# get wrong. The ExitStack is what lets a lock be acquired mid-block without
+# nesting the whole remaining transaction one level deeper.
 _slot_switch_session_locks: "weakref.WeakValueDictionary[str, asyncio.Lock]" = (
     weakref.WeakValueDictionary()
 )
@@ -5550,11 +5559,12 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
     # slotSwitch failure-recovery relies on, with no rollback machinery to
     # race against concurrent writers (e.g. the project endpoint, which does
     # not take this lock).
-    # Serialize against every OTHER alias slot on this same session before
-    # taking the per-slot lock (see _slot_switch_session_lock for the order):
-    # slot._lock alone is disjoint across aliases and would let a second
-    # switch through another alias commit and reset this same session.
-    async with _slot_switch_session_lock(effective_session_key(slot)), slot._lock:
+    # Two locks, in the order documented at _slot_switch_session_lock:
+    # slot._lock, then the session lock. An ExitStack because the session
+    # lock's KEY is only known after the in-lock read below, and locking on
+    # any earlier read could leave this holding the wrong session lock.
+    async with contextlib.AsyncExitStack() as _stack:
+        await _stack.enter_async_context(slot._lock)
         # The session the switch resets — ``effective_session_key``, never
         # ``_history_key_for`` (see api_chat_slot_model): a channel- or
         # cron-born slot runs its turns under its linked key, and the
@@ -5563,6 +5573,13 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
         # kept the old agent. Resolved INSIDE the lock: the binding can land
         # while this request waits on it.
         session_key = effective_session_key(slot)
+        # Now serialize against every OTHER alias slot on this same session.
+        # slot._lock is created per _ChatSlot and so is DISJOINT across
+        # aliases. Keyed on the value resolved just above -- the same one the
+        # probe and reset below use -- so the lock provably guards them even if
+        # a binding landed while this request waited on slot._lock (see
+        # _slot_switch_session_lock).
+        await _stack.enter_async_context(_slot_switch_session_lock(session_key))
         # App isolation on the SESSION, not just the slot (the cancel routes'
         # policy): slot ownership does not imply ownership of a linked
         # channel session, so an app caller may not switch the agent a
@@ -6097,11 +6114,11 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
         # below has nothing to act on: the session that would receive
         # ``session/set_model`` is on the other machine.
         return await _apply_remote_pick(request, state, slot, "model", {"model": model_name})
-    # Three locks, always in this order (session lock outer — see
-    # _slot_switch_session_lock — then slot._lock, then _model_pick_lock; the
-    # bulk handler nests them the same way and nothing takes them in the
-    # opposite order):
-    #
+    # Three locks, always in this order (slot._lock, then the session lock,
+    # then _model_pick_lock -- see _slot_switch_session_lock; the bulk handler
+    # nests them the same way and nothing takes them in the opposite order).
+    # An ExitStack because the session lock's KEY is only known after the
+    # in-lock read below:
     # the session lock — two switches arriving through DIFFERENT alias slots
     # resolve onto ONE session but take DISJOINT per-slot locks, so without
     # it neither waits for the other and both reset this same session.
@@ -6127,11 +6144,8 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
     # on AcpModelUnavailable, so an unlocked equality read could match that
     # transient value and report "already on X" for a model that is then
     # rolled back.
-    async with (
-        _slot_switch_session_lock(effective_session_key(slot)),
-        slot._lock,
-        slot._model_pick_lock,
-    ):
+    async with contextlib.AsyncExitStack() as _stack:
+        await _stack.enter_async_context(slot._lock)
         # The session the switch will probe and, on the reset path, tear
         # down. ``effective_session_key``, never ``_history_key_for`` (the
         # reload handler's rule): a channel- or cron-born slot runs its turns
@@ -6143,6 +6157,14 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
         # workflow slot is linked when its first result is injected), and a
         # key read before the wait would then name the wrong session.
         session_key = effective_session_key(slot)
+        # Now serialize against every OTHER alias slot on this same session.
+        # slot._lock is created per _ChatSlot and so is DISJOINT across
+        # aliases. Keyed on the value resolved just above -- the same one the
+        # probe and reset below use -- so the lock provably guards them even if
+        # a binding landed while this request waited on slot._lock (see
+        # _slot_switch_session_lock).
+        await _stack.enter_async_context(_slot_switch_session_lock(session_key))
+        await _stack.enter_async_context(slot._model_pick_lock)
         # App isolation on the SESSION, not just the slot (the cancel
         # routes' policy): slot ownership does not imply ownership of a
         # linked channel session, so an app caller may not switch the model
@@ -6773,21 +6795,25 @@ async def api_chat_slots_model(request: web.Request) -> web.Response:
         # is cheap: turns do not hold slot._lock, so a running slot's lock
         # only contends with another switch handler.
         #
-        # The session lock goes OUTSIDE both (see _slot_switch_session_lock):
-        # per-slot locks are disjoint across aliases, so without it a single
-        # slot switch through another alias could reset this same session
-        # concurrently. Taken and released per iteration, so two alias slots
-        # in ONE bulk request queue on it in turn rather than re-entering it.
-        async with (
-            _slot_switch_session_lock(effective_session_key(slot)),
-            slot._lock,
-            slot._model_pick_lock,
-        ):
+        # The session lock is entered AFTER slot._lock, once the key below is
+        # known (see _slot_switch_session_lock): per-slot locks are disjoint
+        # across aliases, so without it a single-slot switch through another
+        # alias could reset this same session concurrently.
+        async with contextlib.AsyncExitStack() as _stack:
+            await _stack.enter_async_context(slot._lock)
             # The session this slot's turns run on — effective_session_key,
             # never _history_key_for (see api_chat_slot_model), resolved
             # INSIDE the lock so a binding that lands while this iteration
             # waits on it is what the reset addresses.
             session_key = effective_session_key(slot)
+            # Now serialize against every OTHER alias slot on this session,
+            # keyed on the value resolved just above (see
+            # _slot_switch_session_lock): per-slot locks are disjoint across
+            # aliases. Entered per iteration and released with the stack, so
+            # two alias slots in ONE bulk request queue in turn rather than
+            # re-entering the same lock.
+            await _stack.enter_async_context(_slot_switch_session_lock(session_key))
+            await _stack.enter_async_context(slot._model_pick_lock)
             if not is_dashboard_user and session_key != _history_key_for(name):
                 # Slot ownership does not imply ownership of a linked channel
                 # session (the cancel routes' second condition): an app caller
@@ -6962,9 +6988,12 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
     # lock, and the slot is mutated only AFTER the switch actually took
     # effect (live update, deferral, or reset) — a failed request provably
     # changed nothing.
-    # Serialize against every OTHER alias slot on this same session first
-    # (see _slot_switch_session_lock): slot._lock is disjoint across aliases.
-    async with _slot_switch_session_lock(effective_session_key(slot)), slot._lock:
+    # Two locks, in the order documented at _slot_switch_session_lock:
+    # slot._lock, then the session lock. An ExitStack because the session
+    # lock's KEY is only known after the in-lock read below, and locking on
+    # any earlier read could leave this holding the wrong session lock.
+    async with contextlib.AsyncExitStack() as _stack:
+        await _stack.enter_async_context(slot._lock)
         # The session the switch will probe and, on the fallback path, reset —
         # ``effective_session_key``, never ``_history_key_for`` (see
         # api_chat_slot_model): a channel- or cron-born slot runs its turns
@@ -6974,6 +7003,13 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
         # live process kept the old effort. Resolved INSIDE the lock: the
         # binding can land while this request waits on it.
         session_key = effective_session_key(slot)
+        # Now serialize against every OTHER alias slot on this same session.
+        # slot._lock is created per _ChatSlot and so is DISJOINT across
+        # aliases. Keyed on the value resolved just above -- the same one the
+        # probe and reset below use -- so the lock provably guards them even if
+        # a binding landed while this request waited on slot._lock (see
+        # _slot_switch_session_lock).
+        await _stack.enter_async_context(_slot_switch_session_lock(session_key))
         # App isolation on the SESSION, not just the slot (the cancel routes'
         # policy), BEFORE the same-value fast path so the denial is
         # indistinguishable from a missing slot for every request shape.
@@ -7307,15 +7343,25 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
     # send landing while the reset await is in flight cold-starts a session
     # from the slot's CURRENT bindings, so the new pair must already be
     # visible.
-    # Serialize against every OTHER alias slot on this same session first
-    # (see _slot_switch_session_lock): slot._lock is disjoint across aliases.
-    async with _slot_switch_session_lock(effective_session_key(slot)), slot._lock:
+    # Two locks, in the order documented at _slot_switch_session_lock:
+    # slot._lock, then the session lock. An ExitStack because the session
+    # lock's KEY is only known after the in-lock read below, and locking on
+    # any earlier read could leave this holding the wrong session lock.
+    async with contextlib.AsyncExitStack() as _stack:
+        await _stack.enter_async_context(slot._lock)
         # The session the reset tears down — effective_session_key, never
         # _history_key_for (see api_chat_slot_model), resolved INSIDE the lock
         # so a binding that lands while this request waits on it is what the
         # reset addresses — with the same session-level app isolation the
         # model handler applies.
         session_key = effective_session_key(slot)
+        # Now serialize against every OTHER alias slot on this same session.
+        # slot._lock is created per _ChatSlot and so is DISJOINT across
+        # aliases. Keyed on the value resolved just above -- the same one the
+        # probe and reset below use -- so the lock provably guards them even if
+        # a binding landed while this request waited on slot._lock (see
+        # _slot_switch_session_lock).
+        await _stack.enter_async_context(_slot_switch_session_lock(session_key))
         denied = _app_cancel_denied(request, slot, "chat.slot_workspace", session_key)
         if denied is not None:
             return denied

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -5464,6 +5464,49 @@ class _CommitToken(str):
     __slots__ = ()
 
 
+# Serializes slot SWITCH transactions that share one session, keyed by
+# ``effective_session_key``. The per-slot locks the switch handlers take
+# (``slot._lock``, ``slot._model_pick_lock``) are created per ``_ChatSlot``,
+# so two switches arriving through DIFFERENT alias slots that resolve onto
+# ONE session take disjoint locks and neither waits for the other: both
+# commit, both reset the shared session, and the two slots' committed
+# settings can end up disagreeing with each other and with the live
+# provider. Same shape and same reason as ``_autocompact_txn_locks`` below
+# ("channel-linked aliases resolve distinct slot names onto one file"), keyed
+# by the SESSION the switch handlers probe and reset rather than by the
+# transcript.
+#
+# LOCK ORDER — the one place it is written down. Session lock, then
+# ``slot._lock``, then ``slot._model_pick_lock``. Every switch handler
+# acquires them in that order and nothing acquires them in the opposite one,
+# so two aliases contending on one session cannot cycle. Unrelated slots
+# resolve to DIFFERENT keys and so take different locks: this serializes
+# aliases of one session, never one slot against another session's switch.
+# A WeakValueDictionary so a session's lock is collected once no request
+# holds it.
+#
+# The lock KEY is resolved BEFORE ``slot._lock`` — the only order in which
+# one request can wait for another's whole transaction — while each handler
+# goes on resolving the key it PROBES AND RESETS inside its own lock, so no
+# existing in-lock guarantee moves. If a rebind lands between those two
+# reads this serializes on the previous session; that is the residual
+# ``_autocompact_txn_locks`` documents in the same words ("a rebind
+# mid-request is handled by the expected_history_key pin and the post-persist
+# reauthorization, not by the lock key"), and every handler here already
+# re-checks ``effective_session_key(slot) != session_key`` after its awaits.
+_slot_switch_session_locks: "weakref.WeakValueDictionary[str, asyncio.Lock]" = (
+    weakref.WeakValueDictionary()
+)
+
+
+def _slot_switch_session_lock(session_key: str) -> asyncio.Lock:
+    lock = _slot_switch_session_locks.get(session_key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _slot_switch_session_locks[session_key] = lock
+    return lock
+
+
 async def api_chat_slot_agent(request: web.Request) -> web.Response:
     """POST /api/chat/slots/{slot}/agent — set agent for a chat slot."""
     state: DashboardState = request.app["state"]
@@ -5507,7 +5550,11 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
     # slotSwitch failure-recovery relies on, with no rollback machinery to
     # race against concurrent writers (e.g. the project endpoint, which does
     # not take this lock).
-    async with slot._lock:
+    # Serialize against every OTHER alias slot on this same session before
+    # taking the per-slot lock (see _slot_switch_session_lock for the order):
+    # slot._lock alone is disjoint across aliases and would let a second
+    # switch through another alias commit and reset this same session.
+    async with _slot_switch_session_lock(effective_session_key(slot)), slot._lock:
         # The session the switch resets — ``effective_session_key``, never
         # ``_history_key_for`` (see api_chat_slot_model): a channel- or
         # cron-born slot runs its turns under its linked key, and the
@@ -6050,9 +6097,14 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
         # below has nothing to act on: the session that would receive
         # ``session/set_model`` is on the other machine.
         return await _apply_remote_pick(request, state, slot, "model", {"model": model_name})
-    # Two locks, always in this order (slot._lock outer, _model_pick_lock
-    # inner; the bulk handler nests them the same way and nothing takes them
-    # in the opposite order):
+    # Three locks, always in this order (session lock outer — see
+    # _slot_switch_session_lock — then slot._lock, then _model_pick_lock; the
+    # bulk handler nests them the same way and nothing takes them in the
+    # opposite order):
+    #
+    # the session lock — two switches arriving through DIFFERENT alias slots
+    # resolve onto ONE session but take DISJOINT per-slot locks, so without
+    # it neither waits for the other and both reset this same session.
     #
     # slot._lock — same serialization as the agent, effort and workspace
     # switch handlers: the awaits below yield the event loop, and an
@@ -6075,7 +6127,11 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
     # on AcpModelUnavailable, so an unlocked equality read could match that
     # transient value and report "already on X" for a model that is then
     # rolled back.
-    async with slot._lock, slot._model_pick_lock:
+    async with (
+        _slot_switch_session_lock(effective_session_key(slot)),
+        slot._lock,
+        slot._model_pick_lock,
+    ):
         # The session the switch will probe and, on the reset path, tear
         # down. ``effective_session_key``, never ``_history_key_for`` (the
         # reload handler's rule): a channel- or cron-born slot runs its turns
@@ -6705,7 +6761,7 @@ async def api_chat_slots_model(request: web.Request) -> web.Response:
         # user bypasses the ownership check.
         if not is_dashboard_user and slot._app != request_app:
             continue
-        # Same two locks, same order, as the single-slot pick (slot._lock
+        # Same three locks, same order, as the single-slot pick (slot._lock
         # outer, _model_pick_lock inner). ALL classification happens inside
         # them, equality FIRST: a serialized switch commits slot.model before
         # its provider RPC and rolls it back on failure, so an unlocked
@@ -6716,7 +6772,17 @@ async def api_chat_slots_model(request: web.Request) -> web.Response:
         # model as skipped_running instead of unchanged. Queuing on the locks
         # is cheap: turns do not hold slot._lock, so a running slot's lock
         # only contends with another switch handler.
-        async with slot._lock, slot._model_pick_lock:
+        #
+        # The session lock goes OUTSIDE both (see _slot_switch_session_lock):
+        # per-slot locks are disjoint across aliases, so without it a single
+        # slot switch through another alias could reset this same session
+        # concurrently. Taken and released per iteration, so two alias slots
+        # in ONE bulk request queue on it in turn rather than re-entering it.
+        async with (
+            _slot_switch_session_lock(effective_session_key(slot)),
+            slot._lock,
+            slot._model_pick_lock,
+        ):
             # The session this slot's turns run on — effective_session_key,
             # never _history_key_for (see api_chat_slot_model), resolved
             # INSIDE the lock so a binding that lands while this iteration
@@ -6896,7 +6962,9 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
     # lock, and the slot is mutated only AFTER the switch actually took
     # effect (live update, deferral, or reset) — a failed request provably
     # changed nothing.
-    async with slot._lock:
+    # Serialize against every OTHER alias slot on this same session first
+    # (see _slot_switch_session_lock): slot._lock is disjoint across aliases.
+    async with _slot_switch_session_lock(effective_session_key(slot)), slot._lock:
         # The session the switch will probe and, on the fallback path, reset —
         # ``effective_session_key``, never ``_history_key_for`` (see
         # api_chat_slot_model): a channel- or cron-born slot runs its turns
@@ -7239,7 +7307,9 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
     # send landing while the reset await is in flight cold-starts a session
     # from the slot's CURRENT bindings, so the new pair must already be
     # visible.
-    async with slot._lock:
+    # Serialize against every OTHER alias slot on this same session first
+    # (see _slot_switch_session_lock): slot._lock is disjoint across aliases.
+    async with _slot_switch_session_lock(effective_session_key(slot)), slot._lock:
         # The session the reset tears down — effective_session_key, never
         # _history_key_for (see api_chat_slot_model), resolved INSIDE the lock
         # so a binding that lands while this request waits on it is what the

--- a/test/test_chat_slot_switch_atomicity.py
+++ b/test/test_chat_slot_switch_atomicity.py
@@ -27,6 +27,7 @@ from kiro_crew.dashboard.chat import (
     api_chat_slot_workspace,
     api_chat_slots_model,
 )
+from kiro_crew.dashboard.chat_handlers import _slot_switch_session_lock
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot
 
 # Valid registry aliases the model guard accepts (tests are exempt from the
@@ -1671,6 +1672,222 @@ class TestLinkedSlotSessionKey:
             assert "rebound" in data["warning"]
             assert slot.reasoning_effort == "high"
             state.sessions.reset.assert_not_awaited()
+
+
+_LINKED_KEY = "slack:8442.001"
+
+
+def _alias_state(slot_a: _ChatSlot, slot_b: _ChatSlot) -> DashboardState:
+    """A state holding two alias slots that resolve onto ONE session."""
+    state = _mock_state(slot_a)
+    state._slots = {slot_a.key: slot_a, slot_b.key: slot_b}
+    return state
+
+
+class TestAliasSlotSwitchSerialization:
+    """Two alias slots on ONE session must serialize against each other.
+
+    ``effective_session_key`` folds every alias onto the session a slot's
+    turns actually run on, so two slot names can address one live session
+    (a channel- or cron-born slot carries the real key in
+    ``linked_session_key``). The switch handlers serialize on ``slot._lock``
+    and ``slot._model_pick_lock``, both created per ``_ChatSlot`` — so two
+    switches arriving through DIFFERENT aliases take different locks and
+    neither waits for the other: both commit, both reset the shared session,
+    and the two slots' committed settings can disagree with each other and
+    with the live provider. ``_autocompact_txn_locks`` already solved this
+    class for its own endpoint by keying the lock on the shared resource
+    rather than on the slot; these tests pin the same shape for the switch
+    handlers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_racing_alias_model_switches_serialize(self):
+        slot_a = _ChatSlot("alias-a")
+        slot_b = _ChatSlot("alias-b")
+        for _s in (slot_a, slot_b):
+            _s.model = ""
+            _s.linked_session_key = _LINKED_KEY
+        state = _alias_state(slot_a, slot_b)
+
+        seen_at_reset: list[tuple[str, str]] = []
+        first_reset_started = asyncio.Event()
+        release_first_reset = asyncio.Event()
+
+        async def _reset(*args, **kwargs):
+            seen_at_reset.append((slot_a.model, slot_b.model))
+            if len(seen_at_reset) == 1:
+                first_reset_started.set()
+                await release_first_reset.wait()
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            first = asyncio.create_task(
+                client.post("/api/chat/slots/alias-a/model", json={"model": _MODEL_A})
+            )
+            await first_reset_started.wait()
+            second = asyncio.create_task(
+                client.post("/api/chat/slots/alias-b/model", json={"model": _MODEL_B})
+            )
+            # Give the second request time to run as far as it can. Per-slot
+            # locks are DISJOINT across aliases, so without a session-keyed
+            # lock it runs to completion right here: it commits its model and
+            # resets the very session the first request is still resetting.
+            await asyncio.sleep(0.05)
+            assert slot_b.model == ""
+            assert state.sessions.reset.await_count == 1
+            release_first_reset.set()
+            resp1 = await first
+            resp2 = await second
+            assert resp1.status == 200
+            assert resp2.status == 200
+            # Each reset observed exactly the state its own request committed.
+            assert seen_at_reset == [(_MODEL_A, ""), (_MODEL_A, _MODEL_B)]
+            assert slot_a.model == _MODEL_A
+            assert slot_b.model == _MODEL_B
+            assert {c.args[0] for c in state.sessions.reset.await_args_list} == {_LINKED_KEY}
+
+    # One pin per handler the sweep changed: with the session lock held by
+    # another alias's in-flight switch, each handler must neither mutate nor
+    # reset. Holding the lock externally is the same shape the per-slot
+    # tests above use for slot._lock.
+
+    @pytest.mark.asyncio
+    async def test_agent_switch_waits_for_the_session_lock(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", _boom)
+        slot = _ChatSlot("alias-a")
+        slot.agent = "old-agent"
+        slot.linked_session_key = _LINKED_KEY
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        state.conversation_log = MagicMock()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with _slot_switch_session_lock(_LINKED_KEY):
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/alias-a/agent", json={"agent": "new-agent"})
+                )
+                await asyncio.sleep(0.05)
+                assert slot.agent == "old-agent"
+                state.sessions.reset.assert_not_awaited()
+            resp = await task
+            assert resp.status == 200
+            assert slot.agent == "new-agent"
+
+    @pytest.mark.asyncio
+    async def test_model_switch_waits_for_the_session_lock(self):
+        slot = _ChatSlot("alias-a")
+        slot.model = _MODEL_A
+        slot.linked_session_key = _LINKED_KEY
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with _slot_switch_session_lock(_LINKED_KEY):
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/alias-a/model", json={"model": _MODEL_B})
+                )
+                await asyncio.sleep(0.05)
+                assert slot.model == _MODEL_A
+                state.sessions.reset.assert_not_awaited()
+            resp = await task
+            assert resp.status == 200
+            assert slot.model == _MODEL_B
+
+    @pytest.mark.asyncio
+    async def test_effort_switch_waits_for_the_session_lock(self):
+        slot = _ChatSlot("alias-a")
+        slot.reasoning_effort = ""
+        slot.linked_session_key = _LINKED_KEY
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        state.conversation_log = MagicMock()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with _slot_switch_session_lock(_LINKED_KEY):
+                task = asyncio.create_task(
+                    client.post(
+                        "/api/chat/slots/alias-a/reasoning-effort",
+                        json={"reasoning_effort": "high"},
+                    )
+                )
+                await asyncio.sleep(0.05)
+                assert slot.reasoning_effort == ""
+                state.sessions.reset.assert_not_awaited()
+            resp = await task
+            assert resp.status == 200
+            assert slot.reasoning_effort == "high"
+
+    @pytest.mark.asyncio
+    async def test_workspace_switch_waits_for_the_session_lock(self, monkeypatch):
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.default_project_dir",
+            lambda ws: f"/workspace/{ws}",
+        )
+        slot = _ChatSlot("alias-a")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        slot.linked_session_key = _LINKED_KEY
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with _slot_switch_session_lock(_LINKED_KEY):
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/alias-a/workspace", json={"workspace": "new-ws"})
+                )
+                await asyncio.sleep(0.05)
+                assert slot.workspace == "old-ws"
+                state.sessions.reset.assert_not_awaited()
+            resp = await task
+            assert resp.status == 200
+            assert slot.workspace == "new-ws"
+
+    @pytest.mark.asyncio
+    async def test_bulk_model_switch_waits_for_the_session_lock(self):
+        slot = _ChatSlot("alias-a")
+        slot.model = _MODEL_A
+        slot.linked_session_key = _LINKED_KEY
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with _slot_switch_session_lock(_LINKED_KEY):
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+                )
+                await asyncio.sleep(0.05)
+                assert slot.model == _MODEL_A
+                state.sessions.reset.assert_not_awaited()
+            resp = await task
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["switched"] == ["alias-a"]
+            assert slot.model == _MODEL_B
+
+    @pytest.mark.asyncio
+    async def test_a_different_sessions_switch_is_not_blocked(self):
+        # The complement, and the reason this is a session-keyed lock rather
+        # than one global switch lock: a global lock would also stop the
+        # collision above, by serializing every unrelated slot with it. Keyed
+        # by session, a slot on a DIFFERENT session resolves to a different
+        # lock and runs straight through while this one is held.
+        other = _ChatSlot("other")
+        other.model = _MODEL_A
+        other.linked_session_key = "slack:9999.000"
+        state = _mock_state(other, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with _slot_switch_session_lock(_LINKED_KEY):
+                # Completes WITHOUT the held lock being released. Bounded so a
+                # regression to ONE global switch lock reddens here promptly
+                # instead of hanging: the correct path takes milliseconds.
+                resp = await asyncio.wait_for(
+                    client.post("/api/chat/slots/other/model", json={"model": _MODEL_B}),
+                    timeout=5,
+                )
+                assert resp.status == 200
+                assert other.model == _MODEL_B
+                state.sessions.reset.assert_awaited_once()
 
 
 class TestSlotProjectSwitchAtomicity:

--- a/test/test_chat_slot_switch_atomicity.py
+++ b/test/test_chat_slot_switch_atomicity.py
@@ -1865,6 +1865,52 @@ class TestAliasSlotSwitchSerialization:
             assert slot.model == _MODEL_B
 
     @pytest.mark.asyncio
+    async def test_a_rebind_while_queued_locks_the_new_session(self):
+        # The window GPT 5.6 found on the first revision, closed structurally.
+        # A rebind can land while a request queues on slot._lock, which is why
+        # every handler resolves the key INSIDE that lock (pinned by
+        # test_binding_that_lands_while_queued_on_the_lock_is_the_one_switched).
+        # Had the session lock been keyed on any EARLIER read, the handler would
+        # hold the lock for the OLD session while probing and resetting the new
+        # one -- so an alias switching the new session would not be serialized
+        # against it, and the post-await re-checks could not see it because they
+        # compare against session_key, which is already the new key.
+        # Entering the session lock AFTER the in-lock read makes the lock key
+        # and the acted-on key the same value. This pins that: hold the NEW
+        # session's lock, and the handler must wait for it.
+        s2 = "slack:8442.999"
+        s2_lock = _slot_switch_session_lock(s2)
+        slot = _ChatSlot("alias-a")
+        slot.model = _MODEL_A
+        slot.linked_session_key = _LINKED_KEY
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await s2_lock.acquire()
+            try:
+                async with slot._lock:
+                    task = asyncio.create_task(
+                        client.post("/api/chat/slots/alias-a/model", json={"model": _MODEL_B})
+                    )
+                    await asyncio.sleep(0.05)
+                    # Rebind while it is queued on slot._lock.
+                    slot.linked_session_key = s2
+                # slot._lock is free now, so the handler resolves s2 and must
+                # queue on L(s2) -- which this test holds. Keyed on the stale
+                # pre-lock read it would instead sail through holding L(S1).
+                await asyncio.sleep(0.05)
+                assert not task.done()
+                assert slot.model == _MODEL_A
+                state.sessions.reset.assert_not_awaited()
+            finally:
+                s2_lock.release()
+            resp = await task
+            assert resp.status == 200
+            # The binding that landed is still the one switched.
+            assert slot.model == _MODEL_B
+            assert state.sessions.reset.await_args.args[0] == s2
+
+    @pytest.mark.asyncio
     async def test_a_different_sessions_switch_is_not_blocked(self):
         # The complement, and the reason this is a session-keyed lock rather
         # than one global switch lock: a global lock would also stop the


### PR DESCRIPTION
## Problem / Motivation

Every slot switch handler in `src/kiro_crew/dashboard/chat_handlers.py` serializes on
PER-SLOT locks: `slot._lock`, and for the two model handlers also `slot._model_pick_lock`.
Both are created in `_ChatSlot.__init__` (`state.py:3850` and `:3858`), so each is a
distinct object per slot.

The session a slot's turns run on is NOT per slot. `effective_session_key`
(`chat_utils.py:711`) is one line:

```python
return getattr(slot, "linked_session_key", "") or _history_key_for(slot.key)
```

So two alias slots carrying the same `linked_session_key` -- a channel- or cron-born
conversation addressed under two slot names -- resolve to ONE session while holding TWO
different locks. Two concurrent switches, one through each alias, therefore both proceed:
each probes and resets the shared session under its own lock, both answer 200, and the two
slots' committed settings can end up disagreeing with each other and with the live provider.

The mutual exclusion the lock exists to provide silently does not hold, because the lock is
keyed on the slot object while the resource it guards is keyed on the session.

## Why it matters

A user with a Slack or cron thread open as a dashboard tab has two names for one
conversation. Switching the model in one place while a switch through the other is in
flight leaves the two views claiming different models, with the live provider running
whichever reset landed last. Nothing reports an error: both requests return 200. The same
shape applies to agent, reasoning effort and workspace.

## What changed (motivation -> approach -> change)

Symptom: two aliases on one session can both switch concurrently and disagree.
Root cause: the lock's identity is the slot; the guarded resource's identity is
`effective_session_key(slot)`.
Change: serialize the five switch handlers on a lock keyed by the session.

`_autocompact_txn_locks` already solved this class for its own endpoint, and its comment
states the same hazard in the same words: "channel-linked aliases resolve distinct slot
names onto one file, and two requests through different alias slots must serialize against
each other". This adds the sibling registry for the session the switch handlers probe and
reset, and applies it at all five sites: `api_chat_slot_agent`, `api_chat_slot_model`,
`api_chat_slots_model`, `api_chat_slot_reasoning_effort`, `api_chat_slot_workspace`.

Lock order, documented once at the registry and matching the order the issue prescribed:
`slot._lock`, then the session lock, then `slot._model_pick_lock`. Every site acquires them
in that order and nothing acquires them in the opposite one, so two aliases contending on
one session cannot cycle -- a holder of the session lock already holds its own `slot._lock`
and never waits for another slot's.

The session lock is entered through a `contextlib.AsyncExitStack`, and that detail is
load-bearing rather than stylistic. Its key is only trustworthy once `slot._lock` is held:
a channel/cron rebind can land while a request queues, which is why every handler
deliberately resolves the key INSIDE its lock -- pinned by the existing
`test_binding_that_lands_while_queued_on_the_lock_is_the_one_switched`. Keying the session
lock on any EARLIER read is unsound in exactly that case (see the round-2 note below). The
ExitStack lets the lock be acquired mid-block, after the in-lock read, without nesting the
whole remaining transaction one level deeper -- so the lock key and the acted-on key are
the same value BY CONSTRUCTION, with no window to guard and no new decision point.
`AsyncExitStack` is already the idiom here (`chat_title.py:730`,
`history_consolidation.py:1957`).

### Round 2: a real finding from GPT 5.6, and why its prescribed remedy was not taken

The first revision (`023330123`) read the lock key BEFORE `slot._lock`. GPT 5.6 flagged
that as blocking, and it was right: an uncontended `asyncio.Lock` acquires without
yielding, so there is no window -- but a CONTENDED acquire yields, and a rebind landing in
that queue window leaves the handler holding `L(S1)` while the in-lock `session_key`
resolves to `S2`, so a concurrent alias switch on `S2` is not serialized against it. The
existing post-await re-checks cannot catch it, because they compare
`effective_session_key(slot) != session_key`, i.e. `S2 != S2`. Reproduced as a failing
test before changing anything.

The remedy GPT prescribed -- capture the key and return 409 on a mismatch -- was measured
and rejected: it turns
`test_binding_that_lands_while_queued_on_the_lock_is_the_one_switched` RED. That test
records a deliberate decision from #8415 (a binding that lands while queued is the one
switched), so refusing would relax an existing guard to satisfy a new one. Entering the
lock on the in-lock key instead satisfies both, and removes the defect rather than checking
for it. Round 1's commit is kept in the branch rather than amended away so the verdict it
names stays reachable; the full disposition is in a PR comment.

### Deliberate scope cut

Item 2 of the issue -- mirror the committed value onto every alias slot, OR have aliases
read one shared setting -- is NOT in this PR. The issue itself calls it "an explicit design
fork", and it decides where alias settings live: a product decision, not a mechanically
derivable edit. Hence `Refs`, not `Closes`. The lock-identity defect is fixed here; the
alias-settings question is not, and the open issue is its owner.

### Two handlers deliberately NOT changed

`api_chat_slot_project` also writes under `slot._lock` and names a session, but its own
comment says the reset "stays DEFERRED via the flag ... so no reset is awaited while
holding the lock" -- it does not reset the session in the locked span, so it is not this
predicate. `api_chat_slot_continue` dispatches rather than resets. Both were checked and
excluded; recorded here so the next reader need not re-derive it.

### This does not widen the lock

Keying correctly is the fix. A global switch lock would also stop the collision, and would
serialize every unrelated slot -- a performance regression dressed as a fix. Unrelated
slots resolve to different keys and so take different locks. No previously concurrent path
becomes serial except two switches on the SAME session, which is the defect. There is a
test that fails if that stops being true, and a mutation proving that test can fail.

## Tests

All in `test/test_chat_slot_switch_atomicity.py`, new class
`TestAliasSlotSwitchSerialization`:

- `test_racing_alias_model_switches_serialize` -- the reported scenario end to end: two
  alias slots on one `linked_session_key`, one switch blocked inside its reset, the other
  must not commit. Written FIRST and confirmed failing on clean main with
  `AssertionError: assert 'gpt-5.6-sol' == ''`, i.e. alias B had already committed and
  reset the shared session while alias A's reset was still in flight.
- One pin per changed handler (agent, model, bulk model, effort, workspace): with the
  session lock held by another alias's in-flight switch, the handler neither mutates nor
  resets. Same shape the existing per-slot tests in this file use for `slot._lock`.
- `test_a_rebind_while_queued_locks_the_new_session` -- the round-2 property: hold the NEW
  session's lock, rebind the slot while it is queued on `slot._lock`, and the handler must
  wait for the new session's lock rather than sail through holding the old one.
- `test_a_different_sessions_switch_is_not_blocked` -- the complement: a slot on a
  DIFFERENT session runs straight through while the lock is held, bounded with `wait_for`
  so a regression to one global lock reddens promptly instead of hanging.

Mutation-verified. The whole set was re-run after the restructure, because a mutation whose
anchor no longer exists is a missing measurement rather than a passing one: 7 mutations,
hand-applied one at a time, 7 distinct reddened sets, each red read from the runner's own
failure line.

| mutation | reddened | failure message |
| --- | --- | --- |
| drop the session lock at the agent site | agent pin | `assert 'new-agent' == 'old-agent'` |
| drop it at the model site | model pin | `assert 'gpt-5.6-sol' == 'claude-opus-4.8'` |
| drop it at the bulk site | bulk pin | `assert 'gpt-5.6-sol' == 'claude-opus-4.8'` |
| drop it at the effort site | effort pin | `assert 'high' == ''` |
| drop it at the workspace site | workspace pin | `assert 'new-ws' == 'old-ws'` |
| key the model site on a PRE-LOCK read (the round-1 defect) | rebind-while-queued test | `assert not True` -- the task completed instead of waiting for the new session's lock |
| key the lock on a CONSTANT (one global lock) | complement | `TimeoutError` |

The last two carry the design: one proves the round-2 fix actually detects the reported
defect, the other proves the KEY does the work rather than merely the lock's presence, so
"does not widen the lock" is tested rather than asserted.

Suites run, each with an explicit `-n0` and one file per invocation:
`test_chat_slot_switch_atomicity.py` 83, `test_chat_slot_reasoning_effort.py` 42,
`test_dashboard_chat_handlers_coverage.py` 119, `test_chat_runner_coverage.py` 288
(it reads `_model_pick_lock`, whose acquisition moved), `test_dashboard_chat.py` 766 --
1298 passed, no collateral failures and no deadlock.

Gates run AFTER committing, exactly as ci.yml invokes them: the baselined black gate
(reports "2 changed file(s)", matching this diff, so it gated the work rather than an empty
range), `isort --check-only src/kiro_crew test conftest.py xdist_budget.py`, and
`flake8 src/kiro_crew test conftest.py xdist_budget.py` -- all clean. `mypy src/kiro_crew/`
reports 4 errors, all in `transcribe.py` and
`apps/builtins/ops_mission_control/backend/providers/cloudwatch.py`; this diff touches
neither file and adds no typing surface they consume.

## Manual verification

N/A -- unit coverage sufficient. The defect is a lock-identity race, and both it and the
round-2 window are reproduced deterministically through the real handlers as tests that
failed before each change and pass after, rather than described.

## Related Issues

Refs #8442

Refs #5697 and #8415, the two blockers recorded on the issue. Both have since landed
(#5697 merged 2026-09-05, #8415 closed by merged #8663), and #8415 landing is what makes a
session-keyed lock coherent: every switch handler now addresses `effective_session_key`
rather than `_history_key_for(name)`, so the lock and the work finally name the same thing.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a lock whose key is a different identity from the resource it guards -- a
per-object lock protecting state that several objects alias onto, so the mutual exclusion
silently does not hold across aliases. Its sibling, found in round 2: when the key is
itself mutable, reading it BEFORE acquiring makes the lock guard a resource the request is
no longer acting on, and any guard that compares against the post-read value cannot detect
it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- lock order documented once at the registry
- [x] No secrets, credentials, or internal references in the diff
