### PR TITLE
fix(dashboard): carry the slots offender note on every read path

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -111,6 +111,7 @@ from kiro_crew.dashboard.state import (
     _ChatSlot,
     _mark_permission_resolved,
     _normalize_slot_key,
+    _slots_serialization_note,
     append_and_surface,
     durable_row_count,
     is_stop_event_row,
@@ -1105,7 +1106,18 @@ async def api_chat_slots(request: web.Request) -> web.Response:
         if urls:
             schedule_visibility_refresh(urls, state.push_slots_update)
             schedule_check_refresh(urls, state.push_slots_update)
-    return web.json_response(payloads)
+    # Same offender diagnostic as the slots broadcast (#8745 class), on the same
+    # projection: ``web.json_response`` would run this exact dump internally and
+    # raise a bare TypeError naming neither slot nor field. Dump here so the
+    # failure carries the note; the exception still propagates unchanged.
+    # ``json_response`` is ``Response(text=dumps(data), content_type=...)``, so
+    # the healthy path is byte-identical.
+    try:
+        body = json.dumps(payloads)
+    except (TypeError, ValueError) as exc:
+        exc.add_note(_slots_serialization_note(payloads, path="GET /api/chat/slots"))
+        raise
+    return web.Response(text=body, content_type="application/json")
 
 
 async def api_chat_slot_source_links(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -268,36 +268,36 @@ def _safe_folder_tree(folders: object) -> list[dict[str, Any]]:
     return [f for f in folders if isinstance(f, dict) and isinstance(f.get("id"), str)]
 
 
-def _slots_serialization_note(slots_data: object) -> str:
+def _slots_serialization_note(slots_data: object, *, path: str = "slots-broadcast") -> str:
     """Name the slot and field that broke JSON serialization, for a traceback note.
 
     A dump failure on the slots projection means EVERY slots read path is broken
-    (GET ``/api/chat/slots``, the WS snapshot, and this broadcast all serialize
-    the same shape), and the stock message — "Object of type X is not JSON
-    serializable" — names neither the slot nor the field, which is how #6522 was
-    first misread as a broadcast bug (#8745). Values are withheld by design: slot
-    state can carry user text, and the type is enough to find the producer.
+    — the coalesced broadcast, the dashboard-user WS frame (``_slots_ws_frame``),
+    the WS connect snapshot, and ``GET /api/chat/slots`` all serialize the same
+    shape — and the stock message — "Object of type X is not JSON serializable"
+    — names neither the slot nor the field, which is how #6522 was first misread
+    as a broadcast bug (#8745). All four paths now route their dump failure
+    through this note; ``path`` names the one that raised. Values are withheld
+    by design: slot state can carry user text, and the type is enough to find
+    the producer.
 
-    Diagnosis must never make the failure worse, so any surprise in the walk
-    degrades to a generic note instead of raising.
+    Every caller passes ``serialize_slots()`` output (list-of-dicts by
+    construction), so the walk assumes that shape rather than re-checking it.
+    Diagnosis must never make the failure worse, so any surprise in the walk —
+    including a caller breaking that assumption — degrades to the generic
+    note below instead of raising.
     """
     try:
-        if not isinstance(slots_data, list):
-            return (
-                "[slots-broadcast] slot projection is "
-                f"{type(slots_data).__name__}, not a list (value withheld)"
-            )
+        # Narrowing, not validation: every caller passes a list by construction,
+        # and a violation lands in the defensive except below (degrade, never
+        # raise) exactly like any other surprise in the walk.
+        assert isinstance(slots_data, list)
         for i, entry in enumerate(slots_data):
             try:
                 json.dumps(entry)
                 continue
             except (TypeError, ValueError):
                 pass
-            if not isinstance(entry, dict):
-                return (
-                    f"[slots-broadcast] slot entry #{i} is not JSON-serializable: "
-                    f"type {type(entry).__name__} (value withheld)"
-                )
             key = entry.get("key")
             slot_name = key if isinstance(key, str) else f"#{i}"
             for field, value in entry.items():
@@ -305,18 +305,18 @@ def _slots_serialization_note(slots_data: object) -> str:
                     json.dumps(value)
                 except (TypeError, ValueError):
                     return (
-                        f"[slots-broadcast] slot {slot_name!r} field {field!r} is not "
+                        f"[{path}] slot {slot_name!r} field {field!r} is not "
                         f"JSON-serializable: type {type(value).__name__} (value withheld)"
                     )
             # Every field dumps on its own, yet the entry does not: a non-string
             # key is the one shape that gets here.
             return (
-                f"[slots-broadcast] slot {slot_name!r} fails serialization as a whole; "
+                f"[{path}] slot {slot_name!r} fails serialization as a whole; "
                 "no single offending field — check for non-string dict keys (value withheld)"
             )
-        return "[slots-broadcast] slot list fails serialization; no offending entry found"
-    except Exception:  # pragma: no cover - defensive: a diagnostic must not raise
-        return "[slots-broadcast] slot projection is not JSON-serializable (offender walk failed)"
+        return f"[{path}] slot list fails serialization; no offending entry found"
+    except Exception:  # defensive: a diagnostic must not raise
+        return f"[{path}] slot projection is not JSON-serializable (offender walk failed)"
 
 
 def _slots_ws_frame(
@@ -350,24 +350,32 @@ def _slots_ws_frame(
     it through here would widen an app's payload, so it is a third shape by
     design, not a duplicate awaiting cleanup.
     """
-    return json.dumps(
-        {
-            "type": "slots",
-            "data": slots,
-            "yolo": yolo,
-            "channelTrusted": channel_trusted,
-            "gitlabHostsGeneration": gitlab_hosts_gen,
-            "folders": folders,
-            "foldersGeneration": folders_gen,
-            # Which governance ceiling is installed. A centrally pushed policy
-            # (``policy_distribution.apply_ceiling``) swaps the ceiling mid-session
-            # and bumps this counter; the client invalidates its cached
-            # ``dashboardConfig`` on a change, so a governance-derived field there
-            # (``social_share_enabled``) follows the ceiling instead of waiting out
-            # its stale window. Process-local, like the two counters above.
-            "governanceGeneration": governance_gen,
-        }
-    )
+    frame = {
+        "type": "slots",
+        "data": slots,
+        "yolo": yolo,
+        "channelTrusted": channel_trusted,
+        "gitlabHostsGeneration": gitlab_hosts_gen,
+        "folders": folders,
+        "foldersGeneration": folders_gen,
+        # Which governance ceiling is installed. A centrally pushed policy
+        # (``policy_distribution.apply_ceiling``) swaps the ceiling mid-session
+        # and bumps this counter; the client invalidates its cached
+        # ``dashboardConfig`` on a change, so a governance-derived field there
+        # (``social_share_enabled``) follows the ceiling instead of waiting out
+        # its stale window. Process-local, like the two counters above.
+        "governanceGeneration": governance_gen,
+    }
+    # Same offender diagnostic as the coalesced broadcast (#8745 class): the
+    # dashboard-user frame serializes the ENRICHED projection, so a value that
+    # only enrichment adds raises here and nowhere else. Diagnosis only — the
+    # exception propagates unchanged. A clean-slots note ("no offending entry
+    # found") is itself evidence: the offender is in the envelope extras.
+    try:
+        return json.dumps(frame)
+    except (TypeError, ValueError) as exc:
+        exc.add_note(_slots_serialization_note(slots, path="ws-frame"))
+        raise
 
 
 def _split_namespaced_channel_id(channel_id: str | None) -> tuple[str, str] | None:

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -16,7 +16,11 @@ from kiro_crew import shutdown_event
 from kiro_crew.dashboard.chat_utils import effective_session_key, subagent_event_slot
 from kiro_crew.dashboard.handlers.updates import status_update_fields
 from kiro_crew.dashboard.origin import check_origin
-from kiro_crew.dashboard.state import DashboardState, _safe_folder_tree
+from kiro_crew.dashboard.state import (
+    DashboardState,
+    _safe_folder_tree,
+    _slots_serialization_note,
+)
 from kiro_crew.dashboard.ws_event_scope import (
     _audit_allow,
     _audit_deny,
@@ -672,17 +676,30 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
             # initial push writes to the socket directly -- so record it here
             # or it goes unrecorded entirely.
             _audit_grant_quietly(ws_app, "slots_yolo")
-        await ws.send_json(
-            {
-                "type": "slots",
-                "data": slots_data,
-                **envelope_extras,
-                # Seed the client's generation baseline so a later change is
-                # detectable as a change rather than as a first sighting.
-                "gitlabHostsGeneration": gitlab_hosts_generation(),
-                "governanceGeneration": initial_answer_generation,
-            }
-        )
+        snapshot_frame = {
+            "type": "slots",
+            "data": slots_data,
+            **envelope_extras,
+            # Seed the client's generation baseline so a later change is
+            # detectable as a change rather than as a first sighting.
+            "gitlabHostsGeneration": gitlab_hosts_generation(),
+            "governanceGeneration": initial_answer_generation,
+        }
+        # Same offender diagnostic as the slots broadcast (#8745 class).
+        # ``send_json`` is ``send_str(dumps(data))``, so dumping here is
+        # byte-identical on the healthy path. This whole connect block sits
+        # under ``except Exception: pass``, so a note alone would vanish with
+        # the swallowed exception — log the failure too: a client whose
+        # snapshot dies here shows an empty sidebar with zero evidence
+        # otherwise. The exception still propagates (and is swallowed)
+        # exactly as before.
+        try:
+            snapshot_payload = json.dumps(snapshot_frame)
+        except (TypeError, ValueError) as exc:
+            exc.add_note(_slots_serialization_note(slots_data, path="ws-connect-snapshot"))
+            logger.warning("slots connect snapshot failed to serialize", exc_info=True)
+            raise
+        await ws.send_str(snapshot_payload)
         if owner_request or is_dashboard_user:
             # Issue links carry no check status — skip them so the scheduler
             # never hands an issue URL to the pull-request-only chip fetch.

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -1074,6 +1074,10 @@ class TestOwnerSourceStatusTransport:
         # connect-time frame carries the folder tree — the frame that fixes the
         # first-paint flicker (#4127).
         state._folders = [{"id": "f1", "name": "Work", "order": 0}]
+        # The snapshot is really dumped now (offender-note seam), so every
+        # frame field must be JSON-serializable — a bare MagicMock return
+        # value no longer slips through a fake send_json unserialized.
+        state.folders_generation.return_value = 7
 
         class Request(dict):
             def __init__(self) -> None:
@@ -1105,6 +1109,11 @@ class TestOwnerSourceStatusTransport:
 
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
+
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
 
             def __aiter__(self):
                 return self
@@ -1225,6 +1234,11 @@ class TestOwnerSourceStatusTransport:
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
 
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
+
             def __aiter__(self):
                 return self
 
@@ -1338,6 +1352,11 @@ class TestPeriodicCheckStatusRefresh:
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
 
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
+
             def __aiter__(self):
                 return self
 
@@ -1418,6 +1437,11 @@ class TestPeriodicCheckStatusRefresh:
 
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
+
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
 
             def __aiter__(self):
                 return self
@@ -1529,6 +1553,11 @@ class TestPeriodicCheckStatusRefresh:
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
 
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
+
             def __aiter__(self):
                 return self
 
@@ -1588,6 +1617,11 @@ class TestPeriodicCheckStatusRefresh:
 
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
+
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
 
             def __aiter__(self):
                 return self
@@ -1656,6 +1690,11 @@ class TestPeriodicCheckStatusRefresh:
 
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
+
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
 
             def __aiter__(self):
                 return self
@@ -1736,6 +1775,11 @@ class TestPeriodicCheckStatusRefresh:
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
 
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
+
             def __aiter__(self):
                 return self
 
@@ -1811,6 +1855,11 @@ class TestPeriodicCheckStatusRefresh:
 
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
+
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
 
             def __aiter__(self):
                 return self

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -1066,6 +1066,225 @@ def test_healthy_flush_is_unchanged_by_the_diagnostics(tmp_path, monkeypatch):
     assert seen.count("slots") == 1
 
 
+# ── #8745 follow-up: the REMAINING slots read paths carry the same offender note ──
+#
+# The broadcast got the diagnostic first; the sibling read paths serialize the
+# SAME projection and used to fail with the same bare TypeError: the
+# dashboard-user WS frame (``_slots_ws_frame``, both its send sites), the WS
+# connect snapshot, and ``GET /api/chat/slots``. These pin the note on each
+# path, the ``path`` label that names which one raised, and the benign controls
+# proving healthy outputs are unchanged.
+
+
+def _poisoned_slots() -> list[dict]:
+    return [{"key": "chat-poison", "title": object()}]
+
+
+def test_ws_frame_serialization_failure_names_the_offender():
+    """The dashboard-user WS frame annotates its dump failure with the offender."""
+    from kiro_crew.dashboard.state import _slots_ws_frame
+
+    with pytest.raises(TypeError) as excinfo:
+        _slots_ws_frame(
+            _poisoned_slots(),
+            yolo=False,
+            channel_trusted=False,
+            gitlab_hosts_gen=0,
+            folders=[],
+            folders_gen=0,
+            governance_gen=0,
+        )
+
+    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
+    assert "[ws-frame]" in notes, f"note must name the raising path, got: {notes!r}"
+    assert "'chat-poison'" in notes and "'title'" in notes
+    assert "value withheld" in notes
+
+
+def test_ws_frame_failure_outside_slots_exonerates_the_slot_list():
+    """A clean-slots note is evidence too: the offender is in the envelope extras."""
+    from kiro_crew.dashboard.state import _slots_ws_frame
+
+    with pytest.raises(TypeError) as excinfo:
+        _slots_ws_frame(
+            [{"key": "chat-1", "title": "fine"}],
+            yolo=False,
+            channel_trusted=False,
+            gitlab_hosts_gen=0,
+            folders=object(),  # the actual offender, outside the slot list
+            folders_gen=0,
+            governance_gen=0,
+        )
+
+    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
+    assert "[ws-frame]" in notes
+    assert "no offending entry found" in notes, "clean slots must be exonerated"
+
+
+def test_ws_frame_healthy_roundtrip_unchanged():
+    """Benign control: the wrapped dump produces the same frame."""
+    from kiro_crew.dashboard.state import _slots_ws_frame
+
+    frame = json.loads(
+        _slots_ws_frame(
+            [{"key": "chat-1"}],
+            yolo=True,
+            channel_trusted=False,
+            gitlab_hosts_gen=3,
+            folders=[{"id": "f1"}],
+            folders_gen=7,
+            governance_gen=9,
+        )
+    )
+
+    assert frame == {
+        "type": "slots",
+        "data": [{"key": "chat-1"}],
+        "yolo": True,
+        "channelTrusted": False,
+        "gitlabHostsGeneration": 3,
+        "folders": [{"id": "f1"}],
+        "foldersGeneration": 7,
+        "governanceGeneration": 9,
+    }
+
+
+@pytest.mark.asyncio
+async def test_rest_slots_get_serialization_failure_names_the_offender(tmp_path, monkeypatch):
+    """GET /api/chat/slots annotates its dump failure instead of a bare TypeError."""
+    from aiohttp.test_utils import make_mocked_request
+
+    from kiro_crew.dashboard.chat_handlers import api_chat_slots
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _poison_slots_projection(state)
+
+    request = make_mocked_request("GET", "/api/chat/slots", app={"state": state})
+    request["user"] = "local-app"
+    request["app"] = ""
+
+    with pytest.raises(TypeError) as excinfo:
+        await api_chat_slots(request)
+
+    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
+    assert "[GET /api/chat/slots]" in notes, f"note must name the REST path, got: {notes!r}"
+    assert "'chat-poison'" in notes and "'title'" in notes
+
+
+@pytest.mark.asyncio
+async def test_rest_slots_get_healthy_response_is_unchanged(tmp_path, monkeypatch):
+    """Benign control: explicit dump serves the same 200/JSON as json_response did."""
+    from aiohttp.test_utils import TestClient, TestServer
+    from chat_test_helpers import _make_app
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.get("/api/chat/slots")
+        assert resp.status == 200
+        assert resp.content_type == "application/json"
+        assert await resp.json() == state.serialize_slots(
+            include_check_status=True, dashboard_user=True
+        )
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_snapshot_failure_is_logged_with_the_offender(
+    tmp_path, monkeypatch, caplog
+):
+    """The connect snapshot's swallow gets a WARNING carrying the offender note.
+
+    The whole connect block sits under ``except Exception: pass``, so before
+    this seam a broken snapshot meant an empty sidebar with zero evidence.
+    The exception flow is unchanged (still swallowed); the log is the one new
+    observable, and it carries the note through ``exc_info``.
+    """
+    import logging
+
+    from kiro_crew.dashboard import ws as dashboard_ws
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+
+    state = MagicMock()
+    state.owner_id = "U_OWNER"
+    state.serialize_slots = lambda **kw: _poisoned_slots()
+    state._yolo = False
+    state._folders = [{"id": "f1", "name": "Work", "order": 0}]
+    state.folders_generation = MagicMock(return_value=7)
+
+    class Request(dict):
+        def __init__(self) -> None:
+            super().__init__({"user": "local-app", "app": ""})
+            self.setdefault("is_dashboard_user", True)
+            self.app = {"state": state}
+
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.closed = True
+            self.sent: list = []
+            self._flags: dict = {"_is_dashboard_user": True}
+
+        def __setitem__(self, key, value) -> None:
+            self._flags[key] = value
+
+        def __getitem__(self, key):
+            return self._flags[key]
+
+        def get(self, key, default=None):
+            return self._flags.get(key, default)
+
+        async def prepare(self, request) -> None:
+            return None
+
+        async def send_json(self, payload) -> None:
+            self.sent.append(payload)
+
+        async def send_str(self, payload: str) -> None:
+            self.sent.append(json.loads(payload))
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    fake_ws = FakeWebSocket()
+    monkeypatch.setattr(dashboard_ws, "_check_ws_origin", lambda request: None)
+    monkeypatch.setattr(dashboard_ws.web, "WebSocketResponse", lambda **kwargs: fake_ws)
+
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.dashboard.ws"):
+        result = await dashboard_ws.api_ws(Request())  # type: ignore[arg-type]
+
+    assert result is fake_ws
+    slots_frames = [f for f in fake_ws.sent if isinstance(f, dict) and f.get("type") == "slots"]
+    assert not slots_frames, "the poisoned snapshot must not have been sent"
+    records = [r for r in caplog.records if "connect snapshot" in r.message]
+    assert records, "the swallowed failure must leave a WARNING behind"
+    exc = records[0].exc_info[1]  # type: ignore[index]
+    notes = "\n".join(getattr(exc, "__notes__", []))
+    assert "[ws-connect-snapshot]" in notes
+    assert "'chat-poison'" in notes and "'title'" in notes
+
+
+def test_note_helper_path_label_and_degradation():
+    """The path label lands in every message; a shape surprise degrades, never raises."""
+    from kiro_crew.dashboard.state import _slots_serialization_note
+
+    assert _slots_serialization_note([], path="x") == (
+        "[x] slot list fails serialization; no offending entry found"
+    )
+    # Callers guarantee list-of-dicts; anything else degrades to the generic
+    # note via the defensive except (the shrunken shape-check branches).
+    assert _slots_serialization_note(42) == (
+        "[slots-broadcast] slot projection is not JSON-serializable (offender walk failed)"
+    )
+    assert _slots_serialization_note({"not": "a list"}, path="y") == (
+        "[y] slot projection is not JSON-serializable (offender walk failed)"
+    )
+
+
 # ── The deferred restore must not let a flush truncate the snapshot ──
 #
 # start_flush_loop() is running (every 5s) BEFORE the startup restore. While the

--- a/test/test_ws_event_scoping.py
+++ b/test/test_ws_event_scoping.py
@@ -3318,6 +3318,11 @@ class TestDirectSendGrantsAreAudited:
             async def send_json(self, payload: dict) -> None:
                 self.sent.append(payload)
 
+            async def send_str(self, payload: str) -> None:
+                # Connect snapshot sends a pre-dumped string (offender-note
+                # seam); parse back so assertions keep reading dict frames.
+                self.sent.append(json.loads(payload))
+
             def __aiter__(self):
                 return self
 


### PR DESCRIPTION
## Problem / Motivation

#8888 added `_slots_serialization_note`, so when the open-slots projection picks up a value `json.dumps` cannot serialize, the coalesced slots broadcast fails with a note naming the exact slot and field instead of a bare `Object of type X is not JSON serializable`. But the broadcast is only one of four places that serialize that projection. The three sibling read paths still fail bare:

- the dashboard-user WS frame (`_slots_ws_frame`, covering both of its send sites) — this one serializes the *enriched* projection, so a poisoned value that only enrichment adds raises here and nowhere else;
- the WS connect snapshot — which sits under an `except Exception: pass`, so a broken snapshot today means an empty sidebar with **zero evidence anywhere**;
- `GET /api/chat/slots` — `web.json_response` runs the dump internally, out of reach of the diagnostic.

## Why it matters

The offender note exists precisely because these failures are data-dependent and intermittent: whichever path serializes the poisoned projection first is the one that fails, and three of the four paths still produce the undebuggable bare TypeError (or, on the connect snapshot, silence). The FP review on #8888 called this out and sanctioned the follow-up; this PR completes the seam so every read path fails with the same named-offender diagnostic.

## What changed (motivation → approach → change)

All three remaining paths now dump explicitly and annotate failures through the shared helper:

- `_slots_serialization_note` gains a `path` keyword (default keeps the wired broadcast site byte-identical) so the note names which read path raised, and its two unreachable shape-check branches are removed — every caller passes `serialize_slots()` output, which is list-of-dicts by construction, and any surprise still degrades to the generic note through the defensive `except` instead of raising.
- `_slots_ws_frame` wraps its dump, annotates with `path="ws-frame"`, and re-raises — one seam covering both of its send sites (fan-out and owner projections).
- `GET /api/chat/slots` dumps explicitly and returns `web.Response(text=..., content_type="application/json")` — `json_response` *is* `Response(text=dumps(...))`, so the healthy response is unchanged; the failure path now carries the note.
- The WS connect snapshot dumps explicitly, annotates with `path="ws-connect-snapshot"`, and **also logs a WARNING before re-raising** — a deliberate addition, disclosed here: the outer `except Exception: pass` swallows the annotated exception, so without the log line the note would vanish with it. One log line on a today-silent failure is the minimal honest diagnosability; the exception flow itself (swallow-and-continue) is unchanged. The snapshot also now sends the pre-dumped string via `send_str` — the established shape on every other slots send path (`send_json` is `send_str(dumps(...))`).

Test doubles: the WS fakes gain a `send_str` that parses back to the dict frames existing assertions read; one double's `folders_generation` had returned a raw `MagicMock`, which a fake `send_json` never serialized and the real dump now rightly rejects.

## Tests

Contract-generated, reusing the `_poison_slots_projection` helper and REST app fixtures from the #8888 suite (`test/test_open_slots_persistence.py`, +219 lines):

- REST: poisoned projection → the TypeError carries the note naming slot, field, and `GET /api/chat/slots` (fails-before: bare TypeError from inside `json_response`);
- WS connect: poisoned snapshot → caplog WARNING carries the note, nothing is sent, connection proceeds (fails-before: no log record, silent empty sidebar);
- `_slots_ws_frame` direct: poisoned enriched projection → TypeError note with `[ws-frame]` (fails-before: bare);
- exoneration control: clean slots + poisoned envelope extras → the note says no slots entry offends (the diagnostic must not miscredit);
- degradation pin post-shrink: `helper(42)` → generic note, no raise;
- benign controls: all four paths healthy → byte-identical outputs (REST body equality against `json_response`, WS frame dict equality).

Fails-before reproduced at the pristine base (this suite copied onto `3a6478967`): 5 failed / 69 passed — the three named-offender assertions, the path-label test, and the connect-snapshot log assertion all fail exactly as designed. Full 7-section gate run (targeted 345 passed / seam-neighbor 295 passed / mypy / flake8 / isort / black-baseline / docs-lint) green at the exact commit.

## Manual verification

N/A — the seam is deterministic (same poisoned projection in, same annotated failure out) and the benign controls pin byte-identical healthy behavior on all four paths.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff (dashboard serialization diagnostics; no rendered UI change). The only user-visible delta is a clearer error annotation in logs/API error payloads, covered by the attack tests above.

## Related Issues

Follow-up to #8888 (same seam, deferral named in that PR's review round); completes the offender-note coverage started there. Diagnostic class as #8745.

## Pattern harvest

Pattern: a diagnostic added at one serialization site of a shared projection leaves sibling read paths (REST handler, WS snapshot, WS frame) failing bare — the fix is to route every dump of that projection through the one annotating helper, with a path label so the note also says *where*.
Rule candidate: review-prompt — "when a serialization diagnostic wraps one call site, list every other place the same object is serialized (grep the projection builder's callers); require either shared-helper routing or an explicit rationale per uncovered path, and flag any covered path that sits under a swallowing except without a log line."

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the helper docstring is the doc-of-record for this seam and is updated in the diff
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Per the template placeholder (CLA text pending): offered under the same terms as my prior merged contributions to this repository (#8835, #8888).
