### PR TITLE
perf(memory): skip MMR rerank in the episodic retirement lookup (#8902)

### DIFF
--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -1584,7 +1584,15 @@ class VectorMemoryStore:
         emb = self._try_embed(query)
         with self._db_lock:
             if emb is not None:
-                results = self.search_episodic(query_embedding=emb, query_text="", limit=10)
+                # mmr=False: internal write-path caller that applies its own cosine
+                # threshold below, so the MMR diversity rerank buys nothing here and
+                # cost ~71ms per superseding write at 1,000 pooled candidates
+                # (issue #8902). mmr also SIZES the candidate pool
+                # (limit vs _MMR_MAX_POOL), so keep the limit wide: the 0.7
+                # threshold, not the pool cut, decides what gets retired.
+                results = self.search_episodic(
+                    query_embedding=emb, query_text="", limit=50, mmr=False
+                )
                 for r in results:
                     if r.get("cosine_sim", 0) > 0.7 and r["id"] not in seen:
                         seen.add(r["id"])

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -2956,6 +2956,98 @@ class TestSharedConnectionLockDiscipline:
         assert entry is not None
         assert entry["value_json"] == '"emacs"'
 
+    def test_retire_search_skips_mmr_rerank(self, tmp_path: Path) -> None:
+        """``_retire_stale_episodic``'s internal lookup passes ``mmr=False`` (#8902).
+
+        The caller applies its own ``cosine_sim > 0.7`` threshold, so diversity
+        reranking buys nothing there, and the default MMR rerank cost ~71ms per
+        superseding semantic write at 1,000 pooled candidates.
+        """
+        dim = 16
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=dim)
+        store.init()
+        embed = self._fake_embed(dim)
+        store.embed_fn = embed
+
+        # Matches the retire query "editor: vim" exactly, so the vector path
+        # clears its cosine threshold regardless of tokenizer details.
+        text = "editor: vim"
+        assert store.write_episodic(text, embedding=embed(text)) is True
+
+        calls: list[dict] = []
+        returned: list[list[dict]] = []
+        real_search = store.search_episodic
+
+        def _spy(*args: object, **kwargs: object) -> list[dict]:
+            calls.append(dict(kwargs))
+            out = real_search(*args, **kwargs)  # type: ignore[arg-type]
+            returned.append(out)
+            return out
+
+        store.search_episodic = _spy  # type: ignore[assignment]
+        assert store.set_semantic("pref.editor", "vim", 0.9, "consolidation") is None
+        # The superseding write triggers _retire_stale_episodic on "vim".
+        assert store.set_semantic("pref.editor", "emacs", 0.9, "consolidation") is None
+
+        retire_calls = [c for c in calls if c.get("query_embedding") is not None]
+        assert retire_calls, "superseding write never reached search_episodic"
+        assert all(
+            c.get("mmr") is False for c in retire_calls
+        ), f"retirement search must skip the MMR rerank: {retire_calls}"
+
+        # The VECTOR branch itself cleared the threshold: without this, the
+        # is_deleted check below would be satisfied by the text-LIKE fallback
+        # alone (the fixture text matches its first pattern verbatim) and a
+        # broken vector path under mmr=False would keep the test green.
+        assert any(
+            r.get("cosine_sim", 0) > 0.7 for out in returned for r in out
+        ), "vector retirement path returned no row above the cosine threshold"
+
+        # The superseded episodic row is still soft-deleted without the rerank.
+        row = store.db.execute(
+            "SELECT is_deleted FROM episodic_memories WHERE text = ?", (text,)
+        ).fetchone()
+        assert row is not None
+        assert row["is_deleted"] == 1
+
+    def test_retire_recall_survives_without_the_mmr_pool(self, tmp_path: Path) -> None:
+        """Retirement recall must not collapse to ten rows when MMR is off (#8902).
+
+        ``mmr`` does not only pick a reranker — it sizes the candidate pool
+        (``_MMR_MAX_POOL`` vs ``limit``), so the retirement lookup keeps a wide
+        ``limit``: the caller's own ``cosine_sim > 0.7`` threshold, not the pool
+        cut, decides what gets retired. The row texts avoid both text-LIKE
+        fallback patterns ("editor: vim" / "editor vim"), so only the vector
+        branch can retire them; with a limit of 10 (or the old MMR top-10) five
+        of the fifteen conflicting rows would escape retirement.
+        """
+        dim = 64
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=dim)
+        store.init()
+        embed = self._fake_embed(dim)
+        store.embed_fn = embed
+        store._faiss_index = None  # deterministic: exercise the fallback tier
+
+        fillers = [
+            "alpha", "bravo", "charlie", "delta", "echo",
+            "foxtrot", "golf", "hotel", "india", "juliet",
+            "kilo", "lima", "mike", "november", "oscar",
+        ]
+        # Tokens {vim, editor, <filler>} give cosine ~0.82 against the retire
+        # query "editor: vim" (tokens {editor, vim}) under the bag-of-words
+        # fake embed — above the 0.7 threshold, below the 0.88 dedup gate.
+        texts = [f"vim editor {w}" for w in fillers]
+        for t in texts:
+            assert store.write_episodic(t, embedding=embed(t)) is True
+
+        assert store.set_semantic("pref.editor", "vim", 0.9, "consolidation") is None
+        assert store.set_semantic("pref.editor", "emacs", 0.9, "consolidation") is None
+
+        remaining = store.db.execute(
+            "SELECT COUNT(*) FROM episodic_memories WHERE is_deleted = 0"
+        ).fetchone()[0]
+        assert remaining == 0, f"{remaining} superseded episodic rows escaped retirement"
+
 
 class TestLockedFetchHelpers:
     """The locked fetch helpers (#1947) — the single route for plain SELECTs."""


