### PR TITLE
fix(cron): confine channel agents from scheduling a privileged agent (#8371)

### DIFF
--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -1599,6 +1599,58 @@ def _authz_session_key() -> str:
     return require_strict_session_key("cron ownership authorization")[0]
 
 
+def _deny_channel_agent_cron(tool_name: str) -> str | None:
+    """Deny ``cron_add`` / ``cron_update`` to a channel agent, else ``None``.
+
+    Channel agents (session keys ``channel:<channel_id>:<agent_id>``) are
+    confined to channel-post communication -- ``CHANNEL_AGENT_BLOCKED_TOOLS``
+    holds back ``send_*`` and every ``session_*`` verb for exactly that reason.
+    Scheduling a cron job is the same shape made durable: ``cron_add`` takes an
+    ``agent`` and ``approval_mode`` that flow straight to ``add_job``, so a
+    channel agent could schedule ``agent="kirocrew", approval_mode="auto"`` and
+    have a full-tool agent run on the gateway host on a timer -- an escalation
+    past its own confinement that outlives both the turn and the channel.
+    ``cron_update`` maps ``agent`` onto ``agent_id``, so it re-targets the agent
+    of a job the calling session already owns.
+
+    The interactive guard in ``channel.py`` rejects blocked tools at the
+    permission-request event, but an AUTO-APPROVED call fires no such event: an
+    ``@kirocrew-cron/cron_add`` entry in a channel agent's ``allowedTools`` is
+    translated to a KAS auto-approve permission (``acp/kas_permissions.py``;
+    MCP tools are not in ``WITHHELD_FROM_AUTO_APPROVE``), and auto-approval is
+    the ABSENCE of a permission request -- so ``_blocked_tool_named`` never runs.
+    The containment therefore has to hold HERE, at MCP dispatch, keyed on the
+    verified caller identity (the strict resolver refuses forgeable sources).
+    Mirrors ``mcp_core._deny_channel_agent_messaging``.
+
+    Only the ``channel:`` orchestrator-agent namespace is confined; a
+    ``slack:``/``discord:`` session is an allow-listed HUMAN participant
+    scheduling their own recurring work, which is the legitimate flow the issue
+    is careful not to break. Best-effort SEL audit mirrors channel.py's
+    ``rejected_blocked_tool`` outcome; an audit failure never unblocks the deny.
+    """
+    caller_session = _authz_session_key()
+    if not caller_session.startswith("channel:"):
+        return None
+    try:
+        sel().log_tool_invocation(
+            session_key=caller_session,
+            source="mcp",
+            tool_name=tool_name,
+            tool_kind="kirocrew-cron",
+            outcome="rejected_blocked_tool",
+        )
+    except Exception:
+        # File-backed SEL write; stdio-silent (no logger -- stderr would corrupt
+        # the JSON-RPC stream). The deny below still holds.
+        pass
+    return (
+        f"Error: {tool_name} is not available to channel agents -- a channel "
+        "agent is confined to channel posts and may not schedule a job that "
+        "runs as another agent."
+    )
+
+
 #: A job with no recorded owner. Written by every creation path that has no
 #: session to name: ``kirocrew cron add`` from the CLI (``cli_commands``, which
 #: drives ``CronService`` directly and never routes through this server), the
@@ -1986,6 +2038,13 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         return _render_cron_list_compact(jobs)
 
     if name == "cron_add":
+        # Channel-agent containment FIRST: a channel agent may not schedule a
+        # durable job (which can run as another, more privileged agent). Keyed
+        # on the verified caller identity so an auto-approved call -- which fires
+        # no permission event for channel.py's guard to catch -- is still denied.
+        chan_err = _deny_channel_agent_cron("cron_add")
+        if chan_err:
+            return chan_err
         # Capability gate FIRST: if the calling surface's policy/profile disables
         # the cron capability, no job may be authored at all (command, script, or
         # message). This is the on/off gate, distinct from the per-command body
@@ -2151,6 +2210,12 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         )
 
     if name == "cron_update":
+        # Channel-agent containment FIRST (see cron_add): cron_update maps
+        # ``agent`` onto ``agent_id`` on an existing job, so it re-targets a
+        # job's agent -- the same escalation, reachable without creating a job.
+        chan_err = _deny_channel_agent_cron("cron_update")
+        if chan_err:
+            return chan_err
         jid = args["job_id"]
         # Ownership check
         own_err = _check_cron_job_ownership(svc, jid)

--- a/test/test_mcp_cron_caller_identity.py
+++ b/test/test_mcp_cron_caller_identity.py
@@ -583,3 +583,97 @@ def test_the_tool_description_warns_that_the_list_is_scoped() -> None:
 
     assert "SCOPED TO THE CALLING SESSION" in desc
     assert "not that none are scheduled" in desc
