### PR TITLE
fix(papyrus): keep the located Tectonic binary inside the unpacked tree

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -137,7 +137,6 @@ src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
 src/kiro_crew/apps/builtins/papyrus/backend/latex.py
 src/kiro_crew/apps/builtins/papyrus/backend/routes.py
 src/kiro_crew/apps/builtins/papyrus/backend/store.py
-src/kiro_crew/apps/builtins/papyrus/backend/tectonic.py
 src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py
 src/kiro_crew/apps/builtins/personal_shopper/backend/store.py
 src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py

--- a/src/kiro_crew/apps/builtins/papyrus/backend/tectonic.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/tectonic.py
@@ -51,6 +51,7 @@ work on a daemon thread, and the ``no-blocking-call-on-event-loop`` rule.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import http.client
 import logging
@@ -58,6 +59,7 @@ import os
 import platform
 import shutil
 import ssl
+import stat
 import sys
 import tarfile
 import threading
@@ -69,7 +71,7 @@ import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from kiro_crew import platform_compat
+from kiro_crew import pinned_fs, platform_compat
 from kiro_crew._ssl_compat import _ssl_context_has_ca_trust
 from kiro_crew.apps.builtins.papyrus.backend import store
 from kiro_crew.sel import sel
@@ -557,6 +559,14 @@ def _locate_binary(tree: Path) -> Path | None:
 
         Resolving is what makes the check hold for both: it follows every
         reparse point on the way down and answers where the bytes actually live.
+
+        This is a NAME-level filter and deliberately not the containment
+        witness: it resolves a path, and whatever opens that path afterwards
+        resolves it again, so a link swapped in between is followed by the
+        second resolution and not the first. It exists to refuse the ordinary
+        case early and to name the right file in the failure message.
+        :func:`_open_inside` is what actually decides containment, on the
+        descriptor the install then reads.
         """
         try:
             return candidate.resolve().is_relative_to(root)
@@ -570,6 +580,61 @@ def _locate_binary(tree: Path) -> Path | None:
         if candidate.is_file() and not candidate.is_symlink() and contained(candidate):
             return candidate
     return None
+
+
+def _open_inside(candidate: Path, root_real: str) -> int | None:
+    """Open *candidate* and return a descriptor, but only if it lives in *root_real*.
+
+    This is the containment witness. Every by-name check in this module --
+    ``resolve()``, ``is_file()``, ``is_symlink()`` -- validates a path and then
+    hands that path to something that opens it again, so the inode that was
+    checked and the inode that is used are two separate lookups with a window
+    between them. Inside that window a local writer can retarget the
+    ``.provision.<pid>`` tree the unpack ran into, and the second lookup follows
+    the new link.
+
+    So the order is inverted: open FIRST, then ask the kernel where the thing
+    already held open actually is (:func:`pinned_fs.fd_real_path` --
+    ``/proc/self/fd``, ``F_GETPATH`` or ``GetFinalPathNameByHandleW``). A
+    descriptor cannot be re-pointed, so that answer stays true for as long as it
+    is held, and the caller installs FROM the descriptor rather than reopening
+    the name.
+
+    *root_real* must be captured before the tree is filled, and by the caller --
+    resolving it here would re-open the same window one level up, since the
+    directory whose containment is being asserted is exactly the one an attacker
+    would swap.
+
+    ``O_NOFOLLOW`` guards only the final component and does not exist on
+    Windows; it is passed where available as a cheap early refusal, and the
+    fd-path check is what closes the gap on every platform. Every failure route
+    -- unreadable, not a regular file, unknowable real path -- returns ``None``,
+    never a fallback to the pathname.
+    """
+    try:
+        fd = os.open(candidate, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError:
+        return None
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            return None
+        real = pinned_fs.fd_real_path(fd)
+        if real is None:
+            return None  # cannot witness containment -> fail closed
+        try:
+            if os.path.commonpath([real, root_real]) != root_real:
+                return None
+        except ValueError:  # different drives on Windows
+            return None
+    except OSError:
+        return None
+    else:
+        held, fd = fd, -1
+        return held
+    finally:
+        if fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(fd)
 
 
 # ── download ────────────────────────────────────────────────────────────────
@@ -741,8 +806,8 @@ def _download_to(asset: TectonicAsset, staging: Path) -> tuple[bool, str]:
     return True, ""
 
 
-def _install_binary(extracted: Path, target: Path) -> None:
-    """Move *extracted* into place atomically and make it executable.
+def _install_binary(source_fd: int, target: Path) -> None:
+    """Install the bytes behind *source_fd* atomically and make them executable.
 
     Staged inside the TARGET directory so ``os.replace`` is a same-filesystem
     rename, and named per-process so two concurrent installs cannot interleave
@@ -750,11 +815,23 @@ def _install_binary(extracted: Path, target: Path) -> None:
     binary is never observable at its final path without its exec bit — a
     half-installed compiler that "looks valid" is exactly the state
     :func:`binary_installed` must never see.
+
+    The source is a DESCRIPTOR, not a path, and that is the whole point. This
+    used to ``shutil.move`` the located path, which re-resolves it: the file
+    that was validated and the file that got installed were two lookups of the
+    same name, and a local writer who retargeted the unpack tree in between had
+    an arbitrary file promoted onto the path papyrus executes. A descriptor
+    cannot be re-pointed, so the bytes copied here are exactly the bytes
+    :func:`_open_inside` witnessed inside the tree. The cost is a copy instead
+    of a rename, once, for an artifact that was just downloaded over the
+    network.
     """
     target.parent.mkdir(parents=True, exist_ok=True)
     staging = target.parent / f".{target.name}.{os.getpid()}.tmp"
     try:
