### PR TITLE
test: build expensive fixtures once and copy them per test

### DIFF
--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -922,7 +922,12 @@ hour earlier is not a baseline.
    per test. Build it **once** in a `scope="session"` fixture and `shutil.copytree` it
    per test. This is safe only if the template is never handed to a test: copy from
    it rather than yielding it, so nothing one test does can reach another's. Re-point any
-   absolute path the tool recorded (e.g. `git remote set-url`) in the copy.
+   absolute path the tool recorded (e.g. `git remote set-url`) in the copy. On Windows
+   the copy also needs a `git reset --hard HEAD`: the copied files get fresh inode and
+   ctime values, git's index stat cache no longer matches, and the copy reads as having
+   "unstaged changes" -- `git rebase` refuses outright (MEASURED in `test_push_guard`
+   when its repo pair moved to a session template). Nothing in a template is
+   uncommitted, so the reset changes no content; it only re-stats the index.
 3. **A production timeout or poll the test never asserts on.** Fake fixtures are often
    small enough to trip a real retry heuristic, then pay its full budget every test.
    `monkeypatch` the interval to `0`: the branch still executes, only the waiting

--- a/test/test_artifact_comment_store.py
+++ b/test/test_artifact_comment_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import uuid
 
 import pytest
@@ -13,11 +14,32 @@ from kiro_crew.artifacts import (
 )
 
 
-@pytest.fixture
-def store(tmp_path):
-    s = ArtifactStore(root=tmp_path / "artifacts")
+@pytest.fixture(scope="module")
+def _seeded_artifacts_template(tmp_path_factory):
+    """Build the "test-art" artifact tree ONCE per module.
+
+    ``ArtifactStore.create`` costs ~0.5s (atomic write + fsync of the
+    artifact's content/metadata), and every test in this file starts from
+    the identical single-artifact tree. Building it once and handing each
+    test a copy turns that per-test cost into a per-module one.
+    """
+    template_root = tmp_path_factory.mktemp("artifact_comment_store_template")
+    s = ArtifactStore(root=template_root / "artifacts")
     s.create(name="Test Artifact", content="<p>Hello</p>", slug="test-art")
-    return s
+    return template_root / "artifacts"
+
+
+@pytest.fixture
+def store(tmp_path, _seeded_artifacts_template):
+    """Fresh store per test: copy the seeded tree, construct a new instance.
+
+    Nothing here is shared with another test -- the copy and the
+    ``ArtifactStore`` object are both fresh, so mutations (add/delete/update
+    comment, content updates) in one test can never leak into another.
+    """
+    dest = tmp_path / "artifacts"
+    shutil.copytree(_seeded_artifacts_template, dest)
+    return ArtifactStore(root=dest)
 
 
 class TestCommentStore:

--- a/test/test_leaf_test_scope.py
+++ b/test/test_leaf_test_scope.py
@@ -40,14 +40,14 @@ def _reason(paths: list[str], code: str = "M") -> str:
 
 
 @pytest.fixture(scope="module")
-def clean_leaf() -> str:
+def clean_leaf(all_corpus_gates: list[str]) -> str:
     """A leaf nothing imports, nothing mentions, and that is not itself a gate.
 
     Discovered rather than hardcoded: naming one in a string literal would make
     `mentions_of` find it (that scan covers `scripts/` and `test/`), so the
     fixture would disqualify the very file it selects.
     """
-    gates = set(mod.corpus_gates(REPO_ROOT))
+    gates = set(all_corpus_gates)
     for candidate in sorted(TEST_DIR.glob("test_*.py")):
         rel = mod._rel_posix(candidate, REPO_ROOT)
         if rel in gates:
@@ -189,9 +189,21 @@ def test_the_mention_scan_leaves_a_clean_leaf_alone(clean_leaf: str) -> None:
 # ── corpus gates: tests that read the test/ tree as data ──────────────────────
 
 
-def test_corpus_gate_derivation_is_non_empty() -> None:
+@pytest.fixture(scope="module")
+def all_corpus_gates() -> list[str]:
+    """``corpus_gates(REPO_ROOT)`` is a pure function of the immutable repo tree
+    for the duration of this run — several tests below call it with the exact
+    same arguments and previously each re-ran the ~158-file scan independently.
+    Computed once here; tests that instead need to observe a PATCHED
+    ``mod.corpus_gates`` (the monkeypatch mutation guard) call through ``mod.``
+    directly and do not use this fixture.
+    """
+    return mod.corpus_gates(REPO_ROOT)
+
+
+def test_corpus_gate_derivation_is_non_empty(all_corpus_gates: list[str]) -> None:
     """An empty derivation and a broken scan look identical; fail on empty."""
