### PR TITLE
fix(apps): Job SDK checkpoint observing progress and cancellation

### DIFF
--- a/src/kiro_crew/apps/job_routes.py
+++ b/src/kiro_crew/apps/job_routes.py
@@ -132,6 +132,12 @@ def _public_view(run: JobRun, cancelling: frozenset[str], live: frozenset[str]) 
     them: whether the run may have committed side effects, and whether retrying
     it is even possible now. Withholding them would leave the record honest and
     the API not.
+
+    ``work_observed`` is served for the same reason: a client deciding whether a
+    ``done`` run actually did its work, or whether a ``failed`` one may have
+    committed a side effect before it stopped, reads the observed fact rather than
+    re-deriving it. It is an SDK-minted boolean, not a runner payload, so serving
+    it carries none of the sanitizing cost the P2 result channel does.
     """
     return {
         "run_id": run.run_id,
@@ -146,6 +152,7 @@ def _public_view(run: JobRun, cancelling: frozenset[str], live: frozenset[str]) 
         "error": run.error,
         "interrupted_from": run.interrupted_from,
         "interrupt_cause": run.interrupt_cause,
+        "work_observed": run.work_observed,
     }
 
 

--- a/src/kiro_crew/apps/job_sdk.py
+++ b/src/kiro_crew/apps/job_sdk.py
@@ -9,16 +9,19 @@ kept going, and the UI then reported the task as stopped. See
 
 Five design points are load-bearing rather than incidental.
 
-**P1 records that a run EXISTS and how it ended — nothing it produced.** There
-is no ``params`` a caller passes in, and no ``progress`` or ``result`` a runner
-reports out. A run's record holds its identity, its lifecycle and, if it failed,
-one error string. That is deliberate and is the whole of what the originating
-problem needs: the UI's question is "is my task still running", not "how far
-along is it". The payload channels are structured data that must be sanitized
-before it can be written or served, and P1 has NO consumer that reads them, so
-they were carrying that cost for capability nobody calls. They return in P2,
-designed against a real consumer, as types that are sanitized by construction
-rather than by a rule each writer has to remember.
+**P1 records that a run EXISTS, how it ended, and whether work was OBSERVED --
+nothing it produced.** There is no ``params`` a caller passes in, and no
+``result`` payload a runner reports out. A run's record holds its identity, its
+lifecycle, whether the runner reached a checkpoint, and, if it failed, one error
+string. The checkpoint is a progress OBSERVATION, not a progress PAYLOAD: it
+records the boolean fact "this runner reached a point of work" (see
+``JobHandle.checkpoint``), which is SDK-minted and needs no sanitizing, and it is
+what lets a ``done`` record state something watched rather than inferred. The
+free-form ``result`` and a rich per-checkpoint payload are structured data that
+must be sanitized before it can be written or served, and P1 has NO consumer that
+reads them, so they stay out until P2, designed against a real consumer as types
+that are sanitized by construction rather than by a rule each writer has to
+remember.
 
 **A runner is REGISTERED, not passed per call.** ``register(kind, fn)`` binds a
 kind to the callable that services it, once, at app init. ``start(kind, ...)``
@@ -31,7 +34,13 @@ out whether it ever checks, so cancellability is the app's assertion at
 ``register(..., cancellable=True)`` and defaults to False. A run recorded
 ``cancellable: false`` answers ``cancel()`` with ``False`` rather than
 pretending, and the UI hides the control instead of offering a button that does
-nothing.
+nothing. A runner cooperates in one of two ways: it may poll ``handle.cancelled``
+directly, or it may call ``handle.checkpoint``, which RAISES at a pending cancel
+so the runner unwinds AT that point. The second is the stronger form -- the
+``cancelled`` record then names an observed stop rather than a set flag -- but
+neither can stop work the runner spawned onto a thread the SDK does not own; that
+remaining gap is #7814's execution-ownership half, out of scope here and disclosed
+on the unsettled-future reason string.
 
 **One writer per run file.** There is no lock helper beside ``atomic_write`` and
 concurrent read-modify-write of one document is last-writer-wins, so each run is
@@ -224,6 +233,30 @@ class JobError(RuntimeError):
 
 class UnknownJobKind(JobError):
     """Raised when starting a kind that has no registered runner."""
+
+
+class JobCancelled(Exception):
+    """Raised inside a runner by :meth:`JobHandle.checkpoint` when a cancel was
+    requested, so the runner unwinds AT the checkpoint rather than running on.
+
+    This is the fact that makes ``CANCELLED`` an observed outcome rather than an
+    inference. The old ``CANCELLED`` verdict was chosen from the cancel flag being
+    SET (see the terminal write in ``_execute``): that proves a cancel was
+    REQUESTED, not that the work stopped, so a runner that polled the flag, saw it,
+    and finished anyway was still recorded ``cancelled``. When a runner instead
+    calls ``checkpoint`` and lets this propagate, its stack has unwound to the
+    checkpoint before ``_execute`` records the run -- the record then states a stop
+    the SDK watched happen at a named point in the runner's own body.
+
+    A plain ``Exception`` and NOT a ``JobError``: it is not a refusal by the SDK
+    but the runner's own cooperative exit, and ``_execute`` catches it BEFORE its
+    generic ``except Exception`` so an acknowledged cancel is never miscounted as a
+    failure. It is deliberately NOT a ``BaseException`` subclass like
+    ``asyncio.CancelledError``: a runner is a plain function on a worker thread, so
+    there is no cancellation machinery to cooperate with, and a ``BaseException``
+    would sail through the ``except Exception`` guards a runner's own body may hold
+    around its cleanup.
+    """
 
 
 def _now() -> str:
@@ -529,6 +562,18 @@ class JobRun:
     #: deciding "offer a retry" reads this one and a consumer deciding "warn about
     #: partial work" reads the other.
     interrupt_cause: str = ""
+    #: Whether the runner reached at least one ``handle.checkpoint`` -- an OBSERVED
+    #: fact, not the return-value classifier's inference. This is the record
+    #: STATING that work happened rather than the SDK guessing it from what came
+    #: back: a ``done`` run with this True was watched reaching a point of progress
+    #: in the runner's own body. SDK-minted, never runner-supplied: the runner
+    #: calls ``checkpoint`` (a method) and the SDK sets this bool from the handle
+    #: at the terminal write, so it is not a payload channel the sanitize rule has
+    #: to cover -- the same reason ``interrupted_from`` and ``interrupt_cause`` are
+    #: on the record. Absence does NOT mean no work: a runner may do real work
+    #: without checkpointing, so a False here with ``done`` means "not observed",
+    #: which is why the classifier stays a backstop rather than being deleted.
+    work_observed: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -587,15 +632,30 @@ class JobRun:
 
 
 class JobHandle:
-    """What a runner is handed: the cancel signal it must poll.
+    """What a runner is handed: the cancel signal, and the checkpoint call that
+    reports progress and observes that signal in one act.
 
-    ``cancelled`` is a ``threading.Event`` and checking it is the runner's own
-    responsibility — the SDK has no way to interrupt a thread that never looks.
+    ``cancelled`` is a ``threading.Event`` the runner MAY still poll directly --
+    that door stays open for a loop that wants to test-and-continue rather than
+    unwind. The SDK cannot interrupt a thread that never looks, so cancellation
+    remains cooperative either way.
 
-    There is deliberately no ``progress()`` in P1. With no progress channel the
-    worker writes its record exactly ONCE, terminally, so the record has a
-    single writer over its whole life instead of a stream of mid-run mutations
-    each needing the discard check to be right.
+    ``checkpoint`` is the P1 progress channel, and it is deliberately the SAME
+    call that carries cancellation -- the pairing #7804 and #7814 asked to be
+    designed together. A runner that reports it reached a checkpoint necessarily
+    observes the cancel signal AT that checkpoint, because ``checkpoint`` raises
+    ``JobCancelled`` before it returns when a cancel is pending. There is no way
+    to spell "report progress but ignore cancellation": the channel that answers
+    "did work happen" is the channel that answers "should it stop", so a progress
+    report that left cancellation unobservable -- the half-capability the issues
+    warned about -- is not a state this API can represent.
+
+    It writes NOTHING to disk. The observed fact lives on the handle and is read
+    ONCE by ``_execute`` at the terminal write, so the record keeps its single
+    writer over its whole life -- P1's reason for having no mid-run mutation
+    stream, preserved. What changes is that the terminal ``done`` is now backed by
+    an observation (a checkpoint was reached) with the return-value classifier
+    kept as a backstop, rather than resting on the classifier alone.
     """
 
     def __init__(self, run: JobRun) -> None:
