### PR TITLE
feat(diagnostics): redacting kiro_cli_logs read tool (Refs #6023)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -240,7 +240,6 @@ src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py
 src/kiro_crew/deploy/skills/artifact-deploy/scripts/reaper_lambda/index.py
 src/kiro_crew/deploy/skills/artifact-deploy/templates/handler-example.py
 src/kiro_crew/deploy/webapp_types.py
-src/kiro_crew/diagnostics.py
 src/kiro_crew/discord/attachments.py
 src/kiro_crew/doc_parser.py
 src/kiro_crew/emoji_list.py

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -712,7 +712,23 @@ answers `tools/list` from):
   `browse_outline`, `browse_search`
 - **Workflows and hooks:** `workflow_author`, `workflow_list`,
   `workflow_cancel`, `workflow_rerun_subtree`, `register_hook`
-- **Diagnostics:** `resource_status`, `issue_radar_record_investigation`
+- **Diagnostics:** `resource_status`, `issue_radar_record_investigation`,
+  `kiro_cli_logs` — a redacted tail of kiro-cli's own mcp/lsp protocol logs, so
+  the agent can self-diagnose a rejected turn. Reads log files only: never the
+  fenced identity/token stores, and never the conversation-bearing sources
+  (`kiro-chat.log`, session transcripts), each of which is one shared host file
+  per gateway that would disclose another session's conversation. That scope
+  holds only while mcp.log / lsp.log record protocol traffic rather than full
+  frame bodies, since they share the chat log's single-fixed-path,
+  all-sessions-interleaved shape and an MCP `tools/call` frame carries
+  conversation-derived arguments. Measured on kiro-cli 2.21.1: mcp.log is empty
+  across a session of continuous MCP tool calls, every lsp.log record is a
+  single-line `<timestamp> ERROR <module>: <message>` with no JSON-RPC envelope
+  and a longest line of 313 bytes, and sentinel strings passed as tool-call
+  arguments appear in neither file. Because that measures one version of a
+  component this repo does not pin, a source whose text carries serialized frames
+  is REFUSED whole and visibly, so a kiro-cli that starts logging payloads
+  surfaces as a refusal instead of a silent widening
 - **App bridges (credentialed):** `ops_mission_control_api` — the MCP server
   process holds the gateway's internal secret and forwards only a frozen
   (method, path) allowlist of Ops Mission Control routes; the agent never

--- a/src/kiro_crew/diagnostics.py
+++ b/src/kiro_crew/diagnostics.py
@@ -25,6 +25,7 @@ import logging
 import os
 import platform
 import re
+import stat as stat_module
 import subprocess
 import sys
 import time
@@ -42,6 +43,7 @@ from kiro_crew.security import (
     redact_credentials,
     redact_exfiltration_urls,
 )
+from kiro_crew.validation import strip_hidden_unicode
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +137,22 @@ class BundleResult:
 
 
 def _scrub(text: str) -> tuple[str, int]:
-    """Run the full redaction pipeline over ``text``; return (clean, count)."""
+    """Run the full redaction pipeline over ``text``; return (clean, count).
+
+    Hidden characters go FIRST, and the order is the whole point.
+    ``redact_credentials`` matches on the literal shape of a secret, so an
+    invisible planted inside one defeats it: ``AKIA<ZWSP>IOSFODNN7EXAMPLE``
+    matches no pattern. Stripping afterwards is worse than not stripping at all,
+    because the strip REJOINS the secret into a usable credential that redaction
+    has already been asked about and declined. ``strip_hidden_unicode`` documents
+    this as its own contract -- it is written to run before
+    ``redact_credentials`` -- and every consumer of this text sanitizes later:
+    ``validation.build_tool_response`` puts an MCP tool response through
+    ``sanitize_response``, and a bundle member is normalized by whatever reads the
+    zip. So the strip has to happen here, ahead of the patterns, for the
+    redaction verdict to mean anything.
+    """
+    text = strip_hidden_unicode(text)
     count = 0
     text, warnings = redact_exfiltration_urls(text)
     count += len(warnings)
@@ -145,28 +162,6 @@ def _scrub(text: str) -> tuple[str, int]:
         text, n = pattern.subn(repl, text)
         count += n
     return text, count
-
-
-def _read_text_tail(path: Path, max_bytes: int = _MAX_MEMBER_BYTES) -> str:
-    """Read a text file, keeping only the last ``max_bytes`` (logs grow at end).
-
-    The tail always starts on a LINE boundary. Seeking to ``size - max_bytes``
-    lands mid-line in general, and a partial line is not merely ugly here — it
-    breaks redaction. ``_EXTRA_REDACTIONS`` anchors on the header NAME
-    (``Authorization:`` / ``Set-Cookie:`` / ...) and redacts to end-of-line, so a
-    cut that keeps the credential but drops its anchor leaves a raw secret that
-    no rule matches. Discarding the partial first line costs at most one log line
-    and keeps every surviving credential attached to the token that redacts it.
-    """
-    size = path.stat().st_size
-    with path.open("rb") as fh:
-        if size > max_bytes:
-            fh.seek(size - max_bytes)
-            fh.readline()  # drop the partial line the seek landed inside
-            raw = b"...[truncated: showing last %d bytes]...\n" % max_bytes + fh.read()
-        else:
-            raw = fh.read()
-    return raw.decode("utf-8", errors="replace")
 
 
 def _kiro_log_dirs() -> list[Path]:
@@ -233,9 +228,7 @@ def _kiro_cli_chat_log() -> Path | None:
         # public issue. Redaction is not a backstop for that: .netrc/.pem bodies
         # do not match the credential patterns. Refuse the path outright.
         if is_sensitive_path(str(p)):
-            logger.warning(
-                "ignoring KIRO_CHAT_LOG_FILE: %s resolves to a sensitive path", p
-            )
+            logger.warning("ignoring KIRO_CHAT_LOG_FILE: %s resolves to a sensitive path", p)
             return None
         return p if _usable_log(p) else None
     for base in _kiro_log_dirs():
@@ -259,6 +252,532 @@ def _kiro_cli_extra_logs() -> list[Path]:
     return out
 
 
