### PR TITLE
feat(pipeline-conductor): add pod_required repro admission gate

### DIFF
--- a/docs/request-for-change/rfc-pipeline-conductor.md
+++ b/docs/request-for-change/rfc-pipeline-conductor.md
@@ -238,7 +238,8 @@ default_branch: main
 work_source: {kind: gh_issues, select_labels: [...], skip_signals: [...]}   # SEAM: adapter
 claim: {lock_label, marker_phrase, operator_tag}                            # lock protocol as data
 worker_contract: {branch_pattern, worktree_pattern, brief_template, heartbeat_sla}
-verifier: {gate_profile, reviewer_lanes: [...], readiness_context, acceptance}  # SEAM: adapter
+verifier: {gate_profile, reviewer_lanes: [...], readiness_context, acceptance,
+           repro_gate: best_effort|pod_required}  # SEAM: adapter
 adjudication: {auto_action_categories, blast_radius_max, security_denylist}     # SEAM: policy as data
 governance: {max_in_flight, per_cycle, credit_budget_per_item, session_ceiling, posture}
 interface: {folder_name, worker_model, digest_language, notify_channel}
@@ -250,6 +251,18 @@ adapter (reviewer lanes as a data list), protocol vocabulary as data (labels, ma
 the highest-leverage seam), adjudication policy as data, and per-repo identity (#6221). One
 invariant stays out of the template: the forge is the cross-operator lock (claim label + assignee
 + operator-tagged comments); local state is only a cache.
+
+`verifier.repro_gate` is campaign admission policy, not a score attached after implementation.
+`best_effort` preserves the generic worker contract. `pod_required` admits an issue only after the
+unmodified worktree produces the reported failure through a live pod's real product surface; unit
+or structural repro does not substitute. A missing route, caller identity, scenario, host
+capability, or externally drivable trigger produces an evidence-bearing stand-down with no edits,
+commit, or PR, and the conductor advances the queue. The same pod trace must turn green before the
+item can report green. This distinction prevents a pipeline advertised as pod verification from
+silently measuring ordinary unit-fix throughput instead. The two values are the whole set, checked
+at startup by `scripts/spec_check.py` rather than by prose: a spec whose gate is neither value
+engages neither branch, so it would run generically while reading as gated, and the check refuses
+the run instead of defaulting.
 
 ## Phases
 

--- a/docs/system-specs/modules/pipeline-conductor.md
+++ b/docs/system-specs/modules/pipeline-conductor.md
@@ -28,6 +28,7 @@ is the contract for the machinery underneath it.
 | `.../pipeline-conductor/scripts/claim_preflight.py` | One claim verdict per candidate item |
 | `.../pipeline-conductor/scripts/fleet_probe.py` | The batch patrol probe |
 | `.../pipeline-conductor/scripts/credit_spend.py` | Per-item credit rollup and budget verdict |
+| `.../pipeline-conductor/scripts/spec_check.py` | The spec's closed-value fields, checked once before the run arms |
 | `src/kiro_crew/dashboard/session_control.py` | Worker-session stand-up and control: `create_session`, `send_to_target`, `read_messages`, `stop_target`, `authorize_target` |
 | `src/kiro_crew/session_ledger.py` | The conductor's durable item table and the `[work ledger]` snapshot it must not mistake for the record |
 
@@ -92,6 +93,7 @@ with the defaults that apply when the spec omits them:
                   "skip_signals": ["claimed", "in-progress"]},
   "worker_contract": {"branch_pattern": "fix/{slug}-{n}",
                       "worktree_pattern": "../{repo_name}-fix-{n}"},
+  "verifier": {"repro_gate": "best_effort"},
   "governance": {"max_in_flight": 32, "max_per_cycle": 3,
                  "idle_alert_secs": 900, "session_ceiling": 30,
                  "credit_budget_per_item": 100, "topup_ceiling": 2},
@@ -104,7 +106,11 @@ per-cycle dispatch limit, the silence a worker may accumulate before the probe
 fires `IDLE`, a session budget for the run, a per-item credit allowance, and how
 many budget top-ups an item may receive. The interface block names the chat
 folder the pipeline's sessions live in and the language its digests are written
-in.
+in. `verifier.repro_gate` selects the campaign's admission policy — `best_effort`
+(the generic contract) or `pod_required` (a live pod repro is a precondition for
+implementation, not a score attached afterwards) — and it is the one field with a
+closed value set, so `spec_check.py` refuses the run on any third value rather
+than defaulting.
 
 The spec file's directory is the run's state home: the probe config is
 `<spec-dir>/probe-config.json` and the probe owns
@@ -154,6 +160,36 @@ gateway's usage shards and answers `within`, `exhausted`, `truncated` or
 `unmetered`. `exhausted` is monotone (more shards can only add spend, so it
 stands on a partial view), and `unmetered` means at least one watched slot had no
 shard row, which the caller must treat as unknown spend rather than zero.
+
+**`spec_check.py`** runs once, at startup, over the spec fields whose value set is
+CLOSED, and exit 2 refuses the run. It exists because a closed field is the one
+shape where a typo is silent: a misspelled repo or threshold fails at first use,
+while a misspelled enum matches no branch, so the mode the operator asked for is
+off while the spec says it is on. `verifier.repro_gate` is the field that made
+this concrete — `pod_required` is the gate that makes unit-only evidence
+inadmissible, and `"pod-required"` would leave the generic contract in force
+under a spec that reads as gated, with the campaign metric still counting the run
+as pod-verified. The check therefore fails closed rather than defaulting to
+`best_effort`; the accepted set is declared once, in the script's `_ENUMS` table,
+which is also the seam a future closed field registers in. An ABSENT field is not
+an error (omission is how a pipeline asks for its documented default), while an
+explicit `null` is a value and is refused.
+
+The spec path itself is operator-supplied, so the read is a GATED read: the file
+goes through `hooks.safe_read_file`, which re-checks the RESOLVED target against
+`is_sensitive_path` and opens it `O_NOFOLLOW`. A `--spec` symlinked at a
+credential store is therefore refused through the link (`refused spec: Blocked:
+access to sensitive path: …`, exit 2) rather than parsed. A skill's scripts are
+copied out of the package tree and run under whichever `python3` the operator
+has, which under a managed install is not the interpreter Kiro Crew runs on — so
+the gate import frequently fails where the script is invoked. There is no safe
+degradation for a read gate, so the script does not read plainly and does not
+refuse either: it re-execs itself once under the interpreter beside the
+`kirocrew` launcher, which is the one carrying the package, and the child's
+verdict is the invocation's verdict. Refusal is what remains when the gate is
+reachable from no interpreter — no launcher on `PATH`, or a second import failure
+inside the re-exec — because a startup predicate that refuses every spec on a
+healthy install is the same outage as one that admits a bad one.
 
 ## The patrol cycle
 
@@ -268,6 +304,6 @@ filtered list; only the third mounts `kirocrew-work`.
 | Test | What it holds |
 |---|---|
 | `test/test_pipeline_conductor_agent.py` | Identity and charter, the owned filename, the verbosity placeholder, patrol via `monitor_start` rather than `wait`, that the prompt names the tools and scripts it runs on, that no file-writing tool is mounted, that dashboard grants are create-and-read only, that core grants are named verbs rather than a whole server, that `mcpServers` is narrowed, and that a governed host withholds and audits |
