### PR TITLE
feat(knowledge): scope local_knowledge_search to a namespace

### DIFF
--- a/src/kiro_crew/knowledge/retrieval.py
+++ b/src/kiro_crew/knowledge/retrieval.py
@@ -88,7 +88,13 @@ class HybridRetriever:
         self.store = store
         self.embedder = embedder
 
-    def search(self, query: str, limit: int = 10, source_id: str | None = None) -> list[dict]:
+    def search(
+        self,
+        query: str,
+        limit: int = 10,
+        source_id: str | None = None,
+        namespace: str | None = None,
+    ) -> list[dict]:
         """Hybrid search with RRF fusion. Returns [{id, title, summary, content, score, source, match_type}].
 
         ``source_id`` scopes the SEED legs only (FTS5 keyword + vector
@@ -96,10 +102,21 @@ class HybridRetriever:
         vocabularies collide across a heterogeneous corpus. The graph leg is
         deliberately left unfiltered so cross-source entity connections can
         still contribute traversal context to the fused ranking.
+
+        ``namespace`` scopes the SAME seed legs to items in one namespace
+        (``items.namespace``), the organisational label the store and the
+        dashboard browse filter already use. It is a relevance/organisation
+        filter, NOT a security boundary: like ``source_id`` it narrows the
+        seeds, and the graph leg stays unfiltered for the same reason. The two
+        filters compose (both applied when both are given).
         """
-        kw = self._keyword_search(query, limit=limit * 2, source_id=source_id)
+        kw = self._keyword_search(
+            query, limit=limit * 2, source_id=source_id, namespace=namespace
+        )
         gr = self._graph_search(query, limit=limit * 2)
-        vec = self._vector_search(query, limit=limit * 2, source_id=source_id)
+        vec = self._vector_search(
+            query, limit=limit * 2, source_id=source_id, namespace=namespace
+        )
 
         # Vector leg is weighted higher so semantic matches dominate when the
         # keyword leg is weak. Weights align positionally
@@ -260,12 +277,18 @@ class HybridRetriever:
                 result["artifact_slug"], result["artifact_name"] = artifact
 
     def _keyword_search(
-        self, query: str, limit: int = 20, source_id: str | None = None
+        self,
+        query: str,
+        limit: int = 20,
+        source_id: str | None = None,
+        namespace: str | None = None,
     ) -> list[tuple[str, int]]:
         """FTS5 search. Returns [(item_id, rank)] where rank is position (1=best).
 
         ``source_id`` narrows matches to items of one source via a
-        parameterized WHERE clause (never string interpolation).
+        parameterized WHERE clause (never string interpolation). ``namespace``
+        narrows to items carrying that ``items.namespace`` label the same way;
+        both compose when given together.
         """
         # A legacy database still holds the pre-CJK-segmentation term
         # representation. Migrating it is a reader's job, not the constructor's,
@@ -289,6 +312,11 @@ class HybridRetriever:
                 " (SELECT sl.item_id FROM source_locations sl WHERE sl.source_id = ?))"
             )
             params.extend([source_id, source_id])
+        if namespace is not None:
+            # namespace lives directly on items (organisational label), so this
+            # is a plain column match -- no source_locations join.
+            sql += " AND i.namespace = ?"
+            params.append(namespace)
         sql += " ORDER BY fts.rank LIMIT ?"
         params.append(limit)
         try:
@@ -370,12 +398,18 @@ class HybridRetriever:
         return [(item_id, rank + 1) for rank, (item_id, _) in enumerate(sorted_items)]
 
     def _vector_search(
-        self, query: str, limit: int = 20, source_id: str | None = None
+        self,
+        query: str,
+        limit: int = 20,
+        source_id: str | None = None,
+        namespace: str | None = None,
     ) -> list[tuple[str, int]] | None:
         """Brute-force cosine similarity against stored embeddings. Returns None if no embedder.
 
         ``source_id`` narrows candidates to items of one source via a
-        parameterized WHERE clause (never string interpolation).
+        parameterized WHERE clause (never string interpolation). ``namespace``
+        narrows to items carrying that ``items.namespace`` label the same way;
+        both compose when given together.
         """
         if self.embedder is None:
             return None
@@ -384,14 +418,18 @@ class HybridRetriever:
         if not query_vec:
             return None
         sql = "SELECT id, embedding FROM items WHERE embedding IS NOT NULL AND status = 'active'"