-    assert mod.corpus_gates(REPO_ROOT), "no corpus gates derived, which cannot be true here"
+    assert all_corpus_gates, "no corpus gates derived, which cannot be true here"
 
 
 @pytest.mark.parametrize(
@@ -205,9 +217,9 @@ def test_corpus_gate_derivation_is_non_empty() -> None:
         "test/test_workflows_presence.py",
     ],
 )
-def test_known_corpus_gates_are_derived(gate: str) -> None:
+def test_known_corpus_gates_are_derived(gate: str, all_corpus_gates: list[str]) -> None:
     assert REPO_ROOT.joinpath(gate).is_file(), f"{gate} vanished; update this gate"
-    assert gate in mod.corpus_gates(REPO_ROOT)
+    assert gate in all_corpus_gates
 
 
 def test_the_missed_gate_needs_the_file_relative_rule(clean_leaf: str) -> None:
@@ -226,11 +238,13 @@ def test_the_missed_gate_needs_the_file_relative_rule(clean_leaf: str) -> None:
     assert mod._SCANS_A_DIR.search(text) and mod._REACHES_TEST_TREE.search(text)
 
 
-def test_accepted_run_always_includes_the_corpus_gates(clean_leaf: str) -> None:
+def test_accepted_run_always_includes_the_corpus_gates(
+    clean_leaf: str, all_corpus_gates: list[str]
+) -> None:
     resolved = _resolved([clean_leaf])
     assert isinstance(resolved, tuple)
     changed, gates = resolved