-| `test/test_pipeline_conductor_skill_contract.py` | That the skill cites the script rather than a prose predicate, that every exit code has a documented action, that all five verdicts are named, that `UNKNOWN` is never permission, that a prose closure request needs author authorization, and that an absent script has defined behaviour |
+| `test/test_pipeline_conductor_skill_contract.py` | That the skill cites the script rather than a prose predicate, that every exit code has a documented action, that all five verdicts are named, that `UNKNOWN` is never permission, that a prose closure request needs author authorization, that an absent script has defined behaviour, and that a `verifier.repro_gate` outside its two declared values refuses the run instead of degrading to the generic contract |
 | `test/test_pipeline_conductor_probe_roundtrip.py` | That the probe classifies what the conversation log actually wrote, that the watchdog patterns match the constants the gateway emits, that the index needle matches the real writer, that a raw slot key finds the transcript the dashboard writes, and that `credit_spend.py` sums what the recorder wrote |
 | `test/test_pipeline_conductor_claim_preflight.py` | The claim verdict lattice: merged-PR coverage and its near misses, fork PRs, prose self-claims, closure requests outranking claims, and absent-symbol risk handling |

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -5201,6 +5201,13 @@ class AcpClient:
         # cannot reintroduce a denied pointer; KIRO_API_KEY remains available only
         # to the positively identified Kiro backend.
         env = scrub_agent_subprocess_env(env)
+        # Bundled skill scripts must not depend on a system ``python`` name.
+        # The desktop bundles carry their interpreter outside the user's PATH,
+        # while this path is already running under the exact environment that
+        # can import ``kiro_crew``. Overwrite after the scrub and after
+        # ``extra_env`` so agent configuration cannot redirect the trusted read
+        # gate to a foreign interpreter.
+        env["KIROCREW_RUNTIME_PYTHON"] = sys.executable
         # Pod-scoped kiro-cli children write their OWN MCP OAuth grants,
         # confined to the pod's tree instead of the real host's -- see
         # _apply_pod_home_remap's docstring. No-op outside a pod

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -1325,6 +1325,13 @@ class AcpRuntime:
         # credential-pointer/API-key resolution so no resolver can reintroduce a
         # denied variable; KIRO_API_KEY itself is intentionally not denied.
         env = scrub_agent_subprocess_env(env)
+        # Bundled skill scripts must not depend on a system ``python`` name.
+        # The desktop bundles carry their interpreter outside the user's PATH,
+        # while this path is already running under the exact environment that
+        # can import ``kiro_crew``. Overwrite after the scrub and after
+        # ``extra_env`` so agent configuration cannot redirect the trusted read
+        # gate to a foreign interpreter.
+        env["KIROCREW_RUNTIME_PYTHON"] = sys.executable
         # Pod-scoped kiro-cli children write their OWN MCP OAuth grants,
         # confined to the pod's tree instead of the real host's -- see
         # acp.client._apply_pod_home_remap's docstring. No-op outside a pod and

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -5990,7 +5990,9 @@ is never permission, and REVIEW is a closure request READ in the item's prose,
 which you confirm yourself because prose never closes an item), `scripts/fleet_probe.py` (the ONE batch probe per patrol
 cycle — worker tails, tail index, idle age, error tails, banned-process scan,
 host load, delivery counters) and `scripts/credit_spend.py` (per-item credit
-rollups and budget verdicts). Read their output; never re-derive what they
+rollups and budget verdicts), plus `scripts/spec_check.py` ONCE at startup (the
+spec's closed-value fields; exit 2 refuses the run rather than defaulting a value
+that engages no branch). Read their output; never re-derive what they
 compute from transcripts. A script your install does not carry reads as UNKNOWN
 for the questions it answers — never as permission; the skill says what to do
 in that case.

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
@@ -21,6 +21,8 @@ rather than permission.
   error tails + banned-process scan + host load + delivery counters, in ONE
   call per cycle.
 - `scripts/credit_spend.py` — per-item credit rollup + budget verdict.
+- `scripts/spec_check.py` — the spec's closed-value fields, checked once at
+  startup. Exit 2 refuses the run.
 
 A decision this procedure states as prose rots silently; a decision a script
 computes can be tested. So anything below that cites a script is that script's
@@ -39,6 +41,7 @@ The operator's seed message names a spec file (JSON). Fields you consume now:
                    "skip_signals": ["claimed", "in-progress"]},
   "worker_contract": {"branch_pattern": "fix/{slug}-{n}",
                        "worktree_pattern": "../{repo_name}-fix-{n}"},
+  "verifier": {"repro_gate": "best_effort"},
   "governance": {"max_in_flight": 32, "max_per_cycle": 3,
                   "idle_alert_secs": 900, "session_ceiling": 30,
                   "credit_budget_per_item": 100, "topup_ceiling": 2},
@@ -56,9 +59,53 @@ in the config and it is what makes `cwd=fleet` reachable, so leaving it out
 classifies every banned line as `foreign` or `unknown` and the enforcing row of
 the banned-ops table never fires.
 
+`verifier.repro_gate` has two values, and exactly two — `spec_check.py` refuses
+the run on anything else (`malformed spec: verifier.repro_gate 'pod-required':
+expected 'best_effort' or 'pod_required'`), because a third value engages neither
+branch below and would leave the generic contract in force under a spec that
+reads as gated:
+
+- `best_effort` (default) keeps the generic pipeline behavior: reproduce where
+  cheap, and let the worker justify the narrowest honest verification when a
+  live system adds no signal.
+- `pod_required` is a HARD ADMISSION GATE for a pod-verification campaign. The
+  item is not implementation-eligible until the UNMODIFIED worktree reproduces
+  the reported failure in a live pod running that worktree's code. A unit or
+  structural test, a direct module call, a simulated exception, source reading,
+  or a note that a pod *could* verify the change later does NOT satisfy the
+  gate. No source, test, or documentation edit may precede the live red trace.
+  If the necessary scenario, product route, caller identity, host capability,
+  or externally drivable trigger is absent, the worker reports
+  `STANDDOWN: pod-repro-ineligible — <evidence>; missing=<capability>` without a
+  commit or PR, the conductor releases the claim with that evidence, and the
+  queue advances to the next candidate. After admission, the same live trace
+  must turn green before the worker may report `GREEN`.
+
+A pipeline using `pod_required` is measured by the number of admitted issues,
+not by the number inspected. An issue fixed with unit evidence but no admitted
+pod repro is useful work in another campaign and a FAILED sample in this one;
+never relabel it success in the friction report.
+
 ## Startup (once per run)
 
-1. Read the spec. `chat_folder_create` the pipeline folder.
+1. Run the checker through Kiro Crew's runtime interpreter before reading the
+   spec yourself or doing anything else. On POSIX run
+   `"$KIROCREW_RUNTIME_PYTHON" -I -B "<skill-dir>/scripts/spec_check.py" --spec <path>`;
+   on PowerShell run
+   `& $env:KIROCREW_RUNTIME_PYTHON -I -B "<skill-dir>/scripts/spec_check.py" --spec <path>`.
+   `-I` keeps the current directory, script directory, user site, and inherited
+   Python environment out of the import path before `safe_read_file` loads;
+   `-B` preserves the desktop bundle's no-bytecode-write rule even though
+   isolated mode ignores its `PYTHONDONTWRITEBYTECODE` environment setting.
+   Never substitute bare `python` or `python3`: desktop installs carry their own
+   interpreter and do not require either name on `PATH`. Exit 2 is a REFUSAL TO
+   START, not a warning: it means a field with a closed value set carries a value
+   that is neither of its options, and every such value engages no branch at all
+   — so the mode the operator asked for is silently off while the spec says it is
+   on. Report the message verbatim and stop; do not guess a default, and do not
+   open the folder or claim an item first, because a run that has already
+   dispatched a worker cannot un-dispatch it. Only after exit 0 may you read the
+   spec and use its values. Then `chat_folder_create` the pipeline folder.
 2. Build the queue from the work source (or adopt the operator's seeded
    backlog). **Record the backlog at whatever size it is** — as the queue's
    PROVENANCE, one entry: the work source, its selector, the count, and the item
@@ -430,7 +477,25 @@ Fill `{...}` from the spec; keep every clause — each one closes a failure mode
 > PREFLIGHT (mandatory): view the item; check open PRs and worktrees for
 > overlap — if anything already covers it, reply `STANDDOWN: <reason>` and
 > stop. Never adopt another session's WIP.
