### PR TITLE
fix(chat): allow a mid-conversation workspace switch

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -163,6 +163,7 @@ _SESSION_RELOAD_NOTICE = (
     "agent spec, environment, and MCP servers. The conversation is preserved."
 )
 
+
 # Approval modes that grant auto-approval to the SLOT they name, as opposed to
 # the process-global YOLO grant. A tuple, not a set: membership is tested against
 # a request-supplied value, and tuple `in` compares by equality rather than
@@ -7377,22 +7378,25 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
         return body_err
     assert body is not None  # read_bounded_json returns (dict, None) on success
     ws_name = body.get("workspace", "default")
+    if not isinstance(ws_name, str):
+        # The sibling project handler's guard: with the message-count refusal
+        # lifted, this value reaches `default_project_dir` and the slot header
+        # on a live conversation, so a non-string is rejected at the boundary.
+        return web.json_response(
+            {"error": "workspace must be a string", "code": "invalid_workspace"}, status=400
+        )
     if slot.is_remote:
-        # Same guard as the local path, then hand the pick to the peer.
         # ``slot.project`` is deliberately left alone: it is a path on THIS
         # machine (file search, @-mentions), and `default_project_dir` would
         # write a local directory that has nothing to do with the peer's
         # workspace. The peer resolves its own project from the name. No
         # local session is reset, so this runs outside slot._lock (the
         # effort handler's ordering).
-        if slot.total_messages > 0:
-            return web.json_response(
-                {
-                    "error": "Cannot change workspace after messages have been sent. Open a new session instead.",
-                    "code": "conversation_started",
-                },
-                status=409,
-            )
+        #
+        # No message-count refusal (#1717): the peer owns its own session
+        # lifecycle, so the local message count says nothing about what the
+        # switch costs there, and refusing here would be this side inventing a
+        # policy for state it does not hold. The peer's own handler answers.
         return await _apply_remote_pick(request, state, slot, "workspace", {"workspace": ws_name})
     # Same serialization as the agent switch: the reset await yields the event
     # loop, so the mutate-then-reset section runs under the slot's lock — an
@@ -7425,26 +7429,85 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
         denied = _app_cancel_denied(request, slot, "chat.slot_workspace", session_key)
         if denied is not None:
             return denied
