### PR TITLE
test(atomic-write): make the ACL-carry tests' platform model match the handlers' pin-first gate

### DIFF
--- a/src/kiro_crew/atomic_write.py
+++ b/src/kiro_crew/atomic_write.py
@@ -86,9 +86,13 @@ _CARRIED_INFORMATIONAL_XATTR_PREFIXES = ("user.",)
 
 #: Whether this platform exposes the xattr syscalls an ACL carry needs at all.
 #:
-#: Windows has none of them, and typeshed guards all three behind
+#: CPython exposes all three on Linux only. Windows has none of them, macOS has
+#: ``openat`` but none of them either (its ACLs live behind ``acl_get_file``,
+#: not the Linux xattr API), and typeshed guards all three behind
 #: ``sys.platform == "linux"``, so every use is a ``hasattr`` probe rather than a
-#: direct call.
+#: direct call. This flag gates only what an ACL carry can READ — a pinned
+#: caller still gets a descriptor from :func:`open_access_control_source`
+#: regardless, because the MODE carry needs one (see that function's contract).
 ACCESS_CONTROL_XATTRS_SUPPORTED = all(
     hasattr(os, name) for name in ("listxattr", "getxattr", "setxattr")
 )

--- a/test/test_atomic_write_acl_preservation.py
+++ b/test/test_atomic_write_acl_preservation.py
@@ -212,6 +212,42 @@ def test_no_source_descriptor_is_opened_where_xattrs_do_not_exist(tmp_path, monk
     assert opened == [], "no descriptor may be opened where xattrs do not exist"
 
 
+def test_pinned_caller_gets_a_descriptor_even_without_xattrs(tmp_path, monkeypatch):
+    """With ``dir_fd`` the helper returns a descriptor REGARDLESS of the flag.
+
+    This is the macOS composition (``openat`` and no ``listxattr``), simulated
+    deterministically: the flag is forced off while the platform can still pin.
+    The pinned branch must win — the MODE carry reads the bits off this
+    descriptor so they come from the inode inside the pinned directory, and a
+    ``None`` here would send the caller back to a by-name ``stat``, exactly the
+    re-resolution the pin exists to prevent. The Windows open-handle caveat
+    does not apply: pinning needs ``O_DIRECTORY``, which Windows lacks, so a
+    pinned caller is on POSIX where ``renameat`` publishes past open handles.
+    Issue #9060 group 1: the handler tests used to conflate "no xattr
+    syscalls" with "no descriptor" and reported this contract as a failure.
+    """
+    if not hasattr(os, "O_DIRECTORY") or os.open not in os.supports_dir_fd:
+        pytest.skip("platform cannot pin a parent directory")
+
+    import kiro_crew.atomic_write as aw
+
+    target = tmp_path / "file.txt"
+    target.write_text("before", encoding="utf-8")
+
+    monkeypatch.setattr(aw, "ACCESS_CONTROL_XATTRS_SUPPORTED", False)
+    dir_fd = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        fd = aw.open_access_control_source(target, dir_fd=dir_fd)
+        assert isinstance(fd, int), "pinned branch must not be gated on the xattr flag"
+        try:
+            # The descriptor references the leaf inside the pinned directory.
+            assert os.read(fd, 16) == b"before"
+        finally:
+            os.close(fd)
+    finally:
+        os.close(dir_fd)
+
+
 def test_source_descriptor_is_opened_where_xattrs_exist(tmp_path):
     """Where the syscalls exist, the helper hands back a usable descriptor."""
     _needs_xattr()

--- a/test/test_dashboard_file_io.py
+++ b/test/test_dashboard_file_io.py
@@ -343,11 +343,19 @@ class TestFileWrite:
             assert resp.status == 200
 
         kwargs = captured["kwargs"]
-        # See the steering twin: a descriptor where the xattr syscalls exist,
-        # None where they do not (Windows), because a handle held open there
-        # would make os.replace fail. The kwarg itself must always be passed.
+        # See the steering twin: the handler's gate is PIN-FIRST, not
+        # xattr-first. When the parent pins, open_access_control_source hands
+        # back a descriptor even where the xattr syscalls are absent — the MODE
+        # carry needs it so the bits come off the pinned inode (macOS: openat
+        # and no listxattr). Only on the unpinned floor does the xattr flag
+        # decide, and None there (Windows) is what keeps os.replace working
+        # while any other handle is open. The kwarg itself must always be passed.
+        handler_pins = (
+            files_mod.pinned_fs.supports_pinned_walk()
+            and aw.pinned_parent_replace_supported()
+        )
         assert "preserve_access_control_from" in kwargs
-        if aw.ACCESS_CONTROL_XATTRS_SUPPORTED:
+        if handler_pins or aw.ACCESS_CONTROL_XATTRS_SUPPORTED:
             assert isinstance(kwargs["preserve_access_control_from"], int)
             assert captured["source_bytes"] == b"hello world"
         else:  # pragma: no cover - exercised on Windows CI only

--- a/test/test_steering_api.py
+++ b/test/test_steering_api.py
@@ -1112,15 +1112,20 @@ class TestUpdateDeleteEndpoints:
             ).status == 200
 
         kwargs = captured["kwargs"]