-        shutil.move(str(extracted), str(staging))
+        os.lseek(source_fd, 0, os.SEEK_SET)
+        with open(staging, "wb") as out:
+            shutil.copyfileobj(os.fdopen(os.dup(source_fd), "rb", closefd=True), out)
         platform_compat.chmod_safe(staging, _BINARY_MODE)
         os.replace(staging, target)
     finally:
@@ -783,6 +860,12 @@ def _provision_once(root: Path | None) -> tuple[bool, str]:
         _set_state(STATE_INSTALLING)
         unpacked = work / "unpacked"
         unpacked.mkdir()
+        # Captured HERE, on a directory this process just created and before the
+        # archive is written into it, so it is the extraction's own tree that
+        # containment is asserted against. Resolving it later -- inside the
+        # locator, or after the walk -- would resolve whatever the name points at
+        # by then, which is precisely the thing an attacker would have swapped.
+        root_real = os.path.realpath(unpacked)
         try:
             _extract(archive, unpacked, is_zip=asset.is_zip)
         except (ArchiveRejected, tarfile.TarError, zipfile.BadZipFile, OSError) as exc:
@@ -790,9 +873,23 @@ def _provision_once(root: Path | None) -> tuple[bool, str]:
         binary = _locate_binary(unpacked)
         if binary is None:
             return False, f"no {binary_name()} found inside {asset.name}"
-        if binary.stat().st_size < _MIN_BINARY_BYTES:
-            return False, f"extracted {binary_name()} is implausibly small ({binary.stat().st_size} bytes)"
-        _install_binary(binary, target)
+        source_fd = _open_inside(binary, root_real)
+        if source_fd is None:
+            return False, (
+                f"the {binary_name()} found inside {asset.name} does not live inside "
+                "the unpacked tree — refusing to install it"
+            )
+        try:
+            # From the descriptor, not the path: a second stat() of the name is a
+            # second lookup, and the size that gates the install must be the size
+            # of the file that gets installed.
+            size = os.fstat(source_fd).st_size
+            if size < _MIN_BINARY_BYTES:
+                return False, f"extracted {binary_name()} is implausibly small ({size} bytes)"
+            _install_binary(source_fd, target)
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(source_fd)
         if not binary_installed(root):
             return False, "installed binary failed its post-install check"
         return True, ""

