### PR TITLE
fix(electron): harden the launcher PATH for shell.openPath (#9094)

### DIFF
--- a/website/electron/mochi/index.js
+++ b/website/electron/mochi/index.js
@@ -1092,6 +1092,7 @@ function startMochiWatcher() {
     const fs = require("fs");
     const path = require("path");
     const { shell } = require("electron");
+    const { openPathHardened } = require("../open-path");
     const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"]);
     try {
       // realpath BEFORE the extension test: a `.png` symlink to a key file must
@@ -1100,7 +1101,7 @@ function startMochiWatcher() {
       if (!IMAGE_EXTS.has(path.extname(real).toLowerCase())) return false;
       if (!fs.statSync(real).isFile()) return false;
       // Non-empty return value means the OS refused to open it.
-      const err = await shell.openPath(real);
+      const err = await openPathHardened(shell, real);
       return err === "";
     } catch (err) {
       glog(`Mochi open-image refused: ${err && err.message}`);

--- a/website/electron/open-path.js
+++ b/website/electron/open-path.js
@@ -1,0 +1,158 @@
+"use strict";
+
+// Harden the launcher search path for `shell.openPath` in the main process.
+//
+// THE PROBLEM (LINUX ONLY). On Linux `shell.openPath` delegates to `xdg-open`,
+// which Electron launches by the BARE NAME "xdg-open" (Chromium
+// platform_util_linux.cc: `XDGUtil({"xdg-open", path}, ...)` ->
+// `base::LaunchProcess`, SYNCHRONOUSLY inside the call). A bare name is resolved
+// with `execvp` against the child's PATH, and that child inherits the Electron
+// main process's live `process.env.PATH` -- Electron sets only `MM_NOTTTY` on
+// the launch, it does not scrub PATH. So a directory that sorts ahead of
+// `/usr/bin` on the app's own PATH, if it is writable by the user or an agent,
+// decides which `xdg-open` (or `gio`) actually runs. Every main process
+// `shell.openPath` call site shares this, so it is a property of the primitive,
+// not of any one handler (issue #9094).
+//
+// WHY ONLY LINUX. This is deliberately a no-op on macOS and Windows, because
+// neither resolves a launcher through PATH, so there is nothing there to
+// hijack and nothing for a narrowed PATH to protect:
+//   - macOS  platform_util_mac.mm  OpenPath -> `[NSWorkspace openURL:]`, which
+//     resolves the handler through LaunchServices, not PATH.
+//   - Windows platform_util_win.cc OpenPath -> `ShellExecute`/`OpenFileViaShell`
+//     on a COM STA worker thread, which resolves the handler through the
+//     registry file-type association, not PATH.
+// Narrowing PATH on those platforms would run code that protects nothing and,
+// worse, would READ as protection to a later maintainer. So this hardens the
+// one platform where the threat is real and says so, rather than shipping an
+// inert branch on the other two.
+//
+// A VERSION-FLUID DEPENDENCY, STATED PLAINLY. The mitigation is airtight only
+// while Linux `OpenPath` forks SYNCHRONOUSLY inside the `shell.openPath()` call
+// (verified against Electron 43, the pinned major -- see ELECTRON_MAJOR_VERIFIED
+// below and its guard test). macOS and Windows `OpenPath` ALREADY post the
+// native open to a worker (a dispatch queue; a COM STA task runner), which
+// proves this timing is an implementation detail that varies by platform and
+// can therefore vary by version. If a future Electron moved the Linux launch
+// onto a worker the same way, the `execvp` would run AFTER the `finally` restore
+// and this mitigation would silently revert to pre-fix behaviour -- the worst
+// failure shape, because a fake-`shell` unit test cannot observe real fork
+// timing and would stay green. `shell.openPath` takes no launcher or env
+// argument, so there is no construction here that resolves `xdg-open` to an
+// absolute path up front and removes the timing dependency WITHOUT introducing
+// a `child_process` spawn (a `detect-child-process` SAST sink the repo does not
+// have, and the exact remedy #9094 rejected). The dependency is therefore
+// intrinsic to using `shell.openPath` at all. It is not left implicit: it is
+// pinned to a documented Electron major by `ELECTRON_MAJOR_VERIFIED`, whose
+// guard test in test/open-path.test.js goes RED when the pin in package.json
+// moves past it, forcing a human to re-verify the Linux fork is still
+// synchronous before the bump ships. That converts a silent revert into a
+// visible CI failure, which is the point.
+//
+// WHY NOT NARROW THE WHOLE PROCESS PATH. The app legitimately shells out to
+// tooling the user expects from their own PATH: the bundled Gateway is spawned
+// with `process.env.PATH` as its base (gateway-supervisor.js), and every agent
+// shell tool, MCP server, and ACP runtime the Gateway starts inherits that.
+// mac-env.js exists precisely to RECOVER the user's PATH there (issue #2367),
+// and windows-port.js resolves the Gateway binary through it. Sanitising the
+// process's own PATH at startup would fix the launcher by re-breaking #2367.
+// What the LAUNCHER needs on PATH is not what the PROCESS needs; only the
+// launcher's brief window is narrowed.
+//
+// OBSERVABLE BEHAVIOUR CHANGE (LINUX). While the narrowed PATH is in effect,
+// `xdg-open` and its descendant chain resolve bare command names only against
+// the system directories. A user who relies on a launcher or helper installed
+// under a personal directory like `~/.local/bin` and resolved BY BARE NAME will
+// find that open fall back to the system handler instead. That is the defence
+// working as intended -- a bare-name lookup through a writable directory is the
+// exact hijack surface -- but it is a change from prior behaviour, noted here so
+// it is not mistaken for a regression.
+
+// A narrowed, non-user-writable launcher PATH for Linux. Mirrors auto-update.js
+// `managedPath()` and its stated reason: "an agent-writable entry on the user's
+// own PATH cannot shadow a command." These are the canonical system binary
+// directories where `xdg-open` / `gio` live, so a bare launcher name still
+// resolves while a user- or agent-writable directory earlier on the real PATH
+// cannot participate.
+const LINUX_LAUNCHER_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+// The Electron MAJOR whose Linux `OpenPath` was verified to fork synchronously
+// inside the `shell.openPath()` call (platform_util_linux.cc). Keep this equal
+// to the major pinned in package.json's `electron` dependency. The guard test
+// in test/open-path.test.js fails when package.json moves past this, which is
+// the signal to re-verify the Linux launch is still synchronous and then bump
+// this constant in the same change.
+const ELECTRON_MAJOR_VERIFIED = 43;
+
+/**
+ * The hardened launcher PATH for a platform, or `null` when the platform needs
+ * no hardening (macOS, Windows -- their `OpenPath` resolves the handler through
+ * LaunchServices / the registry, not PATH). `null` means "leave PATH untouched".
+ *
+ * @param {string} [platform] - `process.platform` (injectable for tests)
+ * @returns {string|null}
+ */
+function hardenedLauncherPath(platform = process.platform) {
+  return platform === "linux" ? LINUX_LAUNCHER_PATH : null;
+}
+
+/**
+ * Hand a filesystem path to the OS opener, hardening the launcher PATH on Linux.
+ *
+ * A drop-in wrapper for `shell.openPath(filePath)`: same argument, same
+ * `Promise<string>` return (empty string on success, an error message
+ * otherwise). On Linux it narrows `process.env.PATH` to {@link LINUX_LAUNCHER_PATH}
+ * across the synchronous native launch so the bare launcher name (`xdg-open`)
+ * cannot resolve to a user- or agent-writable binary ahead of the system
+ * directories, then restores PATH. On macOS and Windows it is a pass-through:
+ * those platforms resolve the handler without PATH, so it calls
+ * `shell.openPath` unchanged and touches nothing.
+ *
+ * The caller is still responsible for validating `filePath` before calling
+ * (realpath, extension allowlist, regular-file check) -- this wrapper hardens
+ * only WHICH launcher runs, not WHAT it is asked to open.
+ *
+ * @param {{openPath: (p: string) => Promise<string>}} shell - Electron `shell`
+ * @param {string} filePath - The path to open (already validated by the caller)
+ * @param {object} [deps]
+ * @param {string} [deps.platform] - `process.platform` (injectable for tests)
+ * @param {NodeJS.ProcessEnv} [deps.env] - the env object to mutate/restore
+ *   (defaults to `process.env`; injectable for tests)
+ * @returns {Promise<string>} the promise `shell.openPath` returned
+ */
+function openPathHardened(shell, filePath, { platform = process.platform, env = process.env } = {}) {
+  const narrowed = hardenedLauncherPath(platform);
+  // macOS / Windows: no PATH-based launcher, so hardening protects nothing.
+  // Pass straight through and leave the environment untouched.
+  if (narrowed === null) {
+    return shell.openPath(filePath);
+  }
+
+  // Capture presence, not just value: restoring must be able to DELETE the key
+  // again if it was unset, not resurrect it as an empty string (an empty PATH
+  // entry is the cwd, which is exactly the kind of shadowing this guards).
+  const had = Object.prototype.hasOwnProperty.call(env, "PATH");
+  const previous = env.PATH;
+  env.PATH = narrowed;
+  try {
+    // Synchronous on Linux: the native fork+execvp that reads PATH happens
+    // inside this call, before the returned promise. Do NOT await here --
+    // awaiting would yield the main thread with PATH still narrowed, which is
+    // the one thing that could let another spawn observe it. (See the
+    // version-fluid dependency note at the top of the file.)
+    return shell.openPath(filePath);
+  } finally {
+    if (had) {
+      env.PATH = previous;
+    } else {
+      delete env.PATH;
+    }
+  }
+}
+
+module.exports = {
+  LINUX_LAUNCHER_PATH,
+  ELECTRON_MAJOR_VERIFIED,
+  hardenedLauncherPath,
+  openPathHardened,
+};

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -180,6 +180,7 @@
       "pyspy-dump.js",
       "perf-metrics.js",
       "host-config.js",
+      "open-path.js",
       "store-rename.js",
       "remote-token.js",
       "token-acquire.js",

--- a/website/electron/test/open-path.test.js
+++ b/website/electron/test/open-path.test.js
@@ -1,0 +1,170 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  LINUX_LAUNCHER_PATH,
+  ELECTRON_MAJOR_VERIFIED,
+  hardenedLauncherPath,
+  openPathHardened,
+} = require("../open-path");
+
+// A user PATH with an agent-writable directory sorted AHEAD of the system
+// binaries -- the exact shadowing shape this module exists to defeat on Linux.
+// If `xdg-open` resolved through this, `/home/u/.local/evil/xdg-open` would win.
+const HOSTILE_PATH = "/home/u/.local/evil:/usr/bin:/bin";
+
+describe("hardenedLauncherPath", () => {
+  it("is the canonical system bin dirs on Linux", () => {
+    assert.equal(hardenedLauncherPath("linux"), "/usr/bin:/bin:/usr/sbin:/sbin");
+    assert.equal(hardenedLauncherPath("linux"), LINUX_LAUNCHER_PATH);
+  });
+
+  it("contains no user- or agent-writable directory on Linux", () => {
+    // Every entry is a root-owned system directory, so a writable entry on the
+    // real PATH cannot participate in resolution.
+    for (const entry of hardenedLauncherPath("linux").split(":")) {
+      assert.match(entry, /^\/(usr\/)?s?bin$/);
+    }
+  });
+
+  it("is null (no hardening) on macOS and Windows", () => {
+    // Those platforms resolve the opener through LaunchServices / the registry,
+    // not PATH, so there is nothing to harden -- narrowing would be inert code
+    // that reads as protection. null means "leave PATH untouched".
+    assert.equal(hardenedLauncherPath("darwin"), null);
+    assert.equal(hardenedLauncherPath("win32"), null);
+  });
+});
+
+describe("openPathHardened (Linux: hardening active)", () => {
+  // A fake shell whose openPath records the PATH VISIBLE AT CALL TIME -- this is
+  // what the native fork+execvp would resolve `xdg-open` through.
+  const recordingShell = (result = "", seen = {}) => ({
+    openPath: (p) => {
+      seen.pathAtCall = seen.env.PATH;
+      seen.arg = p;
+      return Promise.resolve(result);
+    },
+  });
+
+  it("narrows PATH to the Linux launcher path AT THE MOMENT of the call", async () => {
+    const env = { PATH: HOSTILE_PATH };
+    const seen = { env };
+    await openPathHardened(recordingShell("", seen), "/tmp/x.png", {
+      platform: "linux",
+      env,
+    });
+    assert.equal(seen.pathAtCall, "/usr/bin:/bin:/usr/sbin:/sbin");
+    assert.doesNotMatch(seen.pathAtCall, /evil/);
+  });
+
+  it("restores the caller's PATH verbatim after the call", async () => {
+    const env = { PATH: HOSTILE_PATH };
+    const seen = { env };
+    await openPathHardened(recordingShell("", seen), "/tmp/x.png", {
+      platform: "linux",
+      env,
+    });
+    // The Gateway spawn and agent tooling read this AFTER the launch -- it must
+    // be exactly what it was, hostile entry included (#2367 wants it preserved).
+    assert.equal(env.PATH, HOSTILE_PATH);
+  });
+
+  it("restores PATH even when openPath throws synchronously", () => {
+    const env = { PATH: HOSTILE_PATH };
+    const throwingShell = {
+      openPath: () => {
+        throw new Error("boom");
+      },
+    };
+    assert.throws(
+      () => openPathHardened(throwingShell, "/tmp/x.png", { platform: "linux", env }),
+      /boom/,
+    );
+    assert.equal(env.PATH, HOSTILE_PATH);
+  });
+
+  it("restores PATH to UNSET when it started unset (never resurrects it as empty)", async () => {
+    // An empty PATH string is a cwd entry -- resurrecting the key as "" would be
+    // its own shadowing bug, so an absent key must stay absent.
+    const env = {};
+    const seen = { env };
+    await openPathHardened(recordingShell("", seen), "/tmp/x.png", {
+      platform: "linux",
+      env,
+    });
+    assert.equal(seen.pathAtCall, "/usr/bin:/bin:/usr/sbin:/sbin");
+    assert.equal(Object.prototype.hasOwnProperty.call(env, "PATH"), false);
+  });
+
+  it("passes the caller's path through unchanged and returns openPath's promise", async () => {
+    const env = { PATH: HOSTILE_PATH };
+    const seen = { env };
+    const err = await openPathHardened(recordingShell("no app", seen), "/tmp/photo.jpg", {
+      platform: "linux",
+      env,
+    });
+    assert.equal(seen.arg, "/tmp/photo.jpg");
+    assert.equal(err, "no app");
+  });
+});
+
+describe("openPathHardened (macOS / Windows: pass-through, no hardening)", () => {
+  const recordingShell = (result = "", seen = {}) => ({
+    openPath: (p) => {
+      seen.pathAtCall = seen.env.PATH;
+      seen.arg = p;
+      return Promise.resolve(result);
+    },
+  });
+
+  for (const platform of ["darwin", "win32"]) {
+    it(`leaves PATH untouched and still opens the path on ${platform}`, async () => {
+      const env = { PATH: HOSTILE_PATH };
+      const seen = { env };
+      const err = await openPathHardened(recordingShell("", seen), "/tmp/x.txt", {
+        platform,
+        env,
+      });
+      // No narrowing: the call sees the real PATH, and it is unchanged after.
+      // (These platforms resolve the opener without PATH, so nothing is exposed
+      // by leaving it alone -- and the launch runs on a worker anyway, so a
+      // narrow/restore around the sync call could not span it even if we tried.)
+      assert.equal(seen.pathAtCall, HOSTILE_PATH);
+      assert.equal(env.PATH, HOSTILE_PATH);
+      assert.equal(seen.arg, "/tmp/x.txt");
+      assert.equal(err, "");
+    });
+  }
+});
+
+describe("Electron-version guard for the synchronous-fork assumption", () => {
+  // The Linux mitigation is airtight only while Electron's Linux OpenPath forks
+  // synchronously inside the shell.openPath() call. That was verified against
+  // the pinned major. This test goes RED when package.json's electron pin moves
+  // past ELECTRON_MAJOR_VERIFIED, forcing a human to re-verify the Linux launch
+  // is still synchronous (platform_util_linux.cc) and bump the constant in the
+  // same change -- turning a silent revert into a visible CI failure.
+  it("ELECTRON_MAJOR_VERIFIED matches the electron major pinned in package.json", () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8"),
+    );
+    const spec =
+      (pkg.devDependencies && pkg.devDependencies.electron) ||
+      (pkg.dependencies && pkg.dependencies.electron) ||
+      "";
+    const major = Number(spec.replace(/^[^\d]*/, "").split(".")[0]);
+    assert.ok(Number.isInteger(major), `could not parse electron major from "${spec}"`);
+    assert.equal(
+      major,
+      ELECTRON_MAJOR_VERIFIED,
+      `package.json pins electron ${major} but the synchronous-fork assumption ` +
+        `was verified against ${ELECTRON_MAJOR_VERIFIED}. Re-verify Linux OpenPath ` +
+        `still forks synchronously in platform_util_linux.cc, then update ` +
+        `ELECTRON_MAJOR_VERIFIED in open-path.js.`,
+    );
+  });
+});

--- a/website/electron/window-lifecycle.js
+++ b/website/electron/window-lifecycle.js
@@ -32,6 +32,7 @@ const { createAgentCommandChannel } = require("./browser-agent-channel");
 const { attachContextMenu } = require("./context-menu");
 const { validateRemoteSettings } = require("./validation");
 const { getRemoteHostConfig, setRemoteHostConfig } = require("./host-config");
+const { openPathHardened } = require("./open-path");
 const { DEFAULT_REMOTE_BIN, DEFAULT_REMOTE_PATH } = require("./remote-token");
 const { identityFamily } = require("./instance-guard");
 const { decideLinuxFrame, applyWindowControl } = require("./linux-frame");
@@ -1100,7 +1101,7 @@ function createWindowLifecycle(options) {
       { type: "separator" },
       { label: "New Connection Window…", click: () => openNewConnectionWindow() },
       { type: "separator" },
-      { label: "Open Config File", click: () => shell.openPath(store.path) },
+      { label: "Open Config File", click: () => openPathHardened(shell, store.path) },
       { type: "separator" },
       { label: "Quit", click: requestQuit },
     ]));
