### PR TITLE
fix(memory): FAISS episodic tier hands MMR the full recall-contract pool

### DIFF
--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -2321,7 +2321,19 @@ class VectorMemoryStore:
             now = datetime.now(tz=timezone.utc)
             candidates: list[dict] = []
             with self._db_lock:
-                k = min(limit * 2, self._faiss_index.ntotal)  # type: ignore[attr-defined]
+                # MMR reranks from the FULL candidate pool (see the _mmr_rerank pool
+                # comment: truncating toward `limit` silently drops the
+                # relevant-but-diverse tail pick that is the whole point of MMR). The
+                # sqlite tiers already hand the rerank their entire embedded
+                # population, bounded only by _MMR_MAX_POOL inside _mmr_rerank — so
+                # the FAISS tier must match that recall contract (#9074). Without
+                # MMR the result is candidates[:limit], where limit * 2 headroom for
+                # tag-filter/tombstone drops is correct and cheaper.
+                k = (
+                    min(_MMR_MAX_POOL, self._faiss_index.ntotal)  # type: ignore[attr-defined]
+                    if mmr
+                    else min(limit * 2, self._faiss_index.ntotal)  # type: ignore[attr-defined]
+                )
                 distances, indices = self._faiss_index.search(vec.reshape(1, -1), k)  # type: ignore[attr-defined]
                 # FAISS returns ids and distances only. The row bodies used to be
                 # fetched one "SELECT *" per hit — an N+1 that also dragged each

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -4333,3 +4333,148 @@ class TestDedupThresholdLoaderValidation:
         assert section.semantic_confidence_threshold == 0.6
         assert section.episodic_max_results == 12
         assert section.episodic_max_count == 500