@@ -608,6 +668,15 @@ class JobHandle:
         #: unconditionally and cannot tell a first write from a resurrection.
         self.discarded = threading.Event()
         self._run = run
+        #: Whether the runner reached a checkpoint. A plain bool, not a guarded
+        #: field: the ONLY writer is the runner thread (in ``checkpoint``) and the
+        #: ONLY reader is ``_execute`` on that SAME thread after the runner
+        #: returns, so there is no cross-thread read to make consistent and no
+        #: lock to justify. A count and a note rode here in an earlier revision
+        #: "for a future progress surface"; they had no reader, so by P1's own
+        #: doctrine -- a payload stays out until the consumer that reads it exists
+        #: -- they are gone and return in P2 with that consumer.
+        self._reached_checkpoint = False
 
     @property
     def run_id(self) -> str:
@@ -620,6 +689,54 @@ class JobHandle:
     @property
     def status(self) -> str:
         return self._run.status
+
+    def checkpoint(self) -> None:
+        """Report that the runner reached a point of real progress, and stop here
+        if a cancel is pending.
+
+        Call this at each unit of work a runner completes. Two things happen, and
+        they are one act on purpose -- the pairing #7804 and #7814 asked to be
+        designed together:
+
+        * The handle records that a checkpoint was reached -- an OBSERVED fact the
+          terminal write reads, so ``done`` rests on "this runner did work" rather
+          than on the return-value classifier's inference about what it handed
+          back.
+
+        * If a cancel has been requested, this RAISES :class:`JobCancelled`,
+          unwinding the runner at the checkpoint. ``_execute`` catches it and
+          records ``cancelled`` -- an outcome it WATCHED, because the stack is
+          already unwound to this call before the record is written. A runner that
+          reaches its next checkpoint after a cancel therefore cannot run to a
+          false ``done``; the stop is where the runner acknowledged it.
+
+        The cancel check comes FIRST: a checkpoint reached in an already-cancelled
+        run is not progress the record should credit, and testing progress before
+        the signal would let one more unit be counted after the stop was asked
+        for.
+
+        It takes no argument. A progress NOTE (a stage name, a count) is a payload
+        with no P1 consumer -- nothing reads it -- and the same module's doctrine
+        keeps a rich per-checkpoint payload out until P2, where the surface that
+        serves it is designed against a real reader. So P1 reports the one fact it
+        can serve: that a checkpoint happened.
+        """
+        if self.cancelled.is_set():
+            raise JobCancelled(
+                f"job {self._run.kind!r} run {self._run.run_id} was cancelled at a checkpoint"
+            )
+        self._reached_checkpoint = True
+
+    @property
+    def work_observed(self) -> bool:
+        """Whether any checkpoint was reached -- the fact the terminal write reads.
+
+        Absence is NOT evidence of no work: a runner that does real work without
+        calling ``checkpoint`` is legitimate, which is why the return-value
+        classifier stays as a backstop rather than being replaced, and why the
+        served value means "not observed", never "did no work".
+        """
+        return self._reached_checkpoint
 
 
 #: A runner receives its handle and nothing else. P1 has no parameter channel:
@@ -828,9 +945,10 @@ class JobSDK:
         """Write a run's record. The ONLY path that writes one.
 
         Three callers used to write directly -- start, the worker's terminal
-        write, and reconcile (a fourth, progress, is gone with the progress
-        channel) -- and each had to remember the same three rules. Two review
-        rounds found a different one missed each time, so the rules live here
+        write, and reconcile (a fourth, a persisting progress write, never
+        existed; ``handle.checkpoint`` reports progress WITHOUT touching disk, so
+        it adds no writer) -- and each had to remember the same three rules. Two
+        review rounds found a different one missed each time, so the rules live here
         instead:
 
         * the discard check and the write happen under ONE lock acquisition, the
@@ -889,9 +1007,11 @@ class JobSDK:
         """Bind ``kind`` to the callable that services it.
 
         Call from the app's ``on_startup`` hook. ``cancellable=True`` is the
-        app's assertion that ``fn`` polls ``handle.cancelled`` at checkpoints;
-        the SDK cannot verify it, so the consumer's migration checklist has to
-        name those checkpoints.
+        app's assertion that ``fn`` observes cancellation at checkpoints -- by
+        calling ``handle.checkpoint`` (which raises at a pending cancel, the
+        stronger form that makes the ``cancelled`` record an observed stop) or by
+        polling ``handle.cancelled`` directly. The SDK cannot verify it, so the
+        consumer's migration checklist has to name those checkpoints.
 
         A CALLABLE WHOSE INVOCATION DOES NOT RUN ITS BODY IS REFUSED HERE, at
         registration, rather than failing at run time. ``_execute`` calls