-        # Block workspace change after conversation has started. Checked
-        # INSIDE the lock: the guard is a check-then-act across an await, so
-        # an unlocked read could pass while a serialized switch this request
-        # waited on was still resetting.
-        if slot.total_messages > 0:
+        # A started conversation is NOT refused (#1717). The refusal that
+        # stood here protected nothing the sibling handlers protect: the
+        # transcript and its session key are workspace-independent (the name
+        # is a metadata field inside the same history file, never part of its
+        # path), so a switch costs the LIVE agent context and nothing
+        # persisted -- and `api_chat_slot_agent` already re-points
+        # ``slot.workspace`` mid-conversation, with no message-count guard,
+        # whenever the picked agent carries different bindings. A transcript
+        # marker for the restart is deliberately NOT added here: every sibling
+        # reset site would need the same row, and that is one design for all of
+        # them (#9086), not a rider on this endpoint.
+        #
+        # Same-value re-pick: nothing to switch, so nothing to tear down.
+        # Checked INSIDE the locks (the model handler's ordering): a serialized
+        # predecessor targeting this workspace may have committed while this
+        # request waited, and resetting again would kill the session that
+        # predecessor just set up. Answers the same 200 a real switch does,
+        # since the slot IS on the requested workspace.
+        if slot.workspace == ws_name:
+            return web.json_response({"ok": True, "workspace": ws_name})
+        # Children attached to this session run on the runtime the reset
+        # below tears down, so refuse rather than discard their work -- the
+        # same probe every sibling switch (agent, model, effort, reload)
+        # applies. Before the commit, so no rollback is needed.
+        children_409 = _subagents_attached_response(state, slot, session_key, "slot_workspace")
+        if children_409 is not None:
+            return children_409
+        # Never tear down an in-flight turn: the model handler's early
+        # refusal, copied here (GPT + Opus review findings on #9084). The reset
+        # below calls _unblock_pending_waits BEFORE SessionManager.reset's
+        # atomic busy decline, so without this check a turn parked on a
+        # pending approval has that approval rejected and only then gets a
+        # 409 -- the turn is altered despite the refusal. slot.running is
+        # checked FIRST because it is set at dispatch, before the multi-second
+        # provider.start() registers a session: a cold-starting first turn is
+        # invisible to get_provider but not to slot.running, and without this
+        # the switch would report success while that turn runs on the old
+        # project. isinstance, not a None check, for the reason the model
+        # handler documents. The atomic skip_if_busy decline stays as the
+        # backstop for a turn that starts after this read.
+        pre_provider = state.sessions.get_provider(session_key)
+        if slot.running or (
+            isinstance(pre_provider, LLMProvider) and pre_provider.has_active_turn()
+        ):
             return web.json_response(
-                {
-                    "error": "Cannot change workspace after messages have been sent. Open a new session instead.",
-                    "code": "conversation_started",
-                },
-                status=409,
+                {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
             )
         prior_workspace = slot.workspace
         prior_project = slot.project
-        slot.workspace = ws_name
-        slot.project = default_project_dir(ws_name)
+        # Commit as identity tokens (the agent handler's _CommitToken
+        # precedent): ``slot.project`` has lock-free writers -- the in-turn
+        # set_project directive lands during the reset await -- so a rollback
+        # must unwind only the value THIS request wrote, never a concurrent
+        # write of a different (or even the same) text.
+        committed_workspace = _CommitToken(ws_name)
+        committed_project = _CommitToken(default_project_dir(ws_name))
+        slot.workspace = committed_workspace
+        slot.project = committed_project
         logger.info("Slot %s workspace switched to %r, resetting session", name, ws_name)
-        # skip_if_busy: the total_messages guard above is checked before this
-        # await, and message dispatch does not take slot._lock — a first send
-        # can slip into that window. SessionManager.reset evaluates busyness
+
+        def _rollback() -> None:
+            """Unwind this request's commit on every 409 path.
+
+            Identity-scoped per field (see the tokens above), then re-marked
+            dirty: the periodic flush runs unlocked every few seconds and may
+            already have written the provisional bindings to disk during the
+            reset await (a started slot is dirty whenever a turn is active),
+            so without the re-mark a rejected switch would survive a restart.
+            The flush rebuilds the metadata line from the live fields, so the
+            re-mark reconverges disk to whatever the rollback left.
+            """
+            if slot.workspace is committed_workspace:
+                slot.workspace = prior_workspace
+            if slot.project is committed_project:
+                slot.project = prior_project
+            slot._dirty = True
+
+        # skip_if_busy: message dispatch does not take slot._lock, so a send
+        # can land while this request holds it. SessionManager.reset evaluates busyness
         # atomically with the session pop (the authoritative backstop
         # api_chat_slot_reload documents), so the slipped-in turn is declined
         # here instead of torn down mid-stream.
@@ -7496,8 +7559,7 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
                     # Roll back the commit (commit-before-reset means the new
                     # pair is already visible) and answer the same 409 the
                     # guard gives.
-                    slot.workspace = prior_workspace
-                    slot.project = prior_project
+                    _rollback()
                     return web.json_response(
                         {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
                     )
@@ -7514,8 +7576,7 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
                     # guard below.
                     teardown_incomplete = True
                 elif not reset_ok:
-                    slot.workspace = prior_workspace
-                    slot.project = prior_project
+                    _rollback()
                     return web.json_response(
                         {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
                     )
@@ -7527,12 +7588,21 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
             # committed bindings would describe a session that never saw the
             # switch. Roll back and answer 409; the retry resolves the
             # current binding.
-            slot.workspace = prior_workspace
-            slot.project = prior_project
+            _rollback()
             return web.json_response(
                 {"error": "slot session was rebound during the switch", "code": "session_rebound"},
                 status=409,
             )
+        # Mark for the periodic flush (GPT review finding): the flush writes a
+        # slot's metadata line only while ``_dirty`` is set, and nothing else
+        # on this path sets it. On main that was harmless -- the message-count
+        # refusal meant only an EMPTY slot ever got here, and the flush skips
+        # a slot with no messages anyway. With the switch allowed on a started
+        # conversation, a gateway crash before the next message would restore
+        # the OLD workspace/project over a switch the user saw succeed. The
+        # remote-peer branch persists through ``_apply_remote_pick`` and the
+        # same-value no-op changes nothing, so neither needs this.
+        slot._dirty = True
     state.push_slots_update()
     ws_resp: dict = {"ok": True, "workspace": ws_name}
     if teardown_incomplete:

--- a/src/kiro_crew/dashboard/remote_relay.py
+++ b/src/kiro_crew/dashboard/remote_relay.py
@@ -665,8 +665,8 @@ async def forward_peer_selection(
                 return accepted
         return {}
     # The peer's own refusal is the useful message — it knows why (an agent that
-    # was removed there, a model its account cannot serve, a workspace with
-    # messages already sent). Only its `error` string is surfaced, and only when
+    # was removed there, a model its account cannot serve, a turn in flight on
+    # the peer). Only its `error` string is surfaced, and only when
     # it is a short string: the rest of a peer reply is not trusted for display.
     detail = ""
     if len(raw) <= _MAX_PEER_SLOT_REPLY_BYTES:

--- a/test/test_chat_slot_switch_atomicity.py
+++ b/test/test_chat_slot_switch_atomicity.py
@@ -13,7 +13,7 @@ the mid-turn 409 (clones of the concurrency template in
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -29,6 +29,8 @@ from kiro_crew.dashboard.chat import (
 )
 from kiro_crew.dashboard.chat_handlers import _slot_switch_session_lock
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+MOD = "kiro_crew.dashboard.chat_handlers"
 
 # Valid registry aliases the model guard accepts (tests are exempt from the
 # hardcoded-model-literal gate; these mirror the ids the existing model-switch
@@ -704,13 +706,11 @@ class TestSlotWorkspaceSwitchAtomicity:
             state.sessions.reset.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_message_guard_is_checked_inside_the_lock(self):
-        # The total_messages guard is a check-then-act across the reset
-        # await: an unlocked read could pass while a serialized predecessor
-        # was still running, then mutate a slot whose conversation had
-        # started in the meantime. Checked inside the lock, a message that
-        # lands while the request waits makes it answer 409 and touch
-        # nothing.
+    async def test_message_landing_during_the_lock_wait_still_switches(self):
+        # #1717 removed the total_messages refusal, so a message that lands
+        # while this request waits on the slot lock no longer turns the switch
+        # into a 409: the switch commits and the session is reset, exactly as
+        # it would have with no message in flight.
         slot = _ChatSlot("test")
         slot.workspace = "old-ws"
         slot.project = "/workspace/old-ws"
@@ -725,10 +725,10 @@ class TestSlotWorkspaceSwitchAtomicity:
                 await asyncio.sleep(0.05)
                 slot.total_messages = 1
             resp = await task
-            assert resp.status == 409
-            assert slot.workspace == "old-ws"
-            assert slot.project == "/workspace/old-ws"
-            state.sessions.reset.assert_not_awaited()
+            assert resp.status == 200
+            assert slot.workspace == "new-ws"
+            assert slot.project == "/workspace/new-ws"
+            state.sessions.reset.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_reset_declined_busy_rolls_back_and_answers_409(self):
@@ -743,7 +743,9 @@ class TestSlotWorkspaceSwitchAtomicity:
         slot.workspace = "old-ws"
         slot.project = "/workspace/old-ws"
         busy = MagicMock(spec=LLMProvider)
-        busy.has_active_turn.return_value = True
+        # Idle at the pre-commit check, mid-turn at the post-decline
+        # re-read: the turn slipped into the reset's own entry window.
+        busy.has_active_turn.side_effect = [False, True]
         state = _mock_state(slot, provider=busy)
         state.sessions.reset = AsyncMock(return_value=False)
         async with TestClient(TestServer(_make_app(state))) as client:
@@ -754,6 +756,137 @@ class TestSlotWorkspaceSwitchAtomicity:
             assert slot.workspace == "old-ws"
             assert slot.project == "/workspace/old-ws"
             assert state.sessions.reset.await_args.kwargs == {"skip_if_busy": True}
+
+    @pytest.mark.asyncio
+    async def test_active_turn_is_refused_before_the_commit(self):
+        # GPT review finding on #9084: the reset path calls
+        # _unblock_pending_waits BEFORE SessionManager.reset's atomic busy
+        # decline, so a turn parked on a pending approval had that approval
+        # rejected and only then got a 409. The model handler's early refusal
+        # is copied here: a live turn at the pre-commit check answers 409 with
+        # nothing committed, nothing unblocked and no reset attempted.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        busy = MagicMock(spec=LLMProvider)
+        busy.has_active_turn.return_value = True
+        state = _mock_state(slot, provider=busy)
+        with patch(f"{MOD}._unblock_pending_waits") as unblock:
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.post(
+                    "/api/chat/slots/test/workspace", json={"workspace": "new-ws"}
+                )
+                data = await resp.json()
+        assert resp.status == 409
+        assert data["code"] == "turn_in_flight"
+        assert slot.workspace == "old-ws"
+        assert slot.project == "/workspace/old-ws"
+        unblock.assert_not_called()
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cold_starting_turn_is_refused_via_slot_running(self):
+        # Opus review finding on #9084: slot.running is set at dispatch, before
+        # the multi-second provider.start() registers a session, so a
+        # cold-starting turn is invisible to get_provider. Without this check
+        # the switch reported success while that turn ran on the OLD project.
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        # `running` is a property over slot.task: a pending future stands in
+        # for the dispatched-but-not-yet-registered turn.
+        slot.task = asyncio.get_running_loop().create_future()
+        state = _mock_state(slot)  # no provider registered yet
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            data = await resp.json()
+        assert resp.status == 409
+        assert data["code"] == "turn_in_flight"
+        assert slot.workspace == "old-ws"
+        state.sessions.reset.assert_not_awaited()
+        slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_busy_rollback_remarks_the_slot_dirty(self):
+        # GPT review finding on #9084: the unlocked periodic flush may have
+        # written the PROVISIONAL bindings to disk during the reset await, so
+        # a 409 rollback must re-mark the slot dirty or the rejected switch
+        # survives a restart. Simulate the flush having cleared the flag
+        # mid-transaction.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        slot.total_messages = 3
+        busy = MagicMock(spec=LLMProvider)
+        # Idle at the pre-commit check, mid-turn at the post-decline
+        # re-read: the turn slipped into the reset's own entry window.
+        busy.has_active_turn.side_effect = [False, True]
+        state = _mock_state(slot, provider=busy)
+
+        async def _flush_then_decline(*_a, **_k):
+            slot._dirty = False  # the periodic flush ran with the new bindings
+            return False
+
+        state.sessions.reset = AsyncMock(side_effect=_flush_then_decline)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            assert resp.status == 409
+            assert slot.workspace == "old-ws"
+            assert slot._dirty is True
+
+    @pytest.mark.asyncio
+    async def test_rollback_spares_a_concurrent_project_write(self):
+        # Opus review finding on #9084: slot.project has lock-free writers (the
+        # in-turn set_project directive) that can land during the reset await.
+        # The rollback is identity-scoped -- it unwinds only THIS request's
+        # commit token -- so a concurrent write of a different project stands
+        # while the workspace (untouched by that writer) is rolled back.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        busy = MagicMock(spec=LLMProvider)
+        # Idle at the pre-commit check, mid-turn at the post-decline
+        # re-read: the turn slipped into the reset's own entry window.
+        busy.has_active_turn.side_effect = [False, True]
+        state = _mock_state(slot, provider=busy)
+
+        async def _concurrent_set_project(*_a, **_k):
+            slot.project = "/elsewhere/picked-by-turn"
+            return False
+
+        state.sessions.reset = AsyncMock(side_effect=_concurrent_set_project)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            assert resp.status == 409
+            assert slot.workspace == "old-ws"
+            assert slot.project == "/elsewhere/picked-by-turn"
+
+    @pytest.mark.asyncio
+    async def test_rollback_unwinds_a_same_text_own_commit(self):
+        # The identity test distinguishes this handler's own token from a
+        # concurrent write of the SAME text: with no concurrent writer, the
+        # committed project (same text as the token) IS rolled back.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        busy = MagicMock(spec=LLMProvider)
+        # Idle at the pre-commit check, mid-turn at the post-decline
+        # re-read: the turn slipped into the reset's own entry window.
+        busy.has_active_turn.side_effect = [False, True]
+        state = _mock_state(slot, provider=busy)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            assert resp.status == 409
+            assert slot.project == "/workspace/old-ws"
 
     @pytest.mark.asyncio
     async def test_reset_declined_idle_session_retries_once(self):
@@ -791,7 +924,7 @@ class TestSlotWorkspaceSwitchAtomicity:
         slot.project = "/workspace/old-ws"
         live = MagicMock(spec=AcpProvider)
         live.cwd = "/workspace/new-ws"
-        live.has_active_turn.return_value = True
+        live.has_active_turn.side_effect = [False, True]
         state = _mock_state(slot, provider=live)
         state.sessions.reset = AsyncMock(return_value=False)
         async with TestClient(TestServer(_make_app(state))) as client:
@@ -815,7 +948,11 @@ class TestSlotWorkspaceSwitchAtomicity:
         slot.project = "/workspace/old-ws"
         newborn = MagicMock(spec=LLMProvider)
         newborn.has_active_turn.return_value = True
-        state = _mock_state(slot, provider=newborn)
+        state = _mock_state(slot)
+        # Pre-commit check and the reset helper's identity snapshot see no
+        # provider; the post-decline re-read sees the session a slipped-in
+        # send registered after the commit.
+        state.sessions.get_provider = MagicMock(side_effect=[None, None, newborn])
         state.sessions.reset = AsyncMock(return_value=False)
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})

--- a/test/test_dashboard_chat_handlers_coverage.py
+++ b/test/test_dashboard_chat_handlers_coverage.py
@@ -1005,13 +1005,94 @@ class TestSlotWorkspace:
             assert resp.status == 400
 
     @pytest.mark.asyncio
-    async def test_switch_is_refused_once_the_conversation_started(self):
+    async def test_switch_is_allowed_once_the_conversation_started(self):
+        # #1717: a started conversation used to answer 409. It now switches,
+        # because the transcript is workspace-independent -- only the live
+        # agent process is restarted, exactly as the sibling switches do.
         slot = _ChatSlot("s1")
         slot.workspace = "default"
         slot.total_messages = 3
-        status, body = await self._post(_state(slot), "s1", {"workspace": "other"})
+        state = _state(slot)
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+            with patch(f"{MOD}.default_project_dir", return_value="/tmp/ws-other"):
+                status, body = await self._post(state, "s1", {"workspace": "other"})
+
+        assert (status, body) == (200, {"ok": True, "workspace": "other"})
+        assert slot.workspace == "other"
+        assert slot.project == "/tmp/ws-other"
+        reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_op_switch_does_not_reset(self):
+        # Re-picking the workspace the slot already has changes nothing, so it
+        # must not tear the live session down (Opus review finding on #9084).
+        slot = _ChatSlot("s1")
+        slot.workspace = "same-ws"
+        slot.project = "/tmp/ws-same"
+        slot.total_messages = 3
+        state = _state(slot)
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+            with patch(f"{MOD}.default_project_dir", return_value="/tmp/ws-same"):
+                status, body = await self._post(state, "s1", {"workspace": "same-ws"})
+
+        assert (status, body) == (200, {"ok": True, "workspace": "same-ws"})
+        reset.assert_not_awaited()
+        assert slot.project == "/tmp/ws-same"
+        assert slot._dirty is False
+
+    @pytest.mark.asyncio
+    async def test_switch_on_started_conversation_marks_the_slot_dirty(self):
+        # The periodic flush persists a slot's metadata only while _dirty is
+        # set (GPT review finding on #9084). Without this a crash before the
+        # next message restores the OLD workspace over a switch the user saw
+        # succeed. Only reachable now that a started conversation may switch.
+        slot = _ChatSlot("s1")
+        slot.workspace = "default"
+        slot.total_messages = 3
+        slot._dirty = False
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()):
+            with patch(f"{MOD}.default_project_dir", return_value="/tmp/ws-other"):
+                status, _ = await self._post(_state(slot), "s1", {"workspace": "other"})
+
+        assert status == 200
+        assert slot._dirty is True
+
+    @pytest.mark.asyncio
+    async def test_switch_refused_while_subagents_attached(self):
+        # The reset kills the runtime attached children run on, so the switch
+        # refuses like every sibling switch handler (GPT review finding on
+        # #9084). Before the commit: workspace/project untouched.
+        slot = _ChatSlot("s1")
+        slot.workspace = "default"
+        slot.project = "/tmp/ws-default"
+        slot.total_messages = 3
+        state = _state(slot)
+        refusal = web.json_response(
+            {"error": "sub-agents are running", "code": "slot_subagents_running"}, status=409
+        )
+        with patch(f"{MOD}._subagents_attached_response", return_value=refusal) as probe:
+            with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+                status, body = await self._post(state, "s1", {"workspace": "other"})
+
         assert status == 409
-        assert "new session" in body["error"]
+        assert body["code"] == "slot_subagents_running"
+        assert probe.call_args.args[3] == "slot_workspace"
+        reset.assert_not_awaited()
+        assert slot.workspace == "default"
+        assert slot.project == "/tmp/ws-default"
+
+    @pytest.mark.asyncio
+    async def test_non_string_workspace_is_400(self):
+        # With the message-count refusal lifted this value reaches
+        # `default_project_dir` and the slot header on a live conversation, so
+        # it is type-checked at the boundary (the sibling project handler's
+        # guard).
+        slot = _ChatSlot("s1")
+        slot.workspace = "default"
+        status, body = await self._post(_state(slot), "s1", {"workspace": {"evil": 1}})
+        assert status == 400
+        assert body["code"] == "invalid_workspace"
+        assert "string" in body["error"]
         assert slot.workspace == "default"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

`POST /api/chat/slots/{slot}/workspace` answered HTTP 409 (`Cannot change workspace after messages have been sent. Open a new session instead.`) as soon as a slot had any message. No sibling switch handler does this: agent, model, reasoning-effort and reload all reset the live session mid-conversation and refuse only on an in-flight turn (`turn_in_flight`). `api_chat_slot_agent` even re-points `slot.workspace` mid-conversation itself, with no message-count check, whenever the picked agent carries different bindings — so the same field was switchable through one endpoint and forbidden through the other.

## Why it matters

A caller of the workspace endpoint (the App Kit, a remote-crew peer, or a future UI) hits a refusal that protects nothing. The transcript and its session key derive from the slot key alone — the workspace name is a metadata field *inside* the same history file, never part of its path — and `SessionManager.reset` tears down process state only, keeping the resume pointer so the next turn reloads the conversation. A switch costs the live agent process and nothing persisted, exactly what the reload endpoint already does on purpose. The endpoint's contract should say what the code actually guarantees.

## What changed (motivation → approach → change)

Observed: 409 on any non-empty slot. Root cause: a guard present since the first public commit (`64e47961a`), never justified; the one later commit to touch it (#5697) only moved it under the slot lock. Verified against the siblings and against persistence before removing it (see the in-code comment at the former guard site).

- **Dropped both 409s** — the local branch and the remote-peer branch (the peer owns its own session lifecycle; the local message count says nothing about the cost there). Every `turn_in_flight` ladder, rollback path and `session_rebound` guard is untouched, so the endpoint now refuses on the same condition as its siblings.
- **Refuses before the commit when a turn is in flight** (409 `turn_in_flight`) — the model handler's early check, `slot.running or provider.has_active_turn()`. The reset path calls `_unblock_pending_waits` before the atomic busy decline, so without this a turn parked on a pending approval had that approval rejected and only then got a 409; and `slot.running` catches a cold-starting turn the provider registry cannot see yet. The atomic `skip_if_busy` decline stays as the backstop.
- **Refuses while sub-agent children are attached** (409 `slot_subagents_running`) — the same `_subagents_attached_response` probe the agent, model, effort and reload handlers already run. The reset kills the runtime attached children run on; the workspace handler never had the probe, and lifting the 409 made that reachable on a started conversation. Checked before the commit, so no rollback is needed.
- **A same-value re-pick is a no-op**: 200 with the current workspace, no reset — checked inside the locks (model-handler ordering) so a serialized predecessor that already landed the same value is not torn down again.
- **`workspace` body field is type-checked** (400, code `invalid_workspace`), mirroring the project handler: with the refusal lifted the value reaches `default_project_dir` and the slot header on a live conversation.
- **The slot is marked dirty after a committed local switch.** The periodic flush writes a slot's metadata only while `_dirty` is set and skips slots with no messages, so on `main` the missing mark was unreachable (only empty slots passed the 409). With a started conversation allowed to switch, a crash before the next message would restore the old workspace/project over a switch the user saw succeed. The remote-peer path already persists via `update_metadata`; the no-op changes nothing.
- **Rollback is identity-scoped and re-marks dirty.** Both fields are committed as `_CommitToken` (the agent handler's precedent) and every 409 rollback unwinds a field only while it still holds this request's token, so a concurrent lock-free `set_project` write during the reset await is not clobbered; and every rollback re-marks `_dirty`, so provisional bindings the periodic flush may already have written are reconverged rather than surviving a restart.

- **Stale comment in `remote_relay.py`** that cited "a workspace with messages already sent" as a peer-refusal example now names a refusal that still exists (First Principles review).

**Deliberately not in this PR: a transcript marker for the restart.** Earlier revisions carried a `workspace_switch` feed notice; three review rounds found edge cases in it (remote-path coverage, a false "the agent forgets" claim, concurrent no-op picks) while the guard removal itself drew none. Every sibling reset site has the same silent restart, so the marker is one design for all of them — tracked in #9086 — not a rider on the one endpoint that has no production caller.

No UI change: no chat surface calls `api.chatSlotWorkspace` today, and #1717 is closed rather than adding a control that would sit between the agent picker (which owns memory) and the project picker (which owns the code directory) and overlap both.

## Tests

`test/test_dashboard_chat_handlers_coverage.py::TestSlotWorkspace`
- `test_switch_is_allowed_once_the_conversation_started` — replaces the test that pinned the 409; **red on pristine source (`assert 409 == 200`)**.
- `test_switch_refused_while_subagents_attached` — 409, no reset, bindings untouched.
- `test_no_op_switch_does_not_reset` — same-value re-pick never awaits the reset and leaves `_dirty` False.
- `test_switch_on_started_conversation_marks_the_slot_dirty` — **red on the prior head**.
- `test_non_string_workspace_is_400` — boundary check with `code`.

`test/test_chat_slot_switch_atomicity.py::TestSlotWorkspaceSwitchAtomicity`
- `test_message_landing_during_the_lock_wait_still_switches` — rewrites the test that asserted the in-lock 409: a message landing while the request waits on the slot lock now yields a 200 switch with one reset.
- `test_active_turn_is_refused_before_the_commit` — 409, nothing committed, `_unblock_pending_waits` never called; **red on the prior head**.
- `test_cold_starting_turn_is_refused_via_slot_running` — pending `slot.task`, no provider → 409; **red on the prior head**.
- `test_busy_rollback_remarks_the_slot_dirty` — flush clears the flag mid-await, the 409 rollback sets it back; **red on the prior head**.
- `test_rollback_spares_a_concurrent_project_write` / `test_rollback_unwinds_a_same_text_own_commit` — identity-scoped rollback; the first **red on the prior head**.

Run locally: `test_dashboard_chat_handlers_coverage.py` + `test_chat_slot_switch_atomicity.py` + `test_dashboard_chat.py` + `test_json_object_body_guard.py` + `test_remote_crew_execution.py` + `test_error_code_contract.py` → 1225 passed. `flake8`, `mypy` on the touched module: clean. Backend-only diff — no frontend files touched. `test_remote_crew_execution.py` 190/190 after the comment edit.

## Manual verification

N/A — unit coverage sufficient: the change is a guard removal plus two pre-commit checks already exercised end-to-end through the aiohttp test client against a real `_ChatSlot`.

## Related Issues

Refs #1717 — closed separately with the analysis above (memory follows the agent; the project picker already retargets code), not fixed by this PR.
Refs #9086 — the transcript-marker design for every mid-conversation reset.
Refs #9155 — the agent handler's 409 rollbacks share the flush-race exposure fixed here (deferred, First Principles review).
Refs #9179 — every switch handler's in-flight-turn refusal is blind to a sibling alias cold-starting on the shared session (deferred, GPT round 9; overridden here because the exposure is shared, not introduced).

no linked issue: this PR closes nothing by keyword; #1717 is closed by maintainer decision, not by this diff.

## Pattern harvest

Not generalizable: a single endpoint carried a refusal none of its four siblings had, dating from before the repo's history; the fix is alignment with the existing sibling contract, not a new class of defect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, in-code comments carry the rationale
- [x] No secrets, credentials, or internal references in the diff
