### PR TITLE
fix(dashboard): make the skill-bundle link defence see a Windows junction

### DIFF
--- a/src/kiro_crew/dashboard/handlers/discover.py
+++ b/src/kiro_crew/dashboard/handlers/discover.py
@@ -17,6 +17,7 @@ import shutil
 
 from aiohttp import web
 
+from kiro_crew import platform_compat
 from kiro_crew.dashboard.handlers._shared import _get_skills
 from kiro_crew.frontmatter import SKILL_LOADER, parse_frontmatter
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -476,15 +477,26 @@ async def api_skills_discover_install(request: web.Request) -> web.Response:
                     "Refusing bundle install outside skills root: %s", skill_dir
                 )
                 return 0
-            # Symlink defense: if the skill dir itself is a symlink, every
-            # containment check below resolves against the symlink TARGET, so
-            # a pre-planted link would redirect the whole bundle write outside
-            # the skills root (nested rel_paths traverse it via mkdir, and the
-            # parent-symlink guard below misses not-yet-existing parents).
-            # Remove the link itself — never follow it.
-            if skill_dir.is_symlink():
-                logger.warning("Replacing symlinked skill dir: %s", skill_dir)
-                skill_dir.unlink()
+            # Link defense: if the skill dir itself is a link, every containment
+            # check below resolves against the link TARGET, so a pre-planted one
+            # would redirect the whole bundle write outside the skills root
+            # (nested rel_paths traverse it via mkdir, and the parent-symlink
+            # guard below misses not-yet-existing parents). Remove the link
+            # itself — never follow it.
+            #
+            # `is_symlink`/`unlink` cover only half of that on Windows, where a
+            # DIRECTORY symlink needs SeCreateSymbolicLinkPrivilege but a
+            # junction needs none — so the junction is the shape an unprivileged
+            # process can actually plant, and `is_symlink` reports False for it.
+            # The defence then never fires and `shutil.rmtree` below REFUSES a
+            # junction just as it refuses a symlink, raising out of the
+            # `asyncio.to_thread` call, which has no `except` in scope.
+            # `unlink_link_or_junction` detaches a junction with `rmdir`, so the
+            # target's contents are left alone exactly as `unlink` leaves a
+            # symlink's.
+            if platform_compat.is_link_or_junction(skill_dir):
+                logger.warning("Replacing linked skill dir: %s", skill_dir)
+                platform_compat.unlink_link_or_junction(skill_dir)
             # Overwrite semantics: clear the previous install first so stale
             # files from an older bundle version don't linger. The user
             # explicitly consented via the 409 -> overwrite flow.

--- a/test/test_skill_discover.py
+++ b/test/test_skill_discover.py
@@ -21,6 +21,9 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from conftest import make_dir_link
+from kiro_crew import platform_compat
+
 
 @pytest.fixture
 def fake_home(tmp_path, monkeypatch):
@@ -250,6 +253,91 @@ class TestDiscoverInstall:
             assert (link / "SKILL.md").exists()
             # ...and NOTHING landed at the old symlink target.
             assert list(outside.iterdir()) == []