-        params: tuple[str, ...] = ()
+        params: list[object] = []
         if source_id is not None:
             # Ownership OR location — same membership rule as _keyword_search.
             sql += (
                 " AND (source_id = ? OR id IN"
                 " (SELECT sl.item_id FROM source_locations sl WHERE sl.source_id = ?))"
             )
-            params = (source_id, source_id)
+            params.extend([source_id, source_id])
+        if namespace is not None:
+            # namespace lives directly on items — plain column match.
+            sql += " AND namespace = ?"
+            params.append(namespace)
         rows = self.store.db.execute(sql, params).fetchall()
 
         scored = []

--- a/src/kiro_crew/mcp_tools/knowledge.py
+++ b/src/kiro_crew/mcp_tools/knowledge.py
@@ -68,6 +68,17 @@ def schemas() -> list[dict[str, Any]]:
                             "IDs with knowledge_list_sources."
                         ),
                     },
+                    "namespace": {
+                        "type": "string",
+                        "description": (
+                            "Optional namespace to scope keyword/vector seeding "
+                            "to documents filed under one organisational label "
+                            "(graph traversal still surfaces cross-namespace "
+                            "connections). This is a relevance filter, not a "
+                            "security boundary. Discover namespaces in the "
+                            "dashboard Knowledge panel; composes with source_id."
+                        ),
+                    },
                 },
                 "required": ["query"],
             },
@@ -176,6 +187,7 @@ def local_knowledge_search(name: str, args: dict[str, Any]) -> str:
     query = args["query"]
     limit = args.get("limit", 3)
     source_id = args.get("source_id") or None
+    namespace = args.get("namespace") or None
 
     db_path = Path(mcp_core.config_dir()) / "workspace" / "knowledge" / "knowledge.db"
     if not db_path.exists():
@@ -225,7 +237,7 @@ def local_knowledge_search(name: str, args: dict[str, Any]) -> str:
     embed_fn = embedder.embed if embedder and embedder.is_available() else None
     retriever = mcp_core.HybridRetriever(store, embedder=embed_fn)
 
-    results = retriever.search(query, limit=limit, source_id=source_id)
+    results = retriever.search(query, limit=limit, source_id=source_id, namespace=namespace)
 
     # Filter by minimum confidence score
     min_score = 0.012

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2735,6 +2735,11 @@ LOCAL_KNOWLEDGE_SEARCH_SCHEMA = ToolSchema(
         # the handler for a graceful "use knowledge_list_sources" reply, not a
         # ValidationError; every downstream use is a parameterized SQL bind.
         FieldSpec("source_id", str, required=False, max_len=64),
+        # Organisational namespace label (items.namespace). Same 64-char cap the
+        # store enforces on ingest (handlers/knowledge.py). No pattern: an
+        # unknown namespace just yields no results, and the value is a
+        # parameterized SQL bind. It is a relevance filter, not a boundary.
+        FieldSpec("namespace", str, required=False, max_len=64),
     ],
 )
 

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -979,6 +979,62 @@ class TestHybridRetrieverSourceFilter:
         assert [r["title"] for r in retriever.search("JWT", source_id=src_b)] == ["Shared Doc"]
 
 
