### PR TITLE
fix(agents): hold the wave-close fallback open while a member's report is in flight

### DIFF
--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -138,6 +138,22 @@ reports are pending, so bulk cancellation cannot rediscover them as running work
 Agents waiting on spawn approval are excluded; their approval card remains the
 authority for approve/reject.
 
+Wave close itself is decided by the completion consumer: a wave finishes when
+its done-count reaches the total, or — for members that failed at spawn and can
+never reach the consumer — when nothing is pending (`batch_members_pending`)
+AND no member's terminal report is still in flight
+(`batch_reports_in_flight`). A member counts as in flight from the moment
+`info.done` flips until the consumer lands its done-count contribution (the
+consumer marks `_report_consumed` in the same synchronous block as the
+increment), because in that done-but-unreported window `batch_members_pending`
+no longer counts the member while the done-count does not include it either —
+without the in-flight hold, a sibling completion landing in the window
+finalizes the wave early and the in-flight report finalizes it a second time.
+Terminal arms that end a report without ever reaching the consumer (injection
+timeout, announce failure, the cancelled-recovery limbo arm) clear the hold
+themselves, so the wave keeps its degraded a-sibling-can-close liveness
+instead of stranding.
+
 The dashboard exposes this through `POST /api/spawn/stop-all` with a validated
 slot name. App tokens are denied before slot lookup because ownership of an app
 slot does not imply ownership of its linked session; a request missing the
@@ -219,7 +235,7 @@ An unmarked `CancelledError` (see intentional-cancel rule) triggers `_schedule_c
 - One-shot: gated by `info._cancel_retry_used`; the recovered run's own cancel is terminal.
 - Explicit handshake: `_resume` awaits the ORIGINAL task's full teardown (session release/reset, slot decrement, registry pop) before respawning — never a timed sleep.
 - Slot re-acquisition: waits (bounded, `_RECOVERY_SLOT_WAIT_SECS`) for free capacity; the slot claim and `create_task` are ATOMIC (no await between) so a concurrent `_drain_queue` cannot overshoot `max_concurrent`.
-- Shutdown-reachable: the pending `_resume` task is registered in `_tasks` under `"{id}:recovery"` so `cancel_all()` cancels it; a cancelled recovery finalizes the record terminally and never respawns.
+- Shutdown-reachable: the pending `_resume` task is registered in `_tasks` under `"{id}:recovery"` so `cancel_all()` cancels it; a cancelled recovery finalizes the record terminally and never respawns. This arm is report-free (no finalize claim is taken), so it also clears the member's done-but-unreported hold — a batch member finalized here must not hold `batch_reports_in_flight` open forever.
 - Failed recovery (no slot / teardown timeout) still fully finalizes: `subagent_done` emitted, tombstoned, delivered via `on_done`.
 - Replay-safety at respawn: when the first attempt streamed partial text, the respawned prompt is prefixed with `_CANCEL_RESUME_PREFIX` so the model continues instead of restarting (the prefix also gates on `tool_count` as defense-in-depth, though the side-effect gate above means a tool-activity run never reaches respawn). A bare original prompt is re-sent only for a zero-activity first attempt.
 

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -143,16 +143,26 @@ its done-count reaches the total, or — for members that failed at spawn and ca
 never reach the consumer — when nothing is pending (`batch_members_pending`)
 AND no member's terminal report is still in flight
 (`batch_reports_in_flight`). A member counts as in flight from the moment
-`info.done` flips until the consumer lands its done-count contribution (the
-consumer marks `_report_consumed` in the same synchronous block as the
-increment), because in that done-but-unreported window `batch_members_pending`
-no longer counts the member while the done-count does not include it either —
-without the in-flight hold, a sibling completion landing in the window
-finalizes the wave early and the in-flight report finalizes it a second time.
-Terminal arms that end a report without ever reaching the consumer (injection
-timeout, announce failure, the cancelled-recovery limbo arm) clear the hold
-themselves, so the wave keeps its degraded a-sibling-can-close liveness
-instead of stranding.
+`info.done` flips — EVERY terminal done transition (the report machinery's,
+the run's failure except-bodies, the in-run limit bails, the reaper's, and
+spawn-rejection flips) arms a hold in the manager-level `_reports_in_flight`
+registry in the same synchronous block; safe-announced synthetics arm
+immediately before their announce — until the consumer lands its
+done-count contribution (the consumer releases the hold in the same
+synchronous block as the increment), because in that done-but-unreported
+window `batch_members_pending` no longer counts the member while the
+done-count does not include it either — without the in-flight hold, a sibling
+completion landing in the window finalizes the wave early and the in-flight
+report finalizes it a second time. The hold lives in the manager registry
+rather than on the agent records because `_agents` membership is
+operator-mutable: a clear-completed (`DELETE /api/spawn`) popping a
+done-but-unreported member must not drop the hold mid-window. A report that
+ends without ever reaching the consumer (injection timeout, announce failure,
+cancellation) releases its hold through the report path's structural
+`finally`, so the wave keeps its degraded a-sibling-can-close liveness instead
+of stranding; if that degraded close never comes (no member left to complete),
+the reaper's digest-hold sweep force-flushes the held results once the hold
+deadline passes.
 
 The dashboard exposes this through `POST /api/spawn/stop-all` with a validated
 slot name. App tokens are denied before slot lookup because ownership of an app
@@ -235,7 +245,7 @@ An unmarked `CancelledError` (see intentional-cancel rule) triggers `_schedule_c
 - One-shot: gated by `info._cancel_retry_used`; the recovered run's own cancel is terminal.
 - Explicit handshake: `_resume` awaits the ORIGINAL task's full teardown (session release/reset, slot decrement, registry pop) before respawning — never a timed sleep.
 - Slot re-acquisition: waits (bounded, `_RECOVERY_SLOT_WAIT_SECS`) for free capacity; the slot claim and `create_task` are ATOMIC (no await between) so a concurrent `_drain_queue` cannot overshoot `max_concurrent`.
-- Shutdown-reachable: the pending `_resume` task is registered in `_tasks` under `"{id}:recovery"` so `cancel_all()` cancels it; a cancelled recovery finalizes the record terminally and never respawns. This arm is report-free (no finalize claim is taken), so it also clears the member's done-but-unreported hold — a batch member finalized here must not hold `batch_reports_in_flight` open forever.
+- Shutdown-reachable: the pending `_resume` task is registered in `_tasks` under `"{id}:recovery"` so `cancel_all()` cancels it; a cancelled recovery finalizes the record terminally and never respawns. This arm is report-free (no finalize claim is taken), and a record it terminalizes never carries a done-but-unreported hold — holds are armed only at a report's done-flip, which this arm's `not info.done` guard proves never ran — so `batch_reports_in_flight` cannot strand on it.
 - Failed recovery (no slot / teardown timeout) still fully finalizes: `subagent_done` emitted, tombstoned, delivered via `on_done`.
 - Replay-safety at respawn: when the first attempt streamed partial text, the respawned prompt is prefixed with `_CANCEL_RESUME_PREFIX` so the model continues instead of restarting (the prefix also gates on `tool_count` as defense-in-depth, though the side-effect gate above means a tool-activity run never reaches respawn). A bare original prompt is re-sent only for a zero-activity first attempt.
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -7407,9 +7407,14 @@ class GatewayOrchestrator:
                 # This member's report has been consumed: its contribution is
                 # about to land in the wave's done-count, so it no longer holds
                 # the wave-close fallback open (batch_reports_in_flight, issue
-                # #8554). Set in the same synchronous block as the increment so
-                # the flag and the count can never be observed apart.
-                info._report_consumed = True
+                # #8554). Release in the same synchronous block as the
+                # increment so the hold and the count can never be observed
+                # apart. The release goes to the manager-level registry — NOT
+                # an agent-record flag — so an operator clear (DELETE
+                # /api/spawn) popping this member from `_agents` mid-flight
+                # cannot have dropped the hold before this line lands it.
+                if self.subagent_mgr is not None:
+                    self.subagent_mgr.consume_report_hold(_batch_id, info.id)
                 bp["done"] += 1
                 # Fold EVERY member's orchestration escalation into the wave
                 # digest — held members return before the announce is sent, so

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -7404,6 +7404,12 @@ class GatewayOrchestrator:
                         },
                     )
             if _batch_id and not _flush_only:
+                # This member's report has been consumed: its contribution is
+                # about to land in the wave's done-count, so it no longer holds
+                # the wave-close fallback open (batch_reports_in_flight, issue
+                # #8554). Set in the same synchronous block as the increment so
+                # the flag and the count can never be observed apart.
+                info._report_consumed = True
                 bp["done"] += 1
                 # Fold EVERY member's orchestration escalation into the wave
                 # digest — held members return before the announce is sent, so
@@ -7463,10 +7469,19 @@ class GatewayOrchestrator:
                     # stagger gate) — an unrelated agent under the same
                     # parent must neither hold the digest hostage nor
                     # release it early.
+                    #
+                    # A member whose `done` flag has flipped but whose terminal
+                    # report has not reached this consumer yet is OUTSTANDING
+                    # too: `batch_members_pending` no longer counts it while
+                    # its contribution to bp["done"] is still in flight, so
+                    # without the reports-in-flight check a sibling landing in
+                    # that window finalizes the wave early and the in-flight
+                    # report then finalizes it again (issue #8554).
                     try:
                         _last = bool(
                             self.subagent_mgr
                             and not self.subagent_mgr.batch_members_pending(_batch_id)
+                            and not self.subagent_mgr.batch_reports_in_flight(_batch_id)
                         )
                     except Exception:
                         _last = False

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -1433,6 +1433,17 @@ class SubagentInfo:
     # a report cancelled BEFORE delivery — which must be made recoverable on the
     # next start — from one cancelled AFTER it, which must not be re-delivered.
     _reported_to_parent: bool = False
+    # True once this member's terminal report has been CONSUMED by the batch
+    # completion consumer — its contribution has landed in the wave's
+    # done-count — or its announce terminally failed and nothing further will
+    # arrive. From `done = True` until this flips, the member is
+    # "done-but-unreported": `batch_members_pending()` no longer counts it,
+    # but the wave's done-count does not include it either, so a SIBLING
+    # completion reaching the consumer in that window would finalize the wave
+    # early and the in-flight report would then finalize it a second time.
+    # `batch_reports_in_flight()` reads this to hold the wave-close fallback
+    # open across the window (issue #8554).
+    _report_consumed: bool = False
 
     @property
     def outcome(self) -> str:
@@ -2210,6 +2221,9 @@ class SubagentManager:
 
     def batch_members_pending(self, batch_id: str) -> bool:
         return self._waves.batch_members_pending_impl(batch_id)
+
+    def batch_reports_in_flight(self, batch_id: str) -> bool:
+        return self._waves.batch_reports_in_flight_impl(batch_id)
 
     def finalize_batch(self, batch_id: str) -> None:
         return self._waves.finalize_batch_impl(batch_id)

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -1433,17 +1433,6 @@ class SubagentInfo:
     # a report cancelled BEFORE delivery — which must be made recoverable on the
     # next start — from one cancelled AFTER it, which must not be re-delivered.
     _reported_to_parent: bool = False