--- a/src/kiro_crew/apps/builtins/papyrus/backend/tectonic.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/tectonic.py
@@ -543,11 +543,31 @@ def _locate_binary(tree: Path) -> Path | None:
     top-level directory does not need a code change to keep working.
     """
     wanted = binary_name()
+    root = tree.resolve()
+
+    def contained(candidate: Path) -> bool:
+        """True only when *candidate* is a file the extraction itself produced.
+
+        The walk below already refuses a candidate that IS a link, so refusing a
+        link-mediated escape is this function's own intent. But ``rglob``
+        DESCENDS through a directory link, and the executable on the far side is
+        an ordinary file -- ``is_file()`` true, ``is_symlink()`` false -- so it
+        passes that filter while resolving outside the tree. On Windows the link
+        is typically a junction, which ``is_symlink`` does not report at all.
+
+        Resolving is what makes the check hold for both: it follows every
+        reparse point on the way down and answers where the bytes actually live.
+        """
+        try:
+            return candidate.resolve().is_relative_to(root)
+        except OSError:
+            return False
+
     direct = tree / wanted
-    if direct.is_file():
+    if direct.is_file() and contained(direct):
         return direct
     for candidate in sorted(tree.rglob(wanted)):
-        if candidate.is_file() and not candidate.is_symlink():
+        if candidate.is_file() and not candidate.is_symlink() and contained(candidate):
             return candidate
     return None
 

--- a/test/test_papyrus_tectonic.py
+++ b/test/test_papyrus_tectonic.py
@@ -40,6 +40,7 @@ from unittest import mock
 
 import pytest
 
+from conftest import make_dir_link
 from kiro_crew.apps.builtins.papyrus.backend import latex, store, tectonic
 
 
@@ -1063,3 +1064,92 @@ class TestErrorMessagesNeverCarryMirrorCredentials:
         assert audited and all("sup3rsecret" not in a for a in audited), (
             f"credential leaked into the audit record: {audited}"
         )
+
+
+# ── the located binary must come from inside the unpacked tree ──────────────
+
+
+class TestLocateBinaryStaysInsideTheUnpackedTree:
+    """`_locate_binary` may only return a path the extraction itself produced.
+
+    The walk already refuses a candidate that IS a link, so refusing a link-mediated
+    escape is the site's own stated intent. That guard is blind to the escape that
+    costs the most: `rglob` DESCENDS through a directory link, and the executable it
+    finds on the far side is an ordinary file — `is_file()` true, `is_symlink()`
+    false — so it passes the filter unchanged while resolving outside the tree.
+
+    What follows the return is not a read. `_provision_once` hands the path to
+    `_install_binary`, which `shutil.move`s it (so the file leaves its original
+    location), applies `_BINARY_MODE`, and `os.replace`s it onto `binary_path()` —
+    the compiler papyrus then executes. So an escape here promotes an arbitrary
+    local file to an executed binary path.
+
+    Threat model, stated plainly and not inflated: the asset is pinned and fetched
+    over TLS, and neither tar nor zip can create a Windows junction, so the archive
+    cannot plant this. It needs a local writer racing the per-process
+    `.provision.<pid>` unpack directory. This is the containment layer that walk was
+    already reaching for, not a remote-archive escape.
+
+    On Windows the link is a junction (`make_dir_link`), because a *directory*
+    symlink needs a privilege an unelevated shell does not have — so the platform
+    the blind spot lives on is exercised rather than skipped.
+    """
+
+    def test_an_executable_reached_through_a_directory_link_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        tree = tmp_path / "unpacked"
+        tree.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        planted = outside / tectonic.binary_name()
+        planted.write_bytes(_payload())
+        make_dir_link(tree / "vendor", outside)
+
+        # Guard the guard, through an oracle OUTSIDE the module under test: if
+        # `rglob` did not descend, or the descendant were itself a link, this test
+        # would pass for a reason that has nothing to do with the fix.
+        reached = sorted(tree.rglob(tectonic.binary_name()))
+        assert reached, "rglob never descended the link, so nothing was under test"
+        assert reached[0].is_file()
+        assert not reached[0].is_symlink()
+        assert not reached[0].resolve().is_relative_to(tree.resolve())
+
+        assert tectonic._locate_binary(tree) is None
+
+    def test_a_direct_hit_that_resolves_outside_the_tree_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """The fast path takes `tree / wanted` on `is_file()` alone — which follows a
+        link — so it never had even the walk's own `is_symlink` filter."""
+        tree = tmp_path / "unpacked"
+        tree.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        planted = outside / tectonic.binary_name()
+        planted.write_bytes(_payload())
+        make_dir_link(tree / tectonic.binary_name(), outside)
+
+        direct = tree / tectonic.binary_name()
+        assert direct.is_file() or direct.is_dir()
+        assert tectonic._locate_binary(tree) is None
+
+    def test_a_real_binary_at_the_top_of_the_tree_is_still_found(
+        self, tmp_path: Path
+    ) -> None:
+        """Positive control: the flat pinned layout must keep resolving."""
+        tree = tmp_path / "unpacked"
+        tree.mkdir()
+        real = tree / tectonic.binary_name()
+        real.write_bytes(_payload())
+        assert tectonic._locate_binary(tree) == real
+
+    def test_a_real_binary_in_a_subdirectory_is_still_found(self, tmp_path: Path) -> None:
+        """Positive control for the walk: a future release adding a top-level
+        directory must keep working, which is the reason the walk exists."""
+        tree = tmp_path / "unpacked"
+        nested = tree / "tectonic-0.1" / "bin"
+        nested.mkdir(parents=True)
+        real = nested / tectonic.binary_name()
+        real.write_bytes(_payload())
+        assert tectonic._locate_binary(tree) == real

