### PR TITLE
fix(messaging): keep prose that merely mentions [STEERING visible

### DIFF
--- a/src/kiro_crew/messaging/driver.py
+++ b/src/kiro_crew/messaging/driver.py
@@ -34,6 +34,7 @@ from kiro_crew.acp.types import (
     EVENT_TOOL_CALL,
     EVENT_TOOL_RESULT,
 )
+from kiro_crew.constants import _STEERING_TAIL_PREFIX_RE
 from kiro_crew.messaging.renderer import (
     COMPACTION,
     DONE,
@@ -90,6 +91,20 @@ _STEER_MARKER_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _MAX_STEER_MARKER_CHARS = 16_384
+#: Prefix closure of the same grammar :data:`_STEER_MARKER_RE` completes, reused
+#: from ``constants`` rather than respelled: it answers "could this unterminated
+#: tail still become a marker?", which is the question the drain below has to ask
+#: before it holds text back. Sourcing the pattern from the one place the grammar
+#: is written keeps the two probes from drifting apart -- a divergence a reviewer
+#: flagged on #9117 and which ``test_the_two_spellings_of_the_grammar_agree``
+#: now pins.
+#:
+#: Recompiled with ``IGNORECASE`` because THIS module's recognizer carries it:
+#: ``constants``' copy is case-sensitive on purpose (it probes the exact
+#: sentinels a detach walk locates), but here a tail judged prose is EMITTED, so
+#: a probe stricter than the recognizer beside it would leak the very frames
+#: ``[steering steer-4a2f: ...]`` is accepted as.
+_STEER_TAIL_PREFIX_RE = re.compile(_STEERING_TAIL_PREFIX_RE.pattern, re.IGNORECASE | re.DOTALL)
 
 # These are KiroCrew-generated status prefixes, not model-authored prose. A
 # legacy dashboard transcript can contain the completed summary as an assistant
@@ -222,7 +237,25 @@ class _SteeringMarkerFilter:
                 if len(self._buffer) > _MAX_STEER_MARKER_CHARS:
                     self._buffer = ""
                     self._dropping_oversized = True
-                elif final:
+                    break
+                if _STEER_TAIL_PREFIX_RE.match(self._buffer) is None:
+                    # Starting with the sentinel is not the same as being a
+                    # marker. This tail cannot become one however the stream
+                    # continues -- the grammar has already diverged -- so it is
+                    # prose, and holding it back would end in deleting it at
+                    # flush. Handed on the same way a CLOSED frame that fails
+                    # `_STEER_MARKER_RE` already is, which is why "[STEERING
+                    # nonsense] tail" survives today and "[STEERING nonsense"
+                    # did not: the only difference between them was a "]" the
+                    # writer happened to type later.
+                    frames.append(("text", self._buffer[0]))
+                    self._buffer = self._buffer[1:]
+                    continue
+                # Still a viable prefix: hold it. At `final` it is a marker the
+                # stream was cut in the middle of, and that is dropped rather
+                # than emitted -- leaking half a control frame to a channel is
+                # the failure this class exists to prevent.
+                if final:
                     self._buffer = ""
                 break
 

--- a/test/test_messaging_driver.py
+++ b/test/test_messaging_driver.py
@@ -22,11 +22,13 @@ from kiro_crew.acp.types import (
     AcpEvent,
     TurnUsage,
 )
+from kiro_crew.constants import split_trailing_protocol_suffix
 from kiro_crew.messaging import (
     APPROVAL_AUTO,
     APPROVAL_INTERACTIVE,
     TransportCapabilities,
     TurnDriver,
+    driver,
 )
 from kiro_crew.messaging.renderer import Renderer
 from kiro_crew.monitoring.completion import MonitorCompletionHook
@@ -1019,3 +1021,189 @@ class TestPromptChoiceNamesItsOwnTool:
             ]
         )
         assert "AKIAIOSFODNN7EXAMPLE" not in prompts[0][3]
