### PR TITLE
test: remove host side effects, flakes and hot spots found by a 5-run audit

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -366,7 +366,6 @@ test/metrics/test_cost_breakdown.py
 test/metrics/test_gateway_http_metrics.py
 test/metrics/test_generation_disclosure.py
 test/metrics/test_mcp_gateway_metrics.py
-test/metrics/test_provider_bucket_views.py
 test/metrics/test_schema.py
 test/metrics/test_startup_channel_attrs.py
 test/metrics/test_telemetry_titles.py
@@ -777,7 +776,6 @@ test/test_knowledge_items_source_filter.py
 test/test_knowledge_kiroignore.py
 test/test_knowledge_source_spend.py
 test/test_knowledge_sync_local_file.py
-test/test_lazy_data_home_paths.py
 test/test_learn.py
 test/test_lesson_contradiction.py
 test/test_lesson_ranking.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ in the **same commit** when you change what it documents.
 | themes | [themes](docs/system-specs/modules/themes.md) + [theming-contract](website/docs/theming-contract.md) |
 | anything under `website/` | [`website/AGENTS.md`](website/AGENTS.md) |
 | user-facing strings, dates, numbers, sort order | [i18n-catalog](website/docs/i18n-catalog.md) (authoring) + [i18n-gates](docs/ci/i18n-gates.md) (CI) |
-| tests: flakes, speed, fixtures, sharding, side effects, conftest isolation | [testing-conventions](docs/system-specs/common/testing-conventions.md) + the [writing-tests](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md) skill |
+| tests: flakes, hangs, speed, memory, fixtures, sharding, side effects, conftest isolation, Windows | [testing-conventions](docs/system-specs/common/testing-conventions.md) + the [writing-tests](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md) skill; frontend and Electron tests: [website/docs/testing.md](website/docs/testing.md) |
 | browser E2E | [e2e-gate](docs/ci/e2e-gate.md) |
 | proving a worktree change against an isolated running gateway | [worktree-verification-recipes](docs/guides/worktree-verification-recipes.md) |
 | CI, PR flow, review gates, commit messages | [ci-and-reviews](docs/ci/ci-and-reviews.md) + [CONTRIBUTING.md](CONTRIBUTING.md) |
