### PR TITLE
test(release): skip the assembly-step tests where bash cannot run the step

### DIFF
--- a/test/test_release_macos_fail_closed.py
+++ b/test/test_release_macos_fail_closed.py
@@ -24,9 +24,54 @@ import yaml
 
 from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
+
+def _bash_can_run_the_assembly_step() -> bool:
+    """Whether this host's ``bash`` is close enough to ubuntu-latest's to mean anything.
+
+    The step uses ``mapfile``, a bash **4+** builtin, and these tests execute it for
+    real. macOS ships ``/bin/bash`` 3.2.57, where the step dies with
+    ``mapfile: command not found`` -- so on a Mac four of these tests failed while
+    testing nothing, and the ``os.name == "nt"`` guard they replaced did not catch it
+    even though its own reason named ubuntu-latest.
+
+    A capability probe rather than ``sys.platform != "darwin"``: a Mac with a bash 4+
+    first on PATH runs the step faithfully and keeps the coverage. ``os.name == "nt"``
+    is kept as well, so no platform that skipped before starts running these now.
+    """
+    try:
+        probe = subprocess.run(
+            ["bash", "-c", "type -t mapfile"],
+            capture_output=True,
+            check=False,
+            # A CONSTRUCTED environment, not the inherited one. `pytestmark` runs
+            # this at COLLECTION time, and conftest.py's
+            # `_scrub_inherited_preload_env` is function-scoped, so it has not run
+            # yet -- this is the only bash in this file outside that protection.
+            # An inherited `BASH_ENV` is a file bash SOURCES before it reaches
+            # `type -t mapfile`, and that fixture's own docstring treats such a
+            # variable as ordinary host state ("a login profile exporting
+            # BASH_ENV, or a container image setting it"), not an exotic one.
+            #
+            # `PATH` is passed on deliberately and is the only thing passed on:
+            # this is a capability probe, so a Mac with bash 4+ first on PATH has
+            # to be discovered, and PATH selects which program runs rather than
+            # supplying code for it to run. The literal fallback avoids
+            # `os.defpath`, whose leading empty entry would put the working
+            # directory on the search path.
+            env={"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
+            **UTF8_TEXT,
+        )
+    except OSError:
+        return False  # no bash on PATH at all
+    return probe.returncode == 0 and (probe.stdout or "").strip() == "builtin"
+
+
 pytestmark = pytest.mark.skipif(
-    os.name == "nt",
-    reason="the GitHub Release assembly step runs under bash on ubuntu-latest",
+    os.name == "nt" or not _bash_can_run_the_assembly_step(),
+    reason=(
+        "the GitHub Release assembly step runs under bash on ubuntu-latest; this host "
+        "has no bash providing mapfile (a bash 4+ builtin the step uses)"
+    ),
 )
 
 ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
Fixes one of the four root causes in #9060 — the one that is entirely a test-guard problem, so it stands alone.

## Problem / Motivation

`test_release_macos_fail_closed.py` executes the release workflow's assembly step for real. That step uses `mapfile`, a bash **4+** builtin. The guard was:

```python
pytestmark = pytest.mark.skipif(
    os.name == "nt",
    reason="the GitHub Release assembly step runs under bash on ubuntu-latest",
)
```

The reason names **ubuntu-latest**; the condition only excludes **Windows**. macOS is `os.name == "posix"`, so on a Mac all twelve tests run against `/bin/bash` 3.2.57 and four of them die before reaching any assertion:

```
AssertionError: bash: line 130: mapfile: command not found
```

Measured on pristine `main` (`5bb7728ca`), macOS 15 arm64, Python 3.12.12 — the version `backend-test-macos` pins: **4 failed, 8 passed**.

## Why it matters

The shipped release path is fine — `github-release` runs on `ubuntu-latest` with bash 5. Nothing about the product is broken here. What is broken is the signal a contributor gets: four red tests, on a file they did not touch, whose failure text points at a workflow line rather than at their change. `Gateway Tests (macOS)` runs exactly one test, so CI cannot show them that this is pre-existing. I hit it myself and spent a while assuming it was mine.

## What changed (motivation → approach → change)

**A capability probe, not a platform check.** `sys.platform != "darwin"` would have worked for the failure I saw and been wrong in general: a Mac with a bash 4+ first on PATH runs the step faithfully and should keep the coverage. The probe asks the question the guard actually cares about — can this host's `bash` run the step at all:

```python
probe = subprocess.run(["bash", "-c", "type -t mapfile"], capture_output=True, check=False, **UTF8_TEXT)
return probe.returncode == 0 and (probe.stdout or "").strip() == "builtin"
```

`OSError` (no `bash` on PATH) returns False rather than raising at import time.

**`os.name == "nt"` is retained.** Git Bash on Windows would satisfy the probe, so dropping the Windows clause would start running these tests on a platform that has skipped them since they were written. That is a separate decision and not this PR's to make, so the guard is the union.

## Tests

Verified in **both** directions, on two hosts:

| host | `bash` | pristine `main` | with this change |
|---|---|---|---|
| macOS 15 arm64 | 3.2.57 | **4 failed**, 8 passed | **12 skipped** |
| Amazon Linux 2023 x86_64 | 5.2.15 (`mapfile: builtin`) | 12 passed | **12 passed** |

So the change is behaviour-neutral where the step can run, and converts four uninterpretable reds into skips with a reason where it cannot.

**Mutation:** forcing the probe to `return True` on the Mac brings the same four failures straight back (`4 failed, 8 passed`), so the guard is load-bearing rather than decorative. I did not add a test that pins the guard itself — a probe of the host's own `bash` cannot be asserted on portably, and a test that mocked the probe would only be testing `skipif`.

## Cost, stated rather than hidden

The eight tests that passed on bash 3.2 passed for a real reason: they assert the step's **early** fail-closed checks, which execute fine before line 130. Because `pytestmark` is module-level, they now skip too — so this trades eight real assertions on macOS for four honest skips.

A per-test marker on just the four that reach `mapfile` would keep them. I did not do that because it needs an owner's judgement on which of those assertions are *meant* to hold under an older bash, and encoding my guess as a marker would be worse than flagging it. Say the word and I will split it.

I also considered having the harness shim `mapfile` in when absent, and rejected it: these tests exist so that the assembly step's fail-closed behaviour cannot silently regress, and a shimmed run would be exercising a script that never ships.

## Manual verification

No line exceeds the 100-column limit. `ruff` is not installed in either environment I had, so formatting was checked by hand against `line-length = 100` rather than by the tool — worth a reviewer's eye.

## Related Issues

Refs #9060 (the other three root causes there are untouched by this PR: ACL preservation on Darwin, the `/private/tmp` realpath group, and the `test_prompts` durability-ordering pair).
