### PR TITLE
refactor(members): retire the dead acp_backend factory kwarg (#8166 item 1)

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -4211,7 +4211,6 @@ class KiroCrewConfig:
             extra_env: dict[str, str] | None = None,
             reasoning_effort_override: str | None = None,
             crew_agent: str | None = None,
-            acp_backend: str | None = None,
             **_kwargs: object,
         ) -> AcpProvider:
             wdir = Path(cwd) if cwd else _session_work_dir(session_key)
@@ -4290,19 +4289,18 @@ class KiroCrewConfig:
                         m or "auto",
                     )
             # Per-session backend selection — ONE call to the selection gate's
-            # per-session half (members.select_provider_backend: explicit
-            # caller pick > member-DM auto-route > configured default). The
-            # factory body carries no branching of its own, so the kiro
-            # construction path gains no second check (harness-parity H3/H13);
-            # resolve_selected_backend inside the helper applies the same
-            # governance/selectability gate as the persisted field, so a
-            # denied or unknown value degrades to kiro — the member thread
-            # then runs as plain chat and the mount step logs why.
+            # per-session half (members.select_provider_backend: member-DM
+            # auto-route > configured default). The factory body carries no
+            # branching of its own, so the kiro construction path gains no
+            # second check (harness-parity H3/H13); resolve_selected_backend
+            # inside the helper applies the same governance/selectability gate
+            # as the persisted field, so a denied or unknown value degrades to
+            # kiro — the member thread then runs as plain chat and the mount
+            # step logs why.
             # circular import: members sits above config in the layering.
             from kiro_crew.members import select_provider_backend
 
             _backend = select_provider_backend(
-                acp_backend,
                 session_key,
                 self.agent.member_acp_backend,
                 self.agent.acp_backend,

--- a/src/kiro_crew/members.py
+++ b/src/kiro_crew/members.py
@@ -148,18 +148,16 @@ def is_member_session_key(session_key: str | None) -> bool:
 
 
 def select_provider_backend(
-    explicit: str | None,
     session_key: str | None,
     member_backend: str,
     configured_default: str,
 ) -> str:
     """The per-session half of the ONE backend-selection gate (H3/H13).
 
-    Precedence: an explicit caller pick, then the member-DM auto-route, then
-    the configured default. Both non-default arms go through
-    :func:`resolve_selected_backend` — the same governance/selectability gate
-    the persisted field crosses, so a denied or unknown value degrades to kiro
-    and the member thread runs as plain chat.
+    Precedence: the member-DM auto-route, then the configured default. The
+    member arm goes through :func:`resolve_selected_backend` — the same
+    governance/selectability gate the persisted field crosses, so a denied or
+    unknown value degrades to kiro and the member thread runs as plain chat.
 
     Lives here rather than inline in ``create_provider_factory`` so the
     factory body stays a single selection CALL with no branching of its own:
@@ -168,8 +166,6 @@ def select_provider_backend(
     """
     from kiro_crew.acp_backends import resolve_selected_backend
 
-    if explicit:
-        return resolve_selected_backend(explicit)
     if is_member_session_key(session_key):
         backend = resolve_selected_backend(member_backend)
         logger.info(

--- a/test/test_member_dispatch_mount.py
+++ b/test/test_member_dispatch_mount.py
@@ -326,15 +326,10 @@ class TestMemberServerJoinsSubtraction:
 class TestSelectProviderBackend:
     """The per-session half of the one backend-selection gate (H3/H13)."""
 
-    def test_explicit_pick_wins(self):
-        from kiro_crew.members import select_provider_backend
-
-        assert select_provider_backend("kas", MEMBER_KEY, "claude", "") == "kas"
-
     def test_member_route(self):
         from kiro_crew.members import select_provider_backend
 
-        assert select_provider_backend(None, MEMBER_KEY, "kas", "") == "kas"
+        assert select_provider_backend(MEMBER_KEY, "kas", "") == "kas"
 
     def test_non_member_gets_the_configured_default_unresolved(self):
         """The default arm passes the configured value through UNCHANGED —
@@ -342,12 +337,12 @@ class TestSelectProviderBackend:
         would be the second check H3 forbids."""
         from kiro_crew.members import select_provider_backend
 
-        assert select_provider_backend(None, "dashboard_abc", "kas", "") == ""
+        assert select_provider_backend("dashboard_abc", "kas", "") == ""
 
     def test_denied_member_backend_degrades_to_kiro(self):
         from kiro_crew.members import select_provider_backend
 
-        assert select_provider_backend(None, MEMBER_KEY, "no-such-backend", "") == ""
+        assert select_provider_backend(MEMBER_KEY, "no-such-backend", "") == ""
 
 
 class TestSessionHistoryWriteProtected:


### PR DESCRIPTION
## What is the problem?

Issue #8166 recorded two accepted follow-ups from PR #8153's review. This PR takes **item 1 only**: `create_provider_factory`'s `_acp(acp_backend=...)` kwarg and the `explicit` precedence arm of `members.select_provider_backend` that it feeds have no non-test consumers. They are an unconsumed seam sitting on the provider-construction path.

Item 2 (session-key prefix normalization at one boundary) is deliberately **out of scope** - see the last section.

## Why this issue matters to the user

An unconsumed seam on a construction path is a maintenance and review cost with no user benefit: it is one more parameter every reader of the factory has to account for, one more arm the harness-parity review has to reason about, and a false signal that a per-slot backend picker is imminent. The repo's boundary/harness-parity gate already pushes toward exactly one selection gate on the kiro construction path with no branching of its own; a dead precedence arm is friction against that direction. Removing it is behavior-preserving for every user.

## How our fix solves it (symptom -> root cause)

- **Symptom**: `select_provider_backend` takes a leading `explicit: str | None` and returns `resolve_selected_backend(explicit)` when it is truthy; `_acp` declares `acp_backend: str | None = None` and forwards it as that `explicit` argument.
- **Root cause**: the only live caller of the factory closure (`config/loader.py`) never passes `acp_backend`, and no per-slot backend picker consumes it anywhere in `src/`. I confirmed the absence with a control - the same grep method finds the live member-route caller (which passes `session_key`, not `acp_backend`) - so the instrument is not failing silent. The three tests that exercised the arm were its only exercisers, matching PR #8153's review and dwu96's re-triage on the issue.
- **Fix**: drop the `explicit` param + its arm from `select_provider_backend` (precedence is now member-DM auto-route > configured default), and drop the `acp_backend` param from the `_acp` closure. The closure keeps `**_kwargs`, so a stray keyword is still absorbed harmlessly. The kiro construction path is unchanged (harness-parity H13: no conditional/argument/failure-mode added to it - a branch is *removed*), and the member/default arms are behaviorally identical.

## What tests we did

- `pytest -n0 test/test_member_dispatch_mount.py` - 35 passed (deleted `test_explicit_pick_wins`, which only exercised the removed arm; updated the 3 surviving `select_provider_backend` calls to the 3-arg signature).
- `pytest -n0 test/test_config_loader.py -k "factory or provider or backend"` - 18 passed, including `test_factory_resolves_canonical_crew_identity` (exercises the `_acp` closure).
- `black --check`, `isort --check-only`, `flake8`, `mypy` on the three touched files - all clean. Brand-name gate clean on added prose.
- Enumerated every non-test `acp_backend=` site and confirmed each is an `AcpClient`/`AcpProvider`/`AcpRuntime` constructor (the instance attribute), not the factory kwarg - untouched.

## Any other suggestions on the work

- **Item 2 is out of scope and stays open.** Session-key prefix normalization touches security-sensitive readers that branch on prefixes (`mcp_core.py`'s `startswith("channel:")` guard, `dashboard/token_auth.py`, `mcp_gateway/claim.py`/`stub.py`, `session_allocation.py`) with no agreed canonical-key contract; `history_search.py` already carries idempotent "collapse stacked `dashboard_` prefixes" logic and `is_member_session_key` accepts three spellings - both symptoms of keys travelling un-normalized. The issue text, CrysisDeu's triage, and dwu96's re-triage all call item 2 "larger than any one feature PR" / architecture. A mechanical sweep without that contract risks silently disarming a confinement check, so it wants its own design pass, not a rider on this cleanup.
- **The either/or in item 1's text.** The issue frames item 1 as "remove them OR land their first real consumer (a per-slot backend picker)." I searched every open PR/issue and found no picker planned or in flight, so this PR takes the remove branch. If a maintainer knows a per-slot picker is imminent, the seam can be re-added by that author - the point of removing it now is not to carry an unconsumed parameter indefinitely. Flagging so review can decide.

Refs #8166
