### PR TITLE
fix(browser-cli): install the CLI into a pinned, fenced prefix

### DIFF
--- a/src/kiro_crew/browser_cli/install.py
+++ b/src/kiro_crew/browser_cli/install.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 from collections.abc import Callable
 from functools import lru_cache
@@ -34,7 +35,12 @@ from typing import Any
 from kiro_crew import platform_compat
 from kiro_crew.browser_cli import os_deps
 from kiro_crew.config.paths import config_dir
-from kiro_crew.env import augmented_path, find_node_tool, node_augmented_path
+from kiro_crew.env import (
+    augmented_path,
+    describe_search_path,
+    find_node_tool,
+    node_augmented_path,
+)
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -136,8 +142,38 @@ def cli_path() -> str | None:
     inherit it on ``$PATH``. Without this the standalone install would SUCCEED
     and the panel would keep reporting the CLI as absent -- the worst shape of
     failure available here, since nothing errors and the offer never withdraws.
+
+    A THIRD location is consulted last: :func:`managed_prefix_bin_dir`, the bin dir
+    of the prefix THIS MODULE installs into, and only while
+    :func:`managed_prefix_is_fenceable` holds -- the prefix supplies an executable
+    the gateway spawns, so it is worth resolving from only while it sits inside the
+    tree fenced against agent writes. :func:`install` pins that prefix rather than
+    letting npm's configuration choose one, so the launcher's location is known by
+    construction -- which is what removes the guessing this function used to have
+    to do. It is consulted last so it only ever resolves a name found nowhere
+    else, and it is a pure path computation, so the repeated presence probes
+    (:func:`available`, :func:`detect`, the panel) stay subprocess-free.
+
+    Deliberately NOT contributed to :func:`kiro_crew.env.augmented_path`: that
+    function's invariant keeps contributed directories out of the search it shares
+    with the resolvers for the trusted agent runtime. A fixed product-owned
+    directory is a materially different proposition from an ``.npmrc``-nameable
+    one, but it is still a trust question for that search, so a bare-name
+    ``playwright-cli`` in an agent shell remains unresolved from here pending that
+    ruling.
     """
-    return find_node_tool(CLI_BIN, base_path=augmented_path(os.environ.get("PATH", "")))
+    found = find_node_tool(CLI_BIN, base_path=augmented_path(os.environ.get("PATH", "")))
+    if found is not None:
+        return found
+    if not managed_prefix_is_fenceable():
+        logger.debug(
+            "not resolving %s from %s: the prefix is outside the fenced data home "
+            "or reached through a symlink",
+            CLI_BIN,
+            managed_prefix(),
+        )
+        return None
+    return shutil.which(CLI_BIN, path=str(managed_prefix_bin_dir()))
 
 
 def _first_version(text: str) -> str | None:
@@ -220,16 +256,88 @@ _PLAYWRIGHT_CORE_PKG = "playwright-core"
 _CLI_PKG_SCOPE = "@playwright"
 _CLI_PKG_NAME = "cli"
 
-#: Where the standalone installer puts the package tree. `npm --global --prefix`
-#: writes under ``<prefix>/lib/node_modules`` on POSIX and ``<prefix>/node_modules``
-#: on Windows, so both are probed.
+#: Where this module installs the CLI, and where the shell installer puts it too.
+#: `npm --global --prefix` writes the package under ``<prefix>/lib/node_modules``
+#: on POSIX and ``<prefix>/node_modules`` on Windows, so both are probed.
 _STANDALONE_PREFIX_ENV = "KIROCREW_PLAYWRIGHT_CLI_HOME"
 _STANDALONE_PREFIX_DIR = "playwright-cli"
 _NODE_MODULES = "node_modules"
 
 
+def managed_prefix() -> Path:
+    """The npm prefix this product installs the CLI into.
+
+    Fixed and product-owned -- the data home, or an operator's
+    ``KIROCREW_PLAYWRIGHT_CLI_HOME`` -- rather than whatever npm's configuration
+    names. :func:`install` pins it, so the launcher's location is decided here
+    rather than discovered afterwards; the shell installer (``playwright-cli.sh``)
+    already defaults to the same directory, so both install paths converge.
+
+    Why not npm's own global prefix: it is CONFIGURATION (``prefix`` in an
+    .npmrc, ``npm_config_prefix``, a distro default), so it varies per host, no
+    list of well-known directories can cover it, and resolving from it means
+    trusting a directory that configuration can point anywhere.
+    """
+    override = os.environ.get(_STANDALONE_PREFIX_ENV, "").strip()
+    return Path(override) if override else config_dir() / _STANDALONE_PREFIX_DIR
+
+
+def managed_prefix_bin_dir() -> Path:
+    """Where a ``--prefix`` install lands the launcher.
+
+    ``<prefix>/bin`` on POSIX; ``<prefix>`` itself on Windows, where npm writes
+    the ``.cmd`` wrapper into the prefix root instead of a ``bin`` subdirectory.
+    """
+    prefix = managed_prefix()
+    return prefix if platform_compat.IS_WINDOWS else prefix / "bin"
+
+
+def managed_prefix_is_fenceable() -> bool:
+    """Whether :func:`managed_prefix` is the ONE path both write gates seal.
+
+    Fenceability is not containment. The fence is keyed to a literal leaf NAME --
+    ``_WRITE_PROTECTED_HOME_PATHS`` adds ``<crew home>/playwright-cli`` and
+    ``_CREW_READONLY_LEAVES`` carries ``"playwright-cli"`` -- because a static leaf
+    under a known home prefix is what a seal built at spawn time can express. So
+    membership of the data home is NOT enough: a differently-named directory in
+    there is inside the home and outside the fence.
+
+    The prefix supplies an executable the gateway SPAWNS, so only the canonical,
+    actually-sealed path is worth resolving from. Three shapes are refused:
+
+    * an override (``KIROCREW_PLAYWRIGHT_CLI_HOME``) pointing OUTSIDE the data
+      home. The fence is expressed as a path within the data home, so bytes over
+      there are simply not covered by it;
+    * an override naming a DIFFERENT directory inside the data home. It is not the
+      leaf either gate seals, so a sandboxed turn may write there while the
+      gateway would execute what it finds -- the exposure both AI reviews caught,
+      and the reason this predicate is an equality rather than a containment test;
+    * a SYMLINK at the prefix itself. A read-only bind covers the inode it
+      resolves to, but the link NAME lives in the writable data home, so a
+      sandboxed process can unlink it and put a directory of its own in its
+      place -- the seal would still report success while the executable changed.
+
+    Refusing to TRUST rather than refusing to run: an unfenceable prefix skips
+    this module's last resolution tier and nothing else. Agent turns still start,
+    :func:`install` still installs there, and a CLI installed anywhere on ``PATH``
+    is still found by the first tier, so an operator who relocated the tree loses
+    a fallback lookup, not the product. To relocate and STAY covered, move
+    ``KIROCREW_HOME``: the fence is anchored to the home, so it travels with it.
+    """
+    prefix = managed_prefix()
+    try:
+        if prefix.is_symlink():
+            return False
+        canonical = config_dir().resolve() / _STANDALONE_PREFIX_DIR
+        resolved = prefix.resolve()
+    except OSError:
+        # Cannot establish where it is, so cannot establish that it is fenced.
+        return False
+    return resolved == canonical
+
+
 def _standalone_node_modules() -> list[Path]:
-    """``node_modules`` roots of a standalone (unprivileged) CLI install.
+    """``node_modules`` roots of an install under :func:`managed_prefix`.
 
     Probed by KNOWN PATH rather than found by searching, because the standalone
     installer generates a **wrapper script** instead of a symlink: the package
@@ -238,8 +346,7 @@ def _standalone_node_modules() -> list[Path]:
     for that install shape at all, and the check would silently degrade to the
     presence-only answer whose false positives it exists to remove.
     """
