### PR TITLE
feat(usage): detect ambiguous CREDIT-typed pools in plan slot

### DIFF
--- a/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
@@ -711,6 +711,27 @@ def _map_response(data: dict) -> dict | None:
     if not credit:
         return None
 
+    # Ambiguity probe (observation only — selection above is unchanged). The
+    # plan-pool picker takes the FIRST entry that is exactly resourceType
+    # "CREDIT", so a second CREDIT-typed pool (e.g. a promotional/welcome grant
+    # typed literally "CREDIT" rather than a bonus marker) can win the plan slot
+    # by list order and displace the real plan pool — a latent, unobserved case
+    # with no captured payload. When more than one entry satisfies the plan-pool
+    # test we record the SHAPE so a maintainer can choose a remedy (fail-closed
+    # vs deterministic pick) against real evidence. Log resource types and
+    # counts only, never balances or identifiers (billing-adjacent). Additive:
+    # nothing about which pool wins changes.
+    _credit_typed = [b for b in breakdowns if b.get("resourceType") == "CREDIT"]
+    if len(_credit_typed) > 1:
+        logger.warning(
+            "Kiro usage API: %d CREDIT-typed pools in usageBreakdownList "
+            "(resource types %s); plan pool selected by list order at index %d "
+            "— a second CREDIT-typed pool may be displacing the real plan pool",
+            len(_credit_typed),
+            [str(b.get("resourceType")) for b in breakdowns],
+            breakdowns.index(credit),
+        )
+
     # Prefer the *-WithPrecision fields only when they are valid numbers; a
     # present-but-null/malformed precision value must fall back to the legacy
     # currentUsage/usageLimit rather than reject an otherwise-valid response.

--- a/test/test_kiro_usage_api.py
+++ b/test/test_kiro_usage_api.py
@@ -145,6 +145,38 @@ class TestMapResponse:
         ]}
         assert "bonus_limit" not in api._map_response(data)
 
+    def test_warns_on_two_credit_typed_pools(self, caplog):
+        # The exact payload nobody has captured: TWO entries typed literally
+        # "CREDIT". The picker takes the first by list order; detection must fire
+        # AND selection must stay byte-for-byte identical (first entry wins).
+        data = {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 5, "usageLimit": 100},
+            {"resourceType": "CREDIT", "currentUsage": 999, "usageLimit": 2000},
+        ]}
+        with caplog.at_level("WARNING", logger=api.logger.name):
+            out = api._map_response(data)
+        # Selection unchanged: the first CREDIT entry still wins.
+        assert out["credits_used"] == 5.0
+        assert out["credits_plan"] == 100.0
+        warnings = [r for r in caplog.records if "CREDIT-typed pools" in r.getMessage()]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "2 CREDIT-typed pools" in msg
+        assert "index 0" in msg
+        # Shape only — no balances/identifiers leak into the log line.
+        assert "999" not in msg and "2000" not in msg
+
+    def test_no_warn_on_single_credit_typed_pool(self, caplog):
+        # Mutate the fixture: one CREDIT entry. Detection must NOT fire — a
+        # detector that fires on every payload is worse than none.
+        data = {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 5, "usageLimit": 100},
+            {"resourceType": "FREE_TRIAL", "currentUsage": 10, "usageLimit": 50},
+        ]}
+        with caplog.at_level("WARNING", logger=api.logger.name):
+            api._map_response(data)
+        assert not [r for r in caplog.records if "CREDIT-typed pools" in r.getMessage()]
+
     def test_none_when_response_not_dict(self):
         assert api._map_response([]) is None
         assert api._map_response(None) is None


### PR DESCRIPTION
## What is the problem?