+class TestHybridRetrieverNamespaceFilter:
+    def test_namespace_narrows_keyword_seeds(self, store):
+        # Both items match the query; scoping to one namespace keeps only its
+        # item. namespace is an organisational label on items, not a source.
+        store.add_item("Auth A", "JWT tokens for service alpha", "doc", namespace="client-a")
+        store.add_item("Auth B", "JWT tokens for service beta", "doc", namespace="client-b")
+        retriever = HybridRetriever(store)
+        results = retriever.search("JWT", namespace="client-a")
+        assert [r["title"] for r in results] == ["Auth A"]
+
+    def test_omitted_namespace_keeps_current_behavior(self, store):
+        # Regression: no namespace == the pre-filter result set.
+        store.add_item("Auth A", "JWT tokens for service alpha", "doc", namespace="client-a")
+        store.add_item("Auth B", "JWT tokens for service beta", "doc", namespace="client-b")
+        retriever = HybridRetriever(store)
+        results = retriever.search("JWT")
+        assert {r["title"] for r in results} == {"Auth A", "Auth B"}
+
+    def test_namespace_narrows_vector_seeds(self, store):
+        # Identical embeddings in two namespaces; scoping keeps one. The query
+        # shares no tokens with the content, isolating the vector leg.
+        vec = json.dumps([1.0, 0.0, 0.0, 0.0]).encode()
+        store.add_item("Vec A", "alpha content", "doc", namespace="client-a", embedding=vec)
+        store.add_item("Vec B", "beta content", "doc", namespace="client-b", embedding=vec)
+        retriever = HybridRetriever(store, embedder=lambda q: [1.0, 0.0, 0.0, 0.0])
+        results = retriever.search("unrelatedquerytoken", namespace="client-a")
+        assert [r["title"] for r in results] == ["Vec A"]
+
+    def test_unknown_namespace_returns_no_results(self, store):
+        # A nonexistent namespace empties the seed legs without raising; unlike
+        # source_id there is no existence probe, so it just yields nothing.
+        store.add_item("Auth", "JWT tokens", "doc", namespace="client-a")
+        retriever = HybridRetriever(store)
+        assert retriever.search("JWT", namespace="no-such-namespace") == []
+
+    def test_namespace_and_source_id_compose(self, store):
+        # Both filters apply together: only the item matching BOTH the source
+        # and the namespace survives the seed legs.
+        src_a = store.add_source("Docs A", "local_folder", "/tmp/a")
+        src_b = store.add_source("Docs B", "local_folder", "/tmp/b")
+        store.add_item(
+            "Match", "JWT tokens here", "doc", source_id=src_a, namespace="client-a"
+        )
+        # Same source, wrong namespace.
+        store.add_item(
+            "Wrong NS", "JWT tokens here", "doc", source_id=src_a, namespace="client-b"
+        )
+        # Right namespace, wrong source.
+        store.add_item(
+            "Wrong Src", "JWT tokens here", "doc", source_id=src_b, namespace="client-a"
+        )
+        retriever = HybridRetriever(store)
+        results = retriever.search("JWT", source_id=src_a, namespace="client-a")
+        assert [r["title"] for r in results] == ["Match"]
+
+
 # ---------------------------------------------------------------------------
 # 6. SimpleDiGraph
 # ---------------------------------------------------------------------------

--- a/test/test_mcp_knowledge_search.py
+++ b/test/test_mcp_knowledge_search.py
@@ -129,7 +129,7 @@ class TestKnowledgeSearchResults:
 
         _call_tool_inner("local_knowledge_search", {"query": "test"})
         mock_retriever_cls.return_value.search.assert_called_once_with(
-            "test", limit=3, source_id=None
+            "test", limit=3, source_id=None, namespace=None
         )
 
     @patch("kiro_crew.mcp_core.config_dir")
@@ -260,6 +260,14 @@ class TestKnowledgeSearchToolDefinition:
         assert "source_id" in tool["inputSchema"]["properties"]
         assert "source_id" not in tool["inputSchema"]["required"]
 
+    def test_namespace_is_optional(self):
+        from kiro_crew.mcp_core import _list_tools
+
+        tools = _list_tools()
+        tool = next(t for t in tools if t["name"] == "local_knowledge_search")
+        assert "namespace" in tool["inputSchema"]["properties"]
+        assert "namespace" not in tool["inputSchema"]["required"]
+
     def test_list_sources_tool_listed(self):
         from kiro_crew.mcp_core import _list_tools
 
@@ -297,7 +305,39 @@ class TestKnowledgeSearchSourceFilter:
 
         _call_tool_inner("local_knowledge_search", {"query": "auth", "source_id": "src-1"})
         mock_retriever_cls.return_value.search.assert_called_once_with(
-            "auth", limit=3, source_id="src-1"
+            "auth", limit=3, source_id="src-1", namespace=None
+        )
+
+    def test_namespace_rejects_non_string(self):
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        with pytest.raises(ValidationError):
+            _call_tool_inner("local_knowledge_search", {"query": "q", "namespace": 7})
+
+    def test_namespace_rejects_overlong_value(self):
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        with pytest.raises(ValidationError):
+            _call_tool_inner("local_knowledge_search", {"query": "q", "namespace": "x" * 65})
+
+    @patch("kiro_crew.mcp_core.config_dir")
+    @patch("kiro_crew.mcp_core.HybridRetriever")
+    @patch("kiro_crew.mcp_core._get_knowledge_search")
+    def test_namespace_passed_through_to_retriever(
+        self, mock_get_search, mock_retriever_cls, mock_config_dir, mock_db_exists
+    ):
+        # A namespace does not need to exist as a source, so no sources probe
+        # is required (unlike source_id): it flows straight to the retriever.
+        mock_config_dir.return_value = mock_db_exists
+        mock_store = MagicMock()
+        mock_get_search.return_value = (mock_store, None)
+        mock_retriever_cls.return_value.search.return_value = []
+
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        _call_tool_inner("local_knowledge_search", {"query": "auth", "namespace": "client-a"})
+        mock_retriever_cls.return_value.search.assert_called_once_with(
+            "auth", limit=3, source_id=None, namespace="client-a"
         )
 
     @patch("kiro_crew.mcp_core.config_dir")