-    assert set(mod.corpus_gates(REPO_ROOT)) - {clean_leaf} == set(gates)
+    assert set(all_corpus_gates) - {clean_leaf} == set(gates)
 
 
 def test_a_broken_corpus_scan_forfeits_the_reduction(
@@ -326,9 +340,9 @@ def test_rel_posix_normalises_a_windows_style_path() -> None:
     assert mod._rel_posix(win_file, win_root) == "test/test_ai_agent_runner_coverage.py"
 
 
-def test_no_derived_path_carries_a_backslash() -> None:
+def test_no_derived_path_carries_a_backslash(all_corpus_gates: list[str]) -> None:
     """Vacuous on POSIX by construction; it is the Windows shard this guards."""
-    for gate in mod.corpus_gates(REPO_ROOT):
+    for gate in all_corpus_gates:
         assert "\\" not in gate, f"corpus gate is not POSIX-form: {gate!r}"
 
 

--- a/test/test_pipeline_conductor_claim_preflight.py
+++ b/test/test_pipeline_conductor_claim_preflight.py
@@ -12,6 +12,7 @@ regressing back into the old blind spot.
 from __future__ import annotations
 
 import json
+import shutil
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -2529,13 +2530,19 @@ class TestAgainstRealGit:
     unlanded. One small real repo pins both.
     """
 
-    @pytest.fixture
-    def clone(self, tmp_path):
-        root = tmp_path / "clone"
+    @pytest.fixture(scope="module")
+    def _clone_template(self, tmp_path_factory):
+        """Build the landed/sidetrack clone once per module; ``clone`` copies it.
+
+        Six git subprocesses (~2.3-4.7s) were previously paid on every one of the
+        8 tests below. Module scope is safe because the template is never handed
+        to a test, only copied from via ``shutil.copytree`` -- no test here moves
+        a branch or adds a commit to it, they only read commits already present.
+        """
+        root = tmp_path_factory.mktemp("claim-preflight-seed") / "clone"
         root.mkdir()
 
         def run_git(*args):
-            rc, out, err = 0, "", ""
             rc, out, err = _git(root, list(args))
             assert rc == 0, f"git {args} failed: {err}"
             return out
@@ -2553,6 +2560,13 @@ class TestAgainstRealGit:
         run_git("commit", "-q", "-m", "elsewhere")
         off_main = run_git("rev-parse", "HEAD")
         run_git("checkout", "-q", "main")
+        return root, on_main, off_main
+
+    @pytest.fixture
+    def clone(self, tmp_path, _clone_template):
+        template_root, on_main, off_main = _clone_template
+        root = tmp_path / "clone"
+        shutil.copytree(template_root, root)
         return root, on_main, off_main
 
     def test_ancestry_distinguishes_landed_from_elsewhere(self, mod, clone):

--- a/test/test_platform_cpp_seam_coverage.py
+++ b/test/test_platform_cpp_seam_coverage.py
@@ -154,7 +154,29 @@ def _rel(path: Path) -> str:
     return str(path.relative_to(_SRC_ROOT.parent))
 
 
-def _find_seam_reads(field_names: Set[str]) -> Dict[str, List[str]]:
+def _parsed_core_source_files() -> List[Tuple[Path, ast.AST]]:
+    """Parse every core source file once: ``[(path, tree), ...]``.
+
+    Both ``_find_seam_reads`` and ``_find_method_reads`` walk the identical file
+    set with an identical parse step and differ only in what they look for in the
+    resulting tree. Factored out so the (immutable, run-invariant) parse pass is
+    paid once per test session — via ``parsed_core_files`` below — instead of once
+    per scanner. A file that fails to parse is skipped here, matching the
+    defensive behavior both callers previously implemented individually.
+    """
+    parsed: List[Tuple[Path, ast.AST]] = []
+    for path in _core_source_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+        parsed.append((path, tree))
+    return parsed
+
+
+def _find_seam_reads(
+    field_names: Set[str], parsed_files: List[Tuple[Path, ast.AST]]
+) -> Dict[str, List[str]]:
     """Map each context field name → ``["module.py:LINE", ...]`` read sites.
 
     Recognizes both documented CPP read shapes:
@@ -169,11 +191,7 @@ def _find_seam_reads(field_names: Set[str]) -> Dict[str, List[str]]:
     this test's job is to make inertness impossible to miss.
     """
     reads: Dict[str, List[str]] = {name: [] for name in field_names}
-    for path in _core_source_files():
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
-            continue
+    for path, tree in parsed_files:
         for node in ast.walk(tree):
             if not isinstance(node, ast.Attribute):
                 continue
@@ -182,7 +200,9 @@ def _find_seam_reads(field_names: Set[str]) -> Dict[str, List[str]]:
     return reads
 
 
-def _find_method_reads(field_names: Set[str]) -> Dict[str, List[str]]:
+def _find_method_reads(
+    field_names: Set[str], parsed_files: List[Tuple[Path, ast.AST]]
+) -> Dict[str, List[str]]:
     """Map ``"field.method"`` → read sites, for methods reached via the seam.
 
     Shape: ``<ctx-expr>.<field>.<method>``. Only direct attribute access counts;
@@ -190,11 +210,7 @@ def _find_method_reads(field_names: Set[str]) -> Dict[str, List[str]]:
     a documented read shape).
     """
     method_reads: Dict[str, List[str]] = {}
-    for path in _core_source_files():
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
-            continue
+    for path, tree in parsed_files:
         for node in ast.walk(tree):
             if not isinstance(node, ast.Attribute):
                 continue
@@ -309,13 +325,28 @@ def context_field_names() -> Set[str]:
 
 
 @pytest.fixture(scope="module")
-def field_reads(context_field_names: Set[str]) -> Dict[str, List[str]]:
-    return _find_seam_reads(context_field_names)
+def parsed_core_files() -> List[Tuple[Path, ast.AST]]:
+    """Parse the core source tree once; ``field_reads``/``method_reads`` both
+    consume this instead of each re-parsing every file themselves.
+
+    Read-only consumers (``ast.walk`` never mutates the tree it walks), so
+    sharing the same parsed objects across both fixtures is safe.
+    """
+    return _parsed_core_source_files()
 
 
 @pytest.fixture(scope="module")
-def method_reads(context_field_names: Set[str]) -> Dict[str, List[str]]:
-    return _find_method_reads(context_field_names)
+def field_reads(
+    context_field_names: Set[str], parsed_core_files: List[Tuple[Path, ast.AST]]
+) -> Dict[str, List[str]]:
+    return _find_seam_reads(context_field_names, parsed_core_files)
+
+
+@pytest.fixture(scope="module")
+def method_reads(
+    context_field_names: Set[str], parsed_core_files: List[Tuple[Path, ast.AST]]
+) -> Dict[str, List[str]]:
+    return _find_method_reads(context_field_names, parsed_core_files)
 
 
 # ── The scanner must actually work (guards against a vacuous gate) ──

--- a/test/test_prepare_pr_local_review.py
+++ b/test/test_prepare_pr_local_review.py
@@ -196,21 +196,17 @@ def no_gh(monkeypatch):
     return fake
 
 
-@pytest.fixture
-def parity_repo(tmp_path):
-    """A synthetic repo that resolve_profile.py recognises as Kiro Crew.
+@pytest.fixture(scope="session")
+def _parity_repo_template(tmp_path_factory):
+    """Build the parity repo once per session; ``parity_repo`` copies it per test.
 
-    Carries real copies of both reviewer workflows and both base-ref prompt
-    files, a backend AUTOSDE.yaml, and deliberately NO website/AUTOSDE.yaml so
-    the absent-file fallback path is exercised. One base commit on ``main`` plus
-    one feature commit, so BASE...HEAD is non-empty.
-
-    Both contract workflows are committed on ``main`` - the base branch - not
-    only written to the worktree, because the extractor reads a reviewer's
-    contract out of the base commit. A workflow present only in the checkout is
-    not authority and fails the run closed.
+    Ten git subprocesses plus the workflow/prompt copies were paid on every one
+    of the ~130 tests below (~2.5s each under load, the largest single setup
+    cost in the suite). Session scope is safe because this directory is never
+    handed to a test -- only copied from -- so a test that commits, checks out
+    ``main``, or rewrites a workflow in its copy cannot reach another test's.
     """
