### PR TITLE
fix: show domain instead of auth-gate title in link previews

### DIFF
--- a/src/kiro_crew/dashboard/handlers/link_meta.py
+++ b/src/kiro_crew/dashboard/handlers/link_meta.py
@@ -28,7 +28,7 @@ import logging
 import socket
 import time
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Mapping, Optional, Tuple
 from urllib.parse import urljoin, urlsplit
 
@@ -51,6 +51,7 @@ from kiro_crew.link_unfurl import (
     build_icon_data_uri,
     decode_html,
     extract_meta,
+    is_login_page_title,
     normalize_cache_key,
     vet_unfurl_url,
 )
@@ -375,6 +376,17 @@ async def _build_payload(url: str) -> Dict[str, Any]:
         # untouched: `cut` is False there, so a genuinely titleless page still gets
         # its domain-only preview.
         raise _UnfurlFailed("title did not survive the read cap")
+    if is_login_page_title(meta.title):
+        # An auth-gated page answered this ANONYMOUS fetch with its sign-in
+        # interstitial, so every text field describes the gate, not the page the
+        # link names ("Sign in to Amazon | Slack" for a Slack thread). Blank
+        # them and the client falls back to the domain — the one label that is
+        # still true. Deliberately left a POSITIVE cache entry: the fetcher
+        # never carries credentials, so retrying on the negative TTL would
+        # re-fetch the same gate every 10 minutes for no gain. The icon fetch
+        # below still runs — a gate serves the site's own favicon, which keeps
+        # identifying the chip.
+        meta = replace(meta, title="", description="", site_name="")
     icon = await _fetch_icon(meta.icon_candidates)
     # Fetched only when the page actually declares a dark variant, and after the
     # default icon rather than beside it: concurrent icon fetches would double

--- a/src/kiro_crew/link_unfurl.py
+++ b/src/kiro_crew/link_unfurl.py
@@ -86,6 +86,24 @@ _WHITESPACE_RUN = re.compile(r"\s+")
 _META_CHARSET = re.compile(rb"""charset\s*=\s*["']?\s*([\w.:+-]{1,40})""", re.IGNORECASE)
 _COLOR_SCHEME_MEDIA = re.compile(r"prefers-color-scheme\s*:\s*(dark|light)", re.IGNORECASE)
 _MEDIA_NEGATION = re.compile(r"\bnot\b", re.IGNORECASE)
+#: Title shapes an auth wall serves in place of the page a link names. Every
+#: alternative is anchored at BOTH ends: the leading gate phrase must be
+#: followed by the end of the title, an explicit separator, or a gate
+#: continuation ("to …", "with your …") — a bare prefix match would also blank
+#: real titles that merely start with the phrase ("Login security best
+#: practices", "Sign in with Apple: a guide"). English-only on purpose: each
+#: added language multiplies the false-positive surface, and a missed gate
+#: degrades to today's behavior.
+_LOGIN_PAGE_TITLE = re.compile(
+    r"""(?x)
+      ^\s* (?:please\s+)? (?:sign|log) [\s-]? (?:in|on)
+          \s* (?: $ | [|\-–—·:•] | to\b | with\s+your\b )   # "Sign In", "Sign in to X | Slack"
+    | [|\-–—·:•] \s* (?:sign|log) [\s-]? in \s*$            # "Acme Corp - Sign In"
+    | ^\s* single\s+sign [\s-]? on \s* (?: $ | [|\-–—·:•] ) # "Single Sign-On", "SSO - Okta"
+    | ^\s* authentication\s+required \s*$
+    """,
+    re.IGNORECASE,
+)
 
 
 class UnfurlRejected(Exception):
@@ -565,6 +583,23 @@ class _HeadParser(HTMLParser):
         return [h for h, s, apple in self._icon_links if not apple and keep(s)] + [
             h for h, s, apple in self._icon_links if apple and keep(s)
         ]
