### PR TITLE
fix(security): teach the span walk bash case-pattern paren terminators (#8830)

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -6702,6 +6702,25 @@ def _iter_shell_chars(text: str, state: int = 0, ansi: bool = False) -> "Iterato
         i += 1
 
 
+#: Reserved words after which bash still reads the NEXT word in command
+#: position.  The ``case`` tracker in :func:`_matching_close_paren` needs this
+#: because ``case`` (and ``esac``) are reserved words ONLY in command position:
+#: ``if true; then case x in ...`` must open a case context even though the
+#: word before ``case`` is not a separator, while ``echo case`` must not.
+_KEEPS_COMMAND_POSITION = frozenset(
+    {"if", "then", "else", "elif", "fi", "while", "until", "do", "done", "!", "{", "time", "coproc"}
+)
+
+# ``case`` tracker states for _matching_close_paren, one frame per (possibly
+# nested) case statement.  A frame is ``[state, pattern_started, had_lparen,
+# pattern_depth]`` -- a mutable list, not a class, because the walk is on the
+# hot path of every substitution extraction.
+_CASE_AWAIT_SUBJECT = 0  # ``case`` seen, the subject word is next
+_CASE_AWAIT_IN = 1  # subject consumed, waiting for the literal ``in``
+_CASE_PATTERN = 2  # pattern position: ``)`` here terminates the pattern
+_CASE_BODY = 3  # clause body: ordinary commands until ;; / ;& / ;;& / esac
+
+
 def _matching_close_paren(text: str, open_end: int) -> "tuple[int, bool]":
     """``(index just past the matching ``)``, proven)`` for a paren opened before
     *open_end*, walked QUOTE-AWARELY through :func:`_iter_shell_chars`.
@@ -6714,21 +6733,224 @@ def _matching_close_paren(text: str, open_end: int) -> "tuple[int, bool]":
     payload came back as ``X='`` and the nested publish of a protected branch was
     never scanned at all -- ``is_denied`` allowed a command bash runs.
 
+    The walk also models bash's ``case`` pattern terminator (#8830).  Inside a
+    substitution bash accepts an UNBALANCED ``)`` after each case pattern --
+    ``$(case x in x) : ;; esac; pgrep -f <name>)`` runs the ``pgrep`` -- so a
+    paren-counting walk that treats that pattern ``)`` as the substitution
+    closer truncates the extracted body, and every consumer then scans LESS
+    than bash executes: ``_is_self_kill`` missed the pgrep clause and the
+    git-publish boundary walk missed a nested protected-branch push.  The
+    tracker below recognises a command-position ``case`` word, follows the
+    subject / ``in`` / pattern / body positions (``;;`` / ``;&`` / ``;;&``
+    reopen pattern position; ``esac`` closes the case; cases nest), and skips
+    depth accounting ONLY for parens in pattern position -- bash consumes those
+    as case syntax, never as closers.  On any input with no command-position
+    ``case`` word the tracker never activates and the walk is byte-identical
+    to the plain count.  Ambiguity fails toward the LONGER span: keeping more
+    text inside the body means consumers scan MORE, never less.
+
     ``proven`` is False when the parens never balance before the text ends. The
     caller must fail CLOSED on that: for an extractor the safe reading is the
     whole remainder (scan more, never less).
     """
     depth = 1
+    # One frame per open ``case``: [state, pattern_started, had_lparen,
+    # pattern_depth, open_depth].  ``had_lparen`` records the optional leading
+    # ``(`` bash allows before a pattern, and is what distinguishes a
+    # first-word ``esac`` (ends the case: ``case x in esac``) from ``esac`` as
+    # pattern content after ``(`` (``case x in (esac) ...``); ``pattern_started``
+    # covers the sibling shape where earlier pattern content precedes it
+    # (``case x in a|esac) ...``).  ``pattern_depth`` tracks extglob-style
+    # parens INSIDE a pattern so their closers are not read as the terminator.
+    # ``open_depth`` is the structural paren depth the ``case`` was seen at: a
+    # frame is ACTIVE only while the walk is at that same depth, so a nested
+    # substitution or subshell suspends the enclosing case (its words cannot
+    # mutate the parent frame) and closing it resumes the parent -- without
+    # this, a case nested in another case's SUBJECT advanced the parent's
+    # states and re-opened the short-span truncation.
+    frames: "list[list[int]]" = []
+    word: "list[str]" = []
+    at_cmd = True  # a substitution body begins in command position
+    fn_name_pending = False  # ``function`` consumed; the NEXT word is its name
+    name_grace = False  # ``coproc`` consumed; ONE word may pass as its name
+    redirect_pending = False  # ``<``/``>`` consumed; the NEXT word is a filename
+    prev_char = ""
+    prev_offset = -2
+    prev_sig = ""  # last significant (non-whitespace) char, quoted included
+
+    def _active() -> "list[int] | None":
+        """The innermost case frame, only while the walk is at its depth."""
+        if frames and frames[-1][4] == depth:
+            return frames[-1]
+        return None
+
+    def _flush_word() -> None:
+        """Classify the pending word and advance the case tracker."""
+        nonlocal at_cmd, fn_name_pending, name_grace, redirect_pending
+        if not word:
+            return
+        w = "".join(word)
+        word.clear()
+        if redirect_pending:
+            # A redirect TARGET is a filename, never a reserved word: bash
+            # writes ``> esac`` to a FILE named esac (verified live), so the
+            # word must not pop, push, or transition anything.  Command
+            # position is left untouched -- a command may still follow the
+            # redirect (``> f echo hi``).
+            redirect_pending = False
+            return
+        top = _active()
+        if top is not None and top[0] == _CASE_AWAIT_SUBJECT:
+            top[0] = _CASE_AWAIT_IN  # any word serves as the subject
+            at_cmd = False
+            return
+        if top is not None and top[0] == _CASE_AWAIT_IN:
+            # bash demands the literal ``in`` here; on anything else the
+            # statement is malformed and never runs.  Waiting for a later
+            # ``in`` rather than abandoning the frame is the longer-span
+            # (fail-toward-detection) reading.
+            if w == "in":
+                top[0] = _CASE_PATTERN
+                top[1] = top[2] = top[3] = 0
+            at_cmd = False
+            return
+        if top is not None and top[0] == _CASE_PATTERN:
+            if w == "esac" and not top[1] and not top[2]:
+                frames.pop()  # ``case x in esac`` / ``;; esac`` -- case over
+            else:
+                top[1] = 1  # pattern content began
+            at_cmd = False
+            return
+        # Command position proper (top level, or a clause body).
+        if fn_name_pending:
+            # ``function NAME`` -- this word is the name; the definition BODY
+            # that follows is a compound command in command position, so
+            # ``function f case x in x) ...`` spans like the bare statement.
+            fn_name_pending = False
+            at_cmd = True
+            return
+        if at_cmd and w == "esac" and top is not None:
+            frames.pop()  # last clause may omit its ``;;``
+            at_cmd = False
+            return
+        if at_cmd and w == "case":
+            frames.append([_CASE_AWAIT_SUBJECT, 0, 0, 0, depth])
+            at_cmd = False
+            return
+        if at_cmd and w == "function":
+            fn_name_pending = True
+            at_cmd = False
+            return
+        if at_cmd and w == "coproc":
+            # ``coproc [NAME] compound-command``: the optional NAME must not
+            # cost command position, or ``coproc c case x in x) ...`` (which
+            # bash executes) re-opens the truncation one token away.
+            name_grace = True
+            return  # at_cmd stays True for an immediate ``case`` too
+        if name_grace:
+            name_grace = False
+            return  # the name passes; at_cmd stays for the compound body
+        # Reserved words hold command position only when they were THEMSELVES
+        # in command position -- ``echo then case ...`` is three arguments, and
+        # letting the argument ``then`` reopen command position pushed a false
+        # frame that swallowed a real closer (an over-deny on case-free text).
+        at_cmd = at_cmd and w in _KEEPS_COMMAND_POSITION
+
     for step in _iter_shell_chars(text, 0, False):
         if step.offset < open_end:
             continue
-        if step.active:
-            if step.char == "(":
+        if not step.active:
+            # Quoted or escaped text is word CONTENT (raw spelling, so
+            # ``'case'`` / ``ca\se`` never equal the bare keyword) and never
+            # shell syntax.
+            word.append(step.text)
+            prev_sig = step.char
+            continue
+        ch = step.char
+        sig_before = prev_sig  # what preceded THIS char, for the ``()`` test
+        if ch not in " \t":
+            prev_sig = ch
+        if ch in " \t":
+            _flush_word()
+        elif ch in ";&|\n`<>":
+            _flush_word()
+            top = _active()
+            if (
+                top is not None
+                and top[0] == _CASE_BODY
+                and prev_char == ";"
+                and prev_offset == step.offset - 1
+                and ch in ";&"
+            ):
+                # ``;;`` or ``;&`` -- the clause ends, the next pattern opens
+                # (a trailing ``&`` of ``;;&`` then lands harmlessly in
+                # pattern position).
+                top[0] = _CASE_PATTERN
+                top[1] = top[2] = top[3] = 0
+            if ch in "<>":
+                # The next WORD is this redirect's filename operand; only a
+                # word consumes the flag (whitespace between ``>`` and its
+                # target is routine), while any command separator cancels it
+                # -- after ``cmd > f & case`` the ``case`` is a real keyword.
+                redirect_pending = True
+            else:
+                redirect_pending = False
+                at_cmd = True  # redirections do not change command position
+        elif ch == "(":
+            _flush_word()
+            redirect_pending = False  # ``<(`` / ``>(`` is a substitution, not a redirect
+            top = _active()
+            if (
+                top is not None
+                and top[0] == _CASE_PATTERN
+                and not (prev_offset == step.offset - 1 and prev_char in "$<>")
+            ):
+                if not top[1] and not top[2] and top[3] == 0:
+                    top[2] = 1  # bash's optional ``(`` before the pattern
+                else:
+                    top[3] += 1  # extglob-style paren inside the pattern
+            else:
+                # Outside a pattern, OR a substitution opener (``$(``, ``<(``,
+                # ``>(``) glued into pattern position -- ``case x in <(printf
+                # x)) ...`` runs its tail in bash, so the substitution's parens
+                # are REAL nesting: depth scoping parks the case frame until
+                # the substitution closes, and only THEN can a ``)`` terminate
+                # the pattern.  Reading that ``(`` as pattern syntax made its
+                # closer the pattern terminator and the next ``)`` the span
+                # end -- the exact truncation this walk exists to prevent.
                 depth += 1
-            elif step.char == ")":
+                at_cmd = True  # a nested body starts its own command context
+        elif ch == ")":
+            _flush_word()
+            top = _active()
+            if top is not None and top[0] == _CASE_PATTERN:
+                if top[3] > 0:
+                    top[3] -= 1  # closes an intra-pattern paren
+                else:
+                    top[0] = _CASE_BODY  # pattern terminator, NOT a closer
+                    at_cmd = True
+            else:
                 depth -= 1
                 if depth == 0:
                     return (step.offset + len(step.text), True)
+                # Frames opened inside the group that just closed cannot
+                # survive it -- an unterminated inner case must not go on
+                # eating the enclosing context's words and closers.
+                while frames and frames[-1][4] > depth:
+                    frames.pop()
+                # An EMPTY group is a POSIX function definition's ``()``
+                # (``f() case x in x) ...`` -- bash executes the case as the
+                # function body), so command position follows.  A closed
+                # substitution or subshell had content and lands mid-word,
+                # which is NOT command position.
+                at_cmd = sig_before == "("
+        else:
+            word.append(step.text)
+            prev_char = ch
+            prev_offset = step.offset
+            continue
+        prev_char = ch
+        prev_offset = step.offset
     return (len(text), False)
 
 

--- a/test/test_push_branch_gate.py
+++ b/test/test_push_branch_gate.py
@@ -2015,3 +2015,217 @@ class TestNestedPayloadExtractionSpansTheProvenBoundary:
         )
         assert security._GIT_PUBLISH_UNGATED in floor("git push origin feature > >(echo main")
         assert security._git_push_args("bash -c '(cd /tmp && git push origin my-feature)'") is None
