### PR TITLE
fix(acp): degrade every dispatch-path encode, not just the marker branch

### DIFF
--- a/docs/system-specs/modules/agent-host-contract.md
+++ b/docs/system-specs/modules/agent-host-contract.md
@@ -270,6 +270,16 @@ not symmetric: a dropped directive silently unarms a loop the model was told was
 armed, while dropped sibling detail costs transcript content the user can see is
 missing. The directive is emitted even when no sibling copy survives at all.
 
+**The refusal posture covers every encode on the dispatch path, not just the
+marker branch.** The permission event's cache-miss input fallback, the initial
+`tool_call` input, the two non-marker tool-result branches and the refinement
+input all serialise backend-shaped payloads through a refusal-guarded encode
+(`_dumps_degraded`): an encoder refusal degrades that one frame to readable
+text — `str(payload)` for a `(TypeError, ValueError)` refusal, the
+`UNSERIALISABLE_SIBLING_VALUE` placeholder for a `RecursionError` — instead of
+propagating and aborting the turn. A payload that encodes today keeps its exact
+rendering; only the frames that previously killed the turn change.
+
 **A provider must declare:** whether its tool-result text arrives verbatim or
 pre-serialised, and — if any builder it adds can emit an `EVENT_TOOL_RESULT` —
 that the builder runs the repair. This is the one bucket in this document with a