+
+
+def is_login_page_title(title: str) -> bool:
+    """Whether *title* names an auth gate rather than the page the URL names.
+
+    An unauthenticated fetch of an auth-gated link is answered with the site's
+    sign-in page — a 200, so it parses like any other document — and its title
+    ("Sign in to Amazon | Slack") describes the gate, not the linked content.
+    Rendering it verbatim mislabels the chip; the caller blanks the text fields
+    instead so the client falls back to the domain.
+
+    The pattern is deliberately conservative (see :data:`_LOGIN_PAGE_TITLE`).
+    The asymmetry justifies the remaining false positives: matching a real
+    article title costs a domain-labelled chip that is still true, while missing
+    a gate title shows a claim about the page that is false.
+    """
+    return bool(_LOGIN_PAGE_TITLE.search(title))
 
 
 def extract_meta(html: str, *, base_url: str) -> ExtractedMeta:

--- a/test/test_link_unfurl.py
+++ b/test/test_link_unfurl.py
@@ -486,6 +486,58 @@ def test_extract_drops_non_http_icon_href() -> None:
     assert meta.icon_candidates == ("https://example.com/favicon.ico",)
 
 
+# --- login-gate titles -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Sign in to Amazon | Slack",
+        "Sign In",
+        "sign-in",
+        "Signin",
+        "Log in",
+        "Login",
+        "Log On",
+        "Sign in - Google Accounts",
+        "Sign in to GitHub · GitHub",
+        "Sign into your account",
+        "Sign in with your Apple ID",
+        "Please log in",
+        "Acme Corp - Sign In",
+        "Slack | Sign in",
+        "Single Sign-On",
+        "Authentication Required",
+    ],
+)
+def test_login_gate_titles_are_detected(title: str) -> None:
+    assert lu.is_login_page_title(title)
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "",
+        "Slack is your digital HQ",
+        "How to sign in to AWS",
+        "Assign in bulk",
+        "Logging in production systems",
+        "Log4j vulnerability",
+        "The Sign",
+        "Design tokens - a primer",
+        "Login security best practices",
+        "Sign in with Apple: a guide",
+        "Single sign-on explained",
+        "Sign-in sheets for classrooms",
+    ],
+)
+def test_ordinary_titles_are_not_login_gates(title: str) -> None:
+    """Both ends are anchored: a leading gate phrase must be followed by the
+    title's end, a separator, or a gate continuation — a real title that merely
+    STARTS with "Login"/"Sign in" stays a title."""
+    assert not lu.is_login_page_title(title)
+
+
 # --- icon colour-scheme lanes ----------------------------------------------
 
 
@@ -818,6 +870,37 @@ def test_success_payload_shape(monkeypatch) -> None:
     assert body["domain"] == "example.com"
     assert body["icon"] == "data:image/png;base64,iVBORw=="
     assert isinstance(body["fetched_at"], int) and body["fetched_at"] > 0
+
+
+def test_login_gate_title_falls_back_to_domain_end_to_end(monkeypatch) -> None:
+    """An auth wall's 200 must not label the chip with the gate's own title.
+
+    The text fields are blanked so the client renders the domain; the entry
+    still lands in the POSITIVE cache, because an anonymous re-fetch would be
+    answered by the same gate.
+    """
+    _install(
+        monkeypatch,
+        {
+            "https://ws.slack.com/archives/C123/p456": (
+                200,
+                _HTML_HEADERS,
+                _html(
+                    title="Sign in to Amazon | Slack",
+                    extra='<meta property="og:site_name" content="Slack">',
+                ),
+            ),
+            "https://ws.slack.com/favicon.ico": (404, {}, b""),
+        },
+    )
+    status, body = _run(_call("https://ws.slack.com/archives/C123/p456"))
+    assert status == 200
+    assert body["title"] == ""
+    assert body["description"] == ""
+    assert body["site_name"] == ""
+    assert body["domain"] == "ws.slack.com"
+    entry = lm._CACHE[lu.normalize_cache_key("https://ws.slack.com/archives/C123/p456")]
+    assert entry.payload is not None
 
 
 def test_icon_failure_does_not_fail_the_preview(monkeypatch) -> None:


### PR DESCRIPTION
## Problem / Motivation

A link to an auth-gated page — a Slack thread
(`https://<workspace>.slack.com/archives/...`), a private wiki, a Quip doc —
renders its chip with the title "Sign in to Amazon | Slack" (or the site's
equivalent) instead of anything describing the link. The link-preview fetch is
deliberately anonymous, so the site answers with its sign-in page as a `200`,
and the chip shows that page's `<title>` verbatim.

## Why it matters

Every user who pastes links from a workspace behind SSO (Slack, Quip, internal
wikis) gets chips that all claim to be a sign-in page — the one thing the
reader already knows is not what the link is about. Because the sign-in page is
a `200`, the wrong title also lands in the positive cache and sticks for 6 h.

## What changed (motivation → approach → change)

- Observed symptom: chips labelled "Sign in to Amazon | Slack" for Slack
  thread links.
- Root cause: the unfurl fetcher carries no credentials (by design — it fetches
  arbitrary model-emitted URLs, so attaching cookies would leak them). An
  auth-gated page answers with its sign-in interstitial, which parses like any
  ordinary document, so its title/description/site_name describe the gate, not
  the linked content.
- Change: `link_unfurl.is_login_page_title()` recognises gate-title shapes —
  edge-anchored patterns only ("Sign in to …", "… - Sign In", "Single
  Sign-On", "Authentication Required"), English-only, deliberately
  conservative so a title merely *mentioning* signing in stays a title.
  `_build_payload` blanks `title`/`description`/`site_name` on a match; the
  client's existing `meta.title || meta.domain` fallback then renders the
  domain — the one label that is still true. The entry deliberately stays a
  POSITIVE cache hit (an anonymous re-fetch would be answered by the same
  gate, so the negative TTL would just re-fetch it every 10 min), and the icon
  fetch still runs (a gate serves the site's own favicon, which keeps
  identifying the chip). No frontend change needed.

The asymmetry justifies the remaining false positives: matching a real article
title costs a domain-labelled chip that is still true, while missing a gate
title shows a claim about the page that is false.

## Tests

- `test_login_gate_titles_are_detected` — 15 gate-title shapes (Slack, Google,
  GitHub, Okta-style trailing "— Sign In", SSO, plain "Login"/"Log On") are
  recognised.
- `test_ordinary_titles_are_not_login_gates` — anchoring keeps real titles
  ("How to sign in to AWS", "Assign in bulk", "Logging in production
  systems") untouched.
- `test_login_gate_title_falls_back_to_domain_end_to_end` — a `200` sign-in
  page served through the fake transport yields a payload with blank
  title/description/site_name, the domain intact, and a positive cache entry.

All 252 tests in `test/test_link_unfurl.py` pass; `mypy` (macOS and
`--platform linux`), `flake8`, `isort`, the black/subprocess-encoding ratchet
gates, the harness-parity gate, and `scrub-lint.sh` are clean.

## Manual verification

N/A — the endpoint test drives the real handler path (vet → fetch → extract →
blank → cache) through the fake transport; the only unexercised layer is the
network socket itself. No UI change: the frontend's domain fallback for a
titleless payload already existed.

## Related Issues

N/A — observed directly on a local gateway.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: no doc under `docs/` covers the link-preview endpoint; module docstrings updated in place
- [x] No secrets, credentials, or internal references in the diff

## Pattern harvest

Rule candidate: review-prompt
Pattern: a feature that renders fetched remote metadata must state what an
unauthenticated fetch of an auth-gated resource returns (typically a `200`
SSO interstitial) and how the surface degrades when it does. A semgrep/lint
rule cannot see this class: the defect is in trusting a well-formed upstream
document, not in any local code shape.

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