+
+
+def _drain_text(*chunks: str) -> tuple[str, list[str]]:
+    """Feed *chunks* through the marker filter and split what came out.
+
+    Returns the visible text and the steer payloads, so a test can assert on
+    both halves: nothing that keeps prose is worth anything if it also stops
+    consuming real markers.
+    """
+    parser = driver._SteeringMarkerFilter()
+    frames: list[tuple[str, str]] = []
+    for chunk in chunks:
+        frames.extend(parser.feed(chunk))
+    frames.extend(parser.flush())
+    return (
+        "".join(payload for kind, payload in frames if kind == "text"),
+        [payload for kind, payload in frames if kind == "steer"],
+    )
+
+
+class TestProseMentioningSteeringSurvives:
+    """Starting with the sentinel is not the same as being a marker.
+
+    `_SteeringMarkerFilter` held any tail that began `[STEERING` until it found
+    a `]`, and deleted it at flush if none arrived. That is a locate-by-substring
+    decision: the same sentence survived if the writer happened to type a `]`
+    later and vanished if they did not, so an agent explaining the steering
+    protocol lost the rest of its message on every channel the driver feeds
+    (Discord, Telegram, WhatsApp).
+
+    The tail is now judged by the GRAMMAR the marker actually has. A tail that can
+    still extend into `[STEERING steer-<id>]` is held, exactly as before; one that
+    has already diverged is prose and is handed on. This is the same rule
+    `constants.split_trailing_protocol_suffix` applies downstream — and it was
+    only reachable there because the driver upstream had already deleted the text.
+    """
+
+    PROSE = [
+        "Use the [STEERING protocol to redirect",
+        "see [STEERING acknowledgment format",
+        # The exact string `test_unfinished_marker_prefix_grammar.py` pins as
+        # visible at the renderer. The driver runs first, so that contract was
+        # being negated before the renderer ever saw the text.
+        "The [STEERING acknowledgment renders as a chip",
+    ]
+
+    @pytest.mark.parametrize("text", PROSE)
+    def test_an_unclosed_steering_tail_that_is_prose_is_left_visible(self, text):
+        visible, steer = _drain_text(text)
+        assert visible == text
+        assert steer == []
+
+    @pytest.mark.parametrize("text", PROSE)
+    def test_the_same_prose_already_survived_when_a_bracket_closed_it(self, text):
+        """The contrast that makes the defect a defect rather than a policy.
+
+        A closed frame that fails `_STEER_MARKER_RE` was already handed on as
+        prose. So the only thing separating "your sentence is delivered" from
+        "your sentence is deleted" was a `]` somewhere later in the stream —
+        which is not a property of the text's meaning.
+        """
+        closed = text + " ] and the rest"
+        visible, steer = _drain_text(closed)
+        assert visible == closed
+        assert steer == []
+
+    def test_prose_split_across_provider_chunks_still_survives(self):
+        """The hold happens mid-stream, so the split is where the bug lived."""
+        visible, steer = _drain_text("see [STEER", "ING acknowledgment format")
+        assert visible == "see [STEERING acknowledgment format"
+        assert steer == []
+
+
+class TestRealMarkersAreStillConsumed:
+    """Negative controls. A filter that kept prose by keeping everything would
+    leak control frames to the channel, which is the failure this class exists
+    to prevent — so each case below has to keep working unchanged."""
+
+    @pytest.mark.parametrize(
+        "chunks",
+        [
+            ("before [STEERING steer-4a2f: pause] after",),
+            # The recognizer is IGNORECASE, so the prefix probe beside it must be
+            # too: a probe that judged these prose would EMIT half a control frame.
+            ("before [STEERING STEER-4A2F: pause] after",),
+            ("before [steering steer-4a2f: pause] after",),
+            # Split inside the id: the classic reason the filter buffers at all.
+            ("before [STEERING steer-4a", "2f: pause] after"),
+        ],
+    )
+    def test_a_marker_is_consumed_and_never_reaches_the_text(self, chunks):
+        visible, steer = _drain_text(*chunks)
+        assert visible == "before  after"
+        assert steer == ["pause"]
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "before [STEERING steer-4a2f",
+            "before [STEERING steer-",
+            "tail [STEE",
+            # Prose by intent, but every byte of it could still extend into a
+            # marker, so it is held and dropped -- correctly. The rule is about
+            # what the grammar admits, not about what the writer meant.
+            "id prefix, as in [STEERING steer",
+        ],
+    )
+    def test_a_marker_the_stream_was_cut_inside_is_still_dropped(self, text):
+        """Fail-closed is preserved: a tail that could still have become a marker
+        is dropped at flush rather than emitted. Half a control frame on a channel
+        is worse than a lost fragment, and unlike the prose above this text really
+        was on its way to being a marker."""
+        visible, steer = _drain_text(text)
+        assert visible == text.split("[")[0]
+        assert steer == []
+
+    def test_an_oversized_unterminated_marker_still_enters_drop_mode(self):
+        """The 16 KiB ceiling is checked before the grammar probe, so an
+        adversarial buffer cannot make the export re-scan a growing string."""
+        visible, steer = _drain_text("[STEERING steer-" + "a" * 20_000)
+        assert visible == ""
+        assert steer == []
+
+
+class TestTheTwoSpellingsOfTheGrammarAgree:
+    """The recognizer and the prefix probe are one grammar written once.
+
+    `_STEER_TAIL_PREFIX_RE` is compiled from `constants._STEERING_TAIL_PREFIX_RE`'s
+    pattern precisely so the marker grammar has a single source. This pins the
+    relationship that makes that safe, which a shared string alone does not: every
+    cut point of anything the recognizer accepts must be admitted by the probe.
+    Miss one and the filter emits half a real marker; admit too much and prose is
+    held. Requested in review on #9117, where the two spellings were noted as
+    already diverging on `IGNORECASE`.
+    """
+
+    ACCEPTED = [
+        "[STEERING steer-4a2f]",
+        "[STEERING steer-4a2f: pause]",
+        "[STEERING steer-4a2f-9b1c: stop and re-plan]",
+        "[STEERING STEER-4A2F: pause]",
+        "[steering steer-4a2f]",
+        "[STEERING  steer-4a2f  :  spaced  ]",
+    ]
+
+    @pytest.mark.parametrize("marker", ACCEPTED)
+    def test_no_chunk_split_of_an_accepted_marker_leaks(self, marker):
+        """The property in the form that actually matters: split an accepted
+        marker at every byte and no part of it may reach the text."""
+        assert (
+            driver._STEER_MARKER_RE.match(marker) is not None
+        ), "the corpus entry is not actually accepted, so it pins nothing"
+        for cut in range(len(marker) + 1):
+            visible, steer = _drain_text(marker[:cut], marker[cut:])
+            assert visible == "", f"a split at byte {cut} leaked {visible!r}"
+            assert len(steer) == 1, f"a split at byte {cut} lost the marker"
+
+    @pytest.mark.parametrize("marker", ACCEPTED)
+    def test_every_prefix_past_the_sentinel_is_admitted_by_the_probe(self, marker):
+        """The regex half of the same property, stated where the probe applies.
+
+        Cuts shorter than `[STEERING` never reach it -- the drain answers those
+        from its own partial-sentinel branch -- so asserting on them would pin a
+        contract this regex does not have. From the sentinel onward the probe is
+        the only thing standing between a buffered fragment and the channel.
+        """
+        for cut in range(len(driver._STEER_PREFIX), len(marker)):
+            prefix = marker[:cut]
+            assert (
+                driver._STEER_TAIL_PREFIX_RE.match(prefix) is not None
+            ), f"the probe would call {prefix!r} prose and emit part of a marker"
+
+    def test_the_probe_can_actually_refuse(self):
+        """Guard the guard: a probe that admitted everything would satisfy the
+        test above and restore the deletion this change removes."""
+        assert driver._STEER_TAIL_PREFIX_RE.match("[STEERING acknowledgment") is None
+
+    def test_the_driver_and_the_renderer_read_the_same_prose_the_same_way(self):
+        """Cross-layer pin. `split_trailing_protocol_suffix` decides the same
+        question downstream; a tail either layer calls prose must survive both,
+        or the visible contract depends on which one ran first — which is exactly
+        how this defect stayed hidden behind a passing renderer test."""
+        for text in TestProseMentioningSteeringSurvives.PROSE:
+            visible, suffix = split_trailing_protocol_suffix(text)
+            assert (visible, suffix) == (text, ""), "the renderer's own view changed"
+            assert _drain_text(text)[0] == text