@@ -1178,7 +1298,30 @@ class JobSDK:
                         undriven,
                     )
                 else:
+                    # CANCELLED two ways, and both are true here. A runner that
+                    # called ``checkpoint`` after a cancel has already unwound
+                    # through the ``JobCancelled`` handler below, so this branch is
+                    # reached only when the runner RETURNED normally: either it
+                    # never saw a cancel, or it polled ``cancelled`` directly and
+                    # chose to finish its cleanup and return. The flag being set
+                    # here still means a cancel was honoured cooperatively, so
+                    # ``cancelled`` remains the honest label -- the checkpoint path
+                    # is the STRONGER form (an observed stop), not the only one.
                     run.status = CANCELLED if handle.cancelled.is_set() else DONE
+        except JobCancelled:
+            # An OBSERVED stop: the runner called ``checkpoint``, it raised, and
+            # the stack unwound to here -- so the SDK watched the work stop at a
+            # named point in the runner's own body, rather than inferring it from
+            # the flag alone. Caught BEFORE the generic handler so an acknowledged
+            # cancel is never miscounted as a failure. No ``error`` is set: a
+            # cancel is an outcome, not a fault.
+            run.status = CANCELLED
+            logger.info(
+                "App %s job %s (%s) stopped at a checkpoint after a cancel request",
+                self._app_name,
+                run.run_id,
+                run.kind,
+            )
         except Exception as exc:  # noqa: BLE001 - a runner's failure is data, not a crash
             run.status = FAILED
             run.error = _redact(str(exc))[:2000]
@@ -1191,6 +1334,13 @@ class JobSDK:
             )
         finally:
             run.finished_at = _now()
+            # Record the OBSERVED fact, whatever the verdict: a done/failed/
+            # cancelled run all state whether a checkpoint was reached, so a
+            # consumer can tell a run that demonstrably did work from one that may
+            # have done none. Read once, here, from the handle -- the record stays
+            # a single-writer document. Set before ``_write_terminal`` so the one
+            # terminal write carries it.
+            run.work_observed = handle.work_observed
             # The guarded writer owns the discard check, so a cleanup landing
             # mid-write cannot have this record recreated, and a failure comes
             # back as False rather than as an exception that would skip the

