### PR TITLE
feat(app-sdk): MessageRenderContext carries an optional session-open seam (plumbing for #8254)

### DIFF
--- a/website/src/app-sdk/ChatMessageList.tsx
+++ b/website/src/app-sdk/ChatMessageList.tsx
@@ -50,6 +50,14 @@ export interface ChatMessageListProps {
    *  (#5400, #5434). */
   canTrust?: boolean
   onFileOpen?: (path: string, opts?: { line?: number; endLine?: number }) => void
+  /** Host-supplied session switch for a `/chat?sid=<slot-key>` link in any row
+   *  this list draws. A prop rather than a store read so the component stays
+   *  dependency-free for the embed SDK (#3299); the dashboard host passes its
+   *  `selectSessionTab` + roster, and a host that omits these gets today's
+   *  behaviour — the link opens a new browser tab. */
+  onSessionOpen?: (key: string) => void
+  sessions?: ReadonlyMap<string, string>
+  activeSession?: string
   /** Optional host-injected renderer for tool messages (role 'tool'/'tool_call'/
    *  'tool_result'). Lets a Redux-connected host (e.g. the dashboard's split-view
    *  ChatPane) render the full slot-aware ToolCallLine while this component stays
@@ -81,6 +89,9 @@ const ChatMessageList = memo(function ChatMessageList({
   onApproveBatch,
   canTrust,
   onFileOpen,
+  onSessionOpen,
+  sessions,
+  activeSession,
   renderTool,
   hideCardOwnedOAuth = false,
   renderers,
@@ -186,6 +197,9 @@ const ChatMessageList = memo(function ChatMessageList({
       running,
       key,
       onFileOpen,
+      onSessionOpen,
+      sessions,
+      activeSession,
       hideCardOwnedOAuth,
       autoDeniedIds,
       renderTool,
@@ -193,7 +207,7 @@ const ChatMessageList = memo(function ChatMessageList({
       row,
     }
     return entry.render(m, ctx)
-  }, [messages, running, contentWidth, onFileOpen, renderTool, autoDeniedIds, hideCardOwnedOAuth, activeRenderers])
+  }, [messages, running, contentWidth, onFileOpen, onSessionOpen, sessions, activeSession, renderTool, autoDeniedIds, hideCardOwnedOAuth, activeRenderers])
 
 
   // Render a TurnItem (single or group)

--- a/website/src/app-sdk/messageRenderers.tsx
+++ b/website/src/app-sdk/messageRenderers.tsx
@@ -55,6 +55,17 @@ export interface MessageRenderContext {
   /** Stable React key the list computed for this row. */
   key: string
   onFileOpen?: (path: string, opts?: { line?: number; endLine?: number }) => void
+  /** Host-supplied session switch for a `/chat?sid=<slot-key>` link. Same shape
+   *  as `onFileOpen`: the host provides the capability, the registry stays
+   *  store-free (#3299), and a host that omits it gets today's behaviour — the
+   *  link falls through to an external tab. Threaded to every row that renders
+   *  markdown so a session chip resolves in place instead of opening a new tab. */
+  onSessionOpen?: (key: string) => void
+  /** Slot-key → title roster the host knows. Absent (not empty) means the host
+   *  never wired it, so `resolveSessionChip` leaves the link external. */
+  sessions?: ReadonlyMap<string, string>
+  /** The currently active slot key. A link naming it stays inert. */
+  activeSession?: string
   /** Drop mcp_oauth banners a Connections card already owns. */
   hideCardOwnedOAuth: boolean
   /** tool_call_ids whose call a policy or hook blocked. */
@@ -79,7 +90,15 @@ export interface MessageRenderer {
   render: (m: ChatMessage, ctx: MessageRenderContext) => React.ReactNode
 }
 
-function renderUserContent(content: string, meta: Record<string, unknown> | undefined): React.ReactNode {
+/** Host-supplied session-navigation props, forwarded verbatim to MarkdownRenderer.
+ *  All optional: a host that wires none gets today's external-link behaviour. */
+interface SessionRenderActions {
+  onSessionOpen?: (key: string) => void
+  sessions?: ReadonlyMap<string, string>
+  activeSession?: string
+}
+
+function renderUserContent(content: string, meta: Record<string, unknown> | undefined, session?: SessionRenderActions): React.ReactNode {
   // History load re-serves the fully-EXPANDED paste content alongside
   // meta.pastes. Handing a large paste (hundreds of KB / tens of thousands of
   // lines) straight to MarkdownRenderer parses + lays it out on the main thread
@@ -113,7 +132,7 @@ function renderUserContent(content: string, meta: Record<string, unknown> | unde
       return <MessageErrorBoundary rawContent={text}>{out}</MessageErrorBoundary>
     }
   }
-  return <MessageErrorBoundary rawContent={content}><MarkdownRenderer content={content} /></MessageErrorBoundary>
+  return <MessageErrorBoundary rawContent={content}><MarkdownRenderer content={content} onSessionOpen={session?.onSessionOpen} sessions={session?.sessions} activeSession={session?.activeSession} /></MessageErrorBoundary>
 }
 
 /**
@@ -391,7 +410,7 @@ export const defaultMessageRenderers: readonly MessageRenderer[] = [
         meta={m.meta}
         timestamp={formatTs(m.ts)}
         timestampTitle={fmtMessageTimeFull(m.ts)}
-        renderContent={renderUserContent}
+        renderContent={(content, meta) => renderUserContent(content, meta, { onSessionOpen: ctx.onSessionOpen, sessions: ctx.sessions, activeSession: ctx.activeSession })}
       />,
       true,
     ),
@@ -430,6 +449,9 @@ export const defaultMessageRenderers: readonly MessageRenderer[] = [
             showFooter={showFooter}
             slotRunning={ctx.running}
             onFileOpen={ctx.onFileOpen}
+            onSessionOpen={ctx.onSessionOpen}
+            sessions={ctx.sessions}
+            activeSession={ctx.activeSession}
             variants={m.variants}
             variantIdx={m.variant_idx}
             turnStats={(m.meta as Record<string, unknown> | undefined)?.turn_stats as TurnStats | undefined}
@@ -471,7 +493,7 @@ export const defaultMessageRenderers: readonly MessageRenderer[] = [
         <>
           {cronLabel && <span className="text-muted text-[11px] leading-4 font-medium px-1 mb-1"><Clock size={11} className="inline mr-0.5" />{cronLabel}</span>}
           <div className="msg-content px-4 py-3 text-sm leading-6 rounded-lg bg-warn-subtle text-text ring-1 ring-inset forced-colors:border ring-warn/30 rounded-bl-[4px] overflow-hidden min-w-0" style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
-            <MessageErrorBoundary rawContent={cleanContent}><MarkdownRenderer content={cleanContent} softBreaks /></MessageErrorBoundary>
+            <MessageErrorBoundary rawContent={cleanContent}><MarkdownRenderer content={cleanContent} softBreaks onSessionOpen={ctx.onSessionOpen} sessions={ctx.sessions} activeSession={ctx.activeSession} /></MessageErrorBoundary>
           </div>
         </>,
       )

--- a/website/src/test/ChatMessageList.test.tsx
+++ b/website/src/test/ChatMessageList.test.tsx
@@ -8,16 +8,22 @@ import type { TurnItem } from '../pages/chat/types'
 // Each mock types only the props it actually reads.
 
 vi.mock('../pages/chat/AssistantMessage', () => ({
-  default: (props: { content: string; isStreaming?: boolean }) => (
-    <div data-testid="assistant-message" data-streaming={String(props.isStreaming)}>
+  default: (props: { content: string; isStreaming?: boolean; onSessionOpen?: (k: string) => void; sessions?: ReadonlyMap<string, string>; activeSession?: string }) => (
+    <div
+      data-testid="assistant-message"
+      data-streaming={String(props.isStreaming)}
+      data-has-session-open={String(!!props.onSessionOpen)}
+      data-has-sessions={String(!!props.sessions)}
+      data-active-session={props.activeSession ?? ''}
+    >
       {props.content}
     </div>
   ),
 }))
 
 vi.mock('../pages/chat/UserMessage', () => ({
-  default: (props: { content: string }) => (
-    <div data-testid="user-message">{props.content}</div>
+  default: (props: { content: string; meta?: Record<string, unknown>; renderContent: (c: string, m: Record<string, unknown> | undefined) => ReactNode }) => (
+    <div data-testid="user-message">{props.renderContent(props.content, props.meta)}</div>
   ),
 }))
 
@@ -57,7 +63,16 @@ vi.mock('../pages/chat/TurnBlock', () => ({
 }))
 
 vi.mock('../components/MarkdownRenderer', () => ({
-  default: ({ content }: { content: string }) => <span data-testid="markdown">{content}</span>,
+  default: ({ content, onSessionOpen, sessions, activeSession }: { content: string; onSessionOpen?: (k: string) => void; sessions?: ReadonlyMap<string, string>; activeSession?: string }) => (
+    <span
+      data-testid="markdown"
+      data-has-session-open={String(!!onSessionOpen)}
+      data-has-sessions={String(!!sessions)}
+      data-active-session={activeSession ?? ''}
+    >
+      {content}
+    </span>
+  ),
 }))
 
 import ChatMessageList from '../app-sdk/ChatMessageList'
@@ -448,5 +463,69 @@ describe('ChatMessageList — batch approval wiring (Req 4.1-4.4)', () => {
       />,
     )
     expect(screen.getByTestId('collapsible-tool-group')).toHaveAttribute('data-has-batch', 'false')
+  })
+})
+
+describe('session-navigation callback threading (#8254)', () => {
+  // The registry stays store-free (#3299): these are host-supplied optional
+  // props, mirroring onFileOpen. When the host wires them, every row that draws
+  // markdown gets them so a /chat?sid= link resolves in place; when the host
+  // wires nothing, the rows fall back to today's external-link behaviour.
+  const sessions = new Map<string, string>([['dashboard_chat-2', 'Other session']])
+  const onSessionOpen = () => {}
+
+  it('forwards onSessionOpen / sessions / activeSession to the user row', () => {
+    render(
+      <ChatMessageList
+        messages={[msg('user', 'see /chat?sid=dashboard_chat-2')]}
+        running={false}
+        onSessionOpen={onSessionOpen}
+        sessions={sessions}
+        activeSession="dashboard_chat-1"
+      />,
+    )
+    const md = screen.getByTestId('markdown')
+    expect(md.getAttribute('data-has-session-open')).toBe('true')
+    expect(md.getAttribute('data-has-sessions')).toBe('true')
+    expect(md.getAttribute('data-active-session')).toBe('dashboard_chat-1')
+  })
+
+  it('forwards the session props to the assistant row', () => {
+    render(
+      <ChatMessageList
+        messages={[msg('user', 'q'), msg('assistant', 'a')]}
+        running={false}
+        onSessionOpen={onSessionOpen}
+        sessions={sessions}
+        activeSession="dashboard_chat-1"
+      />,
+    )
+    const asst = screen.getByTestId('assistant-message')
+    expect(asst.getAttribute('data-has-session-open')).toBe('true')
+    expect(asst.getAttribute('data-has-sessions')).toBe('true')
+    expect(asst.getAttribute('data-active-session')).toBe('dashboard_chat-1')
+  })
+
+  it('forwards the session props to a note / inject row', () => {
+    render(
+      <ChatMessageList
+        messages={[msg('inject', 'Injected /chat?sid=dashboard_chat-2')]}
+        running={false}
+        onSessionOpen={onSessionOpen}
+        sessions={sessions}
+        activeSession="dashboard_chat-1"
+      />,
+    )
+    const md = screen.getByTestId('markdown')
+    expect(md.getAttribute('data-has-session-open')).toBe('true')
+    expect(md.getAttribute('data-has-sessions')).toBe('true')
+  })
+
+  it('leaves rows without session props when the host wires nothing (negative control)', () => {
+    render(<ChatMessageList messages={[msg('user', 'plain')]} running={false} />)
+    const md = screen.getByTestId('markdown')
+    expect(md.getAttribute('data-has-session-open')).toBe('false')
+    expect(md.getAttribute('data-has-sessions')).toBe('false')
+    expect(md.getAttribute('data-active-session')).toBe('')
   })
 })


### PR DESCRIPTION
## What is the problem?

`MessageRenderContext` (the exported app-sdk render context, `messageRenderers.tsx:46`) had no way to resolve a `/chat?sid=<slot-key>` session link. Its `MarkdownRenderer` call sites passed content alone, so `resolveSessionChip` refused for want of `onSessionOpen`/`sessions` and the link fell through to an external new-tab link. #8254 asks - as a CONTRIBUTING-routed RFC question, since the interface is exported - whether the context **should carry** an optional session-open callback, the way the dashboard's own rows already do.

This PR ships the answer as **plumbing only**: the seam is added, no dashboard host is wired to it, and the user-visible new-tab behaviour is unchanged. #8254 stays open for the host-wiring half (see the last section for why that half is not mechanical).

## Why this issue matters to the user

Nothing changes for the user in this PR. The value is to the next contributor: the exported context now *can* carry the session-open capability with `onFileOpen`'s exact shape, so a host that has a correct in-place switch to offer can supply it without touching the store-free registry. Absent a host, every row behaves exactly as today.

## How our fix solves it

The context already carries a host-supplied optional callback - `onFileOpen?` at `messageRenderers.tsx:55` - and that is the shape the session case needs. #3299's constraint is "no store import", not "no host callbacks".

- `MessageRenderContext` and `ChatMessageListProps` gain optional `onSessionOpen` / `sessions` / `activeSession`, mirroring `onFileOpen?` verbatim. The registry stays store-free.
- The three default rows that render markdown - **user**, **assistant**, **note/inject** - forward the trio to `MarkdownRenderer`, whose `resolveSessionChip` switches in place when they are present, drops a link naming the active slot (the #8253 negative control), and falls through to an external link when they are absent (every host today).
- `MarkdownRenderer` and `AssistantMessage` already accept these props end-to-end, so the forwarding is the whole wiring on the registry side.

**Scope is honest:** this is the seam, not a behaviour change. There are **zero host consumers** in this PR by design.

## What tests we did

- `ChatMessageList.test.tsx` gains a `session-navigation callback threading (#8254)` block: the user, assistant, and note/inject rows each receive the trio when a host supplies it, plus a **negative control** proving the rows fall back to no session props when the host wires nothing.
- `vitest run` on `ChatMessageList.test.tsx`, `messageRenderers.test.ts`, `transcriptRenderers.test.tsx`, and `ChatPane.switchLabelOptimistic.test.tsx` (proving `ChatPane` is untouched) - all passing.
- `tsc -b` zero errors in the changed files; `eslint` clean. No Python touched. Diff is 3 files: `messageRenderers.tsx`, `ChatMessageList.tsx`, `ChatMessageList.test.tsx`.
- No security surface: an in-app slot switch has no credential or network boundary.

## Any other suggestions on the work

**Why no host is wired here, and why that half is not mechanical.** All three `ChatMessageList` hosts render a **fixed** slot, none renders `chat.activeSlot`: `SessionGridView` binds each pane to `leaf.slot`, `MembersPage` binds its pane to a page-local slot, and `ChatEmbed` is store-free. `switchSlot(key)` mutates the global `chat.activeSlot` and has no router side-effect, so dispatching it from any of these panes would change global state with **no visible effect in the pane the user clicked in** - a callback that looks wired but silently does nothing, which is worse than the honest external link. A correct in-place wiring is host-shaped (rebind the fixed pane to the target slot, or drive that host's own navigation) and also needs the offline guard the main page documents (an offline `switchSlot` rejects and clears the target slot's messages). That belongs in a focused follow-up per host; shipping the seam first keeps this PR small and never fires the callback into a no-op.

- Open PR #8947 adds sibling optional fields to the same struct at the same anchor; whichever lands second takes a trivial rebase.

Refs #8254
