### PR TITLE
fix(workflows): bootstrap the platform context

### DIFF
--- a/src/kiro_crew/apps/builtins/workflows/server.py
+++ b/src/kiro_crew/apps/builtins/workflows/server.py
@@ -31,7 +31,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
 from kiro_crew.apps.proxy_auth import verify_proxy_request
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.platform import boot_platform, redact_via_context
 from kiro_crew.workflows.runner import WorkflowRunner
 from kiro_crew.workflows.validate import validate
 
@@ -48,9 +49,7 @@ def _redact_obj(obj: Any) -> Any:
     ``_send`` so every response surface is covered.
     """
     if isinstance(obj, str):
-        s, _ = redact_exfiltration_urls(obj)
-        s, _ = redact_credentials(s)
-        return s
+        return redact_via_context(obj)
     if isinstance(obj, list):
         return [_redact_obj(x) for x in obj]
     if isinstance(obj, dict):
@@ -226,6 +225,9 @@ class _Handler(BaseHTTPRequestHandler):
 
 
 def main() -> None:
+    # This backend is a separate process, so it must compose the platform before
+    # serving any workflow output or reaching a platform-aware security control.
+    boot_platform(KiroCrewConfig.load())
     logging.basicConfig(level=logging.INFO)
     server = ThreadingHTTPServer(("127.0.0.1", PORT), _Handler)
     logger.info("workflows app backend on 127.0.0.1:%d", PORT)

--- a/test/test_workflows_app.py
+++ b/test/test_workflows_app.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import json
 import os
 
+import pytest
+
 from kiro_crew.apps.builtins.workflows.server import (
     handle_examples,
     handle_run,
@@ -196,6 +198,22 @@ def test_redact_obj_scrubs_credentials_and_exfil_urls_in_run_payload() -> None:
     assert out["events"][0]["type"] == "log"
 
 
+def test_redact_obj_routes_every_string_through_platform_context(monkeypatch) -> None:
+    """Responses must use the composed credential policy, including mapping keys."""
+    from kiro_crew.apps.builtins.workflows import server
+
+    seen: list[str] = []
+
+    def _redact(value: str) -> str:
+        seen.append(value)
+        return f"context:{value}"
+
+    monkeypatch.setattr(server, "redact_via_context", _redact)
+
+    assert server._redact_obj({"key": ["value"]}) == {"context:key": ["context:value"]}
+    assert seen == ["key", "value"]
+
+
 def test_handler_send_redacts_before_writing_to_the_wire() -> None:
     """The fix is wired centrally in _Handler._send, so EVERY response surface is
     redacted. Drive _send with fakes (no socket bound) and assert the bytes
@@ -224,3 +242,55 @@ def test_handler_send_redacts_before_writing_to_the_wire() -> None:
     assert _PLANTED_URL not in wire
     assert "[REDACTED: credential]" in wire
     assert "[REDACTED: suspicious URL" in wire
+
+
+# --------------------------------------------------------------------------- #
+# Process entrypoint
+# --------------------------------------------------------------------------- #
+
+
+def test_main_boots_platform_before_binding_server(monkeypatch) -> None:
+    """The app process must compose security before accepting workflow requests."""
+    from types import SimpleNamespace
+
+    from kiro_crew.apps.builtins.workflows import server
+
+    calls: list[str] = []
+
+    def _boot(_cfg) -> None:
+        calls.append("boot")
+
+    class _FakeServer:
+        def __init__(self, *args, **kwargs) -> None:
+            calls.append("bind")
+
+        def serve_forever(self) -> None:
+            calls.append("serve")
+
+    monkeypatch.setattr(server, "boot_platform", _boot)
+    monkeypatch.setattr(server.KiroCrewConfig, "load", classmethod(lambda cls: SimpleNamespace()))
+    monkeypatch.setattr(server, "ThreadingHTTPServer", _FakeServer)
+
+    assert server.main() is None
+    assert calls == ["boot", "bind", "serve"]
+
+
+def test_main_fails_closed_when_platform_cannot_compose(monkeypatch) -> None:
+    """A failed composition must not expose the backend with baseline policy."""
+    from kiro_crew.apps.builtins.workflows import server
+    from kiro_crew.platform.context import PlatformCompositionError
+
+    def _boom(_cfg) -> None:
+        raise PlatformCompositionError("companion missing")
+
+    served: list[str] = []
+    monkeypatch.setattr(server, "boot_platform", _boom)
+    monkeypatch.setattr(
+        server,
+        "ThreadingHTTPServer",
+        lambda *args, **kwargs: served.append("bind"),
+    )
+
+    with pytest.raises(PlatformCompositionError):
+        server.main()
+    assert served == []


### PR DESCRIPTION
## Problem / Motivation

The standalone Workflows backend serves workflow-derived output without composing the platform context used by platform security and redaction controls.

## Why it matters

A separate backend must apply the same composed policy before it exposes workflow output.

## What changed

Boot the platform before binding the server and route response redaction through the platform context. Startup fails before binding if composition fails.

## Pattern harvest

Rule candidate: every standalone backend must compose platform policy before serving data through platform-aware controls.

## Tests

`python -m pytest test/test_workflows_app.py -n0 -q` — 17 passed. Import/lint/diff checks pass; mypy reaches an unchanged Python 3.14/typeshed error in `cli.py`.

## What changed (motivation → approach → change)

N/A — covered by the existing `## What changed` section.

## Manual verification

N/A — focused automated coverage is sufficient.

## Related Issues

N/A.

## Checklist

- [x] Existing tests pass and regression coverage is included.
- [x] Self-review completed; code follows project style guidelines.
- [x] Documentation updated where applicable.
- [x] No secrets, credentials, or internal references in the diff.

## Contribution License Agreement

N/A — template placeholder; no CLA wording is supplied.