--- a/test/test_papyrus_tectonic.py
+++ b/test/test_papyrus_tectonic.py
@@ -40,7 +40,8 @@ from unittest import mock
 
 import pytest
 
-from conftest import make_dir_link
+from conftest import make_dir_link, requires_symlinks
+from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.papyrus.backend import latex, store, tectonic
 
 
@@ -1066,35 +1067,76 @@ class TestErrorMessagesNeverCarryMirrorCredentials:
         )
 
 
-# ── the located binary must come from inside the unpacked tree ──────────────
+# ── the installed binary must be the file that was validated ────────────────
+
+
+#: ``Path.rglob`` recurses with pathlib's ``**`` selector, which deliberately does
+#: NOT descend a directory SYMLINK — so on POSIX the walk cannot reach past one at
+#: all. A Windows JUNCTION is a different reparse tag: ``DirEntry.is_symlink()``
+#: answers False for it, so the same walk descends it and hands back an ordinary
+#: file living outside the tree. MEASURED both ways rather than assumed: on this
+#: repo's Linux shard the guard-the-guard assertion below reported an empty walk,
+#: and on Windows it reports the file beyond the junction.
+#:
+#: The consequence is a platform fact, not a preference: the walk-descent escape is
+#: reachable on Windows and not on POSIX, and a test that manufactured a POSIX
+#: equivalent would be pinning a premise that does not hold there.
+_WALK_DESCENDS_A_DIRECTORY_LINK = platform_compat.IS_WINDOWS
+
+walk_descends_a_directory_link = pytest.mark.skipif(
+    not _WALK_DESCENDS_A_DIRECTORY_LINK,
+    reason=(
+        "pathlib's ** does not descend a POSIX directory symlink, so the walk cannot "
+        "reach past one; this escape is the Windows junction shape"
+    ),
+)
+
+
+def _detach_dir_link(link: Path) -> None:
+    """Remove the link ITSELF at *link*, leaving whatever it pointed at alone.
+
+    The call differs by platform and the wrong one raises rather than misbehaving
+    quietly: a POSIX directory symlink is a link entry, so ``rmdir`` answers
+    ``NotADirectoryError`` and only ``unlink`` removes it; a Windows junction is a
+    real directory entry, which ``unlink`` refuses. ``is_symlink()`` separates them
+    -- it is False for a junction, which is the same property the production code
+    under test is about.
+    """
+    if link.is_symlink():
+        link.unlink()
+    else:
+        os.rmdir(link)
+
+
+def _small(body: bytes = b"\x7fELFgood") -> bytes:
+    """A body for the containment tests, which never reach the plausibility floor."""
+    return body
 
 
 class TestLocateBinaryStaysInsideTheUnpackedTree:
-    """`_locate_binary` may only return a path the extraction itself produced.
+    """`_locate_binary` may only offer a path the extraction itself produced.
 
     The walk already refuses a candidate that IS a link, so refusing a link-mediated
     escape is the site's own stated intent. That guard is blind to the escape that
-    costs the most: `rglob` DESCENDS through a directory link, and the executable it
-    finds on the far side is an ordinary file — `is_file()` true, `is_symlink()`
-    false — so it passes the filter unchanged while resolving outside the tree.
+    costs the most: on Windows `rglob` DESCENDS through a directory junction, and
+    the executable it finds on the far side is an ordinary file — `is_file()` true,
+    `is_symlink()` false — so it passes the filter unchanged while resolving outside
+    the tree.
 
