### PR TITLE
refactor(dashboard): redact session-search rows through one owner

### DIFF
--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -64,6 +64,23 @@ def _redact_memory_field(val: object) -> object:
     return val
 
 
+#: The session-search row fields carrying LLM-authored or peer-supplied prose,
+#: which every pass returning such a row must put through
+#: :func:`kiro_crew.security.redact` before egress.
+#:
+#: Three passes return these rows -- ``api_sessions_search``, and
+#: ``api_instances_search_sessions``' local-row and peer-row passes -- and each
+#: used to hand-copy both the redaction chain AND this field list. The chain
+#: already had an owner (``security.redact`` composes the exfiltration-URL and
+#: credential passes in that order); this tuple gives the field list one too, so
+#: a caller cannot redact ``title`` and quietly forget ``snippet``. That is the
+#: drift half of #3940 follow-up 3, and the quieter half: a missing field reads
+#: as correct at the call site.
+#:
+#: Order is irrelevant; membership is the contract.
+SESSION_SEARCH_TEXT_FIELDS: tuple[str, ...] = ("title", "snippet")
+
+
 # Shared body cap for the small JSON-object endpoints that must bound the
 # request BEFORE decoding (the strict-internal notification routes). Kept
 # module-level and in one place so the security-relevant cap cannot drift

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -29,6 +29,7 @@ from kiro_crew.acp.client import _resolve_kiro_bin_for_spawn
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.dashboard import directive_queue
 from kiro_crew.dashboard.handlers import kiro_usage_api
+from kiro_crew.dashboard.handlers._shared import SESSION_SEARCH_TEXT_FIELDS
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.session_memory import SessionMemorySampler
 from kiro_crew.dashboard.state import DashboardState
@@ -1252,16 +1253,10 @@ async def api_sessions_search(request: web.Request) -> web.Response:
         None, state.conversation_log.search_sessions, q, limit
     )
     for s in sessions:
-        title = s.get("title")
-        if title:
-            title, _ = _h.redact_exfiltration_urls(title)
-            title, _ = _h.redact_credentials(title)
-            s["title"] = title
-        snip = s.get("snippet")
-        if snip:
-            snip, _ = _h.redact_exfiltration_urls(snip)
-            snip, _ = _h.redact_credentials(snip)
-            s["snippet"] = snip
+        for field in SESSION_SEARCH_TEXT_FIELDS:
+            value = s.get(field)
+            if value:
+                s[field] = redact(value)
     return web.json_response({"sessions": sessions})
 
 

--- a/src/kiro_crew/dashboard/handlers_instances.py
+++ b/src/kiro_crew/dashboard/handlers_instances.py
@@ -29,8 +29,8 @@ from urllib.parse import unquote
 from aiohttp import web
 
 import kiro_crew
