### PR TITLE
test: fix flaky, hanging, heavy and side-effecting tests found by 5 full runs

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -150,7 +150,6 @@ src/kiro_crew/apps/dependencies.py
 src/kiro_crew/apps/dependency_ledger.py
 src/kiro_crew/apps/dev_mode.py
 src/kiro_crew/apps/execution.py
-src/kiro_crew/apps/install_receipt.py
 src/kiro_crew/apps/manager.py
 src/kiro_crew/apps/manifest.py
 src/kiro_crew/apps/module_loader.py
@@ -368,7 +367,6 @@ test/metrics/test_cost_breakdown.py
 test/metrics/test_gateway_http_metrics.py
 test/metrics/test_generation_disclosure.py
 test/metrics/test_mcp_gateway_metrics.py
-test/metrics/test_provider_bucket_views.py
 test/metrics/test_schema.py
 test/metrics/test_startup_channel_attrs.py
 test/metrics/test_telemetry_titles.py
@@ -538,7 +536,6 @@ test/test_connections_registry.py
 test/test_connections_tool_aliases.py
 test/test_consolidate_cmd.py
 test/test_consolidation_placeholder_guard.py
-test/test_context.py
 test/test_context_marker_neutralization.py
 test/test_context_ui_language.py
 test/test_continuable_followups.py
@@ -734,7 +731,6 @@ test/test_host_isolation_floor.py
 test/test_host_service_guard.py
 test/test_image_artifacts.py
 test/test_inbound_unbind_notice.py
-test/test_install_receipt.py
 test/test_installer_distro.py
 test/test_installer_node_floor.py
 test/test_installer_shim_and_cleanup.py
@@ -780,7 +776,6 @@ test/test_knowledge_items_source_filter.py
 test/test_knowledge_kiroignore.py
 test/test_knowledge_source_spend.py
 test/test_knowledge_sync_local_file.py
-test/test_lazy_data_home_paths.py
 test/test_learn.py
 test/test_lesson_contradiction.py
 test/test_lesson_ranking.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ in the **same commit** when you change what it documents.
 | themes | [themes](docs/system-specs/modules/themes.md) + [theming-contract](website/docs/theming-contract.md) |
 | anything under `website/` | [`website/AGENTS.md`](website/AGENTS.md) |
 | user-facing strings, dates, numbers, sort order | [i18n-catalog](website/docs/i18n-catalog.md) (authoring) + [i18n-gates](docs/ci/i18n-gates.md) (CI) |
-| tests: flakes, speed, fixtures, sharding, side effects, conftest isolation | [testing-conventions](docs/system-specs/common/testing-conventions.md) + the [writing-tests](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md) skill |
+| tests: flakes, hangs, speed, memory, fixtures, sharding, side effects, conftest isolation, Windows | [testing-conventions](docs/system-specs/common/testing-conventions.md) + the [writing-tests](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md) skill; frontend and Electron tests: [website/docs/testing.md](website/docs/testing.md) |
 | browser E2E | [e2e-gate](docs/ci/e2e-gate.md) |
 | proving a worktree change against an isolated running gateway | [worktree-verification-recipes](docs/guides/worktree-verification-recipes.md) |
 | CI, PR flow, review gates, commit messages | [ci-and-reviews](docs/ci/ci-and-reviews.md) + [CONTRIBUTING.md](CONTRIBUTING.md) |