-    What follows the return is not a read. `_provision_once` hands the path to
-    `_install_binary`, which `shutil.move`s it (so the file leaves its original
-    location), applies `_BINARY_MODE`, and `os.replace`s it onto `binary_path()` —
-    the compiler papyrus then executes. So an escape here promotes an arbitrary
-    local file to an executed binary path.
+    What follows the return is not a read. `_provision_once` installs the located
+    binary onto `binary_path()` with `_BINARY_MODE`, and papyrus then executes it.
+    So an escape here promotes an arbitrary local file to an executed binary path.
 
     Threat model, stated plainly and not inflated: the asset is pinned and fetched
     over TLS, and neither tar nor zip can create a Windows junction, so the archive
     cannot plant this. It needs a local writer racing the per-process
-    `.provision.<pid>` unpack directory. This is the containment layer that walk was
-    already reaching for, not a remote-archive escape.
+    `.provision.<pid>` unpack directory.
 
-    On Windows the link is a junction (`make_dir_link`), because a *directory*
-    symlink needs a privilege an unelevated shell does not have — so the platform
-    the blind spot lives on is exercised rather than skipped.
+    This class covers the by-name filter only. It is a first refusal, not the
+    containment decision — see `TestTheInstalledBytesAreTheValidatedBytes`.
     """
 
+    @walk_descends_a_directory_link
     def test_an_executable_reached_through_a_directory_link_is_refused(
         self, tmp_path: Path
     ) -> None:
@@ -1103,12 +1145,13 @@ class TestLocateBinaryStaysInsideTheUnpackedTree:
         outside = tmp_path / "outside"
         outside.mkdir()
         planted = outside / tectonic.binary_name()
-        planted.write_bytes(_payload())
+        planted.write_bytes(_small())
         make_dir_link(tree / "vendor", outside)
 
         # Guard the guard, through an oracle OUTSIDE the module under test: if
         # `rglob` did not descend, or the descendant were itself a link, this test
-        # would pass for a reason that has nothing to do with the fix.
+        # would pass for a reason that has nothing to do with the fix. The skipif
+        # above says where this holds; this says it still holds HERE.
         reached = sorted(tree.rglob(tectonic.binary_name()))
         assert reached, "rglob never descended the link, so nothing was under test"
         assert reached[0].is_file()
@@ -1117,21 +1160,34 @@ class TestLocateBinaryStaysInsideTheUnpackedTree:
 
         assert tectonic._locate_binary(tree) is None
 
+    @requires_symlinks
     def test_a_direct_hit_that_resolves_outside_the_tree_is_refused(
         self, tmp_path: Path
     ) -> None:
         """The fast path takes `tree / wanted` on `is_file()` alone — which follows a