### PR DESCRIPTION
## Problem / Motivation

`_SteeringMarkerFilter` (`messaging/driver.py`) strips streamed
`[STEERING steer-<id>]` acknowledgments before any renderer sees the text. It held
any buffered tail that began `[STEERING` until it found a `]`, and **deleted it at
flush** if none arrived.

That is a locate-by-substring decision, not a grammar one — and the filter already
knows the difference, because a **closed** frame that fails `_STEER_MARKER_RE` is
handed on as ordinary text. So the same sentence survived or vanished depending on
whether the writer happened to type a `]` later. Measured on current `main`:

| input | text delivered to the channel |
|---|---|
| `Use the [STEERING protocol to redirect` | `Use the ` |
| `see [STEERING acknowledgment format` | `see ` |
| `The [STEERING acknowledgment renders as a chip` | `The ` |
| `text [STEERING nonsense] tail` | `text [STEERING nonsense] tail` |

The last row is the point: nothing about the *meaning* of the first three differs
from it. Only a bracket does.

Two consequences follow, and neither is hypothetical:

* The filter runs inside `TurnDriver`, **upstream of every renderer**, so an agent
  explaining the steering protocol loses the rest of its message on Discord,
  Telegram and WhatsApp. `sanitize_channel_replay_text` runs the same parser, so
  transcript replays lose it too.
