### PR TITLE
refactor(monitoring): remove duplicated logic and unreachable branches

### DIFF
--- a/src/kiro_crew/monitoring/decision.py
+++ b/src/kiro_crew/monitoring/decision.py
@@ -37,7 +37,7 @@ def decide_monitor(
     """
     if state.version != MONITOR_STATE_VERSION:
         return MonitorDecision.STOP_BLOCKED
-    terminal = _terminal_decision(state.outcome)
+    terminal = terminal_decision_for_outcome(state.outcome)
     if terminal is not None:
         return terminal
     if monitor_budget_reason(state, now=now):
@@ -63,7 +63,16 @@ def decide_monitor(
     return MonitorDecision.STOP_BLOCKED
 
 
-def _terminal_decision(outcome: MonitorOutcome | None) -> MonitorDecision | None:
+def terminal_decision_for_outcome(outcome: MonitorOutcome | None) -> MonitorDecision | None:
+    """Return the decision a recorded terminal outcome forces, or None if live.
+
+    Both :func:`decide_monitor` and the persistence-only shadow path
+    short-circuit here so a stopped monitor is never re-probed. This is NOT the
+    verdict the delivery controller reports: ``autonudge``'s
+    ``apply_monitor_probe`` refuses a monitor with a recorded outcome before
+    :func:`decide_monitor` runs, flattening every terminal outcome to
+    ``STOP_BLOCKED``.
+    """
     if outcome is MonitorOutcome.SUCCESS:
         return MonitorDecision.STOP_SUCCESS
     if outcome is MonitorOutcome.BUDGET:

--- a/src/kiro_crew/monitoring/github_pull_request.py
+++ b/src/kiro_crew/monitoring/github_pull_request.py
@@ -179,18 +179,8 @@ class GitHubPullRequestProvider:
                     unresolved_review_threads=unresolved,
                     review_threads_complete=complete,
                 )
-        except SetupError as exc:
-            if _transient_os_error(exc.__cause__):
-                return _provider_error(ProviderErrorKind.TRANSIENT, "provider_transient")
-            return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
-        except FileNotFoundError:
-            return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
-        except subprocess.TimeoutExpired:
-            return _provider_error(ProviderErrorKind.TRANSIENT, "provider_transient")
-        except OSError as exc:
-            if _transient_os_error(exc):
-                return _provider_error(ProviderErrorKind.TRANSIENT, "provider_transient")
-            return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
+        except (SetupError, FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            return _provider_exception_error(exc)
         except (TypeError, ValueError, KeyError):
             return _provider_error(
                 ProviderErrorKind.TRANSIENT,
@@ -271,7 +261,7 @@ class GitHubPullRequestProvider:
         unresolved = 0
         cursor: str | None = None
         seen_cursors: set[str] = set()
-        for page in range(_REVIEW_THREAD_MAX_PAGES):
+        for _ in range(_REVIEW_THREAD_MAX_PAGES):
             argv = [
                 gh,
                 "api",
@@ -337,8 +327,9 @@ class GitHubPullRequestProvider:
                 return unresolved, False, ProviderErrorKind.TRANSIENT
             seen_cursors.add(next_cursor)
             cursor = next_cursor
-            if page + 1 == _REVIEW_THREAD_MAX_PAGES:
-                return unresolved, False, None
+        # Falling out of the loop means the page cap was reached with more pages
+        # still advertised: the count so far is real but incomplete, and that is
+        # not a provider failure.
         return unresolved, False, None
 
 
@@ -710,10 +701,16 @@ def _classify_cli_error(raw: str) -> ProviderErrorKind:
             return ProviderErrorKind.TRANSIENT
     if "could not resolve host" in lowered:
         return ProviderErrorKind.TRANSIENT
-    if any(
-        marker in lowered
-        for marker in ("http 429", "rate limit", "abuse detection", "too many requests")
-    ):
+    # The status regex above reads only the first `http <ddd>` it matches, so a
+    # real 429 behind an earlier status reaches here instead: on
+    # "http 200 ... http 429" the regex matches the 200, which is not a status
+    # that block maps, so it returns nothing and the 429 survives to this check.
+    # The substring form also fires on a malformed "http 4290", which the regex
+    # skips because \b rejects a fourth digit. That false positive is accepted
+    # but not free: RATE_LIMITED is retryable, yet every provider error still
+    # spends one of the monitor's `max_provider_errors` (3 by default) and that
+    # cumulative count is never refunded, so mislabelling shortens the watch.
+    if "http 429" in lowered:
         return ProviderErrorKind.RATE_LIMITED
     if any(
         marker in lowered
@@ -791,6 +788,24 @@ def _provider_exception_kind(error: BaseException) -> ProviderErrorKind:
     if isinstance(error, OSError) and _transient_os_error(error):
         return ProviderErrorKind.TRANSIENT
     return ProviderErrorKind.SETUP
+
+
+def _provider_exception_error(error: BaseException) -> GitHubPullRequestProbeResult:
+    """Turn a runner exception into its provider-error result.
+
+    ``_provider_exception_kind`` returns only TRANSIENT or SETUP, so the reason
+    code is derivable from the kind. The split is not cosmetic: TRANSIENT
+    becomes RETRY_PROVIDER, but only until ``max_provider_errors`` (3 by
+    default) is reached, after which it too retires the monitor; SETUP is not
+    retryable at all and retires it on the FIRST occurrence (STOP_BLOCKED,
+    outcome BLOCKED). So a host fault mislabelled SETUP costs the whole watch
+    immediately rather than after the budget. If that classifier ever gains a
+    third kind, this ternary must gain the matching reason rather than stamping
+    ``"provider_setup"`` on it.
+    """
+    kind = _provider_exception_kind(error)
+    reason = "provider_transient" if kind is ProviderErrorKind.TRANSIENT else "provider_setup"
+    return _provider_error(kind, reason)
 
 
 def _provider_error(kind: ProviderErrorKind, reason_code: str) -> GitHubPullRequestProbeResult:

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -87,7 +87,13 @@ MONITOR_PUBLIC_FIELDS = (
 )
 
 
-def _is_finite_non_negative_number(value: object) -> bool:
+def is_finite_non_negative_number(value: object) -> bool:
+    """Whether *value* is a real, finite, non-negative timestamp-shaped number.
+
+    ``bool`` is excluded even though it is an ``int`` subclass, and an ``int``
+    too large to convert to a float (``10**400``) is rejected rather than
+    letting ``math.isfinite``'s ``OverflowError`` escape to the caller.
+    """
     if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
         return False
     try:
@@ -294,16 +300,15 @@ class MonitorState:
     last_provider_error: ProviderErrorKind | None = None
     #: Adoption metering. Without these two numbers a probe gate that never
     #: fires and a probe gate that is doing its job are indistinguishable from
-    #: the outside -- which is how the earlier attempts at this saving stayed at
-    #: zero adoption, unnoticed, for over a week. ``quiet_ticks`` counts the ticks
-    #: the probe judged QUIET; ``wakes`` counts the turns actually DELIVERED because
-    #: it judged otherwise -- not every non-quiet tick, since a gate that could not
-    #: decide is ``gate_fallbacks`` below and a fire the slot refuses is charged to
-    #: neither. A quiet verdict is
-    #: not the same as a free tick: the streak floor below deliberately delivers on
-    #: one of them, so ``quiet_ticks`` minus ``floor_ticks`` is the count that cost
-    #: no model turn. Saying "cost no turn" here would overstate the saving by
-    #: exactly the floor, which is the one number this PR must not get wrong.
+    #: the outside, so a gate stuck at zero adoption goes unnoticed.
+    #: ``quiet_ticks`` counts the ticks the probe judged QUIET; ``wakes`` counts
+    #: the turns actually DELIVERED because it judged otherwise -- not every
+    #: non-quiet tick, since a gate that could not decide is ``gate_fallbacks``
+    #: below and a fire the slot refuses is charged to neither. A quiet verdict
+    #: is not the same as a free tick: the streak floor below deliberately
+    #: delivers on one of them, so ``quiet_ticks`` minus ``floor_ticks`` is the
+    #: count that cost no model turn. Reading ``quiet_ticks`` alone as "cost no
+    #: turn" overstates the saving by exactly the floor.
     quiet_ticks: int = 0
     wakes: int = 0
     #: Ticks where the gate could not decide, so the tick resolved toward firing on
@@ -399,7 +404,7 @@ class MonitorState:
             "stopped_at",
         ):
             value = getattr(self, name)
-            if not _is_finite_non_negative_number(value):
+            if not is_finite_non_negative_number(value):
                 raise ValueError(f"{name} must be a finite non-negative number")
         for name in (
             "wake_count",
@@ -520,7 +525,7 @@ def monitor_state_from_dict(raw: object) -> MonitorState:
             value = raw.get(key)
             values[key] = value if isinstance(value, str) and value else f"unsupported_{key}"
         created_ts = raw.get("created_ts")
-        values["created_ts"] = created_ts if _is_finite_non_negative_number(created_ts) else 0.0
+        values["created_ts"] = created_ts if is_finite_non_negative_number(created_ts) else 0.0
         values["budgets"] = MonitorBudgets()
         values["_raw_payload"] = deepcopy(raw)
         return MonitorState(**values)
@@ -539,8 +544,6 @@ def monitor_state_from_dict(raw: object) -> MonitorState:
     outcome = values.get("outcome")
     if outcome is not None:
         values["outcome"] = MonitorOutcome(outcome)
-    else:
-        values["outcome"] = None
     disposition = values.get("last_completion_disposition")
     if disposition is not None:
         values["last_completion_disposition"] = MonitorActionDisposition(disposition)
@@ -567,7 +570,7 @@ def quarantine_monitor_state(raw: object) -> MonitorState:
 
     raw_created_ts = raw.get("created_ts")
     created_ts: int | float = 0.0
-    if _is_finite_non_negative_number(raw_created_ts):
+    if is_finite_non_negative_number(raw_created_ts):
         assert isinstance(raw_created_ts, (int, float)) and not isinstance(raw_created_ts, bool)
         created_ts = raw_created_ts
     return MonitorState(

--- a/src/kiro_crew/monitoring/shadow.py
+++ b/src/kiro_crew/monitoring/shadow.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-import math
 from collections.abc import Awaitable, Callable, Mapping
 from copy import deepcopy
 from dataclasses import fields
 from typing import Protocol
 
-from kiro_crew.monitoring.decision import decide_monitor, monitor_budget_reason
+from kiro_crew.monitoring.decision import (
+    decide_monitor,
+    monitor_budget_reason,
+    terminal_decision_for_outcome,
+)
 from kiro_crew.monitoring.github_pull_request import GitHubPullRequestProbeResult
 from kiro_crew.monitoring.models import (
     MonitorDecision,
@@ -17,6 +20,7 @@ from kiro_crew.monitoring.models import (
     MonitorOutcome,
     MonitorState,
     ProviderErrorKind,
+    is_finite_non_negative_number,
 )
 
 ShadowStatePersistence = Callable[[MonitorState], Awaitable[None]]
@@ -50,18 +54,12 @@ async def run_shadow_probe(
         raise ShadowWakeDeliveryRefused("wake delivery is unavailable in shadow mode")
     if state.kind != "github_pull_request" or state.objective != "review_ready":
         raise ValueError("shadow mode supports only github_pull_request review_ready")
-    if isinstance(now, bool) or not isinstance(now, (int, float)) or now < 0:
-        raise ValueError("now must be a finite non-negative number")
-    try:
-        now_is_finite = math.isfinite(now)
-    except OverflowError as exc:
-        raise ValueError("now must be a finite non-negative number") from exc
-    if not now_is_finite:
+    if not is_finite_non_negative_number(now):
         raise ValueError("now must be a finite non-negative number")
     if not callable(persist):
         raise ValueError("persist must be callable")
 
-    terminal = _decision_for_outcome(state.outcome)
+    terminal = terminal_decision_for_outcome(state.outcome)
     if terminal is not None:
         return terminal
     budget_reason = monitor_budget_reason(state, now=now)
@@ -135,13 +133,3 @@ def _terminal_outcome(
     if provider_error is ProviderErrorKind.NOT_FOUND:
         return MonitorOutcome.TARGET_UNAVAILABLE
     return MonitorOutcome.BLOCKED
-
-
-def _decision_for_outcome(outcome: MonitorOutcome | None) -> MonitorDecision | None:
-    if outcome is MonitorOutcome.SUCCESS:
-        return MonitorDecision.STOP_SUCCESS
-    if outcome is MonitorOutcome.BUDGET:
-        return MonitorDecision.STOP_BUDGET
-    if outcome is not None:
-        return MonitorDecision.STOP_BLOCKED
-    return None


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/monitoring/` says the same thing twice in several places, and keeps
two branches that cannot run. None of it is a bug — it is friction for the next
reader, and in two cases the duplication is the kind that drifts:

- `shadow.py`'s `_decision_for_outcome` is a **line-for-line copy** of
  `decision.py`'s `_terminal_decision`. Two copies of a terminal-outcome policy in
  one module is one edit away from the two paths disagreeing.
- `shadow.py` reimplements `models.py`'s finite/non-negative number check inline in
  eight lines, while three of the module's other users of that check call the helper.
  A **fourth** inline copy remains in `MonitorActionCompletion.__post_init__` and has
  already drifted — see "Known remaining copy" below.
- `probe()`'s four `except` clauses each rebuild, by hand, the classification that
  `_provider_exception_kind` — fifteen lines below, already called from two other
  sites in the same class — performs.
- `_review_threads` returns the identical tuple from inside its loop on the last
  iteration and again immediately after it.
- `_classify_cli_error` re-tests three rate-limit markers that its own **first
  statement** has already returned on.
- `monitor_state_from_dict` writes `outcome = None` in an `else` branch; that is the
  dataclass default, and its four sibling decoders already rely on it.

## Why it matters

Duplicated policy is a correctness risk, not a style one: whoever fixes the
terminal-outcome mapping or the exception classification will find one copy and
leave the other. The unreachable branches cost differently — they make a reader
reason about a case that cannot occur, and in `_classify_cli_error` they actively
mislead, because reading it suggests the second block is what catches rate limits
when the first block already did.

## What changed (motivation → approach → change)

Behaviour-preserving throughout. Six sites, four files, no test changes:

| Site | Change |
|---|---|
| `shadow.py` | `_decision_for_outcome` deleted; `decision.py`'s twin promoted to `terminal_decision_for_outcome` and shared |
| `shadow.py` | 8-line inline `now` validation → `is_finite_non_negative_number` (promoted from `models.py`); drops the now-unused `import math` |
| `github_pull_request.py` | `probe()`'s four `except` clauses → one clause delegating to a new `_provider_exception_error`, which wraps the pre-existing `_provider_exception_kind` |
| `github_pull_request.py` | `_review_threads`: in-loop duplicate of the post-loop `return` deleted; the orphaned loop variable becomes `_` |
| `github_pull_request.py` | `_classify_cli_error`: the second rate-limit block narrowed to its only reachable marker, `"http 429"` |
| `models.py` | `monitor_state_from_dict`: redundant `else: values["outcome"] = None` deleted |

Two private helpers became public because a second module in the same package now
uses them. That is the whole extent of the API change: no `__all__` exists in this
package, and no spec or doc names either symbol.

Comments in the files touched were **corrected against the code**, not merely
restated (three of them were wrong):

- `is_finite_non_negative_number` now names the input that actually reaches its
  `except OverflowError` — an `int` outside float range, which is what
  `test_monitor_persistence.py` and `test_github_pull_request_monitor.py` already
  exercise with `10**400`. The example first written there, `Decimal('Infinity')`,
  is rejected by the preceding `isinstance` guard and does not raise anyway.
- `_provider_exception_error` says what the TRANSIENT/SETUP split actually costs:
  TRANSIENT becomes `RETRY_PROVIDER`, SETUP is unretryable and retires the monitor
  (`STOP_BLOCKED`, outcome `BLOCKED`). It also states plainly that only the reason
  *string* falls back, so a future third kind needs its own reason rather than
  being stamped `"provider_setup"`.
- `terminal_decision_for_outcome` does **not** claim parity with the delivery
  controller. It has none: `autonudge`'s `apply_monitor_probe` refuses a monitor
  with a recorded outcome *before* `decide_monitor` runs, flattening every terminal
  outcome to `STOP_BLOCKED`, so `outcome=SUCCESS` yields `STOP_SUCCESS` on the
  shadow path and `STOP_BLOCKED` on the delivery path. Documenting the divergence is
  the point — a reader who believed the parity claim would "fix" the shadow path.
- `models.py`'s `quiet_ticks` comment loses an incident anecdote and a PR-scoped
  aside (`AGENTS.md` forbids both in code comments); every constraint it carried is
  retained.

### Known remaining copy — deliberately not fixed here

`grep math.isfinite src/kiro_crew/monitoring/` leaves exactly one non-helper hit after
this PR: `models.py:187`, inside `MonitorActionCompletion.__post_init__`. It is a fourth
inline copy of the same predicate and it has **already drifted** in the way this PR's
premise predicts — it omits the `OverflowError` guard, so:

```
MonitorState(..., created_ts=10**400)              -> ValueError   (uses the helper)
MonitorActionCompletion(..., completed_ts=10**400)  -> OverflowError (inline copy)
```

It is left alone because replacing it **changes the raised exception type**, and this PR
is behaviour-preserving by contract. Tracked as #9045 with the repro, the one-line fix and
the regression test. Raised by `First Principles Review`; deferral agreed on those grounds.

### One observable delta, disclosed deliberately

`shadow.py` no longer chains the swallowed `OverflowError` as `__cause__` on the
`now` validation, because the shared predicate returns a bool and has nothing to
chain from. Exception **type and message are unchanged**, no test asserts on
`__cause__`, and the three pre-existing callers of that same predicate — including
`MonitorState.__post_init__` — never chained either, so this makes `shadow.py`
consistent with its module rather than divergent. Reachable only by a caller passing
an out-of-float-range `int`, which is rejected identically either way. Say the word
and I will drop that one hunk.

### Overlap with in-flight work

Three open PRs touch these files: **#5305** (`github_pull_request.py`, `models.py`),
**#5185** (`models.py`, `shadow.py`), **#5186** (`models.py`). None deletes or
rewrites a function this PR changes, so the file-overlap bar is not met — but #5305
inserts a `return` immediately above the `except SetupError` line this PR removes,
so that one adjacency will conflict. **This PR should rebase behind them**, not the
reverse: a readability change should absorb the conflict, never charge it to a
feature.

## Tests

None added or changed — a behaviour-preserving refactor of covered code should move
no assertion. Instead, each rewrite was **proven** equivalent before it was kept:

- The four collapsed `except` clauses were differentially executed old-vs-new over
  57 constructed exceptions (7 errno values × 7 `OSError` subclasses,
  `TimeoutExpired`, and `SetupError` with 6 different `__cause__` values): zero
  divergences in the resulting `(kind, reason_code)`. `SetupError` is
  `RuntimeError`-derived and `TimeoutExpired` is `SubprocessError`-derived, so the
  only subtype relation among the four is `FileNotFoundError ⊂ OSError` — and
  `_provider_exception_kind` tests `FileNotFoundError` ahead of the `OSError`
  branch, exactly as the old clause order did.
- The narrowed rate-limit block was fuzzed old-vs-new over every 1-, 2- and 3-token
  concatenation of 27 adversarial markers under 4 separators, plus 200,000 random
  strings: zero divergences.
- `_review_threads` was run against a stub runner on both versions: the page-cap
  case returns `(10, False, None)` after 10 runner calls in both, the early-exit
  case `(3, True, None)` after 3 in both.
- The `outcome` deletion was checked for a missing key, an explicit `null`, and a
  real value, comparing `state.outcome`, `monitor_state_to_dict`,
  `monitor_state_public_dict` and `asdict`: identical in all three.
- The deleted `shadow._decision_for_outcome` was diffed against
  `decision.terminal_decision_for_outcome` from `origin/main`: line-for-line
  identical bodies.

**2,230 passed, 1 skipped** across every test module that imports `monitoring.`
(22 files) plus `test_monitor_mcp.py` and `test_monitor_start_ack.py`, re-run after
the rebase onto `5767e0d9c`.

## Manual verification

N/A — unit coverage sufficient: the change is confined to pure functions and
exception classification that the 2,230 tests above already cover, and no runtime
surface, wire format, or persisted field changes.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only refactor under `src/kiro_crew/monitoring/`; no
frontend file, rendered output, or user-visible string changes.

## Related Issues

no linked issue: routine readability sweep of one backend module, not a tracked defect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (none needed — no new functionality)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `learn-cron-dashboard.md` documents this module's *behaviour*, which is unchanged, and names none of the touched symbols
- [x] No secrets, credentials, or internal references in the diff