--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -889,7 +889,7 @@ def build_permission_event(
         raw_input = tool_call.get("input") or tool_call.get("params")
         if raw_input:
             tool_input = (
-                json.dumps(raw_input, indent=2)
+                _dumps_degraded(raw_input, indent=2)
                 if isinstance(raw_input, (dict, list))
                 else str(raw_input)
             )
@@ -1055,7 +1055,7 @@ def _build_tool_call_event(
     input_str = ""
     if tool_call_id and raw_input:
         input_str = (
-            json.dumps(raw_input, indent=2)
+            _dumps_degraded(raw_input, indent=2)
             if isinstance(raw_input, (dict, list))
             else str(raw_input)
         )
@@ -1222,10 +1222,44 @@ def _marker_bearing_text(payload: dict[str, Any], _max_nodes: int = 512) -> str 
 ELIDED_MARKER_VALUE = "[[directive marker emitted on its own line above]]"
 
 #: Stands in for one top-level sibling whose value the JSON encoder refuses (see
-#: :func:`_dumps_elided_siblings`). Visible in the transcript on purpose: the
-#: user can see that detail is missing, which is the whole difference between
-#: this and dropping the field.
+#: :func:`_dumps_elided_siblings`), and for a whole payload the encoder refuses
+#: at any dispatch-path encode (see :func:`_dumps_degraded`). Visible in the
+#: transcript on purpose: the user can see that detail is missing, which is the
+#: whole difference between this and dropping the field.
 UNSERIALISABLE_SIBLING_VALUE = "[[value omitted: nested too deeply to serialise]]"
+
+
+def _dumps_degraded(payload: Any, **kwargs: Any) -> str:
+    """``json.dumps`` that degrades to readable text instead of raising.
+
+    Every encode on the dispatch path serialises a payload whose shape the agent
+    backend chooses, so the encoder can always be pushed past its ceiling:
+    ``json.dumps`` raises ``RecursionError`` on a sufficiently nested structure
+    -- a ``RuntimeError``, which the ``(TypeError, ValueError)`` arm that guards
+    one of these sites does not catch and the others do not guard at all, so the
+    raise escapes frame rendering and aborts the whole agent turn. The intended
+    cost of an unrenderable frame is that ONE frame, degraded visibly, never the
+    turn. The marker-bearing branch got this treatment in
+    :func:`_dumps_elided_siblings`; this is the same refusal posture for the
+    remaining encodes, which carry no directive and so need no per-field walk.
+
+    A ``TypeError``/``ValueError`` refusal degrades to ``str(payload)`` -- the
+    payload still has a repr, and this preserves byte-identically the arm that
+    :func:`_build_tool_refinement_event` already carried. A ``RecursionError``
+    refusal cannot count on that (``repr`` recurses too, just with a different
+    ceiling than the encoder's), so it degrades to the
+    :data:`UNSERIALISABLE_SIBLING_VALUE` placeholder, and the ``str`` fallback
+    keeps its own arm for the payload that is both deep and unencodable.
+    """
+    try:
+        return json.dumps(payload, **kwargs)
+    except (TypeError, ValueError):
+        try:
+            return str(payload)
+        except RecursionError:
+            return UNSERIALISABLE_SIBLING_VALUE
+    except RecursionError:
+        return UNSERIALISABLE_SIBLING_VALUE
 
 
 def _elide_marker_value(payload: Any, marker: str) -> Any:
@@ -1766,7 +1800,7 @@ def _build_tool_result_event(update: dict[str, Any], cache_scope: str = "") -> A
                                         output_parts.append(_siblings)
                                 output_parts.append(_mcp_text)
                             else:
-                                output_parts.append(json.dumps(j, default=str))
+                                output_parts.append(_dumps_degraded(j, default=str))
             # Path 3: an object that is not that envelope at all. ``rawOutput``
             # is unstructured passthrough, so ``items[]`` is ONE producer's
             # private wrapper rather than a contract, and an object Crew does
@@ -1786,7 +1820,7 @@ def _build_tool_result_event(update: dict[str, Any], cache_scope: str = "") -> A
             # only when Path 1 found nothing, which is what keeps a content block
             # winning over the raw envelope.
             if raw_output and "items" not in raw_output:
-                output_parts.append(json.dumps(raw_output, default=str))
+                output_parts.append(_dumps_degraded(raw_output, default=str))
     if not output_parts:
         log_unrenderable_content(logger, tool_use_id, content)
         return None
@@ -1984,10 +2018,10 @@ def _build_tool_refinement_event(
         return None
     input_str = ""
     if isinstance(raw_input, (dict, list)) and raw_input:
-        try:
-            input_str = json.dumps(raw_input, indent=2)
-        except (TypeError, ValueError):
-            input_str = str(raw_input)
+        # _dumps_degraded keeps this site's pre-existing (TypeError, ValueError)
+        # -> str(raw_input) degrade and adds the RecursionError arm that the
+        # old except list here missed (RecursionError is a RuntimeError).
+        input_str = _dumps_degraded(raw_input, indent=2)
     elif isinstance(raw_input, str):
         input_str = raw_input
     content_blocks = update.get("content", [])

--- a/test/test_session_directive_transport.py
+++ b/test/test_session_directive_transport.py
@@ -37,10 +37,13 @@ from kiro_crew.acp import _dispatch
 from kiro_crew.acp._dispatch import (
     ELIDED_MARKER_VALUE,
     UNSERIALISABLE_SIBLING_VALUE,
+    _build_tool_call_event,
+    _build_tool_refinement_event,
     _build_tool_result_event,
     _elide_marker_value,
     _mcp_content_text,
     _repair_escaped_marker,
+    build_permission_event,
     parse_session_update,
 )
 from kiro_crew.acp.client import AcpClient
@@ -975,3 +978,103 @@ class TestPathologicallyNestedEnvelopeDegrades:
             cache_scope="scope",
         )
         assert [e for e in events if e.kind == EVENT_TOOL_RESULT], "the result event still arrives"
+
+
+class TestDispatchEncodeRefusalDegrades:
+    """Every dispatch-path encode degrades its one frame, never the turn.
+
+    The class above guards the marker-bearing branch (#8954). These are the
+    remaining ``json.dumps`` sites on the dispatch path -- the permission
+    event's cache-miss input fallback, the initial ``tool_call`` input, the two
+    non-marker result branches, and the refinement input -- whose payload shape
+    the backend chooses, so each can be handed a structure the encoder refuses.
+    ``RecursionError`` is a ``RuntimeError``: the ``(TypeError, ValueError)``
+    arm at the refinement site did not catch it and the other four sites had no
+    guard at all, so the raise escaped frame rendering and aborted the whole
+    agent turn (#8970).
+
+    The ``indent=2`` sites encode on json's pure-Python path (the C encoder is
+    used only with ``indent=None``), which recurses per Python frame -- so real
+    nesting past ``sys.recursionlimit`` reds them deterministically on every
+    platform. The ``default=str`` sites take the C encoder, whose ceiling is
+    the process stack (a platform property), so those two inject the refusal
+    directly via :func:`_encoder_refusing_past`, same as the class above, while
+    still carrying a genuinely deep payload.
+    """
+
+    def test_permission_event_fallback_degrades_deep_input(self):
+        msg = JsonRpcMessage(
+            id="req-1",
+            params={
+                "toolCall": {
+                    "toolCallId": "tc-perm",
+                    "title": "deep tool",
+                    "input": _nest(sys.getrecursionlimit() * 3, 1),
+                }
+            },
+        )
+        event, _recorded = build_permission_event(msg)
+        assert event.tool_input == UNSERIALISABLE_SIBLING_VALUE, "the frame degrades visibly"
+
+    def test_tool_call_event_degrades_deep_raw_input(self):
+        event = _build_tool_call_event(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc-call",
+                "title": "deep tool",
+                "rawInput": _nest(sys.getrecursionlimit() * 3, 1),
+            },
+            None,
+        )
+        assert event.tool_input == UNSERIALISABLE_SIBLING_VALUE, "the frame degrades visibly"
+
+    def test_result_event_degrades_deep_unrecognised_json_item(self, monkeypatch):
+        # The non-marker ``Json`` envelope branch: no directive anywhere, so
+        # the whole item is dumped -- and the dump must not kill the turn.
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(4))
+        event = _build_tool_result_event(
+            _update(rawOutput={"items": [{"Json": {"out": _nest(sys.getrecursionlimit() * 3, 1)}}]})
+        )
+        assert event is not None, "the result event still arrives"
+        assert UNSERIALISABLE_SIBLING_VALUE in (event.tool_output or ""), "degraded, not dropped"
+
+    def test_result_event_degrades_deep_raw_output_passthrough(self, monkeypatch):
+        # The no-``items`` passthrough: ``rawOutput`` is unstructured, so an
+        # object Crew does not recognise is serialised rather than dropped --
+        # and that serialisation must not kill the turn either.
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(4))
+        event = _build_tool_result_event(
+            _update(rawOutput={"out": _nest(sys.getrecursionlimit() * 3, 1)})
+        )
+        assert event is not None, "the result event still arrives"
+        assert UNSERIALISABLE_SIBLING_VALUE in (event.tool_output or ""), "degraded, not dropped"
+
+    def test_refinement_event_widens_the_incomplete_arm(self):
+        # This site already HAD a try: its except list named (TypeError,
+        # ValueError) only. First pin the pre-existing degrade byte-identically
+        # (green before and after the fix) ...
+        unencodable = {"x": {1, 2}}  # a set: json refuses with TypeError
+        event = _build_tool_refinement_event(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc-refine-t",
+                "title": "deep tool",
+                "rawInput": unencodable,
+            },
+            None,
+        )
+        assert event is not None
+        assert event.tool_input == str(unencodable), "the (TypeError, ValueError) arm is preserved"
+        # ... then the arm the old except list missed: RecursionError is a
+        # RuntimeError and fell straight through, aborting the turn.
+        event = _build_tool_refinement_event(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc-refine-r",
+                "title": "deep tool",
+                "rawInput": _nest(sys.getrecursionlimit() * 3, 1),
+            },
+            None,
+        )
+        assert event is not None
+        assert event.tool_input == UNSERIALISABLE_SIBLING_VALUE, "the frame degrades visibly"