-    # True once this member's terminal report has been CONSUMED by the batch
-    # completion consumer — its contribution has landed in the wave's
-    # done-count — or its announce terminally failed and nothing further will
-    # arrive. From `done = True` until this flips, the member is
-    # "done-but-unreported": `batch_members_pending()` no longer counts it,
-    # but the wave's done-count does not include it either, so a SIBLING
-    # completion reaching the consumer in that window would finalize the wave
-    # early and the in-flight report would then finalize it a second time.
-    # `batch_reports_in_flight()` reads this to hold the wave-close fallback
-    # open across the window (issue #8554).
-    _report_consumed: bool = False
 
     @property
     def outcome(self) -> str:
@@ -1705,6 +1694,16 @@ class SubagentManager:
         # submissions and no progress is force-reconciled). Pruned by
         # finalize_batch alongside _batch_submitted.
         self._batch_progress_ts: dict[str, float] = {}
+        # Done-but-unreported holds per wave: batch_id -> agent ids whose
+        # ``done`` has flipped but whose terminal report the completion
+        # consumer has not yet consumed. Held OUTSIDE the agent records
+        # because ``_agents`` membership is operator-mutable (DELETE
+        # /api/spawn pops done members) — the wave-close fallback must not
+        # lose its hold to a concurrent clear (issue #8554). Armed by the
+        # report machinery at the done-flip, disarmed by the consumer when
+        # the contribution lands or structurally when a report ends without
+        # reaching the consumer. Pruned by finalize_batch.
+        self._reports_in_flight: dict[str, set[str]] = {}
         self._reaper_task: asyncio.Task | None = None  # type: ignore[type-arg]
         # Cache global approval_mode at init to avoid disk I/O on every
         # parentless spawn (cron, webhooks).
@@ -1982,6 +1981,25 @@ class SubagentManager:
             teardown_done=teardown_done,
         )
 
