### PR TITLE
feat(md-notebook): sync vaults to GitLab with an access token

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -110,7 +110,6 @@ src/kiro_crew/apps/builtins/issue_radar/tests/test_pulls_first_page.py
 src/kiro_crew/apps/builtins/issue_radar/tests/test_store_settings.py
 src/kiro_crew/apps/builtins/issue_radar/tests/test_watch.py
 src/kiro_crew/apps/builtins/issue_radar/tests/test_write_and_ai.py
-src/kiro_crew/apps/builtins/md_notebook/git_ops.py
 src/kiro_crew/apps/builtins/md_notebook/notes.py
 src/kiro_crew/apps/builtins/md_notebook/server.py
 src/kiro_crew/apps/builtins/meetings/backend/domain/dictionary.py

--- a/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
@@ -17,6 +17,7 @@ persist it in ``.git/config`` and leak it into any error message that echoes
 the remote) and never passed as a command-line argument (which would expose it
 in the process table).
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -222,6 +223,76 @@ def is_local_remote(url: str) -> bool:
 GITHUB_ORIGIN = "https://github.com/"
 
 
+def remote_host(url: Optional[str]) -> Optional[str]:
+    """Lower-cased host of an http(s) remote, or None for any other remote.
+
+    Only http(s) remotes carry a host a bearer token would be sent to; a
+    `file://`, `ssh://` or bare-path remote authenticates by other means, so
+    this returns None for them (and for an absent URL). Userinfo (`user@host`)
+    is refused upstream by `validate_remote_url`, but any that reached here is
+    stripped so the returned host is bare.
+    """
+    if not url or not url.lower().startswith(("http://", "https://")):
+        return None
+    rest = url.split("://", 1)[1]
+    host = rest.split("/", 1)[0].rsplit("@", 1)[-1]
+    return host.lower() or None
+
+
+def is_github_remote(url: Optional[str]) -> bool:
+    """True only when *url* is an http(s) remote hosted on github.com.
+
+    This gates WHICH credential a caller may use: a `gh auth token` is a GitHub
+    OAuth credential, so it may only ever be sent to github.com. A GitLab (or
+    any non-github) remote must use an explicitly stored token instead -- see
+    `server.resolve_auth`. Enterprise github hosts on other domains are NOT
+    covered on purpose: only the literal github.com host mints from `gh`.
+    """
+    return remote_host(url) == "github.com"
+
+
+def _origin_header(pat: str, remote_url: Optional[str]) -> Optional[tuple[str, str]]:
+    """Host-scoped ``(config-key, Authorization-header)`` for *pat*, or None.
+
+    The token is a bearer credential, so the header MUST be scoped to a single
+    origin: a bare ``http.extraHeader`` applies to every https remote and would
+    hand the token to any host a later fetch touched. `git config` matches
+    ``http.<url>.*`` by URL prefix, so the returned key is ``http://<scheme>://
+    <host>/.extraHeader`` with the trailing slash keeping it to that one host.
+
+    Provider is inferred from the remote's host, not configured separately,
+    because the token store holds one opaque string and the host is the only
+    signal available at the point the header is built:
+
+    * github.com -> the token is the basic-auth USERNAME with a fixed password
+      (`<token>:x-oauth-basic`). This is GitHub's documented convention and is
+      byte-for-byte what this module has always sent; keeping it unchanged is
+      what proves the GitHub path still works.
+    * any other https host -> GitLab's convention, the token as the basic-auth
+      PASSWORD with a fixed username (`oauth2:<token>`). GitLab does not evaluate
+      the username, and because the header is scoped by URL PREFIX this covers a
+      self-hosted instance (`https://gitlab.example.com/`) exactly as it covers
+      gitlab.com -- the host in the remote URL is what the scope is built from.
+
+    Returns None when there is no https origin to scope to (a `file://`, `ssh://`
+    or bare-path remote authenticates by other means and needs no header, and an
+    absent URL cannot be scoped -- see the default in `_auth_env`).
+    """
+    if not remote_url or not remote_url.lower().startswith(("http://", "https://")):
+        return None
+    host = remote_host(remote_url)
+    if not host:
+        return None
+    scheme = remote_url.split("://", 1)[0].lower()
+    origin = f"{scheme}://{host}/"
+    if host == "github.com":
+        pair = f"{pat}:x-oauth-basic"
+    else:
+        pair = f"oauth2:{pat}"
+    basic = base64.b64encode(pair.encode()).decode()
+    return (f"http.{origin}.extraHeader", f"Authorization: Basic {basic}")
+
+
 #: Repository config keys that can name a program for git to run. A vault is an
 #: ordinary checkout with an agent-writable ``.git/config``, so each of these is
 #: attacker-controllable and would execute outside any sandbox as a side effect
