### PR TITLE
fix: pin test_channel_slots reconcile tests to a frozen clock so long shards cannot decay eligibility

### DIFF
--- a/test/test_channel_slots.py
+++ b/test/test_channel_slots.py
@@ -29,7 +29,27 @@ from kiro_crew.messaging.link import (
     is_channel_session_key,
 )
 
+# Shared time origin for session stamps. Captured at import, so any test whose
+# production path reads the LIVE clock must also pin that clock to NOW (see
+# ``frozen_clock``) — otherwise eligibility decays with elapsed shard time and
+# the module fails deterministically once a shard runs past the recency window
+# (#8968).
 NOW = time.time()
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin ``time.time`` to the module's NOW for tests that call the real
+    reconcile pass.
+
+    ``reconcile_channel_slots`` derives its recency cutoff from the live clock
+    (``channel_slots.py``: ``cutoff = time.time() - window_minutes * 60``),
+    while fixtures stamp sessions against the import-time NOW. Freezing the one
+    clock both sides read makes eligibility pure arithmetic: the tests hold at
+    any elapsed time, and the ``== 0`` assertions cannot pass vacuously because
+    an eligible stamp can never age out mid-suite.
+    """
+    monkeypatch.setattr(time, "time", lambda: NOW)
 
 
 @pytest.fixture
@@ -470,6 +490,7 @@ class _FakeLog:
         return list(self.transcripts.get(key, []))
 
 
+@pytest.mark.usefixtures("frozen_clock")
 class TestReconcilePass:
     def test_surfaces_eligible_and_pushes_once(self, dashboard_state: Any) -> None:
         dashboard_state.conversation_log = _FakeLog(
@@ -898,6 +919,7 @@ class TestClosedAtStamp:
         assert "closed_at" not in meta
 
 
+@pytest.mark.usefixtures("frozen_clock")
 class TestReconcileMore:
 
     def test_a_steady_state_pass_re_reads_metadata_but_no_transcripts(
@@ -961,6 +983,67 @@ class TestReconcileMore:
         assert "slack_2.2" in dashboard_state._slots
 
 
+class TestReconcileClockCoherence:
+    """Regression pins for #8968: reconcile eligibility verdicts must be a
+    function of the stamps alone, never of wall-clock time elapsed since this
+    module was imported.
+
+    ``NOW`` is captured at import while the real pass computes its cutoff from
+    the live clock, so before ``frozen_clock`` the module had a 30-minute shelf
+    life: any CI shard running longer aged every default stamp out of the
+    window, failing the nonzero assertions while the ``== 0`` ones passed
+    vacuously. These pins simulate the long-running shard directly instead of
+    waiting to become one.
+    """
+
+    #: Simulated seconds since module import — well past every window in use.
+    ELAPSED = 7200.0
+
+    def _freeze(self, monkeypatch: pytest.MonkeyPatch, instant: float) -> None:
+        monkeypatch.setattr(time, "time", lambda: instant)
+
+    def test_a_fresh_stamp_survives_any_shard_elapsed_time(
+        self, dashboard_state: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A session stamped at the pass's own now is eligible even when the
+        module has been imported for hours — the exact spot the defect fired."""
+        pass_now = NOW + self.ELAPSED
+        self._freeze(monkeypatch, pass_now)
+        log = _FakeLog([_session("slack:1.1", modified=pass_now)], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert "slack_1.1" in dashboard_state._slots
+
+    def test_the_window_still_filters_under_a_frozen_clock(
+        self, dashboard_state: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Freezing the clock must not disable the recency rule: a stamp older
+        than the window is still filtered, keeping the suite's ``== 0``
+        verdicts meaningful rather than vacuous."""
+        pass_now = NOW + self.ELAPSED
+        self._freeze(monkeypatch, pass_now)
+        log = _FakeLog([_session("slack:1.1", modified=pass_now - 1801)], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 0
+        assert dashboard_state._slots == {}
+
+    def test_a_stamp_exactly_at_the_cutoff_is_eligible(
+        self, dashboard_state: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Boundary pin: eligibility filters strictly (``modified < cutoff``),
+        so a session exactly at the window edge still surfaces. Guards the
+        comparison against drifting to ``<=`` now that the clock is pinnable."""
+        pass_now = NOW + self.ELAPSED
+        self._freeze(monkeypatch, pass_now)
+        log = _FakeLog([_session("slack:1.1", modified=pass_now - 1800)], {})
+        dashboard_state.conversation_log = log
+        dashboard_state.push_slots_update = lambda: None  # type: ignore[method-assign]
+        assert asyncio.run(channel_slots.reconcile_channel_slots(dashboard_state, 30)) == 1
+        assert "slack_1.1" in dashboard_state._slots
+
+
 class TestImmediateDispatcherSurface:
     def test_reconciles_with_the_configured_restore_window(
         self, dashboard_state: Any, monkeypatch: pytest.MonkeyPatch
@@ -1012,6 +1095,7 @@ class TestImmediateDispatcherSurface:
         assert not called
 
 
+@pytest.mark.usefixtures("frozen_clock")
 class TestFailedTranscriptReadDefers:
     """A read failure must not look like an empty conversation.
 


### PR DESCRIPTION
## Problem / Motivation

`Backend Tests (3.12, N)` fails with 10 errors in `test/test_channel_slots.py` (all `assert 0 == 1` / `assert 0 == 2`) on any shard that runs longer than ~30 minutes. The file passes in seconds when run alone, so it reads as a flake — but it is deterministic in elapsed time, and shard composition reshuffles (no committed `.test_durations`, so pytest-split balances by count) decide which PRs get hit. Observed on run 34021088434, where the shard ran 37:27 and all 10 failed on every xdist worker.

## Why it matters

Every PR is exposed: the slowest 3.12 shard already runs ~29 minutes, within one minute of the 1800s window this module silently depends on. Any shard growth or reshuffle trips it, costing contributors a spurious red CI round and re-run time. Worse, past the window the suite's `== 0` assertions keep passing vacuously — everything is ineligible, so the tests stop testing what they were written to test before they fail loudly.

## What changed (motivation → approach → change)

- **Symptom**: reconcile tests fail once elapsed-since-import exceeds the recency window.
- **Root cause**: `NOW = time.time()` is captured at module import and stamps sessions via `_session()`, while `reconcile_channel_slots` derives its cutoff from the **live** clock (`cutoff = time.time() - window_minutes * 60`). A session stamped `modified=NOW` is eligible only while `time.time() - NOW < 1800`.
- **Change** (option 2 from the issue — freeze the production clock): a `frozen_clock` fixture pins `time.time` to the module's `NOW` for the three classes that drive the real reconcile pass, so stamps and cutoff read one clock and eligibility becomes pure arithmetic at any elapsed time. Applied to `TestReconcilePass`, `TestReconcileMore`, **and `TestFailedTranscriptReadDefers`** — the latter was not in the CI failure list only because its window is 60 minutes: the same landmine one slow shard further out (reproduced: shifting `NOW` by −4000s fails `test_a_genuinely_empty_transcript_still_surfaces` on `main`).
- Classes that pass an explicit `cutoff=NOW - 1800` (self-consistent) or that legitimately bracket production writes with live-clock reads (`TestClosedAtStamp`, `TestCompareAndClear`, `TestMtimeOf`) are deliberately **not** frozen — freezing them would change what they verify.
- Freezing `time.time` also makes the previously wall-clock-coupled assertions exact: the snapshot-cutoff bracket (`before <= cutoff <= after`) collapses to equality, and tombstone TTL arithmetic is unchanged. `asyncio` scheduling uses `time.monotonic`, which is untouched.

## Tests

- `TestReconcileClockCoherence::test_a_fresh_stamp_survives_any_shard_elapsed_time` — the defect's exact firing point: a session stamped at the pass's own now surfaces even with 7200 simulated seconds elapsed since import (fails on `main`'s shape).
- `TestReconcileClockCoherence::test_the_window_still_filters_under_a_frozen_clock` — a stamp older than the window is still filtered: the freeze does not disable the recency rule, so `== 0` verdicts stay meaningful (guards against the vacuous-pass failure mode).
- `TestReconcileClockCoherence::test_a_stamp_exactly_at_the_cutoff_is_eligible` — boundary pin: eligibility filters strictly (`modified < cutoff`); a stamp exactly at the edge surfaces.
- Fails-before / fails-after: with `NOW = time.time() - 2000` (the issue's reproduction) `main` fails the same 10 tests byte-for-byte; with this fix the full file passes 73/73 at rest, under −2000s, and under −4000s.
- Seam neighbors: 59 test files touching `channel_slots` / `chat_persistence` pass (5063 tests).

## Manual verification

N/A — unit coverage sufficient: the defect and fix are both fully expressed in the test process (clock perturbation reproduces CI's elapsed-time condition deterministically).

## Screenshots / video

<!-- no-visual-delta -->
Test-only change to one backend test file; zero shipped pixels, no UI surface touched.

## Related Issues

Fixes #8968

## Pattern harvest

Rule candidate: lint
Pattern: module-level `NOW = time.time()` in a test file whose subject reads the live clock — stamps decay against the code under test as shard elapsed time grows; flag module-scope wall-clock captures used as default fixture stamps.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test-only change
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

I confirm this contribution is made under the same terms as my prior merged contributions to this repository (#8835).