-import kiro_crew.dashboard.handlers as _h
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.dashboard.handlers._shared import SESSION_SEARCH_TEXT_FIELDS
 from kiro_crew.dashboard.session_transfer import (
     SnapshotUnstable,
     build_transfer_bundle_async,
@@ -52,6 +52,7 @@ from kiro_crew.instances.registry import (
 )
 from kiro_crew.instances.ssh_tunnel_manager import ProxyRequestError, TunnelState
 from kiro_crew.instances.warm_set import resolve_warm_set_cap
+from kiro_crew.security import redact
 from kiro_crew.sel import sel
 from kiro_crew.validation import sanitize_string
 
@@ -835,9 +836,8 @@ async def api_instances_search_sessions(request: web.Request) -> web.Response:
                 # ship megabyte strings to the browser (or feed the redaction
                 # regexes unbounded input).
                 value = value[:_PEER_FIELD_MAX_CHARS]
-                if field in ("title", "snippet"):
-                    value, _ = _h.redact_exfiltration_urls(value)
-                    value, _ = _h.redact_credentials(value)
+                if field in SESSION_SEARCH_TEXT_FIELDS:
+                    value = redact(value)
                 out[field] = value
         for field in ("modified", "messages"):
             value = row.get(field)
@@ -866,12 +866,10 @@ async def api_instances_search_sessions(request: web.Request) -> web.Response:
         # here before the rows reach the browser.
         redacted_local: list[dict] = []
         for row in local_rows:
-            for field in ("title", "snippet"):
+            for field in SESSION_SEARCH_TEXT_FIELDS:
                 value = row.get(field)
                 if isinstance(value, str) and value:
-                    value, _ = _h.redact_exfiltration_urls(value)
-                    value, _ = _h.redact_credentials(value)
-                    row[field] = value
+                    row[field] = redact(value)
             redacted_local.append(row)
         sources.append(redacted_local)
     for iid, result in zip(connected, results[1:]):

--- a/test/test_dashboard_sessions_search.py
+++ b/test/test_dashboard_sessions_search.py
@@ -88,12 +88,13 @@ class TestSessionsSearchHandler:
             calls.append(("urls", text))
             return (text, [])
 
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.handlers.redact_credentials", _fake_redact_creds
-        )
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.handlers.redact_exfiltration_urls", _fake_redact_urls
-        )
+        # Patched on `kiro_crew.security`, not on the `handlers` re-exports: the
+        # handler redacts through `security.redact`, which resolves both passes
+        # from security's own globals, so patching the handlers-level names would
+        # no longer reach it -- and this test's subject is that BOTH passes run
+        # over the title, which is what these two fakes assert.
+        monkeypatch.setattr("kiro_crew.security.redact_credentials", _fake_redact_creds)
+        monkeypatch.setattr("kiro_crew.security.redact_exfiltration_urls", _fake_redact_urls)
         async with TestClient(TestServer(_make_app(log))) as client:
             resp = await client.get("/api/sessions/search?q=matches")
             sessions = (await resp.json())["sessions"]

