### PR TITLE
feat(dashboard): badge an installed app's rail row from its own notifications

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -150,6 +150,7 @@ import WindowsTitlebarMenu from './components/WindowsTitlebarMenu'
 
 import { i18nT } from './i18n/t'
 import { appNavTarget } from './appNav'
+import { appNotificationBadges, isAppNavId, mergeAppBadges } from './appNotificationBadges'
 import { resolveSlotOverlays, type SlotOwners } from './apps/overlaySlots'
 import { fmtCompact, fmtNumber, fmtPercent, fmtUnit } from './i18n/format'
 // Static on purpose, and the tradeoff is real: the sidebar updates badge
@@ -2067,6 +2068,31 @@ export default function App() {
     [appBadges, appUpdatesCount],
   )
 
+  // Rail badges for INSTALLED apps, derived from notifications the app already
+  // published: the host stamps `source: "app:<name>"` on every pushed record
+  // and owns the `acked` flag, so the count needs no new manifest field and no
+  // new app-implemented route -- see `appNotificationBadges`.
+  //
+  // Merged only into the badge map the rail rows read -- NOT into the
+  // `appBadges` state, for the same reason `discoverBadges` above stays out of
+  // it: that map feeds the tab-title `totalAttention` sum, and the
+  // notifications bell ALREADY badges these same records, so adding them there
+  // would count one notification twice in the tab title.
+  //
+  // An app that pushes its own count through `useNavBadge()` still wins on its
+  // own key, so an app using the SDK hook today sees no change at all; the
+  // derivation only fills rows that had no badge.
+  //
+  // Handed ONLY to rows that pass `isAppNavId` (see the call site). `NavBadge`
+  // keys its fallback on the BARE navId for an unprefixed row, so a host row
+  // such as `schedule` indexes the same map an app name would -- an app could
+  // otherwise put attention on host chrome by choosing its own name.
+  const notificationItems = useAppSelector(s => s.notifications.items)
+  const railAppBadges = useMemo(
+    () => mergeAppBadges(appBadges, appNotificationBadges(notificationItems)),
+    [appBadges, notificationItems],
+  )
+
   const [updating, setUpdating] = useState(false)
   const [showUpdateModal, setShowUpdateModal] = useState(false)
   const [kiroUsageOpen, setKiroUsageOpen] = useState(false)
@@ -2823,7 +2849,7 @@ export default function App() {
       collapsed={effectiveCollapsed}
       onClick={closeMobileNav}
       onClickOverride={isChat && (activePath === n.path || activePath.startsWith(n.path + '/')) ? () => window.dispatchEvent(new Event('toggle-pin-chat-sidebar')) : undefined}
-      badge={<NavBadge navId={n.id} collapsed={effectiveCollapsed} appBadges={appBadges} />}
+      badge={<NavBadge navId={n.id} collapsed={effectiveCollapsed} appBadges={isAppNavId(n.id) ? railAppBadges : appBadges} />}
     />
   )
 

