### PR TITLE
fix(seed): apply the $KIROCREW_HOME link guardrails to a Windows junction

### DIFF
--- a/src/kiro_crew/seed.py
+++ b/src/kiro_crew/seed.py
@@ -518,10 +518,10 @@ def seed(fixture_name: str, *, replace: bool = False) -> None:
         # populated-symlink case is the "rmtree would follow the link"
         # risk the name calls out; ``GUARDRAIL_SYMLINK_EMPTY`` distinguishes
         # the empty-symlink branch below.
-        if dst.is_symlink():
+        if pinned_fs.is_reparse_point(dst):
             raise SeedError(
-                f"refusing to seed into a symlinked $KIROCREW_HOME: {dst}. "
-                "Point it at a real directory.",
+                f"refusing to seed into a symlinked or junctioned "
+                f"$KIROCREW_HOME: {dst}. Point it at a real directory.",
                 guardrail=SeedError.GUARDRAIL_SYMLINK_REPLACE,
             )
         if not replace:
@@ -531,7 +531,7 @@ def seed(fixture_name: str, *, replace: bool = False) -> None:
                 guardrail=SeedError.GUARDRAIL_NON_EMPTY,
             )
         shutil.rmtree(dst)
-    elif dst.exists() and dst.is_symlink():
+    elif dst.exists() and pinned_fs.is_reparse_point(dst):
         # Empty-but-existing symlink: ``shutil.copytree(src, dst)`` would
         # raise ``FileExistsError`` with a raw message because the symlink
         # itself exists as a path. Previously this fell through to the
@@ -541,8 +541,8 @@ def seed(fixture_name: str, *, replace: bool = False) -> None:
         # a symlink-empty guardrail so the same symlink-is-dangerous message
         # pattern applies whether the link target is empty or populated.
         raise SeedError(
-            f"refusing to seed into a symlinked $KIROCREW_HOME: {dst}. "
-            "Point it at a real directory.",
+            f"refusing to seed into a symlinked or junctioned "
+            f"$KIROCREW_HOME: {dst}. Point it at a real directory.",
             guardrail=SeedError.GUARDRAIL_SYMLINK_EMPTY,
         )
     elif dst.exists():

--- a/test/test_seed.py
+++ b/test/test_seed.py
@@ -15,7 +15,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from conftest import requires_symlinks
+from conftest import make_dir_link, requires_symlinks
+from kiro_crew import pinned_fs
 from kiro_crew import seed as seed_mod
 
 # A test here spawns a real `python -m kiro_crew gateway --help` child interpreter;