--- a/test/test_job_routes.py
+++ b/test/test_job_routes.py
@@ -304,6 +304,35 @@ async def test_the_interruption_fields_reach_the_client(
 
 
 @pytest.mark.asyncio
+async def test_work_observed_reaches_the_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """``work_observed`` is served: a client deciding whether a run actually did
+    its work reads the observed fact rather than re-deriving it. An SDK-minted
+    boolean, so it carries none of the sanitizing cost the P2 result channel does.
+    """
+    from kiro_crew.apps.job_sdk import DONE, JobRun
+
+    _setup_guards(tmp_path, monkeypatch)
+    run_id = "7d" * 16
+    sdk.store.write(
+        JobRun(
+            run_id=run_id,
+            app=sdk.app_name,
+            kind="observed",
+            status=DONE,
+            work_observed=True,
+        )
+    )
+
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/{run_id}")
+        assert resp.status == 200
+        run = (await resp.json())["run"]
+    assert run["work_observed"] is True
+
+
+@pytest.mark.asyncio
 async def test_unknown_kind_error_is_scrubbed_before_it_is_reflected(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
 ) -> None:

--- a/test/test_job_sdk.py
+++ b/test/test_job_sdk.py
@@ -40,6 +40,7 @@ from kiro_crew.apps.job_sdk import (
     STARTING,
     TERMINAL_STATES,
     CleanupResult,
+    JobCancelled,
     JobError,
     JobHandle,
     JobRun,
@@ -212,6 +213,13 @@ class TestHappyRun:
             # field wearing a new name.
             "interrupted_from",
             "interrupt_cause",
+            # An SDK-minted boolean recording whether the runner reached a
+            # ``handle.checkpoint`` -- an OBSERVED fact, not the runner's return
+            # value. Set by the SDK from the handle at the terminal write, never
+            # supplied by the runner, so like the two above it is a lifecycle fact
+            # and not the result payload this guard blocks. Its arrival is the
+            # deliberate design decision #7804 asked for.
+            "work_observed",
         }
 
 
@@ -294,6 +302,119 @@ class TestCancellation:
         _wait_terminal(sdk, run_id)
         # Popped from _live once terminal, so cancel returns False.
         assert sdk.cancel(run_id) is False
+
+
+# ---------------------------------------------------------------------------
+# 5a. checkpoint - the progress OBSERVATION and the observed-stop cancel (#7804/#7814)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpoint:
+    """The checkpoint channel: one call reports progress AND observes cancel.
+
+    #7804 asked the record to STATE observed progress rather than infer it from
+    the return value; #7814 asked ``cancelled`` to name an observed stop rather
+    than a set flag. Both are answered by ``handle.checkpoint``, and the pairing
+    is the point: a checkpoint that reports progress necessarily observes the
+    cancel signal at the same call, so a progress channel that could not carry
+    cancellation is not representable.
+    """
+
+    def test_checkpoint_records_work_observed_on_done(self, sdk: JobSDK) -> None:
+        """A runner that checkpoints and returns leaves ``work_observed`` True."""
+
+        def runner(h, **kw):
+            h.checkpoint()
+            return {}
+
+        sdk.register("obs", runner)
+        run_id = sdk.start("obs")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+        assert run.work_observed is True
+
+    def test_no_checkpoint_leaves_work_observed_false_but_still_done(self, sdk: JobSDK) -> None:
+        """Absence of a checkpoint is NOT penalised: the run is still ``done``,
+        and the classifier stays the backstop. ``work_observed`` reads False so a
+        consumer can tell "did work, observed" from "may have done work"."""
+
+        sdk.register("silent", lambda h, **kw: {})
+        run_id = sdk.start("silent")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+        assert run.work_observed is False
+
+    def test_checkpoint_raises_and_records_cancelled_as_observed_stop(self, sdk: JobSDK) -> None:
+        """A cancel pending at a checkpoint raises ``JobCancelled``; the run is
+        recorded ``cancelled`` because the stack unwound at the checkpoint -- an
+        observed stop, not the flag alone. Work done BEFORE the cancel is still
+        observed."""
+        started = threading.Event()
+        ran_on = []
+
+        def runner(h, **kw):
+            h.checkpoint()  # progress observed before any cancel
+            started.set()
+            for _ in range(500):
+                # Reaches a checkpoint each iteration; raises once cancel lands.
+                h.checkpoint()
+                ran_on.append(1)
+                time.sleep(0.01)
+
+        sdk.register("stoppable", runner, cancellable=True)
+        run_id = sdk.start("stoppable")
+        assert started.wait(5.0)
+        assert sdk.cancel(run_id) is True
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == CANCELLED
+        # The stop was observed at a checkpoint, so work_observed is True and no
+        # error was recorded (a cancel is an outcome, not a fault).
+        assert run.work_observed is True
+        assert run.error == ""
+
+    def test_checkpoint_after_cancel_does_not_reach_a_false_done(self, sdk: JobSDK) -> None:
+        """The concrete #7814 hazard for in-thread work: a runner that would
+        run on to a ``done`` after a cancel cannot, because the next checkpoint
+        raises before the return."""
+        started = threading.Event()
+        reached_end = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            while not h.cancelled.is_set():
+                time.sleep(0.01)
+            # A cancel is now pending. The runner tries to finish anyway; the
+            # checkpoint refuses to let it record success.
+            h.checkpoint()
+            reached_end.set()
+            return {}
+
+        sdk.register("racer", runner, cancellable=True)
+        run_id = sdk.start("racer")
+        assert started.wait(5.0)
+        assert sdk.cancel(run_id) is True
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == CANCELLED
+        assert not reached_end.is_set()
+
+    def test_checkpoint_cancel_check_precedes_progress(self) -> None:
+        """A checkpoint reached in an already-cancelled run credits no progress:
+        the cancel check comes first, so the raise happens before the flag is
+        set. Tested on a bare handle to isolate the ordering."""
+        run = JobRun(run_id="a" * 32, app="x", kind="k", cancellable=True)
+        handle = JobHandle(run)
+        handle.cancelled.set()
+        with pytest.raises(JobCancelled):
+            handle.checkpoint()
+        assert handle.work_observed is False
+
+    def test_jobcancelled_is_not_a_joberror(self) -> None:
+        """A cancel is the runner's cooperative exit, not an SDK refusal, so it
+        must not be caught by handlers that catch ``JobError``; and it is an
+        ``Exception`` not a ``BaseException`` so a runner's own ``except
+        Exception`` cleanup guard still runs."""
+        assert not issubclass(JobCancelled, JobError)
+        assert issubclass(JobCancelled, Exception)
 
 
 # ---------------------------------------------------------------------------
@@ -2052,6 +2173,12 @@ class TestSanitizeInvariant:
             # can reach either, so the one-line backstop still has one input.
             "interrupted_from",
             "interrupt_cause",
+            # A boolean the SDK sets from the handle at the terminal write: the
+            # runner CALLS ``checkpoint`` (a method), it does not SUPPLY this
+            # value. A runner cannot write True here without having reached a
+            # checkpoint, and cannot write a payload through it -- so it stays a
+            # lifecycle fact the one-line backstop need not sanitize.
+            "work_observed",
         }
         fields = set(JobRun.__dataclass_fields__)
         assert fields - sdk_minted == {"error"}