--- a/test/test_session_search_redaction_seam.py
+++ b/test/test_session_search_redaction_seam.py
@@ -1,0 +1,239 @@
+"""The three session-search egress passes redact through ONE owner.
+
+``/api/sessions/search`` and ``/api/instances/search-sessions`` both return
+search rows carrying LLM-authored titles and peer-supplied snippets, and each
+hand-composed ``redact_exfiltration_urls`` -> ``redact_credentials``: THREE
+copies across TWO modules (#3940, Design review). ``security.redact`` already
+owned that composition, so the fix is that all three passes call IT, over the
+one shared ``SESSION_SEARCH_TEXT_FIELDS`` tuple -- which gives the field list an
+owner too, so a caller cannot redact ``title`` and forget ``snippet``.
+
+The pins are BEHAVIOURAL rather than source-text: each replaces ``redact`` in the
+module under test with a wrapping marker and requires the response to carry it.
+A site that reintroduced a private copy of the chain would still redact
+correctly and would still fail these tests, which is the bypass the seam exists
+to prevent. The marker WRAPS its input rather than returning a constant, so each
+assertion pairs a row's output with that row's OWN input -- three rows with
+distinct text, because with one row every candidate key expression coincides and
+a loop-variable slip is invisible.
+
+Harness mirrors ``test_instances_search_federation.py`` (the owner of the
+federated-search stubs) and ``test_dashboard_sessions_search.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew import security
+from kiro_crew.dashboard import handlers_instances as hi
+from kiro_crew.dashboard.handlers import _shared
+from kiro_crew.dashboard.handlers import sessions as hs
+from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+#: The redacted field set, spelled out HERE rather than read from
+#: ``_shared.SESSION_SEARCH_TEXT_FIELDS``. Iterating the constant under test
+#: made these assertions shrink with it: narrowing the tuple to ``("title",)``
+#: left the pins green because they stopped checking ``snippet`` at all. A test
+#: must not derive its expectations from the value it exists to pin.
+REDACTED_FIELDS = ("title", "snippet")
+
+#: Three rows with DISTINCT text in both redacted fields. Distinct per row so a
+#: pairing assertion can catch a wrong-key slip; distinct per FIELD so a pass
+#: that redacts `title` and skips `snippet` cannot pass by coincidence.
+ROWS = [
+    {"key": "k1", "title": "title-one", "snippet": "snippet-one"},
+    {"key": "k2", "title": "title-two", "snippet": "snippet-two"},
+    {"key": "k3", "title": "title-three", "snippet": "snippet-three"},
+]
+
+
+def _marker(value: str) -> str:
+    """Stand-in redactor that WRAPS, so the caller's own input stays visible."""
+    return f"SEAM<{value}>"
+
+
+class _Log:
+    """ConversationLog stub returning a fixed local ranking."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def search_sessions(self, _q, _limit):
+        return [dict(r) for r in self._rows]
+
+
+class _Req:
+    """Request stub mirroring aiohttp's mapping surface (see
+    test_instances_search_federation.py, which owns this shape)."""
+
+    def __init__(self, state, identity):
+        self.app = {"state": state}
+        self.match_info = {}
+        self.headers = {}
+        self.query = {"q": "apollo"}
+        self._attrs = identity
+
+    def get(self, key, default=""):
+        return self._attrs.get(key, default)
+
+    def __contains__(self, key):
+        return key in self._attrs
+
+    def __getitem__(self, key):
+        return self._attrs[key]
+
+
+def _request(state):
+    # `_guard`'s owner check is POSITIVE: with no configured owner_id only the
+    # local dashboard subjects pass, so "local-app" with an empty app slug is
+    # the owner's own context.
+    return _Req(state, {"user": "local-app", "app": ""})
+
+
+def _enable_instances(monkeypatch):
+    monkeypatch.setattr(
+        hi.KiroCrewConfig,
+        "load",
+        staticmethod(lambda: SimpleNamespace(instances=SimpleNamespace(enabled=True))),
+    )
+
+
+class _Mgr:
+    """Instances manager stub with scriptable per-peer search replies."""
+
+    def __init__(self, replies):
+        self._replies = replies
+
+    def status_all(self):
+        return {
+            iid: SimpleNamespace(state=TunnelState.CONNECTED, local_port=17777)
+            for iid in self._replies
+        }
+
+    async def search_sessions_remote(self, iid, _q, _limit):
+        return self._replies[iid]
+
+
+def _state(local_rows, mgr=None):
+    ids = list(getattr(mgr, "_replies", {})) if mgr is not None else []
+    return SimpleNamespace(
+        conversation_log=_Log(local_rows),
+        instances_manager=mgr,
+        instances_registry=SimpleNamespace(
+            get=lambda iid: SimpleNamespace(id=iid, name=f"crew-{iid}"),
+            list=lambda: [SimpleNamespace(id=iid, name=f"crew-{iid}") for iid in ids],
+        ),
+    )
+
+
+async def _json_of(resp):
+    return json.loads(resp.body.decode())
+
+
+def _assert_every_field_paired_with_its_own_row(rows, expected_inputs):
+    """Each row's every redacted field wraps THAT row's own input.
+
+    The pairing is what a single-row test cannot check: with one row a
+    ``rows[0]``-for-``row`` slip reads identically to the correct expression.
+    """
+    assert len(rows) == len(expected_inputs), f"expected {len(expected_inputs)} rows, got {rows}"
+    for row, source in zip(rows, expected_inputs):
+        for field in REDACTED_FIELDS:
+            assert row[field] == f"SEAM<{source[field]}>", (
+                f"row {row.get('key')} field {field!r} did not come through the shared "
+                f"redactor carrying its own input: {row[field]!r}"
+            )
+
+
+class TestOneRedactionOwnerForThreePasses:
+    def test_both_modules_redact_through_the_one_shared_owner(self):
+        """Neither module composes the chain itself; both hold `security.redact`.
+
+        `security.redact` (security.py) is the repo's single composition of the
+        exfiltration-URL and credential passes, in that order. Pinning identity
+        rather than behaviour is what catches a module that goes back to
+        hand-composing the pair while still redacting correctly.
+        """
+        assert hs.redact is security.redact
+        assert hi.redact is security.redact
+        assert hs.SESSION_SEARCH_TEXT_FIELDS is _shared.SESSION_SEARCH_TEXT_FIELDS
+        assert hi.SESSION_SEARCH_TEXT_FIELDS is _shared.SESSION_SEARCH_TEXT_FIELDS
+
+    def test_the_redacted_field_set_is_title_and_snippet(self):
+        """Pins the field set as a VALUE, against this file's own literal.
+
+        Separate from the routing pins on purpose: narrowing the set is a
+        deliberate act (it stops redacting a field that reaches the browser),
+        so it should fail one test that says exactly that rather than quietly
+        shrinking what the other pins check.
+        """
+        assert _shared.SESSION_SEARCH_TEXT_FIELDS == REDACTED_FIELDS
+
+    @pytest.mark.asyncio
+    async def test_local_search_pass_routes_every_text_field_through_the_owner(self, monkeypatch):
+        """``/api/sessions/search`` -- pass 1 of 3."""
+        monkeypatch.setattr(hs, "redact", _marker)
+
+        resp = await hs.api_sessions_search(_request(_state(ROWS)))
+
+        _assert_every_field_paired_with_its_own_row((await _json_of(resp))["sessions"], ROWS)
+
+    @pytest.mark.asyncio
+    async def test_federated_local_row_pass_routes_every_text_field_through_the_owner(
+        self, monkeypatch
+    ):
+        """``/api/instances/search-sessions``, LOCAL rows -- pass 2 of 3.
+
+        This endpoint calls ``conversation_log.search_sessions`` directly rather
+        than going through ``api_sessions_search``, so it carries its own copy of
+        the pass; before this test nothing pinned it at all.
+        """
+        _enable_instances(monkeypatch)
+        monkeypatch.setattr(hi, "redact", _marker)
+
+        resp = await hi.api_instances_search_sessions(_request(_state(ROWS)))
+
+        _assert_every_field_paired_with_its_own_row((await _json_of(resp))["sessions"], ROWS)
+
+    @pytest.mark.asyncio
+    async def test_federated_peer_row_pass_routes_every_text_field_through_the_owner(
+        self, monkeypatch
+    ):
+        """``/api/instances/search-sessions``, PEER rows -- pass 3 of 3."""
+        _enable_instances(monkeypatch)
+        monkeypatch.setattr(hi, "redact", _marker)
+        mgr = _Mgr({"a": (True, {"sessions": [dict(r) for r in ROWS]})})
+
+        resp = await hi.api_instances_search_sessions(_request(_state([], mgr)))
+
+        _assert_every_field_paired_with_its_own_row((await _json_of(resp))["sessions"], ROWS)
+
+
+class TestFederatedLocalRowsRedactForReal:
+    """The pass that had no coverage before, driven with the REAL redactors.
+
+    The behavioural pins above prove ROUTING; this proves the routed chain
+    actually removes a credential, and asserts the secret appears NOWHERE in the
+    serialized body rather than only in the field it was planted in.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_credential_in_a_local_row_never_reaches_the_browser(self, monkeypatch):
+        _enable_instances(monkeypatch)
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        rows = [
+            {"key": "k1", "title": f"deploy {secret}", "snippet": f"ran with {secret}"},
+            {"key": "k2", "title": "clean title", "snippet": "clean snippet"},
+        ]
+
+        resp = await hi.api_instances_search_sessions(_request(_state(rows)))
+
+        body = resp.body.decode()
+        # Control: the rows really did reach the response, so an absent secret is
+        # redaction rather than an empty result set.
+        assert "clean title" in body
+        assert secret not in body, "a credential survived the federated local-row pass"