+# ── Live log reader (kiro_cli_logs MCP tool) ─────────────────────────────────
+# A dedicated read-only view of kiro-cli's OWN protocol logs, so the agent
+# driving kiro-cli has first-hand diagnostics when the backend rejects a turn.
+# The sources sit OUTSIDE the eight fenced identity stores
+# (``identity_stores.IDENTITY_STORE_ROOTS`` -> ``kiro-log/{mcp,lsp}.log`` under
+# XDG_RUNTIME_DIR|TMPDIR).
+#
+# SCOPE IS THE SECURITY PROPERTY, not just the redaction. Two sources kiro-cli
+# writes are deliberately NOT read, for the same reason:
+#
+# * ``sessions/cli/<sid>.jsonl`` transcripts, and
+# * ``kiro-chat.log`` — one FIXED host path (see :func:`_kiro_cli_chat_log`),
+#   not a per-session file, so on a host running one gateway with many
+#   concurrent sessions (web, CLI, messaging, subagents, cron) it interleaves
+#   every session's request/response traffic.
+#
+# Both carry CONVERSATION PROSE across the session boundary, and ``_scrub`` is a
+# CREDENTIAL pass: it strips tokens/headers/cookies, not prose. There is no
+# per-session kiro-cli chat log to scope to and no reliable per-session
+# delimiter in the flat one, so an agent-callable read of it would hand session
+# A's private conversation to session B with nothing to narrow it — and a
+# disclosure into a model context cannot be recalled. The bundle collector still
+# includes the chat log because that path is USER->USER (the user triggers the
+# collection and downloads it for their own machine); this tool is CROSS-SESSION
+# and therefore stays on the mcp/lsp protocol logs, which explain a rejected
+# turn without carrying the conversation.
+#
+# This does NOT open a path carve-out on the fence: the output still flows
+# through the exact ``_scrub`` stack the bundle uses
+# (``redact_exfiltration_urls`` then ``redact_credentials`` then
+# ``_EXTRA_REDACTIONS``), so redaction closes the credential gap while the
+# narrow source list closes the conversation-content one. Two controls, because
+# redaction alone cannot reach the second: it is a per-pattern pass, and
+# conversation prose matches no pattern. The source list is therefore the
+# primary control here and the redaction is the secondary one.
+#
+# THE PROPERTY THIS SCOPE DEPENDS ON, and how it is held. mcp.log / lsp.log are
+# safe to read here only while they record protocol TRAFFIC (method names, ids,
+# timings, errors) and not full frame BODIES. They share ``kiro-chat.log``'s
+# single-fixed-path, all-sessions-interleaved shape, so payload content is the
+# ONLY thing separating them, and an MCP ``tools/call`` frame carries
+# conversation-derived arguments (search queries, message bodies, file contents).
+#
+# Measured on kiro-cli 2.21.1: mcp.log is empty (0 bytes) across a session making
+# continuous MCP tool calls, and every lsp.log record is a single-line
+# ``<timestamp> ERROR <module>: <message>`` with no JSON-RPC envelope and a
+# longest line of 313 bytes. Sentinel strings passed as tool-call ARGUMENTS in
+# that same session appear in neither file, so this binary logs no frame payloads.
+#
+# That is a measurement of one version, not a guarantee about a component this
+# repo neither builds nor pins, so a later kiro-cli could start logging bodies.
+# :func:`_looks_like_protocol_frames` is the tripwire for exactly that: a source
+# whose text carries serialized frames is REFUSED whole and visibly, so the drift
+# surfaces as a refusal rather than as a silent widening. Refusing the whole
+# source is deliberate -- it decides only whether a file is the KIND the tool
+# assumes, and never claims to separate one session's frames from another's.
+
+#: Hard ceiling on the returned text PER SOURCE, independent of ``tail``. A log
+#: tail is precisely the shape that deadlocks a pipe, so the bound is by BYTES;
+#: ``tail`` (lines) narrows within it but can never raise it.
+_MAX_LOG_READ_BYTES = 64 * 1024
+#: Ceiling on the WHOLE assembled response, and the reason the per-source cap
+#: above is divided among the sources rather than applied to each in full.
+#:
+#: The MCP transport has its own ceiling: every tool response leaves through
+#: ``validation.build_tool_response``, which calls ``sanitize_response`` -- and
+#: that truncation drops the TAIL (``text[:max_len]``). For a LOG TAIL that is
+#: the worst possible end to lose: the newest lines are the entire reason the
+#: tool was called, and its ``[response truncated]`` marker reads like the tool
+#: cut the OLDEST content, which is the normal convention for a tail. So the
+#: agent would be misled about which end it lost, not merely short-changed.
+#:
+#: This reader therefore does its own trimming, from the FRONT, so the newest
+#: output always survives and the drop is labelled for what it is. Kept a round
+#: number well under the transport's limit rather than imported from
+#: ``validation``: ``diagnostics`` does not otherwise depend on that module, and
+#: ``test_response_budget_stays_under_the_transport_ceiling`` imports both and
+#: pins the relationship, so the invariant is enforced without the coupling.
+#: (``mcp_tools/skills.py`` bounds its own fields against the same ceiling for
+#: the same reason, so this is an existing contract, not a new one.)
+_MAX_LOG_RESPONSE_CHARS = 80_000
+#: Prepended when the response budget forced older output out. Deliberately
+#: says which end went, since the transport's own marker does not.
+_RESPONSE_TRIM_NOTE = (
+    "...[older output dropped to fit the tool-response limit; "
+    "the NEWEST lines are kept -- narrow with `tail` or `since` to see more]...\n"
+)
+#: Default line count when the caller does not pass ``tail``.
+_DEFAULT_LOG_TAIL = 200
+
+
+def _read_log_tail(path: Path, max_bytes: int) -> str | None:
+    """Tail a log file through one descriptor, refusing a symlinked final component.
+
+    Closes the check-then-open TOCTOU window that a plain ``path.open()`` leaves:
+    the source directories include the world-writable ``/tmp/kiro-log``, so a
+    local principal could swap a validated regular file for a symlink to
+    ``~/.ssh/config`` between the ``is_sensitive_path`` check and the read, and a
+    following ``open`` would return the sensitive target's bytes (redaction is no
+    backstop — a ``.ssh``/``.pem`` body matches no credential pattern).
+
+    Where the platform offers ``O_NOFOLLOW`` (POSIX) the open uses it, so the
+    kernel refuses at open time if the final component is a symlink (``ELOOP``);
+    the descriptor is then ``fstat``-confirmed to be a regular file and THAT
+    descriptor is tailed, so the bytes returned are provably from the path that
+    was validated, not one swapped in afterward. ``O_NOFOLLOW`` guards only the
+    FINAL component; the intermediate dirs are the source pickers' own fixed,
+    non-symlinked anchors (``_usable_dir`` already rejects a linked ``kiro-log``).
+
+    Where the platform lacks ``O_NOFOLLOW`` (Windows) the flag is omitted, and an
+    ``is_symlink`` check plus the regular-file ``fstat`` is not enough on its own:
+    a Windows JUNCTION is a reparse point ``is_symlink`` does not report, and it
+    is the only link an unprivileged Windows user can create -- so the platform
+    where planting one is easiest is the platform with no kernel no-follow. A
+    reparse point swapped in after the check and pointing at a regular sensitive
+    file satisfies ``S_ISREG``, and its bytes would reach the caller.
+
+    An IDENTITY MATCH closes that, and it closes it on every platform rather than
+    only the one missing a flag. ``os.lstat`` describes the path WITHOUT following
+    its final component, ``os.fstat`` describes what the descriptor actually
+    opened, and this function refuses unless the two name the same file
+    (``st_dev``/``st_ino``; on Windows those come from the file's volume and
+    index). Two things fail that comparison: a final component that is a link of
+    any kind, because ``lstat`` sees the link while the descriptor sees its
+    target, and a swap landing between the ``lstat`` and the open, because the
+    descriptor then holds a different file. So the bytes returned are provably
+    from the path that was checked. ``O_NOFOLLOW`` remains a POSIX
+    STRENGTHENING -- it refuses at open time rather than after -- not a
+    precondition for reading.
+
+    This is the module's ONLY tail reader: both the agent-facing
+    :func:`read_kiro_cli_logs` and :func:`collect_bundle` read through it, so the
+    check-then-open hardening cannot be present in one path and missing in the
+    other (a second reader with mirrored comments would drift).
+
+    Returns ``None`` (skip this source) on any refusal or non-regular file rather
+    than raising. The byte cut lands on a LINE boundary, same as the bundle
+    collector's own tail: a cut inside ``Authorization: Basic <b64>`` would keep
+    the credential and drop the header token that redacts it, so the partial
+    first line is discarded. When the window holds NO newline at all -- the
+    file's final line is itself longer than ``max_bytes`` -- there is no boundary
+    to cut on and the whole chunk is a partial line, so only the truncation
+    marker is returned. That case loses one oversized entry, which is the
+    correct trade against emitting a fragment whose redaction anchor was cut
+    away.
+
+    ``O_NONBLOCK`` is set for the same check-then-open window: ``O_NOFOLLOW``
+    refuses a swapped-in SYMLINK, but the same local writer to the world-writable
+    ``/tmp/kiro-log`` can swap the validated regular file for a FIFO, and an
+    ``O_RDONLY`` open of a FIFO with no writer BLOCKS INDEFINITELY — the
+    ``S_ISREG`` guard below cannot run, because it only sees a descriptor the
+    open already returned, so the agent's tool call would hang rather than be
+    refused. With ``O_NONBLOCK`` the FIFO open returns immediately and the
+    ``S_ISREG`` check then rejects it. It is a no-op for the regular-file case
+    (``O_NONBLOCK`` has no effect on regular-file reads).
+    """
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        # lstat BEFORE the open, and do not follow the final component: this is
+        # the identity the descriptor below must match.
+        pre = os.lstat(path)
+    except OSError:
+        return None
+    try:
+        fd = os.open(str(path), flags)
+    except OSError:
+        # ELOOP (final component is a symlink, where O_NOFOLLOW is honored) lands
+        # here too — refuse, do not fall back to a following open.
+        return None
+    try:
+        st = os.fstat(fd)
+        if not stat_module.S_ISREG(st.st_mode):
+            return None
+        if (st.st_dev, st.st_ino) != (pre.st_dev, pre.st_ino):
+            # The descriptor is not the file that was checked: either the final
+            # component is a link the open followed (lstat saw the link, fstat
+            # sees its target) or it was swapped between the two calls. This is
+            # the whole Windows defense, where there is no O_NOFOLLOW to refuse
+            # a junction at open time, and it costs one stat on every platform.
+            return None
+        size = st.st_size
+        if size > max_bytes:
+            os.lseek(fd, size - max_bytes, os.SEEK_SET)
+            marker = b"...[truncated: showing last %d bytes]...\n" % max_bytes
+            raw = os.read(fd, max_bytes)
+            # Drop the partial line the offset landed inside (line-boundary cut).
+            nl = raw.find(b"\n")
+            if nl == -1:
+                # No newline anywhere in the window: the file's final line is
+                # itself longer than max_bytes, so the WHOLE chunk is one
+                # partial line and there is no boundary to cut on. Return only
+                # the marker. Emitting the fragment would be a credential
+                # disclosure, not a cosmetic truncation: `_EXTRA_REDACTIONS`
+                # anchors on the header NAME and redacts to end-of-line, so a
+                # cut landing after `Authorization:` but before its value
+                # strips the token that redacts it and hands the raw secret to
+                # the caller -- and the caller here is an agent's model
+                # context. A serialized JSON-RPC frame is exactly the shape
+                # that gets this long. Dropping one oversized entry loses
+                # evidence; keeping half of it leaks.
+                raw = marker
+            else:
+                raw = marker + raw[nl + 1 :]
+        else:
+            # `size` is a snapshot, so the read is bounded by `max_bytes` and not
+            # by EOF: a file being appended to faster than this loop drains it
+            # never reaches EOF, and an unbounded loop would grow `chunks` until
+            # the MCP process is OOM-killed. The world-writable log directory is
+            # exactly where a local writer can do that, and it is the same
+            # adversary O_NOFOLLOW and O_NONBLOCK are here for. `max_bytes` is a
+            # hard ceiling on every branch, not only the truncating one.
+            chunks: list[bytes] = []
+            remaining = max_bytes
+            while remaining > 0:
+                block = os.read(fd, min(1 << 16, remaining))
+                if not block:
+                    break
+                chunks.append(block)
+                remaining -= len(block)
+            raw = b"".join(chunks)
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+    return raw.decode("utf-8", errors="replace")
+
+
+def _tail_lines(text: str, tail: int) -> str:
+    """Keep the last ``tail`` lines of ``text`` (whole file when tail <= 0)."""
+    if tail <= 0:
+        return text
+    lines = text.splitlines(keepends=True)
+    if len(lines) <= tail:
+        return text
+    return "".join(lines[-tail:])
+
+
+def _filter_since(text: str, since: str) -> str:
+    """Keep only events at/after ``since``, each with its own continuation lines.
+
+    kiro-cli log lines lead with an ISO-ish timestamp, so a lexical compare of
+    the line's leading token against ``since`` is a monotone filter without
+    parsing every timestamp shape. ``since`` is matched against the start of each
+    line, so any leading slice of that timestamp works: a bare calendar day, or a
+    day plus hour to narrow within it.
+
+    A line with no recognizable leading timestamp is a CONTINUATION of the event
+    above it (a JSON body, a stack trace), so it inherits that event's verdict:
+    kept when the event was kept, dropped when the event was filtered out. Both
+    halves matter. Keeping continuations unconditionally leaves orphaned bodies
+    from events ``since`` rejected -- so the filter would not actually narrow the
+    window, and the bulk of an old event (its payload) would ride along without
+    the header line that identified it. Dropping them unconditionally would
+    silently cut a kept event's own multi-line frame in half.
+
+    Continuation lines appearing BEFORE any timestamped line are kept: that is
+    the truncation marker :func:`_read_log_tail` prepends, plus any fragment
+    ahead of the first full event, and there is no earlier verdict to inherit.
+    """
+    since = since.strip()
+    if not since:
+        return text
+    out: list[str] = []
+    # No event seen yet -> keep, so the truncation marker survives.
+    event_kept = True
+    for line in text.splitlines(keepends=True):
+        head = line.lstrip()
+        # A record START carries the timestamp and sets the verdict the following
+        # continuation lines inherit. Same predicate the boundary trim uses, so a
+        # line the two classify differently cannot exist.
+        if _starts_a_record(line):
+            event_kept = head[: len(since)] >= since
+        if not event_kept:
+            continue
+        out.append(line)
+    return "".join(out)
+
+
+#: A serialized JSON-RPC ENVELOPE KEY. Its presence means a source is recording
+#: protocol FRAMES rather than log records, which is the one condition under which
+#: reading it would cross the session boundary this tool's source list exists to
+#: hold: a ``tools/call`` frame carries conversation-derived arguments.
+#:
+#: Keyed on the quoted JSON key rather than on line LENGTH. Length is the obvious
+#: signal and the wrong one: a legitimate record can be long (a deep path, a
+#: wrapped error, a stack frame), so a length rule both misses a short frame and
+#: refuses honest output. The quoted-key form also does not fire on prose that
+#: merely mentions the protocol, e.g. ``failed to parse jsonrpc reply``.
+_FRAME_BODY_MARKER = re.compile(r'"jsonrpc"\s*:|"params"\s*:\s*[{\[]|"result"\s*:\s*[{\[]')
+
+
+#: Leading text of the note :func:`_read_log_tail` prepends to a cut window. Both
+#: that function and :func:`_begin_at_event_boundary` key on it, so it lives here
+#: rather than being spelled twice.
+_TRUNCATION_NOTE_PREFIX = "...[truncated"
+
+#: The shape that STARTS a log record: an ISO calendar date, then ``T`` or a space
+#: before the time. Anything else on a line's left edge is a continuation of the
+#: record above it.
+#:
+#: A bare "leading digit" test is not enough, and the difference is a disclosure
+#: rather than a tidiness point: a serialized frame can hold a JSON array of bare
+#: numbers, so ``      1000000,`` begins with a digit and would pass as a record
+#: boundary -- which lets :func:`_begin_at_event_boundary` stop trimming inside a
+#: frame and return the argument text after it. A JSON number cannot match this
+#: pattern, because ``1234-56-78`` is not a number and a quoted string starts with
+#: ``"``.
+_RECORD_START = re.compile(r"\d{4}-\d{2}-\d{2}[T ]")
+
+
+def _starts_a_record(line: str) -> bool:
+    """True when ``line`` begins a log record rather than continuing one.
+
+    One predicate for both :func:`_begin_at_event_boundary` and
+    :func:`_filter_since`, which each need the same event/continuation split. Two
+    copies would drift, and here they would drift on a security boundary.
+    """
+    return _RECORD_START.match(line.lstrip()) is not None
+
+
+def _begin_at_event_boundary(text: str) -> str:
+    """Drop leading lines of a CUT window until a timestamped event starts one.
+
+    Closes a bypass in :func:`_looks_like_protocol_frames`. That check keys on the
+    envelope tokens of a serialized frame, and in a pretty-printed frame those sit
+    at the TOP. :func:`_read_log_tail` cuts from the front, so an oversized
+    multiline frame can have its envelope fall outside the window while its
+    trailing ARGUMENT lines remain -- the marker then finds nothing and those
+    lines, which carry another session's conversation content, are returned.
+
+    A cut window whose first line is not an event is therefore sitting inside a
+    record whose beginning is gone, and nothing here can know what that record
+    was. Those orphaned lines are discarded, so the window starts where a record
+    does. A frame that STARTS inside the window still carries its envelope and is
+    caught by the marker, so the two together cover both positions of the cut. A
+    window with no event line at all yields the note alone.
+
+    Only a CUT window is trimmed. When nothing was truncated the first line is
+    genuinely the file's own first line, so there is no orphan to drop, and
+    trimming would discard real output for no safety gain.
+
+    This lives in the agent-facing reader rather than in :func:`_read_log_tail`,
+    which :func:`collect_bundle` shares. Unlike the hidden-character strip in
+    :func:`_scrub`, this DISCARDS data, and the only thing that justifies the loss
+    is the cross-session boundary -- which the bundle, a user-to-user path, does
+    not cross. Placement follows the boundary, not convenience.
+    """
+    lines = text.splitlines(keepends=True)
+    if not lines or not lines[0].startswith(_TRUNCATION_NOTE_PREFIX):
+        return text
+    note, rest = lines[0], lines[1:]
+    for i, line in enumerate(rest):
+        # Must be a record START, not merely a line beginning with a digit: a
+        # frame's JSON array of bare numbers would satisfy the looser test and let
+        # the trim stop inside the frame.
+        if _starts_a_record(line):
+            return note + "".join(rest[i:])
+    return note
+
+
+def _looks_like_protocol_frames(text: str) -> bool:
+    """True when ``text`` reads as serialized JSON-RPC frames rather than records.
+
+    The tripwire behind this tool's scope argument. That argument holds only while
+    mcp.log / lsp.log record protocol TRAFFIC and not frame BODIES -- a property
+    of kiro-cli, which this repo neither builds nor pins. Rather than leave the
+    assumption asserted and undetectable, a source that trips this is REFUSED
+    whole, so a kiro-cli that starts logging payloads produces a visible refusal
+    instead of a silent widening.
+
+    Refusing the whole source is the point, and it is what separates this from the
+    filter this module deliberately does not implement: a per-line filter over
+    interleaved sessions would look scoped without being scoped, which is worse
+    than nothing. This makes no claim to separate one session's frames from
+    another's -- it decides only whether the file is the KIND of file the tool
+    assumes, and stops if it is not.
+    """
+    return _FRAME_BODY_MARKER.search(text) is not None
+
+
+def read_kiro_cli_logs(
+    *,
+    tail: int | None = None,
+    since: str | None = None,
+) -> str:
+    """Redacted tail of kiro-cli's own PROTOCOL logs, for diagnosing a rejected turn.
+
+    Reads ONLY the ``kiro-log`` mcp/lsp log files — never the fenced identity
+    stores, and deliberately NOT the two conversation-bearing sources kiro-cli
+    also writes:
+
+    * ``sessions/cli/<sid>.jsonl`` transcripts, and
+    * ``kiro-chat.log``, which is ONE fixed host path rather than a per-session
+      file, so a host running one gateway with many concurrent sessions
+      interleaves every session's traffic into it.
+
+    Both are conversation content shared across every gateway session (including
+    incognito/temporary ones), and ``_scrub`` is a CREDENTIAL pass that does not
+    narrow prose — so returning either would disclose another session's private
+    conversation to the calling session, with no per-session delimiter available
+    to filter on. This tool therefore stays on the mcp/lsp protocol logs, which
+    are what explain a rejected turn. :func:`collect_bundle` still includes the
+    chat log because that path is user-to-user (the user triggers the collection
+    and downloads it themselves); this one is cross-session.
+
+    Every source is byte-capped, line-tailed to ``tail`` (default
+    :data:`_DEFAULT_LOG_TAIL`), optionally filtered to lines at/after ``since``,
+    and then passed through the shared redaction stack via :func:`_scrub`.
+    Returns a human-readable report with one ``===`` section per source, or a
+    note when no logs exist.
+
+    Output is bounded at BOTH levels, and the second one exists because of which
+    END the transport drops. :data:`_MAX_LOG_READ_BYTES` caps each source (a log
+    tail is the shape that deadlocks a pipe, so that bound is by BYTES; ``tail``
+    narrows lines within it but can never raise it), and
+    :data:`_MAX_LOG_RESPONSE_CHARS` caps the whole assembled response. Every MCP
+    response leaves through ``validation.build_tool_response``, whose
+    ``sanitize_response`` truncates the TAIL -- so left alone it would drop the
+    NEWEST log lines, the entire reason a tail was requested, behind a marker
+    that reads like the oldest were cut. This function therefore trims its own
+    output from the FRONT and labels the drop, so the newest lines always
+    survive.
+
+    The read goes through :func:`_read_log_tail`, which opens each source and
+    (where the platform offers ``O_NOFOLLOW``) refuses a symlinked final
+    component at open time, tailing that same descriptor — so a symlink swapped in
+    after the ``is_sensitive_path`` check (the source dirs include the shared
+    ``/tmp/kiro-log``) is refused at open time rather than followed to a
+    sensitive target. Redaction runs AFTER truncation on purpose: the byte cut
+    lands on a line boundary, so no credential is separated from the header token
+    that redacts it.
+    """
+    tail = _DEFAULT_LOG_TAIL if tail is None else tail
+    sections: list[str] = []
+    total_redactions = 0
+
+    # mcp/lsp only. `kiro-chat.log` is deliberately absent — see the docstring:
+    # it is one shared host file carrying every session's conversation prose,
+    # which `_scrub` (a credential pass) does not narrow.
+    sources: list[tuple[str, Path]] = [(p.name, p) for p in _kiro_cli_extra_logs()]
+
+    # Read the caps from the module at CALL time so a test can monkeypatch them.
+    # Divide the response budget among the sources instead of giving each the
+    # full per-source cap: `_read_log_tail` keeps the NEWEST bytes of whatever
+    # window it is given, so dividing up front means every source contributes its
+    # own newest lines and the assembled total already fits. Applying the full
+    # cap to each and trimming afterwards would throw away one source entirely.
+    max_bytes = min(_MAX_LOG_READ_BYTES, _MAX_LOG_RESPONSE_CHARS // max(len(sources), 1))
+
+    for label, path in sources:
+        try:
+            # First-pass filters over the source pickers (defense in depth): a
+            # symlink or a path resolving into a fenced/sensitive store is
+            # skipped before we even open. On POSIX the authoritative guard
+            # against a check-then-open swap is _read_log_tail's O_NOFOLLOW open;
+            # on Windows (no O_NOFOLLOW) this pre-open is_symlink check plus
+            # _read_log_tail's fstat regular-file check are the symlink defense.
+            if path.is_symlink() or not path.is_file():
+                continue
+            if is_sensitive_path(str(path)):
+                continue
+        except OSError:
+            continue
+        text = _read_log_tail(path, max_bytes)
+        if text is None:
+            continue
+        # A cut window can start inside a record whose beginning is gone. Discard
+        # those orphaned lines FIRST, so the frame check below cannot be bypassed
+        # by a multiline frame whose envelope fell outside the window.
+        text = _begin_at_event_boundary(text)
+        if _looks_like_protocol_frames(text):
+            # Fail closed: this source is recording protocol FRAMES, not log
+            # records, so it can carry another session's conversation-derived
+            # arguments, and the scope argument for reading it does not cover
+            # that. Refuse the whole source and SAY SO -- a silent skip reads as
+            # "no logs", which is the same output as a healthy empty log.
+            sections.append(
+                f"=== {label} (REFUSED) ===\n"
+                "This source contains serialized JSON-RPC frames rather than log\n"
+                "records. Frame arguments carry conversation content from every\n"
+                "session sharing this host file, so it is not readable here. Use\n"
+                "the diagnostics bundle, which is a user-to-user path.\n"
+            )
+            continue
+        if since:
+            text = _filter_since(text, since)
+        text = _tail_lines(text, tail)
+        clean, n = _scrub(text)
+        total_redactions += n
+        sections.append(f"=== {label} ({n} secret(s) redacted) ===\n{clean.rstrip(chr(10))}\n")
+
+    if not sections:
+        return (
+            "No kiro-cli protocol logs found. kiro-cli writes mcp.log / lsp.log "
+            "under $XDG_RUNTIME_DIR|$TMPDIR/kiro-log/; none exist or are readable "
+            "here. (kiro-chat.log is a single shared host file carrying every "
+            "session's conversation, so it is deliberately not a source for this "
+            "tool.)"
+        )
+    header = (
+        f"kiro-cli logs (tail={tail}"
+        + (f", since={since}" if since else "")
+        + f", {total_redactions} secret(s) redacted, capped at {max_bytes // 1024} KiB/source)\n"
+    )
+    out = header + "\n".join(sections)
+    if len(out) <= _MAX_LOG_RESPONSE_CHARS:
+        return out
+    # Belt and braces over the pre-read division above, which bounds BYTES while
+    # the transport's ceiling counts CHARACTERS: `_scrub` can grow the text (a
+    # short token replaced by `[REDACTED]`), and the section framing adds to it.
+    # Keep the header and the NEWEST characters; the header must survive because
+    # it is what states the tail/since/redaction count the rest is read against.
+    budget = _MAX_LOG_RESPONSE_CHARS - len(header) - len(_RESPONSE_TRIM_NOTE)
+    if budget <= 0:
+        # Degenerate only if the ceiling is set below the framing itself.
+        return (header + _RESPONSE_TRIM_NOTE)[:_MAX_LOG_RESPONSE_CHARS]
+    kept = out[-budget:]
+    # Start on a line boundary, purely so the first surviving line is readable:
+    # unlike the cut in `_read_log_tail`, this one cannot expose a credential,
+    # because `_scrub` has already run over every section above.
+    nl = kept.find("\n")
+    if nl != -1:
+        kept = kept[nl + 1 :]
+    return header + _RESPONSE_TRIM_NOTE + kept
+
+
 def _macos_crash_reports() -> list[Path]:
     """Newest kiro-cli / kiro .ips crash reports (macOS only)."""
     if sys.platform != "darwin":
@@ -271,11 +790,7 @@ def _macos_crash_reports() -> list[Path]:
         if not _usable_dir(base):
             continue
         try:
-            reports.extend(
-                p
-                for p in base.glob("kiro*.ips")
-                if p.is_file() and not p.is_symlink()
-            )
+            reports.extend(p for p in base.glob("kiro*.ips") if p.is_file() and not p.is_symlink())
         except OSError:
             continue
     reports.sort(key=lambda p: p.stat().st_mtime, reverse=True)
@@ -545,9 +1060,7 @@ def collect_bundle(
         os.O_CREAT | os.O_WRONLY | os.O_TRUNC | getattr(os, "O_BINARY", 0),
         0o600,
     )
-    with os.fdopen(_fd, "wb") as _raw, zipfile.ZipFile(
-        _raw, "w", zipfile.ZIP_DEFLATED
-    ) as zf:
+    with os.fdopen(_fd, "wb") as _raw, zipfile.ZipFile(_raw, "w", zipfile.ZIP_DEFLATED) as zf:
         # Generated members first.
         versions = _versions_text(note)
         zf.writestr("versions.txt", versions)
@@ -561,8 +1074,16 @@ def collect_bundle(
                 if src.is_symlink() or not src.is_file():
                     result.skipped.append(member)
                     continue
-                text = _read_text_tail(src)
             except OSError:
+                result.skipped.append(member)
+                continue
+            # Same hardened reader the agent-facing tool uses: the check above is
+            # check-then-open, and these sources include the world-writable
+            # /tmp/kiro-log, so the O_NOFOLLOW|O_NONBLOCK open plus the fstat
+            # regular-file check are what make the bytes provably come from the
+            # path that was validated. Returns None (skip) instead of raising.
+            text = _read_log_tail(src, _MAX_MEMBER_BYTES)
+            if text is None:
                 result.skipped.append(member)
                 continue
             clean, n = _scrub(text)

--- a/src/kiro_crew/mcp_tools/__init__.py
+++ b/src/kiro_crew/mcp_tools/__init__.py
@@ -20,6 +20,7 @@ DOMAIN_MODULES: tuple[str, ...] = (
     "learn",
     "ledger",
     "skills",
+    "logs",
     "control",
     "messaging",
     "artifacts",

--- a/src/kiro_crew/mcp_tools/logs.py
+++ b/src/kiro_crew/mcp_tools/logs.py
@@ -1,0 +1,133 @@
+"""The kiro-cli log reader tool: what it advertises and what it does.
+
+``schemas()`` returns the ADVERTISEMENT half; ``HANDLERS`` maps the name to the
+function that runs it. Both halves live here so the contract and behavior are
+read together, and ``test_mcp_tool_registry`` fails if one arrives without the
+other (see ``skills.py`` — this module follows the same template).
+
+WHY THIS TOOL EXISTS: kiro-cli's identity store is fenced (it also holds SSO
+tokens), and the command gate is a deliberately coarse, verb-independent path
+matcher — so the agent driving kiro-cli has no sanctioned way to read kiro-cli's
+own logs when the backend rejects a turn. This is that
+sanctioned channel: ONE reviewed code path that reads only kiro-cli's mcp/lsp
+PROTOCOL logs and runs every byte through the shared redaction stack
+(``redact_credentials`` / ``redact_exfiltration_urls`` plus the diagnostics
+collector's ``_EXTRA_REDACTIONS`` for the bearer/Authorization/mc_token shapes
+those two miss) before returning it. It does NOT widen the gate and does NOT
+take a path carve-out on the fence: redaction is what makes returning the bytes
+safe.
+
+SCOPE IS THE OTHER HALF OF THAT SAFETY. ``kiro-chat.log`` and the session
+transcripts are deliberately NOT read. Each is a single shared host file per
+gateway, so it interleaves every concurrent session's conversation, and the
+redaction stack is a CREDENTIAL pass that does not narrow prose — an
+agent-callable read would hand session A's private conversation to session B.
+The mcp/lsp protocol logs are what actually explain a rejected turn, so the
+tool stays there. See ``diagnostics.read_kiro_cli_logs``.
+
+Handlers reach shared plumbing as attributes of ``mcp_core`` (``mcp_core.sel``,
+``mcp_core._resolve_session_key``) so a test that rebinds one still intercepts —
+an attribute lookup resolves at CALL time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from kiro_crew import diagnostics, mcp_core
+from kiro_crew.validation import KIRO_CLI_LOGS_SCHEMA, validate_tool_args
+
+
+def schemas() -> list[dict[str, Any]]:
+    """Descriptor for the kiro-cli log reader."""
+    return [
+        {
+            "name": "kiro_cli_logs",
+            "description": (
+                "Read a REDACTED tail of kiro-cli's OWN protocol logs — the "
+                "runtime you are driving — to diagnose a rejected or failed "
+                "turn. Reads only the mcp/lsp log files, never the fenced "
+                "identity/token store, and NOT the conversation-bearing sources "
+                "(session transcripts, kiro-chat.log): those are one shared host "
+                "file per gateway, so returning them would hand another "
+                "session's private conversation to yours. The output runs "
+                "through the same credential + exfiltration-URL scrubbers the "
+                "diagnostics bundle uses, so live tokens, Authorization headers "
+                "and auth cookies are stripped before you see them. Use it when "
+                "the backend rejected a turn, an ACP request errored, or you "
+                "need first-hand evidence of what kiro-cli did. `tail` bounds "
+                "the number of lines (default 200); `since` keeps lines at/after "
+                'a leading-timestamp prefix like "2026-09-06T16:". Output is '
+                "byte-capped per source AND bounded as a whole; when it does not "
+                "all fit, the OLDEST lines are dropped and the newest are kept, "
+                "with a note saying so. Returns the log text with one section "
+                "per source, or a note when no logs exist."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "tail": {
+                        "type": "integer",
+                        "description": (
+                            "Max number of lines to return per source (default "
+                            "200). The output is byte-capped independently, so a "
+                            "large value cannot enlarge the response past the cap."
+                        ),
+                    },
+                    "since": {
+                        "type": "string",
+                        "description": (
+                            "Keep only lines at or after this leading-timestamp "
+                            "prefix (lexical match against the start of each log "
+                            'line), e.g. "2026-09-06" or "2026-09-06T16:". '
+                            "Continuation lines of a kept event ride along."
+                        ),
+                    },
+                },
+            },
+        },
+    ]
+
+
+def kiro_cli_logs(name: str, args: dict[str, Any]) -> str:
+    args = validate_tool_args(args, KIRO_CLI_LOGS_SCHEMA)
+    tail = args.get("tail")
+    if tail is not None:
+        try:
+            tail = int(tail)
+        except (TypeError, ValueError):
+            tail = None
+    since = str(args.get("since", "") or "").strip() or None
+
+    try:
+        # diagnostics.read_kiro_cli_logs reads only log files and scrubs every
+        # byte through the shared redaction stack before returning.
+        out = diagnostics.read_kiro_cli_logs(tail=tail, since=since)
+    except Exception as exc:  # pragma: no cover — defensive
+        mcp_core.sel().log_tool_invocation(
+            session_key=mcp_core._resolve_session_key(),
+            source="mcp",
+            tool_name="kiro_cli_logs",
+            tool_kind="read",
+            outcome="error",
+            metadata={"error": type(exc).__name__},
+        )
+        # "Error:" prefix is load-bearing: the shared call_tool_with_logging
+        # wrapper classifies a result by result.startswith("Error:").
+        return f"Error: kiro_cli_logs failed: {type(exc).__name__}: {exc}"
+
+    mcp_core.sel().log_tool_invocation(
+        session_key=mcp_core._resolve_session_key(),
+        source="mcp",
+        tool_name="kiro_cli_logs",
+        tool_kind="read",
+        outcome="success",
+        metadata={"tail": tail, "since_set": since is not None},
+    )
+    return out
+
+
+HANDLERS: dict[str, Callable[[str, dict[str, Any]], str]] = {
+    "kiro_cli_logs": kiro_cli_logs,
+}

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -1344,6 +1344,20 @@ SKILL_FETCH_SCHEMA = ToolSchema(
     ],
 )
 
+# kiro_cli_logs reads kiro-cli's own log files (never the fenced identity
+# stores) and returns a redacted tail. ``tail`` is a line count bounded by the
+# reader's own hard BYTE cap — the schema ceiling only guards against an absurd
+# value; the byte cap is what actually bounds the output. ``since`` is a leading
+# slice of a log line's own timestamp, matched lexically, so it is a short
+# string, not a parsed datetime.
+KIRO_CLI_LOGS_SCHEMA = ToolSchema(
+    tool_name="kiro_cli_logs",
+    fields=[
+        FieldSpec("tail", int, min_val=1, max_val=100000),
+        FieldSpec("since", str, max_len=MAX_SHORT_STRING),
+    ],
+)
+
 # Absolute filesystem path. Empty string is allowed (clears the project) —
 # the validator skips the pattern check on empty values, so the regex only
 # needs to cover the non-empty case.

--- a/test/test_kiro_cli_logs.py
+++ b/test/test_kiro_cli_logs.py
@@ -1,0 +1,856 @@
+"""Tests for the kiro_cli_logs reader (diagnostics.read_kiro_cli_logs) + MCP tool.
+
+Two security-critical properties, and both have a mutation guard so a green run
+is attributable to the code rather than to the fixture:
+
+1. SCOPE. The tool reads kiro-cli's mcp/lsp PROTOCOL logs only. The two
+   conversation-bearing sources kiro-cli also writes — ``kiro-chat.log`` and the
+   ``sessions/cli/<sid>.jsonl`` transcripts — are single shared host files per
+   gateway, so returning either would disclose another session's private
+   conversation to the calling session; the credential-oriented redaction stack
+   does not narrow prose. ``test_chat_log_is_not_a_source`` plants a populated
+   chat log and asserts none of it comes back.
+2. REDACTION. Every live-secret shape kiro-cli writes into its logs — a bearer
+   token, a mid-line ``Authorization: Basic <b64>`` header, an ``mc_token`` auth
+   cookie, and the serialized ``"authorization": ...`` JSON form — must be gone
+   from the returned text. ``test_redaction_is_load_bearing`` empties the extra
+   stack and asserts the very same secrets then leak, so the passing assertion
+   is not vacuous.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from conftest import requires_symlinks
+from kiro_crew import diagnostics
+from kiro_crew.mcp_tools import logs as logs_tool
+
+# All four secret shapes the issue names, in one log body.
+_LOG = (
+    "2026-09-06T16:00:01 boot ok\n"
+    "2026-09-06T16:00:02 Authorization: Bearer sk-ant-SECRETtoken1234567890abcXYZ\n"
+    "2026-09-06T16:00:03 Set-Cookie: mc_token_5476=supersecretcookievalueABCDEF123456\n"
+    "2026-09-06T16:00:04 ERROR request used Authorization: Basic TWlkTGluZUxFQUsxMjNhYmM=\n"
+    '2026-09-06T16:00:05 {"headers": {"authorization": "Basic UVVPVEVEbGVha0FCQzEyMw=="}}\n'
+    "2026-09-06T16:00:06 a perfectly normal log line\n"
+)
+
+_SECRETS = (
+    "sk-ant-SECRETtoken1234567890abcXYZ",
+    "supersecretcookievalueABCDEF123456",
+    "TWlkTGluZUxFQUsxMjNhYmM=",
+    "UVVPVEVEbGVha0FCQzEyMw==",
+)
+
+
+def _source(monkeypatch, tmp_path: Path, body: str, name: str = "mcp.log") -> Path:
+    """Write ``body`` to a protocol log and make it the reader's only source.
+
+    ``encoding="utf-8"`` is required, not tidiness: bare ``write_text`` encodes
+    with the platform's locale codec, which on a Windows runner is cp1252 and
+    cannot represent the zero-width space a hidden-character fixture needs -- the
+    test dies in its own setup with a ``UnicodeEncodeError``. UTF-8 also matches
+    what the reader does, since ``_read_log_tail`` decodes bytes as UTF-8
+    explicitly rather than following the locale.
+    """
+    log = tmp_path / name
+    log.write_text(body, encoding="utf-8")
+    monkeypatch.setattr(diagnostics, "_kiro_cli_extra_logs", lambda: [log])
+    return log
+
+
+def _no_sources(monkeypatch) -> None:
+    monkeypatch.setattr(diagnostics, "_kiro_cli_extra_logs", lambda: [])
+
+
+def test_reads_and_redacts_every_secret_shape(tmp_path, monkeypatch):
+    _source(monkeypatch, tmp_path, _LOG)
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    for secret in _SECRETS:
+        assert secret not in out, f"secret leaked from kiro_cli_logs: {secret!r}"
+    assert "a perfectly normal log line" in out
+    assert "[REDACTED]" in out
+    assert "mcp.log" in out
+
+
+def test_redaction_is_load_bearing(tmp_path, monkeypatch):
+    """Mutation guard: disable the extra-redaction stack and the secrets leak.
+
+    A redaction test that still passes with redaction disabled proves nothing.
+    Here we empty ``_EXTRA_REDACTIONS`` (the stack that covers the bearer /
+    Authorization / mc_token shapes) and assert the SAME secrets now appear —
+    so the green assertion in ``test_reads_and_redacts_every_secret_shape`` is
+    attributable to that stack, not to the secrets never being there.
+    """
+    _source(monkeypatch, tmp_path, _LOG)
+    monkeypatch.setattr(diagnostics, "_EXTRA_REDACTIONS", ())
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    # With the extra stack gone, the header/bearer/cookie shapes leak verbatim
+    # (redact_credentials / redact_exfiltration_urls do not cover them — that is
+    # exactly why _EXTRA_REDACTIONS exists).
+    leaked = [s for s in _SECRETS if s in out]
+    assert leaked, "no secret leaked with _EXTRA_REDACTIONS disabled — the test is vacuous"
+
+
+def test_chat_log_is_not_a_source(tmp_path, monkeypatch):
+    """kiro-chat.log is cross-session conversation content and must not be read.
+
+    ``_kiro_cli_chat_log`` resolves ONE fixed host path
+    (``<runtime-or-tmp>/kiro-log/kiro-chat.log``), not a per-session file, so on a
+    host running one gateway with many concurrent sessions it interleaves every
+    session's request/response traffic. ``_scrub`` is a credential pass and does
+    not narrow conversation prose, and there is no per-session delimiter to filter
+    on — so an agent-callable read of it would hand session A's private
+    conversation to session B. The bundle collector still includes it (that path
+    is user-to-user); this tool must not.
+
+    The guard is mutation-shaped: the chat log EXISTS and is discoverable here,
+    so an implementation that appended it as a source would fail this test.
+    """
+    chat = tmp_path / "kiro-chat.log"
+    chat.write_text("2026-09-06T16:00:00 SESSION-B-PRIVATE-CONVERSATION-PROSE\n")
+    monkeypatch.setattr(diagnostics, "_kiro_cli_chat_log", lambda: chat)
+    # A protocol log is present too, so the tool has something to return and the
+    # assertion below cannot pass merely because the reader found nothing at all.
+    _source(monkeypatch, tmp_path, "2026-09-06T16:00:00 mcp handshake ok\n")
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    assert "mcp handshake ok" in out, "the protocol log should still be read"
+    assert "SESSION-B-PRIVATE-CONVERSATION-PROSE" not in out
+    assert "=== kiro-chat.log" not in out, "the chat log must not appear as a section"
+
+
+def test_oversized_single_line_returns_only_the_marker(tmp_path, monkeypatch):
+    """An unterminated line longer than the cap has no boundary to cut on.
+
+    The byte window is meant to start on a line boundary, because
+    ``_EXTRA_REDACTIONS`` anchors on the header NAME and redacts to end-of-line:
+    a cut landing after ``Authorization:`` but before its value strips the token
+    that would have redacted the value and hands the raw secret to the caller.
+
+    Reaching the no-newline case needs the file's final line to be BOTH longer
+    than the cap AND UNTERMINATED -- which is a log being appended to right now,
+    with a large JSON-RPC frame partially flushed. If the file ended with a
+    newline the read window would contain it (the window runs to EOF), the cut
+    would land there and the result would be just the marker anyway; so a
+    fixture with a trailing newline does not exercise this branch at all.
+
+    Mutation-verified: the secret sits AFTER the cut point with its anchor
+    BEFORE it, the arrangement `_scrub` cannot catch, so the previous behavior
+    (return the fragment) leaks it and fails this test.
+    """
+    cap = 4096
+    secret = "OVERSIZEDlineLEAKsecret9876543210"
+    # ONE unterminated line: anchor first, padding so the last `cap` bytes begin
+    # past the anchor, then the secret. No trailing newline -- see the docstring.
+    one_line = "2026-09-06T16:00:00 Authorization: Basic " + ("Q" * cap * 3) + secret
+    log = _source(monkeypatch, tmp_path, one_line)
+    monkeypatch.setattr(diagnostics, "_MAX_LOG_READ_BYTES", cap)
+
+    # Preconditions: this really is the no-boundary leak arrangement.
+    assert log.stat().st_size > cap
+    window = one_line[-cap:]
+    assert "\n" not in window, "fixture must put NO newline in the read window"
+    assert "Authorization" not in window, "anchor must fall outside the window"
+    assert secret in window, "secret must fall inside the window"
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    assert secret not in out, "a mid-line fragment leaked a credential past its anchor"
+    assert "truncated" in out, "the truncation marker should still say the tail was cut"
+
+
+def test_oversized_terminated_line_also_yields_no_fragment(tmp_path, monkeypatch):
+    """The sibling case: same oversized line, but newline-terminated.
+
+    Here the window DOES contain a newline (it runs to EOF), so the cut lands on
+    it and the remainder is empty. Pinned alongside the unterminated case so a
+    future change to the cut logic cannot fix one and regress the other.
+    """
+    cap = 4096
+    secret = "TERMINATEDoversizedLEAK55555"
+    _source(
+        monkeypatch,
+        tmp_path,
+        "2026-09-06T16:00:00 Authorization: Basic " + ("Q" * cap * 3) + secret + "\n",
+    )
+    monkeypatch.setattr(diagnostics, "_MAX_LOG_READ_BYTES", cap)
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    assert secret not in out
+    assert "truncated" in out
+
+
+def test_since_drops_continuations_of_rejected_events(tmp_path, monkeypatch):
+    """A continuation line inherits the verdict of the event it belongs to.
+
+    Keeping continuations unconditionally left orphaned bodies from events
+    ``since`` had rejected, so the filter did not actually narrow the window --
+    the bulk of an old event (its payload) rode along without the header line
+    that identified it.
+    """
+    _source(
+        monkeypatch,
+        tmp_path,
+        "2026-09-06T15:00:00 HEADEROLD\n"
+        "  BODYOLD is the old event's payload\n"
+        "2026-09-06T17:00:00 HEADERNEW\n"
+        "  BODYNEW is the new event's payload\n",
+    )
+
+    out = diagnostics.read_kiro_cli_logs(since="2026-09-06T16:")
+
+    assert "HEADEROLD" not in out
+    assert "BODYOLD" not in out, "continuation of a rejected event rode along"
+    assert "HEADERNEW" in out
+    assert "BODYNEW" in out, "continuation of a KEPT event must still ride along"
+
+
+def test_since_keeps_the_truncation_marker(tmp_path, monkeypatch):
+    """The marker precedes every event, so it has no verdict to inherit -- keep it.
+
+    Guard against fixing the orphaned-continuation bug by dropping every
+    pre-event line, which would silently hide the fact that the tail was cut.
+    """
+    marker_line = "...[truncated: showing last 4096 bytes]...\n"
+    filtered = diagnostics._filter_since(
+        marker_line + "2026-09-06T17:00:00 late event\n",
+        "2026-09-06T16:",
+    )
+    assert "truncated" in filtered
+    assert "late event" in filtered
+
+
+def test_response_budget_stays_under_the_transport_ceiling():
+    """The reader's own ceiling must sit under the MCP transport's.
+
+    This is the whole point of `_MAX_LOG_RESPONSE_CHARS`: every tool response
+    leaves through `validation.build_tool_response`, whose `sanitize_response`
+    truncates the TAIL at `MAX_RESPONSE_LEN`. If the reader's budget ever rose to
+    or above that, the transport would start cutting again -- and it cuts the end,
+    which for a log tail is the newest lines.
+
+    The coupling deliberately lives HERE rather than as an import in
+    `diagnostics`, which does not otherwise depend on `validation`. The test is
+    what keeps the two numbers in the right order, so a change to either side
+    fails rather than silently re-opening the truncation.
+    """
+    from kiro_crew import validation
+
+    assert diagnostics._MAX_LOG_RESPONSE_CHARS < validation.MAX_RESPONSE_LEN
+    # And with room for the framing the reader adds on top of the log text.
+    assert diagnostics._MAX_LOG_RESPONSE_CHARS + 2000 <= validation.MAX_RESPONSE_LEN
+
+
+def test_response_over_budget_keeps_the_newest_lines(tmp_path, monkeypatch):
+    """When the whole response will not fit, the OLDEST output goes.
+
+    The transport would drop the tail, i.e. the newest lines -- the entire reason
+    a tail was requested. The reader trims from the front instead, so this test
+    asserts the direction: the last line survives, the first does not, the header
+    stays (it states the tail/since/redaction count), and the drop is labelled.
+    """
+    monkeypatch.setattr(diagnostics, "_MAX_LOG_RESPONSE_CHARS", 3000)
+    body = "".join(f"2026-09-06T16:00:00 line{i:05d} {'z' * 60}\n" for i in range(200))
+    _source(monkeypatch, tmp_path, body)
+
+    out = diagnostics.read_kiro_cli_logs(tail=100000)
+
+    assert len(out) <= 3000, "the reader must respect its own response budget"
+    assert "line00199" in out, "the NEWEST line must survive"
+    assert "line00000" not in out, "the oldest line should have been dropped"
+    assert out.startswith("kiro-cli logs (tail="), "the header must survive the trim"
+    assert "older output dropped" in out, "the drop must say which end went"
+
+
+def test_per_source_cap_is_divided_across_sources(tmp_path, monkeypatch):
+    """Two sources share the response budget, so neither is crowded out.
+
+    Giving each source the full per-source cap and trimming the assembled result
+    afterwards would drop one source entirely -- the trim runs from the front, so
+    the first section would go. Dividing up front means each source contributes
+    its own newest lines.
+    """
+    a = tmp_path / "mcp.log"
+    b = tmp_path / "lsp.log"
+    a.write_text("".join(f"2026-09-06T16:00:00 AAA{i:05d}\n" for i in range(400)))
+    b.write_text("".join(f"2026-09-06T16:00:00 BBB{i:05d}\n" for i in range(400)))
+    monkeypatch.setattr(diagnostics, "_kiro_cli_extra_logs", lambda: [a, b])
+    monkeypatch.setattr(diagnostics, "_MAX_LOG_RESPONSE_CHARS", 4000)
+
+    out = diagnostics.read_kiro_cli_logs(tail=100000)
+
+    assert len(out) <= 4000
+    assert "AAA00399" in out, "the first source's newest line must survive"
+    assert "BBB00399" in out, "the second source's newest line must survive"
+
+
+def test_byte_cap_bounds_output_regardless_of_tail(tmp_path, monkeypatch):
+    # Write a large log the honest way.
+    big = "".join(f"2026-09-06T16:00:{i:02d} {'y' * 80}\n" for i in range(1000))
+    _source(monkeypatch, tmp_path, big)
+    monkeypatch.setattr(diagnostics, "_MAX_LOG_READ_BYTES", 4096)
+
+    # A huge tail cannot enlarge the output past the byte cap.
+    out = diagnostics.read_kiro_cli_logs(tail=100000)
+    # Output = header + section framing + <=4096 bytes of log; give generous slack.
+    assert len(out) < 4096 + 500
+    assert "truncated" in out  # the tail marker _read_log_tail prepends
+
+
+def test_tail_limits_line_count(tmp_path, monkeypatch):
+    _source(
+        monkeypatch,
+        tmp_path,
+        "".join(f"2026-09-06T16:00:00 line{i}\n" for i in range(50)),
+    )
+
+    out = diagnostics.read_kiro_cli_logs(tail=3)
+
+    assert "line49" in out
+    assert "line47" in out
+    assert "line46" not in out  # only the last 3 survive
+
+
+def test_since_filters_by_leading_timestamp(tmp_path, monkeypatch):
+    _source(
+        monkeypatch,
+        tmp_path,
+        "2026-09-06T15:00:00 early line\n"
+        "2026-09-06T16:00:00 kept line\n"
+        "  continuation of kept event\n"
+        "2026-09-06T17:00:00 later line\n",
+    )
+
+    out = diagnostics.read_kiro_cli_logs(since="2026-09-06T16:")
+
+    assert "early line" not in out
+    assert "kept line" in out
+    assert "continuation of kept event" in out  # non-timestamp line rides along
+    assert "later line" in out
+
+
+def test_no_logs_returns_a_note(tmp_path, monkeypatch):
+    _no_sources(monkeypatch)
+    out = diagnostics.read_kiro_cli_logs()
+    assert "No kiro-cli protocol logs found" in out
+
+
+def test_sensitive_path_source_is_refused(tmp_path, monkeypatch):
+    """Defense in depth: a source that resolves to a fenced/sensitive path is skipped."""
+    _source(monkeypatch, tmp_path, _LOG)
+    # Force every path to read as sensitive; the reader must return zero sources.
+    monkeypatch.setattr(diagnostics, "is_sensitive_path", lambda p: True)
+
+    out = diagnostics.read_kiro_cli_logs()
+    assert "No kiro-cli protocol logs found" in out
+
+
+@requires_symlinks
+def test_symlinked_source_is_not_followed(tmp_path, monkeypatch):
+    off_tree = tmp_path / "off_tree_secret.txt"
+    off_tree.write_text("TOPSECRETsymlinkVALUE123\n")
+    link = tmp_path / "mcp.log"
+    link.symlink_to(off_tree)
+    monkeypatch.setattr(diagnostics, "_kiro_cli_extra_logs", lambda: [link])
+
+    out = diagnostics.read_kiro_cli_logs()
+    assert "TOPSECRETsymlinkVALUE123" not in out
+    assert "No kiro-cli protocol logs found" in out
+
+
+@requires_symlinks
+@pytest.mark.skipif(
+    not hasattr(os, "O_NOFOLLOW"),
+    reason=(
+        "O_NOFOLLOW is a POSIX flag absent on Windows; the kernel-enforced "
+        "no-follow open this test exercises cannot be applied there. On Windows "
+        "the symlink defense is the caller's pre-open is_symlink check (covered "
+        "by test_symlinked_source_is_not_followed, which runs on both), so "
+        "this platform-specific strengthening is gated rather than asserted "
+        "cross-platform."
+    ),
+)
+def test_toctou_symlink_swap_is_refused_by_nofollow(tmp_path, monkeypatch):
+    """A path swapped to a symlink AFTER the checks must not be followed (POSIX).
+
+    The source dirs include the world-writable /tmp/kiro-log, so a local writer
+    could replace a validated regular log with a symlink to ~/.ssh/config
+    between the is_sensitive_path check and the open. _read_log_tail opens with
+    O_NOFOLLOW and tails that same descriptor, so the swapped-in link is refused
+    (ELOOP) rather than read. Simulated by making the source path a symlink and
+    pushing the pre-open checks past it: only the O_NOFOLLOW open stands between
+    the reader and the target.
+    """
+    target = tmp_path / "secret_target"
+    target.write_text("TOCTOUsymlinkTARGETleak5555\n")
+    link = tmp_path / "mcp.log"
+    link.symlink_to(target)
+
+    # The reader is what we exercise; force the pre-open guards to pass so the
+    # O_NOFOLLOW open is the ONLY thing that can stop the swapped-in link.
+    monkeypatch.setattr(diagnostics, "_kiro_cli_extra_logs", lambda: [link])
+    monkeypatch.setattr(diagnostics.Path, "is_symlink", lambda self: False)
+    monkeypatch.setattr(diagnostics, "is_sensitive_path", lambda p: False)
+
+    out = diagnostics.read_kiro_cli_logs()
+    assert "TOCTOUsymlinkTARGETleak5555" not in out
+    assert "No kiro-cli protocol logs found" in out
+
+
+def test_read_log_tail_reads_a_regular_file(tmp_path):
+    """_read_log_tail returns a regular file's bytes on every platform."""
+    regular = tmp_path / "plain.log"
+    regular.write_text("regular content\n")
+    assert diagnostics._read_log_tail(regular, 4096) == "regular content\n"
+
+
+def test_reader_works_without_o_nofollow(tmp_path, monkeypatch):
+    """The tool still reads when O_NOFOLLOW is unavailable (the Windows path).
+
+    Regression guard: an earlier version returned None (read nothing) whenever
+    O_NOFOLLOW was absent, which silently disabled the whole tool on Windows.
+    The no-follow open is a POSIX strengthening, not a precondition for reading.
+    Exercised on any platform by deleting the attribute so `getattr(os,
+    "O_NOFOLLOW", 0)` degrades to 0 (a plain open), matching Windows.
+    """
+    monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+    _source(monkeypatch, tmp_path, "2026-09-06T16:00:00 windows path reads fine\n")
+
+    out = diagnostics.read_kiro_cli_logs()
+    assert "windows path reads fine" in out
+    assert "No kiro-cli protocol logs found" not in out
+
+
+def test_reader_works_without_o_nonblock(tmp_path, monkeypatch):
+    """O_NONBLOCK is also a strengthening, not a precondition for reading.
+
+    Same class of regression guard as the O_NOFOLLOW one, for the platform that
+    does not define the flag (Windows). Simulated by SETTING it to 0 rather than
+    deleting it: 0 is exactly what ``getattr(os, "O_NONBLOCK", 0)`` yields when
+    the attribute is absent, and unlike a delattr it does not break unrelated
+    machinery in this process that reads the attribute during the test.
+    """
+    monkeypatch.setattr(os, "O_NONBLOCK", 0, raising=False)
+    _source(monkeypatch, tmp_path, "2026-09-06T16:00:00 no nonblock reads fine\n")
+
+    out = diagnostics.read_kiro_cli_logs()
+    assert "no nonblock reads fine" in out
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "mkfifo"),
+    reason="os.mkfifo is POSIX-only; the FIFO swap this test plants cannot exist on Windows.",
+)
+def test_fifo_swapped_in_is_refused_without_hanging(tmp_path, monkeypatch):
+    """A FIFO swapped in past the checks is refused, not waited on (O_NONBLOCK).
+
+    Companion to the symlink TOCTOU case. O_NOFOLLOW refuses a swapped-in
+    SYMLINK, but the same local writer to the world-writable /tmp/kiro-log can
+    swap the validated regular file for a FIFO, and an O_RDONLY open of a FIFO
+    with no writer BLOCKS INDEFINITELY — the fstat regular-file guard cannot run,
+    because it only sees a descriptor the open already returned, so the agent's
+    tool call would hang. O_NONBLOCK makes the open return immediately so the
+    S_ISREG check can reject it.
+
+    This test would HANG (not fail) without O_NONBLOCK, which is the point: no
+    reader is ever opened on the FIFO.
+    """
+    fifo = tmp_path / "mcp.log"
+    os.mkfifo(fifo)
+    monkeypatch.setattr(diagnostics, "_kiro_cli_extra_logs", lambda: [fifo])
+    # Push the pre-open guards past it so the open flags are the only defense.
+    monkeypatch.setattr(diagnostics.Path, "is_symlink", lambda self: False)
+    monkeypatch.setattr(diagnostics.Path, "is_file", lambda self: True)
+    monkeypatch.setattr(diagnostics, "is_sensitive_path", lambda p: False)
+
+    assert diagnostics._read_log_tail(fifo, 4096) is None
+    out = diagnostics.read_kiro_cli_logs()
+    assert "No kiro-cli protocol logs found" in out
+
+
+@requires_symlinks
+@pytest.mark.skipif(
+    not hasattr(os, "O_NOFOLLOW"),
+    reason=(
+        "O_NOFOLLOW is POSIX-only; on Windows the open would follow the link "
+        "and _read_log_tail would return the target's bytes, so the None result "
+        "this asserts is a POSIX guarantee. The Windows symlink defense is the "
+        "caller's pre-open is_symlink check, exercised by "
+        "test_symlinked_source_is_not_followed."
+    ),
+)
+def test_read_log_tail_refuses_a_symlink_on_posix(tmp_path):
+    """_read_log_tail: None for a symlinked final component (O_NOFOLLOW ELOOP)."""
+    target = tmp_path / "target.log"
+    target.write_text("SECRETviaSymlink\n")
+    link = tmp_path / "link.log"
+    link.symlink_to(target)
+    assert diagnostics._read_log_tail(link, 4096) is None
+
+
+def test_read_log_tail_refuses_when_descriptor_identity_differs(tmp_path):
+    """A descriptor that is not the checked file is refused, flag or no flag.
+
+    This is the Windows defense: there is no ``O_NOFOLLOW`` there to refuse a
+    junction at open time, and a reparse point is not reported by ``is_symlink``,
+    so a swap landing after the pre-open check would satisfy ``S_ISREG`` and its
+    bytes would reach the caller. ``lstat`` before the open and ``fstat`` after
+    must name the same file.
+
+    Simulated portably by making ``lstat`` describe a DIFFERENT file than the one
+    opened, which is exactly what a followed link or a mid-flight swap produces.
+    Restored in a ``finally`` rather than by ``monkeypatch``, because
+    ``diagnostics.os`` IS the ``os`` module: the stub is process-wide, and pytest's
+    own fixture cleanup would run against it before monkeypatch undid it.
+    """
+    real = tmp_path / "mcp.log"
+    real.write_text("SWAPPEDtargetCONTENT4242\n")
+    decoy = tmp_path / "decoy.log"
+    decoy.write_text("decoy\n")
+    decoy_stat = os.lstat(decoy)
+
+    real_lstat = os.lstat
+    try:
+        os.lstat = lambda p, **kw: decoy_stat  # type: ignore[assignment]
+        result = diagnostics._read_log_tail(real, 4096)
+    finally:
+        os.lstat = real_lstat  # type: ignore[assignment]
+
+    assert result is None
+
+
+def test_read_log_tail_reads_when_identity_matches(tmp_path):
+    """The identity check must not reject the ordinary case it guards."""
+    regular = tmp_path / "plain.log"
+    regular.write_text("identity matches\n")
+    assert diagnostics._read_log_tail(regular, 4096) == "identity matches\n"
+
+
+def test_read_log_tail_bounds_a_growing_file(tmp_path):
+    """The read stops at max_bytes even when the file never reaches EOF.
+
+    ``size`` is a snapshot taken at ``fstat``. A writer appending faster than the
+    loop drains means EOF never arrives, so a loop bounded only by EOF grows
+    until the process is OOM-killed -- and the world-writable log directory is
+    where a local writer can do exactly that. ``max_bytes`` has to bound the
+    non-truncating branch too, not only the truncating one.
+
+    Simulated with an ``os.read`` that never returns empty, so the ONLY thing that
+    can end the loop is the byte budget. Without it this test hangs or dies on
+    memory rather than failing.
+
+    Restored in a ``finally`` rather than by ``monkeypatch``: ``diagnostics.os``
+    IS the ``os`` module, so this replacement is process-wide, and monkeypatch
+    undoes it at teardown -- after pytest's own fixture cleanup has already tried
+    to use the stubbed ``os.read``.
+    """
+    log = tmp_path / "mcp.log"
+    log.write_text("seed\n")
+    cap = 8192
+    real_read = os.read
+    try:
+        os.read = lambda fd, n: b"A" * n  # type: ignore[assignment]
+        out = diagnostics._read_log_tail(log, cap)
+    finally:
+        os.read = real_read  # type: ignore[assignment]
+
+    assert out is not None
+    assert len(out) <= cap, "the read must stop at max_bytes on a file with no EOF"
+
+
+def test_hidden_character_split_credential_does_not_survive_the_transport(tmp_path, monkeypatch):
+    """A credential split by an invisible must not be rejoined downstream.
+
+    ``redact_credentials`` matches the literal shape of a secret, so an invisible
+    planted inside one defeats it: ``AKIA<ZWSP>IOSFODNN7EXAMPLE`` matches no
+    pattern. The danger is what happens NEXT. Every MCP response leaves through
+    ``validation.build_tool_response`` -> ``sanitize_response`` ->
+    ``sanitize_string`` -> ``strip_hidden_unicode``, which removes the invisible
+    and REJOINS the credential -- after redaction has already been asked about it
+    and declined. Stripping late is worse than not stripping, and
+    ``strip_hidden_unicode`` documents that it is meant to run BEFORE
+    ``redact_credentials`` for exactly this reason.
+
+    So this asserts the property end to end, through the real transport call, not
+    just that `_scrub` returned something.
+    """
+    from kiro_crew import validation
+
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    split = "AKIA\u200bIOSFODNN7EXAMPLE"
+    _source(monkeypatch, tmp_path, f"2026-09-06T16:00:00 request key={split}\n")
+
+    out = diagnostics.read_kiro_cli_logs()
+    delivered = validation.sanitize_response(out)
+
+    assert secret not in out, "the reader returned a credential a later strip would rejoin"
+    assert secret not in delivered, "the transport rejoined the credential after redaction"
+
+
+def test_scrub_strips_hidden_characters_before_redacting(tmp_path):
+    """Unit form of the ordering, plus the control that makes it non-vacuous.
+
+    The control matters: it shows `redact_credentials` DOES catch this credential
+    when it is intact, so the split form passing through is attributable to the
+    invisible rather than to the pattern never having covered the shape.
+    """
+    from kiro_crew import validation
+
+    secret = "AKIAIOSFODNN7EXAMPLE"
+
+    intact, n_intact = diagnostics._scrub(f"key={secret}\n")
+    assert n_intact >= 1 and secret not in intact, "control: the intact form must be redacted"
+
+    split, n_split = diagnostics._scrub("key=AKIA\u200bIOSFODNN7EXAMPLE\n")
+    assert secret not in split, "the split form must not survive _scrub"
+    assert secret not in validation.sanitize_response(split), "and must not be rejoinable"
+
+
+def test_a_frame_bearing_source_is_refused_whole(tmp_path, monkeypatch):
+    """A source recording protocol FRAMES is refused, not filtered.
+
+    The scope argument holds only while mcp.log / lsp.log record protocol traffic
+    rather than frame bodies. A `tools/call` frame carries conversation-derived
+    arguments from every session sharing the host file, so if kiro-cli starts
+    logging bodies the source stops being readable here. This asserts the refusal
+    is WHOLE and VISIBLE: none of the payload comes back, and the output says the
+    source was refused rather than looking like an empty log.
+    """
+    payload = "SESSION-B-TOOL-ARGUMENT-PROSE"
+    _source(
+        monkeypatch,
+        tmp_path,
+        "2026-09-06T16:00:00 sending\n"
+        '{"jsonrpc": "2.0", "method": "tools/call", "params": {"q": "' + payload + '"}}\n',
+    )
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    assert payload not in out, "a frame body reached the caller"
+    assert "REFUSED" in out, "the refusal must be visible, not a silent skip"
+    assert "No kiro-cli protocol logs found" not in out, "refusal must not read as absence"
+
+
+def test_a_real_shaped_log_is_not_refused(tmp_path, monkeypatch):
+    """The tripwire must not fire on the log shape kiro-cli actually writes.
+
+    Modelled on the observed lsp.log on kiro-cli 2.21.1: single-line
+    `<timestamp> ERROR <module>: <message>` records. Includes the two shapes a
+    length-based rule would get wrong -- a long legitimate line, and prose that
+    merely mentions the protocol -- since the tripwire keys on the serialized
+    JSON-RPC key instead of on length.
+    """
+    _source(
+        monkeypatch,
+        tmp_path,
+        "2026-09-06T16:00:00 ERROR code_agent_sdk::sdk::workspace_manager: 1: "
+        "Failed to start LSP server for " + ("/very/deep/path" * 12) + "\n"
+        "2026-09-06T16:00:01 ERROR transport: failed to parse jsonrpc reply\n",
+    )
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    assert "REFUSED" not in out, "the tripwire fired on an honest log record"
+    assert "Failed to start LSP server" in out
+    assert "failed to parse jsonrpc reply" in out, "prose mentioning the protocol is not a frame"
+
+
+def test_truncation_cannot_bypass_the_frame_refusal(tmp_path, monkeypatch):
+    """An oversized MULTILINE frame must not smuggle its tail past the tripwire.
+
+    `_looks_like_protocol_frames` keys on a frame's envelope tokens, and in a
+    pretty-printed frame those sit at the TOP. The byte cut runs from the FRONT,
+    so an oversized multiline frame can have its envelope fall outside the window
+    while its trailing ARGUMENT lines survive: the marker then finds nothing to
+    match and returns lines carrying another session's conversation content.
+
+    `_begin_at_event_boundary` closes it by discarding leading lines of a cut
+    window until a timestamped record starts one, so orphaned frame lines never
+    reach the caller. Mutation-verified: without that call this fixture leaks
+    `payload`.
+    """
+    payload = "SESSION-B-PRIVATE-ARGUMENT-TEXT"
+    frame = (
+        '{\n  "jsonrpc": "2.0",\n  "method": "tools/call",\n  "params": {\n'
+        '    "name": "search",\n'
+        + "".join(f'    "pad{i}": "{"x" * 80}",\n' for i in range(200))
+        + f'    "query": "{payload}"\n  }}\n}}\n'
+    )
+    _source(monkeypatch, tmp_path, frame)
+    monkeypatch.setattr(diagnostics, "_MAX_LOG_READ_BYTES", 4096)
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    assert payload not in out, "a truncated frame's arguments reached the caller"
+
+
+def test_a_cut_window_keeps_records_from_the_first_event(tmp_path, monkeypatch):
+    """The boundary trim drops the orphan and keeps every whole record after it.
+
+    Guard against over-trimming: only the leading partial record goes, and the
+    truncation note stays so the caller still knows the tail was cut.
+    """
+    body = "  ORPHANCONTINUATION belonging to a record whose start was cut\n" + "".join(
+        f"2026-09-06T16:00:00 KEPTRECORD{i:04d} {'y' * 60}\n" for i in range(200)
+    )
+    _source(monkeypatch, tmp_path, body)
+    monkeypatch.setattr(diagnostics, "_MAX_LOG_READ_BYTES", 4096)
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    assert "truncated" in out, "the cut must still be announced"
+    assert "ORPHANCONTINUATION" not in out
+    assert "KEPTRECORD0199" in out, "whole records after the boundary must survive"
+
+
+def test_an_untruncated_window_is_not_trimmed(tmp_path, monkeypatch):
+    """Nothing was cut, so the first line is real output and must be kept.
+
+    Trimming an untruncated window would discard genuine content for no safety
+    gain: a frame in a file small enough to be read whole still carries its
+    envelope, so the marker catches it.
+    """
+    _source(monkeypatch, tmp_path, "  leading continuation\n2026-09-06T16:00:00 record\n")
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    assert "truncated" not in out
+    assert "leading continuation" in out
+    assert "record" in out
+
+
+def test_a_numeric_frame_line_is_not_a_record_boundary(tmp_path, monkeypatch):
+    """A bare-number JSON line must not pass as the start of a log record.
+
+    `_begin_at_event_boundary` trims a cut window forward to the first line that
+    STARTS a record. A leading-digit test is too loose for that: a serialized frame
+    can carry a JSON array of bare numbers, so `      1000000,` begins with a digit
+    and would end the trim INSIDE the frame, returning the argument text after it.
+    The predicate matches an ISO date followed by `T` or a space, which no JSON
+    number can satisfy.
+    """
+    payload = "SESSION-B-ARGUMENT-AFTER-NUMERIC-LINE"
+    frame = (
+        '{\n  "jsonrpc": "2.0",\n  "method": "tools/call",\n  "params": {\n'
+        + "".join(f'    "pad{i}": "{"x" * 80}",\n' for i in range(200))
+        + '    "ids": [\n'
+        + "".join(f"      {1000000 + i},\n" for i in range(30))
+        + "    ],\n"
+        + f'    "query": "{payload}"\n  }}\n}}\n'
+    )
+    _source(monkeypatch, tmp_path, frame)
+    monkeypatch.setattr(diagnostics, "_MAX_LOG_READ_BYTES", 3000)
+
+    out = diagnostics.read_kiro_cli_logs()
+
+    assert payload not in out, "a numeric JSON line was treated as a record boundary"
+
+
+def test_starts_a_record_accepts_real_records_and_rejects_frame_lines():
+    """The predicate's two directions, stated as a unit test.
+
+    Both ISO variants the module's `since` semantics describe are records; a JSON
+    number, a quoted key and an indented continuation are not.
+    """
+    assert diagnostics._starts_a_record("2026-09-06T16:00:00.123Z ERROR boot failed\n")
+    assert diagnostics._starts_a_record("2026-09-06 16:00:00 ERROR boot failed\n")
+    assert not diagnostics._starts_a_record("      1000000,\n")
+    assert not diagnostics._starts_a_record("      1234-5,\n")
+    assert not diagnostics._starts_a_record('    "query": "text"\n')
+    assert not diagnostics._starts_a_record("  continuation of an event\n")
+
+
+def test_session_transcripts_are_not_read(tmp_path, monkeypatch):
+    """Cross-session conversation content is deliberately out of scope.
+
+    Session transcripts (`sessions/cli/<sid>.jsonl`) are shared across every
+    gateway session, including incognito/temporary ones, and `_scrub` is a
+    credential pass that does not narrow conversation prose — so returning the
+    globally-newest ones would disclose another session's private conversation.
+    The tool stays scoped to the mcp/lsp PROTOCOL logs: with no protocol log
+    present it reports none found rather than falling back to transcripts.
+    """
+    # A populated sessions dir must NOT be a source.
+    sessions = tmp_path / "sessions" / "cli"
+    sessions.mkdir(parents=True)
+    (sessions / "abc.jsonl").write_text("2026-09-06T16:00:00 private conversation\n")
+    _no_sources(monkeypatch)
+
+    # There is no session-log reader to stub — the feature was removed.
+    assert not hasattr(diagnostics, "_kiro_cli_session_logs")
+    out = diagnostics.read_kiro_cli_logs()
+    assert "private conversation" not in out
+    assert "No kiro-cli protocol logs found" in out
+
+
+# ── MCP tool wrapper ─────────────────────────────────────────────────────────
+
+
+def _stub_sel(monkeypatch):
+    from unittest.mock import MagicMock
+
+    sel = MagicMock()
+    monkeypatch.setattr("kiro_crew.mcp_core.sel", lambda: sel)
+    monkeypatch.setattr("kiro_crew.mcp_core._resolve_session_key", lambda: "sk")
+    return sel
+
+
+def test_tool_returns_reader_output_and_audits(tmp_path, monkeypatch):
+    sel = _stub_sel(monkeypatch)
+    monkeypatch.setattr(
+        logs_tool.diagnostics, "read_kiro_cli_logs", lambda **kw: "REDACTED LOGS OK"
+    )
+
+    result = logs_tool.kiro_cli_logs("kiro_cli_logs", {"tail": 10})
+
+    assert result == "REDACTED LOGS OK"
+    assert sel.log_tool_invocation.call_args.kwargs["outcome"] == "success"
+    assert sel.log_tool_invocation.call_args.kwargs["tool_kind"] == "read"
+
+
+def test_tool_error_is_prefixed_and_audited(monkeypatch):
+    sel = _stub_sel(monkeypatch)
+
+    def _boom(**kw):
+        raise RuntimeError("disk gone")
+
+    monkeypatch.setattr(logs_tool.diagnostics, "read_kiro_cli_logs", _boom)
+
+    result = logs_tool.kiro_cli_logs("kiro_cli_logs", {})
+
+    assert result.startswith("Error:")
+    assert sel.log_tool_invocation.call_args.kwargs["outcome"] == "error"
+
+
+def test_tool_rejects_out_of_range_tail(monkeypatch):
+    _stub_sel(monkeypatch)
+    # Schema bound is 1..100000; a validation error surfaces as a string, not a raise.
+    from kiro_crew.validation import ValidationError
+
+    with pytest.raises(ValidationError):
+        logs_tool.kiro_cli_logs("kiro_cli_logs", {"tail": 0})
+
+
+def test_tool_descriptor_does_not_advertise_the_chat_log(monkeypatch):
+    """The advertisement must match the scope: no chat log, no transcripts.
+
+    The model picks a tool off this description, so a description promising
+    kiro-chat.log would send the agent looking for conversation content the
+    reader deliberately does not return.
+    """
+    (descriptor,) = logs_tool.schemas()
+    description = descriptor["description"]
+    assert "mcp/lsp" in description
+    assert "kiro-chat.log" in description, "the exclusion should be stated, not silent"
+    assert "chat/mcp/lsp" not in description, "stale claim: the chat log is not read"


### PR DESCRIPTION
## What is the problem?

The agent that drives kiro-cli has no sanctioned way to read kiro-cli's own
logs. kiro-cli's data directory is fenced by the command gate (it also holds SSO
tokens), and the gate is deliberately coarse and verb-independent: naming a
fenced path is enough to be refused, and a refused call ends the agent's turn.
So when the backend rejects a turn, the agent has no first-hand diagnostics for
the runtime it is driving. This is Class 2 of issue #6023.

