### PR TITLE
fix: judge unfinished-marker tails by grammar prefix, not substring location

### DIFF
--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -305,6 +305,66 @@ def strip_control_comments(text: str) -> str:
     return text[: m.start()]
 
 
+#: Prefix closures of the marker grammars, for
+#: :func:`split_trailing_protocol_suffix`'s unfinished-marker probe: a tail is
+#: a STILL-STREAMING marker only when every byte it holds so far could extend
+#: into a complete marker. ``[OPTIONS`` must be followed by ``:`` and then
+#: :data:`OPTIONS_RE_TRAILER`'s body (DOTALL; ``[`` admitted only when not
+#: opening a nested ``[OPTIONS:``). ``[STEERING`` follows the steer-ack
+#: grammar (``messaging/driver.py``): whitespace gap, literal ``steer-``, a
+#: nonempty hex/dash id, then an optional ``:`` summary -- spelled as nested
+#: optionals so every cut point of the literal run is admitted, while a tail
+#: that diverges from the grammar (``[OPTIONSDOC``, ``[STEERING
+#: acknowledgment``, ``steer-:``) is prose and stays visible. Case-sensitive
+#: on purpose: these probe the exact sentinels the detach walk locates.
+_OPTIONS_TAIL_PREFIX_RE = re.compile(
+    r"\[OPTIONS(?::(?:[^[]|\[(?!OPTIONS:))*)?\Z",
+    re.DOTALL,
+)
+_STEERING_TAIL_PREFIX_RE = re.compile(
+    r"\[STEERING(?:\s+(?:s(?:t(?:e(?:e(?:r(?:-(?:[0-9a-f-]+(?:\s*(?::\s*.*)?)?)?)?)?)?)?)?)?)?\Z",
+    re.DOTALL,
+)
+_MARKER_SENTINELS = (
+    ("[STEERING", _STEERING_TAIL_PREFIX_RE),
+    ("[OPTIONS", _OPTIONS_TAIL_PREFIX_RE),
+)
+
+
+def _rightmost_unfinished_marker(text: str) -> int:
+    """Start of the rightmost tail that is a strict prefix of a marker grammar.
+
+    Occurrences are probed RIGHTMOST-FIRST so label bytes that merely contain
+    a sentinel (a bare ``[OPTIONS`` without its colon is legal label content)
+    cannot shadow the genuine fragment start to their left. Each probe is
+    cheap: the ASCII ``]`` gate is one precomputed ``rfind`` comparison, and
+    the prefix regexes are anchored at the occurrence and die on the first
+    diverging byte, so an adversarial buffer repeating failing sentinels
+    walks linearly. Returns ``-1`` when no admissible occurrence exists.
+    """
+    last_close = text.rfind("]")
+    cursors = []
+    for sentinel, prefix_re in _MARKER_SENTINELS:
+        pos = text.rfind(sentinel)
+        if pos != -1:
+            cursors.append((pos, sentinel, prefix_re))
+    while cursors:
+        cursors.sort()
+        pos, sentinel, prefix_re = cursors.pop()  # rightmost overall
+        if pos <= last_close:
+            # ASCII-only unfinished gate (see the closer comment in
+            # ``split_trailing_protocol_suffix``): a ``]`` at/after this
+            # occurrence means the tail is not still-streaming -- and every
+            # remaining occurrence sits further left of that closer too.
+            break
+        if prefix_re.match(text, pos) is not None:
+            return pos
+        nxt = text.rfind(sentinel, 0, pos)
+        if nxt != -1:
+            cursors.append((nxt, sentinel, prefix_re))
+    return -1
+
+
 def split_trailing_protocol_suffix(text: str) -> tuple[str, str]:
     """Detach protocol trailers before a renderer length-splits ``text``.
 
@@ -314,20 +374,26 @@ def split_trailing_protocol_suffix(text: str) -> tuple[str, str]:
     marker leaves the complete block eligible for a mid-token chunk split.
     Return the visible prefix plus the entire protocol suffix so renderers can
     keep both markers together on the surviving tail.
+
+    An occurrence is judged against the marker GRAMMAR, never by bare
+    substring location: a mid-prose mention of ``[OPTIONS`` or ``[STEERING``
+    whose tail cannot extend into a complete marker stays visible, instead of
+    being detached and silently dropped from the rendered cut.
     """
     suffix_start = len(text)