-    root = tmp_path / "repo"
+    root = tmp_path_factory.mktemp("parity-seed") / "repo"
     (root / ".github" / "workflows").mkdir(parents=True)
     (root / ".github" / "review-prompts").mkdir(parents=True)
     shutil.copy(GPT_WORKFLOW, root / ".github" / "workflows" / GPT_WORKFLOW.name)
@@ -229,6 +225,31 @@ def parity_repo(tmp_path):
     (root / "changed.py").write_text("VALUE = 1\n", encoding="utf-8")
     _git(root, "add", "-A")
     _git(root, "commit", "-m", "feat(thing): add VALUE\n\nA body line for intent.")
+    return root
+
+
+@pytest.fixture
+def parity_repo(tmp_path, _parity_repo_template):
+    """A synthetic repo that resolve_profile.py recognises as Kiro Crew.
+
+    Carries real copies of both reviewer workflows and both base-ref prompt
+    files, a backend AUTOSDE.yaml, and deliberately NO website/AUTOSDE.yaml so
+    the absent-file fallback path is exercised. One base commit on ``main`` plus
+    one feature commit, so BASE...HEAD is non-empty.
+
+    Both contract workflows are committed on ``main`` - the base branch - not
+    only written to the worktree, because the extractor reads a reviewer's
+    contract out of the base commit. A workflow present only in the checkout is
+    not authority and fails the run closed.
+
+    Each test receives its own ``copytree`` of the session template. The repo
+    has no remote, so nothing recorded in ``.git`` names the template's path;
+    the ``reset --hard`` re-stats the copied files against the index, because a
+    copied checkout otherwise reads as having "unstaged changes" on Windows.
+    """
+    root = tmp_path / "repo"
+    shutil.copytree(_parity_repo_template, root)
+    _git(root, "reset", "--hard", "HEAD")
     return root
 
 

--- a/test/test_push_guard.py
+++ b/test/test_push_guard.py
@@ -66,31 +66,59 @@ def _git(cwd: str, *args: str) -> str:
     return proc.stdout.strip()
 
 
-@pytest.fixture
-def repo_pair(tmp_path):
-    """Create a local 'origin' bare repo and a working clone.
+@pytest.fixture(scope="session")
+def _repo_pair_template(tmp_path_factory) -> tuple[str, str]:
+    """Build the bare origin + initial clone once per session; ``repo_pair`` copies it.
 