## Why this issue matters to the user

Diagnosing a rejected or failed turn today means asking the user to collect a
bundle by hand, or guessing from the gateway side without the kiro-cli side of
the exchange. The authoritative evidence exists on disk and KiroCrew already
knows how to read and scrub it for its diagnostics bundle, but there is no read
path an agent can call. The user is left relaying logs manually for a class of
failure the agent is otherwise well placed to investigate itself.

## How our fix solves it

Symptom: a blocked log read ends the turn, so the agent cannot self-diagnose.
Root cause: the only safe way to expose fenced-adjacent logs is through a
reviewed code path with redaction attached -- a path carve-out on the fence would
require proving the log subtree never contains credentials, which is the exact
separability question the issue leaves unresolved. Fix: a dedicated read-only
MCP tool.

**Scope is the primary control, not redaction.**
`diagnostics.read_kiro_cli_logs(tail, since)` reads ONLY kiro-cli's mcp/lsp
PROTOCOL logs under `kiro-log/`. Three things kiro-cli writes are deliberately
NOT sources:

- the eight fenced identity stores in `identity_stores.IDENTITY_STORE_ROOTS`;
- the `sessions/cli/<sid>.jsonl` session transcripts; and
- `kiro-chat.log`.

The last two are excluded for the same reason. Each is a SINGLE FIXED HOST PATH,
not a per-session file, so on a host running one gateway with many concurrent
sessions (web, CLI, messaging, subagents, cron) it interleaves every session's
traffic. Both carry conversation prose, and `_scrub` is a CREDENTIAL pass: it
strips tokens, headers and cookies, not prose. An agent-callable read of either
would therefore hand session A's private conversation to session B, and a
disclosure into a model context cannot be recalled. There is no per-session
kiro-cli chat log to scope to and no reliable per-session delimiter in the flat
one, so a filter that looked scoped but was not would be worse than no filter --
which is why the fix is the SOURCE LIST rather than a narrowing pass. The
mcp/lsp protocol logs are what actually explain a rejected turn.

