### PR TITLE
fix(dashboard): settle orphaned stop tasks

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -643,6 +643,12 @@ applier — a raised turn budget is in force on the next prompt.
    - `"timeout"` or `"error"` → fall through to hard kill.
 4. Hard kill: `reset(key)` → fire-and-forget `_eager_respawn(key)` task → call `on_hard` callback → return `"hard"`.
 
+Dashboard stop and interrupt handlers snapshot the runner task before calling
+`stop_turn()`. A terminal `"hard"` or `"idle"` result means the provider cannot
+drive that runner to its `finally` block, so the handler cancels and awaits only
+the captured task. A later turn is never touched; a task that does not settle
+within two seconds emits a warning for investigation.
+
 ### Cancelled-turn context restore
 
 `_Session.prev_turn_cancelled` is a one-shot flag set on soft-cancel

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -3727,6 +3727,22 @@ def _make_stop_resolver(
     return _resolve
 
 
+async def _cancel_terminal_stop_task(task_at_stop: asyncio.Task[Any] | None) -> None:
+    """Settle a captured runner once no provider can finish its turn."""
+    if task_at_stop is None or task_at_stop is asyncio.current_task() or task_at_stop.done():
+        return
+    task_at_stop.cancel()
+    try:
+        await asyncio.wait_for(asyncio.shield(task_at_stop), timeout=2.0)
+    except asyncio.CancelledError:
+        # A cancelled runner raises here too, but cancellation of this request
+        # must still abort its response and shutdown path.
+        if asyncio.current_task() is not None and asyncio.current_task().cancelling():
+            raise
+    except asyncio.TimeoutError:
+        logger.warning("Stopped turn task did not settle within 2 seconds; inspect the slot")
+
+
 def _slot_not_found() -> web.Response:
     """The one 404 every cancel-route refusal returns.
 
@@ -3876,6 +3892,11 @@ async def stop_slot_turn(
         # the mirrored chat_done. Nothing local to tear down.
         return {"ok": True}
 
+    # Capture the runner before stopping the provider. A provider that reports
+    # no active turn cannot drive this task's finally block, while a newer
+    # runner must never be cancelled by an older stop request.
+    task_at_stop = slot.task
+
     # Escalation path: a second stop press while a cooperative cancel is
     # already pending hard-kills. We escalate on ANY second press — not only
     # when the client computed force=true — because the client derives force
@@ -3929,6 +3950,7 @@ async def stop_slot_turn(
         # reports success and cancels nothing. The SEL record below stays on the
         # slot-derived key, which identifies the tab the operator pressed.
         await state.sessions.stop_turn(cancel_key, force=True, on_hard=_on_hard_force)
+        await _cancel_terminal_stop_task(task_at_stop)
         sel().log_tool_invocation(
             session_key=_history_key_for(name),
             agent=getattr(slot, "agent", "") or "kirocrew",
@@ -4016,9 +4038,12 @@ async def stop_slot_turn(
         on_soft=_on_soft,
         on_hard=_on_hard,
     )
+    if outcome in {"hard", "idle"}:
+        await _cancel_terminal_stop_task(task_at_stop)
     # Resolve orphaned card when provider reports no active turn
-    if outcome == "idle" and slot._stop_event_id:
-        _resolve_stop_event(slot, "soft")
+    if outcome == "idle":
+        if slot._stop_event_id:
+            _resolve_stop_event(slot, "soft")
         slot._stop_state = "idle"
         state.push_slots_update()
     sel().log_tool_invocation(
@@ -4379,6 +4404,7 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
         return web.json_response({"ok": True, "info": "stop already in progress"})
     if not slot._queue:
         return web.json_response({"error": "queue empty, use /stop instead"}, status=400)
+    task_at_stop = slot.task
 
     # Claim the stop slot synchronously BEFORE the await below: the
     # idempotency guard above is check-then-act, and a concurrent /interrupt
@@ -4495,11 +4521,24 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
         on_soft=_on_soft,
         on_hard=_on_hard,
     )
+    if outcome in {"hard", "idle"}:
+        await _cancel_terminal_stop_task(task_at_stop)
     # Resolve orphaned card when provider reports no active turn
-    if outcome == "idle" and slot._stop_event_id:
-        _resolve_stop_event(slot, "soft")
+    if outcome == "idle":
+        if slot._stop_event_id:
+            _resolve_stop_event(slot, "soft")
         slot._stop_state = "idle"
         state.push_slots_update()
+        # An "idle" outcome means the provider has no active turn, so there is
+        # no running runner whose finally-block dequeue will pick up the next
+        # queued message — but preserve_queue=True left it waiting, so it would
+        # be stranded. Dispatch it here. Only when no successor turn has already
+        # taken the slot (a newer slot.task): a successor owns the queue and
+        # re-dispatching would double-fire a turn against it. `task_at_stop` is
+        # the captured predecessor; cancelling it (above) does not reassign
+        # slot.task, so `slot.task is task_at_stop` is exactly "no successor."
+        if slot.task is task_at_stop:
+            await _start_next_queued_turn(state, slot)
     sel().log_tool_invocation(
         session_key=_history_key_for(name),
         agent=getattr(slot, "agent", "") or "kirocrew",

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -15645,6 +15645,168 @@ class TestStopTurnSlotState:
         slot.task.cancel()
 
     @pytest.mark.asyncio
+    async def test_stop_turn_idle_cancels_orphaned_task(self, tmp_path, monkeypatch):
+        """An idle provider outcome cannot leave a dashboard turn running."""
+        state = self._make_state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        slot.task = asyncio.ensure_future(asyncio.sleep(999))
+        state.sessions.stop_turn = AsyncMock(return_value="idle")
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post("/api/chat/slots/s1/stop")
+            assert response.status == 200
+
+        assert slot._stop_state == "idle"
+        assert slot.task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_stop_turn_idle_does_not_cancel_successor_task(self, tmp_path, monkeypatch):
+        """A stop settles its captured runner, never one claimed while it waited."""
+        state = self._make_state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        stopped_task = asyncio.ensure_future(asyncio.sleep(999))
+        slot.task = stopped_task
+        successor_task: asyncio.Task[None] | None = None
+
+        async def fake_stop_turn(*args, **kwargs):
+            nonlocal successor_task
+            successor_task = asyncio.ensure_future(asyncio.sleep(999))
+            slot.task = successor_task
+            return "idle"
+
+        state.sessions.stop_turn = fake_stop_turn
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post("/api/chat/slots/s1/stop")
+            assert response.status == 200
+
+        assert stopped_task.cancelled()
+        assert successor_task is not None
+        assert not successor_task.cancelled()
+        successor_task.cancel()
+        await asyncio.gather(successor_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_terminal_stop_task_propagates_request_cancellation(self):
+        """The stop request must not swallow its own cancellation while draining."""
+        from kiro_crew.dashboard.chat_handlers import _cancel_terminal_stop_task
+
+        release = asyncio.Event()
+
+        async def waits_after_cancel():
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                await release.wait()
+
+        runner = asyncio.create_task(waits_after_cancel())
+        await asyncio.sleep(0)
+        request_task = asyncio.current_task()
+        assert request_task is not None
+        asyncio.get_running_loop().call_soon(request_task.cancel)
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await _cancel_terminal_stop_task(runner)
+        finally:
+            release.set()
+            await runner
+
+    @pytest.mark.asyncio
+    async def test_interrupt_idle_runner_finally_starts_only_one_queued_turn(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancelled runner owns the preserved-queue handoff."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        state = self._make_state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        runner_started = asyncio.Event()
+        successor_release = asyncio.Event()
+        dispatched: list[str] = []
+
+        async def successor():
+            await successor_release.wait()
+
+        async def runner():
+            runner_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                queued = slot._queue.pop(0)
+                dispatched.append(queued["content"])
+                slot.task = asyncio.create_task(successor())
+
+        runner_task = asyncio.create_task(runner())
+        slot.task = runner_task
+        await runner_started.wait()
+        slot.queue_append("first queued prompt")
+        slot.queue_append("second queued prompt")
+        state.sessions.stop_turn = AsyncMock(return_value="idle")
+        handler_dispatch = AsyncMock(return_value=True)
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/interrupt", api_chat_slot_interrupt)
+        try:
+            with patch(
+                "kiro_crew.dashboard.chat_handlers._start_next_queued_turn", handler_dispatch
+            ):
+                async with TestClient(TestServer(app)) as client:
+                    response = await client.post("/api/chat/slots/s1/interrupt")
+                    assert response.status == 200
+
+            assert slot._stop_state == "idle"
+            assert runner_task.cancelled()
+            assert dispatched == ["first queued prompt"]
+            assert [queued["content"] for queued in slot._queue] == ["second queued prompt"]
+            handler_dispatch.assert_not_awaited()
+        finally:
+            successor_release.set()
+            await asyncio.gather(slot.task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_interrupt_idle_dispatches_queue_when_no_successor(self, tmp_path, monkeypatch):
+        """An idle provider outcome leaves no active runner to drive the
+        preserved-queue handoff, so a cancelled runner that never dispatches a
+        successor must not strand the queue — the handler dispatches it itself
+        (issue #9118)."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        state = self._make_state(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        # A real, cancellable runner that, unlike the test above, does NOT
+        # reassign slot.task in a finally — mirroring the idle _stage_loop whose
+        # queue handoff is skipped on cancellation.
+        runner_task = asyncio.ensure_future(asyncio.sleep(999))
+        slot.task = runner_task
+        slot.queue_append("first queued prompt")
+        state.sessions.stop_turn = AsyncMock(return_value="idle")
+        handler_dispatch = AsyncMock(return_value=True)
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/interrupt", api_chat_slot_interrupt)
+        try:
+            with patch(
+                "kiro_crew.dashboard.chat_handlers._start_next_queued_turn", handler_dispatch
+            ):
+                async with TestClient(TestServer(app)) as client:
+                    response = await client.post("/api/chat/slots/s1/interrupt")
+                    assert response.status == 200
+            assert slot._stop_state == "idle"
+            assert runner_task.cancelled()
+            # No successor took the slot (slot.task is still the cancelled
+            # runner), so the handler dispatches the preserved queue itself.
+            assert slot.task is runner_task
+            handler_dispatch.assert_awaited_once()
+        finally:
+            if not runner_task.done():
+                runner_task.cancel()
+            await asyncio.gather(runner_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
     async def test_stop_turn_force_query_param(self, tmp_path, monkeypatch):
         """POST stop?force=true when soft_pending → skips cancel, hard kill."""
         state = self._make_state(tmp_path, monkeypatch)


### PR DESCRIPTION
## Problem / Motivation

Dashboard Stop and Interrupt ask the provider to end the turn, then treat a terminal outcome — the provider reporting no active turn, a hard kill, or a second press — as the end of the lifecycle. The slot's runner task can still be live at that point, and nothing settles it, so the turn stays open after the user asked for it to end.

## Why it matters

Users see a turn remain stuck after requesting stop. Because the runner never unwinds, the teardown it owns — including the handoff of a preserved queued message — never runs, so an interrupt can report success while the queued message sits undelivered.

## What changed (motivation → approach → change)

Stop and interrupt capture the slot runner before asking the provider to stop. The fallback fires on a terminal outcome with a live task reference — `_cancel_terminal_stop_task` returns early when the captured reference is absent or already finished — and cancels that captured task, never a successor that took ownership while the stop was in flight, waiting up to two seconds for it to settle.

Cancelling the runner trips the `not _cancelled` gate in `chat_orchestrator`, which skips the queue handoff in the runner's `finally`, and that same exit clears `slot.task`. The idle interrupt path therefore dispatches the preserved queue itself, guarded on no successor holding the slot (a cleared `slot.task` or the captured task still in place), so a successor turn is never dispatched twice.

The force/second-press path follows the same captured-runner settlement, and every idle terminal outcome releases stop state and refreshes the slot view whether or not a stop card is open.

## Tests

- Added stop-lifecycle coverage for an idle slot with an orphaned task, for the successor-owns-the-slot guard, and for the idle queue dispatch when no successor took the slot.
- `python -m pytest -q test/test_dashboard_chat.py -k 'stop or task'` — 53 passed.
- `python -m pytest -q test/test_dashboard_chat.py` — 794 passed.

## Manual verification

N/A — the task ownership and cancellation transitions are covered at the dashboard lifecycle boundary.

## Related Issues

N/A

## Pattern harvest

Rule candidate: review-prompt
Pattern: a stop path that cancels a runner inherits every handoff that runner's teardown owned.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — no CLA wording has been supplied by the project.