@@ -1656,7 +1657,7 @@ function createWindowLifecycle(options) {
       renameCurrentWindow: () => renameCurrentWindow(),
       promptRemoteHost: () => promptRemoteHost(),
       refreshToken: () => refreshToken(),
-      openConfigFile: () => shell.openPath(store.path),
+      openConfigFile: () => openPathHardened(shell, store.path),
     }));
     Menu.setApplicationMenu(appMenu);
     return appMenu;


### PR DESCRIPTION
## What is the problem?

On Linux, `shell.openPath` delegates to `xdg-open`, which Electron launches by
the BARE NAME `"xdg-open"` (Chromium `platform_util_linux.cc`:
`XDGUtil({"xdg-open", path}, ...)` -> `base::LaunchProcess`). A bare name is
resolved by `execvp` against the child's `PATH`, and that child inherits the
Electron main process's live `process.env.PATH` -- Electron sets only
`MM_NOTTTY` on the launch, it does not scrub `PATH`. So a directory that sorts
ahead of `/usr/bin` on the app's own `PATH`, if it is writable by the user or an
agent, decides which `xdg-open` (or `gio`) actually runs.

Every main process `shell.openPath` call site shares this, so it is a property
of the primitive rather than of any one handler. On `main` there are three:
`mochi/index.js` (`mochi-pet:open-image`) and the two "Open Config File" menu
entries in `window-lifecycle.js`. GPT flagged the concern while reviewing #9007,
which deliberately deferred the repo-wide fix here (#9094).

## Why this matters to the user

`shell.openPath` hands a path to the OS opener on the user's own machine. If the
launcher itself is hijacked, opening a perfectly innocent image or the config
file runs an attacker-chosen binary with the user's privileges -- the file being
opened is fine; the tool that opens it is the exposure. This is the launcher
half of the same agent-writable-`PATH` class tracked on the approval side in
#4438.

## How the fix solves it

Symptom -> root cause: an innocuous open can run a hijacked launcher (symptom)
because `shell.openPath` resolves a bare launcher name through the main
process's full inherited `PATH`, which may lead with a writable directory (root
cause). The fix removes the writable directory from the search the launcher name
resolves through, and only there.

