### PR TITLE
fix(history): bound consolidation input

### DIFF
--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -658,6 +658,12 @@ cron/heartbeat/lesson extraction) to extract:
 - `preferences_update` → overwrites `preferences.md` if changed
 - `projects_update` → overwrites `projects.md` if changed
 
+Each history pass receives at most 64 KiB of rendered transcript as a
+message-aligned prefix. On success, only that prefix advances
+`last_consolidated`; the remaining tail is left for a later pass. A single
+message larger than the window is not truncated or marked consolidated, because
+that would silently discard its unprocessed remainder.
+
 The two `*_update` values replace the whole file, so each is gated by
 `_is_plausible_memory_file()` before writing: a value that does not start with
 the file's mandated markdown header (`# User Preferences` / `# Active

--- a/src/kiro_crew/history_consolidation.py
+++ b/src/kiro_crew/history_consolidation.py
@@ -52,6 +52,10 @@ _CONSOLIDATION_THRESHOLD = 30
 _CONSOLIDATION_MAX_ATTEMPTS = 5
 _CONSOLIDATION_BACKOFF_BASE_SECS = 900.0
 _CONSOLIDATION_BACKOFF_MAX_SECS = 86400.0
+# The consolidator cannot know a provider's tokenizer or hidden system prompt.
+# This conservative character window leaves room for provider-supplied context
+# while preserving message boundaries.
+_CONSOLIDATION_CHUNK_MAX_CHARS = 64 * 1024
 _SKILL_DETECTION_WINDOW = 200
 
 _CONSOLIDATION_META_KEYS: frozenset[str] = frozenset(
@@ -94,6 +98,21 @@ def _fmt_message(message: dict) -> str:
         f"[{message.get('ts', '?')[:16]}] {message['role'].upper()}"
         f"{tools}: {message['content']}"
     )
+
+
+def _consolidation_chunk(messages: list[dict]) -> list[dict]:
+    """Return the longest message-aligned prefix that fits one consolidation pass."""
+    chunk: list[dict] = []
+    size = 0
+    for message in messages:
+        rendered_size = len(_fmt_message(message))
+        if not chunk and rendered_size > _CONSOLIDATION_CHUNK_MAX_CHARS:
+            return []
+        if chunk and size + rendered_size > _CONSOLIDATION_CHUNK_MAX_CHARS:
+            break
+        chunk.append(message)
+        size += rendered_size
+    return chunk
 
 
 _PLACEHOLDER_BODIES = frozenset(
@@ -759,6 +778,15 @@ class HistoryConsolidator:
                 generation=generation_at_snapshot,
                 offset=total - len(unconsolidated),
             )
+            if include_history:
+                chunk = _consolidation_chunk(unconsolidated)
+                if not chunk:
+                    await self._note_environment_failure(
+                        key, "one transcript message exceeds the automatic consolidation window"
+                    )
+                    return None
+            else:
+                chunk = unconsolidated
 
             # Resolve workspace-scoped memory from session metadata
             meta = self._log.get_metadata(key)
@@ -770,7 +798,7 @@ class HistoryConsolidator:
             else:
                 memory = self._memory
 
-            conversation = "\n".join(_fmt_message(m) for m in unconsolidated)
+            conversation = "\n".join(_fmt_message(m) for m in chunk)
 
             current_prefs = memory.read_preferences()
             current_projects = memory.read_projects()
@@ -933,7 +961,7 @@ class HistoryConsolidator:
                 # asyncio.create_task). Running it inline would let cross-process
                 # lock contention stall the whole gateway loop.
                 await run_in_embed_pool(memory.append_history, entry)
-                self._logger.info("Consolidated %d messages for %s", len(unconsolidated), key)
+                self._logger.info("Consolidated %d messages for %s", len(chunk), key)
 
             # Structured memory writes (Phase 2/3). Offloaded to a worker thread:
             # _write_structured_memory embeds each item via a blocking urllib call
@@ -1043,7 +1071,7 @@ class HistoryConsolidator:
                 await asyncio.to_thread(
                     self._log.mark_consolidated,
                     key,
-                    total,
+                    attempted.offset + len(chunk),
                     generation_at_snapshot,
                 )
 

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from windows_sim import builtin_open_sharing_violation
 
-from kiro_crew import history, history_search
+from kiro_crew import history, history_consolidation, history_search
 from kiro_crew.history import (
     _CONSOLIDATION_THRESHOLD,
     _METADATA_CACHE_MAX,
@@ -2759,6 +2759,45 @@ class TestConsolidationOffset:
 
         asyncio.run(run())
         assert c._prefs_offset["k"] == _CONSOLIDATION_THRESHOLD
+
+
+class TestConsolidationChunks:
+    def test_refuses_to_truncate_an_oversized_first_message(self):
+        message = {
+            "role": "user",
+            "content": "x" * history_consolidation._CONSOLIDATION_CHUNK_MAX_CHARS,
+        }
+
+        assert history_consolidation._consolidation_chunk([message]) == []
+
+    @pytest.mark.asyncio
+    async def test_marks_only_the_message_aligned_prefix(self):
+        cap = history_consolidation._CONSOLIDATION_CHUNK_MAX_CHARS
+        first = {"role": "user", "content": "first " + "x" * (cap // 3)}
+        second = {"role": "assistant", "content": "second " + "y" * (cap // 3)}
+        tail = {"role": "user", "content": "tail " + "z" * (cap // 2)}
+        log = MagicMock()
+        log.snapshot_for_consolidation.return_value = ([first, second, tail], 10, 7)
+        log.consolidation_retry_state.return_value = (0, 0.0)
+        log.get_metadata.return_value = {}
+
+        memory = MagicMock()
+        memory.read_preferences.return_value = ""
+        memory.read_projects.return_value = ""
+        consolidator = HistoryConsolidator(log=log, memory=memory, sessions=None)
+        prompts: list[str] = []
+
+        async def fake_llm(prompt: str) -> dict:
+            prompts.append(prompt)
+            return {"history_entry": "First two messages were consolidated."}
+
+        with patch.object(consolidator, "_call_llm", side_effect=fake_llm):
+            await consolidator._consolidate("k", include_history=True)
+
+        assert first["content"] in prompts[0]
+        assert second["content"] in prompts[0]
+        assert tail["content"] not in prompts[0]
+        log.mark_consolidated.assert_called_once_with("k", 9, 7)
 
 
 class TestConsolidationDoesNotBlockLoop:


### PR DESCRIPTION
## Problem / Motivation

History consolidation renders the entire unconsolidated transcript tail into one provider prompt. A large tail can exceed the provider context window, while the current success marker advances through every tail message.

## Why it matters

Background memory extraction then cannot make bounded progress on long-lived sessions. Any future truncation shortcut would also risk marking unseen content as consolidated.

## What changed (motivation → approach → change)

Provider context capacity is not available to the consolidator, so this uses a conservative 64 KiB rendered-input ceiling. Each pass selects the longest message-aligned prefix within that ceiling and advances `last_consolidated` only through that prefix. An oversized first message is left unmodified and unmarked, with backoff, rather than silently truncating its content.

## Tests

Added coverage that an oversized first message is not truncated, and that a multi-message tail prompts and marks only its bounded prefix. `python -m pytest test/test_history.py -n0 -q` — 332 passed.

## Manual verification

N/A — the isolated consolidator tests cover prompt membership and durable-offset arguments without a provider call.

## Related Issues

N/A

## Pattern harvest

Rule candidate: review-prompt

Pattern: a durable progress offset must advance only through input actually passed to an external processor.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — no CLA text is supplied by the repository template.