### PR DESCRIPTION
## What is the problem?

The Job SDK could not OBSERVE whether a runner's work happened, nor OBSERVE that
work stopped when a cancel was requested. It only inferred.

- #7804: a runner that returns a plain value having done nothing is
  indistinguishable from one that did everything asked -- the SDK's only input
  was the returned object. `_undriven_result` classifies that object well, but it
  answers "did this thing need driving?", not "did the work happen?".
- #7814 (in-thread half): `cancel()` sets a `threading.Event` the runner MAY
  poll. A runner that polled it, saw it, and finished anyway was still recorded
  `cancelled` -- the record named a REQUESTED cancel, not a stop that happened.

Our own comment on #7804 named the constraint: these are one missing capability
seen from two sides, and "a progress channel that cannot also carry cancellation
answers one and leaves the other."

## Why this issue matters to the user

A durable run record is the product. A `done` that rests on inference can be a
`done` for a run that did nothing, and a `cancelled` that rests on a set flag can
be a `cancelled` for work that ran to completion. An owner reading either record
to decide "is it safe to retry / did my task actually run" is reading a claim the
SDK never watched happen.

## How our fix solves it (symptom -> root cause)

Root cause: the runner-facing surface (`JobHandle`) had a cancel flag and nothing
a runner which did real work would necessarily have touched. So there was no FACT
to read, and inference was the only option.

The fix adds one call, `handle.checkpoint()`, and the pairing is the point -- it
is deliberately the SAME call for both answers, so the broken "progress without
cancellation" state is not representable:

1. It records an OBSERVED fact -- the runner reached a point of progress -- onto
   the handle (`_reached_checkpoint`). `_execute` reads it once at the terminal
   write into the new SDK-minted boolean `JobRun.work_observed`, so a `done`
   record now STATES something watched. (#7804)
2. It RAISES `JobCancelled` when a cancel is pending, unwinding the runner AT the
   checkpoint. `_execute` catches it before its generic handler and records
   `cancelled` -- an outcome it watched, because the stack is already unwound to
   the checkpoint. A runner cannot reach its next checkpoint after a cancel and
   still run to a false `done`. (#7814, in-thread half)

The cancel check comes FIRST, so a checkpoint reached in an already-cancelled run
credits no progress. The classifier stays a backstop -- absence of a checkpoint
is NOT absence of work, so `work_observed=False` means "not observed", never "did
no work" -- and direct `handle.cancelled` polling still works; checkpoint is the
stronger, observed form. `checkpoint()` writes nothing to disk, and
`_reached_checkpoint` is a plain bool whose only writer and only reader are the
same runner thread, so the single-writer-per-record invariant holds with no lock.

`checkpoint()` takes NO argument. An earlier revision carried a `note`, a
`_last_note`, a `_checkpoint_count` and a `_progress_lock` "for a future progress
surface"; a first-principles review showed none had a reader, and the module's
own doctrine keeps a rich per-checkpoint payload out until P2, designed against a
real consumer. They were removed -- the bool plus the raise deliver both fixes
alone.

**Scope, stated honestly.** This closes #7804 and the IN-THREAD half of #7814.
The other half of #7814 -- stopping work a runner spawned onto a thread pool the
SDK does not own (the unsettled `concurrent.futures.Future` case) -- requires the
SDK to OWN execution, a runner-contract restructuring. Measured blast radius: the
whole codebase has exactly ONE production runner (`aws_control` backup via
`make_job_runner`), and it does not delegate, so the ownership change is small in
reach but is a genuine contract change not folded here. Both issues therefore
carry `Refs`, not `Closes`; #7814 stays open for the ownership half, already
disclosed on the unsettled-future reason string. The one production runner does
not yet call `checkpoint`, so shipped records still rest on the classifier
backstop until runners adopt it -- the capability lands here, the migration is a
separable follow-up.

## What tests we did

`pytest -n0` on the changed files: `test_job_sdk.py`, `test_job_routes.py`
(201 passed), plus consumer suites `test_aws_control_backup_job.py`,
`test_cloud_launch_job.py`, `test_windows_job_limits.py` (95 passed, 11 skipped).
The `TestCheckpoint` class pins: checkpoint records `work_observed` on done; a
no-checkpoint run stays `done` with `work_observed=False` (backstop preserved); a
pending cancel at a checkpoint raises and records `cancelled` as an observed stop
with no error; a runner cannot run past a cancel to a false `done`; the cancel
check precedes progress crediting; `JobCancelled` is an `Exception` and not a
`JobError`. A route test pins `work_observed` reaching the client. Both drift
guards (`test_a_returned_value_is_not_persisted_anywhere`,
`test_error_is_the_only_runner_supplied_field`) updated with justification that
`work_observed` is SDK-minted, not a runner payload. black/isort/flake8/mypy clean
on all four files (the only mypy errors are pre-existing in `transcribe.py`, not
touched). Black ratchet baseline not grown. ASCII-only. Diff is 4 files, +339/-26
against the merge-base.

The org security-guidance search was unreachable here; the query I would have run
is "credential handling in serialized job records" -- absence is not clearance,
but `work_observed` is a boolean minted by the SDK and the runner-payload sanitize
invariant is unchanged and still pinned.

## Any other suggestions on the work

The execution-ownership half of #7814 is the natural follow-up: if the SDK held
the only reference to the work, it could refuse to release the dedupe claim until
that reference settled, making the unsettled-future overlap unrepresentable
rather than disclosed. With one non-delegating runner today, that is a contained
change to attempt next -- alongside migrating that runner to call `checkpoint`.

## Pattern harvest

Rule candidate: when a review lane identifies a real concern but prescribes a
remedy that would revert a stated invariant, answer the concern its own way and
say why -- do not apply the prescription. Here First Principles correctly flagged
speculative payload (`note`/`_checkpoint_count`/`_progress_lock`) riding in a fix;
the right answer was subtraction, not designing the payload's consumer now. And
GPT's "persist each checkpoint durably" remedy for the crash-window finding would
reintroduce the mid-run mutation stream P1 deliberately excludes -- so the record
stays single-writer and the served `work_observed` remains a documented "not
observed" diagnostic, which the Opus adjudication independently judged acceptable.

Refs #7804
Refs #7814