### PR DESCRIPTION
## Problem / Motivation

The knowledge store already models a `namespace` label on every item -- `items.namespace TEXT DEFAULT 'default'` with a `CREATE INDEX idx_items_namespace`, and the dashboard already lists namespaces (`GET /api/knowledge/namespaces`), assigns them (upload picker, `PATCH /api/knowledge/items/{id}` accepts `namespace`) and browse-filters the item list by them (`?namespace=`).

Search was the one verb the label never reached. `HybridRetriever.search()` and the `local_knowledge_search` MCP tool scoped only by `source_id`, so an agent (or a user driving the KB) could organise documents into namespaces and filter the browse view by them, but could not tell a search "only look in this namespace". A single flat retrieval surface is exactly what #8266 asks to fix for the per-client / per-project / per-topic separation use cases.

## Why it matters to the user

Someone who has bothered to file documents under namespaces wants retrieval to honour that split -- keeping a topic's reference docs from diluting an unrelated query's results, or scoping an agent's `local_knowledge_search` to the namespace it is working in. Today they can see the label everywhere except where it would actually change what a search returns.

## What changed

- `knowledge/retrieval.py`: `search()`, `_keyword_search()` and `_vector_search()` take an optional `namespace`. It is applied to the same SEED legs as `source_id` (FTS5 keyword + vector similarity) as a parameterized `items.namespace = ?` match. The graph leg stays unfiltered, exactly as it is for `source_id`, so cross-namespace entity connections still contribute traversal context. `source_id` and `namespace` compose when both are given.
- `mcp_tools/knowledge.py`: `local_knowledge_search` gains an optional `namespace` argument (schema + validation + passthrough), mirroring `source_id`.
- `validation.py`: a `namespace` `FieldSpec` on `LOCAL_KNOWLEDGE_SEARCH_SCHEMA`, `max_len=64` to match the cap the ingest handler already enforces.

Design note, stated up front so it is not mistaken: knowledge namespaces are an ORGANISATIONAL LABEL, not a security boundary. There is no authorization anywhere in the tree keyed on the knowledge `namespace` column -- it is a plain SQL filter with a `'default'` fallback. This change is a relevance/organisation filter with the same trust properties as the existing `?namespace=` browse filter; it does not and must not be read as confidentiality enforcement. Chain from symptom to root cause: the symptom (search ignores namespaces) traces directly to the seed-leg WHERE clauses only knowing `source_id`; the fix adds the parallel clause the label already earned everywhere else.

Scope is deliberately the smallest coherent slice -- search scoping only. The issue's other verbs (a CLI create/delete surface, and binding a namespace to a workspace, its item 4) are separate, larger changes, so this is `Refs`, not `Closes`.

## Tests

Only the touched test files, run at `-n0`:
- `test/test_knowledge.py`: new `TestHybridRetrieverNamespaceFilter` -- keyword-leg narrowing, vector-leg narrowing, omitted-namespace regression (keeps all), unknown-namespace returns nothing, and `namespace` + `source_id` composing.
- `test/test_mcp_knowledge_search.py`: `namespace` optional in the advertised schema, rejects non-string, rejects overlong (>64), and passes through to the retriever. Two existing `search(...)` call assertions were updated to carry the new `namespace=None` kwarg.

293 passed. Each new enforcement site was mutation-verified by hand and reddened a DISTINCT set on a real assertion: neutering the keyword-leg filter reddened the keyword + compose tests (not the vector test); neutering the vector-leg filter reddened only the vector test; neutering the MCP passthrough reddened only the passthrough test. flake8, isort, mypy (my files) and the diff-scoped black gate are clean; merge-tree against main is clean.

## Pattern harvest

Mirrored the existing `source_id` seed-leg scoping verbatim rather than inventing a new mechanism, including its "seed legs only, graph leg unfiltered" contract and its parameterized-bind discipline. The one intentional divergence from the `source_id` shape: `namespace` is a direct `items.namespace` column with no `source_locations` ownership-OR-location join, because a namespace lives on the item itself.

Refs #8266