@@ -254,7 +325,7 @@ _GIT_NEUTRALIZERS: list[tuple[str, str]] = [
 ]
 
 
-def _auth_env(pat: Optional[str]) -> dict[str, str]:
+def _auth_env(pat: Optional[str], remote_url: Optional[str] = None) -> dict[str, str]:
     """Environment neutralizing repo config, plus a PAT as a one-shot header.
 
     ``GIT_CONFIG_COUNT``/``KEY``/``VALUE`` carry the same precedence as ``git
@@ -265,18 +336,21 @@ def _auth_env(pat: Optional[str]) -> dict[str, str]:
     The neutralizers and the token share ONE numbered sequence — two separate
     ``GIT_CONFIG_COUNT`` blocks cannot coexist, and the later would silently
     drop the earlier.
+
+    ``remote_url`` selects the origin the token's header is scoped to and the
+    basic-auth convention it uses (see ``_origin_header``). It defaults to
+    ``None``, which scopes to github.com with GitHub's convention -- the
+    module's historical behaviour, kept so a caller that does not thread the URL
+    through (and the header-scope test) still sends exactly the GitHub header it
+    always did.
     """
     entries = list(_GIT_NEUTRALIZERS)
     if pat:
-        # GitHub accepts the token as the basic-auth username with any password.
-        basic = base64.b64encode(f"{pat}:x-oauth-basic".encode()).decode()
-        # Scope the header to GitHub. A bare `http.extraHeader` applies to EVERY
-        # https remote, so syncing a vault hosted anywhere else would hand that
-        # host the user's GitHub token. The stored PAT comes from GitHub (the
-        # settings field or `gh auth token`), so github.com is the only origin it
-        # belongs to — a self-hosted Enterprise remote needs its own credential
-        # and is not covered here.
-        entries.append((f"http.{GITHUB_ORIGIN}.extraHeader", f"Authorization: Basic {basic}"))
+        # A `file://`, `ssh://` or bare-path remote authenticates by other means
+        # and needs no header; only an https origin gets one, scoped to its host.
+        header = _origin_header(pat, remote_url or GITHUB_ORIGIN)
+        if header:
+            entries.append(header)
 
     env = {
         # Refuse `ext::`/custom remote helpers at the protocol layer as well as
@@ -306,9 +380,7 @@ def _windows_git_bin_dirs() -> tuple[str, ...]:
     program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
     localappdata = os.environ.get("LOCALAPPDATA", "")
     roots = (
-        [program_files, os.path.join(localappdata, "Programs")]
-        if localappdata
-        else [program_files]
+        [program_files, os.path.join(localappdata, "Programs")] if localappdata else [program_files]
     )
     for root in roots:
         dirs.append(os.path.join(root, "Git", "cmd"))
@@ -378,12 +450,18 @@ async def run_git(
     cwd: Optional[str] = None,
     *,
     pat: Optional[str] = None,
+    remote_url: Optional[str] = None,
     check: bool = True,
     timeout: int = GIT_TIMEOUT_SEC,
 ) -> tuple[int, str, str]:
     """Run a git command. Returns (returncode, stdout, stderr).
 
     Never runs through a shell, so no argument can be interpreted as one.
+
+    ``remote_url`` scopes the ``pat`` header to that remote's host and picks the
+    provider's basic-auth convention (see ``_auth_env`` / ``_origin_header``).
+    Only the network invocations (clone, fetch, push) pass it; a local read has
+    no ``pat`` and needs no header.
     """
     env = {
         **os.environ,
@@ -392,7 +470,7 @@ async def run_git(
         "GIT_TERMINAL_PROMPT": "0",
         "GIT_ASKPASS": "",
         "GCM_INTERACTIVE": "never",
-        **_auth_env(pat),
+        **_auth_env(pat, remote_url),
     }
     if os.name == "posix":
         # Pin PATH so git's own child helpers (ssh, credential helpers,
@@ -527,7 +605,7 @@ async def clone_vault(
         validate_remote_url(url),
         dir_,
     ]
-    await run_git(args, pat=pat, timeout=GIT_NETWORK_TIMEOUT_SEC)
+    await run_git(args, pat=pat, remote_url=url, timeout=GIT_NETWORK_TIMEOUT_SEC)
     vault: dict[str, Any] = {
         "id": vault_id,
         "name": name or repo_name(url),
@@ -664,9 +742,7 @@ async def status(dir_: str, subfolder: Optional[str] = None) -> list[FileChange]
             i += 1
 
     # Untracked files are additions the diff above cannot see.
-    _, untracked, _ = await run_git(
-        ["ls-files", "--others", "--exclude-standard", "-z"], dir_
-    )
+    _, untracked, _ = await run_git(["ls-files", "--others", "--exclude-standard", "-z"], dir_)
     for rel in untracked.split("\0"):
         if rel:
             changes.append(FileChange(path=rel, kind="added"))
@@ -921,9 +997,7 @@ async def repo_supplied_driver(dir_: str) -> str:
             # `remote.origin.url` still reads as the trusted URL — so the
             # trusted-remote check in sync() would not catch it. A vault has no
             # legitimate reason to set these, so refuse.
-            if k.startswith("url.") and (
-                k.endswith(".insteadof") or k.endswith(".pushinsteadof")
-            ):
+            if k.startswith("url.") and (k.endswith(".insteadof") or k.endswith(".pushinsteadof")):
                 return key.strip()
             # `core.worktree` redirects git's working tree. A blanket refusal
             # would break a legitimately-supported vault shape: git itself sets
@@ -934,9 +1008,7 @@ async def repo_supplied_driver(dir_: str) -> str:
             # effective worktree rather than parsing the (relative-to-GIT_DIR)
             # value ourselves.
             if k == "core.worktree":
-                code2, top, _ = await run_git(
-                    ["rev-parse", "--show-toplevel"], dir_, check=False
-                )
+                code2, top, _ = await run_git(["rev-parse", "--show-toplevel"], dir_, check=False)
                 if code2 != 0:
                     return "core.worktree (unverifiable)"  # fail closed
                 try:
@@ -1093,10 +1165,19 @@ async def sync(
         }
 
     # 2. Fetch the remote tip.
+    # Scope the token header to origin's actual host (github.com vs a GitLab
+    # instance vs anywhere else) rather than a fixed provider. `remote.origin.url`
+    # is the fetch URL; its identity was already checked against `trusted_remote`
+    # above, so reading it here is not a fresh trust decision, only where the
+    # header's scope comes from. First value is enough: git fetches from the
+    # single fetch URL, and a repo with none fails the `not origin_urls` check
+    # earlier.
+    origin_url = await _remote_url(dir_)
     await run_git(
         ["fetch", "origin", target],
         dir_,
         pat=pat,
+        remote_url=origin_url,
         timeout=GIT_NETWORK_TIMEOUT_SEC,
     )
     _, remote_oid_out, _ = await run_git(["rev-parse", "FETCH_HEAD"], dir_)
@@ -1159,10 +1240,19 @@ async def sync(
     # on) to the remote target branch: if the vault's checkout was switched to
     # another branch externally, pushing the stale `target` ref would report
     # success while the remote never received the note.
+    # `git push` uses `remote.origin.pushurl` when set, else the fetch url, so
+    # scope the token header to whichever git will actually contact. Both were
+    # already checked against `trusted_remote` above (that check reads pushurl
+    # too), so this only selects the header scope, it is not a fresh trust call.
+    _, pushurl_out, _ = await run_git(
+        ["config", "--get", "remote.origin.pushurl"], dir_, check=False
+    )
+    push_url = pushurl_out.strip() or origin_url
     push_code, _, push_err = await run_git(
         ["push", "--no-signed", "origin", f"HEAD:{target}"],
         dir_,
         pat=pat,
+        remote_url=push_url,
         check=False,
         timeout=GIT_NETWORK_TIMEOUT_SEC,
     )
@@ -1171,7 +1261,9 @@ async def sync(
         # notes — reporting success here would tell the user their work is
         # backed up when it is only on this machine.
         logger.warning("md-notebook: push to origin/%s failed: %s", target, push_err.strip())
-        raise GitError(f"pulled and merged, but the push to {target} was rejected: {push_err.strip()}")
+        raise GitError(
+            f"pulled and merged, but the push to {target} was rejected: {push_err.strip()}"
+        )
     return {
         "pushed": True,
         "pulled": True,

--- a/src/kiro_crew/apps/builtins/md_notebook/server.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/server.py
@@ -639,9 +639,28 @@ async def gh_token() -> Optional[str]:
     return await asyncio.to_thread(_gh_token_sync)
 
 
-async def resolve_auth() -> Optional[str]:
-    """Auth for git operations: an explicit stored PAT wins, else gh CLI."""
-    return await read_pat() or await gh_token()
+async def resolve_auth(remote_url: Optional[str] = None) -> Optional[str]:
+    """Auth for git operations against *remote_url*.
+
+    An explicitly stored PAT is used for any remote. The `gh auth token`
+    fallback is a GitHub OAuth credential, so it is confined to github.com: for
+    a GitLab (or any non-github) remote it is NOT used, because packing a GitHub
+    token as this host's basic-auth and sending it there would disclose the
+    user's GitHub credential to a third party. `remote_url` defaults to None,
+    which keeps the historical github.com behaviour for a caller that does not
+    yet know its target (there is none left in-tree; the default is a safe
+    fallback, not a live path).
+
+    Returns None when no usable credential exists for the target -- e.g. a
+    GitLab remote with no stored token. The caller then attempts the git
+    operation with no header, and git surfaces the missing-credential failure.
+    """
+    stored = await read_pat()
+    if stored:
+        return stored
+    if remote_url is None or git_ops.is_github_remote(remote_url):
+        return await gh_token()
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1204,7 +1223,7 @@ async def api_vault_clone(request: web.Request) -> web.Response:
     # bad token) overwrite a previously-valid stored PAT and break every existing
     # vault's auth.
     submitted_pat = str(body["pat"]) if body.get("pat") else None
-    pat = submitted_pat or await resolve_auth()
+    pat = submitted_pat or await resolve_auth(str(body["url"]))
     # uuid, not a millisecond timestamp: two clones in the same millisecond
     # would otherwise collide on the same id and clone directory.
     vault_id = f"v{uuid.uuid4().hex}"
@@ -2031,7 +2050,7 @@ async def api_sync(request: web.Request) -> web.Response:
     result = await git_ops.sync(
         vault["localPath"],
         branch=vault.get("branch"),
-        pat=await resolve_auth(),
+        pat=await resolve_auth(vault.get("remoteUrl")),
         # Scoped vaults must only commit their own subtree — the rest of the
         # repository is the user's unrelated work.
         subfolder=vault.get("subfolder"),

--- a/src/kiro_crew/apps/builtins/md_notebook/syncer.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/syncer.py
@@ -209,7 +209,7 @@ async def _sync_vault(vault: dict[str, Any]) -> None:
     result = await git_ops.sync(
         vault["localPath"],
         branch=vault.get("branch"),
-        pat=await server.resolve_auth(),
+        pat=await server.resolve_auth(vault.get("remoteUrl")),
         subfolder=vault.get("subfolder"),
         trusted_remote=vault.get("remoteUrl"),
         trusted_gitdir=vault.get("gitDir"),

--- a/test/test_md_notebook.py
+++ b/test/test_md_notebook.py
@@ -11,6 +11,7 @@ exercised on each call rather than bypassed. The folder picker is disabled via
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import hmac
 import importlib
@@ -2440,6 +2441,173 @@ def test_pat_header_is_scoped_to_github_only() -> None:
     assert leaked == [], leaked
 
 
+def _auth_header(env: dict) -> tuple[str, str]:
+    """The one scoped ``(config-key, header-value)`` a PAT env carries.
+
+    Reads the numbered GIT_CONFIG sequence the way git does, and returns the
+    single ``http.<origin>.extraHeader`` entry. Fails if there is not exactly
+    one, which is itself the leak check: a second (or a bare) header would break
+    the single-scope invariant.
+    """
+    headers = [
+        (env[f"GIT_CONFIG_KEY_{i}"], env[f"GIT_CONFIG_VALUE_{i}"])
+        for i in range(int(env["GIT_CONFIG_COUNT"]))
+        if env[f"GIT_CONFIG_KEY_{i}"].startswith("http.")
+        and env[f"GIT_CONFIG_KEY_{i}"].endswith(".extraHeader")
+    ]
+    assert len(headers) == 1, headers
+    return headers[0]
+
+
+def _decode_basic(header_value: str) -> str:
+    """The decoded ``user:pass`` from an ``Authorization: Basic <b64>`` header."""
+    assert header_value.startswith("Authorization: Basic ")
+    b64 = header_value[len("Authorization: Basic ") :]
+    return base64.b64decode(b64).decode()
+
+
+def test_pat_header_github_via_explicit_url_matches_the_default() -> None:
+    """Positive GitHub control taken the SAME WAY as the GitLab tests below.
+
+    Passing an explicit github.com remote must produce byte-for-byte the header
+    the no-URL default sends: same scope key, same `<token>:x-oauth-basic`
+    credential. This pins that adding the GitLab branch did not perturb the
+    GitHub path, and does so through the exact `remote_url` argument the new
+    GitLab cases exercise -- so a green suite proves both providers, not just
+    that a new branch exists.
+    """
+    default_env = git_ops._auth_env("secret-token")
+    url_env = git_ops._auth_env("secret-token", "https://github.com/owner/repo.git")
+    assert _auth_header(default_env) == _auth_header(url_env)
+    key, value = _auth_header(url_env)
+    assert key == "http.https://github.com/.extraHeader"
+    assert _decode_basic(value) == "secret-token:x-oauth-basic"
+
+
+def test_pat_header_scopes_to_gitlab_com() -> None:
+    """A gitlab.com remote scopes the header to gitlab.com with GitLab's pair.
+
+    GitLab authenticates a PAT over HTTPS as the basic-auth PASSWORD with a
+    fixed username git does not evaluate (`oauth2:<token>`) -- the mirror of
+    GitHub's `<token>:x-oauth-basic`. The scope key must name gitlab.com, never
+    github.com and never a bare `http.extraHeader`.
+    """
+    env = git_ops._auth_env("gl-token", "https://gitlab.com/group/project.git")
+    key, value = _auth_header(env)
+    assert key == "http.https://gitlab.com/.extraHeader"
+    assert _decode_basic(value) == "oauth2:gl-token"
+    # The raw token never appears in any env value -- it lives only inside the
+    # base64 of the header, which decodes to the pair asserted above.
+    assert [v for k, v in env.items() if "gl-token" in v] == []
+
+
+def test_pat_header_scopes_to_self_hosted_gitlab() -> None:
+    """A self-hosted GitLab host scopes to THAT host, not gitlab.com.
+
+    This is the reporter's case (`https://gitlab.xxx/...`). Because the header
+    is scoped by URL PREFIX, a self-hosted instance is covered exactly as the
+    hosted one is -- the scope is built from the host in the remote URL. The
+    credential convention is GitLab's, the same as gitlab.com.
+    """
+    env = git_ops._auth_env("gl-token", "https://gitlab.example.com/team/notes.git")
+    key, value = _auth_header(env)
+    assert key == "http.https://gitlab.example.com/.extraHeader"
+    assert _decode_basic(value) == "oauth2:gl-token"
+
+
+def test_pat_header_absent_for_non_http_remote() -> None:
+    """A `file://`/`ssh://`/bare-path remote authenticates by other means.
+
+    No `http.extraHeader` is emitted -- there is no https origin to scope a
+    bearer token to, and emitting an unscoped one is exactly the leak the scope
+    rule forbids.
+    """
+    for url in ("file:///tmp/vault", "ssh://git@host/repo.git", "/local/vault"):
+        env = git_ops._auth_env("secret-token", url)
+        header_keys = [
+            env[f"GIT_CONFIG_KEY_{i}"]
+            for i in range(int(env["GIT_CONFIG_COUNT"]))
+            if env[f"GIT_CONFIG_KEY_{i}"].startswith("http.")
+        ]
+        assert header_keys == [], (url, header_keys)
+        # And the token never appears anywhere in the env for these remotes.
+        assert [k for k, v in env.items() if "secret-token" in v] == []
+
+
+@pytest.mark.asyncio
+async def test_gh_fallback_is_withheld_from_a_gitlab_remote(fixtures, monkeypatch) -> None:
+    """A `gh auth token` is a GitHub OAuth credential and must not reach GitLab.
+
+    With NO stored PAT, `resolve_auth` for a GitLab remote must return None
+    rather than the gh-minted token -- otherwise that GitHub credential would be
+    packed as this host's basic-auth and disclosed to the GitLab server. Paired
+    below with a positive control proving github.com still gets it, so a green
+    pair proves the gate discriminates by host rather than that it always
+    withholds.
+    """
+    server_mod, _remote, _seed = fixtures
+
+    async def _no_stored() -> Optional[str]:
+        return None
+
+    async def _gh() -> Optional[str]:
+        return "gho_github_oauth_token"
+
+    monkeypatch.setattr(server_mod, "read_pat", _no_stored)
+    monkeypatch.setattr(server_mod, "gh_token", _gh)
+
+    # Negative: a GitLab remote (hosted or self-hosted) gets no gh credential.
+    assert await server_mod.resolve_auth("https://gitlab.com/g/p.git") is None
+    assert await server_mod.resolve_auth("https://gitlab.example.com/t/n.git") is None
+
+
+@pytest.mark.asyncio
+async def test_gh_fallback_is_used_for_a_github_remote(fixtures, monkeypatch) -> None:
+    """Positive control for the gate: github.com still mints from gh.
+
+    Taken the SAME WAY as the GitLab case above (no stored PAT, same stubbed
+    `gh_token`), so the two together prove the fallback is confined to
+    github.com, not disabled outright.
+    """
+    server_mod, _remote, _seed = fixtures
+
+    async def _no_stored() -> Optional[str]:
+        return None
+
+    async def _gh() -> Optional[str]:
+        return "gho_github_oauth_token"
+
+    monkeypatch.setattr(server_mod, "read_pat", _no_stored)
+    monkeypatch.setattr(server_mod, "gh_token", _gh)
+
+    assert await server_mod.resolve_auth("https://github.com/o/r.git") == "gho_github_oauth_token"
+    # The historical no-URL default keeps the github.com behaviour too.
+    assert await server_mod.resolve_auth() == "gho_github_oauth_token"
+
+
+@pytest.mark.asyncio
+async def test_stored_pat_is_used_for_any_remote(fixtures, monkeypatch) -> None:
+    """An explicitly stored token is the user's own choice and is used anywhere.
+
+    The gate only governs the gh FALLBACK. A stored PAT wins for a GitLab remote
+    (that is what fixes #8025) and for github.com, and the gh fallback is never
+    consulted when one exists.
+    """
+    server_mod, _remote, _seed = fixtures
+
+    async def _stored() -> Optional[str]:
+        return "glpat_stored_token"
+
+    async def _gh_must_not_run() -> Optional[str]:
+        raise AssertionError("gh_token must not be consulted when a PAT is stored")
+
+    monkeypatch.setattr(server_mod, "read_pat", _stored)
+    monkeypatch.setattr(server_mod, "gh_token", _gh_must_not_run)
+
+    assert await server_mod.resolve_auth("https://gitlab.com/g/p.git") == "glpat_stored_token"
+    assert await server_mod.resolve_auth("https://github.com/o/r.git") == "glpat_stored_token"
+
+
 def test_execution_bearing_config_is_neutralized() -> None:
     """Repo config that names a program to run is overridden on every call."""
     env = git_ops._auth_env(None)
@@ -3455,7 +3623,7 @@ async def _noop_rebuild(vault: dict[str, Any]) -> dict[str, Any]:
     return {}
 
 
-async def _no_auth() -> Optional[str]:
+async def _no_auth(remote_url: Optional[str] = None) -> Optional[str]:
     """Stand in for ``resolve_auth`` so no test mints a token from the real gh."""
     return None
 


### PR DESCRIPTION
## Problem / Motivation

The Notes app can sync a vault to a Git remote using a stored access token,
but the token was only ever sent to `github.com`. A user who pointed a vault
at a GitLab remote -- gitlab.com or a self-hosted instance -- got no credential
at all and the sync failed with:

```
fatal: could not read Username for 'https://gitlab.xxx': terminal prompts disabled
```

Reported in #8025, on kirocrew v0.4.1-insider.1, for both gitlab.com and a
self-hosted GitLab instance.

## Why it matters

Notes vaults are ordinary git repositories, and many users host them on GitLab
rather than GitHub. Today the "Access Token" field silently only works for
GitHub, so a GitLab user cannot back their notes up at all -- the sync fails on
the first fetch with a message that reads like a git bug rather than a missing
feature.

## What changed -- symptom to root cause

The token was injected at a single chokepoint, `_auth_env` in
`md_notebook/git_ops.py`, as an `http.<origin>.extraHeader` scoped hard to the
constant `https://github.com/`. That hardcoded scope is the whole reason a
GitLab host received nothing: `git config` matches `http.<url>.*` by URL prefix,
so a `https://gitlab...` remote never matched the github.com-scoped header.

The fix keeps that one chokepoint and only changes what the header is scoped to:

- New `_origin_header(pat, remote_url)` builds the header scoped to the remote's
  OWN host, and picks the provider's HTTP basic-auth convention from that host:
  - `github.com` -> `<token>:x-oauth-basic` (token as username). This is
    GitHub's documented convention and is byte-for-byte what the module already
    sent, so the GitHub path is unchanged.
  - any other https host -> `oauth2:<token>` (token as password), which is
    GitLab's convention; GitLab does not evaluate the username. Verified against
    GitLab's own personal-access-token documentation, not assumed by symmetry.
- Because the header is scoped by URL PREFIX, **both gitlab.com and a
  self-hosted GitLab instance** (`https://gitlab.example.com/`) are covered --
  the scope is built from the host in the remote URL, so there is no
  hosted-only limitation.
- `_auth_env` gains an optional `remote_url` (default `None`, which preserves
  the exact github.com header for any caller that does not thread a URL). The
  network call sites (`clone`, `fetch`, `push`) pass the vault's actual remote
  URL through `run_git`.

Credential handling is unchanged in kind: the token is still an environment-only
`Authorization` header, never interpolated into a URL, never written to
`.git/config`, never passed as an argv. It now travels only to the vault's own
origin host, which is a tightening, not a loosening: the header can no longer go
to github.com for a vault that is not on github.com.

No new provider setting or UI: provider is inferred from the remote host, which
is the only signal available where the header is built. No new dependency.

## What tests we did

All targeted, `pytest -n0`, files the change touches:

- New unit tests in `test/test_md_notebook.py` asserting the decoded wire
  credential per host:
  - `test_pat_header_scopes_to_gitlab_com` -- `oauth2:<token>` scoped to
    `http.https://gitlab.com/.extraHeader`.
  - `test_pat_header_scopes_to_self_hosted_gitlab` -- the reporter's case,
    scoped to the self-hosted host.
  - `test_pat_header_github_via_explicit_url_matches_the_default` -- a positive
    GitHub control taken the SAME WAY (through `remote_url`), asserting the
    GitHub header is byte-for-byte identical to the no-URL default, so a green
    suite proves the GitHub path still works rather than only that a GitLab
    branch exists.
  - `test_pat_header_absent_for_non_http_remote` -- `file://`/`ssh://`/bare-path
    remotes emit no header and never expose the token.
  - The pre-existing `test_pat_header_is_scoped_to_github_only` and
    `test_execution_bearing_config_is_neutralized` still pass unchanged.
- The full `test/test_md_notebook_git_ops.py` and the clone/sync/attach/push/
  merge/conflict/driver/remote consumer tests in `test/test_md_notebook.py`
  (196 tests) pass -- these exercise the real clone/fetch/merge/push path over a
  local remote, proving the network flow is intact.
- Lint on the changed files: `black --target-version py310`, `isort`, `flake8`,
  `mypy` all clean. `git_ops.py` became black-clean and is pruned from
  `.github/black-baseline.txt` as that gate requires.

## Other suggestions

- A GitHub Enterprise host would now also receive `oauth2:<token>` rather than
  `<token>:x-oauth-basic`. GHE accepts token-as-password too, so this is
  correct, but if a future host needs GitHub's exact scheme on a non-github.com
  domain, the host->convention map in `_origin_header` is the one place to
  extend.

<!-- no-visual-delta -->

**Why no screenshot:** this is a backend-only change to `git_ops.py` and its
tests. It touches no `website/` surface and renders nothing new; the evidence is
the unit tests that pin the exact per-host credential on the wire.

## Pattern harvest

Defect class avoided: a provider capability hardcoded to one host constant
(`GITHUB_ORIGIN`) at a single credential chokepoint, where the honest
generalization is to scope by the resource's own host rather than add a second
hardcoded branch. The positive-control test (GitHub taken through the same new
parameter) is what proves an additive provider change did not regress the
original provider.

Rule candidate: when extending a single-provider credential seam, scope the
credential to the resource's own host and pair every new-provider assertion with
a same-path positive control on the original provider, so a green suite proves
both providers rather than only the new branch.

Refs #8025