### PR DESCRIPTION
## Problem / Motivation

Every superseding semantic write pays a full-pool MMR diversity rerank it does not need. `_retire_stale_episodic` (the helper `set_semantic` calls to soft-delete episodic rows that reference a superseded value) called `search_episodic(query_embedding=emb, query_text="", limit=10)` with the default `mmr=True`, so the entire candidate pool went through `_mmr_rerank` — measured by the reporter at ~71ms per call at 1,000 pooled candidates (~0.07ms/candidate, linear), versus 0.11ms with `mmr=False`.

## Why it matters

The cost lands on the semantic-write path, inside the `_db_lock` hold, on every superseding write — consolidation batches pay it repeatedly, and it grows linearly with store size. Diversity reranking buys nothing for this caller: it immediately applies its own `cosine_sim > 0.7` threshold and only wants the nearest neighbours of one phrase.

## What changed (motivation → approach → change)

- Symptom: ~71ms of MMR rerank per superseding semantic write, for a caller that discards MMR's ordering entirely.
- Root cause: the internal retirement lookup used `search_episodic`'s dashboard-facing defaults (`mmr=True`).
- Change: pass `mmr=False` at this one call site, removing the rerank (the reporter's suggested fix).
- One deliberate refinement found in pre-push review: `mmr` does not only pick a reranker — it also **sizes the candidate pool** (`_MMR_MAX_POOL` vs `limit` in `_rank_from_scoring_set`, and the post-sort slice on the other tiers). A naive `limit=10, mmr=False` would truncate to the top-10 by *decayed* score before the caller's cosine threshold ever ran, so aged high-cosine conflicts could escape retirement. The call therefore keeps a wide `limit=50`: the caller's own `cosine_sim > 0.7` threshold, not the pool cut, decides what gets retired. This retires strictly more conflicting rows than the old MMR top-10 sample while still removing the rerank cost (truncation is a slice, not a rerank).

Untouched, per the issue's scope notes: `_mmr_rerank`, `_MMR_MAX_POOL`, `_MMR_LAMBDA`, the FAISS recall-pool expression (`k = min(limit*2, ntotal)`), `relevance_filter` defaults, and `get_episodic_context` (unaffected — it passes `relevance_filter=True`).

## Tests

- `test_retire_search_skips_mmr_rerank` — spies on `search_episodic` on a live store, triggers a superseding `set_semantic` write, and pins that the retirement call carries `mmr=False`; also asserts the **vector branch itself** returned a row above the cosine threshold (so the text-LIKE fallback cannot mask a broken vector path) and that the superseded row is soft-deleted. Proven red against the pre-fix call site.
- `test_retire_recall_survives_without_the_mmr_pool` — writes fifteen conflicting rows whose texts avoid both text-LIKE fallback patterns, then asserts all fifteen are retired after a superseding write. Proven red both on the old code (MMR's top-10 left five rows live) and on a naive `limit=10, mmr=False` (same five escape) — green only with the wide limit.

## Manual verification

N/A — unit coverage sufficient: the change is a single internal call-site argument change whose observable behavior (retirement membership and the removed rerank) is pinned by the two tests above. Full local gate suite run (isort/flake8/mypy/black gate, full pytest at pristine-main baseline parity: the identical 105-failure/18-error set reproduces on pristine main).

## Screenshots / video

N/A — backend-only change, no user-visible UI surface.

## Related Issues

Reported by @swchoi0102 with per-candidate timing measurements and the suggested fix adopted here — thank you.

Fixes #8902

## Pattern harvest

Rule candidate: review-prompt
Pattern: a boolean "algorithm on/off" flag that also silently resizes the candidate pool — callers disabling the algorithm for cost must re-check recall, not just ordering.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