+
+
+class TestCasePatternParenIsNotACloser:
+    """#8830: bash accepts an UNBALANCED ``)`` after each ``case`` pattern inside a
+    substitution, so a paren-counting walk that honoured it as the closer truncated
+    every consumer's extracted body. All vectors here are bash-verified: each
+    substitution RUNS the clause the old span dropped."""
+
+    def test_the_span_runs_past_a_case_pattern_paren(self):
+        from kiro_crew.security import _matching_close_paren
+
+        # The issue's own shape: the pattern ``)`` after ``x`` is case syntax;
+        # the substitution closes at the final ``)``.
+        text = "$(case x in x) : ;; esac; pgrep -f kirocrew)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+        # bash's optional leading ``(`` before the pattern.
+        text = "$(case x in (x) echo lead ;; esac; echo tail)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+        # Cases nest: the inner case's parens are all case syntax too.
+        text = "$(case a in a) case b in b) : ;; esac ;; esac)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+        # ``;&`` fall-through and ``|`` alternation reopen/extend pattern position.
+        text = "$(case x in x) echo one ;& y|z) echo two ;; esac)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+        # A QUOTED ``)`` in a clause body is data (the earlier fix), and the
+        # pattern paren is case syntax (this fix) -- together in one vector.
+        text = "$(case x in x) echo ')' ;; esac)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+        # ``esac`` directly after ``in`` ends the case; the next ``)`` closes.
+        text = "$(case z in esac; echo after)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+        # A substitution as the case SUBJECT keeps its own parens balanced.
+        text = "$(case $(echo x) in x) echo subj ;; esac)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+
+    def test_the_extracted_body_spans_the_whole_case_statement(self):
+        from kiro_crew.security import _substitution_bodies
+
+        # The two vectors measured in the issue, previously cut to 'case x in x'.
+        assert _substitution_bodies("kill $(case x in x) : ;; esac; pgrep -f kirocrew)") == [
+            "case x in x) : ;; esac; pgrep -f kirocrew"
+        ]
+        assert _substitution_bodies("echo $(case x in x) git push origin main; esac)") == [
+            "case x in x) git push origin main; esac"
+        ]
+
+    def test_the_self_kill_consumer_convicts_through_a_case_pattern(self):
+        # bash-verified: this command RESOLVES the pgrep and kills the product,
+        # and the truncated span made _is_self_kill return False on it.
+        assert security._is_self_kill("kill $(case x in x) : ;; esac; pgrep -f kirocrew)")
+
+    def test_the_git_publish_consumer_sees_the_nested_push(self):
+        # The full body reaching the boundary walk is what this fix restores;
+        # the deny itself is pinned so the gate cannot reopen if the redundant
+        # raw-text layers that also catch these shapes are later narrowed.
+        for cmd in (
+            "echo $(case x in x) git push origin main; esac)",
+            "true > >(case x in x) git push origin main ;; esac)",
+        ):
+            assert security.is_denied(cmd) is not None, (
+                f"{cmd!r}: the case-pattern paren truncated the extracted body "
+                f"and the nested protected push was never scanned"
+            )
+
+    def test_case_free_inputs_are_byte_identical(self):
+        from kiro_crew.security import _matching_close_paren, _substitution_bodies
+
+        # Parity pins for the tracker's OFF path: no command-position ``case``
+        # word, so every span must equal the plain count's answer.
+        assert _matching_close_paren(">(a)", 2) == (4, True)
+        assert _matching_close_paren(">(a(b))", 2) == (7, True)
+        assert _matching_close_paren(">(X=')' a)", 2) == (10, True)
+        assert _matching_close_paren(">(a", 2) == (3, False)
+        assert _substitution_bodies("echo $(pgrep -f foo) tail") == ["pgrep -f foo"]
+        assert _substitution_bodies("$(X=')' echo hi)") == ["X=')' echo hi"]
+        # ``case`` as DATA (not in command position) must not open a context:
+        # the first unquoted ``)`` still closes, exactly as before.
+        assert _substitution_bodies("echo $(echo case x in y) tail") == ["echo case x in y"]
+        # A QUOTED ``case`` in command position is data too.
+        assert _substitution_bodies("echo $('case' x in y) tail") == ["'case' x in y"]
+
+    def test_ambiguity_fails_toward_the_longer_span(self):
+        from kiro_crew.security import _matching_close_paren
+
+        # A malformed case (no ``in`` yet) holds the walk in its waiting state,
+        # where parens still count normally -- but an unterminated case whose
+        # pattern position never resolves runs to the end UNPROVEN, the
+        # fail-closed direction (consumers scan the whole remainder).
+        text = "$(case x in y) echo never-closed"
+        assert _matching_close_paren(text, 2) == (len(text), False)
+
+    def test_function_definition_bodies_are_command_position(self):
+        from kiro_crew.security import _matching_close_paren
+
+        # bash executes the trailing clause in BOTH function-definition forms
+        # (verified live), so the span must run to the final paren.
+        for text in (
+            "$(function f case x in x) : ;; esac; pgrep -f kirocrew)",
+            "$(f() case x in x) : ;; esac; f; pgrep -f kirocrew)",
+        ):
+            assert _matching_close_paren(text, 2) == (len(text), True), text
+        assert security._is_self_kill(
+            "kill $(function f case x in x) : ;; esac; pgrep -f kirocrew)"
+        )
+
+    def test_coproc_name_does_not_cost_command_position(self):
+        from kiro_crew.security import _matching_close_paren
+
+        # ``coproc [NAME] compound-command``: bash executes the trailing
+        # clause with and without the name (verified live).
+        for text in (
+            "$(coproc c case x in x) : ;; esac; pgrep -f kirocrew)",
+            "$(coproc case x in x) : ;; esac; pgrep -f kirocrew)",
+        ):
+            assert _matching_close_paren(text, 2) == (len(text), True), text
+
+    def test_a_nested_case_in_a_subject_substitution_cannot_corrupt_the_parent(self):
+        from kiro_crew.security import _matching_close_paren
+
+        # The inner case lives at a deeper paren depth; its ``in``/``esac``
+        # must not advance the OUTER frame's states (bash executes the
+        # trailing clause -- verified live).
+        text = "$(case $(case y in y) printf x ;; esac) in x) : ;; esac; pgrep -f kirocrew)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+        assert security._is_self_kill(
+            "kill $(case $(case y in y) printf x ;; esac) in x) : ;; esac; pgrep -f kirocrew)"
+        )
+
+    def test_reserved_looking_arguments_do_not_reopen_command_position(self):
+        from kiro_crew.security import _matching_close_paren, _substitution_bodies
+
+        # ``then`` / ``time`` here are plain arguments to echo -- bash closes
+        # the substitution at the first unquoted ``)`` -- so the walk must
+        # match the plain count exactly (no false case frame).
+        for text in ("$(echo then case x in y) tail", "$(echo time case x in y) tail"):
+            close = text.index(")") + 1
+            assert _matching_close_paren(text, 2) == (close, True), text
+        assert _substitution_bodies("git push origin my-feature > >(echo then case x in y)") == [
+            "echo then case x in y"
+        ]
+        # ``time -p case`` / ``time case``: bash's own parser CUTS the
+        # substitution at the pattern paren (syntax error inside the
+        # substitution -- the tail never executes), so the truncated span is
+        # the bash-correct reading for ``-p`` and the longer span for the
+        # bare form is the documented fail-toward-detection bias.
+        text = "$(time -p case x in x) : ;; esac; echo x)"
+        close = text.index(")") + 1
+        assert _matching_close_paren(text, 2) == (close, True)
+
+    def test_a_substitution_in_pattern_position_is_nested_not_a_terminator(self):
+        from kiro_crew.security import _matching_close_paren
+
+        # Server GPT round-1 finding: bash expands ``$( )`` / ``<( )`` / ``>( )``
+        # in pattern position and executes the tail (all verified live), so a
+        # substitution's parens are real nesting and its closer is never the
+        # pattern terminator.
+        for text in (
+            "$(case x in <(printf x)) : ;; esac; pgrep -f kirocrew)",
+            "$(case x in $(printf x)) : ;; esac; pgrep -f kirocrew)",
+            "$(case x in x$(printf y)) : ;; esac; pgrep -f kirocrew)",
+        ):
+            assert _matching_close_paren(text, 2) == (len(text), True), text
+        assert security._is_self_kill("kill $(case x in <(printf x)) : ;; esac; pgrep -f kirocrew)")
+        # Extglob-style parens (no glued ``$<>``) stay pattern-local.
+        text = "$(case x in x@(a|b)) : ;; esac; echo tail)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+
+    def test_a_redirect_target_is_a_filename_not_a_reserved_word(self):
+        from kiro_crew.security import _matching_close_paren
+
+        # Server GPT round-2 finding: ``> esac`` writes a FILE named esac
+        # (verified live -- the case stays open and the tail executes), so a
+        # redirect operand must not pop the frame.
+        for text in (
+            "$(case x in x) > esac ;; y) : ;; esac; pgrep -f kirocrew)",
+            "$(case x in x) : > esac ;; y) : ;; esac; pgrep -f kirocrew)",
+        ):
+            assert _matching_close_paren(text, 2) == (len(text), True), text
+        assert security._is_self_kill(
+            "kill $(case x in x) > esac ;; y) : ;; esac; pgrep -f kirocrew)"
+        )
+        # An ordinary redirect inside a clause body stays inert (verified
+        # live), and a separator after the operator cancels the operand read.
+        text = "$(case x in x) cat < /dev/null ;; esac; echo tail)"
+        assert _matching_close_paren(text, 2) == (len(text), True)
+
+    def test_the_two_keyword_tables_are_cross_pinned(self):
+        from kiro_crew.security import _KEEPS_COMMAND_POSITION, _SHELL_RESERVED_WORDS
+
+        # Two tables answer "is this word shell syntax?" for different
+        # purposes: _SHELL_RESERVED_WORDS makes the redirect-skip walk BAIL
+        # fail-closed, _KEEPS_COMMAND_POSITION drives this grammar model.
+        # They must not drift silently -- every difference is intentional and
+        # named here, so a future edit to one table trips this pin and the
+        # editor decides about the other deliberately.
+        only_reserved = _SHELL_RESERVED_WORDS - _KEEPS_COMMAND_POSITION
+        only_keeps = _KEEPS_COMMAND_POSITION - _SHELL_RESERVED_WORDS
+        assert only_reserved == {
+            # tracked as their own tracker states, not as position-keepers:
+            "case",  # opens a frame
+            "esac",  # pops a frame
+            "in",  # the AWAIT_IN transition
+            "function",  # the name-consuming prefix state
+            # loop/conditional heads whose operands are NOT command position;
+            # their bodies re-enter it via do/then, which ARE in the set:
+            "for",
+            "select",
+            # bracket commands whose operands are test expressions:
+            "[[",
+            "]]",
+            # a block CLOSER -- nothing after it opens a command:
+            "}",
+        }
+        assert only_keeps == set()


