### PR TITLE
fix(design-critique): refuse a junctioned dir in the served signature

### DIFF
--- a/src/kiro_crew/apps/builtins/design_critique/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/design_critique/backend/routes.py
@@ -330,6 +330,16 @@ def _served_signature(build_dir: Path) -> _ServedToken | None:
     symlinked directory nor a symlinked file as one, and skips dot-entries, so none
     of those is ever reachable over the preview server — and none is signed here.
 
+    Matching that test needs ``is_link_or_junction``, not ``os.path.islink``. Node's
+    Dirent reports a Windows junction as a symbolic link and therefore serves nothing
+    behind it, while ``os.path.islink`` calls the same junction a plain directory —
+    so the bare check descended into it and signed bytes the server will not serve.
+    Nothing outside ``build_dir`` is disclosed by that (the token is a digest, and it
+    is never served), but it is exactly the "false mismatches and needless
+    re-captures" this paragraph rules out, it lets an unserved tree raise
+    ``newest_mtime_ns`` for the mid-capture check, and its files count against
+    ``_SIGNATURE_MAX_FILES``.
+
     Returns ``None`` whenever the served set cannot be read in full: missing,
     unreadable, or larger than ``_SIGNATURE_MAX_FILES``. A caller MUST treat ``None``
     as "unknown" rather than "unchanged" and refuse reuse — a token over part of a
@@ -353,7 +363,8 @@ def _served_signature(build_dir: Path) -> _ServedToken | None:
             dirs[:] = sorted(
                 d
                 for d in dirs
-                if not d.startswith(".") and not os.path.islink(os.path.join(root, d))
+                if not d.startswith(".")
+                and not platform_compat.is_link_or_junction(os.path.join(root, d))
             )
             # Each directory's own mtime feeds ``newest_mtime_ns`` but NOT the digest.
             # It has to feed the former because a DELETION leaves no file behind to
@@ -366,7 +377,7 @@ def _served_signature(build_dir: Path) -> _ServedToken | None:
             rel_root = os.path.relpath(root, build_dir)
             for name in sorted(files):
                 path = os.path.join(root, name)
-                if name.startswith(".") or os.path.islink(path):
+                if name.startswith(".") or platform_compat.is_link_or_junction(path):
                     continue
                 seen += 1
                 if seen > _SIGNATURE_MAX_FILES:

--- a/src/kiro_crew/apps/builtins/design_critique/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/design_critique/tests/test_backend_routes.py
@@ -17,6 +17,17 @@ from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.design_critique import register_routes
 from kiro_crew.apps.builtins.design_critique.backend import routes
 
+if platform_compat.IS_WINDOWS:
+    import _winapi
+
+    # Resolved at runtime, not as a typed attribute: typeshed guards CreateJunction
+    # behind sys.platform == "win32", so a direct reference is an attr-defined error
+    # when mypy checks this in-package test file on Linux. Same shape as
+    # platform_compat's own `getattr(os.path, "isjunction", None)`.
+    _create_junction = getattr(_winapi, "CreateJunction", None)
+else:  # pragma: no cover - junctions exist on Windows only
+    _create_junction = None
+
 
 def test_register_routes_mounts_the_three_endpoints() -> None:
     app = web.Application()
@@ -1191,10 +1202,14 @@ def _make_dir_link(link: Path, target: Path) -> None:
     # 1314 unelevated), which is why the test above can only skip there. A junction
     # needs no privilege and is the reparse point a real build tree would carry, so
     # the Windows half of this contract stays exercised instead of being skipped.
+    #
+    # A junction, never "a junction OR a symlink": os.symlink SUCCEEDS on a runner
+    # with Developer Mode on, and a symlink is the shape os.path.islink already
+    # refused. Degrading to it would turn the Windows red-before green for the
+    # wrong reason.
     if platform_compat.IS_WINDOWS:
-        import _winapi
-
-        _winapi.CreateJunction(str(target), str(link))
+        assert _create_junction is not None, "_winapi.CreateJunction missing on Windows"
+        _create_junction(str(target), str(link))
         return
     link.symlink_to(target, target_is_directory=True)
 

--- a/src/kiro_crew/apps/builtins/design_critique/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/design_critique/tests/test_backend_routes.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 from aiohttp import web
 
+from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.design_critique import register_routes
 from kiro_crew.apps.builtins.design_critique.backend import routes
 
@@ -1183,6 +1184,60 @@ def test_served_signature_ignores_what_the_server_will_not_serve(tmp_path) -> No
     _bump(outside / "extra.js")
     behind = routes._served_signature(build)
     assert behind is not None and behind.digest == sig.digest
+
+
+def _make_dir_link(link: Path, target: Path) -> None:
+    # A directory SYMLINK needs SeCreateSymbolicLinkPrivilege on Windows (WinError
+    # 1314 unelevated), which is why the test above can only skip there. A junction
+    # needs no privilege and is the reparse point a real build tree would carry, so
+    # the Windows half of this contract stays exercised instead of being skipped.
+    if platform_compat.IS_WINDOWS:
+        import _winapi
+
+        _winapi.CreateJunction(str(target), str(link))
+        return
+    link.symlink_to(target, target_is_directory=True)
+
+
+def test_served_signature_refuses_a_junctioned_directory(tmp_path) -> None:
+    # capture-build.mjs's Dirent test reports a junction as a symbolic link, so it
+    # walks nothing behind one and the preview server serves nothing from it. The
+    # token has to agree, and `os.path.islink` cannot make it agree: it calls a
+    # junction a plain directory, so the walk descended and signed bytes that are
+    # not served. Windows is the only platform with junctions and the only one where
+    # the symlink test above can be skipped for want of a privilege.
+    build = tmp_path / "dist"
+    _build_tree(build)
+    sig = routes._served_signature(build)
+    assert sig is not None
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "extra.js").write_text("x", encoding="utf-8")
+    _make_dir_link(build / "vendor", outside)
+
+    # Guard the guard: on Windows the link must really be the shape `os.path.islink`
+    # misreads. Without this the test could pass on a plain directory and prove
+    # nothing about the fix.
+    if platform_compat.IS_WINDOWS:
+        assert not os.path.islink(build / "vendor")
+        assert os.path.isdir(build / "vendor")
+    assert platform_compat.is_link_or_junction(build / "vendor")
+
+    # Only the DIGEST can hold still across the link's creation: that writes a new
+    # entry into dist/, and newest_mtime_ns reads directory mtimes on purpose.
+    linked = routes._served_signature(build)
+    assert linked is not None and linked.digest == sig.digest
+
+    # A change BEHIND the link moves neither field. Rewriting a file leaves its
+    # parent directory's mtime alone, so newest_mtime_ns is pinned exactly here —
+    # it feeds the discover-time mid-capture check, which an unserved tree must not
+    # be able to trip.
+    (outside / "extra.js").write_text("changed-and-longer", encoding="utf-8")
+    _bump(outside / "extra.js")
+    behind = routes._served_signature(build)
+    assert behind is not None and behind.digest == sig.digest
+    assert behind.newest_mtime_ns == linked.newest_mtime_ns
 
 
 def test_probe_build_dir_rejects_a_path_outside_the_project(tmp_path) -> None:


### PR DESCRIPTION
## Problem / Motivation

`_served_signature` in the Design Critique backend digests the files
`capture-build.mjs` will actually serve, so `/render` can tell whether a cached
probe screenshot still depicts the current build output. That script's own header
calls the two enumerations a contract:

> WHAT THIS ENUMERATES IS A CONTRACT with routes.py's `_served_signature` … the
> Dirent test below counts neither a symlinked directory nor a symlinked file,
> and dot-entries are skipped … Change both together.

