### PR TITLE
fix(context): restore skills after compaction

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5930,6 +5930,16 @@ async def _run_chat(
     session_key = effective_session_key(slot)
     sessions = getattr(state, "sessions", None)
 
+    def _restore_skills_context_after_compaction() -> None:
+        """Re-inject the session-start skills context on the next turn."""
+        try:
+            state.sessions.mark_needs_reinjection(session_key)
+        except Exception:
+            logger.warning(
+                "post-compaction skills context reinjection could not be armed",
+                exc_info=True,
+            )
+
     # Time-to-first-token clock: starts when the user's message reaches the
     # runner, stops at the first visible model output (text OR thinking chunk).
     # This is the end-to-end latency eager spawn / warm pooling exist to cut —
@@ -9880,6 +9890,7 @@ async def _run_chat(
                     saw_compaction = True
                     if event.text == "completed":
                         _compaction_completed = True
+                        _restore_skills_context_after_compaction()
                     _produced_visible_output = True
                     if not event.synthesized:
                         # A REAL mid-turn terminal IS a segment boundary: text
@@ -10670,6 +10681,7 @@ async def _run_chat(
             # backend that reports asynchronously loses the notice, and awaiting one
             # that already finished strands the waiter for its whole timeout.
             if capabilities_of(client).compacts_inline:
+                _restore_skills_context_after_compaction()
                 msg = "✅ Conversation compacted."
                 _append_compaction_notice(state, slot, msg)
                 state.broadcast_context_usage(slot.key, _context_usage_payload(slot.key, client))
@@ -10685,6 +10697,7 @@ async def _run_chat(
                 compaction_result = await client.wait_for_compaction()
                 logger.info("Deferred compaction result: %s", compaction_result)
                 if compaction_result["type"] == "completed":
+                    _restore_skills_context_after_compaction()
                     summary, _ = redact_credentials(compaction_result.get("summary", ""))
                     summary, _ = redact_exfiltration_urls(summary)
                     msg = (

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -5824,6 +5824,7 @@ class TestRunChatCompactDeferredWait:
         await _run_chat(state, slot, "/compact")
 
         client.wait_for_compaction.assert_not_called()
+        state.sessions.mark_needs_reinjection.assert_called_once_with("dashboard:s1")
         assistant_msgs = [m for m in slot.messages if m.get("role") == "assistant"]
         assert any("Conversation compacted" in m["content"] for m in assistant_msgs)
         assert not any("timed out" in m["content"] for m in assistant_msgs)
@@ -5874,6 +5875,7 @@ class TestRunChatCompactDeferredWait:
         await _run_chat(state, slot, "/compact")
 
         client.wait_for_compaction.assert_awaited_once()
+        state.sessions.mark_needs_reinjection.assert_called_once_with("dashboard:s1")
         assistant_msgs = [m for m in slot.messages if m.get("role") == "assistant"]
         assert any("summary text" in m["content"] for m in assistant_msgs)
         # A completed deferred compaction must send the `reset` form — the
@@ -5889,6 +5891,27 @@ class TestRunChatCompactDeferredWait:
         compaction_msgs = [m for m in assistant_msgs if "summary text" in m["content"]]
         assert compaction_msgs
         assert all(m.get("meta", {}).get("kind") == "compaction" for m in compaction_msgs)
+
+    @pytest.mark.asyncio
+    async def test_completed_status_arms_skills_context_reinjection(self, tmp_path, monkeypatch):
+        """A provider-native completed status restores skills context once."""
+        from kiro_crew.providers.base import EVENT_COMPACTION_STATUS, EVENT_COMPLETE, LLMEvent
+
+        state = self._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        client = self._make_mock_client(
+            [
+                LLMEvent(kind=EVENT_COMPACTION_STATUS, text="completed"),
+                LLMEvent(kind=EVENT_COMPLETE),
+            ]
+        )
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        from kiro_crew.dashboard.chat import _run_chat
+
+        await _run_chat(state, slot, "continue after provider compaction")
+
+        state.sessions.mark_needs_reinjection.assert_called_once_with("dashboard:s1")
 
     @pytest.mark.asyncio
     async def test_kiro_backend_broadcasts_real_post_compaction_usage(self, tmp_path, monkeypatch):
@@ -5916,6 +5939,7 @@ class TestRunChatCompactDeferredWait:
 
         await _run_chat(state, slot, "/compact")
 
+        state.sessions.mark_needs_reinjection.assert_called_once_with("dashboard:s1")
         usage_calls = [
             c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "context_usage"
         ]
@@ -5953,6 +5977,7 @@ class TestRunChatCompactDeferredWait:
 
         await _run_chat(state, slot, "/compact")
 
+        state.sessions.mark_needs_reinjection.assert_not_called()
         usage_calls = [
             c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "context_usage"
         ]


### PR DESCRIPTION
## Problem / Motivation

Provider-native and manual ACP compaction replace the model context but do not arm the existing one-shot skills-context reinjection. The next user turn can therefore no longer discover the skills available to the session.

## Why it matters

Compaction is meant to preserve an ongoing session. Losing the skills index after it completes makes tool and workflow discovery depend on a restart rather than the normal next turn.

## What changed

Arm the existing `mark_needs_reinjection` flag when a native compaction completes, including immediate Claude completion, deferred Kiro completion, and provider-emitted completion status. The next turn consumes the flag through the established prompt-building path.

## Pattern harvest

Rule candidate: review-prompt
Pattern: Provider context replacement must rearm session-start context.

When a provider mutates or replaces its context outside the normal session lifecycle, rearm durable session-start context at the completion event. Reuse the existing one-shot reinjection seam rather than duplicating prompt assembly in each provider path.

## Tests

`PYTHONPATH=src /home/prems/dev/repos/premshay/KiroCrew/.venv/bin/pytest -q test/test_dashboard_chat.py -n0` — 767 passed.

## What changed (motivation → approach → change)

N/A — covered by the existing `## What changed` section.

## Manual verification

N/A — focused automated coverage is sufficient.

## Related Issues

N/A.

## Checklist

- [x] Existing tests pass and regression coverage is included.
- [x] Self-review completed; code follows project style guidelines.
- [x] Documentation updated where applicable.
- [x] No secrets, credentials, or internal references in the diff.

## Contribution License Agreement

N/A — template placeholder; no CLA wording is supplied.