### PR TITLE
fix(dev-fleet): stop a junctioned node_modules wedging the sync

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
@@ -52,6 +52,37 @@ import sys
 #: aside for the duration of a step lands at ``<stash>`` + this.
 _BACKUP_SUFFIX = ".kirocrew-sync-backup"
 
+#: Reparse tag identifying a Windows directory junction, from ``winnt.h``.
+_IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003
+
+
+def is_junction(path: str) -> bool:
+    """True for a Windows directory junction, on every interpreter this runs on.
+
+    ``platform_compat`` owns this predicate for the rest of the package, and this
+    module cannot import it -- the stdlib-only rule at the top of this file is an
+    invariant, so the check is spelled out here instead. ``os.path.isjunction``
+    is 3.12+, and the runner is executed by whatever interpreter the gateway is
+    installed under, which the project still floors at 3.10; without the reparse
+    fallback the guard below would be a silent no-op on exactly the older Windows
+    installs most likely to be carrying a junction.
+
+    ``follow_symlinks=False``: the question is what THIS name is, not what it
+    points at. False off Windows, where the attributes do not exist and junctions
+    do not either.
+    """
+    isjunction = getattr(os.path, "isjunction", None)
+    if isjunction is not None:
+        try:
+            return bool(isjunction(path))
+        except (OSError, ValueError):
+            return False
+    try:
+        info = os.stat(path, follow_symlinks=False)
+    except (OSError, ValueError):
+        return False
+    return getattr(info, "st_reparse_tag", 0) == _IO_REPARSE_TAG_MOUNT_POINT
+
 
 def gone(path: str) -> bool:
     """Remove *path* and report whether it is now absent.
@@ -71,6 +102,15 @@ def gone(path: str) -> bool:
     and every Pull + Build from then on refused as ambiguous: a permanent wedge
     escapable only by hand. So unlink the link, and ``rmtree`` only real trees.
 
+    A Windows JUNCTION reaches that same wedge and needs the same treatment.
+    ``os.path.islink`` reports False for one, so it fell through to ``rmtree``,
+    which refuses a junction exactly as it refuses a symlink -- the refusal is
+    swallowed, the backup survives, and every later Pull + Build sees both paths
+    and stops as ambiguous. A junction is the ordinary Windows spelling of the
+    shared-store layout the paragraph above describes, because a directory
+    symlink there needs a privilege a junction does not. It is removed with
+    ``rmdir``, which unlinks the reparse point and never the target.
+
     ``lexists``, not ``exists``: a DANGLING symlink is still something at this
     path, and reporting it as gone would let the runner proceed as though the
     slot were clear.
@@ -78,6 +118,11 @@ def gone(path: str) -> bool:
     if os.path.islink(path):
         try:
             os.unlink(path)
+        except OSError:
+            pass
+    elif is_junction(path):
+        try:
+            os.rmdir(path)
         except OSError:
             pass
     else:

--- a/src/kiro_crew/node_modules_txn.py
+++ b/src/kiro_crew/node_modules_txn.py
@@ -45,6 +45,8 @@ import shutil
 from pathlib import Path
 from typing import Callable
 
+from kiro_crew import platform_compat
+
 logger = logging.getLogger(__name__)
 
 #: Suffix appended to the tree path to name its backup. MUST match the literal
@@ -62,14 +64,24 @@ def _gone(path: Path) -> bool:
     ambiguous. A permanent wedge escapable only by hand. So: unlink links,
     rmtree only real trees.
 
+    ``is_link_or_junction``, not ``os.path.islink``, because a Windows JUNCTION
+    reaches the identical wedge. ``islink`` reports False for one, so the
+    junction went to ``rmtree``, which refuses it exactly as it refuses a
+    symlink -- same swallowed refusal, same surviving backup, same ambiguous
+    refusal on every run after. A junctioned ``node_modules`` is the ordinary
+    Windows spelling of the shared-store layout this branch was written for,
+    since a directory symlink there needs a privilege a junction does not.
+
     The outcome is CONFIRMED rather than assumed because every removal here
     decides what the next rename does; a partial removal that is silently
     ignored leaves a directory in place, makes the rename fail, and can end with
     a PARTIAL tree restored over a good one.
     """
-    if os.path.islink(path):
+    if platform_compat.is_link_or_junction(path):
         try:
-            os.unlink(path)
+            # Removes the link ITSELF: unlink for a symlink, rmdir for a
+            # junction's reparse point. The target is never touched.
+            platform_compat.unlink_link_or_junction(path)
         except OSError:
             pass
     else:

--- a/test/test_dev_fleet_sync_runner.py
+++ b/test/test_dev_fleet_sync_runner.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import pytest
 
+from conftest import make_dir_link
+from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.dev_fleet import npm_preflight, sync_runner
 
 _BACKUP = sync_runner._BACKUP_SUFFIX
@@ -292,6 +294,50 @@ class TestRunSteps:
         steps = [_echo_step("Verify dependencies", code, tmp_path)]
         rc = sync_runner.run_steps(steps, str(tmp_path), reserved, "Verify dependencies", 47)
         assert rc == code
+
+
+# --- gone() ------------------------------------------------------------------
+
+
+class TestGone:
+    def test_a_linked_tree_is_unlinked_and_its_target_survives(self, tmp_path):
+        """A junction is the Windows spelling of the shared-store layout.
+
+        ``os.path.islink`` reports False for one, so it fell through to
+        ``rmtree``, which refuses a junction exactly as it refuses a symlink --
+        the refusal is swallowed by ``ignore_errors``, ``gone`` reports False,
+        and the transaction that reads it stops with a backup it can never
+        clear. Every later Pull + Build then sees both paths and refuses as
+        ambiguous.
+
+        ``make_dir_link`` gives a junction on Windows and a symlink elsewhere, so
+        the POSIX run is a no-regression check on the branch that already worked.
+        """
+        store = tmp_path / "store"
+        _tree(store, "store")
+        link = tmp_path / "node_modules"
+        make_dir_link(link, store)
+
+        # Guard the guard, through an oracle OUTSIDE the module under test, so
+        # the first thing to fail here is the behaviour and not a missing name.
+        if platform_compat.IS_WINDOWS:
+            assert not os.path.islink(link)
+            assert os.path.isdir(link)
+        else:
+            assert os.path.islink(link)
+        assert platform_compat.is_link_or_junction(link)
+
+        assert sync_runner.gone(str(link)) is True
+        assert not os.path.lexists(link)
+        # Removed as a LINK: the shared store behind it is untouched.
+        assert (store / "sentinel").read_text(encoding="utf-8") == "store"
+
+    def test_a_real_tree_is_still_removed(self, tmp_path):
+        # The junction branch must not shadow the ordinary case.
+        tree = tmp_path / "node_modules"
+        _tree(tree)
+        assert sync_runner.gone(str(tree)) is True
+        assert not os.path.lexists(tree)
 
 
 # --- the snapshot-not-import invariant ---------------------------------------

--- a/test/test_node_modules_txn.py
+++ b/test/test_node_modules_txn.py
@@ -24,8 +24,10 @@ from pathlib import Path
 
 import pytest
 
+from conftest import make_dir_link
 from kiro_crew import frontend
 from kiro_crew import node_modules_txn as nmt
+from kiro_crew import platform_compat
 from kiro_crew.node_modules_txn import BACKUP_SUFFIX, NodeModulesBackup
 
 MARKER = "left-by-the-previous-install"
@@ -568,6 +570,45 @@ class TestTransactionPolicy:
         assert os.path.islink(tree)
         assert (tree / "sentinel.txt").read_text() == MARKER
         assert not os.path.lexists(Path(str(tree) + BACKUP_SUFFIX))