-        link — so it never had even the walk's own `is_symlink` filter."""
+        link — so it never had even the walk's own `is_symlink` filter.
+
+        This one needs a FILE symlink, and only a file symlink: a junction is a
+        directory, so `is_file()` is False for it and the fast path is never entered
+        (an earlier draft used one and silently tested the walk instead). Creating a
+        file symlink needs a privilege an unelevated Windows shell does not hold, so
+        this case is POSIX-and-elevated-Windows by construction — which is also
+        where the escape it describes exists.
+        """
         tree = tmp_path / "unpacked"
         tree.mkdir()
         outside = tmp_path / "outside"
         outside.mkdir()
         planted = outside / tectonic.binary_name()
-        planted.write_bytes(_payload())
-        make_dir_link(tree / tectonic.binary_name(), outside)
-
+        planted.write_bytes(_small())
         direct = tree / tectonic.binary_name()
-        assert direct.is_file() or direct.is_dir()
+        direct.symlink_to(planted)
+
+        # Guard the guard: the fast path is only under test when `is_file()` is
+        # true, which is exactly what the junction version failed to arrange.
+        assert direct.is_file(), "the fast path was not entered, so nothing was tested"
+        assert not direct.resolve().is_relative_to(tree.resolve())
+
         assert tectonic._locate_binary(tree) is None
 
     def test_a_real_binary_at_the_top_of_the_tree_is_still_found(
@@ -1141,7 +1197,7 @@ class TestLocateBinaryStaysInsideTheUnpackedTree:
         tree = tmp_path / "unpacked"
         tree.mkdir()
         real = tree / tectonic.binary_name()
-        real.write_bytes(_payload())
+        real.write_bytes(_small())
         assert tectonic._locate_binary(tree) == real
 
     def test_a_real_binary_in_a_subdirectory_is_still_found(self, tmp_path: Path) -> None:
@@ -1151,5 +1207,133 @@ class TestLocateBinaryStaysInsideTheUnpackedTree:
         nested = tree / "tectonic-0.1" / "bin"
         nested.mkdir(parents=True)
         real = nested / tectonic.binary_name()
-        real.write_bytes(_payload())
+        real.write_bytes(_small())
         assert tectonic._locate_binary(tree) == real
+
+
+class TestTheInstalledBytesAreTheValidatedBytes:
+    """Containment is decided on the DESCRIPTOR, and the install reads that descriptor.
+
+    Every by-name check in this module — `resolve()`, `is_file()`, `is_symlink()` —
+    validates a path and then hands the path to something that opens it again. The
+    inode that was checked and the inode that is used are two separate lookups, and
+    a local writer who retargets the unpack tree in the window between them has an
+    arbitrary file installed onto the path papyrus executes. Reviewers found exactly
+    that hole in the by-name-only version of this fix.
+
+    `_open_inside` inverts the order — open first, then ask the kernel where the
+    open thing actually is — and `_install_binary` copies from that descriptor. So
+    the property under test is not "the check is stricter" but "the check and the
+    use address one object".
+    """
+
+    def test_a_file_reached_through_a_directory_link_gets_no_descriptor(
+        self, tmp_path: Path
+    ) -> None:
+        tree = tmp_path / "unpacked"
+        tree.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        planted = outside / tectonic.binary_name()
+        planted.write_bytes(_small())
+        make_dir_link(tree / "vendor", outside)
+
+        candidate = tree / "vendor" / tectonic.binary_name()
+        # Guard the guard: the lexical path IS inside the tree, so a check that
+        # only looked at the name would accept it. That is the whole point.
+        assert candidate.is_file()
+        assert tree in candidate.parents
+
+        assert tectonic._open_inside(candidate, os.path.realpath(tree)) is None
+
+    def test_a_real_file_inside_the_tree_gets_a_descriptor_on_its_own_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        """Positive control, and the one that would catch an over-tight check.
+
+        `fd_real_path` and `realpath` reach the same name by different kernel
+        routes, and on Windows a path can also come back in 8.3 short form — so a
+        containment comparison that agrees only by luck must fail here, not in
+        production.
+        """
+        tree = tmp_path / "unpacked"
+        nested = tree / "tectonic-0.1" / "bin"
+        nested.mkdir(parents=True)
+        real = nested / tectonic.binary_name()
+        real.write_bytes(_small(b"\x7fELFreal"))
+
+        fd = tectonic._open_inside(real, os.path.realpath(tree))
+        assert fd is not None
+        try:
+            assert os.read(fd, 64) == b"\x7fELFreal"
+        finally:
+            os.close(fd)
+
+    def test_retargeting_the_link_after_validation_cannot_change_what_is_installed(
+        self, tmp_path: Path
+    ) -> None:
+        """The regression for the race itself.
+
+        The link points INSIDE the tree when the candidate is validated, so a
+        by-name check accepts it — correctly. It is then retargeted outside before
+        the install. A build that re-opens the path installs the attacker's file; a
+        build that installs from the validated descriptor installs the bytes it
+        checked.
+
+        Deterministic on purpose: the swap is placed exactly where a racing writer
+        would land, rather than run concurrently and hoped for.
+        """
+        tree = tmp_path / "unpacked"
+        genuine = tree / "real"
+        genuine.mkdir(parents=True)
+        (genuine / tectonic.binary_name()).write_bytes(_small(b"\x7fELFgenuine"))
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / tectonic.binary_name()).write_bytes(_small(b"\x7fELFplanted!"))
+
+        link = tree / "vendor"
+        make_dir_link(link, genuine)
+        candidate = link / tectonic.binary_name()
+
+        fd = tectonic._open_inside(candidate, os.path.realpath(tree))
+        assert fd is not None, "the contained candidate was refused; nothing under test"
+        try:
+            # The window. Detaching the link is not the same call on both
+            # platforms and the wrong one raises rather than misbehaving quietly:
+            # a POSIX directory SYMLINK is a link entry, so `rmdir` answers
+            # `NotADirectoryError` and only `unlink` removes it, while a Windows
+            # JUNCTION is a real directory entry that `unlink` refuses. Neither
+            # call touches what the link points at.
+            _detach_dir_link(link)
+            make_dir_link(link, outside)
+            assert candidate.read_bytes() == b"\x7fELFplanted!", (
+                "the swap did not take effect, so the race was never simulated"
+            )
+
+            target = tmp_path / "install" / tectonic.binary_name()
+            tectonic._install_binary(fd, target)
+        finally:
+            os.close(fd)
+
+        assert target.read_bytes() == b"\x7fELFgenuine"
+
+    def test_containment_fails_closed_when_the_real_path_is_unknowable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A host whose kernel route for "where is this fd" is unavailable gets a
+        refusal, never a fallback to the pathname the descriptor was opened by."""
+        tree = tmp_path / "unpacked"
+        tree.mkdir()
+        real = tree / tectonic.binary_name()
+        real.write_bytes(_small())
+        assert tectonic._open_inside(real, os.path.realpath(tree)) is not None
+
+        monkeypatch.setattr(tectonic.pinned_fs, "fd_real_path", lambda _fd: None)
+        assert tectonic._open_inside(real, os.path.realpath(tree)) is None
+
+    def test_a_directory_never_yields_a_descriptor(self, tmp_path: Path) -> None:
+        """`_install_binary` copies bytes; a non-regular source must be refused
+        before it reaches that, not turned into an unreadable install."""
+        tree = tmp_path / "unpacked"
+        (tree / "adir").mkdir(parents=True)
+        assert tectonic._open_inside(tree / "adir", os.path.realpath(tree)) is None