The diagnostics bundle still includes the chat log, and that asymmetry is the
point: the bundle is a USER->USER path (the user triggers the collection and
downloads it for their own machine), while this tool is CROSS-SESSION.
`test_chat_log_is_not_a_source` pins the exclusion with the chat log present and
discoverable, so an implementation that re-added it fails.

**The property this scope rests on is MEASURED, and enforced.** mcp.log / lsp.log
share the chat log's shape exactly -- one fixed host path, every session's traffic
interleaved -- so the only thing separating them is payload content, and an MCP
`tools/call` frame carries conversation-derived arguments. On kiro-cli 2.21.1:
mcp.log is 0 bytes across a session of continuous MCP tool calls; every one of
lsp.log's 1,284 records is a single-line timestamped ERROR with no JSON-RPC
envelope and a longest line of 313 bytes; and six sentinel strings passed as
tool-call ARGUMENTS in that session appear in neither file. Version and evidence
are recorded in the module comment and in `docs/architecture/mcp.md`.

Because that measures one version of a component this repo does not pin, a source
whose text carries serialized JSON-RPC frames is REFUSED whole and visibly, so
drift surfaces as a refusal instead of a silent widening. It keys on the
serialized JSON-RPC key rather than on line length The refusal is paired with a
boundary rule, because the marker alone is bypassable: a frame's envelope tokens
sit at the TOP of a pretty-printed frame while the byte cut runs from the FRONT,
so an oversized multiline frame could have its envelope fall outside the window
and smuggle its trailing argument lines through. A cut window whose first line is
not a timestamped record is therefore trimmed to the first record that starts one, and
"starts a record" means an ISO date followed by `T` or a space, not merely a
leading digit -- a frame's JSON array of bare numbers would satisfy the looser test
and end the trim inside the frame. `_filter_since` shares that one predicate, so
the two cannot classify a line differently on a security boundary,
so orphaned frame lines are discarded; a frame that STARTS inside the window still
carries its envelope for the marker. Only a cut window is trimmed, and the trim
lives in the agent-facing reader rather than the shared tail reader -- unlike the
hidden-character strip it discards data, and the cross-session boundary that
justifies the loss is one `collect_bundle` does not cross., since a legitimate record can
be long (the real lsp.log lines carry deep paths) and a short frame is still a
frame. And it refuses the SOURCE rather than filtering lines: it decides only
whether a file is the KIND the tool assumes, never claiming to separate one
session's frames from another's, which is the pretend-scoped filter this design
rejects for the chat log.