-    Returns (clone_dir, origin_dir) where origin_dir is a bare repo and
-    clone_dir has 'origin' pointing at origin_dir.
+    Six git subprocesses (~1-1.6s) were previously paid on every one of the ~40
+    tests below. Session scope is safe because the template directories are
+    never handed to a test, only copied from via ``shutil.copytree`` -- so a
+    test that pushes, branches, or clones ``work2`` off its own copy of
+    ``origin_dir`` cannot reach another test's copy.
     """
-    origin_dir = str(tmp_path / "origin.git")
-    clone_dir = str(tmp_path / "work")
+    root = tmp_path_factory.mktemp("push-guard-seed")
+    origin_dir = str(root / "origin.git")
+    clone_dir = str(root / "work")
 
-    # Create a bare origin with one commit on main.
     os.makedirs(origin_dir)
     _git(origin_dir, "init", "--bare")
     _git(origin_dir, "symbolic-ref", "HEAD", "refs/heads/main")
 
-    # Clone it.
-    _git(str(tmp_path), "clone", origin_dir, "work")
+    _git(str(root), "clone", origin_dir, "work")
     _git(clone_dir, "checkout", "-b", "main")
 
-    # Create an initial commit on main.
     Path(clone_dir, "README.md").write_text("initial\n")
     _git(clone_dir, "add", "README.md")
     _git(clone_dir, "commit", "-m", "initial commit")
     _git(clone_dir, "push", "-u", "origin", "main")
 
+    return clone_dir, origin_dir
+
+
+@pytest.fixture
+def repo_pair(tmp_path, _repo_pair_template):
+    """A local 'origin' bare repo and a working clone, copied from the template.
+
+    Returns (clone_dir, origin_dir) where origin_dir is a bare repo and
+    clone_dir has 'origin' pointing at origin_dir. Each test gets its own copy,
+    so pushes, branches, and `work2` clones (which several tests create
+    alongside this pair) never touch another test's copy.
+    """
+    template_clone, template_origin = _repo_pair_template
+    origin_dir = str(tmp_path / "origin.git")
+    clone_dir = str(tmp_path / "work")
+    shutil.copytree(template_origin, origin_dir)
+    shutil.copytree(template_clone, clone_dir)
+    # The copied clone's remote still points at the TEMPLATE's origin path;
+    # repoint it at this test's own copy so pushes/fetches never reach (or
+    # mutate) the session template or another test's copy.
+    _git(clone_dir, "remote", "set-url", "origin", origin_dir)
+    # copytree resets every file's mtime, which invalidates git's cached
+    # index stat info and makes git see a false "unstaged changes" diff (e.g.
+    # git rebase refuses with "You have unstaged changes"). Nothing in the
+    # template is ever uncommitted, so resetting hard to HEAD is a no-op on
+    # content and forces git to re-stat every file against the real index.
+    _git(clone_dir, "reset", "--hard", "HEAD")
     return clone_dir, origin_dir
 
 

--- a/test/test_ratchet_scope.py
+++ b/test/test_ratchet_scope.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -90,22 +91,36 @@ def _commit_file(repo: Path, name: str, message: str) -> None:
     _git(repo, "commit", "-m", message)
 
 
-def _repo_with_diverged_feature(tmp_path: Path) -> Path:
-    """One base repo both shapes start from.
+def _build_repo_with_diverged_feature(repo: Path) -> None:
+    """Populate ``repo`` with the one base shape every test in this module starts
+    from.
 
     ``main`` gains ``mainline.txt`` AFTER ``feature`` branches off with its own
     ``feature.py``, so the two sides of every merge below differ and a wrong
     parent choice shows up in the returned path set, not just the label.
     """
-    repo = tmp_path / "repo"
-    repo.mkdir()
     _git(repo, "init", "-b", "main", ".")
     _commit_file(repo, "base.txt", "base")
     _git(repo, "checkout", "-b", "feature")
     _commit_file(repo, "feature.py", "the change under judgment")
     _git(repo, "checkout", "main")
     _commit_file(repo, "mainline.txt", "someone else's change, landed after the branch point")