--- a/website/src/appNotificationBadges.ts
+++ b/website/src/appNotificationBadges.ts
@@ -1,0 +1,173 @@
+/**
+ * Per-app rail badge counts, derived from notifications the app already published.
+ *
+ * An app that wants to signal "something is waiting for you" already has a
+ * public route for it, and it is not a new one: it declares
+ * `notifications.channels[]` in its manifest (`apps/manifest.py`
+ * `NotificationChannel`) and pushes through `POST /api/notifications/push`.
+ * The HOST stamps the producer onto every stored record as `source:
+ * "app:<name>"` -- `notifications_push.py` marks that "server-resolved; body
+ * cannot override" -- and `acked` is a RESERVED note key, so an app can neither
+ * forge another app's attribution nor pre-acknowledge its own note.
+ *
+ * So the number a rail badge needs is already in the notification list the
+ * dashboard fetches. Nothing here asks an app to declare a new manifest field
+ * or implement a new endpoint; this module is only the join the dashboard was
+ * missing: unacknowledged notes, grouped by the app the host attributed them to.
+ *
+ * Why the badge cannot simply come from the app's own frontend: `useNavBadge()`
+ * exists and is public, but it is a hook inside the app's UI bundle, which is
+ * imported when its page mounts. Before the user has opened the app there is no
+ * app code running to call it -- which is exactly the case a "something is
+ * waiting" badge is for. A notification pushed by the app's BACKEND does not
+ * have that problem.
+ */
+
+/**
+ * The prefix the host stamps onto an app-published notification's `source`.
+ *
+ * Server-side spelling is `f"app:{app_name}"`, so the app name is everything
+ * after this prefix. Matched as a prefix rather than by splitting on ":"
+ * because an app name cannot contain one but a future source scheme might.
+ */
+export const APP_SOURCE_PREFIX = 'app:'
+
+/**
+ * Upper bound on a rendered per-app count.
+ *
+ * The count is influenced by app-supplied content -- an app decides how many
+ * notifications to push -- and it is rendered in the host's own chrome, where
+ * an unbounded number is a layout- and spoofing-surface rather than
+ * information. Bounding it here keeps the cap on the value this module
+ * introduces; it deliberately does not reach into `BadgeIndicator`, whose other
+ * callers are host-owned counts and are not this change's business.
+ */
+export const MAX_APP_BADGE_COUNT = 99
+
+/**
+ * Nav-id prefix an AppHost-routed app's rail row carries (`appNav.ts` builds
+ * `app-<name>`).
+ *
+ * Load-bearing for safety, not cosmetics. `NavBadge` keys its fallback lookup on
+ * the BARE name for a row without this prefix, so a host row's own id -- e.g.
+ * `schedule` -- indexes the same map an app name would. Derived counts must
+ * therefore reach ONLY prefixed rows, or an app could put attention on host
+ * chrome by choosing its name.
+ */
+export const APP_NAV_ID_PREFIX = 'app-'
+
+/**
+ * Whether *navId* is an installed app's row, and so may show a derived count.
+ *
+ * Every installed app is AppHost-routed and therefore prefixed; a bare id is a
+ * host surface (or a native builtin), which keeps its own badge source.
+ */
+export function isAppNavId(navId: string): boolean {
+  return navId.startsWith(APP_NAV_ID_PREFIX)
+}
+
+/**
+ * The subset of a notification this derivation reads.
+ *
+ * Pinned locally rather than importing the full `Notification` type, for the
+ * reason `appNav.ts` pins its own `/api/apps` subset: a field this derivation
+ * depends on cannot then quietly change shape underneath it. Both fields are
+ * optional in the wire type, and both are host-written.
+ */
+export interface BadgeNote {
+  /** Host-stamped producer, e.g. `"app:my-ledger"`. Absent on older records. */
+  source?: string
+  /** Host-owned read flag. A reserved key: an app cannot set it. */
+  acked?: boolean
+  /** Channel priority. `"passive"` is explicitly not an attention item. */
+  priority?: string
+  /** Set when the note's channel is muted. Also a reserved key. */
+  silenced?: boolean
+}
+
+/**
+ * The priority the host already excludes from its own unread count.
+ *
+ * Not a judgement call made here: `notification_coordinator.py` increments
+ * `_unread_count` only `if note.get("priority") != "passive"`, and the feed
+ * renders a passive note dimmed as non-attention (`notifMeta.tsx`). Counting
+ * one as rail attention would contradict the very subsystem this derives from.
+ */
+const PASSIVE_PRIORITY = 'passive'
+
+/**
+ * Whether *note* is an attention item, by the host's OWN definition.
+ *
+ * That definition is three clauses, not two, and it is written down in the
+ * dashboard already: `!n.acked && n.priority !== 'passive' && !n.silenced`
+ * (`App.tsx`, commented "mirroring the backend's `_unread_count` semantics";
+ * the same predicate again in `hooks/useWebSocket.ts`, and an existing test
+ * pins the expression). This mirrors it rather than inventing a variant.
+ *
+ * `silenced` matters for more than consistency: muting a channel is the ONLY
+ * opt-out that works while the app's page is unmounted, which is exactly the
+ * regime this badge covers. Ignoring it would leave a badge no user could
+ * switch off without the app's own UI running.
+ */
+function isAttention(note: BadgeNote): boolean {
+  return !note.acked && note.priority !== PASSIVE_PRIORITY && !note.silenced
+}
+
+/**
+ * Count unacknowledged notifications per producing app.
+ *
+ * Returns a map of app name to count, carrying an entry ONLY for apps that
+ * currently have at least one unacknowledged note -- an app with nothing
+ * waiting is absent rather than present-and-zero, so a caller merging this map
+ * cannot accidentally clear a count another source set.
+ */
+export function appNotificationBadges(notes: readonly BadgeNote[]): Record<string, number> {
+  // Prototype-less ON PURPOSE. An app name is attacker-chosen, and `manifest.py`
+  // reserves only a namespace list -- `constructor`, `toString` and `__proto__`
+  // are all valid kebab names. On a plain `{}`, `counts['constructor']` reads the
+  // inherited `Object` function, which is truthy, so `+ 1` string-concatenates
+  // and the row renders a function body as its count.
+  const counts: Record<string, number> = Object.create(null)
+  for (const note of notes) {
+    // One predicate, mirroring the host's three-clause definition, so a future
+    // clause is added in one place rather than drifting between two.
+    if (!isAttention(note)) continue
+    const source = note.source
+    if (!source || !source.startsWith(APP_SOURCE_PREFIX)) continue
+    // Keyed by the name the HOST stamped, which is also how `appBadges` and
+    // `NavBadge`'s `app-<name>` id are keyed, so the join needs no translation.
+    const name = source.slice(APP_SOURCE_PREFIX.length)
+    // A bare "app:" names no app: it must not become an empty-string key that
+    // matches no rail row and silently accumulates.
+    if (!name) continue
+    const next = (counts[name] || 0) + 1
+    counts[name] = next > MAX_APP_BADGE_COUNT ? MAX_APP_BADGE_COUNT : next
+  }
+  return counts
+}
+
+/**
+ * Merge an app's explicitly pushed badge over the derived counts.
+ *
+ * `pushed` wins on every key it carries, INCLUDING an explicit `0`: an app that
+ * called `useNavBadge(0)` has stated it wants no badge, and a count derived
+ * from its notifications must not overrule that statement.
+ *
+ * The consequence is the property that makes this safe to ship: an app already
+ * using the SDK hook today keeps exactly its current behaviour, because its key
+ * is present in `pushed` and therefore always wins. The derivation only fills
+ * rows that had no badge at all.
+ */
+export function mergeAppBadges(
+  pushed: Record<string, number>,
+  derived: Record<string, number>,
+): Record<string, number> {
+  // Prototype-less for the SECOND half of the same hazard, which is one level
+  // out from where the count is built: `{ ...derived, ...pushed }` produces a
+  // normal object literal, so a LOOKUP of `railAppBadges['constructor']` for an
+  // app with no entry would resolve to the inherited `Object` function -- truthy,
+  // so `NavBadge`'s `|| 0` does not catch it and `BadgeIndicator`'s `count <= 0`
+  // does not either. Fixing only the accumulator leaves the read reachable.
+  // `Object.assign` copies own enumerable keys only, so precedence is unchanged.
+  return Object.assign(Object.create(null) as Record<string, number>, derived, pushed)
+}

