### PR TITLE
fix(dashboard): write SEL audit record before wire delivery on deny paths

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -728,12 +728,11 @@ async def _reject_hook_blocked(
     # ConversationLog, and the sibling reject path (_safe_reject_title) redacts for
     # both that row and the audit.
     title, reason = _redacted_hook_block(event, pre_hook_results)
-    # BEFORE reject_tool: the unanswered permission request is what proves the
-    # turn is still in flight, so the steer is queued rather than dropped.
-    if refusal_notices is not None:
-        await _steer_policy_notice(client, title, reason, refusal_notices, slot)
-    await client.reject_tool(event.request_id)
-    slot.append("tool", f"🚫 {title} (hook blocked)", "msg msg-tool")
+    # Audit FIRST, before any wire I/O for this decision: the steer and the
+    # rejection both await the ACP pipe, and a backend that stops reading stdin
+    # blocks those awaits until the turn deadline cancels this coroutine — an
+    # SEL write sequenced after them never runs. Record the decision, then
+    # attempt delivery.
     sel().log_tool_invocation(
         session_key=session_key,
         agent=slot.agent or "kirocrew",
@@ -744,6 +743,12 @@ async def _reject_hook_blocked(
         request_id=event.request_id,
         metadata=metadata,
     )
+    # BEFORE reject_tool: the unanswered permission request is what proves the
+    # turn is still in flight, so the steer is queued rather than dropped.
+    if refusal_notices is not None:
+        await _steer_policy_notice(client, title, reason, refusal_notices, slot)
+    await client.reject_tool(event.request_id)
+    slot.append("tool", f"🚫 {title} (hook blocked)", "msg msg-tool")
     refusal_reasons.append((title, reason))
 
 
@@ -783,6 +788,20 @@ async def _reject_invalid_tool(
     """
     title = _redact_display_text(event.title)
     _reason = str(error)
+    # Audit FIRST, before any wire I/O for this decision (see
+    # _reject_hook_blocked): a stalled ACP reader cancels this coroutine at the
+    # turn deadline, and an SEL write sequenced after the awaits never runs.
+    sel().log_tool_invocation(
+        session_key=session_key,
+        agent=slot.agent or "kirocrew",
+        source="dashboard",
+        tool_name=title,
+        tool_kind=event.tool_kind,
+        outcome="denied",
+        request_id=event.request_id,
+        error=f"validation_failed: {error}",
+        metadata=metadata,
+    )
     # BEFORE reject_tool: the unanswered permission request is what proves the
     # turn is still in flight, so the steer is queued rather than dropped.
     if refusal_notices is not None:
@@ -797,17 +816,6 @@ async def _reject_invalid_tool(
         )
     await client.reject_tool(event.request_id)
     slot.append("tool", f"🚫 {title} (invalid: {error})", "msg msg-tool")
-    sel().log_tool_invocation(
-        session_key=session_key,
-        agent=slot.agent or "kirocrew",
-        source="dashboard",
-        tool_name=title,
-        tool_kind=event.tool_kind,
-        outcome="denied",
-        request_id=event.request_id,
-        error=f"validation_failed: {error}",
-        metadata=metadata,
-    )
     # The fallback's input. Without this entry a harness with no steer — or a
     # steer that was never folded in — leaves this deny with NO channel to the
     # model at all, while the policy path still gets its continuation. The
@@ -844,6 +852,20 @@ async def _reject_hook_error(
     """
     title = _redact_display_text(event.title)
     _safe_error = _redact_display_text(error)
+    # Audit FIRST, before any wire I/O for this decision (see
+    # _reject_hook_blocked): a stalled ACP reader cancels this coroutine at the
+    # turn deadline, and an SEL write sequenced after the awaits never runs.
+    sel().log_tool_invocation(
+        session_key=session_key,
+        agent=slot.agent or "kirocrew",
+        source="dashboard",
+        tool_name=title,
+        tool_kind=event.tool_kind,
+        outcome="hook_error",
+        request_id=event.request_id,
+        error=_safe_error,
+        metadata=metadata,
+    )
     # BEFORE reject_tool, for the same in-flight-turn reason as the sibling paths.
     if refusal_notices is not None:
         await _steer_policy_notice(
@@ -857,17 +879,6 @@ async def _reject_hook_error(
         )
     await client.reject_tool(event.request_id)
     slot.append("tool", f"🚫 {title} (hook error)", "msg msg-tool")
-    sel().log_tool_invocation(
-        session_key=session_key,
-        agent=slot.agent or "kirocrew",
-        source="dashboard",
-        tool_name=title,
-        tool_kind=event.tool_kind,
-        outcome="hook_error",
-        request_id=event.request_id,
-        error=_safe_error,
-        metadata=metadata,
-    )
     # See _reject_invalid_tool: the fallback needs an entry or this deny reaches
     # the model through no channel at all when the steer could not be delivered.
     refusal_reasons.append((title, _safe_error))
@@ -8362,6 +8373,20 @@ async def _run_chat(
                         _deny_title = _redact_display_text(event.title)
                         _deny_msg, _ = redact_exfiltration_urls(_deny_reason)
                         _deny_msg, _ = redact_credentials(_deny_msg)
+                        # Audit FIRST, before any wire I/O for this decision
+                        # (see _reject_hook_blocked): a stalled ACP reader
+                        # cancels this coroutine at the turn deadline, and an
+                        # SEL write sequenced after the awaits never runs.
+                        sel().log_tool_invocation(
+                            session_key=session_key,
+                            agent=slot.agent or "kirocrew",
+                            source="dashboard",
+                            tool_name=_deny_title,
+                            tool_kind=event.tool_kind,
+                            outcome="denied",
+                            request_id=event.request_id,
+                            error="hook_deny",
+                        )
                         # In-band first, and BEFORE the rejection goes on the
                         # wire: holding the unanswered permission request is what
                         # guarantees the turn is still in flight, so the notice is
@@ -8388,16 +8413,6 @@ async def _run_chat(
                                 "kind": "permission",
                                 "text": f"Blocked: {_deny_title} — {_deny_msg}",
                             },
-                        )
-                        sel().log_tool_invocation(
-                            session_key=session_key,
-                            agent=slot.agent or "kirocrew",
-                            source="dashboard",
-                            tool_name=_deny_title,
-                            tool_kind=event.tool_kind,
-                            outcome="denied",
-                            request_id=event.request_id,
-                            error="hook_deny",
                         )
                         # Recoverable host-gate refusal: record for auto-recovery.
                         # _deny_title/_deny_msg are ALREADY redacted just above
@@ -8886,6 +8901,27 @@ async def _run_chat(
                 if getattr(slot, "_batch_rejected", False):
                     _title = _redact_display_text(event.title)
                     _cascade_cause = getattr(slot, "_batch_rejected_cause", "")
+                    # Audit FIRST, before any wire I/O for this decision (see
+                    # _reject_hook_blocked): a stalled ACP reader cancels this
+                    # coroutine at the turn deadline, and an SEL write sequenced
+                    # after the awaits never runs.
+                    sel().log_tool_invocation(
+                        session_key=session_key,
+                        agent=slot.agent or "kirocrew",
+                        source="dashboard",
+                        tool_name=_title,
+                        tool_kind=event.tool_kind,
+                        outcome="rejected",
+                        request_id=event.request_id,
+                        # Additive provenance: an auditor separating "the user
+                        # refused this group" from "a host auto-decline cut it
+                        # short" needs the cause on the cascaded members too.
+                        metadata=(
+                            {"reason": "batch_rejection", "cause": _cascade_cause}
+                            if _cascade_cause
+                            else {"reason": "batch_rejection"}
+                        ),
+                    )
                     if _cascade_cause and not _batch_cascade_steered:
                         # Host-caused cascade: the batch's originating decline
                         # was an auto-decline (approval timeout, no budget,
@@ -8933,23 +8969,6 @@ async def _run_chat(
                         "resolved": "rejected",
                     }
                     slot.append("permission", _title, json.dumps(perm_meta))
-                    sel().log_tool_invocation(
-                        session_key=session_key,
-                        agent=slot.agent or "kirocrew",
-                        source="dashboard",
-                        tool_name=_title,
-                        tool_kind=event.tool_kind,
-                        outcome="rejected",
-                        request_id=event.request_id,
-                        # Additive provenance: an auditor separating "the user
-                        # refused this group" from "a host auto-decline cut it
-                        # short" needs the cause on the cascaded members too.
-                        metadata=(
-                            {"reason": "batch_rejection", "cause": _cascade_cause}
-                            if _cascade_cause
-                            else {"reason": "batch_rejection"}
-                        ),
-                    )
                     logger.warning("AUTO-REJECTED tool=%r (batch rejection)", event.title)
                     continue
                 # Interactive approval — send to frontend, wait for decision
@@ -9362,7 +9381,6 @@ async def _run_chat(
                             metadata={"reason": "interactive"},
                         )
                 else:
-                    await client.reject_tool(event.request_id)
                     # Explain WHY when the command tripped the read-only safety
                     # gate, so the pill reads "Cancelled due to unsafe shell
                     # pattern …" instead of the bare adapter default.
@@ -9375,13 +9393,10 @@ async def _run_chat(
                         _safety_reason, _ = redact_credentials(_safety_reason)
                     _safe_reject_title, _ = redact_exfiltration_urls(event.title)
                     _safe_reject_title, _ = redact_credentials(_safe_reject_title)
-                    if _safety_reason:
-                        _reject_label = f"🚫 {_safe_reject_title} (cancelled — {_safety_reason})"
-                    elif outcome == "rejected_once":
-                        _reject_label = f"🚫 {_safe_reject_title} (rejected — this call only)"
-                    else:
-                        _reject_label = f"🚫 {_safe_reject_title} (rejected)"
-                    slot.append("tool", _reject_label, "msg msg-tool")
+                    # Audit FIRST, before the rejection goes on the wire (see
+                    # _reject_hook_blocked): a stalled ACP reader cancels this
+                    # coroutine at the turn deadline, and an SEL write sequenced
+                    # after the await never runs.
                     sel().log_tool_invocation(
                         session_key=session_key,
                         agent=slot.agent or "kirocrew",
@@ -9392,6 +9407,14 @@ async def _run_chat(
                         request_id=event.request_id,
                         metadata={"reason": _safety_reason or "interactive"},
                     )
+                    await client.reject_tool(event.request_id)
+                    if _safety_reason:
+                        _reject_label = f"🚫 {_safe_reject_title} (cancelled — {_safety_reason})"
+                    elif outcome == "rejected_once":
+                        _reject_label = f"🚫 {_safe_reject_title} (rejected — this call only)"
+                    else:
+                        _reject_label = f"🚫 {_safe_reject_title} (rejected)"
+                    slot.append("tool", _reject_label, "msg msg-tool")
                     # NOTE: Do NOT append to _refusal_reasons here.
                     # This is an interactive user denial — the user chose to reject
                     # the tool. Refusal-recovery is only for system-side blocks —

--- a/test/test_deny_audit_first.py
+++ b/test/test_deny_audit_first.py
@@ -1,0 +1,310 @@
+"""Audit-first ordering on deny paths (SEL write precedes wire I/O).
+
+Every deny path answers the permission request over the ACP stdin pipe and
+records the decision to SEL. The pipe write is unbounded: a backend that stops
+reading stdin blocks ``reject_tool`` -> ``_send_response`` -> ``stdin.drain()``
+until the turn deadline cancels the coroutine. When the SEL write is sequenced
+AFTER that await, cancellation destroys the audit record: the permission
+decision was made, acted on locally, and never audited.
+
+The invariant these tests pin (issue #8621): **the SEL audit write must
+precede any wire I/O for that decision** — record the decision first, then
+attempt delivery. The steer is wire I/O too, so the audit precedes it as well.
+
+Two layers, mirroring TestEveryHostDenyCallSiteIsWired in
+test_refusal_inband_notice.py:
+
+* behavioral — a stalled client plus a real ``task.cancel()`` proves the audit
+  record survives turn-deadline cancellation at each deny helper;
+* source-scan — every ``await client.reject_tool(`` site in the runner must
+  have its ``sel().log_tool_invocation(`` textually before it, bounded to the
+  site's own window, so a future deny path cannot re-open the gap by putting
+  the audit back after the wire await.
+
+Failure semantics on the flip side (audit recorded, delivery cancelled) are
+the issue's own chosen direction: an audit row for a rejection the backend
+never received is recoverable noise; a delivered rejection with no audit row
+is an unmeetable compliance guarantee.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import re
+from unittest import mock
+
+import pytest
+
+import kiro_crew.dashboard.chat_runner as chat_runner
+from kiro_crew.dashboard.chat_runner import (
+    _reject_hook_blocked,
+    _reject_hook_error,
+    _reject_invalid_tool,
+)
+
+
+class _Slot:
+    key = "slot-1"
+    agent = "tester"
+
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, str]] = []
+
+    def append(self, kind: str, content: str, *_args, **_kwargs) -> None:
+        self.rows.append((kind, content))
+
+
+class _Event:
+    request_id = "req-1"
+    tool_call_id = "call-1"
+    title = "bash"
+    tool_kind = "execute"
+
+
+class _StalledRejectClient:
+    """A backend that answered nothing since the decision: reject stalls."""
+
+    supports_steer = True
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def steer(self, message: str) -> bool:
+        self.calls.append("steer")
+        return True
+
+    async def reject_tool(self, request_id) -> None:
+        self.calls.append("reject")
+        await asyncio.Event().wait()  # stdin.drain() against a stopped reader
+
+
+class _StalledSteerClient(_StalledRejectClient):
+    """The stall can hit the FIRST wire await of the path: the steer."""
+
+    async def steer(self, message: str) -> bool:
+        self.calls.append("steer")
+        await asyncio.Event().wait()
+        return True
+
+
+class _HealthyClient(_StalledRejectClient):
+    """Records order; nothing stalls."""
+
+    def __init__(self, order: list[str]) -> None:
+        super().__init__()
+        self._order = order
+
+    async def steer(self, message: str) -> bool:
+        self._order.append("steer")
+        return True
+
+    async def reject_tool(self, request_id) -> None:
+        self._order.append("reject")
+
+
+async def _cancelled_at_the_turn_deadline(coro) -> None:
+    """Run ``coro`` until it parks on the stalled pipe, then cancel it."""
+    task = asyncio.get_running_loop().create_task(coro)
+    for _ in range(20):
+        await asyncio.sleep(0)
+    assert not task.done(), "the double never stalled -- harness rotted"
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+class TestAuditSurvivesStalledPipe:
+    """Attack: decision made, pipe dead, coroutine cancelled -- audit must exist."""
+
+    @pytest.mark.asyncio
+    async def test_hook_blocked_audit_lands_before_the_stalled_reject(self):
+        with mock.patch.object(chat_runner, "sel") as sel_factory:
+            audit = sel_factory.return_value
+            await _cancelled_at_the_turn_deadline(
+                _reject_hook_blocked(
+                    _StalledRejectClient(),
+                    _Slot(),
+                    _Event(),
+                    session_key="s",
+                    pre_hook_results=["BLOCKED: unsafe shell pattern"],
+                    refusal_reasons=[],
+                    refusal_notices=None,
+                )
+            )
+            assert audit.log_tool_invocation.called, (
+                "the permission decision was made and the coroutine cancelled at "
+                "the turn deadline, but no SEL record exists -- the audit write is "
+                "sequenced after the unbounded wire await"
+            )
+            kwargs = audit.log_tool_invocation.call_args.kwargs
+            assert kwargs["outcome"] == "hook_blocked"
+            assert kwargs["request_id"] == "req-1"
+
+    @pytest.mark.asyncio
+    async def test_invalid_tool_audit_lands_before_the_stalled_reject(self):
+        with mock.patch.object(chat_runner, "sel") as sel_factory:
+            audit = sel_factory.return_value
+            await _cancelled_at_the_turn_deadline(
+                _reject_invalid_tool(
+                    _StalledRejectClient(),
+                    _Slot(),
+                    _Event(),
+                    session_key="s",
+                    error=ValueError("tool name failed validation"),
+                    refusal_reasons=[],
+                    refusal_notices=None,
+                )
+            )
+            assert audit.log_tool_invocation.called
+            assert audit.log_tool_invocation.call_args.kwargs["outcome"] == "denied"
+
+    @pytest.mark.asyncio
+    async def test_hook_error_audit_lands_before_the_stalled_reject(self):
+        with mock.patch.object(chat_runner, "sel") as sel_factory:
+            audit = sel_factory.return_value
+            await _cancelled_at_the_turn_deadline(
+                _reject_hook_error(
+                    _StalledRejectClient(),
+                    _Slot(),
+                    _Event(),
+                    session_key="s",
+                    error="hook raised",
+                    refusal_reasons=[],
+                    refusal_notices=None,
+                )
+            )
+            assert audit.log_tool_invocation.called
+            assert audit.log_tool_invocation.call_args.kwargs["outcome"] == "hook_error"
+
+    @pytest.mark.asyncio
+    async def test_audit_lands_even_when_the_steer_is_the_await_that_stalls(self):
+        # The steer is wire I/O for the same decision and runs FIRST on notice
+        # paths, so audit-after-reject and audit-between would both lose here.
+        with mock.patch.object(chat_runner, "sel") as sel_factory:
+            audit = sel_factory.return_value
+            await _cancelled_at_the_turn_deadline(
+                _reject_hook_blocked(
+                    _StalledSteerClient(),
+                    _Slot(),
+                    _Event(),
+                    session_key="s",
+                    pre_hook_results=["BLOCKED: unsafe shell pattern"],
+                    refusal_reasons=[],
+                    refusal_notices=[],
+                )
+            )
+            assert audit.log_tool_invocation.called, (
+                "the stall hit the steer (the decision's first wire await) and the "
+                "audit record is missing -- the SEL write must precede ALL wire I/O"
+            )
+
+
+class TestHealthyPathUnchanged:
+    """Control: with a live pipe the reorder changes ordering only, not effects."""
+
+    @pytest.mark.asyncio
+    async def test_audit_first_then_steer_then_reject_and_effects_intact(self):
+        order: list[str] = []
+        with mock.patch.object(chat_runner, "sel") as sel_factory:
+            audit = sel_factory.return_value
+            audit.log_tool_invocation.side_effect = lambda **_: order.append("audit")
+            slot = _Slot()
+            reasons: list[tuple[str, str]] = []
+            notices: list[str] = []
+            await _reject_hook_blocked(
+                _HealthyClient(order),
+                slot,
+                _Event(),
+                session_key="s",
+                pre_hook_results=["BLOCKED: unsafe shell pattern"],
+                refusal_reasons=reasons,
+                refusal_notices=notices,
+            )
+        assert order == ["audit", "steer", "reject"]
+        assert audit.log_tool_invocation.call_count == 1
+        # Every downstream effect of the deny is preserved.
+        assert reasons and reasons[0][0] == "bash"
+        assert notices, "the in-band notice list must still be fed"
+        # The steer's own inject row may precede the blocked row; the deny's
+        # visible row must still exist regardless.
+        assert any(kind == "tool" for kind, _ in slot.rows)
+
+    @pytest.mark.asyncio
+    async def test_benign_no_new_deny_and_audit_record_shape_unchanged(self):
+        # The reorder must not invent denies or alter the record's fields.
+        with mock.patch.object(chat_runner, "sel") as sel_factory:
+            audit = sel_factory.return_value
+            order: list[str] = []
+            await _reject_invalid_tool(
+                _HealthyClient(order),
+                _Slot(),
+                _Event(),
+                session_key="s",
+                error=ValueError("bad name"),
+                refusal_reasons=[],
+                refusal_notices=None,
+            )
+        kwargs = audit.log_tool_invocation.call_args.kwargs
+        assert kwargs["tool_name"] == "bash"
+        assert kwargs["tool_kind"] == "execute"
+        assert kwargs["error"] == "validation_failed: bad name"
+        assert order == ["reject"], "fallback-only callers still deny exactly once"
+
+
+class TestEveryDenySiteAuditsBeforeTheWire:
+    """Source-level guard over ALL deny sites, inline ones included.
+
+    The direct tests above cover the three helpers; the runner also denies
+    inline (hook TOOL_DENY, batch cascade, interactive rejection) inside the
+    turn coroutine where a unit test cannot reach. Same doctrine as
+    TestEveryHostDenyCallSiteIsWired: the coverage claim must be checkable.
+    For each ``await client.reject_tool(`` site, its decision's
+    ``sel().log_tool_invocation(`` must appear BEFORE it within the site's own
+    window (bounded by the nearest preceding wire answer or function def, so
+    one site's audit cannot vouch for another's).
+    """
+
+    RUNNER = pathlib.Path(__file__).resolve().parents[1] / "src/kiro_crew/dashboard/chat_runner.py"
+    REJECT = re.compile(r"^\s*await client\.reject_tool\(")
+    BOUNDARY = re.compile(
+        r"^\s*(?:await client\.approve_tool\(|await client\.reject_tool\(|async def )"
+    )
+    AUDIT = "log_tool_invocation("
+
+    def _lines(self) -> list[str]:
+        return self.RUNNER.read_text(encoding="utf-8").splitlines()
+
+    def _reject_sites(self, lines: list[str]) -> list[int]:
+        return [i for i, line in enumerate(lines) if self.REJECT.match(line)]
+
+    def test_the_scan_finds_every_reject_site(self):
+        # Count-matched against a plain textual count so a call-shape drift
+        # cannot silently drop a site out of the ordering assertion below.
+        lines = self._lines()
+        textual = sum("await client.reject_tool(" in line for line in lines)
+        found = len(self._reject_sites(lines))
+        assert found == textual, (
+            f"the site scan found {found} of {textual} reject sites -- its regex "
+            "no longer matches every call shape"
+        )
+        assert found >= 6, f"expected the known deny sites, saw {found}"
+
+    def test_every_reject_site_has_its_audit_before_the_wire(self):
+        lines = self._lines()
+        unaudited: list[int] = []
+        for site in self._reject_sites(lines):
+            audited = False
+            for j in range(site - 1, -1, -1):
+                if self.AUDIT in lines[j]:
+                    audited = True
+                    break
+                if self.BOUNDARY.match(lines[j]):
+                    break
+            if not audited:
+                unaudited.append(site + 1)
+        assert not unaudited, (
+            "these deny sites answer the wire before their SEL audit write -- a "
+            "stalled reader cancels the coroutine and the decision is never "
+            f"audited (issue #8621 invariant): lines {unaudited}"
+        )

--- a/test/test_refusal_inband_notice.py
+++ b/test/test_refusal_inband_notice.py
@@ -702,7 +702,10 @@ class TestEveryHostDenyCallSiteIsWired:
         src = self._src()
         anchor = 'if getattr(slot, "_batch_rejected", False):'
         assert anchor in src, "the cascade site moved -- guard is stale"
-        block = src.split(anchor, 1)[1][:3500]
+        # Window sized for the full cascade block: the audit-first SEL write
+        # (issue #8621) now sits between the anchor and the reject answer, so
+        # the original 3500-char window no longer reached the reject.
+        block = src.split(anchor, 1)[1][:5200]
         steer_at = block.find("_steer_policy_notice")
         reject_at = block.find("reject_tool(")
         assert steer_at != -1, "host-caused cascade no longer steers a notice"


### PR DESCRIPTION
<!-- no-visual-delta -->

## Problem / Motivation

On every deny path in `src/kiro_crew/dashboard/chat_runner.py`, the SEL audit record is written **after** the `reject_tool` wire I/O. That wire write is an unbounded await against the ACP peer: when the peer's reader has stalled or gone away, the await never completes, the coroutine is eventually cancelled, and the audit write on the lines below it never runs. The permission decision was made and acted on, but no audit record of it exists.

Issue #8621 states the invariant directly: **the SEL audit write must precede, or be independent of, any wire I/O.** Today it is neither.

## Why it matters

The audit log is the security record of which tool calls were denied and why. The exact failure mode that loses the record — a hung or disconnected peer — is the one an operator most wants records for afterwards. A deny that fires during a transport failure is currently a deny that never happened as far as the audit trail is concerned, and the gap is silent: nothing fails, the record is simply absent.

## What changed (motivation → approach → change)

Observed symptom: stall the ACP client so `reject_tool` never resolves, cancel the runner (what a dead peer produces), and the SEL record for the deny is absent.

Root cause: ordering. Each deny site awaits peer-facing wire I/O first and records the decision second, so the audit record's existence depends on the peer's health.

Change: hoist the SEL audit write above **all** wire I/O (the steer send included) at every deny site, so the record lands before the coroutine can be cancelled by a stalled peer. The decision is recorded at the moment it is made; delivery to the peer is attempted afterwards and may still fail, which is now survivable.

Sites changed — the issue enumerates 7 sites; the current tree has 6, because two of the sites it lists have since been consolidated into a shared helper. All 6 at today's tip are reordered:

- the three reject helpers (`_reject_hook_blocked`, `_reject_invalid_tool`, `_reject_hook_error`), and
- the three inline deny paths (hook tool-deny, batch cascade rejection, interactive rejection).

At the interactive-rejection site the redaction computation moved up together with the audit write, because its output is an input to the SEL record. The pre-existing "before reject_tool" comments at some sites describe the steer in-flight invariant — a distinct mechanism — and that ordering is preserved intact: the audit write now simply precedes both.

The approve-path siblings (auto-approve and interactive approve) have the same record-after-wire shape but are outside this issue's scope, which is deny paths; see Pattern harvest.

Not changed here: the transport-failure recovery design (bounded writes, session reset) discussed on the issue. The maintainer re-triage comment on 2026-09-05 separates that out as a genuine architecture decision; this PR is only the mechanical ordering half the issue itself settles in bold.

## Tests

New `test/test_deny_audit_first.py`, 8 tests:

- 4 stalled-pipe attack tests — a fake ACP client whose `reject_tool` (and, in one, whose steer send) never resolves; the runner is cancelled; each asserts the SEL record is present anyway, one per deny-site class. These fail before the fix (6 failed / 2 passed at the unfixed base; the failures show the audit record missing, and the ordering control shows the pre-fix order steer → reject → audit).
- 2 healthy-pipe control tests — with a responsive peer, the deny outcome, the wire payloads, and the record content are unchanged; only the order moved.
- a 2-part source-scan guard — walks `chat_runner.py`, finds every `reject_tool` call site with a count-matched walker (so a newly added deny site fails the count), and asserts each site's SEL write precedes its wire await. A future deny path written record-last fails this test, not just review.

Updated `test/test_refusal_inband_notice.py`: the cascade provenance scan window widened (3500 → 5200) because the hoisted SEL block moved the scanned region; semantics unchanged, with a comment attributing the widening.

## Manual verification

N/A — unit coverage sufficient: the seam is deterministic and fully exercisable offline with a fake ACP client; there is no UI or external-service surface.

**Why no screenshot:** backend-only ordering change in `chat_runner.py` deny paths; no user-visible surface is touched.

## Related Issues

Addresses the settled ordering half of #8621 (the bolded invariant). The transport-failure recovery design discussed there remains open and maintainer-owned, so this deliberately does not close the issue.

Compatible with #8603 (also non-closing): an ordering guard of the kind proposed there would require exactly these site fixes — this reorder is the compliance side of such a guard, not a competing design.

## Pattern harvest

Rule candidate: review-prompt
Pattern: "audit/telemetry record ordered after an unbounded peer-facing await on the same failure path — a stalled peer cancels the coroutine before the record lands; record the decision first, then attempt delivery."

The class has known remaining members in this file: the approve-path siblings (auto-approve and interactive approve) share the record-after-wire shape and are out of this issue's deny scope — tracked as follow-up work rather than silently widened into this PR.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