-    prefix_override = os.environ.get(_STANDALONE_PREFIX_ENV, "").strip()
-    prefix = Path(prefix_override) if prefix_override else config_dir() / _STANDALONE_PREFIX_DIR
+    prefix = managed_prefix()
     return [prefix / "lib" / _NODE_MODULES, prefix / _NODE_MODULES]
 
 
@@ -770,22 +877,49 @@ def install() -> dict[str, Any]:
         )
         return {"ok": False, "steps": steps}
 
+    # ``--prefix`` is the whole fix: without it npm installs into whatever prefix
+    # its CONFIGURATION names (`prefix` in an .npmrc, `npm_config_prefix`, a
+    # distro default), which is host-specific, frequently on no PATH, and covered
+    # by no list of well-known directories -- so the step below exited 0 while the
+    # launcher landed somewhere nothing looked, and the install read as a failure
+    # on every retry. Pinning it makes the location known by construction. The
+    # shell installer (``playwright-cli.sh``) already does exactly this, so the
+    # two install paths now converge on one directory.
+    prefix = managed_prefix()
     steps.append(
-        _step("npm-install-global", [npm, "install", "-g", NPM_SPEC], _NPM_INSTALL_TIMEOUT_S)
+        _step(
+            "npm-install-global",
+            [npm, "install", "-g", "--prefix", str(prefix), NPM_SPEC],
+            _NPM_INSTALL_TIMEOUT_S,
+        )
     )
     if not steps[-1]["ok"]:
         return {"ok": False, "steps": steps}
 
-    # Resolved after the global install, not before: the binary does not exist
-    # until that step succeeds.
+    # Resolved after the install, not before: the binary does not exist until that
+    # step succeeds.
     path = cli_path()
     if path is None:
+        searched = describe_search_path(augmented_path(os.environ.get("PATH", "")))
+        if managed_prefix_is_fenceable():
+            where = f"not found after a successful install into {managed_prefix_bin_dir()}"
+        else:
+            # Loud rather than silent: the install went where the operator asked,
+            # and the reason it is not trusted afterwards is a property of WHERE
+            # that is, not of the install. Naming the one trusted path, because
+            # "inside the data home" is NOT the rule -- the fence seals one leaf.
+            where = (
+                f"installed into {managed_prefix()}, which is not the fenced prefix "
+                f"{config_dir() / _STANDALONE_PREFIX_DIR} (or is reached through a "
+                f"symlink), so it is not resolved from. Unset {_STANDALONE_PREFIX_ENV}, "
+                f"or relocate KIROCREW_HOME so the fence moves with it"
+            )
         steps.append(
             {
                 "name": "resolve-binary",
                 "ok": False,
                 "returncode": 127,
-                "stderr": f"{CLI_BIN} not found on PATH after a successful global install",
+                "stderr": f"{CLI_BIN} {where}; {searched}",
             }
         )
         return {"ok": False, "steps": steps}

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -319,6 +319,39 @@ _CREW_READONLY_LEAVES: tuple[str, ...] = (
     # fence how a command SPELLS this path, and the kernel denial is what still
     # holds when a spelling is built at runtime (``$(printf ...)``).
     "settings_seeds.json",
+    # The browse CLI's install prefix (``browser_cli/install.py``'s
+    # ``managed_prefix``; ``playwright-cli.sh`` defaults to the same directory).
+    # Whatever resolves out of it is EXECUTED by the gateway -- ``detect()`` spawns
+    # ``[path, "--version"]`` through ``cli_env()`` on every browser-status read --
+    # so a sandboxed process that can write here chooses a program the gateway
+    # runs with its own environment.
+    #
+    # READONLY rather than hidden, and this one is not a close call: the agent's
+    # own shell has to EXECUTE the launcher for browsing to work at all, so a mask
+    # would break the very feature this protects. Read + execute with a
+    # kernel-denied write is the asymmetry every legitimate consumer already lives
+    # within -- ``install()`` writes the tree from the GATEWAY and never from a
+    # sandboxed turn, ``cli_path``/``detect``/``available`` only resolve and spawn,
+    # and the revision probe only reads. Precedent in this same list:
+    # ``aws-control-staging``, gateway-owned and fenced so a same-UID agent cannot
+    # swap the contents between the gateway's write and its read.
+    #
+    # Paired with the same leaf on ``security``'s write floors -- the deny rules
+    # fence how a command SPELLS this path, and the kernel denial is what still
+    # holds when a spelling is built at runtime.
+    #
+    # Two shapes escape this seal, and both are answered by REFUSING TO TRUST them
+    # rather than by refusing to launch. A SYMLINK here seals the target inode while
+    # the link name stays writable (``_warn_if_alias_backed`` reports it), and an
+    # operator's ``KIROCREW_PLAYWRIGHT_CLI_HOME`` may name a directory outside the
+    # data home entirely, which no ``$HOME``-relative rule can cover. In both cases
+    # ``browser_cli.install`` does not resolve the launcher from the prefix at all,
+    # so nothing is executed out of an unfenced directory. Refusing the SPAWN
+    # instead would turn a relocated install tree -- a reasonable thing to do with
+    # a 500 MB directory -- into a host where no agent turn starts, which is a far
+    # wider blast radius than the exposure. That is the same trade
+    # ``_warn_if_alias_backed`` argues for the config ceilings.
+    "playwright-cli",
 )
 
 #: Crew-home leaves that MUST stay read-write for a sandboxed process. Every entry is
@@ -528,6 +561,11 @@ def carveout_shadowed_by_foreign_mask(path: str, mode: str = "standard") -> bool
 #: 1. An EMPTY document must mean what an ABSENT file means to the reader:
 #:
 #:    * ``profiles`` — an empty dir yields no profile, same as no dir;
+#:    * ``playwright-cli`` — the browse CLI's install prefix. An empty dir resolves
+#:      no launcher (``cli_path``'s last tier finds nothing in it) and holds no
+#:      ``@playwright/cli`` tree for the revision probe, which is precisely what an
+#:      absent prefix means: the CLI is not installed. Like ``profiles`` it is a
+#:      DIRECTORY, so criterion 2 does not arise — see the note there;
 #:    * ``computer_use.json`` — ``computer_use.enable_state.load_state`` reads ``{}``
 #:      as DISABLED, which is what an absent keystone means;
 #:    * ``oauth_endpoints.json`` — ``security._validate_operator_oauth_entries``
@@ -550,7 +588,10 @@ def carveout_shadowed_by_foreign_mask(path: str, mode: str = "standard") -> bool
 #:    for ``settings_seeds.json`` at "Crew owns no settings file", so the writer takes
 #:    its leave-it-alone branch: the seed is not refreshed, and nothing is overwritten
 #:    or unlinked. The empty ``profiles`` dir is exempt from the concern entirely: a
-#:    directory bind shows live contents, so a profile added later is visible.
+#:    directory bind shows live contents, so a profile added later is visible — and
+#:    the same holds for ``playwright-cli``, which is what makes sealing it
+#:    compatible with installing into it afterwards: the gateway writes the real
+#:    tree and a sandboxed process sees it, read-only.
 #:
 #: DELIBERATELY EXCLUDED, and each for a different one of those two reasons:
 #:
@@ -573,7 +614,7 @@ def carveout_shadowed_by_foreign_mask(path: str, mode: str = "standard") -> bool
 #: this list closes: a mask needs the opposite treatment (an empty bind OVER the
 #: name), and ``_CREW_HIDDEN_LEAVES`` has no reader to prove an empty document is
 #: absent-equivalent, so each leaf needs its own argument.
