### PR TITLE
feat(session): test-only interleaving seam for slot reset races

### DIFF
--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -867,6 +867,55 @@ generous — a real complexity regression is orders of magnitude, so a wide boun
 catches it. Raising an absolute budget instead banks the overhead as headroom and hides
 the next real regression.
 
+### Interleavings: name the point, do not sleep toward it
+
+Some races are not reachable from outside the process. Which of two coroutines lands inside
+the other's critical section is decided by who holds the event loop between two awaits, and
+an HTTP client can only issue both requests and hope — so `await asyncio.sleep(0.05); assert
+nothing_happened_yet()` is the shape these tests keep taking, and it is a wall-clock race
+(class 2) dressed as a concurrency test.
+
+Where a race matters enough to pin, the answer is a **test-only interception seam**: a
+module-level `Callable[[str], Awaitable[None]] | None`, default `None`, awaited at named
+points inside the paths that race. `chat_handlers._test_interleave` is the worked example,
+with four points across the session-teardown paths (`reload:pre_reset`,
+`switch:post_commit`, `reset:pre_pop`, `reset:post_pop`). A test suspends one racer at a
+point by name and drives the other from there, so the interleaving is a property of the test
+and identical on every host.
+
+The rules such a seam follows, each of which it stops being safe without:
+
+- **`None` by default, and settable only from tests.** No env var, no config key: a knob that
+  suspends a teardown mid-pop is a way to wedge a live session, and nothing outside the suite
+  wants one. Production pays one global read and an identity comparison per point, and
+  creates no coroutine.
+- **Points earn their names.** Each marks a boundary the race actually crosses, with a
+  comment at the call site saying what suspending there intercepts. A point reachable only
+  where a test could already observe the state is one more thing to keep correct for nothing.
+- **Placed on the shared chokepoint, not per caller.** One point on the helper every switch
+  handler resets through covers the family; a point per handler is how one of them ends up
+  without one.
+- **Assigned with `monkeypatch`**, which reverts even when the test fails, and floored by an
+  autouse fixture that fails a test which INHERITED a set hook. Check on the way in, not at
+  teardown: `monkeypatch` is built early as a dependency of an earlier autouse fixture, so its
+  undo runs *after* a teardown-side check, which then cannot tell a pending undo from a real
+  leak and reddens every legitimate test. Entry-side, the only thing that can still be set is
+  a raw assignment — exactly the leak worth catching.
+
+Two shapes recur when writing against a seam:
+
+- **Bounded yields, not sleeps, to let the other racer run.** Yield the loop until a monotone
+  marker holds (`task.done()`), capped by a turn count. Turns are not milliseconds: how many
+  a given interleaving needs is a property of the code, so the cap only bounds a coroutine
+  that can never progress and never decides the outcome for one that can.
+- **Report, do not assert, inside the helper.** Returning a bool keeps a test readable in the
+  world where a future fix makes the other racer BLOCK: it fails on its own named assertion
+  instead of hanging until `--timeout` kills it with nothing to read.
+
+A test that pins today's WRONG outcome says so at the assertion, names the issue, and states
+which assertion the fix flips — otherwise the next reader repairs the test instead of the
+defect.
+
 ```python
 # WRONG: passes bare, fails under --cov, and the margin shrinks as the catalog grows
 assert self._elapsed(build(8000)) < 5.0

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -3077,6 +3077,32 @@ def _subagents_attached_response(
     return None
 
 
+# Test-only scheduling seam for the session-teardown races. Production leaves it
+# None, so each point below costs one global read and an identity comparison, and
+# no coroutine is created. It is reachable from no env var and no config key on
+# purpose: an operator-facing knob that can suspend a teardown mid-pop is a way to
+# wedge a live session, and nothing outside the test suite has a reason to want
+# one.
+#
+# The interleavings it exists to make reachable cannot be driven from outside the
+# process. Which of two teardowns lands inside the other's span is decided by
+# which coroutine holds the event loop between two awaits; an HTTP client can only
+# issue both requests and hope. A test awaits a named point, drives the other
+# racer while suspended there, and so fixes the interleaving as a property of the
+# test rather than of the scheduler -- the shape-determinism the async-flake rules
+# ask for, with no sleep to tune.
+#
+# The names are the contract. Each marks a boundary the race actually crosses, and
+# the comment at each call site says what suspending there is positioned to
+# intercept; a point whose boundary no test can otherwise reach is the only kind
+# worth adding.
+#
+# Assign it with monkeypatch, which reverts on teardown even when the test fails.
+# ``_no_leaked_interleave_hook`` in test/conftest.py fails any test that leaves it
+# set, because nothing legitimately does.
+_test_interleave: Callable[[str], Awaitable[None]] | None = None
+
+
 async def _reset_slot_session(
     state: DashboardState,
     slot: _ChatSlot,
@@ -3116,6 +3142,12 @@ async def _reset_slot_session(
     stale-evidence failure that report exists to remove.
     """
     _unblock_pending_waits(state, slot)
+    if _test_interleave is not None:
+        # The near side of the pop. Every teardown in the process funnels through
+        # this one await, and the pop is what decides a race between two of them,
+        # so this is the position from which a test can hold one teardown open and
+        # put a second in flight over the same key.
+        await _test_interleave("reset:pre_pop")
     try:
         reloaded = await state.sessions.reset(session_key, skip_if_busy=skip_if_busy)
     except BaseException:
@@ -3123,6 +3155,13 @@ async def _reset_slot_session(
         # cannot vouch for, so neither is its verdict. Unknown fails open.
         slot.record_model_withheld(None)
         raise
+    if _test_interleave is not None:
+        # The far side of the pop, ahead of the verdict-gated bookkeeping below.
+        # That bookkeeping describes the session this call just tore down, and a
+        # concurrent teardown can have registered and popped a successor under the
+        # same key by the time it runs -- reachable only by suspending here,
+        # because the pop and the bookkeeping are otherwise adjacent.
+        await _test_interleave("reset:post_pop")
     if reloaded:
         # The withhold verdict describes the session that advertised the model
         # list, not the slot, so it goes with the session. Routed through this one
@@ -3216,6 +3255,14 @@ async def _reset_slot_session_or_warn(
     # cold-started from the slot's CURRENT (committed) bindings, so the
     # committed-success answer is truthful for it.
     prior_provider = state.sessions.get_provider(session_key)
+    if _test_interleave is not None:
+        # Inside the caller's locks, after it committed its new setting, before
+        # the old session goes -- the span a concurrent teardown must be able to
+        # land in for the ordering to be observable at all. Placed on this shared
+        # helper rather than in each handler because all four commit-before-reset
+        # switches reach the teardown through here, and a point per handler is how
+        # one of them ends up without one.
+        await _test_interleave("switch:post_commit")
     try:
         return await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
     except Exception:
@@ -7322,6 +7369,12 @@ async def api_chat_slot_reload(request: web.Request) -> web.Response:
     denied_409 = _subagents_attached_response(state, slot, session_key, "reload")
     if denied_409 is not None:
         return denied_409
+    if _test_interleave is not None:
+        # Reload's teardown takes neither slot._lock nor the session-keyed switch
+        # lock, so nothing orders it against a switch's commit-then-reset span.
+        # Suspending here is the only way to hold the unguarded teardown open
+        # across another actor's whole transaction and observe what that produces.
+        await _test_interleave("reload:pre_reset")
     reloaded = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
     if not reloaded:
         provider = state.sessions.get_provider(session_key)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1385,3 +1385,37 @@ def gateway_posts(request, monkeypatch):
 
     monkeypatch.setattr(mcp_core, "_post", _capture)
     yield posted
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_interleave_hook():
+    """Fail a test that INHERITED a set ``chat_handlers._test_interleave``.
+
+    The seam suspends a session teardown mid-pop, so a leaked hook does not
+    merely pollute state -- it re-enters an unrelated test's teardown path and
+    can await an event that test will never set, which under ``-n auto`` reads as
+    a timeout in a file that never mentioned the seam. Nothing legitimately
+    leaves it set, so this restores AND fails.
+
+    Checked on the way IN, not at teardown, and that is not a preference. The
+    supported way to set the hook is ``monkeypatch``, whose undo is registered
+    against the shared ``monkeypatch`` fixture -- and that fixture is built early,
+    as a dependency of an autouse fixture above, so its teardown runs AFTER this
+    one. A teardown-side check therefore cannot tell a pending undo from a real
+    leak and fails every legitimate test. Entry-side, the only thing that can
+    still be set is a raw assignment, which is exactly the leak worth catching.
+    The cost is that the report names the test that inherited the hook rather
+    than the one that leaked it, so the message says so.
+
+    Read through ``sys.modules`` rather than an import: a test that never touches
+    the dashboard pays one dict lookup and does not drag ``chat_handlers`` and its
+    import graph into every worker's collection.
+    """
+    mod = sys.modules.get("kiro_crew.dashboard.chat_handlers")
+    if mod is not None and mod._test_interleave is not None:
+        mod._test_interleave = None
+        pytest.fail(
+            "chat_handlers._test_interleave was already set on entry, so an "
+            "earlier test leaked it (this test is the victim, not the cause). "
+            "Set it with monkeypatch.setattr so it reverts even on failure."
+        )

--- a/test/test_slot_reset_interleaving_seam.py
+++ b/test/test_slot_reset_interleaving_seam.py
@@ -1,0 +1,322 @@
+"""The test-only interleaving seam, and the reload-vs-switch race it reaches.
+
+``chat_handlers._test_interleave`` is awaited at four named points across the
+session-teardown paths. These tests pin its contract -- unset by default, called
+with the point names in the order the code reaches them -- and then use it for the
+thing it exists for: driving a reload's teardown into the middle of a switch
+handler's commit-then-reset span, deterministically, with no sleep.
+
+That interleaving is the one described in issue #9019, and the test named for it
+below asserts TODAY's outcome, not the desired one. See its docstring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard import chat_handlers
+from kiro_crew.dashboard.chat import api_chat_slot_model, api_chat_slot_reload
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+# Registry aliases the model guard accepts, matching the ids the sibling
+# switch-atomicity tests use.
+_MODEL_OLD = "claude-opus-4.8"
+_MODEL_NEW = "gpt-5.6-sol"
+_SLOT = "s1"
+_SESSION_KEY = f"dashboard:{_SLOT}"
+
+# Loop turns a bounded yield will spend before giving up. Turns, not seconds:
+# the cap exists only to bound a coroutine that can never make progress, and is
+# far above what any interleaving here needs.
+_MAX_TURNS = 500
+
+
+async def _yield_until(predicate: Callable[[], bool]) -> bool:
+    """Hand the loop back until *predicate* holds, then report whether it did.
+
+    Scheduler turns, not wall clock. ``asyncio.sleep(0)`` reschedules this
+    coroutine behind whatever is already runnable, so how many turns a given
+    interleaving needs is a property of the code under test, identical on a busy
+    host and an idle one -- unlike a sleep, whose duration decides the outcome.
+
+    Returning a bool rather than asserting is what keeps a caller readable in
+    both worlds: a racer that becomes blocked by a future fix reports False here
+    and the caller fails on its own assertion, instead of hanging until the
+    suite-wide timeout kills it with no explanation.
+    """
+    for _ in range(_MAX_TURNS):
+        if predicate():
+            return True
+        await asyncio.sleep(0)
+    return predicate()
+
+
+def _make_app(state: DashboardState) -> web.Application:
+    # Mirror production: the token_auth middleware sets request["app"] on every
+    # authenticated path ("" = dashboard user), and the app-isolation guards on
+    # both routes fail closed without it.
+    @web.middleware
+    async def dashboard_auth_marker(request, handler):
+        if "app" not in request:
+            request["app"] = ""
+        return await handler(request)
+
+    app = web.Application(middlewares=[dashboard_auth_marker])
+    app["state"] = state
+    app.router.add_post("/api/chat/slots/{slot}/model", api_chat_slot_model)
+    app.router.add_post("/api/chat/slots/{slot}/reload", api_chat_slot_reload)
+    return app
+
+
+def _idle_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.has_active_turn = MagicMock(return_value=False)
+    return provider
+
+
+def _mock_state(slot: _ChatSlot) -> DashboardState:
+    state = MagicMock(spec=DashboardState)
+    state._slots = {slot.key: slot}
+    state.sessions = MagicMock()
+    state.sessions.reset = AsyncMock(return_value=True)
+    state.sessions.get_provider = MagicMock(return_value=_idle_provider())
+    return state
+
+
+@pytest.fixture
+def slot() -> _ChatSlot:
+    s = _ChatSlot(_SLOT)
+    s.model = _MODEL_OLD
+    return s
+
+
+@pytest.fixture
+def state(slot: _ChatSlot) -> DashboardState:
+    return _mock_state(slot)
+
+
+@pytest.fixture(autouse=True)
+def _no_eager_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reload re-arms the resume spawn; there is no runtime here to spawn onto."""
+    monkeypatch.setattr(chat_handlers, "schedule_eager_spawn", MagicMock(return_value=None))
+
+
+class TestInterleaveSeamContract:
+    """What the seam promises when nothing sets it, and what it reports when set."""
+
+    def test_hook_defaults_to_none(self):
+        # Production cost is this attribute being None: each point reads the
+        # global, compares, and creates no coroutine.
+        assert chat_handlers._test_interleave is None
+
+    @pytest.mark.asyncio
+    async def test_unset_hook_leaves_the_teardown_untouched(self, state, slot):
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+        assert resp.status == 200
+        state.sessions.reset.assert_awaited_once_with(_SESSION_KEY, skip_if_busy=True)
+
+    @pytest.mark.asyncio
+    async def test_reload_reaches_its_points_in_order(self, state, slot, monkeypatch):
+        seen: list[str] = []
+
+        async def _record(point: str) -> None:
+            seen.append(point)
+
+        monkeypatch.setattr(chat_handlers, "_test_interleave", _record)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+
+        assert resp.status == 200
+        # Reload owns the outer point and reaches the shared chokepoint's two
+        # through _reset_slot_session. No switch point: reload commits nothing.
+        assert seen == ["reload:pre_reset", "reset:pre_pop", "reset:post_pop"]
+
+    @pytest.mark.asyncio
+    async def test_model_switch_reaches_its_points_in_order(self, state, slot, monkeypatch):
+        seen: list[str] = []
+
+        async def _record(point: str) -> None:
+            seen.append(point)
+
+        monkeypatch.setattr(chat_handlers, "_test_interleave", _record)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/model", json={"model": _MODEL_NEW})
+
+        assert resp.status == 200
+        assert slot.model == _MODEL_NEW
+        # switch:post_commit precedes the chokepoint's pair, which is the whole
+        # point of where it sits: the new value is already committed and both
+        # locks are held while the old session is still alive.
+        assert seen == ["switch:post_commit", "reset:pre_pop", "reset:post_pop"]
+
+    @pytest.mark.asyncio
+    async def test_a_raising_hook_is_not_swallowed(self, state, slot, monkeypatch):
+        """A broken hook must fail its test, not silently skip the interleaving.
+
+        Pins the ABSENCE of a suppress around the points: were one added, the
+        teardown would proceed and every seam test would still pass while
+        interleaving nothing.
+        """
+
+        async def _boom(point: str) -> None:
+            raise RuntimeError(f"hook failed at {point}")
+
+        monkeypatch.setattr(chat_handlers, "_test_interleave", _boom)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+
+        assert resp.status == 500
+        state.sessions.reset.assert_not_awaited()
+
+
+class TestReloadRacesSwitchCommitResetSpan:
+    """The race in issue #9019, driven through the seam.
+
+    ``api_chat_slot_reload`` tears down the slot's effective session while
+    holding neither ``slot._lock`` nor the session-keyed switch lock. The four
+    commit-before-reset switch handlers hold both across their commit-then-reset
+    span. Nothing orders the two, so a reload's teardown can land inside that
+    span -- which is what these tests make happen, deterministically, by
+    suspending one racer at a named point and driving the other from there.
+    """
+
+    @pytest.mark.asyncio
+    async def test_switch_transaction_completes_inside_reloads_unguarded_teardown(
+        self, state, slot, monkeypatch
+    ):
+        """A whole model switch runs while reload sits on its pre-teardown point.
+
+        DEFECT PIN for issue #9019: this asserts the CURRENT outcome, which is
+        the wrong one. Reload holds no lock here, so the switch takes both of
+        its own locks unopposed, commits the new model, and tears the session
+        down -- all inside reload's window -- and reload's own teardown then
+        lands on the session that switch just prepared.
+
+        Serializing reload onto the session-keyed lock flips this test: the
+        switch would block on that lock instead, so ``switch.done()`` stays
+        False and the two assertions marked below fail. That is the intended
+        signal to the fix -- invert them and drop the "unguarded" wording.
+        """
+        order: list[str] = []
+        switch: asyncio.Task[object] | None = None
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+
+            async def _interleave(point: str) -> None:
+                order.append(point)
+                if point != "reload:pre_reset":
+                    return
+                # Suspended inside reload's teardown. Start the switch here:
+                # whether it can proceed while reload is mid-teardown IS the
+                # question, so run it to completion and record what happened.
+                nonlocal switch
+                switch = asyncio.create_task(
+                    client.post(f"/api/chat/slots/{_SLOT}/model", json={"model": _MODEL_NEW})
+                )
+                await _yield_until(lambda: switch is not None and switch.done())
+
+            monkeypatch.setattr(chat_handlers, "_test_interleave", _interleave)
+            reload_resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+
+            assert switch is not None
+            try:
+                # DEFECT (#9019): the switch got all the way through while
+                # reload's teardown was open. A serialized reload leaves this
+                # False.
+                assert switch.done(), "switch never completed inside reload's window"
+                switch_resp = switch.result()
+            finally:
+                switch.cancel()
+                await asyncio.gather(switch, return_exceptions=True)
+
+            assert switch_resp.status == 200
+            assert reload_resp.status == 200
+
+        # DEFECT (#9019): the switch's committed value and its teardown both land
+        # between reload's own two points, so reload's pop -- the last entry --
+        # destroys the session the switch reported success for. A serialized
+        # reload orders every switch entry AFTER reload's pair.
+        assert order == [
+            "reload:pre_reset",
+            "switch:post_commit",
+            "reset:pre_pop",
+            "reset:post_pop",
+            "reset:pre_pop",
+            "reset:post_pop",
+        ]
+        assert slot.model == _MODEL_NEW
+        # Two teardowns of ONE session key, unserialized.
+        assert state.sessions.reset.await_count == 2
+        assert {c.args[0] for c in state.sessions.reset.await_args_list} == {_SESSION_KEY}
+
+    @pytest.mark.asyncio
+    async def test_reload_teardown_lands_inside_a_suspended_switch_span(
+        self, state, slot, monkeypatch
+    ):
+        """The same race driven from the other side: switch first, reload second.
+
+        DEFECT PIN for issue #9019, and the direction that shows the harm the
+        issue names. The switch is suspended after committing its new model and
+        before tearing the old session down, holding both of its locks. Reload
+        then runs its ENTIRE teardown from inside that span, because it joins
+        neither lock -- so the switch resumes and tears down a session that has
+        already been replaced.
+
+        A serialized reload leaves ``reload.done()`` False while the switch is
+        suspended, failing the assertion marked below.
+        """
+        order: list[str] = []
+        reload_task: asyncio.Task[object] | None = None
+        # Guards against a vacuous pass: proves the hook body ran to its end
+        # rather than the yield loop exiting on an early predicate.
+        hook_completed = asyncio.Event()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+
+            async def _interleave(point: str) -> None:
+                order.append(point)
+                if point != "switch:post_commit":
+                    return
+                nonlocal reload_task
+                reload_task = asyncio.create_task(client.post(f"/api/chat/slots/{_SLOT}/reload"))
+                await _yield_until(lambda: reload_task is not None and reload_task.done())
+                hook_completed.set()
+
+            monkeypatch.setattr(chat_handlers, "_test_interleave", _interleave)
+            switch_resp = await client.post(
+                f"/api/chat/slots/{_SLOT}/model", json={"model": _MODEL_NEW}
+            )
+
+            assert reload_task is not None
+            try:
+                # DEFECT (#9019): reload completed a full teardown while the
+                # switch held both locks with its commit already applied.
+                assert reload_task.done(), "reload never completed inside the switch span"
+                reload_resp = reload_task.result()
+            finally:
+                reload_task.cancel()
+                await asyncio.gather(reload_task, return_exceptions=True)
+
+            assert reload_resp.status == 200
+            assert switch_resp.status == 200
+
+        assert hook_completed.is_set()
+        # DEFECT (#9019): reload's whole teardown pair sits between the switch's
+        # commit and the switch's own pop, so the switch reports success for a
+        # session reload had already torn down and re-armed.
+        assert order == [
+            "switch:post_commit",
+            "reload:pre_reset",
+            "reset:pre_pop",
+            "reset:post_pop",
+            "reset:pre_pop",
+            "reset:post_pop",
+        ]
+        assert state.sessions.reset.await_count == 2


### PR DESCRIPTION
## What

Adds a **test-only interception seam** so races between a slot's session teardown and a switch handler's commit-then-reset span can be driven deterministically from a test, and uses it to pin the reload-vs-switch interleaving described in #9019.

This is an **enabler**. It deliberately does **not** change reload's locking — the lock asymmetry #9019 describes is untouched, and the issue's open premise (whether `skip_if_busy=True` alone suffices, or reload must join the session-keyed lock) is left to whoever owns the reload contract.

## Why

That interleaving was not reachable by any test. Which of two teardowns lands inside the other's critical section is decided by which coroutine holds the event loop between two awaits, so an HTTP client can only issue both requests and hope. The suite's existing workaround is `await asyncio.sleep(0.05)` followed by "assert nothing happened yet" — a wall-clock race dressed as a concurrency test, and one that still cannot express *run the other racer to completion right here*. A grep for any existing scheduling-interception point (`KIROCREW_TEST_*`, `fault_inject`, `inject_delay`, `_race_hook`) returned nothing, so the interleaving was untestable in-process and entirely untestable in a pod.

## The seam

`chat_handlers._test_interleave`, a module-level `Callable[[str], Awaitable[None]] | None`, awaited at four named points:

| Point | Where | What suspending there intercepts |
|---|---|---|
| `reload:pre_reset` | `api_chat_slot_reload`, before its teardown | The teardown that holds neither the slot lock nor the session-keyed switch lock — the only place a test can hold it open across another actor's whole transaction |
| `switch:post_commit` | `_reset_slot_session_or_warn` | Inside the caller's locks, after its new setting is committed, before the old session goes |
| `reset:pre_pop` | `_reset_slot_session`, before the pop | The near side of the pop, which is what decides a race between two teardowns |
| `reset:post_pop` | `_reset_slot_session`, after the pop | The far side, ahead of the verdict-gated bookkeeping that a concurrent teardown may have invalidated |

Properties, each of which it stops being safe without:

- **Default `None`; production pays one global read and an identity comparison per point, and creates no coroutine.**
- **No env var, no config key.** A knob that can suspend a teardown mid-pop is a way to wedge a live session; nothing outside the suite has a reason to want one. Tests set it with `monkeypatch`, which reverts even on failure.
- **The switch point sits on the shared commit-before-reset helper**, not in each of the four switch handlers, so none of them can end up without one.
- **Leak floor**: an autouse conftest fixture fails a test that *inherited* a set hook. It checks on entry rather than at teardown because the shared `monkeypatch` fixture is built early as a dependency of an earlier autouse fixture, so its undo runs *after* a teardown-side check would — which then cannot tell a pending undo from a real leak and reddens every legitimate test.

## Scope

In: the seam, its contract tests, two defect-pin tests for #9019, and the determinism spec section that documents the pattern.

Out: any change to reload's locking, to `skip_if_busy` semantics, or to any handler's concurrency posture. The production diff adds only the four gated awaits and the declaration; no existing line of logic moved.

## Testing

7 new tests, green under `-n0` and under `-n 4 --dist loadgroup`. No sleeps, no timing assertions, no `xdist_group` needed.

- 5 pin the seam contract: unset by default, the teardown is untouched when unset, reload and a model switch each reach their points in the expected order, and a raising hook is not swallowed.
- 2 pin the #9019 interleaving, driven from both directions: a whole model switch completing inside reload's unguarded teardown window, and reload's entire teardown landing inside a suspended switch span. Both assert **today's** outcome and state at the assertion which one a fix flips.

**Red-first proof.** Temporarily joining reload to the session-keyed lock (a local probe, reverted byte-exact and not in this diff) turns both pins red with their own named assertions in 0.66s — `switch never completed inside reload's window` and `reload never completed inside the switch span` — while the 5 contract tests stay green. Waiting for the other racer uses bounded loop yields against a monotone `task.done()` marker rather than a sleep, and the helper *reports* instead of asserting, so a future fix that makes a racer block fails on a named assertion rather than hanging to the suite timeout.

