### PR TITLE
fix(messaging): keep grammar-dead prose on streaming surfaces when hide_partial trims OPTIONS fragments

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -2856,7 +2856,12 @@ parameter rather than a baked-in policy:
 - **`True` — a streaming surface** (Discord, Telegram, Teams, WeCom, and Webex's
   status frame). Text is still arriving, so an unfinished `[OPTIONS` fragment may
   be a marker mid-flight; hiding it keeps reserved protocol off the screen, and the
-  next frame re-renders from the full buffer, so nothing is lost.
+  next frame re-renders from the full buffer, so nothing is lost. Only a tail that
+  can still become the trailer is held back — `[OPTIONS` as the final bytes, or
+  `[OPTIONS:` with content still open. Any other byte after `[OPTIONS` is
+  grammar-dead (the trailer opens `[OPTIONS:`), so the fragment is quoted prose
+  and is kept: when no `]` ever arrives, the sealed frame re-trims too, so cutting
+  it would be the permanent loss below wearing a streaming excuse.
 - **`False` — a buffered surface that sends once** (Webex's final answer and the
   zero-widget path). Such a caller cannot tell a live fragment from prose, and
   cutting prose is permanent: a reply ending `see the [OPTIONS section` keeps its

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -438,7 +438,12 @@ def split_options_trailer(text: str, *, hide_partial: bool = False) -> tuple[str
       status frame). The text is still arriving, so a partial marker really may be
       a marker mid-flight, and showing reserved protocol as raw text is the cost
       being avoided. Safe there precisely because the frame is transient: the next
