### PR TITLE
fix(acp): reset warm client conversations

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -259,6 +259,13 @@ Custom agents use cold start with `--agent <name>` flag at spawn time.
 
 `initialize` → `session/load` or `session/new` → `set_mode` (conditional) → `set_model` (conditional) → drain notifications → `session/prompt`
 
+`new_conversation()` keeps the process warm but follows the fresh-session
+configuration contract: it creates a new `session/new`, restores the mode,
+model, and any session-scoped permission routing, then adopts that session.
+Until reconfiguration succeeds, the client retains its prior session; a failed
+reset therefore raises without leaving a caller on a partially configured
+conversation.
+
 `ensure_ready()` creates `_work_dir` once per instance (off-loop `mkdir -p`,
 remembered via a flag) so the per-prompt warm path pays no filesystem syscall;
 `_spawn()` re-creates it (also off-loop) on every spawn, and `_reset_state()`

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -122,6 +122,7 @@ from kiro_crew.acp.types import (
     METHOD_REQUEST_PERMISSION,
     METHOD_SESSION_LOAD,
     METHOD_SESSION_NEW,
+    METHOD_SESSION_TERMINATE,
     METHOD_SESSION_UPDATE,
     METHOD_SET_MODE,
     METHOD_SET_MODEL,
@@ -1335,6 +1336,9 @@ _INIT_TIMEOUT = 240.0  # 4 min — MCP servers can be slow to initialize
 # disk, with headroom. On expiry the adapter is REFUSED, never started with
 # its mask missing.
 _SANDBOX_PREFLIGHT_TIMEOUT = 60.0
+# A reset must not leave its prior session and MCP children alive indefinitely.
+# Kiro's targeted terminate is a request, so this is its bounded acknowledgement window.
+_RESET_SESSION_RETIRE_TIMEOUT = 5.0
 # set_mode/set_model: fire-and-forget.  kiro-cli accepts these commands
 # but usually never sends a JSON-RPC response — MCP servers load
 # asynchronously.  Any late responses land in _buffer and are harmlessly
@@ -4590,6 +4594,119 @@ class AcpClient:
                 {"sessionId": self._session_id, "modelId": self._model},
             )
         logger.info("ACP model: %s", self._model)
