### PR TITLE
fix(portability): keep the export archive inside the crew directory

### DIFF
--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -3775,6 +3775,38 @@ def pin_directory(path: str | os.PathLike) -> int:
             os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
         )
 
+    fd = _win_open_without_following(path)
+    try:
+        attrs = getattr(os.fstat(fd), "st_file_attributes", 0)
+        if not attrs & _WIN_FILE_ATTRIBUTE_DIRECTORY or attrs & _WIN_FILE_ATTRIBUTE_REPARSE_POINT:
+            raise NotADirectoryError(errno.ENOTDIR, "not a real directory", os.fspath(path))
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _win_open_without_following(path: str | os.PathLike) -> int:
+    """``CreateFileW`` *path* for reading, opening a reparse point INSTEAD of following it.
+
+    Shared by :func:`pin_directory` and :func:`open_file_no_reparse` so the two do
+    not carry separate copies of the same security-critical flags. What each of
+    them then asserts about the descriptor differs; how the object is reached must
+    not.
+
+    ``OPEN_REPARSE_POINT`` is the whole point: a junction or symlink at the name is
+    opened AS ITSELF, so the caller sees what is really there and the target is
+    never touched. That is what makes the refusal atomic rather than a check
+    followed by an open -- and on Windows the difference is not academic, because
+    resolving a reparse point aimed at a UNC share is itself an outbound SMB
+    authentication. ``BACKUP_SEMANTICS`` is what allows a directory to be opened at
+    all and is harmless on a file. The share mode omits ``FILE_SHARE_DELETE``: while
+    this descriptor lives, the object cannot be renamed or deleted -- and for a
+    directory, neither can anything above it.
+
+    The handle is wrapped in a CRT descriptor so ``os.fstat`` can read the
+    attributes of what was actually opened and ``os.close`` can release it.
+    """
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
     kernel32.CreateFileW.argtypes = [
         wintypes.LPCWSTR,
@@ -3797,13 +3829,41 @@ def pin_directory(path: str | os.PathLike) -> int:
     )
     if handle is None or handle == wintypes.HANDLE(-1).value:
         raise ctypes.WinError(ctypes.get_last_error())  # type: ignore[attr-defined]