### PR DESCRIPTION
## Problem / Motivation

`tectonic._locate_binary` picks the executable out of an extracted archive and
`_provision_once` installs it onto the path papyrus later **executes**. The walk
filtered candidates with `candidate.is_file() and not candidate.is_symlink()`, so
refusing a link-mediated escape was already the site's own intent — but the filter
cannot see the escape that matters.

`Path.rglob` **descends** a directory link, and the executable on the far side is an
ordinary file: `is_file()` true, `is_symlink()` false. It passed the filter unchanged
while living outside the tree. On Windows the link is a junction, which
`os.path.islink` does not report at all — measured on an unelevated box:

```
junction is_symlink        : False
os.path.islink(junction)   : False
DirEntry.is_symlink        : False
rglob('tectonic') from tree: ['...\\unpacked\\vendor\\tectonic']   <- descended
through-junction is_file   : True
through-junction resolve   : ...\outside\tectonic                  <- outside
```

The `tree / wanted` fast path was weaker still: it took the candidate on `is_file()`
alone, which **follows** a link, so it had no filter at all.

**A resolve-and-compare is not enough, and the first commit here only did that.**
Reviewers held it, correctly: the check resolves a path and then `_install_binary`
opens the same path again. The inode that was checked and the inode that is
installed are two separate lookups, and a writer who retargets the unpack directory
in the window between them wins. Measured against the base commit:

```
by-name containment check at validation time: True  (accepts it)
installed bytes: b'\x7fELFplanted!'
VULNERABLE: True
```

## Why it matters

The located path is not read — it is installed. `_install_binary` moves it, applies
`_BINARY_MODE` (`0o755`) and `os.replace`s it onto `binary_path()`, and
`binary_installed` re-checks only size and the exec bit, so a plausibly-sized planted
file passes. An arbitrary local file is promoted to an executed compiler with no
recovery once it is in place.

Stated plainly and not inflated: the asset is pinned and fetched over TLS, and
neither tar nor zip can create a Windows junction, so the archive cannot plant this.
It needs a local writer racing the per-process `.provision.<pid>` unpack directory.
That is the containment layer this walk was already reaching for — a defence that
was inert on the platform its own link shape belongs to, not a remote-archive escape.

## What changed (motivation → approach → change)

Root cause: **the check and the use are two lookups of one name**, and the by-name
check is additionally blind to a junction.

Approach: resolve once, open once, address everything downstream through the
descriptor. That is the discipline `pinned_fs` already exists for in this repo, and
this change consumes its `fd_real_path` rather than adding a second mechanism. The
heavier `stage_tree_pinned` was not used: it is gated on `supports_pinned_walk()`,
which is false on Windows — the platform this defect lives on.