+    async def _report_terminal_guarded(
+        self,
+        info: SubagentInfo,
+        *,
+        source: str,
+        injection_timeout_reason: str,
+        mark_delivered_on_success: bool,
+        settle_digest: bool = False,
+        teardown_done: "asyncio.Event | None" = None,
+    ) -> None:
+        return await self._terminal._report_terminal_guarded_impl(
+            info,
+            source=source,
+            injection_timeout_reason=injection_timeout_reason,
+            mark_delivered_on_success=mark_delivered_on_success,
+            settle_digest=settle_digest,
+            teardown_done=teardown_done,
+        )
+
     async def _run_terminal_report(
         self,
         info: SubagentInfo,
@@ -2224,6 +2242,12 @@ class SubagentManager:
 
     def batch_reports_in_flight(self, batch_id: str) -> bool:
         return self._waves.batch_reports_in_flight_impl(batch_id)
+
+    def arm_report_in_flight(self, info: SubagentInfo) -> None:
+        return self._waves.arm_report_in_flight_impl(info)
+
+    def consume_report_hold(self, batch_id: str, agent_id: str) -> None:
+        return self._waves.consume_report_hold_impl(batch_id, agent_id)
 
     def finalize_batch(self, batch_id: str) -> None:
         return self._waves.finalize_batch_impl(batch_id)

--- a/src/kiro_crew/subagent_manager/admission.py
+++ b/src/kiro_crew/subagent_manager/admission.py
@@ -574,6 +574,12 @@ class SpawnAdmissionCoordinator(ManagerComponent):
         try:
             await self._manager._on_done(info)
         except Exception:
+            # A failed announce never reaches the consumer's accounting. Most
+            # announces routed here are for UNREGISTERED synthetic records, but
+            # the approval-parked rejection is registered with done=True — clear
+            # its done-but-unreported hold so `batch_reports_in_flight` cannot
+            # strand the wave-close fallback (issue #8554).
+            info._report_consumed = True
             logger.exception("Subagent announce failed for %s", info.id)
 
     def _announce_rejection_impl(self, info: SubagentInfo) -> SubagentInfo:

--- a/src/kiro_crew/subagent_manager/admission.py
+++ b/src/kiro_crew/subagent_manager/admission.py
@@ -524,6 +524,9 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             else:
                 info.done = True
                 info.error = "spawn rejected: no approval mechanism configured"
+                # Registered terminal flip whose announce task arms a loop
+                # cycle later — arm with the flip (issue #8554).
+                self._manager.arm_report_in_flight(info)
                 self._manager._running_count -= 1
                 self._manager._drain_queue()
                 sel().log_tool_invocation(
@@ -547,6 +550,9 @@ class SpawnAdmissionCoordinator(ManagerComponent):
         else:
             info.done = True
             info.error = "spawn rejected: no approval mechanism configured"
+            # Registered terminal flip whose announce task arms a loop cycle
+            # later — arm with the flip (issue #8554).
+            self._manager.arm_report_in_flight(info)
             self._manager._running_count -= 1
             self._manager._drain_queue()
             sel().log_tool_invocation(
@@ -571,16 +577,25 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             info (SubagentInfo): The subagent metadata.
         """
         assert self._manager._on_done is not None
+        # Records routed here never pass through `_report_terminal`, so this
+        # is their done-flip-equivalent moment: arm the done-but-unreported
+        # hold immediately before the announce (registered approval-parked
+        # rejections, batch rejections, lost-submission synthetics — all
+        # created/flipped ``done=True`` before reaching this coroutine).
+        # Flush-only records never arm (guarded inside the arm itself): they
+        # skip the consumer's accounting block entirely (issue #8554).
+        self._manager.arm_report_in_flight(info)
         try:
             await self._manager._on_done(info)
         except Exception:
-            # A failed announce never reaches the consumer's accounting. Most
-            # announces routed here are for UNREGISTERED synthetic records, but
-            # the approval-parked rejection is registered with done=True — clear
-            # its done-but-unreported hold so `batch_reports_in_flight` cannot
-            # strand the wave-close fallback (issue #8554).
-            info._report_consumed = True
             logger.exception("Subagent announce failed for %s", info.id)
+        finally:
+            # Structural release, mirroring `_report_terminal`'s: whether the
+            # consumer landed the contribution (idempotent no-op), the
+            # announce raised, or this task was cancelled — an announce that
+            # has ended is no longer in flight, and `batch_reports_in_flight`
+            # must not strand the wave-close fallback (issue #8554).
+            self._manager.consume_report_hold(info.batch_id, info.id)
 
     def _announce_rejection_impl(self, info: SubagentInfo) -> SubagentInfo:
         """Route a terminal spawn rejection through the done callback.
@@ -603,8 +618,15 @@ class SpawnAdmissionCoordinator(ManagerComponent):
         """
         if info.batch_id and self._manager._on_done:
             try:
-                self._manager._tasks[f"reject-{info.id}"] = asyncio.ensure_future(
-                    self._manager._safe_announce(info)
+                _announce_task = asyncio.ensure_future(self._manager._safe_announce(info))
+                self._manager._tasks[f"reject-{info.id}"] = _announce_task
+                # Strand-guard mirroring `_spawn_terminal_report`'s (issue
+                # #8554): the rejection flip above armed the hold, and an
+                # announce task cancelled before its first run never reaches
+                # `_safe_announce`'s structural release. Idempotent no-op on
+                # every path where the release already happened.
+                _announce_task.add_done_callback(
+                    lambda _t: self._manager.consume_report_hold(info.batch_id, info.id)
                 )
             except RuntimeError:
                 pass  # no running loop (sync/test context)
@@ -829,6 +851,9 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             # separates this from a decline for a machine; the prose is what
             # separates it for the agent that receives the completion event.
             info.error = no_surface_error or "spawn rejected"
+            # Registered terminal flip whose announce task arms a loop cycle
+            # later — arm with the flip (issue #8554).
+            self._manager.arm_report_in_flight(info)
             # Slot accounting through the one-shot token, NOT a bare decrement.
             # A user Stop funnels into `_force_reap` and can land while this
             # approval is still pending (a human prompt has no deadline), and

--- a/src/kiro_crew/subagent_manager/cancellation.py
+++ b/src/kiro_crew/subagent_manager/cancellation.py
@@ -187,13 +187,14 @@ class CancellationCoordinator(ManagerComponent):
                     # This arm is deliberately report-free (limbo-avoidance
                     # only — no finalize claim is taken, so no terminal report
                     # will ever reach the completion consumer for this record).
-                    # Clear the done-but-unreported hold with the same
-                    # degraded-liveness contract as the report path's failure
-                    # arms: a sibling completion keeps its ability to close the
-                    # wave with this member's line missing, instead of
-                    # `batch_reports_in_flight` stranding the wave-close
-                    # fallback forever (issue #8554).
-                    info._report_consumed = True
+                    # No done-but-unreported hold needs releasing here: holds
+                    # are armed only by the report machinery in the same
+                    # synchronous block that flips ``done`` (or immediately
+                    # before a safe-announce of an already-done record), so a
+                    # record reaching this arm with ``done`` still False can
+                    # never carry one — `batch_reports_in_flight` ignores it
+                    # and a sibling completion keeps its ability to close the
+                    # wave with this member's line missing (issue #8554).
                     info.error = "cancelled"
                     info.elapsed = time.time() - info.started
                     if not info.user_stopped:

--- a/src/kiro_crew/subagent_manager/cancellation.py
+++ b/src/kiro_crew/subagent_manager/cancellation.py
@@ -184,6 +184,16 @@ class CancellationCoordinator(ManagerComponent):
                 # tombstone the reaper could no longer correct.
                 if not info.done and not info._reap_started and not info.reaped:
                     info.done = True
+                    # This arm is deliberately report-free (limbo-avoidance
+                    # only — no finalize claim is taken, so no terminal report
+                    # will ever reach the completion consumer for this record).
+                    # Clear the done-but-unreported hold with the same
+                    # degraded-liveness contract as the report path's failure
+                    # arms: a sibling completion keeps its ability to close the
+                    # wave with this member's line missing, instead of
+                    # `batch_reports_in_flight` stranding the wave-close
+                    # fallback forever (issue #8554).
+                    info._report_consumed = True
                     info.error = "cancelled"
                     info.elapsed = time.time() - info.started
                     if not info.user_stopped:

--- a/src/kiro_crew/subagent_manager/run.py
+++ b/src/kiro_crew/subagent_manager/run.py
@@ -378,6 +378,15 @@ class RunEventCoordinator(ManagerComponent):
             if not info.reaped:
                 info.error = f"Timed out after {self._manager._default_timeout // 60} minutes [{_timeout_context(info, turn_limit=self._manager._effective_turn_limit(info))}]"
                 info.done = True
+                # Armed HERE, synchronously with the flip — not left to the
+                # report task spawned in the ``finally`` below. Between this
+                # flip and that task's first run the coroutine yields (the
+                # teardown awaits), and in that done-but-unarmed window a
+                # sibling completion reads this member as neither pending nor
+                # in flight and closes the wave early; the report then
+                # finalizes it AGAIN (issue #8554, failure-path window). The
+                # report machinery's own arm stays as an idempotent no-op.
+                self._manager.arm_report_in_flight(info)
                 Stats().inc_subagent_failed()
                 self._manager._write_tombstone(info, "timeout")
             logger.warning("Subagent %s timed out", info.id)
@@ -428,6 +437,10 @@ class RunEventCoordinator(ManagerComponent):
                     self._manager._schedule_cancel_recovery(info)
                 else:
                     info.done = True
+                    # Same synchronous flip+arm as the timeout arm above —
+                    # the cancel path yields at teardown before its report
+                    # task first runs (issue #8554, failure-path window).
+                    self._manager.arm_report_in_flight(info)
                     if (
                         info.tool_count > 0
                         and not info.user_stopped
@@ -461,6 +474,9 @@ class RunEventCoordinator(ManagerComponent):
                     _describe_exception(exc), exc, budget=_MAX_ERROR_DETAIL_LEN
                 )
                 info.done = True
+                # Same synchronous flip+arm as the timeout arm above (issue
+                # #8554, failure-path window).
+                self._manager.arm_report_in_flight(info)
                 Stats().inc_subagent_failed()
                 self._manager._write_tombstone(info, "error")
             logger.exception("Subagent %s failed", info.id)
@@ -1282,6 +1298,10 @@ class RunEventCoordinator(ManagerComponent):
                         info.result = result_text or "_Partial output._"
                         info.error = f"child_escalation_limit:{child_escalation_limit}"
                         info.done = True
+                        # In-run terminal flip: the report is spawned only
+                        # after this return unwinds to ``_run``'s ``finally``
+                        # — arm with the flip (issue #8554).
+                        self._manager.arm_report_in_flight(info)
                         Stats().inc_subagent_failed()
                         logger.warning(
                             "Subagent %s hit child escalation limit (%d)",
@@ -1329,6 +1349,9 @@ class RunEventCoordinator(ManagerComponent):
                     info.result = result_text or "_Partial output._"
                     info.error = f"turn_limit:{turn_limit}"
                     info.done = True
+                    # In-run terminal flip — same arm as the escalation-limit
+                    # return above (issue #8554).
+                    self._manager.arm_report_in_flight(info)
                     Stats().inc_subagent_failed()
                     logger.warning("Subagent %s hit turn limit (%d)", info.id, turn_limit)
                     self._manager._write_tombstone(info, "turn_limit")
@@ -1714,6 +1737,11 @@ class RunEventCoordinator(ManagerComponent):
             logger.debug("usage row (subagent) persist failed", exc_info=True)
 
         info.done = True
+        # Success is a terminal done transition like any other: between this
+        # flip and the report task's first run, ``wait_for``'s unwind and the
+        # caller's teardown can both yield — arm with the flip so the window
+        # is closed on EVERY terminal path, not just failures (issue #8554).
+        self._manager.arm_report_in_flight(info)
         self._manager._sessions.record_success(session_key)
 
         Stats().inc_subagent_completed()

--- a/src/kiro_crew/subagent_manager/terminal.py
+++ b/src/kiro_crew/subagent_manager/terminal.py
@@ -119,6 +119,52 @@ class TerminalCoordinator(ManagerComponent):
         # exclusive report task owns the terminal transition; flipping here
         # means only the last sibling can observe the batch as fully settled.
         info.done = True
+        # Arm the done-but-unreported hold in the same synchronous block as
+        # the flip, so the hold and the flip can never be observed apart: from
+        # this line until the completion consumer lands the member's
+        # contribution, `batch_reports_in_flight` holds the wave-close
+        # fallback open (issue #8554).
+        self._manager.arm_report_in_flight(info)
+        try:
+            await self._report_terminal_guarded_impl(
+                info,
+                source=source,
+                injection_timeout_reason=injection_timeout_reason,
+                mark_delivered_on_success=mark_delivered_on_success,
+                settle_digest=settle_digest,
+                teardown_done=teardown_done,
+            )
+        finally:
+            # ONE structural release replacing the former per-arm clears: by
+            # the time the report coroutine ends — success (the consumer
+            # already released the hold inside its accounting block; this is
+            # an idempotent no-op), injection timeout, announce failure,
+            # cancellation, or the no-consumer early return — the report is no
+            # longer in flight. A hold that outlived its report would strand
+            # the wave-close fallback forever; releasing here keeps the wave's
+            # degraded a-sibling-can-close liveness instead (issue #8554).
+            self._manager.consume_report_hold(info.batch_id, info.id)
+
+    async def _report_terminal_guarded_impl(
+        self,
+        info: SubagentInfo,
+        *,
+        source: str,
+        injection_timeout_reason: str,
+        mark_delivered_on_success: bool,
+        settle_digest: bool = False,
+        teardown_done: "asyncio.Event | None" = None,
+    ) -> None:
+        """Body of :meth:`_report_terminal_impl` past the terminal transition.
+
+        Split out so the done-flip + hold-arm above can wrap the ENTIRE
+        remainder — every await, every failure arm, every early return — in
+        one structural ``try/finally`` release without re-indenting the report
+        machinery. Only :meth:`_report_terminal_impl` may call this. (The
+        ``_impl`` suffix keeps it inside ``bind_component_globals``' rebind
+        set, like every other coordinator body that touches ``subagent``
+        module globals.)
+        """
         await self._manager._fire_event(
             "subagent_done",
             info,
@@ -220,13 +266,13 @@ class TerminalCoordinator(ManagerComponent):
                     logger.debug("Failed to clean workspace result for %s", info.id, exc_info=True)
         except asyncio.TimeoutError:
             # The report is terminally over — nothing further will reach the
-            # completion consumer for this member. Clear the
-            # done-but-unreported hold (usually already cleared: the consumer's
-            # accounting runs before the injection await this timeout
-            # interrupts) so `batch_reports_in_flight` cannot strand the wave;
-            # a sibling completion keeps its degraded ability to close the wave
-            # with this member's line missing (issue #8554).
-            info._report_consumed = True
+            # completion consumer for this member. The structural ``finally``
+            # in `_report_terminal_impl` releases the done-but-unreported hold
+            # (usually already released: the consumer's accounting runs before
+            # the injection await this timeout interrupts), so
+            # `batch_reports_in_flight` cannot strand the wave; a sibling
+            # completion keeps its degraded ability to close the wave with
+            # this member's line missing (issue #8554).
             logger.error(
                 "%s: completion injection timed out for %s after %.0fs",
                 source,
@@ -246,10 +292,10 @@ class TerminalCoordinator(ManagerComponent):
                 )
             self._manager.notify_injection_failed(info, reason=injection_timeout_reason)
         except Exception:
-            # Same liveness backstop as the timeout arm: a report whose
-            # announce raised will never reach the consumer, so it must not
-            # hold `batch_reports_in_flight` open forever (issue #8554).
-            info._report_consumed = True
+            # Same liveness backstop as the timeout arm, owned by the same
+            # structural ``finally``: a report whose announce raised will
+            # never reach the consumer, so it must not hold
+            # `batch_reports_in_flight` open forever (issue #8554).
             logger.exception("%s: announce failed for %s", source, info.id)
 
     async def _run_terminal_report_impl(
@@ -323,6 +369,14 @@ class TerminalCoordinator(ManagerComponent):
         def _forget(t: "asyncio.Task") -> None:  # type: ignore[type-arg]
             self._manager._report_tasks.discard(t)
             self._manager._report_owners.pop(t, None)
+            # Strand-guard for the flip-site arms (issue #8554): a report task
+            # cancelled BEFORE its first execution step never runs its body's
+            # structural release, and a hold that nothing releases pins
+            # `batch_reports_in_flight` — making even the reaper's deadline
+            # sweep skip the wave forever. By task-done time the report is not
+            # in flight on ANY path, so this release is always correct (and an
+            # idempotent no-op when the body or consumer already released).
+            self._manager.consume_report_hold(info.batch_id, info.id)
 
         task.add_done_callback(_forget)
         return task
@@ -454,6 +508,11 @@ class TerminalCoordinator(ManagerComponent):
         # first-arrival-wins on `info.done`, so it is never written twice.
         if not info.done:
             info.done = True
+            # Terminal done transition: arm with the flip. The reap's own
+            # report is awaited below, but the award of the finalize claim and
+            # the SEL/teardown bookkeeping sit between — keep the hold and the
+            # flip observable only together (issue #8554).
+            self._manager.arm_report_in_flight(info)
             if not info.error and not info.user_stopped:
                 # A user stop is neutral — never synthesize a reap error for it.
                 if approval_parked:

--- a/src/kiro_crew/subagent_manager/terminal.py
+++ b/src/kiro_crew/subagent_manager/terminal.py
@@ -219,6 +219,14 @@ class TerminalCoordinator(ManagerComponent):
                 except Exception:
                     logger.debug("Failed to clean workspace result for %s", info.id, exc_info=True)
         except asyncio.TimeoutError:
+            # The report is terminally over — nothing further will reach the
+            # completion consumer for this member. Clear the
+            # done-but-unreported hold (usually already cleared: the consumer's
+            # accounting runs before the injection await this timeout
+            # interrupts) so `batch_reports_in_flight` cannot strand the wave;
+            # a sibling completion keeps its degraded ability to close the wave
+            # with this member's line missing (issue #8554).
+            info._report_consumed = True
             logger.error(
                 "%s: completion injection timed out for %s after %.0fs",
                 source,
@@ -238,6 +246,10 @@ class TerminalCoordinator(ManagerComponent):
                 )
             self._manager.notify_injection_failed(info, reason=injection_timeout_reason)
         except Exception:
+            # Same liveness backstop as the timeout arm: a report whose
+            # announce raised will never reach the consumer, so it must not
+            # hold `batch_reports_in_flight` open forever (issue #8554).
+            info._report_consumed = True
             logger.exception("%s: announce failed for %s", source, info.id)
 
     async def _run_terminal_report_impl(

--- a/src/kiro_crew/subagent_manager/waves.py
+++ b/src/kiro_crew/subagent_manager/waves.py
@@ -43,6 +43,28 @@ class WaveDigestCoordinator(ManagerComponent):
             return True
         return any(p.get("batch_id") == batch_id for p in self._manager._queue)
 
+    def batch_reports_in_flight_impl(self, batch_id: str) -> bool:
+        """True while any registered member of *batch_id* is done-but-unreported:
+        ``info.done`` has flipped (so :meth:`batch_members_pending_impl` no
+        longer counts it) but its terminal report has not yet been consumed by
+        the completion consumer, so its contribution to the wave's done-count
+        has not landed. In that window a sibling completion reaching the
+        consumer sees ``done < total`` with no pending members — without this
+        check the last-member fallback finalizes the wave early, and the
+        in-flight report then re-creates the batch-progress record and
+        finalizes the same wave again (issue #8554). The flag is set by the
+        consumer itself the moment the member's contribution lands, and by the
+        report path's failure arms (a report that terminally failed is no
+        longer in flight — the wave keeps its degraded a-sibling-can-close
+        liveness instead of stranding).
+        """
+        if not batch_id:
+            return False
+        return any(
+            a.batch_id == batch_id and a.done and not a._report_consumed
+            for a in self._manager._agents.values()
+        )
+
     def finalize_batch_impl(self, batch_id: str) -> None:
         """Prune per-wave bookkeeping once the wave digest has fired.
 

--- a/src/kiro_crew/subagent_manager/waves.py
+++ b/src/kiro_crew/subagent_manager/waves.py
@@ -44,7 +44,7 @@ class WaveDigestCoordinator(ManagerComponent):
         return any(p.get("batch_id") == batch_id for p in self._manager._queue)
 
     def batch_reports_in_flight_impl(self, batch_id: str) -> bool:
-        """True while any registered member of *batch_id* is done-but-unreported:
+        """True while any member of *batch_id* is done-but-unreported:
         ``info.done`` has flipped (so :meth:`batch_members_pending_impl` no
         longer counts it) but its terminal report has not yet been consumed by
         the completion consumer, so its contribution to the wave's done-count
@@ -52,18 +52,57 @@ class WaveDigestCoordinator(ManagerComponent):
         consumer sees ``done < total`` with no pending members — without this
         check the last-member fallback finalizes the wave early, and the
         in-flight report then re-creates the batch-progress record and
-        finalizes the same wave again (issue #8554). The flag is set by the
-        consumer itself the moment the member's contribution lands, and by the
-        report path's failure arms (a report that terminally failed is no
-        longer in flight — the wave keeps its degraded a-sibling-can-close
-        liveness instead of stranding).
+        finalizes the same wave again (issue #8554).
+
+        The hold lives in the manager-level ``_reports_in_flight`` registry,
+        NOT on the agent records: ``_agents`` membership is operator-mutable
+        (``DELETE /api/spawn`` pops every done member), so a predicate derived
+        from it silently drops the hold when a clear lands inside the window —
+        reopening the exact hole this predicate closes. The registry is armed
+        by the report machinery in the same synchronous block that flips
+        ``done`` and disarmed by the consumer the moment the contribution
+        lands (or structurally, when the report coroutine ends without
+        reaching the consumer — the wave keeps its degraded
+        a-sibling-can-close liveness instead of stranding).
         """
         if not batch_id:
             return False
-        return any(
-            a.batch_id == batch_id and a.done and not a._report_consumed
-            for a in self._manager._agents.values()
-        )
+        return bool(self._manager._reports_in_flight.get(batch_id))
+
+    def arm_report_in_flight_impl(self, info: SubagentInfo) -> None:
+        """Register *info*'s terminal report as in flight toward the consumer.
+
+        Called in the same synchronous block as EVERY terminal ``info.done``
+        flip — the report machinery's, the run's failure except-bodies, the
+        in-run limit bails, the reaper's, and spawn-rejection flips (or, for
+        synthetic records created ``done=True``, immediately before their
+        announce) — so the hold and the flip can never be observed apart
+        (issue #8554: a done-but-unarmed window lets a sibling close the wave
+        early). Idempotent: a set add, so the flip-site arm and the report
+        machinery's arm compose. Flush-only records never arm: they skip the
+        consumer's accounting block entirely, so a hold would only be released
+        by the structural disarm and would transiently pin the wave open for
+        no accounting reason.
+        """
+        if not info.batch_id or getattr(info, "_digest_flush_only", False):
+            return
+        self._manager._reports_in_flight.setdefault(info.batch_id, set()).add(info.id)
+
+    def consume_report_hold_impl(self, batch_id: str, agent_id: str) -> None:
+        """Release *agent_id*'s done-but-unreported hold on *batch_id*.
+
+        Idempotent. Called by the completion consumer in the same synchronous
+        block that lands the member's done-count contribution, and by the
+        report machinery's structural ``finally`` (a report that ended without
+        reaching the consumer is no longer in flight).
+        """
+        if not batch_id:
+            return
+        holds = self._manager._reports_in_flight.get(batch_id)
+        if holds is not None:
+            holds.discard(agent_id)
+            if not holds:
+                self._manager._reports_in_flight.pop(batch_id, None)
 
     def finalize_batch_impl(self, batch_id: str) -> None:
         """Prune per-wave bookkeeping once the wave digest has fired.
@@ -76,6 +115,7 @@ class WaveDigestCoordinator(ManagerComponent):
         self._manager._seen_batches.discard(batch_id)
         self._manager._batch_submitted.pop(batch_id, None)
         self._manager._batch_progress_ts.pop(batch_id, None)
+        self._manager._reports_in_flight.pop(batch_id, None)
 
     def record_lost_submission_impl(
         self,
@@ -214,11 +254,23 @@ class WaveDigestCoordinator(ManagerComponent):
             if age < DIGEST_HOLD_SECS:
                 continue  # still inside the grace window
             if not self._manager.batch_members_pending(batch_id):
-                # The wave is closing on its own — the real wave-close flush is
-                # already in flight (or the held flags are stale bookkeeping).
-                # Forcing a partial digest here would race it and could emit a
-                # duplicate chunk for the same members.
-                continue
+                if self._manager.batch_reports_in_flight(batch_id):
+                    # The wave is closing on its own — the final member's
+                    # report is in flight and the real wave-close flush lands
+                    # when it is consumed. Forcing a partial digest here would
+                    # race it and could emit a duplicate chunk for the same
+                    # members. (The consumer clears every hold clock in the
+                    # same synchronous block that fires the chunk, so this
+                    # skip cannot observe a just-flushed wave's stale clocks.)
+                    continue
+                # No pending members AND no report in flight, yet a hold has
+                # aged past the deadline: the wave-close flush is never coming.
+                # A terminal report ended without reaching the consumer (the
+                # injection-timeout / announce-failure arms release the hold
+                # but land no accounting), so no further completion event will
+                # re-enter the consumer for this wave — the held sibling
+                # results would strand until gateway restart. Fall through and
+                # force the flush: this sweep is the only remaining exit.
             logger.warning(
                 "Reaper: wave %s held results for %.0fs (deadline %.0fs) —"
                 " forcing partial digest flush",

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -2124,3 +2124,147 @@ class TestPlatformConstants:
         back to 100 there."""
         assert isinstance(sa._CLK_TCK, int)
         assert sa._CLK_TCK > 0
+
+
+# ── Manager: done-but-unreported wave accounting (issue #8554) ────────────
+
+
+class TestBatchReportsInFlight:
+    """``batch_reports_in_flight`` holds the wave-close fallback open across the
+    done-but-unreported window: ``info.done`` has flipped (so
+    ``batch_members_pending`` no longer counts the member) but its terminal
+    report has not yet been consumed, so the wave's done-count does not include
+    it either. Without the hold, a sibling completion landing in that window
+    finalizes the wave early and the in-flight report finalizes it again."""
+
+    def test_no_batch_id_is_never_in_flight(self) -> None:
+        assert _manager().batch_reports_in_flight("") is False
+
+    def test_done_but_unreported_member_is_in_flight(self) -> None:
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", batch_id="w1", done=True)
+        assert mgr.batch_reports_in_flight("w1") is True
+
+    def test_consumed_report_is_not_in_flight(self) -> None:
+        mgr = _manager()
+        info = _info("a", batch_id="w1", done=True)
+        info._report_consumed = True
+        mgr._agents["a"] = info
+        assert mgr.batch_reports_in_flight("w1") is False
+
+    def test_live_member_is_not_in_flight(self) -> None:
+        """A member still RUNNING is `batch_members_pending`'s job — counting it
+        here too would make the two predicates redundant rather than
+        complementary."""
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", batch_id="w1", done=False)
+        assert mgr.batch_reports_in_flight("w1") is False
+
+    def test_other_waves_members_do_not_count(self) -> None:
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", batch_id="w2", done=True)
+        assert mgr.batch_reports_in_flight("w1") is False
+
+
+class TestReportsInFlightStrandBackstops:
+    """Every terminal arm that can end a member's report WITHOUT reaching the
+    completion consumer must clear the hold, or `batch_reports_in_flight`
+    would strand the wave-close fallback forever. The wave keeps its degraded
+    a-sibling-can-close liveness instead (issue #8554)."""
+
+    @pytest.mark.asyncio
+    async def test_report_injection_timeout_clears_the_hold(self) -> None:
+        """`asyncio.wait_for(self._on_done(info), …)` timing out is terminal for
+        the report: nothing further reaches the consumer for this member."""
+        mgr = _manager(on_done=AsyncMock(side_effect=asyncio.TimeoutError))
+        info = _info("a", batch_id="w1", done=True)
+        mgr._agents["a"] = info
+        assert mgr.batch_reports_in_flight("w1") is True
+
+        await mgr._run_terminal_report(
+            info,
+            source="Test",
+            injection_timeout_reason="delivery timed out (test)",
+            mark_delivered_on_success=False,
+        )
+
+        assert info._report_consumed is True
+        assert mgr.batch_reports_in_flight("w1") is False
+
+    @pytest.mark.asyncio
+    async def test_report_announce_failure_clears_the_hold(self) -> None:
+        mgr = _manager(on_done=AsyncMock(side_effect=RuntimeError("boom")))
+        info = _info("a", batch_id="w1", done=True)
+        mgr._agents["a"] = info
+
+        await mgr._run_terminal_report(
+            info,
+            source="Test",
+            injection_timeout_reason="delivery timed out (test)",
+            mark_delivered_on_success=False,
+        )
+
+        assert info._report_consumed is True
+        assert mgr.batch_reports_in_flight("w1") is False
+
+    @pytest.mark.asyncio
+    async def test_safe_announce_failure_clears_the_hold(self) -> None:
+        """The registered approval-parked rejection announces through
+        `_safe_announce`; a raising consumer must not leave it holding."""
+        mgr = _manager(on_done=AsyncMock(side_effect=RuntimeError("boom")))
+        info = _info("a", batch_id="w1", done=True)
+        mgr._agents["a"] = info
+
+        await mgr._safe_announce(info)
+
+        assert info._report_consumed is True
+        assert mgr.batch_reports_in_flight("w1") is False
+
+    @pytest.mark.asyncio
+    async def test_successful_report_leaves_the_flag_to_the_consumer(self) -> None:
+        """On the happy path the CONSUMER owns the flag (set in the same
+        synchronous block as the done-count increment) — the report machinery
+        itself must not set it early, or the window between `_on_done` starting
+        and the count landing would reopen."""
+        seen: list[bool] = []
+
+        async def _consumer(info: SubagentInfo) -> None:
+            seen.append(info._report_consumed)
+
+        mgr = _manager(on_done=_consumer)
+        info = _info("a", batch_id="w1", done=True)
+        mgr._agents["a"] = info
+
+        await mgr._run_terminal_report(
+            info,
+            source="Test",
+            injection_timeout_reason="delivery timed out (test)",
+            mark_delivered_on_success=False,
+        )
+
+        assert seen == [False]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_recovery_arm_clears_the_hold(self) -> None:
+        """The cancelled-recovery arm is deliberately report-free (limbo
+        avoidance — no finalize claim, no terminal report ever runs), so it is
+        the one terminal RECORD writer that must clear the hold itself."""
+        mgr = _manager()
+        info = _info("a", batch_id="w1")
+        info.started = 1.0
+        mgr._agents["a"] = info
+
+        with patch.object(mgr, "_write_tombstone"):
+            # From the test task, `_resume` awaits the ORIGINAL task — this
+            # test's own — which never finishes first: a deterministic block
+            # point with no timing dependence.
+            mgr._schedule_cancel_recovery(info)
+            recovery = mgr._tasks["a:recovery"]
+            await asyncio.sleep(0)  # let _resume start and park on the wait
+            recovery.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await recovery
+
+        assert info.done is True
+        assert info._report_consumed is True
+        assert mgr.batch_reports_in_flight("w1") is False

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -1721,15 +1721,39 @@ class TestSweepDigestHolds:
         flush.assert_not_called()
 
     def test_closing_wave_not_forced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No pending members + a report in flight = the wave is closing on its
+        own; the real wave-close flush lands when the consumer runs. Forcing a
+        partial digest here would race it and could duplicate a chunk."""
         monkeypatch.setattr(sa, "DIGEST_HOLD_SECS", 10.0)
         mgr = _manager(on_done=AsyncMock())
         held = _info("a", batch_id="w1", batch_total=1, done=True)
         held._digest_held_at = 1.0
         mgr._agents["a"] = held
         mgr._batch_submitted["w1"] = [1, 1]
+        mgr.arm_report_in_flight(held)
         with patch.object(mgr, "force_digest_flush") as flush:
             mgr._sweep_digest_holds(now=1e6)
         flush.assert_not_called()
+
+    def test_stranded_hold_past_deadline_is_forced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No pending members AND no report in flight, yet a hold aged past the
+        deadline: the wave-close flush is never coming (a terminal report ended
+        without reaching the consumer — injection-timeout / announce-failure
+        arms release the hold but land no accounting). The sweep is the only
+        remaining exit; before the in-flight-aware guard this state was
+        unsweepable and the held sibling results stranded until restart."""
+        monkeypatch.setattr(sa, "DIGEST_HOLD_SECS", 10.0)
+        mgr = _manager(on_done=AsyncMock())
+        held = _info("a", batch_id="w1", batch_total=1, done=True, parent_session_key="dash:1")
+        held._digest_held_at = 1.0
+        mgr._agents["a"] = held
+        mgr._batch_submitted["w1"] = [1, 1]  # no pending members
+        # No arm: the member's report ended without reaching the consumer.
+        with patch.object(mgr, "force_digest_flush") as flush:
+            mgr._sweep_digest_holds(now=1e6)
+        assert flush.call_count == 1
+        assert flush.call_args[0][0] == "w1"
+        assert flush.call_args[0][1] == "dash:1"
 
     def test_expired_hold_forces_partial_flush(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sa, "DIGEST_HOLD_SECS", 10.0)
@@ -2142,27 +2166,80 @@ class TestBatchReportsInFlight:
 
     def test_done_but_unreported_member_is_in_flight(self) -> None:
         mgr = _manager()
-        mgr._agents["a"] = _info("a", batch_id="w1", done=True)
+        info = _info("a", batch_id="w1", done=True)
+        mgr._agents["a"] = info
+        mgr.arm_report_in_flight(info)
         assert mgr.batch_reports_in_flight("w1") is True
 
     def test_consumed_report_is_not_in_flight(self) -> None:
         mgr = _manager()
         info = _info("a", batch_id="w1", done=True)
-        info._report_consumed = True
         mgr._agents["a"] = info
+        mgr.arm_report_in_flight(info)
+        mgr.consume_report_hold("w1", "a")
+        assert mgr.batch_reports_in_flight("w1") is False
+        # The consumed wave's registry entry is pruned, not left empty.
+        assert "w1" not in mgr._reports_in_flight
+
+    def test_operator_clear_cannot_drop_the_hold(self) -> None:
+        """THE #8554 fix-round conviction (GPT 5.6 F1): the hold lives in the
+        manager-level registry, NOT on `_agents` membership. An operator
+        clear-completed (DELETE /api/spawn) pops every done member — landing
+        inside the done-but-unreported window it must NOT release the hold, or
+        a sibling completion would finalize the wave early and the in-flight
+        report would finalize it a second time."""
+        mgr = _manager()
+        info = _info("a", batch_id="w1", done=True)
+        mgr._agents["a"] = info
+        mgr.arm_report_in_flight(info)
+        # What the DELETE /api/spawn handler does to done members:
+        mgr._agents.pop("a")
+        assert mgr.batch_reports_in_flight("w1") is True
+        # The consumer still holds `info` by reference and releases on landing.
+        mgr.consume_report_hold("w1", "a")
         assert mgr.batch_reports_in_flight("w1") is False
 
+    def test_flush_only_records_never_arm(self) -> None:
+        """Flush-only synthetics skip the consumer's accounting block, so a
+        hold would only ever be released structurally — transiently pinning
+        the wave open for no accounting reason."""
+        mgr = _manager()
+        info = _info("a", batch_id="w1", done=True)
+        info._digest_flush_only = True
+        mgr.arm_report_in_flight(info)
+        assert mgr.batch_reports_in_flight("w1") is False
+
+    def test_consume_is_idempotent_and_unarmed_release_is_a_noop(self) -> None:
+        mgr = _manager()
+        mgr.consume_report_hold("w1", "never-armed")
+        assert mgr.batch_reports_in_flight("w1") is False
+        info = _info("a", batch_id="w1", done=True)
+        mgr.arm_report_in_flight(info)
+        mgr.consume_report_hold("w1", "a")
+        mgr.consume_report_hold("w1", "a")
+        assert mgr.batch_reports_in_flight("w1") is False
+
+    def test_finalize_batch_prunes_the_hold_registry(self) -> None:
+        mgr = _manager()
+        info = _info("a", batch_id="w1", done=True)
+        mgr.arm_report_in_flight(info)
+        mgr.finalize_batch("w1")
+        assert mgr.batch_reports_in_flight("w1") is False
+        assert "w1" not in mgr._reports_in_flight
+
     def test_live_member_is_not_in_flight(self) -> None:
-        """A member still RUNNING is `batch_members_pending`'s job — counting it
-        here too would make the two predicates redundant rather than
-        complementary."""
+        """A member still RUNNING is `batch_members_pending`'s job — the arm
+        happens only at the report's done-flip, so a live member never holds
+        here and the two predicates stay complementary, not redundant."""
         mgr = _manager()
         mgr._agents["a"] = _info("a", batch_id="w1", done=False)
         assert mgr.batch_reports_in_flight("w1") is False
 
     def test_other_waves_members_do_not_count(self) -> None:
         mgr = _manager()
-        mgr._agents["a"] = _info("a", batch_id="w2", done=True)
+        info = _info("a", batch_id="w2", done=True)
+        mgr._agents["a"] = info
+        mgr.arm_report_in_flight(info)
         assert mgr.batch_reports_in_flight("w1") is False
 
 
@@ -2175,11 +2252,18 @@ class TestReportsInFlightStrandBackstops:
     @pytest.mark.asyncio
     async def test_report_injection_timeout_clears_the_hold(self) -> None:
         """`asyncio.wait_for(self._on_done(info), …)` timing out is terminal for
-        the report: nothing further reaches the consumer for this member."""
-        mgr = _manager(on_done=AsyncMock(side_effect=asyncio.TimeoutError))
+        the report: nothing further reaches the consumer for this member. The
+        structural `finally` must release the hold the report armed."""
+        seen: list[bool] = []
+
+        async def _consumer(info: SubagentInfo) -> None:
+            seen.append(_manager_ref[0].batch_reports_in_flight("w1"))
+            raise asyncio.TimeoutError
+
+        mgr = _manager(on_done=_consumer)
+        _manager_ref = [mgr]
         info = _info("a", batch_id="w1", done=True)
         mgr._agents["a"] = info
-        assert mgr.batch_reports_in_flight("w1") is True
 
         await mgr._run_terminal_report(
             info,
@@ -2188,12 +2272,21 @@ class TestReportsInFlightStrandBackstops:
             mark_delivered_on_success=False,
         )
 
-        assert info._report_consumed is True
+        # The report armed the hold at its done-flip (visible mid-announce)…
+        assert seen == [True]
+        # …and the structural `finally` released it when the report ended.
         assert mgr.batch_reports_in_flight("w1") is False
 
     @pytest.mark.asyncio
     async def test_report_announce_failure_clears_the_hold(self) -> None:
-        mgr = _manager(on_done=AsyncMock(side_effect=RuntimeError("boom")))
+        seen: list[bool] = []
+
+        async def _consumer(info: SubagentInfo) -> None:
+            seen.append(_manager_ref[0].batch_reports_in_flight("w1"))
+            raise RuntimeError("boom")
+
+        mgr = _manager(on_done=_consumer)
+        _manager_ref = [mgr]
         info = _info("a", batch_id="w1", done=True)
         mgr._agents["a"] = info
 
@@ -2204,34 +2297,44 @@ class TestReportsInFlightStrandBackstops:
             mark_delivered_on_success=False,
         )
 
-        assert info._report_consumed is True
+        assert seen == [True]
         assert mgr.batch_reports_in_flight("w1") is False
 
     @pytest.mark.asyncio
     async def test_safe_announce_failure_clears_the_hold(self) -> None:
         """The registered approval-parked rejection announces through
-        `_safe_announce`; a raising consumer must not leave it holding."""
-        mgr = _manager(on_done=AsyncMock(side_effect=RuntimeError("boom")))
+        `_safe_announce`; it must arm before the announce (its done-flip
+        equivalent) and a raising consumer must not leave it holding."""
+        seen: list[bool] = []
+
+        async def _consumer(info: SubagentInfo) -> None:
+            seen.append(_manager_ref[0].batch_reports_in_flight("w1"))
+            raise RuntimeError("boom")
+
+        mgr = _manager(on_done=_consumer)
+        _manager_ref = [mgr]
         info = _info("a", batch_id="w1", done=True)
         mgr._agents["a"] = info
 
         await mgr._safe_announce(info)
 
-        assert info._report_consumed is True
+        assert seen == [True]
         assert mgr.batch_reports_in_flight("w1") is False
 
     @pytest.mark.asyncio
-    async def test_successful_report_leaves_the_flag_to_the_consumer(self) -> None:
-        """On the happy path the CONSUMER owns the flag (set in the same
-        synchronous block as the done-count increment) — the report machinery
-        itself must not set it early, or the window between `_on_done` starting
-        and the count landing would reopen."""
+    async def test_hold_is_visible_to_the_consumer_and_released_after(self) -> None:
+        """On the happy path the hold is armed BEFORE the announce and the
+        CONSUMER owns the release (same synchronous block as the done-count
+        increment) — so the wave-close fallback stays held open for exactly
+        the window between the done-flip and the count landing. The report's
+        structural `finally` then re-releases as an idempotent no-op."""
         seen: list[bool] = []
 
         async def _consumer(info: SubagentInfo) -> None:
-            seen.append(info._report_consumed)
+            seen.append(_manager_ref[0].batch_reports_in_flight("w1"))
 
         mgr = _manager(on_done=_consumer)
+        _manager_ref = [mgr]
         info = _info("a", batch_id="w1", done=True)
         mgr._agents["a"] = info
 
@@ -2242,13 +2345,15 @@ class TestReportsInFlightStrandBackstops:
             mark_delivered_on_success=False,
         )
 
-        assert seen == [False]
+        assert seen == [True]
+        assert mgr.batch_reports_in_flight("w1") is False
 
     @pytest.mark.asyncio
-    async def test_cancelled_recovery_arm_clears_the_hold(self) -> None:
+    async def test_cancelled_recovery_arm_never_strands_the_wave(self) -> None:
         """The cancelled-recovery arm is deliberately report-free (limbo
-        avoidance — no finalize claim, no terminal report ever runs), so it is
-        the one terminal RECORD writer that must clear the hold itself."""
+        avoidance — no finalize claim, no terminal report ever runs). Holds are
+        armed only at a report's done-flip, so a record terminalized here never
+        carries one — the wave must read as hold-free throughout."""
         mgr = _manager()
         info = _info("a", batch_id="w1")
         info.started = 1.0
@@ -2266,5 +2371,4 @@ class TestReportsInFlightStrandBackstops:
                 await recovery
 
         assert info.done is True
-        assert info._report_consumed is True
         assert mgr.batch_reports_in_flight("w1") is False

--- a/test/test_subagent_scale.py
+++ b/test/test_subagent_scale.py
@@ -1191,13 +1191,15 @@ class TestWaveDigest:
         # Structural guarantee: the settle call sits AFTER the awaited
         # _on_done inside the same try-block, so an _on_done exception
         # (routing failure / crash) skips it entirely. The terminal report
-        # (subagent_done + _on_done + settle) now lives in _report_terminal,
-        # which `_run` runs on a shielded task — the ordering invariant is
-        # unchanged, only its owning function moved.
+        # (subagent_done + _on_done + settle) now lives in
+        # _report_terminal_guarded (the body of _report_terminal past the
+        # done-flip, split out so the in-flight hold's try/finally wraps it —
+        # issue #8554), which `_run` runs on a shielded task — the ordering
+        # invariant is unchanged, only its owning function moved.
         import inspect
 
         from kiro_crew.subagent_manager.terminal import TerminalCoordinator
-        src = inspect.getsource(TerminalCoordinator._report_terminal_impl)
+        src = inspect.getsource(TerminalCoordinator._report_terminal_guarded_impl)
         on_done_pos = src.index("await asyncio.wait_for(self._manager._on_done(info)")
         settle_pos = src.index("self._manager._settle_digest_holds(info)")
         assert settle_pos > on_done_pos
@@ -1722,9 +1724,12 @@ class TestDigestHoldDeadline:
         assert age >= DIGEST_HOLD_SECS + 10 - 1
 
     def test_closing_wave_is_not_force_flushed(self):
-        """When no member is outstanding the real wave-close digest (counts +
-        release guidance) is already in flight; forcing a partial one here would
-        race it and could double-deliver the same members."""
+        """When no member is outstanding AND a terminal report is in flight the
+        real wave-close digest (counts + release guidance) lands when that
+        report is consumed; forcing a partial one here would race it and could
+        double-deliver the same members. (Without the in-flight hold this
+        aged-hold state is the STRANDED one — the sweep force-flushes it; see
+        TestSweepDigestHolds.test_stranded_hold_past_deadline_is_forced.)"""
         from kiro_crew.subagent import DIGEST_HOLD_SECS
 
         mgr = self._mgr(pending=False)
@@ -1732,6 +1737,7 @@ class TestDigestHoldDeadline:
         m = self._held_member(0)
         m._digest_held_at = now - (DIGEST_HOLD_SECS + 60)
         mgr._agents["h0"] = m
+        mgr.arm_report_in_flight(m)
         with patch.object(mgr, "force_digest_flush") as forced:
             mgr._sweep_digest_holds(now)
         forced.assert_not_called()

--- a/test/test_wave_digest_double_finalize.py
+++ b/test/test_wave_digest_double_finalize.py
@@ -1,0 +1,218 @@
+"""A wave digest must fire exactly once, even around done-but-unreported members.
+
+``batch_members_pending()`` stops counting a member the moment ``info.done``
+flips, but that member's contribution to the consumer's ``bp["done"]`` only
+lands when its (shielded, possibly slow) terminal report actually reaches the
+completion consumer. In that window a SIBLING completion sees
+``done < total`` with no pending members, so the last-member fallback
+finalized the wave early — and the in-flight report then re-created the
+batch-progress record via ``setdefault`` and finalized the same wave a second
+time (issue #8554). Reachable with two RUNNING members alone: member A
+done-but-unreported while member B's report executes the consumer.
+
+The fix holds the fallback open while ``batch_reports_in_flight()`` — any
+registered member with ``done`` flipped whose report has not yet been consumed
+— and the consumer clears the flag in the same synchronous block that lands
+the done-count, so the flag and the count can never be observed apart.
+
+These tests drive the REAL ``_subagent_done`` closure (captured from
+``_init_subagents`` exactly like the cron-injection suite) with a scripted
+manager, so the race window is deterministic instead of a timing lottery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from kiro_crew.subagent import SubagentInfo
+
+
+def _build_gw():  # type: ignore[no-untyped-def]
+    """Minimal gateway whose captured ``on_done`` closure is the unit under test.
+
+    Same construction as ``TestCronSubagentInjection`` (test_cron_approval_mode):
+    ``__new__`` plus only the attributes the consumer actually reads. Batch
+    accounting additionally needs ``_batch_progress`` (normally created in
+    ``__init__``) and a slack/dashboard-free routing surface so the wave digest
+    lands on the patched cron-injection path.
+    """
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    gw = GatewayOrchestrator.__new__(GatewayOrchestrator)
+    gw.sessions = MagicMock()
+    gw.sessions.get_pid = MagicMock(return_value=None)
+    gw.ctx_builder = MagicMock()
+    gw.slack = None
+    gw.conv_log = None
+    gw.dashboard_state = None
+    gw._owner_id = "U000"
+    gw._cron_injecting = {}
+    gw._batch_progress = {}
+    gw._cfg = MagicMock()
+    gw._cfg.agent.max_subagents = 5
+    gw.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    gw.sessions.release = MagicMock()
+    gw.sessions.reset = AsyncMock()
+    gw.sessions.cancel_current = AsyncMock()
+    gw.ctx_builder.build_message = MagicMock(return_value=("msg", None))
+    gw.ctx_builder.memory = MagicMock()
+    gw._interactive_approval = MagicMock(return_value=AsyncMock(return_value=True))
+    return gw
+
+
+def _init_and_get_done_cb(gw):  # type: ignore[no-untyped-def]
+    captured_done = None
+
+    with patch("kiro_crew.slack.gateway.SubagentManager") as mock_cls:
+
+        def capture_mgr(**kwargs):  # type: ignore[no-untyped-def]
+            nonlocal captured_done
+            captured_done = kwargs["on_done"]
+            mgr = MagicMock()
+            mgr.running = []
+            mgr.queued_count_for = MagicMock(return_value=0)
+            return mgr
+
+        mock_cls.side_effect = capture_mgr
+        gw._init_subagents()
+
+    assert captured_done is not None
+    return captured_done
+
+
+def _member(agent_id: str, *, total: int = 2) -> SubagentInfo:
+    return SubagentInfo(
+        id=agent_id,
+        task=f"task {agent_id}",
+        result=f"result {agent_id}",
+        parent_session_key="cron:wave-parent",
+        done=True,
+        batch_id="w1",
+        batch_total=total,
+    )
+
+
+def _patches(stream_rv: str = "ok"):  # type: ignore[no-untyped-def]
+    return (
+        patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            AsyncMock(return_value=stream_rv),
+        ),
+        patch(
+            "kiro_crew.slack.gateway.redact_exfiltration_urls",
+            side_effect=lambda s: (s, False),
+        ),
+        patch(
+            "kiro_crew.slack.gateway.redact_credentials",
+            side_effect=lambda s: (s, False),
+        ),
+    )
+
+
+class TestWaveDigestDoubleFinalize:
+    def test_sibling_completion_in_the_done_but_unreported_window_does_not_close_the_wave(
+        self,
+    ) -> None:
+        """THE RACE, scripted: member A is done-but-unreported while sibling B's
+        report executes the consumer.
+
+        ``batch_members_pending`` returns False (A's ``done`` flag has flipped,
+        nothing queued) and ``batch_reports_in_flight`` returns True (A's
+        contribution has not landed). Before the fix, B's event finalized the
+        wave here — ``done=1 < total=2`` with the fallback tripping — and A's
+        in-flight report then re-created the record and finalized it AGAIN.
+        The wave must stay open until A's report is consumed, then close
+        exactly once.
+        """
+        gw = _build_gw()
+        done_cb = _init_and_get_done_cb(gw)
+        gw.subagent_mgr.batch_members_pending = MagicMock(return_value=False)
+        gw.subagent_mgr.batch_reports_in_flight = MagicMock(return_value=True)
+        gw.subagent_mgr.finalize_batch = MagicMock()
+
+        p1, p2, p3 = _patches()
+        with p1, p2, p3:
+            # Sibling B's report reaches the consumer inside A's window.
+            asyncio.run(done_cb(_member("b")))
+
+            # The wave is still open: not finalized, progress record retained,
+            # B's result held for the wave-close digest.
+            gw.subagent_mgr.finalize_batch.assert_not_called()
+            assert "w1" in gw._batch_progress
+            assert gw._batch_progress["w1"]["done"] == 1
+
+            # A's report is finally consumed (the consumer clears the hold in
+            # the same block that lands the count — modeled by the scripted
+            # predicate flipping with the arrival).
+            gw.subagent_mgr.batch_reports_in_flight.return_value = False
+            asyncio.run(done_cb(_member("a")))
+
+        # Exactly one finalize, and the record is gone — no second digest.
+        gw.subagent_mgr.finalize_batch.assert_called_once_with("w1")
+        assert "w1" not in gw._batch_progress
+
+    def test_in_flight_report_cannot_refinalize_after_the_wave_closed(self) -> None:
+        """No-double-fire control from the count side: once done reaches total,
+        the wave closes on the count alone and a stray flush-only re-entry for
+        the same batch does not resurrect or re-finalize it."""
+        gw = _build_gw()
+        done_cb = _init_and_get_done_cb(gw)
+        gw.subagent_mgr.batch_members_pending = MagicMock(return_value=True)
+        gw.subagent_mgr.batch_reports_in_flight = MagicMock(return_value=False)
+        gw.subagent_mgr.finalize_batch = MagicMock()
+
+        p1, p2, p3 = _patches()
+        with p1, p2, p3:
+            asyncio.run(done_cb(_member("a")))
+            gw.subagent_mgr.batch_members_pending.return_value = False
+            asyncio.run(done_cb(_member("b")))
+
+            flush = SubagentInfo(
+                id="fl1",
+                task="(wave digest flush)",
+                parent_session_key="cron:wave-parent",
+                done=True,
+                batch_id="w1",
+                batch_total=2,
+            )
+            flush._digest_flush_only = True
+            asyncio.run(done_cb(flush))
+
+        gw.subagent_mgr.finalize_batch.assert_called_once_with("w1")
+        assert "w1" not in gw._batch_progress
+
+    def test_spawn_failure_fallback_still_closes_the_wave(self) -> None:
+        """No-new-deny: the last-member fallback this fix constrains exists for
+        members that failed AT SPAWN and never reach the consumer, so
+        ``done`` can never hit ``total``. With nothing pending AND nothing
+        in flight, a sibling completion must still close the wave."""
+        gw = _build_gw()
+        done_cb = _init_and_get_done_cb(gw)
+        gw.subagent_mgr.batch_members_pending = MagicMock(return_value=False)
+        gw.subagent_mgr.batch_reports_in_flight = MagicMock(return_value=False)
+        gw.subagent_mgr.finalize_batch = MagicMock()
+
+        p1, p2, p3 = _patches()
+        with p1, p2, p3:
+            asyncio.run(done_cb(_member("b")))
+
+        gw.subagent_mgr.finalize_batch.assert_called_once_with("w1")
+        assert "w1" not in gw._batch_progress
+
+    def test_consumer_marks_the_member_report_consumed_with_the_count(self) -> None:
+        """The flag and the count land in the same synchronous block: after the
+        consumer accounts a member, that member no longer reads as an
+        in-flight report (this is what lets the real predicate flip exactly
+        when the scripted one did above)."""
+        gw = _build_gw()
+        done_cb = _init_and_get_done_cb(gw)
+        gw.subagent_mgr.batch_members_pending = MagicMock(return_value=True)
+        gw.subagent_mgr.batch_reports_in_flight = MagicMock(return_value=False)
+
+        member = _member("a")
+        assert member._report_consumed is False
+        p1, p2, p3 = _patches()
+        with p1, p2, p3:
+            asyncio.run(done_cb(member))
+        assert member._report_consumed is True

--- a/test/test_wave_digest_double_finalize.py
+++ b/test/test_wave_digest_double_finalize.py
@@ -23,9 +23,26 @@ manager, so the race window is deterministic instead of a timing lottery.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from kiro_crew.subagent import SubagentInfo
+from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+
+def _mk_real_manager(**kwargs):  # type: ignore[no-untyped-def]
+    """A REAL ``SubagentManager`` (no scripted seams) for the run-side tests.
+
+    Sessions double carries only the seams ``_run``'s terminal paths touch;
+    every process boundary stays stubbed — nothing here launches a runtime.
+    """
+    sessions = MagicMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+    sessions.record_success = MagicMock()
+    kwargs.setdefault("sessions", sessions)
+    kwargs.setdefault("ctx_builder", None)
+    return SubagentManager(**kwargs)  # type: ignore[arg-type]
 
 
 def _build_gw():  # type: ignore[no-untyped-def]
@@ -200,19 +217,184 @@ class TestWaveDigestDoubleFinalize:
         gw.subagent_mgr.finalize_batch.assert_called_once_with("w1")
         assert "w1" not in gw._batch_progress
 
-    def test_consumer_marks_the_member_report_consumed_with_the_count(self) -> None:
-        """The flag and the count land in the same synchronous block: after the
-        consumer accounts a member, that member no longer reads as an
+    def test_consumer_releases_the_hold_with_the_count(self) -> None:
+        """The hold release and the count land in the same synchronous block:
+        after the consumer accounts a member, that member no longer reads as an
         in-flight report (this is what lets the real predicate flip exactly
-        when the scripted one did above)."""
+        when the scripted one did above). The release goes to the manager-level
+        registry, so it survives the member having been popped from `_agents`
+        by an operator clear mid-flight."""
         gw = _build_gw()
         done_cb = _init_and_get_done_cb(gw)
         gw.subagent_mgr.batch_members_pending = MagicMock(return_value=True)
         gw.subagent_mgr.batch_reports_in_flight = MagicMock(return_value=False)
 
         member = _member("a")
-        assert member._report_consumed is False
         p1, p2, p3 = _patches()
         with p1, p2, p3:
             asyncio.run(done_cb(member))
-        assert member._report_consumed is True
+        gw.subagent_mgr.consume_report_hold.assert_called_once_with("w1", "a")
+
+
+class TestFailurePathFlipAndArmAreInseparable:
+    """The done-flip and the hold-arm must never be observable apart — on the
+    RUN side, not just inside the report machinery.
+
+    The c2 revision armed the hold at the top of ``_report_terminal`` (the
+    report task's first execution step). But on the failure paths
+    (``_run``'s timeout / cancel / exception except-bodies) ``info.done``
+    flips in the except-body, and the report task spawned by the ``finally``
+    does not run until after the coroutine yields at
+    ``_teardown_run_session``. At that yield a sibling completion reads the
+    member as neither pending (``not a.done`` drops it) nor in flight (never
+    armed) and closes the wave early; the member's report then finalizes it
+    a second time — the exact double-digest the hold exists to prevent.
+
+    These tests drive the REAL ``_run`` coroutine on a REAL manager and probe
+    the registry at the real yield point (a checkpoint patched over
+    ``_teardown_run_session``), so the window is checked deterministically
+    where the adjudicated finding located it, not via a timing lottery.
+    """
+
+    @staticmethod
+    def _mgr_and_member():  # type: ignore[no-untyped-def]
+        mgr = _mk_real_manager()
+        info = SubagentInfo(id="a-fail", task="t", batch_id="w9", batch_total=2)
+        mgr._agents[info.id] = info
+        return mgr, info
+
+    @staticmethod
+    def _checkpoint(mgr, info, seen):  # type: ignore[no-untyped-def]
+        async def _teardown_probe(_info, _session_key):  # type: ignore[no-untyped-def]
+            # The real run.py yield point: record what a sibling scheduled
+            # here would observe about this member.
+            seen.append((_info.done, mgr.batch_reports_in_flight(info.batch_id)))
+
+        return _teardown_probe
+
+    def test_exception_path_arms_in_the_same_synchronous_block(self) -> None:
+        mgr, info = self._mgr_and_member()
+        seen: list = []
+
+        async def _boom(_info, _sk):  # type: ignore[no-untyped-def]
+            raise RuntimeError("boom")
+
+        async def _drive() -> None:
+            with (
+                patch.object(mgr, "_run_inner", _boom),
+                patch.object(mgr, "_teardown_run_session", self._checkpoint(mgr, info, seen)),
+            ):
+                await mgr._run(info)
+
+        asyncio.run(_drive())
+        assert seen, "teardown checkpoint never reached"
+        done_at_yield, in_flight_at_yield = seen[0]
+        assert done_at_yield is True
+        # The window under attack: done observable without the hold.
+        assert in_flight_at_yield is True, (
+            "done-but-unarmed window at the teardown yield: a sibling "
+            "completion here closes the wave early and the report "
+            "re-finalizes it (issue #8554)"
+        )
+
+    def test_timeout_path_arms_in_the_same_synchronous_block(self) -> None:
+        mgr, info = self._mgr_and_member()
+        mgr._default_timeout = 0.001
+        seen: list = []
+
+        async def _slow(_info, _sk):  # type: ignore[no-untyped-def]
+            await asyncio.sleep(30)
+
+        async def _drive() -> None:
+            with (
+                patch.object(mgr, "_run_inner", _slow),
+                patch.object(mgr, "_teardown_run_session", self._checkpoint(mgr, info, seen)),
+            ):
+                await mgr._run(info)
+
+        asyncio.run(_drive())
+        assert seen and seen[0] == (True, True)
+
+    def test_cancel_path_arms_in_the_same_synchronous_block(self) -> None:
+        mgr, info = self._mgr_and_member()
+        info.user_stopped = True  # deterministic terminal (recovery-free) arm
+        seen: list = []
+        started = asyncio.Event()
+
+        async def _hang(_info, _sk):  # type: ignore[no-untyped-def]
+            started.set()
+            await asyncio.sleep(30)
+
+        async def _drive() -> None:
+            with (
+                patch.object(mgr, "_run_inner", _hang),
+                patch.object(mgr, "_teardown_run_session", self._checkpoint(mgr, info, seen)),
+            ):
+                run_task = asyncio.create_task(mgr._run(info))
+                await started.wait()
+                run_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await run_task
+
+        asyncio.run(_drive())
+        assert seen and seen[0] == (True, True)
+
+
+class TestStrandGuards:
+    """An early-armed hold must always have a releaser.
+
+    Arming at the flip (instead of inside the report body) creates one new
+    hazard: a report/announce task cancelled BEFORE its first execution step
+    never runs its body's structural ``finally`` release. A hold nothing
+    releases pins ``batch_reports_in_flight`` forever — and the reaper's
+    deadline sweep deliberately SKIPS waves with a report in flight, so even
+    the last-resort exit is fenced off. The task done-callbacks own the
+    rescue: by task-done time a report is not in flight on any path.
+    """
+
+    def test_report_task_cancelled_before_first_run_releases_the_hold(self) -> None:
+        mgr = _mk_real_manager()
+        info = SubagentInfo(id="a-strand", task="t", batch_id="w9", batch_total=2)
+        mgr._agents[info.id] = info
+        info.done = True
+        mgr.arm_report_in_flight(info)  # the flip-site arm
+
+        async def _drive() -> None:
+            task = mgr._spawn_terminal_report(
+                info,
+                source="Subagent",
+                injection_timeout_reason="t/o",
+                mark_delivered_on_success=True,
+            )
+            task.cancel()  # before its first execution step
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            # Let the done-callback run.
+            await asyncio.sleep(0)
+
+        asyncio.run(_drive())
+        assert mgr.batch_reports_in_flight("w9") is False, (
+            "a report task cancelled before first run stranded the hold — "
+            "the wave-close fallback and the reaper sweep are both fenced "
+            "off forever (issue #8554)"
+        )
+
+    def test_rejection_announce_cancelled_before_first_run_releases_the_hold(self) -> None:
+        async def _noop_done(_info):  # type: ignore[no-untyped-def]
+            return None
+
+        mgr = _mk_real_manager(on_done=_noop_done)
+        info = SubagentInfo(id="a-rej", task="t", batch_id="w9", batch_total=2)
+        info.done = True
+        mgr.arm_report_in_flight(info)  # the rejection flip-site arm
+
+        async def _drive() -> None:
+            mgr._announce_rejection(info)
+            task = mgr._tasks[f"reject-{info.id}"]
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await asyncio.sleep(0)
+
+        asyncio.run(_drive())
+        assert mgr.batch_reports_in_flight("w9") is False


### PR DESCRIPTION
## Problem / Motivation

A multi-member wave can emit its final digest **twice**, or emit a premature "wave finished" with results missing, when one member's `SubagentInfo.done` flips before that member's terminal report reaches the gateway completion consumer (issue #8554).

`batch_members_pending()` stops counting a member the moment `info.done` flips, but the member's contribution to the consumer's `bp["done"]` only lands when its (shielded, possibly slow) terminal report actually executes the consumer. In that gap, ANY sibling completion that reaches the consumer sees `done < total` AND `batch_members_pending() == False`, so the last-member fallback finalizes early — and the in-flight report then re-creates the batch-progress record via `setdefault` and "finalizes" the same wave again. Reachable with two RUNNING members alone: member A done-but-unreported while member B's report executes the consumer.

## Why it matters

The parent hears "wave finished — all results delivered" while a member's result is still in flight, then receives a second contradictory wave-close digest for the same batch. Both digests carry wrong counts (the premature one is missing the in-flight member entirely), the spawn-discipline gate releases early, and `finalize_batch` prunes wave bookkeeping twice. Anything a parent agent does on the strength of the first "complete" digest — spawning follow-ups, synthesizing results — runs against a wave that was not actually finished.

## What changed (motivation → approach → change)

Observed symptom: double/premature wave-close digests. Root cause: the done-but-unreported window above — the wave-close fallback consults a predicate (`batch_members_pending`) that stops counting a member strictly before the count it guards (`bp["done"]`) includes that member.

The change extends the issue's suggested direction — count a member as outstanding from `done=True` until its report enters the consumer:

- `WaveDigestCoordinator.batch_reports_in_flight_impl()` (new, `subagent_manager/waves.py`): True while any member of the batch is done-but-unreported. The consumer's last-member fallback now requires `not batch_members_pending(id) and not batch_reports_in_flight(id)`.
- The hold lives in a manager-level `_reports_in_flight` registry (`batch_id -> set of member ids`), NOT on the agent records: `_agents` membership is operator-mutable (`DELETE /api/spawn` pops every done member), so a predicate derived from it silently drops the hold when a clear-completed lands inside the window — reopening the exact hole it closes. The report machinery arms the hold in the same synchronous block that flips `info.done` (safe-announced synthetics arm immediately before their announce; flush-only records never arm), and the consumer (`slack/gateway.py`) releases it in the same synchronous block that increments `bp["done"]`, so the hold and the count can never be observed apart.
- A report that ends **without** reaching the consumer releases its hold through ONE structural `try/finally` wrapping the entire report body past the done-flip (`subagent_manager/terminal.py`, mirrored for `_safe_announce` in `subagent_manager/admission.py` — covers the registered approval-parked rejection): injection timeout, announce failure, cancellation, and early returns all funnel through it, preserving the wave's degraded a-sibling-can-close liveness instead of stranding. The cancelled-recovery limbo arm (`subagent_manager/cancellation.py`) needs no release at all: holds are armed only at a report's done-flip, which that arm's `not info.done` guard proves never ran.
- The reaper's digest-hold sweep is in-flight-aware in both directions: it skips a wave only while its close is genuinely in flight, and force-flushes a wave whose hold aged past the deadline with **no** report in flight — the state where the wave-close flush is never coming (a terminal report ended without reaching the consumer); previously that state was unsweepable and the held sibling results stranded until gateway restart.

Commit 2 (review round): the first commit kept the hold as a flag on the agent records (`_report_consumed`) with four per-arm clears. Review convicted the record-derived predicate — an operator clear-completed landing inside the done-but-unreported window popped the member from `_agents` and the hold evaporated with it, reopening the premature-finalize hole (probe: hold established → operator clear → `batch_reports_in_flight` flips False at the commit-1 tree; stays True after). Commit 2 moves the hold to the manager registry, replaces the per-arm clears with the structural `finally`, and closes both design concerns raised alongside: a stranded hold is now sweepable, and a report-path failure on the final member no longer parks held siblings behind an unconditional sweep skip.

Alternatives considered and rejected:

- **Per-batch outstanding-report counter** (the issue's other sketch): a counter decremented "at the top of the report path" is distributed arithmetic with an increment/decrement pairing to keep balanced across the shield, `_force_reap`, and cancel-recovery — a missed or doubled decrement is invisible (the count is just wrong). The registry keeps per-member identity instead: release is an idempotent `discard` keyed by member id (double-release harmless, structurally guaranteed by the report path's `finally`), and a stranded entry names exactly which member stranded. Commit 1's per-member flag had the same idempotence but derived the predicate from `_agents` membership; the registry keeps the flag design's degrade-safety without the membership dependence.
- **Consulting report-task liveness**: report tasks are shielded and keyed by several owners (`_tasks[id]`, recovery keys, queued-stop synthetics); deriving "in flight" from task registry state couples wave accounting to task-registry lifecycle details that `cancel_all()` and the reaper mutate mid-teardown.
- **Generalizing a `_batch_unqueued_pending` bridge**: the issue notes the #8270-adjacent bridge as prior art, but it never landed on main (its PR closed unmerged), so there is nothing to generalize — this change stands alone against current main.

Scope note: if the FINAL member's report terminally fails (timeout/announce-failure), no later completion re-evaluates the wave. Commit 1 left that pre-existing gap to the reaper's sweep as backstop; commit 2 makes the sweep actually able to take it — the in-flight-aware guard force-flushes an aged hold with no report in flight, where before the sweep skipped every no-pending-members wave unconditionally. Held sibling results now flush after the hold deadline instead of stranding until restart.

## Tests

`test/test_wave_digest_double_finalize.py` (new) drives the REAL `_subagent_done` closure (captured from `_init_subagents`, same construction as the existing cron-injection suite) with a scripted manager, so the race window is deterministic instead of a timing lottery:

- `test_sibling_completion_in_the_done_but_unreported_window_does_not_close_the_wave` — THE race: fails before the fix with `Expected 'finalize_batch' to not have been called. Called 1 time` (the premature finalize), passes after; then the in-flight report lands and the wave closes exactly once.
- `test_in_flight_report_cannot_refinalize_after_the_wave_closed` — count-side no-double-fire control (passes both sides).
- `test_spawn_failure_fallback_still_closes_the_wave` — no-new-deny control: the fallback this fix constrains still closes waves whose members failed at spawn (passes both sides).
- `test_consumer_releases_the_hold_with_the_count` — pins the hold-release/count same-block contract; the release goes to the manager-level registry, so it survives the member having been popped from `_agents` by an operator clear mid-flight.

`test/test_subagent_coverage.py` (extended, sibling of `TestBatchMembersPending`):

- `TestBatchReportsInFlight` — 8 predicate/registry pins: done-but-unreported → True; consumed → False **and the wave's registry entry is pruned, not left empty**; `test_operator_clear_cannot_drop_the_hold` — THE commit-2 conviction: the hold survives the member being popped from `_agents` (what `DELETE /api/spawn` does to done members) and the consumer still releases by id; flush-only synthetics never arm; release is idempotent and unarmed release is a no-op; `finalize_batch` prunes the registry; still-running member → False (that is `batch_members_pending`'s job — the arm happens only at the report's done-flip); other wave's member → False.
- `TestReportsInFlightStrandBackstops` — 5 pins that the structural `finally` releases however a report ends: injection-timeout arm and announce-failure arm (each also asserts the hold was VISIBLE mid-announce — armed at the done-flip, released only when the report ended); `_safe_announce` failure arm (arms before its announce, releases on the raise); the happy path (hold visible to the consumer, released with the count, the report's `finally` re-release an idempotent no-op); the cancelled-recovery limbo arm (driven deterministically: recovery parked on its original-task wait, then cancelled) never strands the wave — a record terminalized there never carried a hold.
- `TestSweepDigestHolds` — the sweep's two new directions: `test_closing_wave_not_forced` (hold armed → skip: the real wave-close flush is in flight) and `test_stranded_hold_past_deadline_is_forced` (no pending members, no hold, deadline passed → force-flush fires with the wave's parent key: the previously unsweepable stranded state).

`test/test_subagent_scale.py` (adjacent pins updated to the commit-2 contract): the settle-after-`_on_done` source inspection follows the report body into `_report_terminal_guarded_impl` (the split that hosts the structural `finally`), and `TestDigestHoldDeadline.test_closing_wave_is_not_force_flushed` now arms the in-flight hold — the aged-hold state WITHOUT one is the stranded state the sweep must flush.

Fails-before, commit 1 (fix stashed, committed tests kept): **12 failed / 2 passed** — failures are the race conviction plus the predicate/hold absence; the 2 passes are the two both-sides controls. Fixed tree: **14/14**.

Fails-before, commit 2 (at the commit-1 tree): the operator-clear probe — hold established (`in_flight=True`), `DELETE /api/spawn`-equivalent pop, `in_flight` flips **False** (premature-finalize hole reopened); at the commit-2 tree the same probe holds **True** through the pop. `test_stranded_hold_past_deadline_is_forced` also fails at the commit-1 tree (`force_digest_flush` never called — the sweep skipped every no-pending-members wave unconditionally). Full gate mirror green at each commit: targeted + seam-neighbor suites (subagent, batch injection, scale, reap-race, approval-parked, delivery-TTL, manager boundaries, persistence), mypy clean on all six touched source files, flake8/isort clean, black baseline gate pass, docs-lint pass.

## Manual verification

N/A — unit coverage sufficient: the race is convicted deterministically through the real completion-consumer closure with a scripted manager (no timing dependence), and both liveness directions (hold open / never strand) are pinned at the manager level.

## Screenshots / video

<!-- no-visual-delta -->
No visual delta: backend-only PR — subagent wave-close logic, gateway wiring, docs, and tests; zero rendered surfaces change.

## Related Issues

Part of #8554 — addresses the done-but-unreported double-finalize mechanism; the issue also discusses whether the finalize decision should move entirely onto the report path (single source of truth), which is a maintainer-owned design question this change deliberately leaves open.

## Pattern harvest

Rule candidate: review-prompt — "when a completion decision combines a COUNT (incremented by consumers) with a PREDICATE (derived from state flags), verify the predicate keeps counting every entity until its count contribution lands; a predicate that releases before the count includes it opens an early-completion window between the two." The same shape is worth checking anywhere a `done`-style flag feeds a pending-predicate while a separate consumer owns the tally.

Adjacent audit performed (not changed here): every `done = True` writer in `subagent_manager/` was audited for report routing — run-path arms report via the finalize claim, the reap path reports, admission rejections announce, queued-stop synthetics register-then-report, lost-submission/digest-flush synthetics never register (invisible to the predicate by construction). The cancelled-recovery limbo arm was the one report-free writer, and it is covered in this change.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/system-specs/modules/subagent.md` (the AGENTS.md-routed owning doc) gains the wave-close contract paragraph and the cancelled-recovery hold-clearing note, same commit
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Per the template placeholder (CLA text pending): offered under the same terms as my prior merged contributions to this repository (#8835).