**Hidden characters are stripped BEFORE redaction, inside `_scrub`.**
`redact_credentials` matches a secret's literal shape, so an invisible planted
inside one defeats it -- `AKIA<ZWSP>IOSFODNN7EXAMPLE` matches no pattern. What
makes that dangerous rather than merely leaky is what happens next: every MCP
response leaves through `validation.build_tool_response` ->
`sanitize_response` -> `sanitize_string` -> `strip_hidden_unicode`, which removes
the invisible and REJOINS the credential, after redaction was already asked about
it and declined. Stripping late is strictly worse than not stripping at all, and
`strip_hidden_unicode` states this ordering as its own contract in its docstring,
using that same `AKIA` example. Reproduced end to end before fixing: the intact
credential is redacted, the split one passes `_scrub` untouched, and
`sanitize_response` then hands back `AKIAIOSFODNN7EXAMPLE` in full.

The strip goes in `_scrub` rather than in the reader, so `collect_bundle` is
covered by the same change instead of being left as a second path with the order
still inverted. That is why `diagnostics` now imports `strip_hidden_unicode` from
`validation`, which is not in tension with keeping the response CEILING out of
that import: a policy number is worth decoupling and pinning with a test, while a
shared sanitizer is exactly the thing that must not be forked.

**One hardened reader for the whole module.** Every source is read through a
single descriptor by `_read_log_tail`, which is now the module's ONLY tail
reader: `collect_bundle` was reading the same world-writable `/tmp/kiro-log`
sources through a plain following `path.open()`, so the check-then-open window
this PR set out to close was still open in the sibling, and two readers with
mirrored comments would drift. `_read_text_tail` is deleted and `collect_bundle`
reads through `_read_log_tail`, so the hardening cannot be present in one path
and missing in the other.