The Python half held that contract with `os.path.islink`, which **returns False
for a Windows directory junction**. So the walk descended into a junction inside
the build dir and signed bytes the preview server never serves.

Measured on Windows, with the same junction on both sides:

| | junction `dist/vendor` → an outside dir |
|---|---|
| Node `readdirSync(withFileTypes)` (the mjs predicate) | `isDirectory=false isFile=false isSymbolicLink=true` → not walked; served URLs = `["/app.js"]` |
| `os.path.islink` (main) | `False` — so `os.walk` descended |
| `os.path.isdir` | `True` |
| `platform_compat.is_link_or_junction` | `True` |

With main's guard, editing a file behind the junction — one the server has no
route to — moved the token's digest **and** raised `newest_mtime_ns`.

## Why it matters

The signature's own docstring states the cost this direction: "signing something
the server never serves yields false mismatches and needless re-captures."
Concretely, on Windows:

* **Needless re-captures.** Unrelated churn behind a junction invalidates a valid
  cached screenshot for the whole `_PROBE_REUSE_TTL_SEC` window, and a re-capture
  is a full headless browser render.
* **A false mid-capture staleness signal.** `newest_mtime_ns` is the high-water
  mark the discover-time mid-capture check reads, deliberately including
  directory mtimes so a deletion cannot hide. An unserved tree could raise it and
  make a capture that is actually fine look stale.
* **`_SIGNATURE_MAX_FILES` pressure.** Files behind the junction increment `seen`,
  so a junction pointing at a large tree can push a small build over 20 000 and
  make `_served_signature` return `None` — which callers must read as "unknown"
  and refuse reuse entirely.

**This is not a disclosure bug and the PR does not claim one.** The token is a
digest and is never served; nothing behind the junction is read as content or
returned to a client. First Principles graded the same site "digest coverage, not
disclosure" when it named it on #8767, and that grading is unchanged here.

## What changed (motivation → approach → change)

Symptom: the token moves for bytes the server will not serve, on Windows only.
Root cause: `os.path.islink` is the wrong predicate for the contract — the Node
side refuses a junction, the Python side admits it. Change: both guards in
`_served_signature` now go through `platform_compat.is_link_or_junction`, which
is already imported in this module and tries `os.path.islink` first, so symlink
behaviour is bit-for-bit unchanged and each guard is strictly widened.

Two guards, one contract:

* the `dirs[:]` prune — the load-bearing one, and the only site the measurement
  reproduces against;
* the files-loop check — **behaviour-preserving on its own**, because a junction
  is a directory reparse point and never lands in `os.walk`'s `files` list. It is
  changed so both halves of one contract read through one predicate, rather than
  leaving a second spelling of the same guard behind. This is stated rather than
  implied: it is not a second fix.

`capture-build.mjs` needs no change — it was measured to already exclude the
junction, so the contract is restored by moving the Python side alone.

The docstring paragraph that asserted the two enumerations agree is corrected in
the same commit; it was the thing that was false.

**Deliberately not changed:** a junction in an ANCESTOR of `build_dir` (the
`first_linked_ancestor` case). `_probe_build_dir` already anchors `build_dir`
lexically under the validated project dir, and an ancestor link is a different
threat with a different helper. Out of scope, and not measured here.

## Tests

`test_served_signature_refuses_a_junctioned_directory` (in the existing
`design_critique/tests/test_backend_routes.py`) pins:

* the digest does not move when a junction appears inside the build dir;
* the digest does not move when a file **behind** it changes;
* `newest_mtime_ns` is unchanged by that same edit — the field the mid-capture
  check reads, which the existing symlink test does not assert.

It carries a guard-the-guard assertion: on Windows the link must really be the
shape `os.path.islink` misreads (`islink` False, `isdir` True), so the test
cannot pass against a plain directory and prove nothing.

**Red-before, measured on unpatched `origin/main`** (`routes.py` restored in-tree,
patch copied aside):

