### PR TITLE
fix(protocol): tolerate a Markdown wrapper around the [OPTIONS:] marker

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -884,7 +884,6 @@ test/test_one_conversation_one_session.py
 test/test_open_dm_retry.py
 test/test_open_slots_persistence.py
 test/test_options_click_validation.py
-test/test_options_marker_closers.py
 test/test_options_submit.py
 test/test_orphaned_approval_card.py
 test/test_outbox_binary.py

--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -161,8 +161,44 @@ SUBAGENT_TIMEOUT_MAX = 86400
 MARKER_CLOSERS = "]\u3011\uff3d\u3015"
 _MARKER_CLOSE_CLASS = "[" + re.escape(MARKER_CLOSERS) + "]"
 
+#: Markdown WRAPPER characters tolerated around a complete marker line (#9110).
+#: A model sometimes wraps the whole marker in inline code or emphasis --
+#: ``\`[OPTIONS: A | B]\``` or ``**[OPTIONS: A | B]**``. The wrapper character
+#: lands AFTER the closer, breaks the end anchor, and the marker leaks into the
+#: visible message as literal text while the turn silently loses its pills --
+#: the same class of model tic as the stray ``](OPTIONS)`` suffix the grammar
+#: already absorbs. Scope is deliberately tight so real prose never matches:
+#: a LEADING wrapper is accepted only at line start (after optional indent), so
+#: emphasis belonging to preceding prose (``**Choose:** [OPTIONS: ...]``) is
+#: never eaten, and a TRAILING wrapper only when the marker itself OPENED one:
+#: the ``(?(lwrap)...)`` conditional arms only when the ``lwrap`` group
+#: captured a nonempty line-leading run. This is the invariant that makes every
+#: reviewed corruption shape unreachable at once (mid-line code span
+#: ``\`Use [OPTIONS: A | B]\```, a streaming frame's stray run, a MULTILINE
+#: emphasis closer ``**Choose one\n[OPTIONS: A | B]**``): a run at line start
+#: can only OPEN emphasis under CommonMark flanking rules (preceded by a
+#: newline, it is not right-flanking), while a run after the closer can only
+#: CLOSE something -- and if the marker did not open it, it belongs to the
+#: enclosing prose and must survive the strip. A bare or mid-line marker keeps
+#: the pre-widening grammar exactly. Leading-only stays absorbed (nothing
+#: follows the closer, so nothing can be stolen); trailing-only does not
+#: match and renders literally, as it did before the widening. Runs are capped
+#: at 3 (``***`` is the longest CommonMark emphasis run; 4+ is not a wrapper).
+#:
+#: ReDoS profile unchanged: the class shares no character with the trailing
+#: ``[ \t]*`` / ``\s*`` or the indent class, and both wrapper positions are
+#: anchored by the required ``[OPTIONS:`` literal, so no new ambiguity exists.
+MARKER_WRAPPERS = "`*_"
+_MARKER_WRAP_CLASS = "[" + re.escape(MARKER_WRAPPERS) + "]"
+
+# The ``labels`` group is NAMED because the ``lwrap`` conditional group
+# necessarily precedes it, shifting positional numbering: consumers read
+# ``group("labels")`` (and iterate with ``finditer``, since ``findall`` on a
+# multi-group pattern yields tuples).
 OPTIONS_RE_LINE = re.compile(
-    rf"\[OPTIONS:((?:[^[\n]|\[(?!OPTIONS:))*){_MARKER_CLOSE_CLASS}(?:\([^\s()]*\))?[ \t]*$",
+    rf"(?:^[ \t]*(?P<lwrap>{_MARKER_WRAP_CLASS}{{1,3}}))?"
+    rf"\[OPTIONS:(?P<labels>(?:[^[\n]|\[(?!OPTIONS:))*){_MARKER_CLOSE_CLASS}"
+    rf"(?:\([^\s()]*\))?(?(lwrap){_MARKER_WRAP_CLASS}{{0,3}})[ \t]*$",
     re.MULTILINE,
 )
 
