### PR TITLE
docs(prepare-pr): colour-coded Mermaid diagram in the PR body contract

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -539,9 +539,73 @@ the depth — the facts stay complete and technically exact.
   thread, not the body.
 - **Say the effect in user words.** What a person sees now that they did not see
   before, or stops seeing. Not "improves robustness".
+- **Show it, when words alone are slow.** A ten-year-old gets a moved flow from
+  one picture before they finish the first paragraph about it. When the change
+  moves steps, states, or who calls whom, add one Mermaid diagram. See *Draw it*
+  below.
 
 Rewrite check before opening the PR: read section 3 once, out loud. If any
 sentence needs a second read to find its point, rewrite that sentence.
+
+#### Draw it — the Age 10 diagram
+
+The doctrine lives in the `explain-for` skill: *Draw it when the thing has a
+shape* says when a Mermaid fence beats prose, and *Colour it, and make every
+colour mean something* says how to colour it. Do not restate it here — follow it.
+What this section adds is only what a PR body needs on top: the trigger, the fixed
+diff palette, the legend, the placement, and the render check.
+
+Draw one when the change alters **a sequence, a state machine, or who calls
+whom** — a step added, removed, reordered, or given a new owner. Skip it for a
+one-line fix, a rename, a test-only change, or a doc edit. **One diagram, at most.**
+
+- **Mermaid, in the body.** GitHub renders a ```` ```mermaid ```` fence in the PR
+  body directly. Nothing to commit, no SHA to re-pin, nothing for
+  `cleanup-temp-screenshots.yml` to prune, and a reviewer can fix a box label in
+  the text. A real rendered screen or a pixel before/after is not a diagram — that
+  is a screenshot; see *Screenshots* below, which owns the path and pinning rules.
+- **Show the delta, not the whole system.** Before → after side by side
+  (`flowchart LR` with two subgraphs), or one graph where the changed edge is the
+  only thing that stands out. Six to ten nodes is the ceiling.
+- **The diff palette is fixed.** Declare these four `classDef`s and tag every
+  node, so each PR reads the same way at a glance:
+
+  | class | fill / stroke | meaning |
+  |---|---|---|
+  | `added` | `#DCFCE7` / `#16A34A` | new after this PR |
+  | `changed` | `#FEF3C7` / `#D97706` | behaviour changed |
+  | `removed` | `#FEE2E2` / `#DC2626`, dashed | gone after this PR |
+  | `ctx` | `#E0F2FE` / `#0284C7` | untouched, shown for context |
+
+  Colour the edges too: `linkStyle <n> stroke:#16A34A,stroke-width:2px` on the
+  new path, `stroke:#DC2626,stroke-dasharray:4 3` on the removed one. Put one
+  legend line under the fence: `🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged`.
+- **Caption in the Age 10 register**, one sentence: who now calls whom, and what
+  the reader sees because of it.
+- **Place it inside section 3**, right after the paragraph it illustrates.
+
+```mermaid
+flowchart LR
+  subgraph Before
+    A1[cron fires]:::ctx --> B1[LLM turn]:::removed --> C1[open PR]:::ctx
+  end
+  subgraph After
+    A2[cron fires]:::ctx --> B2[open_maintenance_prs.py]:::added --> C2[open PR]:::ctx
+  end
+  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
+  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
+  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
+  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
+  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
+  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
+```
+
+🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged
+
+*The cron now runs a script instead of spending an LLM turn; the PR still opens.*
+
+Check the render before pushing — `gh pr view <n> --web`. A fence that fails to
+parse shows as a red error box, which is worse than no diagram.
 
 ### Screenshots
 


### PR DESCRIPTION
## Problem / Motivation

A PR that moves a flow is hard to read from prose alone. Three paragraphs about "A used to call B, now it calls C" take longer to check than one picture. The prepare-pr skill has a Screenshots section for pixels, but nothing that asks for a diagram when the change is about steps, states, or who calls whom.

## Why it matters

Reviewers spend their time rebuilding the flow in their head. A picture cuts that to one glance. Doing it with committed PNGs would add files to the branch, need SHA re-pinning on every amend, and grow `temp-screenshots/` for the cleanup workflow to prune.

## What changed (motivation → approach → change)

The PR description contract in `src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md` gets a new **Draw it — the Age 10 diagram** sub-section. It lives inside the **Writing register — Age 10** section as a `Draw it` sub-heading, plus one new register bullet (the only pointer to it): a ten-year-old reads a moved flow from one picture faster than from a paragraph. Section 3 (What changed) is untouched; the register bullet is the only route to it.

Mermaid is the first choice. GitHub renders a ```` ```mermaid ```` fence in the PR body on its own. So there is no file to commit, no SHA to re-pin, and nothing for `cleanup-temp-screenshots.yml` to delete. A real screen or a pixel before/after is a screenshot, not a diagram, and stays with the Screenshots section that owns the path and SHA-pin rules.

The when-to-draw and colour-means-something doctrine already lives in the `explain-for` skill, so the new section points there instead of restating it. What it adds is PR-only: a fixed diff palette of four `classDef`s (green `added`, amber `changed`, red-dashed `removed`, blue `ctx`), coloured edges, a one-line legend under the fence, placement inside section 3, and one new author step: check the fence renders (`gh pr view <n> --web`) before pushing, because a broken fence shows as a red error box. The rule is one diagram at most, and only when the change moves a sequence, a state machine, or a call graph.

```mermaid
flowchart LR
  subgraph Before
    A1[cron fires]:::ctx --> B1[LLM turn]:::removed --> C1[open PR]:::ctx
  end
  subgraph After
    A2[cron fires]:::ctx --> B2[open_maintenance_prs.py]:::added --> C2[open PR]:::ctx
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*This is the example the section ships. It is here so the reviewer sees the palette render on GitHub.*

## Tests

N/A — prose-only skill change. The existing skill-tree gates still pass: `test/test_frontmatter.py`, `test/test_builtin_skill_scope.py`, `test/test_agent_template_skills.py`, `test/test_prepare_pr_profiles.py` (360 passed).

## Manual verification

- The example fence was rendered with Mermaid 11 through the repo's Playwright and parses clean.
- `scripts/check_brand_name.py`, `scripts/docs-lint.sh`, and `scripts/check_builtin_skill_scope.py` all pass on the diff.
- `SKILL.md` mtime bumped so the built-in skill tree re-syncs.

## Screenshots / video

N/A — no dashboard UI change. The Mermaid render above is the visible effect.

## Related Issues

no linked issue: skill authoring improvement, no tracked issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
