### PR TITLE
fix(governance): let a profile-layer edit invalidate the dashboard config

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -2549,6 +2549,35 @@ during connection setup registers as a change. The client invalidates its cached
 counter restarts with the process) — so a withdrawn entry disappears within one
 status tick rather than waiting out the cache's stale window.
 
+**And follows a profile-layer edit.** The value in that frame is
+`governance_profiles.governance_answer_generation()`, which is
+`context.governance_generation()` plus a module-private `_profile_generation()`
+bumped whenever `ProfileStore._ensure_fresh` publishes a new snapshot. The field's
+contract is unchanged — it stays an opaque, comparison-only integer, so combining two
+monotonic counters is not a change of meaning and no consumer needs to know. This
+exists because the ceiling counter alone missed Level-2 edits: a profile file
+tightening a capability is enforced on the very next decision (the authorization
+path calls `_ensure_fresh`), while the dashboard's cached answer kept the withdrawn
+entry until its 30-second stale window, focus, or an unrelated slot mutation.
+
+Detecting the edit needs the profiles directory re-stat'd, and on an idle dashboard
+nothing else would touch the store, so the watcher has to be what looks. That walk
+lives in a separate `poll_profiles_fresh()`, which the watcher offloads with
+`asyncio.to_thread`: `_dir_fingerprint` is an `iterdir` plus a `stat` per file, and
+AUTOSDE's `no-blocking-call-on-event-loop` names filesystem walks as the prohibited
+class, so a slow or large profile store must delay one socket's tick rather than
+stall chat turns and heartbeats for every session. `governance_answer_generation()`
+itself is two locked integer reads with no filesystem access, which is why the
+synchronous slots broadcast may call it inline. Measured walk cost on one host: 57us
+at 5 profile files, 107us at 15, 303us at 50, 1.12ms at 200 — small at a realistic
+count and unbounded in principle, hence offloaded rather than defended by the number.
+
+`_profile_generation()` is an OUTPUT of the profile store and must never become an
+input to it. Folding it into `_ceiling_token()` — the obvious-looking symmetry with
+the ceiling half described below — would make the store reload on every access
+forever, because `_ensure_fresh` computes its fingerprint *before* reloading and so
+would commit a pre-bump value that the next read can never match.
+
 The Security panel picks the row up automatically (`api_governance_policy` iterates
 `SCOPE_CATALOG`; its label is the humanised leaf, "Social share").
 

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -7800,7 +7800,9 @@ class DashboardState:
         from kiro_crew.dashboard.handlers.source_providers import (
             gitlab_hosts_generation,
         )
-        from kiro_crew.platform.context import governance_generation
+        from kiro_crew.platform.governance_profiles import (
+            governance_answer_generation,
+        )
 
         yolo_active = self.is_yolo_active()  # expire first if needed
         # PUBLIC-repo chip status rides the general frame so any authenticated
@@ -7833,6 +7835,16 @@ class DashboardState:
             raise
         mgr = getattr(self, "channel_manager", None)
         ch_trusted = bool(mgr and any(ch.trusted for ch in mgr._channels.values()))
+        # ONE read, shared by the generic and owner frames below. Two independent
+        # reads could straddle a ceiling install or a profile reload and ship two
+        # different tokens for one broadcast, which would make one of the two
+        # audiences invalidate while the other did not.
+        # test_public_repo_status_rides_general_frame_owner_gets_full asserts the two
+        # frames' governanceGeneration values are equal, so a torn read reddens it.
+        # Filesystem-free by contract: governance_answer_generation is two locked
+        # integer reads. The profiles directory re-stat lives in poll_profiles_fresh,
+        # which only the async watcher calls, and only off the event loop.
+        answer_generation = governance_answer_generation()
         # Piggyback the allowlist generation so clients invalidate the cached
         # ['dashboardConfig'] query only when the GitLab-hosts allowlist actually
         # changed -- an event-driven refresh that replaces a constant 30s poll
@@ -7878,7 +7890,7 @@ class DashboardState:
                 # blinked": this frame fires on routine slot activity, so the
                 # tree alone is not a change signal.
                 "foldersGeneration": self.folders_generation(),
-                "governanceGeneration": governance_generation(),
+                "governanceGeneration": answer_generation,
             }
         )
         # The owner frame is the owner's ONLY slots frame — `_send_ws_all` skips