- New `website/electron/open-path.js` exports `openPathHardened(shell, path)`, a
  drop-in wrapper for `shell.openPath` with the identical `Promise<string>`
  contract. **On Linux** it narrows `process.env.PATH` to a fixed,
  non-user-writable launcher path (`/usr/bin:/bin:/usr/sbin:/sbin`) for the
  duration of the synchronous native launch, then restores it. The narrow path
  and its rationale are lifted verbatim from `auto-update.js`'s existing
  `managedPath()`: "an agent-writable entry on the user's own PATH cannot shadow
  a command." `xdg-open` / `gio` live in those system directories, so the
  launcher still resolves.
- **On macOS and Windows the wrapper is an explicit pass-through -- it hardens
  nothing, by design.** Those platforms do not resolve the opener through PATH:
  macOS `OpenPath` uses LaunchServices (`[NSWorkspace openURL:]`) and Windows
  uses the registry file-type association (`ShellExecute` on a COM STA worker),
  so there is no bare launcher name to hijack. Narrowing PATH there would run
  code that protects nothing and, worse, reads as protection to a later
  maintainer -- so the branch is a no-op and the module comment says so.
- The three call sites route through it (`mochi-pet:open-image`, the two "Open
  Config File" menu entries). Validation at each site (realpath, extension
  allowlist, regular-file check) is unchanged -- this hardens WHICH launcher
  runs, not WHAT it opens.