-        # On a platform with the xattr syscalls the handler must hand over a real
-        # descriptor; where they do not exist (Windows) the contract is the
-        # opposite -- open_access_control_source returns None ON PURPOSE, because
-        # os.replace there fails while any other handle is open on either path.
-        # Asserting `int` unconditionally would demand the very handle that would
-        # break every save. Either way the kwarg must be PASSED, so a revert to
-        # the bits-only call still fails here.
+        # The handler's gate is PIN-FIRST, not xattr-first. When the parent
+        # pins (its own _DIR_FD_SUPPORTED plus the stage-and-rename probe),
+        # open_access_control_source hands back a real descriptor even where
+        # the xattr syscalls are absent — the MODE carry below reads the bits
+        # off that descriptor so they come from the pinned inode (macOS:
+        # openat and no listxattr). Only on the unpinned floor does the xattr
+        # flag decide, and None there (Windows) is deliberate — os.replace
+        # fails while any other handle is open on either path. Asserting
+        # `int` unconditionally would demand the very handle that would break
+        # every save there. Either way the kwarg must be PASSED, so a revert
+        # to the bits-only call still fails here.
+        handler_pins = mod._DIR_FD_SUPPORTED and aw.pinned_parent_replace_supported()
         assert "preserve_access_control_from" in kwargs
-        if aw.ACCESS_CONTROL_XATTRS_SUPPORTED:
+        if handler_pins or aw.ACCESS_CONTROL_XATTRS_SUPPORTED:
             assert isinstance(kwargs["preserve_access_control_from"], int)
             assert captured["source_bytes"] == b"original\n"
         else:  # pragma: no cover - exercised on Windows CI only


### PR DESCRIPTION
# test(atomic-write): make the ACL-carry tests' platform model match the handlers' pin-first gate

## Problem / Motivation

Issue #9060 group 1: on macOS, `test_write_routes_acl_preservation_through_atomic_write` (file-io) and `test_update_routes_acl_preservation_through_atomic_write` (steering) fail with `assert 21 is None` / `assert 22 is None`.

Both tests key their descriptor expectation on `ACCESS_CONTROL_XATTRS_SUPPORTED` alone:

```python
if aw.ACCESS_CONTROL_XATTRS_SUPPORTED:
    assert isinstance(kwargs["preserve_access_control_from"], int)
else:  # pragma: no cover - exercised on Windows CI only
    assert kwargs["preserve_access_control_from"] is None
```

But the handlers' actual gate is pin-first. When the parent directory pins, `open_access_control_source` hands back a descriptor regardless of the xattr flag — its docstring names exactly this case:

> With *dir_fd* the descriptor comes back even where the xattr syscalls are absent … That case is not hypothetical — macOS has `openat` and no `listxattr` — and the MODE carry needs a descriptor even when the ACL carry has nothing to read, or a by-name `stat` would reintroduce exactly the mismatch above on that platform.

And both handlers consume that descriptor on such platforms — the mode bits are read via `os.fstat(src_fd)` so they come from the same pinned inode the write publishes into (`files.py`: "with dir_fd the helper always hands back a descriptor, so the mode comes from the same inode the ACL does and neither is re-resolved").

macOS is the platform that exposes the model gap: it pins (has `O_DIRECTORY`/`openat`) and has no Linux xattr syscalls. Windows cannot pin at all, which is the only reason the tests' two-bucket model ever held.

## Why it matters