-    # Wrapping the handle in a CRT descriptor lets ``os.fstat`` read the
-    # attributes of what was actually opened, and ``os.close`` release it.
-    fd = msvcrt.open_osfhandle(handle, os.O_RDONLY)  # type: ignore[attr-defined]
+    return msvcrt.open_osfhandle(handle, os.O_RDONLY)  # type: ignore[attr-defined]
+
+
+def open_file_no_reparse(path: str | os.PathLike) -> int:
+    """Open a regular FILE for reading, refusing a reparse point at the final name.
+
+    The leaf counterpart to :func:`pin_directory`. ``pin_directory`` freezes the
+    ancestors so the path cannot be re-pointed underneath a caller; this one settles
+    the last component, and it has to do so in the SAME operation that opens it --
+    an ``is_symlink()`` (or ``lstat``) check followed by ``os.open`` is a
+    check-to-open window, and an adversary that can plant the link chooses when.
+
+    * POSIX: ``O_NOFOLLOW`` already refuses a link at the final component; this is
+      exactly the open the callers were doing, named.
+    * Windows: there is no ``O_NOFOLLOW`` -- ``getattr(os, "O_NOFOLLOW", 0)`` is 0,
+      so ``os.open`` FOLLOWS a reparse point at the name. ``CreateFileW`` with
+      ``FILE_FLAG_OPEN_REPARSE_POINT`` opens the reparse point itself instead, and
+      the attribute read off the resulting descriptor is therefore a fact about what
+      was opened, not a prediction about what a later open will find. Refused with
+      ``ELOOP``, matching what POSIX reports for the same shape.
+
+    Refuses a directory with ``IsADirectoryError`` (POSIX reports ``EISDIR`` from the
+    read, Windows from ``os.open``; the two are made to agree here). Release the
+    descriptor with ``os.close``.
+    """
+    if IS_POSIX:
+        return os.open(os.fspath(path), os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+
+    fd = _win_open_without_following(path)
     try:
         attrs = getattr(os.fstat(fd), "st_file_attributes", 0)
-        if not attrs & _WIN_FILE_ATTRIBUTE_DIRECTORY or attrs & _WIN_FILE_ATTRIBUTE_REPARSE_POINT:
-            raise NotADirectoryError(errno.ENOTDIR, "not a real directory", os.fspath(path))
+        if attrs & _WIN_FILE_ATTRIBUTE_REPARSE_POINT:
+            raise OSError(errno.ELOOP, "reparse point at the final component", os.fspath(path))
+        if attrs & _WIN_FILE_ATTRIBUTE_DIRECTORY:
+            raise IsADirectoryError(errno.EISDIR, "is a directory", os.fspath(path))
     except BaseException:
         os.close(fd)
         raise

--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -156,6 +156,11 @@ def create_export_zip() -> tuple[bytes, dict]:
                 contents_summary[db_name] = db_buf.tell()
 
         # Directory trees: workspace, plan_memory, skills
+        #
+        # ``mc`` is resolved once so the containment test below compares real
+        # paths: ``$KIROCREW_HOME`` may itself legitimately be a link, and the
+        # test must not reject the whole export because of it.
+        mc_real = mc.resolve()
         dir_counts: dict[str, int] = {}
         for dirname in ("workspace", "plan_memory", "skills"):
             src_dir = mc / dirname
@@ -163,6 +168,20 @@ def create_export_zip() -> tuple[bytes, dict]:
             if src_dir.is_dir():
                 for fpath in src_dir.rglob("*"):
                     if fpath.is_symlink():
+                        continue
+                    # ``rglob`` DESCENDS a directory link, and the file on the far
+                    # side is an ordinary one -- ``is_symlink()`` false -- so the
+                    # skip above never fires for it. The two filters below cannot
+                    # catch it either: both read the LEXICAL path, which runs
+                    # through the link's own name and so looks ordinary. Only the
+                    # RESOLVED path says where the bytes live, and it is what
+                    # decides whether they belong in an archive the user hands on.
+                    # On Windows the link is typically a junction, which
+                    # ``is_symlink`` does not report at all.
+                    try:
+                        if not fpath.resolve().is_relative_to(mc_real):
+                            continue
+                    except OSError:
                         continue
                     rel = fpath.relative_to(mc)
                     if _is_excluded(PurePosixPath(str(rel))):

--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -9,6 +9,7 @@ Credentials (.env, session secrets) are always excluded from exports.
 
 from __future__ import annotations
 
+import contextlib
 import io
 import json
 import logging
@@ -17,15 +18,18 @@ import shutil
 import socket
 import stat
 import tempfile
+import time
 import zipfile
+from collections.abc import Callable, Iterator
 from datetime import datetime, timezone
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePath, PurePosixPath
 
 try:
     import pysqlite3 as sqlite3
 except ImportError:
     import sqlite3
 
+from kiro_crew import pinned_fs, platform_compat
 from kiro_crew.config.paths import config_dir
 from kiro_crew.mcp_cron import _log_cron_denial, _vet_shell_command
 from kiro_crew.security import is_sensitive_path
@@ -119,6 +123,266 @@ def _backup_sqlite(src: Path, dst_buffer: io.BytesIO) -> None:
         mem_conn.close()
 
 
+#: A Windows junction is a reparse point whose tag is not the symlink tag, so
+#: ``islink``/``DirEntry.is_symlink`` are False for one. The ATTRIBUTE is what
+#: every kind of reparse point has in common. Absent off Windows, where the
+#: concept does not exist.
+_FILE_ATTRIBUTE_REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+
+
+def _entry_is_link(entry: os.DirEntry) -> bool:
+    """True if *entry* is a symlink or, on Windows, any other reparse point.
+
+    Answered entirely from the directory listing the kernel has ALREADY
+    returned: ``FindFirstFileW`` carries ``dwFileAttributes`` and the reparse tag
+    inline, so ``entry.stat(follow_symlinks=False)`` reads cached bytes rather
+    than issuing a lookup -- and, decisively, never a lookup THROUGH the child.
+    That is the property this walk is built on. The ordinary way to ask the same
+    question, ``Path(child).is_file()`` or ``is_sensitive_path(str(child))``,
+    resolves the name; if a junction there aims at ``\\\\host\\share`` that
+    resolution IS an outbound SMB authentication, and no later refusal recalls
+    it.
+
+    ``DirEntry.is_symlink()`` alone is not enough and is exactly how ``rglob``
+    came to descend a junction: a junction's tag is ``IO_REPARSE_TAG_MOUNT_POINT``
+    rather than ``IO_REPARSE_TAG_SYMLINK``, so that method reports False for one
+    while ``is_dir(follow_symlinks=False)`` reports True.
+
+    Every reparse point is treated the same rather than only link-shaped ones,
+    because that is already what the layer below refuses --
+    :func:`platform_compat.pin_directory` rejects any reparse point at a
+    directory name and :func:`platform_compat.open_file_no_reparse` rejects one
+    at a file name. This classifies what those opens would refuse anyway: a cheap
+    skip, never the enforcement. On POSIX the attribute check is skipped
+    entirely; ``is_symlink()`` uses ``d_type`` and costs nothing, and asking for
+    a stat there would add a real syscall for a concept the platform lacks.
+    """
+    if entry.is_symlink():
+        return True
+    if os.name != "nt":
+        return False
+    try:
+        info = entry.stat(follow_symlinks=False)
+    except OSError:
+        return True  # unclassifiable -> refuse to walk into it
+    return bool(getattr(info, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _keep_for_export(rel: PurePath) -> bool:
+    """The old loop's by-name filters, unchanged and in the same order.
+
+    Purely lexical, and it has to stay that way: this runs on a child the walk
+    has not verified yet, so a filesystem call here would be the very probe the
+    walk exists to remove.
+
+    The old loop also asked ``is_sensitive_path`` at this point, about the
+    PATHNAME. That call is gone rather than moved, because resolving an
+    unverified name is the probe. The same question is still asked -- in
+    :func:`_open_verified`, of the descriptor's real path -- and that was always
+    the load-bearing one: a name can be re-pointed between the check and the
+    open, a descriptor cannot.
+    """
+    # ``PurePosixPath(*rel.parts)``, never ``PurePosixPath(str(rel))``: on Windows
+    # ``str(rel)`` is backslash-separated, so ``PurePosixPath`` parses the whole
+    # relative path as a SINGLE component. ``.name`` is then the entire path and
+    # ``.parts`` has length one, so the ``EXPORT_EXCLUDE`` basename set and the
+    # ``EXCLUDE_DIRS`` walk both stop matching -- ``workspace/notes/.env`` was
+    # exported on Windows. Rebuilding from ``parts`` keeps the separator the
+    # exclusion rules are written against.
+    if _is_excluded(PurePosixPath(*rel.parts)):
+        return False
+    return not (rel.parts[0] == "skills" and "auto" in rel.parts)
+
+
+def _walk_contained(
+    root_real: str,
+    rel_dir: PurePath,
+    keep: Callable[[PurePath], bool],
+) -> Iterator[tuple[PurePath, int]]:
+    """Yield ``(rel, fd)`` for every regular file under ``root_real / rel_dir``.
+
+    The export's own enumeration, in place of ``rglob``. ``rglob`` DESCENDS a
+    Windows junction, and every by-name question then asked about what it yields
+    resolves that junction before any guard has run. Measured on this module
+    before the change, exporting a workspace holding one pre-planted junction:
+    twelve resolving calls went out through it -- four ``os.path.realpath``,
+    eight ``ntpath._getfinalpathname`` -- while the export correctly archived
+    nothing from behind it. Nothing being archived was never the question. If the
+    junction names a UNC share those resolutions are the outbound authentication,
+    and containment refusing the bytes afterwards has already paid the cost it
+    exists to prevent.
+
+    So this descends and verifies in one motion, root first:
+
+    1. the directory is PINNED. :func:`platform_compat.pin_directory` opens it
+       with ``OPEN_REPARSE_POINT``, so a junction sitting at the name fails here
+       instead of being traversed -- the refusal and the open are one operation,
+       not a check followed by an open. On Windows the handle also omits
+       ``FILE_SHARE_DELETE``, so while it lives neither that directory nor
+       anything above it can be renamed or deleted;
+    2. only then is it listed, and each child classified from the listing itself
+       (:func:`_entry_is_link`) -- nothing resolves a child;
+    3. a child directory is descended only by re-entering at step 1, so the path
+       the kernel walks to reach component *n* runs entirely through components
+       already opened and verified;
+    4. a child file is opened by :func:`_open_verified`, which does not follow a
+       reparse point at the final name, while its whole parent chain is still
+       held.
+
+    Each pin is held for as long as the subtree under it is being produced --
+    a generator frame stays alive across ``yield``, so an outer level's handle
+    outlives the inner walk -- and released in ``finally``, which also runs when
+    the consumer abandons the walk. Depth, not breadth, bounds how many are open.
+
+    *keep* is asked about relative paths only and must not touch the filesystem.
+    It is applied to FILES only, exactly where the old loop applied it: matching
+    a directory NAME does not prune its contents, because ``_is_excluded``
+    decides that through ``parts`` and did so before.
+
+    On POSIX ``pin_directory`` is ``O_RDONLY | O_DIRECTORY | O_NOFOLLOW``. Its
+    refusal of a symlinked directory is real there and is what ``rglob`` already
+    did, so the set of exported files is unchanged; the anti-rename property is
+    NOT real there -- POSIX has no such lock -- and nothing here relies on it.
+    Containment on POSIX rests where it always did, on ``_open_verified``
+    checking the descriptor's real path.
+    """
+    yield from _walk_pinned(root_real, PurePath(), rel_dir.parts, keep)
+
+
+def _walk_pinned(
+    root_real: str,
+    rel_dir: PurePath,
+    descend: tuple[str, ...],
+    keep: Callable[[PurePath], bool],
+) -> Iterator[tuple[PurePath, int]]:
+    """Pin ``root_real / rel_dir``, then walk it -- or step into *descend*'s first name.
+
+    One frame per directory, and the frame that lists a directory is the frame
+    that pinned it, so nothing is ever listed by a frame that did not verify it.
+    The chain therefore starts at the crew root itself: the kernel walks that name
+    to reach every candidate, so leaving it unpinned would leave the whole export
+    hanging off a component that could still be renamed away.
+
+    *descend* carries the components between the root and the tree being exported
+    (``workspace``, ``plan_memory``, ``skills``). They are stepped through by NAME
+    with no classification, which is safe for the same reason the walk needs no
+    pre-check anywhere else: :func:`platform_compat.pin_directory` refuses a
+    reparse point at the name itself, so a junction planted at ``workspace``
+    fails at its own open rather than being followed.
+    """
+    here = os.path.join(root_real, *rel_dir.parts)
+    try:
+        pin = platform_compat.pin_directory(here)
+    except OSError:
+        return  # not a real directory, or a reparse point: refused, not followed
+    try:
+        if descend:
+            yield from _walk_pinned(root_real, rel_dir / descend[0], descend[1:], keep)
+            return
+        try:
+            with os.scandir(here) as scan:
+                entries = sorted(scan, key=lambda e: e.name)
+        except OSError:
+            return
+        for entry in entries:
+            if _entry_is_link(entry):
+                continue
+            rel = rel_dir / entry.name
+            if entry.is_dir(follow_symlinks=False):
+                yield from _walk_pinned(root_real, rel, (), keep)
+            elif entry.is_file(follow_symlinks=False) and keep(rel):
+                fd = _open_verified(os.path.join(root_real, *rel.parts), root_real)
+                if fd is not None:
+                    yield rel, fd
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(pin)
+
+
+def _open_verified(target: str, root_real: str) -> int | None:
+    """Open *target* without following a link at its name, and vet the descriptor.
+
+    Split out so :func:`_open_inside` can hold the ancestor pins across the whole
+    of it: the descriptor checks below are only worth anything while the path they
+    were reached through is still the path that was verified.
+    """
+    try:
+        fd = platform_compat.open_file_no_reparse(target)
+    except OSError:
+        return None
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            return None
+        if st.st_nlink > 1:
+            # A hardlink is invisible to every path-based guard: it shares the
+            # target's inode, so the fd's real path is the ALIAS's own name --
+            # `fd_real_path` reports the path the descriptor was opened by, not a
+            # canonical one -- and `is_sensitive_path` is then asked about an
+            # innocent workspace name while the bytes behind it are a credential
+            # file's. `O_NOFOLLOW` has no link to refuse, because there is no
+            # symlink. Only the link COUNT, read off this descriptor, sees it.
+            #
+            # Refused rather than resolved: there is no way to ask "which of my
+            # names is the sensitive one?", and the cost is honest and small --
+            # a workspace file that legitimately has a second link is left out of
+            # the export. Same rule and same reasoning as
+            # `pinned_fs.refuse_hardlink_alias` and
+            # `hooks.safe_read_file_bytes_nolink`.
+            return None
+        real = pinned_fs.fd_real_path(fd)
+        if real is None:
+            return None  # cannot witness containment -> fail closed
+        try:
+            if os.path.commonpath([real, root_real]) != root_real:
+                return None
+        except ValueError:  # different drives on Windows
+            return None
+        if is_sensitive_path(real):
+            return None
+    except OSError:
+        return None
+    else:
+        held, fd = fd, -1
+        return held
+    finally:
+        if fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+
+
+def _add_from_fd(zf: zipfile.ZipFile, fd: int, arcname: str) -> None:
+    """Stream the bytes behind *fd* into *zf* as *arcname*.
+
+    ``ZipFile.write`` takes a NAME and opens it itself, which is the re-open
+    :func:`_open_inside` exists to remove, so the entry is built by hand instead.
+    Streaming rather than reading the file whole is deliberate: a workspace file
+    has no size bound here, and the export used to copy one of any size.
+
+    The entry's timestamp and mode come from the same descriptor, so the metadata
+    describes the bytes actually archived — not whatever the name pointed at when
+    the header was built.
+
+    ``force_zip64`` is not optional here. ``ZipFile.write`` took a name, stat'd it,
+    and turned ZIP64 on by itself for a large source; a streamed entry does not know
+    its size when the header is written, so without this a file over
+    ``zipfile.ZIP64_LIMIT`` raises ``RuntimeError`` part-way through and the export
+    endpoint answers 500. A multi-GiB file under ``workspace/`` is ordinary — a
+    dataset, a model artifact — and it used to export fine, so leaving this off
+    would trade one defect for a regression.
+    """
+    st = os.fstat(fd)
+    info = zipfile.ZipInfo(arcname, date_time=time.localtime(st.st_mtime)[:6])
+    info.compress_type = zf.compression
+    info.external_attr = (st.st_mode & 0xFFFF) << 16
+    os.lseek(fd, 0, os.SEEK_SET)
+    with (
+        os.fdopen(os.dup(fd), "rb", closefd=True) as src,
+        zf.open(info, "w", force_zip64=True) as dest,
+    ):
+        shutil.copyfileobj(src, dest)
+
+
 def create_export_zip() -> tuple[bytes, dict]:
     """Create a zip archive of KiroCrew state. Returns (zip_bytes, manifest_dict)."""
     mc = _mc_dir()
@@ -157,42 +421,25 @@ def create_export_zip() -> tuple[bytes, dict]:
 
         # Directory trees: workspace, plan_memory, skills
         #
-        # ``mc`` is resolved once so the containment test below compares real
-        # paths: ``$KIROCREW_HOME`` may itself legitimately be a link, and the
-        # test must not reject the whole export because of it.
-        mc_real = mc.resolve()
+        # ``mc`` is resolved once, before the walk, and the walk is anchored on the
+        # RESOLVED root: ``$KIROCREW_HOME`` may itself legitimately be a link, and
+        # ``pin_directory`` refuses a reparse point at a name, so pinning the
+        # configured spelling would return an empty archive on such a host.
+        mc_real = os.path.realpath(mc)
         dir_counts: dict[str, int] = {}
         for dirname in ("workspace", "plan_memory", "skills"):
-            src_dir = mc / dirname
             count = 0
-            if src_dir.is_dir():
-                for fpath in src_dir.rglob("*"):
-                    if fpath.is_symlink():
-                        continue
-                    # ``rglob`` DESCENDS a directory link, and the file on the far
-                    # side is an ordinary one -- ``is_symlink()`` false -- so the
-                    # skip above never fires for it. The two filters below cannot
-                    # catch it either: both read the LEXICAL path, which runs
-                    # through the link's own name and so looks ordinary. Only the
-                    # RESOLVED path says where the bytes live, and it is what
-                    # decides whether they belong in an archive the user hands on.
-                    # On Windows the link is typically a junction, which
-                    # ``is_symlink`` does not report at all.
-                    try:
-                        if not fpath.resolve().is_relative_to(mc_real):
-                            continue
-                    except OSError:
-                        continue
-                    rel = fpath.relative_to(mc)
-                    if _is_excluded(PurePosixPath(str(rel))):
-                        continue
-                    if is_sensitive_path(str(fpath)):
-                        continue
-                    if dirname == "skills" and "auto" in rel.parts:
-                        continue
-                    if fpath.is_file():
-                        zf.write(str(fpath), f"{prefix}/{rel}")
-                        count += 1
+            for rel, fd in _walk_contained(mc_real, PurePath(dirname), _keep_for_export):
+                try:
+                    # ``as_posix()`` for the same reason the filter rebuilds from
+                    # parts: a zip member name is POSIX-separated by spec.
+                    # ``ZipInfo`` happens to rewrite ``os.sep`` today, so this is
+                    # not a fix for a live bug -- it stops the archive name
+                    # depending on that, next to a filter that must not.
+                    _add_from_fd(zf, fd, f"{prefix}/{rel.as_posix()}")
+                finally:
+                    os.close(fd)
+                count += 1
             dir_counts[dirname] = count
         contents_summary["workspace_files"] = dir_counts.get("workspace", 0)
         contents_summary["plan_memory_files"] = dir_counts.get("plan_memory", 0)

--- a/test/test_portability.py
+++ b/test/test_portability.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 
 import pytest
 
-from conftest import requires_o_nofollow
+from conftest import make_dir_link, requires_o_nofollow
 from kiro_crew.jsonl_util import UnreadableRecord
 from kiro_crew.portability import (
     EXPORT_EXCLUDE,
@@ -252,6 +252,60 @@ class TestExport:
         names = zf.namelist()
         assert not any("evil_link" in n for n in names)
         zf.close()
+
+    def test_export_does_not_package_files_reached_through_a_directory_link(
+        self, patched_config_dir, tmp_path
+    ):
+        """`rglob` DESCENDS a directory link, and the file on the far side is real.
+
+        `test_export_skips_symlinks` above covers a link that IS the entry. It does
+        not cover a link crossed on the way DOWN: the executable/document found
+        beyond it answers False to `is_symlink()`, so the skip never fires, and
+        `zf.write` packages bytes from outside the exported tree into an archive
+        the user hands to someone else.
+
+        The two filters below the skip do not catch it either — `_is_excluded` and
+        `is_sensitive_path` both read the LEXICAL path, which runs through the
+        link's own name and therefore looks ordinary.
+
+        Built with `conftest.make_dir_link`, so this is a junction on Windows,
+        where a directory symlink needs SeCreateSymbolicLinkPrivilege — that
+        symlink test skips there, which is exactly why this one must not.
+        """
+        outside = tmp_path / "outside-the-crew-dir"
+        outside.mkdir()
+        (outside / "not-ours.md").write_text("private notes", encoding="utf-8")
+        link = patched_config_dir / "workspace" / "memory" / "linked"
+        make_dir_link(link, outside)
+
+        # Guard the guard, through oracles OUTSIDE the module under test: the walk
+        # must actually reach the far side, and what it reaches must be a real
+        # file rather than a link, or the existing skip would have handled it.
+        reached = [p for p in link.rglob("*") if p.name == "not-ours.md"]
+        assert reached, "rglob never descended the link, so nothing was under test"
+        assert reached[0].is_file() and not reached[0].is_symlink()
+
+        zip_bytes, _ = create_export_zip()
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+        names = zf.namelist()
+        zf.close()
+        assert not any("not-ours" in n for n in names), (
+            f"content from outside the crew dir was packaged: {names}"
+        )
+
+    def test_export_still_packages_a_real_nested_workspace_file(
+        self, patched_config_dir
+    ):
+        """Negative control: ordinary nested content must still be exported."""
+        nested = patched_config_dir / "workspace" / "memory" / "deep" / "keep.md"
+        nested.parent.mkdir(parents=True, exist_ok=True)
+        nested.write_text("ours", encoding="utf-8")
+
+        zip_bytes, _ = create_export_zip()
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+        names = zf.namelist()
+        zf.close()
+        assert any(n.endswith("workspace/memory/deep/keep.md") for n in names), names
 
     def test_export_empty_kirocrew_dir(self, tmp_path):
         mc = tmp_path / "empty_mc"

--- a/test/test_portability.py
+++ b/test/test_portability.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
+import contextlib
+import errno
 import io
 import json
+import ntpath
 import os
 import sqlite3
+import sys
 import tempfile
+import time
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from unittest.mock import patch
 
 import pytest
 
 from conftest import make_dir_link, requires_o_nofollow
+from kiro_crew import platform_compat, portability
 from kiro_crew.jsonl_util import UnreadableRecord
 from kiro_crew.portability import (
     EXPORT_EXCLUDE,
@@ -21,6 +27,38 @@ from kiro_crew.portability import (
     apply_import_zip,
     create_export_zip,
     validate_import_zip,
+)
+from kiro_crew.security import is_sensitive_path
+
+
+def _detach_dir_link(link: Path) -> None:
+    """Remove the link ITSELF at *link*, leaving whatever it pointed at alone.
+
+    The call differs by platform and the wrong one raises rather than misbehaving
+    quietly: a POSIX directory symlink is a link entry, so ``rmdir`` answers
+    ``NotADirectoryError`` and only ``unlink`` removes it; a Windows junction is a
+    real directory entry, which ``unlink`` refuses. ``is_symlink()`` separates them
+    -- it is False for a junction, which is the same property the production code
+    under test is about.
+    """
+    if link.is_symlink():
+        link.unlink()
+    else:
+        os.rmdir(link)
+
+
+#: pathlib's ``**`` deliberately does NOT descend a directory SYMLINK, so on POSIX
+#: the export walk cannot reach past one at all. A Windows JUNCTION is a different
+#: reparse tag -- ``DirEntry.is_symlink()`` answers False for it -- so the same walk
+#: descends it and reaches an ordinary file living outside the crew directory.
+#: MEASURED both ways rather than assumed; the guard-the-guard assertion in the test
+#: below re-checks it on the platform that runs.
+walk_descends_a_directory_link = pytest.mark.skipif(
+    not platform_compat.IS_WINDOWS,
+    reason=(
+        "pathlib's ** does not descend a POSIX directory symlink, so the export walk "
+        "cannot reach past one; this escape is the Windows junction shape"
+    ),
 )
 
 
@@ -253,24 +291,28 @@ class TestExport:
         assert not any("evil_link" in n for n in names)
         zf.close()
 
+    @walk_descends_a_directory_link
     def test_export_does_not_package_files_reached_through_a_directory_link(
         self, patched_config_dir, tmp_path
     ):
         """`rglob` DESCENDS a directory link, and the file on the far side is real.
 
         `test_export_skips_symlinks` above covers a link that IS the entry. It does
-        not cover a link crossed on the way DOWN: the executable/document found
-        beyond it answers False to `is_symlink()`, so the skip never fires, and
-        `zf.write` packages bytes from outside the exported tree into an archive
-        the user hands to someone else.
+        not cover a link crossed on the way DOWN: the document found beyond it
+        answers False to `is_symlink()`, so the skip never fires, and the file is
+        packaged into an archive the user hands to someone else.
 
-        The two filters below the skip do not catch it either — `_is_excluded` and
-        `is_sensitive_path` both read the LEXICAL path, which runs through the
-        link's own name and therefore looks ordinary.
+        Neither filter below the skip is a containment test. `_is_excluded` is a
+        rule about the archive NAME. `is_sensitive_path` does resolve links — so a
+        linked `~/.aws` really would be caught — but it asks whether a path is a
+        PROTECTED location, never whether it is inside the crew directory. An
+        ordinary file of the user's is neither, and that is what leaked.
 
-        Built with `conftest.make_dir_link`, so this is a junction on Windows,
-        where a directory symlink needs SeCreateSymbolicLinkPrivilege — that
-        symlink test skips there, which is exactly why this one must not.
+        Windows-only by construction, and measured rather than assumed: pathlib's
+        `**` does not descend a POSIX directory symlink, so the production walk
+        cannot reach past one there at all. A junction carries a different reparse
+        tag, `DirEntry.is_symlink()` answers False for it, and the same walk goes
+        straight through.
         """
         outside = tmp_path / "outside-the-crew-dir"
         outside.mkdir()
@@ -278,11 +320,16 @@ class TestExport:
         link = patched_config_dir / "workspace" / "memory" / "linked"
         make_dir_link(link, outside)
 
-        # Guard the guard, through oracles OUTSIDE the module under test: the walk
-        # must actually reach the far side, and what it reaches must be a real
-        # file rather than a link, or the existing skip would have handled it.
-        reached = [p for p in link.rglob("*") if p.name == "not-ours.md"]
-        assert reached, "rglob never descended the link, so nothing was under test"
+        # Guard the guard, through an oracle OUTSIDE the module under test — and
+        # from the root the PRODUCTION walk starts at, not from the link itself.
+        # Walking from the link would descend on every platform and prove nothing
+        # about whether `workspace/`'s own walk ever gets there.
+        reached = [
+            p
+            for p in (patched_config_dir / "workspace").rglob("*")
+            if p.name == "not-ours.md"
+        ]
+        assert reached, "the walk never descended the link, so nothing was under test"
         assert reached[0].is_file() and not reached[0].is_symlink()
 
         zip_bytes, _ = create_export_zip()
@@ -307,6 +354,23 @@ class TestExport:
         zf.close()
         assert any(n.endswith("workspace/memory/deep/keep.md") for n in names), names
 
+    def test_export_preserves_the_mtime_of_what_it_packages(self, patched_config_dir):
+        """The archive entry is built by hand now, so its metadata must not regress.
+
+        `ZipFile.write` took the timestamp from the file it opened; the entry is
+        assembled from a descriptor instead, and the timestamp has to keep coming
+        from the same bytes rather than from "now".
+        """
+        nested = patched_config_dir / "workspace" / "dated.md"
+        nested.write_text("ours", encoding="utf-8")
+        os.utime(nested, (1_000_000_000, 1_000_000_000))
+        expected = time.localtime(1_000_000_000)[:6]
+
+        zip_bytes, _ = create_export_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            entry = next(i for i in zf.infolist() if i.filename.endswith("dated.md"))
+        assert entry.date_time == expected
+
     def test_export_empty_kirocrew_dir(self, tmp_path):
         mc = tmp_path / "empty_mc"
         mc.mkdir()
@@ -318,6 +382,704 @@ class TestExport:
 
 
 # ── Validate Tests ──
+
+
+class TestTheArchivedBytesAreTheValidatedBytes:
+    """Containment is decided on the DESCRIPTOR, and the archive reads that descriptor.
+
+    A resolve-and-compare answers "where does this path point?" for an instant.
+    `ZipFile.write` then opens the path AGAIN, so the file that was checked and the
+    file that is read are two separate lookups, and a parent component retargeted in
+    between is followed by the second one. A running gateway hands agent tools write
+    access to the workspace while an export can be triggered, so that window is not
+    theoretical — which is why a reviewer held the by-name-only version of this fix.
+
+    `_open_verified` inverts the order — open first, then ask the kernel where the open
+    thing actually is — and `_add_from_fd` streams from that descriptor. The property
+    under test is not "the check is stricter" but "the check and the use address one
+    object".
+    """
+
+    def test_a_file_reached_through_a_directory_link_gets_no_descriptor(
+        self, patched_config_dir, tmp_path
+    ):
+        outside = tmp_path / "outside-the-crew-dir"
+        outside.mkdir()
+        (outside / "not-ours.md").write_text("private notes", encoding="utf-8")
+        link = patched_config_dir / "workspace" / "linked"
+        make_dir_link(link, outside)
+
+        candidate = link / "not-ours.md"
+        # Guard the guard: the lexical path IS inside the crew dir, so a check
+        # that only read the name would accept it. That is the whole point.
+        assert candidate.is_file()
+        assert patched_config_dir in candidate.parents
+
+        root = os.path.realpath(patched_config_dir)
+        assert portability._open_verified(str(candidate), root) is None
+
+    def test_a_real_file_inside_the_crew_dir_gets_a_descriptor_on_its_own_bytes(
+        self, patched_config_dir
+    ):
+        """Positive control, and the one that catches an over-tight check.
+
+        `fd_real_path` and `realpath` reach the same name by different kernel
+        routes, and on Windows a path can also come back in 8.3 short form — a
+        comparison that agrees only by luck must fail here, not in production.
+        """
+        nested = patched_config_dir / "workspace" / "deep" / "keep.md"
+        nested.parent.mkdir(parents=True, exist_ok=True)
+        nested.write_text("ours", encoding="utf-8")
+
+        fd = portability._open_verified(
+            str(nested), os.path.realpath(patched_config_dir)
+        )
+        assert fd is not None
+        try:
+            assert os.read(fd, 64) == b"ours"
+        finally:
+            os.close(fd)
+
+    def test_retargeting_the_link_after_validation_cannot_change_what_is_archived(
+        self, tmp_path
+    ):
+        """The regression for the race itself.
+
+        The link resolves INSIDE the crew directory when the candidate is
+        validated, so containment accepts it — correctly. It is then retargeted
+        before the archive step. A build that re-opens the path packages the
+        attacker's file; a build that streams the validated descriptor packages the
+        bytes it checked.
+
+        The link IS the crew root here rather than a directory under it, and the
+        placement is the point rather than a convenience. The walk refuses a linked
+        component BELOW the root — it is classified from the directory listing and
+        never descended, opened or resolved — so a link there is no longer a
+        reachable swap site at all. The root
+        itself and everything above it are deliberately outside the screen — that
+        is configuration, not a workspace an agent tool can write into — which
+        makes it exactly where a swap can still land, and running the race here
+        keeps the descriptor property covered on both platforms rather than on
+        POSIX alone.
+
+        Deterministic on purpose: the swap is placed exactly where a racing writer
+        would land, rather than run concurrently and hoped for.
+        """
+        genuine = tmp_path / "genuine-home"
+        (genuine / "workspace").mkdir(parents=True)
+        (genuine / "workspace" / "note.md").write_text("ours", encoding="utf-8")
+        outside = tmp_path / "outside-the-crew-dir"
+        (outside / "workspace").mkdir(parents=True)
+        (outside / "workspace" / "note.md").write_text("private notes", encoding="utf-8")
+
+        link = tmp_path / "kirocrew-home"
+        make_dir_link(link, genuine)
+        candidate = link / "workspace" / "note.md"
+
+        # Resolved ONCE before the window, exactly as the export hoists `mc_real`
+        # out of its walk -- a root re-resolved after the swap would agree with
+        # the attacker's tree and prove nothing.
+        fd = portability._open_verified(str(candidate), os.path.realpath(link))
+        assert fd is not None, "the contained candidate was refused; nothing under test"
+        buf = io.BytesIO()
+        try:
+            # The window. Detaching the link is not the same call on both
+            # platforms and getting it wrong fails the whole test: a POSIX
+            # directory SYMLINK is a link entry, so `rmdir` answers
+            # `NotADirectoryError` and only `unlink` removes it, while a Windows
+            # JUNCTION is a real directory entry that `unlink` refuses. Neither
+            # call touches what the link points at.
+            _detach_dir_link(link)
+            make_dir_link(link, outside)
+            assert candidate.read_text(encoding="utf-8") == "private notes", (
+                "the swap did not take effect, so the race was never simulated"
+            )
+
+            with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+                portability._add_from_fd(zf, fd, "export/note.md")
+        finally:
+            os.close(fd)
+
+        with zipfile.ZipFile(io.BytesIO(buf.getvalue())) as zf:
+            assert zf.read("export/note.md") == b"ours"
+
+    def test_containment_fails_closed_when_the_real_path_is_unknowable(
+        self, patched_config_dir, monkeypatch
+    ):
+        """A host whose kernel route for "where is this fd" is unavailable gets a
+        refusal, never a fallback to the pathname the descriptor was opened by."""
+        nested = patched_config_dir / "workspace" / "keep.md"
+        nested.write_text("ours", encoding="utf-8")
+        root = os.path.realpath(patched_config_dir)
+        fd = portability._open_verified(str(nested), root)
+        assert fd is not None
+        os.close(fd)
+
+        monkeypatch.setattr(portability.pinned_fs, "fd_real_path", lambda _fd: None)
+        assert portability._open_verified(str(nested), root) is None
+
+    def test_a_sensitive_target_is_refused_on_the_descriptor(
+        self, patched_config_dir, monkeypatch
+    ):
+        """`is_sensitive_path` runs again on the fd's real path, not only the name.
+
+        Re-running it there is what keeps the protected-location rule from being
+        the one filter the swap defeats: it is asked about the inode that will
+        actually be read.
+        """
+        nested = patched_config_dir / "workspace" / "keep.md"
+        nested.write_text("ours", encoding="utf-8")
+        root = os.path.realpath(patched_config_dir)
+        real = os.path.realpath(nested)
+
+        seen: list[str] = []
+
+        def _sensitive(path: str, base_dir: str | None = None) -> bool:
+            seen.append(path)
+            return os.path.normcase(path) == os.path.normcase(real)
+
+        monkeypatch.setattr(portability, "is_sensitive_path", _sensitive)
+        assert portability._open_verified(str(nested), root) is None
+        assert seen == [real], f"the gate was not asked about the fd's real path: {seen}"
+
+    def test_a_hardlinked_alias_gets_no_descriptor(self, patched_config_dir, tmp_path):
+        """A hardlink is the one alias no path-based guard can see.
+
+        It shares the target's inode, so there is no symlink for `O_NOFOLLOW` to
+        refuse, `is_symlink()` is False, and `fd_real_path` reports the path the
+        descriptor was OPENED BY — the innocent workspace name — not a canonical
+        one. `is_sensitive_path` is therefore asked about the alias and answers
+        "not sensitive" while the bytes behind it are the target's.
+
+        Only the link COUNT, read off the descriptor, sees it. Same rule as
+        `pinned_fs.refuse_hardlink_alias` and `hooks.safe_read_file_bytes_nolink`.
+        """
+        target = tmp_path / "outside-the-crew-dir" / "credentials"
+        target.parent.mkdir()
+        target.write_text("aws_secret_access_key = hunter2", encoding="utf-8")
+        alias = patched_config_dir / "workspace" / "innocent.txt"
+        try:
+            os.link(target, alias)
+        except (OSError, NotImplementedError) as exc:  # pragma: no cover
+            pytest.skip(f"this filesystem cannot create a hardlink: {exc}")
+
+        root = os.path.realpath(patched_config_dir)
+        # Guard the guard, through oracles OUTSIDE the module under test: every
+        # path-based check the export had ACCEPTS this alias, and it really does
+        # carry the target's bytes. Without this the test could pass because the
+        # alias was refused for some unrelated reason.
+        assert not alias.is_symlink()
+        assert os.path.realpath(alias) == str(alias)
+        assert not is_sensitive_path(str(alias))
+        assert alias.read_text(encoding="utf-8").startswith("aws_secret")
+        assert os.stat(alias).st_nlink == 2
+
+        assert portability._open_verified(str(alias), root) is None
+
+    def test_an_ordinary_single_link_file_is_still_accepted(self, patched_config_dir):
+        """Negative control for the link-count rule: one name is the normal case,
+        and refusing it would empty every export."""
+        ordinary = patched_config_dir / "workspace" / "ordinary.txt"
+        ordinary.write_text("ours", encoding="utf-8")
+        assert os.stat(ordinary).st_nlink == 1
+
+        fd = portability._open_verified(
+            str(ordinary), os.path.realpath(patched_config_dir)
+        )
+        assert fd is not None
+        os.close(fd)
+
+    def test_a_streamed_entry_larger_than_the_zip64_limit_still_exports(
+        self, patched_config_dir, monkeypatch
+    ):
+        """A streamed entry does not know its size when the header is written.
+
+        `ZipFile.write` stat'd the source and enabled ZIP64 on its own; hand-building
+        the entry gave that up, and a source over `ZIP64_LIMIT` then raises
+        `RuntimeError` part-way through — the export endpoint answers 500 for a file
+        that used to archive fine.
+
+        The limit is lowered rather than the fixture inflated: the branch under test
+        is selected by `size > ZIP64_LIMIT`, and a multi-gigabyte artifact in the
+        suite would buy nothing but minutes.
+        """
+        monkeypatch.setattr(zipfile, "ZIP64_LIMIT", 1024)
+        big = patched_config_dir / "workspace" / "big.bin"
+        payload = b"x" * 4096
+        big.write_bytes(payload)
+
+        zip_bytes, _ = create_export_zip()
+
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            assert zf.read(
+                next(n for n in zf.namelist() if n.endswith("workspace/big.bin"))
+            ) == payload
+
+    def test_the_zip64_guard_can_actually_fail(self, patched_config_dir, monkeypatch):
+        """Guard the guard: prove the lowered limit really selects the ZIP64 branch.
+
+        Without this, `..._still_exports` would pass just as happily on a build that
+        never crosses the limit at all, and the fix it pins would be untested.
+        """
+        monkeypatch.setattr(zipfile, "ZIP64_LIMIT", 1024)
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            info = zipfile.ZipInfo("e/big.bin", date_time=(2020, 1, 1, 0, 0, 0))
+            info.compress_type = zf.compression
+            # Matched case-insensitively because CPython's wording for this branch
+            # is not stable across the versions this project supports: 3.10 raises
+            # "File size unexpectedly exceeded ZIP64 limit" and 3.12 raises "File
+            # size too large, try using force_zip64". `zip64` is the one token both
+            # spellings share, so this stays specific to the ZIP64 branch without
+            # pinning a message the stdlib is free to reword again.
+            with pytest.raises(RuntimeError, match="(?i)zip64"):
+                with zf.open(info, "w") as dest:  # the call WITHOUT force_zip64
+                    dest.write(b"x" * 4096)
+
+    def test_a_directory_never_yields_a_descriptor(self, patched_config_dir):
+        """`_add_from_fd` streams bytes; a non-regular source must be refused before
+        it reaches that, not turned into an unreadable archive entry."""
+        adir = patched_config_dir / "workspace" / "adir"
+        adir.mkdir(parents=True, exist_ok=True)
+        assert (
+            portability._open_verified(str(adir), os.path.realpath(patched_config_dir))
+            is None
+        )
+
+
+pins_are_a_windows_property = pytest.mark.skipif(
+    not platform_compat.IS_WINDOWS,
+    reason=(
+        "the walk pins on both platforms, but the ANTI-RENAME half is a Windows "
+        "share-mode property -- a handle opened without FILE_SHARE_DELETE blocks "
+        "rename/delete, and POSIX has no equivalent to hold a name still"
+    ),
+)
+
+
+class TestTheAncestorSwapIsRefusedNotDetected:
+    """The names are HELD, not inspected — which is a different kind of guarantee.
+
+    Any check of a pathname is a check-to-open window: an adversary that can plant
+    a link chooses when to plant it, so "we looked and it was fine" says nothing
+    about the open that follows. On Windows that window is not merely a wrong
+    answer, it is an outbound SMB authentication — resolving a reparse point aimed
+    at a UNC share IS the probe — so a refusal computed afterwards has already paid
+    the cost it exists to prevent.
+
+    `platform_compat.pin_directory` removes the window instead of narrowing it. The
+    handle omits `FILE_SHARE_DELETE`, so while it lives the directory can be neither
+    renamed nor deleted; and the open refuses to follow a reparse point, so a
+    junction already at the name fails there rather than being traversed. Pinning
+    each component before naming the next means the only path the kernel walks to
+    reach component *n* runs through components already opened and verified — the
+    pattern `aws_control/backend/storage.py` already uses for the path a sandboxed
+    CLI writes through.
+
+    These tests do not assert that the mechanism is present. They run the attacker
+    at the exact instant the old code was vulnerable and assert the operating system
+    refused them.
+    """
+
+    @pins_are_a_windows_property
+    def test_a_racing_writer_cannot_swap_a_pinned_ancestor(
+        self, patched_config_dir, tmp_path, monkeypatch
+    ):
+        """The blocking finding's own scenario, executed rather than described.
+
+        "Writable directory swapped to a UNC reparse point after inspection." The
+        swap is performed from inside `pin_directory`, immediately after the
+        component it targets has been verified and pinned and before the next
+        filesystem call — the precise instant a real racing writer would aim for,
+        rather than a thread that has to be lucky.
+
+        Two things are asserted, and both matter. The rename must FAIL, because that
+        is the property: the export no longer depends on nobody having swapped the
+        directory, it depends on nobody being able to. And the descriptor must still
+        come back on the genuine bytes, because a guard that closed the race by
+        refusing everything would pass the first assertion and be useless.
+        """
+        nested = patched_config_dir / "workspace" / "deep"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "keep.md").write_text("ours", encoding="utf-8")
+        outside = tmp_path / "outside-the-crew-dir"
+        outside.mkdir()
+
+        workspace = os.path.realpath(patched_config_dir / "workspace")
+        attempts: list[str] = []
+        real_pin = platform_compat.pin_directory
+
+        def _pin_then_race(path):
+            fd = real_pin(path)
+            if os.path.normcase(os.fspath(path)) == os.path.normcase(workspace):
+                # The racing writer, at the worst possible moment: the component is
+                # verified, the walk is about to name what is under it.
+                try:
+                    os.rename(workspace, str(tmp_path / "carried-off"))
+                    attempts.append("SWAPPED")
+                except OSError as exc:
+                    attempts.append(f"refused:{type(exc).__name__}")
+            return fd
+
+        monkeypatch.setattr(platform_compat, "pin_directory", _pin_then_race)
+        found = list(
+            portability._walk_contained(
+                os.path.realpath(patched_config_dir),
+                PurePath("workspace"),
+                lambda _rel: True,
+            )
+        )
+        try:
+            assert attempts and attempts[0].startswith("refused:"), (
+                f"the racing writer swapped a verified ancestor: {attempts}"
+            )
+            assert found, "the guard refused every legitimate file; nothing proven"
+            fd = next(fd for rel, fd in found if rel.name == "keep.md")
+            assert os.read(fd, 64) == b"ours"
+        finally:
+            for _rel, fd in found:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+
+    def test_the_same_rename_succeeds_once_nothing_is_pinned(
+        self, patched_config_dir, tmp_path
+    ):
+        """Guard the guard: prove the refusal above is the pin and not the filesystem.
+
+        Without this, the test above would pass just as happily on a host where that
+        rename could never have worked, and would be pinning nothing at all.
+        """
+        workspace = patched_config_dir / "workspace"
+        carried_off = tmp_path / "carried-off"
+        os.rename(workspace, carried_off)
+        try:
+            assert not workspace.exists()
+        finally:
+            os.rename(carried_off, workspace)
+
+    def test_a_reparse_point_at_the_leaf_is_refused_without_being_followed(
+        self, patched_config_dir, tmp_path
+    ):
+        """The final component gets the same treatment, in one operation.
+
+        Windows has no `O_NOFOLLOW`, so `os.open` FOLLOWS a reparse point at the
+        name — the guard-the-guard below proves it on the very path under test, so
+        the refusal cannot be mistaken for the link being unopenable. The refusal
+        has to come from the open itself rather than from a check before it, or it
+        is the same window again.
+        """
+        outside = tmp_path / "outside-the-crew-dir"
+        outside.mkdir()
+        (outside / "marker.txt").write_text("private notes", encoding="utf-8")
+        leaf = patched_config_dir / "workspace" / "leaf-link"
+        make_dir_link(leaf, outside)
+
+        with pytest.raises(OSError):
+            fd = platform_compat.open_file_no_reparse(leaf)
+            os.close(fd)  # pragma: no cover - only runs if the refusal regressed
+
+        # Guard the guard: this exact name really is traversable by an ordinary
+        # open, so the refusal above is the no-follow flag doing its job.
+        fd = os.open(str(leaf / "marker.txt"), os.O_RDONLY)
+        try:
+            assert os.read(fd, 32) == b"private notes"
+        finally:
+            os.close(fd)
+
+    def test_an_ordinary_file_still_opens_through_the_no_follow_open(
+        self, patched_config_dir
+    ):
+        """Negative control for the leaf open: it must still return usable bytes.
+
+        The descriptor is also the one `_add_from_fd` streams from, so it has to
+        support the same operations the previous `os.open` descriptor did — on
+        Windows it is now a `CreateFileW` handle wrapped in a CRT descriptor, which
+        is exactly the kind of difference that passes a shallow test and breaks the
+        archive.
+        """
+        ordinary = patched_config_dir / "workspace" / "ordinary.md"
+        ordinary.write_text("ours", encoding="utf-8")
+
+        fd = platform_compat.open_file_no_reparse(ordinary)
+        try:
+            st = os.fstat(fd)
+            assert st.st_nlink == 1  # the hardlink rule reads this off the handle
+            os.lseek(fd, 0, os.SEEK_SET)  # `_add_from_fd` rewinds before streaming
+            with os.fdopen(os.dup(fd), "rb", closefd=True) as src:
+                assert src.read() == b"ours"
+        finally:
+            os.close(fd)
+
+    @pins_are_a_windows_property
+    def test_every_pin_is_released_even_when_a_component_refuses(
+        self, patched_config_dir, tmp_path, monkeypatch
+    ):
+        """A handle leak here would exhaust an export, not just look untidy.
+
+        `_pin_ancestors` holds one descriptor per directory for every file the walk
+        offers, so an unbalanced open on the refusal path would run a real export
+        out of handles part-way through — a failure that would only show up on a
+        large workspace.
+        """
+        nested = patched_config_dir / "workspace" / "deep"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "keep.md").write_text("ours", encoding="utf-8")
+
+        opened: list[int] = []
+        closed: list[int] = []
+        real_pin = platform_compat.pin_directory
+        real_close = os.close
+
+        def _counting_pin(path):
+            if len(opened) == 2:  # refuse the third component, mid-chain
+                raise NotADirectoryError(errno.ENOTDIR, "planted refusal", str(path))
+            fd = real_pin(path)
+            opened.append(fd)
+            return fd
+
+        def _counting_close(fd):
+            closed.append(fd)
+            return real_close(fd)
+
+        monkeypatch.setattr(platform_compat, "pin_directory", _counting_pin)
+        monkeypatch.setattr(portability.os, "close", _counting_close)
+        assert (
+            list(
+                portability._walk_contained(
+                    os.path.realpath(patched_config_dir),
+                    PurePath("workspace"),
+                    lambda _rel: True,
+                )
+            )
+            == []
+        )
+        assert opened, "no component was pinned, so nothing was under test"
+        assert set(opened) <= set(closed), (
+            f"pinned descriptors leaked: opened={opened} closed={closed}"
+        )
+
+
+#: Calls that RESOLVE the pathname handed to them, i.e. follow a reparse point at
+#: the final component. On Windows each one IS the outbound SMB authentication
+#: when that reparse point aims at a UNC share, which is why the property under
+#: test is about the calls and not about the archive.
+#:
+#: ``os.lstat`` and ``os.path.islink`` are deliberately absent: they do not follow
+#: the final component, so naming the link with one of them traverses nothing. The
+#: recorder still flags ANY call naming a path BELOW the link, whatever the call
+#: is, because reaching one at all means the link was traversed.
+_RESOLVING_CALLS = (
+    (os, "stat", "os.stat"),
+    (os, "open", "os.open"),
+    (os, "listdir", "os.listdir"),
+    (os, "scandir", "os.scandir"),
+    (os.path, "realpath", "os.path.realpath"),
+    (os.path, "isfile", "os.path.isfile"),
+    (os.path, "isdir", "os.path.isdir"),
+    (os.path, "exists", "os.path.exists"),
+    (os.path, "getsize", "os.path.getsize"),
+)
+
+#: ``pathlib`` binds ``scandir`` at import time, so patching ``os.scandir`` does
+#: not see ``rglob``'s own descent -- the single most important call to catch
+#: here. An audit hook sees it wherever it was bound from. Hooks cannot be
+#: removed once installed, so one is installed lazily for the whole process and
+#: routes into whichever sink is active.
+_audit_sink: list[tuple[str, str]] | None = None
+_audit_installed = False
+
+
+def _audit_probe(event: str, args: tuple) -> None:
+    if _audit_sink is None or event not in ("os.scandir", "os.listdir"):
+        return
+    for arg in args:
+        try:
+            name = os.fspath(arg)
+        except TypeError:
+            continue
+        if isinstance(name, bytes):
+            name = name.decode("utf-8", "replace")
+        if isinstance(name, str):
+            _audit_sink.append((event, name))
+        return
+
+
+@contextlib.contextmanager
+def recording_probes_through(link: Path, monkeypatch):
+    """Record every call that resolves *link*, or that names anything beneath it.
+
+    Yields the list it fills. Emptiness is the assertion: a refusal computed after
+    the probe went out is exactly the defect, so "nothing was archived" cannot be
+    the oracle -- that was already true of the code this replaces.
+    """
+    global _audit_sink, _audit_installed
+    seen: list[tuple[str, str]] = []
+    prefix = os.path.normcase(str(link))
+
+    def _record(label: str, target) -> None:
+        try:
+            name = os.fspath(target)
+        except TypeError:
+            return
+        if isinstance(name, bytes):
+            name = name.decode("utf-8", "replace")
+        if not isinstance(name, str):
+            return
+        normed = os.path.normcase(name)
+        if normed == prefix or normed.startswith(prefix + os.sep):
+            seen.append((label, name))
+
+    for module, attr, label in _RESOLVING_CALLS:
+        original = getattr(module, attr)
+
+        def _spy(*args, __original=original, __label=label, **kwargs):
+            if args:
+                _record(__label, args[0])
+            return __original(*args, **kwargs)
+
+        monkeypatch.setattr(module, attr, _spy)
+
+    # `os.path.realpath` reaches the filesystem through this, and a caller that
+    # imported it directly would bypass the patch above.
+    if hasattr(ntpath, "_getfinalpathname"):
+        original_final = ntpath._getfinalpathname
+
+        def _spy_final(*args, **kwargs):
+            if args:
+                _record("ntpath._getfinalpathname", args[0])
+            return original_final(*args, **kwargs)
+
+        monkeypatch.setattr(ntpath, "_getfinalpathname", _spy_final)
+
+    if not _audit_installed:
+        sys.addaudithook(_audit_probe)
+        _audit_installed = True
+    _audit_sink = []
+    try:
+        yield seen
+    finally:
+        for event, name in _audit_sink:
+            _record(event, name)
+        _audit_sink = None
+
+
+class TestNothingIsProbedThroughAPlantedReparsePoint:
+    """The walk must not TOUCH a planted junction, not merely refuse its bytes.
+
+    This is the difference the exact-head blocking finding turned on. The previous
+    build already archived nothing from behind a junction — containment worked —
+    and still issued twelve resolving calls through it while deciding that:
+    `rglob` descended it, then `is_file()` and `is_sensitive_path()` resolved what
+    it yielded. If the junction names `\\\\host\\share`, those resolutions are an
+    outbound SMB authentication that leaks this process's credentials to whoever
+    planted it, and `return None` afterwards cannot recall them.
+
+    So the assertion is on the CALLS, not on the archive. A test that only checked
+    the archive passes on the vulnerable build — measured, not assumed.
+    """
+
+    @pytest.mark.skipif(
+        not platform_compat.IS_WINDOWS,
+        reason=(
+            "the probe is a Windows reparse-point property: `rglob` descends a "
+            "junction there, while `pathlib` does not descend a POSIX directory "
+            "symlink, so the traversal under test cannot be staged on POSIX"
+        ),
+    )
+    def test_a_pre_planted_junction_is_never_resolved_during_an_export(
+        self, patched_config_dir, tmp_path, monkeypatch
+    ):
+        """Plant the junction BEFORE the export, then assert nothing reached it.
+
+        Pre-planted rather than raced on purpose: the swap race is the previous
+        finding and has its own test. This is the plant-and-wait case, which needs
+        no timing at all — the attacker leaves the link in the workspace a gateway
+        tool can write to and waits for an export to walk into it.
+        """
+        target = tmp_path / "never-touch-me"
+        target.mkdir()
+        (target / "loot.txt").write_text("private notes", encoding="utf-8")
+        junction = patched_config_dir / "workspace" / "trap"
+        make_dir_link(junction, target)
+        genuine = patched_config_dir / "workspace" / "keep.md"
+        genuine.write_text("ours", encoding="utf-8")
+
+        # Guard the guard, through oracles OUTSIDE the module under test: this is
+        # really a junction and not a symlink, which is the whole reason `rglob`
+        # walked into it -- `is_symlink()` answers False because a junction's tag
+        # is IO_REPARSE_TAG_MOUNT_POINT, not IO_REPARSE_TAG_SYMLINK -- and the far
+        # side really is reachable by an ordinary resolving call.
+        assert not junction.is_symlink()
+        assert platform_compat.is_link_or_junction(junction)
+        assert (junction / "loot.txt").read_text(encoding="utf-8") == "private notes"
+
+        with recording_probes_through(junction, monkeypatch) as probed:
+            zip_bytes, _ = create_export_zip()
+
+        assert probed == [], (
+            "the export resolved a path through the planted junction "
+            f"({len(probed)} calls): {probed[:6]}"
+        )
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+        # Negative control: the guard must not have "passed" by refusing the whole
+        # tree, and the loot must still be out.
+        assert any(n.endswith("workspace/keep.md") for n in names), names
+        assert not any("loot.txt" in n for n in names), names
+
+    @pytest.mark.skipif(
+        not platform_compat.IS_WINDOWS,
+        reason="the recorder is exercised against a Windows junction",
+    )
+    def test_the_recorder_actually_catches_a_probe(
+        self, patched_config_dir, tmp_path, monkeypatch
+    ):
+        """Guard the guard: an oracle that can never fire proves nothing.
+
+        Every call here is one the previous build made on this exact path, so this
+        also pins WHY that build was vulnerable rather than asserting it in prose.
+        """
+        target = tmp_path / "never-touch-me"
+        target.mkdir()
+        (target / "loot.txt").write_text("private notes", encoding="utf-8")
+        junction = patched_config_dir / "workspace" / "trap"
+        make_dir_link(junction, target)
+
+        with recording_probes_through(junction, monkeypatch) as probed:
+            junction.is_file()  # what the old `if not fpath.is_file()` did
+            os.path.realpath(junction)  # what `is_sensitive_path` did
+            list((patched_config_dir / "workspace").rglob("*"))  # the descent
+
+        labels = {label for label, _ in probed}
+        assert "os.path.realpath" in labels, probed
+        assert "os.scandir" in labels, (
+            "the audit hook did not observe `rglob` descending the junction, so "
+            f"the strongest half of the oracle is dead: {probed}"
+        )
+
+
+class TestALinkedCrewRootStillExports:
+    def test_a_crew_root_reached_through_a_link_still_packages_its_workspace(
+        self, fake_kirocrew_home, tmp_path, monkeypatch
+    ):
+        """The regression the screen's scoping exists to avoid.
+
+        Screening with `first_linked_ancestor` as-is would refuse every candidate
+        on a host whose `$KIROCREW_HOME` is a link -- a perfectly ordinary setup,
+        and the export would come back EMPTY rather than safe. A silently empty
+        backup is a worse outcome than the leak being fixed, so the boundary gets
+        its own test rather than a comment.
+        """
+        (fake_kirocrew_home / "workspace" / "keep.md").write_text("ours", encoding="utf-8")
+        linked_home = tmp_path / "linked-home"
+        make_dir_link(linked_home, fake_kirocrew_home)
+        monkeypatch.setenv("KIROCREW_HOME", str(linked_home))
+
+        zip_bytes, _ = create_export_zip()
+
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+        assert any(n.endswith("workspace/keep.md") for n in names), names
 
 
 class TestValidate:
@@ -1232,3 +1994,75 @@ async def test_import_handler_outcome_reflects_a_refused_merge(
     assert len(events) == 1, events
     assert events[0]["outcome"] == expected_outcome
     assert ("refused=crons" in events[0]["resources"]) is expect_refused_tag
+
+
+class TestExclusionsSurviveAWindowsSeparator:
+    """`_is_excluded` must be asked in the separator its rules are written in.
+
+    `_keep_for_export` built its argument as `PurePosixPath(str(rel))`. On Windows
+    `str(rel)` is backslash-separated, so `PurePosixPath` parses the WHOLE relative
+    path as one component: `.name` becomes `workspace\\notes\\.env` and `.parts`
+    has length one. The `EXPORT_EXCLUDE` basename set and the `EXCLUDE_DIRS` walk
+    then both stop matching, and `workspace/notes/.env` — a credential file the
+    export exists to keep out — went into an archive the user downloads and hands
+    on.
+
+    Driven through `PureWindowsPath` rather than through a real export, so the
+    assertion is PLATFORM-INDEPENDENT: `parts` and `str()` differ on every host,
+    so these fail everywhere if the `PurePosixPath(str(rel))` spelling returns.
+    """
+
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "workspace/notes/.env",
+            "workspace/deep/.local_secret",
+            "workspace/a/sel_hmac.key",
+            "workspace/b/telemetry_salt",
+            "workspace/nested/gateway.pid",
+        ],
+    )
+    def test_an_excluded_basename_is_excluded_below_the_top_level(self, rel: str) -> None:
+        assert portability._keep_for_export(PureWindowsPath(rel)) is False, (
+            f"{rel} would be packaged on Windows"
+        )
+
+    @pytest.mark.parametrize("bad_dir", sorted(portability.EXCLUDE_DIRS))
+    def test_an_excluded_directory_is_excluded_below_the_top_level(self, bad_dir: str) -> None:
+        rel = PureWindowsPath(f"workspace/{bad_dir}/inner.txt")
+        assert portability._keep_for_export(rel) is False, (
+            f"workspace/{bad_dir}/ would be packaged on Windows"
+        )
+
+    def test_an_ordinary_nested_file_is_still_kept(self) -> None:
+        """Negative control: the rebuild must not start excluding everything."""
+        assert portability._keep_for_export(PureWindowsPath("workspace/notes/ok.txt")) is True
+        assert portability._keep_for_export(PureWindowsPath("skills/manual/s1.md")) is True
+
+    def test_the_skills_auto_rule_still_reads_parts(self) -> None:
+        assert portability._keep_for_export(PureWindowsPath("skills/auto/gen.md")) is False
+        assert portability._keep_for_export(PureWindowsPath("workspace/auto/keep.md")) is True
+
+    def test_the_guard_can_actually_fail(self) -> None:
+        """Guard the guard: the OLD spelling really does miss these.
+
+        Without this the tests above would pass on a build where `str()` and
+        `parts` happened to agree, and would be pinning nothing.
+        """
+        rel = PureWindowsPath("workspace/notes/.env")
+        assert len(PurePosixPath(str(rel)).parts) == 1  # the bug, reproduced
+        assert PurePosixPath(str(rel)).name != ".env"
+        assert PurePosixPath(*rel.parts).name == ".env"  # the fix
+
+    def test_the_archive_name_is_posix_separated(self, patched_config_dir) -> None:
+        """A zip member name is POSIX-separated by spec, on every host."""
+        nested = patched_config_dir / "workspace" / "deep" / "keep.md"
+        nested.parent.mkdir(parents=True, exist_ok=True)
+        nested.write_text("ours", encoding="utf-8")
+
+        zip_bytes, _ = create_export_zip()
+
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+        assert any(n.endswith("workspace/deep/keep.md") for n in names), names
+        assert not any("\\" in n for n in names), names


### PR DESCRIPTION
## Problem / Motivation

`portability.create_export_zip` walks `workspace/`, `plan_memory/` and `skills/` with
`rglob("*")` and writes each file into an archive the user downloads and hands on.
The walk skipped an entry that **is** a symlink — but `rglob` **descends** a
directory link, and the file on the far side is an ordinary one, so that skip never
fired for it. Measured: `workspace/memory/linked/not-ours.md`, living outside the
crew directory entirely, appeared in the export's namelist.

**Correction to this PR's earlier description.** It said `_is_excluded` and
`is_sensitive_path` "both read the LEXICAL path". That is wrong about the second one,
and a reviewer was right to flag it: `is_sensitive_path` → `_path_in_home_dirs` →
`_candidate_forms` builds `_resolved_forms_bounded(expanded)`, so it **does** resolve
links — a linked `~/.aws` really was caught. The accurate statement is narrower and
different in kind: **neither filter is a containment test at all.** `_is_excluded` is
a rule about the archive *name*; `is_sensitive_path` asks whether a path is a
*protected location*, never whether it is *inside the crew directory*. An ordinary
file of the user's — notes, documents, anything under a link somebody dropped in the
workspace — was neither, and went into the archive.

**A resolve-and-compare is not enough, and the first commit here only did that.**
`ZipFile.write` takes a **name** and opens it itself, so the file that was checked and
the file that is read are two separate lookups. Measured against the shape `main`
ships:

```
by-name containment check at validation time: True  (accepts it)
archived bytes: b'private notes'
VULNERABLE: True
```

**And a refusal computed *after* the open is already too late on Windows** — the
third finding. `_open_inside` called `os.open(candidate, ...)` and only then asked
`fd_real_path` where the descriptor had landed. Opening a path whose ancestor is a
link to a UNC share **is itself an outbound SMB authentication as this process**, so
the containment, sensitivity and hardlink checks were all correct and all ran one
syscall too late. This is the ordering `hooks.validate_file_path` states as its own
contract — the Windows UNC and linked-ancestor gates run **before** any resolution,
"because `realpath` on a UNC path is itself the outbound SMB probe".

**And a pathname screen could not fix it — the fourth finding, which is what this
revision answers.** The previous head refused a candidate whose ancestor was a
reparse point, checked with `lstat`. A reviewer was right that this is still
raceable: any check of a *name* is a check-to-open window, and an adversary who can
plant the link chooses when. **Measured, not conceded** — the same racing writer,
run at the same instant, against both builds:

```
ARM A: previous head be3caf39b (lstat screen, then os.open by name)
  attacker      : rename SUCCEEDED, junction planted
  os.open called: keep.md                    <- the outbound probe
  bytes archived: None                       <- containment refused it, too late

ARM B: this revision (pinned ancestor walk)
  attacker      : rename REFUSED (PermissionError winerror=32)
  bytes archived: b'ours'
```

Arm A is the finding in three lines: the guard worked — nothing was archived — and
the probe went out anyway.

**And the ENUMERATION was still probing before any of that ran — the fifth finding,
which this revision answers.** Pinning the candidate's ancestors closed the *swap*
race, but a junction already sitting in the workspace when the export starts was
never raced for: `rglob` descended it, and `is_file()` and `is_sensitive_path()`
resolved what it yielded, before `_open_inside` was ever reached. Measured by
wrapping every resolving call and exporting a workspace holding one planted junction:

```
head 5663dd30a (pinned read, rglob enumeration)
  resolving calls through the junction : 14   (os.path.realpath, ntpath._getfinalpathname)
  loot archived                        : False

this revision (pinned walk)
  resolving calls through the junction : 0
  loot archived                        : False
```

Both builds archive nothing from behind the junction, which is exactly why the
archive cannot be the oracle. If the junction names `\\host\share`, those 14
resolutions **are** the outbound SMB authentication, and `return None` afterwards
cannot recall them. The previous revision disclosed this as an unclosed residual; it
is closed here.

## Why it matters

An export is a file the user deliberately hands to someone else — another machine, a
support thread, a backup. Content that was never theirs to share leaves the host with
no recovery once the archive has left.

The race is not theoretical here: a running gateway gives agent tools write access to
the same workspace the export walks, and an export can be triggered while they are
working. Under the race the harm is also strictly worse than under the plain blind
spot, because the sensitivity gate is one of the checks the swap gets to skip — the
name is validated, and something else is read.

The ordering finding is a different kind of harm rather than more of the same: a leaked
NTLM exchange is not something a later `return None` can take back, and it costs the
attacker nothing but a junction in a directory their tools can already write to.

## What changed (motivation → approach → change)

Root cause: **the check and the use are two lookups of one name**, and no lookup was
asking about containment in the first place.

Approach: resolve once, open once, address everything downstream through the
descriptor — the discipline `pinned_fs` already exists for in this repo. This change
consumes its `fd_real_path` rather than adding a second mechanism.

* **`_open_verified(target, root_real)`** — opens with `O_NOFOLLOW` where it
  exists, rejects a non-regular file on the descriptor's own `fstat`, then asks the
  kernel where the open descriptor actually is (`/proc/self/fd`, `F_GETPATH`, or
  `GetFinalPathNameByHandleW`) and compares that against the crew root.
  **`is_sensitive_path` is re-asked about that real path**, so the protected-location
  rule is not the one check the swap defeats. Every failure route — unreadable,
  non-regular, unknowable real path — returns `None`, never a fallback to the
  pathname.
* **`_add_from_fd`** streams the entry from that descriptor instead of letting
  `ZipFile.write` reopen the name. Streaming rather than reading whole is deliberate:
  a workspace file has no size bound here and the export used to copy one of any
  size. This is also why `hooks.safe_read_file_bytes_nolink` — which performs exactly
  the right validation — was not reused: its 50 MB cap would silently drop a large
  workspace file from the export.
* **The entry's timestamp and mode come from the same `fstat`**, so hand-building the
  `ZipInfo` does not quietly lose what `write` used to record.
* **The crew root is resolved once, before the walk** (`os.path.realpath(mc)`), since
  `$KIROCREW_HOME` may itself legitimately be a link and the test must not reject the
  whole export because of it.
* The by-name filters stay as cheap pre-filters that avoid opening what is already
  known to be unwanted, with a comment saying what each one actually decides.

Three things the descriptor alone does not settle, all raised in review and all fixed
here:

* **A hardlink defeats every path-based guard, including this one.** It shares its
  target's inode, so there is no symlink for `O_NOFOLLOW` to refuse, `is_symlink()`
  is False, and `fd_real_path` reports the path the descriptor was *opened by* — the
  innocent workspace alias — not a canonical one. `is_sensitive_path` is then asked
  about the alias and answers "not sensitive" while the bytes behind it are a
  credential file's. Only the link COUNT, read off the descriptor, sees it, so
  `st_nlink > 1` is refused. Same rule and same reasoning as
  `pinned_fs.refuse_hardlink_alias` and `hooks.safe_read_file_bytes_nolink`; the cost
  is honest and small — a workspace file that legitimately has a second link is left
  out of the export.
* **`force_zip64=True` on the streamed entry.** `ZipFile.write` stat'd the source and
  turned ZIP64 on by itself; a streamed entry does not know its size when the header
  is written, so without this a source over `zipfile.ZIP64_LIMIT` raises
  `RuntimeError` part-way through and the export endpoint answers 500. A multi-GiB
  file under `workspace/` is ordinary — a dataset, a model artifact — and it used to
  archive fine, so leaving this off would trade one defect for a regression.
* **The walk descends and verifies in one motion.** `_walk_contained` /
  `_walk_pinned` replace `rglob`. A directory is PINNED with
  `platform_compat.pin_directory` *before* it is listed, and each child is then
  classified from the listing itself (`_entry_is_link`) rather than by a call that
  resolves it: on Windows `FindFirstFileW` returns the attributes and the reparse tag
  inline, so a child's type and link-ness cost no lookup THROUGH that child. A child
  directory is descended only by pinning it in turn, so the path the kernel walks to
  reach component *n* runs entirely through components already opened and verified —
  starting at the crew root itself, which the kernel walks to reach every candidate.
  `pin_directory` supplies both halves on Windows: its handle omits
  `FILE_SHARE_DELETE`, so a held directory can be neither renamed nor deleted — nor
  can anything above it — and its open refuses to follow a reparse point, so a
  junction sitting at the name fails there instead of being traversed. **This is not
  a new mechanism**: `aws_control/backend/storage.py` already pins root-then-child for
  exactly this reason — "a watcher can no longer rename the directory away and plant a
  junction at its name between our create and the CLI's open".
* **`_pin_ancestors` and `_open_inside` are deleted rather than kept beside it.** The
  walk holds the same chain, for a whole subtree instead of re-walking it once per
  file, so keeping both would be two mechanisms doing one job. `_entry_is_link`
  refuses every reparse point rather than only link-shaped ones — which is precisely
  what `pin_directory` and `open_file_no_reparse` already refuse, so it classifies
  what the opens would reject anyway: a cheap skip, never the enforcement.
  `DirEntry.is_symlink()` alone would not do: a junction's tag is
  `IO_REPARSE_TAG_MOUNT_POINT`, not `IO_REPARSE_TAG_SYMLINK`, so that method answers
  False for one — which is how `rglob` came to descend it in the first place.
* **`is_sensitive_path` is no longer asked about the PATHNAME.** That call was the
  probe — 12 of the 14 measured resolutions. It is removed, not relocated: the same
  question is still asked in `_open_verified`, of the descriptor's real path, which
  was always the load-bearing one because a name can be re-pointed and a descriptor
  cannot.
* **The leaf is opened and judged in one operation.** New
  `platform_compat.open_file_no_reparse` opens with `FILE_FLAG_OPEN_REPARSE_POINT`, so
  a reparse point at the final name is opened *as itself* and refused (`ELOOP`) rather
  than followed — Windows has no `O_NOFOLLOW`, so `os.open` follows one. The attribute
  is read off the descriptor, which makes it a fact about what was opened rather than
  a prediction about what a later open will find. It shares the `CreateFileW` wiring
  with `pin_directory` via one private helper, so the two do not carry separate copies
  of the same security-critical flags. On POSIX it is the `O_NOFOLLOW` open the code
  already had, named.

Three deliberate boundaries, each stated because getting one wrong is worse than the
defect:

* **The walk starts at the RESOLVED root.** `pin_directory` refuses a reparse point at
  a name, so pinning the configured spelling of `$KIROCREW_HOME` would fail on a host
  where the crew directory is itself a link — and return an **empty archive** rather
  than a safer one. A silently empty backup is worse than the leak. Resolving first
  means the chain that gets pinned is the real one; the crew root's own ancestors are
  configuration this export has already read through.
* **POSIX is not handed Windows semantics.** The walk pins on both platforms, but
  only half the property is real there: `pin_directory` on POSIX is
  `O_RDONLY | O_DIRECTORY | O_NOFOLLOW`, whose refusal of a symlinked directory is
  genuine and is exactly what `rglob` already did — so the exported set is unchanged —
  while the anti-rename half has no POSIX equivalent and nothing here claims it. The
  Windows-only tests say so in their skip reason. Containment on POSIX rests where it
  always did, on `_open_verified` checking the descriptor's real path; resolving a
  symlink there is local and leaks nothing, so there is no outbound probe to prevent.
* **No lexical UNC screen.** A candidate here is the configured root joined with
  components the export itself enumerated, so it is UNC-shaped only when the root is —
  and refusing on that would break a deliberately configured UNC home for nothing.

**What it costs, stated exactly.** Nothing outside the crew directory is newly
dropped — containment already refused that. Content still inside it is either walked
under its own name anyway, or, if it lives in a part of the crew directory the export
does not walk, is left out on Windows — which is already the behaviour on POSIX, where
`rglob` never descends a directory link. The walk holds one descriptor per directory
for as long as that directory's subtree is being produced — depth, not breadth, bounds
how many are open at once, and it is strictly fewer opens than the previous revision,
which re-pinned the whole ancestor chain once per file. Each is released in a
`finally` that also runs if the consumer abandons the walk; a test pins that they are
released even when a component mid-chain refuses, because a handle leak here would
exhaust a large export rather than merely look untidy.

The exported set is unchanged **by the walk rewrite**, measured rather than argued:
on a tree covering nesting, `EXCLUDE_DIRS`, `EXPORT_EXCLUDE`, `.pid` and
`skills/auto`, the archive namelist and manifest counts were byte-identical to the
ones the previous walk produced. The exclusion fix below then deliberately CHANGES
that set on Windows — see the next section.

**The Windows exclusion bypass — disclosed here first, then fixed here.** An earlier
revision of this description scoped this out as a separate defect. A security review
disagreed and was right, so it ships in this PR.

`_keep_for_export` asked `_is_excluded(PurePosixPath(str(rel)))`. On Windows
`str(rel)` is backslash-separated, so `PurePosixPath` parses the whole relative path
as a SINGLE component: `.name` becomes `workspace
otes\.env` and `.parts` has
length one, so the `EXPORT_EXCLUDE` basename set and the `EXCLUDE_DIRS` walk both
stop matching. `workspace/notes/.env` — a credential file this export exists to keep
out — went into the archive the user downloads and hands on.

Fixed with `PurePosixPath(*rel.parts)` for the filter and `rel.as_posix()` for the
archive name. Measured on the same fixture tree as the parity run above:

```
before: workspace/notes/.env, workspace/__pycache__/x.pyc, workspace/snapshots/s.md
        all EXPORTED   (7 files)
after : excluded        (4 files)
```

**So the exported set does change on Windows, and that is the fix**: every nested
`.env`, `.local_secret`, `sel_hmac.key`, `telemetry_salt`, `*.pid`, and everything
under `snapshots/`, `outbox/`, `uploads/` and `__pycache__/` now stays out. POSIX is
unaffected — `str(rel)` and `parts` already agreed there.

On the archive name: `ZipInfo` rewrites `os.sep` today, so that half fixes no live
bug; it stops the member name depending on that behaviour, next to a filter that must
not.

## Tests

`TestTheAncestorSwapIsRefusedNotDetected` (new — replaces the screen's tests):

* `test_a_racing_writer_cannot_swap_a_pinned_ancestor` — **the blocking finding's own
  scenario, executed rather than described.** The swap is performed from inside
  `pin_directory`, immediately after the targeted component has been verified and
  pinned and before the next filesystem call — the precise instant a real racing
  writer would aim for, rather than a thread that has to get lucky. Two assertions,
  both load-bearing: the rename must **fail**, because that is the property (the
  export no longer depends on nobody having swapped the directory, but on nobody being
  able to); and the descriptor must still come back on the genuine bytes, because a
  guard that closed the race by refusing everything would pass the first assertion and
  be useless.
* `test_the_same_rename_succeeds_once_nothing_is_pinned` — guards that guard: the
  refusal above is the pin, not a filesystem that could never have done the rename.
* `test_a_reparse_point_at_the_leaf_is_refused_without_being_followed` —
  `open_file_no_reparse` refuses the link, and the guard-the-guard then proves *that
  exact name* is traversable by an ordinary `os.open`, so the refusal cannot be
  mistaken for the link being unopenable.
* `test_an_ordinary_file_still_opens_through_the_no_follow_open` — the descriptor is
  the one `_add_from_fd` streams from, and on Windows it is now a `CreateFileW` handle
  wrapped in a CRT descriptor. The test exercises `st_nlink` (the hardlink rule reads
  it off this handle), `lseek` and `dup`+`fdopen` — exactly the operations a shallow
  test would miss and the archive would break on.
* `test_every_pin_is_released_even_when_a_component_refuses` — a component mid-chain
  is made to refuse and every pinned descriptor must still be closed.

`TestNothingIsProbedThroughAPlantedReparsePoint` (new — the fifth finding):

* `test_a_pre_planted_junction_is_never_resolved_during_an_export` — **the assertion
  is on the CALLS, not on the archive.** A junction is planted under `workspace/`
  before the export runs; every resolving call (`os.stat`, `os.open`, `os.listdir`,
  `os.scandir`, `os.path.realpath` / `isfile` / `isdir` / `exists` / `getsize`, and
  `ntpath._getfinalpathname`) is wrapped, and the test fails if any of them names the
  junction or anything beneath it. `os.lstat` and `os.path.islink` are deliberately
  *not* in that set — they do not follow the final component, so naming the link with
  one traverses nothing. An audit hook covers `os.scandir` / `os.listdir` as well,
  because `pathlib` binds `scandir` at import time and patching `os.scandir` does not
  see `rglob`'s own descent — the single most important call to catch. Two negative
  controls sit beside it: the genuine `workspace/keep.md` must still be archived (a
  guard that refused the whole tree would otherwise pass), and the loot must still be
  absent.
* `test_the_recorder_actually_catches_a_probe` — guards that guard. It performs the
  three calls the *previous* build made on that exact path (`is_file()`,
  `realpath()`, `rglob`) and asserts the recorder saw both a `realpath` and the
  `scandir` descent. An oracle that can never fire proves nothing, and this one is
  the whole test.
* Guard-the-guard on the fixture itself, through oracles outside the module:
  `is_symlink()` must be **False** (it really is a junction, which is why `rglob`
  walked in), `is_link_or_junction` must be True, and the far side must really be
  readable through the link.

**Red-before for these two:** with only `portability.py` reverted to `5663dd30a` and
the new tests kept, `test_a_pre_planted_junction_is_never_resolved_during_an_export`
fails with `AssertionError: the export resolved a path through the planted junction
(14 calls)`, listing `os.path.realpath` and `ntpath._getfinalpathname` on the junction
path. The recorder test passes on both builds, as it must — it tests the oracle, not
the fix.

The tests that depend on the rename lock are marked Windows-only with the reason
stated: the walk pins on both platforms, but the anti-rename half is a share-mode
property (`FILE_SHARE_DELETE` omitted) that POSIX has no equivalent of.

`TestALinkedCrewRootStillExports`:

* `test_a_crew_root_reached_through_a_link_still_packages_its_workspace` — drives the
  public `create_export_zip` with `$KIROCREW_HOME` on a real link. This is the
  regression the resolved-root rule exists to avoid, and it would otherwise be silent.

`TestTheArchivedBytesAreTheValidatedBytes` (same assertions, retargeted from
`_open_inside` to `_open_verified` now that the pins live in the walk):
`test_retargeting_the_link_after_validation_cannot_change_what_is_archived` (the
descriptor race, with the swap at the crew root — the one component outside the pins),
`test_a_sensitive_target_is_refused_on_the_descriptor`,
`test_a_file_reached_through_a_directory_link_gets_no_descriptor`,
`test_a_real_file_inside_the_crew_dir_gets_a_descriptor_on_its_own_bytes`,
`test_a_hardlinked_alias_gets_no_descriptor` (+ its single-link control),
`test_a_streamed_entry_larger_than_the_zip64_limit_still_exports` (+
`test_the_zip64_guard_can_actually_fail`),
`test_containment_fails_closed_when_the_real_path_is_unknowable`,
`test_a_directory_never_yields_a_descriptor`.

`TestExport`: `test_export_does_not_package_files_reached_through_a_directory_link`
(Windows-marked, with its guard-the-guard walking from the root the *production* walk
starts at), `test_export_preserves_the_mtime_of_what_it_packages`,
`test_export_still_packages_a_real_nested_workspace_file`.

**Red-before is the A/B in Problem / Motivation**, run against `be3caf39b` loaded
side-by-side with this build and driven by the identical attacker: on the previous
head the racing rename succeeded, the junction was planted, and `os.open` was still
called on the candidate; on this head the rename is refused with `WinError 32` and the
genuine bytes come back. The same swap, injected through the shipped test, is
`test_a_racing_writer_cannot_swap_a_pinned_ancestor`.

**Gates.** `test/test_portability.py` 78 passed / 4 skipped on Windows against real
junctions. `pin_directory`'s existing consumers re-run clean:
`test_platform_compat.py`, `test_aws_control_storage.py`, `test_pinned_staging.py` =
383 passed / 72 skipped, the single failure being
`TestFindPythonInterpreterReal::test_version_gate_ignores_a_sitecustomize_decoy_on_pythonpath`,
**reproduced with this branch's production files reverted to `be3caf39b`** — it is an
artefact of the `PYTHONPATH` override this Windows box needs to run the suite at all,
which is the very thing that test is about. `mypy --platform linux` reports 0 errors
in `portability.py` (the 4 it finds are pre-existing in `dashboard/state.py` and one
other, reached by import following). `black --check` clean on `portability.py`;
`test/test_portability.py` is in the repository's black baseline (1164 known-
unformatted files) and `scripts/check_black_formatting.py` passes, so it is
deliberately not reformatted — doing so would bury this diff under an unrelated
rewrite of its SQL fixtures. `flake8` and `isort --check-only` clean on both;
`scripts/scrub-lint.sh --no-history` passes.

## Manual verification

N/A — unit coverage sufficient: the whole defect is the relationship between the
containment decision and the archive read, and the tests drive both against a real
junction rather than a mock, including through the public `create_export_zip`. The
ordering property is asserted on the syscall itself rather than on an observable
side effect, which is what a manual run could not have shown either.

## Related Issues

None — found by inspection while auditing `is_symlink`-based containment guards for
the Windows junction blind spot, the same family as #7881.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a containment guard that **validates a path and then reopens it**. Two
distinct failures ride together — a recursive walk descends a directory link and the
leaf beyond it carries no mark (a Windows junction carries none anywhere), and
`resolve()`-then-`open(name)` is a check-to-use window. Where a walk feeds something
that reads, writes, moves or executes the result, the fix is not a stricter name
check: open once and address the descriptor. A second lesson for review prompts:
"filter X already resolves links" does not mean filter X answers *containment* — ask
which question each filter actually answers before crediting it with an unrelated one.

Third lesson, and the one this PR was blocked twice to learn: **on Windows a correct
refusal computed after the open is still a leak, and no pathname check can fix it.**
Touching an untrusted path *is* the outbound probe, so the sequence must be
open-and-judge in one operation, with the ancestors held rather than inspected —
`lstat`-then-open and `is_symlink()`-then-open are the same defect wearing different
clothes. The repository already had the primitive (`platform_compat.pin_directory`)
and already had the pattern (`aws_control/backend/storage.py`); the review prompt
worth writing is "if this guard checks a name and then opens that name, what holds the
name still in between?".

Fourth: **when reusing an ancestor-walking guard, ask what it is scoped to.** A walk
that runs to the drive root fails closed on *everything* when the configured root is
itself a link — which would have turned a leak fix into a silently empty backup.

Fifth, and the one this revision cost: **guarding the read does not guard the walk.**
Four revisions hardened what the export was allowed to OPEN while the enumeration in
front of it kept resolving untrusted names for free. The review prompt worth writing
is "before the guard runs, what has already touched this path?" — and the test that
catches it must assert on the calls, because every build here archived the right
thing. `rglob`, `glob`, `os.walk` and `Path.iterdir` are all guard-free surface. The
enumeration primitive that *is* safe was already available: `os.scandir` hands back a
child's type and reparse tag from the directory listing, so a walk can decide about a
child without ever addressing it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)