-_CREW_PRECREATE_READONLY_DIR_LEAVES: tuple[str, ...] = ("profiles",)
+_CREW_PRECREATE_READONLY_DIR_LEAVES: tuple[str, ...] = ("profiles", "playwright-cli")
 _CREW_PRECREATE_READONLY_FILE_LEAVES: tuple[str, ...] = (
     "computer_use.json",
     "oauth_endpoints.json",

--- a/src/kiro_crew/security/paths.py
+++ b/src/kiro_crew/security/paths.py
@@ -911,6 +911,26 @@ _WRITE_PROTECTED_HOME_PATHS += [
 _KIRO_AGENTS_DIR = ".kiro/agents"
 _WRITE_PROTECTED_HOME_PATHS += [_KIRO_AGENTS_DIR]
 
+# The browse CLI's install PREFIX (``browser_cli/install.py``; the same directory
+# ``playwright-cli.sh`` installs into). Same shape as ``playwright-cli-config.json``
+# above, one step further along: that file is an input to a security decision, this
+# directory holds the EXECUTABLE the decision runs. ``detect()`` spawns
+# ``[cli_path(), "--version"]`` through ``cli_env()`` on every browser-status read,
+# so an agent able to write here is choosing a program the gateway executes with
+# its own environment.
+#
+# WRITE-protected rather than read+write sensitive: every legitimate consumer reads
+# or EXECUTES -- ``cli_path``, ``detect``, ``available``, the revision probe, and
+# the agent's own shell running the CLI -- and only the gateway writes. Hiding it
+# would break browsing while doing nothing about the write, which is the whole
+# risk. ``_path_in_home_dirs`` resolves paths UNDER each entry, so one directory
+# entry covers the launcher and the package tree alike.
+#
+# Paired with the same leaf in ``sandbox._CREW_READONLY_LEAVES``: this gate fences
+# the agent's file-edit tool, and the kernel denial is what still holds for a path
+# spelled at runtime. Protected on one path only is not protected.
+_WRITE_PROTECTED_HOME_PATHS += [f"{prefix}/playwright-cli" for prefix in _CREW_HOME_PREFIXES]
+
 #: Longest command ``is_sensitive_bash_command`` will scan. Longer input is
 #: REFUSED, not skipped and not scanned: both detectors the gate runs are linear
 #: in the subject, so this bound is what turns "linear" into a hard wall-clock

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from kiro_crew import env as env_mod
+from kiro_crew import platform_compat
 from kiro_crew.browser_cli import install as mod
 
 # The real implementation, captured before the autouse fixture below replaces
@@ -85,7 +86,7 @@ def _wire(
 
     monkeypatch.setattr(mod, "find_node_tool", lambda name, base_path=None: tools.get(name))
 
-    def fake_run(argv: list[str], timeout: float) -> tuple[int, str, str]:
+    def fake_run(argv, timeout, cwd=None):
         calls.append(list(argv))
         return outcomes.get(argv[0], (0, "", ""))
 
@@ -226,7 +227,16 @@ def test_install_runs_all_three_steps_and_scopes_browser_to_chromium(
         "install-browser",
         "install-skills",
     ]
-    assert calls[0] == ["/n/npm", "install", "-g", "@playwright/cli@latest"]
+    # `--prefix` pins where the launcher lands, instead of leaving it to whatever
+    # prefix npm's configuration names — see TestManagedPrefix.
+    assert calls[0] == [
+        "/n/npm",
+        "install",
+        "-g",
+        "--prefix",
+        str(mod.managed_prefix()),
+        "@playwright/cli@latest",
+    ]
     # Omitting the argument installs every engine. Optional WebKit dependencies
     # must not veto a baseline Chromium install on a host where Chromium works.
     assert calls[1] == ["/n/playwright-cli", "install-browser", "chromium"]
@@ -276,7 +286,7 @@ def test_install_falls_back_without_deps_when_the_package_step_is_refused(
         # step too; the with-deps branch is distinguished below by argv content.
     )
 
-    def fake_run(argv: list[str], timeout: float) -> tuple[int, str, str]:
+    def fake_run(argv, timeout, cwd=None):
         calls.append(list(argv))
         if "--with-deps" in argv:
             return (
@@ -1439,3 +1449,245 @@ def test_lifecycle_contract_never_falls_through_to_stale_package(
     mod._source_contains.cache_clear()
 
     assert mod.cli_lifecycle_env_supported() is False
+
+
+class TestManagedPrefix:
+    """The CLI installs into a prefix THIS module pins, not npm's configured one.
+
+    The regression: `npm install -g` exited 0 having linked the launcher into
+    whatever prefix npm's CONFIGURATION named (`prefix` in an .npmrc,
+    `npm_config_prefix`, a distro default). That directory is host-specific,
+    frequently on no PATH, and covered by no list of well-known directories, so
+    the resolve step that followed reported the CLI absent — identically on every
+    retry, with the CLI sitting on disk.
+
+    Pinning `--prefix` makes the location known by construction, which is also
+    what keeps external configuration out of the decision about which executable
+    the gateway later spawns.
+    """
+
+    @staticmethod
+    def _launcher_name() -> str:
+        """The launcher's on-disk name for THIS platform.
+
+        `shutil.which` is PATHEXT-aware on Windows, where an extensionless file is
+        not executable — so a fixture writing a bare `playwright-cli` there is
+        invisible to the very lookup under test. npm writes a `.cmd` wrapper on
+        Windows, which is what this mirrors.
+        """
+        return mod.CLI_BIN + (".cmd" if platform_compat.IS_WINDOWS else "")
+
+    def _install_launcher(self, prefix: Path) -> Path:
+        bin_dir = prefix if platform_compat.IS_WINDOWS else prefix / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        launcher = bin_dir / self._launcher_name()
+        launcher.write_text("")
+        launcher.chmod(0o755)
+        return launcher
+
+    @staticmethod
+    def _same_path(a: str | None, b: Path) -> bool:
+        """Whether *a* names the same file as *b*, tolerating Windows spelling.
+
+        `shutil.which` returns the extension in the casing PATHEXT declares, so on
+        Windows it answers `playwright-cli.CMD` for a file written as `.cmd`.
+        `normcase` folds case and separator flavour there, and is a no-op on POSIX.
+        """
+        return a is not None and os.path.normcase(a) == os.path.normcase(str(b))
+
+    def test_the_prefix_is_the_data_home_by_default(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path)
+        monkeypatch.delenv(mod._STANDALONE_PREFIX_ENV, raising=False)
+
+        assert mod.managed_prefix() == tmp_path / "playwright-cli"
+
+    def test_an_operator_may_relocate_the_prefix(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(tmp_path / "elsewhere"))
+
+        assert mod.managed_prefix() == tmp_path / "elsewhere"
+
+    def test_the_bin_dir_follows_the_platform_layout(self, monkeypatch, tmp_path):
+        """npm links into `<prefix>/bin` on POSIX and `<prefix>` on Windows."""
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path)
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(tmp_path / mod._STANDALONE_PREFIX_DIR))
+        pw = tmp_path / mod._STANDALONE_PREFIX_DIR
+        expected = pw if platform_compat.IS_WINDOWS else pw / "bin"
+
+        assert mod.managed_prefix_bin_dir() == expected
+
+    def test_the_install_pins_the_prefix_on_argv(self, monkeypatch, tmp_path):
+        """The fix itself: npm is told where to install, not asked afterwards."""
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path)
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(tmp_path / mod._STANDALONE_PREFIX_DIR))
+        self._install_launcher(tmp_path / mod._STANDALONE_PREFIX_DIR)
+        monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: False)
+        monkeypatch.setattr(mod.os_deps, "missing_deps_hint", lambda: "")
+        monkeypatch.setattr(
+            mod, "find_node_tool", lambda name, base_path=None: "/n/npm" if name == "npm" else None
+        )
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            mod, "_run", lambda argv, timeout: (calls.append(list(argv)), (0, "", ""))[1]
+        )
+
+        result = mod.install()
+
+        assert result["ok"] is True
+        install_argv = calls[0]
+        assert install_argv[:4] == ["/n/npm", "install", "-g", "--prefix"]
+        assert install_argv[4] == str(tmp_path / mod._STANDALONE_PREFIX_DIR)
+        assert install_argv[5] == mod.NPM_SPEC
+
+    def test_cli_path_resolves_from_the_managed_prefix(self, monkeypatch, tmp_path):
+        """Nothing on PATH, yet the launcher we installed is still found."""
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path)
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(tmp_path / mod._STANDALONE_PREFIX_DIR))
+        launcher = self._install_launcher(tmp_path / mod._STANDALONE_PREFIX_DIR)
+        monkeypatch.setattr(mod, "find_node_tool", lambda name, base_path=None: None)
+
+        assert self._same_path(mod.cli_path(), launcher)
+
+    def test_the_managed_prefix_never_outranks_an_ordinary_hit(self, monkeypatch, tmp_path):
+        """Last tier means last: it resolves only a name found nowhere else."""
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path)
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(tmp_path / mod._STANDALONE_PREFIX_DIR))
+        self._install_launcher(tmp_path / mod._STANDALONE_PREFIX_DIR)
+        monkeypatch.setattr(mod, "find_node_tool", lambda name, base_path=None: "/n/playwright-cli")
+
+        assert mod.cli_path() == "/n/playwright-cli"
+
+    def test_an_absent_prefix_resolves_to_nothing(self, monkeypatch, tmp_path):
+        """A fenced but empty prefix: nothing to resolve, and no error either."""
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path)
+        monkeypatch.delenv(mod._STANDALONE_PREFIX_ENV, raising=False)
+        monkeypatch.setattr(mod, "find_node_tool", lambda name, base_path=None: None)
+
+        assert mod.managed_prefix_is_fenceable() is True
+        assert mod.cli_path() is None
+
+    def test_the_revision_probe_reads_the_same_prefix(self, monkeypatch, tmp_path):
+        """One directory, not two: the install and the revision check must agree."""
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path)
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(tmp_path / mod._STANDALONE_PREFIX_DIR))
+
+        roots = mod._standalone_node_modules()
+
+        assert tmp_path / mod._STANDALONE_PREFIX_DIR / "lib" / "node_modules" in roots
+        assert tmp_path / mod._STANDALONE_PREFIX_DIR / "node_modules" in roots
+
+    def test_an_unresolvable_install_names_the_prefix_it_installed_into(
+        self, monkeypatch, tmp_path
+    ):
+        """The residual failure must say WHERE it put things, not just that it failed."""
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path)
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(tmp_path / mod._STANDALONE_PREFIX_DIR))
+        monkeypatch.setattr(
+            mod, "find_node_tool", lambda name, base_path=None: "/n/npm" if name == "npm" else None
+        )
+        monkeypatch.setattr(mod, "_run", lambda argv, timeout: (0, "", ""))
+
+        result = mod.install()
+
+        assert result["ok"] is False
+        step = result["steps"][-1]
+        assert step["name"] == "resolve-binary"
+        assert str(mod.managed_prefix_bin_dir()) in step["stderr"]
+        assert "searched" in step["stderr"]
+
+    def test_a_prefix_outside_the_data_home_is_not_trusted(self, monkeypatch, tmp_path):
+        """Refuse to TRUST, not refuse to run: the tier is skipped, nothing breaks.
+
+        The prefix supplies an executable the gateway spawns, so it is only worth
+        resolving from while it sits inside the tree fenced against agent writes.
+        An operator may still point the override anywhere — they just lose this
+        fallback lookup, and a CLI on PATH is still found by the first tier.
+        """
+        outside = tmp_path / "outside"
+        self._install_launcher(outside)
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path / "crew")
+        (tmp_path / "crew").mkdir()
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(outside))
+        monkeypatch.setattr(mod, "find_node_tool", lambda name, base_path=None: None)
+
+        assert mod.managed_prefix_is_fenceable() is False
+        assert mod.cli_path() is None
+
+    def test_a_differently_named_in_home_override_is_not_trusted(self, monkeypatch, tmp_path):
+        """Inside the data home is NOT the rule — the fence seals one leaf name.
+
+        Both AI reviews caught this: `_WRITE_PROTECTED_HOME_PATHS` adds
+        `<crew home>/playwright-cli` and `_CREW_READONLY_LEAVES` carries the same
+        literal, so `<crew home>/elsewhere` is inside the home and outside the
+        fence. Trusting it by containment would have let a sandboxed turn write a
+        launcher that `detect()` then spawns from the gateway. An earlier revision
+        of this test asserted the opposite and was wrong.
+        """
+        crew = tmp_path / "crew"
+        inside = crew / "elsewhere"
+        self._install_launcher(inside)
+        monkeypatch.setattr(mod, "config_dir", lambda: crew)
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(inside))
+        monkeypatch.setattr(mod, "find_node_tool", lambda name, base_path=None: None)
+
+        assert mod.managed_prefix_is_fenceable() is False
+        assert mod.cli_path() is None
+
+    def test_the_canonical_prefix_is_trusted(self, monkeypatch, tmp_path):
+        """The one shape both gates seal, named explicitly rather than by default."""
+        crew = tmp_path / "crew"
+        canonical = crew / mod._STANDALONE_PREFIX_DIR
+        self._install_launcher(canonical)
+        monkeypatch.setattr(mod, "config_dir", lambda: crew)
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(canonical))
+        monkeypatch.setattr(mod, "find_node_tool", lambda name, base_path=None: None)
+
+        assert mod.managed_prefix_is_fenceable() is True
+        assert mod.cli_path() is not None
+
+    @pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="symlink creation needs privilege")
+    def test_a_symlinked_prefix_is_not_trusted(self, monkeypatch, tmp_path):
+        """A read-only bind seals the target inode; the link NAME stays writable.
+
+        So the seal would report success while a sandboxed process replaced the
+        name with a directory of its own.
+        """
+        crew = tmp_path / "crew"
+        crew.mkdir()
+        target = tmp_path / "target"
+        self._install_launcher(target)
+        (crew / "playwright-cli").symlink_to(target)
+        monkeypatch.setattr(mod, "config_dir", lambda: crew)
+        monkeypatch.delenv(mod._STANDALONE_PREFIX_ENV, raising=False)
+        monkeypatch.setattr(mod, "find_node_tool", lambda name, base_path=None: None)
+
+        assert mod.managed_prefix_is_fenceable() is False
+        assert mod.cli_path() is None
+
+    def test_an_unfenceable_prefix_fails_loudly_with_the_remedy(self, monkeypatch, tmp_path):
+        """Silence is the failure mode to avoid: the install went where asked."""
+        outside = tmp_path / "outside"
+        self._install_launcher(outside)
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path / "crew")
+        (tmp_path / "crew").mkdir()
+        monkeypatch.setenv(mod._STANDALONE_PREFIX_ENV, str(outside))
+        monkeypatch.setattr(
+            mod, "find_node_tool", lambda name, base_path=None: "/n/npm" if name == "npm" else None
+        )
+        monkeypatch.setattr(mod, "_run", lambda argv, timeout: (0, "", ""))
+
+        result = mod.install()
+
+        step = result["steps"][-1]
+        assert step["name"] == "resolve-binary"
+        assert "is not the fenced prefix" in step["stderr"]
+        # Names the ONE path that is trusted, rather than the old and now-wrong
+        # advice to put the override "inside the data home".
+        assert str(tmp_path / "crew" / mod._STANDALONE_PREFIX_DIR) in step["stderr"]
+        assert "KIROCREW_HOME" in step["stderr"]
+
+    def test_the_default_prefix_is_fenceable(self, monkeypatch, tmp_path):
+        """The shape every ordinary install has, including before it exists."""
+        monkeypatch.setattr(mod, "config_dir", lambda: tmp_path)
+        monkeypatch.delenv(mod._STANDALONE_PREFIX_ENV, raising=False)
+
+        assert mod.managed_prefix_is_fenceable() is True

