### PR TITLE
fix(kas): key subagent auto-approve on the Crew tool name

### DIFF
--- a/src/kiro_crew/acp/kas_permissions.py
+++ b/src/kiro_crew/acp/kas_permissions.py
@@ -63,9 +63,16 @@ CAPABILITY_BY_TOOL: dict[str, str] = {
     # Network.
     "web_fetch": "web_fetch",
     "web_search": "web_search",
-    # Sub-agents and skills.
-    "invoke_sub_agent": "subagent",
-    "disclose_context": "skill",
+    # Sub-agents. Keyed on the CREW tool name that lands in ``allowedTools``
+    # (``use_subagent``), not KAS's internal toolId (``invoke_sub_agent``): this
+    # map is consulted against the allowlist Crew writes, so a KAS-internal key
+    # never matches and the capability is never granted -- the subagent request
+    # then falls through to prompt and, on a non-interactive backend, is
+    # auto-refused (#9024). For the same reason there is no skill entry here: no
+    # Crew ``allowedTools`` names a skill-disclosure tool, so any such key would
+    # be a dead promise that never matches (the earlier ``disclose_context`` was
+    # KAS's internal name and matched nothing).
+    "use_subagent": "subagent",
 }
 
 #: Tools this module refuses to translate even though the capability exists.

--- a/test/test_kas_permissions.py
+++ b/test/test_kas_permissions.py
@@ -46,9 +46,24 @@ class TestBuiltinToolsBecomeCapabilities:
         """KAS reads a missing ``match`` as every resource — the intended meaning."""
         assert "match" not in _rule(allowed_tools_to_permissions(["web_search"]), "web_search")
 
+    def test_the_crew_subagent_name_grants_the_subagent_capability(self):
+        """The name ``allowedTools`` carries is ``use_subagent``, not KAS's
+        internal ``invoke_sub_agent`` -- so the capability must be keyed on the
+        former or the grant is silently never emitted (#9024)."""
+        assert CAPABILITY_BY_TOOL.get("use_subagent") == "subagent"
+        policy = allowed_tools_to_permissions(["use_subagent"])
+        assert policy == {"rules": [{"capability": "subagent", "effect": "allow"}]}
+
+    def test_the_kas_internal_subagent_name_is_not_the_key(self):
+        """A regression guard: keying on the KAS toolId is the original bug, and
+        that name never appears in a Crew ``allowedTools`` list, so it must NOT
+        classify -- an entry that cannot match the allowlist emits no rule."""
+        assert "invoke_sub_agent" not in CAPABILITY_BY_TOOL
+        assert allowed_tools_to_permissions(["invoke_sub_agent"]) is None
+
     def test_rules_are_ordered_deterministically(self):
         """Two rebuilds of the same list must produce byte-identical output."""
-        entries = ["web_search", "invoke_sub_agent", "web_fetch"]
+        entries = ["web_search", "use_subagent", "web_fetch"]
         first = allowed_tools_to_permissions(entries)
         second = allowed_tools_to_permissions(list(reversed(entries)))
         assert first == second


### PR DESCRIPTION
## What is the problem?

On the `kas` ACP backend, a sub-agent spawn is always auto-denied. The user is
shown "claims to run a command, but its command could not be verified" and told
the request was rejected -- though no human rejected it. Reproduced 5/5 via
non-interactive `kirocrew chat -m`.

## Why this matters to the user

Sub-agents are unusable on the `kas` backend, and the denial message is
factually false twice over: the sub-agent spawn is not a shell command, and no
human declined it. A user acting on that message would look for a command they
never issued and a rejection they never made.

## How the fix solves it (symptom -> root cause)

There are two independent causes on two different code paths. This PR fixes the
one that lives here and is the reported repro's proximate cause; it documents
the second precisely, correcting a wrong file attribution from our own triage.