### PR DESCRIPTION
## Problem / Motivation

Three separate code paths return session-search rows to the browser, and each
one hand-composed the same egress redaction chain over its own copy of the same
field list:

| pass | site at base `0d65dc969` | what it returns |
|---|---|---|
| `/api/sessions/search` | `handlers/sessions.py:1254-1264` | local rows |
| `/api/instances/search-sessions`, local rows | `handlers_instances.py:867-873` | local rows again -- this endpoint calls `conversation_log.search_sessions` directly and so bypasses the handler above |
| `/api/instances/search-sessions`, peer rows | `handlers_instances.py:831-841` | rows from every connected peer |

All three spelled it identically: `redact_exfiltration_urls(value)` then
`redact_credentials(value)`, applied to a literal `("title", "snippet")`. Three
hand-compositions of a chain the repo already owns, and three copies of the
field list it runs over.

#3940 records this as follow-up 3 of six, from PR #3826's Design review: "each
hand-copy the title/snippet redaction ... a shared seam would make bypass
impossible by construction".

## Why it matters

The values are LLM-authored session titles and peer-supplied snippets, so the
chain is what stops a credential a model wrote into a title from reaching the
browser. Duplication matters in two directions here:

- **The chain can drift, and elsewhere it already has.** Order is not cosmetic:
  `security.redact` runs the URL pass first, and on
  `see https://evil.example.com/x?token=AKIAIOSFODNN7EXAMPLE now` that yields
  `see [REDACTED: suspicious URL to evil.example.com] now`, while the reverse
  order yields `see https://evil.example.com/x?token=[REDACTED: credential] now`
  -- the exfiltration host survives, because redacting the credential first
  destroys the pattern the URL matcher keys on. Measured. Three sites in
  `instances/token_mint.py` compose the pair in that reverse order today; that
  is outside this PR and filed separately (see "Other notes").