* It negates a contract another test already pins.
  `test/test_unfinished_marker_prefix_grammar.py:33`
  (`test_prose_mentioning_steering_is_left_visible`) asserts
  `"The [STEERING acknowledgment renders as a chip"` stays visible at the renderer —
  and it passes, because the driver had already deleted the text before the renderer
  ran.

Found as a reviewer-named residual on merged #9117, which fixed the renderer half of
this defect class and whose review recorded that
"`_SteeringMarkerFilter._drain` … sits upstream of every renderer this PR names,
holds any unclosed `[STEERING`-prefixed tail by bare substring, and deletes it at
flush … Needs a named follow-up on the driver filter."

## Why it matters

Losing the tail of a message is silent and total: there is no placeholder, no
warning, and the sender's own transcript shows what they wrote. The text most likely
to trigger it is text *about* the steering feature — documentation, an explanation to
a user, a support answer — so the failure is concentrated exactly where an assistant
is being most helpful.

It also makes a green test lie. `test_prose_mentioning_steering_is_left_visible`
reads as coverage for this behaviour and is not: it exercises a layer the real
pipeline never reaches with that input.

## What changed (motivation → approach → change)

Root cause: the drain asked "does this tail **start with** the sentinel?" when the
question it needed answered was "could this tail **still become** a marker?".

Approach: reuse the closure the repository already has for that question rather than
inventing a second rule. `constants._STEERING_TAIL_PREFIX_RE` — added by #9117 — is
the prefix closure of this exact grammar, documented there as admitting every cut
point of a real marker while leaving a diverging tail (`[STEERING acknowledgment`)
as prose. `split_trailing_protocol_suffix` already uses it downstream.

* **`_STEER_TAIL_PREFIX_RE`** in `driver.py` is compiled from that constant's
  `.pattern`, so the marker grammar keeps a single source. `IGNORECASE` is added,
  and the reason is stated where it is added: `constants`' copy is case-sensitive on
  purpose because it probes sentinels a detach walk *locates*, whereas here a tail
  judged prose is **emitted** — a probe stricter than the `_STEER_MARKER_RE` sitting
  beside it would leak part of a real `[steering steer-4a2f: …]` frame.
* **The unterminated branch of `_drain`** now consults it. A tail that has already
  diverged from the grammar is handed on the same way a closed-but-invalid frame
  already was; a tail that is still viable is held exactly as before.
* **Fail-closed is unchanged.** A tail that was still a viable marker when the stream
  ended is dropped rather than emitted — half a control frame on a channel is worse
  than a lost fragment, and unlike the prose above that text really was on its way to
  being a marker.
* **The 16 KiB ceiling is checked before the grammar probe**, so an adversarial
  buffer cannot make the drain re-scan a growing string. The existing
  oversized/drop-mode behaviour is byte-for-byte unchanged.

Deliberately not changed: the partial-sentinel branch (`[STEE` and shorter) is a
viable prefix by construction and keeps its existing fail-closed drop; and the
`.upper()`-per-iteration cost in the drain loop is pre-existing and left alone rather
than folded into a behaviour fix.

## Tests

`TestProseMentioningSteeringSurvives` — the defect:

* `test_an_unclosed_steering_tail_that_is_prose_is_left_visible`, parametrized over
  three prose strings including **the exact string
  `test_unfinished_marker_prefix_grammar.py` pins as visible at the renderer**, so
  the two layers are pinned to agree rather than to disagree quietly.
* `test_the_same_prose_already_survived_when_a_bracket_closed_it` — the contrast that
  makes this a defect rather than a policy: append `] and the rest` and the identical
  text was already delivered whole, before and after this change.
