### PR TITLE
fix: detect managed venvs through interpreter directory

### DIFF
--- a/src/kiro_crew/platform/wheel_engine.py
+++ b/src/kiro_crew/platform/wheel_engine.py
@@ -235,12 +235,16 @@ def running_from_managed_venv(layout: ManagedVenvLayout | None = None) -> bool:
     something else, and building a sibling tree beside a data home they do not
     use would be litter at best. POSIX-only by construction: cli.sh is a POSIX
     installer, so on Windows there is no managed venv to detect.
+
+    Identity comes from the interpreter's ``bin/`` directory, not the file:
+    ``python -m venv`` symlinks ``bin/python3`` to the base interpreter, so
+    resolving that file leaves the venv before the layout can recognize it.
     """
     if not IS_POSIX:
         return False
     if layout is None:
         layout = managed_venv_layout()
-    return layout.is_managed_tree(Path(sys.executable))
+    return layout.is_managed_tree(Path(sys.executable).parent)
 
 
 def _legacy_nested_venv() -> Path:

--- a/test/test_wheel_engine.py
+++ b/test/test_wheel_engine.py
@@ -576,24 +576,30 @@ class TestLayoutAndDetection:
 
         assert layout.legacy == Path(f"{str(data_home()).rstrip('/')}-venv")
 
-    def test_running_from_legacy_tree_detected(
+    def test_running_from_legacy_tree_detects_symlinked_interpreter(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         legacy = tmp_path / "crew-venv"
         (legacy / "bin").mkdir(parents=True)
+        base_python = tmp_path / "base-python" / "python3"
+        base_python.parent.mkdir()
+        base_python.write_text("")
         exe = legacy / "bin" / "python3"
-        exe.write_text("")
+        exe.symlink_to(base_python)
         layout = ManagedVenvLayout(legacy=legacy, stable_link=tmp_path / "crew-venv-current")
         monkeypatch.setattr(sys, "executable", str(exe))
         assert running_from_managed_venv(layout) is True
 
-    def test_running_from_versioned_tree_detected(
+    def test_running_from_versioned_tree_detects_symlinked_interpreter(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         tree = tmp_path / "crew-venv-1.2.3"
         (tree / "bin").mkdir(parents=True)
+        base_python = tmp_path / "base-python" / "python3"
+        base_python.parent.mkdir()
+        base_python.write_text("")
         exe = tree / "bin" / "python3"
-        exe.write_text("")
+        exe.symlink_to(base_python)
         # Every real versioned install carries the console script; the
         # positive-identification rule keys on it.
         (tree / "bin" / "kirocrew").write_text("")


### PR DESCRIPTION
## Problem / Motivation

`cli.sh` managed-venv installs are misclassified as non-managed because `running_from_managed_venv()` asks `is_managed_tree()` about `sys.executable`. A standard `python -m venv` makes `bin/python3` a symlink to the base interpreter, so resolving that file leaves the venv and the predicate returns `False`.

The dashboard consequently exposes only the installer-copy/notify fallback, while the shadow-update and in-app arm paths remain disabled for genuine managed installs.

## Why it matters

Every normal POSIX managed-venv install created without `--copies` misses the safer versioned-tree update path. Users must re-run the installer manually even though the install shape supports atomic shadow updates.

## What changed (motivation → approach → change)

- Resolve managed-install identity from the interpreter's containing `bin/` directory instead of the symlinked interpreter file.
- Keep `ManagedVenvLayout.is_managed_tree()` unchanged, preserving its existing legacy-root and positively identified versioned-tree checks.
- Make both legacy-tree and versioned-tree tests use realistic interpreter symlinks to an external base Python.

## Tests

- `196 passed`: complete wheel-engine, dashboard update-step-up, and CLI update coverage.
- Mutation proof: reverting the production hunk makes the symlinked-interpreter assertions fail; the two patch files remained byte-identical after rebasing.
- Black, isort, flake8, mypy, backend static/rule/doc/vendor/scrub/CloudFormation gates: passed.
- Frontend build, TypeScript, ESLint, i18n, cross-surface Vitest, duplication, Electron, and bundle-size gates: passed.
- Full backend run reached 89,847 passed with 30 host/base failures; representative failures from every cluster reproduced on clean `main` under the same host environment.

## Manual verification

N/A — the regression is the POSIX venv symlink layout itself, modeled directly in unit tests and mutation-proven. The existing install guide already documents the intended managed-venv shadow-update behavior.

## Related Issues

Fixes #8938

## Pattern harvest

Rule candidate: review-prompt
Pattern: Resolve virtual-environment identity from the interpreter directory, never from a symlinked interpreter file.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