* **`_open_inside(candidate, root_real)`** — opens with `O_NOFOLLOW` where it exists,
  rejects a non-regular file on the descriptor's own `fstat`, then asks the kernel
  where the open descriptor actually is (`/proc/self/fd`, `F_GETPATH`, or
  `GetFinalPathNameByHandleW`) and compares that against the root. A descriptor
  cannot be re-pointed, so the answer stays true while it is held. Every failure
  route — unreadable, non-regular, unknowable real path — returns `None`, never a
  fallback to the pathname.
* **`_install_binary` takes a descriptor, not a path**, and copies from it. The
  atomic-publish shape is unchanged: staged in the target directory, mode applied
  before the rename, `os.replace` onto the final path. The cost is a copy instead of
  a rename, once, for an artifact that was just fetched over the network.
* **The root is captured in `_provision_once`**, immediately after `unpacked.mkdir()`
  and before the archive is written into it. Resolving it inside the locator would
  reopen the same window one level up, since the directory whose containment is
  being asserted is exactly the one an attacker would swap.
* **The by-name filter stays** as an early refusal that names the right file in the
  error message, and its docstring now says it is not the containment witness.
* The size floor is read from `os.fstat(fd)` rather than `binary.stat()`, so the size
  that gates the install is the size of the file that gets installed.

## Tests

`TestTheInstalledBytesAreTheValidatedBytes` — the property is not "the check is
stricter" but "the check and the use address one object":

* `test_retargeting_the_link_after_validation_cannot_change_what_is_installed` — the
  regression for the race. The link points **inside** the tree at validation, so a
  by-name check accepts it; it is retargeted outside before the install. Asserts the
  installed bytes are the validated ones. Deterministic: the swap is placed where a
  racing writer would land rather than run concurrently and hoped for.
* `test_a_file_reached_through_a_directory_link_gets_no_descriptor` — guards itself
  by asserting the lexical path **is** inside the tree, so a name-only check would
  have accepted it.
* `test_a_real_file_inside_the_tree_gets_a_descriptor_on_its_own_bytes` — positive
  control, and the one that catches an over-tight comparison: `fd_real_path` and
  `realpath` reach the same name by different kernel routes.
* `test_containment_fails_closed_when_the_real_path_is_unknowable`,
  `test_a_directory_never_yields_a_descriptor` — the refusal routes.

`TestLocateBinaryStaysInsideTheUnpackedTree` keeps the by-name filter's own coverage,
with **two corrections a reviewer was right about**:

* The fast-path case built a *directory* link, so `is_file()` was false and it
  silently exercised the walk instead. It now uses a **file symlink** — the only
  shape that reaches that branch — and is skipped where one cannot be created.
* The walk-descent case asserted `rglob` descends the link. That is true for a
  Windows junction and **false for a POSIX directory symlink**: pathlib's `**`
  deliberately does not descend one, and the Linux shard failed on exactly that
  guard-the-guard assertion (`rglob never descended the link, so nothing was under
  test`). Measured on both platforms; the test is now marked for the platform whose
  shape it describes, and **keeps** the guard-the-guard so a behaviour change fails
  loudly rather than passing vacuously.

Negative control run against the base commit (output quoted above): the unpatched
install writes the planted bytes, the patched install writes the genuine ones.

`.github/black-baseline.txt`: `tectonic.py` became black-clean as a result of this
change, and the gate fails on a graduated entry that is still listed, so its row is
pruned. No file was reformatted.

## Manual verification

N/A — unit coverage sufficient: the whole defect is the relationship between the
validation and the install, and the tests drive both against a real junction on the
affected platform rather than a mock.

## Related Issues

None — found by inspection while auditing `is_symlink`-based containment guards for
the Windows junction blind spot, the same family as #7881.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a containment guard that **validates a path and then reopens it**. Two
distinct failures ride together — the guard tests the candidate's own node type
(`is_symlink`/`islink`) rather than where it resolves, and a Windows junction is
invisible to both `islink` and `DirEntry.is_symlink`, so a recursive walk descends
it. Where the walk is `rglob`/`os.walk` and the result is later written, moved or
executed, `resolve()`-then-reopen is not a fix: open once and address the descriptor.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
