### PR TITLE
fix(dashboard): stop trusting pointercancel end coordinates in drag hook

### DIFF
--- a/website/src/hooks/usePointerDrag.test.tsx
+++ b/website/src/hooks/usePointerDrag.test.tsx
@@ -152,3 +152,73 @@ describe('usePointerDrag capture-loss termination', () => {
     })
   })
 })
+
+describe('usePointerDrag pointercancel sentinel coordinates', () => {
+  // pointercancel is platform-fired (touch scroll takeover, pen leaving range,
+  // palm rejection) — the user never chose its position. Pointer Events L3
+  // requires its coordinates to match the last dispatched pointer event, but
+  // engines have shipped pointercancel with 0,0 (the spec carries an explicit
+  // late "clarification about pointercancel coordinates" because behavior
+  // diverged). Trusting the event's coordinates is therefore at best equal to
+  // the hook's own tracker and at worst a dx of ≈ -startX that resizers
+  // persist to storage. The end payload must derive from the tracker.
+
+  it('a pointercancel with sentinel 0,0 coordinates ends from the last tracked position', () => {
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd, threshold: 0 })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 100, clientY: 100 })
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 150, clientY: 110 })
+    // Legacy-engine shape: cancel delivered with default-initialized coords.
+    fireEvent.pointerCancel(handle, { pointerId: 1, clientX: 0, clientY: 0 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd.mock.calls[0][0]).toMatchObject({
+      dx: 50, dy: 10, x: 150, y: 110, committed: true,
+    })
+  })
+
+  it('a pointercancel before any move ends at the drag origin (dx 0), not at 0,0', () => {
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 100, clientY: 100 })
+    fireEvent.pointerCancel(handle, { pointerId: 1, clientX: 0, clientY: 0 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd.mock.calls[0][0]).toMatchObject({
+      dx: 0, dy: 0, x: 100, y: 100, committed: false,
+    })
+  })
+
+  it('a spec-conformant pointercancel (coordinates match the last dispatched event) ends identically', () => {
+    // Control: on an engine following Pointer Events L3 §4.2.7 the cancel
+    // carries the last dispatched coordinates — exactly what the tracker
+    // holds — so deriving from the tracker changes nothing.
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd, threshold: 0 })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 100, clientY: 100 })
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 150, clientY: 110 })
+    fireEvent.pointerCancel(handle, { pointerId: 1, clientX: 150, clientY: 110 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd.mock.calls[0][0]).toMatchObject({
+      dx: 50, dy: 10, x: 150, y: 110, committed: true,
+    })
+  })
+
+  it('does not double-fire onEnd when lostpointercapture follows a pointercancel', () => {
+    // The spec's implicit-release steps fire lostpointercapture immediately
+    // after pointercancel for a captured pointer — the same idempotence
+    // contract as the pointerup twin above.
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 10, clientY: 10 })
+    fireEvent.pointerCancel(handle, { pointerId: 1, clientX: 0, clientY: 0 })
+    fireEvent.lostPointerCapture(handle, { pointerId: 1 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+})

