### PR TITLE
fix(acp): back off before retrying adapter startup

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -206,6 +206,9 @@ KIRO_CLI_BIN = "kiro-cli"
 KIRO_CLI_SUBCMD = "acp"
 
 CLAUDE_ACP_BIN = "claude-agent-acp"
+# A self-updating ACP adapter can briefly disappear or remain locked while its
+# executable is replaced. Delay the one permitted startup retry past that window.
+_ACP_RESPAWN_BACKOFF_S = 2.0
 # On-disk name of the Claude backend CLI.  The claude-agent-acp adapter
 # delegates the actual model turn to @anthropic-ai/claude-agent-sdk, which
 # needs a per-platform native binary (~250 MB each).  Those ship as npm
@@ -5526,11 +5529,13 @@ class AcpClient:
                     await self._cleanup_failed_live_spawn()
                     self._reset_state()
                     raise
-                except (AcpTimeoutError, AcpError) as exc:
+                except (AcpTimeoutError, AcpError, OSError) as exc:
                     if attempt == 0:
                         logger.warning("ACP init failed (%s), retrying with fresh process...", exc)
                         await self._cleanup_failed_live_spawn()
                         self._reset_state()
+                        if isinstance(exc, OSError):
+                            await asyncio.sleep(_ACP_RESPAWN_BACKOFF_S)
                     else:
                         # AcpAuthRequired subclasses AcpError; label it distinctly
                         # so a not-logged-in exit is never counted as a generic

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -3718,6 +3718,35 @@ class TestEnsureReadyRetryOnAcpError:
         client._kill_process.assert_called_once_with(force=True)
 
     @pytest.mark.asyncio
+    async def test_retries_spawn_os_error_after_backoff(self, monkeypatch):
+        client = AcpClient()
+        client._work_dir_ready = True
+        spawn_count = 0
+
+        async def fake_spawn():
+            nonlocal spawn_count
+            spawn_count += 1
+            if spawn_count == 1:
+                raise FileNotFoundError("adapter replaced in place")
+            client._process = MagicMock(returncode=None, pid=101)
+
+        async def fake_init():
+            client._session_id = "sess-ok"
+
+        sleep = AsyncMock()
+        client._spawn = fake_spawn
+        client._initialize_session = fake_init
+        client._cleanup_failed_live_spawn = AsyncMock()
+        client._snapshot_process_tree = AsyncMock()
+        monkeypatch.setattr(acp_client.asyncio, "sleep", sleep)
+
+        await client.ensure_ready()
+
+        assert spawn_count == 2
+        sleep.assert_awaited_once_with(acp_client._ACP_RESPAWN_BACKOFF_S)
+        client._cleanup_failed_live_spawn.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_cancel_during_retry_kill_releases_bound_workspace(self, tmp_path, monkeypatch):
         client = AcpClient(work_dir=tmp_path)
         kill_entered = asyncio.Event()


### PR DESCRIPTION
## Problem / Motivation

An ACP adapter self-update can briefly leave its executable missing or locked while it is replaced in place. The immediate startup retry repeats that race.

## Why it matters

A recoverable adapter replacement can be reported as an unusable ACP backend even though waiting briefly permits the next spawn.

## What changed

Retry one spawn-level `OSError` after a two-second delay. Existing timeout and ACP-error retry timing remains unchanged.

## Tests

`python -m pytest test/test_acp_client.py -n0 -q` — 604 passed.

## What changed (motivation → approach → change)

N/A — covered by the existing `## What changed` section.

## Manual verification

N/A — focused automated coverage is sufficient.

## Related Issues

N/A.

## Checklist

- [x] Existing tests pass and regression coverage is included.
- [x] Self-review completed; code follows project style guidelines.
- [x] Documentation updated where applicable.
- [x] No secrets, credentials, or internal references in the diff.

## Contribution License Agreement

N/A — template placeholder; no CLA wording is supplied.

## Pattern harvest

Not generalizable: this is a bounded adapter-startup retry at a specific process-creation boundary.