- Added to the `package.json` `build.files` packaging allowlist, enforced by
  `test/shell-contract.test.js` (a required-but-unlisted module ships fine from
  source and is silently absent from the packaged DMG).

Two directions were rejected on evidence, not taste:

- **Not** sanitising the whole process `PATH` at startup. The bundled Gateway is
  spawned with `process.env.PATH` as its base (`gateway-supervisor.js`), and
  every agent shell tool, MCP server, and ACP runtime the Gateway starts
  inherits it. `mac-env.js` exists precisely to RECOVER the user's `PATH` there
  (#2367), and `windows-port.js` resolves the Gateway binary through it.
  Narrowing the process `PATH` would fix the launcher by re-breaking #2367. What
  the LAUNCHER needs on `PATH` is not what the process needs; only the launcher
  is narrowed.
- **Not** spawning `xdg-open` ourselves under a constructed `PATH`. That would
  add a `detect-child-process` SAST sink the repo does not have today. This
  keeps `shell.openPath` and hardens only the one value it resolves through.

A version-fluid dependency, stated plainly (not papered over): the Linux
mitigation is airtight ONLY while Electron's Linux `OpenPath` forks
SYNCHRONOUSLY inside the `shell.openPath()` call -- verified against Electron 43,
the pinned major, in `platform_util_linux.cc`. macOS and Windows `OpenPath`
ALREADY post the open to a worker, which proves this timing is an implementation
detail that varies by platform and can vary by version. If a future Electron
moved the Linux launch onto a worker the same way, the `execvp` would run AFTER
the `finally` restore and the mitigation would silently revert to pre-fix
behaviour, while a fake-`shell` unit test stayed green -- the worst failure
shape. `shell.openPath` takes no launcher or env argument, so there is no
construction here that resolves `xdg-open` to an absolute path up front and
removes the timing dependency WITHOUT the rejected spawn sink; the dependency is
intrinsic to using `shell.openPath` at all. So it is made non-silent instead:
the assumption is pinned to `ELECTRON_MAJOR_VERIFIED` in the module, and a guard
test fails when `package.json`'s electron pin moves past it -- forcing a human
to re-verify the Linux launch is still synchronous before the bump ships, which
turns a silent revert into a red CI lane. The dependency is documented at the
two places a bump passes through: the module comment and the version-pinned
guard test keyed to `package.json`.

Why the save/restore has no race on Linux: Node's main thread is single-threaded
and the wrapper performs no `await` between narrowing `PATH` and the synchronous
`shell.openPath(...)` call, restoring synchronously in a `finally` before the
returned promise. The `fork`+`execvp` that reads `PATH` happens inside that
synchronous call. No other JavaScript -- and therefore no other
`spawn`/`execFile` -- runs in that window, so the Gateway spawn and the agent
tooling never observe the narrowed value. The wrapper also restores an absent
`PATH` to absent rather than resurrecting it as an empty string, since an empty
`PATH` entry is the cwd -- the same shadowing shape this guards against.

Observable behaviour change (Linux), documented not widened: while the narrowed
PATH is in effect, `xdg-open` and its descendant chain resolve bare command
names only against the system directories. A user who relies on a launcher or
helper installed under a personal directory such as `~/.local/bin` and resolved
BY BARE NAME will see that open fall back to the system handler instead. That is
the defence working as intended -- a bare-name lookup through a writable
directory is the exact hijack surface -- but it is a change from prior
behaviour, called out here and in the module comment so it is not mistaken for a
regression. The narrowing is deliberately NOT widened to re-admit `~/.local/bin`,
because doing so would re-open the surface the fix closes.

Security-guidance note: the org security-guidance search tool was unavailable
in this session. The query I would have run: "handing a bare launcher name to a
host OS open primitive that resolves it against an inherited, possibly
user-writable PATH -- narrowing the launcher search path to system-only
directories without altering the environment inherited by other child
processes." I did not treat its absence as clearance; the design follows the
in-repo `managedPath()` precedent.

## What tests we did

- `node --test website/electron/test/open-path.test.js` (11 tests, all pass):
  `hardenedLauncherPath` is the canonical system dirs on Linux with no
  user-writable entry, and returns `null` (no hardening) on macOS and Windows.
  On Linux `openPathHardened` narrows `PATH` to the hardened value AT THE MOMENT
  of the call (a recording fake `shell` asserts the value `execvp` would see),
  restores the caller's `PATH` verbatim afterwards, restores even when
  `openPath` throws, restores an unset `PATH` to unset (never empty), passes the
  path through unchanged, and returns `openPath`'s promise. On macOS and Windows
  it leaves `PATH` untouched and still opens the path (pass-through).
- A version guard test asserts `ELECTRON_MAJOR_VERIFIED` equals the electron
  major pinned in `package.json`, so a bump past the verified major reddens CI
  and forces re-verification of the synchronous-fork assumption.
- Three mutations, each reddens tests: (1) drop the Linux narrowing
  (`hardenedLauncherPath` returns `null` for linux) -> 4 hardening assertions
  fail; (2) drop the `finally` restore -> the restore assertions fail; (3) bump
  `ELECTRON_MAJOR_VERIFIED` past the pin -> the version guard fails.
- `node --test test/shell-contract.test.js test/window-lifecycle.test.js`
  (31 tests) pass, including the packaging-allowlist drift guard that initially
  caught the unlisted module. `node --check` clean on all three touched JS
  files.
- Not run: eslint (no `node_modules` in the fresh worktree; the registry is
  unauthenticated here). One pre-existing failure in `mochi/test/petOverlays.test.js`
  ("Cannot find module 'electron'") reproduces on clean `origin/main` with this
  change stashed -- it is the missing `electron` dep in the checkout, unrelated
  to `openPath`.

## Any other suggestions on the work

- Scope, stated honestly: this hardens `shell.openPath` and its three consumers,
  which is complete for that primitive. The SAME root cause -- a bare launcher
  resolved through the inherited PATH on Linux -- also reaches the OS through
  `shell.openExternal` (about 9 sites) and `shell.showItemInFolder` (about 4
  sites), which this PR does NOT touch. Those surfaces remain; `openPathHardened`
  is the shared helper a follow-up can extend to them. #9007 already deferred the
  repo-wide helper to this issue, and when it lands its `ipc-registrar.js`
  `dashboard:open-file` channel (not on `main` yet) is a fourth `openPath` site
  that should route through this helper in the same one-line shape.
- Platform reality, corrected: this does NOT harden all call sites uniformly
  across platforms. The mitigation is Linux-only, because only Linux `OpenPath`
  resolves a launcher through PATH; on macOS and Windows the wrapper is an
  explicit pass-through that protects nothing (there is nothing to protect), and
  the module comment says so, so a later reader does not trust protection that
  is not there.

## Pattern harvest

Rule candidate: When a fix hardens security by narrowing an environment value
or a value space, restrict the space the RISK actually flows through, not a
larger space that merely contains it. Here the launcher name resolves through
`PATH`, but so does every other child the process spawns -- the bundled Gateway
and the agent tooling it starts inherit `process.env.PATH` on purpose (#2367).
Narrowing the process-wide `PATH` would have hardened the launcher by breaking
that inheritance, turning a safe-looking hardening into a regression. What the
LAUNCHER needs on `PATH` is not what the PROCESS needs; the fix narrows only the
value the launcher reads, only while it reads it. The general shape: before
narrowing X to fix a consumer of X, enumerate the OTHER consumers of X and
confirm the narrowing is invisible to them -- if it is not, narrow a scope that
only the at-risk consumer sees.

Not generalizable: the specific narrow-PATH string (`/usr/bin:/bin:/usr/sbin:/sbin`)
and the choice to restore an absent `PATH` to absent rather than empty are
launcher- and POSIX-specific mechanics, not a reusable rule.

Refs #9094