-    idx = max(text.rfind("[STEERING"), text.rfind("[OPTIONS"))
-    # DELIBERATELY ASCII-ONLY -- do not widen this to ``MARKER_CLOSERS``.
-    # This asks "is the tail an UNFINISHED marker?", and mere PRESENCE of a
-    # closer is not completeness: a closer sitting inside a still-streaming
-    # label (``[OPTIONS: Use 】 the bracket``) would read as finished, the
-    # fragment would not be detached, and a length rotation could split the
-    # marker so raw fragments render and the pills are lost. Completeness is
-    # decided by ``OPTIONS_RE_TRAILER`` on the next line, which DOES accept the
-    # lookalikes -- so a complete lookalike-closed block is still pulled into
-    # the suffix. Widening here buys nothing (both paths already yield the same
-    # split for a complete tail) and reintroduces that bug.
-    if idx != -1 and "]" not in text[idx:]:
+    idx = _rightmost_unfinished_marker(text)
+    # DELIBERATELY ASCII-ONLY -- do not widen the helper's gate to
+    # ``MARKER_CLOSERS``. It asks "is the tail an UNFINISHED marker?", and
+    # mere PRESENCE of a closer is not completeness: a closer sitting inside
+    # a still-streaming label (``[OPTIONS: Use 】 the bracket``) would read as
+    # finished, the fragment would not be detached, and a length rotation
+    # could split the marker so raw fragments render and the pills are lost.
+    # Completeness is decided by ``OPTIONS_RE_TRAILER`` on the next line,
+    # which DOES accept the lookalikes -- so a complete lookalike-closed block
+    # is still pulled into the suffix. Widening there buys nothing (both paths
+    # already yield the same split for a complete tail) and reintroduces that
+    # bug.
+    if idx != -1:
         suffix_start = idx
 
     options = OPTIONS_RE_TRAILER.search(text[:suffix_start])