+
+    def test_a_junctioned_tree_does_not_wedge_the_next_run(self, tmp_path: Path) -> None:
+        # The Windows spelling of the same shared-store layout: a directory
+        # symlink needs SeCreateSymbolicLinkPrivilege there, a junction needs
+        # none, so a junction is what such a worktree actually has. os.path.islink
+        # reports False for it, so the backup went to rmtree -- which refuses a
+        # junction exactly as it refuses a symlink. The refusal is swallowed, the
+        # backup survives, and the NEXT run sees both paths and refuses by hand.
+        #
+        # Driven through commit(), not rollback(): the success path is where the
+        # backup is removed, so it is the only one that can leave the wedge.
+        store = tmp_path / "store"
+        store.mkdir()
+        (store / "sentinel.txt").write_text(MARKER)
+        tree = tmp_path / "node_modules"
+        backup = Path(str(tree) + BACKUP_SUFFIX)
+        make_dir_link(tree, store)
+
+        # Guard the guard: on Windows this must be the shape islink misreads,
+        # or the test would pass against a plain directory and prove nothing.
+        if platform_compat.IS_WINDOWS:
+            assert not os.path.islink(tree)
+            assert os.path.isdir(tree)
+        assert platform_compat.is_link_or_junction(tree)
+
+        txn = NodeModulesBackup(tree, lambda _m: None)
+        assert txn.begin() is True
+        # npm ci writes a fresh real tree where the link used to be.
+        tree.mkdir()
+        (tree / "installed.txt").write_text("new")
+        txn.commit()
+
+        assert not os.path.lexists(backup), "the junctioned backup survived commit()"
+        # The link was removed, never followed: the shared store is untouched.
+        assert (store / "sentinel.txt").read_text() == MARKER
+        # The consequence that actually reaches an operator: with a surviving
+        # backup the next run refuses as ambiguous and stays refused until
+        # someone deletes a path by hand.
+        assert NodeModulesBackup(tree, lambda _m: None).begin() is True
 
     def test_a_dangling_tree_link_does_not_crash_the_transaction(self, tmp_path: Path) -> None:
         # lexists, not isdir: isdir follows the link, so a DANGLING one reads as


### PR DESCRIPTION
## Problem / Motivation

The `node_modules` transaction removes a stashed tree with one rule, spelled out
in both copies of it:

> `rmtree` REFUSES a symlink ("Cannot call rmtree on a symbolic link") and
> `ignore_errors=True` swallows that refusal -- which once left a symlinked
> tree's backup undeletable, so every later run saw both paths and refused as
> ambiguous. **A permanent wedge escapable only by hand.**

`os.path.islink` reports **False for a Windows directory junction**, so a
junctioned tree skipped the unlink branch and went to `rmtree` — which refuses a
junction exactly as it refuses a symlink. Same swallowed refusal, same surviving
backup, same wedge.

Measured end-to-end on unpatched `main` (Windows, `_winapi.CreateJunction`, a
junctioned `node_modules` pointing at a shared store):

| step | result |
|---|---|
| `os.path.islink(tree)` / `os.path.isdir(tree)` | `False` / `True` |
| `begin()` | `True` — the junction is renamed to the backup |
| `commit()` | the backup **survives** |
| store behind the junction | **intact** |
| **next run** `begin()` | **`False`** — logs *"remove one by hand"* |

A junction is not an exotic layout here: it is the ordinary Windows spelling of
the shared-store `node_modules` the symlink branch was written for, because a
directory symlink on Windows needs `SeCreateSymbolicLinkPrivilege` and a junction
needs nothing.

## Why it matters

**Availability, not data loss** — and the PR does not claim more. The store behind
the junction is never touched (`rmtree` refuses before it descends; verified in the
table above). What breaks is the flow:

* Dev Fleet **Pull + Build** stops on every subsequent press with
  `EXIT_TREE_AMBIGUOUS`, naming two paths and touching neither.
* The **unattended auto-update** path reaches the same refusal with no operator
  present. It never retries — the next boot sees the commit already applied — so
  its only self-heal is Dev Fleet's reconciliation, which is exactly what is now
  refusing.

Neither clears on its own. The transaction is deliberately built to refuse rather
than guess, so this state persists until a human deletes one of the two paths.

## What changed (motivation → approach → change)

Symptom: a junctioned `node_modules` wedges the sync. Root cause: the link guard
uses a predicate that does not recognise a junction. Change: recognise it, and
remove it **as a link** rather than trying to walk it.

Two files, because the transaction has two copies **by design** and they share
semantics rather than code:

1. **`src/kiro_crew/node_modules_txn.py`** (the in-process half) uses
   `platform_compat.is_link_or_junction` and `unlink_link_or_junction` — the
   latter unlinks a symlink and `rmdir`s a junction's reparse point, never the
   target. Its only consumer, `frontend.py`, **already imports `platform_compat`
   and already uses both helpers** for the `static/dist` link, so this adds
   nothing to any import path.
