### PR TITLE
fix(instances): journal every warm-set write and the handshake drops behind a stuck pane

### DIFF
--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -39,8 +39,9 @@ import { SettingsLink } from './SettingsLink'
 import { useAppDispatch, useAppSelector } from '../store'
 import { clearPaneReady, removeWarm, setActiveId, setPaneReady, setUnread, setWarm } from '../store/instancesSlice'
 import InstanceTabBar, { visibleInstanceTabs, useCrewPins, toggleCrewPin, useCrewSwitcherStableOrder, setStableOrder } from './InstanceTabBar'
-import { resolveTunnelOrigin } from '../lib/tunnelOrigin'
+import { parseLoopbackOriginPort, resolveTunnelOrigin } from '../lib/tunnelOrigin'
 import { frameDocumentState, paneLog, safePaneUrl } from '../lib/paneLog'
+import { connectInstanceInto } from '../lib/connectInstance'
 import { LINUX_CAPTION_CONTROLS_WIDTH, TRAFFIC_LIGHT_INSET_PX, WIN_CAPTION_OVERLAY_WIDTH } from '../lib/electron'
 import { isEmbeddedPane } from '../lib/embedded'
 import ErrorNotice from './ErrorNotice'
@@ -224,26 +225,15 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   const autoWarm = useCallback(
     async (id: string) => {
       try {
-        const st = await api.connectInstance(id)
-        if (st.state === 'connected' && st.local_port && st.token) {
-          dispatch(setWarm({ id, conn: { port: st.local_port, token: st.token } }))
-          paneLog('warm', { id, port: st.local_port, via: 'auto' })
-        } else {
-          // No `else` used to exist here, and that is why a failed auto-warm was
-          // untraceable: it leaves any PREVIOUS warm entry in place, so the tab
-          // still renders a pane and the user sees only "loading" forever.
-          paneLog('warm-declined', {
-            id,
-            via: 'auto',
-            state: st.state,
-            hasPort: !!st.local_port,
-            hasToken: !!st.token,
-            error: st.error || undefined,
-            reason: st.diagnosis?.reason || undefined,
-          })
-        }
-      } catch (err) {
-        paneLog('warm-failed', { id, via: 'auto', error: (err as Error)?.message || 'unknown' })
+        // The shared connect step journals its own outcome (`warm` /
+        // `warm-declined` / `warm-failed`, tagged via=auto-warm), so a failed
+        // auto-warm is no longer untraceable: it used to leave any PREVIOUS warm
+        // entry in place with nothing in the log, and the user saw only
+        // "loading" forever.
+        await connectInstanceInto(dispatch, id, 'auto-warm')
+      } catch {
+        // Already journaled by connectInstanceInto; the sticky tab + in-pane
+        // panel handle an instance that cannot be warmed.
       }
     },
     [dispatch],
@@ -273,10 +263,25 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
 
   useEffect(() => {
     const onMessage = (e: MessageEvent) => {
-      const id = resolveTunnelOrigin(e.origin, portToIdRef.current)
-      if (!id) return
       const data = e.data
       if (!data || typeof data !== 'object') return
+      const id = resolveTunnelOrigin(e.origin, portToIdRef.current)
+      if (!id) {
+        // A readiness announce from a loopback origin this parent does not
+        // currently map to a warm pane is the handshake being dropped on the
+        // floor: the pane loaded and said so, and the parent could not tell
+        // whose voice it was (the warm entry moved to another port, was
+        // evicted, or the origin map has not caught up). Only THIS type is
+        // journaled, and the child sends it at most six times per load, so the
+        // line cannot flood; every other unattributed message stays silent.
+        if (data.type === 'mc-embedded-ready' && parseLoopbackOriginPort(e.origin) !== null) {
+          paneLog('ready-unattributed', {
+            origin: e.origin,
+            knownPorts: [...portToIdRef.current.keys()].join(','),
+          })
+        }
+        return
+      }
       if (data.type === 'mc-unread-slots') {
         const count = Number(data.count)
         if (!Number.isFinite(count) || count < 0) return
@@ -433,29 +438,13 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // iframe. Idempotent on the backend (the tunnel is often already live after a
   // startup auto-reconnect), so this mainly restores the browser-side token.
   const connectMutation = useMutation({
-    mutationFn: (id: string) => api.connectInstance(id),
-    onSuccess: (st, id) => {
-      if (st.state === 'connected' && st.local_port && st.token) {
-        dispatch(setWarm({ id, conn: { port: st.local_port, token: st.token } }))
-        paneLog('warm', { id, port: st.local_port, via: 'connect' })
-      } else {
-        // Same silent shape as the auto-warm path: Retry can "succeed" as a
-        // request while warming nothing, and the pane then reloads into the same
-        // stuck state with no error anywhere.
-        paneLog('warm-declined', {
-          id,
-          via: 'connect',
-          state: st.state,
-          hasPort: !!st.local_port,
-          hasToken: !!st.token,
-          error: st.error || undefined,
-          reason: st.diagnosis?.reason || undefined,
-        })
-      }
+    // The shared connect step writes the warm entry and journals the outcome
+    // (via=retry). Retry can "succeed" as a request while warming nothing, and
+    // the pane then reloads into the same stuck state — that case is the
+    // `warm-declined` line the step emits.
+    mutationFn: (id: string) => connectInstanceInto(dispatch, id, 'retry'),
+    onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['instances'] })
-    },
-    onError: (err, id) => {
-      paneLog('warm-failed', { id, via: 'connect', error: (err as Error)?.message || 'unknown' })
     },
   })
 
@@ -511,6 +500,12 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     if (!activeId || activeWarmPort === undefined || activeReady) return
     const id = activeId
     const port = activeWarmPort
+    // The countdown STARTING is journaled too, not only its expiry. A pane that
+    // shows "loading" forever without ever producing `load-timeout` is a pane
+    // whose watchdog never armed — because this effect saw `activeReady` as
+    // true while the overlay used a different verdict, or because it re-armed
+    // in a loop — and the absence of an arm line is what says so.
+    paneLog('watchdog-armed', { id, port, seq: activeSeq })
     const t = window.setTimeout(() => {
       setTimedOut(prev => (prev[id] ? prev : { ...prev, [id]: true }))
       // `frame` is the verdict: `cross-origin` means the pane really loaded the
@@ -554,7 +549,15 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     const ids = Object.keys(warm)
     if (ids.length <= warmCap) return
     const victim = [...mru].reverse().find(id => id !== activeId && warm[id])
-    if (victim) dispatch(removeWarm(victim))
+    if (victim) {
+      // Journaled because eviction is the one teardown the user never asked
+      // for: the tab stays, the tunnel stays, only the iframe goes — and the
+      // next click re-warms it as a brand-new load. Without this line a pane
+      // that was evicted and then failed to re-warm reads, in the log, like a
+      // pane that never had a problem until it suddenly did.
+      paneLog('evict', { id: victim, port: warm[victim]?.port, warmCount: ids.length, cap: warmCap })
+      dispatch(removeWarm(victim))
+    }
   }, [warm, warmCap, mru, activeId, dispatch])
 
   // Drop the per-pane load facts of a pane that is no longer warm. Both the

--- a/website/src/hooks/useAutoConnectInstances.ts
+++ b/website/src/hooks/useAutoConnectInstances.ts
@@ -159,7 +159,7 @@ export function useAutoConnectInstances() {
       await runBounded(targets, CONCURRENCY, async id => {
         lastAttempt.current[id] = Date.now()
         try {
-          await connectInstanceInto(dispatch, id)
+          await connectInstanceInto(dispatch, id, 'auto-connect')
         } catch {
           // A failed/unreachable host settles into the switcher's terminal error
           // dot via the status poll; auto-connect stays silent and lets the

--- a/website/src/lib/connectInstance.test.ts
+++ b/website/src/lib/connectInstance.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const connectInstance = vi.fn()
+vi.mock('../api/client', () => ({ api: { connectInstance: (...a: unknown[]) => connectInstance(...a) } }))
+
+import { connectInstanceInto } from './connectInstance'
+import { setWarm } from '../store/instancesSlice'
+
+function captureInfo() {
+  const lines: string[] = []
+  vi.spyOn(console, 'info').mockImplementation((...args: unknown[]) => { lines.push(args.join(' ')) })
+  return lines
+}
+
+describe('connectInstanceInto pane journal', () => {
+  beforeEach(() => { connectInstance.mockReset() })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('journals a live connect as `warm` with the caller tag and never the token', async () => {
+    const lines = captureInfo()
+    const dispatch = vi.fn()
+    connectInstance.mockResolvedValue({ state: 'connected', local_port: 7781, token: 'supersecret' })
+    await connectInstanceInto(dispatch as never, 'shizuka', 'auto-connect')
+    expect(dispatch).toHaveBeenCalledWith(setWarm({ id: 'shizuka', conn: { port: 7781, token: 'supersecret' } }))
+    expect(lines).toEqual(['[pane] warm id=shizuka port=7781 via=auto-connect'])
+    expect(lines.join('\n')).not.toContain('supersecret')
+  })
+
+  it('journals a connected-but-unusable response as `warm-declined` and leaves warm untouched', async () => {
+    const lines = captureInfo()
+    const dispatch = vi.fn()
+    connectInstance.mockResolvedValue({ state: 'connected', local_port: 0, token: '', error: 'x' })
+    await connectInstanceInto(dispatch as never, 'shizuka')
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(lines).toEqual([
+      '[pane] warm-declined id=shizuka via=select state=connected hasPort=false hasToken=false error=x',
+    ])
+  })
+
+  it('journals a rejection as `warm-failed` and re-throws it unchanged', async () => {
+    const lines = captureInfo()
+    const err = new Error('502 tunnel down')
+    connectInstance.mockRejectedValue(err)
+    await expect(connectInstanceInto(vi.fn() as never, 'shizuka', 'auto-connect')).rejects.toBe(err)
+    expect(lines).toEqual(['[pane] warm-failed id=shizuka via=auto-connect error="502 tunnel down"'])
+  })
+})

--- a/website/src/lib/connectInstance.ts
+++ b/website/src/lib/connectInstance.ts
@@ -18,16 +18,55 @@
  *  - Returns the tunnel status so callers can branch (e.g. surface the error).
  *    Rejections propagate — react-query's mutation and the auto-connect fan-out
  *    each handle failure their own way (in-pane error panel / silent backoff).
+ *  - Journals the outcome through `paneLog` under `via`. Every warm-writer —
+ *    the manual select, the auto-connect fan-out, the viewport's auto-warm and
+ *    its Retry — funnels through here, so the journal block exists once. Before
+ *    this unit journaled, it was the one silent warm path: a
+ *    connect that came back `connected` but with no port or no token left the
+ *    PREVIOUS warm entry (a dead port) standing, so the pane kept its stale src,
+ *    the tab still rendered an iframe, and the user saw only "loading" — with
+ *    nothing in the journal, because the viewport's own warm paths log and this
+ *    one did not. A rejection is journaled here too, then re-thrown unchanged.
  */
 import { api } from '../api/client'
+import { paneLog } from './paneLog'
 import { setWarm, type WarmConn } from '../store/instancesSlice'
 import type { AppDispatch } from '../store'
 
-export async function connectInstanceInto(dispatch: AppDispatch, id: string) {
-  const st = await api.connectInstance(id)
+/**
+ * Which caller asked. One checked vocabulary for the journal's `via` field, so
+ * a log reader learns four names once: `select` (tab click / ⌘-digit chord),
+ * `auto-connect` (the web-app-load fan-out), `auto-warm` (the viewport
+ * pre-mounting already-connected panes after a poll), `retry` (the in-pane
+ * error panel's Retry button).
+ */
+export type ConnectVia = 'select' | 'auto-connect' | 'auto-warm' | 'retry'
+
+export async function connectInstanceInto(dispatch: AppDispatch, id: string, via: ConnectVia = 'select') {
+  let st
+  try {
+    st = await api.connectInstance(id)
+  } catch (err) {
+    paneLog('warm-failed', { id, via, error: (err as Error)?.message || 'unknown' })
+    throw err
+  }
   if (st.state === 'connected' && st.local_port && st.token) {
     const conn: WarmConn = { port: st.local_port, token: st.token }
     dispatch(setWarm({ id, conn }))
+    paneLog('warm', { id, port: st.local_port, via })
+  } else {
+    // Same shape as the viewport's own `warm-declined`: the response says
+    // something other than "connected with a port and a token", and whatever
+    // warm entry existed before is left exactly as it was.
+    paneLog('warm-declined', {
+      id,
+      via,
+      state: st.state,
+      hasPort: !!st.local_port,
+      hasToken: !!st.token,
+      error: st.error || undefined,
+      reason: st.diagnosis?.reason || undefined,
+    })
   }
   return st
 }


### PR DESCRIPTION
## Problem / Motivation

A remote crew pane can sit on its "loading pane" spinner indefinitely, and when it does, `gateway-launch.log` has nothing that says why. The pane journal (#8274, #8813) covers the viewport's own warm paths, but the warm-set writer it does **not** own — `connectInstanceInto`, shared by tab clicks (`useSelectInstance`) and the auto-connect fan-out (`useAutoConnectInstances`) — writes nothing. Three further state changes that can put a pane into that bucket also left no line: the K-cap LRU eviction, the load watchdog arming, and a readiness announce the parent could not attribute to a warm pane.

## Why it matters

The failure is intermittent and per-crew: one registered crew lands in the bucket, the rest load fine, and the stuck one changes between restarts. Without a record of *which* warm write, eviction or dropped handshake preceded the spin, every occurrence is a fresh dead end — the state is gone by the time anyone looks. The user's only affordance is Retry, and a Retry that re-warms into the same silent path teaches nothing.

## What changed (motivation → approach → change)

- **Symptom:** pane stuck on "loading", journal empty for that crew.
- **Root cause (of the silence):** `connectInstanceInto` writes `warm` only when the response is `connected` AND carries a port AND a token. Any other answer leaves the *previous* warm entry standing — a dead port — so the tab still renders an iframe pointed at the old src, the user sees "loading", and nothing was ever journaled. The viewport's own `autoWarm` / `connectMutation` paths log this exact case as `warm-declined`; the shared helper did not.
- **Change:** `connectInstanceInto` now journals `warm` / `warm-declined` / `warm-failed`, and is the ONLY place that block exists: the viewport's `autoWarm` and its Retry `connectMutation` are folded onto it, so all four warm-writers funnel through one unit and `via` is one checked union (`select | auto-connect | auto-warm | retry`) rather than four strings across two mechanisms. `hasToken` is a boolean; the token string never reaches the log. Behaviour is unchanged at both folded sites — `autoWarm` still swallows rejections, the mutation still exposes them to the error panel and still invalidates `['instances']` on success, and `setWarm` fires under the same condition. `InstancesViewport` adds three lines:
  - `evict id port warmCount cap` — the K-cap LRU eviction. The only teardown the user never asked for; the next click re-warms as a brand-new load.
  - `watchdog-armed id port seq` — the 15 s load watchdog starting. A pane that spins forever *without* a later `load-timeout` is a pane whose watchdog never armed; only this line's absence says so.
  - `ready-unattributed origin knownPorts` — an `mc-embedded-ready` from a loopback origin the parent cannot map to a warm pane (origin map behind a port change / eviction). Gated to this one message type and a loopback origin; the child sends it at most six times per load (#8813's bounded backoff), so it cannot flood.

All lines ride the existing `[pane]` prefix → `frame-load-log` allowlist → `gateway-launch.log` path. One line per event, no polling emitters, so the terminal / log volume is bounded by the number of connects and evictions, not by time.

## Tests

- `website/src/lib/connectInstance.test.ts` (new, 3 cases): `warm` line carries `via` and never the token string; `connected`-but-unusable response journals `warm-declined` and does not touch the store; a rejection journals `warm-failed` and is re-thrown unchanged.
- Existing `InstancesViewport.test.tsx` (32; its connect/retry cases now exercise the fold, and the journal lines they emit read `via=auto-warm` / `via=retry`), `useAutoConnectInstances.test.ts` (13), `paneLog.test.ts`, `EmbeddedSwitcher.test.tsx`, `i18nLintExemptions.test.ts` — 124 pass unchanged.
- `tsc --noEmit` and `eslint` clean on the touched files.

## Manual verification

N/A — unit coverage sufficient. The change adds `console.info` lines on existing code paths and alters no control flow; the three new viewport lines sit inside effects and a listener the existing suite already exercises (eviction, watchdog, `mc-embedded-ready`).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the diff adds `console.info` journal lines on existing code paths and changes no markup, layout, styling or user-visible string; the loading overlay and error panel render exactly as before.

## Related Issues

Follows #8274 and #8813 (pane journal / bounded re-announce).

no linked issue: no issue is filed for the stuck-pane occurrence this instruments; these lines are the diagnostic prerequisite for filing one with evidence.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a shared helper extracted from N call sites keeps the state write but drops the per-site diagnostics — check that the extracted unit journals every branch the originals did.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing behavior change
- [x] No secrets, credentials, or internal references in the diff