In `src/kiro_crew/dashboard/handlers/kiro_usage_api.py`, `_map_response`
selects the plan pool by first-match on exact equality
(`b.get("resourceType") == "CREDIT"`, ~:700), while a separate bonus loop
(~:774-780) only accepts entries whose type carries a bonus marker
(`FREE_TRIAL`, `BONUS`, `PROMO`, `GIFT`, `WELCOME`, ...). A promotional or
welcome pool typed literally `"CREDIT"` falls between the two: the bonus
loop skips it (no marker) and the plan-pool picker can select it by list
order, displacing the real plan pool. The case is latent and unobserved --
no captured payload shows two `CREDIT`-typed entries.

## Why this issue matters to the user

The plan pool drives the dashboard's credit total, plan limit, overage,
and percentage. If a second `CREDIT`-typed pool wins the slot by list
order, the user is shown an unrelated pool's numbers as their plan usage.
Nobody can currently choose a remedy because there is no evidence the
trigger occurs in the wild.

## How our fix solves it

This PR builds detection only -- it does NOT pick a winner. The two obvious
remedies (fail closed, or make a deterministic pick) have opposite
consequences and are a product decision; that decision is deliberately
left open. What blocks the decision is the absence of an observable
trigger, and that is the part this change addresses.

Chain from symptom to root cause:
- Symptom: a CREDIT-typed promo/welcome pool could be shown as the plan.
- Mechanism: the plan-pool picker takes the FIRST `resourceType == "CREDIT"`
  entry; the bonus loop requires a marker, so a marker-less CREDIT-typed
  pool is claimed by neither correctly.
- Root cause: the selection has no signal when more than one entry
  satisfies the plan-pool test.

The change: after `credit` is resolved, count the entries that satisfy the
plan-pool test. When there is more than one, emit a single
`logger.warning` (the handler's existing anomaly convention, same
`"Kiro usage API: ..."` prefix as the degraded-fallback warning) recording
the SHAPE -- the count, the list of resource types, and the list-order
index selected. It logs types and counts only, never balances or
identifiers, because this is billing-adjacent. It is strictly additive: the
returned mapping and the list-order selection are byte-for-byte identical,
and no new failure mode is introduced. The untyped-fallback path (an entry
with no `resourceType`) does not satisfy the exact-CREDIT test, so the
probe never fires spuriously on it.

The fail-closed versus deterministic-pick choice is left to a maintainer,
who now has the exact fixture as evidence.

## What tests we did

Extended the existing `test/test_kiro_usage_api.py` fixture (which already
references `resourceType`):
- `test_warns_on_two_credit_typed_pools`: the payload nobody has captured --
  two entries typed literally `"CREDIT"`. Asserts the probe fires exactly
  once, that selection is unchanged (the first entry still wins:
  `credits_used == 5.0`, `credits_plan == 100.0`), and that no balance
  figure (`999`, `2000`) leaks into the log line.
- `test_no_warn_on_single_credit_typed_pool`: mutates the fixture down to a
  single CREDIT entry (plus a FREE_TRIAL bonus) and asserts the probe does
  NOT fire -- a detector that fires on every payload is worse than none.

Ran targeted only, `-n0`: `pytest test/test_kiro_usage_api.py::TestMapResponse`
-> 20 passed. Lint run independently on both touched files: isort clean,
flake8 clean, mypy clean on the handler (the 2 mypy errors reported are in
`src/kiro_crew/transcribe.py`, untouched by this PR). black: my added lines
conform; the only black-diff hunks are pre-existing baselined lines, left
untouched per the baseline convention.

## Any other suggestions on the work

The fixture is arguably the more valuable half: it converts "we think this
is possible" into "here is the payload that does it", which is what lets a
human choose fail-closed versus deterministic-pick with evidence instead of
speculation.

## Pattern harvest

Rule candidate: when two selection paths partition a list by different
predicates (here: exact `== "CREDIT"` for the plan pool vs marker-substring
for the bonus pool), an item that satisfies neither correctly can be
mis-claimed by list order. Before deciding a remedy for a latent selection
bug with no captured trigger, ship an additive observation that records the
ambiguity SHAPE plus a fixture that reproduces it -- the observation carries
no policy and unblocks the product decision that does.

Refs #8945
