### PR TITLE
feat(sketch): deploy-time flag to prune 13MB CJK canvas font

### DIFF
--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -176,15 +176,51 @@ function vendorRuntimePlugin(): Plugin {
  * plugin makes that path real: build emits every font file from the npm
  * package into `dist/vendor/excalidraw/fonts/**`, and the dev server serves
  * the same files straight from node_modules.
+ *
+ * Deployment-time size choice (issue #8091): the Xiaolai CJK handwriting family
+ * is 12.67 MB of the 13.11 MB emitted here (96.6%); everything else combined is
+ * 0.44 MB. A size-sensitive deployment can opt OUT of shipping it by setting
+ * `KIROCREW_PRUNE_SKETCH_CJK_FONT=1` at build time. The DEFAULT is unset, which
+ * ships every family exactly as before, so no existing build changes and no user
+ * is affected unless a deployer deliberately opts in. When engaged, a pruned build
+ * emits a loud build-time warning rather than silently changing what a user sees:
+ * zh/ja/ko sketch text falls back to a system font (Excalidraw substitutes one when
+ * the family is absent), losing only the hand-drawn style, not legibility. What a
+ * pruned build should surface to those users at RUNTIME is a product decision left
+ * open on the issue and deliberately not made here.
  */
+// Families excluded from the emitted set when the prune flag is on. Kept as a set
+// so the predicate is a filename lookup over what listFonts() already enumerates,
+// not a new configuration layer. Only Xiaolai carries meaningful weight.
+const PRUNABLE_CJK_FONT_FAMILIES = new Set(['Xiaolai'])
+
 function excalidrawFontsPlugin(): Plugin {
   const FONTS_ROOT = path.resolve(__dirname, 'node_modules/@excalidraw/excalidraw/dist/prod/fonts')
   const SERVE_PREFIX = '/vendor/excalidraw/fonts/'
+  // Default OFF: unset ships everything (today's behaviour). Only an explicit
+  // opt-in prunes. Evaluated once so the warning fires once per build/serve.
+  const pruneCjk = process.env.KIROCREW_PRUNE_SKETCH_CJK_FONT === '1'
+  // familyOf('Xiaolai/Xiaolai-Regular-....woff2') === 'Xiaolai'
+  const familyOf = (rel: string): string => rel.split('/')[0]
+  const isPruned = (rel: string): boolean => pruneCjk && PRUNABLE_CJK_FONT_FAMILIES.has(familyOf(rel))
+  if (pruneCjk) {
+    // A line of build output, not a runtime UI surface. It must be loud because
+    // an inherited env var would otherwise SILENTLY ship a build with degraded
+    // CJK sketching, which is the one thing #8091's direction forbids.
+    console.warn(
+      `\n[kirocrew-excalidraw-fonts] KIROCREW_PRUNE_SKETCH_CJK_FONT=1: pruning ` +
+        `${[...PRUNABLE_CJK_FONT_FAMILIES].join(', ')} (~12.67 MB) from the sketch-pad fonts. ` +
+        `zh/ja/ko sketch text will fall back to a system font (no hand-drawn style). ` +
+        `Unset the variable to ship every family.\n`,
+    )
+  }
   const listFonts = (): string[] => {
     const out: string[] = []
     for (const family of readdirSync(FONTS_ROOT)) {
       for (const file of readdirSync(path.join(FONTS_ROOT, family))) {
-        out.push(`${family}/${file}`)
+        const rel = `${family}/${file}`
+        if (isPruned(rel)) continue
+        out.push(rel)
       }
     }
     return out
@@ -199,6 +235,9 @@ function excalidrawFontsPlugin(): Plugin {
         // Path-traversal guard: the joined path must stay under FONTS_ROOT.
         const abs = path.resolve(FONTS_ROOT, rel)
         if (!abs.startsWith(FONTS_ROOT + path.sep) || !existsSync(abs)) return next()
+        // Dev-server parity with a pruned build: 404 the pruned family so a dev
+        // preview shows the same fallback a pruned deployment would.
+        if (isPruned(rel)) return next()
         res.setHeader('Content-Type', 'font/woff2')
         res.end(readFileSync(abs))
       })


### PR DESCRIPTION
## What is the problem?

The sketch pad (#8041) self-hosts Excalidraw's canvas fonts so no CDN is contacted, emitting them at build time via `excalidrawFontsPlugin()` in `website/vite.config.ts`. Measured at main `31cd87f2` (package pin `@excalidraw/excalidraw@0.18.1`): the plugin emits 13,107,068 bytes across 234 files with no filter, of which the Xiaolai CJK handwriting family is 12,667,492 bytes across 209 files -- 96.6% of the payload. Every other family combined is 0.44 MB. A size-sensitive deployment has no way to opt out of the 12.67 MB CJK family.

## Why this matters to the user

Two different users are in tension. A zh/ja/ko user needs Xiaolai to sketch with hand-drawn CJK text; without it Excalidraw substitutes a system font, losing the hand-drawn style. A deployer building a size-sensitive image wants the 12.67 MB gone. Today only the first is served, and there is no lever for the second.

## How the fix solves it

A single build-time env var, `KIROCREW_PRUNE_SKETCH_CJK_FONT`, gates a filename filter over the families the plugin already enumerates -- no new configuration layer, no new dependency, one file.

- Chain from symptom to root cause: the size cost is 96.6% one family (symptom) -> the plugin emits every family unconditionally with no seam to exclude one (root cause) -> add a default-off predicate that drops the named family from both the build emit and the dev-server route.
- The default is unset, which ships every family exactly as before. No existing build changes and no CJK user is degraded unless a deployer deliberately sets the variable.
- It does NOT silently drop CJK. When engaged, the plugin prints a loud build-time warning naming the pruned family, its size, and the fallback consequence. That is a line of build output, not a runtime UI surface.
- The existing edition seam (`editionExtensionPlugin`, `KIROCREW_EDITION_DIR`/`KIROCREW_ALLOW_EDITION`) handles branding and asset overlays but has no font hook, so a new `KIROCREW_*` var in the same family is the minimal addition.

Still needing a human, and deliberately NOT decided here: what a pruned build should show CJK users at runtime (accept silent system fallback, or surface a notice). Defaulting the flag off decouples that product-policy call from this reversible build option. This re-triage was routed to needs-human by dwu96 (2026-09-03T20:37Z), whose read that "neither branch is derivable from the measurement" still holds -- this PR ships only the reversible, default-off half.

## What tests we did

Verified by real `vite build` runs in the worktree against the installed `0.18.1` package (full `npm run build` was not runnable here: its `tsc -b` step fails on missing `@storybook/react-vite` stubs in the borrowed node_modules, all errors under `src/stories/`, none in `vite.config.ts`; ran `vite build` directly):

- Flag unset (default): 234 font files emitted, 209 Xiaolai -- identical to today.
- `KIROCREW_PRUNE_SKETCH_CJK_FONT=1`: 25 font files emitted (234 minus Xiaolai's 209), 0 Xiaolai, 8 other families intact, and the build-time warning fired once.

## Other suggestions

The open runtime-signal question above is worth its own issue once a maintainer picks the acceptable-degradation bar; it is not blocked by this flag.

## Pattern harvest

Rule candidate: when an asset-emitting build plugin enumerates a set (fonts, locales, vendored files), a deployment-time prune is a filename filter over what it already lists plus a loud build-time warning, defaulted off -- not a new config layer. This keeps the size lever reversible and the policy question (what the pruned build shows the user) separable from the code.

Refs #8091
