### PR TITLE
fix(pod): send the token-mint secret over the pod's unix socket, never TCP

### DIFF
--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -143,8 +143,9 @@ the version selector (channel tags track their channel; version tags pin).
      similar non-secret static files are served without a token (standard
      SPA bootstrap; the app is useless without a token once loaded).
   3. **Local bootstrap** — `/api/token/local` and `/api/shutdown` require
-     a loopback peer **plus** a filesystem secret, so they are unreachable
-     through the published port by construction.
+     a same-machine peer (a loopback address, or for the token endpoint the
+     dashboard's kernel-verified unix socket) **plus** a filesystem secret,
+     so they are unreachable through the published port by construction.
   CSRF origin checks apply to all state-changing requests, and the
   DNS-rebinding Host barrier applies to every request except the three
   probe paths.

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -2504,6 +2504,41 @@ async def api_kirocrew_config_patch(request: web.Request) -> web.Response:
 # ── Local token bootstrap (Electron / local apps) ─────────────────────
 
 
+def _unix_peer_is_self(request: web.Request) -> bool:
+    """True iff *request* arrived on an ``AF_UNIX`` socket AND the kernel
+    positively confirms the peer runs as this process's own principal.
+
+    Transport-admission twin of ``is_loopback`` for the local-secret endpoints
+    (#8552): an ``AF_UNIX`` request has an EMPTY ``request.remote``, so the
+    loopback test alone 403s the transport that is strictly HARDER to reach
+    than loopback TCP — the dashboard's socket sits ``0600`` inside a ``0700``
+    owner-only directory, and the kernel reports who connected, which loopback
+    TCP cannot. Because ``/api/token/local`` is ``token_auth``-bypassed, this
+    admission is deny-by-default via ``check_peer_is_self``: ``MISMATCH``
+    (another principal reached our socket — exactly when the directory gate
+    has failed and refusing matters most) and ``UNVERIFIABLE`` (no mechanism,
+    failed syscall) are BOTH refused, so a platform without peer credentials
+    never silently widens the gate. This admits a TRANSPORT, never a caller —
+    the ``X-Local-Secret`` check downstream is unchanged.
+    """
+    # Function-local imports mirror the sibling admission in handlers/updates.py.
+    from kiro_crew.dashboard.origin import request_is_unix_socket
+    from kiro_crew.mcp_gateway.socketsec import PeerCredResult, check_peer_is_self
+
+    if not request_is_unix_socket(request):
+        return False
+    transport = getattr(request, "transport", None)
+    if transport is None:  # pragma: no cover — request_is_unix_socket excluded it
+        return False
+    try:
+        sock = transport.get_extra_info("socket")
+    except Exception:  # pragma: no cover — request_is_unix_socket excluded it
+        return False
+    if sock is None:  # pragma: no cover — request_is_unix_socket excluded it
+        return False
+    return check_peer_is_self(sock) is PeerCredResult.MATCH
+
+
 async def api_token_local(request: web.Request) -> web.Response:
     """GET /api/token/local — issue a token for local apps.
 
@@ -2511,10 +2546,15 @@ async def api_token_local(request: web.Request) -> web.Response:
     gateway startup. Only processes on the same machine can read the file.
     Secret passed via ``X-Local-Secret`` header (not query string, to avoid
     leaking in logs).
+
+    Reachable over loopback TCP or the dashboard's ``AF_UNIX`` socket; unix
+    peers are admitted only on a positive kernel same-principal check
+    (``_unix_peer_is_self``), which is stronger locality evidence than a
+    loopback address. The secret is required on both transports.
     """
     import kiro_crew.dashboard.handlers as _h  # noqa: F811
 
-    if not _h.is_loopback(request.remote or ""):
+    if not _h.is_loopback(request.remote or "") and not _unix_peer_is_self(request):
         _sel().log_api_access(
             caller=request.remote or "unknown",
             operation="token.local",

--- a/src/kiro_crew/loopback_http.py
+++ b/src/kiro_crew/loopback_http.py
@@ -38,6 +38,7 @@ import os
 import socket
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 
 __all__ = ["build_loopback_opener", "loopback_urlopen", "unix_socket_urlopen"]
 
@@ -74,12 +75,19 @@ class _UnixHTTPConnection(http.client.HTTPConnection):
     only ``connect()`` is rerouted onto the unix socket.
     """
 
-    def __init__(self, socket_path: str, host: str, timeout=None) -> None:
+    def __init__(
+        self,
+        socket_path: str,
+        host: str,
+        timeout=None,
+        verify_peer: "Callable[[socket.socket], None] | None" = None,
+    ) -> None:
         if timeout is None:
             super().__init__(host)
         else:
             super().__init__(host, timeout=timeout)
         self._socket_path = socket_path
+        self._verify_peer = verify_peer
 
     def connect(self) -> None:  # noqa: D102 -- contract inherited
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -87,7 +95,14 @@ class _UnixHTTPConnection(http.client.HTTPConnection):
             sock.settimeout(self.timeout)
         try:
             sock.connect(self._socket_path)
-        except OSError:
+            if self._verify_peer is not None:
+                # Between connect() and the first send: a peer that fails
+                # verification must never see the request line, let alone the
+                # credential headers behind it. The callback raising is the
+                # refusal; BaseException so even an interrupt cannot leak the
+                # connected fd.
+                self._verify_peer(sock)
+        except BaseException:
             sock.close()
             raise
         self.sock = sock
@@ -100,21 +115,33 @@ class _UnixHTTPHandler(urllib.request.HTTPHandler):
     handler (same displacement rule ``build_loopback_opener`` documents).
     """
 
-    def __init__(self, socket_path: str) -> None:
+    def __init__(
+        self,
+        socket_path: str,
+        verify_peer: "Callable[[socket.socket], None] | None" = None,
+    ) -> None:
         super().__init__()
         self._socket_path = socket_path
+        self._verify_peer = verify_peer
 
     def http_open(self, req):  # noqa: D102 -- contract inherited
         def _factory(host, timeout=None, **_kwargs):
-            return _UnixHTTPConnection(self._socket_path, host, timeout=timeout)
+            return _UnixHTTPConnection(
+                self._socket_path, host, timeout=timeout, verify_peer=self._verify_peer
+            )
 
         return self.do_open(_factory, req)
 
 
-def _build_unix_opener(socket_path: str) -> urllib.request.OpenerDirector:
+def _build_unix_opener(
+    socket_path: str,
+    verify_peer: "Callable[[socket.socket], None] | None" = None,
+) -> urllib.request.OpenerDirector:
     """Opener twin of :func:`build_loopback_opener` bound to a unix socket."""
     return urllib.request.build_opener(
-        urllib.request.ProxyHandler({}), _NoRedirect(), _UnixHTTPHandler(socket_path)
+        urllib.request.ProxyHandler({}),
+        _NoRedirect(),
+        _UnixHTTPHandler(socket_path, verify_peer),
     )
 
 
@@ -123,6 +150,7 @@ def unix_socket_urlopen(
     timeout: float,
     *,
     socket_path: "str | os.PathLike[str]",
+    verify_peer: "Callable[[socket.socket], None] | None" = None,
 ):
     """Open ``req`` over *socket_path* and **only** over *socket_path*.
 
@@ -144,12 +172,24 @@ def unix_socket_urlopen(
     *socket_path* is trusted (derived, never caller-supplied); the URL's host is
     preserved, so the gateway's Host validation sees exactly what it would on
     TCP.
+
+    *verify_peer*, when given, is called with the **connected** socket before
+    any HTTP bytes are written. It is the caller's identity policy: raise to
+    refuse (the socket is closed and the exception propagates unwrapped, so a
+    caller's own error type survives urllib), return to proceed. A unix socket
+    proves which *user* answers by where the file lives, but not which
+    *process*: the path sits in a directory its owner can always rewrite, so a
+    same-UID process can unlink it and bind its own listener. Kernel peer
+    credentials on the connected socket (``SO_PEERCRED`` / ``LOCAL_PEERPID``)
+    are the one channel that survives that swap, and they are only readable
+    once connected -- which is why the hook lives here and not at the call
+    site.
     """
     if not hasattr(socket, "AF_UNIX"):
         # Windows. Raised as OSError so callers' existing transport handling
         # catches it instead of an AttributeError escaping from connect().
         raise OSError("AF_UNIX sockets are not available on this platform")
-    return _build_unix_opener(os.fspath(socket_path)).open(req, timeout=timeout)
+    return _build_unix_opener(os.fspath(socket_path), verify_peer).open(req, timeout=timeout)
 
 
 def loopback_urlopen(

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -38,6 +38,7 @@ from kiro_crew.dashboard.urls import dashboard_socket_name
 from kiro_crew.identity_stores import StoreMapping, store_mappings
 from kiro_crew.instances import run_marker
 from kiro_crew.loopback_http import loopback_urlopen, unix_socket_urlopen
+from kiro_crew.mcp_gateway.socketsec import get_peer_pid
 from kiro_crew.platform_compat import (
     IS_LINUX,
     IS_MACOS,
@@ -1772,8 +1773,46 @@ def health(cfg: PodConfig, name: str, port: int, timeout: int = 3) -> int:
 # calls /api/token/local with X-Local-Secret over the pod's private unix
 # socket. Keeps the secret read inside this process (never an agent-issued
 # `cat`), and keeps the secret's delivery inside the pod's owner-only home
-# (never a rebindable loopback port — #8552).
+# (never a rebindable loopback port — #8552). The connected socket's peer is
+# kernel-verified against the attested gateway pid before any bytes are sent,
+# so even a same-UID rebind of the socket path receives nothing.
 # --------------------------------------------------------------------------- #
+def _attested_gateway_verifier(cfg: PodConfig, name: str, port: int, socket_path: Path):
+    """Build a connect-time peer check pinned to pod *name*'s attested gateway.
+
+    ``port_owner`` proves the pid RECORD is fresh, but a record cannot prove
+    who answers the socket FILE: the path sits in a directory its owner can
+    always rewrite, so a same-UID process can unlink it and bind its own
+    listener there — and the mint request would hand that listener the pod's
+    ``.local_secret``. The kernel can prove it: peer credentials on the
+    connected socket (``SO_PEERCRED`` on Linux, ``LOCAL_PEERPID`` on macOS)
+    name the listener's pid as of ``listen()``, so requiring that pid to equal
+    the attested gateway pid refuses a rebound socket BEFORE any HTTP bytes.
+    Deny-by-default, same shape as the server-side admission this feature
+    added: a mismatched peer and an unreadable peer both refuse.
+    """
+    attested = _pod_recorded_pid(cfg, name, port)
+    if attested is None:
+        raise PodOwnershipUnproven(
+            f"withholding pod {name!r}'s credential: its gateway pid record "
+            f"could not be re-proven at send time, so the process answering "
+            f"{socket_path} cannot be verified. {_unproven_remedy(cfg, name, port)}"
+        )
+
+    def _verify(sock: socket.socket) -> None:
+        peer = get_peer_pid(sock)
+        if peer != attested:
+            who = "an unidentifiable process" if peer is None else f"pid {peer}"
+            raise PodError(
+                f"refusing to send pod {name!r}'s credential: {socket_path} is "
+                f"answered by {who}, not the attested gateway (pid {attested}). "
+                f"The socket path may have been rebound since the pod started; "
+                f"`kirocrew pod status {name}` shows the gateway's state."
+            )
+
+    return _verify
+
+
 def mint_token(cfg: PodConfig, name: str, ttl: str = "2h") -> str:
     secret_file = cfg.home_dir(name) / ".local_secret"
     try:
@@ -1805,6 +1844,7 @@ def mint_token(cfg: PodConfig, name: str, ttl: str = "2h") -> str:
             f"{_unproven_remedy(cfg, name, port)}"
         )
     socket_path = pod_socket_path(cfg, name, port)
+    verify_peer = _attested_gateway_verifier(cfg, name, port, socket_path)
     url = f"http://127.0.0.1:{port}/api/token/local?ttl={urllib.parse.quote(str(ttl))}"
     req = urllib.request.Request(url, headers={"X-Local-Secret": secret})
     try:
@@ -1816,8 +1856,12 @@ def mint_token(cfg: PodConfig, name: str, ttl: str = "2h") -> str:
         # a missing, stale, or refusing socket raises instead of handing the
         # header to whatever answered. The URL keeps the loopback host so the
         # gateway's Host validation sees exactly what it saw on TCP; the socket
-        # path is derived, never caller-supplied.
-        with unix_socket_urlopen(req, timeout=5, socket_path=socket_path) as resp:  # nosemgrep
+        # path is derived, never caller-supplied. verify_peer closes the residual
+        # window on the socket itself: a same-UID process that rebinds the path
+        # fails the kernel peer-pid check and never sees the header.
+        with unix_socket_urlopen(  # nosemgrep
+            req, timeout=5, socket_path=socket_path, verify_peer=verify_peer
+        ) as resp:
             token = json.loads(resp.read()).get("token", "")
     except (urllib.error.URLError, OSError, ValueError) as exc:
         raise PodError(
@@ -2010,6 +2054,7 @@ def pod_api(
             f"  Restart it:    kirocrew pod down {name} && kirocrew pod up {name}"
         )
     token = mint_token(cfg, name)
+    verify_peer = _attested_gateway_verifier(cfg, name, port, socket_path)
     url = _authenticated_url(port, normalized, token)
     body = data.encode("utf-8") if data else None
     headers = {"Content-Type": "application/json"} if data else {}
@@ -2018,8 +2063,14 @@ def pod_api(
         # Over the pod's own unix socket, never TCP: `unix_socket_urlopen` has no
         # TCP handler, so a dead or replaced listener cannot receive this token.
         # Caller input contributes only the path, never the host or the socket.
+        # This is a NEW connection after the mint's, so it re-verifies the peer:
+        # a socket rebound between the two sends would otherwise capture a live
+        # (if short-TTL) credential.
         with unix_socket_urlopen(  # nosemgrep
-            request, timeout=API_TIMEOUT_SECS, socket_path=socket_path
+            request,
+            timeout=API_TIMEOUT_SECS,
+            socket_path=socket_path,
+            verify_peer=verify_peer,
         ) as response:
             raw = _read_capped(response, method, normalized, name)
             return response.status, _scrub_token(raw, token)

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -1769,8 +1769,10 @@ def health(cfg: PodConfig, name: str, port: int, timeout: int = 3) -> int:
 
 # --------------------------------------------------------------------------- #
 # Token mint — reads the pod's OWN .local_secret (in its isolated HOME), then
-# calls /api/token/local with X-Local-Secret. Keeps the secret read inside this
-# process (never an agent-issued `cat`).
+# calls /api/token/local with X-Local-Secret over the pod's private unix
+# socket. Keeps the secret read inside this process (never an agent-issued
+# `cat`), and keeps the secret's delivery inside the pod's owner-only home
+# (never a rebindable loopback port — #8552).
 # --------------------------------------------------------------------------- #
 def mint_token(cfg: PodConfig, name: str, ttl: str = "2h") -> str:
     secret_file = cfg.home_dir(name) / ".local_secret"
@@ -1783,14 +1785,11 @@ def mint_token(cfg: PodConfig, name: str, ttl: str = "2h") -> str:
     port = derive_port(cfg, name)
     owner = port_owner(cfg, name, port)
     if owner != OWNER_POD:
-        # Positive proof REQUIRED here, unlike `health`. This call sends the pod's
-        # own ``.local_secret`` and returns a dashboard credential for whatever
-        # answered, so the two ways of being wrong are not symmetrical: refusing a
-        # live pod costs an error message, while proceeding on an unproven port
-        # hands a different local user -- who can bind 127.0.0.1 but cannot read
-        # this 0600 secret -- a credential for this pod. That is the same reason
-        # ``port_resolution._gateway_owns_port`` fails closed on the path that
-        # sends the secret, including when the listener lookup is simply missing.
+        # Positive proof kept even though the send below rides the pod's own
+        # unix socket: the pre-check costs one process lookup and buys the
+        # refusal messages below, which name WHY the pod cannot answer instead
+        # of surfacing a bare connection error from the socket. The transport
+        # is what makes the secret safe; this is what makes the failure legible.
         if owner == OWNER_FOREIGN:
             raise PodError(
                 f"refusing to mint a credential for pod {name!r}: :{port} is held "
@@ -1805,15 +1804,27 @@ def mint_token(cfg: PodConfig, name: str, ttl: str = "2h") -> str:
             f"process would receive the pod's secret. "
             f"{_unproven_remedy(cfg, name, port)}"
         )
+    socket_path = pod_socket_path(cfg, name, port)
     url = f"http://127.0.0.1:{port}/api/token/local?ttl={urllib.parse.quote(str(ttl))}"
     req = urllib.request.Request(url, headers={"X-Local-Secret": secret})
     try:
-        # Loopback-only call to the pod's own gateway on 127.0.0.1; the URL is
-        # internally derived, so the dynamic-URL SSRF audit rule is a false positive.
-        with loopback_urlopen(req, timeout=5) as resp:  # nosemgrep
+        # Over the pod's own unix socket, never TCP (#8552): this request CARRIES
+        # the pod's `.local_secret`, and the pod's TCP port is ordinary loopback
+        # that any local user can bind the moment the pod releases it — with no
+        # peer-credential API on the wire to tell the squatter from the gateway.
+        # `unix_socket_urlopen` has no TCP handler, so "no fallback" is structural:
+        # a missing, stale, or refusing socket raises instead of handing the
+        # header to whatever answered. The URL keeps the loopback host so the
+        # gateway's Host validation sees exactly what it saw on TCP; the socket
+        # path is derived, never caller-supplied.
+        with unix_socket_urlopen(req, timeout=5, socket_path=socket_path) as resp:  # nosemgrep
             token = json.loads(resp.read()).get("token", "")
     except (urllib.error.URLError, OSError, ValueError) as exc:
-        raise PodError(f"token mint failed on :{port} ({name}): {exc}") from exc
+        raise PodError(
+            f"token mint for pod {name!r} did not complete over its API socket "
+            f"({socket_path}): {exc}. Not retried on 127.0.0.1:{port} — the pod's "
+            f"secret must not be sent to a process that is not this pod's gateway."
+        ) from exc
     if not token:
         raise PodError(f"gateway returned empty token on :{port} ({name})")
     return token

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -2085,6 +2085,101 @@ class TestLocalToken:
         assert minted["extra"] == {"embed_parent_port": "5476"}
 
     @pytest.mark.asyncio
+    async def test_unix_peer_match_with_valid_secret_issues_a_token(
+        self, monkeypatch, fake_sel
+    ) -> None:
+        """A kernel-verified same-uid AF_UNIX peer is admitted (#8552).
+
+        The pod's `mint_token` connects over the pod's private unix socket,
+        where ``request.remote`` is EMPTY -- the loopback test alone 403s the
+        transport that is strictly harder to reach than loopback TCP. The
+        positive `check_peer_is_self` MATCH plus the unchanged secret check
+        must mint.
+        """
+        from kiro_crew.mcp_gateway.socketsec import PeerCredResult
+
+        monkeypatch.setattr("kiro_crew.dashboard.origin.request_is_unix_socket", lambda _r: True)
+        monkeypatch.setattr(
+            "kiro_crew.mcp_gateway.socketsec.check_peer_is_self",
+            lambda _s: PeerCredResult.MATCH,
+        )
+        monkeypatch.setattr(core_mod, "generate_token", lambda *a, **k: "issued-value")
+        resp = await core_mod.api_token_local(
+            _req(remote="", app={"local_secret": "right"}, headers={"X-Local-Secret": "right"})
+        )
+        assert resp.status == 200
+        assert json.loads(resp.body)["token"] == "issued-value"
+
+    @pytest.mark.asyncio
+    async def test_unix_peer_still_needs_the_secret(self, monkeypatch, fake_sel) -> None:
+        """Unix admission is a TRANSPORT gate: the secret check is unchanged.
+
+        A MATCH peer with the wrong secret is refused at the SECRET check
+        ("invalid secret"), not the transport check ("loopback only") -- which
+        also pins that the admitted request reached past the transport gate.
+        """
+        from kiro_crew.mcp_gateway.socketsec import PeerCredResult
+
+        monkeypatch.setattr("kiro_crew.dashboard.origin.request_is_unix_socket", lambda _r: True)
+        monkeypatch.setattr(
+            "kiro_crew.mcp_gateway.socketsec.check_peer_is_self",
+            lambda _s: PeerCredResult.MATCH,
+        )
+        resp = await core_mod.api_token_local(
+            _req(remote="", app={"local_secret": "right"}, headers={"X-Local-Secret": "wrong"})
+        )
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "invalid secret"
+
+    @pytest.mark.asyncio
+    async def test_unix_peer_uid_mismatch_is_refused_even_with_the_secret(
+        self, monkeypatch, fake_sel
+    ) -> None:
+        """A foreign-uid unix peer is refused BEFORE the secret is considered.
+
+        MISMATCH means the kernel positively identified another principal on
+        our socket -- exactly when the 0700-home directory gate has failed and
+        denying matters most. Deny-by-default: transport refusal even though
+        the request carries the correct secret.
+        """
+        from kiro_crew.mcp_gateway.socketsec import PeerCredResult
+
+        monkeypatch.setattr("kiro_crew.dashboard.origin.request_is_unix_socket", lambda _r: True)
+        monkeypatch.setattr(
+            "kiro_crew.mcp_gateway.socketsec.check_peer_is_self",
+            lambda _s: PeerCredResult.MISMATCH,
+        )
+        resp = await core_mod.api_token_local(
+            _req(remote="", app={"local_secret": "right"}, headers={"X-Local-Secret": "right"})
+        )
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "loopback only"
+        assert fake_sel.log_api_access.call_args.kwargs["resources"] == "non-loopback"
+
+    @pytest.mark.asyncio
+    async def test_unix_peer_unverifiable_is_refused_even_with_the_secret(
+        self, monkeypatch, fake_sel
+    ) -> None:
+        """Failure to verify the peer is never conflated with permission.
+
+        UNVERIFIABLE (no mechanism, non-AF_UNIX family, syscall failure) must
+        refuse -- a platform without a peer-credential mechanism never silently
+        widens this token_auth-bypassed endpoint.
+        """
+        from kiro_crew.mcp_gateway.socketsec import PeerCredResult
+
+        monkeypatch.setattr("kiro_crew.dashboard.origin.request_is_unix_socket", lambda _r: True)
+        monkeypatch.setattr(
+            "kiro_crew.mcp_gateway.socketsec.check_peer_is_self",
+            lambda _s: PeerCredResult.UNVERIFIABLE,
+        )
+        resp = await core_mod.api_token_local(
+            _req(remote="", app={"local_secret": "right"}, headers={"X-Local-Secret": "right"})
+        )
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "loopback only"
+
+    @pytest.mark.asyncio
     async def test_bad_embed_port_is_dropped(self, monkeypatch, fake_sel) -> None:
         monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: True)
         minted: dict = {}

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -6,15 +6,19 @@ import argparse
 import ast
 import json
 import os
+import shutil
+import socket
 import stat
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from tmpdir_helpers import short_tmp_base
 
 from kiro_crew import platform_compat
 from kiro_crew.pod import cli as pod_cli
@@ -4252,6 +4256,7 @@ class TestRuntimeHelpers:
                 return b'{"token":"tok-xyz"}'
 
         monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
+        monkeypatch.setattr(rt, "_pod_recorded_pid", lambda cfg, name, port: 4242)
         monkeypatch.setattr(rt, "unix_socket_urlopen", lambda *a, **k: _Resp())
         assert rt.mint_token(c, "demo", "1h") == "tok-xyz"
 
@@ -4293,11 +4298,14 @@ class TestRuntimeHelpers:
             tcp_calls.append(a)
             return _Resp()
 
-        def _uds(req: object, timeout: float, *, socket_path: object) -> "_Resp":
-            uds_calls.append({"req": req, "socket_path": socket_path})
+        def _uds(
+            req: object, timeout: float, *, socket_path: object, verify_peer: object = None
+        ) -> "_Resp":
+            uds_calls.append({"req": req, "socket_path": socket_path, "verify_peer": verify_peer})
             return _Resp()
 
         monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
+        monkeypatch.setattr(rt, "_pod_recorded_pid", lambda cfg, name, port: 4242)
         monkeypatch.setattr(rt, "loopback_urlopen", _tcp)
         monkeypatch.setattr(rt, "unix_socket_urlopen", _uds)
 
@@ -4305,6 +4313,7 @@ class TestRuntimeHelpers:
         assert tcp_calls == []  # the secret-bearing call has no TCP path at all
         port = rt.derive_port(c, "demo")
         assert uds_calls[0]["socket_path"] == rt.pod_socket_path(c, "demo", port)
+        assert callable(uds_calls[0]["verify_peer"])  # peer check rides every send
         req = uds_calls[0]["req"]
         assert req.get_header("X-local-secret") == "s3cret"  # urllib-normalized key
 
@@ -5148,16 +5157,175 @@ class TestReviewRound1Fixes:
             def read(self) -> bytes:
                 return b'{"token":"t"}'
 
-        def _urlopen(req: object, timeout: int = 5, *, socket_path: object = None) -> "_Resp":
+        def _urlopen(
+            req: object,
+            timeout: int = 5,
+            *,
+            socket_path: object = None,
+            verify_peer: object = None,
+        ) -> "_Resp":
             captured["url"] = req.full_url  # type: ignore[attr-defined]
             return _Resp()
 
         # Mint now requires positive ownership proof; this test is about the URL
         # it builds, so grant the proof rather than exercising the guard here.
         monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
+        monkeypatch.setattr(rt, "_pod_recorded_pid", lambda cfg, name, port: 4242)
         monkeypatch.setattr(rt, "unix_socket_urlopen", _urlopen)
         rt.mint_token(c, "demo", "1 h")
         assert "ttl=1%20h" in captured["url"]
+
+
+class TestMintPeerVerification:
+    """Connect-time peer verification on the pod's unix socket (#8552, round 2).
+
+    ``port_owner`` proves the pid RECORD is fresh; these tests pin the other
+    half: the process ANSWERING the socket file must be that recorded pid, as
+    read from the kernel's peer credentials on the connected socket, before a
+    single HTTP byte (and the ``X-Local-Secret`` header behind it) is sent.
+    """
+
+    def _grant_record_freshness(self, monkeypatch: pytest.MonkeyPatch, pid: int) -> None:
+        monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
+        monkeypatch.setattr(rt, "_pod_recorded_pid", lambda cfg, name, port: pid)
+
+    def test_verifier_refuses_a_mismatched_peer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path))
+        c = PodConfig.load()
+        self._grant_record_freshness(monkeypatch, 4242)
+        monkeypatch.setattr(rt, "get_peer_pid", lambda sock: 9999)
+        verify = rt._attested_gateway_verifier(c, "demo", 7999, Path("/x/sock"))
+        with pytest.raises(rt.PodError, match="refusing to send"):
+            verify(object())
+
+    def test_verifier_refuses_an_unreadable_peer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``None`` from the kernel is a refusal, never a pass (deny-by-default)."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path))
+        c = PodConfig.load()
+        self._grant_record_freshness(monkeypatch, 4242)
+        monkeypatch.setattr(rt, "get_peer_pid", lambda sock: None)
+        verify = rt._attested_gateway_verifier(c, "demo", 7999, Path("/x/sock"))
+        with pytest.raises(rt.PodError, match="unidentifiable process"):
+            verify(object())
+
+    def test_verifier_refuses_when_no_pid_is_attested(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No provable record at send time = no verifier at all, fail closed."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path))
+        c = PodConfig.load()
+        monkeypatch.setattr(rt, "_pod_recorded_pid", lambda cfg, name, port: None)
+        with pytest.raises(rt.PodOwnershipUnproven):
+            rt._attested_gateway_verifier(c, "demo", 7999, Path("/x/sock"))
+
+    def test_verifier_accepts_the_attested_peer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path))
+        c = PodConfig.load()
+        self._grant_record_freshness(monkeypatch, 4242)
+        monkeypatch.setattr(rt, "get_peer_pid", lambda sock: 4242)
+        verify = rt._attested_gateway_verifier(c, "demo", 7999, Path("/x/sock"))
+        assert verify(object()) is None  # no raise = the send may proceed
+
+    @staticmethod
+    def _serve_once(server_sock: socket.socket, received: list[bytes]) -> threading.Thread:
+        """Accept one connection and record whatever arrives (empty = refused)."""
+
+        def _run() -> None:
+            try:
+                conn, _ = server_sock.accept()
+            except OSError:
+                return
+            with conn:
+                conn.settimeout(2)
+                data = b""
+                try:
+                    while b"\r\n\r\n" not in data:
+                        chunk = conn.recv(4096)
+                        if not chunk:
+                            break
+                        data += chunk
+                except OSError:
+                    pass
+                received.append(data)
+                if data:
+                    body = b'{"token":"tok-live"}'
+                    conn.sendall(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                        b"Content-Length: %d\r\n\r\n%s" % (len(body), body)
+                    )
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        return thread
+
+    def _mint_against_live_listener(
+        self, monkeypatch: pytest.MonkeyPatch, attested_pid: int
+    ) -> tuple[list[bytes], "rt.PodError | None"]:
+        """Drive the REAL kernel peer check: a live in-process unix listener
+        (peer pid = ``os.getpid()``) answers the pod's derived socket path,
+        while the attested record names *attested_pid*. Only record freshness
+        is granted; ``get_peer_pid`` runs unpatched against the real socket.
+        """
+        if platform_compat.IS_WINDOWS:
+            pytest.skip("AF_UNIX transport is POSIX-only")
+        root = Path(tempfile.mkdtemp(prefix="podpeer-", dir=short_tmp_base()))
+        try:
+            monkeypatch.setenv("KIROCREW_POD_ROOT", str(root))
+            c = PodConfig.load()
+            home = c.home_dir("demo")
+            home.mkdir(parents=True)
+            (home / ".local_secret").write_text("s3cret")
+            port = rt.derive_port(c, "demo")
+            socket_path = rt.pod_socket_path(c, "demo", port)
+            socket_path.parent.mkdir(parents=True, exist_ok=True)
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                server.bind(str(socket_path))
+                server.listen(1)
+                received: list[bytes] = []
+                thread = self._serve_once(server, received)
+                self._grant_record_freshness(monkeypatch, attested_pid)
+                error: rt.PodError | None = None
+                try:
+                    assert rt.mint_token(c, "demo", "1h") == "tok-live"
+                except rt.PodError as exc:
+                    error = exc
+                server.close()
+                thread.join(timeout=5)
+                return received, error
+            finally:
+                server.close()
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_mint_refuses_a_rebound_socket_before_any_bytes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """THE #8552 round-2 window: a same-UID process rebinds the socket path.
+
+        The listener is real and answering, the pid record is fresh, but the
+        kernel says the peer is this test process, not the attested gateway
+        (pid 1). The mint must refuse AND the listener must observe zero bytes
+        -- the request line, let alone the secret header, never went out.
+        """
+        received, error = self._mint_against_live_listener(monkeypatch, attested_pid=1)
+        assert error is not None and "refusing to send" in str(error)
+        assert received in ([], [b""])  # connection at most; never a byte of HTTP
+
+    def test_mint_sends_when_the_kernel_names_the_attested_peer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Benign path, no new denials: attest THIS process, the real
+        ``SO_PEERCRED``/``LOCAL_PEERPID`` read agrees, the mint completes."""
+        received, error = self._mint_against_live_listener(monkeypatch, attested_pid=os.getpid())
+        assert error is None
+        assert len(received) == 1 and b"X-Local-Secret: s3cret" in received[0]
 
 
 class TestReviewRound2Fix:

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -4252,8 +4252,61 @@ class TestRuntimeHelpers:
                 return b'{"token":"tok-xyz"}'
 
         monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
-        monkeypatch.setattr(rt, "loopback_urlopen", lambda *a, **k: _Resp())
+        monkeypatch.setattr(rt, "unix_socket_urlopen", lambda *a, **k: _Resp())
         assert rt.mint_token(c, "demo", "1h") == "tok-xyz"
+
+    def test_mint_token_sends_the_secret_only_over_the_pod_socket(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The X-Local-Secret request rides the pod's AF_UNIX socket, never TCP.
+
+        The TCP-era transport (#8552) attested ownership and then opened a
+        SEPARATE loopback connection carrying the secret: a pod exiting inside
+        that window frees the port for any local user, and loopback TCP has no
+        peer-credential API to tell the squatter from the gateway. The socket
+        lives inside the pod's owner-only home, so delivery there cannot reach
+        another user -- and `unix_socket_urlopen` has no TCP handler, making
+        "no fallback" structural. This test pins both properties: the TCP
+        opener is never consulted, and the secret-bearing request lands on
+        exactly the pod's own socket path.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path))
+        c = PodConfig.load()
+        home = c.home_dir("demo")
+        home.mkdir(parents=True)
+        (home / ".local_secret").write_text("s3cret")
+
+        class _Resp:
+            def __enter__(self) -> "_Resp":
+                return self
+
+            def __exit__(self, *a: object) -> bool:
+                return False
+
+            def read(self) -> bytes:
+                return b'{"token":"tok-uds"}'
+
+        tcp_calls: list[object] = []
+        uds_calls: list[dict[str, object]] = []
+
+        def _tcp(*a: object, **k: object) -> "_Resp":
+            tcp_calls.append(a)
+            return _Resp()
+
+        def _uds(req: object, timeout: float, *, socket_path: object) -> "_Resp":
+            uds_calls.append({"req": req, "socket_path": socket_path})
+            return _Resp()
+
+        monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
+        monkeypatch.setattr(rt, "loopback_urlopen", _tcp)
+        monkeypatch.setattr(rt, "unix_socket_urlopen", _uds)
+
+        assert rt.mint_token(c, "demo", "1h") == "tok-uds"
+        assert tcp_calls == []  # the secret-bearing call has no TCP path at all
+        port = rt.derive_port(c, "demo")
+        assert uds_calls[0]["socket_path"] == rt.pod_socket_path(c, "demo", port)
+        req = uds_calls[0]["req"]
+        assert req.get_header("X-local-secret") == "s3cret"  # urllib-normalized key
 
     def test_mint_token_refuses_a_foreign_port_holder(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -5095,14 +5148,14 @@ class TestReviewRound1Fixes:
             def read(self) -> bytes:
                 return b'{"token":"t"}'
 
-        def _urlopen(req: object, timeout: int = 5) -> "_Resp":
+        def _urlopen(req: object, timeout: int = 5, *, socket_path: object = None) -> "_Resp":
             captured["url"] = req.full_url  # type: ignore[attr-defined]
             return _Resp()
 
         # Mint now requires positive ownership proof; this test is about the URL
         # it builds, so grant the proof rather than exercising the guard here.
         monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
-        monkeypatch.setattr(rt, "loopback_urlopen", _urlopen)
+        monkeypatch.setattr(rt, "unix_socket_urlopen", _urlopen)
         rt.mint_token(c, "demo", "1 h")
         assert "ttl=1%20h" in captured["url"]
 

--- a/test/test_pod_api.py
+++ b/test/test_pod_api.py
@@ -164,6 +164,13 @@ def stub_gateway(monkeypatch: pytest.MonkeyPatch) -> _RecordingUnixServer:
         # these tests red instead of silently pointing them at a dead path.
         socket_path = cfg.home_dir("wt") / dashboard_socket_path(port).name
         socket_path.parent.mkdir(parents=True, exist_ok=True)
+        # Attest THIS process as the pod's gateway: the fixture's unix server
+        # answers from the test process, so the kernel's peer credentials on
+        # every connection name ``os.getpid()``. Recording that pid (with its
+        # live start identity) lets the connect-time peer check added for
+        # #8552 prove the fixture gateway exactly the way it proves a real one
+        # -- these tests exercise the verification path, not a bypass of it.
+        _write_record(cfg, "wt", port, f"{os.getpid()}\n", _live_start_token())
         unix = _RecordingUnixServer(str(socket_path), _Handler)
         stack.callback(unix.server_close)
         unix.seen = []


### PR DESCRIPTION
## Problem / Motivation

`mint_token` reads the pod's `.local_secret` and sends it in an `X-Local-Secret` header over loopback TCP to `http://127.0.0.1:<port>/api/token/local`. Ownership is attested (`OWNER_POD` positive proof) and *then* a separate TCP connection carries the secret — a pod exiting inside that window frees the port for any local user to bind, and loopback TCP has no peer-credential API, so nothing on the wire can tell the squatter from the pod's gateway. #8218 closed exactly this class for the token-bearing request; `mint_token` is the residual its review disposition called out, and it could not ride #8218 because the server refuses the better transport: `api_token_local` gates on `is_loopback(request.remote)`, and an `AF_UNIX` request has an empty `request.remote`, so the endpoint answers 403 to the transport that is strictly harder to reach than loopback TCP.

## Why it matters

The captured value is the pod's per-gateway-start `.local_secret`. The impact is bounded exactly as the issue bounds it (capture-now / replay-before-any-gateway-restart, and #8218's socket transport means a fabricated token is only ever handed to the pod's own socket) — but pods carry ~2h TTLs and are torn down routinely, so the port-release window is a normal lifecycle event, not an anomaly. A secret-bearing request should not depend on winning a race against ordinary pod churn.

## What changed (motivation → approach → change)

The secret now rides a connection whose peer the kernel vouches for, end to end. Three pieces, client / transport / server:

- **Client** (`src/kiro_crew/pod/runtime.py`): `mint_token` sends the mint over the pod's private `AF_UNIX` socket via `unix_socket_urlopen(req, timeout=5, socket_path=pod_socket_path(cfg, name, port), verify_peer=...)`. That opener has no TCP handler, so "no fallback" is structural rather than a flag: a missing, stale, or refusing socket raises instead of handing the header to whatever answered — the error says explicitly that the call is not retried on `127.0.0.1:<port>` and why. An HTTP 403 over the socket gets its own message that separates the two causes an operator can hit: a pod worktree whose gateway predates unix-socket admission on `/api/token/local` (remedy named in the error: update the pod's worktree, then restart it) versus a genuine secret rejection. The URL keeps the loopback host so the gateway's Host validation sees exactly what it saw on TCP; the socket path is derived, never caller-supplied. The `OWNER_POD` pre-check stays: it costs one process lookup and buys refusal messages that name *why* the pod cannot answer. **On Windows the mint keeps the OWNER_POD-attested loopback transport**: CPython there has no `AF_UNIX`, so the pod binds no socket, and the `IS_WINDOWS` branch returns before any unix-socket machinery is built — the strongest transport the platform offers, unchanged in behavior.
- **Transport** (`src/kiro_crew/loopback_http.py`, `src/kiro_crew/pod/runtime.py`): `unix_socket_urlopen` accepts a `verify_peer` connect-time callback that runs on the connected socket before any HTTP bytes. `_attested_gateway_verifier` builds that check from the recorded gateway pid vs the kernel's peer credentials (`SO_PEERCRED` on Linux, `LOCAL_PEERPID` on macOS), and re-proves the freshness-checked record on the connected socket itself — so a pid recycled between the record read and the connect cannot attest: the socket path lives in an owner-writable directory, so a confined same-UID process can unlink it and bind its own listener there — a fresh pid record proves the gateway is alive, not that it is the process answering the file. Deny-by-default: a mismatched peer, an unreadable peer, an unprovable pid record, and a record that cannot be re-proven at connect time all refuse before the request line goes out. Both send sites are covered (token mint and pod api — a rebind between the two sends would otherwise capture a live credential), and the stub-gateway fixture attests itself, so every pod-api test drives the real kernel check end to end.
- **Server** (`src/kiro_crew/dashboard/handlers/core.py`): `api_token_local` admits kernel-verified unix peers via `_unix_peer_is_self` — the shared `token_auth._unix_request_socket` discriminator (one definition of "arrived on the dashboard's unix socket" for the CSRF and token-auth layers) plus `check_peer_is_self(sock) is PeerCredResult.MATCH`, both imported at module level. Because this endpoint is `token_auth`-bypassed, admission is deny-by-default: `MISMATCH` (another principal reached our socket — precisely when the `0700` directory gate has failed and refusing matters most) and `UNVERIFIABLE` (no platform mechanism, failed syscall) are both refused, so a platform without peer credentials never silently widens the gate. This admits a *transport*, never a caller: the `X-Local-Secret` check downstream is unchanged on both transports.
- **Deliberately unchanged:** `health()` / probe stay on TCP — they carry no credential, and `port_owner()` already reports who replied. The four sibling `X-Local-Secret` sends against the MAIN gateway in `cli_server.py` also stay on loopback TCP: the main gateway is out of this PR's scope (pod mint only), and migrating those sites onto the gateway's unix socket is tracked in #11091. The docker guide (`docs/guides/docker.md`) local-bootstrap paragraph describes the two admitted transports.

```mermaid
flowchart LR
  subgraph Before
    m1[mint_token] -->|X-Local-Secret over loopback TCP| p1[whoever holds :port]
  end
  subgraph After
    m2[mint_token] -->|X-Local-Secret over AF_UNIX| v2{peer pid == attested gateway?}
    v2 -->|MATCH| g2[pod's gateway]
    v2 -->|MISMATCH / UNVERIFIABLE| r2[refused, zero bytes sent]
  end
  classDef added fill:#DCFCE7,stroke:#16A34A;
  classDef removed fill:#FEE2E2,stroke:#DC2626,stroke-dasharray:4 3;
  classDef ctx fill:#E0F2FE,stroke:#0284C7;
  class m2,v2,r2 added
  class p1 removed
  class m1,g2 ctx
```
🟩 added · 🟥 removed · 🟦 unchanged

The secret leaves the process only after the kernel names the listener, so a squatter on the port — or on the socket file — receives nothing.

## Tests

Server half (`test/test_dashboard_handlers_core_coverage.py`, `TestLocalToken`):
- `test_unix_peer_match_with_valid_secret_issues_a_token` — kernel MATCH + valid secret mints (the benign path is admitted, not just attacks refused).
- `test_unix_peer_still_needs_the_secret` — admitted transport, wrong secret → 403 `invalid secret` (not `loopback only`), pinning that admission never weakens the secret check.
- `test_unix_peer_uid_mismatch_is_refused_even_with_the_secret` — kernel says another principal: refused with the audit log recording `non-loopback`.
- `test_unix_peer_unverifiable_is_refused_even_with_the_secret` — no peer-credential mechanism: refused (deny-by-default pin).

Client half (`test/test_pod.py`):
- `test_mint_token_sends_the_secret_only_over_the_pod_socket` — asserts the TCP opener list stays *empty*, the unix opener got `pod_socket_path(...)`, and the `X-Local-Secret` header rode the socket.
- `test_mint_token_uses_attested_loopback_on_windows` — with `IS_WINDOWS` true, the mint rides the loopback opener with the secret header, and building the unix socket path, the unix opener, or the peer verifier each fails the test outright.
- `TestMintPeerVerification` — a live in-process listener answering the pod's derived socket path with a mismatched attested pid observes ZERO bytes (the refusal precedes the request line), and the same listener attested as this process completes the mint through the real peer-credential read — no monkeypatch on the kernel path. `test_verifier_refuses_when_attestation_expires_before_connect` pins the connect-time re-proof: a record valid when the verifier is built but gone at connect time refuses even when the numeric peer pid matches.
- `test_mint_token_reads_secret_and_posts` rides the socket transport; `test_mint_token_refuses_a_foreign_port_holder` passes unchanged on both sides (control: the pre-check's refusal behavior is untouched).

Fixture half (`test/test_pod_api.py`): the stub gateway records its own pid with a live start identity, so pod-api tests exercise the verification path rather than bypassing it.

Targeted files: 696 passed / 1 skipped. Scoped backend suite (721 related targets): green apart from 15 host-environment failures that reproduce byte-identically on pristine `origin/main` (doctor probes, a dev-fleet path assertion, member-context routing). mypy clean over 1539 files; flake8 / isort / black-baseline / comment-history / docs-lint all pass.

## Manual verification

N/A — unit coverage sufficient: the two new seams are unit-pinned with the kernel verdict and transports faked, and both underlying primitives carry their own pre-existing real-socket suites (`test_pod_api.py` binds a live `AF_UNIX` server against `unix_socket_urlopen`; `test_socketsec*.py` covers `check_peer_is_self` including real-socket SO_PEERCRED). CI exercises the composed path.

## Screenshots / video

N/A — backend transport and error-message change only; no user-visible dashboard or app state changes.

## Related Issues

Fixes #8552

## Pattern harvest

Rule candidate: review-prompt
Pattern: "attest-then-send across separate connections is a TOCTOU on the *transport* — a credential-bearing request must ride a connection whose peer is verified at send time (unix socket + peer creds), not a port whose owner was checked moments earlier". Flag any request that sends a secret over plain loopback TCP when a peer-verified unix transport exists for the same server.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
