### PR TITLE
fix(acp): retry transient connection failures

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1834,6 +1834,13 @@ _RE_5XX_NAMED = re.compile(
     re.IGNORECASE,
 )
 _RE_5XX_STATUS = re.compile(r"(?:HTTP|status)\s*(?:code\s*)?(?:50[0234]|529)\b", re.IGNORECASE)
+_RE_CONNECTION = re.compile(
+    r"\bE(?:CONNREFUSED|CONNRESET|CONNABORTED|TIMEDOUT|PIPE|HOSTUNREACH|AI_AGAIN)\b"
+    r"|\bsocket hang ?up\b"
+    r"|\bfetch failed\b"
+    r"|\bconnection (?:refused|reset|closed|error|timed ?out)\b",
+    re.IGNORECASE,
+)
 # Genuine retry hint only. "response stream" is deliberately NOT matched here,
 # because that would make this branch a catch-all: kiro-cli wraps EVERY mid-stream
 # provider failure as "Encountered an error in the response stream: <real cause>",
@@ -2057,9 +2064,10 @@ def _is_transient_raw_error(error: object, available_models: Sequence[str] | Non
     unentitled-model(terminal) → usage-limit(terminal) →
     malformed-request(terminal) → model-unavailable → throttle →
     credential-propagation(transient) → auth(terminal) →
-    session-expiry(terminal) → generic 5xx / pre-stream generation failure →
-    unknown(terminal). Every step mirrors :func:`_format_acp_error`'s if/elif
-    order EXCEPT malformed-request, which that formatter checks LAST: this
+    session-expiry(terminal) → connection failure(transient) → generic 5xx /
+    pre-stream generation failure → unknown(terminal). Every step mirrors
+    :func:`_format_acp_error`'s if/elif order EXCEPT malformed-request, which
+    that formatter checks LAST: this
     classifier deliberately hoists it above the 5xx family so a co-occurring
     connector token or retry hint cannot rescue a payload the backend rejected
     for its shape (see
@@ -2117,6 +2125,9 @@ def _is_transient_raw_error(error: object, available_models: Sequence[str] | Non
     if _is_session_expired(haystack):
         # Session expiry is terminal — retrying can't refresh an expired login.
         return False
+    if _RE_CONNECTION.search(haystack):
+        # A temporary endpoint failure is safe for the bounded retry ladder.
+        return True
     return bool(
         _RE_5XX_NAMED.search(haystack)
         or _RE_5XX_STATUS.search(haystack)
@@ -2557,6 +2568,13 @@ def _format_acp_error(
                 f"{host_auth.signed_out_message(backend)} "
                 "Retrying or switching models will not help — this is a "
                 "sign-in issue, not a backend error."
+                f"{req_id_suffix}"
+            )
+        elif _RE_CONNECTION.search(haystack):
+            formatted = (
+                "Could not reach the model backend (connection refused, reset, "
+                "or timed out). Retry in a moment. If it keeps happening, check "
+                "that the backend endpoint is up and listening."
                 f"{req_id_suffix}"
             )
         elif (

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -132,6 +132,18 @@ _TRANSIENT_MARKERS = (
     # in the request is invalid") is matched structurally instead — see the
     # is_credential_propagation_delay call below.
     "credential-propagation delay",
+    # Connection-level failures (client._RE_CONNECTION): raw errno tokens for
+    # restored errors, plus the formatter's wording for fresh ones.
+    "econnrefused",
+    "econnreset",
+    "econnaborted",
+    "etimedout",
+    "epipe",
+    "ehostunreach",
+    "eai_again",
+    "socket hang up",
+    "fetch failed",
+    "could not reach the model backend",
 )
 
 

--- a/test/test_acp_error_surface.py
+++ b/test/test_acp_error_surface.py
@@ -449,6 +449,58 @@ class TestTransientMarkerCoupling:
         assert "set agent.model to 'auto'" in _format_acp_error(unnamed, with_auto)
 
 
+class TestConnectionErrorClassification:
+    """Connection failures are transient, while credential failures win precedence."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "fetch failed",
+            "connect ECONNREFUSED 127.0.0.1:8484",
+            "Connection error.",
+            "socket hang up",
+            "read ECONNRESET",
+            "connect ETIMEDOUT 127.0.0.1:8484",
+            "getaddrinfo EAI_AGAIN fleet-router",
+            "write EPIPE",
+        ],
+    )
+    def test_connection_failures_are_transient(self, text):
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        assert _is_transient_raw_error({"code": -32603, "message": text, "data": ""})
+
+    def test_dns_resolution_failure_stays_terminal(self):
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        assert not _is_transient_raw_error(
+            {"code": -32603, "message": "getaddrinfo ENOTFOUND fleet-router", "data": ""}
+        )
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            "Monthly usage limit has been reached. connect ECONNREFUSED 127.0.0.1:8484",
+            "AccessDeniedException after connect ETIMEDOUT 127.0.0.1:8484",
+        ],
+    )
+    def test_terminal_branches_keep_precedence_over_connection(self, data):
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        assert not _is_transient_raw_error({"code": -32603, "message": "", "data": data})
+
+    def test_formatted_connection_wording_classifies_via_fallback(self):
+        from kiro_crew.acp.client import _format_acp_error
+        from kiro_crew.llm_helpers import is_transient_backend_error
+
+        formatted = _format_acp_error(
+            {"code": -32603, "message": "connect ECONNREFUSED 127.0.0.1:8484", "data": ""}
+        )
+
+        assert "Could not reach the model backend" in formatted
+        assert is_transient_backend_error(formatted)
+
+
 class TestMalformedRequestReachesTheHandlePath:
     """The shared-runtime path must surface the structural-rejection guidance
     (#6022) and carry a terminal verdict, mirroring TestNoRawDictInUserFacingError.


### PR DESCRIPTION
## Problem / Motivation

ACP connection failures such as refused/reset/timeouts and plain service-unavailable responses are currently terminal, though they can clear without user intervention.

## Why it matters

A transient backend or transport outage ends a session unnecessarily instead of using the existing bounded retry path.

## What changed

Classify common connection failures and plain 5xx service-unavailable responses as retryable. Authentication, quota, and session-expiry classifications retain precedence. The surfaced fallback now tells the user that the backend could not be reached.

## Tests

`python -m pytest test/test_acp_error_surface.py test/test_acp_client.py -n0 -q` — 651 passed.

## What changed (motivation → approach → change)

N/A — covered by the existing `## What changed` section.

## Manual verification

N/A — focused automated coverage is sufficient.

## Related Issues

N/A.

## Checklist

- [x] Existing tests pass and regression coverage is included.
- [x] Self-review completed; code follows project style guidelines.
- [x] Documentation updated where applicable.
- [x] No secrets, credentials, or internal references in the diff.

## Contribution License Agreement

N/A — template placeholder; no CLA wording is supplied.

## Pattern harvest

Not generalizable: this is a bounded adapter-startup retry at a specific process-creation boundary.