Root cause A (fixed here) -- the capability is never granted.
`src/kiro_crew/acp/kas_permissions.py` translates a Crew agent's `allowedTools`
into a KAS permissions policy via `CAPABILITY_BY_TOOL`. That map was keyed on
KAS's internal toolId `invoke_sub_agent`, but `allowed_tools_to_permissions` is
consulted against the allowlist Crew actually writes, which carries the CREW
name `use_subagent` (see `apps/builtins/pptx_maker/agents/*.json`,
`acp/liveness._MODEL_WRAPPING_TOOLS`, and `dashboard/chat_runner`). The name
`invoke_sub_agent` appears nowhere else in the tree, so the key never matched
and the `subagent` capability was never emitted. The working `web_fetch` /
`web_search` entries already use their Crew names -- the subagent entry was the
odd one out. Re-keying to `use_subagent` follows the pattern the surrounding
code already implies (the map's own docstring: "the built-in tools Crew's specs
actually name"). With the capability granted, KAS auto-approves the spawn and no
permission request is raised, which is what clears the reported repro.

Root cause B (documented, NOT fixed here, and it IS in this repo).
Our own earlier triage placed B in `_dispatch.py` and hypothesized it lived in
`kiro-cli`. Both are wrong. The exact reported string is emitted at
`src/kiro_crew/cli_chat.py:786`, inside the `_unverifiable_shell` branch of the
CLI permission handler. `_unverifiable_shell` (`cli_chat.py:464`) returns True
whenever `not event.shell_classified` -- i.e. whenever the preceding `tool_call`
frame carried no resolvable string `kind` to cache (`_dispatch.py:979`,
`shell_classified = cached_shell is not None`; the cache is written only when
`_kind_resolved`). A sub-agent spawn that KAS does not label with a shell `kind`
is therefore treated as an unverifiable command and auto-refused with this exact
message -- but ONLY on the interactive-prompt path, i.e. for a sub-agent that is
NOT auto-approved. A auto-approves the reported case (spawn never reaches this
gate), so A alone clears the repro; B remains a latent false-denial for any
sub-agent that legitimately needs a prompt.

B is deliberately out of scope here: `_unverifiable_shell` is a fail-closed
authorization gate whose contract is "an absent classification is not a negative
one." Making it distinguish "sub-agent tool, legitimately non-shell" from
"uncached shell call" must rely on a TRUSTED classification signal, not the
agent-authored `tool_kind` (trusting that to WAIVE the check is the bypass the
gate exists to prevent). That is a design change with real blast radius, not a
minimal fix, so it belongs in its own change. This PR does not claim the symptom
is fully resolved for the non-auto-approved case; it references #9024 with
`Refs`, not a closing keyword.

## What tests we did

- Added `test_the_crew_subagent_name_grants_the_subagent_capability` and
  `test_the_kas_internal_subagent_name_is_not_the_key` to
  `test/test_kas_permissions.py` (capability-lookup level, as requested).
- `pytest -n0 test/test_kas_permissions.py test/test_derived_agent_permissions_consumers.py`
  -> 66 passed (run with `-n0` explicitly; no full suite).
- Lint on both touched files, run independently:
  `black --check --target-version py310` (clean), `isort --check-only` (clean),
  `flake8` (clean), `mypy src/kiro_crew/acp/kas_permissions.py` (clean).
- B's location established by paired probe: `git grep` for
  `def _unverifiable_shell|def _can_prompt` under `acp/_dispatch.py` returns
  nothing (rc=1), while the same probe form under `cli_chat.py` fires (rc=0,
  lines 464/318); and the literal deny string is at `cli_chat.py:786`.

## Any other suggestions

- The dead `disclose_context -> skill` entry (KAS's internal name; no Crew
  `allowedTools` names a skill tool, so it never matched) was removed in this
  PR at the First Principles reviewer's suggestion -- deletion is
  behavior-identical (a never-matching key and an absent key both prompt) and
  removes a false promise from a map documented as keyed on Crew tool names.
- B deserves its own issue/PR: teach the CLI gate that a trusted non-shell
  classification (or a known model-wrapping tool like `use_subagent`) is not an
  "unverifiable command," so the false denial does not survive on the
  interactive path.

## Pattern harvest

Rule candidate: When a lookup table is "keyed on a tool name," verify which
NAMESPACE the key must be in by reading the call site that consumes it, not by
trusting the value's plausibility. Here the map is consulted against Crew's
`allowedTools` (Crew names), so a KAS-internal toolId key is dead on arrival --
and the working sibling entries (`web_fetch`) already showed the correct
namespace. A one-line data bug can hide behind a correct-looking value.

Refs #9024
