### PR TITLE
feat(session-control): add agent.member_dispatch operator ceiling

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -57,6 +57,7 @@
         "session_start_timeout_secs": 90,
         "tool_approval_timeout_secs": 600,
         "session_control": true,
+        "member_dispatch": true,
         "subagent_cost_gb": 0.5,
         "subagent_cpu_cost_cores": 1.0,
         "subagent_auto_max": 32,
@@ -773,6 +774,20 @@
       "tags": [],
       "label": "Session Control",
       "help": "Let one chat session open a new session, and stop, read or send to another session of yours. Reading returns a transcript tail, stopping cancels an in-flight turn, a created session starts empty for you to type into, and a send runs text as the target's next turn. On by default, because the grant that decides who can do this is the agent config: the tools come from the kirocrew-dashboard MCP server, so an agent that does not mount it never has them, exactly like any other MCP server. Turn this off to withdraw the capability from every agent at once without editing each spec. Sessions can only reach peers in the same workspace; incognito, app-scoped and scheduled sessions are never addressable, and a crew member or a scheduled run reaches only sessions it created itself.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": true
+    },
+    {
+      "path": "agent.member_dispatch",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Member Dispatch",
+      "help": "Let a crew member's DM session open and drive worker sessions it creates, even when Session Control is off. On by default, because dispatching work into workers is the crew-member operating model, not an opt-in: this is the zero-configuration contract. Turn this off to put member callers back under the Session Control switch, so an operator who withdrew session control keeps member DM threads chat-only without disabling the member. When on, a member's reach is still bounded to sessions it created itself (creator ownership), the same fence that binds it when Session Control is on.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": true

--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -141,7 +141,7 @@ that is out of bounds is visible after the fact even though nothing happened.
 
 | Refusal | Status | Why |
 |---------|--------|-----|
-| Config switch off (`agent.session_control` explicitly `false`) | 403 | Operator withdrew the capability from every agent at once. Defaults to true — the agent's `kirocrew-dashboard` mount is the grant. **Exception:** a crew-member DM slot (`member-*` caller key) bypasses this switch — see "Member callers" below |
+| Config switch off (`agent.session_control` explicitly `false`) | 403 | Operator withdrew the capability from every agent at once. Defaults to true — the agent's `kirocrew-dashboard` mount is the grant. **Exception:** a crew-member DM slot (`member-*` caller key) bypasses this switch while `agent.member_dispatch` is true (its default) — see "Member callers" below |
 | Caller session cannot be identified | 403 | An unidentifiable caller makes the self-target guard blind |
 | Caller is an unattended session (`workflow-*`) | 403 | A `workflow-<run_id>` slot exists only once its originating tab is gone, so there is no owning session to fence it to. **Exception:** a cron slot (`cron-*` caller key) is admitted and fenced by creator ownership instead — see "Cron callers" below |
 | Caller is itself incognito, temporary, or app-scoped | 403 | Caller-side isolation — the direction the target-side checks cannot see |
@@ -171,8 +171,15 @@ operator configuration. Two rules give it that shape:
 - **The `agent.session_control` switch does not gate a member caller.** Members
   work out of the box — this is the zero-configuration contract, and it is a
   deliberate trade-off: an operator who turned session control off has NOT
-  thereby disabled member dispatch. There is currently no separate switch for
-  it; disabling a member disables its dispatch.
+  thereby disabled member dispatch. The operator ceiling on that bypass is
+  `agent.member_dispatch` (bool, default **true**). Left at its default it
+  reproduces this exactly — the member bypasses the switch. Set to `false`, a
+  member caller stops bypassing and falls back under `agent.session_control`
+  like any ordinary caller, so an operator who withdrew session control can
+  keep member DM threads chat-only without disabling the member itself. The
+  ceiling is read at the switch gate (`member_dispatch_enabled()`) and, like
+  the switch, **fails closed** — an unreadable config withdraws the bypass
+  rather than granting it.
 - **A member caller may only act on sessions it created.** Slot creation records
   `created_by` (the creator's caller key) in the slot's birth metadata; it is
   persisted with the session and rehydrated on restart (both restore paths).
@@ -548,6 +555,31 @@ conductor is in the second class for `session_create` and `session_read_message`
 loop runs with nobody at the keyboard and must not block on an approval no one is
 there to give. An operator who wants folder tools without session control names the
 folder tools individually.
+
+`agent.member_dispatch` (bool, default **true**). The operator ceiling on the
+member switch bypass described under "Member callers". At its default a member DM
+caller bypasses `agent.session_control` — the zero-configuration contract, and
+today's behaviour, so installing this key changes nothing until it is set. Set it
+`false` and a member caller stops bypassing: it falls back under
+`agent.session_control` like any ordinary caller, which lets an operator who
+withdrew session control keep member DM threads chat-only without disabling the
+member. Read at the switch gate via `member_dispatch_enabled()`, and **fails
+closed** everywhere it can go wrong. (1) An unreadable config withdraws the member
+bypass (`member_dispatch_enabled()` returns false on a raising read). (2) A config
+that loads but *discarded the `agent` section* (or the whole file) also withdraws
+it: `load()` does not raise on a malformed section — it drops the section and
+falls back to the permissive `member_dispatch=True` default, recording the loss in
+`degraded_sections`, so `member_dispatch_enabled()` returns false when
+`degraded_sections` names `agent` or the whole-config marker `*`, the same
+"could not read it" vs "was never set" distinction `tailnet_identity_unknown` and
+the publish gate draw. (3) At load time a *missing* key defaults to true (today's
+behaviour) while any *present but malformed* value — including a quoted `"false"`,
+a routine operator quoting mistake — coerces to false BEFORE schema validation, so
+a botched opt-out withdraws the bypass rather than silently leaving it on. This is
+a config-level ceiling, not an enterprise `SCOPE_CATALOG` scope: `session_control`
+itself is a plain `agent.*` bool with no catalog entry, and a scope would need a
+new governance enforcement seam rather than a data-only append, so it is left to a
+follow-up.
 
 ## What is deliberately not here
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2478,6 +2478,19 @@ class KiroCrewConfig:
                 data["resource_limits"] = asdict(
                     ResourceLimitsConfig.from_raw(data["resource_limits"])
                 )
+            # Same fail-closed-before-validation reason for the member-dispatch
+            # ceiling. `agent.member_dispatch` gates whether a crew member
+            # bypasses `session_control`; its safe direction is FALSE (bypass
+            # off). Schema validation pops a present-but-malformed value and the
+            # missing-field default is TRUE, so a quoted `"false"` — a routine
+            # operator quoting mistake — would silently ride that default back
+            # to an authorized bypass. Coerce a present non-bool to False HERE,
+            # so validation sees a valid bool and keeps it; a genuinely absent
+            # key is left absent and still defaults to true (today's behaviour).
+            _agent_section = data.get("agent")
+            if isinstance(_agent_section, dict) and "member_dispatch" in _agent_section:
+                if not isinstance(_agent_section["member_dispatch"], bool):
+                    _agent_section["member_dispatch"] = False
             # Validate against JSON Schema (advisory — never fatal)
             _validate_config_data(data)
             # Clamp security-relevant resource-limit knobs to their API ceilings
@@ -2768,6 +2781,14 @@ class KiroCrewConfig:
                 # `bool("false")` is `True`, and `_safe_bool` is what keeps a
                 # quoted opt-out from loading as enabled.
                 session_control=_safe_bool(agent_data.get("session_control", True), True),
+                # Default true preserves the zero-configuration member-dispatch
+                # grant (today's behaviour) for a MISSING key. A present-but-
+                # malformed value was already coerced to False upstream, BEFORE
+                # schema validation, so it cannot ride the missing-field default
+                # back to true — see the `member_dispatch` normalization above
+                # the `_validate_config_data` call. `_safe_bool` here is the
+                # final guard for a real bool.
+                member_dispatch=_safe_bool(agent_data.get("member_dispatch", True), True),
                 subagent_cost_gb=_safe_float(agent_data.get("subagent_cost_gb", 0.5), 0.5),
                 subagent_cpu_cost_cores=_safe_float(
                     agent_data.get("subagent_cpu_cost_cores", 1.0), 1.0

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -1202,6 +1202,21 @@ class AgentConfig:
             "sessions it created itself.",
         ),
     )
+    member_dispatch: bool = field(
+        default=True,
+        metadata=_meta(
+            "Member Dispatch",
+            "Let a crew member's DM session open and drive worker sessions it "
+            "creates, even when Session Control is off. On by default, because "
+            "dispatching work into workers is the crew-member operating model, "
+            "not an opt-in: this is the zero-configuration contract. Turn this "
+            "off to put member callers back under the Session Control switch, so "
+            "an operator who withdrew session control keeps member DM threads "
+            "chat-only without disabling the member. When on, a member's reach is "
+            "still bounded to sessions it created itself (creator ownership), the "
+            "same fence that binds it when Session Control is on.",
+        ),
+    )
     subagent_cost_gb: float = field(
         default=0.5,
         metadata=_meta(

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -42,6 +42,7 @@ from kiro_crew.config.loader import (
     default_project_dir,
     resolve_agent_bindings,
 )
+from kiro_crew.config.resolution import DEGRADED_WHOLE_CONFIG
 from kiro_crew.dashboard.chat_delivery import sanitize_outbound
 from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_persistence import _TRANSIENT_ROLES as _PERSISTENCE_TRANSIENT_ROLES
@@ -349,6 +350,67 @@ def session_control_enabled() -> bool:
             "session_control: config read failed — refusing until config loads", exc_info=True
         )
         return False
+
+
+def member_dispatch_enabled() -> bool:
+    """Whether a crew member's DM session may bypass the ``session_control`` switch.
+
+    The operator ceiling on the zero-configuration member grant. Default true
+    reproduces today's behaviour exactly: a member caller bypasses
+    ``agent.session_control`` and dispatches into workers it created. Set
+    ``agent.member_dispatch`` to false and a member caller stops bypassing —
+    it falls back under ``session_control_enabled()`` like any ordinary caller,
+    so an operator who turned session control off keeps member DM threads
+    chat-only without disabling the member itself.
+
+    Fails CLOSED in BOTH ways the ceiling can lose the operator's value, the
+    same direction :func:`session_control_enabled` does:
+
+    * a config read that RAISES resolves to false; and
+    * a config that LOADS but discarded the ``agent`` section (or the whole
+      file) resolves to false too. ``load()`` does not raise on a malformed
+      section -- it coerces it away, falls back to the field default (which is
+      ``member_dispatch=True``, permissive), and records the loss in
+      ``degraded_sections``. Without this second check a degraded ``agent``
+      overlay carrying ``member_dispatch: false`` would silently revert to the
+      bypass the operator meant to withdraw -- a governance-ceiling fail-open.
+      This is the same "could not read it" vs "was never set" distinction
+      :func:`tailnet_identity_unknown` and the publish gate already draw from
+      ``degraded_sections``. The bypass never fails open.
+    """
+    try:
+        cfg = KiroCrewConfig.load()
+    except Exception:
+        logger.warning(
+            "member_dispatch: config read failed — withdrawing member bypass until config loads",
+            exc_info=True,
+        )
+        return False
+    if cfg.degraded_sections & {DEGRADED_WHOLE_CONFIG, "agent"}:
+        # The agent section (or the whole file) was discarded, so a stored
+        # `member_dispatch: false` was replaced by the permissive default.
+        # Withdraw the bypass rather than trust that default.
+        logger.warning("member_dispatch: agent config section degraded — withdrawing member bypass")
+        return False
+    return bool(cfg.agent.member_dispatch)
+
+
+def _member_bypass(caller_key: str) -> bool:
+    """Whether *caller_key* may skip the ``session_control`` switch as a member.
+
+    The single expression both switch gates key on, extracted rather than
+    copy-pasted so the member-bypass condition cannot drift between
+    :func:`create_session` and :func:`authorize_target`. A member caller
+    bypasses only while the operator ceiling ``agent.member_dispatch`` is on;
+    turned off, the member is no longer exempt and the switch gate applies to
+    it like any other caller.
+
+    Keyed on the immutable slot-key prefix (via :func:`_member_caller`) AND the
+    config ceiling — the two together decide the bypass, and neither is a proxy
+    for it. ``member_dispatch_enabled`` is read at the gate, synchronously,
+    right before the act, exactly as ``session_control_enabled`` is beside it.
+    """
+    return _member_caller(caller_key) and member_dispatch_enabled()
 
 
 async def prewarm_enabled_check() -> None:
@@ -876,11 +938,13 @@ async def create_session(
         )
     # The caller is resolved BEFORE the config gate so a member DM session —
     # for which dispatching work into workers is the operating model, not an
-    # opt-in — passes without `agent.session_control`. Every other caller
-    # still needs the switch. The member's automatic grant is bounded by
-    # ownership in `authorize_target`, not here: creation makes the caller
-    # the owner by construction.
-    if not session_control_enabled() and not _member_caller(caller_key):
+    # opt-in — passes without `agent.session_control`. That member bypass is
+    # itself gated by the operator ceiling `agent.member_dispatch` (default
+    # true = today's behaviour); with it off the member falls back under the
+    # switch like any other caller. Every other caller still needs the switch.
+    # The member's automatic grant is bounded by ownership in `authorize_target`,
+    # not here: creation makes the caller the owner by construction.
+    if not session_control_enabled() and not _member_bypass(caller_key):
         raise SessionControlError(
             "session control is disabled in config (agent.session_control)",
             code="session_control_disabled",
@@ -1395,9 +1459,11 @@ def authorize_target(
         raise deny("caller session could not be identified", "caller_unidentified")
     # Resolved before the config gate: a member DM session is authorized
     # WITHOUT `agent.session_control` — dispatching and patrolling workers is
-    # its operating model — and is bounded instead by the ownership check
-    # below, which restricts it to slots it created itself.
-    if not skip_enabled_check and not session_control_enabled() and not _member_caller(caller_key):
+    # its operating model — while the operator ceiling `agent.member_dispatch`
+    # (default true = today's behaviour) is on. Turn that ceiling off and the
+    # member falls back under the switch. The member's reach stays bounded by
+    # the ownership check below, which restricts it to slots it created itself.
+    if not skip_enabled_check and not session_control_enabled() and not _member_bypass(caller_key):
         raise deny(
             "session control is disabled in config (agent.session_control)",
             "session_control_disabled",

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -347,6 +347,44 @@ def test_slack_home_tab_sessions_per_kind_parsed_and_round_trips():
     assert reloaded.slack.home_tab_sessions_per_kind == 42
 
 
+class TestMemberDispatchLoad:
+    """agent.member_dispatch load-time coercion (issue #8073).
+
+    The operator ceiling on the member session-control bypass. A MISSING key
+    defaults to true (today's behaviour), but a PRESENT-but-malformed value —
+    the routine quoted `"false"` config mistake — must coerce to FALSE, so a
+    botched opt-out withdraws the bypass rather than silently leaving it on
+    (a governance ceiling that fails open otherwise).
+    """
+
+    def test_missing_key_defaults_true(self) -> None:
+        assert _load_from_dict({}).agent.member_dispatch is True
+
+    def test_explicit_true_and_false(self) -> None:
+        assert _load_from_dict({"agent": {"member_dispatch": True}}).agent.member_dispatch is True
+        assert _load_from_dict({"agent": {"member_dispatch": False}}).agent.member_dispatch is False
+
+    def test_quoted_false_coerces_to_false_not_true(self) -> None:
+        # The GPT-flagged fail-open: `"false"` is not a bool, and defaulting it
+        # to true would keep the bypass authorized against the operator's intent.
+        assert (
+            _load_from_dict({"agent": {"member_dispatch": "false"}}).agent.member_dispatch is False
+        )
+
+    def test_any_present_non_bool_coerces_to_false(self) -> None:
+        # A present but malformed value fails to the SAFE direction (bypass off),
+        # including a truthy-looking string that must not be trusted.
+        for bad in ("true", "yes", 1, 0, {}, [], None):
+            assert (
+                _load_from_dict({"agent": {"member_dispatch": bad}}).agent.member_dispatch is False
+            ), bad
+
+    def test_round_trips_through_to_dict(self) -> None:
+        loaded = _load_from_dict({"agent": {"member_dispatch": False}})
+        reloaded = _load_from_dict(loaded.to_dict())
+        assert reloaded.agent.member_dispatch is False
+
+
 class TestFallbackModelLoad:
     """agent.fallback_model flows through the explicit load() kwargs."""
 

--- a/test/test_member_session_control.py
+++ b/test/test_member_session_control.py
@@ -71,9 +71,12 @@ class TestAuthorizeTargetMemberPath:
         # caller_slot_key maps a session key to an open slot; the member path
         # is exercised below the identity resolution, so pin the mapping and
         # the workspace reads to keep the fixture at the authorization layer.
+        # member_dispatch_enabled is pinned True here — these tests assert the
+        # DEFAULT (bypass on) behaviour; the ceiling-off case has its own class.
         with (
             patch.object(sc, "caller_slot_key", return_value=caller_key),
             patch.object(sc, "session_control_enabled", return_value=False),
+            patch.object(sc, "member_dispatch_enabled", return_value=True),
             patch.object(sc, "_resolve_slot", return_value=state._slots.get(target_key)),
         ):
             return sc.authorize_target(
@@ -200,3 +203,115 @@ class TestCreatedByProjection:
         # "" rather than a missing key: the frontend must be able to tell "a
         # person's own tab" from "an older gateway that never sent the field".
         assert _ChatSlot("chat-1-own").to_dict()["created_by"] == ""
+
+
+class TestMemberDispatchCeiling:
+    """The operator ceiling `agent.member_dispatch` on the member switch bypass.
+
+    Default true reproduces today's behaviour (member bypasses the switch); set
+    false, a member caller stops bypassing and falls back under
+    `session_control`. The bypass condition is `_member_bypass` = member caller
+    AND dispatch enabled, and the ceiling read fails CLOSED (withdraws the
+    bypass on an unreadable config) the same direction `session_control` does.
+    """
+
+    def test_bypass_requires_member_and_ceiling_on(self):
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        with patch.object(sc, "member_dispatch_enabled", return_value=True):
+            assert sc._member_bypass(member) is True
+            assert sc._member_bypass("chat-1-abc") is False  # not a member
+        with patch.object(sc, "member_dispatch_enabled", return_value=False):
+            assert sc._member_bypass(member) is False  # ceiling off
+            assert sc._member_bypass("chat-1-abc") is False
+
+    def test_member_dispatch_enabled_reads_the_config_field(self):
+        cfg = SimpleNamespace(
+            agent=SimpleNamespace(member_dispatch=True), degraded_sections=frozenset()
+        )
+        with patch.object(sc.KiroCrewConfig, "load", return_value=cfg):
+            assert sc.member_dispatch_enabled() is True
+        cfg_off = SimpleNamespace(
+            agent=SimpleNamespace(member_dispatch=False), degraded_sections=frozenset()
+        )
+        with patch.object(sc.KiroCrewConfig, "load", return_value=cfg_off):
+            assert sc.member_dispatch_enabled() is False
+
+    def test_member_dispatch_enabled_fails_closed_on_read_error(self):
+        with patch.object(sc.KiroCrewConfig, "load", side_effect=RuntimeError("boom")):
+            # An unreadable config withdraws the bypass rather than granting it.
+            assert sc.member_dispatch_enabled() is False
+
+    def test_member_dispatch_enabled_fails_closed_on_degraded_section(self):
+        # load() does not raise on a discarded `agent` section: it falls back to
+        # the permissive default (member_dispatch=True) and records the loss in
+        # degraded_sections. A stored `member_dispatch: false` would otherwise
+        # silently revert to the bypass -- so a degraded `agent` or whole-config
+        # (`*`) marker must withdraw it.
+        for degraded in ("agent", sc.DEGRADED_WHOLE_CONFIG):
+            cfg = SimpleNamespace(
+                agent=SimpleNamespace(member_dispatch=True),
+                degraded_sections=frozenset({degraded}),
+            )
+            with patch.object(sc.KiroCrewConfig, "load", return_value=cfg):
+                assert sc.member_dispatch_enabled() is False, degraded
+
+    def test_member_dispatch_enabled_trusts_value_when_not_degraded(self):
+        # An unrelated degraded section does not withdraw the bypass -- only the
+        # agent section or the whole config does.
+        cfg = SimpleNamespace(
+            agent=SimpleNamespace(member_dispatch=True),
+            degraded_sections=frozenset({"dashboard"}),
+        )
+        with patch.object(sc.KiroCrewConfig, "load", return_value=cfg):
+            assert sc.member_dispatch_enabled() is True
+
+    def test_member_falls_back_under_switch_when_ceiling_off(self):
+        # Switch off AND ceiling off: the member is no longer exempt, so it hits
+        # the same session_control_disabled refusal an ordinary caller gets.
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        worker = _slot("chat-1-w1", created_by=member)
+        state = _State({member: _slot(member), "chat-1-w1": worker})
+        with (
+            patch.object(sc, "caller_slot_key", return_value=member),
+            patch.object(sc, "session_control_enabled", return_value=False),
+            patch.object(sc, "member_dispatch_enabled", return_value=False),
+            patch.object(sc, "_resolve_slot", return_value=worker),
+        ):
+            with pytest.raises(sc.SessionControlError) as exc_info:
+                sc.authorize_target(
+                    state,
+                    caller_session_key="dashboard:whatever",
+                    target="chat-1-w1",
+                    operation="send",
+                )
+        assert exc_info.value.code == "session_control_disabled"
+
+    def test_member_still_bypasses_when_ceiling_on_and_switch_off(self):
+        # Default behaviour preserved: ceiling on, switch off -> member passes
+        # the config gate (may still be bounded by ownership, but not by the
+        # switch). Pin an owned worker so ownership does not intervene.
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        worker = _slot("chat-1-w1", created_by=member)
+        state = _State({member: _slot(member), "chat-1-w1": worker})
+        with (
+            patch.object(sc, "caller_slot_key", return_value=member),
+            patch.object(sc, "session_control_enabled", return_value=False),
+            patch.object(sc, "member_dispatch_enabled", return_value=True),
+            patch.object(sc, "_resolve_slot", return_value=worker),
+        ):
+            try:
+                sc.authorize_target(
+                    state,
+                    caller_session_key="dashboard:whatever",
+                    target="chat-1-w1",
+                    operation="send",
+                )
+            except sc.SessionControlError as exc:
+                assert exc.code not in ("session_control_disabled", "not_creator"), exc.code
+
+    def test_config_default_is_true(self):
+        # The knob's default IS today's behaviour, so installing the change
+        # alters nothing until an operator opts in.
+        from kiro_crew.config.sections import AgentConfig
+
+        assert AgentConfig().member_dispatch is True


### PR DESCRIPTION
## What is the problem?

A crew member's DM session is a conductor by design: it dispatches work into
worker sessions it creates and patrols, with zero configuration. To make that
work, a member caller bypasses the global `agent.session_control` switch at both
`_member_caller` switch-bypass gates in `src/kiro_crew/dashboard/session_control.py`.
The consequence, flagged by the Design and First Principles lanes on the original
work: an operator who explicitly turned session control off has no lever short of
disabling the member entirely to keep that member's thread chat-only. There was
no separate switch for the member bypass.

## Why it matters to the user

An operator who withdraws session control is making a deliberate statement that
agents may not open and drive each other's sessions. Today that statement is
silently not honoured for crew members, and the only workaround is a blunt one
(disable the member), which also removes the member's legitimate chat use. The
operator needs a narrow ceiling: keep the member as a chat participant while
denying it the dispatch bypass.

## How the fix solves it

Add `agent.member_dispatch` (bool, default **true**), a sibling of
`agent.session_control` and `agent.member_acp_backend` under `AgentConfig`.

- Symptom: an operator cannot restrict member dispatch without disabling the
  member.
- Root cause: the member switch-bypass at the two gates is unconditional -- it
  keys only on the immutable member slot-key prefix (`_member_caller`), with no
  operator input.
- Fix: a shared `_member_bypass(caller_key)` helper gates the bypass on
  `_member_caller(caller_key) AND member_dispatch_enabled()`. Both bypass gates
  (`create_session` and `authorize_target`) call the one helper, so the condition
  cannot drift between them. `member_dispatch_enabled()` reads
  `agent.member_dispatch` at the gate, synchronously, right beside the existing
  `session_control_enabled()` read.

Default true reproduces today's behaviour exactly, so installing this change
alters nothing until an operator opts in. Set false, a member caller stops
bypassing and falls back under `agent.session_control` like any ordinary caller.
The knob reads through `_safe_bool` (so a quoted `"false"` disables the bypass
rather than loading as enabled), and **fails closed** in the same direction
`session_control_enabled()` does: an unreadable config withdraws the member
bypass rather than granting it. The creator-ownership fence
(`_caller_is_ownership_fenced`, and the fence-reason selector) is deliberately
untouched -- it binds a member to sessions it created itself either way, even
when the global switch is on.

On the two questions a permission-gate change must answer:

- **The property the gate keys on is the one that decides the answer.** The
  bypass is decided by two things read together at the gate: whether the caller
  is a member (immutable slot-key prefix) and whether the operator ceiling is on
  (config, read synchronously right before the act). Neither is a proxy for the
  bypass; both are inputs to it, evaluated in the same synchronous window as the
  existing switch read beside them.
- **What this makes newly reachable: nothing.** The default is today's behaviour,
  and the only new state (`member_dispatch: false`) *removes* a bypass -- it makes
  a member more restricted, never less. This is not an opt-in that unlocks a path;
  it is an opt-in that closes one.

On the enterprise scope question the issue raised ("consider whether an enterprise
`SCOPE_CATALOG` scope should cover it"): a lookup, not a new decision.
`session_control` itself is a plain `agent.*` bool with **no** `SCOPE_CATALOG`
entry, and no existing catalog scope reaches the session-control surface. A scope
would need a new governance enforcement seam rather than a data-only append, which
is out of scope for a minimal ceiling. Left to a follow-up, and stated as such in
the module doc.

### Note on the issue's second half (schema-parity test)

The issue asks for a second thing: a `WORKER_*_SCHEMA` subset-of `SESSION_*_SCHEMA`
parity test. That half's premise is gone on `main`. `src/kiro_crew/mcp_tools/workers.py`
and the `worker_*` tools were part of PR #8021's shape; #8021 was closed by
maintainer decision, and the member-dispatch feature landed instead via #8153 with
a per-session `session_*` mount. There is no second schema to hold parity with, so
this PR does not implement it. This is called out rather than silently omitted.

### Note on the knob's spelling

The issue names the knob `members.dispatch`, written against #8021's shape. On the
landed #8153 design there is no `members:` config namespace -- member configuration
lives on `agent.*` (`agent.member_acp_backend`, `agent.session_control`). The
in-tree-consistent spelling is therefore `agent.member_dispatch`, a sibling of the
switch it ceilings. Today's behaviour is expressible as its default (`true`), so
the knob's shape is right.

## What tests we did

Scoped `pytest -n0` on the touched files and their session-control consumers:

- `test/test_member_session_control.py` (15 tests, 6 new in
  `TestMemberDispatchCeiling`): the `_member_bypass` truth table (member AND
  ceiling-on required; non-member never bypasses), `member_dispatch_enabled()`
  reading the field and failing closed on a raising config read, a member falling
  back to `session_control_disabled` at `authorize_target` when the ceiling is off
  and the switch is off, the default behaviour preserved (ceiling on + switch off
  still passes the config gate), and the config default being `true`. The existing
  member-bypass tests were made robust to the new ceiling by pinning
  `member_dispatch_enabled=True` in their shared helper (they assert the default).
- `test/test_session_control.py`, `test/test_session_control_boundaries.py`,
  `test/test_cron_session_control.py` (211 tests): the gate change touches shared
  code; these consumers still pass.
- `test/test_config_baseline.py`, `test/test_config_loader.py` (503 tests): the new
  field round-trips through load and the committed `config-baseline.json` snapshot
  was regenerated (`scripts/generate_config_baseline.py`); the diff is exactly the
  one new `agent.member_dispatch` entry (+15 lines), nothing else.

`black --target-version py310`, `isort`, `flake8` clean on all four changed Python
files; `mypy` clean on the three changed source files. On the security posture:
this is a permission-ceiling change, so I attempted the organizational
security-guidance search; it is unreachable from this session. The query I would
have run is for least-privilege operator config ceilings on an automatic grant. The
change only ever tightens (default = current behaviour, opt-in removes a bypass),
and the ceiling fails closed.

<!-- no-visual-delta -->
**Why no screenshot:** backend config + gate wiring, a docs spec update, and a unit
test. No `website/` surface is touched and there is no rendered delta.

## Any other suggestions on the work

- The enterprise `SCOPE_CATALOG` scope for member dispatch is a real follow-up, but
  it needs a governance enforcement seam (a chokepoint that reads the scope), not a
  catalog append -- the same reason `session_control` is not a catalog scope today.
- If a future change adds a `members:` config namespace, `agent.member_dispatch`
  would be the natural thing to alias/move there; until then the `agent.*` sibling
  is the consistent home.

## Pattern harvest

Defect class avoided: a permission-gate knob whose default silently shifts an
existing deployment's behaviour, or whose gate keys on a mutable proxy. Here the
default is pinned to today's behaviour (verified by a test asserting
`AgentConfig().member_dispatch is True` and by the config-baseline diff being the
single new entry), the two gates share one extracted predicate so they cannot
drift, and the new state only ever tightens so nothing is made newly reachable.

Rule candidate: when adding an operator ceiling on an existing automatic grant,
prove three things in the PR and in a test -- (1) the default equals current
behaviour so install is a no-op, (2) the two-or-more enforcement sites share one
extracted predicate rather than copy-pasted conditions, and (3) the new
configurable state removes reach rather than adding it. If the current behaviour
cannot be expressed as a default value of the knob, the knob's shape is wrong.

Refs #8073