-> CONFIRM the mechanism before fixing: reproduce where cheap; wrong premise →
+> REPRO ADMISSION (`{verifier.repro_gate}`): expand this clause from the spec.
+> In `pod_required` mode, keep the worktree byte-clean and run `kirocrew pod
+> scenarios`, choose the closest shipped state, boot the UNMODIFIED worktree in
+> that scenario, and drive the externally visible failing behavior through
+> `pod api`, pod-e2e/Playwright, or another real product route. Run pod
+> status/token/API commands through the worktree's `./.venv/bin/kirocrew` after
+> provisioning: the globally installed binary may be sandbox-blind to the pod
+> process's sockets and fail closed on ownership proof. If `playwright-cli`
+> cannot launch on the host, the repository's own Playwright runner against the
+> same live pod is equivalent evidence; record the engine and launch flags, and
+> treat a missing REQUIRED engine (for example Safari/WebKit-specific behavior)
+> as `missing=<capability>` rather than silently substituting Chromium.
+> Record the scenario, exact probe, and failing observable. A unit test, direct
+> import, simulated error, or post-fix friction note is NOT admission. No live pod red →
+> `STANDDOWN: pod-repro-ineligible — <evidence>; missing=<capability>` and STOP
+> with no edit, commit, or PR. Live red admitted → implement, then run the SAME
+> pod trace green and tear the pod down to zero residue before `GREEN`.
+> CONFIRM the mechanism before fixing: in `best_effort` mode, reproduce where
+> cheap; wrong premise →
 > `STANDDOWN: premise disproven — <evidence>`. A design decision →
 > `PROPOSAL: <link>` (write the proposal on the item; do not build).
 > IMPLEMENT in your own worktree (`{worktree_pattern}`, branch

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/spec_check.py
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/spec_check.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Pipeline spec check — the startup predicate for the spec's closed-value fields.
+
+One invocation answers "is this spec runnable?" for every field whose value set
+is CLOSED, before the run arms anything.
+
+WHY ONLY THE CLOSED FIELDS. A closed field is the one shape where a typo is
+SILENT. A misspelled repo, branch pattern or threshold fails at first use, loudly
+and immediately. A misspelled enum matches no branch: the mode the operator asked
+for never engages, the run proceeds under whatever the surrounding procedure does
+by default, and the report reads as a normal run. ``verifier.repro_gate`` is the
+field where that bites hardest — ``pod_required`` is a hard admission gate whose
+whole purpose is to make unit-only evidence inadmissible, and
+``"pod-required"`` (hyphen) is neither value, so the gate is off while the spec
+says it is on and the campaign's own metric still counts the run as pod-verified.
+That is precisely the failure the gate exists to prevent, one typo lower.
+
+So the check FAILS CLOSED: any value outside the declared set refuses the run
+rather than picking a default. Choosing a default here would be the same silent
+degradation with an extra step.
+
+An ABSENT field is not an error — the spec documents a default for every field,
+and omission is how a pipeline asks for it. An explicit ``null`` is not omission
+and is refused: it is a value, and it is not one of the declared ones.
+
+Usage (the startup procedure supplies ``<skill-dir>``):
+
+POSIX::
+
+    "$KIROCREW_RUNTIME_PYTHON" -I -B "<skill-dir>/scripts/spec_check.py" --spec <pipeline-spec.json>
+
+PowerShell::
+
+    & $env:KIROCREW_RUNTIME_PYTHON -I -B "<skill-dir>/scripts/spec_check.py" --spec <pipeline-spec.json>
+
+``-I`` removes the current directory, script directory, user site, and inherited
+Python environment from startup before the sensitive-path gate imports. ``-B``
+keeps the packaged desktop from writing bytecode even though isolated mode
+ignores its ``PYTHONDONTWRITEBYTECODE`` environment setting.
+
+``KIROCREW_RUNTIME_PYTHON`` is overwritten by the Kiro Crew ACP parent with the
+absolute interpreter already running Kiro Crew. That path works in venv, POSIX
+desktop (``bin/python3.12``), and Windows desktop (bundle-root ``python.exe``)
+layouts without requiring a system ``python`` name. A manual invocation under a
+foreign interpreter can still relocate through :func:`bundled_python` below.
+
+Exit codes:
+
+    0   the spec's closed-value fields are usable
+    2   malformed spec — stderr names the field, the offending value, and the
+        accepted set, or, where the document is unusable before any field is
+        reachable, what makes it unusable. Do not start the run. Also returned
+        when the spec path is REFUSED by the sensitive-path read gate, or when
+        that gate cannot be reached from any interpreter: an unenforceable
+        precondition is a refusal here, never a plain read.
+
+Reads one file; writes nothing. Spawns at most one subprocess, and only ever
+itself, under the interpreter that carries the read gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+try:
+    # The spec path comes from the operator's seed message, so it is
+    # caller-influenced: a symlink could point it at a credential store the
+    # sandbox leaves readable. ``safe_read_file`` canonicalizes the path,
+    # re-checks the RESOLVED target against ``is_sensitive_path``, and opens it
+    # ``O_NOFOLLOW``, so the gate holds through a link and through a TOCTOU swap.
+    from kiro_crew.hooks import safe_read_file
+except Exception:  # pragma: no cover - exercised when the package is not importable
+    # The normal startup procedure uses Kiro Crew's injected runtime, but the
+    # copied skill script can still be run manually under a foreign interpreter,
+    # where ``kiro_crew`` is not guaranteed to be importable. There is no safe
+    # degradation for a READ GATE: falling back to ``read_text`` would reopen
+    # exactly the bypass this import exists to close, and it would do so silently,
+    # in the case that is hardest to notice. So this is not the fallback —
+    # ``main`` re-execs under an interpreter that HAS the gate, and refuses only
+    # when there is none.
+    safe_read_file = None  # type: ignore[assignment]
+
+#: Set on the child when this script re-execs itself, so an interpreter that
+#: also lacks the gate refuses instead of spawning a third.
+_REEXEC_ENV = "KIROCREW_SPEC_CHECK_REEXEC"
+
+#: Spec field (dotted path) -> the values it accepts.
+#:
+#: This table is the seam: a future closed field is registered here and inherits
+#: the fail-closed behavior and the error shape, rather than growing a second
+#: validator somewhere else. Fields with open value sets belong nowhere near it —
+#: listing one would turn a legitimate value into a refused startup.
+_ENUMS: dict[str, tuple[str, ...]] = {
+    "verifier.repro_gate": ("best_effort", "pod_required"),
+}
+
+
+def bundled_python() -> str | None:
+    """Path to an interpreter that can import the read gate, or ``None``.
+
+    The ACP parent supplies the authoritative answer in
+    ``KIROCREW_RUNTIME_PYTHON``. It is the exact ``sys.executable`` already
+    running Kiro Crew, injected after the child-env scrub and after agent
+    overrides, so a desktop install never depends on a Python name on ``PATH``.
+
+    The launcher-derived candidates keep manual and older invocations usable:
+    a venv keeps Python beside ``kirocrew``; the POSIX desktop bundle keeps
+    ``python3.12`` beside it; and the Windows desktop shim lives in ``bin`` with
+    ``python.exe`` one directory above. ``realpath`` matters for the common
+    user-bin symlink into any of those layouts.
+    """
+    injected = os.environ.get("KIROCREW_RUNTIME_PYTHON", "").strip()
+    if injected and os.path.isfile(injected):
+        return injected
+
+    launcher = shutil.which("kirocrew")
+    if not launcher:
+        return None
+    script_dir = os.path.dirname(os.path.realpath(launcher))
+    if os.name == "nt":
+        candidates = (
+            os.path.join(script_dir, "python.exe"),
+            os.path.join(os.path.dirname(script_dir), "python.exe"),
+        )
+    else:
+        candidates = (
+            os.path.join(script_dir, "python"),
+            os.path.join(script_dir, "python3.12"),
+        )
+    return next((candidate for candidate in candidates if os.path.isfile(candidate)), None)
+
+
+def _refuse_unenforceable(reason: str) -> int:
+    """Refuse a spec whose read gate cannot be reached from any interpreter."""
+    print(
+        "malformed spec: cannot enforce the sensitive-path read gate "
+        f"(kiro_crew.hooks is not importable and {reason}); refusing to read the spec",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def _reexec_with_the_gate(spec: str) -> int:
+    """Re-run this check under the interpreter that has the read gate.
+
+    A relocation, not a second opinion: the child answers the same question with
+    the gate in force, so its exit code and its message are this invocation's.
+    """
+    if os.environ.get(_REEXEC_ENV):
+        return _refuse_unenforceable(f"the re-exec under {sys.executable} already happened")
+    interpreter = bundled_python()
+    if interpreter is None:
+        return _refuse_unenforceable(
+            "KIROCREW_RUNTIME_PYTHON names no usable file and no supported "
+            "interpreter was found from the 'kirocrew' launcher"
+        )
+    env = {**os.environ, _REEXEC_ENV: "1"}
+    return subprocess.call(
+        [interpreter, "-I", "-B", os.path.abspath(__file__), "--spec", spec], env=env
+    )
+
+
+def _expected(values: tuple[str, ...]) -> str:
+    """Render an accepted set the way the error message needs it."""
+    quoted = [repr(value) for value in values]
+    if len(quoted) == 1:
+        return quoted[0]
+    if len(quoted) == 2:
+        return f"{quoted[0]} or {quoted[1]}"
+    return f"{', '.join(quoted[:-1])}, or {quoted[-1]}"
+
+
+def spec_error(spec: dict[str, Any]) -> str | None:
+    """Return the first problem in ``spec``, or ``None`` when it is runnable.
+
+    One message, not a list: a spec with two bad enums is refused on the first,
+    and the operator re-runs the check after fixing it. A partial spec is never
+    "runnable except for" — there is no degraded mode to report.
+    """
+    for path, allowed in _ENUMS.items():
+        parent: Any = spec
+        keys = path.split(".")
+        for key in keys[:-1]:
+            if not isinstance(parent, dict) or key not in parent:
+                parent = None
+                break
+            parent = parent[key]
+            if not isinstance(parent, dict):
+                # A block spelled as a scalar or a list hides every field under
+                # it, so the enum below would read as absent and default.
+                return f"{key}: expected a JSON object"
+        leaf = keys[-1]
+        if not isinstance(parent, dict) or leaf not in parent:
+            # Absent: the spec's documented default applies.
+            continue
+        value = parent[leaf]
+        if not isinstance(value, str) or value not in allowed:
+            return f"{path} {value!r}: expected {_expected(allowed)}"
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a pipeline spec before a run.")
+    parser.add_argument("--spec", required=True, help="path to the pipeline spec JSON")
+    args = parser.parse_args(argv)
+
+    if safe_read_file is None:
+        return _reexec_with_the_gate(args.spec)
+    try:
+        spec = json.loads(safe_read_file(args.spec))
+        if not isinstance(spec, dict):
+            raise ValueError("spec must be a JSON object")
+    except PermissionError as exc:
+        # The gate's own refusal, kept distinct from a malformed file: the spec
+        # may be perfectly well-formed and still not be ours to read.
+        print(f"refused spec: {exc}", file=sys.stderr)
+        return 2
+    except (OSError, ValueError, RecursionError) as exc:
+        # ``RecursionError`` is listed because a deeply nested document exhausts
+        # the scanner's stack instead of failing to parse, and it subclasses
+        # ``RuntimeError`` rather than ``ValueError`` — so without it the one
+        # malformed shape that is not a parse error would leave through the
+        # traceback as exit 1. Every unusable spec exits 2, which is the code
+        # documented above and the only one a caller reads as "malformed".
+        print(f"malformed spec: {exc}", file=sys.stderr)
+        return 2
+    problem = spec_error(spec)
+    if problem is not None:
+        print(f"malformed spec: {problem}", file=sys.stderr)
+        return 2
+    print(f"OK {args.spec}: {len(_ENUMS)} closed-value field(s) checked")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -11124,6 +11124,7 @@ class TestSpawnEnvScrub:
             assert key not in env, f"{key} leaked into ACP child env"
         assert env.get("KIROCREW_UNRELATED_KEEPME") == "keep-this-value"
         assert env.get("AWS_ACCESS_KEY_ID") == "FAKE-akid"
+        assert env.get("KIROCREW_RUNTIME_PYTHON") == sys.executable
 
 
 class TestSetModelRebasesContextStats:

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -6268,6 +6268,7 @@ async def test_runtime_spawn_scrubs_sensitive_env_on_default_auto(monkeypatch):
         assert key not in env, f"{key} leaked into runtime child env"
     assert env.get("KIROCREW_UNRELATED_KEEPME") == "keep-this-value"
     assert env.get("AWS_ACCESS_KEY_ID") == "FAKE-akid"
+    assert env.get("KIROCREW_RUNTIME_PYTHON") == runtime_mod.sys.executable
 
 
 @pytest.mark.asyncio

--- a/test/test_pipeline_conductor_skill_contract.py
+++ b/test/test_pipeline_conductor_skill_contract.py
@@ -24,27 +24,44 @@ couple this file to that one for no additional coverage.
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import shutil
+import stat
+import subprocess
+import sys
 from pathlib import Path
 
+import pytest
 from skill_script_helpers import load_skill_script
 
-from kiro_crew import agent
+from kiro_crew import agent, hooks
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILL_DIR = REPO_ROOT / "src" / "kiro_crew" / "builtin_skills" / "pipeline-conductor"
 SKILL_MD = SKILL_DIR / "SKILL.md"
 DESIGN_DOC = REPO_ROOT / "docs" / "request-for-change" / "rfc-pipeline-conductor.md"
 
-#: The three scripts the procedure delegates its deterministic half to. Named
+#: The scripts the procedure delegates its deterministic half to. Named
 #: here rather than globbed from the directory on purpose: the point is that the
 #: PROSE cites each one, and a glob would pass on a skill body that mentions
 #: none of them.
-BUNDLED_SCRIPTS = ("claim_preflight.py", "fleet_probe.py", "credit_spend.py")
+BUNDLED_SCRIPTS = (
+    "claim_preflight.py",
+    "fleet_probe.py",
+    "credit_spend.py",
+    "spec_check.py",
+)
 
 
 def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def _make_executable(path: Path) -> None:
+    """Grant the execute bit, for a file a ``PATH`` lookup or an ``exec`` reaches."""
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def _flat(text: str) -> str:
@@ -240,6 +257,575 @@ class TestClaimPreflightIsDocumented:
 
     def test_an_already_fixed_item_is_triage_debt_not_a_dispatch(self):
         assert "triage debt" in _flat(_skill_section(self.HEADING))
+
+
+class TestPodReproAdmissionGate:
+    """A pod campaign must reject unit-only fixes before implementation.
+
+    The first pilot silently weakened "pod repro required" into an after-the-fact
+    friction note: all three issues were fixed, none was reproduced in a pod, and
+    the run was still reported as evidence for the pod loop. These assertions pin
+    the distinction between campaign admission and ordinary verification quality.
+    """
+
+    def test_the_spec_exposes_a_safe_generic_default_and_the_hard_mode(self):
+        spec = _flat(_skill_section("## The pipeline spec"))
+        assert '"repro_gate": "best_effort"' in spec
+        assert "`pod_required` is a hard admission gate" in spec
+
+    def test_pod_required_forbids_edits_before_the_live_red_trace(self):
+        spec = _flat(_skill_section("## The pipeline spec"))
+        assert "no source, test, or documentation edit may precede the live red trace" in spec
+        assert "unmodified worktree" in spec
+
+    def test_unit_evidence_cannot_be_relabelled_as_pod_admission(self):
+        spec = _flat(_skill_section("## The pipeline spec"))
+        for inadequate in (
+            "unit or structural test",
+            "direct module call",
+            "simulated exception",
+            "source reading",
+        ):
+            assert inadequate in spec
+        assert "failed sample in this one" in spec
+
+    def test_an_ineligible_issue_stands_down_without_a_pr_and_advances(self):
+        spec = _flat(_skill_section("## The pipeline spec"))
+        assert "standdown: pod-repro-ineligible" in spec
+        assert "without a commit or pr" in spec
+        assert "queue advances to the next candidate" in spec
+
+    def test_the_worker_brief_runs_the_gate_before_implementation(self):
+        brief = _flat(_skill_section("### The work-order brief (seed message skeleton)"))
+        assert "repro admission (`{verifier.repro_gate}`)" in brief
+        assert "no live pod red" in brief
+        assert "no edit, commit, or pr" in brief
+        assert "run the same pod trace green" in brief
+        assert "tear the pod down to zero residue" in brief
+        assert "worktree's `./.venv/bin/kirocrew`" in brief
+        assert "repository's own playwright runner" in brief
+        assert "missing required engine" in brief
+
+
+class TestSpecCheckRefusesAnUndeclaredGate:
+    """A two-value field is only two-valued if something refuses a third value.
+
+    ``verifier.repro_gate`` is documented as an enum, and a value outside the
+    declared set matches neither branch of the procedure: ``pod_required``'s
+    admission gate never engages while the spec file says it is on, the generic
+    implementation instructions stay reachable, and the campaign metric still
+    counts the run as pod-verified. That is the gate's own failure mode one level
+    down, which is why the check refuses the run rather than falling back to
+    ``best_effort``.
+    """
+
+    @staticmethod
+    def _script():
+        return load_skill_script("spec_check", SKILL_DIR / "scripts" / "spec_check.py")
+
+    def test_a_misspelled_gate_is_refused_by_name_value_and_option_set(self):
+        problem = self._script().spec_error({"verifier": {"repro_gate": "pod-required"}})
+        assert problem is not None
+        # The operator has to be able to act on the message without opening the
+        # spec's documentation: which field, what it read, what it accepts.
+        assert "verifier.repro_gate" in problem
+        assert "pod-required" in problem
+        assert "best_effort" in problem
+        assert "pod_required" in problem
+
+    def test_both_declared_values_are_accepted(self):
+        spec_error = self._script().spec_error
+        for value in ("best_effort", "pod_required"):
+            assert spec_error({"verifier": {"repro_gate": value}}) is None, value
+
+    def test_an_omitted_gate_takes_the_documented_default(self):
+        """Omission is how a pipeline asks for the default, so it is not an
+        error -- otherwise every pre-existing spec stops running."""
+        spec_error = self._script().spec_error
+        assert spec_error({}) is None
+        assert spec_error({"verifier": {}}) is None
+
+    def test_a_non_string_gate_is_refused_rather_than_coerced(self):
+        """An explicit ``null`` is a value, not an omission, and truthiness
+        coercion is how ``0`` or ``[]`` would silently select a branch."""
+        spec_error = self._script().spec_error
+        for value in (None, 0, True, [], {}, "BEST_EFFORT", ""):
+            assert spec_error({"verifier": {"repro_gate": value}}) is not None, value
+
+    def test_a_scalar_verifier_block_is_refused(self):
+        """A block spelled as a scalar hides every field under it, so the enum
+        would read as absent and default -- the same silent outcome."""
+        problem = self._script().spec_error({"verifier": "pod_required"})
+        assert problem is not None
+        assert "verifier" in problem
+
+    def test_the_cli_exits_two_on_a_misspelled_gate_and_zero_on_a_valid_one(self, tmp_path, capsys):
+        script = self._script()
+        bad = tmp_path / "bad-spec.json"
+        bad.write_text(json.dumps({"verifier": {"repro_gate": "pod-required"}}), encoding="utf-8")
+        assert script.main(["--spec", str(bad)]) == 2
+        assert "malformed spec" in capsys.readouterr().err
+
+        good = tmp_path / "good-spec.json"
+        good.write_text(json.dumps({"verifier": {"repro_gate": "pod_required"}}), encoding="utf-8")
+        assert script.main(["--spec", str(good)]) == 0
+
+    def test_an_unreadable_or_non_object_spec_refuses_the_run(self, tmp_path):
+        script = self._script()
+        assert script.main(["--spec", str(tmp_path / "absent.json")]) == 2
+        listy = tmp_path / "listy.json"
+        listy.write_text("[]", encoding="utf-8")
+        assert script.main(["--spec", str(listy)]) == 2
+
+    def test_a_deeply_nested_spec_refuses_with_the_documented_code(self, tmp_path, capsys):
+        """Every unusable spec leaves through exit 2, including the one shape that
+        exhausts the scanner's stack rather than failing to parse.
+
+        A document nested past the scanner's depth raises ``RecursionError``, which
+        subclasses ``RuntimeError`` and not ``ValueError``, so it is the one
+        malformed input that can leave as a traceback and exit 1. Exit 1 is not the
+        code the usage block gives a caller for a malformed spec, and a traceback is
+        not the message that names the field to fix.
+
+        The nesting is of OBJECTS so that parsing, if it somehow succeeded, would
+        yield a dict with no ``verifier`` block and exit 0 -- a nested ARRAY is
+        refused as a non-object anyway, which would pass this assertion without
+        the stack ever being the reason.
+        """
+        deep = tmp_path / "deep.json"
+        depth = sys.getrecursionlimit() * 20
+        deep.write_text('{"a":' * depth + "1" + "}" * depth, encoding="utf-8")
+        assert self._script().main(["--spec", str(deep)]) == 2
+        assert "malformed spec" in capsys.readouterr().err
+
+    def test_the_accepted_set_reads_as_a_sentence_at_any_arity(self):
+        """The message is the whole remedy an operator gets, so its rendering is
+        part of the contract rather than cosmetic: a bare tuple repr is what sends
+        someone back to the documentation to find out what to type."""
+        expected = self._script()._expected
+        assert expected(("only",)) == "'only'"
+        assert expected(("best_effort", "pod_required")) == "'best_effort' or 'pod_required'"
+        assert expected(("a", "b", "c")) == "'a', 'b', or 'c'"
+
+    def test_the_prose_declares_exactly_the_values_the_script_accepts(self):
+        """The value set is read from the SCRIPT, not restated here. Two copies
+        of one fact drift, and the drift is invisible: the prose is what the
+        operator writes the spec from, the script is what refuses it."""
+        allowed = self._script()._ENUMS["verifier.repro_gate"]
+        spec = _flat(_skill_section("## The pipeline spec"))
+        for value in allowed:
+            assert f"`{value}`" in spec, value
+
+    def test_startup_runs_the_check_before_it_dispatches_anything(self):
+        startup = _flat(_skill_section("## Startup (once per run)"))
+        posix = startup.index(
+            '`"$kirocrew_runtime_python" -i -b "<skill-dir>/scripts/spec_check.py" --spec <path>`'
+        )
+        powershell = startup.index(
+            '`& $env:kirocrew_runtime_python -i -b "<skill-dir>/scripts/spec_check.py" --spec <path>`'
+        )
+        agent_read = startup.index("only after exit 0 may you read the spec")
+        folder = startup.index("`chat_folder_create`")
+        assert max(posix, powershell) < agent_read < folder
+        assert "current directory, script directory, user site" in startup
+        assert "never substitute bare `python` or `python3`" in startup
+        assert "refusal to start" in startup
+
+
+class TestSpecCheckReadsThroughTheSensitivePathGate:
+    """The spec path is operator-supplied, so the read is a gated read.
+
+    ``--spec`` comes from the seed message, which makes it caller-influenced: a
+    symlink there could aim the validator at a credential store the sandbox
+    leaves readable, and the script would open it with the operator's own
+    permissions. Reading through ``safe_read_file`` puts the resolved target
+    behind ``is_sensitive_path`` and opens it ``O_NOFOLLOW``, so the gate holds
+    through the link and through a TOCTOU swap of the final component.
+
+    Each case below writes a spec whose CONTENT would produce a *different*
+    message if the gate were bypassed (a bad ``repro_gate`` value, which the
+    validator reports by name). So a passing test proves the file was refused
+    rather than merely proving some non-zero exit.
+
+    The fixture does NOT relocate ``HOME``. Re-anchoring the home directory into
+    ``tmp_path`` would make the planted tree *be* the sensitive location, so the
+    tests would pass without the real credential-boundary classification ever
+    running -- they would be checking the fixture. Instead exactly one planted
+    path is declared sensitive and every other path DELEGATES to the real
+    ``is_sensitive_path``, so the production boundary logic still decides the
+    ordinary-spec cases and a regression in it is not masked.
+    """
+
+    @staticmethod
+    def _script():
+        return load_skill_script("spec_check", SKILL_DIR / "scripts" / "spec_check.py")
+
+    @staticmethod
+    def _plant_credential_store(monkeypatch, root):
+        """Plant a credential store and classify ONLY it as sensitive.
+
+        Returns the planted path. ``safe_read_file`` calls the bare
+        ``is_sensitive_path`` name out of ``kiro_crew.hooks``' module globals, so
+        patching the attribute there intercepts the real call site rather than a
+        copy. The wrapper compares canonical paths, which is what makes the
+        symlink case meaningful: the link resolves to the planted target.
+        """
+        aws = root / ".aws"
+        aws.mkdir(parents=True)
+        cred = aws / "credentials"
+        # Valid JSON carrying a bad gate value: bypassing the read gate yields
+        # "malformed spec: verifier.repro_gate ...", never a refusal.
+        cred.write_text(json.dumps({"verifier": {"repro_gate": "pod-required"}}), encoding="utf-8")
+
+        real_is_sensitive_path = hooks.is_sensitive_path
+        planted = os.path.realpath(str(cred))
+
+        def classify(path_str, *args, **kwargs):
+            if os.path.realpath(os.path.expanduser(str(path_str))) == planted:
+                return True
+            # Everything else is the real gate's call, so the ordinary-spec
+            # assertions below are answered by production code.
+            return real_is_sensitive_path(path_str, *args, **kwargs)
+
+        monkeypatch.setattr(hooks, "is_sensitive_path", classify)
+        return cred
+
+    def test_a_spec_path_inside_a_credential_store_is_refused_not_parsed(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        cred = self._plant_credential_store(monkeypatch, tmp_path)
+        assert self._script().main(["--spec", str(cred)]) == 2
+        err = capsys.readouterr().err
+        assert "refused spec" in err
+        assert "sensitive path" in err
+        # The discriminator: the validator never got to look at the content.
+        assert "repro_gate" not in err
+
+    def test_a_symlinked_spec_is_refused_through_the_link(self, tmp_path, capsys, monkeypatch):
+        """The attack shape: an innocuous-looking `spec.json` whose target is the
+        credential store. Checking the link's own path would pass it."""
+        cred = self._plant_credential_store(monkeypatch, tmp_path)
+        link = tmp_path / "spec.json"
+        link.symlink_to(cred)
+        assert self._script().main(["--spec", str(link)]) == 2
+        err = capsys.readouterr().err
+        assert "refused spec" in err
+        # Named by RESOLVED target, so the refusal says what it actually blocked.
+        assert ".aws" in err
+        assert "repro_gate" not in err
+
+    def test_an_ordinary_spec_beside_the_store_still_validates(self, tmp_path, capsys, monkeypatch):
+        """The gate must not cost the tool its job: a normal spec beside the
+        credential store reads and validates as before. This is the case the real
+        ``is_sensitive_path`` answers -- the wrapper delegates it."""
+        self._plant_credential_store(monkeypatch, tmp_path)
+        spec = tmp_path / "pipeline-spec.json"
+        spec.write_text(json.dumps({"verifier": {"repro_gate": "pod_required"}}), encoding="utf-8")
+        assert self._script().main(["--spec", str(spec)]) == 0
+        assert "OK" in capsys.readouterr().out
+
+        bad = tmp_path / "typo-spec.json"
+        bad.write_text(json.dumps({"verifier": {"repro_gate": "pod-required"}}), encoding="utf-8")
+        assert self._script().main(["--spec", str(bad)]) == 2
+        assert "verifier.repro_gate" in capsys.readouterr().err
+
+    def test_an_unenforceable_gate_refuses_rather_than_reading_plainly(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """A skill's scripts can run as bare files with ``kiro_crew`` off the
+        path. Degrading to ``read_text`` there would reopen the bypass in
+        the case least likely to be noticed, so absence of the gate is itself a
+        refusal.
+
+        The gate is unenforceable only once BOTH routes to it are gone: the
+        import here, and the re-exec under Kiro Crew's own interpreter that
+        ``TestSpecCheckRunsWhereTheGateIsImportable`` covers. Both are stubbed
+        out, so what this pins is the terminal state rather than the relocation.
+        """
+        script = self._script()
+        monkeypatch.setattr(script, "safe_read_file", None)
+        monkeypatch.setattr(script, "bundled_python", lambda: None)
+        spec = tmp_path / "pipeline-spec.json"
+        spec.write_text(json.dumps({"verifier": {"repro_gate": "pod_required"}}), encoding="utf-8")
+        assert script.main(["--spec", str(spec)]) == 2
+        err = capsys.readouterr().err
+        assert "cannot enforce the sensitive-path read gate" in err
+
+
+class TestSpecCheckRunsWhereTheGateIsImportable:
+    """The check has to reach an interpreter that can import the gate.
+
+    The procedure runs this script with a plain ``python3``, and the default
+    install is a managed venv whose interpreter is not the ``python3`` on the
+    operator's ``PATH``. Under that pairing the gate import fails, and since an
+    unenforceable gate is a refusal, the startup predicate refuses EVERY spec:
+    the fail-closed branch stops a healthy install from starting any run at all,
+    which is the opposite of what it exists for.
+
+    So the script re-runs itself under Kiro Crew's own interpreter -- the
+    ``kirocrew`` launcher's sibling -- the way ``web-verify``'s downscale helper
+    reaches Pillow. The read gate is never degraded, only relocated to a process
+    that has it, and the refusal stays last: a build with no launcher, and a
+    second failure inside the re-exec, both still refuse.
+    """
+
+    @staticmethod
+    def _script():
+        return load_skill_script("spec_check", SKILL_DIR / "scripts" / "spec_check.py")
+
+    @staticmethod
+    def _install(tmp_path):
+        """A synced copy of the script plus a launcher whose sibling has the gate.
+
+        Both halves mirror production. ``_ensure_builtin_skills`` copies the
+        packaged skill into the skills directory, so the file the agent runs sits
+        outside ``kiro_crew/`` and no ``__file__``-relative walk reaches the
+        package from it. And the launcher is the only handle on the interpreter:
+        a managed install puts ``kirocrew`` on ``PATH`` while the interpreter
+        beside it is on ``PATH`` nowhere.
+        """
+        scripts = tmp_path / "skills" / "pipeline-conductor" / "scripts"
+        scripts.mkdir(parents=True)
+        synced = scripts / "spec_check.py"
+        shutil.copy2(SKILL_DIR / "scripts" / "spec_check.py", synced)
+
+        bindir = tmp_path / "venv" / "bin"
+        bindir.mkdir(parents=True)
+        launcher = bindir / "kirocrew"
+        launcher.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        # A ``PATH`` lookup skips a file it cannot execute, so the mode is part of
+        # the fixture rather than decoration.
+        _make_executable(launcher)
+        # A shell shim, not a copied binary: the sibling only has to BE an
+        # interpreter that can import the gate, and the interpreter running this
+        # test already is one.
+        shim = bindir / "python"
+        shim.write_text(f'#!/bin/sh\nexec "{sys.executable}" "$@"\n', encoding="utf-8")
+        _make_executable(shim)
+        return synced, bindir
+
+    @staticmethod
+    def _run(synced, bindir, spec, home):
+        """Run the synced copy the way a managed install runs it.
+
+        ``-S`` drops ``site-packages``, which is where an install of any shape
+        puts the package, and ``-E`` drops ``PYTHONPATH``, which is how a source
+        tree can still be on it. Together they make this process's own
+        interpreter stand in for the operator's ``python3``, so the simulation
+        holds however the checkout under test happens to be installed.
+
+        ``KIROCREW_HOME`` and ``KIROCREW_WORKSPACE`` are pinned EXPLICITLY rather
+        than inherited. The rootdir ``_isolate_kirocrew_home`` fixture pins them
+        for this process, but a child assembled from ``os.environ`` is isolated
+        only for as long as that keeps being true, and reaching the operator's
+        real home is not a read: the gate imports ``config.paths``, whose
+        ``config_dir()`` CREATES the home and its marker on first use and can run
+        the legacy home migration as a side effect. Pinning also keeps one
+        developer's config drift out of the streams these assertions read, which
+        is why they check an exit code and one substring rather than the absence
+        of other output.
+        """
+        return subprocess.run(
+            [sys.executable, "-S", "-E", str(synced), "--spec", str(spec)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                **os.environ,
+                "PATH": str(bindir),
+                "KIROCREW_HOME": str(home),
+                "KIROCREW_WORKSPACE": str(home / "workspace"),
+            },
+        )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="the stand-in launcher sibling needs a POSIX '#!' line"
+    )
+    def test_a_valid_spec_starts_the_run_under_an_interpreter_without_the_package(self, tmp_path):
+        synced, bindir = self._install(tmp_path)
+        spec = tmp_path / "pipeline-spec.json"
+        spec.write_text(json.dumps({"verifier": {"repro_gate": "pod_required"}}), encoding="utf-8")
+        done = self._run(synced, bindir, spec, tmp_path / "home")
+        # Exit code plus the one line that only a completed check prints. The
+        # refusal exits 2, so a zero here already rules it out, and asserting on
+        # the ABSENCE of other stderr would make any incidental notice a failure.
+        assert done.returncode == 0, done.stderr
+        assert "OK" in done.stdout
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="the stand-in launcher sibling needs a POSIX '#!' line"
+    )
+    def test_a_malformed_spec_is_named_rather_than_traced(self, tmp_path):
+        """The operator's remedy travels through the re-exec, or the relocation
+        bought nothing: a traceback names no field to fix, and the gate refusal
+        names the wrong problem."""
+        synced, bindir = self._install(tmp_path)
+        bad = tmp_path / "typo-spec.json"
+        bad.write_text(json.dumps({"verifier": {"repro_gate": "pod-required"}}), encoding="utf-8")
+        done = self._run(synced, bindir, bad, tmp_path / "home")
+        assert done.returncode == 2
+        assert "verifier.repro_gate" in done.stderr
+        # The one negative worth keeping: an unimportable gate leaving as a
+        # traceback is the shape this whole path exists to prevent.
+        assert "Traceback" not in done.stderr, done.stderr
+
+    def test_the_injected_runtime_interpreter_is_authoritative(self, tmp_path, monkeypatch):
+        """The ACP parent supplies the exact interpreter already running Crew.
+
+        This is the normal path and must not depend on a launcher or a Python
+        basename being discoverable on the user's PATH.
+        """
+        script = self._script()
+        runtime_python = tmp_path / "sealed bundle" / "python3.12"
+        runtime_python.parent.mkdir(parents=True)
+        runtime_python.write_text("", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_RUNTIME_PYTHON", str(runtime_python))
+        monkeypatch.setattr(
+            script.shutil,
+            "which",
+            lambda _name: pytest.fail(
+                "launcher lookup must not run when the parent injected Python"
+            ),
+        )
+        assert script.bundled_python() == str(runtime_python)
+
+    def test_the_interpreter_is_the_launcher_s_sibling_resolved_through_the_link(
+        self, tmp_path, monkeypatch
+    ):
+        """``bin/kirocrew`` -> ``bin/python``, resolved on the REAL path.
+
+        The launcher is habitually a symlink from a user's ``bin`` directory into
+        the venv, so the sibling lookup has to run in the venv rather than beside
+        the link. ``realpath`` is patched instead of planting a symlink because
+        creating one needs a privilege the Windows runner does not hold.
+        """
+        script = self._script()
+        monkeypatch.delenv("KIROCREW_RUNTIME_PYTHON", raising=False)
+        bindir = tmp_path / "venv" / "bin"
+        bindir.mkdir(parents=True)
+        (bindir / "kirocrew").write_text("", encoding="utf-8")
+        (bindir / "python").write_text("", encoding="utf-8")
+        monkeypatch.setattr(
+            script.shutil, "which", lambda _name: str(tmp_path / "link" / "kirocrew")
+        )
+        monkeypatch.setattr(script.os.path, "realpath", lambda _p: str(bindir / "kirocrew"))
+        monkeypatch.setattr(script.os, "name", "posix")
+        assert script.bundled_python() == str(bindir / "python")
+
+    def test_the_posix_desktop_interpreter_is_the_versioned_sibling(self, tmp_path, monkeypatch):
+        """Desktop PBS layout: ``bin/kirocrew`` -> ``bin/python3.12``."""
+        script = self._script()
+        monkeypatch.delenv("KIROCREW_RUNTIME_PYTHON", raising=False)
+        bindir = tmp_path / "backend-dist" / "bin"
+        bindir.mkdir(parents=True)
+        launcher = bindir / "kirocrew"
+        launcher.write_text("", encoding="utf-8")
+        python = bindir / "python3.12"
+        python.write_text("", encoding="utf-8")
+        monkeypatch.setattr(script.shutil, "which", lambda _name: str(launcher))
+        monkeypatch.setattr(script.os, "name", "posix")
+        assert script.bundled_python() == str(python)
+
+    def test_the_windows_venv_interpreter_carries_the_exe_suffix(self, tmp_path, monkeypatch):
+        """``Scripts/kirocrew.exe`` -> ``Scripts/python.exe``."""
+        script = self._script()
+        monkeypatch.delenv("KIROCREW_RUNTIME_PYTHON", raising=False)
+        scripts = tmp_path / "venv" / "Scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "kirocrew.exe").write_text("", encoding="utf-8")
+        (scripts / "python.exe").write_text("", encoding="utf-8")
+        monkeypatch.setattr(script.shutil, "which", lambda _name: str(scripts / "kirocrew.exe"))
+        monkeypatch.setattr(script.os, "name", "nt")
+        got = script.bundled_python()
+        assert got is not None
+        # Compared as resolved paths: a Windows temporary directory is handed back
+        # in the short 8.3 form while ``realpath`` returns the long one, and the
+        # two name the same file.
+        assert os.path.realpath(got) == os.path.realpath(str(scripts / "python.exe"))
+
+    def test_the_windows_desktop_interpreter_is_above_the_cmd_shim(self, tmp_path, monkeypatch):
+        """Desktop PBS layout: ``bin\\kirocrew.cmd`` -> ``python.exe``."""
+        script = self._script()
+        monkeypatch.delenv("KIROCREW_RUNTIME_PYTHON", raising=False)
+        root = tmp_path / "backend-dist"
+        bindir = root / "bin"
+        bindir.mkdir(parents=True)
+        launcher = bindir / "kirocrew.cmd"
+        launcher.write_text("@echo off\n", encoding="utf-8")
+        python = root / "python.exe"
+        python.write_text("", encoding="utf-8")
+        monkeypatch.setattr(script.shutil, "which", lambda _name: str(launcher))
+        monkeypatch.setattr(script.os, "name", "nt")
+        assert script.bundled_python() == str(python)
+
+    def test_no_injected_path_or_launcher_leaves_no_interpreter_to_reach(self, monkeypatch):
+        script = self._script()
+        monkeypatch.delenv("KIROCREW_RUNTIME_PYTHON", raising=False)
+        monkeypatch.setattr(script.shutil, "which", lambda _name: None)
+        assert script.bundled_python() is None
+
+    def test_the_re_exec_refuses_instead_of_recursing(self, tmp_path, capsys, monkeypatch):
+        """An interpreter that also lacks the gate must not spawn a third: the
+        marker on the child is what turns a loop into the refusal."""
+        script = self._script()
+        monkeypatch.setattr(script, "safe_read_file", None)
+        monkeypatch.setenv(script._REEXEC_ENV, "1")
+        called = []
+        monkeypatch.setattr(script.subprocess, "call", lambda *a, **k: called.append(a) or 0)
+        spec = tmp_path / "pipeline-spec.json"
+        spec.write_text("{}", encoding="utf-8")
+        assert script.main(["--spec", str(spec)]) == 2
+        assert not called
+        assert "cannot enforce the sensitive-path read gate" in capsys.readouterr().err
+
+    def test_the_child_s_verdict_is_this_check_s_verdict(self, tmp_path, monkeypatch):
+        """The re-exec is a relocation, not a second opinion: the caller reads
+        the same exit code it would have read from a gate-carrying interpreter,
+        and the child's own message is what reaches the operator.
+        """
+        script = self._script()
+        monkeypatch.setattr(script, "safe_read_file", None)
+        monkeypatch.setattr(script, "bundled_python", lambda: "/venv/bin/python")
+        seen = {}
+
+        def record(argv, env=None):
+            seen["argv"] = argv
+            seen["env"] = env
+            return 2
+
+        monkeypatch.setattr(script.subprocess, "call", record)
+        spec = tmp_path / "pipeline-spec.json"
+        spec.write_text("{}", encoding="utf-8")
+        assert script.main(["--spec", str(spec)]) == 2
+        assert seen["argv"][0] == "/venv/bin/python"
+        assert seen["argv"][1:3] == ["-I", "-B"]
+        assert seen["argv"][3] == os.path.abspath(script.__file__)
+        assert seen["argv"][4:] == ["--spec", str(spec)]
+        # The marker travels on the child, or the child re-execs in turn.
+        assert seen["env"][script._REEXEC_ENV] == "1"
+
+    def test_the_caller_s_data_home_reaches_the_child_unchanged(self, tmp_path, monkeypatch):
+        """The script pins no home of its own, in either direction.
+
+        Which home the check reads is the CALLER's decision -- an operator with a
+        relocated ``KIROCREW_HOME``, and a pod whose whole isolation is that
+        variable, both need the child to resolve exactly what the parent was
+        given. So the re-exec forwards the environment and adds only its own loop
+        marker; a home pinned here would silently retarget the sensitive-path
+        gate away from the caller's own boundary.
+        """
+        script = self._script()
+        monkeypatch.setattr(script, "safe_read_file", None)
+        monkeypatch.setattr(script, "bundled_python", lambda: "/venv/bin/python")
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "relocated"))
+        seen = {}
+        monkeypatch.setattr(
+            script.subprocess, "call", lambda argv, env=None: seen.update(env=env) or 0
+        )
+        spec = tmp_path / "pipeline-spec.json"
+        spec.write_text("{}", encoding="utf-8")
+        script.main(["--spec", str(spec)])
+        assert seen["env"]["KIROCREW_HOME"] == str(tmp_path / "relocated")
 
 
 class TestProbeSignalsAreDocumented:
@@ -798,7 +1384,7 @@ class TestDesignDocTracksTheSkill:
         doc = _flat(_read(DESIGN_DOC))
         assert "admission is sized on delivery" in doc
 
-    def test_design_doc_names_all_three_scripts(self):
+    def test_design_doc_names_every_bundled_script(self):
         doc = _read(DESIGN_DOC)
         for script in BUNDLED_SCRIPTS:
             assert script in doc, script


### PR DESCRIPTION
## Problem / Motivation

A pipeline marked `pod_required` could still fix issues with unit evidence and count the run as pod-verified. A typo such as `pod-required` also matched neither mode, which silently disabled the admission rule while the spec said it was active.

## Why it matters

A pod-verification campaign must measure real product-path reproductions. Otherwise a green report proves only that unit tests passed, not that the reported failure was seen and fixed in a live pod.

## What changed (motivation → approach → change)

`PipelineSpec` now has `verifier.repro_gate`. `best_effort` is the default. `pod_required` forbids source, test, or documentation edits until the unmodified worktree reproduces the issue through a live pod product route. Missing routes, identities, scenarios, host capabilities, or required browser engines produce `STANDDOWN: pod-repro-ineligible — <evidence>; missing=<capability>` with no commit or PR. The same live trace must turn green before `GREEN`. Existing `best_effort` behavior stays the same, but every rendered work-order brief gains the repro-gate text because both modes share the template.

`scripts/spec_check.py` is now the first startup action. It reads the operator-supplied spec through `hooks.safe_read_file`, validates closed-value fields, and exits 2 on malformed or unreadable input instead of guessing a mode. Both ACP spawn paths overwrite `KIROCREW_RUNTIME_PYTHON` with their own `sys.executable` after environment scrubbing, and startup invokes the checker through that absolute path instead of a system `python` name. Direct and fallback invocations pass `-I` so user-site, script-directory, current-directory, and inherited Python startup code cannot run before the read gate. `-B` preserves the sealed desktop bundle's no-bytecode-write rule because isolated mode ignores `PYTHONDONTWRITEBYTECODE`. Manual and older invocations still resolve venv, POSIX desktop `bin/python3.12`, and Windows desktop bundle-root `python.exe` layouts. `KIROCREW_SPEC_CHECK_REEXEC` prevents recursive relocation. Only after the checker exits 0 may the conductor read and use the spec or create the pipeline folder.

```mermaid
flowchart LR
  subgraph Before
    A1[agent reads spec]:::removed --> B1[checker validates it]:::removed --> C1[pipeline starts]:::ctx
  end
  subgraph After
    A2[checker safely reads and validates spec]:::added --> B2[agent reads validated spec]:::changed --> C2[pipeline starts]:::ctx
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The checker now performs the first read; the conductor sees the spec only after validation succeeds.*

## Scope

This PR changes ten files: the pipeline spec, shared work-order brief, agent prompt, RFC, module spec, three contract/spawn tests, both ACP spawn paths, and the 242-line `scripts/spec_check.py` startup validator. The ACP parents inject `KIROCREW_RUNTIME_PYTHON`; the validator retains `KIROCREW_SPEC_CHECK_REEXEC` for its manual/legacy relocation fallback. The pod admission verdict remains an agent-enforced procedure checked by contract tests and campaign audit. This PR does not add a machine-verified trace artifact before `GREEN`. It does not change `fleet_probe.py`'s conductor-generated config read or replace the one-entry closed-field registry.

## Tests

- `python -m pytest -q -n0 test/test_pipeline_conductor_skill_contract.py test/test_acp_client.py::TestSpawnEnvScrub::test_client_spawn_scrubs_sensitive_env_on_default_auto test/test_acp_runtime.py::test_runtime_spawn_scrubs_sensitive_env_on_default_auto test/test_security_posture.py test/test_spawn_audit.py` — 185 passed. The tests pin validation before the conductor read, the injected interpreter on both ACP paths, venv/POSIX-desktop/Windows-desktop resolution, and the security/spawn contracts.
- Black, isort, and flake8 pass on all touched Python files; mypy passes on the three touched production modules.
- `./scripts/docs-lint.sh`, `python3 scripts/check_builtin_skill_scope.py`, `python3 scripts/check_subprocess_encoding.py`, `git diff --check`, and the single-commit push guard pass.

## Manual verification

The original change was exercised by a live ten-issue campaign: four issues entered through real pod reproductions, five stood down with measured missing capabilities, and one recorded an orchestration failure. No unit-only fix counted as pod-loop success.

## Related Issues

no linked issue: this is a pipeline-conductor workflow hardening slice from the verification campaign.

## Pattern harvest

Rule candidate: review-prompt
Pattern: A guard instruction must place the guard before every unguarded use, and its contract test must assert ordering rather than substring presence.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
