### PR TITLE
fix: strict-read governance boot flags fail-closed

### DIFF
--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -2457,6 +2457,34 @@ def _parse_controls(
 # ──────────────────────────────────────────────────────────────────────────
 # Loader
 # ──────────────────────────────────────────────────────────────────────────
+def _coerce_boot_flag(
+    boot_raw: Mapping[str, object], key: str, *, default: bool, closed: bool
+) -> bool:
+    """Strict read of one ``boot`` gate flag.
+
+    A real boolean is honoured and an absent key takes the documented
+    default. Anything else (including explicit null) is warned about and
+    read in the fail-closed direction: a bare ``bool()`` would read a
+    ``"false"`` string as true, which is the fail-open direction.
+    """
+    if key not in boot_raw:
+        return default
+    value = boot_raw[key]
+    if isinstance(value, bool):
+        return value
+    # Log the TYPE, never the value: a mis-typed flag can carry a secret
+    # (a credential pasted into the policy), and this warning lands in the
+    # persistent gateway log. The key names the misconfiguration; the type
+    # is all an operator needs to fix it.
+    logger.warning(
+        "security policy boot flag %r must be a boolean, got %s — reading fail-closed as %s",
+        key,
+        type(value).__name__,
+        closed,
+    )
+    return closed
+
+
 def parse_policy(
     data: Mapping[str, object], *, signature_state: str = SIGNATURE_UNCHECKED
 ) -> GovernanceCeiling:
@@ -2480,9 +2508,9 @@ def parse_policy(
     if not isinstance(boot_raw, dict):
         raise PlatformCompositionError("security policy requires a 'boot' object")
     boot = BootControls(
-        require_sandbox=bool(boot_raw.get("require_sandbox", True)),
-        allow_terminal=bool(boot_raw.get("allow_terminal", False)),
-        fail_closed=bool(boot_raw.get("fail_closed", True)),
+        require_sandbox=_coerce_boot_flag(boot_raw, "require_sandbox", default=True, closed=True),
+        allow_terminal=_coerce_boot_flag(boot_raw, "allow_terminal", default=False, closed=False),
+        fail_closed=_coerce_boot_flag(boot_raw, "fail_closed", default=True, closed=True),
     )
     controls = _parse_controls(data, is_policy=True)
     composed_posture = _apply_agentcore_posture(data, controls, boot)

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -443,6 +443,53 @@ class TestLoader:
         assert "sandbox._flags" not in ceiling.controls
 
 
+class TestBootFlagCoercion:
+    """Non-boolean ``boot`` gate flags read fail-closed, never via ``bool()``.
+
+    A ``"false"`` string is truthy, so the old read turned the terminal ON
+    for a policy that says off. Real booleans are honoured, absent keys take
+    their documented defaults, and anything else warns and reads in the
+    fail-closed direction per flag.
+    """
+
+    @staticmethod
+    def _boot(**flags):
+        body = _policy_body()
+        body["boot"] = flags
+        return parse_policy(body).boot
+
+    def test_absent_flags_take_documented_defaults(self):
+        boot = self._boot()
+        assert boot.require_sandbox is True
+        assert boot.allow_terminal is False
+        assert boot.fail_closed is True
+
+    def test_real_booleans_honoured(self):
+        boot = self._boot(require_sandbox=False, allow_terminal=True, fail_closed=False)
+        assert boot.require_sandbox is False
+        assert boot.allow_terminal is True
+        assert boot.fail_closed is False
+
+    def test_string_false_reads_fail_closed(self):
+        boot = self._boot(require_sandbox="false", allow_terminal="false", fail_closed="false")
+        assert boot.require_sandbox is True
+        assert boot.allow_terminal is False
+        assert boot.fail_closed is True
+
+    def test_string_true_reads_fail_closed(self):
+        boot = self._boot(require_sandbox="true", allow_terminal="true", fail_closed="true")
+        assert boot.require_sandbox is True
+        assert boot.allow_terminal is False
+        assert boot.fail_closed is True
+
+    def test_null_and_numbers_read_fail_closed(self):
+        for stray in (None, 0, 1):
+            boot = self._boot(require_sandbox=stray, allow_terminal=stray, fail_closed=stray)
+            assert boot.require_sandbox is True
+            assert boot.allow_terminal is False
+            assert boot.fail_closed is True
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # Policy / Profile parsing
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem / Motivation

`parse_policy` read the three `boot` gate flags with `bool()` on the raw
JSON value. `bool("false")` is `True`, so a hand-edited or
template-rendered policy writing `"allow_terminal": "false"` (a string)
turned the terminal ON — the fail-open direction — while the file reads
the opposite.

## Why it matters

The boot flags are the security ceiling's front gate. A policy that reads
one way while the host behaves another is a silent fail-open on the exact
surface the ceiling exists to hold.

## What changed (motivation → approach → change)

Added a strict per-flag read next to `parse_policy`: a real boolean is
honoured, an absent key takes the documented default, and anything else
(including explicit null) logs a warning and reads in the fail-closed
direction for that flag (`allow_terminal` closes as `False`; the other
two close as `True`). Wired into all three `BootControls` fields.

## Tests

`TestBootFlagCoercion` in `test/test_governance_policy.py`: absent keys
take documented defaults, real booleans honoured, `"false"`/`"true"`/
`null`/`0`/`1` all read fail-closed per flag.

## Manual verification

N/A — unit coverage sufficient (pure parsing logic, no I/O).

## Related Issues

Fixes #9176

## Pattern harvest

Rule candidate: lint — flag bare `bool()` on JSON/YAML-derived values
where a strict boolean read with fail-closed default exists nearby.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