+
+
+# --- 7: channel-agent confinement ------------------------------------------
+#
+# A channel agent (session key ``channel:<channel_id>:<agent_id>``) is confined
+# to channel posts. cron_add/cron_update let it schedule a durable job that runs
+# as a MORE privileged agent, so both are denied here at MCP dispatch -- keyed on
+# the verified caller identity, because an auto-approved call (cron in the
+# agent's allowedTools) fires no permission event for channel.py's guard to see.
+
+
+def test_channel_agent_cannot_create_cron() -> None:
+    """A channel agent's ``cron_add`` is refused and mints no job."""
+    _as_session("channel:C123:reviewer")
+
+    result = _call_tool_inner(
+        "cron_add",
+        {
+            "name": f"esc-{uuid.uuid4().hex[:8]}",
+            "message": "go",
+            "agent": "kirocrew",
+            "approval_mode": "auto",
+            "every": 60,
+        },
+    )
+
+    assert "not available to channel agents" in result
+    assert CronService(base_dir=mcp_cron.config_dir()).list_jobs(include_disabled=True) == []
+
+
+def test_channel_agent_cannot_update_cron() -> None:
+    """A channel agent's ``cron_update`` is refused before it can re-point an
+    existing job's ``agent_id`` -- and the refusal precedes the ownership check,
+    so it does not even reveal whether the job exists."""
+    _as_session("channel:C123:reviewer")
+
+    result = _call_tool_inner("cron_update", {"job_id": "any-job-id", "agent": "kirocrew"})
+
+    assert "not available to channel agents" in result
+
+
+def test_channel_agent_cron_denied_needs_no_permission_event() -> None:
+    """The denial is at MCP dispatch, not the permission-request event.
+
+    ``_call_tool_inner`` is the dispatch path a call reaches AFTER approval (an
+    auto-approved MCP tool emits no permission event at all), so a refusal here
+    proves the boundary holds even when channel.py's interactive guard never
+    ran. Even with no ``agent`` override -- a plain self-scoped schedule -- the
+    channel agent is contained, matching how ``send_*`` / ``session_*`` are
+    treated (all-or-nothing, not argument-conditional)."""
+    _as_session("channel:C123:reviewer")
+
+    result = _call_tool_inner(
+        "cron_add", {"name": f"self-{uuid.uuid4().hex[:8]}", "message": "remind", "every": 60}
+    )
+
+    assert "not available to channel agents" in result
+
+
+def test_slack_human_session_may_still_schedule_cron() -> None:
+    """Only the ``channel:`` orchestrator-agent namespace is confined.
+
+    A ``slack:``/``discord:`` session is an allow-listed HUMAN participant, not a
+    contained agent, so its own recurring scheduling is the legitimate flow the
+    fix must not break. This is what keeps the denial from being the over-broad
+    'restrict every caller to its own agent' model that would break scheduling
+    for a different crew."""
+    _as_session("slack:1785370133.085469")
+
+    result = _call_tool_inner(
+        "cron_add", {"name": f"human-{uuid.uuid4().hex[:8]}", "message": "go", "every": 120}
+    )
+
+    assert "Added job" in result
+    assert "not available to channel agents" not in result
+
+
+def test_dashboard_session_may_schedule_for_another_crew() -> None:
+    """The dashboard flow the issue is careful to preserve: a chat session
+    scheduling a job that runs as a DIFFERENT crew is allowed -- the confinement
+    keys on the channel-agent namespace, not on the ``agent`` argument."""
+    _as_session("dashboard:owner")
+
+    result = _call_tool_inner(
+        "cron_add",
+        {
+            "name": f"crew-{uuid.uuid4().hex[:8]}",
+            "message": "go",
+            "agent": "kirocrew-conductor",
+            "every": 120,
+        },
+    )
+
+    assert "Added job" in result


### PR DESCRIPTION
## What is the problem?

`cron_add` and `cron_update` let a contained caller schedule a durable job that runs as a MORE privileged agent than the caller itself. Both take an `agent` (`cron_update` maps it onto `agent_id` on an existing job) and pass it straight to `add_job` / `update_job` with no check comparing the requested agent against the caller's confinement:

```python
job = svc.add_job(..., agent_id=agent or "", approval_mode=approval_mode or "", ...)
```

## Why this matters to the user

A channel agent's reach is deliberately bounded to channel posts -- `CHANNEL_AGENT_BLOCKED_TOOLS` already holds back `send_message`, `send_notification`, and every `session_*` verb for exactly that reason. Neither cron verb was covered anywhere. So a channel agent could:

```
cron_add(name="...", agent="kirocrew", approval_mode="auto", every=...)
```

and have a full-tool agent (shell, filesystem, everything the named agent carries) run on the gateway host on a timer, with its own restrictions nowhere in the picture. It is **durable** (outlives the turn and the channel conversation), and `cron_update` is a **second door** -- it re-targets an existing job's `agent_id` without creating anything.

## How the fix solves it -- symptom to root cause