+        finally:
+            await client.close()
+
+    async def test_install_overwrite_replaces_junctioned_skill_dir(
+        self, fake_home, reset_registry, tmp_path
+    ):
+        """The same regression as the test above, spelled the way Windows spells it.
+
+        `skill_dir.is_symlink()` is False for a junction, so the leaf-link defence
+        never fires. With `overwrite=True` the next line is
+        `shutil.rmtree(skill_dir)`, and `rmtree` REFUSES a junction exactly as it
+        refuses a symlink — an uncaught `OSError` out of
+        `asyncio.to_thread(_write_bundle)`, which has no `except` in scope.
+
+        A junction is not an exotic spelling of this layout: a *directory* symlink
+        on Windows needs `SeCreateSymbolicLinkPrivilege`, a junction needs none, so
+        it is the shape an unprivileged process can actually plant.
+        """
+        client, skills_dir = await self._client(fake_home)
+        try:
+            outside = tmp_path / "outside-target"
+            outside.mkdir()
+            provider_dir = skills_dir / "fakeprov"
+            provider_dir.mkdir(parents=True, exist_ok=True)
+            link = provider_dir / "fake-skill"
+            make_dir_link(link, outside)
+
+            # Guard the guard, through an oracle OUTSIDE the module under test:
+            # if this were an ordinary directory the test would prove nothing.
+            assert platform_compat.is_link_or_junction(link)
+            assert link.exists(), "the link must be followable, or rmtree never runs"
+
+            resp = await client.post(
+                "/api/skills/-/discover/install",
+                json={
+                    "provider": "fakeprov",
+                    "skill_id": "fake-skill",
+                    "overwrite": True,
+                },
+            )
+            assert resp.status == 200
+            assert not platform_compat.is_link_or_junction(link)
+            assert (link / "SKILL.md").exists()
+            # ...and NOTHING landed at the old link target.
+            assert list(outside.iterdir()) == []
+        finally:
+            await client.close()
+
+    async def test_the_junctions_target_survives_being_replaced(
+        self, fake_home, reset_registry, tmp_path
+    ):
+        """Removing the link must not remove what it pointed at.
+
+        This is the property `unlink_link_or_junction` exists for and the reason
+        the defence cannot simply be `shutil.rmtree`: a junction is a directory
+        reparse point, so it is unlinked with `rmdir` — which detaches the
+        junction and never touches the target's contents.
+
+        The sibling test above proves nothing was WRITTEN outside the root; this
+        one proves nothing was DELETED outside it either.
+        """
+        client, skills_dir = await self._client(fake_home)
+        try:
+            outside = tmp_path / "outside-target"
+            outside.mkdir()
+            bystander = outside / "keep-me.txt"
+            bystander.write_text("not ours to delete", encoding="utf-8")
+            provider_dir = skills_dir / "fakeprov"
+            provider_dir.mkdir(parents=True, exist_ok=True)
+            link = provider_dir / "fake-skill"
+            make_dir_link(link, outside)
+            assert platform_compat.is_link_or_junction(link)
+
+            resp = await client.post(
+                "/api/skills/-/discover/install",
+                json={
+                    "provider": "fakeprov",
+                    "skill_id": "fake-skill",
+                    "overwrite": True,
+                },
+            )
+            assert resp.status == 200
+            assert bystander.read_text(encoding="utf-8") == "not ours to delete"
+            assert (link / "SKILL.md").exists()
+            assert not (outside / "SKILL.md").exists()
         finally:
             await client.close()
 


### PR DESCRIPTION
## Problem / Motivation

`_write_bundle` in `dashboard/handlers/discover.py` (the skill-bundle install path)
opens with a deliberate leaf-link defence, and its comment states the reason:

```python
# Symlink defense: if the skill dir itself is a symlink, every
# containment check below resolves against the symlink TARGET ...
# Remove the link itself — never follow it.
if skill_dir.is_symlink():
    skill_dir.unlink()
```

`is_symlink()` is False for a **Windows junction** — and the junction is precisely
the shape that matters here, because a *directory* symlink on Windows needs
`SeCreateSymbolicLinkPrivilege` while a junction needs none. So the shape an
unprivileged process can actually plant is the one the defence does not see.

With the defence inert, the very next line runs:

```python
if overwrite and skill_dir.exists():   # exists() follows the junction → True
    shutil.rmtree(skill_dir)           # rmtree REFUSES a junction
```

`shutil.rmtree` treats a junction as a link exactly as it treats a symlink
(`_rmtree_islink` matches `IO_REPARSE_TAG_MOUNT_POINT` on Windows) and raises.
`_write_bundle` runs under `await asyncio.to_thread(_write_bundle)` with **no
`except` in scope**, so the `OSError` leaves the handler uncaught.

**Measured** against unpatched `origin/main`, driving the real
`POST /api/skills/-/discover/install` endpoint with a real
`_winapi.CreateJunction` junction:

```
AssertionError: assert 500 == 200
  ...
  raise OSError("Cannot call rmtree on a symbolic link")
OSError: Cannot call rmtree on a symbolic link
```

## Why it matters

**Graded honestly: this is a dead defence-in-depth layer plus a 500, NOT a
containment escape.** The layer below still holds — `skill_dir.resolve()` follows
the junction and the `relative_to(skills_root)` check refuses — so nothing is
written outside the skills root either way. That is stated up front so the
severity is not read as higher than it is.