-      frame, or the sealed answer, re-renders from the full buffer.
+      frame, or the sealed answer, re-renders from the full buffer. Held back is
+      only a tail that can still BECOME the trailer -- ``[OPTIONS`` as the final
+      bytes, or ``[OPTIONS:`` with its content still open. A tail where any other
+      byte follows ``[OPTIONS`` is grammar-dead (the trailer opens ``[OPTIONS:``),
+      so it is quoted prose and is kept even here: cutting it would be the
+      permanent loss described below, wearing a streaming excuse.
     * ``False`` -- a BUFFERED surface that sends once (Slack's extraction, Webex's
       final answer, and this module's own zero-widget path). Such a caller cannot
       tell a live fragment from the assistant's prose, and cutting prose is
@@ -461,7 +466,24 @@ def split_options_trailer(text: str, *, hide_partial: bool = False) -> tuple[str
     if hide_partial:
         idx = text.rfind("[OPTIONS")
         if idx != -1 and "]" not in text[idx:]:
-            return text[:idx].rstrip(), []
+            # Judge the fragment against the grammar it would have to satisfy,
+            # not by substring presence alone. :data:`OPTIONS_RE_TRAILER` opens
+            # ``[OPTIONS:`` -- once any byte other than ``:`` follows the
+            # substring, no later bytes can complete a marker there, so the
+            # fragment is the assistant's PROSE and holding it back protects
+            # nothing. It costs plenty: the trim point is wherever the quoted
+            # token sits, everything after it to buffer end goes with it, and
+            # when no ``]`` ever arrives the sealed frame re-trims too, so the
+            # transient-frame consolation above does not apply. Locating a
+            # marker by substring without asking whether it READS as one is
+            # the class #8983 fixed at the directive seam; this is the same
+            # rule at the trailer seam. Only the tail-most occurrence can be
+            # mid-flight -- a stream appends, so text after an opener means
+            # that opener was never in flight -- which is why one viability
+            # check here beats walking earlier occurrences.
+            tail = text[idx + len("[OPTIONS") :]
+            if not tail or tail.startswith(":"):
+                return text[:idx].rstrip(), []
     return text, []
 
 

--- a/test/test_options_cap_contract.py
+++ b/test/test_options_cap_contract.py
@@ -356,6 +356,41 @@ class TestSplitOptionsTrailer:
         text = "See [OPTIONS: in the docs] for the list."
         assert split_options_trailer(text, hide_partial=True) == (text, [])
 
+    def test_hide_partial_keeps_grammar_dead_prose(self) -> None:
+        """A quoted ``[OPTIONS`` that can never become the marker is prose.
+
+        The trailer grammar opens ``[OPTIONS:`` -- once any other byte follows
+        the substring, no later bytes can complete it, so holding it back
+        protects nothing. And the streaming consolation (the next frame
+        re-renders) fails exactly here: when no ``]`` ever arrives, every
+        frame including the sealed one re-trims, so the cut is permanent on
+        the channel. Same reply as the buffered-default pin above; the policy
+        split is about live fragments, not about deleting quoted prose.
+        """
+        text = "Read the docs, see the [OPTIONS section"
+        assert split_options_trailer(text, hide_partial=True) == (text, [])
+
+    def test_hide_partial_keeps_everything_after_a_dead_fragment(self) -> None:
+        """The loss is unbounded: everything from the quote to buffer end went.
+
+        The trim point is wherever the substring sits, so one quoted token
+        positioned early deletes every later paragraph -- located-by-substring
+        without asking whether it READS as the marker (the #8983 class).
+        """
+        text = (
+            "The [OPTIONS grammar is end-anchored.\n\n"
+            "A whole later paragraph of real prose that the reader needs."
+        )
+        assert split_options_trailer(text, hide_partial=True) == (text, [])
+
+    def test_a_bare_opener_at_buffer_end_is_still_hidden(self) -> None:
+        """Boundary control: ``[OPTIONS`` as the final bytes may still become
+        the marker (the ``:`` can be the next byte to arrive), so the
+        streaming surface keeps hiding it."""
+        body, choices = split_options_trailer("Working on it. [OPTIONS", hide_partial=True)
+        assert body == "Working on it."
+        assert choices == []
+
     def test_the_default_is_the_non_destructive_one(self) -> None:
         """Pins the DIRECTION of the default, not just its value.
 


### PR DESCRIPTION
## Problem / Motivation

`split_options_trailer(text, hide_partial=True)` in `src/kiro_crew/messaging/renderer.py` locates an in-flight options marker by substring: it takes the tail-most `[OPTIONS` with no `]` after it and trims from that point to buffer end. But the trailer grammar (`OPTIONS_RE_TRAILER`) opens `[OPTIONS:` — once any byte other than `:` follows the substring, no later bytes can ever complete a marker there. The fragment is the assistant's quoted prose (e.g. a reply ending `…see the [OPTIONS section`), and the trim deletes it plus everything after it.

The streaming consolation in the docstring — "the next frame re-renders from the full buffer, so nothing is lost" — fails exactly in this case: when no `]` ever arrives, every frame *including the sealed final one* re-trims at the same spot, so the loss is permanent on every surface that passes `hide_partial=True` (Discord, Telegram, Teams, WeCom, and Webex's status frame).

## Why it matters

The loss is silent and unbounded. The trim point is wherever the quoted token sits, so one `[OPTIONS` mentioned early in a reply deletes every later paragraph the user was meant to read. The user sees a truncated answer with no error and no hint that content was cut; the assistant believes it delivered the full reply. Five renderers share this call site through one helper, so the defect lands on every streaming channel at once.

## What changed (motivation → approach → change)

- **Motivation:** stop deleting prose that can never become a marker, while keeping genuine in-flight fragments hidden.
- **Approach:** judge the fragment against the grammar it would have to satisfy, not by substring presence alone. This is the same rule the directive seam adopted in #8983 (its `rfind` picked a sentinel substring inside a payload; the fix required the located text to also *read* as the sentinel) — applied here at the trailer seam. Only the tail-most occurrence can be mid-flight (a stream appends, so text after an opener means that opener was never in flight), which is why one viability check beats walking earlier occurrences.
- **Change:** in the `hide_partial` branch, examine the tail after `[OPTIONS`: hold the fragment back only when the tail is empty (the `:` may be the next byte to arrive) or starts with `:` (content still open). Any other byte makes the fragment grammar-dead prose, which is now kept. The ASCII `]` guard is untouched. The function docstring and `docs/system-specs/modules/messaging.md` state the viability rule so the documented streaming policy matches the code.

1 source file + its doc page + tests; no behavior change for genuine in-flight fragments or complete markers.

## Tests

- **Fails-before:** at the unfixed function, the two attack pins fail exactly on the deleted prose — `test_hide_partial_keeps_grammar_dead_prose` (quoted token, prose trimmed) and `test_hide_partial_keeps_everything_after_a_dead_fragment` (unbounded loss: a later paragraph deleted) — while the boundary control passes, proving the harness is healthy: 2 failed / 1 passed on the new selection.
- **After:** full targeted contract suite `test/test_options_cap_contract.py` — 68/68.
- **Boundary control:** `test_a_bare_opener_at_buffer_end_is_still_hidden` pins that `[OPTIONS` as the final bytes is still held back (it may yet become the marker), so the streaming policy survives.
- **Seam-neighbor sweep:** marker closers, options parsing, options buttons, and the four consuming renderers (Teams, Webex, WeCom, Discord render config) — 132/132.
- mypy clean on the touched module; flake8, isort, black (baselined checker), and docs-lint all RC=0.

## Manual verification

N/A — unit coverage sufficient: the change is a pure-function branch condition in a helper with a dedicated contract suite; both the kept-prose and still-hidden behaviors are pinned by tests, and no I/O or channel integration is touched.

## Screenshots / video

**Why no screenshot:** no visual delta to capture — the fix changes which text a pure splitting function *keeps*; surfaces render exactly as before except that previously-deleted prose now appears. The kept/hidden contract is pinned by tests, and a before/after image would only show a truncated reply versus a complete one.

## Related Issues

Follow-up to the review discussion on #8983: that PR fixed the located-by-substring class at the directive seam and its review named the trailer seam's `hide_partial` trim as the sibling still carrying the pattern. Not closing any open issue.

## Pattern harvest

A marker located by substring (`find`/`rfind` on a sentinel) must also be validated against the grammar it would have to satisfy before acting on it. Presence alone conflates the assistant's quoted prose with live protocol; here the destructive action (trim) ran on grammar-dead text.

Rule candidate: review-prompt — "when code locates a sentinel/marker by substring search and then acts destructively (trim, replace, redact), verify it first checks the match can still parse as the marker (grammar viability), not merely that the substring occurs."

## Checklist

- [x] At most two commits (one), Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added (fails-before proven; attack + boundary-control pins)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (docstring + `docs/system-specs/modules/messaging.md`)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