+
+    async def new_conversation(self) -> None:
+        """Reset a warm client without changing its process.
+
+        A fresh ACP session loses the active mode, model, and session-scoped
+        permission configuration. Keep the prior session selected until those
+        settings are re-applied so a failed reset cannot leave the caller on a
+        half-configured conversation.
+        """
+        if not self._is_process_alive():
+            raise AcpProcessDied("Process is not alive — cannot start a new conversation")
+        if not self._session_id:
+            raise AcpError("Cannot reset a conversation before the session is initialized")
+        if self.has_active_turn():
+            raise AcpError("Cannot reset a conversation while a turn is in flight")
+
+        old_session_id = self._session_id
+        if not self._is_kiro:
+            await self._retire_reset_session(old_session_id)
+            raise AcpError(
+                "This ACP backend does not support targeted session retirement; "
+                "the raw client was discarded for a clean hard reset"
+            )
+
+        session_resp = await self._new_session_following_substitution()
+        new_session_id = session_resp.get("sessionId")
+        if not new_session_id:
+            raise AcpError(
+                "session/new returned no sessionId during conversation reset; "
+                "the prior conversation remains active"
+            )
+
+        self._session_id = new_session_id
+        try:
+            self._capture_available_models(session_resp)
+            if self._uses_advertised_model_selection:
+                await self._persist_advertised_models_if_changed()
+                await self._reseed_after_capture()
+            self._store_session_config(session_resp)
+            if self._is_kiro:
+                if not self._modes_advertised or self._agent in self._available_mode_ids:
+                    await self._send_request(
+                        METHOD_SET_MODE,
+                        {"sessionId": new_session_id, "modeId": self._agent},
+                    )
+                else:
+                    raise AcpError(
+                        f"Agent mode {self._agent!r} is not available on this session "
+                        f"(advertised modes: {self._available_mode_ids or 'none'}); "
+                        "refusing to reset onto the backend default mode."
+                    )
+            await self._apply_startup_model()
+            if acp_tool_gate.routing_for(self.backend) is acp_tool_gate.Routing.SESSION_CONFIG:
+                await self._apply_session_permission_routing()
+        except BaseException:
+            self._session_id = old_session_id
+            await self._retire_reset_session(new_session_id)
+            raise
+
+        if not await self._retire_reset_session(old_session_id):
+            raise AcpError(
+                "The prior ACP session could not be retired; the raw client was "
+                "discarded for a clean hard reset"
+            )
+
+        self._resumed = False
+        if self._is_kiro:
+            jsonl_path = kiro_sessions_dir() / f"{new_session_id}.jsonl"
+            try:
+                self._jsonl_pos = jsonl_path.stat().st_size if jsonl_path.exists() else 0
+            except OSError:
+                self._jsonl_pos = 0
+        self._last_activity = time.monotonic()
+        logger.info("ACP conversation reset: %s -> %s", old_session_id, new_session_id)
+
+    async def _retire_reset_session(self, session_id: str) -> bool:
+        """Retire one reset session, or dispose this unshared process instead.
+
+        Generic ACP has no session-close operation. Kiro's extension can reclaim
+        exactly one session and its MCP children; every other case must drop the
+        raw process so the workflow pool's existing hard-reset path starts clean.
+        """
+        if self._is_kiro:
+            try:
+                request_id = await self._send_request(
+                    METHOD_SESSION_TERMINATE, {"sessionId": session_id}
+                )
+                await self._wait_for_response(
+                    request_id,
+                    timeout=_RESET_SESSION_RETIRE_TIMEOUT,
+                    method=METHOD_SESSION_TERMINATE,
+                )
+                return True
+            except asyncio.CancelledError:
+                await self.shutdown()
+                raise
+            except Exception:
+                logger.warning(
+                    "ACP session retirement failed for %s; discarding raw process",
+                    session_id,
+                    exc_info=True,
+                )
+        else:
+            logger.debug(
+                "ACP backend %s has no targeted session retirement; discarding raw process",
+                self.backend,
+            )
+
+        try:
+            await self.shutdown()
+        except Exception:
+            logger.debug("raw ACP process disposal after reset failed", exc_info=True)
+        return False
 
     async def _reseed_after_capture(self) -> None:
         """Re-seed settings.local.json once the backend's model list is known.

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -40,7 +40,9 @@ from kiro_crew.acp.liveness import (
 )
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_KIRO,
     JSONRPC_METHOD_NOT_FOUND,
+    METHOD_SESSION_TERMINATE,
     AcpPromptStats,
 )
 
@@ -10385,6 +10387,120 @@ class TestSubstitutionFollow:
         assert resp.get("sessionId") is None
         client._write_claude_local_settings.assert_not_called()
         assert sent.count("session/new") == 1
+
+
+class TestNewConversation:
+    @staticmethod
+    def _make_warm_client(tmp_path):
+        client = AcpClient(work_dir=tmp_path, acp_backend=ACP_BACKEND_KIRO)
+        process = MagicMock()
+        process.returncode = None
+        client._process = process
+        client._session_id = "session-old"
+        client._turn_done.set()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_reconfigures_a_fresh_session_before_adopting_it(self, tmp_path):
+        client = self._make_warm_client(tmp_path)
+        client._new_session_following_substitution = AsyncMock(
+            return_value={"sessionId": "session-new"}
+        )
+        client._apply_startup_model = AsyncMock()
+        client._wait_for_response = AsyncMock(return_value={})
+        sent: list[tuple[str, dict]] = []
+
+        async def send(method, params):
+            sent.append((method, params))
+            return len(sent)
+
+        client._send_request = send
+
+        await client.new_conversation()
+
+        assert client._session_id == "session-new"
+        assert sent == [
+            ("session/set_mode", {"sessionId": "session-new", "modeId": client._agent}),
+            (METHOD_SESSION_TERMINATE, {"sessionId": "session-old"}),
+        ]
+        client._apply_startup_model.assert_awaited_once()
+        client._wait_for_response.assert_awaited_once_with(
+            2,
+            timeout=acp_client._RESET_SESSION_RETIRE_TIMEOUT,
+            method=METHOD_SESSION_TERMINATE,
+        )
+
+    @pytest.mark.asyncio
+    async def test_failed_reconfiguration_keeps_the_prior_session(self, tmp_path):
+        client = self._make_warm_client(tmp_path)
+        client._new_session_following_substitution = AsyncMock(
+            return_value={"sessionId": "session-new"}
+        )
+        client._apply_startup_model = AsyncMock(side_effect=AcpError("model rejected"))
+        client._send_request = AsyncMock(return_value=1)
+        client._wait_for_response = AsyncMock(return_value={})
+
+        with pytest.raises(AcpError, match="model rejected"):
+            await client.new_conversation()
+
+        assert client._session_id == "session-old"
+        client._send_request.assert_any_await(
+            METHOD_SESSION_TERMINATE, {"sessionId": "session-new"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_discards_the_raw_process_when_targeted_retirement_fails(self, tmp_path):
+        client = self._make_warm_client(tmp_path)
+        client._new_session_following_substitution = AsyncMock(
+            return_value={"sessionId": "session-new"}
+        )
+        client._apply_startup_model = AsyncMock()
+        client._send_request = AsyncMock(return_value=1)
+        client._wait_for_response = AsyncMock(side_effect=AcpError("terminate unavailable"))
+        client.shutdown = AsyncMock()
+
+        with pytest.raises(AcpError, match="prior ACP session could not be retired"):
+            await client.new_conversation()
+
+        client._send_request.assert_any_await(
+            METHOD_SESSION_TERMINATE, {"sessionId": "session-old"}
+        )
+        client.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_discards_an_unsupported_raw_backend_before_creating_a_session(self, tmp_path):
+        client = AcpClient(work_dir=tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        process = MagicMock()
+        process.returncode = None
+        client._process = process
+        client._session_id = "session-old"
+        client._turn_done.set()
+        client._new_session_following_substitution = AsyncMock()
+        client.shutdown = AsyncMock()
+
+        with pytest.raises(AcpError, match="does not support targeted session retirement"):
+            await client.new_conversation()
+
+        client._new_session_following_substitution.assert_not_awaited()
+        client.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_session_dead_process_and_active_turn(self, tmp_path):
+        client = self._make_warm_client(tmp_path)
+        client._new_session_following_substitution = AsyncMock(return_value={})
+
+        with pytest.raises(AcpError, match="no sessionId"):
+            await client.new_conversation()
+        assert client._session_id == "session-old"
+
+        client._process = None
+        with pytest.raises(AcpProcessDied):
+            await client.new_conversation()
+
+        client = self._make_warm_client(tmp_path)
+        client._turn_done.clear()
+        with pytest.raises(AcpError, match="turn is in flight"):
+            await client.new_conversation()
 
 
 class TestSubstitutionWrappersAndRedaction:


### PR DESCRIPTION
## Problem / Motivation

Direct `AcpClient` reset can replace its session ID without retiring the prior backend session and its MCP children.

## Why it matters

Repeated warm-worker resets can leak backend resources. A backend without targeted session teardown must not pretend it can safely reuse the raw process.

## What changed

For Kiro, create and configure the fresh session before retiring the old one with `_kiro.dev/session/terminate`; discard the raw process if targeted retirement fails. Retire a provisional session after failed configuration. Generic ACP backends fall back to the existing hard reset.

## Pattern harvest

Rule candidate: a warm reset may adopt a new handle only when the prior resource is retired or the whole owning process is discarded.

## Tests

`python -m pytest -q test/test_acp_client.py -k TestNewConversation` — 5 passed.

## What changed (motivation → approach → change)

N/A — covered by the existing `## What changed` section.

## Manual verification

N/A — focused automated coverage is sufficient.

## Related Issues

N/A.

## Checklist

- [x] Existing tests pass and regression coverage is included.
- [x] Self-review completed; code follows project style guidelines.
- [x] Documentation updated where applicable.
- [x] No secrets, credentials, or internal references in the diff.

## Contribution License Agreement

N/A — template placeholder; no CLA wording is supplied.
