### PR TITLE
fix: use canonical redaction order at five egress sites (#9014)

### DIFF
--- a/src/kiro_crew/instances/ssm_token_mint.py
+++ b/src/kiro_crew/instances/ssm_token_mint.py
@@ -51,7 +51,7 @@ from kiro_crew.instances.validation import (
     validate_ssm_run_as,
     validate_ssm_target,
 )
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import redact
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ def _redacted_tail(text: str, limit: int = _OUTPUT_TAIL_CHARS) -> str:
     """
     if not text:
         return ""
-    safe = redact_exfiltration_urls(redact_credentials(text)[0])[0]
+    safe = redact(text)
     return safe.strip()[-limit:]
 
 

--- a/src/kiro_crew/instances/token_mint.py
+++ b/src/kiro_crew/instances/token_mint.py
@@ -26,7 +26,7 @@ import re
 from kiro_crew.config.paths import CONFIG_DIR_NAME, LEGACY_CONFIG_DIR_NAME
 from kiro_crew.instances.constants import DEFAULT_MINT_TIMEOUT_SECS, TTL_PATTERN
 from kiro_crew.platform_compat import kill_and_reap
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import redact
 
 logger = logging.getLogger(__name__)
 
@@ -361,10 +361,13 @@ def _redacted_output_tail(stdout: str, limit: int = _OUTPUT_TAIL_CHARS) -> str:
     Why stripping is mandatory: unlike stderr, stdout is the one stream that
     *does* carry the minted JWT on success. This tail is only ever built on a
     failure path, but a partially-successful remote (URL printed, then a
-    non-zero exit) could still put a live credential in it — so the token is
-    substituted out FIRST, before the generic credential/exfil redactors run,
-    and the result is truncated to the last *limit* chars (the tail, because the
-    reason is the last thing printed).
+    non-zero exit) could still put a live credential in it. The generic
+    credential/exfil redactors run FIRST: the exfiltration-URL pass keys on the
+    token-bearing URL shape, so scrubbing the token value first would disarm it
+    and let a suspicious destination survive (#9014). The token-specific
+    ``_TOKEN_RE`` / ``_JWT_RE`` substitutions run AFTER as belt-and-suspenders
+    for token shapes the generic passes miss. The result is truncated to the
+    last *limit* chars (the tail, because the reason is the last thing printed).
 
     Why the scan is bounded: the scrubbers cost ~1s per MB of stdout and `re`
     holds the GIL, so scanning an unbounded remote payload stalls the gateway's
@@ -381,9 +384,9 @@ def _redacted_output_tail(stdout: str, limit: int = _OUTPUT_TAIL_CHARS) -> str:
     window = stdout
     if len(window) > _OUTPUT_SCAN_CHARS:
         window = _CLIPPED_RUN_RE.sub(_CLIPPED_MARKER, window[-_OUTPUT_SCAN_CHARS:], count=1)
-    stripped = _TOKEN_RE.sub(lambda m: m.group(0)[0] + "token=<redacted>", window)
-    stripped = _JWT_RE.sub("<redacted>", stripped)
-    safe = redact_exfiltration_urls(redact_credentials(stripped)[0])[0]
+    safe = redact(window)
+    safe = _TOKEN_RE.sub(lambda m: m.group(0)[0] + "token=<redacted>", safe)
+    safe = _JWT_RE.sub("<redacted>", safe)
     return safe.strip()[-limit:]
 
 
@@ -446,7 +449,7 @@ async def mint_remote_token(
     # stderr is proxy-controlled (WSSH banner etc.); redact credentials/exfil URLs
     # before surfacing it in an exception that may reach logs/status. The token
     # only ever appears on stdout, never stderr.
-    safe_stderr = redact_exfiltration_urls(redact_credentials(stderr)[0])[0] if stderr else ""
+    safe_stderr = redact(stderr) if stderr else ""
 
     if proc.returncode != 0:
         # stderr may carry the "binary not found" diagnostic — safe to log; it
@@ -524,5 +527,5 @@ async def run_remote_kirocrew(
     err = err_b.decode("utf-8", "replace").strip()
     # Proxy-controlled stderr (e.g. a WSSH banner) can carry credential-looking
     # text or exfil URLs; redact before returning since callers surface this tail.
-    safe_err = redact_exfiltration_urls(redact_credentials(err)[0])[0] if err else ""
+    safe_err = redact(err) if err else ""
     return (proc.returncode if proc.returncode is not None else -1), safe_err[:300]

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2237,7 +2237,7 @@ class GatewayOrchestrator:
         # Tool titles are LLM-originated input. Redact before any external
         # surface — SEL audit AND dashboard-visible logger warnings —
         # per the security-controls "never trust LLM output" guideline.
-        safe_title = redact_exfiltration_urls(redact_credentials(title)[0])[0]
+        safe_title = redact(title)
 
         def _audit(outcome: str, *, critical: bool = False, **metadata: str) -> None:
             """Emit a SEL ``log_tool_invocation`` event.

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -799,10 +799,8 @@ class TestTokenMint:
         from kiro_crew.instances import token_mint as tm
 
         seen: list[int] = []
-        real = tm.redact_credentials
-        monkeypatch.setattr(
-            tm, "redact_credentials", lambda text, *a, **k: seen.append(len(text)) or real(text)
-        )
+        real = tm.redact
+        monkeypatch.setattr(tm, "redact", lambda text: seen.append(len(text)) or real(text))
 
         huge = ("x" * 60 + " could not reach gateway\n") * 20_000  # ~1.7 MB
         self._fake_proc(monkeypatch, 1, huge.encode(), b"")
@@ -3503,6 +3501,67 @@ class TestTokenMintGeneric:
         assert rc == 255
         assert "AKIAIOSFODNN7EXAMPLE" not in err
         assert "[REDACTED: credential]" in err
+
+    def test_run_remote_kirocrew_redacts_urls_before_credentials(self, monkeypatch):
+        """#9014: pin the ORDER of the redaction passes, not just the redaction.
+
+        The exfiltration-URL pass keys on the token-bearing URL shape, so
+        running the credential pass first substitutes a placeholder into the
+        query string and disarms it — the suspicious destination host then
+        survives into the returned tail. Each pass is green in isolation, so
+        only an input carrying a suspicious URL whose query string also carries
+        a credential distinguishes the two orders. This test fails if the
+        composition is ever reversed again.
+        """
+        from kiro_crew.instances import token_mint as tm
+
+        class FakeProc:
+            returncode = 255
+
+            async def communicate(self):
+                return b"", b"banner https://evil.example.com/x?token=AKIAIOSFODNN7EXAMPLE end"
+
+        async def fake_exec(*a, **k):
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        rc, err = asyncio.run(tm.run_remote_kirocrew("cd-1", "restart"))
+        assert rc == 255
+        # The URL pass must fire: the destination must be suppressed, not just
+        # the credential inside it. Under the reversed (credentials-first)
+        # order the URL survives as https://evil.example.com/x?token=[...].
+        assert "https://evil.example.com" not in err
+        assert "[REDACTED: suspicious URL" in err
+        assert "AKIAIOSFODNN7EXAMPLE" not in err
+
+    def test_stdout_tail_url_pass_not_disarmed_by_token_prescrub(self, monkeypatch):
+        """#9014: the stdout-tail site has a second disarm path — its own
+        ``_TOKEN_RE`` pre-scrub. Substituting ``token=<redacted>`` into a URL's
+        query string before the exfiltration-URL pass destroys the token-bearing
+        shape that pass keys on, so a suspicious destination would survive into
+        the raised TokenMintError even with the composed helper in place. Pins
+        that the generic redactors see the window before the token scrubs.
+        """
+        from kiro_crew.instances import token_mint as tm
+
+        stdout = b"fail: see https://evil.example.com/x?token=AKIAIOSFODNN7EXAMPLE now"
+
+        class FakeProc:
+            returncode = 1
+
+            async def communicate(self):
+                return stdout, b""
+
+        async def fake_exec(*a, **k):
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        with pytest.raises(tm.TokenMintError) as excinfo:
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        msg = str(excinfo.value)
+        assert "https://evil.example.com" not in msg
+        assert "[REDACTED: suspicious URL" in msg
+        assert "AKIAIOSFODNN7EXAMPLE" not in msg
 
     class _HangProc:
         """First ``communicate`` times out; the reap (a SECOND communicate)


### PR DESCRIPTION
## Problem / Motivation

Five egress sites across three modules compose the credential and exfiltration-URL redaction passes in the **reverse** of the order the canonical helper `kiro_crew.security.redact` uses. The exfiltration-URL pass keys on the token-bearing URL shape, so running the credential pass first substitutes a placeholder into the query string and disarms it: a suspicious destination host survives into surfaced output. Reproduced:

```
input     : see https://evil.example.com/x?token=AKIA... now
canonical : see [REDACTED: suspicious URL to evil.example.com] now
reversed  : see https://evil.example.com/x?token=[REDACTED: credential] now
```

The affected sites are `instances/token_mint.py` (`_redacted_output_tail`, `mint_remote_token` stderr, `run_remote_kirocrew` stderr), `instances/ssm_token_mint.py` (`_redacted_tail`), and `slack/gateway.py` (LLM-originated tool title before SEL audit / dashboard-visible warnings).

## Why it matters

These paths surface remote stdout tails, proxy-controlled ssh/SSM stderr, and LLM-originated tool titles into exception messages, logs, SEL audit records, and the dashboard. The credential is removed either way; what the reversed order loses is suppression of the **destination** — the part an operator reading the tail most needs suppressed on an exfiltration-shaped line.

## What changed (motivation → approach → change)

Symptom: a suspicious URL host survives redaction at these sites. Root cause: hand-composed passes in credentials-first order, which destroys the pattern the URL pass matches. Change: replace each of the five hand-compositions with a single call to the composed helper `redact()`, fixing the order by construction and deleting five duplicated compositions. The `if stderr` / `if err` / `if not text` guards and `[-limit:]` / `[:300]` truncations are unchanged.

At the stdout-tail site (`_redacted_output_tail`) the module-local `_TOKEN_RE`/`_JWT_RE` pre-scrub was a second instance of the same disarm mechanism (it substitutes `token=<redacted>` into the query string before the URL pass runs), so the generic redactors now run first there and the token-specific scrubs run after as belt-and-suspenders; the docstring records the ordering rationale. Verified against all four token-shape cases (mint URL on localhost, bare JWT, exfil URL with AWS key, exfil URL with JWT): no token survives and suspicious destinations are suppressed.

Out of scope, deliberately: the change-detection site in `metrics/schema.py` (order-invariant boolean, not egress) and the ~25 sites that already compose urls-first as sequential statements — those match the canonical order already.

## Tests

- `test_run_remote_kirocrew_redacts_urls_before_credentials` — pins the pass ORDER at the returned-stderr site: input carries a suspicious URL whose query string also carries a credential; asserts the destination is suppressed. Fails on the reversed composition (proven red pre-fix).
- `test_stdout_tail_url_pass_not_disarmed_by_token_prescrub` — pins that the generic redactors see the stdout window before the `_TOKEN_RE` pre-scrub; fails on the pre-scrub-first ordering (proven red pre-fix).
- Existing `test_run_remote_kirocrew_redacts_stderr` still passes (no-URL inputs agree under both orders, confirming the divergence is URL-specific).
- The bounded-window perf test's length probe is retargeted from the removed per-pass import to the composed helper; its `max(seen) <= _OUTPUT_SCAN_CHARS` assertion is unchanged.

## Manual verification

Probed the real `redact` composition and `_redacted_output_tail` in a venv against the four token-shape cases above; scoped suites green (`test_instances.py`, `test_redaction_mirror_parity.py`, `test_refresh_tokens.py`, `test_slack_gateway_coverage.py` — 492 passed; the 2 `TestSshTunnelMultiplexing` failures reproduce identically on the pristine base and are environmental). isort / flake8 / mypy clean.

## Related Issues

Fixes #9014

## Pattern harvest

Rule candidate: semgrep
Pattern: hand-composed call chain `redact_exfiltration_urls(redact_credentials(...))` (creds-first) instead of the canonical `redact()` — order-sensitive security composition duplicated at call sites.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