--- a/test/test_browser_cli_launch.py
+++ b/test/test_browser_cli_launch.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from kiro_crew.browser_cli import launch as mod
+from kiro_crew.config.paths import config_dir
 
 
 def test_launch_config_path_is_under_the_data_home(
@@ -585,3 +586,76 @@ def test_browser_socket_env_refuses_relative_configured_roots(
     }
 
     assert mod.browser_socket_env(env) == {}
+
+
+class TestTheInstallPrefixIsFenced:
+    """The prefix the CLI installs into must not be agent-WRITABLE.
+
+    Whatever resolves out of it is executed by the gateway — `detect()` spawns
+    `[cli_path(), "--version"]` through `cli_env()` on every browser-status read —
+    so an agent able to write there chooses a program the gateway runs with its own
+    environment. Fenced on both paths, because protected on one is not protected:
+    the tool gate refuses the agent's file-edit tool, and the sandbox's kernel
+    denial holds for a path spelled at runtime.
+
+    Read and EXECUTE stay open on purpose. Browsing requires the agent's own shell
+    to run the launcher, so hiding the prefix would break the feature the fence
+    exists to protect.
+    """
+
+    @staticmethod
+    def _prefix_paths() -> list[str]:
+        """The prefix, named by the helper the install itself uses.
+
+        Both halves live in this diff, so the fence can be asserted against
+        `managed_prefix()` directly rather than re-deriving the path — one source of
+        truth for where the CLI lands, what is sealed, and what is resolved from.
+        """
+        from kiro_crew.browser_cli import install as install_mod
+
+        prefix = install_mod.managed_prefix()
+        return [
+            str(prefix),
+            str(install_mod.managed_prefix_bin_dir() / install_mod.CLI_BIN),
+            str(prefix / "lib" / "node_modules" / "@playwright" / "cli" / "package.json"),
+        ]
+
+    def test_the_edit_gate_refuses_every_path_under_the_prefix(self) -> None:
+        from kiro_crew import security
+
+        for path in self._prefix_paths():
+            assert security.is_sensitive_write_path(path) is True, path
+
+    def test_the_prefix_stays_readable(self) -> None:
+        """Hiding it would stop the agent executing the launcher at all."""
+        from kiro_crew import security
+
+        for path in self._prefix_paths():
+            assert security.is_sensitive_path(path) is False, path
+
+    def test_the_sandbox_seals_the_prefix_read_only(self) -> None:
+        from kiro_crew import sandbox
+
+        assert "playwright-cli" in sandbox._CREW_READONLY_LEAVES
+        # Hidden and read-only are different tiers, and this leaf must be the
+        # second: a mask would deny the exec browsing depends on.
+        assert "playwright-cli" not in sandbox._CREW_HIDDEN_LEAVES
+
+    def test_the_seal_is_not_skipped_on_a_host_that_never_installed(self) -> None:
+        """`mount(2)` cannot target an absent path, so the launcher creates it.
+
+        Without this the data home stays writable at that name on exactly the
+        installs that have never run the browser install — the population the fence
+        matters most for.
+        """
+        from kiro_crew import sandbox
+
+        assert "playwright-cli" in sandbox._CREW_PRECREATE_READONLY_DIR_LEAVES
+
+    def test_an_unrelated_data_home_path_is_untouched(self) -> None:
+        """The fence is one subtree, not a broad write-lock on the data home."""
+        from kiro_crew import security
+
+        assert (
+            security.is_sensitive_write_path(str(config_dir() / "workspace" / "notes.md")) is False
+        )


### PR DESCRIPTION
## Problem / Motivation

The Settings one-click browser install runs `npm install -g @playwright/cli@latest`, that step exits 0, and the very next step fails:

```
resolve-binary: playwright-cli not found on PATH after a successful global install
```

The launcher *was* installed — into npm's **configured** global prefix (`prefix` in an .npmrc, `npm_config_prefix`, a distro default). That is configuration, not a property of where the `npm` binary sits, so it is host-specific, frequently on no PATH, and covered by no list of well-known directories. On the reporting host it landed in a Homebrew cellar path with an mtime exactly matching the "failed" install.

Reviewing the fix surfaced a second, related defect: whatever resolves out of that prefix is **executed by the gateway** — `detect()` spawns `[cli_path(), "--version"]` through `cli_env()` on every browser-status read — and the prefix was writable by a sandboxed agent turn.

## Why it matters

The install failure is permanent, not transient. Every retry installs successfully and reports the same miss, `detect()` keeps reporting the CLI absent, the Browser panel keeps offering the install button, and the browse capability stays withheld with a working CLI on disk.

The execution exposure is the supported install shape, not a misconfiguration: the shipped unprivileged installer (`playwright-cli.sh`) exists precisely to install without a privileged prefix, and its target sits inside the data home.

## What changed (motivation → approach → change)

**Symptom** — install exits 0, resolution reports the binary absent.
**Root cause** — the install lets npm's *configuration* decide where the launcher lands, and only then goes looking for it.
**Change** — don't surrender the location; pin it, then fence the location we chose.

### Why one PR and not two

These were #9208 and #9256. Split, each one's AI review blocked on the half implemented in the other: the fence's verdict asked to *"refuse execution unless the resolved prefix is covered by both write gates"* (that is `managed_prefix_is_fenceable()`, in the other PR), and the resolution fix's verdict asked to *"OS-seal the managed prefix against agent writes"* (that is the fence, in the other PR). A reviewer reads one diff and cannot see its sibling, so each correctly reported a residual the pair does not have.

They are also one argument on the merits: **pinning is what makes fencing possible** — a fixed path can be sealed, a configured one cannot — and **the fence is what makes resolving from it safe**. Combined here so the security argument is self-contained in a single diff.

### Pinning

- `managed_prefix()` names the prefix this product installs into: the data home, or an operator's `KIROCREW_PLAYWRIGHT_CLI_HOME`. `playwright-cli.sh` already defaults to the same directory, so both install paths converge on one. `install.py` already knew that location (`_STANDALONE_PREFIX_ENV`, `_STANDALONE_PREFIX_DIR`) and `_standalone_node_modules()` already probed it — the one-click path simply did not use it. #7268's triage noted the same thing from the other end: *"The working installer was present but the button did not use it."*
- `install()` passes `--prefix <that>` to npm.
- `cli_path()` consults `managed_prefix_bin_dir()` **last**, after both locations it already knew about (`<prefix>/bin` on POSIX, `<prefix>` on Windows).
- `_standalone_node_modules()` derives from the same helper, so the install and the revision check cannot disagree about the directory.
- The residual failure names the prefix it installed into plus the searched directories.

### Fencing

- `security/paths.py` — the prefix joins `_WRITE_PROTECTED_HOME_PATHS`, so the agent's file-edit tool refuses. `_path_in_home_dirs` resolves paths *under* each entry, so one directory entry covers the launcher and the package tree alike.
- `sandbox.py` — the leaf joins `_CREW_READONLY_LEAVES`: read + execute, kernel-denied write, which holds for a path spelled at runtime that no deny rule can match.
- `sandbox.py` — and `_CREW_PRECREATE_READONLY_DIR_LEAVES`, because `mount(2)` cannot target an absent path: without it the seal is skipped on exactly the installs that never ran the browser install.

**READONLY, not hidden** — load-bearing, not a preference. Browsing requires the agent's own shell to EXECUTE the launcher, so a mask would break the feature the fence protects. Every legitimate consumer already lives within that asymmetry:

| consumer | needs |
|---|---|
| `install()` | writes — but from the **gateway**, never from a sandboxed turn |
| `cli_path` / `detect` / `available` | resolve + spawn |
| `_standalone_node_modules()` | read |
| the agent's shell running the CLI | execute |
| `playwright-cli.sh` | writes — run by the operator from their own shell |

`aws-control-staging` is the precedent in the same list: gateway-owned, fenced so a same-UID agent cannot swap the contents between the gateway's write and its read.

### The two shapes that escape the fence

A **symlink** at the prefix (the seal binds the target inode while the link name stays writable) and an **override outside the data home** (no `$HOME`-relative rule can cover it). Both are answered by refusing to **trust**, not by refusing to launch: `managed_prefix_is_fenceable()` gates the resolution tier, so nothing is executed out of an unfenced directory, and `resolve-binary` says so and names the remedy (put the override inside the data home, or relocate `KIROCREW_HOME` so the fence moves WITH the prefix).

Refusing the spawn instead would raise `SandboxCeilingUnsealable`, which does not degrade — a host that symlinked this prefix to another volume, a reasonable thing to do with a 500 MB tree, would stop starting agent turns entirely. That is the same trade `_warn_if_alias_backed` already argues for the config ceilings, and its note that closing it properly *"needs the data-home root sealed, which is a different change"* still applies.

I also tried sealing a symlink's resolved target as defence in depth and **reverted it**: `_relocated_crew_targets` forbids exactly that — *"`normpath`, never `realpath` — this runs inside `_build_launcher_script` and the seatbelt builder, which execute on the event loop for every async spawn, and a link-resolving syscall on a stalled NFS home would freeze the gateway."*

### Behaviour change, stated plainly

The CLI installs into the product's private prefix rather than the user's global one, and therefore **stops appearing on the user's own `PATH`**. `playwright-cli.sh` compensates with a wrapper in `~/.local/bin` and remains available; `install()` cannot, because `browser_cli/` may only write from `token.py` and `launch.py`. Matching every host's global npm configuration is unbounded work, and the shipped unprivileged installer had already made this choice.

**An existing global install is unaffected**: `cli_path()`'s first tier still searches `augmented_path()` and wins, so an upgrade does not strand anyone whose CLI is already on PATH.

## Tests

`TestManagedPrefix` (14) in `test_browser_cli_install.py` and `TestTheInstallPrefixIsFenced` (5) in `test_browser_cli_launch.py`:

- the prefix defaults to the data home; an operator may relocate it; the bin dir follows the platform layout
- **the install pins the prefix on argv** — the fix itself
- `cli_path()` resolves from it, and **never outranks an ordinary PATH hit**
- the revision probe reads the same prefix (install and check cannot diverge)
- an unresolvable install names the prefix it installed into
- **a prefix outside the data home, and a symlinked prefix, are not trusted** — with the loud diagnostic asserted
- the edit gate refuses the prefix, the launcher, and the package tree; **the prefix stays readable**; the sandbox seals it read-only and it is **not** in `_CREW_HIDDEN_LEAVES`; the seal is not skipped on a host that never installed; an unrelated data-home path is untouched

Fixtures are platform-correct: `playwright-cli.cmd` on Windows (an extensionless file is not executable there, so `shutil.which` — the lookup under test — would not see it), compared through `os.path.normcase` (`which` returns the PATHEXT casing).

## Manual verification

Reproduced on the reporting host (macOS 26.6.2 arm64):

```
write refused: True | still readable: True
$ sh playwright-cli.sh --dry-run
prefix    <data-home>/playwright-cli      # the directory this PR now shares
```

Gates on this branch: `pytest` on `test_browser_cli_install.py`, `test_browser_cli_launch.py`, `test_browser_cli_journeys.py`, `test_spawn_audit.py`, `test_env.py`, `test_app_sources_write_protection.py` and every `test_sandbox*.py` — **1581 passed**, plus `black --check --target-version py310`, `flake8`, `isort --check-only`, `mypy` on all three changed modules.

Eight failures in `test_sandbox_first_party_exec.py` reproduce identically on a **pristine `origin/main` worktree with this commit absent** (`assert 'foreign_sandbox' == 'no_backend'` — the host running the suite is itself sandboxed), so they are environmental to my machine.

## Related Issues

Fixes #9203
Fixes #9252

Supersedes #9256, which carried the fence half alone. Does **not** close #4438.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a component installs a dependency to a location chosen by *external configuration*, then has to discover where it went — and every discovery mechanism becomes a trust decision about what to execute. Pinning the location at install time removes the class, and is also what makes the location fenceable at all. #5083 was the discovery-side symptom of the same shape.

Second, from this PR's own review cycle: splitting a fix from the trust boundary it depends on can make each half individually unmergeable, because a diff-scoped reviewer sees a residual that the pair does not have.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A; the rationale lives beside both fence lists as their convention requires
- [x] No secrets, credentials, or internal references in the diff