```
>       assert linked is not None and linked.digest == sig.digest
E       AssertionError: assert (_ServedToken(digest='3a195d46...', ...) is not None
E         - 8916bb526b932080bb194fe24aaaaa1c
E         + 3a195d46bcdb32f2492880253cd717fd
```

Green after: `110 passed, 1 skipped` across
`src/kiro_crew/apps/builtins/design_critique/tests/`.

**Platform honesty.** The one skip is the pre-existing
`test_served_signature_ignores_what_the_server_will_not_serve`, which needs
`SeCreateSymbolicLinkPrivilege` to make a directory symlink and skips on Windows
without it — that is, the existing test for this contract does not run on the
only platform that has junctions. The new test uses a junction on Windows (no
privilege required) and a symlink elsewhere, so on Linux CI it is a
no-regression check, **not** a red-before; only Windows exercises the fix.

**Second commit — a type-check fix on this test file, no product change.**
`Backend Lint & Type Check (3.12)` failed on the first head: typeshed guards
`_winapi.CreateJunction` behind `sys.platform == "win32"`, so the direct
reference is an `attr-defined` error whenever mypy checks this in-package test on
Linux. The import is now a guarded module-level one — the shape the
`top-level-imports` rule exempts, which also closes the review's advisory finding
on the function-local import — and `CreateJunction` is resolved with `getattr`,
mirroring `platform_compat`'s own `getattr(os.path, "isjunction", None)`.

The Windows path still creates a real **junction and nothing else**. It is
deliberately NOT routed through a helper that can fall back to `os.symlink`:
symlink creation succeeds on a runner with Developer Mode enabled, and a symlink
is the shape `os.path.islink` already refused — so that fallback would turn the
Windows red-before green for the wrong reason. A missing `CreateJunction` now
asserts rather than silently degrading, and the red-before was re-verified
against unpatched `origin/main` with the new helper in place.

Gates on this head: `flake8` clean, `isort --check-only` clean,
`scripts/check_black_formatting.py` PASS scoped `origin/main...HEAD`,
`scripts/check_subprocess_encoding.py` PASS. `mypy --platform linux` reports
nothing for `design_critique/` — run with that flag deliberately, because mypy's
default platform on a Windows box resolves `CreateJunction` and hides the CI
error. Its remaining 4 findings are in `apps/routes.py` and
`dashboard/state.py` and are Python-3.10-only artifacts of the local
interpreter (`asyncio.timeout`, `BaseException.add_note`), not this diff.

The `Build Desktop (ubuntu-22.04)` red on the first head was **not** author-owned:
the frontend build, AppImage, `.deb` and `.rpm` all completed and the job failed
in `actions/upload-artifact` with `ETIMEDOUT`. No rerun was requested for it.

## Manual verification

N/A — unit coverage sufficient. The behaviour is a pure function of a directory
tree, and the test builds the exact tree (junction included) that the defect
needs; the cross-language half of the contract was measured directly against
Node's `Dirent` predicate and is quoted above rather than assumed.

## Related Issues

No issue. This site was named by First Principles on merged
kirodotdev/KiroCrew#8767 and explicitly accepted-and-deferred there, then
re-measured against current `main` before this PR.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: an `os.path.islink` guard that must refuse a **junction** — the guard is
correct on POSIX and silently open on Windows, where `islink` calls a junction a
plain directory.

Scoped deliberately as a review prompt, not a lint autofix or a sweep: #8767's
review cites #8165's ruling that these sites are decided **one at a time on
harm**, and the harm differs enormously between them (this one is digest
coverage; a sweep would lump it with deletion and write paths). The generalizable
part is "flag the site and ask what the guard protects", not "replace every
`islink`".

Second, narrower pattern, and the one that hid this: **a contract asserted across
two languages, tested on only one of them.** The existing test for this exact
invariant skips on the only platform where it can break.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the corrected paragraph is the function's own docstring; no `docs/` spec covers `_served_signature`
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