@@ -173,9 +209,14 @@ OPTIONS_RE_LINE = re.compile(
 # the same optional markdown-link close as LINE (same ``[^\s()]`` inner class, so it
 # shares no character with the trailing ``\s*`` — ReDoS-safe) so the grammar stays
 # identical.
+# ``re.MULTILINE`` is added ONLY so the optional leading-wrapper group can
+# anchor ``^`` at the marker's own line start; the pattern has no ``$`` and
+# ``\Z`` is unaffected by the flag, so nothing else changes.
 OPTIONS_RE_TRAILER = re.compile(
-    rf"\[OPTIONS:((?:[^[]|\[(?!OPTIONS:))*){_MARKER_CLOSE_CLASS}(?:\([^\s()]*\))?\s*\Z",
-    re.DOTALL,
+    rf"(?:^[ \t]*(?P<lwrap>{_MARKER_WRAP_CLASS}{{1,3}}))?"
+    rf"\[OPTIONS:(?P<labels>(?:[^[]|\[(?!OPTIONS:))*){_MARKER_CLOSE_CLASS}"
+    rf"(?:\([^\s()]*\))?(?(lwrap){_MARKER_WRAP_CLASS}{{0,3}})\s*\Z",
+    re.DOTALL | re.MULTILINE,
 )
 
 # CONTROL-TAG HTML COMMENTS — canonical grammar (single source of truth).
@@ -365,6 +406,28 @@ def _rightmost_unfinished_marker(text: str) -> int:
     return -1
 
 
+def _leading_wrapper_start(text: str, idx: int) -> int:
+    """Start of a line-leading Markdown wrapper run abutting *idx*, else *idx*.
+
+    Mirrors the regexes' optional leading-wrapper group (see
+    :data:`MARKER_WRAPPERS`) for the STILL-STREAMING path: a wrapped marker's
+    head is located at its ``[``, and without this the leading wrapper stays in
+    the visible half, where a length rotation can split it from the marker it
+    belongs to. The run must abut *idx*, be at most 3 characters, and carry
+    only indent before it on its line -- a mid-line wrapper belongs to prose
+    (the completed regex leaves it visible too) and a 4+ run is not a wrapper.
+    """
+    run = idx
+    while run > 0 and idx - run < 3 and text[run - 1] in MARKER_WRAPPERS:
+        run -= 1
+    if run == idx:
+        return idx
+    line_start = text.rfind("\n", 0, run) + 1
+    if text[line_start:run].strip(" \t") == "":
+        return run
+    return idx
+
+
 def split_trailing_protocol_suffix(text: str) -> tuple[str, str]:
     """Detach protocol trailers before a renderer length-splits ``text``.
 
@@ -394,7 +457,7 @@ def split_trailing_protocol_suffix(text: str) -> tuple[str, str]:
     # already yield the same split for a complete tail) and reintroduces that
     # bug.
     if idx != -1:
-        suffix_start = idx
+        suffix_start = _leading_wrapper_start(text, idx)
 
     options = OPTIONS_RE_TRAILER.search(text[:suffix_start])
     if options:

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3112,10 +3112,10 @@ def _redact(text: str) -> str:
 
 def _parse_options(text: str) -> list[str]:
     """Extract pipe-separated choices from the LAST [OPTIONS: A | B | C] in text."""
-    matches = _OPTIONS_RE.findall(text)
+    matches = list(_OPTIONS_RE.finditer(text))
     if not matches:
         return []
-    parts = [p.strip() for p in matches[-1].split("|")]
+    parts = [p.strip() for p in matches[-1].group("labels").split("|")]
     return [p for p in parts if p]
 
 

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -35,7 +35,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER, strip_control_comments
+from kiro_crew.constants import (
+    OPTIONS_RE_TRAILER,
+    _leading_wrapper_start,
+    strip_control_comments,
+)
 from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.tables import render_tables, render_tables_with_metadata
 from kiro_crew.messaging.transport import TransportCapabilities
@@ -461,7 +465,7 @@ def split_options_trailer(text: str, *, hide_partial: bool = False) -> tuple[str
     """
     match = OPTIONS_RE_TRAILER.search(text)
     if match:
-        choices = [c.strip() for c in match.group(1).split("|") if c.strip()]
+        choices = [c.strip() for c in match.group("labels").split("|") if c.strip()]
         return text[: match.start()].rstrip(), choices
     if hide_partial:
         idx = text.rfind("[OPTIONS")
@@ -483,7 +487,13 @@ def split_options_trailer(text: str, *, hide_partial: bool = False) -> tuple[str
             # check here beats walking earlier occurrences.
             tail = text[idx + len("[OPTIONS") :]
             if not tail or tail.startswith(":"):
-                return text[:idx].rstrip(), []
+                # A LINE-LEADING Markdown wrapper run abutting the fragment is
+                # part of the marker-to-be (``**[OPTIONS: A``): cutting at the
+                # ``[`` alone publishes a stray ``**`` on this frame. Widen the
+                # cut with the same rule the grammar and
+                # ``split_trailing_protocol_suffix`` apply, so every backend
+                # partial path agrees; a mid-line run is prose and stays.
+                return text[: _leading_wrapper_start(text, idx)].rstrip(), []
     return text, []
 
 

--- a/src/kiro_crew/slack/format.py
+++ b/src/kiro_crew/slack/format.py
@@ -47,7 +47,7 @@ def extract_options(text: str) -> tuple[str, list[str]]:
     m = _OPTIONS_RE.search(text)
     if not m:
         return text, []
-    choices = [c.strip() for c in m.group(1).split("|") if c.strip()]
+    choices = [c.strip() for c in m.group("labels").split("|") if c.strip()]
     cleaned = text[: m.start()].rstrip()
     return cleaned, choices
 

--- a/test/test_options_cap_contract.py
+++ b/test/test_options_cap_contract.py
@@ -446,9 +446,12 @@ class TestOnlyOneTrailerParseExists:
         )
 
     def test_only_the_shared_helper_and_slack_split_the_choice_group(self) -> None:
-        # Slack keeps its own because its GRAMMAR differs (OPTIONS_RE_LINE).
-        allowed = {"messaging/renderer.py", "slack/format.py"}
-        offenders = self._hits('group(1).split("|")') - allowed
+        # Slack and the dashboard keep their own because their GRAMMAR differs
+        # (OPTIONS_RE_LINE, end-of-line). The dashboard's ``_parse_options``
+        # always re-derived this split; the named-``labels`` spelling merely
+        # makes it visible to this needle.
+        allowed = {"messaging/renderer.py", "slack/format.py", "dashboard/state.py"}
+        offenders = self._hits('group("labels").split("|")') - allowed
         assert not offenders, (
             "these re-derive the choice split instead of calling "
             f"messaging.renderer.split_options_trailer: {sorted(offenders)}"
@@ -457,7 +460,7 @@ class TestOnlyOneTrailerParseExists:
     def test_the_ratchet_is_not_vacuous(self) -> None:
         """A grep that matches nothing would make both checks pass forever."""
         assert "messaging/renderer.py" in self._hits('rfind("[OPTIONS")')
-        assert "messaging/renderer.py" in self._hits('group(1).split("|")')
+        assert "messaging/renderer.py" in self._hits('group("labels").split("|")')
 
 
 class TestRenderOptionsAsText:

--- a/test/test_options_marker_closers.py
+++ b/test/test_options_marker_closers.py
@@ -39,7 +39,7 @@ class TestLookalikeClosersAccepted:
             text = f"body prose\n\n[OPTIONS: Alpha | Beta{close}"
             match = OPTIONS_RE_LINE.search(text)
             assert match is not None, f"U+{ord(close):04X} not accepted by LINE"
-            labels = [s.strip() for s in match.group(1).split("|")]
+            labels = [s.strip() for s in match.group("labels").split("|")]
             assert labels == ["Alpha", "Beta"], f"U+{ord(close):04X} -> {labels}"
 
     def test_trailer_grammar_agrees_with_line_grammar(self):
@@ -51,7 +51,7 @@ class TestLookalikeClosersAccepted:
         assert MARKER_CLOSERS[0] == "]"
         match = OPTIONS_RE_LINE.search("[OPTIONS: A | B]")
         assert match is not None
-        assert [s.strip() for s in match.group(1).split("|")] == ["A", "B"]
+        assert [s.strip() for s in match.group("labels").split("|")] == ["A", "B"]
 
 
 class TestClosersNotOverlyBroad:
@@ -74,7 +74,7 @@ class TestClosersNotOverlyBroad:
         # line, not the first, so a label may itself contain one.
         match = OPTIONS_RE_LINE.search("[OPTIONS: a] | b\u3011")
         assert match is not None
-        assert [s.strip() for s in match.group(1).split("|")] == ["a]", "b"]
+        assert [s.strip() for s in match.group("labels").split("|")] == ["a]", "b"]
 
 
 class TestStreamingAgreesWithTheRegexes:
@@ -94,9 +94,13 @@ class TestStreamingAgreesWithTheRegexes:
         what makes it a real regression guard rather than a restatement.
         """
         for close in MARKER_CLOSERS:
-            visible, suffix = split_trailing_protocol_suffix(f"body [OPTIONS: A | B{close} [STEERING")
+            visible, suffix = split_trailing_protocol_suffix(
+                f"body [OPTIONS: A | B{close} [STEERING"
+            )
             assert visible == "body ", f"U+{ord(close):04X} -> {visible!r}"
-            assert suffix == f"[OPTIONS: A | B{close} [STEERING", f"U+{ord(close):04X} -> {suffix!r}"
+            assert (
+                suffix == f"[OPTIONS: A | B{close} [STEERING"
+            ), f"U+{ord(close):04X} -> {suffix!r}"
 
     def test_lookalike_closed_marker_reads_as_finished(self):
         """Contract guard, NOT a fix-discriminator.
@@ -106,7 +110,9 @@ class TestStreamingAgreesWithTheRegexes:
         it pins the intended split point for a complete lookalike-closed tail.
         """
         for close in MARKER_CLOSERS:
-            visible, suffix = split_trailing_protocol_suffix(f"visible text\n\n[OPTIONS: A | B{close}")
+            visible, suffix = split_trailing_protocol_suffix(
+                f"visible text\n\n[OPTIONS: A | B{close}"
+            )
             assert visible == "visible text\n\n", f"U+{ord(close):04X} -> {visible!r}"
             assert suffix == f"[OPTIONS: A | B{close}", f"U+{ord(close):04X} -> {suffix!r}"
 
@@ -125,7 +131,9 @@ class TestStreamingAgreesWithTheRegexes:
             text = f"body prose [OPTIONS: Use {close} the bracket"
             visible, suffix = split_trailing_protocol_suffix(text)
             assert visible == "body prose ", f"U+{ord(close):04X} -> {visible!r}"
-            assert suffix == f"[OPTIONS: Use {close} the bracket", f"U+{ord(close):04X} -> {suffix!r}"
+            assert (
+                suffix == f"[OPTIONS: Use {close} the bracket"
+            ), f"U+{ord(close):04X} -> {suffix!r}"
 
     def test_genuinely_unfinished_marker_is_still_detached(self):
         visible, suffix = split_trailing_protocol_suffix("visible\n\n[OPTIONS: A | B")

--- a/test/test_options_marker_wrapper.py
+++ b/test/test_options_marker_wrapper.py
@@ -1,0 +1,199 @@
+"""Tests for Markdown-wrapped ``[OPTIONS:]`` markers (#9110).
+
+A model sometimes wraps the whole marker line in inline code or emphasis --
+``` `[OPTIONS: A | B]` ``` or ``**[OPTIONS: A | B]**``. The wrapper character
+lands AFTER the closing bracket, breaks the end-of-line anchor, and the marker
+is neither parsed nor stripped: the turn loses its follow-up pills and the raw
+marker leaks to the user as literal (code-styled) text. Same class of model tic
+as the stray ``](OPTIONS)`` suffix the grammar already absorbs.
+
+The widening is deliberately tight, and the negatives here are the real
+regression risk (a widened grammar swallowing genuine prose):
+
+* a LEADING wrapper is accepted only at line start (after optional indent), so
+  emphasis belonging to preceding prose is never eaten;
+* a TRAILING wrapper only when it abuts the closer (or its ``(...)`` tic);
+* runs are capped at 3 (``***`` is the longest CommonMark emphasis run);
+* the ReDoS-linearity guard stays green -- the wrapper class shares no
+  character with the trailing whitespace classes.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from kiro_crew.constants import (
+    MARKER_WRAPPERS,
+    OPTIONS_RE_LINE,
+    OPTIONS_RE_TRAILER,
+    split_trailing_protocol_suffix,
+)
+from kiro_crew.messaging.renderer import split_options_trailer
+
+WRAPPED = [
+    "`[OPTIONS: Alpha | Beta]`",  # backtick-wrapped (the reported shape)
+    "**[OPTIONS: Alpha | Beta]**",  # emphasis-wrapped
+    "_[OPTIONS: Alpha | Beta]_",  # underscore emphasis
+    "**[OPTIONS: Alpha | Beta]",  # leading wrapper only (nothing to steal)
+    "***[OPTIONS: Alpha | Beta]***",  # longest legal run
+    "  `[OPTIONS: Alpha | Beta]`",  # indented, wrapper still at line start
+    "`[OPTIONS: Alpha | Beta](OPTIONS)`",  # wrapper around the paren tic too
+]
+
+NOT_A_MARKER = [
+    "[OPTIONS: Alpha | Beta].",  # trailing prose: a period
+    "[OPTIONS: Alpha | Beta] pick one",  # trailing prose: words
+    "[OPTIONS: Alpha | Beta] **",  # wrapper must ABUT the closer
+    "[OPTIONS: Alpha | Beta]****",  # a 4+ run is not a wrapper
+    "[OPTIONS: Alpha | Beta]` and more",  # wrapper then prose breaks the anchor
+    # The trailing tolerance requires the marker to have OPENED a wrapper
+    # (nonempty ``lwrap``): a run the marker did not open belongs to the
+    # enclosing Markdown and must survive. These are the three reviewed
+    # corruption shapes (GPT rounds 1/3/4, span f634241daeea).
+    "`Use [OPTIONS: Alpha | Beta]`",  # inline code span quoting a marker
+    "Pick **[OPTIONS: Alpha | Beta]**",  # mid-line emphasis-wrapped marker
+    "x [OPTIONS: Alpha | Beta]**",  # mid-line marker, trailing wrapper
+    "[OPTIONS: Alpha | Beta]**",  # trailing-only: nothing opened it, prose
+]
+
+
+class TestWrappedMarkersParse:
+    @pytest.mark.parametrize("text", WRAPPED)
+    def test_line_grammar_accepts_and_labels_are_clean(self, text):
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None, text
+        labels = [s.strip() for s in match.group("labels").split("|")]
+        assert labels == ["Alpha", "Beta"], (text, labels)
+
+    @pytest.mark.parametrize("text", WRAPPED)
+    def test_trailer_grammar_agrees(self, text):
+        match = OPTIONS_RE_TRAILER.search(text)
+        assert match is not None, text
+        labels = [s.strip() for s in match.group("labels").split("|")]
+        assert labels == ["Alpha", "Beta"], (text, labels)
+
+    def test_strip_removes_the_wrapper_with_the_marker(self):
+        # The dashboard/Slack surfaces cut at match.start(); a line-leading
+        # wrapper must go with the marker, not survive as stray punctuation.
+        text = "All done.\n\n**[OPTIONS: Alpha | Beta]**"
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None
+        assert text[: match.start()] == "All done.\n\n"
+
+
+class TestScopeStaysTight:
+    @pytest.mark.parametrize("text", NOT_A_MARKER)
+    def test_negative_rows_stay_negative(self, text):
+        assert OPTIONS_RE_LINE.search(text) is None, text
+        assert OPTIONS_RE_TRAILER.search(text) is None, text
+
+    def test_emphasis_belonging_to_preceding_prose_is_not_eaten(self):
+        # The leading wrapper is only legal at line start: here the ``**``
+        # pair closes real emphasis, and the match must start at the bracket.
+        text = "**Choose one:** [OPTIONS: Alpha | Beta]"
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None
+        assert match.start() == text.index("[OPTIONS")
+
+    def test_mid_line_bare_marker_still_matches(self):
+        # The mid-line branch is the pre-widening grammar, byte for byte: a
+        # bare marker ending its line still parses wherever it sits.
+        text = "Pick one [OPTIONS: Alpha | Beta]"
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None
+        assert match.start() == text.index("[OPTIONS")
+        assert [s.strip() for s in match.group("labels").split("|")] == ["Alpha", "Beta"]
+
+    def test_multiline_emphasis_closer_is_not_consumed(self):
+        # GPT round 4: emphasis opened on a PRIOR line, closed abutting the
+        # marker's closer. The trailing run was not opened by the marker, so
+        # the marker must not match at all -- the emphasis pair survives.
+        text = "**Choose one\n[OPTIONS: Alpha | Beta]**"
+        assert OPTIONS_RE_LINE.search(text) is None
+        assert OPTIONS_RE_TRAILER.search(text) is None
+
+    def test_inline_code_span_keeps_its_closing_backtick(self):
+        # The GPT server finding on e0709b843: with an unconditional trailing
+        # tolerance, this stripped the marker AND the span's closing backtick,
+        # corrupting the prose and emitting bogus buttons. It must not match.
+        text = "`Use [OPTIONS: Alpha | Beta]`"
+        assert OPTIONS_RE_LINE.search(text) is None
+        assert OPTIONS_RE_TRAILER.search(text) is None
+
+    def test_labels_group_contract(self):
+        # The ``lwrap`` conditional group precedes ``labels``, so positional
+        # ``group(1)`` no longer means the labels: every consumer reads
+        # ``group("labels")`` and iterates with ``finditer``.
+        for pattern in (OPTIONS_RE_LINE, OPTIONS_RE_TRAILER):
+            match = pattern.search("`[OPTIONS: A | B]`")
+            assert match is not None
+            assert match.group("labels") == " A | B"
+        hits = list(OPTIONS_RE_LINE.finditer("[OPTIONS: A]\n`[OPTIONS: B | C]`"))
+        assert [m.group("labels") for m in hits] == [" A", " B | C"]
+
+
+class TestStreamingSplitAgrees:
+    def test_complete_wrapped_marker_is_detached_whole(self):
+        visible, suffix = split_trailing_protocol_suffix("body\n**[OPTIONS: A | B]**")
+        assert visible == "body\n"
+        assert suffix == "**[OPTIONS: A | B]**"
+
+    def test_unfinished_wrapped_marker_takes_its_wrapper_along(self):
+        # Without the widening the leading wrapper stays in the visible half,
+        # where a length rotation can split it from the marker it belongs to.
+        visible, suffix = split_trailing_protocol_suffix("body\n**[OPTIONS: A | ")
+        assert visible == "body\n"
+        assert suffix == "**[OPTIONS: A | "
+
+    def test_indent_before_the_wrapper_is_still_line_leading(self):
+        visible, suffix = split_trailing_protocol_suffix("body\n  `[OPTIONS: A | ")
+        assert visible == "body\n  "
+        assert suffix == "`[OPTIONS: A | "
+
+    def test_mid_line_wrapper_stays_in_the_visible_half(self):
+        visible, suffix = split_trailing_protocol_suffix("pick **[OPTIONS: A")
+        assert visible == "pick **"
+        assert suffix == "[OPTIONS: A"
+
+    def test_a_four_char_run_is_not_a_wrapper(self):
+        visible, suffix = split_trailing_protocol_suffix("body\n****[OPTIONS: A")
+        assert visible == "body\n****"
+        assert suffix == "[OPTIONS: A"
+
+    def test_hide_partial_cut_takes_a_line_leading_wrapper_along(self):
+        # GPT round-3 finding on 5b593b50a: the streaming trim cut a partial
+        # marker at its ``[`` and published the stray leading wrapper for the
+        # frame. The cut now applies the same line-leading rule as the grammar.
+        visible, choices = split_options_trailer("body\n**[OPTIONS: A", hide_partial=True)
+        assert visible == "body"
+        assert choices == []
+
+    def test_hide_partial_keeps_a_mid_line_wrapper_as_prose(self):
+        visible, choices = split_options_trailer("pick **[OPTIONS: A", hide_partial=True)
+        assert visible == "pick **"
+        assert choices == []
+
+    def test_buffered_default_still_keeps_the_whole_tail(self):
+        text = "see the **[OPTIONS section"
+        visible, choices = split_options_trailer(text)
+        assert visible == text
+        assert choices == []
+
+
+class TestNoRedosRegression:
+    def test_wrapper_classes_share_no_character_with_whitespace(self):
+        # The structural invariant the linearity below rests on: neither the
+        # indent class nor the trailing run can also be read as a wrapper.
+        assert not set(MARKER_WRAPPERS) & set(" \t\n\r\f\v")
+
+    def test_adversarial_wrapper_runs_stay_linear(self):
+        # CWE-1333: the new optional groups must not create a second parse of
+        # long runs around a marker that never completes.
+        evil = ("`" * 100_000) + "[OPTIONS:" + ("\t" * 100_000) + "x"
+        start = time.perf_counter()
+        assert OPTIONS_RE_LINE.search(evil) is None
+        assert OPTIONS_RE_TRAILER.search(evil) is None
+        elapsed = time.perf_counter() - start
+        assert elapsed < 1.0, f"marker match too slow ({elapsed:.2f}s) — may backtrack"

--- a/website/src/app-sdk/protocol/optionMarker.ts
+++ b/website/src/app-sdk/protocol/optionMarker.ts
@@ -36,12 +36,41 @@
 // `\]`: the class shares no character with the trailing `[ \t]*`, and the
 // tempered body already admitted `]` via `[^[\n]`.
 //
+// MARKDOWN WRAPPERS (#9110): a model sometimes wraps the whole marker line in
+// inline code or emphasis — `` `[OPTIONS: A | B]` `` or `**[OPTIONS: A | B]**`.
+// The wrapper character lands AFTER the closer, breaks the end anchor, and the
+// marker leaks as literal (code-styled) text while the turn loses its pills —
+// the same class of tic as the stray `](OPTIONS)` suffix above. The grammar
+// absorbs a wrapper run of `` ` `` / `*` / `_` up to 3 long (`***` is the
+// longest CommonMark emphasis run; 4+ is not a wrapper): LEADING only at line
+// start after optional indent (so emphasis belonging to preceding prose, like
+// `**Choose:** [OPTIONS: …]`, is never eaten — the marker still parses, the
+// emphasis stays), TRAILING only when the marker itself OPENED one: the first
+// alternation branch requires a NONEMPTY leading run (`{1,3}`) before it may
+// absorb a trailing run; the second branch is the pre-widening grammar, byte
+// for byte, for bare and mid-line markers. That balanced requirement is the
+// invariant that keeps every wrapper-shaped piece of enclosing Markdown
+// intact at once: a mid-line code span's closer (`` `Use [OPTIONS: A | B]` ``),
+// and a MULTILINE emphasis closer (`**Choose one\n[OPTIONS: A | B]**`) — under
+// CommonMark flanking rules a run at line start can only OPEN emphasis, so a
+// leading run is safely the marker's own, while a trailing run without one
+// belongs to the prose and must survive the strip. Leading-only still parses
+// (nothing follows the closer, so nothing can be stolen); trailing-only
+// renders literally, as it did before the widening. JS has no conditional
+// groups, hence the alternation: groups 1/2 are the anchored-wrapped branch's
+// (S, labels), groups 3/4 the bare branch's — exactly one pair is defined per
+// match, so read `m[1] ?? m[3]` / `m[2] ?? m[4]` (parseOptions does). ReDoS
+// profile unchanged: each branch is the proven linear shape, a position is
+// attempted against at most both, and the wrapper class shares no character
+// with the indent/trailing `[ \t]*`.
+// Mirrors the backend's MARKER_WRAPPERS + `(?(lwrap)...)` conditional
+// (constants.py).
 // `String#replace` is the only use that is safe on this shared const as-is: it resets `lastIndex`.
 // `String#matchAll` does NOT — it seeds its internal clone from `lastIndex`, so pass a fresh
 // `new RegExp(OPTION_MARKER_RE)` there. Never call `.exec`/`.test` on it: both leave the index
 // advanced, and the next reader silently scans from the wrong offset.
 export const OPTION_MARKER_RE =
-  /\[OPTION(S)?:((?:[^[\n]|\[(?!OPTIONS?:))*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[ \t]*$/gim
+  /(?:^[ \t]*[`*_]{1,3}\[OPTION(S)?:((?:[^[\n]|\[(?!OPTIONS?:))*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}|\[OPTION(S)?:((?:[^[\n]|\[(?!OPTIONS?:))*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?)[ \t]*$/gim
 
 /** The closing brackets OPTION_MARKER_RE accepts — ASCII plus the CJK lookalikes.
  *  Module-private and used with matchAll only (to take the LAST closer in the
@@ -66,6 +95,25 @@ const CONTINUES_LABELS_RE = /^[ \t]*[|,]/
  *  it cannot backtrack. Module-private and used with matchAll only (to take the
  *  LAST head in the probed tail), so the g-flag `lastIndex` hazard never applies. */
 const HEAD_RE = /\[OPTIONS?:/gi
+
+/** One Markdown wrapper character — mirrors OPTION_MARKER_RE's wrapper class. */
+const WRAP_CHAR_RE = /[`*_]/
+
+/** Start of a LINE-LEADING wrapper run abutting position `p` of `tail`, else `p`.
+ *
+ * The streaming counterpart to OPTION_MARKER_RE's optional leading-wrapper
+ * group: a wrapped marker's head is located at its `[`, and cutting there
+ * would leave the wrapper visible while the marker it belongs to is hidden.
+ * The run must abut `p`, be at most 3 characters, and carry only indent before
+ * it on the line — a mid-line wrapper belongs to prose (the completed regex
+ * leaves it visible too, since its leading group is `^`-anchored) and a 4+ run
+ * is not a wrapper. */
+function wrapperStart(tail: string, p: number): number {
+  let w = p
+  while (w > 0 && p - w < 3 && WRAP_CHAR_RE.test(tail[w - 1])) w--
+  if (w === p) return p
+  return /^[ \t]*$/.test(tail.slice(0, w)) ? w : p
+}
 
 /** A head that is still being TYPED — every prefix of `[OPTIONS:` / `[OPTION:`,
  *  from the bare `[` up to the full head, spelled as nested optionals.
@@ -166,17 +214,25 @@ export function stripPartialOptionMarker(text: string): string {
     // (parseOptions would have stripped that marker), so it falls in with "cut".
     const rest = closer < 0 ? '' : body.slice(closer + 1)
     const forming = closer < 0 || rest.trim() === '' || CONTINUES_LABELS_RE.test(rest)
-    return forming ? cutAt(text, start + head) : text
+    return forming ? cutAt(text, start + wrapperStart(tail, head)) : text
   }
 
   const open = tail.lastIndexOf('[')
-  const abs = start + open
+  // Walk back over a wrapper run abutting the `[` (≤3): `` `[OPT `` / `**[OPT`
+  // is a marker-to-be. A LINE-LEADING run is cut with the head — the completed
+  // OPTION_MARKER_RE strips it too. A mid-line run after whitespace stays
+  // visible while the head behind it is hidden, again mirroring the completed
+  // regex, whose leading-wrapper group is `^`-anchored.
+  let run = open
+  while (run > 0 && open - run < 3 && WRAP_CHAR_RE.test(tail[run - 1])) run--
+  const lineLeading = /^[ \t]*$/.test(tail.slice(0, run))
   // The canonical marker opens its own line; the same-line variant the regex
-  // also accepts still has a space before the `[`. Requiring that boundary
-  // costs the marker nothing and takes every in-word bracket (`arr[0`, a
-  // footnote ref) out of scope entirely.
-  if (abs > 0 && !/\s/.test(text[abs - 1])) return text
+  // also accepts still has a space before the `[` (or before its wrapper run).
+  // Requiring that boundary costs the marker nothing and takes every in-word
+  // bracket (`arr[0`, a footnote ref, `arr**[` behind a glued run) out of
+  // scope entirely.
+  if (!lineLeading && !/\s/.test(tail[run - 1] ?? '')) return text
   const frag = tail.slice(open)
   const partial = PARTIAL_HEAD_UPPER_RE.test(frag) || PARTIAL_HEAD_LOWER_RE.test(frag)
-  return partial ? cutAt(text, abs) : text
+  return partial ? cutAt(text, start + (lineLeading ? run : open)) : text
 }

--- a/website/src/app-sdk/protocol/options.ts
+++ b/website/src/app-sdk/protocol/options.ts
@@ -29,9 +29,14 @@ export function parseOptions(content: string): ParsedOptions {
   // the cost is one regex construction, the alternative is a silent parse failure.
   for (const m of content.matchAll(new RegExp(OPTION_MARKER_RE))) last = m
   if (!last || last.index === undefined) return { text: content, options: [], multi: true, isPlan: false }
-  const multi = !!last[1] // [OPTIONS:] is the multi-select syntax; [OPTION:] is single
-  const sep = last[2].includes('|') ? '|' : ','
-  const options = last[2].split(sep).map(o => o.trim()).filter(Boolean)
+  // OPTION_MARKER_RE is a two-branch alternation (line-anchored-with-wrappers
+  // vs mid-line): groups 1/2 belong to the first branch, 3/4 to the second, and
+  // exactly one pair is defined per match. `??` (not `||`) so an empty label
+  // string from the matched branch is kept rather than falling through.
+  const multi = !!(last[1] ?? last[3]) // [OPTIONS:] is the multi-select syntax; [OPTION:] is single
+  const labels = (last[2] ?? last[4]) ?? ''
+  const sep = labels.includes('|') ? '|' : ','
+  const options = labels.split(sep).map(o => o.trim()).filter(Boolean)
   const isPlan = PLAN_HEADER_RE.test(content) && STAGE_RE.test(content)
   // Strip ALL markers from the displayed text (not just the last) so a stray earlier
   // marker can't leak as raw "[OPTION: …]" syntax to the user; options still come from

--- a/website/src/test/optionsMarkerWrapper.test.ts
+++ b/website/src/test/optionsMarkerWrapper.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import { stripPartialOptionMarker } from '../app-sdk/protocol'
+// The pattern is in-tree only — the barrel deliberately withholds it from the app surface.
+import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+
+/** What the reader sees for a given stream prefix: the finished-marker strip
+ *  (OPTION_MARKER_RE, what parseOptions does) followed by the partial-marker
+ *  strip. Mirrors AssistantMessage's streaming pipeline. */
+const visible = (prefix: string) =>
+  stripPartialOptionMarker(prefix.replace(OPTION_MARKER_RE, '').trim())
+
+// #9110: a model sometimes wraps the whole marker line in inline code or
+// emphasis — `` `[OPTIONS: A | B]` `` / `**[OPTIONS: A | B]**`. The wrapper
+// character lands AFTER the closer, which used to break the end-of-line
+// anchor: the marker was neither parsed nor stripped, the turn lost its pills,
+// and the raw marker leaked as literal (code-styled) text.
+describe('OPTION_MARKER_RE with Markdown wrappers (#9110)', () => {
+  const wrapped = [
+    '`[OPTIONS: Alpha | Beta]`', // backtick-wrapped (the reported shape)
+    '**[OPTIONS: Alpha | Beta]**', // emphasis-wrapped
+    '_[OPTIONS: Alpha | Beta]_', // underscore emphasis
+    '**[OPTIONS: Alpha | Beta]', // leading wrapper only (nothing to steal)
+    '***[OPTIONS: Alpha | Beta]***', // longest legal run
+    '  `[OPTIONS: Alpha | Beta]`', // indented, wrapper still at line start
+    '`[OPTIONS: Alpha | Beta](OPTIONS)`', // wrapper around the paren tic too
+  ]
+
+  it('parses the wrapped marker and keeps the labels clean', () => {
+    for (const line of wrapped) {
+      let last: RegExpMatchArray | null = null
+      for (const m of `Done.\n${line}`.matchAll(new RegExp(OPTION_MARKER_RE))) last = m
+      expect(last, line).not.toBeNull()
+      const labels = last![2].split('|').map(s => s.trim())
+      expect(labels, line).toEqual(['Alpha', 'Beta'])
+    }
+  })
+
+  it('strips the wrapper together with the marker', () => {
+    for (const line of wrapped) {
+      expect(`Done.\n${line}`.replace(OPTION_MARKER_RE, '').trim(), line).toBe('Done.')
+    }
+  })
+
+  it('keeps the negative rows negative — real prose still fails the anchor', () => {
+    for (const line of [
+      '[OPTIONS: Alpha | Beta].', // trailing prose: a period
+      '[OPTIONS: Alpha | Beta] pick one', // trailing prose: words
+      '[OPTIONS: Alpha | Beta] **', // wrapper must ABUT the closer
+      '[OPTIONS: Alpha | Beta]****', // a 4+ run is not a wrapper
+      '[OPTIONS: Alpha | Beta]` and more', // wrapper then prose
+      // The trailing tolerance requires the marker to have OPENED a wrapper
+      // (nonempty leading run): a run the marker did not open belongs to the
+      // enclosing Markdown and must survive the strip.
+      '`Use [OPTIONS: Alpha | Beta]`', // inline code span quoting a marker
+      'Pick **[OPTIONS: Alpha | Beta]**', // mid-line emphasis-wrapped marker
+      'x [OPTIONS: Alpha | Beta]**', // mid-line marker, trailing wrapper
+      '[OPTIONS: Alpha | Beta]**', // trailing-only: nothing opened it, prose
+    ]) {
+      const text = `Done.\n${line}`
+      expect(text.replace(OPTION_MARKER_RE, ''), line).toBe(text)
+    }
+  })
+
+  it('does not consume a multiline emphasis closer', () => {
+    // Emphasis opened on a prior line, closed abutting the marker's closer:
+    // the marker did not open that run, so nothing matches and the pair
+    // survives intact.
+    const text = '**Choose one\n[OPTIONS: Alpha | Beta]**'
+    expect(text.replace(OPTION_MARKER_RE, '')).toBe(text)
+  })
+
+  it('never eats emphasis belonging to preceding prose', () => {
+    // The leading wrapper is only legal at line start: here the `**` pair
+    // closes real emphasis, and only the marker itself is stripped.
+    expect('**Choose one:** [OPTIONS: A | B]'.replace(OPTION_MARKER_RE, ''))
+      .toBe('**Choose one:** ')
+  })
+
+  it('still parses a mid-line BARE marker (the pre-widening grammar)', () => {
+    expect('Pick one [OPTIONS: A | B]'.replace(OPTION_MARKER_RE, '')).toBe('Pick one ')
+  })
+
+  it('branch group pairs: (1,2) anchored, (3,4) mid-line — exactly one defined', () => {
+    let last: RegExpMatchArray | null = null
+    for (const m of '`[OPTION: Solo]`'.matchAll(new RegExp(OPTION_MARKER_RE))) last = m
+    expect(last![1]).toBeUndefined() // singular [OPTION:], anchored branch
+    expect(last![2].trim()).toBe('Solo')
+    expect(last![4]).toBeUndefined()
+    last = null
+    for (const m of 'Pick one [OPTIONS: Solo]'.matchAll(new RegExp(OPTION_MARKER_RE))) last = m
+    expect(last![3]).toBe('S') // mid-line branch
+    expect(last![4].trim()).toBe('Solo')
+    expect(last![2]).toBeUndefined()
+  })
+})
+
+describe('stripPartialOptionMarker with Markdown wrappers (#9110)', () => {
+  it('never leaks marker syntax at any prefix of a wrapped reveal', () => {
+    for (const full of [
+      'Done.\n\n`[OPTIONS: Open the PR | Show me the diff]`',
+      'Done.\n\n**[OPTIONS: Open the PR | Show me the diff]**',
+    ]) {
+      for (let n = 0; n <= full.length; n++) {
+        expect(visible(full.slice(0, n))).not.toMatch(/\[OPTION/i)
+      }
+      expect(visible(full)).toBe('Done.')
+    }
+  })
+
+  it('cuts a line-leading wrapper together with the streaming head', () => {
+    expect(stripPartialOptionMarker('Done.\n**[OPTIONS: Merge it')).toBe('Done.')
+    expect(stripPartialOptionMarker('Done.\n`[OPT')).toBe('Done.')
+    expect(stripPartialOptionMarker('Done.\n  `[OPTIONS: A ] | Br')).toBe('Done.')
+  })
+
+  it('hides a mid-line head behind a wrapper but keeps the wrapper', () => {
+    // A mid-line head after a wrapper can still complete as a BARE mid-line
+    // marker (`Pick one **[OPTIONS: A]`), so it is held like any other head;
+    // the wrapper itself is prose and stays, matching the completed grammar.
+    expect(stripPartialOptionMarker('Pick one **[OPTIONS: A')).toBe('Pick one **')
+    expect(stripPartialOptionMarker('Pick one **[OPT')).toBe('Pick one **')
+  })
+
+  it('leaves an in-word bracket behind a glued wrapper run alone', () => {
+    for (const s of ['arr**[', 'x`[', 'a__[0']) {
+      expect(stripPartialOptionMarker(s)).toBe(s)
+    }
+  })
+
+  it('leaves a closed wrapped head followed by prose visible', () => {
+    const s = 'Done.\n`[OPTIONS: A | B]` see note'
+    expect(stripPartialOptionMarker(s)).toBe(s)
+  })
+
+  it('does not treat a 4+ run as a wrapper', () => {
+    // Four backticks open a fence, not an inline span. The complete head is
+    // still cut (a complete head is unambiguous), but the cut stops AT the
+    // head — the run itself stays visible, exactly as the completed regex
+    // would leave it.
+    expect(stripPartialOptionMarker('Done.\n````[OPTIONS: A')).toBe('Done.\n````')
+  })
+
+  it('keeps prose stable once the wrapped marker starts arriving', () => {
+    const prose = 'Renamed the hook and reran the suite.'
+    const full = `${prose}\n\n**[OPTIONS: Open the PR | Skip it]**`
+    // From the `[` onward the visible prose never rewinds nor regrows.
+    const from = full.indexOf('[OPTIONS')
+    for (let n = from + 1; n <= full.length; n++) {
+      expect(visible(full.slice(0, n))).toBe(prose)
+    }
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

A model sometimes wraps the whole trailing `[OPTIONS: …]` marker line in a Markdown wrapper — inline backticks or `**` emphasis. The wrapper character lands after the closing bracket, which breaks the marker grammar's end-of-line anchor. The marker is then neither parsed nor stripped: the turn silently loses its follow-up pills, and the raw marker renders to the user as literal code-styled text. Reported on an insider prerelease build with the Claude Code backend, where the marker rule arrives as embedded conversation text and "code-format the literal syntax token" is a natural model habit.

## Why it matters

The grammar is shared by every surface — the dashboard, Slack, previews, and the Discord/Telegram/WeCom trailer split — so all of them lose their buttons on the same input. The user has to retype the choice, and the bad character self-reinforces: it lands in the transcript and the model copies its own prior formatting on later turns. The grammar already tolerates exactly this class of model tic (the stray `](OPTIONS)` link close), so a wrapper is the same slip with the same cost, just untolerated.

## What changed (motivation → approach → change)

The end-of-line anchor rejects any character between the closer and the line end. A wrapper character sits exactly there, so a wrapped marker fell through both the parse path and the strip path.

The fix widens the marker grammar to absorb a wrapper run (`` ` `` / `*` / `_`, at most 3 — `***` is the longest CommonMark emphasis run) on the marker line, keeping the scope tight so real prose still fails to match. A leading run matches only at line start after optional indent, so emphasis belonging to preceding prose (`**Choose:** [OPTIONS: …]`) is never eaten. A trailing run matches only when it abuts the closer (or its existing `(…)` tolerance) **and the marker itself opened a wrapper** — a nonempty line-leading run. This balanced rule came out of review (GPT rounds 1, 3 and 4 each found a shape where an absorbed trailing run actually belonged to enclosing Markdown: a mid-line inline code span `` `Use [OPTIONS: A | B]` ``, a streaming frame's stray run, and a multiline emphasis closer `**Choose one\n[OPTIONS: A | B]**`), and it is the single invariant that excludes all three: under CommonMark flanking rules a run at line start can only open emphasis, so a leading run is safely the marker's own, while a trailing run the marker did not open belongs to the prose and survives the strip. Leading-only still parses (nothing follows the closer, so nothing can be stolen); trailing-only renders literally, exactly as before the widening; bare and mid-line markers keep the pre-widening grammar byte for byte. Python spells the condition as a `(?(lwrap)…)` conditional whose `lwrap` group captures the nonempty run; JS, which has no conditional groups, as a two-branch alternation whose `(S, labels)` pairs are groups (1,2) for the wrapped-anchored branch and (3,4) for the bare branch. The streaming trims agree end to end: `stripPartialOptionMarker` and the backend `split_trailing_protocol_suffix` / `split_options_trailer(hide_partial=True)` all pull a line-leading wrapper along with a still-streaming marker via one shared rule, so no frame ever strands a stray run.

The frontend regex (`OPTION_MARKER_RE`) and both backend mirrors (`OPTIONS_RE_LINE`, `OPTIONS_RE_TRAILER`) change in one commit so the grammars cannot drift. Because the Python conditional group precedes the labels, the labels group is now named, and the group-reading consumers follow: `slack/format.py` and `messaging/renderer.py` read `group("labels")`, the dashboard's `_parse_options` iterates with `finditer`, and `parseOptions` reads the defined branch pair. The streaming paths follow the same rule: `stripPartialOptionMarker` and the backend `split_trailing_protocol_suffix` pull a line-leading wrapper along with a still-streaming marker, so the wrapper is never stranded in the visible half where a length rotation could split it from its marker. ReDoS linearity is preserved — the wrapper class shares no character with the indent or trailing whitespace classes, each alternation branch keeps the proven tempered-body shape, and both wrapper positions are anchored by the required `[OPTIONS:` literal.

## Tests

Both languages get the same matrix (`test/test_options_marker_wrapper.py`, `website/src/test/optionsMarkerWrapper.test.ts`):

- Positive: backtick-wrapped (the reported shape), emphasis-wrapped, underscore, leading-wrapper-only, trailing-wrapper-only, the longest legal `***` run, indented-and-wrapped, wrapper around the existing `](OPTIONS)` tic, and the mid-line **bare** marker (the pre-widening grammar, unchanged) — labels parse clean in every case.
- Negative (the regression risk of a widening): marker followed by a period, marker followed by prose, a wrapper that does not abut the closer, a 4+ run, emphasis belonging to preceding prose, trailing-only wrappers, and the mid-line/multiline wrapped forms — including all three review-found corruption cases (`` `Use [OPTIONS: A | B]` `` keeps its closing backtick; the streaming frame keeps no stray run; `**Choose one\n[OPTIONS: A | B]**` keeps its emphasis pair).
- Group contracts: Python `group("labels")` on both mirrors plus `finditer` ordering; JS branch pairs (1,2)/(3,4) with exactly one pair defined per match.
- Streaming: a wrapped marker never leaks marker syntax at any stream prefix; the partial stripper cuts a line-leading wrapper with the head, keeps a mid-line wrapper as prose, and leaves in-word brackets behind glued runs (`arr**[`) alone; the backend splitter detaches a complete or still-streaming wrapped marker whole.
- ReDoS: adversarial 100k-char wrapper and whitespace runs stay linear; the wrapper class is asserted disjoint from whitespace. The pre-existing linearity guards (`test_options_marker_closers.py`, the frontend shape check) stay green.

Red-before proven: on pristine main, all wrapped shapes fail both grammars and the splitter strands the wrapper in the visible half.

## Manual verification

N/A — the change is a pure grammar/parser widening with no component or layout change; the full behavior matrix is locked by unit tests in both languages (backend marker/renderer/preview suites: 903 tests; full frontend vitest: 29996 tests, all green on the round-2 head).

## Related Issues

Fixes #9110

## Pattern harvest

Rule candidate: review-prompt
Pattern: "end-of-line-anchored protocol marker grammars must enumerate tolerated model tics (lookalike closers, link-close suffixes, Markdown wrappers) symmetrically across every mirrored copy, and every new tolerance must state which positions (line-anchored vs mid-line) it applies to" — third instance of the same anchor-break class (#1518 lookalike closers, `](OPTIONS)` link close, now wrappers); round 1 of this PR itself showed the position half of the rule (an unconditional trailing tolerance corrupted mid-line spans).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

