### PR TITLE
fix: route watcher ingestion through bulk embeddings

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -181,6 +181,12 @@ Base metadata always carries `format`, `title` (file stem), `file_size`, `extens
 - Returns `[(full_path, mtime)]`.
 
 **Scan bookkeeping (`_do_scan`)**:
+- **Embedding attendance is call-scoped.** Scheduled `KnowledgeWatcher` folder and
+  single-file re-ingest pass `PRIORITY_BULK` through `FolderWatcher` and
+  `IngestionPipeline`, so background work uses the reduced bulk inference pool.
+  Dashboard/manual `scan_source` and `ingest_file` calls omit the argument and retain
+  `PRIORITY_NORMAL`. The priority is never stored on the shared pipeline, so a
+  concurrent attended ingest cannot be downgraded by a watcher sweep.
 - Discovered files above `props["max_files"]` (default `DEFAULT_MAX_FILES` = 5000) are capped **newest-first** (sort by mtime desc); the surplus count is reported as `capped`.
 - Deletion detection uses the **full** discovered set (pre-cap) so capping never triggers false deletions; a vanished file's items are archived via `_handle_deleted` → `store.delete_items_batch`.
 - Change detection is mtime-then-content-hash: unchanged mtime → `last_seen` bump only; changed mtime but identical SHA-256 → state refresh, no re-ingest.

--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Callable
 
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.embeddings import PRIORITY_NORMAL
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
 
@@ -335,13 +336,22 @@ class FolderWatcher:
         self.pipeline = pipeline
         self._locks: dict[str, asyncio.Lock] = {}
 
-    async def scan_source(self, source: dict, *, chunk_budget: int | None = None) -> dict:
+    async def scan_source(
+        self,
+        source: dict,
+        *,
+        chunk_budget: int | None = None,
+        embed_priority: int = PRIORITY_NORMAL,
+    ) -> dict:
         """Scan a folder source. Returns {new, changed, deleted, skipped, capped}.
 
         ``chunk_budget`` stops the scan once that many chunks have been ingested
         in THIS sweep, leaving the rest for later sweeps. ``None`` is unbounded.
         Callers resolve the value with :func:`folder_chunk_budget`, capped by the
         watcher's global ``knowledge.sweep_chunk_budget``.
+
+        ``embed_priority`` is forwarded per scan. Scheduled sweeps choose the
+        bulk pool while dashboard-triggered scans retain the normal default.
 
         **A source Kiro Crew registered itself is refused here, not scanned.** The two
         paths that registered folders on their own are gone, and with them the
@@ -382,9 +392,19 @@ class FolderWatcher:
         if source_id not in self._locks:
             self._locks[source_id] = asyncio.Lock()
         async with self._locks[source_id]:
-            return await self._do_scan(source, chunk_budget=chunk_budget)
+            return await self._do_scan(
+                source,
+                chunk_budget=chunk_budget,
+                embed_priority=embed_priority,
+            )
 
-    async def _do_scan(self, source: dict, *, chunk_budget: int | None = None) -> dict:
+    async def _do_scan(
+        self,
+        source: dict,
+        *,
+        chunk_budget: int | None = None,
+        embed_priority: int = PRIORITY_NORMAL,
+    ) -> dict:
         source_id = source["id"]
         uri = source["uri"]
         props = json.loads(source.get("properties") or "{}") if isinstance(
@@ -556,6 +576,7 @@ class FolderWatcher:
 
             item_ids, outcome = await self._ingest_file(
                 file_path, source_id, namespace, props, old_ids, root=uri,
+                embed_priority=embed_priority,
                 on_duplicate=lambda text_hash: self._record_deduped_state(
                     source_id, file_path, content_hash, mtime, now, text_hash))
             if item_ids is None:
@@ -935,6 +956,7 @@ class FolderWatcher:
                            old_item_ids: list[str],
                            root: str = "",
                            on_duplicate: Callable[[str], None] | None = None,
+                           embed_priority: int = PRIORITY_NORMAL,
                            ) -> tuple[list[str] | None, str]:
         """Ingest one file.
 
@@ -1098,7 +1120,8 @@ class FolderWatcher:
                 original_name=Path(file_path).name,
                 old_item_ids=old_item_ids,
                 on_committed=_record_committed,
-                on_duplicate=_record_refused)
+                on_duplicate=_record_refused,
+                embed_priority=embed_priority)
 
             if refused:
                 return [], "deduped"

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -454,13 +454,28 @@ class IngestionPipeline:
         except Exception:
             logger.debug("Post-ingest dedup skipped", exc_info=True)
 
-    async def ingest_file(self, path: str, on_progress=None, original_name: str = "", namespace: str = "default", source_id: str = "", old_item_ids: list[str] | None = None, on_committed: Callable[[list[str]], None] | None = None, on_duplicate: Callable[[str], None] | None = None) -> str | None:
+    async def ingest_file(
+        self,
+        path: str,
+        on_progress=None,
+        original_name: str = "",
+        namespace: str = "default",
+        source_id: str = "",
+        old_item_ids: list[str] | None = None,
+        on_committed: Callable[[list[str]], None] | None = None,
+        on_duplicate: Callable[[str], None] | None = None,
+        *,
+        embed_priority: int = PRIORITY_NORMAL,
+    ) -> str | None:
         """Full pipeline. Returns job_id, or None if content hash unchanged.
 
         If source_id is provided, ingests into that existing source instead of
         creating a new one (used for remote source sync).
         If old_item_ids is provided, only those items are replaced (folder sources).
         Otherwise all items for the source are replaced (single-file sources).
+
+        ``embed_priority`` is call-scoped so unattended watchers can use the
+        reduced bulk pool without downgrading concurrent attended ingestion.
 
         ``on_committed`` receives the ids this call created -- collected at each
         write, never inferred from a before/after comparison of the source, which
@@ -645,7 +660,7 @@ class IngestionPipeline:
                 display_name=display_name, namespace=namespace,
                 existing=existing, old_item_ids=old_item_ids,
                 _old_item_ids=_old_item_ids, path=path, on_progress=on_progress,
-                on_committed=on_committed,
+                embed_priority=embed_priority, on_committed=on_committed,
             )
         except Exception:
             try:
@@ -671,7 +686,8 @@ class IngestionPipeline:
     async def _ingest_file_body(self, *, job_id, source_id, props, meta, ext, text,
                                 uri, content_hash, display_name, namespace,
                                 existing, old_item_ids, _old_item_ids, path,
-                                on_progress, on_committed=None) -> str | None:
+                                on_progress, embed_priority,
+                                on_committed=None) -> str | None:
         """Chunk/extract/store/finalize — split out so ingest_file can mark the
         pre-inserted job row 'failed' on ANY exception in one place."""
         # 4. Chunk (use per-source chunk size if configured)
@@ -771,7 +787,11 @@ class IngestionPipeline:
                 # and sqlite connections are thread-local, so this is thread-safe.
                 await asyncio.to_thread(self._store_entities, extraction, item_id)
                 await self._embed_item(
-                    item_id, item_title, extraction.get('summary'), chunk['content']
+                    item_id,
+                    item_title,
+                    extraction.get('summary'),
+                    chunk['content'],
+                    embed_priority=embed_priority,
                 )
                 processed += 1
             except Exception:
@@ -1063,13 +1083,20 @@ class IngestionPipeline:
                 )
 
     async def _embed_item(
-        self, item_id: str, title: str, summary: str | None, content: str | None = None
+        self,
+        item_id: str,
+        title: str,
+        summary: str | None,
+        content: str | None = None,
+        *,
+        embed_priority: int = PRIORITY_NORMAL,
     ) -> None:
         """Generate and store embedding for an item. No-op if embedder is None.
 
         Includes chunk ``content`` so vector search matches body text, not just
         the title/summary (which previously left body-only queries unmatchable).
         Respects the global embed rate limiter (knowledge.embed_rate_limit).
+        The caller selects the shared inference scheduling class per ingest.
         """
         if not self.embedder:
             return
@@ -1094,9 +1121,21 @@ class IngestionPipeline:
         # sweep re-embeds it — wasteful, never wrong.
         sig = embedder_signature(self.embedder)
         loop = asyncio.get_running_loop()
-        vec = await loop.run_in_executor(
-            None, self.embedder.embed_for_item, title, summary, content
-        )
+        if embed_priority == PRIORITY_NORMAL:
+            # Preserve the established attended-call contract for lightweight
+            # embedders that do not expose scheduling; bulk is an explicit opt-in.
+            embed_call = functools.partial(
+                self.embedder.embed_for_item, title, summary, content
+            )
+        else:
+            embed_call = functools.partial(
+                self.embedder.embed_for_item,
+                title,
+                summary,
+                content,
+                priority=embed_priority,
+            )
+        vec = await loop.run_in_executor(None, embed_call)
         if vec:
             blob = floats_to_bytes(vec)
             stamped_at = datetime.now().isoformat()

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.embeddings import PRIORITY_BULK
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
 
@@ -129,7 +130,11 @@ class KnowledgeWatcher:
                     else:
                         budget = min(budget, remaining)
 
-                stats = await self._folder_watcher.scan_source(source, chunk_budget=budget)
+                stats = await self._folder_watcher.scan_source(
+                    source,
+                    chunk_budget=budget,
+                    embed_priority=PRIORITY_BULK,
+                )
                 # Track consumed chunks against global budget.
                 sweep_chunks_used += stats.get("chunks_ingested", 0)
                 if stats.get("error"):
@@ -194,6 +199,7 @@ class KnowledgeWatcher:
                                 uri,
                                 source_id=row["id"],
                                 namespace=props.get("namespace", "default"),
+                                embed_priority=PRIORITY_BULK,
                             )
                         except FileTooLargeError:
                             # Warning already logged by the pipeline (names the file

--- a/test/test_knowledge_ingest_scan_off_loop.py
+++ b/test/test_knowledge_ingest_scan_off_loop.py
@@ -222,6 +222,7 @@ async def test_ingest_file_reports_the_committed_ids_without_touching_sqlite(tmp
                 old_item_ids,
                 on_committed=None,
                 on_duplicate=None,
+                embed_priority=None,
             ):
                 def _insert_and_report() -> None:
                     # Mirrors the real finalize hop: insert, then hand the ids to
@@ -295,6 +296,7 @@ async def test_ingest_file_reports_failure_when_the_pipeline_never_commits(tmp_p
                 old_item_ids,
                 on_committed=None,
                 on_duplicate=None,
+                embed_priority=None,
             ):
                 # Rolls back internally and does NOT raise -- exactly the shape
                 # the old sync_status read existed to catch.
@@ -359,6 +361,7 @@ async def test_ingest_file_still_reports_a_refused_duplicate_as_deduped(tmp_path
                 old_item_ids,
                 on_committed=None,
                 on_duplicate=None,
+                embed_priority=None,
             ):
                 assert on_duplicate is not None, "the watcher no longer listens for a refusal"
                 on_duplicate("text-hash-of-body")
@@ -495,6 +498,7 @@ async def test_commit_callback_persists_the_state_row_before_returning(tmp_path)
                 old_item_ids,
                 on_committed=None,
                 on_duplicate=None,
+                embed_priority=None,
             ):
                 def _insert_report_and_observe() -> None:
                     item_id = store.add_item("T", "body", "document", source_id=source_id)
@@ -597,6 +601,7 @@ async def test_a_failed_callback_persistence_does_not_poison_the_ingest(tmp_path
                 old_item_ids,
                 on_committed=None,
                 on_duplicate=None,
+                embed_priority=None,
             ):
                 def _insert_and_report() -> None:
                     created.append(store.add_item("T", "body", "document", source_id=source_id))

--- a/test/test_knowledge_rebuild_bulk_pacing.py
+++ b/test/test_knowledge_rebuild_bulk_pacing.py
@@ -9,21 +9,30 @@ sweep's own coroutine (holding neither the DB connection nor the model). Both
 are keyed on attendance, not corpus size: the dashboard-triggered rebuild a
 human is watching runs unpaced at ``PRIORITY_NORMAL`` on the full interactive
 pool. Mirrors ``test_vector_memory_bulk_pacing.py`` for the knowledge corpus.
+
+The same attendance split applies to per-item ingestion: scheduled folder and
+single-file re-ingest use the bulk class, while direct/manual ingestion retains
+the normal default. Priority stays call-scoped so concurrent paths cannot race.
 """
 
 from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from kiro_crew import embeddings as _embeddings
 from kiro_crew.embeddings import PRIORITY_BULK, PRIORITY_NORMAL
 from kiro_crew.knowledge import ingestion
+from kiro_crew.knowledge.chunker import HeadingAwareChunker
 from kiro_crew.knowledge.embedder import InProcessEmbedder
-from kiro_crew.knowledge.ingestion import rebuild_embeddings
+from kiro_crew.knowledge.folder_watcher import FolderWatcher
+from kiro_crew.knowledge.ingestion import IngestionPipeline, rebuild_embeddings
+from kiro_crew.knowledge.readers import FileReader
 from kiro_crew.knowledge.store import KnowledgeStore
+from kiro_crew.knowledge.watcher import KnowledgeWatcher
 
 # One sentinel delay for the whole file: every test that arms pacing stubs
 # ``bulk_pace_delay`` to return exactly this value, and the recorders below
@@ -96,6 +105,47 @@ def _stale_items(store, n):
     for i in range(n):
         store.add_item(f"stale row {i}", f"body {i}", "document")
     store.db.commit()
+
+
+@pytest.mark.asyncio
+class TestPerItemPriority:
+    @pytest.mark.parametrize(
+        ("priority", "expected"),
+        [(None, PRIORITY_NORMAL), (PRIORITY_BULK, PRIORITY_BULK)],
+    )
+    async def test_priority_reaches_the_shared_backend(
+        self, store, embedder, backend, tmp_path, priority, expected
+    ):
+        class _Extractor:
+            _pool = None
+
+            async def extract_batch(self, chunks):
+                return [
+                    {
+                        "category": "document",
+                        "summary": "summary",
+                        "entities": [],
+                        "relations": [],
+                    }
+                    for _chunk in chunks
+                ]
+
+        pipeline = IngestionPipeline(
+            store,
+            _Extractor(),
+            HeadingAwareChunker(),
+            FileReader(),
+            embedder=embedder,
+        )
+        document = tmp_path / "priority.md"
+        document.write_text("# Priority\n\nBody", encoding="utf-8")
+
+        if priority is None:
+            await pipeline.ingest_file(str(document))
+        else:
+            await pipeline.ingest_file(str(document), embed_priority=priority)
+
+        assert backend.priorities == [expected]
 
 
 @pytest.mark.asyncio
@@ -208,8 +258,6 @@ class TestCallerWiring:
     async def test_watcher_self_heal_sweep_is_paced_on_the_bulk_class(
         self, store, embedder, backend, sleeps, monkeypatch
     ):
-        from kiro_crew.knowledge.watcher import KnowledgeWatcher
-
         monkeypatch.setattr(ingestion, "bulk_pace_delay", lambda elapsed: _PACE)
         _stale_items(store, 2)
 
@@ -226,6 +274,70 @@ class TestCallerWiring:
 
         assert sleeps == [_PACE, _PACE]
         assert backend.priorities == [PRIORITY_BULK, PRIORITY_BULK]
+
+    async def test_scheduled_source_reingest_uses_the_bulk_class(self, store, tmp_path):
+        folder = tmp_path / "folder"
+        folder.mkdir()
+        doc = tmp_path / "changed.md"
+        doc.write_text("# changed", encoding="utf-8")
+        folder_id = await asyncio.to_thread(store.add_source, "folder", "local_folder", str(folder))
+        file_id = await asyncio.to_thread(
+            store.add_source,
+            "changed.md",
+            "local_file",
+            str(doc),
+            properties={"mtime": 0, "content_hash": "stale"},
+        )
+        pipeline = MagicMock()
+        pipeline.embedder = None
+        pipeline.ingest_file = AsyncMock(return_value="job")
+        watcher = KnowledgeWatcher(store, pipeline)
+        watcher._folder_watcher.scan_source = AsyncMock(return_value={})
+        watcher._maybe_reembed_stale = AsyncMock()
+        watcher._maybe_dedup_sweep = AsyncMock()
+
+        await watcher._scan()
+
+        folder_call = watcher._folder_watcher.scan_source.await_args
+        assert folder_call.args[0]["id"] == folder_id
+        assert folder_call.kwargs["embed_priority"] == PRIORITY_BULK
+        file_call = pipeline.ingest_file.await_args
+        assert file_call.kwargs["source_id"] == file_id
+        assert file_call.kwargs["embed_priority"] == PRIORITY_BULK
+
+    @pytest.mark.parametrize(
+        ("priority", "expected"),
+        [(None, PRIORITY_NORMAL), (PRIORITY_BULK, PRIORITY_BULK)],
+    )
+    async def test_folder_scan_forwards_per_call_priority(
+        self, store, tmp_path, priority, expected
+    ):
+        folder = tmp_path / "folder"
+        folder.mkdir()
+        (folder / "note.md").write_text("# note", encoding="utf-8")
+        source_id = await asyncio.to_thread(store.add_source, "folder", "local_folder", str(folder))
+        pipeline = MagicMock()
+        pipeline.embedder = None
+
+        async def _ingest(*_args, **kwargs):
+            await asyncio.to_thread(kwargs["on_committed"], [])
+            return "job"
+
+        pipeline.ingest_file = AsyncMock(side_effect=_ingest)
+        folder_watcher = FolderWatcher(store, pipeline)
+        source = {
+            "id": source_id,
+            "uri": str(folder),
+            "source_type": "local_folder",
+            "properties": "{}",
+        }
+
+        if priority is None:
+            await folder_watcher.scan_source(source)
+        else:
+            await folder_watcher.scan_source(source, embed_priority=priority)
+
+        assert pipeline.ingest_file.await_args.kwargs["embed_priority"] == expected
 
     async def test_dashboard_trigger_runs_unpaced_at_the_interactive_class(
         self, store, embedder, backend, sleeps, monkeypatch


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Scheduled Knowledge watcher updates ingest one changed item at a time through the same pipeline used by attended dashboard and manual work. Those watcher-triggered embeddings therefore entered the interactive worker pool instead of the bulk pool, even though they are unattended background work.

## Why it matters

A large watched folder or repeatedly changing file can consume interactive embedding capacity and delay user-requested Knowledge operations. Background watcher work should yield to attended work just as corpus rebuilds already do.

## What changed (motivation → approach → change)

The ingestion API had no call-scoped scheduling signal, so watcher callers could not distinguish unattended work without mutating shared pipeline state. This change threads a keyword-only `embed_priority` through `IngestionPipeline` and `FolderWatcher`, defaulting to `PRIORITY_NORMAL` for dashboard/manual callers and passing `PRIORITY_BULK` from both scheduled watcher paths (`local_file` and folder/vault scans).

The priority remains per call, so concurrent attended ingestion cannot be downgraded. At the embedder boundary, the normal path retains the legacy `embed_for_item(title, summary, content)` call shape; only explicit non-normal scheduling adds the `priority` keyword. The Knowledge system spec now documents this attendance split. This PR intentionally changes scheduling class only and does not add a pacing delay or shared mutable priority.

## Tests

- Extended `test/test_knowledge_rebuild_bulk_pacing.py` to verify normal-by-default and explicit-bulk priority across the full `ingest_file → _ingest_file_body → _embed_item → backend` chain.
- Covered both scheduled watcher source types and `FolderWatcher` propagation of normal and bulk priorities.
- Updated fixed-signature test doubles in `test/test_knowledge_ingest_scan_off_loop.py`; ownership, one-await, off-loop, callback, and cancellation ratchets remain green.
- Final focused watcher/invariant run: 93 passed. Adjacent watcher/ingestion regression run: 123 passed.
- Full backend run: 89,825 passed, 339 skipped, 9 xfailed. The remaining 22 failures are confined to untouched CLI/public-repo/symbol-manifest tests and reproduce unchanged on current `origin/main` in a detached baseline worktree.
- Repository formatting, lint, mypy (1,303 source files), policy, docs, vendor, OSS scrub, CloudFormation, frontend build/type/lint/i18n, 5,928 scoped frontend tests, duplication, Electron, and bundle-size gates passed.

## Manual verification

N/A — the behavior is an internal concurrency/scheduling-class handoff covered through the real ingestion delegation chain and both watcher routes.

## Related Issues

Fixes #7601

## Pattern harvest

Rule candidate: review-prompt
Pattern: Unattended ingestion paths that delegate per-item embedding must carry a call-scoped bulk priority instead of inheriting interactive defaults.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