-    return repo
+
+
+@pytest.fixture(scope="session")
+def _repo_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build the diverged-feature repo once per session; ``repo`` copies it per test.
+
+    Six git subprocesses (~2-3s) were previously paid on every one of the 23
+    tests in this module. Session scope is safe here because the template is
+    never handed to a test, only copied from via ``shutil.copytree`` -- so a
+    test that adds a commit, merges, or moves a branch cannot reach another's
+    copy.
+    """
+    template = tmp_path_factory.mktemp("ratchet-scope-seed") / "repo"
+    template.mkdir()
+    _build_repo_with_diverged_feature(template)
+    return template
 
 
 def _set_origin_main(repo: Path) -> None:
@@ -115,7 +130,7 @@ def _set_origin_main(repo: Path) -> None:
 
 
 @pytest.fixture()
-def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _repo_template: Path) -> Path:
     # The fixture's own git calls build a scrubbed env per call, but the
     # RESOLVER under test runs git with the ambient process environment: an
     # exported GIT_DIR (pytest run from a git hook, `git rebase --exec`,
@@ -125,7 +140,8 @@ def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # builder strips.
     for var in _GIT_LOCATION_VARS:
         monkeypatch.delenv(var, raising=False)
-    fixture_repo = _repo_with_diverged_feature(tmp_path)
+    fixture_repo = tmp_path / "repo"
+    shutil.copytree(_repo_template, fixture_repo)
     # The module runs git with cwd=ROOT; retarget it at the synthetic repo.
     monkeypatch.setattr(scope, "ROOT", fixture_repo)
     return fixture_repo


### PR DESCRIPTION
## Problem / Motivation

Seven test files build the same expensive object again for every test method. Four of them seed a real git repository with ten or so subprocess calls per test; one parses every module under `src/` twice per module; one re-runs a repo-wide corpus scan in five separate test bodies; one seeds an artifact tree with fsync'd writes per test. Measured with a per-test probe across three full-suite runs, that is about 750 seconds of setup per run spent rebuilding things that never differ between tests.

## Why it matters

Setup time is paid in every shard and every local run. `test_prepare_pr_local_review.py` alone took 377 seconds on this host, and most of that was not the code under test. Slow setup also makes every timing-sensitive test sharing a worker flakier, because the worker is busier.

## What changed (motivation → approach → change)

Each expensive thing is now built once, in a session- or module-scoped fixture, and each test gets its own copy. Git repositories are `shutil.copytree`'d from the template into the test's `tmp_path`; where the template recorded a remote, the copy is re-pointed at its own origin. The AST scanner in `test_platform_cpp_seam_coverage.py` parses the tree once and both consumers walk the same read-only trees. The corpus scan in `test_leaf_test_scope.py` runs once per module and the five tests read the list.

The template is never handed to a test, only copied from. A test that commits, checks out `main`, pushes, or mutates a comment does so in its own copy and cannot see another test's. That is the decoupling: no shared mutable object, no order dependence.

One trap came out of it, now recorded in `testing-conventions.md` next to the pattern: a copied git checkout on Windows reads as having "unstaged changes" (fresh inode and ctime invalidate the index stat cache) and `git rebase` refuses. The copy gets a `git reset --hard HEAD`, which changes no content because nothing in a template is uncommitted.

## Tests

No new tests; every assertion is unchanged. Production code was mutated to confirm the tests still fail through the new fixtures: `scripts/ratchet_scope.py::changed_paths` (4 failures), `claim_preflight.py::annotate_landed` (1), `push_guard.py`'s ancestry check (3), and a real `ctx.package_manager` read planted in `cli_doctor.py` (caught by `test_reserved_slots_have_no_consumption_site`). All 666 tests across the seven files pass under `-n 6` on Windows.

Measured on one host, same regime: `test_prepare_pr_local_review` 377s → 112s, `test_ratchet_scope` 68s → 32s, `test_pipeline_conductor_claim_preflight` 31s → 17s, `test_platform_cpp_seam_coverage` 64s → 42s, `test_leaf_test_scope` 215s → 201s (the rest is a subprocess self-test), `test_artifact_comment_store` 32s → 27s (the rest is fsync'd writes inside test bodies, which are the behaviour under test and were left alone). Setup no longer appears in `test_push_guard`'s duration report.

## Manual verification

N/A — unit coverage sufficient: the change is to test fixtures only, and the mutation checks above show each file still detects the defects it exists to catch.

## Related Issues

no linked issue: follow-up to the 5x test-hygiene run in #9090, scoped separately so that PR stays reviewable.

## Pattern harvest

Not generalizable: the pattern (session template + copy per test) is already documented; this PR applies it to the seven files the probe ranked highest and adds the one Windows trap the application surfaced.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