That reader sets two open flags past `O_RDONLY`, each closing one way the
validated file can be swapped between the `is_sensitive_path` check and the read:

- `O_NOFOLLOW` (POSIX) refuses a swapped-in SYMLINK at open time (ELOOP) rather
  than following it to a sensitive target like `~/.ssh/config`, which redaction
  is no backstop for -- a `.ssh`/`.pem` body matches no credential pattern.
- `O_NONBLOCK` refuses a swapped-in FIFO. Without it, an `O_RDONLY` open of a
  FIFO with no writer BLOCKS INDEFINITELY: the `S_ISREG` guard cannot help,
  because it only sees a descriptor the open already returned, so the agent's
  tool call would hang instead of being refused. It is a no-op for regular
  files.

On a platform without those flags (Windows) the open omits them and the defense
is the caller's pre-open `is_symlink` check plus the descriptor `fstat`
regular-file check -- the protection the bundle collector has always relied on,
so the kernel no-follow is a POSIX STRENGTHENING, not a Windows-only feature
whose absence disables the read.

**Output is bounded at two levels, and the second one is about which END gets
dropped.** Each source is byte-capped (a log tail is the shape that deadlocks a
pipe, so that bound is by BYTES; `tail` narrows lines within it but can never
raise it), and the whole assembled response is capped too. That second bound is
not belt-and-braces: every tool response leaves through
`validation.build_tool_response`, whose `sanitize_response` truncates the TAIL --
its own comment says so. For a log tail that is the worst end to lose, because
the newest lines are the entire reason the tool was called, and the transport's
`[response truncated]` marker reads like the OLDEST content was cut, which is the
universal `tail` convention. The agent would be misled about which end it lost
rather than merely short-changed. So the reader keeps its own output under a
ceiling below the transport's, divides that budget across sources before reading
(so mcp.log and lsp.log each contribute their own newest lines instead of the
first section being trimmed away entirely), trims from the FRONT, and labels the
drop as older output. `diagnostics` does not import the transport's ceiling CONSTANT: the two
ceilings are related by a test that imports both, so a change to either number
fails the build. `mcp_tools/skills.py` already bounds its own fields against the
same limit for the same reason, so this is an existing contract rather than a new
one. Output is then optionally `since`-filtered and run through the collector's
existing `_scrub` stack.