2. **`dev_fleet/sync_runner.py`** (the snapshot half) **cannot** import
   `kiro_crew`: the module header states the stdlib-only rule is "an invariant,
   not a convenience", because the file is copied out and run **by path** while
   the repository is being merged underneath it, and a test asserts it. So the
   predicate is spelled out locally, with the reparse-tag fallback that
   `os.path.isjunction` (3.12+) does not provide on the 3.10/3.11 floor this
   project still supports — without it the guard would be a silent no-op on
   exactly the older Windows installs most likely to carry a junction. Confirmed
   locally: `hasattr(os.path, "isjunction")` is `False` on the 3.10 interpreter.

Fixing only one would leave the identical wedge on the other flow, so both move
together.

**Not changed:** the transaction's shape, its refusal policy, the ambiguous-state
branch, and the shared `BACKUP_SUFFIX`. The dev-fleet and cli specs describe the
transaction at that level and are unaffected, so neither needed a same-commit
update.

## Tests

Three tests, in the files that already own these functions:

* `test_node_modules_txn.py::test_a_junctioned_tree_does_not_wedge_the_next_run`
  — drives `begin()` → fresh install → `commit()`, then asserts the backup is
  gone, the store behind the junction still holds its sentinel, **and the next
  run's `begin()` returns `True`**. That last assertion is the operator-visible
  consequence, not a proxy for it.
* `test_dev_fleet_sync_runner.py::TestGone::test_a_linked_tree_is_unlinked_and_its_target_survives`
  — `gone()` on the link reports `True`, the link is gone, the target survives.
* `…::test_a_real_tree_is_still_removed` — the new branch does not shadow the
  ordinary directory case.

Both link tests use `conftest.make_dir_link`, which yields a **junction** on
Windows and a symlink elsewhere, and both carry guard-the-guard assertions
(`not os.path.islink` / `os.path.isdir` on Windows) through an oracle **outside**
the module under test — so a red-before fails on behaviour, never on a missing
name.

**Red-before, measured against unpatched `origin/main`** with the two production
files restored in-tree:

```
E  AssertionError: the junctioned backup survived commit()
E  assert False is True        # gone(<junction>) reported not-removed
```

Green after: the three new tests pass; `test_node_modules_txn.py` +
`test_dev_fleet_sync_runner.py` + `test_dev_fleet_app.py` show **13 failed / 362
passed on `test_dev_fleet_app.py` both with and without the patch** — an
identical control, so that pre-existing Windows set is not a regression. Those
failures are `WinError 1314` (no symlink privilege in an unelevated shell), which
is precisely why the pre-existing `test_a_symlinked_tree_is_still_protected`
cannot run on Windows — the platform this defect lives on.

**Platform honesty:** on Linux CI `make_dir_link` produces a symlink, which the
original guard already handled, so these are no-regression checks there. Only
Windows exercises the fix.

Gates: `flake8` clean, `isort --check-only` clean,
`scripts/check_black_formatting.py` and `scripts/check_subprocess_encoding.py`
both PASS scoped `origin/main...HEAD` (4 files). `mypy --platform linux` reports
nothing for either production file; its 4 findings are in `dashboard/state.py`
and `apps/routes.py` and are Python-3.10-only artifacts of the local interpreter,
absent on CI's 3.12.

## Manual verification

N/A — unit coverage sufficient. The behaviour is a pure function of a directory
tree, and the tests build the exact tree (junction included) the defect needs,
including the second run that exposes the wedge.

## Related Issues

No issue. Found by auditing link guards for the junction blind spot, then
measured against current `main`.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **a link guard whose failure mode is a refused destructive call, not a
destructive one.** The reflex on `os.path.islink` misses is "does something get
deleted through the link?" — here nothing does, and that is *why* it is a bug:
`rmtree` refuses, the refusal is swallowed by `ignore_errors=True`, and a caller
that reads the removal's success as a gate is left permanently stuck. A guard
miss whose consequence is *availability* is easy to grade as harmless and is not.

That grading matters at the seam level: a sibling `rmtree`-behind-`islink` site
(`auto_improvement/pr_watchers.py:1417`) was measured and **rejected** precisely
because nothing there reads the outcome — worst case a directory is not
reclaimed. Same predicate, same platform, opposite verdict. These sites are
decided one at a time on consequence, never swept.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — both functions' docstrings; no spec documents this branch
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