- **The field list can drift, which is quieter.** A caller that redacts `title`
  and forgets `snippet` looks correct at the call site and leaks the other half.
  Nothing pinned that.

## What changed (motivation -> approach -> change)

Root cause is not a bug in any one pass; it is that neither the chain nor the
field list was single-sourced at these call sites, so correctness had to be
re-established at each one.

The chain already had an owner: `kiro_crew.security.redact`
(`security.py:18341-18345`) composes exactly those two passes in exactly that
order and returns a `str`. So all three passes now **call it directly**. Nothing
new is exported for the chain.

The field list did not have an owner, so it gets one:
`SESSION_SEARCH_TEXT_FIELDS` in `handlers/_shared.py`, carrying the contract in
its docstring.

Deliberately unchanged:

- **Same passes in the same order, same truthiness guards.** No behaviour delta
  on any path.
- **The peer pass keeps its length clamp ahead of redaction.** The clamp bounds
  what a hostile peer can feed the redaction regexes, so it must stay first.

Two consequences, both declared rather than left for a reader to find:

1. `handlers_instances.py` no longer imports `kiro_crew.dashboard.handlers as
   _h`, because those two lines were its only use of it (grepped `_h\.`: 0
   remaining). It imports `security.redact` instead.
2. **One pre-existing test changed its patch targets.**
   `test_dashboard_sessions_search.py::test_title_is_redacted` patched
   `handlers.redact_credentials` / `handlers.redact_exfiltration_urls`. Those are
   re-exports; `security.redact` resolves its passes from `security`'s own
   globals, so the old targets no longer reach the chain -- measured: with the
   old targets that test FAILS. It now patches `kiro_crew.security.*`, which is
   where the composition actually reads from and is already the idiom in
   `test_ai_agent_runner_coverage.py` and `test_ai_runner_coverage.py`. Its
   subject and its strength are unchanged: it still asserts BOTH passes ran over
   the title, and it is still reddened by neutering the chain **and** by
   hand-composing the pair at that site (see the mutation table -- it got
   stronger, not weaker).