@@ -207,9 +207,12 @@ python -m pytest
   --max-worker-restart=2`; a bare override silently drops `--dist loadgroup` and
   scatters `@pytest.mark.xdist_group` tests into flaky races.
 
-Gates, flake classes, the conftest isolation floor and the traps that are invisible
-when reading a test: [code-style](docs/system-specs/common/code-style.md) +
-[testing-conventions](docs/system-specs/common/testing-conventions.md).
+Gates, the six flake classes, the conftest isolation floor and the traps that are
+invisible when reading a test: [code-style](docs/system-specs/common/code-style.md) +
+[testing-conventions](docs/system-specs/common/testing-conventions.md). A test that
+can block forever is a lost RUN, not a failed test: on Windows pytest-timeout kills
+the xdist worker, and with `--max-worker-restart=0` one unbounded `await` aborts the
+whole job (class 6). Frontend and Electron: [website/docs/testing.md](website/docs/testing.md).
 
 ## Cross-platform
 

--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,11 @@ this" contract failed at least once:
   pinned with it. Without this, the ~108 test modules that ship inside the package
   under ``src/kiro_crew/apps/builtins/*/tests/`` -- which see this conftest and no
   other -- write the operator's live ``~/.kiro/crew`` the moment they touch
-  ``config_dir()``.
+  ``config_dir()``. ``KIROCREW_WORKSPACE`` is pinned alongside it for the same
+  reason: ``workspace_root()`` is a SEPARATE default from ``config_dir()`` (it
+  falls back to ``~/workplace/kirocrew-workspace``, not under the data home at
+  all), so pinning only ``KIROCREW_HOME`` leaves it resolving to the operator's
+  real ``~/workplace`` the moment a test reaches an agent working directory.
 * **Credential environment.** Recognised fixed credentials and validated
   ``JIRA_TOKEN_<HEX>`` keys are restored after every test, so a fabricated
   ``.env`` cannot silently override the next test's credentials in the same
@@ -114,6 +118,86 @@ import threading
 import warnings
 
 import pytest
+
+# ── Hypothesis example database (rootdir floor) ─────────────────────────────
+# ``test/conftest.py`` registers the "default"/"thorough" profiles but never sets
+# ``database=``, so hypothesis falls back to its own default: ``.hypothesis/examples``
+# resolved against the CURRENT WORKING DIRECTORY, i.e. the repo root, for every test
+# collected from ANY testpath -- including the ~108 modules under
+# ``src/kiro_crew/apps/builtins/*/tests/`` that never import ``test/conftest.py`` at all.
+# That writes an untracked directory into the checkout on every run (git status shows it
+# under "Ignored files" since ``.gitignore`` covers it, but it still needs a place to live
+# that is not the source tree).
+#
+# Profiles are process-global, so whichever profile is active when a ``@given`` test runs
+# applies regardless of which testpath collected it. Registering a "default" profile here
+# at module level would not stick: ``test/conftest.py`` re-registers "default" by name
+# right after this module loads (pytest imports the rootdir conftest first, then
+# ``test/conftest.py`` -- see ``pytest_load_initial_conftests``), and ``register_profile``
+# without ``parent=`` builds a fresh settings object from scratch, silently resetting
+# ``database`` back to the on-disk default. Doing the redirect from ``pytest_configure``
+# instead runs after both conftests' module-level code, so it lands last: ``parent=`` keeps
+# whatever ``max_examples``/``deadline``/health-check suppression ``test/conftest.py`` set,
+# and only ``database`` is overridden.
+_HYPOTHESIS_DB_DIR: str | None = None
+
+
+def _redirect_hypothesis_database() -> None:
+    """Point the active hypothesis profile's example database off the checkout.
+
+    Uses a stable per-user directory under the platform cache root
+    (``$XDG_CACHE_HOME`` or ``~/.cache``, ``kirocrew/hypothesis``) rather than
+    ``database=None`` or a per-run temp dir: the shrunk counterexample hypothesis
+    saves is what makes a property-test failure replay on the NEXT run instead of
+    costing a full re-search, so the database has to outlive the process. What
+    moves is only WHERE it lives -- out of the checkout and into the same cache
+    tree the xdist slot files already use -- not whether it persists. Tolerates
+    hypothesis being absent (a partial checkout, or an environment where it was
+    never installed), an unwritable cache root (falls back to ``database=None``
+    rather than to the checkout), and no profile named "default" existing yet,
+    since this floor must not be the reason collection fails for a suite that
+    does not use hypothesis at all.
+    """
+    global _HYPOTHESIS_DB_DIR
+    try:
+        from hypothesis import settings as _hyp_settings
+        from hypothesis.database import DirectoryBasedExampleDatabase
+    except ImportError:
+        return
+    try:
+        _current = _hyp_settings.get_profile(_hyp_settings._current_profile)
+    except Exception:  # noqa: BLE001 - no active profile to inherit from
+        return
+    if _HYPOTHESIS_DB_DIR is None:
+        cache_root = os.environ.get("XDG_CACHE_HOME") or os.path.join(
+            os.path.expanduser("~"), ".cache"
+        )
+        candidate = os.path.join(cache_root, "kirocrew", "hypothesis")
+        try:
+            os.makedirs(candidate, exist_ok=True)
+            _HYPOTHESIS_DB_DIR = candidate
+        except OSError:
+            _HYPOTHESIS_DB_DIR = ""
+        # The example database is only one tenant of ``.hypothesis/``: the
+        # unicode-data cache (``storage_directory("unicode_data", ...)``) is written
+        # through hypothesis's HOME directory, which defaults to ``.hypothesis``
+        # under the CWD, i.e. the checkout. Move the home too, so the whole tree
+        # lands in the cache dir; the env var is what a spawned child reads.
+        if _HYPOTHESIS_DB_DIR:
+            try:
+                from hypothesis.configuration import set_hypothesis_home_dir
+
+                set_hypothesis_home_dir(_HYPOTHESIS_DB_DIR)
+                os.environ.setdefault("HYPOTHESIS_STORAGE_DIRECTORY", _HYPOTHESIS_DB_DIR)
+            except Exception:  # noqa: BLE001 - an older hypothesis without the hook
+                pass
+    database = DirectoryBasedExampleDatabase(_HYPOTHESIS_DB_DIR) if _HYPOTHESIS_DB_DIR else None
+    _hyp_settings.register_profile(
+        _hyp_settings._current_profile,
+        parent=_current,
+        database=database,
+    )
+    _hyp_settings.load_profile(_hyp_settings._current_profile)
 
 
 def _root_can_create_real_symlink() -> bool:
@@ -832,6 +916,7 @@ def _prefer_short_tmp_base() -> None:
 def pytest_configure(config: pytest.Config) -> None:
     """Record the working directory pytest started in, before any test can move it."""
     _prefer_short_tmp_base()
+    _redirect_hypothesis_database()
     global _SESSION_CWD
     try:
         _SESSION_CWD = os.getcwd()
@@ -1897,7 +1982,7 @@ _isolation_dirs.seq = 0  # type: ignore[attr-defined]
 
 @pytest.fixture(autouse=True)
 def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
-    """Pin ``KIROCREW_HOME`` to a per-test tmp dir, for EVERY testpath.
+    """Pin ``KIROCREW_HOME`` and ``KIROCREW_WORKSPACE`` to per-test tmp dirs, for EVERY testpath.
 
     This lives at the rootdir rather than in ``test/conftest.py`` because the leak it
     closes is worst in the testpaths that conftest does not reach. The ~108 test
@@ -1940,8 +2025,21 @@ def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
     and they read an empty directory instead of the tree they just built. A test that
     reaches ``kiro_home()`` therefore isolates it itself, with whichever of the two
     levers it already uses.
+
+    ``KIROCREW_WORKSPACE`` is pinned alongside ``KIROCREW_HOME`` for the same
+    reason as the rest of this fixture: ``config.loader.workspace_root()`` is its
+    own default, independent of ``config_dir()`` -- with no override and no saved
+    ``<config_dir>/workspace_dir`` file it falls back to the platform's
+    ``_default_workspace_base()`` plus ``kirocrew-workspace``, which on Linux/macOS
+    is the operator's real ``~/workplace``. Any test that reaches an agent working
+    directory (``workspace_root()``, ``_session_work_dir()``, ``outbox_dir()``)
+    without setting its own ``KIROCREW_WORKSPACE`` therefore ``mkdir``s and writes
+    into that real tree. Unlike ``config_dir()``, ``workspace_root()`` reads the env
+    var fresh on every call and caches nothing, so there is no module-global memo to
+    reset here -- setting the variable is the whole fix.
     """
     monkeypatch.setenv("KIROCREW_HOME", str(_isolation_dirs("kirocrew-home")))
+    monkeypatch.setenv("KIROCREW_WORKSPACE", str(_isolation_dirs("workspace")))
     monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)
     monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
     monkeypatch.delenv("KIROCREW_DEV_MODE", raising=False)
@@ -2317,6 +2415,112 @@ def unpinned_agent_spec_home(_isolate_agent_spec_home, monkeypatch):
     if paths is not None:
         monkeypatch.setattr(paths, "_agents_dir_override", None)
     return _isolate_agent_spec_home
+
+
+#: The operator's real kiro-cli home, captured before any test can repoint
+#: ``Path.home``/``KIRO_HOME``. The sessions-dir floor compares against THIS, so a
+#: test that relocates the home is followed and only the real store is fenced.
+_REAL_KIRO_HOME_AT_START = (pathlib.Path.home() / ".kiro").resolve()
+
+
+def _is_under(path: pathlib.Path, root: pathlib.Path) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:  # pragma: no cover - unresolvable path cannot be the real home
+        return False
+    return resolved == root or root in resolved.parents
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kiro_sessions_dir(_isolation_dirs, monkeypatch):
+    """Pin kiro-cli's transcript store (``<kiro home>/sessions/cli``), for EVERY testpath.
+
+    A fourth ``~/.kiro`` isolation axis, distinct from the data home, the import-time
+    ``_SHARED_KIRO_PATHS`` bindings, and the agent-spec home above. ``kiro_sessions_dir()``
+    is a LAZY resolver (``kiro_home()`` -> ``$KIRO_HOME`` or ``Path.home()/.kiro``), so
+    neither ``KIROCREW_HOME`` nor an import-time path pin reaches it -- the same reason
+    the agent-spec home needed its own fixture instead of folding into one of those.
+
+    Without this, a test that reaches session teardown (``AcpSessionHandle.destroy()`` ->
+    ``_cleanup_transcript``, which calls ``kiro_sessions_dir()`` directly with no override)
+    deletes ``<sid>.json``/``.jsonl`` out of the operator's REAL kiro-cli session store --
+    confirmed live: ``sA.json``, ``sA.jsonl``, ``new-sid.json(l)`` and even a fabricated
+    ``<MagicMock ...>`` filename were removed from ``~/.kiro/sessions/cli`` by
+    ``test_acp_runtime.py`` and ``test_session_transfer.py`` session-teardown tests and
+    ``test_dashboard_chat_rewind.py``'s chained-history tests.
+
+    Installs the override via the single accessor's function BODY, exactly like
+    :func:`_isolate_agent_spec_home` does for ``_agents_dir_override``: ``kiro_sessions_dir``
+    is bound by name in several modules (``session_map``, ``acp.client``,
+    ``dashboard.session_transfer``, ...), and copies the function OBJECT, so patching only
+    ``paths.kiro_sessions_dir`` would never reach them.
+
+    ``session_map.py`` additionally exposes its OWN opt-in override
+    (``_KIRO_SESSIONS_DIR``, ``None`` = defer to ``kiro_sessions_dir()``) for existing
+    monkeypatch call sites -- pinned here too so a test that reads through that module
+    sees the same tree as one that reads through the resolver directly.
+
+    Creates nothing -- an absent sessions dir is the normal fresh-install state, and
+    every writer creates its own parent first. A test that sets its own value still wins,
+    through any lever: ``monkeypatch`` applied later in setup overrides both hooks, and a
+    test that relocates kiro-cli's home itself -- ``KIRO_HOME``, ``HOME``, or a patched
+    ``Path.home`` -- is followed there rather than pinned, because the override only
+    fences the operator's REAL store (see ``_pinned_sessions_dir``). A test that asserts
+    on the real default layout opts out with :func:`unpinned_kiro_sessions_dir`.
+    """
+    root = _isolation_dirs("kiro-sessions-cli")
+    # Imported unconditionally, never patch-if-imported: this floor guards a DELETE
+    # path, and a test that imports its subject inside its own body would otherwise
+    # find no module at setup, leave the override ``None``, and remove transcripts
+    # from the operator's real store at teardown -- the exact failure the floor
+    # exists to close. ``config.paths`` is the stdlib-only leaf, so the import costs
+    # milliseconds once per worker; ``ImportError`` is tolerated so a partial
+    # checkout cannot break collection (a module that cannot import has no seam).
+    try:
+        paths = importlib.import_module("kiro_crew.config.paths")
+    except ImportError:  # pragma: no cover - partial checkout
+        paths = None
+    if paths is not None:
+        real_kiro_home = paths.kiro_home
+
+        def _pinned_sessions_dir() -> pathlib.Path:
+            # A GUARD, not a redirect. The lazy resolver is deliberately left to
+            # each test (see the module docstring): ~35 tests relocate it with
+            # ``patch("pathlib.Path.home", ...)`` or ``KIRO_HOME``, and they must
+            # keep reading the tree they just built. So resolve it the way
+            # production would, and only when that lands in the operator's REAL
+            # ``~/.kiro`` -- the one place a test may never delete from -- answer
+            # the isolation dir instead.
+            unpinned = real_kiro_home() / "sessions" / "cli"
+            if _is_under(unpinned, _REAL_KIRO_HOME_AT_START):
+                return root
+            return unpinned
+
+        monkeypatch.setattr(paths, "_sessions_dir_override", _pinned_sessions_dir)
+    # ``session_map`` defers to ``kiro_sessions_dir()`` when its own override is
+    # unset, so the resolver pin above is the floor; this only keeps a module that IS
+    # loaded reading the same tree through its own lever.
+    session_map = sys.modules.get("kiro_crew.session_map")
+    if session_map is not None:
+        monkeypatch.setattr(session_map, "_KIRO_SESSIONS_DIR", root, raising=False)
+
+
+@pytest.fixture
+def unpinned_kiro_sessions_dir(_isolate_kiro_sessions_dir, monkeypatch):
+    """Opt out of the sessions-dir pin, for a test that ASSERTS on the real layout.
+
+    The two drift guards in ``test_agent_home_isolation`` check that the resolver
+    still derives the transcript store from ``kiro_home()`` -- pinned, they would
+    assert about a tmp path that does not ship. READ-ONLY use only: this hands back
+    the operator's real store, and a test that deletes through it is the harm the
+    pin exists to prevent.
+    """
+    paths = sys.modules.get("kiro_crew.config.paths")
+    if paths is not None:
+        monkeypatch.setattr(paths, "_sessions_dir_override", None)
+    session_map = sys.modules.get("kiro_crew.session_map")
+    if session_map is not None:
+        monkeypatch.setattr(session_map, "_KIRO_SESSIONS_DIR", None, raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -504,7 +504,137 @@ which testpath asked for the workers.
   `loadgroup` runs. Never add the `@group` suffix to an entry — it makes the line match
   in one invocation and silently miss in another.
 - Tests SHOULD be fast (< 1s each)
-- Async tests MUST use `@pytest.mark.asyncio`
+- Async tests MUST use `@pytest.mark.asyncio` — and ONLY async tests. The mark on a
+  plain `def` is accepted silently by pytest-asyncio strict mode and the test then
+  asserts nothing it was meant to `await`; the warning it emits is easy to miss among
+  thousands. A module-level `pytestmark = pytest.mark.asyncio` makes every sync test in
+  the file wrong.
+
+## Side effects: what a full run does to the host, and how to see it
+
+Everything in the Rules above was learned one incident at a time. This section is the
+systematic version: how to MEASURE what the suite does to the machine it runs on, and
+the classes that measurement found on a clean `main` when it was first done (five full
+backend runs, ~89.5k tests each, on one 32-core host).
+
+### The measurement
+
+Attribution by timestamp does not work: under `-n auto` thirty-odd tests are in flight
+whenever a file changes, and the live gateway on a developer box writes the same
+directories the suite must not. What works is an **in-process audit hook**, which names
+the exact test and the exact stack for every write outside the sanctioned roots:
+
+```python
+# audit_home.py -- run: python audit_home.py -q -n0 test/test_foo.py
+import os, sys, traceback
+REAL = (os.path.expanduser("~/.kiro"), os.path.expanduser("~/workplace"), "/workplace")
+def hook(event, args):
+    if event not in ("os.mkdir", "open", "os.rename", "os.remove", "os.symlink"):
+        return
+    path = os.fspath(args[0]) if args and not isinstance(args[0], int) else ""
+    if event == "open" and not any(m in (args[1] or "") for m in "wax+"):
+        return
+    if path.startswith(REAL) and "/scratch/" not in path:
+        sys.stderr.write(f"### {event} {path}\n" + "".join(traceback.format_stack(limit=18)[:-1]))
+sys.addaudithook(hook)
+import pytest
+sys.exit(pytest.main(sys.argv[1:]))
+```
+
+The same hook can watch `subprocess.Popen` (a spawn without `cwd=`), `socket.connect`
+(any non-loopback address is a real network dependency), `os.kill` (a pid that is not a
+child of the worker), and `socket.bind`. Run it as a pytest plugin under `-n auto` to
+survey the whole suite, then re-run each suspect file under `-n0` to get a clean stack.
+Two things the survey CANNOT tell you, both of which misled the first pass:
+
+- **Peak RSS sampled from `/proc/self/statm` is in pages.** A test that fakes
+  `os.sysconf` globally (`lambda _name: 65536`) also changes the page size the sampler
+  multiplies by, so the worker "peaked at +20 GB" while its real maximum RSS was 114 MB.
+  Fake `os.sysconf` for the ONE name under test and delegate the rest to the real
+  function; measure memory with `resource.getrusage(...).ru_maxrss` in a `-n0` run
+  before believing any per-test number taken under xdist.
+- **A hit on a real path in the survey is not attributable to the test it landed on.**
+  The breadcrumb pump below wrote under 106 different files' tests because the thread
+  ran whenever it got scheduled. If a file is clean under `-n0`, look for a background
+  worker, not at the file.
+
+### The classes it found, and the one correct fix for each
+
+- **A background worker resolves its path when it RUNS.** `safety_override`'s breadcrumb
+  publisher hands a job to a long-lived daemon thread; the job called `config_dir()`
+  inside the worker, so it ran after the enqueuing test's `KIROCREW_HOME` monkeypatch was
+  torn down and DELETED the operator's real `~/.kiro/crew/safety_override_last_grant.json`
+  on every full run. Fix: resolve every path on the calling thread and pass it into the
+  job (`_sync_breadcrumb` now closes over `_breadcrumb_path()`), and give the worker a
+  drain: production's `flush_breadcrumb_writes`, wrapped by `test/conftest.py`'s
+  `drain_breadcrumb_writes()` (which raises on a starved worker) and called at teardown
+  while the pin is still in force. When you add a queue-fed worker, ask what it resolves
+  lazily; the answer must be "nothing".
+- **Import must not mutate the host.** `model_registry` and `acp.seed_provenance` called
+  `config_dir()` at import to load a cache sidecar, and `config_dir()` is
+  resolve-AND-maintain: it `mkdir`s the home and refreshes the recovery breadcrumb. Every
+  test collector, and every read-only tool, therefore created `~/.kiro/crew`. Fix:
+  `config.paths.peek_data_home()` resolves the same home without creating it; readers use
+  it, writers keep `config_dir()`. `test_model_registry.py::TestImportDoesNotCreateTheDataHome`
+  imports the package in a fresh interpreter with an empty `$HOME` and asserts nothing
+  appeared.
+- **A second default that the data-home pin does not cover.** `workspace_root()` falls
+  back to `~/workplace/kirocrew-workspace`, not to anything under `KIROCREW_HOME`, so 19
+  files created the operator's real workspace and three wrote real `cli.json`/outbox files
+  into it through `create_provider_factory(session_key=...)`. `kiro_sessions_dir()` is the
+  same shape for kiro-cli's transcript store: session teardown deleted `sA.json` from the
+  operator's real `~/.kiro/sessions/cli`. Both are now pinned per test by the rootdir
+  conftest (`KIROCREW_WORKSPACE`, `_sessions_dir_override`), and
+  `test_host_isolation_floor.py` ratchets them. When you add a resolver with its own
+  default, add it to the floor and the ratchet in the same change.
+- **The checkout's own git dir.** A watcher that ran `git -C ""` (an empty clone path)
+  operated on whatever repository contained the process CWD — the real checkout's
+  `.git/info`. An empty path is not "no repository"; refuse it (`pr_watchers` now returns
+  early when no clone is configured).
+- **Fixed `/tmp/<name>` paths race across files.** `test_review_pool.py` wrote `/tmp/x`
+  and `test_deploy_round3_fixes.py` `rmtree`'d it; under xdist whichever ran second
+  decided the other's outcome. There is no fixed name that is safe under `-n auto`; use
+  `tmp_path`, and monkeypatch the constant at its defining module when production owns
+  the name.
+- **Writes into `src/`.** Skill registration created symlinks inside
+  `src/kiro_crew/apps/builtins/*/skills/`, a task runner wrote `runs.json` relative to
+  CWD, a child interpreter left `__pycache__` in the tree, and hypothesis kept its
+  example database at the repo root. `pytest_configure` now points hypothesis at the
+  per-user cache dir (`~/.cache/kirocrew/hypothesis`), where its shrunk counterexamples
+  still persist across runs; the rest are the CWD rule above, applied.
+- **Real network.** Five system-handler test files reached `8.8.8.8:80` (a local-IP probe
+  in `handlers_system`), the Webex client fetched `webexapis.com`, and the Slack config
+  save handlers validated a pasted secret against Webex and Azure AD. Each passes on a
+  connected host and fails on a firewalled runner. Stub at the seam the code reads
+  (`handlers_system.socket.socket`, `fetch_message`, `_validate_webex_token`).
+- **A module-global set of asyncio tasks outlives its loop.** `source_providers`
+  tracked visibility-refresh tasks in a module-global set whose done-callback never fires
+  for a task whose loop was torn down under it; the next test, on a fresh loop, gathered
+  the set and got `Future belongs to a different loop`. Production now prunes entries
+  bound to a loop that is not the running one before adding; the test module clears the
+  set per test. Any module-global collection of futures/tasks needs both halves.
+- **Ratchets that re-parse the tree per test.** Fourteen files `rglob`+`ast.parse`d all
+  ~1,300 modules under `src/` once per TEST (15–30 s each, ~10 CPU-minutes per run).
+  Cache the derived facts once per module: `test/source_corpus.py` for scans its filters
+  fit, or an `lru_cache` keyed on the tree root (so a test that points the scan at a fake
+  tree under `tmp_path` gets its own entry). Bound the retention — the corpus helper
+  exposes `_clear_caches()` for a module-scoped teardown, because ~160 MB of parsed source
+  held for the life of the worker is paid by every later test on it.
+
+### Coverage that only looks like coverage
+
+- `AsyncMock()` for an object with SYNC methods: every sync call site then gets a
+  coroutine it never awaits, and the test passes while `RuntimeWarning: coroutine ...
+  was never awaited` is attributed to whichever later test triggers GC. Build the mock
+  with `spec=` (`AsyncMock(spec=SessionManager)`) so sync attributes come back as
+  `MagicMock`, or set them explicitly.
+- A `skipif` whose predicate depends on load — a capability probe with a wall-clock
+  timeout skipped two `test_worktree_create.py` tests in two of five runs. A skip that
+  flips is coverage that silently comes and goes; compute the verdict once per session
+  without a timeout.
+- A resolver with a memo that an earlier test on the same worker warmed
+  (`browser_cli.cli_path()` returned the developer's mise shim after `HOME` and `PATH`
+  were pinned). Pin every input the resolver reads AND reset its cache in the test.
 
 ## Running the suite: the defaults, and how to narrow safely
 
@@ -882,7 +1012,7 @@ verify the threshold against a mutated implementation rather than reasoning abou
 
 ## Keeping the suite fast
 
-The suite is ~56.5k tests. At that count a per-test cost is multiplied by 56,500, so
+The suite is ~89.5k tests. At that count a per-test cost is multiplied by 89,500, so
 setup overhead, not any single slow test, is what dominates. Profile before optimizing:
 
 ```bash
@@ -900,7 +1030,7 @@ hour earlier is not a baseline.
 ### The three highest-leverage patterns
 
 1. **Audit what the autouse fixtures cost, before anything else.** Every one of them is
-   paid ~56.5k times, so a few milliseconds there outweighs any single slow test. Two
+   paid ~89.5k times, so a few milliseconds there outweighs any single slow test. Two
    things to look for: a fixture requesting a fixture it never uses (one unused
    `tmp_path` allocated a directory for every test in the suite), and repeated
    `tmp_path_factory.mktemp` calls, which pick a numbered suffix by scanning the whole

--- a/scripts/leaf_test_scope.py
+++ b/scripts/leaf_test_scope.py
@@ -82,6 +82,7 @@ Exit codes: 0 eligible / run green, 1 tests failed, 2 usage or environment error
 from __future__ import annotations
 
 import argparse
+import functools
 import os
 import re
 import subprocess
@@ -167,6 +168,17 @@ def _iter_python(root: Path) -> list[Path]:
     return out
 
 
+# `importers_of` and `mentions_of` each call `_iter_python` + `_read` on every
+# candidate file, and both are called repeatedly for different name sets in one
+# `classify()` (once per changed-file batch) and dozens of times in `_self_test`
+# (once per stem in its dependency-check loop, and again once per `test/test_*.py`
+# candidate while it hunts for a clean leaf). None of that changes which files
+# exist or what they contain within a single process, so caching by root/path is
+# exact, not an approximation -- the walk and the read are each paid once no
+# matter how many times a caller re-asks the same question.
+_iter_python_cached = functools.lru_cache(maxsize=None)(_iter_python)
+
+
 def _read(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8", errors="replace")
@@ -174,6 +186,9 @@ def _read(path: Path) -> str:
         # Unreadable input cannot be cleared, and a reduction that silently
         # skipped a file it could not read would be exactly the wrong failure.
         raise SelectionUntrustworthy(f"cannot read {path} while classifying the diff") from None
+
+
+_read_cached = functools.lru_cache(maxsize=None)(_read)
 
 
 def _run_git(argv: list[str]) -> str:
@@ -234,8 +249,8 @@ def importers_of(stems: set[str], root: Path) -> dict[str, str]:
     if not stems:
         return {}
     found: dict[str, str] = {}
-    for path in _iter_python(root):
-        text = _read(path)
+    for path in _iter_python_cached(root):
+        text = _read_cached(path)
         for match in _IMPORT.finditer(text):
             module = (match.group(1) or match.group(2) or "").split(".")[0]
             if module in stems and module != path.stem:
@@ -260,8 +275,8 @@ def mentions_of(stems: set[str], root: Path) -> dict[str, str]:
         return {}
     found: dict[str, str] = {}
     quoted = {stem: (f'"{stem}"', f"'{stem}'") for stem in stems}
-    for path in _iter_python(root):
-        text = _read(path)
+    for path in _iter_python_cached(root):
+        text = _read_cached(path)
         for stem, forms in quoted.items():
             if stem in found or path.stem == stem:
                 continue
@@ -284,7 +299,7 @@ def corpus_gates(root: Path) -> list[str]:
     if not test_dir.is_dir():
         return gates
     for path in sorted(test_dir.glob("test_*.py")):
-        text = _read(path)
+        text = _read_cached(path)
         scans_tree = _SCANS_A_DIR.search(text) and _REACHES_TEST_TREE.search(text)
         if scans_tree or _JOINS_TEST_DIR.search(text):
             gates.append(_rel_posix(path, root))

--- a/src/kiro_crew/acp/seed_provenance.py
+++ b/src/kiro_crew/acp/seed_provenance.py
@@ -53,7 +53,7 @@ from typing import Any
 
 from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
-from kiro_crew.config.paths import config_dir
+from kiro_crew.config.paths import config_dir, peek_data_home
 
 logger = logging.getLogger(__name__)
 
@@ -105,14 +105,15 @@ _LOCK_FILENAME = ".settings_seeds.lock"
 def _sidecar_path() -> Path:
     """Path to the seed-provenance sidecar under Crew's data home.
 
-    ``config_dir()`` is resolved per call rather than folded into a module
-    constant, so ``KIROCREW_HOME`` and test overrides are honoured on every
-    access instead of being frozen at first resolution. The import-time
-    ``_load()`` does resolve it once, to hydrate ``_RECORDS`` from disk;
-    resolving per call is what keeps every later access following the current
-    override.
+    Resolved per call rather than folded into a module constant, so
+    ``KIROCREW_HOME`` and test overrides are honoured on every access instead of
+    being frozen at first resolution. Resolved through ``peek_data_home()``, not
+    ``config_dir()``: the import-time ``_load()`` only needs to know whether the
+    file exists, and importing this module must not create ``~/.kiro/crew`` on
+    the host. The one writer, :func:`_persist`, creates the directory itself
+    before taking its lock beside the sidecar.
     """
-    return config_dir() / "settings_seeds.json"
+    return peek_data_home() / "settings_seeds.json"
 
 
 def _key(path: Path | str) -> str:
@@ -194,7 +195,7 @@ def _cross_process_lock() -> Iterator[None]:
     that as a failed persist (``False``) — the same honest "grant not durable"
     outcome a failed write already gives, never a silent lost record.
     """
-    lock_file = _sidecar_path().parent / _LOCK_FILENAME
+    lock_file = config_dir() / _LOCK_FILENAME
     fd = os.open(str(lock_file), os.O_CREAT | os.O_RDWR, 0o600)
     try:
         platform_compat.acquire_lock(fd, exclusive=True)

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/pr_watchers.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/pr_watchers.py
@@ -1117,7 +1117,17 @@ class PRWatcherRegistry:
         itself stays best-effort (a lost patch must not fail the watcher), but "the patch
         was lost" and "the directory holding the commits may be deleted" are different
         decisions, and conflating them destroyed verified work.
+
+        No clone configured means no working tree to diff — there is nothing to export
+        and nothing to retain. Without this guard the fallback `git diff`/`git status`
+        calls below still ran with `-C ""`, which git treats as no `-C` at all: it walks
+        up from the process's real CWD and operates on whatever repository (or worktree)
+        happens to contain it, spawning a host-side git call — and `require_pinned`'s
+        attributes pin write — against the operator's real checkout instead of this run's
+        clone.
         """
+        if not clone:
+            return True
         try:
             self._export_fix(st, clone, attempt)
         except (OSError, subprocess.SubprocessError) as exc:

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_pool.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_pool.py
@@ -125,16 +125,29 @@ def _install_fake_runtime(test, script=None, gate=None):
     test.addCleanup(lambda: setattr(rp, "AcpRuntime", orig))
 
 
+def _work_dir(test) -> str:
+    """A real, test-owned scratch directory for ``ReviewPool(work_dir=...)``.
+
+    Even with ``AcpRuntime`` faked, ``ReviewPool._ensure_runtime_locked`` still calls
+    the real ``_write_effort_overlay``, which does ``mkdir(parents=True)`` and writes
+    ``<work_dir>/.kiro/settings/cli.json`` on disk — a fixed path like ``/tmp/x`` would
+    be a real cross-test/cross-file race under xdist, not a placeholder string.
+    """
+    tmp = tempfile.TemporaryDirectory()
+    test.addCleanup(tmp.cleanup)
+    return tmp.name
+
+
 # ── Batch lifecycle + isolation ─────────────────────────────────────────────
 class TestBatchLifecycle(unittest.IsolatedAsyncioTestCase):
     async def test_lazy_no_runtime_until_used(self):
         _install_fake_runtime(self)
-        ReviewPool(work_dir="/tmp/x")
+        ReviewPool(work_dir=_work_dir(self))
         self.assertEqual(FakeRuntime.instances, [])   # nothing spawned on construction
 
     async def test_begin_batch_spawns_one_runtime_shared_across_sends(self):
         _install_fake_runtime(self, script=[_ev(rp.EVENT_TEXT_CHUNK, text="hi")])
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()
         self.assertEqual(len(FakeRuntime.instances), 1)
         self.assertTrue(FakeRuntime.instances[0].is_alive())
@@ -148,7 +161,7 @@ class TestBatchLifecycle(unittest.IsolatedAsyncioTestCase):
 
     async def test_end_batch_kills_runtime_only_when_drained(self):
         _install_fake_runtime(self)
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()          # batches 0->1 spawns
         await pool.begin_batch()          # batches 1->2 (overlapping run)
         rt = FakeRuntime.instances[0]
@@ -159,7 +172,7 @@ class TestBatchLifecycle(unittest.IsolatedAsyncioTestCase):
 
     async def test_new_batch_after_drain_spawns_fresh_runtime(self):
         _install_fake_runtime(self)
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()
         await pool.end_batch()
         await pool.begin_batch()
@@ -168,7 +181,7 @@ class TestBatchLifecycle(unittest.IsolatedAsyncioTestCase):
 
     async def test_session_created_and_destroyed_per_task(self):
         _install_fake_runtime(self, script=[_ev(rp.EVENT_TEXT_CHUNK, text="x")])
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()
         await pool.send("task")
         rt = FakeRuntime.instances[0]
@@ -180,7 +193,7 @@ class TestBatchLifecycle(unittest.IsolatedAsyncioTestCase):
     async def test_standalone_send_lazily_spawns(self):
         # No begin_batch (standalone CLI path) -> acquire() spawns on first send.
         _install_fake_runtime(self, script=[_ev(rp.EVENT_TEXT_CHUNK, text="y")])
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         out = await pool.send("z")
         self.assertEqual(out, "y")
         self.assertEqual(len(FakeRuntime.instances), 1)
@@ -192,7 +205,7 @@ class TestBatchLifecycle(unittest.IsolatedAsyncioTestCase):
         # reports ok=False and the driver never marks the PR reviewed), and the
         # session must still be destroyed.
         _install_fake_runtime(self, script=[_ev(rp.EVENT_COMPLETE, stop_reason="timeout")])
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()
         with self.assertRaises(RuntimeError):
             await pool.send("t")
@@ -205,7 +218,7 @@ class TestBatchLifecycle(unittest.IsolatedAsyncioTestCase):
         # and surface as a failure (matched explicitly, not just by prefix).
         _install_fake_runtime(
             self, script=[_ev(rp.EVENT_COMPLETE, stop_reason=rp.STOP_REASON_TOOL_STALL)])
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()
         with self.assertRaises(RuntimeError):
             await pool.send("t")
@@ -228,7 +241,7 @@ class TestBatchLifecycle(unittest.IsolatedAsyncioTestCase):
         rp.AcpRuntime = factory  # type: ignore[assignment]
         self.addCleanup(lambda: setattr(rp, "AcpRuntime", orig))
         FakeRuntime.instances = []
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         with self.assertRaises(RuntimeError):
             await pool.begin_batch()                 # spawn fails
         self.assertEqual(pool._holder._batches, 0)   # counter not leaked
@@ -243,7 +256,7 @@ class TestConcurrency(unittest.IsolatedAsyncioTestCase):
     async def test_semaphore_caps_concurrent_sessions(self):
         gate = asyncio.Event()
         _install_fake_runtime(self, script=[_ev(rp.EVENT_TEXT_CHUNK, text="q")], gate=gate)
-        pool = ReviewPool(max_workers=2, work_dir="/tmp/x")
+        pool = ReviewPool(max_workers=2, work_dir=_work_dir(self))
         await pool.begin_batch()
         tasks = [asyncio.create_task(pool.send(f"t{i}")) for i in range(4)]
         await asyncio.sleep(0.05)
@@ -256,7 +269,7 @@ class TestConcurrency(unittest.IsolatedAsyncioTestCase):
         await pool.end_batch()
 
     async def test_effective_max_concurrent_clamped(self):
-        pool = ReviewPool(max_workers=999, work_dir="/tmp/x")
+        pool = ReviewPool(max_workers=999, work_dir=_work_dir(self))
         self.assertEqual(pool._max, MAX_CONCURRENT_CEIL)
 
 
@@ -268,7 +281,7 @@ class TestApprovalAndAudit(unittest.IsolatedAsyncioTestCase):
             _ev(rp.EVENT_TEXT_CHUNK, text="done"),
         ]
         _install_fake_runtime(self, script=script)
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()
         out = await pool.send("t")
         self.assertEqual(out, "done")
@@ -291,7 +304,7 @@ class TestApprovalAndAudit(unittest.IsolatedAsyncioTestCase):
         orig_sel = rp._sel
         rp._sel = lambda: _FakeSel()          # type: ignore[assignment]
         self.addCleanup(lambda: setattr(rp, "_sel", orig_sel))
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()
         await pool.send("t")
         await pool.end_batch()
@@ -316,7 +329,7 @@ class TestApprovalAndAudit(unittest.IsolatedAsyncioTestCase):
         orig_sel = rp._sel
         rp._sel = lambda: _FakeSel()          # type: ignore[assignment]
         self.addCleanup(lambda: setattr(rp, "_sel", orig_sel))
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()
         await pool.send("t")
         await pool.end_batch()
@@ -345,7 +358,7 @@ class TestStatsAndConfig(unittest.IsolatedAsyncioTestCase):
 
     async def test_stats_reflect_alive_runtime(self):
         _install_fake_runtime(self)
-        pool = ReviewPool(work_dir="/tmp/x")
+        pool = ReviewPool(work_dir=_work_dir(self))
         await pool.begin_batch()
         st = pool.stats()
         self.assertTrue(st["runtime_alive"])
@@ -378,7 +391,7 @@ class TestSyncDispatchBridge(unittest.TestCase):
         orig = rp.AcpRuntime
         rp.AcpRuntime = factory  # type: ignore[assignment]
         try:
-            pool = ReviewPool(work_dir="/tmp/x")
+            pool = ReviewPool(work_dir=_work_dir(self))
             dispatch = make_sync_dispatch(self.loop, pool, default_timeout=5)
             out = dispatch("hi", 5)
             self.assertTrue(out["ok"])
@@ -401,7 +414,7 @@ class TestSyncDispatchBridge(unittest.TestCase):
         orig = rp.AcpRuntime
         rp.AcpRuntime = factory  # type: ignore[assignment]
         try:
-            pool = ReviewPool(work_dir="/tmp/x")
+            pool = ReviewPool(work_dir=_work_dir(self))
             dispatch = make_sync_dispatch(self.loop, pool, default_timeout=5)
             out = dispatch("x", 5)
             self.assertFalse(out["ok"])

--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -341,6 +341,24 @@ def data_home() -> Path:
     return config_dir()
 
 
+def peek_data_home() -> Path:
+    """Where the data home IS, without creating or maintaining it.
+
+    :func:`config_dir` and :func:`data_home` both create the home on first
+    resolution (and refresh the recovery breadcrumb). A caller that only wants
+    to know whether a file *would* be there -- an import-time cache load, a
+    read-only inspector -- must not turn "import the package" into "mkdir
+    ``~/.kiro/crew``": a test collector imports before any isolation runs, and a
+    tool that reports state should not create it. Applies the SAME override
+    predicate :func:`config_dir` gates on, so a valid ``KIROCREW_HOME`` and the
+    default home agree between reader and writer, and reads nothing else.
+    """
+    override = _valid_override_home()
+    if override is not None:
+        return override
+    return _resolve_default_home()
+
+
 def ensure_data_home() -> Path:
     """Eagerly resolve and create the data home — call BEFORE the loop.
 
@@ -544,6 +562,16 @@ def kiro_home() -> Path:
     return p
 
 
+#: Test/tooling redirect for :func:`kiro_sessions_dir`, consulted on every call
+#: (``None`` = resolve from the environment). Same shape as
+#: :data:`_agents_dir_override` and for the same reason: several modules bind
+#: ``kiro_sessions_dir`` by name (``from ... import kiro_sessions_dir``), which
+#: copies the function OBJECT, so patching this module's attribute would never
+#: reach them. A value read inside the function BODY does, because a function's
+#: globals are always its defining module's.
+_sessions_dir_override: Callable[[], Path] | None = None
+
+
 def kiro_sessions_dir() -> Path:
     """Where kiro-cli stores its chat transcripts: ``<kiro home>/sessions/cli``.
 
@@ -553,7 +581,16 @@ def kiro_sessions_dir() -> Path:
     transcripts from the machine-wide path loses session resume and has its
     mappings pruned. Routing both through the resolver keeps writer and reader in
     agreement.
+
+    Honours :data:`_sessions_dir_override` when one is installed, the same lever
+    :func:`kiro_agents_dir` offers for the agent-spec home — this is the third
+    ``~/.kiro`` axis (agents, transcripts, and the data home ``KIROCREW_HOME``
+    already covers) and it needs its own hook because it is resolved lazily
+    (``kiro_home()`` -> ``$KIRO_HOME`` or ``Path.home()/.kiro``) at every call, so
+    neither ``KIROCREW_HOME`` nor an import-time path pin can reach it.
     """
+    if _sessions_dir_override is not None:
+        return _sessions_dir_override()
     return kiro_home() / "sessions" / "cli"
 
 

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -7314,7 +7314,19 @@ def schedule_visibility_refresh(
             # the redundant spawn.
             continue
         _visibility_inflight.add(key)
-        task = asyncio.get_running_loop().create_task(
+        running_loop = asyncio.get_running_loop()
+        # A task that never finished before its loop was torn down (a caller
+        # closed the loop without awaiting/cancelling the task first) never
+        # runs its done-callback, so ``discard`` never fires and it lingers in
+        # this module-global set forever, bound to a now-dead loop. A later
+        # caller on a DIFFERENT loop that gathers the set then crashes with
+        # "Future belongs to a different loop". Prune those dead-loop entries
+        # before adding this task, so the set only ever holds tasks the current
+        # loop can legally await.
+        for stale_task in list(_VISIBILITY_TASKS):
+            if stale_task.get_loop() is not running_loop:
+                _VISIBILITY_TASKS.discard(stale_task)
+        task = running_loop.create_task(
             _refresh_repo_visibility(ref, on_update, prev_public_override=prev_public_override)
         )
         _VISIBILITY_TASKS.add(task)

--- a/src/kiro_crew/dashboard/handlers_system.py
+++ b/src/kiro_crew/dashboard/handlers_system.py
@@ -482,6 +482,28 @@ def _apply_mcp_process_counts(data: dict[str, object]) -> None:
     data.update(_proc_scan_cache)
 
 
+def _local_ip() -> str:
+    """The address the kernel would source an outbound packet from, best-effort.
+
+    A UDP socket ``connect`` sends nothing (no handshake for a datagram socket),
+    it only selects a route, so ``getsockname`` yields the interface address
+    without a packet leaving the host; ``8.8.8.8`` is just a public address any
+    default route covers. Falls back to loopback when there is no route or no
+    network stack (an offline runner, a sandbox). The one place system-info
+    rendering reaches for the network, kept as its own seam so a test can pin
+    the answer instead of stubbing ``socket.socket`` -- replacing that CLASS
+    breaks ``isinstance`` checks inside asyncio's proactor loop on Windows.
+    """
+    try:
+        # Context manager guarantees the socket fd is closed on every path,
+        # including when connect()/getsockname() raise (CWE-772 fd leak).
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return str(s.getsockname()[0])
+    except Exception:
+        return "127.0.0.1"
+
+
 def _collect_system_metrics() -> dict[str, object]:
     """Collect system metrics synchronously (runs in thread pool).
 
@@ -586,15 +608,7 @@ def _collect_system_metrics() -> dict[str, object]:
                 cpu_pct = 0
     data["cpu_pct"] = cpu_pct
 
-    # Local IP address
-    try:
-        # Context manager guarantees the socket fd is closed on every path,
-        # including when connect()/getsockname() raise (CWE-772 fd leak).
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-            s.connect(("8.8.8.8", 80))
-            data["ip"] = s.getsockname()[0]
-    except Exception:
-        data["ip"] = "127.0.0.1"
+    data["ip"] = _local_ip()
 
     # Network bytes + speed — cross-platform
     try:

--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -157,20 +157,28 @@ _SUPPLEMENTARY_WINDOWS: dict[str, int] = {
 }
 
 
-def _kiro_windows_cache_path() -> Path:
-    """Path to the persisted kiro-window sidecar under the data home.
+def _sidecar_path(name: str) -> Path:
+    """A data-home sidecar path, resolved WITHOUT creating the data home.
 
-    Resolved lazily (not at import) so tests / KIROCREW_HOME overrides are
-    honoured, and so a home-resolution failure never breaks module import.
-    Routes through ``config_dir()`` (deferred import of the stdlib-only
-    ``config.paths`` leaf to avoid a cycle) so it follows the data-home move to
-    ``~/.kiro/crew`` instead of writing to the now-archived legacy ``~/.kirocrew``
-    — where no reader would ever consult it and which would re-create the very
-    directory the migration just archived.
+    ``config_dir()`` is resolve-and-maintain: it ``mkdir``s the home and
+    refreshes the recovery breadcrumb. The import-time loads below only need to
+    know whether a cache file exists, and importing this module must not mutate
+    the host: a test collector imports it before any isolation fixture runs, and
+    a read-only tool must not create ``~/.kiro/crew`` as a side effect of an
+    import. ``peek_data_home()`` resolves the same home ``config_dir()`` would and
+    stops there. The writers need no directory creation of their own:
+    ``atomic_write`` creates the parent. Deferred import of the stdlib-only
+    ``config.paths`` leaf avoids a cycle, and following the data home keeps the
+    sidecars out of the archived legacy ``~/.kirocrew``.
     """
-    from kiro_crew.config.paths import config_dir
+    from kiro_crew.config.paths import peek_data_home
 
-    return config_dir() / "model_windows.json"
+    return peek_data_home() / name
+
+
+def _kiro_windows_cache_path() -> Path:
+    """Path to the persisted kiro-window sidecar under the data home."""
+    return _sidecar_path("model_windows.json")
 
 
 def _load_kiro_windows() -> None:
@@ -290,15 +298,8 @@ _PROVIDER_ID_PREFIXES: tuple[str, ...] = (
 
 
 def _advertised_models_cache_path() -> Path:
-    """Path to the persisted advertised-model sidecar under the data home.
-
-    Resolved lazily (not at import), for the same reasons as
-    :func:`_kiro_windows_cache_path`: honour ``KIROCREW_HOME`` / test overrides
-    and never let home resolution break module import.
-    """
-    from kiro_crew.config.paths import config_dir
-
-    return config_dir() / "provider_models.json"
+    """Path to the persisted advertised-model sidecar under the data home."""
+    return _sidecar_path("provider_models.json")
 
 
 def _load_advertised_models() -> None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -58,8 +58,6 @@ settings.register_profile("default", max_examples=20, suppress_health_check=[Hea
 settings.register_profile("thorough", max_examples=100)
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
 
-# Ensure .hypothesis/tmp exists (build environment may not have it)
-os.makedirs(os.path.join(os.path.dirname(__file__), "..", ".hypothesis", "tmp"), exist_ok=True)
 
 _HAS_GIT = shutil.which("git") is not None
 
@@ -259,6 +257,26 @@ def _windows_restrict_to_owner_stub(request, monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True, scope="module")
+def _release_source_corpus_after_module():
+    """Drop ``test/source_corpus.py``'s whole-tree caches at every module's teardown.
+
+    The corpus helper memoizes the raw and NFKC-normalized text of every module
+    under ``src/`` (~160 MB) the first time any ratchet in a module asks for it,
+    and an ``lru_cache`` global otherwise lives for the rest of the xdist
+    worker -- paid by every later test on that worker. Module scope keeps the
+    sharing the ratchets rely on (one parse per module) while bounding the
+    retention to the module that needed it. Import is deferred and tolerant so a
+    module that never touches the corpus pays nothing.
+    """
+    yield
+    try:
+        from source_corpus import _clear_caches
+    except ImportError:  # pragma: no cover - a partial checkout without the helper
+        return
+    _clear_caches()
+
+
 @pytest.fixture(autouse=True)
 def _isolate_aim_skills_dir(monkeypatch):
     """Prevent SkillsLoader from discovering edition-contributed skill roots.
@@ -433,6 +451,35 @@ def _release_stt_engine():
     stt_engine._engine = None
 
 
+def absent_sysconf(name):
+    """Stand-in for a missing ``os.sysconf`` (Windows has none).
+
+    A test that fakes ONE ``os.sysconf`` name must delegate every other name to
+    the real function -- and on Windows there is no real function to delegate to.
+    Capturing ``getattr(os, "sysconf", absent_sysconf)`` gives the delegating fake
+    the same "unavailable" answer production sees there, instead of an
+    ``AttributeError`` at capture time.
+    """
+    raise ValueError(f"os.sysconf unavailable for {name!r}")
+
+
+def drain_breadcrumb_writes(timeout: float = 5.0) -> None:
+    """Block until every queued safety-override breadcrumb publish has run.
+
+    ``safety_override.flush_breadcrumb_writes`` is production's best-effort
+    drain and reports a bool; a test that relies on the drain to prove the
+    write landed inside its own context needs certainty, so a drain that does
+    not complete raises instead of returning a value a fixture could ignore.
+    """
+    from kiro_crew.safety_override import flush_breadcrumb_writes
+
+    if not flush_breadcrumb_writes(timeout):
+        raise TimeoutError(
+            f"breadcrumb worker did not drain within {timeout}s; a queued publish "
+            "may still run after this test's fixtures tear down"
+        )
+
+
 @pytest.fixture(autouse=True)
 def _reset_safety_override_between_tests():
     """Reset the SafetyOverride singleton between tests to prevent state leaking.
@@ -450,6 +497,18 @@ def _reset_safety_override_between_tests():
     _reset_safety_override()
     _reset_yolo_policy_state()
     yield
+    # Drained BEFORE the reset below, and (by pytest's fixture teardown order --
+    # finalizers run in reverse of setup order, so a fixture set up AFTER this
+    # one, e.g. a test's own ``monkeypatch.setenv("KIROCREW_HOME", ...)``, tears
+    # down BEFORE this line runs) while any KIROCREW_HOME the test itself set is
+    # still in effect. A publish enqueued mid-test resolves ``config_dir()`` on
+    # the CALLING thread at enqueue time (see ``_sync_breadcrumb``), but the
+    # worker that runs the write is on its own thread and can still be
+    # mid-flight when the test function returns. Waiting here for that worker to
+    # finish, before this fixture's own KIROCREW_HOME-independent state reset,
+    # closes the window that let a delayed write land on the real operator home
+    # instead of the test's temp dir (found in review).
+    drain_breadcrumb_writes()
     _reset_safety_override()
     _reset_yolo_policy_state()
 

--- a/test/metrics/test_provider_bucket_views.py
+++ b/test/metrics/test_provider_bucket_views.py
@@ -18,8 +18,10 @@ properties load-bearing, and both are asserted here:
    twice under one metric name. ``test_no_duplicate_streams_per_instrument``
    pins that.
 """
+
 import ast
 import re
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -43,7 +45,8 @@ _SRC = Path(provider_mod.__file__).resolve().parent.parent
 _NAME_RE = re.compile(r'"(kirocrew\.[a-z0-9_.]*\.duration)"')
 
 
-def _source_histogram_names() -> set[str]:
+@lru_cache(maxsize=1)
+def _source_histogram_names() -> frozenset[str]:
     found: set[str] = set()
     for path in _SRC.rglob("*.py"):
         try:
@@ -51,9 +54,10 @@ def _source_histogram_names() -> set[str]:
         except (OSError, UnicodeDecodeError):
             continue
         found.update(_NAME_RE.findall(text))
-    return found
+    return frozenset(found)
 
 
+@lru_cache(maxsize=1)
 def _emitted_histogram_units() -> dict[str, set[str]]:
     """Instrument name -> the set of ``unit=`` values its emit calls pass.
 
@@ -111,7 +115,7 @@ def _emitted_histogram_units() -> dict[str, set[str]]:
 
 
 def _emitted_histogram_names() -> set[str]:
-    return set(_emitted_histogram_units())
+    return set(_emitted_histogram_units().keys())
 
 
 class TestCompleteness:
@@ -199,8 +203,7 @@ class TestNonDurationHistograms:
         """
         units = _emitted_histogram_units()
         wrong = sorted(
-            name for name in _HISTOGRAM_BUCKETS_MS
-            if name in units and units[name] != {"ms"}
+            name for name in _HISTOGRAM_BUCKETS_MS if name in units and units[name] != {"ms"}
         )
         assert not wrong, (
             f"non-millisecond instruments in the ms map: {wrong}. The dashboard "
@@ -209,10 +212,7 @@ class TestNonDurationHistograms:
 
     def test_by_unit_map_holds_no_millisecond_instruments(self):
         units = _emitted_histogram_units()
-        wrong = sorted(
-            name for name in _HISTOGRAM_BUCKETS_BY_UNIT
-            if units.get(name) == {"ms"}
-        )
+        wrong = sorted(name for name in _HISTOGRAM_BUCKETS_BY_UNIT if units.get(name) == {"ms"})
         assert not wrong, f"millisecond instruments belong in the ms map: {wrong}"
 
     def test_one_instrument_never_carries_two_units(self):
@@ -228,8 +228,7 @@ class TestNonDurationHistograms:
         # boundary that a percentile can only report as a floor.
         for observed in (6.76, 53.3, 155.1):
             assert any(
-                lo < observed <= hi
-                for lo, hi in zip(_CREDIT_BUCKETS, _CREDIT_BUCKETS[1:])
+                lo < observed <= hi for lo, hi in zip(_CREDIT_BUCKETS, _CREDIT_BUCKETS[1:])
             ), observed
 
     def test_usd_bounds_span_sub_cent_to_tens_of_dollars(self):
@@ -244,8 +243,23 @@ class TestNonDurationHistograms:
         population lands in the first two buckets, so the reported p50 could only
         ever be 0 or 5.
         """
-        otel_default = [0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0,
-                        1000.0, 2500.0, 5000.0, 7500.0, 10000.0]
+        otel_default = [
+            0.0,
+            5.0,
+            10.0,
+            25.0,
+            50.0,
+            75.0,
+            100.0,
+            250.0,
+            500.0,
+            750.0,
+            1000.0,
+            2500.0,
+            5000.0,
+            7500.0,
+            10000.0,
+        ]
         below_five = sum(1 for b in _CREDIT_BUCKETS if b <= 5.0)
         assert below_five >= 7, "the credit array must resolve the sub-5 decade"
         assert sum(1 for b in otel_default if 0 < b <= 5.0) == 1
@@ -295,8 +309,25 @@ class TestMixedBoundaryGenerations:
     """
 
     OLD_SHARED_BOUNDS = [
-        1, 5, 10, 25, 50, 100, 250, 500, 1000, 2000, 3000,
-        5000, 7500, 10000, 15000, 20000, 30000, 45000, 60000,
+        1,
+        5,
+        10,
+        25,
+        50,
+        100,
+        250,
+        500,
+        1000,
+        2000,
+        3000,
+        5000,
+        7500,
+        10000,
+        15000,
+        20000,
+        30000,
+        45000,
+        60000,
     ]
 
     def _dp(self, bounds, landed_index, count=1, total=None, ns=None):
@@ -323,8 +354,7 @@ class TestMixedBoundaryGenerations:
     def test_legacy_overflow_point_cannot_fabricate_a_one_hour_p90(self):
         h = _Hist()
         # Pre-change: a 227589ms turn, recorded as old-bounds +Inf overflow.
-        h.add(self._dp(self.OLD_SHARED_BOUNDS, len(self.OLD_SHARED_BOUNDS),
-                       count=1, total=227589))
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, len(self.OLD_SHARED_BOUNDS), count=1, total=227589))
         # Post-change: three ordinary ~30s turns under the new bounds.
         for _ in range(3):
             h.add(self._dp(_TURN_BUCKETS_MS, 5, count=1, total=30000))
@@ -339,8 +369,8 @@ class TestMixedBoundaryGenerations:
 
     def test_generations_do_not_cross_contaminate_buckets(self):
         h = _Hist()
-        h.add(self._dp(self.OLD_SHARED_BOUNDS, 11, count=5))   # 5 old samples
-        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=9))           # 9 new samples
+        h.add(self._dp(self.OLD_SHARED_BOUNDS, 11, count=5))  # 5 old samples
+        h.add(self._dp(_TURN_BUCKETS_MS, 2, count=9))  # 9 new samples
         assert h.bounds == list(_TURN_BUCKETS_MS)
         assert sum(h.buckets) == 9, "old-generation counts bled into new buckets"
 
@@ -354,8 +384,15 @@ class TestMixedBoundaryGenerations:
         """
         h = _Hist()
         for _ in range(5):
-            h.add(self._dp(self.OLD_SHARED_BOUNDS, len(self.OLD_SHARED_BOUNDS),
-                           count=1, total=227589, ns=1_000))
+            h.add(
+                self._dp(
+                    self.OLD_SHARED_BOUNDS,
+                    len(self.OLD_SHARED_BOUNDS),
+                    count=1,
+                    total=227589,
+                    ns=1_000,
+                )
+            )
         h.add(self._dp(_TURN_BUCKETS_MS, 2, count=1, total=5000, ns=2_000))
 
         assert h.bounds == list(_TURN_BUCKETS_MS), "stale generation kept winning"
@@ -463,9 +500,7 @@ class TestViewWiring:
     def test_long_turn_does_not_land_in_the_overflow_bucket(self):
         """The regression: 227589ms must fall inside an explicit bucket."""
         mp, reader = self._provider()
-        mp.get_meter("t").create_histogram(
-            "kirocrew.turn.duration", unit="ms"
-        ).record(227589)
+        mp.get_meter("t").create_histogram("kirocrew.turn.duration", unit="ms").record(227589)
 
         (dp,) = self._points(reader, "kirocrew.turn.duration")
         counts = list(dp.bucket_counts)
@@ -481,9 +516,7 @@ class TestViewWiring:
         mp, reader = self._provider()
         meter = mp.get_meter("t")
         meter.create_histogram("kirocrew.turn.duration", unit="ms").record(5000)
-        meter.create_histogram(
-            "kirocrew.session.startup.duration", unit="ms"
-        ).record(4400)
+        meter.create_histogram("kirocrew.session.startup.duration", unit="ms").record(4400)
 
         assert len(self._points(reader, "kirocrew.turn.duration")) == 1
         assert len(self._points(reader, "kirocrew.session.startup.duration")) == 1
@@ -492,9 +525,7 @@ class TestViewWiring:
         mp, reader = self._provider()
         meter = mp.get_meter("t")
         meter.create_histogram("kirocrew.turn.duration", unit="ms").record(60000)
-        meter.create_histogram(
-            "kirocrew.mcp.backend.acquire.duration", unit="ms"
-        ).record(1)
+        meter.create_histogram("kirocrew.mcp.backend.acquire.duration", unit="ms").record(1)
 
         (turn,) = self._points(reader, "kirocrew.turn.duration")
         (fast,) = self._points(reader, "kirocrew.mcp.backend.acquire.duration")
@@ -535,9 +566,7 @@ class TestAggregatorReadsRealPercentiles:
         assert _pct_from_buckets(old_counts, old_bounds, 0.90) == 60000.0
 
         new_bounds = _TURN_BUCKETS_MS
-        landed = next(
-            i for i, b in enumerate(new_bounds) if b >= 227589
-        )
+        landed = next(i for i, b in enumerate(new_bounds) if b >= 227589)
         new_counts = [0] * (len(new_bounds) + 1)
         new_counts[landed] = 1
         p50 = _pct_from_buckets(new_counts, new_bounds, 0.50)

--- a/test/source_corpus.py
+++ b/test/source_corpus.py
@@ -148,3 +148,20 @@ def parsed_candidates(
                 continue
             raise
         yield path, text, tree
+
+
+def _clear_caches() -> None:
+    """Drop the cached raw and NFKC-normalised corpus text.
+
+    ``_read_tree`` and ``_normalized_texts`` are each an ``lru_cache(maxsize=1)``
+    over the whole ``src/`` tree (~80 MB raw text + ~80 MB of its NFKC copy), and
+    once any gate in a worker calls either one, that ~160 MB sits on the heap for
+    the rest of that worker's life -- it is never large enough to trigger a GC
+    that would reclaim it, so it is pure retained RSS on every later test the
+    worker runs. A caller that is done with the corpus for now (a module-scoped
+    fixture at teardown) can drop it here; the next gate that needs it just pays
+    the read again, which is the same one-time cost every gate already paid
+    before this module existed to share it.
+    """
+    _read_tree.cache_clear()
+    _normalized_texts.cache_clear()

--- a/test/test_acp_provider.py
+++ b/test/test_acp_provider.py
@@ -759,8 +759,12 @@ class TestStartKiroRuntimeResume:
         runtime.create_session.assert_not_awaited()
         args = runtime.load_session.await_args.args
         loaded_path, loaded_sid = args[0], args[1]
-        # First positional is the full transcript path, never the bare sid.
-        assert loaded_path.endswith("/.kiro/sessions/cli/abc-123.json")
+        # First positional is the full transcript path under kiro-cli's session
+        # store -- wherever the resolver says that is (the test floor pins it) --
+        # never the bare sid.
+        from kiro_crew.config.paths import kiro_sessions_dir
+
+        assert loaded_path == str(kiro_sessions_dir() / "abc-123.json")
         assert loaded_path != "abc-123"
         # Second positional is the original sid, adopted as the resumed sessionId.
         assert loaded_sid == "abc-123"

--- a/test/test_agent_home_isolation.py
+++ b/test/test_agent_home_isolation.py
@@ -662,7 +662,7 @@ def test_pod_target_is_private_so_the_guard_stands_aside(monkeypatch, tmp_path):
 # --------------------------------------------------------------------------
 # Transcripts follow the same home as the specs
 # --------------------------------------------------------------------------
-def test_sessions_dir_follows_kiro_home(monkeypatch, tmp_path):
+def test_sessions_dir_follows_kiro_home(monkeypatch, tmp_path, unpinned_kiro_sessions_dir):
     """The transcripts dir must move WITH the agent dir, or resume breaks.
 
     ``KIRO_HOME`` is directory-wide: kiro-cli writes transcripts under it. If
@@ -680,7 +680,7 @@ def test_sessions_dir_follows_kiro_home(monkeypatch, tmp_path):
     assert kiro_agents_dir() == root / "agents"
 
 
-def test_sessions_dir_defaults_to_dot_kiro(monkeypatch):
+def test_sessions_dir_defaults_to_dot_kiro(monkeypatch, unpinned_kiro_sessions_dir):
     _no_overrides(monkeypatch)
     from kiro_crew.config.paths import kiro_sessions_dir
 

--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -27,6 +27,7 @@ the ``oversized`` and symlink cases are differential against the old path
 from __future__ import annotations
 
 import ast
+import functools
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -955,6 +956,7 @@ _EXPECTED_WARM_CALL_SITE_LABELS: dict[str, list[tuple[str, str]]] = {
 }
 
 
+@functools.lru_cache(maxsize=None)
 def _labelled_call_sites(target: str) -> dict[str, list[tuple[str | None, str | None]]]:
     """Return every *target* call site and its label pair.
 
@@ -968,6 +970,10 @@ def _labelled_call_sites(target: str) -> dict[str, list[tuple[str | None, str | 
     well, and its labels are read from the handing-off call, which is where the
     forwarded kwargs are written. This applies to every entry in
     ``_RATCHET_INVENTORY``, not to any one callee.
+
+    Cached per *target*: the source tree cannot change mid-run, both tests in
+    ``TestCallSiteLabelRatchet`` ask the same three targets, and the scan itself
+    (rglob + ast.parse of the whole ``src/`` tree) is the expensive part.
     """
     src = Path(__file__).resolve().parent.parent / "src"
     sites: dict[str, list[tuple[str | None, str | None]]] = {}

--- a/test/test_app_identity_provenance.py
+++ b/test/test_app_identity_provenance.py
@@ -37,6 +37,23 @@ def _admit_registry_execution(monkeypatch):
     monkeypatch.setattr(registry, "app_admission_denied", lambda *a, **k: None)
 
 
+@pytest.fixture(autouse=True)
+def _catalog_absent(monkeypatch):
+    """Pin "official catalog reachable, app absent" for the whole module.
+
+    ``get_registry_app`` is patched to a per-test stub everywhere in this file, but
+    its real implementation is upstream of ``official_catalog.inventory_for_install``,
+    whose real lookup performs a fresh uncached HTTPS fetch on every call. Without
+    this guard, any test added here later that forgets to stub ``get_registry_app``
+    (or exercises the real lookup path some other way) would silently depend on the
+    runner's live network being up.
+    """
+    monkeypatch.setattr(
+        "kiro_crew.apps.official_catalog.inventory_for_install",
+        lambda name: None,
+    )
+
+
 @pytest.fixture()
 def sel_calls(monkeypatch) -> MagicMock:
     """Capture SEL audit emissions from the registry install path."""

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -45,6 +45,24 @@ def _explicit_registry_execution_admission(monkeypatch):
     monkeypatch.setattr("kiro_crew.apps.execution.third_party_execution_allowed", lambda: True)
 
 
+@pytest.fixture(autouse=True)
+def _catalog_absent(monkeypatch):
+    """Pin "official catalog reachable, app absent" for the whole module.
+
+    ``get_registry_app`` (patched to a stub in most tests here) is, in its real
+    implementation, upstream of ``official_catalog.inventory_for_install``, whose
+    real lookup performs a fresh uncached HTTPS fetch on every call. A test that
+    exercises the real ``get_registry_app``/catalog path (rather than stubbing it
+    directly) would otherwise depend on the runner's live network being up. A
+    test that wants a different catalog answer overrides this by monkeypatching
+    the same seam itself (see ``TestCatalogAppsIncludesExternalRegistries``).
+    """
+    monkeypatch.setattr(
+        "kiro_crew.apps.official_catalog.inventory_for_install",
+        lambda name: None,
+    )
+
+
 # A portable long-lived child: sleeps well past any test timeout without
 # relying on POSIX-only binaries (``sleep``/``bash`` are absent on native
 # Windows, where they would fail collection with FileNotFoundError).

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from kiro_crew import env as env_mod
 from kiro_crew.browser_cli import install as mod
 
 # The real implementation, captured before the autouse fixture below replaces
@@ -15,6 +16,27 @@ from kiro_crew.browser_cli import install as mod
 # restore THIS (re-reading ``mod._required_revisions`` there would just re-bind
 # the stub to itself, silently leaving every test on the fallback path).
 _REAL_REQUIRED_REVISIONS = mod._required_revisions
+
+
+@pytest.fixture(autouse=True)
+def _clear_node_bin_dir_caches() -> None:
+    """``node_bin_dirs`` / ``_node_all_bin_dirs`` are ``lru_cache``d for the
+    process lifetime, keyed on nothing (the former) or on ``(home, mise_data)``
+    (the latter). ``cli_path()`` reaches both via ``find_node_tool`` ->
+    ``node_augmented_path`` -> ``node_bin_dirs()``. Once any earlier test in
+    this worker (this file or another) resolves a node tool with the real
+    ``$HOME``, the memoized real-machine mise/volta/nvm directories stay
+    prepended to every later PATH lookup regardless of a test's own ``HOME``
+    override -- ``test_the_cli_is_found_where_the_standalone_installer_puts_it``
+    got the operator's real mise-installed ``playwright-cli`` shim instead of
+    the ``tmp_path``-rooted wrapper it wrote, only when an earlier test had
+    warmed the cache first (no-test-side-effects; mirrors the fixture in
+    test_node_toolchain_resolution.py)."""
+    env_mod.node_bin_dirs.cache_clear()
+    env_mod._node_all_bin_dirs.cache_clear()
+    yield
+    env_mod.node_bin_dirs.cache_clear()
+    env_mod._node_all_bin_dirs.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -85,7 +85,7 @@ class TestParallelBatching:
         assert _MAX_PARALLEL_TASKS == 3
 
     @pytest.mark.asyncio
-    async def test_large_group_batched(self):
+    async def test_large_group_batched(self, tmp_path):
         """A group of 6 tasks should be split into batches of 4 + 2."""
         from kiro_crew.task_models import Project, Task, TaskStatus
 
@@ -95,7 +95,7 @@ class TestParallelBatching:
         sessions.release = MagicMock()
         sessions.reset = AsyncMock()
 
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         # Track execution order
         executed: list[int] = []
@@ -122,7 +122,7 @@ class TestParallelBatching:
         assert set(executed) == {1, 2, 3, 4, 5, 6}
 
     @pytest.mark.asyncio
-    async def test_small_group_not_batched(self):
+    async def test_small_group_not_batched(self, tmp_path):
         """A group of 3 tasks should run in a single gather (no batching needed)."""
         from kiro_crew.task_models import Project, Task, TaskStatus
 
@@ -132,7 +132,7 @@ class TestParallelBatching:
         sessions.release = MagicMock()
         sessions.reset = AsyncMock()
 
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         executed: list[int] = []
 

--- a/test/test_cron_trigger.py
+++ b/test/test_cron_trigger.py
@@ -265,7 +265,7 @@ class TestCronTriggerMCP:
 class TestCronTriggerCLI:
     """Tests for the CLI cron trigger subcommand."""
 
-    def test_cli_subcommand_registered(self):
+    def test_cli_subcommand_registered(self, tmp_path):
         """kirocrew cron trigger is a recognized subcommand with job_id argument."""
         # Verify the handler accepts "trigger" action without crashing
         import argparse
@@ -273,9 +273,8 @@ class TestCronTriggerCLI:
         from kiro_crew.cli_commands import _cron
         args = argparse.Namespace(cron_action="trigger", job_id="abc12345")
         # Will fail with connection error (no gateway) but proves the action is recognized
-        from pathlib import Path
         from unittest.mock import patch as _patch
-        with _patch("kiro_crew.cli_commands.config_dir", return_value=Path("/tmp/nonexistent")):
+        with _patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path / "nonexistent"):
             _cron(args)
         # If we get here without "Usage:" being printed, the action was recognized
 
@@ -301,7 +300,7 @@ class TestCronTriggerCLI:
         assert "Triggered job:" in captured.out
         assert "abc12345" in captured.out
 
-    def test_cli_trigger_invalid_id(self, capsys):
+    def test_cli_trigger_invalid_id(self, capsys, tmp_path):
         """CLI rejects malformed job IDs."""
         import argparse
 
@@ -309,7 +308,6 @@ class TestCronTriggerCLI:
 
         args = argparse.Namespace(cron_action="trigger", job_id="../evil")
 
-        from pathlib import Path
         from unittest.mock import patch as _patch
 
         from kiro_crew.config import loader
@@ -317,7 +315,7 @@ class TestCronTriggerCLI:
         orig_port = loader.DASHBOARD_PORT
         loader.DASHBOARD_PORT = 19999
         try:
-            with _patch("kiro_crew.cli_commands.config_dir", return_value=Path("/tmp")):
+            with _patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
                 _cron(args)
         finally:
             loader.DASHBOARD_PORT = orig_port

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -17265,6 +17265,19 @@ class TestRunChatTransientRetry:
     def _client(stream):
         client = AsyncMock()
         client.context_usage_pct = MagicMock(return_value=0.0)
+        # These are sync accessors on the real provider client; _run_chat
+        # calls them without awaiting, so a bare AsyncMock attribute here
+        # would leave an unawaited coroutine per turn.
+        client.context_window_tokens = MagicMock(return_value=0)
+        client.context_used_tokens = MagicMock(return_value=0)
+        client.mcp_session_report = MagicMock(return_value=None)
+        client.pop_pending_oauth_requests = MagicMock(return_value=[])
+        client.available_models = MagicMock(return_value=[])
+        # _drain_session_init_oauth_requests reaches pop_pending_oauth_requests
+        # via client.client (the nested ACP client), not the front client
+        # itself; leaving client.client as a bare AsyncMock attribute would
+        # make that nested lookup resolve to another never-awaited coroutine.
+        client.client = None
         client.stream = stream
         client.stream_command = stream
         # The poisoned-conversation canary reads the session's served model

--- a/test/test_deploy_round3_fixes.py
+++ b/test/test_deploy_round3_fixes.py
@@ -183,7 +183,7 @@ def test_compat_static_map_contents():
 
 
 @pytest.mark.asyncio
-async def test_ttl_hours_string_rejected(monkeypatch):
+async def test_ttl_hours_string_rejected(monkeypatch, tmp_path):
     """F4: ttl_hours as string "12" → 400."""
     from kiro_crew.deploy import handlers
 
@@ -204,8 +204,9 @@ async def test_ttl_hours_string_rejected(monkeypatch):
             return FakeArt()
 
     monkeypatch.setattr("kiro_crew.deploy.handlers.get_default_store", lambda: FakeStore())
+    staged = str(tmp_path / "x")
     monkeypatch.setattr("kiro_crew.deploy.handlers._stage_artifact_html",
-                        lambda kind, content, name: ([], "/tmp/x", 42))
+                        lambda kind, content, name: ([], staged, 42))
 
     status, body = await handlers._do_deploy({
         "site_id": "s", "artifact_slug": "slug", "ttl_hours": "12",
@@ -215,7 +216,7 @@ async def test_ttl_hours_string_rejected(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_ttl_hours_float_rejected(monkeypatch):
+async def test_ttl_hours_float_rejected(monkeypatch, tmp_path):
     """F4: ttl_hours as float 12.5 → 400."""
     from kiro_crew.deploy import handlers
 
@@ -236,8 +237,9 @@ async def test_ttl_hours_float_rejected(monkeypatch):
             return FakeArt()
 
     monkeypatch.setattr("kiro_crew.deploy.handlers.get_default_store", lambda: FakeStore())
+    staged = str(tmp_path / "x")
     monkeypatch.setattr("kiro_crew.deploy.handlers._stage_artifact_html",
-                        lambda kind, content, name: ([], "/tmp/x", 42))
+                        lambda kind, content, name: ([], staged, 42))
 
     status, body = await handlers._do_deploy({
         "site_id": "s", "artifact_slug": "slug", "ttl_hours": 12.5,
@@ -247,7 +249,7 @@ async def test_ttl_hours_float_rejected(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_ttl_hours_bool_rejected(monkeypatch):
+async def test_ttl_hours_bool_rejected(monkeypatch, tmp_path):
     """F4: ttl_hours as bool True → 400."""
     from kiro_crew.deploy import handlers
 
@@ -268,8 +270,9 @@ async def test_ttl_hours_bool_rejected(monkeypatch):
             return FakeArt()
 
     monkeypatch.setattr("kiro_crew.deploy.handlers.get_default_store", lambda: FakeStore())
+    staged = str(tmp_path / "x")
     monkeypatch.setattr("kiro_crew.deploy.handlers._stage_artifact_html",
-                        lambda kind, content, name: ([], "/tmp/x", 42))
+                        lambda kind, content, name: ([], staged, 42))
 
     status, body = await handlers._do_deploy({
         "site_id": "s", "artifact_slug": "slug", "ttl_hours": True,
@@ -279,7 +282,7 @@ async def test_ttl_hours_bool_rejected(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_ttl_hours_int_ok(monkeypatch):
+async def test_ttl_hours_int_ok(monkeypatch, tmp_path):
     """F4: ttl_hours as int 12 → passes validation (hits confirm gate)."""
     from kiro_crew.deploy import handlers
 
@@ -300,8 +303,9 @@ async def test_ttl_hours_int_ok(monkeypatch):
             return FakeArt()
 
     monkeypatch.setattr("kiro_crew.deploy.handlers.get_default_store", lambda: FakeStore())
+    staged = str(tmp_path / "x")
     monkeypatch.setattr("kiro_crew.deploy.handlers._stage_artifact_html",
-                        lambda kind, content, name: ([], "/tmp/x", 42))
+                        lambda kind, content, name: ([], staged, 42))
 
     status, body = await handlers._do_deploy({
         "site_id": "s", "artifact_slug": "slug", "ttl_hours": 12,

--- a/test/test_fixtures_helper.py
+++ b/test/test_fixtures_helper.py
@@ -338,6 +338,11 @@ def test_seeded_home_importable_without_pytest(
     # Force a fresh load by removing any cached copy of the target module.
     monkeypatch.delitem(sys.modules, "kiro_crew.testing.fixtures", raising=False)
     monkeypatch.delitem(sys.modules, "kiro_crew.testing", raising=False)
+    # The fresh import_module below would otherwise byte-compile a real
+    # __pycache__/*.pyc into the checkout's src/kiro_crew/testing/ tree —
+    # this test only cares about the module's runtime attributes, not about
+    # leaving compiled bytecode behind.
+    monkeypatch.setattr(sys, "dont_write_bytecode", True)
 
     fresh = importlib.import_module("kiro_crew.testing.fixtures")
 

--- a/test/test_handlers_system_cpu_pct.py
+++ b/test/test_handlers_system_cpu_pct.py
@@ -95,6 +95,10 @@ class TestCollectSystemMetricsCpuFallback:
             patch.object(hs, "_system_cpu_pct_from_proc_stat", return_value=None),
             patch.object(hs.subprocess, "check_output", return_value=b"%CPU\n10.0\n5.0\n"),
             patch.object(hs.os, "cpu_count", return_value=1),
+            # The local-IP block opens a real UDP socket to 8.8.8.8:80; refusing
+            # the connect exercises the existing except-degrades-to-127.0.0.1
+            # path instead of reaching out over the network.
+            patch.object(hs, "_local_ip", return_value="127.0.0.1"),
         ):
             data = hs._collect_system_metrics()
         assert data["cpu_pct"] == 15.0
@@ -107,6 +111,7 @@ class TestCollectSystemMetricsCpuFallback:
         with (
             patch.object(hs.sys, "platform", "win32"),
             patch.object(hs.platform_compat, "system_cpu_percent", return_value=42.0),
+            patch.object(hs, "_local_ip", return_value="127.0.0.1"),
         ):
             data = hs._collect_system_metrics()
         assert data["cpu_pct"] == 42.0
@@ -119,6 +124,7 @@ class TestCollectSystemMetricsCpuFallback:
         with (
             patch.object(hs.sys, "platform", "win32"),
             patch.object(hs.platform_compat, "system_cpu_percent", return_value=None),
+            patch.object(hs, "_local_ip", return_value="127.0.0.1"),
         ):
             data = hs._collect_system_metrics()
         assert data["cpu_pct"] == 17.0

--- a/test/test_handlers_system_linux_mem.py
+++ b/test/test_handlers_system_linux_mem.py
@@ -42,6 +42,9 @@ def _collect_with_meminfo(meminfo_text: str) -> dict:
         patch.object(handlers_system, "_get_static_system_info", return_value={}),
         patch.object(handlers_system, "_system_cpu_pct_from_proc_stat", return_value=5.0),
         patch("builtins.open", side_effect=_fake_open_for_meminfo(meminfo_text)),
+        # The local-IP probe is the one real network reach in a system-info
+        # render; pin its answer so the test never dials out.
+        patch.object(handlers_system, "_local_ip", return_value="127.0.0.1"),
     ):
         return handlers_system._collect_system_metrics()
 

--- a/test/test_handlers_system_mcp_count.py
+++ b/test/test_handlers_system_mcp_count.py
@@ -16,7 +16,13 @@ def _run_collect() -> dict:
     """
     from kiro_crew.dashboard import handlers_system
 
-    with patch.object(handlers_system, "_get_static_system_info", return_value={}):
+    with (
+        patch.object(handlers_system, "_get_static_system_info", return_value={}),
+        # The local-IP block opens a real UDP socket to 8.8.8.8:80 to learn the
+        # outbound interface address. Refusing the connect exercises the same
+        # except-degrades-to-127.0.0.1 path without a real network reach-out.
+        patch.object(handlers_system, "_local_ip", return_value="127.0.0.1"),
+    ):
         # Reset both caches so each test gets a fresh call — the process scan
         # cache has a 15s TTL that survives across xdist workers.
         handlers_system._metrics_cache.clear()

--- a/test/test_handlers_system_proc_mem.py
+++ b/test/test_handlers_system_proc_mem.py
@@ -20,7 +20,13 @@ def _run_collect() -> dict:
     """
     from kiro_crew.dashboard import handlers_system
 
-    with patch.object(handlers_system, "_get_static_system_info", return_value={}):
+    with (
+        patch.object(handlers_system, "_get_static_system_info", return_value={}),
+        # The local-IP block opens a real UDP socket to 8.8.8.8:80 to learn the
+        # outbound interface address. Refusing the connect exercises the same
+        # except-degrades-to-127.0.0.1 path without a real network reach-out.
+        patch.object(handlers_system, "_local_ip", return_value="127.0.0.1"),
+    ):
         handlers_system._metrics_cache.clear()
         handlers_system._metrics_cache_ts = 0.0
         handlers_system._proc_scan_cache = {}

--- a/test/test_host_available_memory.py
+++ b/test/test_host_available_memory.py
@@ -24,6 +24,7 @@ import ctypes
 
 import pytest
 
+from conftest import absent_sysconf
 from kiro_crew import platform_compat as pc
 
 _SENTINEL_PORT = 0x1111
@@ -98,7 +99,20 @@ def as_macos(monkeypatch: pytest.MonkeyPatch):
         # raising=False: os.sysconf does not exist on Windows, and this fixture has
         # to install a page size there too -- the macOS branch under test reads it,
         # and a bare setattr would fail the whole class on the Windows shard.
-        monkeypatch.setattr(pc.os, "sysconf", lambda name: page_size, raising=False)
+        # ``pc.os`` is the process-wide ``os`` module, not a module-local alias, so
+        # the fake answers SC_PAGE_SIZE only and forwards every other name to the
+        # real os.sysconf -- an unscoped fake would feed this test's page size to
+        # any other thread reading SC_OPEN_MAX/SC_PHYS_PAGES concurrently.
+        real_sysconf = getattr(pc.os, "sysconf", None)
+
+        def fake_sysconf(name: str) -> int:
+            if name == "SC_PAGE_SIZE":
+                return page_size
+            if real_sysconf is not None:
+                return real_sysconf(name)
+            raise ValueError(name)
+
+        monkeypatch.setattr(pc.os, "sysconf", fake_sysconf, raising=False)
         return fake
 
     return _install
@@ -301,8 +315,14 @@ class TestTheMacosReadingFailsSafely:
         """A page count without a page size is not a byte count."""
         as_macos(fields={"free_count": 512 * _PAGES_PER_MIB})
 
+        real_sysconf = getattr(pc.os, "sysconf", absent_sysconf)
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(pc.os, "sysconf", lambda name: 0, raising=False)
+            mp.setattr(
+                pc.os,
+                "sysconf",
+                lambda name: 0 if name == "SC_PAGE_SIZE" else real_sysconf(name),
+                raising=False,
+            )
             assert pc.host_available_mib() == 0
 
     @pytest.mark.parametrize("kern_return", [0, 1])

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -6,6 +6,9 @@ operator's machine from a test that forgot to isolate itself:
 
 * the **data home** -- ``KIROCREW_HOME`` pinned per test, plus the ``~/.kiro`` paths
   production binds at IMPORT time, which the env var cannot reach;
+* the **workspace root** -- ``KIROCREW_WORKSPACE`` pinned per test, a SEPARATE
+  default from the data home that otherwise resolves to the operator's real
+  ``~/workplace``;
 * the **system temp directory** -- ``tempfile``'s base redirected per run, with residue
   reported rather than silently accumulated;
 * the **worker budget** -- how many xdist workers the host can actually back.
@@ -74,6 +77,7 @@ _GUARDED_ROOTS: tuple[pathlib.Path, ...] = (
     pathlib.Path.home() / ".kiro",
     pathlib.Path.home() / ".kirocrew",
     pathlib.Path.home() / ".claude.json",
+    pathlib.Path.home() / "workplace",
 )
 
 
@@ -130,6 +134,49 @@ class TestTheDataHomeIsPinnedForEveryTestpath:
         monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
 
         assert config_dir().resolve() == mine.resolve()
+
+
+class TestTheWorkspaceRootIsPinnedForEveryTestpath:
+    """``KIROCREW_WORKSPACE`` must be a tmp dir here, independent of the data home.
+
+    ``config.loader.workspace_root()`` does not derive from ``config_dir()`` -- with
+    no override and no saved ``<config_dir>/workspace_dir`` file it falls back to the
+    platform's ``_default_workspace_base()`` plus ``kirocrew-workspace``, which on
+    Linux/macOS is the operator's real ``~/workplace``. Pinning ``KIROCREW_HOME``
+    alone therefore leaves this resolver unpinned, and any test that reaches an agent
+    working directory ``mkdir``s and writes into that real tree.
+    """
+
+    def test_kirocrew_workspace_is_not_the_operators_real_workplace(self) -> None:
+        workspace = pathlib.Path(os.environ["KIROCREW_WORKSPACE"]).resolve()
+
+        assert not _inside_a_guarded_root(
+            workspace
+        ), f"KIROCREW_WORKSPACE is a real home path: {workspace}"
+
+    def test_workspace_root_resolves_to_that_same_pinned_dir(self) -> None:
+        """The env var is only worth pinning if the package actually follows it.
+
+        Unlike ``config_dir()``, ``workspace_root()`` caches nothing across calls, so
+        this only needs to prove the env var reaches the resolver -- there is no
+        module-global memo to reset alongside it.
+        """
+        from kiro_crew.config.loader import workspace_root
+
+        assert workspace_root().resolve() == pathlib.Path(
+            os.environ["KIROCREW_WORKSPACE"]
+        ).resolve()
+
+    def test_a_test_can_still_override_the_workspace_itself(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The floor is a safety net, not a cage: a test that isolates itself wins."""
+        from kiro_crew.config.loader import workspace_root
+
+        mine = tmp_path / "my-own-workspace"
+        monkeypatch.setenv("KIROCREW_WORKSPACE", str(mine))
+
+        assert workspace_root().resolve() == mine.resolve()
 
 
 class TestTheAgentSpecHomeIsPinnedForEveryTestpath:
@@ -360,6 +407,120 @@ class TestTheAgentSpecHomeIsPinnedForEveryTestpath:
         monkeypatch.setattr(agent, "KIRO_AGENTS_DIR", mine)
 
         assert agent.kiro_agents_dir_path() == mine
+
+
+class TestTheKiroSessionsDirIsPinnedForEveryTestpath:
+    """kiro-cli's replay store: ``<kiro home>/sessions/cli``, machine-wide.
+
+    A fourth ``~/.kiro`` axis, alongside the data home, ``_SHARED_KIRO_PATHS`` and the
+    agent-spec home: ``kiro_sessions_dir()`` is a LAZY resolver (same shape as
+    ``kiro_agents_dir()``), so none of the other three reach it. Before this floor part
+    existed, session-teardown tests (``AcpSessionHandle.destroy()`` -> a bare
+    ``kiro_sessions_dir()`` call with no override) deleted ``<sid>.json``/``.jsonl`` out
+    of the operator's REAL kiro-cli session store.
+    """
+
+    def test_the_resolved_dir_is_not_the_operators_real_home(self) -> None:
+        from kiro_crew.config import paths
+
+        assert not _inside_a_guarded_root(paths.kiro_sessions_dir().resolve())
+
+    def test_the_resolver_itself_is_pinned_so_no_consumer_needs_registering(self) -> None:
+        """Same proof as the agent-spec resolver: a bound-by-name copy still follows.
+
+        ``session_map`` binds ``kiro_sessions_dir`` by name, so this is what proves the
+        override reaches a copied function object rather than only the definition site.
+        """
+        from kiro_crew import session_map
+        from kiro_crew.config import paths
+
+        assert paths._sessions_dir_override is not None, "the floor installed no override"
+        assert session_map.kiro_sessions_dir is paths.kiro_sessions_dir, (
+            "session_map no longer binds the resolver by name, so this test has "
+            "stopped proving that a bound copy honours the override"
+        )
+        assert not _inside_a_guarded_root(session_map.kiro_sessions_dir().resolve())
+
+    def test_the_pin_is_installed_even_when_paths_was_not_imported_before_setup(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The floor imports the leaf itself; it does not wait for a test to.
+
+        A test that imports its subject inside its own body is a normal shape here, and
+        this floor guards a DELETE path. A patch-if-imported fixture would find no module
+        at setup and leave the override ``None`` for exactly that test. In a real session
+        a sibling fixture usually imports ``paths`` first, which is why this drives the
+        fixture BODY directly with the module evicted from ``sys.modules``: the only
+        way the override can be present afterwards is if the fixture imported it.
+        """
+        import kiro_crew.config as config_pkg
+
+        original = sys.modules["kiro_crew.config.paths"]
+        # Restore the package attribute the re-import will overwrite, and the
+        # sys.modules entry, when monkeypatch unwinds.
+        monkeypatch.setattr(config_pkg, "paths", original)
+        monkeypatch.delitem(sys.modules, "kiro_crew.config.paths")
+        monkeypatch.delitem(sys.modules, "kiro_crew.session_map", raising=False)
+
+        body = _root._isolate_kiro_sessions_dir
+        body = getattr(body, "__wrapped__", body)
+        body(lambda name: tmp_path / name, monkeypatch)
+
+        reimported = importlib.import_module("kiro_crew.config.paths")
+        assert reimported is not original, "sys.modules eviction did not take"
+        assert reimported._sessions_dir_override is not None, (
+            "the floor left kiro_sessions_dir() unpinned for a test whose first import "
+            "of config.paths happens in its own body"
+        )
+        assert reimported.kiro_sessions_dir() == tmp_path / "kiro-sessions-cli"
+
+    def test_a_relocated_kiro_home_is_followed_not_pinned(self, tmp_path, monkeypatch) -> None:
+        """The pin is a fence around the REAL store, not a redirect of every resolution.
+
+        ~35 tests relocate kiro-cli's home themselves (``KIRO_HOME``, or a patched
+        ``Path.home``) and then read the tree they built there; a pin that answered the
+        isolation dir regardless would send every one of them to an empty directory.
+        """
+        from kiro_crew.config import paths
+
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "relocated"))
+        assert paths.kiro_sessions_dir() == tmp_path / "relocated" / "sessions" / "cli"
+
+    def test_the_real_store_is_fenced_even_through_kiro_home(self, monkeypatch) -> None:
+        """Pointing ``KIRO_HOME`` back at the operator's real ``~/.kiro`` is still fenced.
+
+        The guard keys on WHERE the unpinned resolution lands, not on which lever set
+        it, so a test cannot reach the real transcript store by spelling the real path
+        explicitly.
+        """
+        from kiro_crew.config import paths
+
+        monkeypatch.setenv("KIRO_HOME", str(_root._REAL_KIRO_HOME_AT_START))
+        assert not _inside_a_guarded_root(paths.kiro_sessions_dir().resolve())
+
+    def test_the_session_map_own_hook_is_pinned_too(self) -> None:
+        """``session_map._KIRO_SESSIONS_DIR`` is a second, opt-in lever on the same seam.
+
+        Pinned to the SAME directory as the resolver override, not merely a private one,
+        so a test that writes through one seam and reads through the other still sees
+        one tree.
+        """
+        from kiro_crew import session_map
+        from kiro_crew.config import paths
+
+        assert session_map._KIRO_SESSIONS_DIR is not None
+        assert session_map._KIRO_SESSIONS_DIR == paths.kiro_sessions_dir()
+
+    def test_a_test_that_redirects_the_override_itself_is_followed(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The floor is a safety net, not a cage."""
+        from kiro_crew.config import paths
+
+        mine = tmp_path / "my-own-sessions"
+        monkeypatch.setattr(paths, "_sessions_dir_override", lambda: mine)
+
+        assert paths.kiro_sessions_dir() == mine
 
 
 class TestTheSharedKiroPathsArePinned:

--- a/test/test_jsondecodeerror_redundancy_ratchet.py
+++ b/test/test_jsondecodeerror_redundancy_ratchet.py
@@ -55,7 +55,19 @@ def test_no_except_tuple_pairs_jsondecodeerror_with_bare_valueerror() -> None:
     for root in SCAN_ROOTS:
         for path in sorted(root.rglob("*.py")):
             try:
-                tree = ast.parse(path.read_text(encoding="utf-8"))
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue  # not this ratchet's job
+            # A violation needs BOTH names in the same except tuple, so a file
+            # missing either token textually cannot contain one -- necessary,
+            # not sufficient, so parsing the survivors still decides it. This
+            # is the whole tree's ~1250+ modules down to a couple dozen: the
+            # cost was one `ast.parse` per file for a check the text already
+            # answers "no" for on every file that lacks one of the two names.
+            if "JSONDecodeError" not in text or "ValueError" not in text:
+                continue
+            try:
+                tree = ast.parse(text)
             except SyntaxError:
                 continue  # not this ratchet's job
             for lineno in _redundant_handlers(tree):

--- a/test/test_knowledge_namespace.py
+++ b/test/test_knowledge_namespace.py
@@ -33,12 +33,13 @@ def _make_request(body: dict, app_extras: dict | None = None) -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_add_source_folds_namespace_into_properties():
+async def test_add_source_folds_namespace_into_properties(tmp_path):
     """Top-level namespace is folded into properties for local_folder."""
+    folder = tmp_path / "test_folder"
     body = {
         "name": "test",
         "source_type": "local_folder",
-        "uri": "/tmp/test_folder",
+        "uri": str(folder),
         "properties": {"recursive": True},
         "namespace": "my-ns",
     }
@@ -49,7 +50,7 @@ async def test_add_source_folds_namespace_into_properties():
             "kiro_crew.dashboard.handlers.knowledge.is_sensitive_path",
             return_value=False,
         ),
-        patch.object(Path, "resolve", return_value=Path("/tmp/test_folder")),
+        patch.object(Path, "resolve", return_value=folder),
         patch.object(Path, "is_dir", return_value=True),
     ):
         store_mock = MagicMock()
@@ -70,12 +71,13 @@ async def test_add_source_folds_namespace_into_properties():
 
 
 @pytest.mark.asyncio
-async def test_add_source_namespace_from_properties_directly():
+async def test_add_source_namespace_from_properties_directly(tmp_path):
     """Namespace already in properties is preserved (no double-fold)."""
+    folder = tmp_path / "test_folder"
     body = {
         "name": "test",
         "source_type": "local_folder",
-        "uri": "/tmp/test_folder",
+        "uri": str(folder),
         "properties": {"recursive": True, "namespace": "existing-ns"},
     }
     req = _make_request(body)
@@ -85,7 +87,7 @@ async def test_add_source_namespace_from_properties_directly():
             "kiro_crew.dashboard.handlers.knowledge.is_sensitive_path",
             return_value=False,
         ),
-        patch.object(Path, "resolve", return_value=Path("/tmp/test_folder")),
+        patch.object(Path, "resolve", return_value=folder),
         patch.object(Path, "is_dir", return_value=True),
     ):
         store_mock = MagicMock()

--- a/test/test_lazy_data_home_paths.py
+++ b/test/test_lazy_data_home_paths.py
@@ -34,6 +34,7 @@ Keeping the module-level name means existing ``monkeypatch.setattr(mod,
 from __future__ import annotations
 
 import ast
+from functools import lru_cache
 from pathlib import Path
 from unittest.mock import patch
 
@@ -41,7 +42,7 @@ SRC = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
 PATHS_MODULE = SRC / "config" / "paths.py"
 
 
-def _path_factories() -> set[str]:
+def _path_factories() -> frozenset[str]:
     """Names of the **Path-returning** helpers declared in ``config/paths.py``.
 
     Derived from the module rather than hardcoded so a newly added factory is
@@ -58,7 +59,15 @@ def _path_factories() -> set[str]:
     and a guard that cries wolf gets weakened or deleted, which costs more than
     the bug it was written to stop.
     """
-    tree = ast.parse(PATHS_MODULE.read_text(encoding="utf-8"))
+    return _path_factories_for(PATHS_MODULE)
+
+
+@lru_cache(maxsize=None)
+def _path_factories_for(paths_module: Path) -> frozenset[str]:
+    """Cached by the actual module path, so a monkeypatched ``PATHS_MODULE``
+    (see ``TestNoImportTimePathResolution``'s fake-tree tests) gets its own
+    cache entry instead of silently reusing the real tree's result."""
+    tree = ast.parse(paths_module.read_text(encoding="utf-8"))
     out: set[str] = set()
     for node in tree.body:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -68,10 +77,10 @@ def _path_factories() -> set[str]:
         # covers `Path`, `Path | None`, `Optional[Path]`, `list[Path]`
         if "Path" in ast.unparse(node.returns):
             out.add(node.name)
-    return out
+    return frozenset(out)
 
 
-def _transitive_path_factories() -> set[str]:
+def _transitive_path_factories() -> frozenset[str]:
     """Transitive closure: Path-returning functions that resolve through a paths.py factory.
 
     Extends the root set (functions declared in ``paths.py``) with every
@@ -91,13 +100,20 @@ def _transitive_path_factories() -> set[str]:
       even if they return a Path -- this excludes functions that merely
       manipulate a caller-supplied Path argument.
     """
-    roots = _path_factories()
+    return _transitive_path_factories_for(SRC, PATHS_MODULE)
+
+
+@lru_cache(maxsize=None)
+def _transitive_path_factories_for(src: Path, paths_module: Path) -> frozenset[str]:
+    """Cached by the actual (src, paths_module) pair, for the same monkeypatch
+    reason as ``_path_factories_for``."""
+    roots = _path_factories_for(paths_module)
 
     # Build a map: function_name -> set of names it calls, for every
     # Path-returning function in the tree. We only need function names (not
     # qualified paths) because the guard's detector matches bare call names.
     candidates: dict[str, set[str]] = {}  # name -> called names
-    for py in sorted(SRC.rglob("*.py")):
+    for py in sorted(src.rglob("*.py")):
         if "__pycache__" in py.parts:
             continue
         try:
@@ -131,7 +147,7 @@ def _transitive_path_factories() -> set[str]:
                 forbidden.add(name)
                 changed = True
 
-    return forbidden
+    return frozenset(forbidden)
 
 
 def _called_names(node: ast.AST) -> set[str]:
@@ -144,7 +160,7 @@ def _called_names(node: ast.AST) -> set[str]:
     return out
 
 
-def _frozen_path_constants() -> list[str]:
+def _frozen_path_constants() -> tuple[str, ...]:
     """Every import-time evaluation of a path factory (transitively).
 
     Three shapes freeze identically at import and all three are covered:
@@ -162,9 +178,16 @@ def _frozen_path_constants() -> list[str]:
     paths.py factory (e.g. ``kiro_agents_dir_path()``, ``_subagents_dir()``)
     are also forbidden at module level.
     """
-    factories = _transitive_path_factories()
+    return _frozen_path_constants_for(SRC, PATHS_MODULE)
+
+
+@lru_cache(maxsize=None)
+def _frozen_path_constants_for(src: Path, paths_module: Path) -> tuple[str, ...]:
+    """Cached by the actual (src, paths_module) pair, for the same monkeypatch
+    reason as ``_path_factories_for``."""
+    factories = _transitive_path_factories_for(src, paths_module)
     offenders: list[str] = []
-    for py in sorted(SRC.rglob("*.py")):
+    for py in sorted(src.rglob("*.py")):
         if "__pycache__" in py.parts:
             continue
         # App-internal test harnesses legitimately capture the real data-home
@@ -175,12 +198,11 @@ def _frozen_path_constants() -> list[str]:
             tree = ast.parse(py.read_text(encoding="utf-8"))
         except SyntaxError:  # pragma: no cover - syntax is enforced elsewhere
             continue
-        rel = py.relative_to(SRC)
+        rel = py.relative_to(src)
 
         def _record(node: ast.AST, targets: list[str], used: set[str], kind: str) -> None:
             offenders.append(
-                f"{rel}:{node.lineno}  [{kind}] {','.join(targets)} "
-                f"= ...{sorted(used)[0]}()"
+                f"{rel}:{node.lineno}  [{kind}] {','.join(targets)} " f"= ...{sorted(used)[0]}()"
             )
 
         for node in ast.walk(tree):
@@ -208,7 +230,7 @@ def _frozen_path_constants() -> list[str]:
                     used = _called_names(d) & factories
                     if used:
                         _record(d, [f"{node.name}() default"], used, "def-default")
-    return offenders
+    return tuple(offenders)
 
 
 class TestNoImportTimePathResolution:
@@ -252,9 +274,7 @@ class TestNoImportTimePathResolution:
         bad = ast.parse("X = kiro_agents_dir_path()").body[0]
         assert isinstance(bad, ast.Assign)
         called = _called_names(bad.value)
-        assert called & factories, (
-            "kiro_agents_dir_path should be in the transitive factory set"
-        )
+        assert called & factories, "kiro_agents_dir_path should be in the transitive factory set"
         # Also for _subagents_dir
         bad2 = ast.parse("X = _subagents_dir()").body[0]
         assert _called_names(bad2.value) & factories
@@ -350,16 +370,14 @@ class TestNoImportTimePathResolution:
             encoding="utf-8",
         )
         # A module that freezes the accessor at import time
-        (fake_src / "bad_module.py").write_text(
-            "FROZEN = _subagents_dir()\n", encoding="utf-8"
-        )
+        (fake_src / "bad_module.py").write_text("FROZEN = _subagents_dir()\n", encoding="utf-8")
         monkeypatch.setattr(mod, "SRC", fake_src)
         monkeypatch.setattr(mod, "PATHS_MODULE", fake_src / "config" / "paths.py")
 
         found = _frozen_path_constants()
-        assert any("_subagents_dir" in f for f in found), (
-            f"Transitive accessor not detected: {found}"
-        )
+        assert any(
+            "_subagents_dir" in f for f in found
+        ), f"Transitive accessor not detected: {found}"
 
 
 # (module import path, override constant, accessor) for every accessor that
@@ -510,9 +528,7 @@ class TestResolutionDoesNotRepeatStartupMaintenance:
         monkeypatch.setenv("KIROCREW_HOME", str(second))
         assert paths.data_home().resolve() == second.resolve()
 
-    def test_invalid_override_does_not_reopen_the_maintenance_path(
-        self, tmp_path, monkeypatch
-    ):
+    def test_invalid_override_does_not_reopen_the_maintenance_path(self, tmp_path, monkeypatch):
         """An override naming a system dir must NOT re-run maintenance per call.
 
         ``config_dir()`` gates the override branch on ``_valid_override_home()``
@@ -581,9 +597,7 @@ class TestConfigDirMemoIsNotServedAfterTheHomeIsCleared:
     reproducible one.
     """
 
-    def test_entry_from_a_bypassed_resolution_is_not_served_later(
-        self, tmp_path, monkeypatch
-    ):
+    def test_entry_from_a_bypassed_resolution_is_not_served_later(self, tmp_path, monkeypatch):
         from kiro_crew.config import paths
 
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
@@ -610,13 +624,11 @@ class TestConfigDirMemoIsNotServedAfterTheHomeIsCleared:
         with patch("pathlib.Path.home", return_value=real_home):
             resolved = paths.config_dir()
 
-        assert resolved == real_home / ".kiro" / "crew", (
-            f"config_dir() served a memo entry from a foreign home: {resolved}"
-        )
+        assert (
+            resolved == real_home / ".kiro" / "crew"
+        ), f"config_dir() served a memo entry from a foreign home: {resolved}"
 
-    def test_the_memo_still_caches_a_normal_default_resolution(
-        self, tmp_path, monkeypatch
-    ):
+    def test_the_memo_still_caches_a_normal_default_resolution(self, tmp_path, monkeypatch):
         """Negative control: the fix must not turn the memo off.
 
         Two consecutive default-path calls must hit the entry, which is what keeps

--- a/test/test_lockdown_before_publish.py
+++ b/test/test_lockdown_before_publish.py
@@ -25,6 +25,7 @@ Nothing prevented a NEW writer from reintroducing the shape. Two layers here:
 
 from __future__ import annotations
 
+import functools
 import importlib.util
 import sys
 from pathlib import Path
@@ -561,8 +562,34 @@ def reasserter(path):
 class TestTheRealTree:
     """The gate the CI job runs."""
 
+    @staticmethod
+    @functools.lru_cache(maxsize=1)
+    def _scan_src() -> tuple[tuple[str, int, str, str], ...]:
+        """One whole-tree AST scan, shared by every test in this class.
+
+        Both tests below independently re-derive `checker.main`'s per-file
+        `scan_path` results over the same `src/kiro_crew` tree; walking and
+        re-parsing every file twice per test is what made this class slow.
+        """
+        src = REPO_ROOT / "src" / "kiro_crew"
+        found: list[tuple[str, int, str, str]] = []
+        for py in sorted(src.rglob("*.py")):
+            found.extend(checker.scan_path(py, REPO_ROOT))
+        return tuple(found)
+
     def test_src_has_no_unclassified_violation(self) -> None:
-        exit_code = checker.main(["check", str(REPO_ROOT / "src" / "kiro_crew")])
+        """Same pass/fail as `checker.main(["check", <src dir>])`, off the cached scan."""
+        new: list[tuple[str, int, str, str]] = []
+        seen_known: set[str] = set()
+        for rel, line, fn, expr in self._scan_src():
+            key = "%s::%s" % (rel, fn)
+            entry = checker.KNOWN_UNCONVERTED.get(key)
+            if entry is not None and entry[1] == expr:
+                seen_known.add(key)
+            else:
+                new.append((rel, line, fn, expr))
+        stale = set(checker.KNOWN_UNCONVERTED) - seen_known
+        exit_code = 1 if (new or stale) else 0
         assert exit_code == 0, (
             "a lockdown-before-publish violation is unclassified. Convert it to "
             "atomic_write(..., restrict_to_owner=True), or annotate a genuine "
@@ -576,11 +603,7 @@ class TestTheRealTree:
         future regression at one of those very sites would land unnoticed
         because its entry was already there.
         """
-        src = REPO_ROOT / "src" / "kiro_crew"
-        live: set[str] = set()
-        for py in sorted(src.rglob("*.py")):
-            for rel, _line, fn, _expr in checker.scan_path(py, REPO_ROOT):
-                live.add(f"{rel}::{fn}")
+        live = {f"{rel}::{fn}" for rel, _line, fn, _expr in self._scan_src()}
 
         stale = sorted(set(checker.KNOWN_UNCONVERTED) - live)
         assert not stale, (

--- a/test/test_model_registry.py
+++ b/test/test_model_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from kiro_crew import model_registry as mr
 
 
@@ -596,3 +598,63 @@ class TestAdvertisedModelCache:
             mr, "_ADVERTISED_MODELS", {"claude_code": ["global.anthropic.claude-opus-5[1m]"]}
         )
         assert mr.to_provider_id("claude-opus-5", "claude_code") == "claude-opus-5"
+
+
+class TestImportDoesNotCreateTheDataHome:
+    """Importing the registry must not ``mkdir`` the data home.
+
+    ``_load_kiro_windows`` runs at import to pick up the persisted window
+    sidecar. Resolving that path through ``config_dir()`` would CREATE
+    ``~/.kiro/crew`` (and refresh the recovery breadcrumb) as a side effect of a
+    plain import -- observed as a real-host write from every test collector, and
+    a surprise for any read-only tool that imports the package. The import must
+    only ever peek at the path.
+    """
+
+    def test_a_fresh_interpreter_import_leaves_an_absent_home_absent(self, tmp_path):
+        import subprocess
+        import sys
+
+        home = tmp_path / "home"
+        home.mkdir()
+        # The audit hook names the call site on failure, so a regression is
+        # diagnosable from the assertion message alone.
+        probe = (
+            "import os, sys, traceback\n"
+            "def hook(ev, args):\n"
+            "    if ev == 'os.mkdir' and str(args[0]).startswith(sys.argv[1]):\n"
+            "        sys.stderr.write('mkdir %s\\n' % args[0])\n"
+            "        sys.stderr.write(''.join(traceback.format_stack(limit=12)[:-1]))\n"
+            "sys.addaudithook(hook)\n"
+            "import kiro_crew.model_registry\n"
+            "from kiro_crew.config import paths\n"
+            "sys.exit(1 if paths._default_home().exists() else 0)\n"
+        )
+        env = {k: v for k, v in os.environ.items() if k != "KIROCREW_HOME"}
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        proc = subprocess.run(
+            # ``-B``: the child imports the source package; without it the import
+            # leaves ``__pycache__`` in the checkout (no-test-side-effects).
+            [sys.executable, "-B", "-c", probe, str(home)],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=120,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert not (home / ".kiro").exists()
+
+    def test_the_sidecar_path_follows_the_data_home_without_creating_it(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew.config import paths
+
+        data = tmp_path / "data"
+        monkeypatch.setenv("KIROCREW_HOME", str(data))
+        assert mr._kiro_windows_cache_path() == data.resolve() / "model_windows.json"
+        assert mr._advertised_models_cache_path() == data.resolve() / "provider_models.json"
+        assert not data.exists(), "resolving a sidecar path must not create the home"
+        assert mr._kiro_windows_cache_path().parent == paths.config_dir()

--- a/test/test_pptx_maker_engine_source.py
+++ b/test/test_pptx_maker_engine_source.py
@@ -251,7 +251,7 @@ class TestDownloadVerification:
         assert ok is False and engine_source.SKIP_DOWNLOAD_ENV in error
         assert not opener.called
 
-    def test_the_ssl_context_is_installed_on_the_handler_not_the_open_call(self):
+    def test_the_ssl_context_is_installed_on_the_handler_not_the_open_call(self, tmp_path):
         """`OpenerDirector.open` has NO `context` parameter — passing one there
         raises TypeError on every real download while every mock passes. This
         pins the context onto an HTTPSHandler instead."""
@@ -268,7 +268,7 @@ class TestDownloadVerification:
             return mock.Mock(open=mock.Mock(side_effect=urllib.error.URLError("stop")))
 
         with mock.patch.object(engine_source.urllib.request, "build_opener", spy):
-            engine_source.download_archive(Path("/tmp/kc-unused-engine.tar.gz"))
+            engine_source.download_archive(tmp_path / "kc-unused-engine.tar.gz")
         https = [h for h in captured if isinstance(h, engine_source.urllib.request.HTTPSHandler)]
         assert https, "an HTTPSHandler carrying the SSL context must be installed"
         assert getattr(https[0], "_context", None) is not None

--- a/test/test_public_repo_chip_status.py
+++ b/test/test_public_repo_chip_status.py
@@ -34,6 +34,23 @@ def _clear_caches():
     source._visibility_inflight.clear()
     source._visibility_force_gen.clear()
     source._check_cache.clear()
+    # A task a test spawned via schedule_visibility_refresh but never awaited
+    # (e.g. the test raised before its own gather, or simply forgot to drain
+    # it) is bound to THIS test's event loop, which pytest-asyncio strict mode
+    # tears down at teardown. The task then lingers in the module-global set
+    # forever — its done-callback never fires because the loop that would run
+    # it is gone — and a LATER test on a fresh loop that gathers the set
+    # crashes with "Future belongs to a different loop" (no-test-side-effects).
+    # Cancel each leftover so its coroutine is properly closed rather than
+    # silently dropped, then clear the set so the next test starts empty. A
+    # sync fixture's teardown can run after pytest-asyncio has already closed
+    # the loop; ``Task.cancel`` schedules through ``call_soon`` and raises on a
+    # closed loop, so a task whose loop is gone is only dropped (production
+    # prunes dead-loop tasks on the next schedule anyway).
+    for task in list(source._VISIBILITY_TASKS):
+        if not task.get_loop().is_closed():
+            task.cancel()
+    source._VISIBILITY_TASKS.clear()
     # A test that armed the debounced update (force visibility refresh /
     # status-change path) can leave a pending global TimerHandle bound to this
     # test's now-closing event loop; if it survives, a later test's callback

--- a/test/test_remote_crew_execution.py
+++ b/test/test_remote_crew_execution.py
@@ -39,7 +39,6 @@ from kiro_crew.dashboard.state import _ChatSlot
 
 #: Every async test here needs the loop; the repo runs pytest-asyncio in strict
 #: mode, so the marker is explicit rather than inferred from the coroutine.
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture(autouse=True)
@@ -232,11 +231,13 @@ class TestSseFraming:
 
 
 class TestVersionParity:
+    @pytest.mark.asyncio
     async def test_an_equal_version_passes(self):
         mgr = MagicMock()
         mgr.peer_version = AsyncMock(return_value=(True, kiro_crew.__version__))
         await ensure_version_parity(mgr, "nobita")  # does not raise
 
+    @pytest.mark.asyncio
     async def test_a_different_version_is_refused_naming_both_sides(self):
         mgr = MagicMock()
         mgr.peer_version = AsyncMock(return_value=(True, "0.5.9"))
@@ -245,6 +246,7 @@ class TestVersionParity:
         assert "0.5.9" in str(excinfo.value)
         assert kiro_crew.__version__ in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_a_patch_skew_in_the_same_series_passes(self):
         """0.6.0 and 0.6.3 share the frame vocabulary, so a patch skew is allowed.
 
@@ -260,6 +262,7 @@ class TestVersionParity:
         mgr.peer_version = AsyncMock(return_value=(True, peer))
         await ensure_version_parity(mgr, "nobita")  # does not raise
 
+    @pytest.mark.asyncio
     async def test_a_different_minor_is_refused(self):
         """A feature release (minor bump on 0.x) moves the vocabulary — refuse it."""
         from kiro_crew.apps.version import parse_version
@@ -272,6 +275,7 @@ class TestVersionParity:
             await ensure_version_parity(mgr, "nobita")
         assert "major.minor" in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_a_non_semver_build_id_falls_back_to_strict_equality(self, monkeypatch):
         """When a side is a packaging build id, series parity is unprovable.
 
@@ -288,6 +292,7 @@ class TestVersionParity:
         with pytest.raises(RemoteTurnError):
             await ensure_version_parity(mgr, "nobita")
 
+    @pytest.mark.asyncio
     async def test_an_oversized_numeric_version_is_refused_not_crashed(self):
         """A peer-controlled version of thousands of digits must not 500 the create.
 
@@ -302,6 +307,7 @@ class TestVersionParity:
         with pytest.raises(RemoteTurnError):
             await ensure_version_parity(mgr, "nobita")
 
+    @pytest.mark.asyncio
     async def test_an_unknown_version_is_a_mismatch_not_a_pass(self):
         """A peer too old to report its version cannot be proven equal.
 
@@ -315,6 +321,7 @@ class TestVersionParity:
             await ensure_version_parity(mgr, "nobita")
         assert "older Kiro Crew" in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_an_unreachable_peer_is_refused_with_a_different_remedy(self):
         """ "Too old" and "unreachable" need different advice, so they differ.
 
@@ -332,6 +339,7 @@ class TestVersionParity:
 
 
 class TestRelayReplay:
+    @pytest.mark.asyncio
     async def test_chunks_replay_as_local_chat_chunk_frames(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -353,6 +361,7 @@ class TestRelayReplay:
         assert [c.args[1]["seq"] for c in chunk_calls] == [1, 2]
         assert all(c.args[1]["slot"] == slot.key for c in chunk_calls)
 
+    @pytest.mark.asyncio
     async def test_a_mirrored_frame_is_rebroadcast_under_the_local_key(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -381,6 +390,7 @@ class TestRelayReplay:
         assert tool_calls[0].args[1]["slot"] == slot.key
         assert tool_calls[0].args[1]["tool"] == "fs_read"
 
+    @pytest.mark.asyncio
     async def test_the_peers_user_row_is_not_replayed(self, tmp_path):
         """The local side already appended the user's message before dispatch."""
         state = _make_state(tmp_path)
@@ -396,6 +406,7 @@ class TestRelayReplay:
         )
         assert [m["role"] for m in slot.messages] == []
 
+    @pytest.mark.asyncio
     async def test_the_finalized_assistant_row_replaces_its_chunks(self, tmp_path):
         """Keeping both would render the answer twice, once streamed once final."""
         state = _make_state(tmp_path)
@@ -416,6 +427,7 @@ class TestRelayReplay:
         # in the pending queue, so a leak there would strand every token.
         assert [r for r in slot._pending if r.get("role") == "chunk"] == []
 
+    @pytest.mark.asyncio
     async def test_a_stop_row_between_chunks_and_final_does_not_strand_them(self, tmp_path):
         """A mid-stream stop must not leave the streamed deltas rendering twice.
 
@@ -447,6 +459,7 @@ class TestRelayReplay:
         ]
         assert [r for r in slot._pending if r.get("role") == "chunk"] == []
 
+    @pytest.mark.asyncio
     async def test_a_turn_always_ends_with_chat_done(self, tmp_path):
         """Without it the composer stays blocked and the session looks hung."""
         state = _make_state(tmp_path)
@@ -462,6 +475,7 @@ class TestRelayReplay:
             pytest.param(lambda: _stream(), id="truncated"),
         ],
     )
+    @pytest.mark.asyncio
     async def test_the_turn_is_persisted_before_the_composer_unblocks(
         self, tmp_path, monkeypatch, chunks_factory
     ):
@@ -503,6 +517,7 @@ class TestRelayReplay:
         last_save = max(i for i, e in enumerate(order) if e == "save")
         assert last_save < order.index("chat_done")
 
+    @pytest.mark.asyncio
     async def test_a_failing_stream_yields_an_error_row_and_still_finishes(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -516,6 +531,7 @@ class TestRelayReplay:
         assert slot.messages[-1]["role"] == "error"
         assert [c.args[0] for c in state.broadcast_ws.call_args_list][-1] == "chat_done"
 
+    @pytest.mark.asyncio
     async def test_a_stream_that_ends_without_the_terminator_is_not_a_success(self, tmp_path):
         """EOF is not completion, and the difference is invisible to the reader.
 
@@ -541,6 +557,7 @@ class TestRelayReplay:
         # Still unblocked: a truncation is reported, not left hanging.
         assert [c.args[0] for c in state.broadcast_ws.call_args_list][-1] == "chat_done"
 
+    @pytest.mark.asyncio
     async def test_an_empty_stream_is_not_a_success(self, tmp_path):
         """The degenerate case of the same defect: nothing arrived at all."""
         state = _make_state(tmp_path)
@@ -551,6 +568,7 @@ class TestRelayReplay:
 
         assert slot.messages[-1]["role"] == "error"
 
+    @pytest.mark.asyncio
     async def test_rows_after_the_terminator_are_not_replayed(self, tmp_path):
         """The terminator still ends the replay, exactly as the early return did.
 
@@ -744,6 +762,7 @@ class TestBindingAuthorization:
         monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.create_peer_slot", spy)
         return spy
 
+    @pytest.mark.asyncio
     async def test_a_non_owner_identity_cannot_bind_a_session_to_a_crew(self, tmp_path, peer):
         """Authenticated is not the same as authorized on this route.
 
@@ -762,6 +781,7 @@ class TestBindingAuthorization:
             assert resp.status == 403
         peer.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_an_unbound_create_is_untouched_by_the_owner_gate(self, tmp_path, peer):
         """The gate gates the BINDING, not the endpoint.
 
@@ -778,6 +798,7 @@ class TestBindingAuthorization:
             assert resp.status == 200
         peer.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_an_app_token_cannot_bind_a_session_to_a_crew(self, tmp_path, peer):
         """Binding is a human act from the composer's crew picker.
 
@@ -793,6 +814,7 @@ class TestBindingAuthorization:
             assert (await resp.json())["code"] == "slot_not_found"
         peer.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_an_app_token_refusal_names_no_slot(self, tmp_path, peer):
         """One code for both refusal reasons, so it cannot be an existence oracle."""
         from aiohttp.test_utils import TestClient, TestServer
@@ -809,6 +831,7 @@ class TestBindingAuthorization:
             assert "chat-1" not in json.dumps(body)
         peer.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_an_already_bound_slot_is_not_rebound(self, tmp_path, peer):
         """`name` can address an EXISTING slot, and rebinding it is destructive.
 
@@ -833,6 +856,7 @@ class TestBindingAuthorization:
         assert slot.instance_id == "shizuka"
         assert slot.remote_slot == "peer-chat-1"
 
+    @pytest.mark.asyncio
     async def test_an_existing_local_slot_is_not_converted_to_remote(self, tmp_path, peer):
         """The destructive half of the same hole: local -> remote is not a create.
 
@@ -858,6 +882,7 @@ class TestBindingAuthorization:
         assert slot.is_remote is False
         assert len(slot.messages) == 1
 
+    @pytest.mark.asyncio
     async def test_a_dashboard_caller_binds_a_new_slot(self, tmp_path, peer):
         """The allowed path, so the gates above are not just refusing everything."""
         from aiohttp.test_utils import TestClient, TestServer
@@ -875,6 +900,7 @@ class TestBindingAuthorization:
         assert state._slots["chat-1"].remote_slot == "peer-chat-9"
         peer.assert_awaited_once()
 
+    @pytest.mark.asyncio
     async def test_a_peer_that_refuses_leaves_no_local_slot_bound(self, tmp_path, monkeypatch):
         """Peer first, local slot second: a failure over there creates nothing here."""
         from aiohttp.test_utils import TestClient, TestServer
@@ -894,6 +920,7 @@ class TestBindingAuthorization:
         assert "older version" in body["error"]
         assert "chat-1" not in state._slots
 
+    @pytest.mark.asyncio
     async def test_an_app_token_may_still_create_an_ordinary_local_slot(self, tmp_path, peer):
         """The gate is scoped to `instance_id`, not a blanket app refusal."""
         from aiohttp.test_utils import TestClient, TestServer
@@ -918,6 +945,7 @@ class TestBindingAuthorization:
         ],
         ids=["mode", "memory_mode", "remote_mode_unsupported"],
     )
+    @pytest.mark.asyncio
     async def test_a_request_refused_for_its_body_never_reaches_the_peer(
         self, tmp_path, peer, body, code
     ):
@@ -940,6 +968,7 @@ class TestBindingAuthorization:
                 assert (await resp.json())["code"] == code
         peer.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_a_member_name_never_reaches_the_peer(self, tmp_path, peer):
         """A ``member-`` name is reserved for the DM-thread endpoint.
 
@@ -963,6 +992,7 @@ class TestBindingAuthorization:
         assert "member-alice" not in state._slots
 
     @pytest.mark.parametrize("bad_name", [123, ["a"], {"k": "v"}], ids=["int", "list", "dict"])
+    @pytest.mark.asyncio
     async def test_a_non_string_name_never_reaches_the_peer(self, tmp_path, peer, bad_name):
         """A name the slot store cannot key on must not cost a peer session.
 
@@ -986,6 +1016,7 @@ class TestBindingAuthorization:
             # slot exists locally, so the peer session is not orphaned.
             assert any(s.is_remote for s in state._slots.values())
 
+    @pytest.mark.asyncio
     async def test_a_name_taken_while_the_peer_was_awaited_is_not_rebound(
         self, tmp_path, monkeypatch
     ):
@@ -1028,6 +1059,7 @@ class TestBindingAuthorization:
         assert raced.is_remote is False
         assert len(raced.messages) == 1
 
+    @pytest.mark.asyncio
     async def test_an_invalid_folder_project_never_reaches_the_peer(
         self, tmp_path, peer, monkeypatch
     ):
@@ -1081,6 +1113,7 @@ class TestBoundCreateDefaults:
             ),
         )
 
+    @pytest.mark.asyncio
     async def test_a_bound_create_records_no_agent(self, tmp_path, peer, local_default):
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -1097,6 +1130,7 @@ class TestBoundCreateDefaults:
         # peer is told to apply its own default.
         assert peer.await_args.kwargs == {"agent": "", "model": ""}
 
+    @pytest.mark.asyncio
     async def test_a_local_create_still_stamps_the_default(self, tmp_path, peer, local_default):
         """The counterpart, so the skip above is scoped to the binding."""
         from aiohttp.test_utils import TestClient, TestServer
@@ -1107,6 +1141,7 @@ class TestBoundCreateDefaults:
 
         assert body["agent"] == "local-only-crew"
 
+    @pytest.mark.asyncio
     async def test_an_explicit_pick_is_recorded_and_forwarded(self, tmp_path, peer, local_default):
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -1137,6 +1172,7 @@ class TestRemotePickApplication:
         monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.forward_peer_selection", spy)
         return spy
 
+    @pytest.mark.asyncio
     async def test_an_agent_pick_mirrors_the_workspace_the_peer_committed(
         self, tmp_path, monkeypatch
     ):
@@ -1164,6 +1200,7 @@ class TestRemotePickApplication:
         assert slot.agent == "reviewer"
         assert slot.workspace == "peer-ws"
 
+    @pytest.mark.asyncio
     async def test_a_peer_that_names_no_workspace_changes_nothing(self, tmp_path, forward):
         """Only a non-empty string is taken, so an older or terser peer is safe:
         a missing field leaves the local value alone rather than blanking it."""
@@ -1177,6 +1214,7 @@ class TestRemotePickApplication:
 
         assert slot.workspace == "kept"
 
+    @pytest.mark.asyncio
     async def test_only_an_agent_pick_moves_the_workspace(self, tmp_path, monkeypatch):
         """A model or effort pick does not re-resolve bindings, so a `workspace`
         key in its reply is not a commitment this slot should adopt."""
@@ -1194,6 +1232,7 @@ class TestRemotePickApplication:
 
         assert slot.workspace == "kept"
 
+    @pytest.mark.asyncio
     async def test_a_failed_persist_rearms_the_flush_and_still_reports_success(
         self, tmp_path, forward
     ):
@@ -1221,6 +1260,7 @@ class TestRemotePickApplication:
         assert slot.model == "opus"
         assert slot._dirty is True
 
+    @pytest.mark.asyncio
     async def test_the_mirrored_workspace_is_persisted_with_the_agent(self, tmp_path, monkeypatch):
         """One write, or a restart restores the pair inconsistent — an agent from
         the peer next to a workspace the peer never agreed to."""
@@ -1239,6 +1279,7 @@ class TestRemotePickApplication:
         written = state.conversation_log.update_metadata.call_args.args[1]
         assert written == {"agent": "reviewer", "workspace": "peer-ws"}
 
+    @pytest.mark.asyncio
     async def test_an_accepted_pick_is_mirrored_on_the_slot(self, tmp_path, forward):
         from kiro_crew.dashboard.chat_handlers import _apply_remote_pick
 
@@ -1257,6 +1298,7 @@ class TestRemotePickApplication:
         }
         assert slot.agent == "reviewer"
 
+    @pytest.mark.asyncio
     async def test_a_refused_pick_leaves_the_slot_untouched(self, tmp_path, monkeypatch):
         from kiro_crew.dashboard.chat_handlers import _apply_remote_pick
 
@@ -1278,6 +1320,7 @@ class TestRemotePickApplication:
         assert "no such agent" in body["error"]
         assert slot.agent == "coder"
 
+    @pytest.mark.asyncio
     async def test_a_model_pick_bumps_the_pick_generation(self, tmp_path, forward):
         """Same reason the local path bumps it: an explicit pick has to outrank
         the model-fallback restore probe, which would otherwise treat the pick as
@@ -1302,6 +1345,7 @@ class TestRemotePickApplication:
             ("reasoning_effort", "high"),
         ],
     )
+    @pytest.mark.asyncio
     async def test_an_accepted_pick_is_persisted_immediately(
         self, tmp_path, forward, control, value
     ):
@@ -1325,6 +1369,7 @@ class TestRemotePickApplication:
 
         assert state.conversation_log.get_metadata("dashboard:chat-1").get(control) == value
 
+    @pytest.mark.asyncio
     async def test_a_refused_pick_persists_nothing(self, tmp_path, monkeypatch):
         """The write is downstream of the peer's acceptance, like the mirror."""
         from kiro_crew.dashboard.chat_handlers import _apply_remote_pick
@@ -1343,6 +1388,7 @@ class TestRemotePickApplication:
 
         assert "agent" not in state.conversation_log.get_metadata("dashboard:chat-1")
 
+    @pytest.mark.asyncio
     async def test_a_workspace_pick_does_not_rewrite_the_local_project(self, tmp_path, forward):
         """``project`` is a path on THIS machine (file search, @-mentions).
 
@@ -1389,12 +1435,14 @@ def _mgr_returning(status: int, body: bytes):
 
 
 class TestCreatePeerSlot:
+    @pytest.mark.asyncio
     async def test_the_peers_slot_key_is_returned(self, tmp_path):
         state = _make_state(tmp_path)
         state.instances_manager = _mgr_returning(200, b'{"key": "peer-chat-9"}')
 
         assert await create_peer_slot(state, "nobita") == "peer-chat-9"
 
+    @pytest.mark.asyncio
     async def test_no_agent_is_sent_to_the_peer(self, tmp_path):
         """The peer has its own roster, its own default and its own projects.
 
@@ -1411,6 +1459,7 @@ class TestCreatePeerSlot:
         _, kwargs = mgr.proxy_request.call_args
         assert json.loads(kwargs["data"]) == {}
 
+    @pytest.mark.asyncio
     async def test_an_explicit_pick_rides_the_create(self, tmp_path):
         """A pick made in the crew picker comes from the PEER's roster.
 
@@ -1435,6 +1484,7 @@ class TestCreatePeerSlot:
             ({"agent": "", "model": ""}, {}),
         ],
     )
+    @pytest.mark.asyncio
     async def test_only_the_named_picks_are_sent(self, tmp_path, kwargs, expected):
         """An empty pick is OMITTED, not sent as "".
 
@@ -1449,6 +1499,7 @@ class TestCreatePeerSlot:
 
         assert json.loads(mgr.proxy_request.call_args.kwargs["data"]) == expected
 
+    @pytest.mark.asyncio
     async def test_a_gateway_without_instances_refuses(self, tmp_path):
         state = _make_state(tmp_path)
         state.instances_manager = None
@@ -1457,6 +1508,7 @@ class TestCreatePeerSlot:
             await create_peer_slot(state, "nobita")
         assert "not available" in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_a_version_skewed_peer_is_never_asked_to_open_a_slot(self, tmp_path):
         state = _make_state(tmp_path)
         mgr = _mgr_returning(200, b'{"key": "peer-chat-9"}')
@@ -1467,6 +1519,7 @@ class TestCreatePeerSlot:
             await create_peer_slot(state, "nobita")
         mgr.proxy_request.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_a_refusing_peer_reports_its_status(self, tmp_path):
         state = _make_state(tmp_path)
         state.instances_manager = _mgr_returning(503, b"{}")
@@ -1475,6 +1528,7 @@ class TestCreatePeerSlot:
             await create_peer_slot(state, "nobita")
         assert "503" in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_an_unreachable_peer_says_so_without_leaking_the_cause(self, tmp_path):
         """The transcript is a surface the user copies out of.
 
@@ -1492,6 +1546,7 @@ class TestCreatePeerSlot:
         assert "17777" not in str(excinfo.value)
         assert "Reconnect" in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_an_oversized_reply_is_refused_rather_than_decoded(self, tmp_path):
         state = _make_state(tmp_path)
         state.instances_manager = _mgr_returning(200, b"x" * (64 * 1024 + 8))
@@ -1500,6 +1555,7 @@ class TestCreatePeerSlot:
             await create_peer_slot(state, "nobita")
         assert "oversized" in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_a_malformed_reply_is_refused(self, tmp_path):
         state = _make_state(tmp_path)
         state.instances_manager = _mgr_returning(200, b"{not json")
@@ -1509,6 +1565,7 @@ class TestCreatePeerSlot:
         assert "malformed" in str(excinfo.value)
 
     @pytest.mark.parametrize("body", [b"{}", b'{"key": ""}', b'{"key": 7}', b"[]"])
+    @pytest.mark.asyncio
     async def test_a_reply_that_names_no_slot_is_refused(self, tmp_path, body):
         """A missing key would otherwise bind the session to the empty string."""
         state = _make_state(tmp_path)
@@ -1537,6 +1594,7 @@ class TestForwardPeerSelection:
             ("reasoning_effort", {"reasoning_effort": "high"}, "reasoning-effort"),
         ],
     )
+    @pytest.mark.asyncio
     async def test_each_control_reaches_the_peers_own_slot(self, tmp_path, control, body, segment):
         state = _make_state(tmp_path)
         mgr = _mgr_returning(200, b'{"ok": true}')
@@ -1551,6 +1609,7 @@ class TestForwardPeerSelection:
         assert args[2] == f"api/chat/slots/peer-chat-9/{segment}"
         assert json.loads(kwargs["data"]) == body
 
+    @pytest.mark.asyncio
     async def test_the_peers_accepted_state_is_returned_not_discarded(self, tmp_path):
         """What the peer ACCEPTED is not always what was asked for.
 
@@ -1574,6 +1633,7 @@ class TestForwardPeerSelection:
         [b"not json at all", b'"a bare string"', b"", b"[]"],
         ids=["unparseable", "not-an-object", "empty", "array"],
     )
+    @pytest.mark.asyncio
     async def test_a_reply_that_is_not_an_object_yields_nothing_to_mirror(self, tmp_path, body):
         """The pick SUCCEEDED over there — a reply this side cannot read must not
         turn it into a failure. An empty dict degrades to "nothing to mirror"."""
@@ -1582,6 +1642,7 @@ class TestForwardPeerSelection:
 
         assert await forward_peer_selection(state, _remote_slot(), "model", {"model": "opus"}) == {}
 
+    @pytest.mark.asyncio
     async def test_an_oversized_success_reply_is_not_decoded(self, tmp_path):
         """Same byte ceiling the refusal path enforces, and for the same reason:
         a hostile or broken peer must not be able to make the hub decode an
@@ -1594,6 +1655,7 @@ class TestForwardPeerSelection:
 
         assert await forward_peer_selection(state, _remote_slot(), "agent", {"agent": "r"}) == {}
 
+    @pytest.mark.asyncio
     async def test_an_unlisted_control_is_a_programming_error(self, tmp_path):
         """A closed map, because ``control`` is interpolated into a proxied URL.
 
@@ -1609,6 +1671,7 @@ class TestForwardPeerSelection:
             await forward_peer_selection(state, _remote_slot(), "project", {"project": "/etc"})
         mgr.proxy_request.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_a_version_skewed_peer_is_never_asked_to_apply_a_pick(self, tmp_path):
         state = _make_state(tmp_path)
         mgr = _mgr_returning(200, b"{}")
@@ -1619,6 +1682,7 @@ class TestForwardPeerSelection:
             await forward_peer_selection(state, _remote_slot(), "agent", {"agent": "x"})
         mgr.proxy_request.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_the_peers_own_refusal_is_what_the_user_reads(self, tmp_path):
         """Only the peer knows WHY: the agent was deleted there, the model is not
         available to that account, the workspace already has messages."""
@@ -1643,6 +1707,7 @@ class TestForwardPeerSelection:
             pytest.param(b"x" * (64 * 1024 + 8), id="oversized"),
         ],
     )
+    @pytest.mark.asyncio
     async def test_an_unusable_refusal_falls_back_to_the_status(self, tmp_path, body):
         """A peer reply is untrusted: only a short ``error`` STRING is surfaced."""
         state = _make_state(tmp_path)
@@ -1652,6 +1717,7 @@ class TestForwardPeerSelection:
             await forward_peer_selection(state, _remote_slot(), "model", {"model": "x"})
         assert "500" in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_an_overlong_peer_message_is_truncated(self, tmp_path):
         state = _make_state(tmp_path)
         detail = json.dumps({"error": "y" * 900}).encode()
@@ -1661,6 +1727,7 @@ class TestForwardPeerSelection:
             await forward_peer_selection(state, _remote_slot(), "model", {"model": "x"})
         assert len(str(excinfo.value)) == 200
 
+    @pytest.mark.asyncio
     async def test_an_unreachable_peer_says_so_without_leaking_the_cause(self, tmp_path):
         state = _make_state(tmp_path)
         mgr = MagicMock()
@@ -1673,6 +1740,7 @@ class TestForwardPeerSelection:
         assert "17777" not in str(excinfo.value)
         assert "Reconnect" in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_a_gateway_without_instances_refuses(self, tmp_path):
         state = _make_state(tmp_path)
         state.instances_manager = None
@@ -1682,12 +1750,14 @@ class TestForwardPeerSelection:
 
 
 class TestForwardPeerStop:
+    @pytest.mark.asyncio
     async def test_a_local_slot_is_not_forwarded(self, tmp_path):
         state = _make_state(tmp_path)
         state.instances_manager = _mgr_returning(200, b"{}")
 
         assert await forward_peer_stop(state, _ChatSlot("chat-1"), False) is False
 
+    @pytest.mark.asyncio
     async def test_an_accepted_stop_reports_true(self, tmp_path):
         state = _make_state(tmp_path)
         mgr = _mgr_returning(200, b"{}")
@@ -1700,6 +1770,7 @@ class TestForwardPeerStop:
         assert args[2] == "api/chat/slots/peer-chat-9/stop"
         assert kwargs["params"] is None
 
+    @pytest.mark.asyncio
     async def test_a_forced_stop_carries_the_flag(self, tmp_path):
         state = _make_state(tmp_path)
         mgr = _mgr_returning(200, b"{}")
@@ -1709,6 +1780,7 @@ class TestForwardPeerStop:
 
         assert mgr.proxy_request.call_args.kwargs["params"] == {"force": "true"}
 
+    @pytest.mark.asyncio
     async def test_a_refused_stop_reports_false_rather_than_raising(self, tmp_path):
         """The caller turns False into an actionable error for the user.
 
@@ -1720,6 +1792,7 @@ class TestForwardPeerStop:
 
         assert await forward_peer_stop(state, _remote_slot(), False) is False
 
+    @pytest.mark.asyncio
     async def test_an_unreachable_peer_reports_false(self, tmp_path):
         state = _make_state(tmp_path)
         mgr = MagicMock()
@@ -1730,6 +1803,7 @@ class TestForwardPeerStop:
 
 
 class TestPeerTurnRequest:
+    @pytest.mark.asyncio
     async def test_the_turn_asks_the_peer_to_mirror_its_frames(self, tmp_path):
         """Without ``relay=1`` the reply carries the prose and no tool activity."""
         state = _make_state(tmp_path)
@@ -1756,6 +1830,7 @@ class TestPeerTurnRequest:
         # The PEER's slot key, and only the message — see the known gap in the PR.
         assert json.loads(kwargs["data"]) == {"message": "hi", "slot": "peer-chat-9"}
 
+    @pytest.mark.asyncio
     async def test_a_peer_that_refuses_the_turn_becomes_an_error_row(self, tmp_path):
         """The refusal must reach the transcript, not just the log.
 
@@ -1776,6 +1851,7 @@ class TestPeerTurnRequest:
         assert "503" in slot.messages[-1]["content"]
         assert [c.args[0] for c in state.broadcast_ws.call_args_list][-1] == "chat_done"
 
+    @pytest.mark.asyncio
     async def test_a_version_skew_found_at_send_time_is_a_transcript_error(self, tmp_path):
         """The gate is re-checked per turn: a peer can be updated mid-session."""
         state = _make_state(tmp_path)
@@ -1794,6 +1870,7 @@ class TestPeerTurnRequest:
 
 
 class TestRowReplayDetails:
+    @pytest.mark.asyncio
     async def test_a_thinking_row_is_replayed_as_reasoning(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -1812,6 +1889,7 @@ class TestRowReplayDetails:
         assert [(m["role"], m["content"]) for m in slot.messages] == [("thinking", "hmm")]
         assert [c.args[0] for c in state.broadcast_ws.call_args_list].count("chat_thinking") == 1
 
+    @pytest.mark.asyncio
     async def test_a_rows_meta_survives_the_replay(self, tmp_path):
         """Tool rows carry their identity in `meta`; dropping it breaks folding."""
         state = _make_state(tmp_path)
@@ -1838,6 +1916,7 @@ class TestRowReplayDetails:
         # same dict, and the peer's id is what the frontend folds tool rows by.
         assert slot.messages[-1]["meta"]["tool_call_id"] == "t1"
 
+    @pytest.mark.asyncio
     async def test_a_non_string_content_is_carried_as_json(self, tmp_path):
         """A structured row must not vanish because it is not a string."""
         state = _make_state(tmp_path)
@@ -1855,6 +1934,7 @@ class TestRowReplayDetails:
 
         assert json.loads(slot.messages[-1]["content"]) == {"a": 1}
 
+    @pytest.mark.asyncio
     async def test_a_row_with_no_type_is_ignored(self, tmp_path):
         state = _make_state(tmp_path)
         slot = _remote_slot()
@@ -1868,6 +1948,7 @@ class TestRowReplayDetails:
 
         assert slot.messages == []
 
+    @pytest.mark.asyncio
     async def test_a_mirrored_frame_keyed_by_key_is_also_rewritten(self, tmp_path):
         """`slot_title` and `session_summary` name the session in `key`."""
         state = _make_state(tmp_path)
@@ -1893,6 +1974,7 @@ class TestRowReplayDetails:
         assert titles[0].args[1] == {"key": slot.key, "title": "Deploy"}
 
     @pytest.mark.parametrize("payload", ["{not json", '"a string"', "[1, 2]"])
+    @pytest.mark.asyncio
     async def test_an_undecodable_mirrored_frame_is_dropped_not_raised(self, tmp_path, payload):
         """One bad frame must not end an otherwise healthy turn."""
         state = _make_state(tmp_path)
@@ -1912,6 +1994,7 @@ class TestRowReplayDetails:
         assert [c.args[0] for c in state.broadcast_ws.call_args_list] == ["chat_done"]
         assert slot.messages == []
 
+    @pytest.mark.asyncio
     async def test_the_done_sentinel_stops_the_replay(self, tmp_path):
         """Rows after the terminator belong to no turn and must not be appended."""
         state = _make_state(tmp_path)
@@ -1929,9 +2012,11 @@ class TestRowReplayDetails:
 
         assert slot.messages == []
 
+    @pytest.mark.asyncio
     async def test_a_record_with_no_data_line_is_not_a_row(self):
         assert parse_sse_record(b"event: ping\nid: 7") is None
 
+    @pytest.mark.asyncio
     async def test_a_garbled_record_does_not_end_the_turn(self, tmp_path):
         """The rest of the stream is still worth replaying."""
         state = _make_state(tmp_path)
@@ -1951,6 +2036,7 @@ class TestRowReplayDetails:
 
         assert [(m["role"], m["content"]) for m in slot.messages] == [("assistant", "Hello")]
 
+    @pytest.mark.asyncio
     async def test_only_the_trailing_run_of_chunks_is_replaced(self, tmp_path):
         """An earlier segment's finished message must survive the next finalize.
 
@@ -2004,6 +2090,7 @@ class TestPeerStringRedaction:
     so each runs the same chain.
     """
 
+    @pytest.mark.asyncio
     async def test_a_frames_class_is_redacted_like_its_content(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -2022,6 +2109,7 @@ class TestPeerStringRedaction:
         assert _BAIT not in json.dumps([list(c.args) for c in state.broadcast_ws.call_args_list])
         assert _BAIT not in json.dumps(slot.messages)
 
+    @pytest.mark.asyncio
     async def test_a_peers_refusal_message_is_redacted_before_the_clamp(self, tmp_path):
         """Redacted BEFORE the 200-char clamp, or a credential survives by
         sitting past it."""
@@ -2034,6 +2122,7 @@ class TestPeerStringRedaction:
 
         assert _BAIT not in str(excinfo.value)
 
+    @pytest.mark.asyncio
     async def test_a_mirrored_workspace_is_redacted_before_it_is_persisted(
         self, tmp_path, monkeypatch
     ):
@@ -2074,6 +2163,7 @@ class TestRelayedRedaction:
     credentials into this machine's history.
     """
 
+    @pytest.mark.asyncio
     async def test_an_assistant_row_is_redacted_before_it_is_stored(self, tmp_path):
         state = _make_state(tmp_path)
         slot = _remote_slot()
@@ -2090,6 +2180,7 @@ class TestRelayedRedaction:
 
         _assert_redacted(slot.messages[-1]["content"])
 
+    @pytest.mark.asyncio
     async def test_a_streamed_chunk_is_redacted_on_the_wire(self, tmp_path):
         """The chunk frame is its own broadcast, not a by-product of ``append``."""
         state = _make_state(tmp_path)
@@ -2110,6 +2201,7 @@ class TestRelayedRedaction:
         _assert_redacted(chunks[0].args[1]["content"])
         _assert_redacted(slot.messages[-1]["content"])
 
+    @pytest.mark.asyncio
     async def test_a_thinking_row_is_redacted_on_both_surfaces(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -2129,6 +2221,7 @@ class TestRelayedRedaction:
         _assert_redacted(thinking[0].args[1]["content"])
         _assert_redacted(slot.messages[-1]["content"])
 
+    @pytest.mark.asyncio
     async def test_a_rows_meta_is_redacted_too(self, tmp_path):
         """`meta` holds the tool input — the field most likely to carry a secret."""
         state = _make_state(tmp_path)
@@ -2157,6 +2250,7 @@ class TestRelayedRedaction:
         # row's identity still folds.
         assert meta["tool_call_id"] == "t1"
 
+    @pytest.mark.asyncio
     async def test_a_mirrored_frames_nested_strings_are_redacted(self, tmp_path):
         """The mirror is a denylist, so the frame shape is open-ended."""
         state = _make_state(tmp_path)
@@ -2191,6 +2285,7 @@ class TestRelayedRedaction:
         # Redaction runs BEFORE the key rewrite, so the local key still lands.
         assert payload["slot"] == slot.key
 
+    @pytest.mark.asyncio
     async def test_clean_prose_is_passed_through_unchanged(self, tmp_path):
         """Both redactors return their input when nothing matches."""
         state = _make_state(tmp_path)
@@ -2219,6 +2314,7 @@ class TestPeerVersionIsNotAnEchoChannel:
     same reason every other peer string is.
     """
 
+    @pytest.mark.asyncio
     async def test_a_credential_in_the_peers_version_is_redacted(self):
         mgr = MagicMock()
         mgr.peer_version = AsyncMock(return_value=(True, f"0.5.9 {_BAIT}"))
@@ -2231,6 +2327,7 @@ class TestPeerVersionIsNotAnEchoChannel:
         # move, so redacting the peer's half must not cost them that.
         assert kiro_crew.__version__ in message
 
+    @pytest.mark.asyncio
     async def test_an_oversized_peer_version_is_bounded(self):
         mgr = MagicMock()
         mgr.peer_version = AsyncMock(return_value=(True, "9" * 5000))
@@ -2253,6 +2350,7 @@ class TestMirroredClearCannotDestroyLocalRows:
     the next reload.
     """
 
+    @pytest.mark.asyncio
     async def test_a_mirrored_clear_leaves_the_local_rows_and_the_dirty_flag_alone(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -2286,6 +2384,7 @@ class TestMirroredClearCannotDestroyLocalRows:
         # stored transcript never took.
         assert [c.args[0] for c in state.broadcast_ws.call_args_list] == ["chat_done"]
 
+    @pytest.mark.asyncio
     async def test_an_ordinary_mirrored_frame_leaves_the_rows_alone(self, tmp_path):
         """The clear branch must key on the frame type, not fire on every frame."""
         state = _make_state(tmp_path)
@@ -2325,6 +2424,7 @@ class TestRelayedTurnDoesNotDrainLocally:
     tools and local credentials is worse, so the local drain stays out.
     """
 
+    @pytest.mark.asyncio
     async def test_a_queued_message_is_not_handed_to_the_local_runner(self, tmp_path, monkeypatch):
         """``_start_next_queued_turn`` dispatches ``_run_chat``, so it stays unused.
 
@@ -2349,6 +2449,7 @@ class TestRelayedTurnDoesNotDrainLocally:
         # message to work with.
         assert [q["content"] for q in slot._queue] == ["the second send"]
 
+    @pytest.mark.asyncio
     async def test_an_empty_queue_leaves_the_turn_end_untouched(self, tmp_path):
         """The drain must not fire the local finaliser on the common path.
 
@@ -2365,6 +2466,7 @@ class TestRelayedTurnDoesNotDrainLocally:
         assert [c.args[0] for c in state.broadcast_ws.call_args_list] == ["chat_done"]
         assert [m["cls"] for m in slot.messages] != ["done"]
 
+    @pytest.mark.asyncio
     async def test_a_failed_relay_does_not_fall_back_to_the_local_runner(
         self, tmp_path, monkeypatch
     ):
@@ -2436,6 +2538,7 @@ class TestBusyRemoteSlotRefusesInsteadOfQueueing:
         state._slots[slot.key] = slot
         return slot
 
+    @pytest.mark.asyncio
     async def test_a_second_send_is_refused_with_remote_turn_busy(self, tmp_path):
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -2458,6 +2561,7 @@ class TestBusyRemoteSlotRefusesInsteadOfQueueing:
         finally:
             slot.task.cancel()
 
+    @pytest.mark.asyncio
     async def test_a_busy_LOCAL_slot_still_queues(self, tmp_path):
         """The refusal is scoped to remote slots; local queueing is untouched.
 
@@ -2492,6 +2596,7 @@ class TestRemotePicksAreSerialised:
     that runs the next turn took the other.
     """
 
+    @pytest.mark.asyncio
     async def test_a_second_pick_waits_for_the_first_transaction(self, tmp_path, monkeypatch):
         from kiro_crew.dashboard.chat_handlers import _apply_remote_pick
 
@@ -2534,6 +2639,7 @@ class TestRemotePicksAreSerialised:
         assert order == ["enter:a", "exit:a", "enter:b", "exit:b"]
         assert slot.model == "b"
 
+    @pytest.mark.asyncio
     async def test_the_lock_is_not_the_message_window_lock(self, tmp_path):
         """`slot._lock` must stay free while a pick is in flight.
 
@@ -2669,6 +2775,7 @@ class TestEveryPeerDirectedOperationIsOwnerGated:
             first = call.args[0]
             assert isinstance(first, ast.Name) and first.id == "request", name
 
+    @pytest.mark.asyncio
     async def test_a_non_owner_cannot_send_to_a_bound_crew(self, tmp_path, monkeypatch):
         """403 before the relay, so the tunnel is never spent."""
         from aiohttp.test_utils import TestClient, TestServer
@@ -2685,6 +2792,7 @@ class TestEveryPeerDirectedOperationIsOwnerGated:
             assert resp.status == 403
         relay.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_a_non_owner_keeps_its_reach_on_a_LOCAL_slot(self, tmp_path):
         """The gate is scoped to the BINDING, exactly like the create path's.
 
@@ -2704,6 +2812,7 @@ class TestEveryPeerDirectedOperationIsOwnerGated:
             )
             assert resp.status != 403
 
+    @pytest.mark.asyncio
     async def test_a_non_owner_cannot_stop_a_bound_crew(self, tmp_path, monkeypatch):
         """The stop travels over the owner's tunnel and aborts the owner's turn."""
         from aiohttp import web
@@ -2730,6 +2839,7 @@ class TestEveryPeerDirectedOperationIsOwnerGated:
             assert resp.status == 403
         forwarded.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_a_non_owner_cannot_reconfigure_a_bound_crew(self, tmp_path, monkeypatch):
         """Reconfiguring is the same credential spend as sending.
 
@@ -2754,6 +2864,7 @@ class TestEveryPeerDirectedOperationIsOwnerGated:
         # Not mirrored locally either: a refused pick must leave the header alone.
         assert slot.model == "kept"
 
+    @pytest.mark.asyncio
     async def test_the_pick_chokepoint_still_lets_the_owner_through(self, tmp_path, monkeypatch):
         """The gate must not be a blanket refusal of the feature it protects."""
         from kiro_crew.dashboard.chat_handlers import _apply_remote_pick
@@ -2772,6 +2883,7 @@ class TestEveryPeerDirectedOperationIsOwnerGated:
         assert resp.status == 200
         assert slot.model == "ok"
 
+    @pytest.mark.asyncio
     async def test_a_missing_app_claim_is_refused_on_a_bound_slot(self, tmp_path, monkeypatch):
         """An ABSENT ``app`` key means the auth middleware never ran.
 
@@ -2803,6 +2915,7 @@ class TestRelayedContextUsageFeedsTheMeterNotTheTranscript:
     moved.
     """
 
+    @pytest.mark.asyncio
     async def test_a_relayed_reading_broadcasts_and_appends_nothing(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -2835,6 +2948,7 @@ class TestRelayedContextUsageFeedsTheMeterNotTheTranscript:
         # here, and the meter is keyed by slot.
         assert payload["slot"] == slot.key
 
+    @pytest.mark.asyncio
     async def test_an_unparseable_reading_is_dropped_not_appended(self, tmp_path):
         """A missing reading leaves the meter at its last value; a JSON row in the
         transcript would be permanent."""
@@ -2913,6 +3027,7 @@ class TestRemoteSessionLockedWhileTunnelDown:
         assert peer_is_connected(raising, "nobita") is False
         assert peer_is_connected(None, "nobita") is False
 
+    @pytest.mark.asyncio
     async def test_a_send_is_refused_while_the_tunnel_is_down(self, tmp_path):
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -2941,6 +3056,7 @@ class TestRemoteSessionLockedWhileTunnelDown:
 class TestInterruptedTurnSurvivesRestart:
     """F1: a turn in flight when the gateway crashes comes back marked, not silent."""
 
+    @pytest.mark.asyncio
     async def test_relay_clears_the_in_flight_marker_when_the_turn_ends(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -2960,6 +3076,7 @@ class TestInterruptedTurnSurvivesRestart:
         # durability save, so a reload has nothing to recover.
         assert slot._relay_in_flight is False
 
+    @pytest.mark.asyncio
     async def test_cancellation_preserves_the_in_flight_marker(self, tmp_path):
         """A cancelled relay is NOT a terminal outcome — the marker must survive.
 
@@ -3077,6 +3194,7 @@ class TestRelayMirrorIsDetachedIfPrepareFails:
     ownership on that error path so the set comes back clean.
     """
 
+    @pytest.mark.asyncio
     async def test_a_prepare_failure_leaves_no_mirror_registration(self, tmp_path, monkeypatch):
         from aiohttp import web
         from aiohttp.test_utils import TestClient, TestServer
@@ -3127,6 +3245,7 @@ class TestPreStreamRefusalRollsBackTheUserRow:
     running the turn — so that row stays.
     """
 
+    @pytest.mark.asyncio
     async def test_a_pre_stream_refusal_removes_the_user_row(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -3145,6 +3264,7 @@ class TestPreStreamRefusalRollsBackTheUserRow:
         assert [m["role"] for m in slot.messages] == ["error"]
         assert slot.total_messages == before_total
 
+    @pytest.mark.asyncio
     async def test_a_mid_stream_truncation_keeps_the_user_row(self, tmp_path):
         state = _make_state(tmp_path)
         state.broadcast_ws = MagicMock()
@@ -3165,6 +3285,7 @@ class TestPreStreamRefusalRollsBackTheUserRow:
         assert any(m["role"] == "user" for m in slot.messages)
         assert slot.messages[-1]["role"] == "error"
 
+    @pytest.mark.asyncio
     async def test_a_zero_byte_2xx_stream_keeps_the_user_row(self, tmp_path):
         """A 2xx response that closes before a byte is ACCEPTANCE, not refusal.
 
@@ -3254,6 +3375,7 @@ class TestRelayedSendToBusyPeerSlotIsRefused:
     reader raise and surface a reconnect prompt instead.
     """
 
+    @pytest.mark.asyncio
     async def test_a_relayed_send_to_a_busy_local_slot_is_refused(self, tmp_path):
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -3283,6 +3405,7 @@ class TestRemoteSessionIsPlainChatOnly:
     the sibling: the post-create mode switch that would otherwise reopen it.
     """
 
+    @pytest.mark.asyncio
     async def test_a_remote_slot_cannot_switch_to_a_non_plain_mode(self, tmp_path):
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -3358,6 +3481,7 @@ class TestBoundSlotRefusesTurnRestartingActions:
             ("/api/chat/slots/chat-1/continue", None),
         ],
     )
+    @pytest.mark.asyncio
     async def test_each_action_is_refused_and_nothing_is_truncated(
         self, tmp_path, monkeypatch, path, body
     ):
@@ -3406,6 +3530,7 @@ class TestBoundSlotRefusesTurnRestartingActions:
             ("/api/chat/slots/chat-1/continue", None),
         ],
     )
+    @pytest.mark.asyncio
     async def test_a_foreign_app_gets_the_anti_enumeration_404_not_the_409(
         self, tmp_path, monkeypatch, path, body
     ):
@@ -3443,6 +3568,7 @@ class TestRemoteSlotNeverRunsLocally:
     (GPT #7693) — so a new entry point cannot silently reintroduce the divergence.
     """
 
+    @pytest.mark.asyncio
     async def test_run_chat_refuses_a_remote_slot_before_any_execution(self, tmp_path):
         from kiro_crew.dashboard.chat_runner import _run_chat
 

--- a/test/test_resource_health_endpoint.py
+++ b/test/test_resource_health_endpoint.py
@@ -39,10 +39,15 @@ _MOCK_STATUS = ResourceStatus(
 @pytest.mark.asyncio
 async def test_api_system_includes_resource_posture(monkeypatch):
     """The /api/system response must include resource posture fields."""
-    with patch(
-        "kiro_crew.dashboard.handlers_system._resource_probe",
-        return_value=_MOCK_STATUS,
-        create=True,
+    with (
+        patch(
+            "kiro_crew.dashboard.handlers_system._resource_probe",
+            return_value=_MOCK_STATUS,
+            create=True,
+        ),
+        # The local-IP probe is the one real network reach in a system-info
+        # render; pin its answer so the test never dials out.
+        patch.object(hs, "_local_ip", return_value="127.0.0.1"),
     ):
         # Patch at the module level where the lazy import will resolve
         monkeypatch.setattr(
@@ -71,6 +76,7 @@ async def test_api_system_resource_posture_fallback_on_probe_failure(monkeypatch
         raise RuntimeError("probe unavailable")
 
     monkeypatch.setattr("kiro_crew.resource_status.probe", _failing_probe)
+    monkeypatch.setattr(hs, "_local_ip", lambda: "127.0.0.1")
 
     resp = await hs.api_system(_Req())
 
@@ -101,6 +107,7 @@ async def test_api_system_resource_posture_ample(monkeypatch):
     monkeypatch.setattr(
         "kiro_crew.subagent.compute_max_subagents", lambda cfg: 11
     )
+    monkeypatch.setattr(hs, "_local_ip", lambda: "127.0.0.1")
 
     resp = await hs.api_system(_Req())
 

--- a/test/test_safety_override.py
+++ b/test/test_safety_override.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from conftest import drain_breadcrumb_writes
 from kiro_crew.safety_override import (
     ActivationResult,
     OverrideStatus,
@@ -1365,3 +1366,137 @@ class TestStatusDoesNotBlockTheEventLoop:
         # Fail-soft: the call returns cleanly. disabled_modes reflects the
         # real governance layer (not patched here), so assert only its type.
         assert isinstance(disabled_modes, list)
+
+
+# ─── Breadcrumb path resolution (host-isolation regression) ────────────────
+
+
+class TestBreadcrumbPathResolvedAtEnqueueTime:
+    """The breadcrumb publish must resolve ``config_dir()`` on the CALLING
+    thread, before the job is handed to the worker -- never inside the worker
+    itself.
+
+    ``_sync_breadcrumb`` runs synchronously on whatever thread committed the
+    state transition (an event-loop callback, or a test). The actual file I/O
+    is queued onto a long-lived daemon worker (``kirocrew-safety-breadcrumb``)
+    so that thread never blocks the caller. If the worker resolved
+    ``config_dir()`` itself -- lazily, at write time -- then a caller whose
+    ``KIROCREW_HOME`` override has since been reverted (a test's monkeypatch
+    torn down at fixture teardown, or a production reload that changes the
+    active home) would have its publish land wherever ``config_dir()``
+    resolves to BY THEN, not where it resolved when the grant was actually
+    committed.
+    """
+
+    def test_write_and_clear_receive_a_caller_resolved_path(
+        self, override: SafetyOverride, tmp_path, monkeypatch
+    ) -> None:
+        """Mutation guard: ``_write_breadcrumb``/``_clear_breadcrumb`` must be
+        handed the path, not resolve it themselves.
+
+        Pins ``config_dir()`` to *tmp_path* only while the transition commits,
+        then swaps it out for a path that does not exist BEFORE the worker gets
+        a chance to run, and confirms the write still lands under *tmp_path*.
+        If either helper called ``_breadcrumb_path()`` internally instead of
+        using the path handed to it, the swapped-out resolver would send the
+        write somewhere else (or make it fail outright), which this test would
+        catch by finding no breadcrumb under *tmp_path*.
+        """
+        import kiro_crew.safety_override as so_mod
+
+        real_config_dir = so_mod.config_dir
+        pinned_dir = tmp_path / "pinned-home"
+        pinned_dir.mkdir()
+        # A different directory the resolver is swapped to AFTER commit, so any
+        # write happening on the worker under the OLD (reverted) resolver would
+        # land here instead of under pinned_dir -- exactly the bug this test
+        # guards against.
+        diverted_dir = tmp_path / "diverted-home"
+        diverted_dir.mkdir()
+
+        monkeypatch.setattr(so_mod, "config_dir", lambda: pinned_dir)
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            result = override.activate("dashboard", ttl=60)
+        assert result.active is True
+
+        # Revert BEFORE the worker has necessarily run: the fix must have
+        # already captured the path on this (calling) thread inside
+        # activate()/_sync_breadcrumb(), synchronously, before this line.
+        monkeypatch.setattr(so_mod, "config_dir", lambda: diverted_dir)
+
+        drain_breadcrumb_writes()
+
+        pinned_breadcrumb = pinned_dir / so_mod._BREADCRUMB_FILE
+        diverted_breadcrumb = diverted_dir / so_mod._BREADCRUMB_FILE
+        assert pinned_breadcrumb.exists(), (
+            "breadcrumb must land under the home resolved at commit time"
+        )
+        assert not diverted_breadcrumb.exists(), (
+            "breadcrumb must NOT land under a home resolved after the "
+            "calling thread's context changed"
+        )
+        payload = json.loads(pinned_breadcrumb.read_text(encoding="utf-8"))
+        assert payload["source"] == "dashboard"
+
+        monkeypatch.setattr(so_mod, "config_dir", real_config_dir)
+
+    def test_deactivate_clears_the_breadcrumb_under_the_committing_home(
+        self, override: SafetyOverride, tmp_path, monkeypatch
+    ) -> None:
+        """Same guard on the clear path: deactivate() must remove the file
+        under the home that was active when it committed, not wherever
+        ``config_dir()`` resolves to once the worker actually runs.
+        """
+        import kiro_crew.safety_override as so_mod
+
+        real_config_dir = so_mod.config_dir
+        pinned_dir = tmp_path / "pinned-home"
+        pinned_dir.mkdir()
+
+        monkeypatch.setattr(so_mod, "config_dir", lambda: pinned_dir)
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("dashboard", ttl=60)
+        drain_breadcrumb_writes()
+        pinned_breadcrumb = pinned_dir / so_mod._BREADCRUMB_FILE
+        assert pinned_breadcrumb.exists()
+
+        # Divert the resolver AFTER the commit (deactivate() resolves the path
+        # synchronously on this thread before it returns), then drain -- the
+        # worker's clear must still target the home resolved AT COMMIT TIME,
+        # not whatever config_dir() answers once it actually runs.
+        diverted_dir = tmp_path / "diverted-home"
+        diverted_dir.mkdir()
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.deactivate("dashboard")
+        monkeypatch.setattr(so_mod, "config_dir", lambda: diverted_dir)
+        drain_breadcrumb_writes()
+
+        assert not pinned_breadcrumb.exists(), "deactivate must clear the pinned breadcrumb"
+        assert not (diverted_dir / so_mod._BREADCRUMB_FILE).exists()
+
+        monkeypatch.setattr(so_mod, "config_dir", real_config_dir)
+
+    def test_drain_helper_raises_on_a_starved_worker(self, monkeypatch) -> None:
+        """Mutation guard for the drain helper itself: a worker that never
+        empties its queue must make ``drain_breadcrumb_writes`` raise rather
+        than return silently, or a test relying on it to prove isolation would
+        pass without having proven anything.
+
+        Reverts the patch itself (rather than relying on ``monkeypatch``'s own
+        teardown order) because this suite's ``test/conftest.py`` autouse
+        fixture calls the same helper at its OWN teardown, which -- as an autouse
+        fixture with no explicit dependency on ``monkeypatch`` -- is torn down
+        BEFORE ``monkeypatch`` reverts anything. Leaving the stub in place would
+        make that unrelated teardown call also raise.
+        """
+        import kiro_crew.safety_override as so_mod
+
+        monkeypatch.setattr(so_mod, "flush_breadcrumb_writes", lambda timeout=5.0: False)
+        try:
+            with pytest.raises(TimeoutError):
+                drain_breadcrumb_writes(timeout=0.01)
+        finally:
+            monkeypatch.undo()

--- a/test/test_sandbox_probe.py
+++ b/test/test_sandbox_probe.py
@@ -12,6 +12,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 import kiro_crew.sandbox as sb
+from conftest import absent_sysconf
 from kiro_crew.sandbox import _probe_sandbox_exec
 
 # The namespace probe internals are Linux-only by construction: they call
@@ -657,8 +658,19 @@ class TestProbeChildFdSweep:
         a wide span is cheap — and silently clamping it would leave an fd at,
         say, 60000 open on a ``LimitNOFILE=65536`` host with no diagnostic.
         ``raising=False`` because ``os.sysconf`` does not exist on Windows.
+
+        The fake answers ``SC_OPEN_MAX`` only and forwards every other name to
+        the real ``os.sysconf``: ``sb.os`` is the process-wide ``os`` module
+        (not a module-local alias), so an unscoped fake would also feed a
+        wrong ``SC_PAGE_SIZE`` to any other thread reading it concurrently
+        (e.g. a memory-usage sampler) for the life of this test.
         """
-        monkeypatch.setattr(sb.os, "sysconf", lambda _name: 65536, raising=False)
+        real_sysconf = getattr(sb.os, "sysconf", absent_sysconf)
+
+        def fake_sysconf(name):
+            return 65536 if name == "SC_OPEN_MAX" else real_sysconf(name)
+
+        monkeypatch.setattr(sb.os, "sysconf", fake_sysconf, raising=False)
 
         assert sb._fd_sweep_ranges(frozenset({0, 1, 2})) == ((3, 65536),)
 
@@ -667,15 +679,25 @@ class TestProbeChildFdSweep:
 
         The absent case is real: ``os.sysconf`` does not exist off-POSIX, and
         the helper's never-raises contract must hold everywhere it can run.
-        """
 
-        def unavailable(_name):
-            raise ValueError("unrecognized configuration name")
+        Only ``SC_OPEN_MAX`` is broken here; every other name still reaches
+        the real ``os.sysconf`` so a concurrent reader on another thread (of
+        ``sb.os``, the shared stdlib module) never sees the fault.
+        """
+        real_sysconf = getattr(sb.os, "sysconf", absent_sysconf)
+
+        def unavailable(name):
+            if name == "SC_OPEN_MAX":
+                raise ValueError("unrecognized configuration name")
+            return real_sysconf(name)
 
         monkeypatch.setattr(sb.os, "sysconf", unavailable, raising=False)
         first = sb._fd_sweep_ranges(frozenset({0, 1, 2}))
 
-        monkeypatch.setattr(sb.os, "sysconf", lambda _name: -1, raising=False)
+        def nonsense(name):
+            return -1 if name == "SC_OPEN_MAX" else real_sysconf(name)
+
+        monkeypatch.setattr(sb.os, "sysconf", nonsense, raising=False)
         second = sb._fd_sweep_ranges(frozenset({0, 1, 2}))
 
         monkeypatch.delattr(sb.os, "sysconf", raising=False)

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -31,6 +31,23 @@ from kiro_crew.security_posture import (
     build_posture_snapshot_async,
 )
 
+
+@pytest.fixture(autouse=True, scope="module")
+def _drop_source_corpus_after_module():
+    """Release the whole-tree corpus this module's census pulls in.
+
+    ``_package_baseline_log_census`` below is its own ``lru_cache(maxsize=1)``
+    wrapping a ``source_corpus.parsed_candidates`` walk, so it holds two
+    references on the corpus: its own cached census AND (via
+    ``source_corpus``) the ~160 MB raw+NFKC text cache. ``test/conftest.py``
+    releases the corpus itself at every module's teardown; this releases the
+    census on top. Module teardown rather than per test, because the two tests
+    here deliberately share the census cache within the module.
+    """
+    yield
+    _package_baseline_log_census.cache_clear()
+
+
 # ANY use of a redactor, including every wrapper.
 #
 # This alternation is load-bearing: the guard below can only classify a module it

--- a/test/test_slack_agent_passthrough.py
+++ b/test/test_slack_agent_passthrough.py
@@ -40,13 +40,29 @@ def _make_mocks():
 
     mock_client = AsyncMock()
     mock_client.stream = _empty_stream
+    # context_usage_pct() and context_window_tokens() are sync on the real
+    # provider client.
+    mock_client.context_usage_pct = MagicMock(return_value=0.0)
+    mock_client.context_window_tokens = MagicMock(return_value=0)
 
     sessions = AsyncMock()
     sessions.get_or_create = AsyncMock(return_value=(mock_client, True, False))
     sessions.set_channel = AsyncMock()
     sessions.set_slack_link = MagicMock()
     sessions.get_pid = MagicMock(return_value=None)
-    sessions.release = AsyncMock()
+    # release(), is_cancelled(), check_context_usage(), record_success(),
+    # begin_turn(), and get_session_for_thread() are all sync on the real
+    # SessionManager and are called without `await` in handler.py; an
+    # AsyncMock here creates a coroutine handle_message never awaits.
+    sessions.release = MagicMock()
+    sessions.is_cancelled = MagicMock(return_value=False)
+    sessions.check_context_usage = MagicMock(return_value=0.0)
+    sessions.record_success = MagicMock()
+    sessions.begin_turn = MagicMock()
+    sessions.get_session_for_thread = MagicMock(return_value=None)
+    # _sessions is read via getattr(sessions, "_sessions", {}).get(...); a real
+    # dict avoids an AsyncMock attribute chain that creates an unawaited call.
+    sessions._sessions = {}
 
     context_builder = MagicMock()
     context_builder.build_message = MagicMock(return_value=("hello", MagicMock()))

--- a/test/test_slack_config_handlers.py
+++ b/test/test_slack_config_handlers.py
@@ -346,6 +346,12 @@ def test_webex_held_env_lock_leaves_legacy_credential_intact(tmp_path, monkeypat
     monkeypatch.setattr(loader, "env_path", lambda: env)
     monkeypatch.setattr(loader, "config_path", lambda: cfg)
     monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+    # A pasted bot_token is checked against the real Webex API before it is
+    # stored (Phase 1.5); stub that verification so the test's lock-contention
+    # scenario never reaches the network.
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(mod, "_validate_webex_token", AsyncMock(return_value=None))
 
     # Simulate a held .env lock: _write_env_updates raises OSError.
     def _write_env_raises(_updates):
@@ -408,6 +414,12 @@ def test_teams_held_env_lock_leaves_legacy_credential_intact(tmp_path, monkeypat
     monkeypatch.setattr(loader, "env_path", lambda: env)
     monkeypatch.setattr(loader, "config_path", lambda: cfg)
     monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+    # A pasted app_password is checked against Azure AD before it is stored
+    # (client-credentials token exchange); stub that verification so the
+    # test's lock-contention scenario never reaches the network.
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(mod, "_validate_teams_app_credentials", AsyncMock(return_value=None))
 
     # Simulate a held .env lock: asyncio.to_thread(_write_env_updates, ...) raises.
     _orig_to_thread = asyncio.to_thread

--- a/test/test_slack_mirror_unlink.py
+++ b/test/test_slack_mirror_unlink.py
@@ -78,7 +78,17 @@ def _fake_provider():
 
     fake_client.stream = _stream
     fake_client.stream_command = _stream
+    # These provider-client accessors are sync on the real client; leaving
+    # them as AsyncMock attrs creates coroutines _run_chat calls but never
+    # awaits (it reads them synchronously by design).
     fake_client.context_usage_pct = MagicMock(return_value=0.0)
+    fake_client.context_window_tokens = MagicMock(return_value=0)
+    fake_client.context_used_tokens = MagicMock(return_value=0)
+    fake_client.mcp_session_report = MagicMock(return_value=None)
+    # getattr(client, "client", None) is used to reach a nested ACP client for
+    # pop_pending_oauth_requests(); a bare AsyncMock().client would make that
+    # lookup return another AsyncMock whose call also goes unawaited.
+    fake_client.client = None
     return fake_client
 
 

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from conftest import absent_sysconf
 from kiro_crew import subagent as sa
 from kiro_crew.subagent import SubagentInfo, SubagentManager
 
@@ -485,27 +486,53 @@ class TestMacosAvailableMemory:
     ``raising=False`` — the probe's own ``hasattr`` guard is what CI exercises."""
 
     def test_page_size_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(
-            os, "sysconf", lambda _name: (_ for _ in ()).throw(ValueError), raising=False
-        )
+        real_sysconf = getattr(os, "sysconf", absent_sysconf)
+
+        def fake_sysconf(name):
+            if name == "SC_PAGE_SIZE":
+                raise ValueError("SC_PAGE_SIZE unavailable")
+            return real_sysconf(name)
+
+        monkeypatch.setattr(os, "sysconf", fake_sysconf, raising=False)
         assert sa._macos_available_memory_gb() == -1.0
 
     def test_nonpositive_page_size(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(os, "sysconf", lambda _name: 0, raising=False)
+        real_sysconf = getattr(os, "sysconf", absent_sysconf)
+        monkeypatch.setattr(
+            os, "sysconf", lambda n: 0 if n == "SC_PAGE_SIZE" else real_sysconf(n), raising=False
+        )
         assert sa._macos_available_memory_gb() == -1.0
 
     def test_no_reclaimable_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(os, "sysconf", lambda _name: 4096, raising=False)
+        real_sysconf = getattr(os, "sysconf", absent_sysconf)
+        monkeypatch.setattr(
+            os,
+            "sysconf",
+            lambda n: 4096 if n == "SC_PAGE_SIZE" else real_sysconf(n),
+            raising=False,
+        )
         monkeypatch.setattr(sa, "_macos_vm_reclaimable_pages", lambda: None)
         assert sa._macos_available_memory_gb() == -1.0
 
     def test_zero_pages_fails_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(os, "sysconf", lambda _name: 4096, raising=False)
+        real_sysconf = getattr(os, "sysconf", absent_sysconf)
+        monkeypatch.setattr(
+            os,
+            "sysconf",
+            lambda n: 4096 if n == "SC_PAGE_SIZE" else real_sysconf(n),
+            raising=False,
+        )
         monkeypatch.setattr(sa, "_macos_vm_reclaimable_pages", lambda: 0)
         assert sa._macos_available_memory_gb() == -1.0
 
     def test_computes_gb_from_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(os, "sysconf", lambda _name: 4096, raising=False)
+        real_sysconf = getattr(os, "sysconf", absent_sysconf)
+        monkeypatch.setattr(
+            os,
+            "sysconf",
+            lambda n: 4096 if n == "SC_PAGE_SIZE" else real_sysconf(n),
+            raising=False,
+        )
         monkeypatch.setattr(sa, "_macos_vm_reclaimable_pages", lambda: 262144)
         assert sa._macos_available_memory_gb() == pytest.approx(1.0)
 

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -14,6 +14,7 @@ import types
 import pytest
 
 import kiro_crew.subagent as subagent
+from conftest import absent_sysconf
 from kiro_crew.subagent import compute_max_subagents, resolve_max_subagents
 
 # ``SubagentManager.spawn`` refuses -- registering no task -- while the host
@@ -826,7 +827,12 @@ class TestMacosMemoryProbe:
     def test_computes_available_gb_from_pages(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
 
-        monkeypatch.setattr(sub.os, "sysconf", lambda _n: 16384)  # 16 KiB pages
+        real_sysconf = getattr(sub.os, "sysconf", absent_sysconf)
+        monkeypatch.setattr(
+            sub.os,
+            "sysconf",
+            lambda n: 16384 if n == "SC_PAGE_SIZE" else real_sysconf(n),  # 16 KiB pages
+        )
         monkeypatch.setattr(sub, "_macos_vm_reclaimable_pages", lambda: 200000)
         expected = round(200000 * 16384 / (1024 ** 3), 2)
         assert sub._macos_available_memory_gb() == pytest.approx(expected, abs=0.01)
@@ -834,22 +840,32 @@ class TestMacosMemoryProbe:
     def test_none_page_count_fails_open(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
 
-        monkeypatch.setattr(sub.os, "sysconf", lambda _n: 16384)
+        real_sysconf = getattr(sub.os, "sysconf", absent_sysconf)
+        monkeypatch.setattr(
+            sub.os, "sysconf", lambda n: 16384 if n == "SC_PAGE_SIZE" else real_sysconf(n)
+        )
         monkeypatch.setattr(sub, "_macos_vm_reclaimable_pages", lambda: None)
         assert sub._macos_available_memory_gb() == -1.0
 
     def test_zero_page_count_fails_open(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
 
-        monkeypatch.setattr(sub.os, "sysconf", lambda _n: 16384)
+        real_sysconf = getattr(sub.os, "sysconf", absent_sysconf)
+        monkeypatch.setattr(
+            sub.os, "sysconf", lambda n: 16384 if n == "SC_PAGE_SIZE" else real_sysconf(n)
+        )
         monkeypatch.setattr(sub, "_macos_vm_reclaimable_pages", lambda: 0)
         assert sub._macos_available_memory_gb() == -1.0
 
     def test_sysconf_error_fails_open(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
 
-        def _boom(_n):
-            raise ValueError("SC_PAGE_SIZE unavailable")
+        real_sysconf = getattr(sub.os, "sysconf", absent_sysconf)
+
+        def _boom(n):
+            if n == "SC_PAGE_SIZE":
+                raise ValueError("SC_PAGE_SIZE unavailable")
+            return real_sysconf(n)
 
         monkeypatch.setattr(sub.os, "sysconf", _boom)
         assert sub._macos_available_memory_gb() == -1.0
@@ -857,7 +873,10 @@ class TestMacosMemoryProbe:
     def test_nonpositive_page_size_fails_open(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
 
-        monkeypatch.setattr(sub.os, "sysconf", lambda _n: 0)
+        real_sysconf = getattr(sub.os, "sysconf", absent_sysconf)
+        monkeypatch.setattr(
+            sub.os, "sysconf", lambda n: 0 if n == "SC_PAGE_SIZE" else real_sysconf(n)
+        )
         # _macos_vm_reclaimable_pages must not even be consulted
         monkeypatch.setattr(
             sub, "_macos_vm_reclaimable_pages", lambda: pytest.fail("should not run")

--- a/test/test_subagent_spawn_host_pin.py
+++ b/test/test_subagent_spawn_host_pin.py
@@ -52,8 +52,19 @@ def _spawning_modules() -> tuple[tuple[str, bool], ...]:
     found: list[tuple[str, bool]] = []
     for path in sorted(_TEST_DIR.glob("*.py")):
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (OSError, SyntaxError, UnicodeDecodeError):
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        # A qualifying module must spell both names textually -- an AST node
+        # named `SubagentManager` or a `.spawn(` call cannot be parsed from
+        # source that lacks those characters -- so this is a necessary, not
+        # sufficient, precondition and skips straight past every file that
+        # cannot possibly match before paying for its parse.
+        if "SubagentManager" not in text or "spawn" not in text:
+            continue
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
             continue
         names = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
         names |= {a.attr for a in ast.walk(tree) if isinstance(a, ast.Attribute)}

--- a/test/test_taskrunner.py
+++ b/test/test_taskrunner.py
@@ -1155,11 +1155,11 @@ class TestResourceManagement:
     """Verify sessions are released for all task lifecycle paths."""
 
     @pytest.mark.asyncio
-    async def test_single_task_session_reset_after_success(self) -> None:
+    async def test_single_task_session_reset_after_success(self, tmp_path: Path) -> None:
         """After a single task succeeds, its session must be reset."""
         sessions = _make_mock_sessions()
         sessions.reset = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         async def mock_execute(run, task, hk="", session_key=""):
             task.status = StepStatus.PASSED
@@ -1179,11 +1179,11 @@ class TestResourceManagement:
         assert "taskrunner:r1:task1" in reset_keys
 
     @pytest.mark.asyncio
-    async def test_parallel_tasks_all_sessions_reset(self) -> None:
+    async def test_parallel_tasks_all_sessions_reset(self, tmp_path: Path) -> None:
         """After a parallel group completes, ALL task sessions must be reset."""
         sessions = _make_mock_sessions()
         sessions.reset = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         async def mock_execute(run, task, hk="", session_key=""):
             task.status = StepStatus.PASSED
@@ -1204,11 +1204,11 @@ class TestResourceManagement:
             assert f"taskrunner:r2:task{i}" in reset_keys
 
     @pytest.mark.asyncio
-    async def test_parallel_failure_still_resets_all_sessions(self) -> None:
+    async def test_parallel_failure_still_resets_all_sessions(self, tmp_path: Path) -> None:
         """If one task in a parallel group fails, ALL sessions in the group must still be reset."""
         sessions = _make_mock_sessions()
         sessions.reset = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         call_count = 0
 
@@ -1270,10 +1270,10 @@ class TestResourceManagement:
             assert ri < si, f"release must precede reset for {key}: {call_order}"
 
     @pytest.mark.asyncio
-    async def test_pending_tasks_hold_no_sessions(self) -> None:
+    async def test_pending_tasks_hold_no_sessions(self, tmp_path: Path) -> None:
         """Tasks that never execute (PENDING) should not create any sessions."""
         sessions = _make_mock_sessions()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         async def mock_execute(run, task, hk="", session_key=""):
             task.status = StepStatus.FAILED
@@ -1303,11 +1303,11 @@ class TestResourceManagement:
         assert "taskrunner:r4:task3" not in reset_keys
 
     @pytest.mark.asyncio
-    async def test_cancel_running_project_cleans_up_sessions(self) -> None:
+    async def test_cancel_running_project_cleans_up_sessions(self, tmp_path: Path) -> None:
         """cancel() on a running project must trigger _cleanup_run_sessions."""
         sessions = _make_mock_sessions()
         sessions.cancel_current = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         # Simulate a long-running task that blocks until cancelled
         blocked = asyncio.Event()
@@ -1362,11 +1362,11 @@ class TestResourceManagement:
         assert sessions.reset.call_count >= 1
 
     @pytest.mark.asyncio
-    async def test_cancel_mid_parallel_group_resets_all(self) -> None:
+    async def test_cancel_mid_parallel_group_resets_all(self, tmp_path: Path) -> None:
         """Cancelling during a parallel group must clean up all sessions in the group."""
         sessions = _make_mock_sessions()
         sessions.cancel_current = AsyncMock()
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         started = asyncio.Event()
 
@@ -1421,7 +1421,7 @@ class TestResourceManagement:
                 assert key in cleaned_keys, f"Session {key} not cleaned up"
 
     @pytest.mark.asyncio
-    async def test_cancel_mid_parallel_group_reset_completes(self) -> None:
+    async def test_cancel_mid_parallel_group_reset_completes(self, tmp_path: Path) -> None:
         """reset() must run to completion under CancelledError (shield fix)."""
         sessions = _make_mock_sessions()
         sessions.cancel_current = AsyncMock()
@@ -1432,7 +1432,7 @@ class TestResourceManagement:
             reset_completed.append(key)
 
         sessions.reset = slow_reset
-        runner = TaskRunner(sessions=sessions, auto_test=False)
+        runner = TaskRunner(sessions=sessions, auto_test=False, work_dir=tmp_path)
 
         started = asyncio.Event()
 

--- a/test/test_webex_client.py
+++ b/test/test_webex_client.py
@@ -575,11 +575,19 @@ class TestRedeliveryHandling:
         assert "raw-uuid" not in str(c._seen) or c._seen  # the mark is kept
 
     @pytest.mark.asyncio
-    async def test_a_failed_ack_does_not_raise(self) -> None:
+    async def test_a_failed_ack_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # A closed socket is the expected failure and is already surfaced by the
         # reconnect loop; letting it escape would log an unretrieved task
         # exception on every reconnect.
         c = _client()
+        # The handler task fetches the message via a real Webex REST call
+        # unless stubbed; give it a message so it settles without a network
+        # reach-out, matching _wired()'s fake_fetch elsewhere in this file.
+        monkeypatch.setattr(
+            c,
+            "fetch_message",
+            lambda mid: asyncio.sleep(0, result={"personEmail": "user@example.com", "text": "hi"}),
+        )
 
         class DeadWs:
             async def send_json(self, payload: dict) -> None:
@@ -590,8 +598,13 @@ class TestRedeliveryHandling:
         await asyncio.gather(*c._handler_tasks, return_exceptions=False)
 
     @pytest.mark.asyncio
-    async def test_no_socket_means_no_ack_attempt(self) -> None:
+    async def test_no_socket_means_no_ack_attempt(self, monkeypatch: pytest.MonkeyPatch) -> None:
         c = _client()
+        monkeypatch.setattr(
+            c,
+            "fetch_message",
+            lambda mid: asyncio.sleep(0, result={"personEmail": "user@example.com", "text": "hi"}),
+        )
         c._ws = None
         c._handle_frame(_frame())  # must not raise
         await asyncio.gather(*c._handler_tasks)

--- a/test/test_windows_kill_probe_audit.py
+++ b/test/test_windows_kill_probe_audit.py
@@ -33,6 +33,7 @@ invisible to it. This test reads the whole tree on every run.
 from __future__ import annotations
 
 import ast
+import functools
 from pathlib import Path
 
 _SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
@@ -85,8 +86,14 @@ def _enclosing_functions(tree: ast.AST) -> list[tuple[str, ast.AST]]:
     return out
 
 
-def _find_raw_probes() -> dict[str, list[int]]:
-    """Map ``file::function`` -> line numbers of raw signal-0 probes."""
+@functools.lru_cache(maxsize=1)
+def _find_raw_probes() -> dict[str, tuple[int, ...]]:
+    """Map ``file::function`` -> line numbers of raw signal-0 probes.
+
+    Cached: the rglob + ast.parse of the whole tree is the same answer for
+    every one of this module's three tests, and the source tree cannot change
+    mid-run. Values are tuples so a cached entry cannot be mutated in place.
+    """
     found: dict[str, list[int]] = {}
     for path in sorted(_SRC_ROOT.rglob("*.py")):
         rel = path.relative_to(_SRC_ROOT).as_posix()
@@ -111,7 +118,7 @@ def _find_raw_probes() -> dict[str, list[int]]:
             if isinstance(sub, ast.Call) and _is_signal_zero_probe(sub):
                 if not any(sub.lineno in span for span in func_line_spans):
                     found.setdefault(f"{rel}::<module>", []).append(sub.lineno)
-    return found
+    return {k: tuple(v) for k, v in found.items()}
 
 
 def test_no_ungated_signal_zero_probe() -> None:

--- a/test/test_worktree_create.py
+++ b/test/test_worktree_create.py
@@ -22,6 +22,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from kiro_crew import sandbox as sandbox_mod
 from kiro_crew.dashboard.handlers import worktree as wt_mod
 from kiro_crew.dashboard.handlers.worktree import (
     _FILTER_PROBE_FAILED,
@@ -156,7 +157,20 @@ def _sandbox_exec_reason() -> str:
     rather than fail. A backend-availability probe is not enough: GitHub Actions
     runners pass the user-namespace probe but deny `unshare(NEWNS)` at exec time
     (errno 1), which the launcher can only report from the child.
+
+    Resets ``sandbox._backend`` immediately before probing. Without this, the
+    ONE-TIME probe below reads whatever backend verdict another test file
+    already cached in this xdist worker's shared process — `_backend` has a
+    permanent fast path once set to "namespace" or "none", and no fixture in
+    THIS file clears it, so this file's own (also one-time, ``lru_cache``d)
+    verdict silently inherited a coin flip decided by test-collection order:
+    which file's tests happened to run first in this worker on a given
+    invocation. That is the flip this module's own caching cannot fix on its
+    own — the cache was deterministic, but keyed on stale ambient state rather
+    than a probe of THIS host. Forcing a fresh probe here makes the verdict
+    depend only on the host's actual sandbox availability.
     """
+    sandbox_mod.reset_backend()
     # Never let a verdict be produced ON the event loop. `wrap_argv`'s loop guard
     # would be cached here as "sandbox unavailable" and silently skip every
     # git-touching test in this worker for the wrong reason — the exact failure
@@ -196,6 +210,22 @@ def _passthrough_spawn(argv, mode="standard", **kw):
     running (GPT review round 12 / round-11 CI).
     """
     return list(argv), {}, None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _sandbox_backend_session_boundary():
+    """Reset ``sandbox._backend`` at session END, mirroring the reset this file's
+    own :func:`_sandbox_exec_reason` already does at session START.
+
+    ``_sandbox_exec_reason()`` is ``lru_cache``d and forces a fresh probe on its
+    one call, but its result (a real "namespace" or "none" verdict for THIS
+    host) then sits in the shared ``sandbox`` module global for the rest of the
+    xdist worker's process. Clearing it here keeps this file from becoming the
+    same kind of ambient-state donor to whichever test module runs next in this
+    worker that this fix exists to stop this file from being a VICTIM of.
+    """
+    yield
+    sandbox_mod.reset_backend()
 
 
 @pytest.fixture(scope="session")

--- a/test/test_xdist_host_budget.py
+++ b/test/test_xdist_host_budget.py
@@ -23,6 +23,7 @@ import warnings
 import pytest
 
 import xdist_budget as ct
+from conftest import absent_sysconf
 
 needs_symlinks = pytest.mark.skipif(
     os.name != "posix", reason="symlink creation needs privileges on Windows"
@@ -163,10 +164,16 @@ def test_slot_path_is_zero_padded(tmp_path: pathlib.Path) -> None:
 
 
 def test_host_total_gib_converts_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_sysconf = getattr(os, "sysconf", absent_sysconf)
+    fake = {"SC_PHYS_PAGES": 2097152, "SC_PAGE_SIZE": 16384}
+    # ``os`` here is the process-wide stdlib module, not a module-local alias, so
+    # an unscoped fake would also answer SC_OPEN_MAX/SC_CLK_TCK wrong for any other
+    # thread reading them concurrently. Fall through to the real sysconf for every
+    # name this test does not care about.
     monkeypatch.setattr(
         os,
         "sysconf",
-        lambda name: {"SC_PHYS_PAGES": 2097152, "SC_PAGE_SIZE": 16384}[name],
+        lambda name: fake[name] if name in fake else real_sysconf(name),
         raising=False,
     )
     assert ct._host_total_gib() == 32
@@ -189,10 +196,12 @@ def no_win32_memory(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_host_total_gib_rejects_nonsense(
     monkeypatch: pytest.MonkeyPatch, no_win32_memory: None, pages: int, size: int
 ) -> None:
+    real_sysconf = getattr(os, "sysconf", absent_sysconf)
+    fake = {"SC_PHYS_PAGES": pages, "SC_PAGE_SIZE": size}
     monkeypatch.setattr(
         os,
         "sysconf",
-        lambda name: {"SC_PHYS_PAGES": pages, "SC_PAGE_SIZE": size}[name],
+        lambda name: fake[name] if name in fake else real_sysconf(name),
         raising=False,
     )
     assert ct._host_total_gib() == 0
@@ -398,7 +407,7 @@ def test_claim_fails_open_when_the_dir_cannot_be_made(
 
 
 def test_an_unwritable_slot_dir_drops_to_one_worker_and_says_why(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    slot_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A directory that EXISTS but cannot be written is the case ``mkdir`` misses.
 
@@ -408,6 +417,13 @@ def test_an_unwritable_slot_dir_drops_to_one_worker_and_says_why(
     concurrent one, so both would get the full cap with no coordination, which is the
     oversubscription the budget exists to prevent. One worker, and a warning naming the
     fix, because a silent hour-long suite is a bug nobody can see.
+
+    Requests the ``slot_dir`` fixture (rather than a bare ``tmp_path``) so
+    ``ct._slot_dir()`` resolves under the per-test root: this test's own ``os.open``
+    denial only fires for a path containing ``"worker-"``, but without the pin
+    ``_slot_dir()`` still calls the real ``ct._slot_root()`` default
+    (``~/.cache/kirocrew/test-slots``), and the ``mkdir(exist_ok=True)`` this
+    module calls before the denied ``open`` runs against that real host directory.
     """
     monkeypatch.setattr(ct, "_held_slots", [])
     real_open = os.open


### PR DESCRIPTION
## Problem / Motivation

A full backend run of the test suite (~89.5k tests) writes to, and in one case deletes from, the operator's real machine, and carries a handful of order-dependent flakes and a dozen 15–30 s per-test hot spots. Measured on a clean `main` with five full backend runs and five full frontend runs under an in-process `sys.addaudithook` that attributed every filesystem write outside the sanctioned temp roots, every real network connect, every `os.kill` and every cross-run outcome flip to the exact test and stack:

- `~/.kiro/crew/safety_override_last_grant.json` was **deleted from the operator's real home on every full run** (confirmed by before/after snapshot). Root cause: `safety_override`'s breadcrumb pump resolved `config_dir()` on its daemon thread after the enqueuing test's `KIROCREW_HOME` pin had been torn down.
- `model_registry` and `acp.seed_provenance` called `config_dir()` **at import** to peek at a cache sidecar, so every test collector and every read-only tool ran `mkdir ~/.kiro/crew` (plus the recovery-breadcrumb refresh).
- `workspace_root()` (`~/workplace/kirocrew-workspace`) and `kiro_sessions_dir()` (`~/.kiro/sessions/cli`) were not on the rootdir isolation floor: 19 files created the real workspace, three wrote real `cli.json` / outbox files into it, and session-teardown tests deleted transcripts from the real kiro-cli store.
- `pr_watchers` ran `git -C ""` against the real checkout's `.git`; two files raced on a fixed `/tmp/x`; symlinks and `runs.json` were written into `src/`; hypothesis kept its example DB at the repo root; eight test files reached the real network (`8.8.8.8`, `webexapis.com`, `login.microsoftonline.com`).
- Flakes across the 5 runs: `test_public_repo_chip_status` (module-global task set outliving its event loop), `test_browser_cli_install` (a resolver memo warmed by an earlier test), two load-dependent skips in `test_worktree_create`.
- Fourteen ratchet files re-parsed all ~1,300 modules under `src/` once per **test** (≈10 CPU-minutes per run); the shared source corpus held ~160 MB for the life of each worker.
- 7,375 warnings per run, dominated by `AsyncMock` standing in for sync methods and `@pytest.mark.asyncio` on sync tests.

## Why it matters

A test suite that mutates the developer's live `~/.kiro` and workspace is not safe to run locally, and the deletion is silent — it surfaced only because the run was watched. The import-time `mkdir` means even `python -c "import kiro_crew"` in a read-only tool creates state. The hot spots are ~10 CPU-minutes on every shard; the network calls fail on any firewalled runner; and each flake costs a CI rerun and erodes trust in red.

## What changed (motivation → approach → change)

Every fix is at the mechanism, and the measurement recipe is documented so the next class is found the same way rather than one incident at a time.

**Host writes**
- `safety_override`: main had already landed the caller-thread path resolution (#8586); `test/conftest.py` gains `drain_breadcrumb_writes()` (a raising wrapper around production's `flush_breadcrumb_writes`) and drains the worker at teardown *while the pin still holds*, plus a regression class (`TestBreadcrumbPathResolvedAtEnqueueTime`).
- `config.paths.peek_data_home()` — resolves the data home without creating it. `model_registry._sidecar_path()` and `acp.seed_provenance._sidecar_path()` use it; the one writer that needs the directory (`_persist`'s lock file) keeps `config_dir()`. `test_model_registry.py::TestImportDoesNotCreateTheDataHome` imports the package in a fresh interpreter with an empty `$HOME` and asserts nothing appeared.
- Rootdir `conftest.py`: `KIROCREW_WORKSPACE` pinned alongside `KIROCREW_HOME`; new `_isolate_kiro_sessions_dir` fixture backed by a `paths._sessions_dir_override` seam (same shape as the agent-spec home); hypothesis's example database and storage home moved off the checkout to the per-user cache dir (`$XDG_CACHE_HOME`/`~/.cache` → `kirocrew/hypothesis`, the same tree the xdist slot files use) from `pytest_configure`, so shrunk counterexamples still persist across runs; `HYPOTHESIS_STORAGE_DIRECTORY` is exported so a child interpreter lands in the same place; `test/conftest.py` no longer `makedirs` `.hypothesis/tmp` in the checkout at import. `test_host_isolation_floor.py` ratchets the two new pins.
- `pr_watchers._maybe_export_and_retain` returns early when no clone is configured instead of running `git -C ""`.
- Fixed `/tmp` names → `tmp_path`; symlink/`runs.json`/`__pycache__` writes into `src/` → `tmp_path` / `monkeypatch.chdir` / `-B`; network calls stubbed at the seam the code reads (`handlers_system._local_ip`, a new seam for the UDP route probe; `fetch_message`; `_validate_webex_token`; `_validate_teams_app_credentials`).

**Flakes**
- `source_providers.schedule_visibility_refresh` prunes `_VISIBILITY_TASKS` entries bound to a loop other than the running one; the test module clears the set per test (and only cancels tasks whose loop is still open).
- `browser_cli.cli_path()` inputs fully pinned and memo reset in the test; `test_worktree_create` capability probe made deterministic; thread leaks in `test_acp_client` / `test_dashboard_chat` shut down at teardown.

**Hot spots / memory**
- Ratchet scans cached once per module (`lru_cache` keyed on the tree root so a fake tree under `tmp_path` gets its own entry) in `test_lockdown_before_publish`, `test_jsondecodeerror_redundancy_ratchet`, `test_subagent_spawn_host_pin`, `test_lazy_data_home_paths`, `test_windows_kill_probe_audit`, `test_agent_spec_hardened_reads`, `test/metrics/test_provider_bucket_views`, …; `scripts/leaf_test_scope.py` caches its tree walk and reads. `test/source_corpus._clear_caches()` + module-scoped teardown in its eight consumers releases the ~160 MB.
- `os.sysconf` fakes narrowed to the one name under test. (The audit's "+20 GB peak RSS" readings were the fakes changing the page size the sampler multiplied by — verified 114 MB real max RSS — so the narrowing is hygiene, not a leak fix, and the docs record the artifact.)

**Async hygiene**
- `AsyncMock(spec=...)` where sync methods were mocked as coroutines (`test_slack_agent_passthrough`, `test_slack_mirror_unlink`); the module-level `pytestmark = pytest.mark.asyncio` in `test_remote_crew_execution` (which marked 29 sync tests) removed and the 127 async tests marked individually.

**Docs**
- `docs/system-specs/common/testing-conventions.md`: new **§ Side effects** — the audit-hook measurement recipe, the two ways it misleads, the classes found with the one correct fix for each, and "coverage that only looks like coverage". Suite size corrected (`~56.5k` → `~89.5k`). `AGENTS.md` points at it.

**Deliberately not in this PR** (each a follow-up issue): `slack/handler.py` loads the full config at import to build `_PHASE_EMOJIS` (a shared module dict many tests mutate) — the last import-time `mkdir`; `SessionManager._cleanup_loop` / `AutoNudgeService._persist_locked` never-awaited coroutines need a production close API before ~40 test files can drain them; the remaining `AsyncMock`-for-sync files and the seven remaining `asyncio`-mark-on-sync files.

## Tests

- New: `test_model_registry.py::TestImportDoesNotCreateTheDataHome` (fresh-interpreter import leaves an absent home absent; sidecar path follows the data home without creating it), `test_safety_override.py::TestBreadcrumbPathResolvedAtEnqueueTime` (3), `test_host_isolation_floor.py::TestTheWorkspaceRootIsPinnedForEveryTestpath` + sessions-dir ratchet, `test_public_repo_chip_status.py` per-test task-set fixture. Each mutation-verified (pin removed → red).
- All 59 changed files' tests: 3,083 passed / 5 skipped under `-n 8` with the audit hook armed — zero writes under the real `~/.kiro`, `~/workplace`, or `~/Repos` other than the documented `slack/handler.py` follow-up.
- Gates locally: black-baseline, isort, flake8, mypy (1303 files), subprocess-encoding, brand-name, harness-parity, docs-lint — all green.

## Manual verification

Five full backend runs (30 min each, 32 workers) and five full frontend runs (1875 vitest files) on `3a6478967` produced the attribution data; the fixes were verified per file under `-n0` with the same hook. Full-suite re-verification is left to CI shards.

## Related Issues

Related: #8586 (breadcrumb path resolution, already on main — this PR adds the drain + regression tests).

## Pattern harvest

Rule candidate: agents-md (landed here as testing-conventions § Side effects) + a future lint: `config_dir()` reachable from module top level.
Pattern: "a path resolved when the work RUNS instead of when it was REQUESTED" — background workers, import-time loaders, and second defaults (`workspace_root`, `kiro_sessions_dir`) that a `KIROCREW_HOME` pin does not cover.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