* `test_prose_split_across_provider_chunks_still_survives` — the hold happens
  mid-stream, so the chunk split is where the bug actually lived.

`TestRealMarkersAreStillConsumed` — the negative controls, because a filter that kept
prose by keeping everything would leak control frames:

* `test_a_marker_is_consumed_and_never_reaches_the_text` over the plain marker, an
  **uppercase id**, a **lowercase keyword**, and a marker **split inside the id**.
  The two case variants are the ones that would break if the probe did not carry
  `IGNORECASE`.
* `test_a_marker_the_stream_was_cut_inside_is_still_dropped` — fail-closed preserved.
  One corpus entry (`id prefix, as in [STEERING steer`) is prose by intent and is
  still dropped, which is correct and is called out: the rule is what the grammar
  admits, not what the writer meant.
* `test_an_oversized_unterminated_marker_still_enters_drop_mode`.

`TestTheTwoSpellingsOfTheGrammarAgree` — **requested in #9117's review** ("add a
cross-pinning test … so the two spellings cannot drift apart unnoticed"):

* `test_no_chunk_split_of_an_accepted_marker_leaks` — splits each accepted marker at
  **every byte** and asserts nothing reaches the text and the marker still arrives.
  This is the property in the form that matters, and it covers the partial-sentinel
  branch as well as the probe.
* `test_every_prefix_past_the_sentinel_is_admitted_by_the_probe` — the regex half,
  stated only where the probe applies: cuts shorter than `[STEERING` are answered by
  a different branch, so asserting on them would pin a contract this regex does not
  have.
* `test_the_probe_can_actually_refuse` — guard the guard; a probe that admitted
  everything would satisfy the two above and restore the deletion.
* `test_the_driver_and_the_renderer_read_the_same_prose_the_same_way` — the
  cross-layer pin, since a passing renderer test behind a deleting driver is exactly
  how this stayed hidden.

**Red-before**, measured on this branch with only `driver.py` reverted to
`origin/main` and the new tests kept: **12 failed, 18 passed**. Five failures are the
property — e.g.
`assert 'Use the ' == 'Use the [STEERING protocol to redirect'` — and seven are
`AttributeError: module 'kiro_crew.messaging.driver' has no attribute
'_STEER_TAIL_PREFIX_RE'`, which are the cross-pinning tests: they pin a new invariant
rather than a fixed defect, and are reported as such rather than counted as evidence
for the fix. **The 18 that passed are the negative controls**, which is the useful
half of that number: real-marker consumption, fail-closed drops and the oversized
path behave identically before and after.

**Gates.** `test_messaging_driver.py` 83 passed. Broad consumer sweep —
`test_messaging_driver`, `test_unfinished_marker_prefix_grammar`, `test_discord`,
`test_channel_table_rendering`, `test_messaging_tables`,
`test_driver_session_directives`, `test_chat_steer`, `test_steer_settle`,
`test_steer_requeue` — **640 passed, 0 failed**. `black --check` clean (both files
were black-clean at the base, so the additions were formatted rather than left to
drift). No added line over 100 characters. `mypy --platform linux` reports 0 errors
in `driver.py` (the 4 it finds are pre-existing in `apps/routes.py` and
`dashboard/state.py`, reached by import following).

## Manual verification

N/A — unit coverage sufficient: the defect is entirely in a pure text-frame parser
with no I/O, the tests drive it through its real `feed`/`flush` interface including
chunk splits, and the cross-layer test exercises the renderer helper the delivered
text actually flows into.

## Related Issues

None filed — this is the follow-up #9117's own review asked for on the driver filter,
raised there and not tracked in an issue.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: **a parser that decides "is this a control frame?" by a sentinel substring
and then deletes what it held.** The tell is an asymmetry the code already contains —
here, a closed frame that fails the full grammar was handed on as prose while an
unclosed one was deleted, so the module already knew the right answer and applied it
in only one branch. Ask of any buffering filter: *what happens to the buffer at
flush, and is that the same decision the closed path makes?*

Second lesson, about test topology rather than parsing: **a passing test one layer
below a deleting layer is not coverage.** `test_prose_mentioning_steering_is_left_visible`
asserted the right contract at the renderer and was green while the real pipeline
negated it upstream. Where two layers implement the same grammar, pin them against
each other — which is what `test_the_driver_and_the_renderer_read_the_same_prose_the_same_way`
now does.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