@@ -7900,7 +7912,7 @@ class DashboardState:
                     gitlab_hosts_gen=gitlab_hosts_generation(),
                     folders=_safe_folder_tree(getattr(self, "_folders", None)),
                     folders_gen=self.folders_generation(),
-                    governance_gen=governance_generation(),
+                    governance_gen=answer_generation,
                 )
             )
 

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -537,7 +537,10 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
         schedule_check_refresh,
         schedule_visibility_refresh,
     )
-    from kiro_crew.platform.context import governance_generation
+    from kiro_crew.platform.governance_profiles import (
+        governance_answer_generation,
+        poll_profiles_fresh,
+    )
 
     owner_request = is_owner_dashboard_request(request)
     ws = web.WebSocketResponse(heartbeat=30)
@@ -608,12 +611,19 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
 
     # Push current slots immediately so sidebar populates without waiting.
     # App tokens get only the slots their manifest scope allows.
-    # Read the ceiling generation ONCE here and seed both the initial frame and
-    # the refresh loop's baseline from it. Two independent reads would leave a
+    # Read the governance-answer generation ONCE here and seed both the initial frame
+    # and the refresh loop's baseline from it. Two independent reads would leave a
     # gap: a ceiling swapped between them is already the loop's baseline, so the
     # loop never pushes, while the client still holds the number the frame sent —
     # the change would be missed until an unrelated slot mutation.
-    initial_ceiling_generation = governance_generation()
+    #
+    # This token covers the PROFILE layer as well as the ceiling (#8623). Watching
+    # the ceiling counter alone meant an operator tightening a capability in a local
+    # profile file was enforced on the next decision but never invalidated the
+    # dashboard's cached answer, so the UI kept offering a withdrawn entry until the
+    # 30s staleness window. The local is named for the answer, not the ceiling,
+    # because it is no longer ceiling-only.
+    initial_answer_generation = governance_answer_generation()
     try:
         is_dashboard_user = ws.get("_is_dashboard_user", False)
         all_slots = state.serialize_slots(
@@ -670,7 +680,7 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                 # Seed the client's generation baseline so a later change is
                 # detectable as a change rather than as a first sighting.
                 "gitlabHostsGeneration": gitlab_hosts_generation(),
-                "governanceGeneration": initial_ceiling_generation,
+                "governanceGeneration": initial_answer_generation,
             }
         )
         if owner_request or is_dashboard_user:
@@ -709,7 +719,7 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
         # Seeded from the value the initial slots frame carried, not a fresh read:
         # the client's baseline IS that value, so a swap since then must register
         # here as a change or the two sides disagree with no push to reconcile.
-        ceiling_generation = initial_ceiling_generation
+        answer_generation = initial_answer_generation
         try:
             while not ws.closed and not shutdown_event.is_set():
                 # Gateway-wide cache: one store touch per TTL across ALL
@@ -755,8 +765,18 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                 # connection may do, and spends no credentials.
                 if ws.get("_is_dashboard_user", False):
                     try:
-                        if governance_generation() != ceiling_generation:
-                            ceiling_generation = governance_generation()
+                        # The profile half of this token needs the profiles directory
+                        # re-stat'd, and ``_dir_fingerprint`` is an ``iterdir`` plus a
+                        # ``stat`` per file — a synchronous filesystem walk, which is
+                        # what AUTOSDE's ``no-blocking-call-on-event-loop`` prohibits
+                        # here. Offloaded, so a slow or large profile store delays
+                        # this socket's own tick instead of stalling chat turns and
+                        # heartbeats for every session on the loop. The token read
+                        # itself is two locked integer reads and stays inline.
+                        await asyncio.to_thread(poll_profiles_fresh)
+                        current = governance_answer_generation()
+                        if current != answer_generation:
+                            answer_generation = current
                             state.push_slots_update()
                     except Exception:
                         logger.warning("governance watch tick failed; continuing", exc_info=True)

--- a/src/kiro_crew/platform/governance_profiles.py
+++ b/src/kiro_crew/platform/governance_profiles.py
@@ -322,6 +322,105 @@ def _fallback_profile(name: str) -> Profile:
     return deny_all_profile(name)
 
 