--- a/test/test_unfinished_marker_prefix_grammar.py
+++ b/test/test_unfinished_marker_prefix_grammar.py
@@ -1,0 +1,117 @@
+"""``split_trailing_protocol_suffix`` judges occurrences against the marker
+grammar, never by bare substring location.
+
+Sibling of the ``preserve_tail_marker`` locate-by-substring defect: ``rfind``
+located ``[STEERING``/``[OPTIONS`` anywhere in the buffer, and a mid-prose
+mention with no later ASCII ``]`` was detached as a "still-streaming marker".
+Consumers (Discord/Telegram rotation, WhatsApp render) drop the detached
+suffix from the visible cut, so everything from the mention onward vanished
+from display -- prose truncation on an attacker-positionable token.
+
+The fix admits an occurrence only when the tail it starts is a strict PREFIX
+of the marker grammar, probing occurrences rightmost-first so label bytes
+that merely contain a sentinel cannot shadow the genuine fragment start.
+"""
+
+import time
+
+from kiro_crew.constants import split_trailing_protocol_suffix
+
+
+class TestProseMentionIsNotAMarker:
+    def test_prose_mentioning_options_is_left_visible(self):
+        """ATTACK (fails before the fix): a tail mentioning ``[OPTIONS`` in
+        running prose, with no later ``]``, was detached and the prose lost."""
+        text = "Wrap choices with the [OPTIONS marker followed by labels\nMore prose here"
+        visible, suffix = split_trailing_protocol_suffix(text)
+        assert visible == text
+        assert suffix == ""
+
+    def test_prose_mentioning_steering_is_left_visible(self):
+        """ATTACK: ``[STEERING`` followed by a word that is not ``steer-<id>``
+        reads as prose, not a streaming acknowledgment fragment."""
+        text = "The [STEERING acknowledgment renders as a chip"
+        visible, suffix = split_trailing_protocol_suffix(text)
+        assert visible == text
+        assert suffix == ""
+
+    def test_sentinel_glued_to_prose_is_left_visible(self):
+        """ATTACK: no colon after ``[OPTIONS`` means it cannot be a marker."""
+        text = "see [OPTIONSDOC for details"
+        visible, suffix = split_trailing_protocol_suffix(text)
+        assert visible == text
+        assert suffix == ""
+
+
+class TestGenuineFragmentsStillDetach:
+    def test_streaming_options_fragment_detaches(self):
+        """CONTROL: the streaming case the function exists for is unchanged."""
+        visible, suffix = split_trailing_protocol_suffix("visible\n\n[OPTIONS: A | Cho")
+        assert visible == "visible\n\n"
+        assert suffix == "[OPTIONS: A | Cho"
+
+    def test_cut_exactly_at_the_sentinel_detaches(self):
+        for frag in ("[OPTIONS", "[STEERING"):
+            visible, suffix = split_trailing_protocol_suffix(f"body {frag}")
+            assert visible == "body ", frag
+            assert suffix == frag, frag
+
+    def test_streaming_steering_ack_detaches_at_every_cut_point(self):
+        """CONTROL: a genuine ``[STEERING steer-<id>: <summary>]`` ack cut at
+        any byte before its closer is still recognized as unfinished."""
+        full = "[STEERING steer-4a2f: rewrote the loop"
+        for cut in range(len("[STEERING"), len(full) + 1):
+            frag = full[:cut]
+            visible, suffix = split_trailing_protocol_suffix(f"prose {frag}")
+            assert visible == "prose ", f"cut={cut} -> {visible!r}"
+            assert suffix == frag, f"cut={cut} -> {suffix!r}"
+
+    def test_steering_with_empty_id_is_not_a_marker_prefix(self):
+        """The ack grammar requires a nonempty id before the colon, so
+        ``steer-:`` can never be a prefix of a genuine marker."""
+        text = "prose [STEERING steer-: not a real ack"
+        visible, suffix = split_trailing_protocol_suffix(text)
+        assert visible == text
+        assert suffix == ""
+
+
+class TestBenignCompositions:
+    def test_complete_options_block_is_still_pulled(self):
+        """BENIGN: the trailer-regex branch is untouched."""
+        visible, suffix = split_trailing_protocol_suffix("pick one\n\n[OPTIONS: A | B]")
+        assert visible == "pick one\n\n"
+        assert suffix == "[OPTIONS: A | B]"
+
+    def test_no_marker_no_change(self):
+        text = "plain prose with [brackets] and [links](x) but no markers"
+        assert split_trailing_protocol_suffix(text) == (text, "")
+
+    def test_label_bytes_containing_a_sentinel_do_not_shadow_the_fragment(self):
+        """Latent sibling cured by the rightmost-READING probe: an inner
+        ``[OPTIONS`` (legal label content -- the trailer grammar only forbids
+        ``[OPTIONS:``) used to win ``rfind`` and the detach point landed
+        MID-LABEL, splitting the genuine marker."""
+        text = "prose [OPTIONS: mention [OPTIONS in a label"
+        visible, suffix = split_trailing_protocol_suffix(text)
+        assert visible == "prose "
+        assert suffix == "[OPTIONS: mention [OPTIONS in a label"
+
+    def test_prose_mention_after_a_closed_block_leaves_both_alone(self):
+        """A closed block earlier in the buffer plus a later prose mention:
+        the mention must not detach (its tail is not a grammar prefix) and the
+        closed block is mid-buffer, not a trailer."""
+        text = "done [OPTIONS: A | B] and the [OPTIONS token is documented"
+        assert split_trailing_protocol_suffix(text) == (text, "")
+
+
+class TestOccurrenceWalkStaysLinear:
+    def test_adversarial_sentinel_repetition_is_linear(self):
+        """Rightmost-first probing with match-at-pos must not go quadratic on
+        a buffer that repeats failing sentinels."""
+        evil = "x[OPTIONSz" * 50_000
+        start = time.perf_counter()
+        visible, suffix = split_trailing_protocol_suffix(evil)
+        elapsed = time.perf_counter() - start
+        assert visible == evil
+        assert suffix == ""
+        assert elapsed < 1.0, f"occurrence walk too slow ({elapsed:.2f}s)"


### PR DESCRIPTION
## Problem / Motivation

`split_trailing_protocol_suffix` (`src/kiro_crew/constants.py`) locates `[STEERING` / `[OPTIONS` with a bare `rfind` and treats any occurrence with no later ASCII `]` as a still-streaming marker fragment. A mid-prose *mention* of either sentinel therefore gets detached as if it were protocol suffix: everything from the mention onward is stripped out of the visible text the renderer cuts, so ordinary prose like

```
Reply with [OPTIONS if you want the pill row explained
```