@@ -913,6 +914,95 @@ def test_seed_regular_file_target_rejected(
     # Original file must NOT be touched (no rmtree, no copy).
     assert target_file.is_file()
     assert target_file.read_text(encoding="utf-8") == "some stale log the user left behind"
+
+
+def test_seed_refuses_a_junctioned_nonempty_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same guardrail as the symlink test above, on the platform it is reachable.
+
+    Every existing guardrail test here is `@requires_symlinks`, so on Windows —
+    where a *directory* symlink needs SeCreateSymbolicLinkPrivilege — none of
+    them run. A JUNCTION needs no privilege, so `mklink /J` is how a Windows
+    user actually puts `$KIROCREW_HOME` on another drive, and `is_symlink()` is
+    False for one.
+
+    Without the fix that user gets the exact two-step dead end this branch was
+    hoisted to prevent: `GUARDRAIL_NON_EMPTY` says "pass --seed-replace", and
+    doing so reaches `shutil.rmtree`, which refuses a junction just as it
+    refuses a symlink — an `OSError` surfacing as EXIT_IO_ERROR rather than the
+    actionable "point it at a real directory".
+    """
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    (real_dir / "existing.txt").write_text("already here", encoding="utf-8")
+    link = tmp_path / "link"
+    make_dir_link(link, real_dir)
+    # Guard the guard, via an oracle outside the module under test.
+    assert pinned_fs.is_reparse_point(link)
+    assert link.exists() and any(link.iterdir())
+    monkeypatch.setenv("KIROCREW_HOME", str(link))
+
+    with pytest.raises(seed_mod.SeedError) as excinfo:
+        seed_mod.seed("empty")  # NO replace=True
+
+    assert excinfo.value.code == seed_mod.EXIT_GUARDRAIL
+    assert excinfo.value.guardrail == seed_mod.SeedError.GUARDRAIL_SYMLINK_REPLACE
+    assert (real_dir / "existing.txt").read_text(encoding="utf-8") == "already here"
+
+
+def test_seed_replace_refuses_a_junctioned_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--seed-replace` must refuse, not reach `rmtree`, on a junctioned home."""
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    (real_dir / "precious.txt").write_text("must survive", encoding="utf-8")
+    link = tmp_path / "link"
+    make_dir_link(link, real_dir)
+    assert pinned_fs.is_reparse_point(link)
+    monkeypatch.setenv("KIROCREW_HOME", str(link))
+
+    with pytest.raises(seed_mod.SeedError) as excinfo:
+        seed_mod.seed("empty", replace=True)
+
+    assert excinfo.value.code == seed_mod.EXIT_GUARDRAIL
+    assert "symlinked" in str(excinfo.value)
+    assert (real_dir / "precious.txt").read_text(encoding="utf-8") == "must survive"
+
+
+def test_seed_refuses_an_EMPTY_junctioned_home_instead_of_detaching_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The empty branch is the one that fails SILENTLY, and destructively.
+
+    For an empty *symlink* the code raises `GUARDRAIL_SYMLINK_EMPTY`. For an
+    empty *junction* both link checks are False, so control reaches
+    `elif dst.exists(): dst.rmdir()` — and `os.rmdir` on a junction DETACHES
+    THE JUNCTION (that is exactly how `unlink_link_or_junction` removes one).
+    The fixture is then seeded into a fresh real directory at that path, and the
+    user's redirection to another drive is gone without a word.
+
+    So this is not only a worse error message than the symlink case: it is the
+    opposite outcome. The refusal must fire for both shapes.
+    """
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()  # empty
+    link = tmp_path / "link"
+    make_dir_link(link, real_dir)
+    assert pinned_fs.is_reparse_point(link)
+    assert not any(link.iterdir())
+    monkeypatch.setenv("KIROCREW_HOME", str(link))
+
+    with pytest.raises(seed_mod.SeedError) as excinfo:
+        seed_mod.seed("empty")
+
+    assert excinfo.value.code == seed_mod.EXIT_GUARDRAIL
+    assert excinfo.value.guardrail == seed_mod.SeedError.GUARDRAIL_SYMLINK_EMPTY
+    # The link is still a link, still pointing where the user put it...
+    assert pinned_fs.is_reparse_point(link)
+    # ...and nothing was seeded through it.
+    assert list(real_dir.iterdir()) == []
 
 
 @requires_symlinks


### PR DESCRIPTION
## Problem / Motivation

`seed._resolve_dst` refuses to seed into a linked `$KIROCREW_HOME`, and its own
comment gives the reason:

> The downstream ``rmtree`` would follow the link and delete the link target; even
> the ``--replace``-less path leads the user into a dead end.

Both checks ask `dst.is_symlink()`, which is False for a **Windows junction**. That
is the shape that matters here: a *directory* symlink on Windows needs
`SeCreateSymbolicLinkPrivilege`, while `mklink /J` needs none — so putting
`$KIROCREW_HOME` on another drive is something a Windows user does with a junction,
not a symlink. This is an ordinary supported configuration, not a planted one.

Three consequences, all **measured on unpatched `origin/main`** with a real
`_winapi.CreateJunction` junction:

**1. Non-empty, without `--seed-replace`** — fires `GUARDRAIL_NON_EMPTY`:

```
AssertionError: assert 'non_empty' == 'symlink_replace'
```

Its advice is *"Pass --seed-replace to wipe it and re-seed"*. That is precisely the
two-step dead end the symlink check was hoisted above this branch to prevent — the
existing `test_seed_refuses_symlinked_nonempty_target_without_replace` calls it out
by name as a review-bot regression guard. It is restored in full for junctions.

**2. Non-empty, with `--seed-replace`** — reaches `shutil.rmtree`:

```
OSError: Cannot call rmtree on a symbolic link
```

`rmtree` refuses a junction exactly as it refuses a symlink, so the harm the comment
names (deleting the link target) does **not** occur — but the user gets
`EXIT_IO_ERROR` with that text instead of the actionable *"point it at a real
directory"*.

**3. Empty — and this one is the opposite outcome, not a worse message.**

```
Failed: DID NOT RAISE <class 'kiro_crew.seed.SeedError'>
```

Both link checks are False, so control falls to `elif dst.exists(): dst.rmdir()` —
and `os.rmdir` on a junction **detaches the junction** (that is exactly how
`platform_compat.unlink_link_or_junction` removes one). Nothing raises. The user's
redirection to another drive is silently removed, and the fixture is seeded into a
fresh real directory at that path. For a symlink the same situation raises
`GUARDRAIL_SYMLINK_EMPTY` and refuses.

## Why it matters

Case 3 is a silent, destructive divergence: two link shapes that are
interchangeable from the user's point of view produce a refusal and a quiet
reconfiguration respectively. The user's `$KIROCREW_HOME` no longer points where
they put it, and nothing told them.

Cases 1 and 2 are the guardrail failing to do its job on the platform where its
trigger is reachable at all. **Graded honestly: no data loss in either.** `rmtree`
refuses rather than deleting through the junction, so the link target is never
destroyed — the guard's stated worst case does not happen. What is lost is the
refusal itself, the actionable message, and (case 3) the user's configuration.

**This is invisible to CI today.** All three existing guardrail tests here are
`@requires_symlinks`, so they are skipped on Windows — the only platform on which
the junction shape exists. The guard has never been exercised where it can break.

## What changed (motivation → approach → change)

*Symptom:* three different wrong behaviours for a junctioned `$KIROCREW_HOME`.
*Root cause:* one predicate, used twice — `dst.is_symlink()` does not report a
junction.
*Change:* both checks use `pinned_fs.is_reparse_point(dst)`.

```python
if pinned_fs.is_reparse_point(dst):        # non-empty branch
...
elif dst.exists() and pinned_fs.is_reparse_point(dst):   # empty branch
```

**Why `pinned_fs.is_reparse_point` and not `platform_compat.is_link_or_junction`.**
Both would fix the three cases. `is_reparse_point` is already imported by this
module (no import path grows), is already used in exactly this role at
`snapshot.py:3144`, and its docstring names this defect verbatim. It is also the
better *semantic* fit: `is_link_or_junction` narrows to symlink-or-mount-point,
while `is_reparse_point` is true for any reparse tag — and this is a
**refuse-to-act** guard, where the conservative direction is to trip on anything
that redirects. Widening a guard that only ever declines cannot cause the failure a
too-broad predicate causes at a guard that acts.

**Contract deliberately preserved:**

* the guardrail constants `GUARDRAIL_SYMLINK_REPLACE` / `GUARDRAIL_SYMLINK_EMPTY`
  are **unchanged** — they are the audit-record and exit-code contract, and
  renaming them for accuracy would be a breaking change for a cosmetic gain;
* the message becomes *"symlinked or junctioned $KIROCREW_HOME"*, which names both
  shapes while keeping the `"symlinked"` substring the existing tests assert on.

Nothing else in `seed.py` is touched.

## Tests

`test/test_seed.py`, 3 tests — one per measured consequence:

| Test | Locks in |
|---|---|
| `test_seed_refuses_a_junctioned_nonempty_home` | `GUARDRAIL_SYMLINK_REPLACE` on the first attempt, not the `NON_EMPTY` dead end |
| `test_seed_replace_refuses_a_junctioned_home` | `--seed-replace` refuses instead of reaching `rmtree`; the link target survives |
| `test_seed_refuses_an_EMPTY_junctioned_home_instead_of_detaching_it` | the empty branch refuses; the link is **still a link** afterwards and nothing was seeded through it |

They deliberately do **not** carry `@requires_symlinks`: `conftest.make_dir_link`
makes a junction on Windows, which needs no privilege, so these run on the Windows
shards where the three existing symlink tests skip.

**Guard-the-guard.** Each asserts the planted shape through an oracle outside the
module under test — `pinned_fs.is_reparse_point(link)` — plus the branch
precondition the case depends on (`any(link.iterdir())` for the non-empty cases,
`not any(...)` for the empty one). Without those, a test could pass for reaching the
wrong branch.

**Red-before, measured on unpatched `origin/main`:** `3 failed`, one per row above,
with the exact assertions quoted in *Problem / Motivation*.

**Control for pre-existing noise:** `test_seed.py` reports the same **1 failed** on
pristine `origin/main` as with the patch (`test_seed_cli_flag_registered`,
unrelated), and `32 → 35 passed` — exactly the 3 tests added.

Gates on this head: `flake8` clean, `isort --check-only` clean, `mypy --platform
linux` reports nothing in `seed.py`, black and subprocess-encoding gates pass scoped
`origin/main...HEAD`. Both files are in `.github/black-baseline.txt` and were
deliberately not reformatted.

## Manual verification

N/A — unit coverage sufficient: all three behaviours are decided by which branch the
link matches, and the tests build a real junction on the affected platform and drive
`seed()` itself rather than mocking the predicate.

## Related Issues

None — found by inspection while auditing `is_symlink`-based guards for the Windows
junction blind spot, the same family as #7881.

## Pattern harvest

Rule candidate: `agents-md`
Pattern: a link guardrail whose only tests are `@requires_symlinks`. That marker
skips on Windows, which is the one platform where the *junction* spelling exists —
so a guard written against links is verified exclusively on the platform where it
cannot fail. When a test needs a directory link, `conftest.make_dir_link` (junction
on Windows, symlink elsewhere) keeps the coverage instead of skipping it;
`@requires_symlinks` should be reserved for cases that genuinely need symlink
semantics rather than link semantics.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