--- a/website/src/hooks/usePointerDrag.ts
+++ b/website/src/hooks/usePointerDrag.ts
@@ -33,10 +33,13 @@ export interface PointerDragOptions {
 interface DragInternal {
   startX: number
   startY: number
-  /** last position from a coordinate-bearing event (down/move/up/cancel).
-   *  got/lostpointercapture coordinates are not defined by the Pointer Events
-   *  spec (browsers commonly deliver 0,0), so the end payload derives from
-   *  this instead of trusting the terminal event. */
+  /** last position from a user-driven coordinate-bearing event (down/move/up).
+   *  Platform-fired ends can carry sentinel coordinates: the Pointer Events
+   *  spec leaves got/lostpointercapture coordinates undefined, and engines
+   *  have shipped pointercancel with 0,0 (the spec needed an explicit
+   *  clarification that cancel coordinates must match the last dispatched
+   *  event) — so the end payload derives from this instead of trusting a
+   *  terminal event. */
   lastX: number
   lastY: number
   active: boolean
@@ -105,15 +108,22 @@ export function usePointerDrag(opts: PointerDragOptions) {
     // gesture crossed the threshold so it can skip drag-only work.
     //
     // The payload derives from the last coordinate-bearing event, not from
-    // this event unconditionally: pointerup/pointercancel carry real
-    // coordinates and refresh the tracker here, but the Pointer Events spec
-    // leaves got/lostpointercapture coordinates undefined and browsers
-    // commonly deliver 0,0. Trusting those would hand consumers dx of
-    // roughly -startX on a mid-drag capture loss: resizers run
+    // this event unconditionally. This is an ALLOW-list: only pointerup — the
+    // user-driven end whose coordinates are spec-defined — refreshes the
+    // tracker. Every platform-fired end is excluded, because their
+    // coordinates are unreliable by spec or by shipped engines: the Pointer
+    // Events spec leaves got/lostpointercapture coordinates undefined, and
+    // engines have delivered pointercancel with 0,0 (Pointer Events L3 added
+    // an explicit clarification that cancel coordinates must match the last
+    // dispatched event precisely because behavior diverged). Trusting a
+    // sentinel would hand consumers dx of roughly -startX: resizers run
     // persist(apply(sign * dx)) in onEnd, which would snap the pane to a
     // clamped extreme or its collapsed state and WRITE it to localStorage,
     // a persisted wrong layout on the exact path this hook exists to heal.
-    if (e.type !== 'lostpointercapture') {
+    // On a conformant engine the excluded cancel carries the last dispatched
+    // coordinates — exactly what the tracker already holds — so committing
+    // the tracked position is lossless there and fail-safe everywhere else.
+    if (e.type === 'pointerup') {
       s.lastX = e.clientX
       s.lastY = e.clientY
     }


### PR DESCRIPTION
## Problem / Motivation

`usePointerDrag` derives its `onEnd` payload from a position tracker so that terminal events carrying sentinel coordinates cannot corrupt the reported delta (#8958). The tracker-refresh guard, however, is a deny-list that excludes only `lostpointercapture`:

```ts
if (e.type !== 'lostpointercapture') {
  s.lastX = e.clientX
  s.lastY = e.clientY
}
```

`pointercancel` passes this guard. A cancel is platform-fired (touch scroll takeover, pen leaving digitizer range, palm rejection, screen-orientation change) — the user never chose its position — and engines have shipped it with default-initialized coordinates (0,0). Pointer Events Level 3 had to add an explicit clarification that `pointercancel` coordinates must match the last dispatched pointer event precisely because behavior diverged. On an engine delivering the 0,0 shape, the guard refreshes the tracker to 0,0 and `onEnd` reports `dx ≈ -startX`.

The in-code comment claims "pointerup/pointercancel carry real coordinates" — for `pointercancel` that is only true on engines conforming to the L3 clarification, and the hook's own harvested rule from #8958 ("platform-fired ends can carry sentinel coordinates") describes `pointercancel` exactly.

## Why it matters

Resizer consumers run `persist(apply(sign * dx))` in `onEnd`. A mid-drag `pointercancel` with sentinel coordinates commits a clamped-extreme or collapsed pane size and writes it to `localStorage` — a persisted wrong layout from an end the user never performed. This is the same harm class #8958 closed for `lostpointercapture`, reachable through the one platform-fired end type the deny-list still trusts.

## What changed (motivation → approach → change)

Observed symptom: at the unfixed tree, a synthetic `pointercancel` with `clientX: 0, clientY: 0` after mid-drag moves produces `onEnd({ dx: -100, dy: -100, x: 0, … })` instead of the last tracked position (reproducer output below).

Root cause: the coordinate-refresh guard classifies end events by denying known-bad types instead of allowing known-good ones. Any platform-fired end type not on the deny-list is trusted by default — `pointercancel` today, and any future terminal type tomorrow.

Change: invert the guard to an allow-list. Only `pointerup` — the user-driven end whose coordinates are spec-defined — refreshes the tracker; every platform-fired end commits the last tracked position:

```ts
if (e.type === 'pointerup') {
  s.lastX = e.clientX
  s.lastY = e.clientY
}
```

On a conformant engine the excluded cancel carries the last dispatched coordinates — exactly what the tracker already holds — so the inversion is lossless there and fail-safe on engines that deliver sentinels (worst case: one coalesced-move stale, never a corrupt delta). The contract comment and the `DragInternal` docstring are synced to the repaired behavior in the same commit.

Alternatives rejected:
- Extending the deny-list to `pointercancel`: repeats the structural mistake; a future platform-fired terminal type would be trusted by default again.
- Sanitizing 0,0 specifically (`if (x || y)`): 0,0 is a legal on-screen position for a real `pointerup`; guarding by value corrupts a genuine top-left release.

Lineage (one topic per PR): #8904 made the hook terminate on capture loss; #8958 derived end coordinates from the tracker for `lostpointercapture`; this PR closes the remaining cancel-class window that #8958's own review round named as a residual. Each change is a distinct guard on the same seam.

## Tests

Two attack pins, one conformant control, one idempotence pin (all in `website/src/hooks/usePointerDrag.test.tsx`):

- `a pointercancel with sentinel 0,0 coordinates ends from the last tracked position` — mid-drag cancel at 0,0 must report the moved-to position (fails before, passes after).
- `a pointercancel before any move ends at the drag origin (dx 0), not at 0,0` — pre-move cancel must report the origin (fails before, passes after).
- `a spec-conformant pointercancel (coordinates match the last dispatched event) ends identically` — proves the allow-list is lossless on conformant engines (passes both sides; regression control, stated honestly).
- `does not double-fire onEnd when lostpointercapture follows a pointercancel` — the spec's implicit-release sequence fires `lostpointercapture` right after `pointercancel`; end stays single-fire (passes both sides).

Reproducer output at the unfixed tree (base `0d65dc969`):

```
× a pointercancel with sentinel 0,0 coordinates ends from the last tracked position
× a pointercancel before any move ends at the drag origin (dx 0), not at 0,0
AssertionError: expected { dx: -100, dy: -100, x: +0, …(3) } to match object { Object (dx, dy, ...) }
Tests  2 failed | 11 passed (13)
```

After the fix: `13 passed (13)`. All nine pre-existing hook tests pass unchanged — including `a normal pointerup still ends from its own (real) coordinates`, which pins that the user-driven path still trusts its event.

Consumer sweep: 115 test files across every `usePointerDrag` call site (ChatInput, SessionGridLayout, ChatSidebar, useColumnResize, ColumnSplitter, BottomTerminalPanel, DetailPanel, SidePanel, FileExplorerPage, ResizeHandle) — all green. `tsc -b` clean, `eslint` clean, theme/phantom/i18n lints clean, full website suite green.

## Manual verification

Verified through the jsdom harness above (synthetic `pointerCancel` with explicit coordinates). No real-device reproduction was performed — provoking a genuine palm-rejection or scroll-takeover cancel deterministically requires hardware; the unit pins encode both engine behaviors (sentinel and conformant) instead.

<!-- no-visual-delta --> No user-visible UI change: the fix alters which coordinates an internal tracker trusts on a platform-fired drag end. Layout, styling, and the user-driven drag path are untouched, so there is nothing to screenshot.

## Related Issues

Follow-up to #8958 (capture-loss drag ends) and #8904 (capture-loss termination) — closes the `pointercancel` residual named in #8958's review round. Non-closing reference: no tracker issue exists for this residual.

## Pattern harvest

The deny-list trusted an event type nobody had audited: the guard was written for the `lostpointercapture` incident and excluded exactly that type, leaving every other platform-fired end trusted by default. The durable shape is to key coordinate trust to the one user-driven end type and exclude platform-fired ends as a class.

Rule candidate: when guarding against unreliable event payloads, allow-list the event types whose payload the spec defines as user-driven; a deny-list built from the incident that prompted it silently trusts every type not yet witnessed.

Adjacent same-seam residual, deliberately not in this PR (one topic): the hook swallows `setPointerCapture` failure, so a drag whose capture never engaged can still miss its end if the pointer is released off-element. Registered follow-up; distinct mechanism (capture acquisition, not end-coordinate trust).

## Checklist

- [x] Tests added/updated and passing locally (13/13 targeted; 115 consumer files; full suite)
- [x] Reproducer fails before and passes after (output pasted above)
- [x] Docs: no owning doc names this hook's coordinate contract; the in-file contract comment is the doc of record and is updated in the same commit
- [x] Conventional commit, one topic, single commit
- [x] No baselined file reformatted

## Contribution License Agreement

Per the template placeholder (CLA text pending): offered under the same terms as my prior merged contributions to this repository (#8835).