silently loses its tail on every streamed frame that ends without a `]`. The trigger token is attacker-positionable (it is plain message text), and the same locate-by-substring defect class was already fixed once in this file for `preserve_tail_marker` (see #8983 review discussion).

## Why it matters

Any chat turn whose streamed frame ends with a prose mention of `[OPTIONS` or `[STEERING` and no subsequent `]` renders truncated: the user sees their sentence cut mid-thought, with no error and nothing in logs. Because the split runs on every length rotation, the loss is repeatable and surface-independent (every consumer of the split sees the same truncated prefix).

Scope note (post-review correction): the end-to-end visibility win is complete for `[OPTIONS`. For `[STEERING` prose, this fixes the renderer-layer split, but `_SteeringMarkerFilter._drain` (`src/kiro_crew/messaging/driver.py`) sits upstream on streaming channels and holds/deletes unclosed `[STEERING`-prefixed tails by bare substring at flush — the same defect class, registered as a named follow-up (see Related Issues). Renderers of stored transcripts get the full win today; live streaming paths need the follow-up for the STEERING half.

## What changed (motivation → approach → change)

* Symptom: prose tails containing a sentinel substring vanish from rendered output.
* Root cause: the unfinished-marker probe judges an occurrence by *location* (`rfind` + "no `]` after it") instead of by *grammar* (could these bytes still extend into a complete marker?).
* Change: a new module-private helper `_rightmost_unfinished_marker` judges each occurrence against an anchored prefix-closure regex of the marker grammar it claims to start:
  * `[OPTIONS` must be followed by `:` and then `OPTIONS_RE_TRAILER`-compatible body bytes;
  * `[STEERING` must follow the steer-ack grammar (whitespace, literal `steer-`, nonempty id, optional `:` summary), spelled as nested optionals so *every* streaming cut point of the literal run is admitted.
  Occurrences are probed rightmost-first so label bytes that merely contain a sentinel cannot shadow the genuine fragment start to their left. The deliberate ASCII-only `]` gate is preserved unchanged (one precomputed `rfind` comparison), and complete lookalike-closed blocks still flow through `OPTIONS_RE_TRAILER` exactly as before. Anchored probes die on the first diverging byte, so adversarial buffers repeating failing sentinels walk linearly.
* Declared rider (post-review): the steer-ack prefix probe spells the grammar case-sensitively (lowercase `steer-` + hex id), while the driver's `_STEER_MARKER_RE` is `re.IGNORECASE`. A genuinely-streaming steer frame with an uppercase id would no longer detach at this layer (before this fix, any `]`-less tail detached). Known emitters generate lowercase ids; the registered follow-up unifies the two spellings into one shared grammar source with a cross-pinning test so they cannot drift.

## Tests

`test/test_unfinished_marker_prefix_grammar.py` (12 tests, all offline-deterministic):

* 7 fail before the fix (witnessed at the unfixed base): prose mentions of both sentinels stay visible, sentinel glued to prose stays visible, `[STEERING` with an empty steer id is not a marker prefix, label bytes containing a sentinel do not shadow the genuine fragment, prose mention after a closed block leaves both alone, and adversarial sentinel repetition stays linear (time-bounded).
* 5 controls prove no behavior regressed: streaming `[OPTIONS:` fragments detach, a cut exactly at the sentinel detaches, streaming steer-acks detach at every cut point, complete `[OPTIONS: ...]` blocks are still pulled into the suffix, and marker-free text is unchanged.

Seam-neighbor suites (`test_options_cap_contract.py`, `test_options_marker_closers.py`): 76/76 pass.

## Manual verification

N/A — unit coverage sufficient: the changed function is pure (`str -> tuple[str, str]`), fully exercised offline, and both callers consume the same contract locked by the control tests.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no visual delta — backend-only text-splitting fix in `constants.py`; rendered output changes only in that previously-lost prose is no longer dropped, which the unit tests lock in.

## Related Issues

Follow-up to the locate-by-substring defect class discussed in the #8983 review (that PR fixed the `preserve_tail_marker` member; this fixes the sibling in `split_trailing_protocol_suffix`). No standalone tracker issue exists for this member.

Named follow-up (from this PR's design/first-principles reviews): the same locate-by-substring class lives in `_SteeringMarkerFilter._drain` (`src/kiro_crew/messaging/driver.py`), which deletes unclosed `[STEERING` prose tails at stream flush; fixing it with a grammar-prefix probe shared from a single source also cures the case-sensitivity divergence and grammar-drift risk named above, pinned by a cross-grammar test.

## Pattern harvest

Rule candidate: review-prompt
Pattern: "sentinel located by rfind/find and then classified by surrounding bytes instead of by whether the tail parses as a prefix of the sentinel's grammar"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — function docstring + grammar-constant comments updated in the same commit
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — placeholder pending OSPO wording (per template).