Regression: 1024 tests across `test_dashboard_chat.py`, the slot switch/effort/reset/continue files, and the `test_security_posture.py` / `test_spawn_audit.py` / `test_black_gate_contract.py` drift guards — all passing. Gates: `flake8`, `isort`, `mypy src/kiro_crew/` (1303 files clean), and `scripts/check_black_formatting.py` on the real 4-file scope.

`test/conftest.py` is in the black baseline; running `black` on it reformats ~140 lines of unrelated pre-existing code, so that churn was reverted and only the new fixture is in the diff — which is what the gate's own docstring asks for.

## Rollout

No runtime behavior change. The seam is inert unless a test assigns it, and no production code path or configuration surface can reach it.

## No visual delta

Backend and test-infrastructure only. No frontend file, template, style, or rendered surface is touched, so there is no screenshot to attach.

## Pattern harvest

A conftest floor fixture cannot verify a process-global at **teardown** if the supported way to set that global is `monkeypatch`. Because `monkeypatch` is instantiated early as a dependency of an earlier autouse fixture, its undo is finalized *after* later autouse fixtures tear down — so a teardown-side leak check sees every legitimate `monkeypatch.setattr` as a leak and errors on every test that used it. Observed here as 5 teardown ERRORs against 7 passing test bodies. Check such a global on **entry** instead: the only writer that survives into the next test is a raw assignment, which is exactly the leak worth catching, and the report then names the victim rather than the culprit — so the failure message must say so.

Refs #9019
