### PR TITLE
feat(memory): expose read-volume counters for observability

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -247,6 +247,23 @@ SQLite table `episodic_memories` — conversation fragments with optional embedd
 
 Context injection: `_DEFAULT_EPISODIC_LIMIT` = 8 results in an `[Episodic Memory]` block, each fragment sliced to 1,500 chars, total bounded by `min(_EPISODIC_INJECT_CAP, caps.episodic)` where `_EPISODIC_INJECT_CAP` = 3,000. Injected on the first message of new sessions through the single `memory.get_context()` call in `build_session_context()`, which passes the user's message as the query; episodic is query-gated inside `get_context`, so callers without a message (eval runner) inject none, and follow-up turns never re-inject (ACP native history provides in-thread context).
 
+### Read-volume counters (`_ReadCounters`, `read_counters()`)
+
+Six monotonic per-store-instance integer totals recording how much the store READ. They exist because a whole-population scan is otherwise **unobservable from outside the process**: a SELECT moves neither `PRAGMA data_version` nor the WAL, so a second process cannot tell one materialized row from a thousand, and wall-clock timing is not admissible evidence of a read-volume claim. Counting is unconditional (a method call and a few integer adds per SELECT) — only the EXPOSURE is a surface decision.
+
+| Counter | Counts |
+|---|---|
+| `statements_executed` | SELECTs routed through `_fetch_all_locked` / `_fetch_one_locked`, all tables |
+| `rows_read` | rows those SELECTs materialized, all tables |
+| `semantic_rows_read` | rows materialized by whole-population **semantic retrieval** scans |
+| `semantic_full_scans` | how many such semantic scans ran |
+| `episodic_rows_read` | rows materialized by whole-population **episodic retrieval** scans |
+| `episodic_full_scans` | how many such episodic scans ran |
+
+The four marked scan sites (`_fetch_all_locked(..., scan=...)`, plus one direct `record()` inside `_build_episodic_scoring_set`'s own locked block) are exactly the whole-population reads #8971 names: `get_semantic_context`'s query branch, `get_lessons()` unbounded (what the `_stored_similarity_scorer` callers score over), `_sqlite_vector_search`'s per-call read, and the resident scoring-set build. A bounded read — `get_semantic_context` with no query, `get_lessons(limit=N)`, any keyed lookup — contributes to the all-tables totals only, so a rising `*_full_scans` always means a population was re-read. On the episodic side both rungs land on the same counter, so `episodic_full_scans` rising with WRITES rather than with searches is what the resident set (#8956) looks like from outside; the semantic surface has no such set yet, which is #8971.
+
+Semantics that matter to a caller: per instance and per process (two processes over one file report their own reads independently, never a shared total), never persisted, never reset, and no timing metric is recorded or derived. Every increment happens under `_db_lock`, so `read_counters()` — which takes the same lock — returns an untorn snapshot and no count is lost to a concurrent reader. Two identical `GET /api/memory/observability?q=…` calls with no write in between, compared field by field, are the intended probe.
+
 ### Fading: three independent decay mechanisms
 
 Three unrelated mechanisms keep stale memory out of the context budget. They do
@@ -386,12 +403,14 @@ Model: `Qwen/Qwen3-Embedding-0.6B` Q8_0 GGUF (610MB). Apache-2.0 licensed. Serve
 | POST | `/api/memory/migrate` | Migrate markdown → structured memory |
 | POST | `/api/memory/import` | Import from JSON export |
 | GET | `/api/memory/context-preview?q=` | Preview injected semantic + episodic context |
+| GET | `/api/memory/observability?q=` | `stats` + `rejections` + `context_preview`, plus `reads` — the read-volume counters (see above). `reads` is resolved LAST, so it INCLUDES the reads this request itself performed; that is what lets a caller issue the same `q` twice and compare the two objects |
 
 ### CLI
 
 `kirocrew memory {list,search,show,stats,audit,export,migrate,import}` — manage memory from the command line:
 - `show [preferences|projects|history]` — read the markdown layer through `MemoryStore` (all three targets when none given); `--format md|json` (json entries carry `path`, `updated_at` mtime in UTC ISO-8601, `content`), `--since YYYY-MM-DD` filters history days. Missing/empty files print as empty rather than erroring
 - `search <query>` — searches BOTH memories and labels each section: the vector store's episodic recall, then keyword hits from the markdown layer's FTS5 index (`MemoryStore.search`, over `preferences.md` / `projects.md` / every `history/*.md`). `--layer vector|history|all` (default `all`); `--layer vector` reproduces the previous vector-only output exactly, and `--layer history` skips constructing the vector store entirely, the same way `show` does. The two indexes answer different questions — "where did I write this word" versus "what does this mean like" — so they are reported separately rather than merged into one ranking
+- `stats` — counts, embedded coverage, FAISS accelerator status, audit event count, and a **`Reads (this process)`** block from `read_counters()` (rows + statements, then the semantic/episodic population-scan tallies). Labelled per-process because the CLI constructs its own store, so the totals describe only what this invocation read; the gateway's totals are the `reads` object on `GET /api/memory/observability`
 - `export` — vector-store collections; `--include-markdown` opts in a `markdown` collection (`preferences`/`projects` entries + per-day `history` list from `MemoryStore.markdown_snapshot()`) without changing the default payload shape
 - `migrate` — one-time markdown → structured migration (preferences.md → semantic, history/*.md → episodic)
 - `import <file>` — restore from JSON export with full validation

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -2307,6 +2307,21 @@ def _memory_cmd(args: argparse.Namespace) -> None:
             else:
                 print("  FAISS accelerator: not installed — stdlib cosine fallback (exact)")
             print(f"  Audit events: {stats['events_count']}")
+            reads = store.read_counters()
+            # This process only: the store was constructed for this command, so
+            # the totals describe the reads this invocation itself performed, not
+            # the store's lifetime. The gateway's own totals are the `reads`
+            # object on GET /api/memory/observability.
+            print(
+                f"  Reads (this process): {reads['rows_read']} rows over "
+                f"{reads['statements_executed']} statements"
+            )
+            print(
+                f"    population scans: semantic {reads['semantic_full_scans']}"
+                f" ({reads['semantic_rows_read']} rows),"
+                f" episodic {reads['episodic_full_scans']}"
+                f" ({reads['episodic_rows_read']} rows)"
+            )
 
         elif action == "audit":
             findings = scan_memory()

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -1422,11 +1422,17 @@ async def api_memory_observability(request: web.Request) -> web.Response:
     # semantic row (blocking urllib per row) — the worst on-loop amplification
     # in the store; offload so it can't stall the gateway event loop.
     preview = await run_in_embed_pool(store.get_context_preview, query_text=query)
+    # Read LAST, deliberately: the counters then include the reads this very
+    # request performed, so a caller can issue ?q=... twice and compare the two
+    # `reads` objects to see whether the second identical search re-read the
+    # population (#8971). Offloaded like the others — it takes _db_lock.
+    reads = await asyncio.to_thread(store.read_counters)
     return web.json_response(
         {
             "stats": stats,
             "rejections": rejections,
             "context_preview": preview,
+            "reads": reads,
         }
     )
 

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -22,12 +22,12 @@ import struct
 import threading
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Literal
 from uuid import uuid4
 
 from snowballstemmer import stemmer as _snowball_stemmer
@@ -830,6 +830,59 @@ def _is_selective_keyword(word: str) -> bool:
 # ── Store ──
 
 
+# A whole-population retrieval scan, as opposed to a bounded or single-row read.
+# Only the two surfaces #8971 is about are attributed; everything else lands in
+# the all-tables totals.
+_ScanSurface = Literal["semantic", "episodic"]
+
+
+@dataclass
+class _ReadCounters:
+    """How much this store READ, as monotonic per-instance totals.
+
+    A whole-population scan is invisible from outside the process: a SELECT
+    moves neither ``PRAGMA data_version`` nor the WAL, so a second process
+    cannot tell one materialized row from a thousand, and wall-clock timing is
+    not admissible evidence. These counters are the in-band signal instead, so a
+    caller can assert that a second identical search did not re-read the
+    population (#8971) the way ``_EpisodicScoringSet`` already avoids on the
+    episodic side (#8956).
+
+    Cost is a method call and a few integer adds per SELECT, so counting is
+    always on; only the EXPOSURE is a surface decision. Every increment happens
+    under ``_db_lock`` (the fetch helpers hold it, and the one direct caller
+    increments inside its own locked block), so a snapshot taken under the same
+    lock is never torn and no count is lost to a concurrent reader.
+    """
+
+    statements_executed: int = 0
+    rows_read: int = 0
+    semantic_rows_read: int = 0
+    semantic_full_scans: int = 0
+    episodic_rows_read: int = 0
+    episodic_full_scans: int = 0
+
+    def record(self, rows: int, scan: _ScanSurface | None = None) -> None:
+        """Credit one materialized SELECT of *rows* rows.
+
+        *scan* marks the read as a whole-population retrieval scan of that
+        surface; leaving it None still credits the all-tables totals, which is
+        the right answer for a bounded or keyed read.
+        """
+        self.statements_executed += 1
+        self.rows_read += rows
+        if scan == "semantic":
+            self.semantic_rows_read += rows
+            self.semantic_full_scans += 1
+        elif scan == "episodic":
+            self.episodic_rows_read += rows
+            self.episodic_full_scans += 1
+
+    def snapshot(self) -> dict[str, int]:
+        """Return the totals as a plain JSON-serializable dict."""
+        return asdict(self)
+
+
 @dataclass(frozen=True)
 class _EpisodicScoringSet:
     """The episodic columns a vector search needs to SCORE, held in memory.
@@ -908,6 +961,10 @@ class VectorMemoryStore:
         # NOTE: never hold this across a blocking embed call — embeds happen
         # before the locked region so the lock only guards local db/FAISS work.
         self._db_lock = threading.RLock()
+        # Read-volume totals. Guarded by _db_lock (see _ReadCounters) rather than
+        # a lock of their own: every increment already sits inside a locked fetch,
+        # so the counting adds no synchronization to the read path.
+        self._reads = _ReadCounters()
         # FAISS state
         self._faiss_index: object | None = None  # faiss.IndexFlatIP (untyped)
         self._faiss_id_map: list[str] = []
@@ -1145,15 +1202,42 @@ class VectorMemoryStore:
     # so callers never iterate a live cursor unlocked — and per the lock's
     # contract, never call a blocking embed while holding it.
 
-    def _fetch_all_locked(self, sql: str, params: Sequence[object] = ()) -> list[sqlite3.Row]:
-        """Run a SELECT serialized on ``_db_lock``; return materialized rows."""
+    def _fetch_all_locked(
+        self,
+        sql: str,
+        params: Sequence[object] = (),
+        *,
+        scan: _ScanSurface | None = None,
+    ) -> list[sqlite3.Row]:
+        """Run a SELECT serialized on ``_db_lock``; return materialized rows.
+
+        Pass *scan* at the few call sites that read a whole population, so the
+        read-volume counters can attribute it to that surface (see
+        :class:`_ReadCounters`). The default leaves the read in the all-tables
+        totals only, which is correct for a bounded or keyed fetch.
+        """
         with self._db_lock:
-            return self.db.execute(sql, params).fetchall()
+            rows = self.db.execute(sql, params).fetchall()
+            self._reads.record(len(rows), scan)
+            return rows
 
     def _fetch_one_locked(self, sql: str, params: Sequence[object] = ()) -> sqlite3.Row | None:
         """Run a SELECT serialized on ``_db_lock``; return the first row or None."""
         with self._db_lock:
-            return self.db.execute(sql, params).fetchone()
+            row = self.db.execute(sql, params).fetchone()
+            self._reads.record(1 if row is not None else 0)
+            return row
+
+    def read_counters(self) -> dict[str, int]:
+        """Return this store's monotonic read-volume totals.
+
+        Per store INSTANCE and per process: the counts start at zero on
+        construction, only ever rise, and are not persisted, so two processes
+        over one database file report their own reads independently. See
+        :class:`_ReadCounters` for what each key counts.
+        """
+        with self._db_lock:
+            return self._reads.snapshot()
 
     # ── Key Validation ──
 
@@ -1661,7 +1745,8 @@ class VectorMemoryStore:
             # contract). The helper materializes the rows.
             all_rows = self._fetch_all_locked(
                 "SELECT key, value_json, updated_at, embedding FROM semantic_memory "
-                "WHERE is_deleted = 0 AND key NOT LIKE 'lesson.%'"
+                "WHERE is_deleted = 0 AND key NOT LIKE 'lesson.%'",
+                scan="semantic",
             )
 
             # Stored write-time vectors only — one embed per request (the query),
@@ -2350,7 +2435,8 @@ class VectorMemoryStore:
         rows = self._fetch_all_locked(
             "SELECT id, conversation_id, text, tags, importance, created_at, "
             "last_accessed_at, embedding FROM episodic_memories "
-            "WHERE is_deleted = 0 AND embedding IS NOT NULL"
+            "WHERE is_deleted = 0 AND embedding IS NOT NULL",
+            scan="episodic",
         )
 
         logger.debug(
@@ -2509,6 +2595,11 @@ class VectorMemoryStore:
                 "COALESCE(LENGTH(text), 0) AS text_len, embedding "
                 "FROM episodic_memories WHERE is_deleted = 0 AND embedding IS NOT NULL"
             ).fetchall()
+            # This is the population read the resident set exists to pay ONCE per
+            # invalidation instead of once per search, so it is credited like the
+            # per-call scan it replaces — a store on this tier shows
+            # episodic_full_scans rising with writes, not with searches.
+            self._reads.record(len(rows), "episodic")
 
         ids: list[str] = []
         blobs: list[bytes] = []
@@ -3557,7 +3648,12 @@ class VectorMemoryStore:
             sql += " LIMIT ?"
             rows = self._fetch_all_locked(sql, (limit,))
         else:
-            rows = self._fetch_all_locked(sql)
+            # Unbounded: the whole lesson population, which is what the
+            # _stored_similarity_scorer callers (_rank_lessons,
+            # find_contradiction_candidates) score over — the other half of
+            # #8971's read-volume shape. The LIMIT branch above is bounded and
+            # so is not a population scan.
+            rows = self._fetch_all_locked(sql, scan="semantic")
         return [dict(r) for r in rows]
 
     def count_lessons(self) -> int:

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -1679,6 +1679,34 @@ class TestMemoryCli:
         assert "Embedded: 7/7" in out
         assert "FAISS accelerator: 10 vectors indexed" in out
 
+    def test_stats_reports_read_volume_labelled_as_this_process(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The CLI builds its own store, so the totals must not read as lifetime."""
+        with _MemHarness() as h:
+            h.store.memory_stats.return_value = {
+                "semantic_active": 3,
+                "semantic_deleted": 0,
+                "episodic_active": 7,
+                "episodic_deleted": 0,
+                "faiss_index_size": 0,
+                "events_count": 4,
+                "embedded_count": 7,
+                "faiss_available": False,
+            }
+            h.store.read_counters.return_value = {
+                "statements_executed": 9,
+                "rows_read": 40,
+                "semantic_rows_read": 12,
+                "semantic_full_scans": 2,
+                "episodic_rows_read": 21,
+                "episodic_full_scans": 3,
+            }
+            cc._memory_cmd(_ns(mem_action="stats"))
+        out = capsys.readouterr().out
+        assert "Reads (this process): 40 rows over 9 statements" in out
+        assert "population scans: semantic 2 (12 rows), episodic 3 (21 rows)" in out
+
     def test_stats_without_faiss_reports_fallback_not_zero_vectors(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -113,6 +113,7 @@ def _store(**attrs: Any) -> Any:
     store.memory_stats.return_value = {"semantic_count": 0}
     store.get_rejection_stats.return_value = {}
     store.get_context_preview.return_value = {"semantic": ""}
+    store.read_counters.return_value = {"rows_read": 0}
     store.get_semantic_context.return_value = ""
     store.get_episodic_context.return_value = ""
     store.import_memory.return_value = {"semantic": 0, "episodic": 0}
@@ -1077,13 +1078,32 @@ class TestContextPreviewAndObservability:
         store.memory_stats.return_value = {"semantic_count": 1}
         store.get_rejection_stats.return_value = {"allowlist_reject": 2}
         store.get_context_preview.return_value = {"semantic": "s"}
+        store.read_counters.return_value = {"semantic_full_scans": 3}
         state = _make_state(vector_store=store)
         req = _make_request(state, query={"q": "q" * 900})
         body = _body(await mem_mod.api_memory_observability(req))
         assert body["stats"] == {"semantic_count": 1}
         assert body["rejections"] == {"allowlist_reject": 2}
         assert body["context_preview"] == {"semantic": "s"}
+        assert body["reads"] == {"semantic_full_scans": 3}
         assert len(store.get_context_preview.call_args.kwargs["query_text"]) == 500
+
+    @pytest.mark.asyncio
+    async def test_observability_reads_the_counters_after_the_preview(self) -> None:
+        """Ordering is the contract: `reads` must include THIS request's scans.
+
+        The preview is what reaches the full-read branch, so counters resolved
+        before it would under-report by exactly the scan the caller is probing
+        for (#8971). Own-suite coverage of the real numbers lives in
+        ``test_memory_read_counters.py``; here only the order is pinned.
+        """
+        calls: list[str] = []
+        store = _store()
+        store.get_context_preview.side_effect = lambda **_: calls.append("preview") or {}
+        store.read_counters.side_effect = lambda: calls.append("reads") or {}
+        state = _make_state(vector_store=store)
+        await mem_mod.api_memory_observability(_make_request(state, query={"q": "tea"}))
+        assert calls == ["preview", "reads"]
 
 
 class TestPromote:

--- a/test/test_memory_read_counters.py
+++ b/test/test_memory_read_counters.py
@@ -1,0 +1,227 @@
+"""Read-volume counters on ``VectorMemoryStore`` — the observable for #8971.
+
+#8971 reports that the semantic-side searches re-read every row per call. The
+stand-down on that issue found the defect real and HTTP-reachable but
+UNASSERTABLE from outside the process: a SELECT moves neither ``data_version``
+nor the WAL, the observability endpoint reported context sizes rather than rows
+scanned, and wall-clock timing is not admissible evidence. These tests pin the
+structural signal that closes that gap, so a live pod can assert the read
+volume of a query path instead of inferring it from a stopwatch.
+
+They do NOT assert the defect is fixed. ``test_a_second_identical_semantic_search_
+scans_the_population_again`` deliberately pins today's re-read as VISIBLE; when
+#8971 lands, that test is the one that flips, which is the point of having it.
+
+No embedder is wired here (``embed_fn`` stays None), so the semantic path scores
+keyword-only and the episodic path takes its stdlib rung — both still perform the
+population reads under test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import kiro_crew.dashboard.handlers.memory as mem_mod
+from kiro_crew.vector_memory import VectorMemoryStore
+
+_COUNTER_KEYS = {
+    "statements_executed",
+    "rows_read",
+    "semantic_rows_read",
+    "semantic_full_scans",
+    "episodic_rows_read",
+    "episodic_full_scans",
+}
+
+
+def _store(tmp_path: Path, *, semantic: int = 0) -> VectorMemoryStore:
+    store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+    store.init()
+    for i in range(semantic):
+        store.set_semantic(f"pref.item{i}", f"value {i} tea", 0.9, "user_explicit")
+    return store
+
+
+class TestCounterContract:
+    def test_a_fresh_store_exposes_every_counter_at_zero(self, tmp_path: Path) -> None:
+        """The counter-absent assertion: no ``read_counters`` at all fails here."""
+        store = _store(tmp_path)
+        assert store.read_counters() == dict.fromkeys(_COUNTER_KEYS, 0)
+
+    def test_counters_are_monotonic_and_per_instance(self, tmp_path: Path) -> None:
+        store = _store(tmp_path, semantic=2)
+        store.get_semantic_context(query_text="tea")
+        first = store.read_counters()
+        assert first["semantic_full_scans"] == 1
+        store.get_semantic_context(query_text="tea")
+        assert store.read_counters()["semantic_full_scans"] == 2
+        # A second store over the SAME file counts only its own reads, which is
+        # what makes a two-process comparison meaningful rather than shared.
+        other = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        other.init()
+        assert other.read_counters()["semantic_full_scans"] == 0
+        assert store.read_counters()["semantic_full_scans"] == 2
+
+    def test_a_snapshot_does_not_alias_the_live_counters(self, tmp_path: Path) -> None:
+        store = _store(tmp_path, semantic=1)
+        snapshot = store.read_counters()
+        store.get_semantic_context(query_text="tea")
+        assert snapshot["semantic_full_scans"] == 0
+
+
+class TestSemanticSurface:
+    def test_the_full_read_branch_credits_every_row_it_materializes(self, tmp_path: Path) -> None:
+        store = _store(tmp_path, semantic=4)
+        before = store.read_counters()
+        store.get_semantic_context(query_text="tea")
+        after = store.read_counters()
+        assert after["semantic_full_scans"] - before["semantic_full_scans"] == 1
+        assert after["semantic_rows_read"] - before["semantic_rows_read"] == 4
+        assert after["rows_read"] - before["rows_read"] >= 4
+
+    def test_a_second_identical_semantic_search_scans_the_population_again(
+        self, tmp_path: Path
+    ) -> None:
+        """The #8971 assertion, in the form a live pod can make.
+
+        Two identical searches with no write in between read the population
+        twice today. When #8971 lands (resident scoring columns under a
+        (generation, data_version) token, the #8956 shape), the second call
+        stops scanning and these numbers stay flat — so this test is the ratchet
+        that has to be updated by the fix, not silently satisfied by it.
+        """
+        store = _store(tmp_path, semantic=4)
+        store.get_semantic_context(query_text="tea")
+        one = store.read_counters()
+        store.get_semantic_context(query_text="tea")
+        two = store.read_counters()
+        assert two["semantic_full_scans"] - one["semantic_full_scans"] == 1
+        assert two["semantic_rows_read"] - one["semantic_rows_read"] == 4
+
+    def test_the_recency_branch_is_not_counted_as_a_population_scan(self, tmp_path: Path) -> None:
+        """No query means a bounded ``LIMIT`` read, which is a different shape."""
+        store = _store(tmp_path, semantic=4)
+        before = store.read_counters()
+        store.get_semantic_context()
+        after = store.read_counters()
+        assert after["semantic_full_scans"] == before["semantic_full_scans"]
+        assert after["semantic_rows_read"] == before["semantic_rows_read"]
+        assert after["rows_read"] > before["rows_read"]
+
+    def test_unbounded_get_lessons_is_a_population_scan_but_a_limited_one_is_not(
+        self, tmp_path: Path
+    ) -> None:
+        """The other half of #8971: the ``_stored_similarity_scorer`` callers."""
+        store = _store(tmp_path)
+        store.write_lesson("always run the build before pushing")
+        before = store.read_counters()
+        store.get_lessons()
+        unbounded = store.read_counters()
+        assert unbounded["semantic_full_scans"] - before["semantic_full_scans"] == 1
+        store.get_lessons(limit=1)
+        limited = store.read_counters()
+        assert limited["semantic_full_scans"] == unbounded["semantic_full_scans"]
+        assert limited["rows_read"] > unbounded["rows_read"]
+
+
+class TestEpisodicSurface:
+    def test_an_episodic_search_credits_the_population_it_scans(self, tmp_path: Path) -> None:
+        """Either episodic rung — resident build or per-call read — is credited.
+
+        The resident set (#8956) pays the population read once per invalidation
+        and the per-call rung pays it once per search; both land on
+        ``episodic_full_scans``, so the counter reads the same on a numpy install
+        and a stock one, and the DIFFERENCE between them is exactly what the
+        cross-call comparison shows.
+        """
+        store = _store(tmp_path)
+        for i in range(3):
+            store.write_episodic(f"a conversation fragment number {i} about tea")
+        # Stored embeddings need an embedder; without one the rows carry no
+        # vector, so drive the scan through a query embedding directly.
+        before = store.read_counters()
+        store._sqlite_vector_search([0.1, 0.2, 0.3], "tea", 5, None, False)
+        after = store.read_counters()
+        assert after["episodic_full_scans"] - before["episodic_full_scans"] == 1
+        assert after["semantic_full_scans"] == before["semantic_full_scans"]
+
+
+class TestAllTablesTotals:
+    def test_a_keyed_read_counts_a_statement_without_any_population_scan(
+        self, tmp_path: Path
+    ) -> None:
+        store = _store(tmp_path, semantic=1)
+        before = store.read_counters()
+        store.get_semantic("pref.item0")
+        after = store.read_counters()
+        assert after["statements_executed"] > before["statements_executed"]
+        assert after["semantic_full_scans"] == before["semantic_full_scans"]
+        assert after["episodic_full_scans"] == before["episodic_full_scans"]
+
+    def test_a_miss_counts_the_statement_but_no_rows(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        before = store.read_counters()
+        assert store.get_semantic("pref.absent") is None
+        after = store.read_counters()
+        assert after["statements_executed"] - before["statements_executed"] == 1
+        assert after["rows_read"] == before["rows_read"]
+
+
+def _request(store: VectorMemoryStore, *, query: dict[str, str]) -> Any:
+    """A faked ``web.Request`` wired to a REAL store.
+
+    The rest of the memory handler suite mocks the store; here the store must be
+    real, because the assertion under test is that the counters a live gateway
+    would report reach the response body.
+    """
+    mem = MagicMock()
+    mem.vector_store = store
+    state = MagicMock()
+    state.context_builder = MagicMock(memory=mem)
+    state._slots = {}
+    state._restricted_keys = set()
+    req = MagicMock()
+    req.app = {"state": state}
+    req.method = "GET"
+    req.query = query
+    req.match_info = {}
+    req.headers = {}
+    req.can_read_body = False
+    req.json = AsyncMock(return_value=None)
+    return req
+
+
+class TestObservabilityEndpoint:
+    @pytest.mark.asyncio
+    async def test_the_response_carries_a_reads_object(self, tmp_path: Path) -> None:
+        store = _store(tmp_path, semantic=4)
+        body = json.loads(
+            (await mem_mod.api_memory_observability(_request(store, query={"q": "tea"}))).text or ""
+        )
+        assert set(body["reads"]) == _COUNTER_KEYS
+
+    @pytest.mark.asyncio
+    async def test_a_queried_request_reports_its_own_semantic_scan(self, tmp_path: Path) -> None:
+        """The counters are read LAST, so the request's own scan is included.
+
+        That ordering is what makes the endpoint usable as the #8971 probe: an
+        agent calls it twice with the same ``q`` and compares the two objects.
+        """
+        store = _store(tmp_path, semantic=4)
+        first = json.loads(
+            (await mem_mod.api_memory_observability(_request(store, query={"q": "tea"}))).text or ""
+        )["reads"]
+        second = json.loads(
+            (await mem_mod.api_memory_observability(_request(store, query={"q": "tea"}))).text or ""
+        )["reads"]
+        assert first["semantic_full_scans"] >= 1
+        assert first["semantic_rows_read"] >= 4
+        # Identical second request, and the endpoint shows it paid for the
+        # population again — the observation #8971 needs and could not make.
+        assert second["semantic_full_scans"] > first["semantic_full_scans"]
+        assert second["semantic_rows_read"] - first["semantic_rows_read"] >= 4


### PR DESCRIPTION
<!-- no-visual-delta -->

## What

Adds six read-volume counters to the memory vector store and surfaces them on `GET /api/memory/observability` (a new `reads` object) and `kirocrew memory stats`.

This is a **capability enabler, not a fix**. It does not change how much the store reads.

## Why

The stand-down comment on #8971 found the reported defect real and HTTP-reachable, but **unassertable from outside the process**, so no fix was attempted:

> An unmodified `memory-populated` pod booted healthy [...] The query path reaches the full-read branch through `/api/memory/observability?q=...`, but that endpoint reports population/context sizes — not rows scanned. Source-wide search found no sqlite trace/authorizer/progress hook or read/query counter; SELECT changes neither data_version nor WAL, so a second process cannot observe this in-process row materialization. Wall-clock timing is expressly not admission. [...] Missing capability: product-level query/read instrumentation (or a separately designed diagnostic counter) that a live pod can assert.

That is the gap this closes. A `SELECT` moves neither `PRAGMA data_version` nor the WAL, so a second process cannot tell one materialized row from a thousand, and a stopwatch is not admissible evidence of a read-volume claim. With these counters an agent can make the structural assertion directly: call the endpoint twice with the same `q` and compare the two `reads` objects.

## Counter semantics

| Counter | Counts |
|---|---|
| `statements_executed` | SELECTs routed through the two locked-fetch helpers, all tables |
| `rows_read` | rows those SELECTs materialized, all tables |
| `semantic_rows_read` | rows materialized by whole-population **semantic retrieval** scans |
| `semantic_full_scans` | how many such semantic scans ran |
| `episodic_rows_read` | rows materialized by whole-population **episodic retrieval** scans |
| `episodic_full_scans` | how many such episodic scans ran |

Per store instance and per process, monotonic, never persisted, never reset. Two processes over one database file report their own reads independently rather than a shared total. **No timing metric is recorded or derived.**

Only four sites are marked as population scans — exactly the whole-population reads #8971 names: `get_semantic_context`'s query branch, unbounded `get_lessons()` (what the `_stored_similarity_scorer` callers score over), `_sqlite_vector_search`'s per-call read, and the resident scoring-set build introduced by #8956. Any bounded or keyed read lands in the all-tables totals only, so a rising `*_full_scans` always means a population was re-read.

Both episodic rungs credit the same counter deliberately. The resident set (#8956) pays the population read once per invalidation and the per-call rung once per search, so `episodic_full_scans` rising with **writes** rather than with **searches** is what a fixed surface looks like from outside — and the semantic surface having no such set is #8971.

## Design notes

- **Always-on counting, gated exposure.** The cost is a method call and a few integer adds per SELECT, so there is no flag on the counting; only the surfaces are a decision.
- **No sqlite trace/authorizer/progress callback.** Increments sit at the few real fetch sites instead, so the accounting is explicit and reviewable rather than implicit in a global hook.
- **Correctness under concurrency.** Every increment happens inside a region already holding `_db_lock`, and `read_counters()` takes the same lock, so a snapshot is untorn and no count is lost to a concurrent reader. No new synchronization is added to the read path.
- **Ordering on the endpoint is a contract.** `reads` is resolved LAST, after the preview that reaches the full-read branch, so the response includes the reads that request itself performed. Resolved earlier it would under-report by exactly the scan the caller is probing for. Pinned by a test.

## Scope

In: the counters, the two exposure surfaces, the module spec, tests.

Out: any change to read volume or to the retrieval algorithms; the #8971 remedy itself; timing metrics; a persisted or cross-process total.

No feature-map change: `GET /api/memory/observability` is already listed on the Memory graph row and no dashboard surface, route, or component changes — only a field is added to an existing response body. `test_check_feature_map.py` passes.

## Testing

- New `test/test_memory_read_counters.py` (12 tests): the counter contract (fresh-store zeroes, monotonicity, per-instance isolation across two stores over one file, snapshot non-aliasing), the semantic full-read branch crediting every row, the bounded branches NOT counting as population scans, the episodic surface, the all-tables totals on keyed hits and misses, and end-to-end visibility through the handler with a **real** store behind a faked request.
- **Red-first verified:** with only the source changes reverted, all 12 fail with `AttributeError: 'VectorMemoryStore' object has no attribute 'read_counters'`; all 12 pass with them.
- The ratchet test `test_a_second_identical_semantic_search_scans_the_population_again` deliberately pins today's re-read as VISIBLE. When #8971 lands, that test is the one that must flip — which is the point of having it, rather than a test the fix silently satisfies.
- Extended `test_handlers_memory_coverage.py` with the `reads` passthrough and a call-order assertion; extended `test_cli_commands_coverage.py` with the `memory stats` block.
- 1007 passed / 16 skipped across every affected suite by path (`-n0`), `mypy src/kiro_crew` clean (1303 files), `flake8` and `isort` clean on touched files. `black` is clean on every line this PR adds; three touched files carry pre-existing black drift on base-owned lines at `origin/main`, left untouched deliberately.

**Why no screenshots:** backend-only. The change adds a JSON field to an existing API response and two lines of CLI stdout; no dashboard component, route, or rendered surface is touched, so there is no visual delta to capture.

## Pattern harvest

`Rule candidate:` When a defect is real but a pod/second process cannot observe it, ship the OBSERVABLE as its own change before the fix, and have that change's ratchet test pin the CURRENT bad behaviour as visible. A test asserting "the second call still re-reads" forces the eventual fix to update it, whereas a test asserting the desired end state is either red for months or written only by the fix and never independently reviewed. The enabler is also cheap to review in isolation (counters and their exposure) versus tangled into a caching change, and it is what makes the fix's own claim measurable rather than asserted.

Refs #8971
Refs #8956