Scope: this closes the drift, not the whole ask. See "Other notes" for what
`impossible by construction` would additionally require, and for the five
follow-ups #3940 still carries.

## Tests

New `test/test_session_search_redaction_seam.py`, 6 tests. The routing pins are
behavioural rather than source-text: each replaces `redact` in the module under
test with a marker that WRAPS its input, then requires the response to carry it.
A site that went back to hand-composing the pair would still redact correctly
and would still fail, which is precisely the drift being prevented.

- one pin per pass (3), each asserting **both** fields on **three** rows with
  distinct text, paired row-by-row -- a single row cannot catch a
  loop-variable slip because every candidate key expression coincides at N=1;
- the field set pinned as a value against the test's own literal;
- both modules' `redact` pinned as identical to `security.redact`;
- the federated local-row pass driven with the **real** redactors and a real
  credential, asserting the secret appears nowhere in the serialized body, with
  a positive control that the rows reached the response at all. That pass had
  **no** coverage before this PR.

**Mutation-verified, 5 mutations, 5 distinct red sets.** Re-run in full after
each restructure -- a mutation whose anchor has moved is a missing measurement,
not a passing one:

| mutation | reddens |
|---|---|
| pair hand-composed at `api_sessions_search` | 2: the local routing pin **and** `test_title_is_redacted` |
| pair hand-composed at the peer pass | 1: the peer routing pin |
| pair hand-composed at the federated local pass | 1: that routing pin |
| field tuple narrowed to `("title",)` | 5: the value pin, all three snippet assertions, and the real-credential pin |
| `security.redact` neutered to return its input | 2: the real-credential pin and `test_title_is_redacted` |

Five different specific red sets rules out a harness artefact. Every red was
classified from its own assertion message.

One mutation earned its keep by finding a defect in the test rather than in the
code: the assertion helper originally iterated
`_shared.SESSION_SEARCH_TEXT_FIELDS`, so narrowing that tuple made the pins
assert **less** instead of failing. Fixed by giving the test its own literal
field list. A test must not derive its expectations from the value it exists to
pin.

Suites run (`-n0`, one file per invocation):

- `test/test_session_search_redaction_seam.py` -- 6 passed
- `test/test_dashboard_sessions_search.py` -- 6 passed (owns `api_sessions_search`)
- `test/test_instances_search_federation.py` -- 13 passed (owns the federated handler)

Gates run locally, all clean: `check_black_formatting.py` (scope reported 5
changed files, matching the diff), `isort --check-only`, `flake8` whole-tree,
and the four baselined `check_*` gates.

`mypy src/kiro_crew/` reports **4 errors in 2 files** -- `transcribe.py` and
`ops_mission_control/.../cloudwatch.py`, both boto3 argument types, 0 in the
three source files this PR touches. Reproduced identically, same count and same
files, on a detached worktree at base `0d65dc969` with none of this branch's
code present, so it is base-owned rather than introduced here.

## Manual verification

N/A -- backend only, no user-visible surface, and the behavioural pins drive the
real handlers rather than a stub of them.

## Related Issues

Refs #3940

Deliberately a bare `Refs`: this is follow-up 3 of the six that issue carries,
so a closing keyword would be false.

## Pattern harvest

Not strictly required (this is a `refactor`, not a `fix`), but the class is the
interesting part.

Rule candidate: review-prompt. **When a repo owns a composed transform, a
hand-composed copy of it is an ordering bug waiting to happen, and the field
list it runs over drifts before the transform does.** The transform is two
conspicuous lines a reader checks; the field list is a tuple literal that reads
as configuration and gets checked by nobody. So: call the owner, give the field
list an owner too, and pin the field set as a value from the TEST's own literal,
never from the constant under test. The measured `token_mint.py` reversal in
"Why it matters" is what this rule would have caught.