What is actually broken is that the install becomes **unrecoverable through the
UI**. Without `overwrite` the request answers `409 exists` (the junction makes
`skill_dir.exists()` true), and the documented way out of a 409 is to retry with
`overwrite: true` — which is the branch that 500s. A user who lands on a junctioned
skill dir has no path forward from the dashboard, and the response they get is an
unhandled server error rather than anything actionable.

## What changed (motivation → approach → change)

*Symptom:* a junctioned skill dir makes bundle install answer 500.
*Root cause:* the leaf-link defence asks `is_symlink()`, which does not report a
junction, so the link is never removed and the `rmtree` below inherits it.
*Change:* route the defence through the repo's canonical pair.

```python
if platform_compat.is_link_or_junction(skill_dir):
    logger.warning("Replacing linked skill dir: %s", skill_dir)
    platform_compat.unlink_link_or_junction(skill_dir)
```

**The unlink half matters as much as the predicate.** The obvious "fix" — reaching
for `shutil.rmtree` once the junction is detected — would delete *through* it.
`unlink_link_or_junction` detaches a junction with `rmdir`, which removes the
reparse point and leaves the target's contents alone, exactly as `unlink` leaves a
symlink's. Both properties are asserted.

Scope kept to that one guard. The per-file `file_path.parent.is_symlink()` check
further down is **deliberately not touched**: the `file_path.resolve().relative_to(
resolved_root)` check immediately above it already resolves the whole parent chain,
junctions included, so that guard is genuinely belt-and-suspenders and changing it
would be a swap with no behaviour behind it.

`platform_compat` is imported (one line); no other import path grew.

## Tests

`test/test_skill_discover.py`, two tests added to `TestDiscoverInstall`, siblings of
the existing `test_install_overwrite_replaces_symlinked_skill_dir`:

| Test | Locks in |
|---|---|
| `test_install_overwrite_replaces_junctioned_skill_dir` | the junction is removed rather than followed; the install returns 200 and lands **inside** the skills root; nothing is written at the old target |
| `test_the_junctions_target_survives_being_replaced` | a bystander file inside the junction's target is still readable afterwards — the link was detached, not deleted through |

The links use `conftest.make_dir_link`, which yields a real junction on Windows, so
the platform the blind spot lives on is exercised rather than skipped.

**Guard-the-guard.** Each test asserts the planted shape through an oracle before
asserting anything about the handler: `platform_compat.is_link_or_junction(link)` is
true, and `link.exists()` is true (if it were not followable, `rmtree` would never
run and the test would pass for the wrong reason).

The second test's property is distinct from the first's on purpose: the first proves
nothing was **written** outside the root, the second proves nothing was **deleted**
outside it.

**Red-before, measured on unpatched `origin/main`:** `2 failed`, both
`assert 500 == 200`, with `OSError: Cannot call rmtree on a symbolic link` in the
captured server log. After the fix: `test_skill_discover.py` is **21 passed, 1
skipped**, and the sibling `test_discover_handlers_cov80.py` is **35 passed**.

Gates on this head: `flake8` clean, `isort --check-only` clean, `mypy --platform
linux` reports nothing in `discover.py`, black and subprocess-encoding gates both
pass scoped `origin/main...HEAD` (2 files). Both touched files are in
`.github/black-baseline.txt` and were deliberately **not** reformatted.

## Manual verification

N/A — unit coverage sufficient: the tests drive the real HTTP endpoint through
`aiohttp`'s test client against a real junction on the affected platform, which is
the same path the dashboard uses.

## Related Issues

None — found by inspection while auditing `is_symlink`-based defences for the
Windows junction blind spot, the same family as #7881.

## Pattern harvest

Rule candidate: `semgrep`
Pattern: `is_symlink()`/`os.path.islink()` used as a *link defence* immediately
above a `shutil.rmtree` — on Windows the predicate misses a junction while `rmtree`
still refuses one, so the guard silently stops guarding and the refusal it was meant
to prevent surfaces as an unhandled `OSError`. The pair
`platform_compat.is_link_or_junction` / `unlink_link_or_junction` already exists for
exactly this; a grep for `islink`/`is_symlink` within a few lines of `rmtree` finds
the remaining sites.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