### PR DESCRIPTION
Fixes #8970

## Symptom

A tool frame whose payload nests deeply enough aborts the **entire agent turn**: the exception escapes frame rendering, where the intended behaviour is to degrade the single unrenderable frame and keep the turn alive. Merged #8954 fixed this for the marker-bearing branch; this is the deferred residual it named, covering the rest of the dispatch path.

## Root cause

`json.dumps` raises `RecursionError` on a sufficiently nested structure, and `RecursionError` derives from `RuntimeError`. Five encode sites in `src/kiro_crew/acp/_dispatch.py` serialise payloads whose shape the agent backend chooses:

| Site | Function | Prior state |
|---|---|---|
| permission cache-miss input fallback | `build_permission_event` | no guard |
| initial `tool_call` input | `_build_tool_call_event` | no guard |
| non-marker `Json` envelope | `_build_tool_result_event` | no guard |
| no-`items` `rawOutput` passthrough | `_build_tool_result_event` | no guard |
| refinement input | `_build_tool_refinement_event` | **incomplete arm**: has a `try`, but its `except (TypeError, ValueError)` does not catch `RecursionError` |

Note the fifth site is not unguarded — its except list is incomplete, so the fix there widens an existing arm rather than adding a first guard.

## Fix

One module-private refusal-guarded encode helper, `_dumps_degraded`, following the precedent #8954 established (`except RecursionError` arms + the `UNSERIALISABLE_SIBLING_VALUE` placeholder). All five sites route through it:

- Each site keeps its exact argument shape (`indent=2` / `default=str`), so **every payload that encodes successfully today renders byte-identically**.
- A `(TypeError, ValueError)` refusal degrades to `str(payload)` — preserving the refinement site's pre-existing degrade byte-identically (pinned by a test that is green before and after).
- A `RecursionError` refusal degrades to the existing `UNSERIALISABLE_SIBLING_VALUE` placeholder — visible in the transcript on purpose, and `str()` is not a safe fallback there because `repr` recurses too.
- No depth limits, truncation, size caps, or new refusal policy. The only behavioural delta is on frames that currently kill the turn.

Same-commit doc update: `docs/system-specs/modules/agent-host-contract.md` widens the encoder-contract statement from the marker branch to the whole dispatch path.

## Verification

**Red before green** — all five new tests in `test/test_session_directive_transport.py` (class `TestDispatchEncodeRefusalDegrades`) run against unmodified `main` first: 5/5 failed, each with `RecursionError: maximum recursion depth exceeded`; 84/84 pass with the fix. The refinement-site test reds specifically on the `RecursionError` case while its `(TypeError, ValueError)` assertion stays green on unmodified main, proving the incomplete-arm read. The `indent=2` sites are exercised with real nesting past `sys.recursionlimit` (they take json's pure-Python encoder, so the red is deterministic on every platform); the `default=str` sites take the C encoder whose ceiling is a platform property, so those two inject the refusal via the suite's existing `_encoder_refusing_past` stand-in, exactly as #8954's tests do, while still carrying a genuinely deep payload.

**Mutation checks** — six mutants, each applied, confirmed red, restored, confirmed green:

1. Site 1 (permission fallback) reverted to bare `json.dumps` → its test red.
2. Site 2 (tool_call input) reverted → its test red.
3. Site 3 (non-marker `Json` envelope) reverted → its test red.
4. Site 4 (`rawOutput` passthrough) reverted → its test red.
5. Site 5 (refinement) reverted to the old `except (TypeError, ValueError)` arm → its test red on the RecursionError case (TypeError case stayed green, as designed).
6. Helper's `except RecursionError` arm dropped → all five new tests red.

**Gates** — `scripts/local-gate.py --base origin/main`: black 26.3.1 / isort / flake8 / mypy clean; frontend guard specs (backend-only diff selection, 209 specs): 211 test files / 5,767 tests, all green.

**Zero-regression proof** — full backend suite (`pytest -q -n auto --dist loadgroup`, identical bare invocation) on this branch and on a pristine `origin/main` worktree; ANSI-stripped, sorted FAILED/ERROR id sets diffed both directions: byte-identical except one branch-side entry (`test_claude_set_model_routes_through_set_config_option`) that passes standalone on the branch tree — an xdist ordering flake on an untouched surface, not a regression. The ~250-id baseline is this host's known environmental failure set, identical on both trees.

<!-- no-visual-delta --> No frontend change; the delta is exception-handling on backend frame rendering, which a still frame cannot show — evidence is the red-first test suite above.

## Pattern harvest

Rule candidate: any `json.dumps` over an externally-shaped payload (backend/tool/LLM-influenced structure) must be refusal-guarded including `RecursionError` — an `except (TypeError, ValueError)` arm on an encode is a latent turn-killer because `RecursionError` is a `RuntimeError`. In-scope sites are now all routed through `_dumps_degraded`. Known out-of-scope siblings, deliberately not touched here because the #8970 task scope is pinned to `_dispatch.py`: `src/kiro_crew/acp/client.py:7652, 7837, 7852, 7921, 8051` mirror the same extractors over the same backend-shaped `rawInput`/`rawOutput` (7921 carries the identical incomplete except arm) — identified by the First Principles review and tracked as #9040. (An earlier revision of this body wrongly called the untouched encodes "Crew-shaped"; corrected.)