The MCP tool `kiro_cli_logs` (`mcp_tools/logs.py`) wraps it with the same
SEL-audited, validated, local-read shape as `skill_search`. Its model-facing
description states the exclusion rather than staying silent, so the agent does
not go looking for conversation content the reader will not return;
`test_tool_descriptor_does_not_advertise_the_chat_log` pins that the
advertisement matches the scope. `docs/architecture/mcp.md` gains the tool in
its Diagnostics inventory row, as AGENTS.md requires of the owning doc.

Redaction is what makes returning the remaining bytes safe, so this reuses the
EXACT existing stack rather than writing new patterns: `redact_exfiltration_urls`
then `redact_credentials` then `diagnostics._EXTRA_REDACTIONS` -- the last covers
the bearer token, mid-line `Authorization`/`Set-Cookie`/`x-api-key` headers, and
the `mc_token` cookie that the first two miss, with the over-redact-to-end-of-
line and optional-quotes reasoning preserved in that module's comments. No
second copy of those regexes exists to drift.

Built Class 2 with redaction. Deliberately did NOT take the weaker path
carve-out (it would need an upstream guarantee that the log subtree never holds
credentials, and exceptions on fail-safe gates are where bypasses come from).
Class 1 (the trust-root inventory capability) is untouched -- hence `Refs #6023`,
not a closing keyword.