### PR DESCRIPTION
## Problem / Motivation

`_matching_close_paren` — the ONE span computation every substitution/subshell body extraction reads (`_substitution_bodies`, the git-publish boundary walk, the nested-payload extractor) — counts every active `(` / `)` but does not model bash `case` pattern terminators. Inside a substitution bash accepts an UNBALANCED `)` after each case pattern, so the walk honoured that pattern paren as the substitution closer and truncated the extracted body. Measured on pristine main: `_substitution_bodies('kill $(case x in x) : ;; esac; pgrep -f kirocrew)')` returned only `['case x in x']` — the `pgrep` clause bash actually executes was never scanned, so `_is_self_kill` returned False on a real self-kill, and the same truncation reached the git-publish boundary walk for a nested protected-branch push.

## Why it matters

Security-gate correctness defect (under-deny): the deny gate permits commands it is designed to convict. One case pattern paren hides a self-kill or a protected-branch publish from every consumer of the shared extractor at once.

## What changed (motivation → approach → change)

Symptom: consumers scan LESS than bash executes. Root cause: the span walk has no model of bash's one grammar special case where a `)` is syntax rather than a closer. Change (in the ONE shared machine, per the issue's direction — no per-consumer patching): the walk now tracks command position and `case` context — a command-position `case` word opens a frame that follows subject / `in` / pattern / clause-body positions; `;;` / `;&` / `;;&` reopen pattern position; `esac` pops; cases nest. A `)` in pattern position is consumed as case syntax and never as a closer; every other paren counts exactly as before.

