### PR TITLE
test(dashboard): pin a terminal to the chat slot that opened it

### DIFF
--- a/website/src/test/usePanelTabs.test.ts
+++ b/website/src/test/usePanelTabs.test.ts
@@ -396,6 +396,49 @@ describe('usePanelTabs — per-slot isolation', () => {
     expect(result.current.tabs[0].kind).toBe('terminal')
   })
 
+  /* ── A terminal is bound to the chat it was opened in ──────────────────
+   * `openTerminal`'s contract is that "the per-slot bucketing makes those
+   * sessions chat-specific automatically", so selecting a chat surfaces that
+   * chat's own shell. The sibling case above covers the null fallback bucket
+   * only; this covers named slot -> named slot, which is the pairing a user
+   * actually switches between.
+   *
+   * THREE slots, each asserted against ITS OWN session id: with fewer, every
+   * candidate key expression coincides, so a bucketing slip that resolved every
+   * slot to the FIRST chat's terminal would still pass. The complement
+   * assertion (a foreign id appears in NO other strip) is what makes the
+   * isolation claim, rather than merely observing that some terminal is
+   * present. */
+  it('binds a terminal to the chat that opened it, and restores that same session on return', () => {
+    const { result, rerender } = renderHook(({ slot }: { slot: string | null }) => usePanelTabs(slot), {
+      initialProps: { slot: 'chat-a' as string | null },
+    })
+
+    const sid: Record<string, string> = {}
+    for (const slot of ['chat-a', 'chat-b', 'chat-c']) {
+      rerender({ slot })
+      act(() => { sid[slot] = result.current.openTerminal({ cwd: `/srv/${slot}` }) })
+    }
+
+    // Every chat minted its own distinct session.
+    expect(new Set(Object.values(sid)).size).toBe(3)
+
+    // Per-item pairing: each chat restores ITS OWN terminal, addressed by the
+    // stable tab identity rather than by the value under assertion.
+    for (const slot of ['chat-a', 'chat-b', 'chat-c']) {
+      rerender({ slot })
+      expect(result.current.tabs.map(t => t.id)).toEqual([`terminal:${sid[slot]}`])
+      expect(result.current.activeTab).toMatchObject({
+        kind: 'terminal', sessionId: sid[slot], cwd: `/srv/${slot}`,
+      })
+      // Complement: no OTHER chat's shell is reachable from this strip.
+      const foreign = Object.entries(sid).filter(([s]) => s !== slot).map(([, v]) => v)
+      for (const other of foreign) {
+        expect(result.current.tabs.some(t => t.sessionId === other)).toBe(false)
+      }
+    }
+  })
+
   it('syncPinned adds content-gated views at the front, in PINNED_VIEWS order', () => {
     const { result } = renderHook(() => usePanelTabs())
     act(() => result.current.openView('logs'))


### PR DESCRIPTION
## Problem / Motivation

The behaviour was pinned nowhere, and that is the point of this PR rather than
the test itself.

`usePanelTabs.openTerminal` documents its own contract: "every call mints a fresh
session so a chat can hold several shells; the per-slot bucketing makes those
sessions chat-specific automatically" (`website/src/hooks/usePanelTabs.ts:670-675`).
That is a real, shipped guarantee -- a terminal belongs to the chat that opened
it, and selecting a chat surfaces that chat's own shell.

Across the WHOLE frontend suite, however, the hook's `openTerminal` was exercised
in exactly ONE test, and only for the null fallback bucket
(`usePanelTabs.test.ts`, "a null slot uses a stable fallback bucket"). The
named-slot to named-slot case -- the pairing a user actually switches between --
was pinned nowhere. The sibling per-slot isolation test that does cover named
slots uses `openFile` / `openView` / `openDiff` and never opens a terminal.

So the guarantee held only by construction, through a mechanism shared with the
other tab kinds, with no test naming the terminal case.

## Why it matters

A terminal tab is not like a file tab: each one is a live PTY with its own shell
state, history and running processes, capped at `MAX_TERMINALS_PER_CHAT = 4` per
chat. If per-slot bucketing regressed, the failure a user sees is a command run
against the wrong chat's shell -- in the wrong working directory. That is a
silent, data-affecting mistake rather than a cosmetic one, and it is exactly the
cost the per-slot design exists to remove.

Because the mechanism is shared with file and diff tabs, a refactor of the
bucketing would redden those tabs' tests while leaving the terminal case
unmeasured. This PR closes that asymmetry, so the tab kind with the highest
consequence is no longer the one kind with no coverage.

## What changed (motivation -> approach -> change)

Goal: pin the named-slot binding without touching production behaviour.

Approach: extend the existing `usePanelTabs -- per-slot isolation` describe block
rather than add a new surface, so the pin sits beside the sibling cases it
completes.

Two deliberate design choices:

- THREE slots, each asserted against ITS OWN session id. With fewer, every
  candidate key expression coincides, so a bucketing slip that resolved every
  slot to the FIRST chat's terminal would still pass. The per-item pairing
  assertion is what catches that class.
- A COMPLEMENT assertion that a foreign session id appears in NO other strip.
  Without it the test only observes that some terminal is present, which is a
  weaker claim than isolation.

The test locates each tab by its stable identity (`terminal:<sessionId>`) rather
than by the value it is about to assert, so it cannot pass by examining a healthy
sibling tab.

Test-only. No production code changed: the diff is 43 added lines in a single
test file, and zero source files.

## Tests

`npx vitest run src/test/usePanelTabs.test.ts` -> 37 passed (37), exit 0.
36 of those are pre-existing and act as the harness control.

Mutation-verified, one mutation per observable, each red classified from the
runner's own FAILED line:

1. Collapse the bucketing -- `bucketKey` returns a constant so every slot shares
   one bucket. Reddens SEVEN tests including this one. This test fails on
   `toEqual` over tab ids:

   ```
   AssertionError: expected [ ...(3) ] to deeply equal [ Array(1) ]
       "terminal:8c9c1600-d87e-41b7-b1d6-dd75c05cf8de",
   +   "terminal:2246e5c3-1700-4c19-9d66-cc4339c4bd74",
   +   "terminal:4bec2321-5a61-4551-ae63-c3d228fa69b7",
   ```

   All three terminals collapse into one strip. The three distinct UUIDs also
   confirm minting stayed per-call, so this mutation isolates bucketing rather
   than id generation.

2. Drop `sessionId` from `openTerminal`'s upsert payload. Reddens EXACTLY ONE
   test -- this one -- on a different assertion, `toMatchObject`:

   ```
   AssertionError: expected { ...(4) } to match object { kind: 'terminal', ...(2) }
     {
       "cwd": "/srv/chat-a",
       "kind": "terminal",
   -   "sessionId": "47247c3c-c86c-43e3-a52d-3443a83da5ec",
     }
   ```

Two things make this evidence rather than a demonstration:

- The two mutation sites produce DIFFERING reddened sets (7 and 1) on different
  assertion types. A harness that reddened indiscriminately could not produce two
  different specific sets, which is what rules out a harness artefact.
- Under mutation 2 the pre-existing null-slot test STILL PASSES. That is direct
  evidence of the gap this PR closes: the existing coverage does not observe
  session-id carriage, and only the new test does.

Both mutations were reverted and the suite re-verified green (37/37, exit 0)
before pushing; `git status` clean at the pushed head.

`eslint src/test/usePanelTabs.test.ts` -> exit 0.

### Inherited `tsc -b` red -- not from this PR

`tsc -b` fails in my environment, and I disown it with a measurement rather than
an argument. All 15 errors are in `src/stories/*.stories.tsx`
(`Cannot find module '@storybook/react-vite'`, `storybook/test`); ZERO are
outside `src/stories/`, and none mention the file this PR touches. Running the
SAME typecheck in the SAME environment at pure main, with this PR's commit
absent, fails identically: 15 errors, 0 outside `src/stories/`, same exit code.
The cause is a borrowed `node_modules` whose `package.json` had storybook
removed, so the reading is not attributable to this change at all.

## Manual verification

N/A -- unit coverage sufficient. The change adds no production code and no UI
surface, so there is nothing to observe manually; the behaviour it pins is
asserted directly through the hook.

## Related Issues

Refs #8512