+# Monotonic counter of profile-layer RECOMPOSES, bumped by ``ProfileStore._ensure_fresh``
+# whenever the directory fingerprint missed and a reload actually published a new
+# snapshot.  Deliberately a MODULE global rather than instance state, for two reasons:
+#
+#   * ``reset_store()`` replaces the store, and an instance counter would restart at 0.
+#     A consumer comparing a combined token could then see it move BACKWARD, or — worse
+#     — not move at all when a ceiling bump and a profile reset cancel out.
+#   * it mirrors ``context._GOVERNANCE_GENERATION``, which is the sibling this pairs
+#     with and is a process-global for the same reason.
+#
+# NOT folded into ``_ceiling_token()``.  That is load-bearing, not an oversight: the
+# ceiling token is an INPUT to the store's own freshness key, so feeding this counter
+# back into it would make every reload invalidate the fingerprint it just committed
+# (``_ensure_fresh`` computes ``fp`` BEFORE ``_reload``, so the committed value is
+# pre-bump) and the store would reload on every single access forever — on the event
+# loop, since the synchronous PreToolUse gate reaches this path.  This counter is an
+# OUTPUT of the store and must never become an input to it.
+_PROFILE_GENERATION = 0
+_PROFILE_GENERATION_LOCK = threading.Lock()
+
+
+def _profile_generation() -> int:
+    """Monotonic counter of how many profile snapshots have been published.
+
+    Opaque and comparison-only, exactly like ``context.governance_generation()``:
+    callers may test it for equality with a value they stored, never interpret its
+    magnitude.  Module-private on purpose: the public contract is the combined
+    :func:`governance_answer_generation`, and a bare generation accessor with no
+    consumer outside this module would be surface to honor forever.
+    """
+    with _PROFILE_GENERATION_LOCK:
+        return _PROFILE_GENERATION
+
+
+def _bump_profile_generation() -> None:
+    """The single writer of ``_PROFILE_GENERATION``."""
+    global _PROFILE_GENERATION
+    with _PROFILE_GENERATION_LOCK:
+        _PROFILE_GENERATION += 1
+
+
+def poll_profiles_fresh() -> None:
+    """Re-stat the profiles directory and reload if it changed.  MAY BLOCK.
+
+    This is the filesystem half of the #8623 notification edge, kept SEPARATE from
+    :func:`governance_answer_generation` so the read is never accidentally coupled to
+    a directory walk.  ``_dir_fingerprint`` runs ``iterdir`` plus a ``stat`` per file,
+    which is exactly the "large synchronous file IO or filesystem walks" that
+    AUTOSDE's ``no-blocking-call-on-event-loop`` prohibits, so an async caller MUST
+    offload it::
+
+        await asyncio.to_thread(poll_profiles_fresh)
+
+    Measured on one host: 57us at 5 profile files, 107us at 15, 303us at 50, 1.12ms
+    at 200.  Small at a realistic count and unbounded in principle, which is why it
+    is offloaded rather than defended by the measurement.
+
+    Best-effort: a failure here leaves the last published snapshot and its generation
+    in place, so a consumer sees a stale-but-coherent token rather than an exception
+    on a status tick.
+    """
+    try:
+        _STORE._ensure_fresh()
+    except Exception:  # pragma: no cover - defensive; freshness is best-effort here
+        logger.debug("profile freshness poll failed; serving last token", exc_info=True)
+
+
+def governance_answer_generation() -> int:
+    """One opaque token covering BOTH layers that can change a governance answer.
+
+    ``GET /api/dashboard/config`` derives fields (``social_share_enabled``) from the
+    ceiling ∩ profile intersection, so a consumer watching for "the answer may have
+    changed" has to watch both layers.  Watching the ceiling counter alone is issue
+    #8623: a profile-layer tightening is enforced on the next decision but never
+    reaches the dashboard's cache invalidation, so the UI keeps offering an entry
+    policy has withdrawn.
+
+    Both components are monotonic non-decreasing for the life of the process, so
+    their sum is too, and the sum therefore changes if and only if at least one
+    component changed.  That is all a consumer needs: the wire field is documented
+    opaque and comparison-only, so combining is not a change of meaning.
+
+    PURE READ - two locked integer reads, NO filesystem access, safe to call on the
+    event loop.  Detecting a profile edit needs :func:`poll_profiles_fresh`, which is
+    the caller's job precisely because only the caller knows whether it can block;
+    the periodic watcher offloads that to a thread, while the synchronous slots
+    broadcast does not poll at all and simply reads what has been published.
+
+    Re-entrancy: a bump can cause the watcher to call ``push_slots_update()``, whose
+    broadcast reads this token again.  That read touches no filesystem and cannot
+    bump anything, so the cycle terminates immediately.  No listener writes profiles
+    on notify either: the only consumer is a client-side ``dashboardConfig``
+    invalidation, which issues a GET.
+    """
+    from kiro_crew.platform.context import governance_generation
+
+    return governance_generation() + _profile_generation()
+
+
 def _ceiling_token() -> Tuple[bool, int]:
     """The active ceiling's identity, as far as the profile store needs to know it.
 
@@ -462,6 +561,14 @@ class ProfileStore:
             if self._snap.loaded and fp == self._fingerprint:
                 return True  # already fresh (another thread reloaded, or unchanged)
             self._reload(directory)
+            # A new snapshot is published as of the line above, so the generation
+            # describes PUBLISHED snapshots rather than attempted reloads. This is
+            # the notification edge issue #8623 was missing: enforcement already
+            # observed the new profiles (the authorization path calls this method),
+            # but nothing told a cache-invalidation consumer that the governance
+            # answer may have moved. Bumped INSIDE the reload lock, so two threads
+            # cannot publish two snapshots and record one bump.
+            _bump_profile_generation()
             # Commit the fingerprint. An unreadable/malformed file is a
             # bind-preserving deny-all (fail-closed), so the cached state is the SAFE
             # (denying) state; a metadata change (fix/delete/chmod — all bump the

--- a/test/test_social_share_governance.py
+++ b/test/test_social_share_governance.py
@@ -304,3 +304,140 @@ class TestGovernanceGenerationFrame:
             )
         )
         assert frame["governanceGeneration"] == 7
+
+    # ── #8623: the profile layer has to reach this frame too ─────────────────
+
+    @staticmethod
+    def _bind_profiles(tmp_path, monkeypatch):
+        """Redirect the profile store at a tmp dir via the seam its own module
+        docstring names (``_PROFILES_DIR``). No real config or state path is read
+        or written: ``config_dir()`` is never consulted once this is set."""
+        from kiro_crew.platform import governance_profiles as gp
+
+        profiles = tmp_path / "profiles"
+        profiles.mkdir()
+        monkeypatch.setattr(gp, "_PROFILES_DIR", profiles)
+        gp.reset_store()
+
+        def write(*, enabled: bool) -> None:
+            (profiles / "dash.json").write_text(
+                json.dumps(
+                    {
+                        "name": "dash",
+                        "bind": {"type": "surface", "id": "dashboard"},
+                        "capabilities": {"social_share": {"enabled": enabled}},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+        return gp, write
+
+    def test_a_profile_edit_moves_the_generation_the_frame_carries(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A profile-layer tightening is enforced on the next decision, but used to
+        leave the dashboard's cached answer standing, because the frame's generation
+        tracked ceiling installs only. If the value the frame carries does not move,
+        ``useWebSocket`` never invalidates ``['dashboardConfig']`` and the UI keeps
+        offering an entry policy has withdrawn."""
+        gp, write = self._bind_profiles(tmp_path, monkeypatch)
+        try:
+            write(enabled=True)
+            # PRIME FIRST, then take the baseline. Reading the baseline off an
+            # unprimed store would let the first-load bump supply the difference
+            # this test is about: mutation-checked, and without this ordering the
+            # test passes even when the reload stops bumping the counter.
+            permitted_before = gp.governance_permits(
+                _SCOPE, "", session_key="dashboard:ui"
+            ).permitted
+            before = gp.governance_answer_generation()
+
+            write(enabled=False)
+            # What the watcher does, except it offloads this to a thread because it
+            # walks the profiles directory.
+            gp.poll_profiles_fresh()
+            after = gp.governance_answer_generation()
+            permitted_after = gp.governance_permits(
+                _SCOPE, "", session_key="dashboard:ui"
+            ).permitted
+
+            # Control first: if ENFORCEMENT did not observe the edit either, this
+            # test is not measuring the notification gap and its pass means nothing.
+            assert (permitted_before, permitted_after) == (True, False), (
+                "fixture did not actually change the governance answer, so the "
+                "generation assertion below would be vacuous"
+            )
+            assert after != before, (
+                "the profile layer recomposed and enforcement observed it, but the "
+                "generation the slots frame carries did not move, so no client "
+                "invalidates its cached dashboardConfig"
+            )
+        finally:
+            gp.reset_store()
+
+    def test_the_generation_is_stable_while_no_profile_changes(self, tmp_path, monkeypatch) -> None:
+        """The counter must stay an OUTPUT of the profile store and never become an
+        input to its own freshness key. If it were folded into ``_ceiling_token()``,
+        every read would look like a change: ``_ensure_fresh`` computes its
+        fingerprint BEFORE reloading, so it would commit a pre-bump value and then
+        reload on every single access — on the event loop, which the synchronous
+        PreToolUse gate reaches. Repeated reads with nothing edited must be equal."""
+        gp, write = self._bind_profiles(tmp_path, monkeypatch)
+        try:
+            write(enabled=True)
+            gp.poll_profiles_fresh()
+            first = gp.governance_answer_generation()
+            gp.poll_profiles_fresh()
+            second = gp.governance_answer_generation()
+            gp.poll_profiles_fresh()
+            third = gp.governance_answer_generation()
+            assert first == second == third, (
+                f"generation moved with nothing edited ({first} -> {second} -> "
+                f"{third}): the profile counter is feeding its own fingerprint"
+            )
+        finally:
+            gp.reset_store()
+
+    def test_reading_the_generation_never_touches_the_filesystem(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The token read runs on the event loop, from the synchronous slots
+        broadcast. AUTOSDE's ``no-blocking-call-on-event-loop`` names filesystem
+        walks as the prohibited class, so the directory re-stat belongs in
+        ``poll_profiles_fresh`` (which the watcher offloads to a thread) and must not
+        creep back into the read.
+
+        Detects by COUNTING calls, not by raising. ``poll_profiles_fresh`` catches
+        ``Exception`` by design, so an injected exception is swallowed and the test
+        passes with the walk reintroduced -- mutation-checked, and that is exactly
+        how the first version of this test was vacuous."""
+        gp, write = self._bind_profiles(tmp_path, monkeypatch)
+        try:
+            write(enabled=True)
+            gp.poll_profiles_fresh()
+            baseline = gp.governance_answer_generation()
+
+            real = gp._dir_fingerprint
+            calls: list[object] = []
+
+            def _spy(directory):
+                calls.append(directory)
+                return real(directory)
+
+            monkeypatch.setattr(gp, "_dir_fingerprint", _spy)
+
+            # Control: the spy must be capable of recording, or a count of zero
+            # below would prove nothing about the read.
+            gp.poll_profiles_fresh()
+            assert len(calls) >= 1, "spy never fired; it cannot evidence a zero count"
+
+            calls.clear()
+            assert gp.governance_answer_generation() == baseline
+            assert calls == [], (
+                f"governance_answer_generation walked the filesystem "
+                f"({len(calls)} _dir_fingerprint call(s)); that walk belongs in "
+                f"poll_profiles_fresh, off the event loop"
+            )
+        finally:
+            gp.reset_store()


### PR DESCRIPTION
## What is the problem?

A governance change made at the **profile layer** never reached the dashboard's cache
invalidation, so the dashboard kept serving a governance answer that was no longer
true.

The notification chain works for ceilings only. `context._install`
(`platform/context.py:405-411`) is the sole writer of `_GOVERNANCE_GENERATION`, and
its own comment says so: "the ONLY writer of `_ACTIVE` ... so no future install site
can forget to bump it". It is reached only through `set_context`, i.e. boot and
`policy_distribution.apply_ceiling`. `dashboard/ws.py` compares that counter on each
5-second status tick and asks for a coalesced slots push; the value ships as
`governanceGeneration`; `website/src/hooks/useWebSocket.ts:1067-1073` compares it and
invalidates `['dashboardConfig']`.

`ProfileStore._ensure_fresh` (`platform/governance_profiles.py`) recomposes on the
profiles directory's mtime/ctime fingerprint and calls neither `_install` nor
`set_context`, so none of that chain fires. The dependency is explicitly one-way:
`_ceiling_token()` folds `governance_generation()` **into** the profile store's
freshness key, so a ceiling change reaches the profile store and never the reverse.

## Why this issue matters to the user

An operator tightens a capability in a local profile file to withdraw a feature. The
tightening **is** enforced immediately, on the next authorization decision. But the
dashboard keeps offering the withdrawn entry until its 30-second stale window, a
window focus, or an unrelated slot mutation.

So the visible symptom is a governance setting that reads as applied in enforcement
while the UI still advertises it, which is the shape of bug that erodes trust in the
policy surface: the operator cannot tell from the screen whether their change took.
`capabilities.social_share` is the field that exposed it, and every future
`dashboardConfig` field derived from the ceiling-and-profile intersection inherits the
same gap.

To be precise about the blast radius, because the issue text can be read more
strongly than the evidence supports: this is a display-versus-enforcement divergence,
not an enforcement hole. Measured, the authorization decision moves from
`Decision(permitted=True, rule='rule2-intersect')` to
`Decision(permitted=False, reason='profile denies: capability disabled')` on the very
next call.

## How our fix solves it

Chained from the symptom to the root cause:

1. The UI serves a stale answer because nothing invalidated `['dashboardConfig']`.
2. Nothing invalidated it because the client only invalidates on a change in
   `governanceGeneration`.
3. That value only changes when a context is installed.
4. A profile recompose does not install a context, so the value never moves.

The fix adds the missing notification edge at step 4, and nothing else:

* `_profile_generation()`, a monotonic counter bumped when `_ensure_fresh` publishes a
  new snapshot. It is a module global, mirroring `context._GOVERNANCE_GENERATION`, so
  `reset_store()` cannot restart it and make a combined value move backward or cancel
  out against a ceiling bump.
* `governance_answer_generation()`, the single producer both dashboard call sites now
  use. `ws.py` seeds the initial frame and the tick baseline from it, and `state.py`
  reads it once for the generic and owner frames.
* `poll_profiles_fresh()`, the filesystem half, kept deliberately separate.

**The two halves are split because they have different blocking contracts, and that
split is the point rather than a detail.** `governance_answer_generation()` is two
locked integer reads with no filesystem access, so the synchronous slots broadcast may
call it inline on the event loop. Detecting an edit needs the profiles directory
re-stat'd, and `_dir_fingerprint` is an `iterdir` plus a `stat` per file, which is what
AUTOSDE's `no-blocking-call-on-event-loop` prohibits there; so that walk lives in
`poll_profiles_fresh()` and the async watcher does
`await asyncio.to_thread(poll_profiles_fresh)`. A slow or large profile store then
delays one socket's own tick instead of stalling chat turns and heartbeats for every
session on the loop.

Reading the counter alone would not have fixed the issue: nothing bumps it unless some
other caller happens to touch the store, so on an idle dashboard with no tool calls and
no slot mutations an operator's edit would still go unnoticed. The watcher is the only
thing running on the right schedule, so it has to be what looks -- off the loop.

Measured walk cost, so the offload decision rests on a number rather than a feeling:
57us at 5 profile files, 107us at 15, 303us at 50, 1.12ms at 200. Small at a realistic
count and unbounded in principle, which is the argument for offloading it rather than
defending it.

**No wire or schema change.** The frame key keeps its name, its `number` type and its
documented contract, which is already "Opaque and comparison-only: callers may test it
for equality with a value they stored, never interpret its magnitude". Two monotonic
non-decreasing counters sum to a monotonic non-decreasing value that changes if and
only if a component changed, which is exactly what an equality-comparing consumer
needs. So no frontend change, no new key for third-party code to pin to, and no
consumer needs to learn anything. The issue offered this option first ("The frame key
can stay `governanceGeneration` if the value becomes a combined token") and it is the
one that requires no decision from anyone.

**The counter is an OUTPUT of the store and must never become an input to it.** This is
load-bearing rather than a stylistic note, and it is why the obvious symmetric fix is
wrong. `_ensure_fresh` computes its fingerprint *before* calling `_reload`, so a counter
folded into `_ceiling_token()` would commit a pre-bump value that the next read can
never match, and the store would reload on every single access forever, on the event
loop. There is a test pinning this direction, and mutating the code to fold the counter
in reddens it with `generation moved with nothing edited (12 -> 13 -> 14)`.

## What tests we did

Measured at main `0d65dc969d420e26f409a55a14c8451409521321`.

* **The gap reproduced before the fix, as an assertion**, with a validity control that
  runs first: a profile tightening moved enforcement from `permitted=True` to
  `permitted=False` while the token the dashboard compares stayed at `1`. The control
  matters because if enforcement had not observed the edit either, the probe would have
  been measuring nothing.
* **Three tests** in `TestGovernanceGenerationFrame`, the class that already owns this
  wire contract: a profile edit moves the generation the frame carries (with a control
  asserting the fixture really changed the governance answer, so the assertion cannot
  be vacuous); the generation is stable across repeated polls with nothing edited (the
  pin against the re-entry hazard); and the token read performs no filesystem access
  (the pin against the blocking finding regressing).
* **Four mutations, reddening three distinct test sets**, which is what rules out a
  harness artefact. Removing the bump and removing the freshness drive each redden the
  edit test; folding the counter into `_ceiling_token()` reddens the stability test;
  reintroducing the walk into the read reddens the filesystem-free test. Each mutation
  asserted itself applied before the run, and each red was read from the runner's own
  assertion message.
* **Two of those mutations found real holes in my own tests, which is why they are
  reported rather than just counted.** Removing the freshness drive initially left the
  edit test passing, because the baseline was read off an unprimed store and the
  first-load bump supplied the difference the test claimed to be about; it now primes
  before taking the baseline. And the filesystem-free test first detected by injecting
  an exception, which `poll_profiles_fresh` swallows by design, so it passed with the
  walk reintroduced; it now counts `_dir_fingerprint` calls and carries a control
  proving the spy can fire.
* **Suites, by path, at `-n0`:** `test_social_share_governance.py` 17 passed,
  `test_governance_profiles.py` 58 passed 1 skipped,
  `test_dashboard_state_ws.py` 80 passed. That last one matters because
  `test_public_repo_status_rides_general_frame_owner_gets_full` asserts the owner and
  dashboard frames carry an equal generation, which is why `state.py` now reads the
  token once instead of twice.
* **Gates:** black, isort and flake8 clean on all four changed source files. `mypy`
  reports two pre-existing errors in `src/kiro_crew/transcribe.py`, which is not among
  this PR's changed files.
* No probe wrote outside a `tempfile` directory asserted to be under `$TMPDIR`, and no
  real config or state path was read or written: the profiles directory was redirected
  through `_PROFILES_DIR`, the seam that module's own docstring names.

## Any other suggestions on the work

* **What this does NOT cover, so a maintainer can close deliberately.** The issue's
  proposed test was end to end: profile edit, watch tick pushes a frame, client
  invalidates. This PR pins the server-side half. The client comparison at
  `useWebSocket.ts:1067-1073` is unchanged and already covered, so the missing piece
  was the server signal, but no new frontend test was added. That is why this uses
  `Refs` rather than a closing keyword.
* **One declared deviation from the issue's wording.** It asked that `ProfileStore`
  expose a monotonic `profile_generation()`. It ships module-private as
  `_profile_generation()`, because nothing outside the module consumes it and a public
  generation accessor is surface that has to be honored forever. Widening it is a
  one-line change the day a consumer exists.
* **A latent inconsistency fixed in passing, because the mechanism required it.**
  `state.py` read the generation twice while building the generic and owner frames, and
  `ws.py` read it twice in its comparison. Both now read once. Two reads could straddle
  a change and ship different tokens to the two audiences, which is the exact gap
  `ws.py`'s own comment warns about for the initial-frame case.
* **The local variable rename is not cosmetic.** `initial_ceiling_generation` and
  `ceiling_generation` would have become false names, since the value now covers the
  profile layer too. A name that no longer describes the thing is how the next reader
  reintroduces the bug.

## Pattern harvest

Rule candidate: when a cache-invalidation signal is a generation counter, check whether
every layer that can change the answer bumps it, not just the layer the counter was
named for. Here the counter was named for context installs and the authorization answer
had a second input, so one layer notified and the other did not. The tell is a counter
whose docstring names a narrower thing than its consumers depend on.

Rule candidate: a generation counter must never be folded into the freshness key of the
store that bumps it. If the store computes its key before publishing, the committed key
holds a pre-bump value, no later read can match it, and the store reloads forever. The
reviewable form is to pin the stable-when-unchanged direction as its own test, because
the runaway is invisible to a test that only checks the counter moves when it should.

Rule candidate: when a signal needs both a cheap read and an expensive refresh, split
them by blocking contract rather than bundling them for caller convenience. Bundling
reads as fewer decision points and is really one function with two incompatible
contracts, and the loop-safe caller inherits the blocking one. The tell is a function
whose docstring has to explain when it is safe to call.

Rule candidate: an injected exception is not a detector when the code under test
catches broadly. A best-effort helper that swallows `Exception` will eat the injected
failure and the test passes with the defect present, so detect by counting calls or
observing state, and prove the observer can fire before trusting a zero.

Refs #8623