Hardened during pre-push review (two model-pinned reviewer subagents + a focused verifier, all findings bash-verified live):

- Frames are scoped to the paren depth they opened at, so a nested substitution suspends the enclosing case (a case nested in another case's *subject* can no longer corrupt the parent frame) and frames die with their enclosing group.
- Command position is *inherited* (`at_cmd and w in _KEEPS_COMMAND_POSITION`), so an argument spelled `then`/`time` cannot open a false frame (which would have over-denied a legitimate feature-branch push).
- `function NAME` (no-parens form), POSIX `f()` definitions, and `coproc [NAME]` all restore command position for their compound bodies — bash executes a case body in all three, verified live.

Invariants pinned by tests and verified by construction: byte-identical spans on any input with no command-position `case` word (the tracker never activates); ambiguity fails toward the LONGER span (consumers scan more, never less — the walk can never return an earlier index than the old plain count); single-pass, linear, no rescans (the pre-existing quadratic tracked in #8822 is untouched and out of scope). Sibling PR #8821 deliberately reuses this shared finder, and the diff stays scoped to `_matching_close_paren` and its tests to minimize conflict surface.

## Tests

New class `TestCasePatternParenIsNotACloser` in `test/test_push_branch_gate.py` (11 tests, red-before-green proven — 4 fail without the core fix, 4 more fail without the review-round hardening):

- The issue's two measured vectors extract their FULL bodies, and `_is_self_kill` convicts the kill/case vector.
- Span correctness through: leading-paren patterns, nested cases, `;&` fall-through + `|` alternation, quoted parens in clause bodies, `esac` directly after `in`, substitution-as-subject, `function`/POSIX-`f()`/`coproc` compound bodies, and a nested case inside another case's subject substitution.
- Parity pins: case-free inputs byte-identical to the plain count; `case` as data (`echo case …`, quoted `'case'`) never activates the tracker; `echo then case …` opens no false frame; `time -p case …` stays cut (bash's own parser cuts there — verified live, the tail never executes).
- A cross-pin between `_KEEPS_COMMAND_POSITION` and the pre-existing `_SHELL_RESERVED_WORDS`, with every intentional membership difference named, so the two tables cannot drift silently.
- The git consumer pin: both nested-push case vectors stay denied.

## Manual verification

Every non-trivial vector in the tests was executed against real bash first (substitution runs, tail-clause reachability, `time`/`coproc`/`function` forms) — the tests pin bash's observed behavior, not assumptions. Full local gates: isort, flake8, mypy (1303 files), black (test file clean; `security.py` is black-baseline-exempt), 890 security-path tests including the regex-linearity guards, and the full suite (89,958 passed; the only failures reproduce identically on pristine main in this host environment).

## Related Issues

Closes #8830

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a hand-rolled shell-syntax walk that special-cases one grammar construct must be checked against bash's reserved-word POSITION rules (command position, not word spelling) — spelling-only keyword matching both under- and over-triggers"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the module spec does not document this internal helper
- [x] No secrets, credentials, or internal references in the diff