@@ -187,9 +187,12 @@ python -m pytest
   --max-worker-restart=2`; a bare override silently drops `--dist loadgroup` and
   scatters `@pytest.mark.xdist_group` tests into flaky races.
 
-Gates, flake classes, the conftest isolation floor and the traps that are invisible
-when reading a test: [code-style](docs/system-specs/common/code-style.md) +
-[testing-conventions](docs/system-specs/common/testing-conventions.md).
+Gates, the six flake classes, the conftest isolation floor and the traps that are
+invisible when reading a test: [code-style](docs/system-specs/common/code-style.md) +
+[testing-conventions](docs/system-specs/common/testing-conventions.md). A test that
+can block forever is a lost RUN, not a failed test: on Windows pytest-timeout kills
+the xdist worker, and with `--max-worker-restart=0` one unbounded `await` aborts the
+whole job (class 6). Frontend and Electron: [website/docs/testing.md](website/docs/testing.md).
 
 ## Cross-platform
 

--- a/conftest.py
+++ b/conftest.py
@@ -988,6 +988,33 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int | None:
     return xdist_budget.resolve_workers()
 
 
+def _join_install_receipt_workers() -> None:
+    """Join any ``install_receipt.dispatch()`` worker before this test's pins lift.
+
+    ``dispatch()`` hands the receipt write to a daemon thread. The worker receives
+    every environment-derived input (the data home, the config fields) from the
+    dispatching thread and reads nothing itself -- but a thread still alive when
+    ``monkeypatch`` undoes ``KIROCREW_HOME`` is a thread whose WRITE lands after the
+    test that owned it is gone. The per-test probe in the 5x hygiene run saw exactly
+    that: the ``kirocrew-install-receipt`` thread alive after teardown in 3 of 5
+    runs, and once a receipt secret written into the operator's real ``~/.kiro/crew``.
+
+    Structural rather than opt-in, for the same reason as the CWD restore below: the
+    test that leaks is never the test that fails, so relying on each
+    dispatch-triggering test to remember ``wait_for_pending_receipt_writes()`` is the
+    shape that let this through. It lives in the ``tryfirst`` teardown hook for the
+    ordering reason documented on ``pytest_runtest_teardown``: an autouse fixture
+    from this conftest is an OUTER fixture and would tear down AFTER ``monkeypatch``
+    had already restored the environment. With no worker registered this is one
+    lock acquire; the module is looked up rather than imported so a test run that
+    never touches the receipt path pays nothing.
+    """
+    mod = sys.modules.get("kiro_crew.apps.install_receipt")
+    waiter = getattr(mod, "wait_for_pending_receipt_writes", None)
+    if waiter is not None:
+        waiter()
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_teardown(item, nextitem):
     """Put the process working directory back, BEFORE any fixture teardown runs.
@@ -1022,6 +1049,7 @@ def pytest_runtest_teardown(item, nextitem):
     directory for its own duration keeps working, and ``monkeypatch.chdir`` (which reverts
     itself, and whose undo lands on the same value) remains the right tool inside a test.
     """
+    _join_install_receipt_workers()
     if _SESSION_CWD is None:  # pragma: no cover - configure always runs first
         return
     try:

--- a/docs/system-specs/common/README.md
+++ b/docs/system-specs/common/README.md
@@ -9,5 +9,5 @@ rather than restating them.
 | [model-selection.md](model-selection.md) | Never hardcoding a model id: the `"auto"` default, the resolver, role pins, and the entitlement predicate. |
 | [platform-compat.md](platform-compat.md) | The POSIX-call shim table: which `platform_compat` helper replaces each `fcntl` / `os.kill` / `resource` call, and why. |
 | [error-handling.md](error-handling.md) | Exception boundaries, retries, and user-facing failure text. |
-| [testing-conventions.md](testing-conventions.md) | Test patterns, which conftest owns which isolation, the side-effect floor, the five flake classes and the one correct fix for each, and how to keep the suite fast. |
+| [testing-conventions.md](testing-conventions.md) | Test patterns, which conftest owns which isolation, the side-effect floor, the six flake classes and the one correct fix for each, and how to keep the suite fast. |
 | [injected-messages.md](injected-messages.md) | The envelopes automation injects into a session (cron, subagent, auto-nudge) and how to treat them. |

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -331,6 +331,41 @@ which testpath asked for the workers.
   the singleton to a per-test, per-xdist-worker directory built `sync=True` — no
   background writer at all — so no concurrent writer exists to contend with.
 
+  The **lazy-resolving worker** is the second shape, and it writes into the operator's
+  REAL home rather than a stray temp dir. `install_receipt.dispatch()` handed the
+  receipt write to a daemon thread that called `beacon.config_dir()` *on that thread*.
+  `config_dir()` honours `KIROCREW_HOME` at call time; the test's pin was gone by the
+  time the thread ran, so `~/.kiro/crew/app_receipt_secret` appeared on the developer's
+  machine (MEASURED, 1 of 5 runs — the per-test probe showed the
+  `kirocrew-install-receipt` thread alive after teardown in 3 of 5). Two rules follow:
+  **resolve every environment-derived input on the dispatching thread and pass it
+  in** — the data home AND the config fields, since `KiroCrewConfig.load()` honours
+  `KIROCREW_HOME` exactly as `config_dir()` does — so the worker reads nothing from
+  the environment; and **make the worker joinable and join it structurally**: the
+  rootdir `pytest_runtest_teardown` hook calls `wait_for_pending_receipt_writes()`
+  before any fixture (including `monkeypatch`) is torn down, so no test has to
+  remember it. A thread you cannot join is a thread you cannot isolate.
+
+- **A cwd-relative default in a constructor is a write into the checkout.**
+  `TaskRunner(work_dir=None)` falls back to `Path.cwd()`, which under pytest is the repo
+  root, and its first save wrote `runs.json` there. The rootdir conftest's repository
+  residue guard did not flag it because the name happens to be gitignored — so a
+  gitignored artefact is exactly the one that leaks silently. Always pass
+  `work_dir=tmp_path` (or the equivalent) to anything whose default is the process CWD,
+  and when you add such a default to production code, add the test that constructs it
+  with an explicit directory.
+
+- **Production code that edits `os.environ` leaks through a test that exercises the real
+  path.** `dashboard/server.py` startup does `os.environ.update(cli_env_overrides())` on
+  purpose (descendant `playwright-cli` processes need it), and `load_credentials()`
+  `setdefault`s every `.env` key. A test that drives that real startup — via a shared
+  helper like `_start_dashboard` — inherits the mutation for every later test on the
+  worker. The per-test probe in the 5x run caught `PLAYWRIGHT_MCP_OUTPUT_DIR`,
+  `KIROCREW_TELEMETRY`, `PATH`, and a test's own `TEST_CRON_VAR` surviving teardown
+  across ~50 tests. Snapshot the keys the production path is known to touch with
+  `monkeypatch.setenv`/`delenv` **in the shared helper**, so every consumer is restored;
+  never `os.environ[...] =` in a test body.
+
 - **When you stub a lifecycle method, SPY and delegate — never replace.** A stub that
   only records the call leaves whatever that method was supposed to stop still running.
   The worked example cost 19 failures in files that contain no metrics code at all:
@@ -708,7 +743,7 @@ rest of the list, which is why a single-file run needs no `--override-ini` at al
 | Small-RAM laptop | Run a subset. For a full run, let the budget clamp `-n auto` and expect it to be slow; do not raise it. |
 | Checkpoint before committing | `scripts/check_black_formatting.py && scripts/check_subprocess_encoding.py && isort && flake8 && mypy && python -m pytest` |
 
-## Determinism: the five flake classes
+## Determinism: the six flake classes
 
 A test that fails on CI but not locally is almost always one of these. Each has one
 correct fix; reruns and `sleep` increases are not among them.
@@ -799,6 +834,35 @@ answers before its work finishes leaves the assertion racing the loop. There is 
 synchronisation point, so use it — `drain_background_tasks(state)` — and see the Rules
 entry for what it looks like when you do not (a different test failing each run).
 
+Two more shapes, both MEASURED in a 5x full-suite run on Windows:
+
+- **A completion signalled from another thread.** `await handler(...)` returning does
+  not mean everything the handler *scheduled* has run. `_sse_from_thread` hands the
+  terminal `complete`/`failed` event to the loop with `call_soon_threadsafe` from a
+  worker thread, so `assert sse.types() == ["complete"]` on the very next line saw `[]`
+  in 1 of 5 runs (`test_auto_research_handlers_coverage`). Wait on the signal the test
+  asserts on (`await _await_until(lambda: "complete" in sse.types())`), not on the call
+  that eventually causes it.
+- **Two clocks: fixtures on one, production on the other.** `NOW = time.time()` at
+  module level is read when pytest *imports* the file; under `-n auto` the tests run
+  minutes later, and production compares the fixture's `modified=NOW` against its own
+  live `time.time()` recency cutoff. All ten `TestReconcile*` tests in
+  `test_channel_slots` failed together in one run because every session had aged past
+  the cutoff on the way from collection to execution. The defect is the *pair*, not the
+  constant: either both sides read one clock, or neither reads a frozen one. The in-tree
+  fix (`frozen_clock`) pins `time.time` to the module's `NOW` for every test that calls
+  the real pass, which makes eligibility pure arithmetic and also stops an `== 0`
+  assertion passing vacuously because a stamp aged out. Reading the clock inside the
+  test instead is the weaker fix — it shrinks the gap to microseconds without closing it.
+
+**Guess-the-latency sleeps are this class too.** `asyncio.sleep(0.05)` "to let the
+first prompt register" is a bet that two awaits and a `to_thread` hop finish inside
+50ms; on a loaded runner they did not, the guard the test exists to exercise was never
+armed, and the test blocked on a turn nothing would ever complete — see
+[class 6](#6-a-hang-is-a-lost-run-not-a-failed-test). Wait on the observable state
+(`_await_routed`, an `Event`, the queue entry) and put a bounded `wait_for` around the
+call whose *refusal* is under test, so a missed refusal fails at that line by name.
+
 ### 3. Leaked async objects
 
 An `AsyncMock` standing in for a **synchronous** method (`StreamWriter.write`,
@@ -809,6 +873,15 @@ happened to trigger the GC, so the reported test is rarely the guilty one.
 
 Fix: `MagicMock()` for sync methods; `await` the task after `cancel()`, absorbing
 `CancelledError`.
+
+The other member of this class is a **module-level asyncio primitive** in production
+code — a `Lock`, `Event`, `Future`, or an in-flight `dict` of tasks created at import.
+`pytest-asyncio` gives every test a fresh loop, the primitive stays bound to the loop
+that first touched it, and the next test to reach it fails with `The future belongs to a
+different loop` or `Task ... got Future attached to a different loop` — in whichever
+test happens to run second, so four different `test_public_repo_chip_status` tests took
+turns failing across five runs. Either create the primitive lazily inside the running
+loop, or give the test file a fixture that resets the module state before each test.
 
 ### 4. Order dependence and shared state
 
@@ -880,6 +953,41 @@ assert traced(build(4000)) == traced(build(2000))
 Keep a *small*-`n` absolute assertion alongside it so a uniform slowdown is still caught, and
 verify the threshold against a mutated implementation rather than reasoning about it.
 
+**First check that the time is even the algorithm's.** `test_chained_cd_expansions` asserted
+`elapsed < 30s` around the bash gate and took 144s under load — but with the gate's
+filesystem probes (`is_sensitive_path`, `_dir_holds_sensitive_leaf`, `_resolved_forms_bounded`)
+stubbed, the same input ran in 50ms. The budget was measuring ~2,700 `stat` calls, not the
+bounded-working-set property it named. Stub the I/O, **count the probes**, and assert the
+count grows linearly with the input; that is the property, and it costs nothing.
+
+### 6. A hang is a lost run, not a failed test
+
+pytest-timeout has no `SIGALRM` on Windows, so a test that blocks past `--timeout` is not
+failed in place: the whole xdist worker is killed (`node down: Not properly terminated`),
+and with `--max-worker-restart=0` — which the Windows job needs, see `ci.yml` — the run
+**aborts** with every test that worker had not reached still uncollected. MEASURED: one
+test that could wait forever (`test_acp_runtime::test_concurrent_prompt_on_same_handle_rejected`,
+a second `prompt()` awaiting a completion the test never feeds, `timeout=None` resolving to
+the multi-hour dashboard ceiling) ended 2 of 5 full runs at ~3,000 of 62,000 tests. The
+report showed 6 failures; the other 59,000 results simply did not exist.
+
+So a test that awaits anything it must itself cause to happen carries a **bounded** wait
+that fails **by name**:
+
+```python
+# WRONG: if the guard is broken this never returns, and the worker dies with it
+with pytest.raises(AcpRuntimeError):
+    await handle.prompt("again").__anext__()
+# RIGHT: a missed refusal is a TimeoutError at THIS line, attributed to THIS test
+with pytest.raises(AcpRuntimeError):
+    await asyncio.wait_for(handle.prompt("again", timeout=1.0).__anext__(), 5.0)
+```
+
+The same applies to `Event.wait()`, `Queue.get()`, `Condition.wait()`, and a
+`subprocess.communicate()` with no timeout. The ceiling is not a race to tune (it only
+matters when the property is broken); make it generous and keep it well under
+`--timeout`, so the failure is a named assertion and not a dead worker.
+
 ## Keeping the suite fast
 
 The suite is ~56.5k tests. At that count a per-test cost is multiplied by 56,500, so
@@ -946,6 +1054,25 @@ the REAL function runs, the assertion passes for the wrong reason, and the test 
 time. One such target cost 6.1s and left a live transcriber running. Ask which module's
 globals the call resolves through, and treat an unexpectedly slow "mocked" test as
 evidence the mock missed.
+
+Two more, from a 5x full-suite run whose per-test probe recorded wall time and RSS:
+
+- **Setup that goes through a persisting helper.** `CrewStore.add_topic()` saves on
+  every call (three file writes plus a prune scan), so a cap test that built
+  `_TOPIC_IDLE_CAP + 25` filler topics through it paid an O(n²) disk cost for state it
+  only asserted on after the *final* `save()`. Build fixture records directly (a helper
+  with the same record shape) and save once; 47s became 0.2s.
+- **A ratchet that re-walks the tree per test.** Several ratchet files parse every
+  module under `src/` inside each test method — six methods in one class meant six
+  walks, ~45s each under load, and the top ten such tests were 15 minutes of the run.
+  Walk once per file: a module-scoped fixture or an `lru_cache`d loader that skips
+  `node_modules`, `.venv`, `dist`, and `__pycache__`, and hand every test the same
+  parsed set. The assertions do not change, so the planted-violation check below is
+  how you prove nothing got weaker.
+
+Neither of these shows up as a *failure*, which is why they survive: the suite is
+green, just three times slower than it needs to be, and every timing-sensitive test
+in the same shard inherits the load.
 
 ### Verify an optimization did not weaken the test
 

--- a/src/kiro_crew/apps/install_receipt.py
+++ b/src/kiro_crew/apps/install_receipt.py
@@ -20,9 +20,11 @@ import re
 import secrets
 import tempfile
 import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 
 from kiro_crew import __version__, beacon, platform_compat
 from kiro_crew.apps.manifest import KEBAB_RE
@@ -46,7 +48,7 @@ _SECRET_FILE = "app_receipt_secret"
 _SECRET_RE = re.compile(r"[0-9a-f]{64}")
 
 
-def receipt_secret(*, create: bool = True) -> str:
+def receipt_secret(*, create: bool = True, config_dir: Path | None = None) -> str:
     """Return the receipt-only local secret, generating it on first use.
 
     Mirrors ``beacon.install_id``'s atomic create (owner-only temp file +
@@ -54,9 +56,17 @@ def receipt_secret(*, create: bool = True) -> str:
     secret. Every failure returns ``""`` and the caller skips the receipt — a
     receipt is best-effort and must never fail an install or force state into
     existence. With ``create=False`` the file is only read, never generated.
+
+    ``config_dir`` lets a caller pass an already-resolved directory instead of
+    letting this function call ``beacon.config_dir()`` itself. This matters
+    when the call happens on a background thread: ``beacon.config_dir()``
+    honors ``KIROCREW_HOME`` at call time, so resolving it lazily on the
+    worker thread risks reading a different (e.g. unpatched, real-home) value
+    than what the dispatching thread saw. Defaults to ``beacon.config_dir()``
+    for callers that are already on a safe thread (e.g. direct callers, tests).
     """
     try:
-        path = beacon.config_dir() / _SECRET_FILE
+        path = (config_dir if config_dir is not None else beacon.config_dir()) / _SECRET_FILE
         if path.exists():
             existing = beacon._read_state(path)
             if _SECRET_RE.fullmatch(existing):
@@ -132,13 +142,8 @@ def receipt_url(
     if kind not in _KINDS:
         raise ValueError("invalid install kind")
 
-    query = urllib.parse.urlencode(
-        {"t": token, "k": kind, "v": beacon.release(app_version)}
-    )
-    return (
-        f"{endpoint.rstrip('/')}/b/{beacon.BEACON_SCHEMA}/install/"
-        f"{app_slug}?{query}"
-    )
+    query = urllib.parse.urlencode({"t": token, "k": kind, "v": beacon.release(app_version)})
+    return f"{endpoint.rstrip('/')}/b/{beacon.BEACON_SCHEMA}/install/" f"{app_slug}?{query}"
 
 
 def should_send(*, enabled: bool, official: bool, acked: bool) -> beacon.Verdict:
@@ -161,14 +166,20 @@ def send(
     official: bool,
     acked: bool,
     kind: str,
+    config_dir: Path | None = None,
 ) -> bool:
-    """Best-effort GET. Every refusal and transport failure returns ``False``."""
+    """Best-effort GET. Every refusal and transport failure returns ``False``.
+
+    ``config_dir``: forwarded to :func:`receipt_secret` unchanged — see that
+    function's docstring for why a background-thread caller must pass an
+    already-resolved directory rather than let it resolve lazily.
+    """
     if not endpoint:
         return False
     try:
         if not should_send(enabled=enabled, official=official, acked=acked).ok:
             return False
-        secret = receipt_secret()
+        secret = receipt_secret(config_dir=config_dir)
         token = receipt_token(secret, app_slug)
         if not token:
             return False
@@ -197,32 +208,116 @@ def send(
         return False
 
 
-def _send_configured(app_slug: str, *, official: bool, kind: str) -> None:
-    """Load current config and send inside the worker thread."""
+def _send_configured(
+    app_slug: str,
+    *,
+    official: bool,
+    kind: str,
+    config_dir: Path,
+    endpoint: str,
+    enabled: bool,
+    acked: bool,
+) -> None:
+    """Send inside the worker thread, from values the caller already resolved.
+
+    Every input that depends on the process environment -- ``config_dir`` and
+    the three config fields ``send`` reads -- is resolved by ``dispatch()`` on
+    the dispatching thread and passed in. ``beacon.config_dir()`` and
+    ``KiroCrewConfig.load()`` both honor ``KIROCREW_HOME`` at the moment they
+    are called; resolving either on this worker thread would race a test's
+    teardown unpatching ``KIROCREW_HOME`` before this thread gets scheduled,
+    and send the receipt secret to the real data home instead of the pinned
+    test one. The worker therefore reads nothing from the environment.
+    """
     try:
-        config = KiroCrewConfig.load()
         send(
-            config.telemetry.beacon_endpoint,
+            endpoint,
             app_slug,
             app_version=__version__,
-            enabled=config.telemetry.beacon_enabled,
+            enabled=enabled,
             official=official,
-            acked=config.dashboard.privacy_acked,
+            acked=acked,
             kind=kind,
+            config_dir=config_dir,
         )
     except Exception:
         logger.debug("install receipt worker failed (ignored)", exc_info=True)
+    finally:
+        with _pending_lock:
+            _pending_threads.discard(threading.current_thread())
+
+
+# Tracks in-flight dispatch() worker threads so tests can block until they
+# finish (see wait_for_pending_receipt_writes) instead of leaving one alive
+# past teardown, where it would resolve paths against whatever KIROCREW_HOME
+# happens to be set to next.
+_pending_lock = threading.Lock()
+_pending_threads: set[threading.Thread] = set()
+
+# wait_for_pending_receipt_writes() waits at most this long for dispatch()'s
+# worker threads to finish before giving up. Matches the bounded-poll style
+# used by kiro_crew.metrics.provider._wait_for_in_flight_consent_worker.
+_PENDING_WAIT_BOUND_SECS = 10.0
+_PENDING_WAIT_POLL_SECS = 0.01
+
+
+def wait_for_pending_receipt_writes(timeout: float = _PENDING_WAIT_BOUND_SECS) -> None:
+    """Block until every ``dispatch()`` worker thread has finished, or raise.
+
+    Test-only: call this before undoing a ``KIROCREW_HOME`` monkeypatch (or
+    any other per-test env override) so no receipt worker is still alive to
+    resolve paths against a different value once the patch is gone. Raises
+    ``RuntimeError`` if a worker is still running past ``timeout`` — a test
+    must never proceed with a live stale worker able to touch real paths.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        with _pending_lock:
+            live = {t for t in _pending_threads if isinstance(t, threading.Thread) and t.is_alive()}
+            _pending_threads.intersection_update(live)
+            if not live:
+                return
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                "wait_for_pending_receipt_writes: an install-receipt worker "
+                f"is still running after {timeout}s; a test must never "
+                "proceed with a live stale worker able to resolve paths "
+                "against an unpatched KIROCREW_HOME"
+            )
+        time.sleep(_PENDING_WAIT_POLL_SECS)
 
 
 def dispatch(app_slug: str, *, official: bool, kind: str) -> None:
     """Start a detached daemon sender without delaying the completed install."""
     if not official:
         return
+    # Resolved HERE, on the caller's thread, while KIROCREW_HOME (or whatever
+    # pinned it) is still in effect — then handed to the worker as arguments.
+    # The worker must not call beacon.config_dir() or KiroCrewConfig.load()
+    # itself: by the time it runs, a test may already have undone the very env
+    # override that made those resolve to the pinned test home.
     with contextlib.suppress(Exception):
-        threading.Thread(
+        config_dir = beacon.config_dir()
+        config = KiroCrewConfig.load()
+        thread = threading.Thread(
             target=_send_configured,
             args=(app_slug,),
-            kwargs={"official": True, "kind": kind},
+            kwargs={
+                "official": True,
+                "kind": kind,
+                "config_dir": config_dir,
+                "endpoint": config.telemetry.beacon_endpoint,
+                "enabled": config.telemetry.beacon_enabled,
+                "acked": config.dashboard.privacy_acked,
+            },
             name="kirocrew-install-receipt",
             daemon=True,
-        ).start()
+        )
+        with _pending_lock:
+            _pending_threads.add(thread)
+        try:
+            thread.start()
+        except Exception:
+            with _pending_lock:
+                _pending_threads.discard(thread)
+            raise

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-tests
-description: "How to write a Kiro Crew backend test that has NO side effects and does not flake. Use when adding, editing, reviewing, or debugging a pytest test in the Kiro Crew source repo: which conftest is under your file, what leaks (temp dirs, the real data home, ~/.kiro, cron, threads, child processes), how to tell which of the five flake classes you have and where each one's fix is written, and the cross-platform traps on macOS/Linux/Windows and arm64. Also covers diagnosing a residue failure and keeping the parallel suite fast."
+description: "How to write a Kiro Crew backend test that has NO side effects and does not flake. Use when adding, editing, reviewing, or debugging a pytest test in the Kiro Crew source repo: which conftest is under your file, what leaks (temp dirs, the real data home, ~/.kiro, cron, threads, child processes), how to tell which of the six flake classes you have and where each one's fix is written, and the cross-platform traps on macOS/Linux/Windows and arm64. Also covers diagnosing a residue failure and keeping the parallel suite fast."
 triggers: write a test, add a test, fix a flaky test, test is flaky, test side effect, temp dir residue, tmp residue, kirocrew test, pytest kirocrew, test isolation, conftest, xdist, test leaked
 repo_scope: src/kiro_crew
 ---
@@ -213,21 +213,29 @@ The rootdir conftest traps the stdlib spawn funnels and refuses a
 (`show`, `cat`, `is-active`) are allowed and need no stub. A test reaching the make-live
 cutover path must stub **both** `_run_cmd` and `_dropin_path`.
 
-## Rule 2 — Determinism: five classes, one correct fix each
+## Rule 2 — Determinism: six classes, one correct fix each
 
 Never "fix" a flake with a rerun, a longer `sleep`, a weakened assertion, or a skip.
 Full detail and examples: testing-conventions § Determinism.
 
-The five classes, the tell that identifies each, and the ONE correct fix for each are in
+The six classes, the tell that identifies each, and the ONE correct fix for each are in
 [testing-conventions.md](../../../../../docs/system-specs/common/testing-conventions.md)
-§ Determinism. Read the section matching your symptom before changing anything: four of the five
+§ Determinism. Read the section matching your symptom before changing anything: most of them
 have a fix that looks like the obvious one and is not.
 
 What this skill adds is when to go looking — a test that passes alone and fails in the suite, or
-one that splits by Python version rather than by machine load, is one of those five and not a
+one that splits by Python version rather than by machine load, is one of those six and not a
 mystery. Do not reach for a rerun, a longer `sleep`, a weakened assertion, or a skip.
 
-A sixth, adjacent trap: **a patch target that misses.** Patch the namespace whose
+The sixth class has a tell of its own: **the run ends early, not red.** On Windows a test that
+blocks past `--timeout` is not failed, its xdist worker is killed, and with
+`--max-worker-restart=0` the run aborts with every uncollected result missing. If a full run
+reports a few thousand tests instead of ~60k, look for `worker ... crashed while running` in the
+log: the named test is one that can wait forever. Wait on the observable state, not a guessed
+`sleep`, and bound the await whose refusal is under test with `asyncio.wait_for` so a missed
+refusal fails by name at that line.
+
+An adjacent trap: **a patch target that misses.** Patch the namespace whose
 globals the code under test actually reads. It fails in both directions — patching a
 package re-export when the caller reads its own defining module, or patching
 `pkg.mod.fn` when the caller did `from pkg.mod import fn` and holds its own binding.
@@ -235,7 +243,7 @@ Either way the real function runs, the assertion passes for the wrong reason, an
 test pays real time. **Treat an unexpectedly slow "mocked" test as evidence the mock
 missed.**
 
-A seventh: **the host is an input, and a "surely-unused" number is not a constant.**
+Another: **the host is an input, and a "surely-unused" number is not a constant.**
 `999999` reads as an impossible PID and is not — `pid_max` is 4194304, so on a
 long-running host it names a live process. That broke two tests in opposite ways: one
 stopped pruning an entry whose owner "must be dead", and one accused a planted `ps` shim
@@ -367,10 +375,25 @@ The consequence for how you write a test:
 - [ ] Every `mkdtemp` has `addCleanup` on the next line (or uses `tmp_path`)
 - [ ] Every child that may create a file gets `cwd=` under `tmp_path`, and every
       assertion is scoped to where that child actually ran
+- [ ] Anything whose default directory is `Path.cwd()` (`TaskRunner(work_dir=...)`) is
+      constructed with an explicit `tmp_path`; a gitignored name at the repo root is the
+      one leak the residue guard cannot see
+- [ ] A background worker gets every environment-derived input (paths AND config) from the
+      dispatching thread, and registers itself so the rootdir conftest teardown can join it
 - [ ] Every thread, task, child process, socket and connection it starts is stopped in a
       `finally` or an `addCleanup`
-- [ ] Globals mutated through `monkeypatch`, never raw assignment
+- [ ] Globals mutated through `monkeypatch`, never raw assignment — including `os.environ`
+      keys a REAL production startup path is known to write (`PLAYWRIGHT_MCP_OUTPUT_DIR`,
+      `KIROCREW_TELEMETRY`, `PATH`), restored in the shared helper that drives it
 - [ ] No `AsyncMock` standing in for a synchronous method; every `cancel()` awaited
+- [ ] No module-level asyncio primitive (`Lock`/`Event`/`Future`/in-flight dict) reachable
+      from the code under test without a per-test reset
+- [ ] Nothing can block forever: every await the test itself must unblock is wrapped in a
+      bounded `wait_for`; no `sleep(0.05)` standing in for "let the other task register"
+- [ ] A fixture stamped from a module-level `NOW` is only compared by production code
+      whose clock is pinned to that same `NOW` (a `frozen_clock` fixture) -- never two clocks
+- [ ] After `await handler(...)`, an assertion on something a worker thread emits via
+      `call_soon_threadsafe` waits on that signal, not on the handler returning
 - [ ] No assertion on a rate, a sample count, or an absolute duration
 - [ ] Source files read via `_REPO_ROOT = Path(__file__).resolve().parents[N]`, never a
       relative `Path("src/...")` — xdist workers may change CWD

--- a/src/kiro_crew/members.py
+++ b/src/kiro_crew/members.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 from kiro_crew import platform_compat
 from kiro_crew.artifacts import slugify
-from kiro_crew.atomic_write import atomic_write, fsync_dir
+from kiro_crew.atomic_write import atomic_write, fsync_dir, read_bytes_with_retry
 from kiro_crew.config.paths import data_home
 from kiro_crew.jsonl_util import (
     RECORD_CAP,
@@ -510,7 +510,11 @@ def read_dm_binding(slug: str) -> dict | None:
     binding is idempotently re-creatable, so degrading to re-creation is
     always safe and the caller needs no try/except.
 
-    Blocking file IO: call via ``asyncio.to_thread`` from async code.
+    Blocking file IO: call via ``asyncio.to_thread`` from async code. The read
+    goes through :func:`read_bytes_with_retry`, which retries a transient
+    Windows sharing violation (an AV/indexer handle on the file this
+    function's write-side twin, :func:`write_dm_binding`, just atomically
+    replaced) — off-loop only, matching this function's own calling contract.
     """
     try:
         path = dm_binding_path(slug)
@@ -521,7 +525,7 @@ def read_dm_binding(slug: str) -> dict | None:
         # restore paths rely on that to survive any on-disk state at boot.
         return None
     try:
-        raw = path.read_text(encoding="utf-8")
+        raw = read_bytes_with_retry(path).decode("utf-8")
     except (OSError, UnicodeError):
         # Invalid UTF-8 is the same totality case as an unreadable file: the
         # binding reads as absent, never as a 500 out of every member API.
@@ -659,7 +663,11 @@ def read_member_rules(slug: str, member: str) -> str:
     """
     path = member_rules_path(slug)
     try:
-        raw = path.read_text(encoding="utf-8")
+        # Same read-side twin as read_dm_binding: write_member_rules replaces
+        # this file atomically, and on Windows an AV/indexer handle on the
+        # just-replaced file is a transient sharing violation, not a corrupt
+        # rules file -- so it must not surface as MemberRulesUnreadable.
+        raw = read_bytes_with_retry(path).decode("utf-8")
     except FileNotFoundError:
         return ""
     except (OSError, UnicodeError) as exc:

--- a/test/metrics/test_provider_bucket_views.py
+++ b/test/metrics/test_provider_bucket_views.py
@@ -18,8 +18,10 @@ properties load-bearing, and both are asserted here:
    twice under one metric name. ``test_no_duplicate_streams_per_instrument``
    pins that.
 """
+
 import ast
 import re
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -43,7 +45,8 @@ _SRC = Path(provider_mod.__file__).resolve().parent.parent
 _NAME_RE = re.compile(r'"(kirocrew\.[a-z0-9_.]*\.duration)"')
 
 
-def _source_histogram_names() -> set[str]:
+@lru_cache(maxsize=1)
+def _source_histogram_names() -> frozenset[str]:
     found: set[str] = set()
     for path in _SRC.rglob("*.py"):
         try:
@@ -51,9 +54,10 @@ def _source_histogram_names() -> set[str]:
         except (OSError, UnicodeDecodeError):
             continue
         found.update(_NAME_RE.findall(text))
-    return found
+    return frozenset(found)
 
 
+@lru_cache(maxsize=1)
 def _emitted_histogram_units() -> dict[str, set[str]]:
     """Instrument name -> the set of ``unit=`` values its emit calls pass.
 
@@ -111,7 +115,7 @@ def _emitted_histogram_units() -> dict[str, set[str]]:
 
 
 def _emitted_histogram_names() -> set[str]:
-    return set(_emitted_histogram_units())
+    return set(_emitted_histogram_units().keys())
 
 
 class TestCompleteness:
@@ -199,8 +203,7 @@ class TestNonDurationHistograms:
         """
         units = _emitted_histogram_units()
         wrong = sorted(
-            name for name in _HISTOGRAM_BUCKETS_MS
-            if name in units and units[name] != {"ms"}
+            name for name in _HISTOGRAM_BUCKETS_MS if name in units and units[name] != {"ms"}
         )
         assert not wrong, (
             f"non-millisecond instruments in the ms map: {wrong}. The dashboard "
@@ -209,10 +212,7 @@ class TestNonDurationHistograms:
 
     def test_by_unit_map_holds_no_millisecond_instruments(self):
         units = _emitted_histogram_units()
-        wrong = sorted(
-            name for name in _HISTOGRAM_BUCKETS_BY_UNIT
-            if units.get(name) == {"ms"}
-        )
+        wrong = sorted(name for name in _HISTOGRAM_BUCKETS_BY_UNIT if units.get(name) == {"ms"})
         assert not wrong, f"millisecond instruments belong in the ms map: {wrong}"
 
     def test_one_instrument_never_carries_two_units(self):
@@ -228,8 +228,7 @@ class TestNonDurationHistograms:
         # boundary that a percentile can only report as a floor.
         for observed in (6.76, 53.3, 155.1):
             assert any(
-                lo < observed <= hi
-                for lo, hi in zip(_CREDIT_BUCKETS, _CREDIT_BUCKETS[1:])
+                lo < observed <= hi for lo, hi in zip(_CREDIT_BUCKETS, _CREDIT_BUCKETS[1:])
             ), observed
 
     def test_usd_bounds_span_sub_cent_to_tens_of_dollars(self):
@@ -244,8 +243,23 @@ class TestNonDurationHistograms:
         population lands in the first two buckets, so the reported p50 could only
         ever be 0 or 5.
         """
-        otel_default = [0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0,
-                        1000.0, 2500.0, 5000.0, 7500.0, 10000.0]
+        otel_default = [
+            0.0,
+            5.0,
+            10.0,
+            25.0,
+            50.0,
+            75.0,
+            100.0,
+            250.0,
+            500.0,
+            750.0,
+            1000.0,
+            2500.0,
+            5000.0,
+            7500.0,
+            10000.0,
+        ]
         below_five = sum(1 for b in _CREDIT_BUCKETS if b <= 5.0)
         assert below_five >= 7, "the credit array must resolve the sub-5 decade"
         assert sum(1 for b in otel_default if 0 < b <= 5.0) == 1
@@ -295,8 +309,25 @@ class TestMixedBoundaryGenerations:
     """
 
     OLD_SHARED_BOUNDS = [
-        1, 5, 10, 25, 50, 100, 250, 500, 1000, 2000, 3000,
-        5000, 7500, 10000, 15000, 20000, 30000, 45000, 60000,
+        1,
+        5,
+        10,
+        25,
+        50,
+        100,
+        250,
+        500,
+        1000,
+        2000,
+        3000,
+        5000,
+        7500,
+        10000,
+        15000,
+        20000,
+        30000,
+        45000,
+        60000,
     ]
 
     def _dp(self, bounds, landed_index, count=1, total=None, ns=None):
@@ -323,8 +354,7 @@ class TestMixedBoundaryGenerations:
     def test_legacy_overflow_point_cannot_fabricate_a_one_hour_p90(self):
         h = _Hist()
         # Pre-change: a 227589ms turn, recorded as old-bounds +Inf overflow.
-        h.add(self._dp(self.OLD_SHARED_BOUNDS, len(self.OLD_SHARED_BOUNDS),
-                       count=1, total=227589))
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, len(self.OLD_SHARED_BOUNDS), count=1, total=227589))
         # Post-change: three ordinary ~30s turns under the new bounds.
         for _ in range(3):
             h.add(self._dp(_TURN_BUCKETS_MS, 5, count=1, total=30000))
@@ -339,8 +369,8 @@ class TestMixedBoundaryGenerations:
 
     def test_generations_do_not_cross_contaminate_buckets(self):
         h = _Hist()
-        h.add(self._dp(self.OLD_SHARED_BOUNDS, 11, count=5))   # 5 old samples
-        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=9))           # 9 new samples
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, 11, count=5))  # 5 old samples
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=9))  # 9 new samples
         assert h.bounds == list(_TURN_BUCKETS_MS)
         assert sum(h.buckets) == 9, "old-generation counts bled into new buckets"
 
@@ -354,8 +384,15 @@ class TestMixedBoundaryGenerations:
         """
         h = _Hist()
         for _ in range(5):
-            h.add(self._dp(self.OLD_SHARED_BOUNDS, len(self.OLD_SHARED_BOUNDS),
-                           count=1, total=227589, ns=1_000))
+            h.add(
+                self._dp(
+                    self.OLD_SHARED_BOUNDS,
+                    len(self.OLD_SHARED_BOUNDS),
+                    count=1,
+                    total=227589,
+                    ns=1_000,
+                )
+            )
         h.add(self._dp(_TURN_BUCKETS_MS, 2, count=1, total=5000, ns=2_000))
 
         assert h.bounds == list(_TURN_BUCKETS_MS), "stale generation kept winning"
@@ -463,9 +500,7 @@ class TestViewWiring:
     def test_long_turn_does_not_land_in_the_overflow_bucket(self):
         """The regression: 227589ms must fall inside an explicit bucket."""
         mp, reader = self._provider()
-        mp.get_meter("t").create_histogram(
-            "kirocrew.turn.duration", unit="ms"
-        ).record(227589)
+        mp.get_meter("t").create_histogram("kirocrew.turn.duration", unit="ms").record(227589)
 
         (dp,) = self._points(reader, "kirocrew.turn.duration")
         counts = list(dp.bucket_counts)
@@ -481,9 +516,7 @@ class TestViewWiring:
         mp, reader = self._provider()
         meter = mp.get_meter("t")
         meter.create_histogram("kirocrew.turn.duration", unit="ms").record(5000)
-        meter.create_histogram(
-            "kirocrew.session.startup.duration", unit="ms"
-        ).record(4400)
+        meter.create_histogram("kirocrew.session.startup.duration", unit="ms").record(4400)
 
         assert len(self._points(reader, "kirocrew.turn.duration")) == 1
         assert len(self._points(reader, "kirocrew.session.startup.duration")) == 1
@@ -492,9 +525,7 @@ class TestViewWiring:
         mp, reader = self._provider()
         meter = mp.get_meter("t")
         meter.create_histogram("kirocrew.turn.duration", unit="ms").record(60000)
-        meter.create_histogram(
-            "kirocrew.mcp.backend.acquire.duration", unit="ms"
-        ).record(1)
+        meter.create_histogram("kirocrew.mcp.backend.acquire.duration", unit="ms").record(1)
 
         (turn,) = self._points(reader, "kirocrew.turn.duration")
         (fast,) = self._points(reader, "kirocrew.mcp.backend.acquire.duration")
@@ -535,9 +566,7 @@ class TestAggregatorReadsRealPercentiles:
         assert _pct_from_buckets(old_counts, old_bounds, 0.90) == 60000.0
 
         new_bounds = _TURN_BUCKETS_MS
-        landed = next(
-            i for i, b in enumerate(new_bounds) if b >= 227589
-        )
+        landed = next(i for i, b in enumerate(new_bounds) if b >= 227589)
         new_counts = [0] * (len(new_bounds) + 1)
         new_counts[landed] = 1
         p50 = _pct_from_buckets(new_counts, new_bounds, 0.50)

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -1635,17 +1635,35 @@ async def test_handle_cancel_uses_notification():
 
 @pytest.mark.asyncio
 async def test_concurrent_prompt_on_same_handle_rejected():
+    """A second ``prompt()`` on a handle whose turn is in flight must refuse.
+
+    The first turn is only "in flight" once ``_run_turn`` has passed its
+    ``_turn_done`` guard, and that happens AFTER two awaits the driver task has
+    to get through first (``_effective_prompt_timeout_async`` and the
+    ``to_thread`` prompt build). A fixed ``sleep(0.05)`` was a guess at how long
+    those take; on a loaded Windows runner the guess lost, the second prompt
+    passed the guard too, and then waited on a completion this test never feeds
+    -- with ``timeout=None`` resolving to the multi-hour dashboard ceiling. That
+    is not a failure, it is a hang: pytest-timeout kills the xdist worker, and
+    with ``--max-worker-restart=0`` the whole run aborts (observed in 2 of 5
+    full runs). ``_await_routed`` waits on the observable fact instead -- the
+    request exists in ``_routed_requests`` -- and the second prompt carries a
+    bounded timeout so a missed rejection fails at this line, loudly.
+    """
     rt, reader, _ = _make_runtime()
     q = _register(rt, "sA")
     handle = AcpSessionHandle("sA", q["sA"], rt)
     task = await _start_reader(rt)
     try:
-        # First turn is in-flight (no completion fed) — _turn_done stays clear.
+        # First turn is in-flight (no completion fed) -- _turn_done stays clear.
         first = asyncio.ensure_future(handle.prompt("hello").__anext__())
-        await asyncio.sleep(0.05)
+        await _await_routed(rt, "sA")
+        assert not handle._turn_done.is_set(), "first turn must be marked active"
         # A second prompt on the same handle must refuse rather than corrupt state.
+        # The ceiling only matters if the guard is broken: then this raises
+        # TimeoutError (a named failure) instead of blocking the worker.
         with pytest.raises(AcpRuntimeError):
-            await handle.prompt("again").__anext__()
+            await asyncio.wait_for(handle.prompt("again", timeout=1.0).__anext__(), 5.0)
         first.cancel()
         try:
             await first

--- a/test/test_app_ui_file_route.py
+++ b/test/test_app_ui_file_route.py
@@ -557,11 +557,31 @@ async def test_a_stalled_stream_releases_its_permit(ui_root: Path) -> None:
     client that stops reading cannot hold a `_UI_STREAM_SEMAPHORE` permit (and
     its descriptor) forever. This route bypasses token auth, so 8 such clients
     would otherwise wedge every app UI on the host. A zero deadline expires at
-    the first await, which is the same path a stalled reader takes."""
+    the first await, which is the same path a stalled reader takes.
+
+    A bare ``_UI_STREAM_TIMEOUT = 0`` is not itself clock-free: `asyncio.timeout`
+    computes its deadline as ``loop.time() + 0`` when the context is entered, so
+    whether the scheduled expiry callback fires before the first
+    ``to_thread(os.read, ...)`` chunk lands is a real race against wall clock —
+    flake class 2 (testing-conventions.md § Determinism). Patching the event
+    loop's own clock to jump far past that deadline the instant the loop is
+    (re)entered makes the expiry unconditional rather than a race against real
+    elapsed time.
+    """
     payload = b"x" * 4096
     (ui_root / "stalled.js").write_bytes(payload)
+    loop = asyncio.get_running_loop()
+    real_time = loop.time
+
+    # Every read of the loop's clock inside the write loop's `asyncio.timeout`
+    # context sees a time far past the (zero) deadline, so expiry is
+    # unconditional rather than a race against real elapsed wall-clock time.
+    def _jumped_time() -> float:
+        return real_time() + 3600.0
+
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(app_routes, "_UI_STREAM_TIMEOUT", 0)
+        mp.setattr(loop, "time", _jumped_time)
         async with TestClient(TestServer(_make_app())) as client:
             resp = await client.get(f"/apps/{APP}/ui/stalled.js")
             # Headers are sent before the loop, so the abort shows up as a body

--- a/test/test_approval_threading.py
+++ b/test/test_approval_threading.py
@@ -211,10 +211,21 @@ class TestSubagentPassesParentKey:
 
         info = manager.spawn("check oncall", parent_session_key="1775113012.860459")
         assert info is not None
+        assert not info.done and not info.error, (
+            f"spawn refused instead of registering a task: error={info.error!r} "
+            f"(host-memory guard? id={info.id})"
+        )
+        assert info.id in manager._tasks, (
+            "spawn did not schedule _spawn_with_approval — no task registered "
+            f"under id={info.id}; approval callback would never be awaited"
+        )
 
-        # Await the spawned task directly (deterministic, no sleep)
-        with contextlib.suppress(Exception):
-            await manager._tasks[info.id]
+        # Await the spawned task directly (deterministic, no sleep). Do not
+        # swallow the outcome: a broad `except Exception` here would turn a
+        # genuine race (e.g. the task raising before appending to
+        # captured_args) into a silent no-op, surfacing only as a confusing
+        # `len(captured_args) == 0` two lines down.
+        await manager._tasks[info.id]
 
         assert len(captured_args) == 1
         assert captured_args[0][2] == "1775113012.860459"

--- a/test/test_auto_research_handlers_coverage.py
+++ b/test/test_auto_research_handlers_coverage.py
@@ -439,6 +439,11 @@ class TestPollWorkflowCampaign:
         await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=None)), h.get_campaign(cid)["started_at"])
         assert _status(cid) == h.CampaignStatus.FAILED
         assert "snapshot lost" in (h.get_campaign(cid) or {})["error_message"]
+        # The terminal status commit and the SSE emit are two scheduling events:
+        # _sse_from_thread hands _emit_sse to the loop via call_soon_threadsafe
+        # from the worker thread, so a direct await of the poll can return before
+        # that callback has run. Wait on the signal this test asserts on.
+        assert await _await_until(lambda: "failed" in sse.types())
         assert sse.types() == ["failed"]
 
     @pytest.mark.asyncio
@@ -525,6 +530,11 @@ class TestPollWorkflowCampaign:
         await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         assert (h._campaign_dir(cid) / "FINDINGS.md").read_text() == "# Report\nAll done."
         assert _status(cid) == h.CampaignStatus.COMPLETE
+        # The terminal status commit and the SSE emit are two scheduling events:
+        # _sse_from_thread hands _emit_sse to the loop via call_soon_threadsafe
+        # from the worker thread, so a direct await of the poll can return before
+        # that callback has run. Wait on the signal this test asserts on.
+        assert await _await_until(lambda: "complete" in sse.types())
         assert sse.types() == ["complete"]
 
     @pytest.mark.asyncio
@@ -556,6 +566,11 @@ class TestPollWorkflowCampaign:
         await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         assert _status(cid) == h.CampaignStatus.FAILED
         assert (h.get_campaign(cid) or {})["error_message"] == "engine exploded"
+        # The terminal status commit and the SSE emit are two scheduling events:
+        # _sse_from_thread hands _emit_sse to the loop via call_soon_threadsafe
+        # from the worker thread, so a direct await of the poll can return before
+        # that callback has run. Wait on the signal this test asserts on.
+        assert await _await_until(lambda: "failed" in sse.types())
         assert sse.types() == ["failed"]
 
     @pytest.mark.asyncio

--- a/test/test_bot_name.py
+++ b/test/test_bot_name.py
@@ -29,10 +29,20 @@ class TestSanitizeBotName:
 
 
 class TestBotNameSubstitution:
+    # `ContextBuilder()` defaults to a real `SkillsLoader()`, whose
+    # `install_builtins=True` default syncs the whole builtin-skills tree to
+    # disk (~20s, unrelated to bot_name substitution). These tests only touch
+    # `_substitute_bot_name`, a pure string op, so skip that sync explicitly.
+    @staticmethod
+    def _no_install_skills():
+        from kiro_crew.skills import SkillsLoader
+
+        return SkillsLoader(install_builtins=False)
+
     def test_custom_name_substituted(self):
         from kiro_crew.context import ContextBuilder
 
-        ctx = ContextBuilder(bot_name="Alita")
+        ctx = ContextBuilder(bot_name="Alita", skills=self._no_install_skills())
         assert ctx._substitute_bot_name("You are {bot_name} 🐾") == "You are Alita 🐾"
 
     def test_empty_defaults_from_config(self):
@@ -43,19 +53,19 @@ class TestBotNameSubstitution:
         # When provider is ACP, default bot_name is "Kiro"
         with patch("kiro_crew.context.KiroCrewConfig.load") as mock_cfg:
             mock_cfg.return_value.agent.provider = "acp"
-            ctx = ContextBuilder(bot_name="")
+            ctx = ContextBuilder(bot_name="", skills=self._no_install_skills())
             assert ctx._substitute_bot_name("You are {bot_name}.") == "You are Kiro."
 
         # When provider is claude_code, default bot_name is "KiroCrew"
         with patch("kiro_crew.context.KiroCrewConfig.load") as mock_cfg:
             mock_cfg.return_value.agent.provider = "claude_code"
-            ctx = ContextBuilder(bot_name="")
+            ctx = ContextBuilder(bot_name="", skills=self._no_install_skills())
             assert ctx._substitute_bot_name("You are {bot_name}.") == "You are KiroCrew."
 
     def test_no_placeholder_is_noop(self):
         from kiro_crew.context import ContextBuilder
 
-        ctx = ContextBuilder(bot_name="Alita")
+        ctx = ContextBuilder(bot_name="Alita", skills=self._no_install_skills())
         assert ctx._substitute_bot_name("No placeholder here.") == "No placeholder here."
 
     def test_self_referential_no_recursion(self):
@@ -63,5 +73,5 @@ class TestBotNameSubstitution:
         from kiro_crew.context import ContextBuilder
 
         name = _sanitize_bot_name("{bot_name}")
-        ctx = ContextBuilder(bot_name=name)
+        ctx = ContextBuilder(bot_name=name, skills=self._no_install_skills())
         assert ctx._substitute_bot_name("You are {bot_name}.") == "You are bot_name."

--- a/test/test_channel_history.py
+++ b/test/test_channel_history.py
@@ -331,7 +331,12 @@ class TestChannelHistoryContext:
         h.push("C123", "alice", "pipeline broke")
         h.push("C123", "bob", "checking us-west-2")
 
-        builder = ContextBuilder(channel_history=h)
+        # skills=SkillsLoader(install_builtins=False): these tests exercise
+        # channel-history injection, not the builtin-skills sync that a
+        # default SkillsLoader() performs on every construction (~20s each).
+        from kiro_crew.skills import SkillsLoader
+
+        builder = ContextBuilder(channel_history=h, skills=SkillsLoader(install_builtins=False))
         msg, _ = builder.build_message("what's going on?", False, channel_id="C123")
 
         assert "pipeline broke" in msg
@@ -341,11 +346,12 @@ class TestChannelHistoryContext:
     def test_context_builder_no_injection_without_channel_id(self):
         """ContextBuilder does NOT inject channel history for DMs (no channel_id)."""
         from kiro_crew.context import ContextBuilder
+        from kiro_crew.skills import SkillsLoader
 
         h = ChannelHistory()
         h.push("C123", "alice", "secret channel message")
 
-        builder = ContextBuilder(channel_history=h)
+        builder = ContextBuilder(channel_history=h, skills=SkillsLoader(install_builtins=False))
         msg, _ = builder.build_message("hello", False)
 
         assert "secret channel message" not in msg
@@ -353,8 +359,9 @@ class TestChannelHistoryContext:
     def test_context_builder_no_injection_without_history(self):
         """ContextBuilder works fine with no channel_history set."""
         from kiro_crew.context import ContextBuilder
+        from kiro_crew.skills import SkillsLoader
 
-        builder = ContextBuilder()
+        builder = ContextBuilder(skills=SkillsLoader(install_builtins=False))
         msg, _ = builder.build_message("hello", False, channel_id="C123")
 
         assert msg.startswith("hello")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -146,12 +146,16 @@ class TestDoctor:
 
         monkeypatch.setattr(_doc.sandbox, "detect_backend", lambda config_mode="auto": "namespace")
 
-    def test_doctor_with_kiro(self, tmp_path):
+    def test_doctor_with_kiro(self, tmp_path, monkeypatch):
+        import kiro_crew.cli_doctor as _doc
+
         agent_file = tmp_path / "kirocrew.json"
         # A minimally healthy agent config so doctor walks the whole MCP
         # section cleanly and doesn't exit on "missing from mcpServers".
         _healthy_agent_file(agent_file)
         mock_run = MagicMock(returncode=0, stdout="kiro-cli 1.0.0", stderr="")
+        # Left unpatched this mutates the process PATH for every later test.
+        monkeypatch.setattr(_doc, "ensure_ffmpeg_in_path", lambda: None)
         with (
             patch(
                 "kiro_crew.cli_doctor.shutil.which",
@@ -283,10 +287,13 @@ class TestDoctor:
         assert f"  engine:      {expected_mark} no recogniser here" in out
         assert f"  ffmpeg:      {expected_mark} not found" in out
 
-    def test_doctor_reports_platform_boot_error_without_crashing(self, tmp_path, capsys):
+    def test_doctor_reports_platform_boot_error_without_crashing(
+        self, tmp_path, capsys, monkeypatch
+    ):
         """A PlatformCompositionError from boot must be REPORTED by the doctor,
         not crash it — the doctor is the tool that diagnoses a broken setup, so
         it has to survive the very failure it explains."""
+        import kiro_crew.cli_doctor as _doc
         from kiro_crew.platform import PlatformCompositionError
 
         agent_file = tmp_path / "kirocrew.json"
@@ -295,6 +302,8 @@ class TestDoctor:
         boot_err = PlatformCompositionError(
             "profile=amazon resolved no companion; set KIROCREW_PROFILE=standalone"
         )
+        # Left unpatched this mutates the process PATH for every later test.
+        monkeypatch.setattr(_doc, "ensure_ffmpeg_in_path", lambda: None)
         with (
             patch(
                 "kiro_crew.cli_doctor.shutil.which",

--- a/test/test_cli_manifest_signature.py
+++ b/test/test_cli_manifest_signature.py
@@ -49,18 +49,30 @@ def _find_openssl() -> str | None:
     return next((str(path) for path in candidates if path.is_file()), None)
 
 
-@pytest.fixture(scope="module", autouse=True)
-def _openssl_on_path():
-    """Expose Git for Windows' OpenSSL to Python helpers and installer shells."""
+@pytest.fixture(scope="module")
+def _openssl_bin() -> str:
+    """Resolve the OpenSSL executable path once per module (no PATH mutation)."""
     openssl = _find_openssl()
     if openssl is None:
         pytest.skip("OpenSSL is not available")
-    old_path = os.environ.get("PATH", "")
-    os.environ["PATH"] = str(Path(openssl).parent) + os.pathsep + old_path
-    try:
-        yield
-    finally:
-        os.environ["PATH"] = old_path
+    return openssl
+
+
+@pytest.fixture(autouse=True)
+def _openssl_on_path(_openssl_bin: str, monkeypatch):
+    """Expose Git for Windows' OpenSSL to Python helpers and installer shells.
+
+    Function-scoped (not module-scoped): a module-scoped mutation is applied
+    once at the first test's setup and reverted once at the last test's
+    teardown, so every test in between runs correctly but the first/last
+    test's own per-test env snapshot shows PATH changing across the test
+    boundary. monkeypatch.setenv is function-scoped and reverts after EACH
+    test, so no single test's boundary ever sees the mutation persist. The
+    binary lookup itself stays module-scoped (``_openssl_bin``) since it does
+    no PATH mutation and is safe to cache.
+    """
+    openssl_dir = str(Path(_openssl_bin).parent)
+    monkeypatch.setenv("PATH", openssl_dir + os.pathsep + os.environ.get("PATH", ""))
 
 
 @dataclass(frozen=True)
@@ -72,13 +84,13 @@ class SigningKey:
 
 
 @pytest.fixture(scope="module")
-def test_key(tmp_path_factory: pytest.TempPathFactory) -> SigningKey:
+def test_key(tmp_path_factory: pytest.TempPathFactory, _openssl_bin: str) -> SigningKey:
     root = tmp_path_factory.mktemp("cli-manifest-key")
     private = root / "private.pem"
     public = root / "public.pem"
     subprocess.run(
         [
-            "openssl",
+            _openssl_bin,
             "genpkey",
             "-algorithm",
             "RSA",
@@ -92,13 +104,13 @@ def test_key(tmp_path_factory: pytest.TempPathFactory) -> SigningKey:
         stderr=subprocess.DEVNULL,
     )
     subprocess.run(
-        ["openssl", "pkey", "-in", str(private), "-pubout", "-out", str(public)],
+        [_openssl_bin, "pkey", "-in", str(private), "-pubout", "-out", str(public)],
         check=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
     der = subprocess.run(
-        ["openssl", "pkey", "-pubin", "-in", str(public), "-outform", "DER"],
+        [_openssl_bin, "pkey", "-pubin", "-in", str(public), "-outform", "DER"],
         check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -113,14 +113,10 @@ class TestContextBuilder:
         assert ctx.index("in the USER's voice") < ctx.index("SELF-CONTAINED")
         # The per-turn reminder is the version most models actually act on;
         # it must carry the same constraint.
-        msg, _ = builder.build_message(
-            "pick one", is_new_session=False, interactive=True
-        )
+        msg, _ = builder.build_message("pick one", is_new_session=False, interactive=True)
         assert "self-contained" in msg, "interactive reminder missing self-contained rule"
         # Non-interactive turns get no OPTIONS reminder at all, so no rule either.
-        auto_msg, _ = builder.build_message(
-            "pick one", is_new_session=False, interactive=False
-        )
+        auto_msg, _ = builder.build_message("pick one", is_new_session=False, interactive=False)
         assert "self-contained" not in auto_msg
 
     def test_url_backtick_carve_out_follows_the_path_rule(self, tmp_path):
@@ -296,9 +292,7 @@ class TestContextBuilder:
         """With the flag set on a continuing session, the index comes back
         wrapped in the marker so the model can still discover skills."""
         builder = self._reinject_builder(tmp_path)
-        msg, _ = builder.build_message(
-            "carry on", is_new_session=False, needs_reinjection=True
-        )
+        msg, _ = builder.build_message("carry on", is_new_session=False, needs_reinjection=True)
         assert "[REINJECTED AFTER COMPACTION" in msg
         assert "[END REINJECTED]" in msg
         assert "widget-maker" in msg, "the re-injected block must carry the skill index"
@@ -313,9 +307,7 @@ class TestContextBuilder:
         """A new session already gets the index from the session context;
         re-injecting would duplicate it in the same prompt."""
         builder = self._reinject_builder(tmp_path)
-        msg, _ = builder.build_message(
-            "first turn", is_new_session=True, needs_reinjection=True
-        )
+        msg, _ = builder.build_message("first turn", is_new_session=True, needs_reinjection=True)
         assert "[REINJECTED AFTER COMPACTION" not in msg
 
     def test_no_reinjection_for_an_unmapped_custom_agent(self, tmp_path):
@@ -452,9 +444,7 @@ class TestContextBuilder:
             memory=MemoryStore(workspace=tmp_path / "ws"),
             skills=SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False),
         )
-        msg, _ = builder.build_message(
-            "hello", is_new_session=False, folder_path="Backend › 0812"
-        )
+        msg, _ = builder.build_message("hello", is_new_session=False, folder_path="Backend › 0812")
         assert "[FOLDER]" in msg
         assert "Backend › 0812" in msg
 
@@ -896,27 +886,39 @@ class TestRuntimeDisplayName:
 
     def test_agent_identity_injected_with_session_key(self, tmp_path):
         """build_session_context injects [CURRENT AGENT] and [RUNTIME] when session_key is provided."""
-        builder = ContextBuilder(memory=MemoryStore(workspace=tmp_path))
+        builder = ContextBuilder(
+            memory=MemoryStore(workspace=tmp_path),
+            skills=SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False),
+        )
         ctx = builder.build_session_context("dashboard:chat-1", agent="gpu-comms")
         assert "[CURRENT AGENT] gpu-comms" in ctx
         assert "[RUNTIME] KiroCrew dashboard" in ctx
 
     def test_agent_identity_omitted_without_session_key(self, tmp_path):
         """build_session_context omits agent identity when session_key is None."""
-        builder = ContextBuilder(memory=MemoryStore(workspace=tmp_path))
+        builder = ContextBuilder(
+            memory=MemoryStore(workspace=tmp_path),
+            skills=SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False),
+        )
         ctx = builder.build_session_context()
         assert "[CURRENT AGENT]" not in ctx
         assert "[RUNTIME]" not in ctx
 
     def test_agent_defaults_to_kirocrew(self, tmp_path):
         """Agent label defaults to 'kirocrew' when agent param is None."""
-        builder = ContextBuilder(memory=MemoryStore(workspace=tmp_path))
+        builder = ContextBuilder(
+            memory=MemoryStore(workspace=tmp_path),
+            skills=SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False),
+        )
         ctx = builder.build_session_context("dashboard:chat-1")
         assert "[CURRENT AGENT] kirocrew" in ctx
 
     def test_explicit_runtime_source_overrides_stable_session_key(self, tmp_path):
         """The current transport wins when a dashboard session resumes elsewhere."""
-        builder = ContextBuilder(memory=MemoryStore(workspace=tmp_path))
+        builder = ContextBuilder(
+            memory=MemoryStore(workspace=tmp_path),
+            skills=SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False),
+        )
         ctx = builder.build_session_context(
             "dashboard:chat-1",
             runtime_source="discord",

--- a/test/test_crew_chat.py
+++ b/test/test_crew_chat.py
@@ -2225,16 +2225,36 @@ class TestLiveRunIsReOwned:
         assert not CrewStore("s1").forwards, "a live run must not be reported interrupted"
 
 
+def _fill_idle_topics(st, count: int, *, offset: int) -> None:
+    """Append *count* idle filler topics with ascending ``last_activity``.
+
+    Built directly rather than through ``add_topic()``, which persists (a
+    3-file write plus a prune scan) on EVERY call -- O(n^2) disk writes the
+    cap tests do not need, since only the state after the FINAL ``save()``
+    is ever asserted on. Same record shape as ``CrewStore.add_topic``.
+    """
+    for i in range(count):
+        st.topics.append(
+            {
+                "topic_id": f"t{i}",
+                "active_run_id": f"r{i}",
+                "title": f"topic {i}",
+                "digest": "",
+                "status": "idle",
+                "last_activity": float(i + offset),
+                "origin_msg_id": f"m{i}",
+                "held": [],
+            }
+        )
+
+
 class TestTopicCap:
     """topics.json is read INLINE when a slot's store is first touched, so it must
     stay bounded — an unbounded file puts a growing parse on the event loop."""
 
     def test_idle_topics_are_pruned_oldest_first(self) -> None:
         st = CrewStore("s1")
-        for i in range(crew_mod._TOPIC_IDLE_CAP + 25):
-            t = st.add_topic(f"t{i}", f"r{i}", f"topic {i}", f"m{i}")
-            t["status"] = "idle"
-            t["last_activity"] = float(i)          # ascending: t0 is the oldest
+        _fill_idle_topics(st, crew_mod._TOPIC_IDLE_CAP + 25, offset=0)
         st.save()
         kept = {t["topic_id"] for t in CrewStore("s1").topics}
         assert len(kept) == crew_mod._TOPIC_IDLE_CAP
@@ -2250,10 +2270,7 @@ class TestTopicCap:
         old_held["status"] = "idle"
         old_held["held"] = ["m9"]
         old_held["last_activity"] = 0.0
-        for i in range(crew_mod._TOPIC_IDLE_CAP + 10):
-            t = st.add_topic(f"t{i}", f"r{i}", f"topic {i}", f"m{i}")
-            t["status"] = "idle"
-            t["last_activity"] = float(i + 1)
+        _fill_idle_topics(st, crew_mod._TOPIC_IDLE_CAP + 10, offset=1)
         st.save()
         kept = {t["topic_id"] for t in CrewStore("s1").topics}
         assert "keep-running" in kept, "a running topic was pruned"
@@ -2276,10 +2293,7 @@ class TestTopicCap:
             e = st.add_msg("the in-flight request")
             e["state"] = pinning_state
             e["topic_id"] = "keep-claimed"
-            for i in range(crew_mod._TOPIC_IDLE_CAP + 10):
-                t = st.add_topic(f"t{i}", f"r{i}", f"topic {i}", f"m{i}")
-                t["status"] = "idle"
-                t["last_activity"] = float(i + 1)
+            _fill_idle_topics(st, crew_mod._TOPIC_IDLE_CAP + 10, offset=1)
             st.save()
             kept = {t["topic_id"] for t in CrewStore(f"pin-{pinning_state}").topics}
             assert "keep-claimed" in kept, (
@@ -2298,10 +2312,7 @@ class TestTopicCap:
         e = st.add_msg("finished request")
         e["state"] = "done"
         e["topic_id"] = "prunable"
-        for i in range(crew_mod._TOPIC_IDLE_CAP + 10):
-            t = st.add_topic(f"t{i}", f"r{i}", f"topic {i}", f"m{i}")
-            t["status"] = "idle"
-            t["last_activity"] = float(i + 1)
+        _fill_idle_topics(st, crew_mod._TOPIC_IDLE_CAP + 10, offset=1)
         st.save()
         kept = {t["topic_id"] for t in CrewStore("no-pin").topics}
         assert "prunable" not in kept

--- a/test/test_dashboard_server_startup_coverage.py
+++ b/test/test_dashboard_server_startup_coverage.py
@@ -40,6 +40,9 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from kiro_crew.browser_cli import launch as browser_cli_launch
+from kiro_crew.browser_cli import snapshots as browser_cli_snapshots
+from kiro_crew.browser_cli import token as browser_cli_token
 from kiro_crew.dashboard import server as srv
 
 requires_unix_socket = pytest.mark.skipif(
@@ -258,6 +261,24 @@ async def _start_dashboard(tmp_path: Path, monkeypatch, **kwargs: Any) -> Any:
     # would bind a real socket in the data home.
     monkeypatch.setattr(srv, "_start_unix_site", AsyncMock(return_value=None))
     spies = _neutralise_outside_process_work(monkeypatch)
+    # start_dashboard mutates os.environ directly (browser_cli_snapshots /
+    # browser_cli_token / browser_cli_launch cli_env_overrides()) so descendant
+    # `playwright-cli` invocations inherit them -- real, deliberate production
+    # behavior, not a bug. monkeypatch has no visibility into a raw
+    # os.environ.update(), so snapshot+restore the concrete keys it can touch
+    # here instead. `delenv(raising=False)` on an ABSENT key registers no undo,
+    # so a value production writes afterwards would survive teardown; setenv
+    # to "" first records the absence and restores it, and start_dashboard
+    # overwrites the placeholder before anything reads it.
+    for _leak_key in (
+        browser_cli_snapshots.OUTPUT_DIR_ENV,
+        browser_cli_token.TOKEN_ENV,
+        browser_cli_launch.CONFIG_ENV,
+    ):
+        _prior = os.environ.get(_leak_key)
+        monkeypatch.setenv(_leak_key, "" if _prior is None else _prior)
+        if _prior is None:
+            monkeypatch.delenv(_leak_key, raising=False)
 
     sessions = MagicMock(count=0)
     sessions.remove = AsyncMock()

--- a/test/test_file_search_dirs.py
+++ b/test/test_file_search_dirs.py
@@ -369,15 +369,22 @@ class TestApiFileSearchDirs:
         assert "widgets.py" in names, "the file was crowded out by directory candidates"
 
     @pytest.mark.asyncio
-    async def test_files_and_dirs_have_independent_scan_budgets(self, tmp_path, mock_sel):
+    async def test_files_and_dirs_have_independent_scan_budgets(
+            self, tmp_path, mock_sel, monkeypatch):
         """A file-heavy root must not starve the directory scan.
 
         A single shared scan counter let files spend the whole budget before any
         directory was examined, so directory search returned nothing even though
         it was enabled. Non-matching files are used so only the SCAN budget (not
         the candidate cap) is under test.
+
+        Budgets patched DOWN (module-level exactly so tests can, per
+        ``files.py``'s comment on ``_WALK_MAX_SCAN_SCOPED``) so a much smaller
+        tree still exceeds them and exercises the same starvation path.
         """
-        for i in range(5_000):
+        monkeypatch.setattr(files_mod, "_WALK_MAX_SCAN_SCOPED", 100)
+        monkeypatch.setattr(files_mod, "_WALK_MAX_SCAN_UNSCOPED", 100)
+        for i in range(200):
             (tmp_path / f"zz{i:04d}.py").write_text("x")
         (tmp_path / "widgets_dir").mkdir()
 

--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -1774,6 +1774,12 @@ class TestConfigGetHandlers:
     def test_slack_config_get_masks_the_tokens(self, monkeypatch, tmp_path: Path) -> None:
         monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
         monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+        # load_credentials() propagates .env values into os.environ via
+        # setdefault() so spawned children inherit them (real, deliberate
+        # behavior). monkeypatch.delenv(raising=False) snapshots whatever is
+        # currently there (present or absent) and restores exactly that at
+        # teardown, so this protects the var regardless of what an earlier
+        # test in this worker left behind.
         monkeypatch.delenv("OWNER_ID", raising=False)
         self._isolate(
             monkeypatch,

--- a/test/test_install_receipt.py
+++ b/test/test_install_receipt.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import os
+import threading
 import urllib.error
 import urllib.parse
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,6 +27,23 @@ _real_receipt_secret = install_receipt.receipt_secret
 
 
 @pytest.fixture(autouse=True)
+def _clean_pending_receipt_threads():
+    """Drop any leftover dispatch()-tracked thread entries between tests.
+
+    Tests that stub ``threading.Thread`` (e.g. to assert on constructor
+    kwargs) hand ``dispatch()`` a fake object that is added to
+    ``install_receipt._pending_threads`` but never runs, so it never removes
+    itself the way a real worker's ``finally`` block does. Left alone these
+    fakes just accumulate harmlessly (wait_for_pending_receipt_writes ignores
+    anything that is not a real Thread), but clearing them keeps each test's
+    view of pending work honest.
+    """
+    yield
+    with install_receipt._pending_lock:
+        install_receipt._pending_threads.clear()
+
+
+@pytest.fixture(autouse=True)
 def _eligible_telemetry_host(monkeypatch):
     """Neutralize ambient CI/dev-home suppression for explicit gate tests."""
     monkeypatch.delenv(beacon.DISABLE_ENV, raising=False)
@@ -37,7 +57,7 @@ def _eligible_telemetry_host(monkeypatch):
     monkeypatch.setattr(
         install_receipt,
         "receipt_secret",
-        lambda *, create=True: _SECRET,
+        lambda *, create=True, config_dir=None: _SECRET,
     )
 
 
@@ -161,9 +181,7 @@ class TestReceiptTransport:
         assert calls == []
 
     @pytest.mark.parametrize("suppression", ["env", "ci"])
-    def test_env_kill_switch_and_test_mode_dispatch_no_http(
-        self, monkeypatch, suppression
-    ):
+    def test_env_kill_switch_and_test_mode_dispatch_no_http(self, monkeypatch, suppression):
         calls: list[tuple[str, float]] = []
         monkeypatch.setattr(install_receipt.urllib.request, "urlopen", _fake_urlopen(calls))
         if suppression == "env":
@@ -195,7 +213,9 @@ class TestReceiptTransport:
             acked=True,
             kind=install_receipt.KIND_FRESH,
         )
-        monkeypatch.setattr(install_receipt, "receipt_secret", lambda *, create=True: "")
+        monkeypatch.setattr(
+            install_receipt, "receipt_secret", lambda *, create=True, config_dir=None: ""
+        )
         assert not install_receipt.send(
             "https://telemetry.example",
             "issue-radar",
@@ -222,9 +242,7 @@ class TestReceiptTransport:
         )
         assert len(calls) == 1
         assert calls[0][1] == beacon.HTTP_TIMEOUT_SECS == 5.0
-        assert urllib.parse.parse_qs(urllib.parse.urlsplit(calls[0][0]).query)["k"] == [
-            "update"
-        ]
+        assert urllib.parse.parse_qs(urllib.parse.urlsplit(calls[0][0]).query)["k"] == ["update"]
 
     def test_transport_failures_are_silent(self, monkeypatch):
         monkeypatch.setattr(
@@ -252,6 +270,12 @@ class TestReceiptTransport:
             def start(self):
                 threads[-1]["started"] = True
 
+            def is_alive(self):
+                # This fake never runs its target, so nothing is ever in flight;
+                # the rootdir conftest's per-test join asks every registered
+                # worker this question before the test's env pins are undone.
+                return False
+
         monkeypatch.setattr(install_receipt.threading, "Thread", Thread)
 
         install_receipt.dispatch(
@@ -268,6 +292,59 @@ class TestReceiptTransport:
         )
         assert threads[0]["daemon"] is True
         assert threads[0]["started"] is True
+
+    def test_dispatch_resolves_config_dir_before_home_is_unpatched(self, monkeypatch, tmp_path):
+        """dispatch()'s worker must write under the KIROCREW_HOME pinned AT
+
+        DISPATCH TIME, even if that env var is unset again before the
+        background thread finishes. Regression test for a real-home leak: the
+        worker used to call beacon.config_dir() itself, lazily, on the
+        background thread — a race against the caller's teardown unpatching
+        KIROCREW_HOME meant the secret file could land in the operator's real
+        data home instead of the pinned test one.
+        """
+        pinned_home = tmp_path / "pinned-home"
+        real_home_config_dir = tmp_path / "real-home" / ".kiro" / "crew"
+        monkeypatch.setattr(beacon, "is_default_home", lambda: True)
+
+        def fake_config_dir():
+            # Mirrors production: honors KIROCREW_HOME at call time.
+            override = os.environ.get("KIROCREW_HOME")
+            if override:
+                return Path(override) / ".kiro" / "crew"
+            return real_home_config_dir
+
+        monkeypatch.setattr(beacon, "config_dir", fake_config_dir)
+        # Real receipt_secret (not the autouse stub) so it actually touches disk.
+        monkeypatch.setattr(install_receipt, "receipt_secret", _real_receipt_secret)
+        monkeypatch.setattr(
+            install_receipt,
+            "KiroCrewConfig",
+            MagicMock(
+                load=lambda: MagicMock(
+                    telemetry=MagicMock(
+                        beacon_endpoint="https://telemetry.example",
+                        beacon_enabled=True,
+                    ),
+                    dashboard=MagicMock(privacy_acked=True),
+                )
+            ),
+        )
+        monkeypatch.setattr(install_receipt.urllib.request, "urlopen", _fake_urlopen([]))
+
+        monkeypatch.setenv("KIROCREW_HOME", str(pinned_home))
+        install_receipt.dispatch("issue-radar", official=True, kind=install_receipt.KIND_FRESH)
+        # Simulate the test's own teardown unpatching KIROCREW_HOME while the
+        # background thread may still be about to run.
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+
+        install_receipt.wait_for_pending_receipt_writes(timeout=5.0)
+
+        assert not any(
+            t.is_alive() for t in threading.enumerate() if t.name == "kirocrew-install-receipt"
+        )
+        assert (pinned_home / ".kiro" / "crew" / "app_receipt_secret").exists()
+        assert not real_home_config_dir.exists()
 
 
 async def _run_registry_install(
@@ -355,12 +432,8 @@ class TestRegistryEmitPoint:
         ]
 
     @pytest.mark.asyncio
-    async def test_successful_official_update_uses_update_kind(
-        self, monkeypatch, tmp_path
-    ):
-        result, dispatched = await _run_registry_install(
-            monkeypatch, tmp_path, existing=True
-        )
+    async def test_successful_official_update_uses_update_kind(self, monkeypatch, tmp_path):
+        result, dispatched = await _run_registry_install(monkeypatch, tmp_path, existing=True)
         assert result["ok"] is True
         assert dispatched[0][1]["kind"] == install_receipt.KIND_UPDATE
 
@@ -372,27 +445,19 @@ class TestRegistryEmitPoint:
         external repos as a CREDENTIAL decision; that must not promote the
         entry to official-catalog status — no receipt, ever."""
         monkeypatch.setattr(registry, "_is_owner_designated_repo", lambda entry: True)
-        result, dispatched = await _run_registry_install(
-            monkeypatch, tmp_path, external=True
-        )
+        result, dispatched = await _run_registry_install(monkeypatch, tmp_path, external=True)
         assert result["ok"] is True
         assert dispatched == []
 
     @pytest.mark.asyncio
-    async def test_external_registry_success_never_dispatches(
-        self, monkeypatch, tmp_path
-    ):
-        result, dispatched = await _run_registry_install(
-            monkeypatch, tmp_path, external=True
-        )
+    async def test_external_registry_success_never_dispatches(self, monkeypatch, tmp_path):
+        result, dispatched = await _run_registry_install(monkeypatch, tmp_path, external=True)
         assert result["ok"] is True
         assert dispatched == []
 
     @pytest.mark.asyncio
     async def test_failed_install_never_dispatches(self, monkeypatch, tmp_path):
-        result, dispatched = await _run_registry_install(
-            monkeypatch, tmp_path, install_ok=False
-        )
+        result, dispatched = await _run_registry_install(monkeypatch, tmp_path, install_ok=False)
         assert result["ok"] is False
         assert dispatched == []
 
@@ -425,9 +490,7 @@ class TestNonRegistryPaths:
         )
         return source
 
-    def test_local_directory_install_emits_nothing(
-        self, tmp_path, app_home, monkeypatch
-    ):
+    def test_local_directory_install_emits_nothing(self, tmp_path, app_home, monkeypatch):
         monkeypatch.setattr(
             install_receipt,
             "dispatch",
@@ -435,9 +498,7 @@ class TestNonRegistryPaths:
         )
         assert manager.install_app(self._source(tmp_path, "local-app")).ok
 
-    def test_self_registration_emits_nothing(
-        self, app_home, monkeypatch
-    ):
+    def test_self_registration_emits_nothing(self, app_home, monkeypatch):
         monkeypatch.setattr(
             install_receipt,
             "dispatch",

--- a/test/test_lazy_data_home_paths.py
+++ b/test/test_lazy_data_home_paths.py
@@ -34,6 +34,7 @@ Keeping the module-level name means existing ``monkeypatch.setattr(mod,
 from __future__ import annotations
 
 import ast
+from functools import lru_cache
 from pathlib import Path
 from unittest.mock import patch
 
@@ -41,7 +42,7 @@ SRC = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
 PATHS_MODULE = SRC / "config" / "paths.py"
 
 
-def _path_factories() -> set[str]:
+def _path_factories() -> frozenset[str]:
     """Names of the **Path-returning** helpers declared in ``config/paths.py``.
 
     Derived from the module rather than hardcoded so a newly added factory is
@@ -58,7 +59,15 @@ def _path_factories() -> set[str]:
     and a guard that cries wolf gets weakened or deleted, which costs more than
     the bug it was written to stop.
     """
-    tree = ast.parse(PATHS_MODULE.read_text(encoding="utf-8"))
+    return _path_factories_for(PATHS_MODULE)
+
+
+@lru_cache(maxsize=None)
+def _path_factories_for(paths_module: Path) -> frozenset[str]:
+    """Cached by the actual module path, so a monkeypatched ``PATHS_MODULE``
+    (see ``TestNoImportTimePathResolution``'s fake-tree tests) gets its own
+    cache entry instead of silently reusing the real tree's result."""
+    tree = ast.parse(paths_module.read_text(encoding="utf-8"))
     out: set[str] = set()
     for node in tree.body:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -68,10 +77,10 @@ def _path_factories() -> set[str]:
         # covers `Path`, `Path | None`, `Optional[Path]`, `list[Path]`
         if "Path" in ast.unparse(node.returns):
             out.add(node.name)
-    return out
+    return frozenset(out)
 
 
-def _transitive_path_factories() -> set[str]:
+def _transitive_path_factories() -> frozenset[str]:
     """Transitive closure: Path-returning functions that resolve through a paths.py factory.
 
     Extends the root set (functions declared in ``paths.py``) with every
@@ -91,13 +100,20 @@ def _transitive_path_factories() -> set[str]:
       even if they return a Path -- this excludes functions that merely
       manipulate a caller-supplied Path argument.
     """
-    roots = _path_factories()
+    return _transitive_path_factories_for(SRC, PATHS_MODULE)
+
+
+@lru_cache(maxsize=None)
+def _transitive_path_factories_for(src: Path, paths_module: Path) -> frozenset[str]:
+    """Cached by the actual (src, paths_module) pair, for the same monkeypatch
+    reason as ``_path_factories_for``."""
+    roots = _path_factories_for(paths_module)
 
     # Build a map: function_name -> set of names it calls, for every
     # Path-returning function in the tree. We only need function names (not
     # qualified paths) because the guard's detector matches bare call names.
     candidates: dict[str, set[str]] = {}  # name -> called names
-    for py in sorted(SRC.rglob("*.py")):
+    for py in sorted(src.rglob("*.py")):
         if "__pycache__" in py.parts:
             continue
         try:
@@ -131,7 +147,7 @@ def _transitive_path_factories() -> set[str]:
                 forbidden.add(name)
                 changed = True
 
-    return forbidden
+    return frozenset(forbidden)
 
 
 def _called_names(node: ast.AST) -> set[str]:
@@ -144,7 +160,7 @@ def _called_names(node: ast.AST) -> set[str]:
     return out
 
 
-def _frozen_path_constants() -> list[str]:
+def _frozen_path_constants() -> tuple[str, ...]:
     """Every import-time evaluation of a path factory (transitively).
 
     Three shapes freeze identically at import and all three are covered:
@@ -162,9 +178,16 @@ def _frozen_path_constants() -> list[str]:
     paths.py factory (e.g. ``kiro_agents_dir_path()``, ``_subagents_dir()``)
     are also forbidden at module level.
     """
-    factories = _transitive_path_factories()
+    return _frozen_path_constants_for(SRC, PATHS_MODULE)
+
+
+@lru_cache(maxsize=None)
+def _frozen_path_constants_for(src: Path, paths_module: Path) -> tuple[str, ...]:
+    """Cached by the actual (src, paths_module) pair, for the same monkeypatch
+    reason as ``_path_factories_for``."""
+    factories = _transitive_path_factories_for(src, paths_module)
     offenders: list[str] = []
-    for py in sorted(SRC.rglob("*.py")):
+    for py in sorted(src.rglob("*.py")):
         if "__pycache__" in py.parts:
             continue
         # App-internal test harnesses legitimately capture the real data-home
@@ -175,12 +198,11 @@ def _frozen_path_constants() -> list[str]:
             tree = ast.parse(py.read_text(encoding="utf-8"))
         except SyntaxError:  # pragma: no cover - syntax is enforced elsewhere
             continue
-        rel = py.relative_to(SRC)
+        rel = py.relative_to(src)
 
         def _record(node: ast.AST, targets: list[str], used: set[str], kind: str) -> None:
             offenders.append(
-                f"{rel}:{node.lineno}  [{kind}] {','.join(targets)} "
-                f"= ...{sorted(used)[0]}()"
+                f"{rel}:{node.lineno}  [{kind}] {','.join(targets)} " f"= ...{sorted(used)[0]}()"
             )
 
         for node in ast.walk(tree):
@@ -208,7 +230,7 @@ def _frozen_path_constants() -> list[str]:
                     used = _called_names(d) & factories
                     if used:
                         _record(d, [f"{node.name}() default"], used, "def-default")
-    return offenders
+    return tuple(offenders)
 
 
 class TestNoImportTimePathResolution:
@@ -252,9 +274,7 @@ class TestNoImportTimePathResolution:
         bad = ast.parse("X = kiro_agents_dir_path()").body[0]
         assert isinstance(bad, ast.Assign)
         called = _called_names(bad.value)
-        assert called & factories, (
-            "kiro_agents_dir_path should be in the transitive factory set"
-        )
+        assert called & factories, "kiro_agents_dir_path should be in the transitive factory set"
         # Also for _subagents_dir
         bad2 = ast.parse("X = _subagents_dir()").body[0]
         assert _called_names(bad2.value) & factories
@@ -350,16 +370,14 @@ class TestNoImportTimePathResolution:
             encoding="utf-8",
         )
         # A module that freezes the accessor at import time
-        (fake_src / "bad_module.py").write_text(
-            "FROZEN = _subagents_dir()\n", encoding="utf-8"
-        )
+        (fake_src / "bad_module.py").write_text("FROZEN = _subagents_dir()\n", encoding="utf-8")
         monkeypatch.setattr(mod, "SRC", fake_src)
         monkeypatch.setattr(mod, "PATHS_MODULE", fake_src / "config" / "paths.py")
 
         found = _frozen_path_constants()
-        assert any("_subagents_dir" in f for f in found), (
-            f"Transitive accessor not detected: {found}"
-        )
+        assert any(
+            "_subagents_dir" in f for f in found
+        ), f"Transitive accessor not detected: {found}"
 
 
 # (module import path, override constant, accessor) for every accessor that
@@ -510,9 +528,7 @@ class TestResolutionDoesNotRepeatStartupMaintenance:
         monkeypatch.setenv("KIROCREW_HOME", str(second))
         assert paths.data_home().resolve() == second.resolve()
 
-    def test_invalid_override_does_not_reopen_the_maintenance_path(
-        self, tmp_path, monkeypatch
-    ):
+    def test_invalid_override_does_not_reopen_the_maintenance_path(self, tmp_path, monkeypatch):
         """An override naming a system dir must NOT re-run maintenance per call.
 
         ``config_dir()`` gates the override branch on ``_valid_override_home()``
@@ -581,9 +597,7 @@ class TestConfigDirMemoIsNotServedAfterTheHomeIsCleared:
     reproducible one.
     """
 
-    def test_entry_from_a_bypassed_resolution_is_not_served_later(
-        self, tmp_path, monkeypatch
-    ):
+    def test_entry_from_a_bypassed_resolution_is_not_served_later(self, tmp_path, monkeypatch):
         from kiro_crew.config import paths
 
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
@@ -610,13 +624,11 @@ class TestConfigDirMemoIsNotServedAfterTheHomeIsCleared:
         with patch("pathlib.Path.home", return_value=real_home):
             resolved = paths.config_dir()
 
-        assert resolved == real_home / ".kiro" / "crew", (
-            f"config_dir() served a memo entry from a foreign home: {resolved}"
-        )
+        assert (
+            resolved == real_home / ".kiro" / "crew"
+        ), f"config_dir() served a memo entry from a foreign home: {resolved}"
 
-    def test_the_memo_still_caches_a_normal_default_resolution(
-        self, tmp_path, monkeypatch
-    ):
+    def test_the_memo_still_caches_a_normal_default_resolution(self, tmp_path, monkeypatch):
         """Negative control: the fix must not turn the memo off.
 
         Two consecutive default-path calls must hit the entry, which is what keeps

--- a/test/test_lockdown_before_publish.py
+++ b/test/test_lockdown_before_publish.py
@@ -25,6 +25,7 @@ Nothing prevented a NEW writer from reintroducing the shape. Two layers here:
 
 from __future__ import annotations
 
+import functools
 import importlib.util
 import sys
 from pathlib import Path
@@ -561,8 +562,34 @@ def reasserter(path):
 class TestTheRealTree:
     """The gate the CI job runs."""
 
+    @staticmethod
+    @functools.lru_cache(maxsize=1)
+    def _scan_src() -> tuple[tuple[str, int, str, str], ...]:
+        """One whole-tree AST scan, shared by every test in this class.
+
+        Both tests below independently re-derive `checker.main`'s per-file
+        `scan_path` results over the same `src/kiro_crew` tree; walking and
+        re-parsing every file twice per test is what made this class slow.
+        """
+        src = REPO_ROOT / "src" / "kiro_crew"
+        found: list[tuple[str, int, str, str]] = []
+        for py in sorted(src.rglob("*.py")):
+            found.extend(checker.scan_path(py, REPO_ROOT))
+        return tuple(found)
+
     def test_src_has_no_unclassified_violation(self) -> None:
-        exit_code = checker.main(["check", str(REPO_ROOT / "src" / "kiro_crew")])
+        """Same pass/fail as `checker.main(["check", <src dir>])`, off the cached scan."""
+        new: list[tuple[str, int, str, str]] = []
+        seen_known: set[str] = set()
+        for rel, line, fn, expr in self._scan_src():
+            key = "%s::%s" % (rel, fn)
+            entry = checker.KNOWN_UNCONVERTED.get(key)
+            if entry is not None and entry[1] == expr:
+                seen_known.add(key)
+            else:
+                new.append((rel, line, fn, expr))
+        stale = set(checker.KNOWN_UNCONVERTED) - seen_known
+        exit_code = 1 if (new or stale) else 0
         assert exit_code == 0, (
             "a lockdown-before-publish violation is unclassified. Convert it to "
             "atomic_write(..., restrict_to_owner=True), or annotate a genuine "
@@ -576,11 +603,7 @@ class TestTheRealTree:
         future regression at one of those very sites would land unnoticed
         because its entry was already there.
         """
-        src = REPO_ROOT / "src" / "kiro_crew"
-        live: set[str] = set()
-        for py in sorted(src.rglob("*.py")):
-            for rel, _line, fn, _expr in checker.scan_path(py, REPO_ROOT):
-                live.add(f"{rel}::{fn}")
+        live = {f"{rel}::{fn}" for rel, _line, fn, _expr in self._scan_src()}
 
         stale = sorted(set(checker.KNOWN_UNCONVERTED) - live)
         assert not stale, (

--- a/test/test_md_notebook.py
+++ b/test/test_md_notebook.py
@@ -3082,7 +3082,17 @@ async def test_a_sync_while_the_temp_is_still_staging_never_commits_it(
             if staged_path.parent == root and staged_path.name.startswith("One.md."):
                 staged.append(staged_path)
                 temp_written.set()
-                if not release_stage.wait(timeout=30):
+                # Not a synchronisation point -- `release_stage.set()` always
+                # runs in the `finally` below regardless of how long the Sync
+                # or the save's own retries take. This wait is a fail-safe
+                # against a genuine deadlock, not a race the test should ever
+                # actually run out on, so its budget is generous rather than
+                # tight: a loaded CI host's shared `to_thread` executor can
+                # make the Sync's own worker-thread git calls queue behind
+                # this parked slot, stretching how long `finally` takes to
+                # reach `release_stage.set()` well past a tight budget (flake
+                # class 2, see testing-conventions.md).
+                if not release_stage.wait(timeout=120):
                     raise AssertionError("test never released the staging worker")
 
         with pytest.MonkeyPatch.context() as mp:

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -5339,14 +5339,39 @@ class TestIsSensitiveBashCommand:
 
     def test_chained_cd_expansions_do_not_blow_up_the_gate(self) -> None:
         """A chain of `cd ${D:-x}` segments must not grow the tracked base set
-        without bound — each segment can multiply it, so the gate would hang.
-        The cap keeps the synchronous check fast."""
-        import time
+        without bound -- each segment can multiply it, so the gate would hang.
 
-        cmd = "D=bar; " + "; ".join(["cd ${D:-foo}"] * 20) + "; cat notes.txt"
-        start = time.monotonic()
-        is_sensitive_bash_command(cmd)
-        assert time.monotonic() - start < 30.0
+        This used to assert ``elapsed < 30s`` around the real gate. That couples
+        an algorithmic-boundedness property to filesystem I/O: every base the
+        chain produces is probed by ``is_sensitive_path`` /
+        ``_dir_holds_sensitive_leaf`` / ``_resolved_forms_bounded``, and at the
+        cap that is ~50 probes per segment, ~1000 for this chain. On a loaded
+        Windows runner those probes took 144s and pytest-timeout killed the xdist
+        worker (conventions doc, "5. Absolute time budgets"). With the probes
+        stubbed the same chain runs in ~50ms, so the time was never the
+        algorithm. Assert the property directly instead: the number of DISTINCT
+        bases the gate resolves per segment is capped, so probe counts grow
+        LINEARLY with the chain length rather than doubling per segment.
+        """
+        from kiro_crew import security
+
+        def chain(n: int) -> str:
+            return "D=bar; " + "; ".join(["cd ${D:-foo}"] * n) + "; cat notes.txt"
+
+        def probes(n: int) -> int:
+            with (
+                mock.patch.object(security, "_resolved_forms_bounded", return_value=set()),
+                mock.patch.object(security, "_dir_holds_sensitive_leaf", return_value=False),
+                mock.patch.object(security, "is_sensitive_path", return_value=False) as isp,
+            ):
+                assert is_sensitive_bash_command(chain(n)) is None
+                return isp.call_count
+
+        # Unbounded, each segment doubles the base set (2 readings x every
+        # existing base), so probes(20) / probes(10) would be ~2**10. Capped at
+        # _MAX_TRACKED_BASES it is at most ~2x: linear in the segment count.
+        ten, twenty = probes(10), probes(20)
+        assert twenty <= 2 * ten + 2 * security._MAX_TRACKED_BASES, (ten, twenty)
 
     def test_parameter_expansion_resolves_like_a_plain_reference(self) -> None:
         """`${V:-default}` and friends name a variable just as `${V}` does.

--- a/test/test_taskrunner.py
+++ b/test/test_taskrunner.py
@@ -1155,11 +1155,11 @@ class TestResourceManagement:
     """Verify sessions are released for all task lifecycle paths."""
 
     @pytest.mark.asyncio
-    async def test_single_task_session_reset_after_success(self) -> None:
+    async def test_single_task_session_reset_after_success(self, tmp_path: Path) -> None:
         """After a single task succeeds, its session must be reset."""
         sessions = _make_mock_sessions()
         sessions.reset = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         async def mock_execute(run, task, hk="", session_key=""):
             task.status = StepStatus.PASSED
@@ -1179,11 +1179,11 @@ class TestResourceManagement:
         assert "taskrunner:r1:task1" in reset_keys
 
     @pytest.mark.asyncio
-    async def test_parallel_tasks_all_sessions_reset(self) -> None:
+    async def test_parallel_tasks_all_sessions_reset(self, tmp_path: Path) -> None:
         """After a parallel group completes, ALL task sessions must be reset."""
         sessions = _make_mock_sessions()
         sessions.reset = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         async def mock_execute(run, task, hk="", session_key=""):
             task.status = StepStatus.PASSED
@@ -1204,11 +1204,11 @@ class TestResourceManagement:
             assert f"taskrunner:r2:task{i}" in reset_keys
 
     @pytest.mark.asyncio
-    async def test_parallel_failure_still_resets_all_sessions(self) -> None:
+    async def test_parallel_failure_still_resets_all_sessions(self, tmp_path: Path) -> None:
         """If one task in a parallel group fails, ALL sessions in the group must still be reset."""
         sessions = _make_mock_sessions()
         sessions.reset = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         call_count = 0
 
@@ -1270,10 +1270,10 @@ class TestResourceManagement:
             assert ri < si, f"release must precede reset for {key}: {call_order}"
 
     @pytest.mark.asyncio
-    async def test_pending_tasks_hold_no_sessions(self) -> None:
+    async def test_pending_tasks_hold_no_sessions(self, tmp_path: Path) -> None:
         """Tasks that never execute (PENDING) should not create any sessions."""
         sessions = _make_mock_sessions()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         async def mock_execute(run, task, hk="", session_key=""):
             task.status = StepStatus.FAILED
@@ -1303,11 +1303,11 @@ class TestResourceManagement:
         assert "taskrunner:r4:task3" not in reset_keys
 
     @pytest.mark.asyncio
-    async def test_cancel_running_project_cleans_up_sessions(self) -> None:
+    async def test_cancel_running_project_cleans_up_sessions(self, tmp_path: Path) -> None:
         """cancel() on a running project must trigger _cleanup_run_sessions."""
         sessions = _make_mock_sessions()
         sessions.cancel_current = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         # Simulate a long-running task that blocks until cancelled
         blocked = asyncio.Event()
@@ -1362,11 +1362,11 @@ class TestResourceManagement:
         assert sessions.reset.call_count >= 1
 
     @pytest.mark.asyncio
-    async def test_cancel_mid_parallel_group_resets_all(self) -> None:
+    async def test_cancel_mid_parallel_group_resets_all(self, tmp_path: Path) -> None:
         """Cancelling during a parallel group must clean up all sessions in the group."""
         sessions = _make_mock_sessions()
         sessions.cancel_current = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         started = asyncio.Event()
 
@@ -1421,7 +1421,7 @@ class TestResourceManagement:
                 assert key in cleaned_keys, f"Session {key} not cleaned up"
 
     @pytest.mark.asyncio
-    async def test_cancel_mid_parallel_group_reset_completes(self) -> None:
+    async def test_cancel_mid_parallel_group_reset_completes(self, tmp_path: Path) -> None:
         """reset() must run to completion under CancelledError (shield fix)."""
         sessions = _make_mock_sessions()
         sessions.cancel_current = AsyncMock()
@@ -1432,7 +1432,7 @@ class TestResourceManagement:
             reset_completed.append(key)
 
         sessions.reset = slow_reset
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         started = asyncio.Event()
 

--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -236,6 +236,39 @@ into a deterministic local failure. Keep the forced delay in place while you ver
 the fix, then remove it: a fix that only passes once the delay is gone has not been
 shown to fix anything.
 
+### What five full runs under load found
+
+Five back-to-back `vitest run --coverage` passes on a Windows host that was also
+running the backend suite (so every fork was starved) turned up 19 intermittent
+cases and one deterministic Windows failure. They fall into four shapes, and each
+one is a rule:
+
+- **A `React.lazy` boundary races the 1000ms default.** `findByTitle('Copy patch')`
+  waits for `PierrePatch`'s header, which only exists once the
+  `import('./PierreImpl')` chunk resolves and commits; under load that took longer
+  than a second in 3 of 5 runs. The same for `PierreWorkspaceTree`'s `@pierre/trees`
+  chunk. When the element you query sits behind a dynamic import, pass an explicit
+  timeout (`{ timeout: 5000 }`) **and say which lazy boundary it is waiting for** in a
+  comment, so the next reader knows the wait is a chunk load and not a guess.
+- **Expensive engines built per test hit the 15s `testTimeout`.**
+  `approvalOneShotDecisionRule.test.ts` constructed a new `ESLint` instance — which
+  re-parses `eslint.config.js` and the whole plugin graph — inside `lint()`, for 17
+  snippets. Build stateless engines once at module scope.
+- **Fake filesystems and source scans must be Windows-neutral.** Two Electron suites
+  failed on Windows every run: `crash-collector.test.js` keyed a fake `fs` by
+  `path.join(...)` (backslashes) but passed the bare literal `"/reports"` to the code
+  under test, so the prefix match read back empty; `window-lifecycle.test.js`
+  scanned module source for `"}\n"` and a `core.autocrlf` checkout gave it `"}\r\n"`.
+  Build fixture keys with `path.normalize`, and normalise `\r\n` before regex-scanning
+  a source file. Run `npm test` on a Windows checkout before calling an Electron test
+  done — CI's Electron job is Linux-only, so nothing else will.
+- **`mkdtempSync` without an `after()` is a leak on every run.** `petOverlay.test.js`
+  created a `cc-pet-test-*` user-data dir per `stubElectron()` call and its
+  `restore()` never removed it; `store-rename-migration.test.js` did the same with
+  `kc-store-*`. Together they left 64 directories in the real temp dir per run. Track
+  every temp dir the file creates and remove them in one top-level `after()` (or in
+  the helper's own `restore()`), with `fs.rmSync(dir, { recursive: true, force: true })`.
+
 ## Manual procedures
 
 A few flows are deliberately not automated. They are documented rather than

--- a/website/electron/crew-companion/test/petOverlay.test.js
+++ b/website/electron/crew-companion/test/petOverlay.test.js
@@ -114,6 +114,7 @@ function stubElectron() {
     restore() {
       Module._resolveFilename = realResolve;
       delete require.cache.electron;
+      require("fs").rmSync(userDataDir, { recursive: true, force: true });
     },
   };
 }

--- a/website/electron/test/crash-collector.test.js
+++ b/website/electron/test/crash-collector.test.js
@@ -23,9 +23,14 @@ const {
   MAX_CRASH_LOG_LINES,
 } = require("../crash-collector");
 
-const LOGS = "/logs";
-const DUMPS = "/dumps";
-const REPORTS = "/reports";
+// `path.normalize` here, not a bare literal: every file key below is built
+// with `path.join`, which on Windows collapses `/reports` to `\reports` — a
+// raw `"/reports"` passed straight to `collectCrashReports` as
+// `diagnosticReportsDir` then mismatches the backslash-prefixed keys in
+// `fakeFs.readdirSync`'s prefix match and reads back empty.
+const LOGS = path.normalize("/logs");
+const DUMPS = path.normalize("/dumps");
+const REPORTS = path.normalize("/reports");
 // The name the packaged bundle, its executable, and therefore every crash
 // artifact on disk actually carry: electron-builder derives all three from
 // `build.productName`, which is the joined form. The collector is handed the

--- a/website/electron/test/store-rename-migration.test.js
+++ b/website/electron/test/store-rename-migration.test.js
@@ -25,7 +25,7 @@
 //   file absent    -> there is nothing to overwrite, by definition
 //   seeding throws -> file stays absent -> the next launch retries identically
 //   seeding works  -> file exists       -> never eligible again
-const { test } = require("node:test");
+const { test, after } = require("node:test");
 const assert = require("node:assert");
 const fs = require("node:fs");
 const os = require("node:os");
@@ -54,9 +54,20 @@ const DEFAULTS = {
   linuxFrameless: null,
 };
 
+// Every dir this file mkdtemp's is tracked here and swept in the after() hook
+// below, so a run never leaves cc-pet-test-/kc-store- style dirs behind in
+// $TEMP regardless of which test created them or whether it threw first.
+const tmpDirs = [];
+
 function tmpUserData() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "kc-store-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kc-store-"));
+  tmpDirs.push(dir);
+  return dir;
 }
+
+after(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
 
 // Open a REAL electron-store the way main.js does, so assertions run against the
 // library's own merge of file + defaults rather than a hand-rolled fake. An earlier
@@ -302,21 +313,25 @@ test("a CORRUPTED legacy store is final and loud, never retried", () => {
   fs.mkdirSync(legacyDir, { recursive: true });
   fs.writeFileSync(path.join(legacyDir, "config.json"), "{ not json");
 
-  const notes = [];
-  const sleeps = [];
-  const migrated = seedRenamedStore(userData, {
-    log: (m) => notes.push(m),
-    sleep: (ms) => sleeps.push(ms),
-  });
-  assert.strictEqual(migrated, false);
-  assert.deepStrictEqual(sleeps, [], "corruption is not transient, so retrying is pointless");
-  assert.strictEqual(notes.length, 1, "the loss must be visible in the boot log");
-  assert.ok(notes[0].includes("not valid JSON"), notes[0]);
-  assert.strictEqual(
-    fs.existsSync(path.join(userData, "config.json")),
-    false,
-    "a corrupted legacy store must seed nothing"
-  );
+  try {
+    const notes = [];
+    const sleeps = [];
+    const migrated = seedRenamedStore(userData, {
+      log: (m) => notes.push(m),
+      sleep: (ms) => sleeps.push(ms),
+    });
+    assert.strictEqual(migrated, false);
+    assert.deepStrictEqual(sleeps, [], "corruption is not transient, so retrying is pointless");
+    assert.strictEqual(notes.length, 1, "the loss must be visible in the boot log");
+    assert.ok(notes[0].includes("not valid JSON"), notes[0]);
+    assert.strictEqual(
+      fs.existsSync(path.join(userData, "config.json")),
+      false,
+      "a corrupted legacy store must seed nothing"
+    );
+  } finally {
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
 });
 
 test("an ABSENT legacy store is final and silent, never retried", () => {

--- a/website/electron/test/window-lifecycle.test.js
+++ b/website/electron/test/window-lifecycle.test.js
@@ -6,7 +6,12 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const MODULE_PATH = path.join(__dirname, "..", "window-lifecycle.js");
-const SOURCE = fs.readFileSync(MODULE_PATH, "utf8");
+// Normalize to LF regardless of the checkout's line-ending translation: the
+// source-scanning regexes below anchor on a literal "\n", and a Windows
+// checkout with core.autocrlf on disk-translates the file to CRLF, which
+// shifts every "}\n" anchor to "}\r\n" and fails the match on a file that is
+// otherwise unchanged.
+const SOURCE = fs.readFileSync(MODULE_PATH, "utf8").replace(/\r\n/g, "\n");
 const {
   BROWSER_PARTITION,
   createWindowLifecycle,

--- a/website/integration/MarkdownSearch.integration.test.tsx
+++ b/website/integration/MarkdownSearch.integration.test.tsx
@@ -58,13 +58,23 @@ describe('AssistantMessage search highlighting', () => {
   it('single occurrence counter across markdown and code blocks', async () => {
     const content = 'The word deploy here.\n\n```python\nprint("deploy")\n```\n\nAnd deploy again.'
     const { container } = renderWithSearch(content, 'deploy', 1)
+    // The code block's "deploy" starts as plain text (the `pierre-plain`
+    // stand-in in CodeBlock.tsx) and is re-highlighted once Pierre's staged,
+    // chunk-loaded mount admits it -- a MutationObserver re-runs the TreeWalker
+    // pass when that swap lands (AssistantMessage.tsx). On Windows that chunk
+    // load + staged-mount queue can outlast the default waitFor timeout
+    // (1000ms), so the assertion below can observe an in-between DOM state
+    // where the occurrence count is right but the swap hasn't finished
+    // reordering text nodes yet. Same class as DiffBlock.streaming.test.tsx /
+    // PierreWorkspaceTree.lazy.test.tsx; widen rather than assume it always
+    // settles within 1s.
     await waitFor(() => {
       const marks = container.querySelectorAll('mark')
       expect(marks).toHaveLength(3)
       expect(marks[0].className).toBe('search-match')
       expect(marks[1].className).toBe('search-current')
       expect(marks[2].className).toBe('search-match')
-    })
+    }, { timeout: 5000 })
   })
 
   it('highlights clear when term changes to empty', async () => {

--- a/website/src/test/DiffBlock.streaming.test.tsx
+++ b/website/src/test/DiffBlock.streaming.test.tsx
@@ -34,7 +34,11 @@ const fullPatch = `--- /home/user/example/src/greet.py
  *  PatchImpl actually mounts and parses before being torn down. */
 async function warmPierre() {
   const { unmount } = render(<DiffBlock code={fullPatch} complete />)
-  await screen.findByTitle('Copy patch')
+  // The lazy `import('./PierreImpl')` chunk (src/pierre/index.tsx) races the
+  // default findBy timeout (1000ms) under a loaded, concurrent run -- widen
+  // it rather than assume the dynamic import always resolves within 1s
+  // (same class as touchHoverActions.test.tsx).
+  await screen.findByTitle('Copy patch', {}, { timeout: 5000 })
   unmount()
 }
 