## Review dispositions

Both advisory verdicts on earlier heads carried real, actionable findings, and
both were acted on.

**First Principles, round 1 (CONCERNS) -- adopted.** It found that
`security.redact` already composed the same two passes in the same order and
that the first version of this change re-spelled that body, inside a PR whose
thesis is that re-spelling is the defect. Verified at source before acting.

**First Principles, round 2 (CONCERNS) -- adopted.** Round 1 left a
`redact_session_search_text` wrapper that was a pure one-line alias of
`security.redact`. By the test "a finding is a new class only if fixing it would
not have been necessary had an earlier fix been complete", this was not a new
finding -- it was the unfinished half of round 1. Its claim that the routing
pins retain identical detection power on a module-level `redact` import was
checked by re-running the whole mutation set, not taken on faith: all three
site mutations still redden exactly their own pin, and one now reddens the
pre-existing pin as well. The wrapper is gone, one fewer permanent exported
name, and the diff shrank.

**Design (PASS, with a suggestion on the first head) -- filed, not folded in.**
It noted that `sessions.py:1071-1077` is a fourth hand-composition of the same
pair, one screen from the code this PR touched. Real, and now recorded on #3940.
Not folded in, with a mechanism rather than a preference: it is a different
egress class (a `_sanitize` callback for LIST previews, where redaction must run
before a length cap, not a search row), and it has no test today, so folding it
in would owe one and widen this PR past its item. Design offered exactly this
disposition as its alternative.

## Other notes and what remains

**This does not reach `impossible by construction`, and I do not claim it.** A
caller that returns rows without redacting at all is still possible; making that
impossible means redaction moves inside the row producer, or rows become a type
that cannot be serialized unredacted. That is a larger design change than this
issue's item, so it is stated rather than smuggled in.

**The wider class is real and is being tracked, not silently absorbed.** First
Principles counted roughly 25 sibling sites in 8 files that hand-compose the
pair instead of calling `redact`. The sharpest of them is measured in "Why it
matters" above: `instances/token_mint.py:386`, `:449` and `:527` compose it in
the REVERSE order, on paths whose own comment says proxy-controlled stderr "can
carry credential-looking text or exfil URLs". None of the three carries a
comment justifying the order, in a file that justifies its scan bound, its
clipping and its token-first ordering. Filed as its own issue rather than folded
in here.

**#3940 keeps its other five items.** Measured at `0d65dc969`:

1. Deep-link a remote search hit -- still live; `sessionsProvider.ts` still only
   switches to the peer's pane. Substantially owned by #7445, which documents
   why it is not a simple allowlist row (the proxy allowlist matches path
   prefixes, and `GET /api/sessions` shares its prefix with `DELETE
   /api/sessions`).
2. Surface `unreachable` in the UI -- still live, and it now has a counter-claim
   in the tree: `ChatSidebar.tsx` says "Unreachable peers are logged, not
   surfaced" and its eslint rationale says surfacing "would nag about a
   transient the local floor already covered". Worth a maintainer ruling before
   anyone builds it.
4. Palette remote badge rendering -- still live; the palette `Result.subtitle`
   is still a plain string.
5. Shared `useFederatedSessionSearch` policy -- still live; that hook does not
   exist, and the warm-gate plus 403-fallback logic is still duplicated between
   `sessionsProvider.ts` and `ChatSidebar.tsx`.
6. Extend `is_owner_dashboard_request` to the other `_guard`-ed instances routes
   -- **partly landed since the issue was filed.** It is now enforced at three
   routes (`search_sessions`, `capabilities`, `proxy`), not one. The two the
   comment names by name, `connect` and `refresh_token`, still rely on `_guard`
   alone, and `_guard` has no `owner_only` parameter.
