### PR TITLE
fix(channels): retain dismissal for terminal members

### DIFF
--- a/website/src/pages/ChannelPage.tsx
+++ b/website/src/pages/ChannelPage.tsx
@@ -284,7 +284,7 @@ function AgentControlRow({ agent, onDismiss, onListenChange, onClearContext }: {
         </div>
       </div>
       {alive && <Btn onClick={onClearContext} aria-label={i18nT('pages.channelPage.clear_context')} title={i18nT('pages.channelPage.clear_context')}><RotateCcw className="lucide-inline" /></Btn>}
-      {alive && <Btn onClick={onDismiss} aria-label={i18nT('pages.channelPage.dismiss')} danger title={i18nT('pages.channelPage.dismiss')}><X className="lucide-inline" /></Btn>}
+      <Btn onClick={onDismiss} aria-label={i18nT('pages.channelPage.dismiss')} danger title={i18nT('pages.channelPage.dismiss')}><X className="lucide-inline" /></Btn>
     </div>
   )
 }

--- a/website/src/test/ChannelPageCoverage.test.tsx
+++ b/website/src/test/ChannelPageCoverage.test.tsx
@@ -481,17 +481,22 @@ describe('ChannelPage — agents sidebar', () => {
     await userEvent.click(screen.getByTitle('Dismiss'))
     await waitFor(() => expect(vi.mocked(api).channelDismissAgent)
       .toHaveBeenCalledWith('ch1', 'a1'))
-    // A dismissed agent is `done`, so its row loses both action buttons.
-    await waitFor(() => expect(screen.queryByTitle('Dismiss')).not.toBeInTheDocument())
-  })
-
-  it('hides the row actions for an already-finished agent', async () => {
-    mockApi([channelOf({ members: { a1: member({ state: 'failed' }) } })])
-    await renderPage()
-    await openAgentsPanel()
-    expect(screen.queryByTitle('Dismiss')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getByTitle('Dismiss')).toBeInTheDocument())
     expect(screen.queryByTitle('Clear context')).not.toBeInTheDocument()
   })
+
+  it.each(['done', 'failed'] as const)(
+    'allows dismissing a terminal %s agent but not clearing its context',
+    async state => {
+      mockApi([channelOf({ members: { a1: member({ state }) } })])
+      await renderPage()
+      await openAgentsPanel()
+      await userEvent.click(screen.getByTitle('Dismiss'))
+      await waitFor(() => expect(vi.mocked(api).channelDismissAgent)
+        .toHaveBeenCalledWith('ch1', 'a1'))
+      expect(screen.queryByTitle('Clear context')).not.toBeInTheDocument()
+    },
+  )
 
   it('closes the agents sidebar again', async () => {
     await renderPage()


### PR DESCRIPTION
## Problem / Motivation

The channel UI hides both actions for `done` and `failed` members, even though backend dismissal remains valid.

## Why it matters

Terminal members remain stranded in the channel UI and cannot be removed.

## What changed

Keep Dismiss available for every member while retaining Clear Context only for live members. No backend authority behavior changes.

## Pattern harvest

Rule candidate: independently authorized cleanup controls should not inherit unrelated liveness gating.

## Tests

`npx vitest run src/test/ChannelPageCoverage.test.tsx` — 69 passed; `npx tsc -b` and `npm run build` pass.