### PR TITLE
fix: raise ValueError for oversized monitor completion timestamps

### DIFF
--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -181,12 +181,7 @@ class MonitorActionCompletion:
                 raise ValueError(f"{name} must be a non-empty string")
         if not isinstance(self.disposition, MonitorActionDisposition):
             raise ValueError("disposition must be a MonitorActionDisposition")
-        if (
-            isinstance(self.completed_ts, bool)
-            or not isinstance(self.completed_ts, (int, float))
-            or not math.isfinite(self.completed_ts)
-            or self.completed_ts < 0
-        ):
+        if not is_finite_non_negative_number(self.completed_ts):
             raise ValueError("completed_ts must be a finite non-negative number")
         for name in ("input_tokens", "output_tokens"):
             value = getattr(self, name)

--- a/test/test_monitor_turn_completion.py
+++ b/test/test_monitor_turn_completion.py
@@ -56,6 +56,18 @@ def test_monitor_completion_contract_is_typed() -> None:
         )
 
 
+def test_oversized_completed_ts_raises_value_error() -> None:
+    """An int too large for float conversion must raise ValueError like every
+    sibling validator, not OverflowError no caller expects."""
+    with pytest.raises(ValueError, match="completed_ts"):
+        models.MonitorActionCompletion(
+            monitor_id="monitor1",
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.SUCCESS,
+            completed_ts=10**400,
+        )
+
+
 @pytest.mark.asyncio
 async def test_dispatch_charges_nothing_until_the_action_turn_completes(tmp_path) -> None:
     """Moving completed-turn accounting into dispatch would spend budget early."""


### PR DESCRIPTION
## Problem / Motivation

`MonitorActionCompletion` with an out-of-float-range `completed_ts` (e.g.
`10**400` from a malformed provider payload or persisted row) escapes as
`OverflowError`, while every sibling validator in the module raises
`ValueError` — which is what all callers catch.

## Why it matters

Callers that guard record construction with `except ValueError` (the shape
used everywhere else in this module) will not catch this one, so a single
malformed timestamp can abort a turn instead of degrading.

## What changed (motivation → approach → change)

The inline check evaluated `math.isfinite` unguarded (and before the `< 0`
test); the shared `is_finite_non_negative_number` helper puts it after,
inside a `try`. Replaced the drifted inline copy with the helper call,
keeping the existing message — deleting the last inline copy of this
predicate in the module.

## Tests

`test_oversized_completed_ts_raises_value_error` in
`test/test_monitor_turn_completion.py`: asserts `ValueError` (not
`OverflowError`) for `completed_ts=10**400`, mirroring the existing
`created_ts` case.

## Manual verification

N/A — unit coverage sufficient (pure validation logic, no I/O).

## Related Issues

Fixes #9045

## Pattern harvest

Rule candidate: lint — flag inline `math.isfinite` calls on unvalidated
input where a guarded shared predicate exists in the same module.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