## What tests we did

`test/test_kiro_cli_logs.py` (39 tests, run with `-n0`), plus the existing
`test_diagnostics.py`, `test_mcp_tool_registry.py`, `test_papyrus_tectonic.py`
and `test_pptx_maker_engine_source.py` green (360 passed together).

Two security properties, each with a mutation guard so a green run is
attributable to the code and not to the fixture:

- SCOPE. `test_chat_log_is_not_a_source` plants a POPULATED, discoverable
  `kiro-chat.log` next to a real protocol log and asserts the chat prose does not
  come back while the protocol log does -- so the assertion cannot pass merely
  because the reader found nothing. `test_session_transcripts_are_not_read` pins
  the same property for a populated `sessions/cli` dir.
- REDACTION. The suite feeds a synthetic log carrying all four secret shapes the
  issue names -- a bearer token, a mid-line `Authorization: Basic <b64>`, an
  `mc_token` cookie, and the serialized `"authorization": "..."` JSON form -- and
  asserts none survives. `test_redaction_is_load_bearing` then empties
  `_EXTRA_REDACTIONS` and asserts the SAME secrets leak, so the passing
  assertion is attributable to the stack doing the work.

The FIFO guard is verified by mutation, not by assertion alone:
`test_fifo_swapped_in_is_refused_without_hanging` plants a real FIFO past the
pre-open checks. With `O_NONBLOCK` removed from the flags the test HANGS and is
killed by timeout (measured: exit 124 at a 20s bound); with it, the test passes
in under a second. That is the finding reproduced and the fix shown to be
load-bearing.

The byte-boundary cut has its own pair, both mutation-verified. The tail window
is meant to start on a line boundary, because `_EXTRA_REDACTIONS` anchors on the
header NAME: a cut landing after `Authorization:` but before its value strips the
token that would have redacted it.
`test_oversized_single_line_returns_only_the_marker` builds the one arrangement
that reaches the no-boundary case -- a final line both longer than the cap AND
UNTERMINATED, which is a live log with a large frame partly flushed -- and asserts
only the marker comes back; with the fix reverted it fails on the leak.
`test_oversized_terminated_line_also_yields_no_fragment` pins the sibling case
(the window runs to EOF, so it contains the newline and the cut lands there), so
a later change cannot fix one and regress the other.
`test_since_drops_continuations_of_rejected_events` and
`test_since_keeps_the_truncation_marker` pin both halves of the continuation
rule: a continuation inherits its event's verdict, except ahead of the first
event where there is no verdict to inherit and the truncation marker lives.

The check-then-open window is closed by an IDENTITY MATCH, not only by
`O_NOFOLLOW`: `os.lstat` before the open and `os.fstat` after must report the same
`st_dev`/`st_ino`, which refuses both a final component that is a link and a swap
landing between the two calls. That is what defends Windows, where there is no
`O_NOFOLLOW` and where a junction is a reparse point `is_symlink` does not report
while still satisfying `S_ISREG`. `_usable_dir` already used the stronger
`is_link_or_junction` check for directories, so the file path is now consistent
with it. `test_read_log_tail_refuses_when_descriptor_identity_differs` pins it and
`test_read_log_tail_reads_when_identity_matches` pins that the ordinary case is
not rejected.

`max_bytes` bounds every branch, not only the truncating one. `size` is an `fstat`
snapshot, so a file appended to faster than the read drains never reaches EOF, and
a loop bounded only by EOF grows until the process is OOM-killed -- the
world-writable log directory being exactly where a local writer can arrange that.
`test_read_log_tail_bounds_a_growing_file` stubs a read that never returns empty,
so the byte budget is the only thing that can end the loop; without it the test
does not fail, it hangs.

Remaining coverage: byte cap bounds output regardless of `tail`; `tail` limits
line count; `since` filters by leading timestamp and keeps continuation lines; a
symlinked source is skipped; a sensitive-path source is refused; no-logs returns
a note. `test_toctou_symlink_swap_is_refused_by_nofollow` and
`test_read_log_tail_refuses_a_symlink_on_posix` prove the `O_NOFOLLOW` open
refuses a symlink swapped in past the pre-open checks, both gated to platforms
with the flag (a stated skip reason, since it is a POSIX guarantee).
`test_read_log_tail_reads_a_regular_file`, `test_reader_works_without_o_nofollow`
and `test_reader_works_without_o_nonblock` run everywhere -- the last two degrade
each flag to 0 to exercise the Windows path and guard against the tool silently
reading nothing when a flag is absent. Tests construct their own log world by
patching the source picker directly, so they do not depend on ambient
`XDG_RUNTIME_DIR`/`TMPDIR`.

Gates run locally, each redirected to a file and judged by its own exit code:
`check_black_formatting`, `isort --check-only`, `flake8`, `mypy` on the two
touched modules, `docs_lint.py --test`, `scripts/docs-lint.sh`,
`check_brand_name`, `check_feature_map`, `check_changelog_history`,
`check_testpaths_coverage`, `check_per_file_coverage --test`, `check_focus_cue`,
`check_harness_parity`, `check_subprocess_encoding`, `check_agent_sdk_boundary`,
`check_sync_io_in_async`, `check_loop_bound_locks`, `check_builtin_skill_scope`,
`check_lockdown_before_publish` -- all exit 0. Inclusive Language mirrored with
the pinned `woke` 0.19.0 (SHA256 verified against code-review.yml) over added
lines only: no findings. Black formatting the reader graduated `diagnostics.py`
off the repo's black baseline, so `.github/black-baseline.txt` prunes that one
entry (the black gate requires it; run via
`check_black_formatting.py --update-baseline`). No frontend files are touched.

## Any other suggestions on the work

`since` is kept. First Principles suggested deferring it on the grounds that a
rejected turn's evidence is at the log's end, which `tail` already returns. That
is true for the common case, but not when the agent needs the window around a
specific failure in a log that has since grown past the byte cap, which is the
case the filter exists for. It is a lexical prefix compare on the leading
timestamp, chosen over parsing every timestamp shape; a line with no
recognizable leading timestamp is KEPT, so a continuation line rides along with
its event and the failure direction is over-inclusion rather than silent drop.
Happy to drop it if a maintainer prefers the smaller schema.

Design Review's Watch on the protocol logs is answered by documenting the
dependency above rather than by narrowing further: there is no third source to
fall back to, and the reader would have nothing left to return. Confirming what
kiro-cli actually writes to mcp.log/lsp.log is a question for a human with the
kiro-cli source, and the documented assumption is what makes that question
askable later instead of forgotten.

The other two First Principles subtractions are taken: `_read_text_tail` is
deleted in favor of the single hardened reader, and the `max_bytes` parameter is
gone from `read_kiro_cli_logs` (it had one consumer that never passed it; tests
monkeypatch `_MAX_LOG_READ_BYTES`, which the function now reads at call time).

The review lanes should probe the redaction hard -- that is appropriate. The
reasoning is made explicit in the module docstring and the `_EXTRA_REDACTIONS`
comments rather than only here.

## Pattern harvest

One rule worth recording, because three lanes converged on it from different
directions: when a data source is a SINGLE SHARED FILE per host, redaction is
the wrong control and the source list is the right one. Scrubbing is a
per-pattern pass, so it can close a credential gap but never a
conversation-content gap; if the boundary being crossed is between sessions
rather than between a user and a file, the only sound answer is to not read the
source. The corollary is that the asymmetry between an agent-callable tool and a
user-triggered bundle over the SAME file is principled, not an inconsistency:
the bundle is user-to-user, the tool is cross-session.

The rest is not generalizable: this is a single-purpose reader that reuses the
diagnostics collector's redaction stack and source pickers, and the reusable
pieces (`_scrub`, `_EXTRA_REDACTIONS`, the symlink/`is_sensitive_path` guards)
already existed and were reused rather than reinvented.

Refs #6023