--- a/website/src/test/appNotificationBadges.test.ts
+++ b/website/src/test/appNotificationBadges.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest'
+import { appNavTarget } from '../appNav'
+import {
+  APP_NAV_ID_PREFIX,
+  APP_SOURCE_PREFIX,
+  MAX_APP_BADGE_COUNT,
+  appNotificationBadges,
+  isAppNavId,
+  mergeAppBadges,
+  type BadgeNote,
+} from '../appNotificationBadges'
+
+/**
+ * The rail badge for a third-party app is DERIVED from notifications the app
+ * already pushed, so these tests pin the derivation rather than any manifest
+ * field -- there is deliberately no new declared field to pin.
+ *
+ * Counts are asserted by WHOLE-MAP equality, never per key. With one app every
+ * candidate key expression coincides, so a loop-variable slip that stamped the
+ * first note's app onto later ones would be invisible; three apps with THREE
+ * DIFFERENT counts make the pairing itself the assertion.
+ */
+describe('appNotificationBadges', () => {
+  it('counts unacknowledged notes per producing app, pairing each count to its own app', () => {
+    const notes: BadgeNote[] = [
+      { source: 'app:ledger', acked: false },
+      { source: 'app:ledger', acked: false },
+      { source: 'app:ledger', acked: false },
+      { source: 'app:watchtower', acked: false },
+      { source: 'app:watchtower', acked: false },
+      { source: 'app:quiet-app', acked: false },
+    ]
+
+    // Whole-map equality: catches a miscount AND a cross-attributed count.
+    expect(appNotificationBadges(notes)).toEqual({
+      ledger: 3,
+      watchtower: 2,
+      'quiet-app': 1,
+    })
+  })
+
+  it('ignores acknowledged notes, and omits an app whose notes are all acknowledged', () => {
+    const notes: BadgeNote[] = [
+      { source: 'app:ledger', acked: true },
+      { source: 'app:ledger', acked: false },
+      { source: 'app:done', acked: true },
+      { source: 'app:done', acked: true },
+    ]
+
+    const counts = appNotificationBadges(notes)
+
+    expect(counts).toEqual({ ledger: 1 })
+    // Complement: an app with nothing waiting must be ABSENT, not zero. A zero
+    // entry would survive a merge and clear a count another source had set.
+    expect('done' in counts).toBe(false)
+  })
+
+  it('ignores notes that no app produced', () => {
+    const notes: BadgeNote[] = [
+      { source: 'system', acked: false },
+      { source: 'cron', acked: false },
+      { acked: false },
+      { source: '', acked: false },
+      // A bare prefix names no app: it must not become an empty-string key.
+      { source: APP_SOURCE_PREFIX, acked: false },
+    ]
+
+    const counts = appNotificationBadges(notes)
+
+    expect(counts).toEqual({})
+    expect('' in counts).toBe(false)
+  })
+
+  it('treats a note with no acked field as unacknowledged', () => {
+    // Records written before the flag existed rehydrate without it; absent must
+    // read as "not yet acknowledged" rather than being silently dropped.
+    expect(appNotificationBadges([{ source: 'app:ledger' }])).toEqual({ ledger: 1 })
+  })
+
+  it('clamps a count at MAX_APP_BADGE_COUNT', () => {
+    const notes: BadgeNote[] = Array.from(
+      { length: MAX_APP_BADGE_COUNT + 40 },
+      () => ({ source: 'app:noisy', acked: false }),
+    )
+
+    // Exact equality, not a bound: the point is that the clamp fires at the cap
+    // rather than merely that the number is smaller than the input.
+    expect(appNotificationBadges(notes)).toEqual({ noisy: MAX_APP_BADGE_COUNT })
+  })
+
+  it('returns an empty map for no notes', () => {
+    expect(appNotificationBadges([])).toEqual({})
+  })
+})
+
+describe('mergeAppBadges', () => {
+  it('fills only rows that had no pushed badge', () => {
+    expect(mergeAppBadges({ pushy: 7 }, { derived: 2 })).toEqual({ pushy: 7, derived: 2 })
+  })
+
+  it('lets an explicitly pushed count win over a derived one', () => {
+    // An app using useNavBadge() today must see NO change from this derivation.
+    expect(mergeAppBadges({ ledger: 7 }, { ledger: 3 })).toEqual({ ledger: 7 })
+  })
+
+  it('honours an explicit pushed zero, so an app can still clear its own badge', () => {
+    // The direction that matters: 0 is a statement ("no badge"), not an absence.
+    // A spread that dropped falsy values would let the derived 3 resurrect a
+    // badge the app deliberately cleared.
+    expect(mergeAppBadges({ ledger: 0 }, { ledger: 3 })).toEqual({ ledger: 0 })
+  })
+
+  it('does not mutate either input', () => {
+    const pushed = { ledger: 7 }
+    const derived = { ledger: 3, other: 1 }
+
+    mergeAppBadges(pushed, derived)
+
+    expect(pushed).toEqual({ ledger: 7 })
+    expect(derived).toEqual({ ledger: 3, other: 1 })
+  })
+})
+
+/**
+ * Regressions for the two blocking review findings on the first revision.
+ *
+ * An app name is attacker-chosen and the manifest reserves only a namespace
+ * list, so `constructor`, `toString` and `__proto__` are all valid app names,
+ * and an app may also pick a name that equals a HOST nav row's id.
+ */
+describe('appNotificationBadges: an app name cannot reach Object.prototype', () => {
+  // Three inherited names, not one: at N=1 a fix that special-cased a single
+  // name would pass while the class stayed open.
+  const inherited = ['constructor', 'toString', 'hasOwnProperty']
+
+  for (const name of inherited) {
+    it(`counts an app named ${name} as a number`, () => {
+      const counts = appNotificationBadges([{ source: `app:${name}`, acked: false }])
+
+      // The defect produced a STRING (Object's function body concatenated with
+      // 1), so the type assertion is the load-bearing one, not just the value.
+      expect(typeof counts[name]).toBe('number')
+      expect(counts).toEqual({ [name]: 1 })
+    })
+  }
+
+  it('does not resolve an inherited name for an app with no notes', () => {
+    const counts = appNotificationBadges([{ source: 'app:ledger', acked: false }])
+
+    // On a plain object this read returns Object's constructor -- truthy, so
+    // neither NavBadge's `|| 0` nor BadgeIndicator's `count <= 0` filters it.
+    expect(counts['constructor']).toBeUndefined()
+    expect(counts['__proto__']).toBeUndefined()
+  })
+})
+
+describe('mergeAppBadges: the merged map is also prototype-less', () => {
+  it('does not resolve an inherited name for an app absent from both inputs', () => {
+    // The read site, one level out from the counter: a merge that spread into an
+    // object literal would hand NavBadge a function for this lookup even though
+    // the accumulator itself was safe.
+    const merged = mergeAppBadges({ pushy: 1 }, { ledger: 2 })
+
+    expect(merged['constructor']).toBeUndefined()
+    expect(merged['toString']).toBeUndefined()
+  })
+
+  it('still carries real keys and precedence after the prototype change', () => {
+    expect(mergeAppBadges({ ledger: 7 }, { ledger: 3, other: 1 })).toEqual({ ledger: 7, other: 1 })
+  })
+})
+
+describe('isAppNavId', () => {
+  it('accepts an installed app row', () => {
+    expect(isAppNavId(`${APP_NAV_ID_PREFIX}my-ledger`)).toBe(true)
+  })
+
+  it('rejects a host surface row whose id could equal an app name', () => {
+    // The finding: `schedule` is a real host nav id AND a valid app name, and
+    // NavBadge keys its fallback on the bare id for an unprefixed row. If this
+    // returns true, an app named `schedule` badges the host Schedule row.
+    expect(isAppNavId('schedule')).toBe(false)
+    expect(isAppNavId('projects')).toBe(false)
+    expect(isAppNavId('chat')).toBe(false)
+  })
+
+  it('rejects a name that merely contains the prefix later on', () => {
+    expect(isAppNavId('my-app-thing')).toBe(false)
+  })
+})
+
+describe('appNotificationBadges: passive notes are not attention', () => {
+  it('excludes a passive note, matching the host unread definition', () => {
+    // notification_coordinator.py increments _unread_count only when
+    // priority != "passive", and the feed dims a passive note as non-attention.
+    // Counting one here would contradict the subsystem this derives from.
+    const notes: BadgeNote[] = [
+      { source: 'app:ledger', acked: false, priority: 'passive' },
+      { source: 'app:ledger', acked: false, priority: 'default' },
+      { source: 'app:ledger', acked: false, priority: 'critical' },
+    ]
+
+    // Exactly 2, not 3: the two attention priorities count, passive does not.
+    expect(appNotificationBadges(notes)).toEqual({ ledger: 2 })
+  })
+
+  it('still counts a note with no priority, since the default is not passive', () => {
+    expect(appNotificationBadges([{ source: 'app:ledger', acked: false }])).toEqual({ ledger: 1 })
+  })
+
+  it('omits an app whose only notes are passive', () => {
+    const counts = appNotificationBadges([
+      { source: 'app:quiet', acked: false, priority: 'passive' },
+    ])
+
+    expect(counts).toEqual({})
+    expect('quiet' in counts).toBe(false)
+  })
+})
+
+describe('appNotificationBadges: muted channels are not attention', () => {
+  it('excludes a silenced note, completing the host three-clause definition', () => {
+    // The host's own predicate is `!acked && priority !== 'passive' && !silenced`
+    // (App.tsx, "mirroring the backend's _unread_count semantics"; the same
+    // expression again in useWebSocket.ts, and an existing test pins it).
+    // Omitting any one clause invents a second definition of unread.
+    const notes: BadgeNote[] = [
+      { source: 'app:ledger', acked: false, silenced: true },
+      { source: 'app:ledger', acked: false, silenced: false },
+      { source: 'app:ledger', acked: false },
+    ]
+
+    expect(appNotificationBadges(notes)).toEqual({ ledger: 2 })
+  })
+
+  it('lets muting a channel switch the badge off entirely', () => {
+    // The property that matters to a user: muting is the only opt-out available
+    // while the app's page is unmounted, which is the regime this badge covers.
+    const counts = appNotificationBadges([
+      { source: 'app:noisy', acked: false, silenced: true },
+      { source: 'app:noisy', acked: false, silenced: true },
+    ])
+
+    expect(counts).toEqual({})
+    expect('noisy' in counts).toBe(false)
+  })
+
+  it('excludes on ANY one clause, so no clause can be quietly dropped', () => {
+    // Three notes, each failing a different clause: all three must be excluded,
+    // so removing any single clause reddens this.
+    const notes: BadgeNote[] = [
+      { source: 'app:x', acked: true },
+      { source: 'app:x', acked: false, priority: 'passive' },
+      { source: 'app:x', acked: false, silenced: true },
+    ]
+
+    expect(appNotificationBadges(notes)).toEqual({})
+  })
+})
+
+describe('isAppNavId agrees with the id appNav actually builds', () => {
+  // The prefix is spelled in appNav.ts (which BUILDS the id) and in NavBadge
+  // (which slices it). Rather than refactor either, pin the RELATIONSHIP: if
+  // the id shape drifts from this predicate, these reds say so.
+  it('accepts the id appNavTarget builds for an installed app', () => {
+    const target = appNavTarget({
+      name: 'ledger',
+      enabled: true,
+      origin: 'installed',
+      manifest: { ui: { pages: [{ route: '/apps/ledger' }] } },
+    })
+
+    expect(target).not.toBeNull()
+    expect(isAppNavId(target!.id)).toBe(true)
+  })
+
+  it('rejects the id appNavTarget builds for a natively routed builtin', () => {
+    // A native builtin keeps its bare name as its id, which is exactly the
+    // class that must NOT receive a derived count.
+    const target = appNavTarget({
+      name: 'projects',
+      enabled: true,
+      origin: 'builtin',
+      manifest: { ui: { pages: [{ route: '/projects' }] } },
+    })
+
+    expect(target).not.toBeNull()
+    expect(isAppNavId(target!.id)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

An installed app cannot leave a persistent "something is waiting for you" signal on its left-rail nav row. A notification interrupts once and is gone; a user who was away from the screen, or who dismissed the toast, has no residual signal that items are waiting, so they have to open the app page to find out.

The badge slot itself is NOT missing, which is worth stating because the issue assumes it is. `useNavBadge()` (`website/src/app-sdk/index.ts:330`) is public, documented API (`docs/app-kit/getting-started.md:176`) and the rail already renders it for an `app-<name>` row: `mc:app:badge` lands in `appBadges` (`website/src/App.tsx:2016-2024`), `NavBadge` maps the row id to a count (`:519-520`) and `BadgeIndicator` draws it (`:479-485`).

What that existing channel cannot do is the case the badge is for. `useNavBadge()` is a React hook inside the app's own UI bundle, and that bundle is imported when its page mounts (`website/src/components/AppHost.tsx:237`). Before the user has opened the app there is no app code running to call it.

## Why it matters

Notifications and badges serve different needs: one interrupts, the other stays visible. Without the second, background work an app tracks is invisible until the user goes looking, which defeats the point of tracking it. The apps most affected are exactly the ones the user is not currently looking at.

## What changed (motivation -> approach -> change)

Goal: a badge that can appear while the app's page is closed.

Approach, and why this one over the alternative: the issue proposes a new manifest field (`ui.badge`) naming a route the rail would poll. That would be a new public app-manifest surface, and a field third-party manifests set cannot change name, type or semantics once apps ship against it -- removing it later would fail manifest validation and orphan the app's route. It is also unnecessary, because the data already exists. An app that wants to signal waiting work already declares `notifications.channels[]` (`src/kiro_crew/apps/manifest.py:1064-1145`) and already pushes through `POST /api/notifications/push` (`src/kiro_crew/dashboard/handlers/notifications_push.py:58`), where the HOST stamps the producer onto every record as `source="app:<name>"` -- annotated "server-resolved; body cannot override" at `:159` -- and `acked` is a reserved note key (`src/kiro_crew/notifications/bus.py`, `_RESERVED_NOTE_KEYS`) that an app cannot pre-set. Attribution and read state are therefore both host-owned and unspoofable, and both already reach the dashboard on every note.

So the only thing missing was the join. The sole aggregate over notifications today is one global scalar (`src/kiro_crew/dashboard/state.py:5041`), mirrored on the frontend as another global total (`website/src/components/notifications/NotificationFeed.tsx:222`); nothing counts per app.

Change: a pure derivation, `website/src/appNotificationBadges.ts`, counting unacknowledged notes per producing app, plus a memo in `App.tsx` that merges it into the badge map the rail rows read. No new manifest field, no new app-implemented route, no new dependency, and no change to the notification bus.

Three properties chosen deliberately:

- Merged only into the rail map, never into `appBadges` state. This mirrors the `discoverBadges` memo directly above it, for the same stated reason: that state feeds the tab-title `totalAttention` sum (`App.tsx:2668`), and the notifications bell already badges these same records, so adding them there would count one notification twice in the tab title. Tab-title behaviour is unchanged.
- An explicitly pushed count wins on its own key, including an explicit `0`. An app that called `useNavBadge(0)` has stated it wants no badge and a derived count must not overrule it. Scope of that guarantee, narrowed after review: an app that actively pushes a badge keeps exactly its current behaviour. An app that pushes NOTIFICATIONS and never calls the hook does gain a badge it did not ask for, and its only opt-out today is `useNavBadge(0)`, which needs its bundle mounted -- unavailable in the very unmounted regime this feature covers. That is a product change to already-shipped apps and it is called out under "other suggestions" for a maintainer to rule on, not asserted here as harmless.
- Counts are clamped. An app influences how many notifications it pushes and the number renders in the host's own chrome, where an unbounded value is a layout and spoofing surface rather than information. The clamp is applied to the value this change introduces and deliberately does not reach into `BadgeIndicator`, whose other callers are host-owned counts.

### Review round 1: two blocking findings, both real, both fixed

Both were in this diff, both verified reachable before changing anything, and neither was argued with.

**An app name can equal a HOST nav row's id.** `NavBadge` keys its fallback lookup on the BARE navId for an unprefixed row (`App.tsx:519-520`), and the built-in `schedule` surface declares neither `slotMode` nor `unreadSelector` (`website/src/surfaces/builtins.tsx:108-115`), so `surfaceHasBadgeSource` is false and that host row reads the fallback map. An app named `schedule` -- a valid, unreserved kebab name -- would therefore have badged the built-in Schedule row from its own notifications. Fixed as prescribed: derived counts now reach only rows passing the new `isAppNavId`, and host rows keep `appBadges`, which preserves the existing `projects` bridge exactly. This is my own error one level out: the derivation was right about counting and wrong about the namespace it was handing counts into.

**An app can be named `constructor`.** On a plain object the prior-count read `counts[name] || 0` resolves `Object`'s inherited function, which is truthy, so `+ 1` string-concatenates and the row renders a function body as its count. Demonstrated directly: the expression yields the string `function Object() { [native code] }1`. Fixed with a prototype-less accumulator.

I went one step beyond the prescribed remedy here, and the reason is measured rather than defensive: fixing only the accumulator leaves the hazard live at the READ site, because `{ ...derived, ...pushed }` produces a normal object literal, so `railAppBadges['constructor']` for an app with no entry resolves the inherited function again -- truthy, so neither `NavBadge`'s `|| 0` nor `BadgeIndicator`'s `count <= 0` filters it. The merge therefore uses `Object.assign(Object.create(null), ...)`, which copies own enumerable keys only and leaves precedence unchanged. The mutation evidence shows the two guards are independent: restoring the accumulator's prototype reddens 4 tests, restoring the merge's reddens a different single test.

### Review round 2: one conformance fix taken, three items left for a maintainer

**Taken -- passive-priority notes are excluded.** Design Review raised this as a suggestion; it is really a defect, because the host already declares the policy and this derivation contradicted it. `notification_coordinator.py:77-78` increments `_unread_count` only `if note.get("priority") != "passive"`, and the feed renders a passive note dimmed as non-attention (`notifMeta.tsx:88-95`). Counting one as rail attention would have invented a second, inconsistent definition of unread inside the subsystem being derived from. Excluding it is conformance to an existing declared value rather than a new choice.

**Left, because each is a policy call rather than a lookup:**

- **The badge does not clear by opening the app.** `acked` flips only through the bell, the detail panel and the notifications page; visiting the app acks nothing, so the count persists and the row trains badge-blindness. The reviewers are right that this is the feature's main loop. The fix they suggest -- ack an app's notifications when its page opens -- changes what `acked` MEANS globally, marking notifications read that the user never saw in the bell. That is an opt-in/opt-out policy decision affecting the notification centre, not this rail, so it is surfaced here rather than decided.
- **Retroactive opt-in for already-shipped apps**, as narrowed above. Whether existing third-party apps should gain a rail badge without asking is a maintainer's call; the durable opt-out would be a manifest bit, which is precisely the public surface this PR declined to add.
- **The accessible label is inherited and now imprecise.** `NavBadge` labels both counts with `surface?.badgeLabel ?? i18nT('app.updates')` (`App.tsx:522`), so a derived count is announced as "N updates" when it now means unread notifications. A per-row label is NOT the fix: an app row's count may be PUSHED or DERIVED, and "updates" remains right for a pushed one, so labelling by row would be wrong for the other half. Labelling correctly requires `NavBadge` to know each count's provenance, which means passing both maps into the shared badge component and choosing the label there. That is a change to the component every rail row renders through, for one string, so I have not bolted on a label that is wrong for pushed counts. Happy to do the provenance version if you want it in this PR.
- **`MAX_APP_BADGE_COUNT` renders a bare `99` for 139 waiting items.** A "99+" form needs `BadgeIndicator` to accept a string where every other caller passes a number, so it is the same shared-chrome question. The exact-number reading is defensible for now because the clamp exists for bounding, not for reporting.

### Review round 3: the passive fix was one clause of three

First Principles turned this PR's own argument back on it, correctly. Round 2 excluded passive notes on the grounds that counting them "would have invented a second, inconsistent definition of unread inside the subsystem being derived from" -- and that reasoning applies verbatim to `silenced`, which round 2 left counted.

The host's definition is three clauses and it is already written down twice: `!n.acked && n.priority !== 'passive' && !n.silenced` at `App.tsx:922`, under a comment stating it mirrors the backend's `_unread_count` semantics, and the same predicate at `hooks/useWebSocket.ts:1177`. An existing test even pins the expression (`test/useWebSocket.notificationsClear.test.ts:9,62`). Mine had two of the three, while the body claimed to match the host's definition -- so this was a description/code mismatch as well as a conformance gap. The three clauses now live in one `isAttention` predicate, so a future clause is added in one place rather than drifting between two.

**This partly answers the opt-out concern above, so that disposition is updated rather than left standing.** Muting an app's channel is the one opt-out that works while the app's page is unmounted, which is precisely the regime this badge covers. With `silenced` honoured, muting the channel now switches the rail badge off; before this round it did not. What remains for a maintainer is narrower than it was: whether channel-muting is a sufficient opt-out, or whether a manifest bit is still wanted.

On the second Watch item -- `APP_NAV_ID_PREFIX` being a third spelling of `app-`, alongside the inline build at `appNav.ts:139` and the inline slice at `App.tsx:520` -- I did not refactor either sibling, because both are shared code this change has no other reason to touch. Instead the RELATIONSHIP is now pinned: two tests drive the real `appNavTarget` and assert that the id it builds for an installed app satisfies `isAppNavId`, and that the id it builds for a natively routed builtin does not. If the id shape ever drifts from the predicate, that reds rather than silently mis-routing a badge. A coupling test seemed the better trade than a coupling refactor.

## Tests

`website/src/test/appNotificationBadges.test.ts`, 27 cases, run by path with vitest (27 passed).

Counts are asserted by whole-map equality over THREE apps with three different counts, so a loop-variable slip that stamped one app's key onto another's count would fail; with a single app every candidate key expression coincides and such a bug is invisible. Also locked in: acknowledged notes are excluded and an app whose notes are all acknowledged is ABSENT rather than present-and-zero (a zero would survive the merge and clear a count another source set); non-app sources and a bare `app:` prefix contribute nothing and never create an empty-string key; a missing `acked` field reads as unacknowledged, since records written before the flag existed rehydrate without it; the clamp fires exactly at the cap; and merge precedence holds in both directions.

The round-1 regressions are pinned too: three inherited names (`constructor`, `toString`, `hasOwnProperty`) rather than one, because a fix that special-cased a single name would pass at N=1 while the class stayed open; the count's TYPE is asserted, since the defect produced a string rather than a wrong number; the merged map is checked at the read site for an app absent from both inputs; and `isAppNavId` is pinned against the real colliding host ids.

Every decision point was mutation-verified. Eight mutations hand-applied against the committed file -- the original five re-run after the restructure, plus one per new guard -- each reddening on a real AssertionError with a distinct failure set:

| Mutation | Result |
|---|---|
| baseline, unmutated | 27 passed |
| remove the `acked` filter | 1 failed: `{ ledger: 2, done: 2 }` vs `{ ledger: 1 }` |
| drop the app-source requirement | 1 failed: `{ em: 1 }` vs `{}` |
| remove the empty-name guard | 1 failed: `{ '': 1 }` vs `{}` |
| remove the clamp | 1 failed: `{ noisy: 139 }` vs `{ noisy: 99 }` |
| invert merge precedence | 4 failed, both directions: `7` vs `3`, and `0` vs `3` |
| restore the accumulator's prototype | 4 failed: `expected 'string' to be 'number'`, and `[Function Object]` vs undefined |
| restore the merge's prototype | 1 failed, a DIFFERENT single test: `[Function Object]` vs undefined |
| make `isAppNavId` always true | 2 failed: `expected true to be false` on the host-row ids |
| remove the passive-priority guard | 2 failed: `{ ledger: 3 }` vs `{ ledger: 2 }`, and `{ quiet: 1 }` vs `{}` |
| drop the `silenced` clause | 3 failed: `{ ledger: 3 }` vs `{ ledger: 2 }`, and `{ noisy: 2 }` vs `{}` |
| drop the `acked` clause | 2 failed: `{ ledger: 2, done: 2 }` vs `{ ledger: 1 }`, and `{ x: 1 }` vs `{}` |

The last two share one test on purpose -- "excludes on ANY one clause" reddens under both, which is what proves no single clause can be quietly dropped, while each also reddens a clause-specific test so the two are still distinguishable.

One process note, because it nearly cost a silent regression: restoring a mutated file with `git checkout --` reverts it to the COMMITTED state, so it wiped the passive filter, which was still uncommitted at that moment. The suite would have caught it -- its tests were already written -- but what actually caught it was asserting afterwards that the COMMITTED tree contains the guard, rather than trusting a passing run. A green run proves the working tree; only reading the commit proves what ships.

A typecheck over the frontend project is clean. The harness was control-gated first: an unchanged upstream test (`src/test/InstalledAppManifestBoundary.test.ts`) passes in this worktree, so a failure from the new test is attributable to the new code rather than to the toolchain.

## Manual verification

Not performed end to end: exercising this needs a dashboard with an installed app holding unacknowledged pushed notifications, which is a seeded environment rather than a local run. The derivation is a pure function and is unit-covered including its edge cases; the wiring is a one-line prop change plus a memo mirroring the adjacent `discoverBadges` precedent. Reviewer help welcome on a seeded instance.

## Screenshots / video

None attached, and I want to be straight about why rather than lean on the pathspec: the change IS user-visible, since it renders a count in the existing `BadgeIndicator` on an app's rail row. I could not produce an honest screenshot without seeding an app with unacknowledged notifications. Note the visual-evidence gate's own relevance pathspec covers `website/src/components/`, `pages/`, `apps/`, CSS files and `index.html`, and none of the three files here matches it, so the gate will not classify this diff as visual on its own. I have deliberately not applied the maintainer-scoped `no-screenshots` label and have not used the no-visual-delta marker. If you want an image before merging, say so and I will stand up a seeded instance.

## Related Issues

Refs #5601

Deliberately `Refs` and not a closing keyword. The issue asks specifically for a declared `ui.badge` manifest field polled by the rail, and that field is NOT implemented here -- the derivation is offered as the better shape because it serves the same stated need while freezing nothing for third-party app authors. The issue should stay open until a maintainer rules on whether the declared field is still wanted.

## Other suggestions

Three pre-existing defects in the EXISTING `mc:app:badge` channel, found while establishing the above and deliberately left out of this PR as separate concerns. Happy to file them if useful:

1. The host listener trusts `detail.appName` verbatim (`App.tsx:2019-2021`) while an app's bundle runs same-origin in the host's own React tree with no iframe (`AppHost.tsx:10`, `:237`), so any app can set another app's badge. Same isolation root cause as #8394.
2. That listener applies no clamp and no type coercion, and `BadgeIndicator` only guards a non-positive count, so a non-numeric count renders and makes the `totalAttention` sum concatenate instead of add.
3. `appBadges` has no delete path, so a disabled or uninstalled app's count persists for the session and keeps inflating the browser tab badge until reload.

For context on scope: #520 ("Add a hook for apps to reflect runtime state on their sidebar icon") is the general form of this request and is a month older. Its `running` and `error` states look derivable today from `backend_status` and `hooks.health_status`, which the apps listing endpoint already ships (`src/kiro_crew/apps/routes.py:342-359`) and the frontend currently reads nowhere; `success` has no signal behind it. That is a separate change and not attempted here.