--- a/website/src/test/ImeEnterGuardSites.test.tsx
+++ b/website/src/test/ImeEnterGuardSites.test.tsx
@@ -437,8 +437,12 @@ describe('file-explorer PathBar — Tab accepts a suggestion INTO the draft', ()
     fireEvent.click(screen.getByTitle('Click to edit path'))
     const input = screen.getByPlaceholderText('/path/to/folder') as HTMLInputElement
     fireEvent.change(input, { target: { value: '/home/user/s' } })
-    // The suggestion query is debounced, so the row is what proves it arrived.
-    await waitFor(() => expect(screen.getByText('/home/user/src')).toBeInTheDocument())
+    // The suggestion query is debounced (150ms) behind the file-explorer
+    // `complete` fetch, so the row can arrive after the default waitFor
+    // timeout (1000ms) under a loaded, concurrent run -- widen it rather than
+    // assume the debounce + query always resolves within 1s (same class as
+    // DiffBlock.streaming.test.tsx / PierreWorkspaceTree.lazy.test.tsx).
+    await waitFor(() => expect(screen.getByText('/home/user/src')).toBeInTheDocument(), { timeout: 5000 })
     return input
   }
 

--- a/website/src/test/OpsMissionControlPageCoverage.test.tsx
+++ b/website/src/test/OpsMissionControlPageCoverage.test.tsx
@@ -360,26 +360,39 @@ describe('OpsMissionControlPage', () => {
   })
 
   it('renders a compact age per row and an em dash for an unparseable timestamp', async () => {
-    stubRoutes(
-      mkState({
-        incidents: [
-          mkIncident({ incident_id: 'omc-secs', updated_at: agoIso(20) }),
-          mkIncident({ incident_id: 'omc-mins', updated_at: agoIso(90) }),
-          mkIncident({ incident_id: 'omc-hours', updated_at: agoIso(7200) }),
-          mkIncident({ incident_id: 'omc-days', updated_at: agoIso(200000) }),
-          mkIncident({ incident_id: 'omc-bad', updated_at: 'not-a-date', claimed_at: '' }),
-        ],
-      }),
-    )
-    renderWithProviders(<OpsMissionControlPage />)
-    await waitFor(() =>
-      expect(screen.getAllByTestId('omc-incident-row')).toHaveLength(5),
-    )
-    expect(screen.getByText('20s')).toBeInTheDocument()
-    expect(screen.getByText('1m')).toBeInTheDocument()
-    expect(screen.getByText('2h')).toBeInTheDocument()
-    expect(screen.getByText('2d')).toBeInTheDocument()
-    expect(screen.getByText('—')).toBeInTheDocument()
+    // `age()` derives its text from `Date.now() - Date.parse(updated_at)`. The
+    // fixture timestamps are computed from the real clock at test-data-build
+    // time, but rendering (and the `waitFor` below) happens later, so under a
+    // loaded, concurrent run the elapsed wall-clock time can push a boundary
+    // value like 20s into 21s and flip the rendered unit. Pin only `Date.now`
+    // (not the timers `waitFor`/React Query need to keep ticking) so the
+    // elapsed time between building the fixtures and asserting on them is 0.
+    const now = Date.now()
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
+    try {
+      stubRoutes(
+        mkState({
+          incidents: [
+            mkIncident({ incident_id: 'omc-secs', updated_at: new Date(now - 20_000).toISOString() }),
+            mkIncident({ incident_id: 'omc-mins', updated_at: new Date(now - 90_000).toISOString() }),
+            mkIncident({ incident_id: 'omc-hours', updated_at: new Date(now - 7_200_000).toISOString() }),
+            mkIncident({ incident_id: 'omc-days', updated_at: new Date(now - 200_000_000).toISOString() }),
+            mkIncident({ incident_id: 'omc-bad', updated_at: 'not-a-date', claimed_at: '' }),
+          ],
+        }),
+      )
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getAllByTestId('omc-incident-row')).toHaveLength(5),
+      )
+      expect(screen.getByText('20s')).toBeInTheDocument()
+      expect(screen.getByText('1m')).toBeInTheDocument()
+      expect(screen.getByText('2h')).toBeInTheDocument()
+      expect(screen.getByText('2d')).toBeInTheDocument()
+      expect(screen.getByText('—')).toBeInTheDocument()
+    } finally {
+      dateNowSpy.mockRestore()
+    }
   })
 
   it('expands a row into its detail panel and mounts the investigation chat', async () => {

--- a/website/src/test/PierreWorkspaceTree.lazy.test.tsx
+++ b/website/src/test/PierreWorkspaceTree.lazy.test.tsx
@@ -71,7 +71,10 @@ describe('PierreWorkspaceTree', () => {
     expect(screen.getByRole('status', { name: 'Loading workspace…' })).toBeInTheDocument()
     expect(treeMock.models).toHaveLength(0)
 
-    await waitFor(() => expect(screen.getByTestId('file-tree')).toBeInTheDocument())
+    // `PierreWorkspaceTree` is a `React.lazy` boundary over the `@pierre/trees`
+    // chunk (src/pierre/tree.tsx); the default waitFor timeout (1000ms) races
+    // that dynamic import under a loaded, concurrent run.
+    await waitFor(() => expect(screen.getByTestId('file-tree')).toBeInTheDocument(), { timeout: 5000 })
     expect(screen.queryByRole('status', { name: 'Loading workspace…' })).not.toBeInTheDocument()
   })
 
@@ -85,7 +88,7 @@ describe('PierreWorkspaceTree', () => {
         selectedPath={`${ROOT}/README.md`}
       />,
     ))
-    await waitFor(() => expect(screen.getByTestId('file-tree')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId('file-tree')).toBeInTheDocument(), { timeout: 5000 })
 
     expect(api.projectTree).toHaveBeenCalledWith(ROOT)
     const model = treeMock.last()

--- a/website/src/test/approvalOneShotDecisionRule.test.ts
+++ b/website/src/test/approvalOneShotDecisionRule.test.ts
@@ -25,14 +25,21 @@ import { fileURLToPath } from 'node:url'
 const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const RULE_ID = 'approval-one-shot/no-inline-one-shot-decision'
 
+// Built once for the whole file, not per call: constructing an ESLint engine
+// re-parses eslint.config.js and the full plugin graph, and this file lints
+// 17 snippets through it. Re-creating it per `lint()` call paid that cost 17
+// times and was slow enough under load to hit the file's 15s testTimeout
+//. The config and its rules are stateless per lint call, so sharing
+// one engine changes nothing about what is asserted.
+const engine = new ESLint({
+  cwd: WEBSITE_ROOT,
+  overrideConfigFile: 'eslint.config.js',
+  // A snippet must not be able to quietly disable the rule it is testing.
+  allowInlineConfig: false,
+})
+
 /** Lint one snippet through the real `eslint.config.js`, as `npm run lint` does. */
 async function lint(code: string): Promise<ESLint.LintResult['messages']> {
-  const engine = new ESLint({
-    cwd: WEBSITE_ROOT,
-    overrideConfigFile: 'eslint.config.js',
-    // A snippet must not be able to quietly disable the rule it is testing.
-    allowInlineConfig: false,
-  })
   const [result] = await engine.lintText(code, { filePath: path.join(WEBSITE_ROOT, 'src/probe.ts') })
   return result.messages
 }

--- a/website/src/test/touchHoverActions.test.tsx
+++ b/website/src/test/touchHoverActions.test.tsx
@@ -108,15 +108,21 @@ describe('DiffBlock header actions on touch devices', () => {
 
   // Pierre slots the header metadata after mount, so the actions row is absent
   // from the first commit -- await it instead of reading a null node.
+  //
+  // `PierrePatch` is a `React.lazy(() => import('./PierreImpl'))` boundary
+  // (src/pierre/index.tsx): the header only appears once that chunk resolves
+  // and commits. The default `findBy*` timeout (1000ms) races that dynamic
+  // import under a loaded, concurrent test run and loses intermittently
+  // -- widen it rather than assume the import always beats 1s.
   it('reveals and enlarges the diff actions where the pointer cannot hover', async () => {
     const { container } = render(<DiffBlock code={SIMPLE_DIFF} complete />)
-    await screen.findByTitle('Copy patch')
+    await screen.findByTitle('Copy patch', {}, { timeout: 5000 })
     expectRowTouchOverrides(row(container).className)
   })
 
   it('keeps the diff actions hover-revealed for hover-capable pointers', async () => {
     const { container } = render(<DiffBlock code={SIMPLE_DIFF} complete />)
-    await screen.findByTitle('Copy patch')
+    await screen.findByTitle('Copy patch', {}, { timeout: 5000 })
     const cls = row(container).className
     expect(cls).toContain('opacity-0')
     expect(cls).toContain('group-hover/diff:opacity-100')


### PR DESCRIPTION
## Problem / Motivation

I ran the whole test suite five times in a row on one Windows machine: pytest (62k tests), vitest (29k) and the Electron `node --test` suite, with vitest and pytest running at the same time so every worker was starved. A small plugin recorded wall time, memory, thread and environment changes per test, and a filesystem snapshot was taken before and after each run.

Two of the five pytest runs never finished. One test could wait forever, pytest-timeout on Windows kills the xdist worker instead of the test, and `--max-worker-restart=0` then aborts the run at about 3,000 of 62,000 tests. The runs that did finish had 5 to 11 vitest failures each, all in different tests, 7 Electron tests that fail on every Windows run, and about 64 temp directories plus a file in the real `~/.kiro/crew` left behind per run.

## Why it matters

A run that aborts reports six failures and hides 59,000 results. A test that leaks into the operator's real data home writes a secret file onto a developer's machine. A suite that spends 15 minutes re-parsing `src/` in ratchet tests makes every timing-sensitive test in the same shard flakier. None of this shows in a single green CI run.

## What changed (motivation → approach → change)

Every fix is a root cause, not a rerun or a wider tolerance. `test_acp_runtime` used `sleep(0.05)` to let a first prompt register; under load it lost, and the second prompt waited on a completion the test never sends. It now waits on the routed request and bounds the refused await, so a missed refusal fails by name. `test_auto_research_handlers_coverage` asserted on an SSE event before the loop had run the `call_soon_threadsafe` callback that posts it; it now waits on that signal. `test_app_ui_file_route` raced `asyncio.timeout(0)` against the first read; the loop clock is jumped instead. `members.py` gets `read_bytes_with_retry` in both readers (`read_dm_binding`, `read_member_rules`) for a real Windows sharing violation the concurrent-resume test found. Two flakes from the runs (`test_channel_slots`, `test_public_repo_chip_status`) were fixed on `main` while this branch was open and are not in this diff.

`install_receipt.dispatch()` resolved `KIROCREW_HOME` on its daemon thread, after the test had unpinned it, and wrote `app_receipt_secret` into the real data home. It now resolves the data home and the config fields on the calling thread, so the worker reads nothing from the environment, and registers itself so the rootdir `conftest.py` teardown hook joins any live worker before `monkeypatch` restores the environment. That join is structural: the test that leaks is never the test that fails, so no test has to remember to call it. It is the only change to conftest.py (one helper plus its call at the top of the existing 	ryfirst pytest_runtest_teardown, 28 added lines, nothing removed). A regression test pins the write landing under the pinned home. `TaskRunner` tests pass `work_dir=tmp_path` instead of writing `runs.json` into the checkout. Two Electron suites remove the `mkdtemp` dirs they create. Env vars that real startup paths write (`PLAYWRIGHT_MCP_OUTPUT_DIR`, `PLAYWRIGHT_MCP_CONFIG`, the token) are restored by the shared `_start_dashboard` helper; absent keys are first set then deleted so `monkeypatch` records an undo for them. One deliberate widening is declared here: `test_md_notebook`'s `release_stage.wait` fail-safe goes from 30s to 120s. It is a deadlock guard, not a synchronisation point (`release_stage.set()` always runs in the test's `finally`), and a loaded host queued the Sync's own `to_thread` git calls behind the parked slot for longer than 30s.

The slow tests were slow for reasons the assertions did not need: production timeouts the fixtures tripped (three files, 45–56s → under 1s), an `add_topic()` loop that saved to disk on every call (47s → 0.2s), a 30-second wall-clock budget that was really 2,700 `stat` calls (now counts probes with the filesystem stubbed, 144s → 0.5s), scan budgets patched down (80s → 0.8s), and ratchets that walked the whole tree once per test method now walk it once per file. The two Electron Windows failures were a fake filesystem keyed with backslashes but queried with `/reports`, and a source scan that expected `\n` on a CRLF checkout. The vitest flakes were `React.lazy` chunks losing to the 1000ms default wait, an ESLint engine rebuilt per test, and a relative-time label computed from an unpinned `Date.now()`.

## Tests

- `test_install_receipt.py::test_dispatch_resolves_config_dir_before_home_is_unpatched` — the receipt write lands under the pinned home and the thread is joined.
- `test_acp_runtime.py::test_concurrent_prompt_on_same_handle_rejected` — now bounded; a broken guard raises `TimeoutError` at that line instead of hanging the worker.
- `test_security.py::test_chained_cd_expansions_do_not_blow_up_the_gate` — asserts probe count grows linearly (structural), not elapsed time.
- Everything else is an existing test made deterministic or faster with its assertion unchanged; the hoisted ratchets were checked against a planted violation.

Verified on the rebased tree: the 20 touched pytest files (3,924 passed; the one remaining failure is a pre-existing symlink test that needs `SeCreateSymbolicLinkPrivilege`, which CI runners have), the full vitest suite (29,469 passed, 0 failed), Electron 1,784 passed / 0 failed on Windows (was 7 failures every run), flake8, isort, the black baseline gate, harness parity and docs-lint.

## Manual verification

The five full runs are the manual verification: run logs, per-test probe data and before/after filesystem snapshots for all five are on the machine that ran them. After the fixes, the touched Electron suites leave zero `cc-pet-test-*`/`kc-store-*` directories in `%TEMP%`, and `runs.json` no longer appears in the repo root.

## Related Issues

no linked issue: found by a scheduled hygiene pass, not reported by a user.

## Pattern harvest

Rule candidate: agents-md
Pattern: "a test await that the test itself must unblock has no bound" — added as flake class 6 in `testing-conventions.md`, with the class 2/3/5 extensions, three new side-effect rules, two speed patterns, the frontend list in `website/docs/testing.md`, and the writing-tests skill checklist.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