The two failures point a macOS contributor at the ACL-carry mechanism and say it is broken, when what they are observing is its documented contract working. The cost is misdirected debugging on exactly the code whose comments say the opposite of what the test asserts. Worse, a "fix" that made the helper return `None` on the pinned branch to satisfy the test would downgrade macOS saves to by-name mode resolution — reintroducing the parent-swap TOCTOU the pin exists to close.

## What changed (motivation → approach → change)

- **Both handler tests** (`test/test_dashboard_file_io.py`, `test/test_steering_api.py`): the predicate becomes pin-aware — `handler_pins or aw.ACCESS_CONTROL_XATTRS_SUPPORTED`, where `handler_pins` mirrors each handler's own gate off its own module symbols (`files_mod.pinned_fs.supports_pinned_walk() and aw.pinned_parent_replace_supported()` for file-io; `mod._DIR_FD_SUPPORTED and aw.pinned_parent_replace_supported()` for steering). If a handler's gate drifts, its test drifts with it. The `else` branch is now genuinely Windows-only, which makes the existing `pragma: no cover - exercised on Windows CI only` accurate instead of aspirational (the issue flagged the pragma as measured-inaccurate on macOS).
- **`test/test_atomic_write_acl_preservation.py`**: new test `test_pinned_caller_gets_a_descriptor_even_without_xattrs` pins the composition the suite never covered — `dir_fd` passed while the flag is off returns a live descriptor on the correct inode. This is the macOS bucket simulated deterministically on any platform that can pin, so Linux CI now exercises what previously only a Mac could observe.
- **`src/kiro_crew/atomic_write.py`**: the flag's comment named Windows only; it now states the Linux-only reality (macOS ACLs live behind `acl_get_file`, not the Linux xattr API) and points at the pinned-caller contract. Comment-only change; no behavior touched.

**Deliberately untouched:** the Darwin ACL question the issue defers — whether macOS should get a real ACL carry via `acl_get_file`/`com.apple.acl.text` or an explicit documented no-op — is a maintainer policy decision. Nothing here decides it; this PR makes the tests assert the contract the code has, not a new one.

## Tests

- **Fails-before**: forcing `ACCESS_CONTROL_XATTRS_SUPPORTED = False` in-process on a pinning host (the exact macOS composition) reproduces both failures with the issue's signature — `assert 19 is None` / `assert 18 is None`, 2 failed at the unfixed tree. Same probe at the fixed tree: 2 passed. Reproduction note: the flag override must run under `-n0` — xdist workers are fresh interpreters that reset the module state (the `-n0` in the issue author's repro command is load-bearing).
- **Benign control**: both tests pass unmodified on the real (Linux, xattr-supporting) platform before and after.
- New contract test passes solo and in-suite.
- Seam-neighbor sweep: all six suites naming the seam symbols (`test_atomic_write_acl_preservation`, `test_atomic_write_pinned_parent`, `test_dashboard_file_io`, `test_dashboard_files_coverage`, `test_steering_api`, `test_skills_crud_pinned`) — 316 passed, 0 failed.
- mypy / flake8 / isort / black-baseline / docs-lint: all clean.

## Manual verification

Ran the fails-before/fails-after probe pair and the six-suite sweep locally (Linux, Python 3.12); confirmed the new test skips cleanly where the platform cannot pin (guard: `O_DIRECTORY` + `os.open in os.supports_dir_fd`).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** No visual delta: test-model and comment changes only; no UI surface is touched.

## Related Issues

Addresses group 1 (2 of the 11 deterministic failures) in #9060. Groups 2 (own PR #9061), 3 and 4 are not touched here. Not marked as closing, since #9060 tracks four independent root-cause groups.

## Pattern harvest

A platform-conditional assertion that models capabilities as one boolean will misreport any platform that splits them. Here "can pin a parent" and "has Linux xattrs" were fused into one flag, and macOS — which has the first without the second — turned the documented contract into a red test. The test now derives its expectation from the same gate the production code runs, so the two cannot disagree silently.

Rule candidate: when a test branches on a platform capability, assert against the production code's own capability gate (imported from the module under test), never a re-derived approximation of it.

## Checklist

- [x] Tests added/updated for the change
- [x] All tests pass locally
- [x] Lint/format gates clean
- [x] Docs impact considered (comment amended where it was measured stale)

## Contribution License Agreement

- [x] I confirm this contribution is made under the terms of the repository's license and CLA.