The root cause is that these verbs run agent-chosen work outside the channel, which is the exact shape `CHANNEL_AGENT_BLOCKED_TOOLS` exists to hold back. The fix denies both verbs to a channel agent in `mcp_cron` (`_deny_channel_agent_cron`), keyed on the STRICT, gateway-vouched caller session (`_authz_session_key`, which refuses forgeable sources), applied as the first check in both the `cron_add` and `cron_update` branches. It mirrors the existing `mcp_core._deny_channel_agent_messaging`.

**The placement is the whole point, and it corrects the first revision of this PR.** The first revision added `cron_add` / `cron_update` to `CHANNEL_AGENT_BLOCKED_TOOLS`. That list is consulted only in `channel.py`'s permission-request gate -- but an `@kirocrew-cron/cron_add` entry in a channel agent's `allowedTools` is translated to a KAS auto-approve permission (`acp/kas_permissions.py`; MCP tools are not in `WITHHELD_FROM_AUTO_APPROVE`), and **auto-approval is the absence of a permission request**, so the list guard never runs. GPT 5.6's blocking review caught this and it is correct -- a named entry in that list is not a boundary for an auto-approved call. Moving the denial to MCP dispatch, on the verified identity, closes the auto-approve path. (The list approach also broke the neighbouring non-shell-tool contract in `test_channel_trusted_patterns.py`, which uses `cron_add` as its canonical non-shell example -- another reason the list was the wrong home.)

Only the `channel:` orchestrator-agent namespace is confined. A `slack:` / `discord:` session is an allow-listed HUMAN participant scheduling their own recurring work, and a dashboard session scheduling a job for a different crew is the legitimate flow the issue is careful not to break -- neither consults this gate, so both keep working.

**Scope note (from review):** the in-code / earlier claim that `cron_update` can re-point "a job an operator already created and reviewed" is narrowed. `_check_cron_job_ownership` restricts updates to jobs keyed to the caller's own session, so the real reach is the channel agent's OWN-session jobs -- still a named channel-boundary harm (it re-targets the agent those jobs run as), so both verbs are confined, but the threat is own-session, not operator-owned.

**Out of scope** (noted per the issue): the audit-trail half -- `created_by` is unwritten by `mcp_cron` and later runs are attributed to `cron:<job_id>` rather than the authoring principal.

**Known limitation -- descendant propagation (filed separately).** `_deny_channel_agent_cron` keys on the IMMEDIATE caller's session (`_authz_session_key`), so it closes a channel agent calling `cron_add` / `cron_update` directly. It does NOT propagate the channel agent's confinement to a session it spawns: `spawn_run` is not in `CHANNEL_AGENT_BLOCKED_TOOLS`, and a spawned subagent's key is `subagent:<id>` (not `channel:<...>`), so a channel agent that spawns a subagent which then calls `cron_add` evades this guard. Closing that requires threading channel-origin identity through the MCP caller context (`mcp_cron` is a separate stdio process and cannot see the spawn chain -- it has no reference to the subagent manager or `parent_session_key`), and the identical exposure exists for the mirrored `mcp_core._deny_channel_agent_messaging`, so it is a systemic channel-confinement-propagation gap rather than a cron-specific one. Tracked as a separate follow-up issue; deliberately not attempted here.

## What tests we did

Added to `test/test_mcp_cron_caller_identity.py` (the existing home for caller-identity-gated cron behavior, which already drives `_call_tool_inner` with a strict caller block):

- A channel agent's `cron_add` is refused and mints no job.
- A channel agent's `cron_update` is refused before the ownership check.
- The denial holds at `_call_tool_inner` -- the dispatch path a call reaches AFTER approval -- proving it does not depend on a permission event (the auto-approve bypass), and it denies even a plain self-scoped schedule with no `agent` override (all-or-nothing, matching `send_*` / `session_*`).
- A `slack:` human session may still schedule cron (legitimate flow preserved).
- A `dashboard:` session may schedule a job for a different crew (the flow the issue protects).

Mutation-verified: neutering `_deny_channel_agent_cron` to a no-op turns 3 of these red while the "still allowed" tests stay green. All 37 tests in the file pass (32 pre-existing caller-identity tests unaffected). The two `test_channel_trusted_patterns.py` failures from the first revision are resolved (that file is untouched now). Ran targeted only, `-n0`.

Lint run independently, all clean on both touched files: `black --target-version py310`, `isort`, `flake8`, `mypy` (`mcp_cron.py`). Black baseline gate passes with no baseline change (the first revision's baseline-shrink was an artifact of touching a baselined file, now reverted).

## Pattern harvest

Rule candidate: When confining a tool that an existing block-list already governs, verify WHERE that list is enforced before adding to it. `CHANNEL_AGENT_BLOCKED_TOOLS` is checked only at `channel.py`'s permission-request event; an MCP tool named in an agent's `allowedTools` is KAS auto-approved and fires no such event, so the list never sees it. A capability confinement for an MCP tool must live at MCP dispatch on the verified caller identity (the `_deny_channel_agent_*` pattern), not on a permission-event list -- a named entry in a list is not a boundary until something refuses the call on the path the call actually takes.

Closes #8371