+
+
+class TestFaissMmrPoolRecallContract:
+    """FAISS episodic tier must hand MMR the same recall-contract pool as the
+    sqlite tiers (#9074).
+
+    The sqlite tiers (per-call and resident) hand ``_mmr_rerank`` their entire
+    embedded population, bounded only by ``_MMR_MAX_POOL`` — the pool comment in
+    ``_mmr_rerank`` declares truncating toward ``limit`` a recall change. The
+    FAISS tier pre-truncated its pool to ``limit * 2`` (16 at the default
+    ``limit=8``), silently dropping the relevant-but-diverse tail pick that is
+    the whole point of MMR.
+    """
+
+    dim = 16
+
+    class _MiniFlatIP:
+        """Exact IndexFlatIP semantics over a normalized row matrix.
+
+        ``search`` computes true inner products and honors ``k`` exactly like
+        FAISS: only the top-``k`` hits come back. Records every ``k`` received
+        so tests can pin the pool-size request itself.
+        """
+
+        def __init__(self, mat) -> None:
+            self._mat = mat
+            self.ntotal = len(mat)
+            self.received_k: list[int] = []
+
+        def search(self, vec, k):
+            import numpy as np
+
+            self.received_k.append(int(k))
+            sims = self._mat @ vec.reshape(-1)
+            order = np.argsort(-sims)[: int(k)]
+            return sims[order].reshape(1, -1), order.reshape(1, -1).astype(np.int64)
+
+    def _build_store(self, tmp_path: Path, monkeypatch, texts_and_vecs):
+        """Store with rows in sqlite (real embedding blobs) AND a MiniFlatIP index.
+
+        Both tiers see the identical population, so FAISS-vs-sqlite parity is a
+        true recall comparison, not a mock artifact.
+        """
+        import numpy as np
+
+        import kiro_crew.vector_memory as vm_mod
+
+        monkeypatch.setattr(vm_mod, "_HAS_FAISS", True)
+        monkeypatch.setattr(vm_mod, "_HAS_NUMPY", True)
+
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=self.dim)
+        store.init()
+
+        today = datetime.now(tz=timezone.utc).isoformat()
+        mat = np.zeros((len(texts_and_vecs), self.dim), dtype=np.float32)
+        id_map: list[str] = []
+        for i, (mem_id, text, vec) in enumerate(texts_and_vecs):
+            v = np.asarray(vec, dtype=np.float32)
+            v /= np.linalg.norm(v)
+            mat[i] = v
+            id_map.append(mem_id)
+            store.db.execute(
+                "INSERT INTO episodic_memories (id, text, embedding, is_deleted, "
+                "importance, created_at, last_accessed_at) VALUES (?, ?, ?, 0, 1.0, ?, ?)",
+                (mem_id, text, v.tobytes(), today, today),
+            )
+        store.db.commit()
+
+        index = self._MiniFlatIP(mat)
+        store._faiss_index = index
+        store._faiss_id_map = id_map
+        return store, index
+
+    def _population(self):
+        """20 near-duplicate rows outranking one diverse row on pure relevance.
+
+        Duplicates share one token set (pairwise Jaccard 1.0) with cosines
+        descending from ~0.995; the diverse row sits at rank 21 with cosine 0.6
+        and zero token overlap. With the old ``limit * 2`` pool (16) the diverse
+        row never reaches MMR; from the full pool MMR must select it (its MMR
+        value 0.6·rel ≈ 0.36 beats a second duplicate's 0.6·rel − 0.4·1.0 ≈ 0.19).
+        """
+        import numpy as np
+
+        rows = []
+        dup_text = "postgres database migration plan step one"
+        for i in range(20):
+            # e0-dominant with a tiny per-row e1 component: cosine to e0 descends
+            # ~0.9950 → ~0.9046 as eps grows, keeping all 20 above the diverse row.
+            eps = 0.1 + i * 0.02
+            vec = np.zeros(self.dim, dtype=np.float32)
+            vec[0], vec[1] = 1.0, eps
+            rows.append((f"dup-{i:02d}", dup_text, vec))
+        diverse = np.zeros(self.dim, dtype=np.float32)
+        diverse[0], diverse[2] = 0.6, 0.8  # cosine 0.6 to e0, disjoint tokens
+        rows.append(("diverse-x", "kubernetes ingress rollout canary window", diverse))
+        return rows
+
+    def _query(self):
+        q = [0.0] * self.dim
+        q[0] = 1.0
+        return q
+
+    def test_mmr_pool_not_truncated_to_limit_window(self, tmp_path: Path, monkeypatch) -> None:
+        """ATTACK: the rank-21 diverse row must be MMR-reachable (full pool)."""
+        store, index = self._build_store(tmp_path, monkeypatch, self._population())
+        result = store.search_episodic(query_embedding=self._query(), limit=8, mmr=True)
+        ids = [r["id"] for r in result]
+        assert "diverse-x" in ids, (
+            "FAISS tier truncated the MMR candidate pool below the recall "
+            f"contract: rank-21 diverse row unreachable (pool k={index.received_k})"
+        )
+        # The pool request itself must follow the contract, not the limit window.
+        assert index.received_k == [21], index.received_k
+
+    def test_faiss_and_sqlite_tiers_return_identical_mmr_results(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """PARITY (#9074 Q2): identical population → identical MMR selections."""
+        store, _ = self._build_store(tmp_path, monkeypatch, self._population())
+        q = self._query()
+        faiss_ids = [r["id"] for r in store.search_episodic(query_embedding=q, limit=8, mmr=True)]
+        store._faiss_index = None  # falls through to the per-call sqlite tier
+        sqlite_ids = [r["id"] for r in store.search_episodic(query_embedding=q, limit=8, mmr=True)]
+        assert faiss_ids == sqlite_ids
+
+    def test_non_mmr_path_keeps_limit_window(self, tmp_path: Path, monkeypatch) -> None:
+        """CONTROL: mmr=False keeps the cheap limit*2 pool (top-limit slice only)."""
+        store, index = self._build_store(tmp_path, monkeypatch, self._population())
+        result = store.search_episodic(query_embedding=self._query(), limit=8, mmr=False)
+        assert index.received_k == [16]  # limit * 2, unchanged contract
+        assert len(result) == 8
+        assert all(r["id"].startswith("dup-") for r in result)  # pure relevance order
+
+    def test_small_population_unchanged(self, tmp_path: Path, monkeypatch) -> None:
+        """BENIGN: ntotal below both pool bounds → both tiers identical, no new denials."""
+        rows = self._population()[:5]
+        store, index = self._build_store(tmp_path, monkeypatch, rows)
+        q = self._query()
+        faiss_ids = [r["id"] for r in store.search_episodic(query_embedding=q, limit=8, mmr=True)]
+        assert index.received_k == [5]  # min(_MMR_MAX_POOL, ntotal) = ntotal
+        assert len(faiss_ids) == 5
+        store._faiss_index = None
+        sqlite_ids = [r["id"] for r in store.search_episodic(query_embedding=q, limit=8, mmr=True)]
+        assert faiss_ids == sqlite_ids


### PR DESCRIPTION
# fix(memory): FAISS episodic tier hands MMR the full recall-contract pool

## Problem / Motivation

The FAISS episodic search path pre-truncates its candidate pool to `limit * 2` (16 at the default `limit=8`) **before** MMR reranking runs:

```python
k = min(limit * 2, self._faiss_index.ntotal)
```

Both sqlite tiers (per-call and resident) hand `_mmr_rerank` their entire embedded population, bounded only by `_MMR_MAX_POOL = 1000` inside the rerank itself. The pool comment in `_mmr_rerank` declares this a recall contract: "Keep the FULL candidate pool so MMR can still surface a relevant-but-diverse item that ranked below the top-`limit` on pure relevance — that tail pick is the whole point of MMR, and truncating the pool toward `limit` would silently drop it." The `_MMR_MAX_POOL` comment reiterates it is "NOT a perf cap that changes results."

So the same store returns different memories depending on which tier happens to serve the query: a relevant-but-diverse memory at relevance rank 17+ is reachable through sqlite and silently unreachable through FAISS.

## Why it matters

MMR's value is exactly the tail pick. Under a near-duplicate cluster (common for episodic memory: repeated similar events), the FAISS tier returns `limit` near-duplicates while the sqlite tiers surface the diverse item. Recall silently degrades as soon as the FAISS index becomes available — an upgrade that is supposed to be a pure performance win.

## What changed (motivation → approach → change)

- Motivation: align the deviant FAISS tier UP to the declared recall contract; do not touch the sqlite pools (reporter's anti-goal in #9074).
- Approach: make the pool size mmr-conditional at the single seam where FAISS `k` is computed. `IndexFlatIP` scans all vectors regardless of `k` (exact search), so `k` only sizes the result heap and the single batched row fetch — the pool-scale batch fetch is precisely what the sqlite tiers already do.
- Change (one expression in `src/kiro_crew/vector_memory.py`):
  - `mmr=True`: `k = min(_MMR_MAX_POOL, ntotal)` — the same effective bound the sqlite tiers deliver to the rerank.
  - `mmr=False`: `k = min(limit * 2, ntotal)` unchanged — that path returns `candidates[:limit]`, so `limit * 2` headroom for tag-filter/tombstone drops is correct and cheaper, and widening it would change nothing but cost.

## Tests

`test/test_vector_memory.py::TestFaissMmrPoolRecallContract` (4 tests) with a `_MiniFlatIP` that implements exact `IndexFlatIP` semantics (true inner products, honors `k`, records received `k`), over rows present in BOTH the mock index and sqlite (real embedding blobs) so parity is a true recall comparison:

- attack: 20 near-duplicate rows (pairwise Jaccard 1.0, cosines descending from ~0.995) outrank one diverse row (cosine 0.6, disjoint tokens, relevance rank 21). The diverse row must appear in MMR results and the pool request must be `[21]`, not the old 16-window. Fails before: row unreachable.
- parity (issue's open question Q2): identical population through the FAISS tier vs the per-call sqlite tier returns identical id sequences. Fails before: tiers diverge.
- control: `mmr=False` still requests exactly `k = limit * 2` and returns the top-`limit` by pure relevance — non-MMR contract pinned unchanged.
- benign: 5-row population (below both bounds) — identical results across tiers, no new denials.

Fails-before (fix stashed, tests kept): 2 failed (attack + parity) / 2 passed (controls). Full `test_vector_memory.py` suite: 203 passed, 11 skipped.

## Manual verification

Ran the full seam-neighbor suite plus mypy on the touched module, flake8, isort, repo black-formatting gate (`scripts/check_black_formatting.py`), and `scripts/docs-lint.sh` — all green at the fixed tree.

## Screenshots / video

Not applicable: no visual delta (memory-retrieval internals only).

## Related Issues

Fixes #9074

## Pattern harvest

A tier-parity contract stated in comments ("identical results required", "NOT a perf cap that changes results") was enforced by parity harnesses for two of three tiers; the third tier drifted at a pre-filter seam the harnesses never crossed. When a subsystem declares N interchangeable implementations, every implementation needs membership in the same parity harness, and any pre-truncation upstream of the shared algorithm is part of that contract, not an implementation detail.

Rule candidate: when a comment or test declares multiple code paths result-identical, a parity test must exercise every path end-to-end through the shared seam; a new path added without joining the parity harness is a review flag.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
