### PR TITLE
feat: opt-in ACP frame recorder (owner-only perms)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -10,7 +10,6 @@
 src/kiro_crew/_process_group_supervisor.py
 src/kiro_crew/acp/kas_wire.py
 src/kiro_crew/acp/liveness.py
-src/kiro_crew/acp/runtime.py
 src/kiro_crew/acp/session_handle.py
 src/kiro_crew/acp/worker_pool.py
 src/kiro_crew/apps/__init__.py

--- a/conftest.py
+++ b/conftest.py
@@ -120,6 +120,19 @@ import warnings
 
 import pytest
 
+# ── ACP frame recorder switch (rootdir floor) ───────────────────────────────
+# ``kiro_crew.acp._frame_record`` starts its writer thread at IMPORT time when
+# ``KIROCREW_ACP_RECORD_FRAMES`` is set, and ``acp.client`` (hence the dashboard
+# server, the session handle, the Slack handler, ...) imports it transitively. An
+# operator running the suite with a live recording configured would otherwise
+# have every collected test module's fake frames appended to their real corpus
+# file -- from ANY testpath, including the ~108 modules under
+# ``src/kiro_crew/apps/builtins/*/tests/`` that never see ``test/conftest.py``.
+# Cleared here, at rootdir-conftest import, which precedes every test module's
+# first ``kiro_crew`` import; tests that need the switch set it themselves
+# through monkeypatch.
+os.environ.pop("KIROCREW_ACP_RECORD_FRAMES", None)
+
 # ── Hypothesis example database (rootdir floor) ─────────────────────────────
 # ``test/conftest.py`` registers the "default"/"thorough" profiles but never sets
 # ``database=``, so hypothesis falls back to its own default: ``.hypothesis/examples``

--- a/src/kiro_crew/acp/_frame_record.py
+++ b/src/kiro_crew/acp/_frame_record.py
@@ -1,0 +1,1094 @@
+"""Opt-in recorder for raw inbound ACP frames — a no-op unless switched on.
+
+Set ``KIROCREW_ACP_RECORD_FRAMES`` to a directory and every agent->client
+JSON-RPC frame the two transports read is appended, one JSON object per line, to
+``<dir>/<backend>.jsonl``. Unset — which is every ordinary run, and every CI run
+— :func:`record_frame` returns after one environment lookup and touches nothing.
+
+Why it exists: the replay corpus under ``test/fixtures/acp_frames/`` is the
+behavioural gate that stops a refactor of the dispatch layer silently changing
+what a backend's frames become, and a corpus is only worth trusting if a human
+can regenerate it from a real backend rather than hand-writing what they assume
+the wire looks like. The corpus README (``test/fixtures/acp_frames/README.md``,
+introduced with the corpus) documents the recording procedure and the review a
+recording must pass before it is committed.
+
+Four properties this module owes the reader loops that call it, because it sits
+on the hot path of every frame of every session:
+
+* **It never waits on the reader loop.** :func:`record_frame` puts the frame on
+  ONE process-wide, thread-safe, bounded queue and returns; a single daemon
+  thread drains it in arrival order. One queue and one writer for the whole
+  process, not one per event loop: the two transports read on different
+  threads and loops (``AcpRuntime`` on the gateway loop, ``AcpClient`` on a
+  worker's), and a writer bound to "the loop that first recorded" would be
+  replaced each time the other loop recorded, leaving several writers
+  appending to the same file concurrently and each holding its own copy of
+  the byte budget. So neither a slow disk nor a wedged executor can hold a
+  frame back from routing — a reader loop that waited on either would stall
+  every multiplexed session until the liveness watchdog ended the process.
+  The writer is a dedicated thread rather than a job on the shared
+  ``subprocess_executor``: the recorder must not compete with, or be starved
+  by, the pool that runs tool subprocesses. It is started by
+  :func:`start_recorder` at import time, on the importing thread, and never
+  from a reader loop: ``Thread.start()`` waits for the OS to schedule the new
+  thread, which is unbounded on a starved host, and every lazy scheme
+  (``to_thread``, a private bootstrap pool) still paid one such start on the
+  loop. If the switch is set after import without ``start_recorder`` being
+  called, recording stands down with a line saying so. The queue is bounded in BYTES as well
+  as frames: a frame may be up to the transports' 10 MiB line limit, so a count
+  alone would let a burst of large frames hold gigabytes of parsed JSON behind
+  one writer. A full queue drops the frame and stands recording down rather
+  than blocking or growing.
+  The price of never waiting is that the recording is not durable across a
+  hard exit. A frame still queued when the process ends is lost, and a process
+  ending in the middle of an append (one open/append/close per frame) can
+  leave a torn last line. Both cost the last few milliseconds of a session, and
+  a human regenerating a fixture stops the gateway after the scenario is done;
+  the README's review step is what catches a torn tail before it is committed.
+  Nothing in the gateway's shutdown path awaits this module, by design:
+  recording is a development aid and must never add a step to shutdown.
+* **It never raises.** A recorder fault must not reach a reader loop: in
+  ``AcpRuntime._reader_loop`` an exception tears down EVERY multiplexed session
+  on that process, which a user sees as an unexplained chat failure. Every
+  failure mode degrades to one log line and a permanent stand-down, after which
+  anything still queued is discarded unwritten — one failure costs one line,
+  not one per pending frame.
+* **It redacts before it writes.** Frames carry tool output, prompts and
+  transcripts. Recording runs every string leaf (keys and values, at any
+  depth) through the same
+  :func:`kiro_crew.acp._dispatch.redact_text` the dashboard path runs, plus a
+  home-directory scrub, BEFORE serialization so redaction can never eat JSON
+  syntax and every recorded line parses. An accidental commit of a raw
+  recording is then not an
+  accidental commit of a credential. That is a floor and not a guarantee — see
+  the README's review step, which is what actually keeps account ids and
+  private paths out of the corpus.
+* **The recording is owner-only on disk, and lands where the operator said.**
+  Redaction is best-effort, and a recording sits on a developer machine for as
+  long as they take to review it. On POSIX the destination is PINNED by
+  :mod:`kiro_crew.pinned_fs`, the one home for that mechanism: the parent
+  chain is resolved once, every component is opened relative to the previous
+  descriptor with ``O_DIRECTORY | O_NOFOLLOW``, the leaf is created (0o700)
+  through that descriptor, and the file is opened relative to it with
+  ``O_NOFOLLOW`` and tightened (``fchmod`` 0o600) on its own descriptor.
+  A path that already crosses a link is refused outright (the recording must
+  land where the env var reads, not where a link points), and nothing on the
+  way to the frame is resolved by name through a link after that, so another
+  local user who can write to an ancestor cannot redirect the recording by
+  swapping a link in between check and use, and a planted symlink or hard
+  link at the target is refused. Whatever the pinned descriptor lands on must
+  then be owned by this user and owner-only in mode, or the recording stands
+  down. The mode is
+  not the whole story: a 0700 directory can still carry a POSIX ACL that grants
+  another account, and a file created inside inherits the directory's default
+  ACL, so both descriptors are also checked for an extended ACL
+  (``system.posix_acl_access`` / ``_default`` xattrs) and refused if one is
+  present. That check exists only on Linux; macOS keeps ACLs behind
+  ``acl_get_file`` with no xattr view, so a macOS process cannot prove the
+  recording is owner-only and stands down like Windows does. The recorder
+  is Linux-only for exactly this reason: Windows has neither ``dir_fd`` nor
+  ``O_NOFOLLOW``, its DACL lockdown is applied by path after the open, and an
+  ancestor another account can rename in cannot be pinned, so every
+  path-based check there leaves a swap window. Rather than ship a recorder
+  whose owner-only guarantee holds on one platform and is best-effort on the
+  other, a Windows process with the env var set stands down once with a log
+  line naming the reason. The corpus is regenerated on a POSIX host.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import errno
+import functools
+import json
+import logging
+import os
+import re
+import stat
+import threading
+import time
+from pathlib import Path
+
+from kiro_crew import pinned_fs, platform_compat
+from kiro_crew.acp._dispatch import redact_text
+from kiro_crew.acp_backends import POLICY_ID_BY_BACKEND
+
+logger = logging.getLogger(__name__)
+
+#: Directory to append recordings to. Absent or blank disables recording.
+ENV_RECORD_FRAMES = "KIROCREW_ACP_RECORD_FRAMES"
+
+#: Frames that may wait for the writer before the recorder gives up. A frame is
+#: normally a few KB and the writer keeps up with any disk that is not failing,
+#: so this is a stand-down trigger for a wedged destination, not a normal
+#: buffer depth.
+QUEUE_LIMIT = 1024
+
+#: Wire bytes that may wait for the writer. The transports cap a single frame at
+#: 10 MiB, so a count limit alone would admit a burst of large frames that holds
+#: gigabytes of parsed JSON on the heap behind one writer; this bounds the
+#: backlog to a few such frames regardless of how many small ones fit.
+QUEUE_BYTES_LIMIT = 32 * 1024 * 1024
+
+#: POSIX mode bits the recording is held at.
+DIR_MODE = 0o700
+FILE_MODE = 0o600
+
+#: Set once when recording has failed, so a broken destination costs one log
+#: line rather than one per frame for the life of the process.
+_stood_down = False
+_stand_down_lock = threading.Lock()
+#: A stand-down latched ON A READER LOOP stores its reason here instead of
+#: logging: ``logger.warning`` takes the handler lock and runs the handlers
+#: synchronously, which is a wait the reader loop must not pay. The notifier
+#: thread emits it (:func:`_emit_pending_stand_down`) -- not the file writer,
+#: which may be wedged on the very fault being reported.
+_pending_stand_down: BaseException | None = None
+
+
+class _Writer:
+    """The one process-wide queue, its byte budget, and the thread draining it.
+
+    The reader side of this object is LOCK-FREE. A reader loop must never wait
+    on a mutex another thread may be holding while preempted, and every
+    stdlib queue takes one (``queue.Queue.mutex`` inside ``put_nowait``). So the
+    backlog is a ``collections.deque``, whose ``popleft`` is a single bytecode
+    under the GIL and needs no lock on the drain side; the two counters that
+    bound it (``queued`` frames, ``queued_bytes``) and the reader's ``append``
+    are guarded by ``lock`` -- which the reader only ever tries with
+    ``acquire(blocking=False)``.
+    ``queued_bytes`` is the backlog, not a lifetime total: the drain thread
+    releases a frame's bytes once it has been written or discarded.
+    ``in_flight`` is the frame the drain thread has popped but not yet finished;
+    it exists so the test-only flush can tell "empty" from "done".
+    """
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.items: collections.deque = collections.deque()
+        self.queued = 0
+        self.queued_bytes = 0
+        self.in_flight = 0
+        #: Set by the test-only stop path. The drain thread waits on this with
+        #: a timeout so it notices the stop even when the backlog is empty, and
+        #: discards rather than writes once it is set, so teardown never waits
+        #: on a backlog.
+        self.stop = threading.Event()
+        self.thread = threading.Thread(
+            target=_drain, args=(self,), name="acp-frame-recorder", daemon=True
+        )
+        #: A second thread whose only job is to emit a stand-down that was
+        #: latched on a reader loop. It is NOT the file writer: a writer wedged
+        #: in a hung NFS/FUSE ``write`` never returns to its loop, and the one
+        #: warning that says "frames are being dropped" would wait behind it
+        #: forever. This thread touches no file and cannot wedge.
+        self.notifier = threading.Thread(
+            target=_notify, args=(self,), name="acp-frame-recorder-notify", daemon=True
+        )
+        self.thread.start()
+        try:
+            self.notifier.start()
+        except BaseException:
+            # The writer is already running; without this the only handle to
+            # stop it would be lost with the failed constructor, leaving an
+            # idle daemon thread behind for the life of the process.
+            self.stop.set()
+            self.thread.join(10)
+            raise
+
+
+#: ``None`` until :func:`start_recorder` runs. The writer is started at
+#: process start (import time, when the env var is set), never from a reader
+#: loop: ``Thread.start()`` waits for the OS to schedule the new thread, which
+#: is unbounded on a starved host, and no lazy scheme avoids paying that on
+#: the loop at least once. A stopped-then-restarted writer is a test-only path.
+_writer: _Writer | None = None
+_writer_lock = threading.Lock()
+
+
+def fixture_dir_name(backend: str) -> str:
+    """Return the corpus file stem for a backend id.
+
+    The kiro-cli backend's id is the empty string, which is not a filename, so
+    the mapping cannot be identity. It reuses ``POLICY_ID_BY_BACKEND`` — the
+    module that already had to give every backend id a writable wire name —
+    rather than introducing a second table that could disagree with it. The
+    reader loops only ever pass an id from ``ACP_BACKENDS_KNOWN`` (construction
+    rejects anything else), so a ``KeyError`` here is a programming error and is
+    caught by :func:`write_frame`'s stand-down like any other recorder fault.
+    """
+    return POLICY_ID_BY_BACKEND[backend]
+
+
+def recording_destination() -> str:
+    """Return the recording directory, or ``""`` when recording is off.
+
+    The whole cost of recording being off: one environment lookup. Read on every
+    call rather than cached so there is no stale-state path to reason about.
+    """
+    if _stood_down:
+        return ""
+    return os.environ.get(ENV_RECORD_FRAMES, "").strip()
+
+
+# A dict key whose VALUE is a credential by construction, whatever the value
+# looks like. The pattern redactor knows credential SHAPES (an AWS key id, a
+# ``Bearer`` token, a PEM block); it has no branch for ``Authorization: Basic
+# <base64>`` (reversible: it IS the password), ``Proxy-Authorization``, a
+# ``Cookie`` header, an ``api_key`` field, or a ``password`` field holding an
+# arbitrary string. Under one of these keys the value is redacted unconditionally
+# -- the key NAME is the evidence, not the value's shape. Matched against every
+# ancestor key of a leaf, so ``{"Authorization": {"value": ...}}`` and
+# ``{"headers": {"Cookie": [...]}}`` are both covered. The key is CANONICALISED
+# first -- lower-cased, with every ``-``, ``_`` and space removed -- so one
+# spelling here covers ``Authorization`` (RFC 9110 5.1: header names are
+# case-insensitive), ``api_key``/``api-key``/``apiKey``/``X-Api-Key``, and
+# ``accessToken``/``access_token``/``_authToken`` alike. The pattern below is
+# written against that canonical form: no separators, no capitals.
+#
+# It is a SUFFIX rule, not a list of known prefixes: ``slackbottoken``,
+# ``githubenterprisetoken``, ``xinternalsecret`` and ``dbpassword`` all end in
+# a credential noun, and a prefix allowlist would have to be extended for every
+# new integration -- each omission a leak. The one family that shares a suffix
+# and is NOT a credential is the usage COUNTER: ``inputTokens``, ``max_tokens``,
+# ``context_window_tokens``. Those are plural, so the singular suffix ``token``
+# excludes them; the singular counters that do exist are named explicitly in
+# :data:`_NOT_CREDENTIAL_KEY_RE` (``maxtoken``, ``nexttoken`` -- a pagination
+# cursor, which is not secret).
+_CREDENTIAL_KEY_RE = re.compile(
+    r"(?:"
+    r"authorization"
+    r"|cookie"
+    r"|apikey"
+    r"|token"
+    r"|secret|secretkey|privatekey"
+    r"|password|passwd|passphrase|pwd"
+    r"|credentials?"
+    # One-time and verification codes: short, often all digits, and live for
+    # minutes -- a recording is the one place they must not land. ``code`` on
+    # its own is NOT here (an HTTP status code, an exit code, a language code
+    # are all ``code``); the qualified forms are.
+    r"|otp|totp|hotp|pin|pincode|mfacode|2facode|verificationcode|authcode"
+    r"|authorizationcode|securitycode|accesscode|recoverycode|backupcode"
+    # ``auth`` as a suffix: a bare ``auth`` field is a credential blob (npm's
+    # ``_auth`` is ``base64(user:password)``, a requests-style ``auth`` pair),
+    # and so are ``basic_auth``, ``proxyAuth``, ``registryAuth``. The names
+    # that END in ``auth`` and are NOT blobs are exempted by exact name in
+    # :data:`_NOT_CREDENTIAL_KEY_RE`: ``oauth`` is a configuration block whose
+    # ``clientId``/``issuer``/``scopes`` a replay needs.
+    r"|auth"
+    r")$"
+)
+
+# Canonical key names that END in a credential noun but hold nothing secret.
+# ``nexttoken`` / ``continuationtoken`` / ``pagetoken`` are pagination cursors,
+# ``maxtoken`` / ``endoftexttoken`` are model settings, ``tokenizer`` never
+# reaches the suffix rule (it does not end in ``token``).
+_NOT_CREDENTIAL_KEY_RE = re.compile(
+    r"^(?:"
+    r"(?:next|continuation|page|pagination|max|min|stop|eos|eot|bos|endoftext|pad|unk|start|end)token"
+    # OAuth is a configuration block, not a blob; ``preauth``/``reauth`` are
+    # flags or phases. Anything else ending in ``auth`` is a credential.
+    r"|oauth|oauth2|preauth|reauth|noauth|requiresauth|needsauth|hasauth|useauth|skipauth"
+    r")$"
+)
+
+_KEY_SEPARATORS = str.maketrans("", "", "-_ ")
+
+#: Fields whose STRING VALUE names a sibling field. A header list is often
+#: serialised as ``[{"name": "Authorization", "value": "Basic ..."}]``, so the
+#: credential key is a value, not a key, and the walk would otherwise judge
+#: ``value: Basic ...`` with no header context. When one of these fields holds a
+#: credential-bearing name, that name joins the key context for the dict's
+#: OTHER leaves (never for the name field itself, which must survive).
+_NAME_FIELDS = frozenset({"name", "key", "header", "field", "param", "parameter", "label"})
+
+#: The sibling fields a borrowed credential name applies to: the ones that
+#: carry the header's VALUE. ``enabled``, ``source``, ``description`` next to
+#: a ``name: Authorization`` are metadata, not the secret, and must survive.
+_VALUE_FIELDS = frozenset({"value", "values", "val", "content", "data", "secret", "default"})
+
+
+def _is_name_field(key: str) -> bool:
+    return key.translate(_KEY_SEPARATORS).lower() in _NAME_FIELDS
+
+
+def _is_value_field(key: str) -> bool:
+    return key.translate(_KEY_SEPARATORS).lower() in _VALUE_FIELDS
+
+
+def _is_credential_key(key: str) -> bool:
+    """True when *key* names a field whose value is a credential by definition.
+
+    Matched on the canonical form (see :data:`_CREDENTIAL_KEY_RE`), so
+    ``accessToken``, ``access_token``, ``ACCESS-TOKEN``, ``_accessToken`` and
+    ``SLACK_BOT_TOKEN`` are one rule; ``inputTokens`` (plural, a count) and
+    ``NextToken`` (a cursor) are not credentials.
+    """
+    canonical = key.translate(_KEY_SEPARATORS).lower()
+    if _NOT_CREDENTIAL_KEY_RE.match(canonical):
+        return False
+    return _CREDENTIAL_KEY_RE.search(canonical) is not None
+
+
+@functools.lru_cache(maxsize=4)
+def _home_pattern(home: str) -> re.Pattern[str]:
+    """``$HOME`` followed by a path separator or the end of the string, never mid-name."""
+    return re.compile(re.escape(home.rstrip("/")) + r"(?=/|$)")
+
+
+def _scrub_string(text: str, home: str) -> str:
+    """Redact one string leaf: credential SHAPES, then the recording user's $HOME.
+
+    Free text (a tool result, a curl transcript) is scrubbed by the shared
+    ``redact_text`` shape redactor only. The key-NAME rule in ``_scrub_value``
+    applies to structured keys, where the label is unambiguous; guessing labels
+    inside prose is that redactor's job, not a second engine here.
+    """
+    text = redact_text(text)
+    if home:
+        # A recording made on a developer's machine otherwise carries their
+        # login name in every file path a tool call touched. Only a whole
+        # path component is replaced: with ``$HOME=/home/al`` a sibling user's
+        # ``/home/alice/x`` must stay intact, not become ``~ice/x``.
+        text = _home_pattern(home).sub("~", text)
+    return text
+
+
+def _scrub_keyed_string(keys: tuple[str, ...], value: str, home: str) -> str:
+    """Redact a string that sits under dict keys, with each key as context.
+
+    Two tests, in order. First, the key NAME: a value under ``Authorization``,
+    ``Cookie``, ``password``, ``api_key`` (see :data:`_CREDENTIAL_KEY_RE`) is a
+    credential whatever it looks like -- ``Authorization: Basic <base64>`` is
+    the password, reversibly, and no shape detector recognises it -- so it is
+    replaced outright. Second, the key as CONTEXT for a shape: a bare opaque
+    ``Bearer …`` token is not a credential pattern, but ``Authorization: Bearer
+    …`` is, so the pair is re-joined for the CHECK only. *keys* is every
+    enclosing dict key from the outermost down, so ``{"Authorization":
+    {"value": "Bearer …"}}`` is judged under ``Authorization`` as well as under
+    ``value``; an inner key never hides an outer one. The keys themselves are
+    never consumed, which is what keeps the output valid JSON.
+    """
+    for key in keys:
+        if _is_credential_key(key):
+            return "[REDACTED: credential]"
+    for key in keys:
+        joined = f"{key}: {value}"
+        if redact_text(joined) != joined:
+            return "[REDACTED: credential]"
+    return _scrub_string(value, home)
+
+
+#: What a dict KEY looks like when it is a field name rather than a secret
+#: that was used as one: an identifier, optionally dashed, of modest length.
+#: ``value``, ``Content-Type``, ``max_tokens`` pass; ``Basic dXNlcjpwYXNz``
+#: (a space), ``eyJhbGciOi…`` (too long), ``dXNlcjpwYXNz==`` (``=``) do not.
+_FIELD_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_\-]{0,63}\Z")
+
+
+def _scrub_dict_key(keys: tuple[str, ...], key: str, home: str) -> str:
+    """Redact a dict KEY that sits under the enclosing *keys*.
+
+    A key is a string leaf too, and under a credential-named ancestor the
+    secret may BE the key (``{"Authorization": {"Basic …": true}}``). The
+    value rule cannot be applied verbatim, though: under ``Authorization`` a
+    sub-key such as ``value`` is a field name, not the secret. So under a
+    credential context a key is kept only when it looks like a field name
+    (:data:`_FIELD_NAME_RE`); anything else there -- a blob with spaces, a
+    base64 tail, an over-long token -- is replaced. Outside a credential
+    context the key gets the same shape check as any value.
+    """
+    for ancestor in keys:
+        if _is_credential_key(ancestor):
+            if _FIELD_NAME_RE.match(key):
+                break
+            return "[REDACTED: credential]"
+    for ancestor in keys:
+        joined = f"{ancestor}: {key}"
+        if redact_text(joined) != joined:
+            return "[REDACTED: credential]"
+    return _scrub_string(key, home)
+
+
+def _scrub_value(value, home: str, keys: tuple[str, ...] = ()):
+    """Walk a decoded JSON value and redact every string leaf, keys included.
+
+    Structural, not textual: redacting the SERIALIZED frame let one credential
+    pattern span a key, the quote, the colon and the value (``"Authorization":
+    "Bearer …"`` collapsed to one ``[REDACTED]`` token), which leaves a line the
+    corpus loader cannot parse. Per-leaf redaction cannot cross a JSON
+    boundary, so the output is always valid JSON.
+
+    *keys* is the chain of enclosing dict keys, outermost first, carried down
+    through lists and nested dicts so that ``{"Authorization": ["Bearer …"]}``
+    and ``{"Authorization": {"value": "Bearer …"}}`` are both judged with the
+    header context; a bare token under a credential-shaped ancestor key is
+    otherwise unrecognisable, and a nested dict's own key must add to that
+    context, not replace it.
+    """
+    if isinstance(value, str):
+        return _scrub_keyed_string(keys, value, home) if keys else _scrub_string(value, home)
+    if isinstance(value, (int, float, bool)):
+        # A numeric PIN, OTP or all-digit token under a credential key is as
+        # much a secret as a string one; the type says nothing about the value.
+        if any(_is_credential_key(k) for k in keys):
+            return "[REDACTED: credential]"
+        return value
+    if isinstance(value, dict):
+        # Name/value pairs: a ``name`` (or ``key``, ``header``, ...) whose
+        # value names a credential lends that name to the sibling VALUE
+        # fields, so ``{"name": "Authorization", "value": "Basic ..."}`` is
+        # judged as ``Authorization: Basic ...``. Only the value-bearing
+        # siblings borrow it: the name field itself is kept (the recording must
+        # still say which header it was) and metadata such as ``enabled`` or
+        # ``description`` is not the secret.
+        named: tuple[str, ...] = ()
+        for k, v in value.items():
+            if (
+                isinstance(k, str)
+                and isinstance(v, str)
+                and _is_name_field(k)
+                and _is_credential_key(v)
+            ):
+                named = named + (v,)
+        out: dict = {}
+        # Next free ``#n`` suffix per scrubbed spelling, so a frame whose
+        # every key collapses to one spelling (many secrets used as keys
+        # under ``Authorization``) costs one probe per key, not a rescan of
+        # every suffix already taken.
+        next_suffix: dict = {}
+        for k, v in value.items():
+            # A key is a string leaf too: under an inherited credential
+            # context (``{"Authorization": {"Basic ...": true}}``) the
+            # credential may BE the key, so a key there is kept only when it
+            # looks like a field name; ``value`` under ``Authorization`` is
+            # a field name, ``Basic dXNl…`` under it is not.
+            key = _scrub_dict_key(keys, k, home) if isinstance(k, str) else k
+            if key in out:
+                # Two distinct keys scrubbed to one spelling (``/home/al/x``
+                # and a literal ``~/x``). Silently keeping the last would
+                # drop a field from the recording; suffix instead so both
+                # survive and the collision is visible in the corpus.
+                base = key
+                n = next_suffix.get(base, 2)
+                while f"{base}#{n}" in out:
+                    n += 1
+                next_suffix[base] = n + 1
+                key = f"{base}#{n}"
+            own = (k,) if isinstance(k, str) else ()
+            extra = named if (named and isinstance(k, str) and _is_value_field(k)) else ()
+            out[key] = _scrub_value(v, home, keys + extra + own)
+        return out
+    if isinstance(value, list):
+        # A two-item ``[name, value]`` pair is the other common header encoding
+        # (``headers: [["Authorization", "Basic ..."]]``). When the first item
+        # names a credential, the second is judged under it whatever its type
+        # -- a container there (``["Authorization", ["Basic ..."]]``) is walked
+        # with the name in its key chain, exactly as a dict value under a
+        # credential key is; the first item is kept.
+        if len(value) == 2 and isinstance(value[0], str) and _is_credential_key(value[0]):
+            return [
+                _scrub_value(value[0], home, keys),
+                _scrub_value(value[1], home, keys + (value[0],)),
+            ]
+        return [_scrub_value(v, home, keys) for v in value]
+    return value
+
+
+def scrub_frame(frame: dict) -> str:
+    """Serialize *frame* to one JSON line with credentials and $HOME removed.
+
+    Every string in the frame — keys and values, at any depth — goes through
+    :func:`kiro_crew.acp._dispatch.redact_text` before serialization, so a
+    secret is caught wherever it sits (a nested tool result, a header map, a
+    list of content blocks) without this module knowing the shape of every
+    frame kind, and the line that lands on disk is always well-formed JSON.
+    """
+    try:
+        home = str(Path.home())
+    except (OSError, RuntimeError):
+        home = ""
+    if home in ("/", ""):
+        home = ""
+    return json.dumps(_scrub_value(frame, home), ensure_ascii=False, sort_keys=True)
+
+
+def _refuse_linked_component(directory: Path) -> None:
+    """Refuse a destination whose lexical path and physical path disagree.
+
+    :func:`kiro_crew.pinned_fs.pin_parent` resolves the parent once and pins
+    from there, and documents the residual: a component that was ALREADY a
+    link when the path was resolved is followed by that resolution (refusing
+    it there would break ``/tmp`` on macOS). For a snapshot destination that
+    is acceptable; for a recording the env var is the operator's statement of
+    where transcripts will sit on disk, and a link already planted at
+    ``<dest>/..`` by another local user would move them somewhere else while
+    every descriptor check still passes -- the target can be a 0700 directory
+    the same user owns. So before the pinned walk, the lexically-normalised
+    path is compared with its physical resolution and any difference is
+    refused, naming the first linked component so the operator knows what to
+    change (on macOS ``/tmp`` and ``/var`` are OS-provided links, and the fix
+    is the physical path). One comparison, not a walk: the open itself is
+    still done by ``pinned_fs``, so a link swapped in AFTER this check is
+    refused by ``O_NOFOLLOW`` there.
+    """
+    lexical = str(directory)
+    if os.path.realpath(lexical) == lexical:
+        return
+    walked = ""
+    for name in lexical.split(os.sep):
+        if not name:
+            continue
+        walked = f"{walked}{os.sep}{name}"
+        if os.path.islink(walked):
+            break
+    raise OSError(
+        f"recording destination crosses a link at {walked}; "
+        f"set {ENV_RECORD_FRAMES} to the physical path instead"
+    )
+
+
+def _pin_destination(directory: Path) -> int:
+    """Open the destination directory as a descriptor, creating it if absent.
+
+    A thin consumer of :mod:`kiro_crew.pinned_fs`, which owns the walk:
+    :func:`kiro_crew.pinned_fs.pin_parent` opens the parent chain component by
+    component with ``O_DIRECTORY | O_NOFOLLOW`` relative to the previous
+    descriptor and translates ``ELOOP``/``ENOTDIR`` into one refusal; the leaf
+    is then created (0o700) and opened through that pinned parent with the
+    same flags, so a link or non-directory at the leaf's own name is refused
+    too. ``pin_parent`` is handed the LEXICAL parent, not a re-resolved one:
+    :func:`_refuse_linked_component` has just established that the lexical
+    path and the physical path agree, and resolving again between that check
+    and the walk would follow a link swapped in during the gap (review found
+    exactly that window in a version that went through
+    ``create_and_open_dir_pinned``, whose ``realpath`` is its own). ``..``
+    and ``.`` are collapsed lexically first (``Path.absolute`` plus
+    ``normpath``, never ``resolve``) so a ``..`` after a link cannot climb out
+    through the link's target. Whatever the descriptor lands on must then be
+    owned by this user, owner-only in mode, and free of an extended ACL
+    (:func:`_require_owner_only_dir`); a leaf this run created is 0o700 by
+    construction and passes the same check. A pre-existing directory is
+    checked, never changed. The descriptor is returned; the caller owns it.
+    """
+    normalised = Path(os.path.normpath(directory.absolute()))
+    _refuse_linked_component(normalised)
+    parent_fd = pinned_fs.pin_parent(
+        str(normalised.parent), what="recording destination", refusal=OSError
+    )
+    try:
+        try:
+            os.mkdir(normalised.name, DIR_MODE, dir_fd=parent_fd)
+        except FileExistsError:
+            pass
+        try:
+            fd = os.open(normalised.name, pinned_fs.dir_flags(), dir_fd=parent_fd)
+        except OSError as exc:
+            if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                raise OSError(
+                    f"recording destination {directory} is a symbolic link or not a "
+                    f"directory; set {ENV_RECORD_FRAMES} to a directory path"
+                ) from exc
+            raise
+    finally:
+        os.close(parent_fd)
+    try:
+        _require_owner_only_dir(fd, directory)
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _require_owner_only_dir(fd: int, directory: Path) -> None:
+    """Refuse a pre-existing destination that is not already owner-only.
+
+    Tightening it here is what an earlier revision did, and that is the wrong
+    side of the trade: the env var can name a directory the operator shares on
+    purpose, and a recorder that ``chmod``s it to 0700 on the first frame locks
+    every other intended user out with no undo. A directory this run did not
+    create is therefore checked, never changed: it must be owned by this user
+    and grant nothing to group or other. Owner-only is one ``chmod 700`` away
+    for an operator who wants recordings there.
+    """
+    info = os.fstat(fd)
+    if info.st_uid != platform_compat.local_user_id():
+        raise OSError(f"recording destination is not owned by this user: {directory}")
+    mode = stat.S_IMODE(info.st_mode)
+    if mode & 0o077:
+        raise OSError(
+            f"recording destination {directory} is {oct(mode)}, not owner-only; "
+            f"chmod 700 it, or set {ENV_RECORD_FRAMES} to a fresh path"
+        )
+    _require_no_extended_acl(fd, directory)
+
+
+#: The xattrs under which Linux stores a POSIX ACL with named entries. A
+#: minimal ACL (owner/group/other only, i.e. the mode) is NOT stored as an
+#: xattr, so the presence of either name means an entry beyond the mode exists.
+_ACL_XATTRS = ("system.posix_acl_access", "system.posix_acl_default")
+
+
+def _require_no_extended_acl(fd: int, path: Path) -> None:
+    """Refuse a descriptor whose inode carries a POSIX ACL beyond its mode.
+
+    ``mode & 0o077 == 0`` says nothing about a named ACL entry: ``setfacl -m
+    u:other:rx`` on a 0700 directory leaves the mode bits reading owner-only
+    while another account can list and read it, and a default ACL on the
+    directory is inherited by every file created inside, ``fchmod`` 0600
+    notwithstanding. Linux exposes both as xattrs, so the check is one
+    ``flistxattr``. A platform without that view (macOS) is refused outright
+    by :func:`_require_acl_inspectable`; this function is only reached where
+    the answer can be known.
+    """
+    try:
+        names = os.listxattr(fd)
+    except OSError as exc:
+        if exc.errno in (errno.ENOTSUP, errno.EOPNOTSUPP):
+            return  # the filesystem has no xattrs at all, so it has no ACLs
+        raise
+    found = [n for n in _ACL_XATTRS if n in names]
+    if found:
+        raise OSError(
+            f"recording destination {path} carries a POSIX ACL ({', '.join(found)}); "
+            f"the mode is owner-only but the ACL may grant another account -- "
+            f"setfacl -b it, or set {ENV_RECORD_FRAMES} to a fresh path"
+        )
+
+
+def _require_acl_inspectable() -> None:
+    """Stand down where an owner-only guarantee cannot be verified.
+
+    Only Linux exposes ACLs through the xattr API CPython binds; macOS stores
+    them behind ``acl_get_file`` with no ``os`` binding, so a recorder there
+    could pass every mode check while an inheritable ACL lets another account
+    read every frame. Rather than a guarantee that holds on one platform and
+    is a guess on another, the recorder refuses to run where it cannot check.
+    """
+    if not platform_compat.IS_LINUX or not hasattr(os, "listxattr"):
+        raise OSError(
+            f"{ENV_RECORD_FRAMES} is Linux-only: this platform has no way to "
+            "verify the destination carries no ACL granting another account, "
+            "so an owner-only recording cannot be guaranteed here"
+        )
+
+
+class _HardlinkRefused(Exception):
+    """Raised by ``pinned_fs.refuse_hardlink_alias`` AFTER it has closed the fd.
+
+    A private type so the caller can tell "the helper refused and already
+    closed the descriptor" from "the helper failed and left it open" -- the two
+    need opposite cleanup, and both must surface as an ``OSError`` stand-down.
+    """
+
+
+def _open_private_append(directory: Path, name: str):
+    """Open ``<directory>/<name>`` for appending as a regular, owner-only file.
+
+    The directory is pinned by :func:`_pin_destination`, and the file open is
+    relative to that descriptor with ``O_NOFOLLOW``, so nothing on the way to
+    the file is resolved by name through a link.
+
+    The opened inode is then checked to be a regular file (a FIFO would wedge
+    the writer) that still has a name (an unlinked inode would take the frame
+    and lose it on close) and is owned by this user (the rule the directory is
+    already held to: a foreign-owned file would be locked to its owner by the
+    fchmod, not to us), refused if it is a hard-link alias
+    (:func:`kiro_crew.pinned_fs.refuse_hardlink_alias` -- a planted link at
+    ``<name>`` shares its inode with another file, which the append would
+    otherwise write into), checked for an extended ACL, and locked to the
+    owner on the DESCRIPTOR (``os.fchmod``) rather than by path, so the
+    lockdown lands on the same inode the frame does.
+    """
+    if not platform_compat.IS_POSIX:
+        raise OSError(
+            f"{ENV_RECORD_FRAMES} is POSIX-only: Windows cannot pin the destination "
+            "by descriptor, so an owner-only recording cannot be guaranteed there"
+        )
+    _require_acl_inspectable()
+    path = directory / name
+    # O_NONBLOCK: a FIFO planted at <name> would otherwise make the open block
+    # until a reader appears, wedging the writer thread for the life of the
+    # process. With it the open returns at once and the S_ISREG check below
+    # refuses the FIFO. It has no effect on a regular file.
+    flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW | os.O_NONBLOCK
+    dir_fd = _pin_destination(directory)
+    try:
+        fd = os.open(name, flags, FILE_MODE, dir_fd=dir_fd)
+    finally:
+        os.close(dir_fd)
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise OSError(f"recording target is not a regular file: {path}")
+        if info.st_nlink == 0:
+            # Unlinked between the open and here (a log rotator, a cleanup):
+            # the append would succeed onto an inode with no name and vanish on
+            # close. ``refuse_hardlink_alias`` only asks about MORE than one
+            # name, so the zero case is this module's to refuse.
+            raise OSError(f"recording target was removed before it could be written: {path}")
+        if info.st_uid != platform_compat.local_user_id():
+            # The same rule the directory is held to. An owner-only directory
+            # can still hold a foreign-owned inode (a bind mount, a file left by
+            # a privileged run), and fchmod 0600 on it would lock it to THAT
+            # owner, who then reads every frame. Refused, and left as found.
+            raise OSError(f"recording target is not owned by this user: {path}")
+    except Exception:
+        os.close(fd)
+        raise
+    # The helper closes the descriptor itself before raising its refusal, so
+    # that one exception must not reach a second close. Anything ELSE it could
+    # raise (its own fstat failing) leaves the descriptor open and is ours.
+    try:
+        pinned_fs.refuse_hardlink_alias(
+            fd, what="recording target", name=str(path), refusal=_HardlinkRefused
+        )
+    except _HardlinkRefused as exc:
+        raise OSError(str(exc)) from None
+    except Exception:
+        os.close(fd)
+        raise
+    try:
+        # Checked BEFORE fchmod: on a file that carries an ACL, fchmod rewrites
+        # the ACL mask entry, so tightening first would alter a file this run
+        # is about to refuse. A refused file is left exactly as it was found.
+        _require_no_extended_acl(fd, path)
+        os.fchmod(fd, FILE_MODE)
+    except Exception:
+        os.close(fd)
+        raise
+    return os.fdopen(fd, "a", encoding="utf-8")
+
+
+def write_frame(backend: str, frame: dict, dest: str) -> None:
+    """Append one scrubbed frame to ``<dest>/<backend>.jsonl``.
+
+    Runs on a worker thread, never on the event loop. Swallows every failure:
+    the caller is a transport reader whose job is the session, not the
+    recording.
+    """
+    if not dest.strip():
+        # Path("") resolves to the CWD, so a blank destination would append the
+        # frame to ./<backend>.jsonl wherever the gateway happens to be running.
+        # A blank destination means recording is off.
+        return
+    try:
+        directory = Path(dest).expanduser()
+        line = scrub_frame(frame)
+        with _open_private_append(directory, f"{fixture_dir_name(backend)}.jsonl") as handle:
+            handle.write(line + "\n")
+    except Exception as exc:  # noqa: BLE001 - a recorder must never take down a reader
+        _stand_down(exc)
+
+
+def _drain(writer: _Writer) -> None:
+    """The writer thread: one frame at a time, in arrival order, off every loop.
+
+    Once recording has stood down, whatever is still queued is discarded
+    without being written: the stand-down already logged the failure, and
+    retrying each pending frame against a destination known to be broken
+    would emit up to ``QUEUE_LIMIT`` more warnings for one fault.
+    """
+    while True:
+        try:
+            item = writer.items.popleft()
+        except IndexError:
+            if writer.stop.wait(0.05):
+                return
+            continue
+        # The drain thread MAY block on the lock: it is not a reader loop, and
+        # the only other holders (readers) hold it for a few instructions and
+        # never wait on anything while holding it. The frame count is released
+        # at pop time -- the backlog is what waits, not what is being written --
+        # and the bytes when the write is done, since the parsed JSON is held
+        # on the heap until then.
+        with writer.lock:
+            writer.queued -= 1
+            writer.in_flight += 1
+        backend, frame, dest, size = item
+        try:
+            if not _stood_down and not writer.stop.is_set():
+                write_frame(backend, frame, dest)
+        except Exception as exc:  # noqa: BLE001 - the writer must outlive any one fault
+            _stand_down(exc)
+        finally:
+            with writer.lock:
+                writer.queued_bytes -= size
+                writer.in_flight -= 1
+
+
+def _notify(writer: _Writer) -> None:
+    """The notifier thread: emit a reader-latched stand-down, off every loop.
+
+    Separate from :func:`_drain` on purpose (see :class:`_Writer`): the
+    warning must not depend on the file writer being able to return from a
+    write. Wakes every 50 ms; the log line lands within that of the latch.
+    """
+    while not writer.stop.wait(0.05):
+        _emit_pending_stand_down()
+    _emit_pending_stand_down()
+
+
+def start_recorder() -> bool:
+    """Start the writer thread if recording is switched on. Idempotent.
+
+    Called at import time — the gateway imports this module on the main thread
+    before any event loop runs — so ``Thread.start()`` never executes on a
+    reader loop. It is also the explicit entry point for a host that sets the
+    env var after import (tests, an embedding process): call it from a plain
+    thread before recording. Returns ``True`` when a writer is running.
+
+    A start that fails (out of threads) stands recording down: the process
+    keeps running, the recording does not happen, one log line says why.
+    """
+    global _writer
+    if not recording_destination():
+        return False
+    if not platform_compat.IS_POSIX:
+        # No thread is started on Windows: the recorder is POSIX-only (module
+        # docstring), so stand down here, once, rather than start a writer
+        # whose first write would refuse anyway.
+        _stand_down(
+            OSError(
+                f"{ENV_RECORD_FRAMES} is POSIX-only: Windows cannot pin the destination "
+                "by descriptor, so an owner-only recording cannot be guaranteed there"
+            )
+        )
+        return False
+    try:
+        _require_acl_inspectable()
+    except OSError as exc:
+        # Same shape for macOS: no writer or notifier thread is started for a
+        # recorder that cannot verify the destination carries no ACL.
+        _stand_down(exc)
+        return False
+    with _writer_lock:
+        if _writer is not None and _writer.thread.is_alive():
+            return True
+        try:
+            _writer = _Writer()
+        except Exception as exc:  # noqa: BLE001 - a recorder must never take down its host
+            _stand_down(exc)
+            return False
+        return True
+
+
+class _Overflow(RuntimeError):
+    """The backlog is full (by count, by bytes, or its lock was busy)."""
+
+
+def _enqueue(writer: _Writer, backend: str, frame: dict, dest: str, wire_bytes: int) -> None:
+    """Hand a frame to *writer*, never blocking the caller.
+
+    Thread-safe and loop-independent: both transports, on whichever threads
+    and loops they read from, share the one backlog and the one byte budget.
+    Overflow — by count or by bytes — means the writer has fallen far enough
+    behind that the destination is effectively broken, so the frame is dropped
+    and recording stands down.
+    """
+    # The two bounds are guarded by a lock the writer thread also takes, for a
+    # few instructions per frame. A reader loop must not WAIT on it: if the
+    # holder is preempted (a starved host, a GC pause) every session on this
+    # loop would stall behind the recorder. Acquire without blocking; a busy
+    # lock is treated like an overflow -- the frame is dropped and recording
+    # stands down -- which is the same answer the module gives whenever the
+    # writer cannot keep up. In practice the lock is free: two reader loops
+    # and the drain thread contend only when a frame arrives on both
+    # transports within the same microseconds. This ``acquire`` is the ONLY
+    # synchronisation on the reader path, and it never blocks. The append
+    # happens INSIDE the same critical section: admission to the budget and
+    # admission to the backlog are one step, so two readers cannot pass the
+    # check in one order and land in the deque in the other, which would put
+    # the corpus out of arrival order.
+    if not writer.lock.acquire(blocking=False):
+        raise _Overflow("backlog lock busy; not waiting on a reader loop")
+    try:
+        if writer.queued + 1 > QUEUE_LIMIT:
+            raise _Overflow(f"{writer.queued} frames queued reaches {QUEUE_LIMIT}")
+        if writer.queued_bytes + wire_bytes > QUEUE_BYTES_LIMIT:
+            raise _Overflow(
+                f"{writer.queued_bytes + wire_bytes} bytes queued exceeds {QUEUE_BYTES_LIMIT}"
+            )
+        writer.queued += 1
+        writer.queued_bytes += wire_bytes
+        writer.items.append((backend, frame, dest, wire_bytes))
+    finally:
+        writer.lock.release()
+
+
+async def record_frame(backend: str, frame: dict, wire_bytes: int = 0) -> None:
+    """Record one inbound frame, if a recording directory is set.
+
+    Returns after one environment lookup when ``KIROCREW_ACP_RECORD_FRAMES`` is
+    unset, which is the state of every ordinary run. When it is set the frame is
+    queued for the writer thread and this returns without awaiting anything
+    else, so the reader loop never waits on the filesystem, on a thread
+    start, or on a mutex: the writer was started by :func:`start_recorder`
+    before any loop existed, and this function only ever does one
+    non-blocking ``acquire`` plus a lock-free ``deque.append``.
+    If the env var was set after import without :func:`start_recorder` being
+    called, recording stands down with a line saying so rather than starting a
+    thread from the loop.
+
+    *wire_bytes* is the length of the line *frame* was parsed from. The reader
+    loops already hold it, and it is what the byte bound counts — serializing
+    the frame here to measure it would put a ``json.dumps`` of up to 10 MiB on
+    the reader loop, which is the cost this module exists to avoid.
+    """
+    dest = recording_destination()
+    if not dest:
+        return
+    writer = _writer
+    if writer is None or not writer.thread.is_alive():
+        # Misconfigured: the switch is set but no drain thread exists to carry
+        # the log line off this loop. One line, once per process, logged here
+        # directly -- the alternative is a recorder that silently never
+        # records, and there is no other thread to hand the line to.
+        _stand_down(
+            RuntimeError(
+                f"{ENV_RECORD_FRAMES} is set but the recorder was not started before the "
+                "event loop; call kiro_crew.acp._frame_record.start_recorder() at startup"
+            )
+        )
+        return
+    try:
+        _enqueue(writer, backend, frame, dest, wire_bytes)
+    except Exception as exc:  # noqa: BLE001 - a full queue must not reach a reader
+        _stand_down(exc, from_reader_loop=True)
+
+
+def _stand_down(exc: BaseException, *, from_reader_loop: bool = False) -> None:
+    """Disable recording for the rest of the process after one failure.
+
+    One fault, one log line. Callers race: the writer thread (a failed write)
+    and any reader thread (a queue overflow, which is what a failed write tends
+    to cause next). The lock makes the first to arrive the one that logs --
+    directly when the caller is off the loop, via the notifier thread when
+    *from_reader_loop* is set;
+    ``recording_destination`` returns ``""`` once the latch is set and
+    ``_drain`` discards the backlog, so nothing else reaches here afterwards.
+    """
+    global _stood_down, _pending_stand_down
+    # Non-blocking: a reader loop reaches here too (a dropped frame), and must
+    # not wait behind another thread that is mid-latch. If the lock is busy,
+    # someone else IS latching, and their log line is the one that matters.
+    if not _stand_down_lock.acquire(blocking=False):
+        return
+    try:
+        if _stood_down:
+            return
+        _stood_down = True
+        if from_reader_loop:
+            # Latch only. The log line is the notifier thread's job: emitting it
+            # here would take logging's handler lock and run every handler on
+            # the reader loop.
+            _pending_stand_down = exc
+            return
+    finally:
+        _stand_down_lock.release()
+    _log_stand_down(exc)
+
+
+def _log_stand_down(exc: BaseException) -> None:
+    logger.warning(
+        "%s is set but recording failed; frame recording is now off for this process: %s",
+        ENV_RECORD_FRAMES,
+        exc,
+    )
+
+
+def _emit_pending_stand_down() -> None:
+    """Log a stand-down that was latched on a reader loop. Notifier thread only."""
+    global _pending_stand_down
+    # Unlocked peek first. The notifier polls every 50 ms; if it took the
+    # latch lock on every poll, a reader-side ``_stand_down`` that happened to
+    # coincide would find the lock busy, return without latching, and the
+    # frame it was reporting would be dropped silently with recording still on.
+    # The lock is only taken when there IS a reason to consume.
+    if _pending_stand_down is None:
+        return
+    with _stand_down_lock:
+        exc, _pending_stand_down = _pending_stand_down, None
+    if exc is not None:
+        _log_stand_down(exc)
+
+
+async def flush_for_tests() -> None:
+    """Wait for every queued frame to reach disk (or be discarded). For tests only."""
+    writer = _writer
+    if writer is None:
+        return
+
+    def _wait() -> None:
+        while True:
+            with writer.lock:
+                if writer.queued == 0 and writer.in_flight == 0 and not writer.items:
+                    return
+            time.sleep(0.005)
+
+    await asyncio.to_thread(_wait)
+
+
+def _stop_writer(writer: _Writer) -> None:
+    """Tell *writer*'s thread to exit and wait for it. Tests only.
+
+    The drain thread waits on the stop event with a timeout, so it notices this
+    whether the backlog is empty or full. The join is checked: a thread still alive
+    afterwards means a wedged ``write_frame`` (a test's gate never released),
+    and raising here is what turns "pytest later removes a directory the
+    thread still writes into" into a failure at the test that caused it.
+    """
+    writer.stop.set()
+    writer.thread.join(10)
+    writer.notifier.join(10)
+    if writer.thread.is_alive():
+        raise RuntimeError("acp-frame-recorder writer thread did not stop within 10s")
+    if writer.notifier.is_alive():
+        raise RuntimeError("acp-frame-recorder notifier thread did not stop within 10s")
+
+
+async def stop_for_tests() -> None:
+    """Stop the writer thread and wait for it to exit. For tests only.
+
+    A daemon thread would not stop the interpreter, but a test's temporary
+    directory can be removed while the thread is still writing into it, so
+    teardown waits for the thread to exit (and fails if it does not).
+    """
+    global _writer
+    with _writer_lock:
+        writer = _writer
+    if writer is not None:
+        # Stop BEFORE clearing: if the join fails and _stop_writer raises, the
+        # writer stays referenced (and its thread visible) rather than being
+        # dropped while still running.
+        await asyncio.to_thread(_stop_writer, writer)
+    with _writer_lock:
+        if _writer is writer:
+            _writer = None
+
+
+def _reset_for_tests() -> None:
+    """Clear the stand-down latch and drop the writer. For tests only.
+
+    Synchronous, so it is usable from a sync fixture; see :func:`_stop_writer`
+    for why the stop cannot block and why a thread that outlives the join is
+    an error rather than a leak.
+    """
+    global _stood_down, _pending_stand_down, _writer
+    _stood_down = False
+    _pending_stand_down = None
+    with _writer_lock:
+        writer = _writer
+    if writer is not None:
+        _stop_writer(writer)  # raises, keeping _writer set, if the thread survives
+    with _writer_lock:
+        if _writer is writer:
+            _writer = None
+
+
+# Started here, on the importing thread, so that a gateway launched with the
+# switch set never starts the writer from a reader loop (see start_recorder).
+start_recorder()

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -66,6 +66,7 @@ from kiro_crew.acp._dispatch import (
     redact_text,
     tool_call_content_text,
 )
+from kiro_crew.acp._frame_record import record_frame
 from kiro_crew.acp.liveness import (
     EVIDENCE_SAMPLING,
     VERDICT_WORKING,
@@ -6151,6 +6152,15 @@ class AcpClient:
         except json.JSONDecodeError:
             logger.debug("Skipping non-JSON line from ACP: %.100s", text)
             return None
+
+        # Opt-in raw-frame recording for the replay corpus. A no-op unless
+        # KIROCREW_ACP_RECORD_FRAMES names a directory, and the write is
+        # offloaded off this loop when it is set. It never raises -- see
+        # kiro_crew.acp._frame_record. Placed after the buffer early-return
+        # above so a frame is recorded once, when it comes off the wire, not
+        # again when a turn loop replays it out of _buffer.
+        if isinstance(data, dict):
+            await record_frame(self.backend, data, len(line))
 
         return JsonRpcMessage(
             id=data.get("id"),

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -41,6 +41,7 @@ from kiro_crew.acp._dispatch import reject_option_id as _reject_option_id
 from kiro_crew.acp._dispatch import (
     set_mode_params,
 )
+from kiro_crew.acp._frame_record import record_frame
 from kiro_crew.acp.client import (
     OversizeLineUnrecoverable,
     _apply_pod_home_remap,
@@ -268,9 +269,7 @@ def _sanitize_progress_name(name: str) -> str:
     """
     scrubbed, _ = redact_exfiltration_urls(name)
     scrubbed, _ = redact_credentials(scrubbed)
-    return _strip_unprintable(" ".join(scrubbed.split()))[
-        :_MCP_PROGRESS_NAME_LEN_CAP
-    ]
+    return _strip_unprintable(" ".join(scrubbed.split()))[:_MCP_PROGRESS_NAME_LEN_CAP]
 
 
 def _capped_names(names: list[str]) -> str:
@@ -1316,11 +1315,7 @@ class AcpRuntime:
         env.update(browser_env)
         if browser_env:
             lifecycle_env = {**os.environ, **browser_env}
-            env.update(
-                await self._to_thread_guarding_sandbox(
-                    browser_socket_env, lifecycle_env
-                )
-            )
+            env.update(await self._to_thread_guarding_sandbox(browser_socket_env, lifecycle_env))
         # Per-process scratch containment: the agent's temp AND its
         # prompt-guided work products land in an owned directory instead of
         # the shared system temp dir. Allocated off-loop (mkdir + config read)
@@ -1710,6 +1705,7 @@ class AcpRuntime:
         runtime dead resolves every pending wait instead of leaving the remote
         requester unanswered indefinitely.
         """
+
         def _deny() -> bool:
             """Refuse admission, recording the decision first.
 
@@ -1828,9 +1824,7 @@ class AcpRuntime:
         # Bound the redaction input (backend-controlled) BEFORE the regex
         # passes, generously above the display cap so a clipped secret
         # cannot straddle the boundary the display truncation makes.
-        title = (
-            redact_text(str(raw_title)[:4096])[:120] if raw_title else "<unknown>"
-        )
+        title = redact_text(str(raw_title)[:4096])[:120] if raw_title else "<unknown>"
         logger.warning(
             "auto-rejected permission request id=%s for session %s "
             "(tool: %s, reason: %s): no surface on this client can answer it "
@@ -2101,6 +2095,16 @@ class AcpRuntime:
                     logger.debug("non-object JSON stdout line: %s", line[:200])
                     continue
 
+                # Opt-in raw-frame recording for the replay corpus. A no-op
+                # unless KIROCREW_ACP_RECORD_FRAMES names a directory: it
+                # returns before awaiting anything, so an ordinary run pays one
+                # env lookup. When it IS set the frame is queued for the
+                # recorder's own writer thread rather than written here,
+                # because a filesystem syscall on this loop stalls every
+                # multiplexed session. It never raises -- see
+                # kiro_crew.acp._frame_record.
+                await record_frame(self._acp_backend, data, len(line))
+
                 msg = JsonRpcMessage.from_dict(data)
 
                 # Route responses
@@ -2217,9 +2221,7 @@ class AcpRuntime:
                         # prompt's drain, so a background child's request
                         # would sit unanswered — the original hang with extra
                         # steps. Answer it fail-closed NOW instead.
-                        _owner_turn_active = (
-                            self._subagent_owner in self._turn_active_sessions
-                        )
+                        _owner_turn_active = self._subagent_owner in self._turn_active_sessions
                         if (
                             msg.id is not None
                             and msg.is_method(METHOD_REQUEST_PERMISSION)
@@ -2253,12 +2255,8 @@ class AcpRuntime:
                             # request that is neither routed nor answered
                             # leaves its crew waiting on a prompt nobody can
                             # see.
-                            if msg.id is not None and msg.is_method(
-                                METHOD_REQUEST_PERMISSION
-                            ):
-                                emit_counter(
-                                    CHILD_PERMISSION_ROUTED, {"surface": "runtime"}
-                                )
+                            if msg.id is not None and msg.is_method(METHOD_REQUEST_PERMISSION):
+                                emit_counter(CHILD_PERMISSION_ROUTED, {"surface": "runtime"})
                             await next(iter(self._session_queues.values())).put(msg)
                     elif msg.id is not None and msg.is_method(METHOD_REQUEST_PERMISSION):
                         # Unannounced or ambiguous: nobody on this client can
@@ -2311,9 +2309,7 @@ class AcpRuntime:
                     if len(self._answer_tasks) >= self._max_answer_tasks:
                         self._note_dropped_frame(_DROP_NO_SESSION, msg.method)
                         continue
-                    _t = asyncio.ensure_future(
-                        self._answer_ownerless_request(msg.id, msg.method)
-                    )
+                    _t = asyncio.ensure_future(self._answer_ownerless_request(msg.id, msg.method))
                     self._answer_tasks.add(_t)
                     _t.add_done_callback(self._answer_tasks.discard)
                     continue
@@ -2352,9 +2348,7 @@ class AcpRuntime:
             # accounted for instead of vanishing with the task.
             self._flush_dropped_frames()
 
-    async def _answer_ownerless_request(
-        self, request_id: int | str, method: str
-    ) -> None:
+    async def _answer_ownerless_request(self, request_id: int | str, method: str) -> None:
         """Answer a server→client request that names no session with -32601.
 
         Runs OFF the reader loop (same shape as the KAS auth callback) so a
@@ -2369,9 +2363,7 @@ class AcpRuntime:
             request_id,
         )
         try:
-            await self.send_error(
-                request_id, _JSONRPC_METHOD_NOT_FOUND, "Method not found"
-            )
+            await self.send_error(request_id, _JSONRPC_METHOD_NOT_FOUND, "Method not found")
         except AcpRuntimeDead:
             pass
 
@@ -2688,9 +2680,7 @@ class AcpRuntime:
                 # dashboard banner applies before it lands in an exception.
                 err, _ = redact_exfiltration_urls(str(params.get("error") or ""))
                 err, _ = redact_credentials(err)
-                err = _strip_unprintable(" ".join(err.split()))[
-                    :_MCP_PROGRESS_ERROR_CAP
-                ]
+                err = _strip_unprintable(" ".join(err.split()))[:_MCP_PROGRESS_ERROR_CAP]
                 if name not in failed:
                     failed.append(name)
                 if err:
@@ -2708,9 +2698,7 @@ class AcpRuntime:
             # len(reported) can exceed the denominator -- "2/1 reported". The
             # out-of-roster servers still appear by name in the failed and
             # awaiting-authorization buckets, where naming them is the point.
-            parts.append(
-                f"{len(reported & set(roster))}/{len(roster)} MCP server(s) reported"
-            )
+            parts.append(f"{len(reported & set(roster))}/{len(roster)} MCP server(s) reported")
             silent = [n for n in roster if n not in reported]
             if silent:
                 parts.append(f"no report from {_capped_names(silent)}")
@@ -2821,8 +2809,7 @@ class AcpRuntime:
                     # server twice (the injection still wins) rather than
                     # withholding one that nothing else will supply.
                     logger.debug(
-                        "stubbed-server lookup failed for %r; projecting every "
-                        "declared server",
+                        "stubbed-server lookup failed for %r; projecting every " "declared server",
                         agent,
                         exc_info=True,
                     )
@@ -2851,9 +2838,7 @@ class AcpRuntime:
                 # Fail loud: continuing would create a session on KAS's own default
                 # mode, which for a restricted agent means running a BROADER agent
                 # than the caller asked for.
-                raise AcpRuntimeError(
-                    f"cannot project agent {agent!r} onto KAS: {exc}"
-                ) from exc
+                raise AcpRuntimeError(f"cannot project agent {agent!r} onto KAS: {exc}") from exc
         return None
 
     async def _session_start_budget(self) -> float:
@@ -2867,9 +2852,7 @@ class AcpRuntime:
         snapshot semantics as ``watchdog.*`` in session_handle.py).
         """
         if self._session_start_timeout is None:
-            self._session_start_timeout = await asyncio.to_thread(
-                _resolve_session_start_timeout
-            )
+            self._session_start_timeout = await asyncio.to_thread(_resolve_session_start_timeout)
         return self._session_start_timeout
 
     async def create_session(
@@ -2915,9 +2898,9 @@ class AcpRuntime:
             if member_entry is not None:
                 # Session-level entries outrank same-named spec entries, so drop
                 # any stub for the same server rather than registering it twice.
-                mcp_servers = [
-                    e for e in mcp_servers if e.get("name") != member_entry["name"]
-                ] + [member_entry]
+                mcp_servers = [e for e in mcp_servers if e.get("name") != member_entry["name"]] + [
+                    member_entry
+                ]
             else:
                 logger.warning(
                     "member session %s: dashboard server unresolved — the DM "
@@ -2946,9 +2929,7 @@ class AcpRuntime:
         self._session_inits_in_flight += 1
         session_id = ""
         try:
-            resp = await self._send_and_await(
-                METHOD_SESSION_NEW, params, timeout=budget
-            )
+            resp = await self._send_and_await(METHOD_SESSION_NEW, params, timeout=budget)
             session_id = str(resp.get("sessionId") or "")
             if not session_id:
                 raise AcpRuntimeError(f"session/new did not return sessionId: {resp}")
@@ -3103,9 +3084,7 @@ class AcpRuntime:
                 return list(self._entitlement_probe_result)
             if not self._initialized or self._dead or self._process is None:
                 return []
-            params = build_session_new_params(
-                await self._session_work_dir(), mcp_servers=[]
-            )
+            params = build_session_new_params(await self._session_work_dir(), mcp_servers=[])
             session_id = ""
             self._session_inits_in_flight += 1
             try:
@@ -3186,9 +3165,9 @@ class AcpRuntime:
                 member_dispatch_session_server, member_session_key
             )
             if member_entry is not None:
-                mcp_servers = [
-                    e for e in mcp_servers if e.get("name") != member_entry["name"]
-                ] + [member_entry]
+                mcp_servers = [e for e in mcp_servers if e.get("name") != member_entry["name"]] + [
+                    member_entry
+                ]
             else:
                 logger.warning(
                     "member session %s: dashboard server unresolved on resume — "
@@ -3244,16 +3223,12 @@ class AcpRuntime:
             # staging in _reader_loop, closed by _finish_session_init; see
             # docs/system-specs/modules/acp-client.md "loading a session
             # triggers MCP re-initialization") — so it gets the same budget.
-            resp = await self._send_and_await(
-                METHOD_SESSION_LOAD, load_params, timeout=budget
-            )
+            resp = await self._send_and_await(METHOD_SESSION_LOAD, load_params, timeout=budget)
 
             # A genuine resume echoes "modes" in the response (same signal AcpClient
             # keys on). Anything else means load did not actually restore state.
             if "modes" not in resp:
-                raise AcpRuntimeError(
-                    f"session/load did not resume session {resume_sid}: {resp}"
-                )
+                raise AcpRuntimeError(f"session/load did not resume session {resume_sid}: {resp}")
             loaded_session_id = resume_sid
         except AcpRequestTimeout as exc:
             # Read the staged MCP reports before the finally below clears them.

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -2015,6 +2015,12 @@ _PYTHON_ENV_PREFIXES: list[str] = [
 # has the same parent-side scrub as the POSIX sandbox launchers. Loader coverage
 # is pinned by regression test.
 _AGENT_DENIED_ENV_KEYS: list[str] = [
+    # The ACP frame recorder's switch. A child agent that inherited it (a
+    # nested Kiro Crew, or any tool that honours the variable) would record
+    # its own frames into the SAME per-backend file, interleaving another
+    # process's transcript with this gateway's. The recorder is a gateway-side
+    # development aid; the children it observes must not see the switch.
+    "KIROCREW_ACP_RECORD_FRAMES",
     "SLACK_BOT_TOKEN",
     "SLACK_APP_TOKEN",
     "SLACK_USER_TOKEN",

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1295,6 +1295,15 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # a third party — the surfaces that SHOW a refusal (the dashboard's
         # notice line) are the registered sinks.
         "name_grant.py",
+        # Capture-side, not egress: the opt-in frame recorder scrubs a raw ACP
+        # frame as it WRITES it to a local file, so a credential never lands in
+        # a recording the operator may later commit to the replay corpus. There
+        # is no transport and no audience -- the file is on the operator's own
+        # machine, written only while KIROCREW_ACP_RECORD_FRAMES names a
+        # directory, and the scrub is a floor under the hand review the corpus
+        # README requires rather than a boundary's own guarantee. The surfaces
+        # that SHOW frame-derived text are the registered sinks.
+        "acp/_frame_record.py",
         # Internal coordinator partitions behind the single registered
         # ``subagent.py`` output boundary.  They redact lifecycle payloads before
         # handing them to facade-owned event/completion callbacks, but the split

--- a/test/test_acp_frame_record.py
+++ b/test/test_acp_frame_record.py
@@ -1,0 +1,1579 @@
+"""The opt-in ACP frame recorder that produces a replay-corpus fixture.
+
+``kiro_crew.acp._frame_record.record_frame`` sits on the hot path of every frame
+of every session, so the properties worth pinning are the ones whose absence
+would be a production incident rather than a wrong fixture: silent when off, off
+the event loop when on, silent when broken, scrubbed when it writes, and
+owner-only on disk.
+
+The replay corpus itself (``test/fixtures/acp_frames/``) and its snapshot test
+are ``test/test_acp_frame_replay.py``; this module covers only the recorder.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import json
+import logging
+import os
+import stat
+import threading
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import security_posture
+from kiro_crew.acp import _frame_record
+from kiro_crew.acp import client as client_module
+from kiro_crew.acp import runtime as runtime_module
+from kiro_crew.acp_backends import ACP_BACKEND_KIRO, ACP_BACKENDS_KNOWN
+
+# The recorder is POSIX-only (see the module docstring of ``_frame_record``):
+# every test here exercises the pinned-descriptor path. The one Windows
+# behaviour -- stand down with a named reason -- is platform-neutral and lives
+# in ``test_acp_frame_record_windows.py`` so it runs on every runner.
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="ACP frame recorder is POSIX-only")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_recorder(monkeypatch):
+    """Every test starts with the latch clear and no writer, and ends the same way.
+
+    Sync, by this repo's convention (the pinned pytest-asyncio does not collect
+    async fixtures), so it cannot await the drain task's cancellation; the async
+    tests run their body inside :func:`_live_writer` for that.
+    """
+    _frame_record._reset_for_tests()
+    monkeypatch.delenv(_frame_record.ENV_RECORD_FRAMES, raising=False)
+    yield
+    _frame_record._reset_for_tests()
+
+
+@asynccontextmanager
+async def _live_writer():
+    """Await the drain task's cancellation on the way out, even when the body fails.
+
+    An ``async with`` helper rather than an ``@pytest_asyncio.fixture``, by this
+    repo's convention. The teardown has to await: a task still pending when the
+    test's loop closes is reported by pytest as destroyed, and its executor write
+    can still be touching the test's directory. ``try/finally`` so an assertion
+    failure in the body does not skip it.
+    """
+    try:
+        yield
+    finally:
+        await _frame_record.stop_for_tests()
+
+
+def _clean(monkeypatch):
+    """Kept as an explicit call at the top of each test for readability."""
+    _frame_record._reset_for_tests()
+    monkeypatch.delenv(_frame_record.ENV_RECORD_FRAMES, raising=False)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+# ── off by default ───────────────────────────────────────────────────────────
+
+
+def test_unset_env_writes_nothing(monkeypatch):
+    """The state of every ordinary run and every CI run."""
+    _clean(monkeypatch)
+    assert _frame_record.recording_destination() == ""
+
+
+def test_blank_env_is_off(monkeypatch):
+    """A blank value is off, not a directory named "" in the cwd."""
+    _clean(monkeypatch)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, "   ")
+    assert _frame_record.recording_destination() == ""
+
+
+def test_a_blank_destination_is_refused_not_resolved_to_the_cwd(monkeypatch, tmp_path):
+    """Path("") is the CWD, so a blank dest would write into the checkout.
+
+    pytest's CWD is the repository root, which is how a stray kas.jsonl once
+    appeared there.
+    """
+    _clean(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, "")
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, "   ")
+    assert list(tmp_path.iterdir()) == [], "a blank destination wrote a file"
+
+
+@pytest.mark.asyncio
+async def test_record_frame_does_not_touch_the_disk_when_off(monkeypatch):
+    """The async entry point must return before doing any work."""
+    _clean(monkeypatch)
+    async with _live_writer():
+        calls: list[tuple] = []
+        monkeypatch.setattr(_frame_record, "write_frame", lambda *a: calls.append(a))
+        await _frame_record.record_frame("kas", {"jsonrpc": "2.0"})
+        assert calls == []
+
+
+# ── off the event loop when on ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_frame_offloads_the_write_off_the_event_loop(monkeypatch, tmp_path):
+    """A filesystem syscall on a reader loop stalls every session on it.
+
+    The write must reach a worker thread, so this asserts it runs on a
+    DIFFERENT thread than the loop -- not merely that the bytes landed.
+    """
+    _clean(monkeypatch)
+    async with _live_writer():
+        monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+        _frame_record.start_recorder()
+        loop_thread = threading.get_ident()
+        seen: list[int] = []
+        real_write = _frame_record.write_frame
+
+        def spy(backend, frame, dest):
+            seen.append(threading.get_ident())
+            real_write(backend, frame, dest)
+
+        monkeypatch.setattr(_frame_record, "write_frame", spy)
+        await _frame_record.record_frame("kas", {"jsonrpc": "2.0", "id": 1})
+        await _frame_record.flush_for_tests()
+        assert seen, "the write never ran"
+        assert seen[0] != loop_thread, "the write ran on the event loop thread"
+        assert json.loads((tmp_path / "kas.jsonl").read_text(encoding="utf-8"))["id"] == 1
+
+
+# ── what lands on disk ───────────────────────────────────────────────────────
+
+
+def test_a_frame_lands_in_the_backend_file(monkeypatch, tmp_path):
+    _clean(monkeypatch)
+    dest = str(tmp_path / "frames")
+    _frame_record.write_frame(ACP_BACKEND_KIRO, {"jsonrpc": "2.0", "id": 1}, dest)
+    _frame_record.write_frame(ACP_BACKEND_KIRO, {"jsonrpc": "2.0", "id": 2}, dest)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0", "id": 3}, dest)
+
+    # kiro-cli's id is "", so its file is named through POLICY_ID_BY_BACKEND.
+    kiro_file = Path(dest) / "kiro.jsonl"
+    assert kiro_file.exists(), sorted(p.name for p in Path(dest).iterdir())
+    lines = kiro_file.read_text(encoding="utf-8").splitlines()
+    assert [json.loads(ln)["id"] for ln in lines] == [1, 2]
+    assert json.loads((Path(dest) / "kas.jsonl").read_text(encoding="utf-8"))["id"] == 3
+
+
+def test_a_credential_is_scrubbed_before_it_is_written(monkeypatch, tmp_path):
+    _clean(monkeypatch)
+    secret = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+    _frame_record.write_frame("kas", {"params": {"nested": [{"token": secret}]}}, str(tmp_path))
+    written = (tmp_path / "kas.jsonl").read_text(encoding="utf-8")
+    assert secret not in written
+    assert "REDACTED" in written
+
+
+def test_the_recording_home_directory_is_scrubbed(monkeypatch, tmp_path):
+    _clean(monkeypatch)
+    home = tmp_path / "home" / "someone"
+    home.mkdir(parents=True)
+    monkeypatch.setattr(_frame_record.Path, "home", staticmethod(lambda: home))
+    _frame_record.write_frame("kas", {"params": {"path": f"{home}/notes.md"}}, str(tmp_path))
+    written = (tmp_path / "kas.jsonl").read_text(encoding="utf-8")
+    assert str(home) not in written
+    assert "~/notes.md" in written
+
+
+def test_a_sibling_of_the_home_directory_is_not_mangled(monkeypatch, tmp_path):
+    """``$HOME=/home/al`` must not turn ``/home/alice/x`` into ``~ice/x``.
+
+    A bare substring replace matched the prefix; only a whole path component
+    (followed by a separator or the end of the string) is ``$HOME``."""
+    _clean(monkeypatch)
+    home = tmp_path / "home" / "al"
+    home.mkdir(parents=True)
+    sibling = tmp_path / "home" / "alice" / "x"
+    monkeypatch.setattr(_frame_record.Path, "home", staticmethod(lambda: home))
+    frame = {"params": {"mine": f"{home}/notes.md", "theirs": str(sibling), "bare": str(home)}}
+    written = json.loads(_frame_record.scrub_frame(frame))["params"]
+    assert written == {"mine": "~/notes.md", "theirs": str(sibling), "bare": "~"}, written
+
+
+def test_a_credential_nested_under_a_header_key_is_still_redacted(monkeypatch, tmp_path):
+    """``{"Authorization": ["Bearer …"]}``: the token sits in a list, so it is
+    not a dict value and a bare ``Bearer <opaque>`` is not a credential pattern
+    on its own. The enclosing key must travel down into the container."""
+    _clean(monkeypatch)
+    token = "Bearer sk-nested-0123456789abcdef0123456789abcdef"
+    frame = {"headers": {"Authorization": [token, [token]]}}
+    out = json.loads(_frame_record.scrub_frame(frame))
+    assert token not in json.dumps(out), out
+    assert out["headers"]["Authorization"][0].startswith("[REDACTED"), out
+    assert out["headers"]["Authorization"][1][0].startswith("[REDACTED"), out
+
+
+def test_a_credential_under_a_nested_dict_keeps_the_outer_key_context(monkeypatch):
+    """``{"Authorization": {"value": "Bearer …"}}``: the inner dict's own key
+    (``value``) is not credential-shaped. It must ADD to the ancestor context,
+    not replace it, or the token is written verbatim."""
+    _clean(monkeypatch)
+    token = "Bearer sk-inner-0123456789abcdef0123456789abcdef"
+    frame = {"headers": {"Authorization": {"value": token, "items": [{"v": token}]}}}
+    out = json.loads(_frame_record.scrub_frame(frame))
+    assert token not in json.dumps(out), out
+    assert out["headers"]["Authorization"]["value"].startswith("[REDACTED"), out
+    assert out["headers"]["Authorization"]["items"][0]["v"].startswith("[REDACTED"), out
+    # Unrelated siblings are not over-redacted by the inherited context.
+    plain = json.loads(_frame_record.scrub_frame({"headers": {"X-Trace": "hello"}}))
+    assert plain == {"headers": {"X-Trace": "hello"}}, plain
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("Authorization", "Basic dXNlcjpwYXNzd29yZA=="),
+        ("authorization", "Digest username=al, response=abc"),
+        ("Proxy-Authorization", "Basic dXNlcjpwYXNz"),
+        ("Cookie", "session=opaque-not-a-known-shape"),
+        ("Set-Cookie", "sid=abc; HttpOnly"),
+        ("X-Api-Key", "not-a-recognised-shape"),
+        ("api_key", "plainlooking"),
+        ("password", "hunter2"),
+        ("client_secret", "shortsecret"),
+        ("refresh_token", "opaque"),
+        ("accessToken", "short-opaque-value"),
+        ("refreshToken", "opaque"),
+        ("clientSecret", "opaque"),
+        ("_authToken", "opaque"),
+        ("apiKey", "opaque"),
+        ("ACCESS-TOKEN", "opaque"),
+        ("SLACK_BOT_TOKEN", "opaque"),
+        ("GITHUB_ENTERPRISE_TOKEN", "opaque"),
+        ("X-Internal-Secret", "opaque"),
+        ("dbPassword", "opaque"),
+        ("JIRA_API_TOKEN", "opaque"),
+        ("consumerSecret", "opaque"),
+        ("apiSecret", "opaque"),
+        ("authorizationToken", "opaque"),
+        ("otp", "482913"),
+        ("pin", "1234"),
+        ("verificationCode", "482913"),
+        ("authCode", "opaque"),
+        ("mfa_code", "482913"),
+        ("recovery_code", "opaque"),
+        ("_auth", "dXNlcjpwYXNzd29yZA=="),
+        ("auth", "dXNlcjpwYXNzd29yZA=="),
+        ("basic_auth", "opaque"),
+        ("proxyAuth", "Basic dXNlcjpwYXNz"),
+        ("registry_auth", "opaque"),
+    ],
+)
+def test_a_value_under_a_credential_bearing_key_is_redacted_whatever_its_shape(
+    monkeypatch, key, value
+):
+    """The pattern redactor knows credential SHAPES; ``Authorization: Basic
+    <base64>`` has none it recognises and is the password, reversibly. Under a
+    key that names a credential the value is replaced by the key alone, at any
+    depth, whatever it looks like."""
+    _clean(monkeypatch)
+    frame = {"headers": {key: value}, "deep": {key: {"v": [value]}}}
+    out = json.loads(_frame_record.scrub_frame(frame))
+    assert value not in json.dumps(out), out
+    assert out["headers"][key] == "[REDACTED: credential]", out
+    assert out["deep"][key]["v"][0] == "[REDACTED: credential]", out
+
+
+def test_an_oauth_configuration_block_is_not_redacted(monkeypatch):
+    """``oauth`` ends in ``auth`` but is a configuration block, not a blob:
+    its client id, issuer and scopes are what a replay needs. Only the
+    secret-shaped leaves inside it are touched."""
+    _clean(monkeypatch)
+    frame = {
+        "oauth": {
+            "clientId": "abc-123",
+            "issuer": "https://issuer.example",
+            "scopes": ["openid", "email"],
+            "clientSecret": "s3cr3t",
+        }
+    }
+    out = json.loads(_frame_record.scrub_frame(frame))
+    assert out["oauth"]["clientId"] == "abc-123", out
+    assert out["oauth"]["issuer"] == "https://issuer.example", out
+    assert out["oauth"]["scopes"] == ["openid", "email"], out
+    assert out["oauth"]["clientSecret"] == "[REDACTED: credential]", out
+
+
+@pytest.mark.parametrize(
+    "name_field, name, value",
+    [
+        ("name", "Authorization", "Basic dXNlcjpwYXNz"),
+        ("key", "X-Api-Key", "not-a-shape"),
+        ("header", "Cookie", "sid=opaque"),
+        ("name", "password", "hunter2"),
+        ("Name", "SLACK_BOT_TOKEN", "opaque"),
+    ],
+)
+def test_a_name_value_pair_naming_a_credential_is_redacted(monkeypatch, name_field, name, value):
+    """Header lists arrive as ``[{"name": ..., "value": ...}]``: the credential
+    key is a VALUE, so the walk must borrow it as context for the siblings.
+    The name itself is kept so the recording still says which header it was."""
+    _clean(monkeypatch)
+    frame = {"headers": [{name_field: name, "value": value, "enabled": True, "source": "cfg"}]}
+    out = json.loads(_frame_record.scrub_frame(frame))
+    entry = out["headers"][0]
+    assert entry[name_field] == name, entry
+    assert entry["value"] == "[REDACTED: credential]", entry
+    # Metadata siblings are not the secret and must survive intact.
+    assert entry["enabled"] is True and entry["source"] == "cfg", entry
+    assert value not in json.dumps(out), out
+
+
+@pytest.mark.parametrize(
+    "pair",
+    [
+        ["Authorization", "Basic dXNlcjpwYXNz"],
+        ["X-Api-Key", "not-a-shape"],
+        ["password", 123456],
+    ],
+)
+def test_a_two_item_name_value_array_naming_a_credential_is_redacted(monkeypatch, pair):
+    """``headers: [["Authorization", "Basic ..."]]`` is the other common
+    encoding: the first item names the header, the second is its value."""
+    _clean(monkeypatch)
+    out = json.loads(_frame_record.scrub_frame({"headers": [pair, ["Accept", "text/plain"]]}))
+    assert out["headers"][0] == [pair[0], "[REDACTED: credential]"], out
+    assert out["headers"][1] == ["Accept", "text/plain"], out
+    assert str(pair[1]) not in json.dumps(out), out
+
+
+@pytest.mark.parametrize(
+    "second, secret",
+    [
+        (["Basic dXNlcjpwYXNz"], "dXNlcjpwYXNz"),
+        ({"value": "Basic dXNlcjpwYXNz"}, "dXNlcjpwYXNz"),
+        ([["nested", "opaque-blob"]], "opaque-blob"),
+    ],
+)
+def test_a_two_item_pair_with_a_container_value_is_still_redacted(monkeypatch, second, secret):
+    """``["Authorization", ["Basic ..."]]``: the name lends its context to a
+    container second item too, so every leaf inside it is judged under the
+    credential name rather than escaping because of its type."""
+    _clean(monkeypatch)
+    out = json.loads(_frame_record.scrub_frame({"headers": [["Authorization", second]]}))
+    assert out["headers"][0][0] == "Authorization", out
+    assert secret not in json.dumps(out), out
+    assert "[REDACTED: credential]" in json.dumps(out), out
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        {"Authorization": {"Basic dXNlcjpwYXNz": True}},
+        {"Authorization": {"nested": {"Basic dXNlcjpwYXNz": 1}}},
+        {"headers": [{"name": "Authorization", "value": {"Basic dXNlcjpwYXNz": True}}]},
+        {"headers": [["Authorization", {"n": {"Basic dXNlcjpwYXNz": 1}}]]},
+    ],
+)
+def test_a_credential_encoded_as_an_object_key_under_a_credential_name_is_redacted(
+    monkeypatch, frame
+):
+    """A dict KEY is a string leaf too. Under an inherited credential context
+    the secret may be the key itself, so keys are judged against the enclosing
+    chain the same way values are -- through every structural wrapper."""
+    _clean(monkeypatch)
+    out = _frame_record.scrub_frame(frame)
+    json.loads(out)
+    assert "dXNlcjpwYXNz" not in out, out
+    assert "[REDACTED: credential]" in out, out
+
+
+def test_a_key_under_a_credential_name_is_judged_against_the_chain_not_itself(monkeypatch):
+    """``value`` under ``Authorization`` is a key NAME: it stays legible while
+    the secret it points at is replaced, so the recording still says where the
+    header value lived."""
+    _clean(monkeypatch)
+    out = json.loads(_frame_record.scrub_frame({"Authorization": {"value": "Basic dXNlcjpwYXNz"}}))
+    assert out == {"Authorization": {"value": "[REDACTED: credential]"}}, out
+
+
+def test_many_keys_collapsing_to_one_spelling_cost_linear_work(monkeypatch):
+    """A frame whose every key is a secret under ``Authorization`` collapses
+    them all to ``[REDACTED: credential]``; the ``#n`` suffixing must not
+    rescan every taken suffix per key, or such a frame pins the writer.
+    Rescanning from ``#2`` each time is quadratic (about n*n/2 probes: ~2e8
+    for this frame, tens of seconds); one probe per key is well under a
+    second even on a slow CI box."""
+    _clean(monkeypatch)
+    n = 20000
+    frame = {"Authorization": {f"Basic blob{i} {i}": i for i in range(n)}}
+    started = time.monotonic()
+    out = json.loads(_frame_record.scrub_frame(frame))
+    elapsed = time.monotonic() - started
+    inner = out["Authorization"]
+    assert len(inner) == n, len(inner)
+    assert all(k.startswith("[REDACTED: credential]") for k in inner), list(inner)[:3]
+    assert elapsed < 5.0, elapsed
+
+
+def test_a_name_value_pair_naming_a_plain_field_is_not_redacted(monkeypatch):
+    """Only a credential-bearing name lends context; ``Accept`` does not."""
+    _clean(monkeypatch)
+    frame = {"headers": [{"name": "Accept", "value": "text/plain"}, {"name": "count", "value": 3}]}
+    out = json.loads(_frame_record.scrub_frame(frame))
+    assert out == frame, out
+
+
+def test_a_credential_bearing_key_does_not_redact_its_siblings(monkeypatch):
+    """The key-name rule applies to the value UNDER the key, not to its
+    neighbours: a request that carries an ``Authorization`` header still
+    records its method and path."""
+    _clean(monkeypatch)
+    frame = {"method": "GET", "headers": {"Authorization": "Basic x", "Accept": "text/plain"}}
+    out = json.loads(_frame_record.scrub_frame(frame))
+    assert out["method"] == "GET" and out["headers"]["Accept"] == "text/plain", out
+    assert out["headers"]["Authorization"] == "[REDACTED: credential]", out
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "tokenizer",
+        "tokens",
+        "secretary",
+        "passwords_hint",
+        "cookieJar",
+        "inputTokens",
+        "outputTokens",
+        "max_tokens",
+        "context_window_tokens",
+        "cachedReadTokens",
+        "NextToken",
+        "max_token",
+        "stop_token",
+        "authenticated",
+        "author",
+        "auth_method",
+        "authorized",
+        "oauth",
+        "oauth2",
+        "preauth",
+        "requires_auth",
+    ],
+)
+def test_a_key_that_merely_contains_a_credential_word_is_not_redacted(monkeypatch, key):
+    """The key-name rule is a SUFFIX match on the canonical spelling. Usage
+    counters are plural (``inputTokens``) and pagination cursors and model
+    settings are named out (``NextToken``, ``max_token``); ``tokenizer`` and
+    ``secretary`` never end in the noun. All are ordinary fields."""
+    _clean(monkeypatch)
+    out = json.loads(_frame_record.scrub_frame({key: "plain", "usage": {key: 42}}))
+    assert out == {key: "plain", "usage": {key: 42}}, out
+
+
+@pytest.mark.parametrize("value", [123456, 4.2, 0, True])
+def test_a_numeric_value_under_a_credential_key_is_redacted(monkeypatch, value):
+    """A PIN or an all-digit token is a number after JSON decoding; the type
+    says nothing about whether it is secret. Only the key does."""
+    _clean(monkeypatch)
+    frame = {"password": value, "otp": value, "auth": {"pin_token": [value]}}
+    out = json.loads(_frame_record.scrub_frame(frame))
+    assert out["password"] == "[REDACTED: credential]", out
+    assert out["otp"] == "[REDACTED: credential]", out
+    assert out["auth"]["pin_token"][0] == "[REDACTED: credential]", out
+
+
+@pytest.mark.parametrize("key", ["code", "status_code", "exit_code", "language_code", "zip_code"])
+def test_a_bare_code_field_is_not_a_credential(monkeypatch, key):
+    """Only the qualified one-time-code names are credentials; ``code`` on its
+    own is a status, an exit code, a locale."""
+    _clean(monkeypatch)
+    out = json.loads(_frame_record.scrub_frame({key: 200}))
+    assert out == {key: 200}, out
+
+
+def test_a_credential_in_a_header_map_leaves_valid_json(monkeypatch, tmp_path):
+    """Redacting the SERIALIZED frame let one pattern span key, quote, colon and
+    value -- ``"Authorization": "Bearer …"`` collapsed to a single token and the
+    line no longer parsed. Redaction is per string leaf now, so the header key
+    survives, the value is redacted, and the corpus loader can read the line."""
+    _clean(monkeypatch)
+    frame = {
+        "params": {
+            "rawInput": {
+                "headers": {"Authorization": "Bearer abcdefghijklmnopqrstuvwxyz0123456789ABCDEF"}
+            }
+        }
+    }
+    _frame_record.write_frame("kas", frame, str(tmp_path))
+    line = (tmp_path / "kas.jsonl").read_text(encoding="utf-8").splitlines()[0]
+    parsed = json.loads(line)  # must not raise
+    headers = parsed["params"]["rawInput"]["headers"]
+    assert "Authorization" in headers, headers
+    assert "abcdefghijklmnop" not in line
+    assert "REDACTED" in headers["Authorization"]
+
+
+def test_every_known_backend_maps_to_a_usable_file_stem():
+    names = {_frame_record.fixture_dir_name(b) for b in ACP_BACKENDS_KNOWN}
+    assert len(names) == len(ACP_BACKENDS_KNOWN), f"two backends share a file: {names}"
+    for name in names:
+        assert name
+        assert "/" not in name and "\\" not in name and name not in (".", "..")
+
+
+# ── owner-only on disk ───────────────────────────────────────────────────────
+
+
+def test_a_fresh_recording_is_created_owner_only(monkeypatch, tmp_path):
+    """A recording holds redacted-but-not-guaranteed-clean transcripts.
+
+    The first version of this recorder used a bare ``mkdir()`` and ``open("a")``,
+    so a recording took the umask default -- 0o755 / 0o644 on most hosts -- and
+    any other local user could read a developer's transcripts. Passing the mode
+    to ``mkdir`` and ``os.open`` closes that on a fresh path; the pre-existing
+    path is the next test.
+    """
+    _clean(monkeypatch)
+    old = os.umask(0o022)
+    try:
+        dest = tmp_path / "frames"
+        _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    finally:
+        os.umask(old)
+    assert _mode(dest) == _frame_record.DIR_MODE, oct(_mode(dest))
+    assert _mode(dest / "kas.jsonl") == _frame_record.FILE_MODE, oct(_mode(dest / "kas.jsonl"))
+
+
+@pytest.mark.parametrize("mode", [0o755, 0o750, 0o705], ids=["world", "group-only", "other-only"])
+def test_a_pre_existing_shared_directory_is_refused_not_tightened(monkeypatch, tmp_path, mode):
+    """The env var may name a directory the operator shares on purpose.
+
+    An earlier revision ``fchmod``ed every destination to 0700 on the first
+    frame, which locked every other intended user out of a shared directory
+    with no undo. A directory this run did not create is checked and refused,
+    never changed: its mode must survive and nothing may be written into it.
+    """
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=mode)
+    dest.chmod(mode)
+
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0", "id": 1}, str(dest))
+
+    assert _mode(dest) == mode, "a pre-existing directory was re-moded"
+    assert list(dest.iterdir()) == [], "a frame was written into a shared directory"
+    assert _frame_record.recording_destination() == "", "a refused destination must stand down"
+
+
+def _fake_listxattr(names_by_fd_path):
+    """Build an ``os.listxattr`` stand-in keyed on the inode of the descriptor.
+
+    ``setfacl`` needs a filesystem that stores ACLs and a helper binary; a test
+    cannot rely on either, so the xattr view is faked at the ``os`` boundary
+    and keyed by the ``(st_dev, st_ino)`` of the descriptor asked about.
+    """
+
+    def listxattr(fd):
+        info = os.fstat(fd)
+        return list(names_by_fd_path.get((info.st_dev, info.st_ino), ()))
+
+    return listxattr
+
+
+def _inode(path):
+    info = os.stat(path)
+    return (info.st_dev, info.st_ino)
+
+
+@pytest.mark.parametrize("xattr", ["system.posix_acl_access", "system.posix_acl_default"])
+def test_a_pre_existing_owner_only_directory_with_an_acl_is_refused(monkeypatch, tmp_path, xattr):
+    """``mode & 0o077 == 0`` says nothing about a named ACL entry: a 0700
+    directory with ``setfacl -m u:other:rx`` reads owner-only and is not. A
+    default ACL is worse, since every file created inside inherits it."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o700)
+    dest.chmod(0o700)
+    monkeypatch.setattr(_frame_record.os, "listxattr", _fake_listxattr({_inode(dest): [xattr]}))
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    assert list(dest.iterdir()) == [], "a frame was written into an ACL-shared directory"
+    assert _frame_record.recording_destination() == ""
+
+
+def test_a_directory_created_by_this_run_that_inherited_an_acl_is_refused(monkeypatch, tmp_path):
+    """fchmod 0700 on the leaf does not strip the default ACL it inherited from
+    its parent, so a created leaf is checked too, not only a pre-existing one."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    seen = {}
+
+    def listxattr(fd):
+        info = os.fstat(fd)
+        if dest.exists() and (info.st_dev, info.st_ino) == _inode(dest):
+            seen["leaf"] = True
+            return ["system.posix_acl_access"]
+        return []
+
+    monkeypatch.setattr(_frame_record.os, "listxattr", listxattr)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    assert seen.get("leaf"), "the created leaf was never asked about its ACL"
+    assert not dest.exists() or list(dest.iterdir()) == []
+    assert _frame_record.recording_destination() == ""
+
+
+def test_a_recording_file_that_carries_an_acl_is_refused(monkeypatch, tmp_path):
+    """The file descriptor is checked after fchmod: a pre-existing
+    ``kas.jsonl`` given an ACL by hand must not receive another frame."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o700)
+    dest.chmod(0o700)
+    existing = dest / "kas.jsonl"
+    existing.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        _frame_record.os,
+        "listxattr",
+        _fake_listxattr({_inode(existing): ["system.posix_acl_access"]}),
+    )
+    existing.chmod(0o640)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0", "id": 1}, str(dest))
+    assert existing.read_text(encoding="utf-8") == "", "a frame landed in an ACL-shared file"
+    # Refused means left as found: fchmod on an ACL-bearing file rewrites its
+    # mask entry, so the tightening must not run before the check.
+    assert _mode(existing) == 0o640, oct(_mode(existing))
+    assert _frame_record.recording_destination() == ""
+
+
+def test_a_filesystem_without_xattrs_has_no_acls_and_is_accepted(monkeypatch, tmp_path):
+    """tmpfs mounted without xattr support answers ENOTSUP; that is a
+    filesystem with no ACLs at all, not one hiding them."""
+    _clean(monkeypatch)
+
+    def listxattr(fd):
+        raise OSError(errno.ENOTSUP, "not supported")
+
+    monkeypatch.setattr(_frame_record.os, "listxattr", listxattr)
+    dest = tmp_path / "frames"
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0", "id": 1}, str(dest))
+    assert (dest / "kas.jsonl").exists()
+    assert not _frame_record._stood_down, "an ACL-less filesystem must not stand the recorder down"
+
+
+def test_start_recorder_starts_no_thread_where_acls_cannot_be_inspected(monkeypatch, tmp_path):
+    """macOS passes the POSIX gate but not the ACL one: ``start_recorder`` must
+    stand down before starting the writer and notifier threads, not after."""
+    _clean(monkeypatch)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    monkeypatch.setattr(_frame_record.platform_compat, "IS_LINUX", False)
+    started = []
+    real_start = threading.Thread.start
+
+    def spy(self, *a, **kw):
+        started.append(self.name)
+        return real_start(self, *a, **kw)
+
+    monkeypatch.setattr(threading.Thread, "start", spy)
+    assert _frame_record.start_recorder() is False
+    assert started == [], started
+    assert _frame_record.recording_destination() == ""
+
+
+def test_a_platform_that_cannot_inspect_acls_stands_down(monkeypatch, tmp_path, caplog):
+    """macOS stores ACLs behind acl_get_file with no os binding: the recorder
+    cannot prove owner-only there and refuses, naming the reason once."""
+    _clean(monkeypatch)
+    monkeypatch.setattr(_frame_record.platform_compat, "IS_LINUX", False)
+    dest = tmp_path / "frames"
+    with caplog.at_level(logging.WARNING):
+        _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    assert not dest.exists() or list(dest.iterdir()) == []
+    assert _frame_record.recording_destination() == ""
+    assert "Linux-only" in caplog.text
+
+
+def test_a_pre_existing_directory_owned_by_another_user_is_refused(monkeypatch, tmp_path):
+    """0700 is not enough: an owner-only directory owned by SOMEONE ELSE is
+    theirs, not ours, and writing a recording into it (or reading one out of
+    it) is the wrong side of the boundary. A test cannot create a directory
+    owned by another uid without privilege, so the recorder's idea of "this
+    user" is moved instead."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o700)
+    dest.chmod(0o700)
+    monkeypatch.setattr(_frame_record.platform_compat, "local_user_id", lambda: -1)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    assert list(dest.iterdir()) == [], "a frame was written into another user's directory"
+    assert _frame_record.recording_destination() == ""
+
+
+def test_a_pre_existing_owner_only_directory_is_reused_and_a_loose_file_tightened(
+    monkeypatch, tmp_path
+):
+    """An owner-only directory from an earlier run is the normal second-session
+    case: the append lands there, and a loose file inside (an earlier run under
+    a wide umask) is still tightened on its descriptor, since the file is the
+    recorder's own artefact rather than the operator's directory."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o700)
+    dest.chmod(0o700)
+    existing = dest / "kas.jsonl"
+    existing.write_text('{"jsonrpc": "2.0", "id": 0}\n', encoding="utf-8")
+    existing.chmod(0o644)
+
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0", "id": 1}, str(dest))
+
+    assert _mode(existing) == _frame_record.FILE_MODE, oct(_mode(existing))
+    ids = [json.loads(ln)["id"] for ln in existing.read_text(encoding="utf-8").splitlines()]
+    assert ids == [0, 1], "tightening must append, not truncate"
+
+
+# ── never waits on the reader loop ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_frame_returns_while_the_writer_is_wedged(monkeypatch, tmp_path):
+    """A slow disk or a saturated shared executor must not hold a frame back.
+
+    The reader loop routes a frame only after ``record_frame`` returns, so if
+    that awaited the write, a wedged destination would stall every multiplexed
+    session until the liveness watchdog killed the process. The write is queued
+    instead; this holds the worker on a gate and shows the call still returns.
+    """
+    _clean(monkeypatch)
+    async with _live_writer():
+        monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+        _frame_record.start_recorder()
+        gate = threading.Event()
+        real_write = _frame_record.write_frame
+
+        def slow(backend, frame, dest):
+            gate.wait(timeout=10)
+            real_write(backend, frame, dest)
+
+        monkeypatch.setattr(_frame_record, "write_frame", slow)
+        try:
+            for i in range(3):
+                await asyncio.wait_for(
+                    _frame_record.record_frame("kas", {"jsonrpc": "2.0", "id": i}), timeout=0.5
+                )
+        finally:
+            gate.set()
+        await asyncio.wait_for(_frame_record.flush_for_tests(), timeout=10)
+        ids = [json.loads(ln)["id"] for ln in (tmp_path / "kas.jsonl").read_text().splitlines()]
+        assert ids == [0, 1, 2], "frames must land in arrival order"
+
+
+@pytest.mark.asyncio
+async def test_a_full_queue_drops_and_stands_down_instead_of_waiting(monkeypatch, tmp_path):
+    _clean(monkeypatch)
+    async with _live_writer():
+        monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+        monkeypatch.setattr(_frame_record, "QUEUE_LIMIT", 2)  # before the queue is built
+        _frame_record.start_recorder()
+        gate = threading.Event()
+        monkeypatch.setattr(_frame_record, "write_frame", lambda *a: gate.wait(timeout=10))
+        try:
+            for i in range(4):
+                await asyncio.wait_for(_frame_record.record_frame("kas", {"id": i}), timeout=0.5)
+        finally:
+            gate.set()
+        assert _frame_record.recording_destination() == "", "an overflow must stand recording down"
+
+
+@pytest.mark.asyncio
+async def test_a_burst_of_large_frames_is_bounded_by_bytes_not_count(monkeypatch, tmp_path):
+    """The transports admit frames of up to 10 MiB, so a count-only bound would
+    let a burst hold gigabytes of parsed JSON behind one wedged writer.
+
+    The byte bound counts the WIRE length the reader loop already has, not a
+    re-serialization on the loop. Three 1 KiB "frames" under a 2.5 KiB cap:
+    the third must be dropped and stand recording down, well under
+    ``QUEUE_LIMIT``.
+    """
+    _clean(monkeypatch)
+    async with _live_writer():
+        monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+        _frame_record.start_recorder()
+        monkeypatch.setattr(_frame_record, "QUEUE_BYTES_LIMIT", 2560)
+        gate = threading.Event()
+        monkeypatch.setattr(_frame_record, "write_frame", lambda *a: gate.wait(timeout=10))
+        try:
+            for i in range(3):
+                await asyncio.wait_for(
+                    _frame_record.record_frame("kas", {"id": i}, wire_bytes=1024), timeout=0.5
+                )
+                if i < 2:
+                    assert _frame_record.recording_destination() != "", f"frame {i} was refused"
+        finally:
+            gate.set()
+        assert _frame_record.recording_destination() == "", "the byte bound did not trip"
+
+
+@pytest.mark.asyncio
+async def test_record_frame_never_waits_on_the_byte_budget_lock(monkeypatch, tmp_path):
+    """The budget lock is shared with the drain thread. If its holder is
+    preempted, a reader loop must not block behind it: the frame is dropped,
+    recording stands down, and ``record_frame`` returns promptly."""
+    _clean(monkeypatch)
+    async with _live_writer():
+        monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+        assert _frame_record.start_recorder()
+        writer = _frame_record._writer
+        assert writer is not None
+        # Hold the lock for the whole call, as a preempted holder would.
+        assert writer.lock.acquire(blocking=False)
+        try:
+            started = time.monotonic()
+            await _frame_record.record_frame("kas", {"jsonrpc": "2.0", "method": "x"}, 32)
+            elapsed = time.monotonic() - started
+        finally:
+            writer.lock.release()
+        assert elapsed < 0.5, f"record_frame waited {elapsed:.3f}s on the budget lock"
+        assert _frame_record.recording_destination() == "", "a busy lock must stand down, not wait"
+        assert not writer.items, "the frame must be dropped, not queued behind the lock"
+
+
+@pytest.mark.asyncio
+async def test_a_reader_side_stand_down_is_logged_from_the_writer_thread(monkeypatch, tmp_path):
+    """An overflow is detected on the reader loop. The log line for it must
+    NOT be emitted there -- ``logger.warning`` takes the handler lock and runs
+    the handlers -- but from the drain thread, shortly after."""
+    _clean(monkeypatch)
+    async with _live_writer():
+        monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+        assert _frame_record.start_recorder()
+        emitted: list[str] = []
+        logged = threading.Event()
+
+        def spy(*_a, **_k):
+            emitted.append(threading.current_thread().name)
+            logged.set()
+
+        monkeypatch.setattr(_frame_record.logger, "warning", spy)
+        monkeypatch.setattr(_frame_record, "QUEUE_LIMIT", 0)  # every admission overflows
+        await _frame_record.record_frame("kas", {"jsonrpc": "2.0"}, 16)
+        assert _frame_record.recording_destination() == "", "the overflow did not stand down"
+        assert emitted == [], f"the reader loop emitted the log line itself: {emitted}"
+        assert await asyncio.to_thread(logged.wait, 5), "the notifier never emitted the line"
+        assert emitted == ["acp-frame-recorder-notify"], emitted
+
+
+@pytest.mark.asyncio
+async def test_a_reader_side_stand_down_is_logged_even_when_the_writer_is_wedged(
+    monkeypatch, tmp_path
+):
+    """A hung filesystem holds the writer inside ``write`` forever. The one
+    warning that says frames are now being dropped must not wait behind it:
+    it is emitted by a thread that never touches the file."""
+    _clean(monkeypatch)
+    async with _live_writer():
+        monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+        assert _frame_record.start_recorder()
+        wedged = threading.Event()
+        release = threading.Event()
+
+        def hung(*_a):
+            wedged.set()
+            release.wait(timeout=30)
+
+        monkeypatch.setattr(_frame_record, "write_frame", hung)
+        emitted: list[str] = []
+        logged = threading.Event()
+
+        def spy(*_a, **_k):
+            emitted.append(threading.current_thread().name)
+            logged.set()
+
+        monkeypatch.setattr(_frame_record.logger, "warning", spy)
+        try:
+            await _frame_record.record_frame("kas", {"id": 0}, 16)
+            assert await asyncio.to_thread(wedged.wait, 5), "the writer never took the frame"
+            monkeypatch.setattr(_frame_record, "QUEUE_LIMIT", 0)
+            await _frame_record.record_frame("kas", {"id": 1}, 16)
+            assert _frame_record.recording_destination() == "", "the overflow did not stand down"
+            assert await asyncio.to_thread(
+                logged.wait, 5
+            ), "warning waited behind the wedged writer"
+            assert emitted == ["acp-frame-recorder-notify"], emitted
+        finally:
+            release.set()
+
+
+@pytest.mark.asyncio
+async def test_queued_bytes_are_released_as_frames_are_written(monkeypatch, tmp_path):
+    """The bound is on the BACKLOG, not a lifetime total: a recording of any
+    length must fit as long as the writer keeps up."""
+    _clean(monkeypatch)
+    async with _live_writer():
+        monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+        _frame_record.start_recorder()
+        monkeypatch.setattr(_frame_record, "QUEUE_BYTES_LIMIT", 2560)
+        for i in range(6):
+            await _frame_record.record_frame("kas", {"jsonrpc": "2.0", "id": i}, wire_bytes=1024)
+            await _frame_record.flush_for_tests()
+        assert _frame_record.recording_destination() != "", "released bytes were still counted"
+        ids = [json.loads(ln)["id"] for ln in (tmp_path / "kas.jsonl").read_text().splitlines()]
+        assert ids == list(range(6))
+
+
+def test_the_lockdown_is_applied_to_the_opened_descriptor_not_the_path(monkeypatch, tmp_path):
+    """A path-based chmod after the open protects whatever the path names NOW.
+
+    If another local user swaps the parent between the directory check and the
+    open, the descriptor holds their file while the path has been restored, so
+    ``chmod(path)`` tightens the wrong inode and the frame lands attacker-
+    readable. ``fchmod`` on the descriptor cannot be redirected. This pins the
+    mechanism: a chmod by path must not be what tightens the file.
+    """
+    _clean(monkeypatch)
+    by_path: list = []
+    real_chmod = os.chmod
+    monkeypatch.setattr(
+        os, "chmod", lambda p, m, *a, **k: (by_path.append(p), real_chmod(p, m, *a, **k))
+    )
+    monkeypatch.setattr(
+        _frame_record.platform_compat,
+        "restrict_to_owner",
+        lambda p: pytest.fail(f"restrict_to_owner(path) used on POSIX for {p}"),
+    )
+    dest = tmp_path / "frames"
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    target = dest / "kas.jsonl"
+    assert target.exists(), "the frame was not written"
+    assert _mode(target) == _frame_record.FILE_MODE, oct(_mode(target))
+    assert not any(Path(p) == target for p in by_path), "the file was tightened by path"
+
+
+@pytest.mark.asyncio
+async def test_one_failure_logs_once_and_discards_the_backlog(monkeypatch, tmp_path, caplog):
+    """After the destination breaks, the frames already queued must not each be
+    retried against it -- that is up to ``QUEUE_LIMIT`` warnings for one fault."""
+    _clean(monkeypatch)
+    async with _live_writer():
+        monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+        _frame_record.start_recorder()
+        gate = threading.Event()
+        attempts: list[int] = []
+
+        def failing(backend, frame, dest):
+            gate.wait(timeout=10)
+            attempts.append(frame["id"])
+            _frame_record._stand_down(OSError("disk gone"))
+
+        monkeypatch.setattr(_frame_record, "write_frame", failing)
+        with caplog.at_level("WARNING", logger=_frame_record.__name__):
+            for i in range(5):
+                await _frame_record.record_frame("kas", {"id": i}, wire_bytes=10)
+            gate.set()
+            await asyncio.wait_for(_frame_record.flush_for_tests(), timeout=10)
+        assert attempts == [0], f"queued frames were retried after the stand-down: {attempts}"
+        warnings = [r for r in caplog.records if "recording failed" in r.getMessage()]
+        assert len(warnings) == 1, [r.getMessage() for r in warnings]
+
+
+# ── links are not followed ───────────────────────────────────────────────────
+
+
+def test_a_symlinked_destination_is_refused(monkeypatch, tmp_path):
+    """The env var names where the recording lives; a link would say otherwise."""
+    _clean(monkeypatch)
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "frames"
+    link.symlink_to(real, target_is_directory=True)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(link))
+    assert list(real.iterdir()) == [], "the recorder wrote through a symlinked destination"
+    assert _frame_record.recording_destination() == ""
+    _frame_record._reset_for_tests()
+
+
+def test_a_linked_destination_is_refused_before_its_target_is_touched(monkeypatch, tmp_path):
+    """The leaf itself is a link to another user's directory.
+
+    A name-based ``mkdir``/``chmod`` would follow it and tighten the target
+    before any check ran. The pinned walk opens the leaf with ``O_NOFOLLOW``
+    and refuses, so the target's mode and contents are untouched."""
+    _clean(monkeypatch)
+    real = tmp_path / "real"
+    real.mkdir(mode=0o755)
+    real.chmod(0o755)
+    link = tmp_path / "frames"
+    link.symlink_to(real, target_is_directory=True)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(link))
+    assert _mode(real) == 0o755, "the link's target was modified"
+    assert list(real.iterdir()) == []
+    assert _frame_record.recording_destination() == ""
+
+
+def test_a_planted_link_inside_the_directory_is_not_followed(monkeypatch, tmp_path):
+    """Another local user plants ``kas.jsonl -> victim`` in a pre-existing dir.
+
+    Tightening the directory does not remove the link, so the open itself must
+    refuse to follow it; otherwise the append lands in the victim file.
+    """
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o755)
+    victim = tmp_path / "victim"
+    victim.write_text("keep me\n", encoding="utf-8")
+    (dest / "kas.jsonl").symlink_to(victim)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    assert victim.read_text(encoding="utf-8") == "keep me\n", "the append followed the link"
+    assert _frame_record.recording_destination() == ""
+    _frame_record._reset_for_tests()
+
+
+def test_a_linked_ancestor_of_the_destination_is_refused(monkeypatch, tmp_path):
+    """The destination path crosses a link ABOVE the leaf: ``<link>/frames``.
+
+    A single ``O_NOFOLLOW`` open of the leaf walks the ancestors by name and
+    follows the link, so the recording lands under the link's target -- wherever
+    another local user pointed it. Pinning every component by descriptor is
+    what refuses it; the frame must not appear under the target.
+    """
+    _clean(monkeypatch)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir(mode=0o700)
+    hop = tmp_path / "hop"
+    hop.symlink_to(elsewhere, target_is_directory=True)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(hop / "frames"))
+    assert list(elsewhere.iterdir()) == [], "the recording followed a linked ancestor"
+    assert _frame_record.recording_destination() == ""
+
+
+def test_a_refused_linked_component_is_named_in_the_stand_down(monkeypatch, tmp_path, caplog):
+    """On macOS ``/tmp`` and ``/var`` are OS-provided links, so a destination
+    under either is refused by design. The one log line has to tell the
+    operator WHICH component, and that the physical path is the fix, or the
+    refusal reads as a broken recorder."""
+    _clean(monkeypatch)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir(mode=0o700)
+    hop = tmp_path / "hop"
+    hop.symlink_to(elsewhere, target_is_directory=True)
+    with caplog.at_level(logging.WARNING, logger=_frame_record.logger.name):
+        _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(hop / "frames"))
+    text = caplog.text
+    assert f"crosses a link at {hop}" in text, text
+    assert _frame_record.ENV_RECORD_FRAMES in text and "physical path" in text, text
+
+
+def test_an_ancestor_swapped_for_a_link_after_the_check_is_refused(monkeypatch, tmp_path):
+    """The check-to-use window review found in a version that resolved the
+    parent twice: ``_refuse_linked_component`` sees a real directory at
+    ``<tmp>/hop``, then another local user replaces ``hop`` with a link to a
+    0700 directory they own before the pinned walk runs. If the walk resolves
+    the parent again it follows the link and every descriptor check passes on
+    the attacker's directory. The walk must therefore pin the LEXICAL parent
+    the check approved, so the swapped component fails ``O_NOFOLLOW``."""
+    _clean(monkeypatch)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir(mode=0o700)
+    hop = tmp_path / "hop"
+    hop.mkdir(mode=0o700)
+    real_check = _frame_record._refuse_linked_component
+
+    def check_then_swap(directory):
+        real_check(directory)
+        hop.rmdir()
+        hop.symlink_to(elsewhere, target_is_directory=True)
+
+    monkeypatch.setattr(_frame_record, "_refuse_linked_component", check_then_swap)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(hop / "frames"))
+    assert list(elsewhere.iterdir()) == [], "the walk followed an ancestor swapped after the check"
+    assert _frame_record._stood_down, "a redirected destination must stand down"
+
+
+def test_a_target_unlinked_after_the_open_is_refused_not_written(monkeypatch, tmp_path):
+    """A rotator or cleanup that unlinks ``kas.jsonl`` between the open and the
+    append leaves a descriptor onto an inode with no name: the write succeeds
+    and the bytes vanish on close, silently. ``st_nlink == 0`` is the tell, and
+    ``refuse_hardlink_alias`` only asks about MORE than one name, so the
+    recorder has to refuse the zero case itself and stand down loudly."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o700)
+    dest.chmod(0o700)
+    target = dest / "kas.jsonl"
+    real_open = os.open
+
+    def open_then_unlink(*args, **kwargs):
+        fd = real_open(*args, **kwargs)
+        if args and args[0] == "kas.jsonl" and "dir_fd" in kwargs:
+            target.unlink()
+        return fd
+
+    monkeypatch.setattr(_frame_record.os, "open", open_then_unlink)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    assert not target.exists()
+    assert _frame_record._stood_down, "an unlinked target was written silently"
+
+
+def test_a_failing_hardlink_helper_does_not_leak_the_descriptor(monkeypatch, tmp_path):
+    """``refuse_hardlink_alias`` closes the fd itself when it REFUSES, but a
+    failure inside it (its own ``fstat`` raising) leaves the fd open. The two
+    need opposite cleanup; a recorder that treated both alike would either
+    double-close or leak one descriptor per stand-down. Both paths must end
+    with the descriptor closed exactly once."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o700)
+    dest.chmod(0o700)
+    opened = []
+    real_open = os.open
+
+    def tracking_open(*args, **kwargs):
+        fd = real_open(*args, **kwargs)
+        if args and args[0] == "kas.jsonl":
+            opened.append(fd)
+        return fd
+
+    def boom(fd, **kwargs):
+        raise OSError(errno.EIO, "fstat failed")
+
+    monkeypatch.setattr(_frame_record.os, "open", tracking_open)
+    monkeypatch.setattr(_frame_record.pinned_fs, "refuse_hardlink_alias", boom)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    assert _frame_record._stood_down
+    assert len(opened) == 1
+    with pytest.raises(OSError) as info:
+        os.fstat(opened[0])
+    assert info.value.errno == errno.EBADF, "the recording descriptor was leaked"
+
+
+def test_a_recording_file_owned_by_another_user_is_refused_and_left_alone(monkeypatch, tmp_path):
+    """The directory is refused when another user owns it; the file must be
+    too. An owner-only directory can hold a foreign-owned inode (a bind mount,
+    a file a privileged run left behind), and ``fchmod`` 0600 on it locks it to
+    THAT owner, who then reads every frame appended. ``chown`` needs privilege
+    a test does not have, so the uid the recorder compares against is moved
+    instead; the file must be neither written nor re-moded."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o700)
+    dest.chmod(0o700)
+    existing = dest / "kas.jsonl"
+    existing.write_text("", encoding="utf-8")
+    existing.chmod(0o644)
+    me = os.getuid()
+    real_fstat = os.fstat
+
+    def foreign_fstat(fd):
+        info = real_fstat(fd)
+        if (info.st_dev, info.st_ino) == _inode(existing):
+            return os.stat_result(
+                (
+                    info.st_mode,
+                    info.st_ino,
+                    info.st_dev,
+                    info.st_nlink,
+                    me + 1,
+                    info.st_gid,
+                    info.st_size,
+                    info.st_atime,
+                    info.st_mtime,
+                    info.st_ctime,
+                )
+            )
+        return info
+
+    monkeypatch.setattr(_frame_record.os, "fstat", foreign_fstat)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0", "id": 1}, str(dest))
+    assert existing.read_text(encoding="utf-8") == "", "a frame landed in a foreign-owned file"
+    assert _mode(existing) == 0o644, "a foreign-owned file was re-moded"
+    assert _frame_record._stood_down
+
+
+def test_a_dot_dot_component_cannot_climb_out_through_a_link(monkeypatch, tmp_path):
+    """``<link>/../frames`` normalises lexically to ``<tmp>/frames``; a physical
+    walk that resolved the link first would land the ``..`` inside the link's
+    target instead. The lexical collapse happens BEFORE the pinned walk, so the
+    frame lands where the operator's path reads, not where the link points."""
+    _clean(monkeypatch)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir(mode=0o700)
+    hop = tmp_path / "hop"
+    hop.symlink_to(elsewhere, target_is_directory=True)
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(hop / ".." / "frames"))
+    assert (
+        tmp_path / "frames" / "kas.jsonl"
+    ).exists(), "the frame did not land at the lexical path"
+    assert list(elsewhere.iterdir()) == []
+
+
+def test_concurrent_stand_downs_log_exactly_once(monkeypatch, caplog):
+    """The writer thread (a failed write) and the loop thread (the overflow
+    that failed write causes) can both reach ``_stand_down`` at once; the latch
+    must admit exactly one of them to the log."""
+    _clean(monkeypatch)
+    start = threading.Barrier(8)
+
+    def racer():
+        start.wait(timeout=5)
+        _frame_record._stand_down(OSError("disk gone"))
+
+    with caplog.at_level("WARNING", logger=_frame_record.__name__):
+        threads = [threading.Thread(target=racer) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+    warnings = [r for r in caplog.records if "recording failed" in r.getMessage()]
+    assert len(warnings) == 1, len(warnings)
+    assert _frame_record.recording_destination() == ""
+    _frame_record._reset_for_tests()
+
+
+def test_a_fifo_planted_at_the_target_does_not_wedge_the_writer(monkeypatch, tmp_path):
+    """A FIFO at ``kas.jsonl`` with no reader makes a plain ``O_WRONLY`` open
+    block forever, which would park the writer thread for the life of the
+    process. ``O_NONBLOCK`` makes the open return, and ``S_ISREG`` refuses it.
+    The test would hang rather than fail without the flag, so it runs in a
+    thread with a deadline."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o700)
+    os.mkfifo(dest / "kas.jsonl")
+    worker = threading.Thread(
+        target=_frame_record.write_frame,
+        args=("kas", {"jsonrpc": "2.0"}, str(dest)),
+        daemon=True,  # a regression must fail the test, not wedge the pytest process
+    )
+    worker.start()
+    worker.join(timeout=5)
+    try:
+        assert not worker.is_alive(), "the open blocked on the FIFO"
+        assert _frame_record.recording_destination() == ""
+    finally:
+        if worker.is_alive():
+            # Give the blocked O_WRONLY open a reader so the thread can exit
+            # and pytest can remove tmp_path without a writer still inside it.
+            reader = os.open(dest / "kas.jsonl", os.O_RDONLY | os.O_NONBLOCK)
+            worker.join(timeout=5)
+            os.close(reader)
+
+
+def test_a_hard_link_planted_inside_the_directory_is_refused(monkeypatch, tmp_path):
+    """A hard link at ``kas.jsonl`` is a regular file, so ``S_ISREG`` passes and
+    ``O_NOFOLLOW`` has nothing to refuse -- yet it shares its inode with the
+    victim, so the append (and the chmod) would land in the victim. The link
+    count (``pinned_fs.refuse_hardlink_alias`` on the open descriptor) is what
+    tells the two apart. The directory is owner-only so the mode check passes
+    and the alias check is the one doing the refusing; with a shared directory
+    this test would pass for the wrong reason."""
+    _clean(monkeypatch)
+    dest = tmp_path / "frames"
+    dest.mkdir(mode=0o700)
+    dest.chmod(0o700)
+    victim = tmp_path / "victim"
+    victim.write_text("keep me\n", encoding="utf-8")
+    victim.chmod(0o644)
+    os.link(victim, dest / "kas.jsonl")
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    assert (
+        victim.read_text(encoding="utf-8") == "keep me\n"
+    ), "the append wrote through the hard link"
+    assert _mode(victim) == 0o644, "the victim's mode was changed"
+    assert _frame_record.recording_destination() == ""
+
+
+# ── never raises ─────────────────────────────────────────────────────────────
+
+
+def test_an_unwritable_destination_never_raises(monkeypatch, tmp_path):
+    """A recorder fault must not reach a reader loop.
+
+    In ``AcpRuntime._reader_loop`` an escaping exception ends EVERY multiplexed
+    session on the process, so a bad path has to degrade to a log line.
+    Pointing the destination at a FILE makes mkdir fail.
+    """
+    _clean(monkeypatch)
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("", encoding="utf-8")
+    _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(blocker))  # must not raise
+    assert blocker.read_text(encoding="utf-8") == ""
+    assert _frame_record.recording_destination() == "", "a failure must stand recording down"
+    _frame_record._reset_for_tests()
+
+
+def test_an_unknown_backend_stands_down_instead_of_raising(monkeypatch, tmp_path):
+    """Construction rejects an id outside ACP_BACKENDS_KNOWN, so this is a
+    programming error -- and the recorder still must not kill the reader."""
+    _clean(monkeypatch)
+    _frame_record.write_frame("no-such-backend", {"jsonrpc": "2.0"}, str(tmp_path))
+    assert list(tmp_path.iterdir()) == []
+    assert _frame_record.recording_destination() == ""
+    _frame_record._reset_for_tests()
+
+
+def test_a_failed_notifier_start_stops_the_writer_it_already_started(monkeypatch, tmp_path):
+    """``_Writer()`` starts two threads. If the second start fails, the first
+    must not be left running with no handle to stop it."""
+    _clean(monkeypatch)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    real_start = threading.Thread.start
+    started: list[threading.Thread] = []
+
+    def flaky(self):
+        if self.name == "acp-frame-recorder-notify":
+            raise RuntimeError("can't start new thread")
+        started.append(self)
+        real_start(self)
+
+    monkeypatch.setattr(threading.Thread, "start", flaky)
+    assert _frame_record.start_recorder() is False
+    assert _frame_record.recording_destination() == ""
+    assert len(started) == 1 and started[0].name == "acp-frame-recorder", started
+    started[0].join(timeout=5)
+    assert not started[0].is_alive(), "the writer thread outlived its failed constructor"
+
+
+def test_a_stand_down_racing_the_notifier_poll_is_never_lost(monkeypatch, tmp_path):
+    """The notifier polls the latch every 50 ms. A ``_stand_down`` arriving
+    while a poll holds the lock must still latch: the poll must not take the
+    lock when nothing is pending."""
+    _clean(monkeypatch)
+    taken: list[str] = []
+
+    class SpyLock:
+        def __init__(self):
+            self._lock = threading.Lock()
+
+        def acquire(self, *a, **k):
+            taken.append(threading.current_thread().name)
+            return self._lock.acquire(*a, **k)
+
+        def release(self):
+            self._lock.release()
+
+        __enter__ = acquire
+
+        def __exit__(self, *exc):
+            self.release()
+
+    monkeypatch.setattr(_frame_record, "_stand_down_lock", SpyLock())
+    for _ in range(20):
+        _frame_record._emit_pending_stand_down()
+    assert taken == [], f"the notifier took the latch lock with nothing pending: {taken}"
+    # And with a reason pending it is consumed exactly once.
+    monkeypatch.setattr(_frame_record, "_pending_stand_down", OSError("x"))
+    monkeypatch.setattr(_frame_record.logger, "warning", lambda *a, **k: None)
+    _frame_record._emit_pending_stand_down()
+    assert len(taken) == 1 and _frame_record._pending_stand_down is None
+
+
+def test_a_writer_thread_that_cannot_start_never_raises(monkeypatch, tmp_path):
+    """``Thread.start`` raises ``RuntimeError`` when the process is out of
+    threads; ``start_recorder`` must stand down, not propagate."""
+    _clean(monkeypatch)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+
+    def boom(self):
+        raise RuntimeError("can't start new thread")
+
+    monkeypatch.setattr(threading.Thread, "start", boom)
+    assert _frame_record.start_recorder() is False  # must not raise
+    assert _frame_record.recording_destination() == ""
+
+
+def test_teardown_does_not_block_on_a_full_queue(monkeypatch, tmp_path):
+    """``_reset_for_tests`` runs from the autouse fixture. With a bounded queue
+    a blocking ``put`` of the stop sentinel would hang pytest whenever a test
+    left the backlog full; the stop event and the polled ``get`` make the
+    thread exit on its own, and the join is bounded."""
+    _clean(monkeypatch)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    monkeypatch.setattr(_frame_record, "QUEUE_LIMIT", 2)  # before the queue is built
+    _frame_record.start_recorder()
+    gate = threading.Event()
+    started = threading.Event()
+
+    def held(*_a):
+        started.set()
+        gate.wait(timeout=10)
+
+    monkeypatch.setattr(_frame_record, "write_frame", held)
+
+    async def enqueue(ids):
+        for i in ids:
+            await _frame_record.record_frame("kas", {"id": i})
+
+    # One frame first, and wait until the drain thread has TAKEN it (it is now
+    # held on the gate); only then two more, which fill the queue (maxsize 2).
+    asyncio.run(enqueue([0]))
+    assert started.wait(timeout=5), "the drain thread never took the first frame"
+    asyncio.run(enqueue([1, 2]))
+    writer = _frame_record._writer
+    assert writer is not None, "no writer"
+    assert writer.queued == _frame_record.QUEUE_LIMIT, "the queue was not filled"
+    assert _frame_record.recording_destination() != "", "the fill overflowed"
+    gate.set()
+    done = threading.Event()
+
+    def reset():
+        _frame_record._reset_for_tests()
+        done.set()
+
+    threading.Thread(target=reset, daemon=True).start()
+    assert done.wait(timeout=15), "_reset_for_tests blocked on the full queue"
+    assert not writer.thread.is_alive()
+
+
+def test_no_recorder_thread_is_ever_started_from_the_event_loop(monkeypatch, tmp_path):
+    """``Thread.start()`` waits for the OS to schedule the new thread, which is
+    unbounded on a starved host, so no lazy scheme may pay it on a reader
+    loop. The writer is started by ``start_recorder`` before any loop exists;
+    ``record_frame`` only enqueues. Spy on EVERY thread start while a loop
+    records and assert none happened on the loop thread."""
+    _clean(monkeypatch)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder()
+    starts: list[tuple[int, str]] = []
+    real_start = threading.Thread.start
+
+    def spy(self):
+        starts.append((threading.get_ident(), self.name))
+        real_start(self)
+
+    monkeypatch.setattr(threading.Thread, "start", spy)
+
+    async def go():
+        loop_thread = threading.get_ident()
+        for i in range(3):
+            await _frame_record.record_frame("kas", {"jsonrpc": "2.0", "id": i})
+        return loop_thread
+
+    loop_thread = asyncio.run(go())
+    on_loop = [name for ident, name in starts if ident == loop_thread]
+    assert on_loop == [], f"threads started on the event loop: {on_loop}"
+    _frame_record._reset_for_tests()
+
+
+def test_recording_stands_down_if_the_recorder_was_not_started(monkeypatch, tmp_path, caplog):
+    """The env var set after import, with no ``start_recorder`` call: the
+    recorder must not start a thread from the loop to compensate. It stands
+    down with a line naming the entry point."""
+    _clean(monkeypatch)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+
+    async def go():
+        with caplog.at_level(logging.WARNING, logger=_frame_record.logger.name):
+            await _frame_record.record_frame("kas", {"jsonrpc": "2.0"})
+
+    asyncio.run(go())
+    assert _frame_record.recording_destination() == ""
+    assert "start_recorder" in caplog.text, caplog.text
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_two_keys_that_scrub_to_one_spelling_both_survive(monkeypatch, tmp_path):
+    """``/home/al/x`` and a literal ``~/x`` both scrub to ``~/x``; keeping the
+    last would silently drop a field from the recording."""
+    _clean(monkeypatch)
+    home = tmp_path / "home" / "al"
+    home.mkdir(parents=True)
+    monkeypatch.setattr(_frame_record.Path, "home", staticmethod(lambda: home))
+    frame = {f"{home}/x": 1, "~/x": 2}
+    out = json.loads(_frame_record.scrub_frame(frame))
+    assert sorted(out.values()) == [1, 2], out
+    assert "~/x" in out and "~/x#2" in out, out
+
+
+def test_two_event_loops_share_one_writer_and_one_byte_budget(monkeypatch, tmp_path):
+    """The two transports read on different threads and loops. A writer bound
+    to whichever loop recorded first would be replaced each time the other
+    loop recorded, so two writers would append to the same file at once and
+    each would count the byte budget from zero. One process-wide queue means
+    frames from both loops land in one file in arrival order, and the second
+    loop is held to the same backlog bound as the first.
+
+    Both loops here are wedged behind one gate so nothing is written while
+    the second loop enqueues; the byte cap is sized so that only the SUM of
+    the two loops' frames exceeds it."""
+    _clean(monkeypatch)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    _frame_record.start_recorder()
+    monkeypatch.setattr(_frame_record, "QUEUE_BYTES_LIMIT", 2560)
+    gate = threading.Event()
+    real_write = _frame_record.write_frame
+
+    def slow(backend, frame, dest):
+        gate.wait(timeout=10)
+        real_write(backend, frame, dest)
+
+    monkeypatch.setattr(_frame_record, "write_frame", slow)
+
+    def on_fresh_loop(ids):
+        async def go():
+            for i in ids:
+                await _frame_record.record_frame(
+                    "kas", {"jsonrpc": "2.0", "id": i}, wire_bytes=1024
+                )
+
+        asyncio.run(go())
+
+    try:
+        # Loop A: two frames, 2048 bytes, under the cap.
+        t = threading.Thread(target=on_fresh_loop, args=([0, 1],))
+        t.start()
+        t.join(10)
+        writer_after_a = _frame_record._writer
+        assert _frame_record.recording_destination() != ""
+        # Loop B: one more frame. 3072 bytes total; must trip the SHARED cap.
+        t = threading.Thread(target=on_fresh_loop, args=([2],))
+        t.start()
+        t.join(10)
+        assert _frame_record._writer is writer_after_a, "the second loop replaced the writer"
+        assert _frame_record.recording_destination() == "", "the byte budget was per-loop"
+    finally:
+        gate.set()
+    _frame_record._reset_for_tests()
+
+
+# ── wiring ───────────────────────────────────────────────────────────────────
+
+
+def test_the_recording_switch_is_scrubbed_from_agent_children(monkeypatch) -> None:
+    """Both spawn paths build the child env through
+    ``scrub_agent_subprocess_env``; the switch must not survive it, or a nested
+    Kiro Crew would record into the same per-backend file as this gateway."""
+    from kiro_crew.sandbox import scrub_agent_subprocess_env
+
+    env = {_frame_record.ENV_RECORD_FRAMES: "/somewhere", "PATH": "/usr/bin"}
+    scrubbed = scrub_agent_subprocess_env(env)
+    assert _frame_record.ENV_RECORD_FRAMES not in scrubbed
+    assert scrubbed["PATH"] == "/usr/bin"
+
+
+def test_both_transports_record_their_inbound_frames() -> None:
+    """The hook must sit in BOTH reader loops, or a backend records nothing.
+
+    ``AcpRuntime._reader_loop`` serves kiro-cli and KAS; ``AcpClient._read_message``
+    serves Claude Code and Codex. A hook in only one of them silently makes the
+    other two backends unrecordable, which is invisible until someone tries to
+    refresh their corpus.
+    """
+    for module in (runtime_module, client_module):
+        path = Path(module.__file__ or "")
+        source = path.read_text(encoding="utf-8")
+        assert "await record_frame(" in source, (
+            f"{path.name} does not await record_frame; the frames its backends read "
+            "cannot be recorded, or the call blocks the event loop"
+        )
+
+
+def test_the_recorder_is_classified_as_capture_side_not_egress() -> None:
+    """The recorder calls ``redact_text`` but writes to a local file, not a sink.
+
+    The posture census fails any redactor caller that is neither a registered
+    sink nor allowlisted; this pins WHICH bucket it is in, so a later move into
+    ``_REDACTION_SINKS`` (which would claim a transport that does not exist) is a
+    deliberate change rather than drift.
+    """
+    assert "acp/_frame_record.py" in security_posture.NON_EGRESS_REDACTION_MODULES
+    registered = {module for _label, module, _detail in security_posture._REDACTION_SINKS}
+    assert "acp/_frame_record.py" not in registered

--- a/test/test_acp_frame_record_provider_safety.py
+++ b/test/test_acp_frame_record_provider_safety.py
@@ -1,0 +1,523 @@
+"""PROVIDER SAFETY: the frame recorder can never take a live provider down.
+
+Read this file as the answer to one question: "does turning this change on, or
+having it misbehave, break any provider that is running right now?" Every test
+below drives a REAL ``AcpClient._read_message`` for EVERY known backend id --
+kiro-cli (``""``), ``kas``, ``claude``, ``codex`` -- and asserts that the frame
+still comes back as a ``JsonRpcMessage`` no matter what state the recorder is
+in. If one of these tests fails, a provider's reader loop would have raised or
+hung on a frame, and every session on that provider would have died with it.
+
+The states covered, each on every provider:
+
+* recorder OFF (the default for every ordinary run and every CI run) --
+  ``record_frame`` returns after one env lookup and the frame is untouched;
+* recorder ON and healthy -- the frame is delivered to the caller unchanged and
+  the recording is a side effect, never a dependency;
+* recorder ON but the writer thread never started -- stands down, frame flows;
+* recorder ON but the destination is unwritable -- stands down, frame flows;
+* recorder ON but the queue is full (count AND byte bound) -- drops, frame flows;
+* recorder ON but the writer thread is wedged on the filesystem -- the reader
+  does not wait on it, frame flows;
+* recorder already stood down -- zero work, frame flows;
+* ``record_frame`` itself raising an unexpected exception -- the reader loop
+  must NOT propagate it (defence in depth: the function is written never to
+  raise, and this pins that a future bug there still cannot reach a provider);
+* the backend id mapping to a corpus file name for every known backend, so a
+  ``KeyError`` cannot surface at write time for a real provider.
+
+Both reader paths are driven. ``AcpClient._read_message`` is the per-session
+reader; ``AcpRuntime._reader_loop`` is the MULTIPLEXED reader that every session
+on a provider shares, and it matters more: an exception escaping it lands in a
+catch-all that ``_mark_dead``s the runtime, taking every session on that
+provider down at once. So the runtime tests assert three things after each
+fault: the frame reached its session queue, the runtime is not dead, and the
+reader task is still running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="ACP frame recorder is Linux-only")
+
+from kiro_crew.acp import _frame_record  # noqa: E402
+from kiro_crew.acp.client import AcpClient, JsonRpcMessage  # noqa: E402
+from kiro_crew.acp.runtime import AcpRuntime  # noqa: E402
+from kiro_crew.acp.types import METHOD_SESSION_UPDATE  # noqa: E402
+from kiro_crew.acp_backends import ACP_BACKENDS_KNOWN, POLICY_ID_BY_BACKEND  # noqa: E402
+
+# Every backend id this build can construct a provider for. The empty string is
+# kiro-cli, and it is deliberately in the list: a test that forgot it would pass
+# while the default provider broke.
+PROVIDERS = sorted(ACP_BACKENDS_KNOWN, key=lambda b: (b == "", b))
+assert "" in PROVIDERS, "kiro-cli (backend id '') must be under test"
+assert len(PROVIDERS) >= 4, PROVIDERS
+
+WIRE_FRAME = {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {"sessionId": "s-1", "update": {"sessionUpdate": "agent_message_chunk"}},
+}
+
+
+def _client_with_wire(backend: str, frame: dict) -> AcpClient:
+    """An ``AcpClient`` for *backend* whose stdout holds exactly one JSON line.
+
+    No subprocess: ``_process.stdout`` is a real ``asyncio.StreamReader`` so
+    ``_read_message`` runs the genuine decode -> parse -> record -> return path.
+    """
+    client = AcpClient(acp_backend=backend)
+    reader = asyncio.StreamReader()
+    reader.feed_data((json.dumps(frame) + "\n").encode())
+    reader.feed_eof()
+    process = MagicMock()
+    process.stdout = reader
+    process.returncode = None
+    client._process = process
+    return client
+
+
+async def _read_one(backend: str, frame: dict = WIRE_FRAME) -> JsonRpcMessage:
+    """Push one frame through the provider's real reader path, bounded in time.
+
+    The 5s bound is the test's own guard against a reader that blocks: the
+    recorder must never make ``_read_message`` wait, so a timeout here IS the
+    failure this module exists to catch.
+    """
+    client = _client_with_wire(backend, frame)
+    msg = await asyncio.wait_for(client._read_message(timeout=5.0), timeout=5.0)
+    assert msg is not None, f"{backend or 'kiro-cli'}: frame was swallowed"
+    assert msg.method == frame["method"], msg
+    assert msg.params == frame["params"], msg
+    return msg
+
+
+class _LiveRuntime:
+    """An ``AcpRuntime`` for *backend* with a fake process and a live reader task.
+
+    Same shape as ``test_acp_runtime._make_runtime``: stdout is a real
+    ``asyncio.StreamReader``, so ``_reader_loop`` runs the genuine decode ->
+    record -> route path. ``feed`` pushes a frame; ``expect`` waits for it on
+    the session's queue and asserts the runtime survived.
+    """
+
+    def __init__(self, backend: str, session_id: str = "s-rt") -> None:
+        self.rt = AcpRuntime(work_dir="/tmp", acp_backend=backend)
+        self.reader = asyncio.StreamReader()
+        proc = MagicMock()
+        proc.stdout = self.reader
+        proc.stdin = MagicMock()
+        proc.stdin.write = MagicMock()
+        proc.stdin.drain = AsyncMock()
+        proc.returncode = None
+        proc.pid = 4242
+        self.rt._process = proc
+        self.rt._pid = 4242
+        self.rt._initialized = True
+        self.session_id = session_id
+        self.queue: asyncio.Queue = asyncio.Queue()
+        self.rt._session_queues[session_id] = self.queue
+        self.task: asyncio.Task | None = None
+
+    async def __aenter__(self) -> "_LiveRuntime":
+        self.task = asyncio.ensure_future(self.rt._reader_loop())
+        await asyncio.sleep(0)
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        assert self.task is not None
+        self.task.cancel()
+        try:
+            await self.task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    def feed(self, frame: dict | None = None) -> None:
+        frame = frame or dict(
+            WIRE_FRAME, params={**WIRE_FRAME["params"], "sessionId": self.session_id}
+        )
+        self.reader.feed_data((json.dumps(frame) + "\n").encode())
+
+    async def expect(self) -> JsonRpcMessage:
+        """The frame reached its session; the runtime and its reader survived."""
+        msg = await asyncio.wait_for(self.queue.get(), timeout=5.0)
+        assert msg.method == METHOD_SESSION_UPDATE, msg
+        assert not self.rt._dead, "runtime was marked dead by a recorder fault"
+        assert self.task is not None and not self.task.done(), "reader loop exited"
+        return msg
+
+
+def _runtime_frame(session_id: str, **extra_params) -> dict:
+    return dict(
+        WIRE_FRAME, params={**WIRE_FRAME["params"], "sessionId": session_id, **extra_params}
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_recorder(monkeypatch):
+    _frame_record._reset_for_tests()
+    monkeypatch.delenv(_frame_record.ENV_RECORD_FRAMES, raising=False)
+    yield
+    # Never leave a writer thread behind for the next test module.
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_frame_record.stop_for_tests())
+    finally:
+        loop.close()
+    _frame_record._reset_for_tests()
+
+
+# ── 1. OFF: the default state of every real deployment ──────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_provider_reads_frames_normally_with_the_recorder_off(monkeypatch, backend):
+    """PROVIDER SAFETY: with the env var unset (every ordinary run), each
+    provider's reader returns the frame and the recorder does no work at all."""
+    touched: list = []
+    monkeypatch.setattr(_frame_record, "_enqueue", lambda *a: touched.append(a))
+    monkeypatch.setattr(_frame_record, "write_frame", lambda *a: touched.append(a))
+    await _read_one(backend)
+    assert touched == [], f"{backend or 'kiro-cli'}: recorder did work while off"
+    assert not _frame_record._stood_down
+
+
+# ── 2. ON and healthy: recording is a side effect, never a dependency ────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_provider_reads_frames_normally_with_the_recorder_on(monkeypatch, tmp_path, backend):
+    """PROVIDER SAFETY: with recording on and healthy, the provider gets the
+    same frame back, and the recording lands as a side effect."""
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+    await _read_one(backend)
+    await _frame_record.flush_for_tests()
+    out = tmp_path / f"{POLICY_ID_BY_BACKEND[backend]}.jsonl"
+    assert out.exists(), f"{backend or 'kiro-cli'}: recording did not land"
+    assert json.loads(out.read_text().splitlines()[-1])["method"] == "session/update"
+    assert not _frame_record._stood_down
+
+
+# ── 3. ON but broken, every way it can break ────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_provider_survives_a_recorder_whose_thread_never_started(
+    monkeypatch, tmp_path, backend
+):
+    """PROVIDER SAFETY: env var set after import, ``start_recorder`` never
+    called. The recorder stands down; the provider's frame still flows."""
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record._writer is None
+    await _read_one(backend)
+    assert _frame_record._stood_down, "misconfiguration must stand the recorder down"
+    assert list(tmp_path.iterdir()) == []
+    # And every later frame on every provider still flows with zero work.
+    for other in PROVIDERS:
+        await _read_one(other)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_provider_survives_an_unwritable_destination(monkeypatch, tmp_path, backend):
+    """PROVIDER SAFETY: destination is a regular FILE, so the directory pin
+    fails on the writer thread. The provider never sees the error."""
+    bad = tmp_path / "not-a-dir"
+    bad.write_text("x", encoding="utf-8")
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(bad))
+    assert _frame_record.start_recorder() is True
+    await _read_one(backend)
+    await _frame_record.flush_for_tests()
+    assert _frame_record._stood_down
+    assert bad.read_text(encoding="utf-8") == "x", "the bad destination was modified"
+    await _read_one(backend)  # still flows after stand-down
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_provider_survives_a_full_queue_by_count(monkeypatch, tmp_path, backend):
+    """PROVIDER SAFETY: the backlog count bound is hit. The frame is dropped and
+    the recorder stands down; the provider's read returns normally."""
+    monkeypatch.setattr(_frame_record, "QUEUE_LIMIT", 0)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+    await _read_one(backend)
+    await _frame_record.flush_for_tests()
+    assert _frame_record._stood_down
+    await _read_one(backend)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_provider_survives_a_full_queue_by_bytes(monkeypatch, tmp_path, backend):
+    """PROVIDER SAFETY: the backlog BYTE bound is hit by one big frame. Dropped,
+    stood down, and the provider still gets its message."""
+    monkeypatch.setattr(_frame_record, "QUEUE_BYTES_LIMIT", 1)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+    big = dict(WIRE_FRAME, params={"sessionId": "s-1", "blob": "x" * 4096})
+    await _read_one(backend, big)
+    await _frame_record.flush_for_tests()
+    assert _frame_record._stood_down
+    await _read_one(backend)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_provider_never_waits_on_a_wedged_writer_thread(monkeypatch, tmp_path, backend):
+    """PROVIDER SAFETY: the writer thread is stuck inside the filesystem call.
+    The provider's read must return immediately -- a reader that waited here
+    would stall every multiplexed session on that provider."""
+    release = threading.Event()
+
+    def wedged_write(*_a, **_k):
+        release.wait(30)
+
+    monkeypatch.setattr(_frame_record, "write_frame", wedged_write)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+    try:
+        # Wedge the writer with a first frame, then time the next reads.
+        await _read_one(backend)
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if _frame_record._writer.in_flight:
+                break
+        started = time.monotonic()
+        for _ in range(50):
+            await _read_one(backend)
+        elapsed = time.monotonic() - started
+        assert (
+            elapsed < 2.0
+        ), f"{backend or 'kiro-cli'}: reader waited on the writer ({elapsed:.2f}s)"
+        assert not _frame_record._stood_down
+    finally:
+        release.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_provider_is_untouched_once_the_recorder_has_stood_down(
+    monkeypatch, tmp_path, backend
+):
+    """PROVIDER SAFETY: after a stand-down, recording costs one flag read and
+    the provider never reaches the enqueue path again."""
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+    _frame_record._stand_down(RuntimeError("simulated earlier fault"))
+    touched: list = []
+    monkeypatch.setattr(_frame_record, "_enqueue", lambda *a: touched.append(a))
+    await _read_one(backend)
+    assert touched == []
+    assert _frame_record.recording_destination() == ""
+
+
+# ── 4. Defence in depth: even a BUG in record_frame cannot reach a provider ──
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_provider_reader_does_not_propagate_an_unexpected_recorder_exception(
+    monkeypatch, tmp_path, backend
+):
+    """PROVIDER SAFETY (defence in depth): ``record_frame`` is written to never
+    raise. This pins the contract from the recorder's side -- an unexpected
+    exception inside ``_enqueue`` is caught and turned into a stand-down, so
+    the provider's frame still returns and nothing propagates into the loop."""
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+
+    def boom(*_a, **_k):
+        raise ZeroDivisionError("unexpected recorder bug")
+
+    monkeypatch.setattr(_frame_record, "_enqueue", boom)
+    await _read_one(backend)  # would raise ZeroDivisionError if not contained
+    assert _frame_record._stood_down
+    await _read_one(backend)
+
+
+# ── 4b. The MULTIPLEXED runtime reader: one fault here would kill every session ──
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_runtime_routes_frames_normally_with_the_recorder_off(monkeypatch, backend):
+    """PROVIDER SAFETY (runtime): env var unset, the shared reader loop routes
+    the frame to its session and the recorder does no work."""
+    touched: list = []
+    monkeypatch.setattr(_frame_record, "_enqueue", lambda *a: touched.append(a))
+    async with _LiveRuntime(backend) as live:
+        live.feed()
+        await live.expect()
+    assert touched == []
+    assert not _frame_record._stood_down
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_runtime_routes_frames_normally_with_the_recorder_on(monkeypatch, tmp_path, backend):
+    """PROVIDER SAFETY (runtime): recording on and healthy; the frame is routed
+    and the recording lands under the provider's corpus name."""
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+    async with _LiveRuntime(backend) as live:
+        live.feed()
+        await live.expect()
+    await _frame_record.flush_for_tests()
+    out = tmp_path / f"{POLICY_ID_BY_BACKEND[backend]}.jsonl"
+    assert out.exists(), f"{backend or 'kiro-cli'}: runtime recording did not land"
+    assert not _frame_record._stood_down
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_runtime_survives_a_recorder_whose_thread_never_started(
+    monkeypatch, tmp_path, backend
+):
+    """PROVIDER SAFETY (runtime): switch set, no writer started. Stand down;
+    the multiplexed loop keeps routing."""
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    async with _LiveRuntime(backend) as live:
+        live.feed()
+        await live.expect()
+        assert _frame_record._stood_down
+        live.feed()
+        await live.expect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_runtime_survives_a_full_queue(monkeypatch, tmp_path, backend):
+    """PROVIDER SAFETY (runtime): backlog full by count on the very first
+    frame. Dropped, stood down, runtime alive, frame routed."""
+    monkeypatch.setattr(_frame_record, "QUEUE_LIMIT", 0)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+    async with _LiveRuntime(backend) as live:
+        live.feed()
+        await live.expect()
+        await _frame_record.flush_for_tests()
+        assert _frame_record._stood_down
+        live.feed()
+        await live.expect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_runtime_never_waits_on_a_wedged_writer_thread(monkeypatch, tmp_path, backend):
+    """PROVIDER SAFETY (runtime): writer stuck in the filesystem call; the
+    shared loop must keep routing frames for every session without waiting."""
+    release = threading.Event()
+
+    def wedged_write(*_a, **_k):
+        release.wait(30)
+
+    monkeypatch.setattr(_frame_record, "write_frame", wedged_write)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+    try:
+        async with _LiveRuntime(backend) as live:
+            live.feed()
+            await live.expect()
+            started = time.monotonic()
+            for _ in range(50):
+                live.feed()
+                await live.expect()
+            elapsed = time.monotonic() - started
+            assert (
+                elapsed < 2.0
+            ), f"{backend or 'kiro-cli'}: runtime waited on the writer ({elapsed:.2f}s)"
+        assert not _frame_record._stood_down
+    finally:
+        release.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_runtime_does_not_die_on_an_unexpected_recorder_exception(
+    monkeypatch, tmp_path, backend
+):
+    """PROVIDER SAFETY (runtime, defence in depth): an exception escaping
+    ``record_frame`` would reach ``_reader_loop``'s catch-all and ``_mark_dead``
+    the runtime -- every session on this provider gone. The recorder contains
+    it; this pins that the runtime stays alive and keeps routing."""
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+
+    def boom(*_a, **_k):
+        raise ZeroDivisionError("unexpected recorder bug")
+
+    monkeypatch.setattr(_frame_record, "_enqueue", boom)
+    async with _LiveRuntime(backend) as live:
+        live.feed()
+        await live.expect()
+        assert _frame_record._stood_down
+        live.feed()
+        await live.expect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+async def test_runtime_recorder_fault_does_not_leak_across_sessions(monkeypatch, tmp_path, backend):
+    """PROVIDER SAFETY (runtime): the whole point of the multiplexed loop. A
+    recorder fault triggered by session A's frame must not cost session B its
+    next frame."""
+    monkeypatch.setattr(_frame_record, "QUEUE_LIMIT", 0)
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(tmp_path))
+    assert _frame_record.start_recorder() is True
+    async with _LiveRuntime(backend, "sA") as live:
+        q_b: asyncio.Queue = asyncio.Queue()
+        live.rt._session_queues["sB"] = q_b
+        live.feed(_runtime_frame("sA"))
+        await live.expect()
+        assert _frame_record._stood_down
+        live.feed(_runtime_frame("sB"))
+        msg = await asyncio.wait_for(q_b.get(), timeout=5.0)
+        assert msg.params["sessionId"] == "sB"
+        assert not live.rt._dead
+
+
+# ── 5. Every provider has a corpus file name ────────────────────────────────
+
+
+@pytest.mark.parametrize("backend", PROVIDERS, ids=lambda b: b or "kiro-cli")
+def test_every_known_provider_maps_to_a_corpus_file_name(backend):
+    """PROVIDER SAFETY: ``fixture_dir_name`` must not KeyError for any backend a
+    real provider can be built with. kiro-cli's id is ``""``, which is not a
+    filename, so the mapping is the thing to pin."""
+    name = _frame_record.fixture_dir_name(backend)
+    assert name and "/" not in name and name.strip() == name, (backend, name)
+
+
+def test_provider_set_under_test_matches_the_build():
+    """If a new backend id is added, this module must grow with it. A backend
+    that a provider can be constructed for but that is not under test here is a
+    provider whose reader loop this file says nothing about."""
+    assert set(PROVIDERS) == set(ACP_BACKENDS_KNOWN)
+    assert set(PROVIDERS) <= set(POLICY_ID_BY_BACKEND)
+
+
+# ── 6. Import-time: loading the module never raises, on or off ──────────────
+
+
+def test_importing_the_recorder_with_the_switch_unset_starts_nothing(monkeypatch):
+    """PROVIDER SAFETY: every provider imports ``_frame_record`` transitively
+    through ``acp.client``. With the switch unset, import-time
+    ``start_recorder()`` must be a no-op -- no thread, no stand-down."""
+    monkeypatch.delenv(_frame_record.ENV_RECORD_FRAMES, raising=False)
+    _frame_record._reset_for_tests()
+    assert _frame_record.start_recorder() is False
+    assert _frame_record._writer is None
+    assert not _frame_record._stood_down

--- a/test/test_acp_frame_record_windows.py
+++ b/test/test_acp_frame_record_windows.py
@@ -1,0 +1,47 @@
+"""The ACP frame recorder on Windows: one stand-down line, nothing written.
+
+Platform-neutral (``IS_POSIX`` is monkeypatched), so it runs on every CI
+runner, unlike ``test_acp_frame_record.py`` which is skipped off POSIX.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kiro_crew.acp import _frame_record
+
+
+@pytest.fixture(autouse=True)
+def _isolated_recorder(monkeypatch):
+    _frame_record._reset_for_tests()
+    monkeypatch.delenv(_frame_record.ENV_RECORD_FRAMES, raising=False)
+    yield
+    _frame_record._reset_for_tests()
+
+
+def _clean(monkeypatch):
+    _frame_record._reset_for_tests()
+    monkeypatch.delenv(_frame_record.ENV_RECORD_FRAMES, raising=False)
+
+
+def test_windows_stands_down_with_a_named_reason(monkeypatch, tmp_path, caplog):
+    """The recorder is POSIX-only: Windows cannot pin the destination by
+    descriptor (no ``dir_fd``/``O_NOFOLLOW``, DACL applied by path after the
+    open), so an owner-only recording cannot be guaranteed there. Setting the
+    env var on Windows must not raise into the reader, must write nothing, and
+    must say why in the one stand-down line."""
+    _clean(monkeypatch)
+    monkeypatch.setattr(_frame_record.platform_compat, "IS_POSIX", False)
+    dest = tmp_path / "frames"
+    monkeypatch.setenv(_frame_record.ENV_RECORD_FRAMES, str(dest))
+    with caplog.at_level(logging.WARNING, logger=_frame_record.logger.name):
+        assert _frame_record.start_recorder() is False, "a Windows process started a writer"
+        assert _frame_record._writer is None
+        # And the write path refuses on its own too, should it ever be reached.
+        _frame_record._stood_down = False
+        _frame_record.write_frame("kas", {"jsonrpc": "2.0"}, str(dest))
+    assert not dest.exists(), "a Windows process created the recording directory"
+    assert _frame_record.recording_destination() == ""
+    assert caplog.text.count("POSIX-only") == 2, caplog.text


### PR DESCRIPTION
## Problem / Motivation

PR #9161 adds a replay corpus of real ACP frames under `test/fixtures/acp_frames/`. Its README tells a human to make a new fixture by recording frames from a real backend. But nothing in the code records frames. The recorder was pulled out of #9161 by a maintainer ruling, because its first version wrote the recording with default file permissions.

## Why it matters

Without a recorder, the corpus can only be written by hand. A hand-written fixture pins what someone thinks the wire looks like, not what it does look like. The corpus is only worth trusting if it can be regenerated from a live backend.

## What changed (motivation → approach → change)

The goal is a switch a developer can flip to capture every inbound ACP frame, and that costs nothing when the switch is off. `KIROCREW_ACP_RECORD_FRAMES=<dir>` is that switch. When it is unset, which is every normal run and every CI run, the hook does one environment lookup and returns.

The recorder sits on the hot path of both reader loops (`AcpRuntime._reader_loop` and `AcpClient._read_message`). It must never make them wait and never raise into them. So `record_frame()` puts the frame on one bounded backlog and returns. The reader side takes no mutex it could wait on: the backlog is a `deque`, the two bounds (frame count and wire bytes) are checked under one lock that is only ever tried without blocking, and the append happens inside that same step so two loops cannot reorder each other's frames. A busy lock is treated like an overflow. When a frame is dropped on a reader loop, the warning that says so is not logged there either: it is latched and emitted by a small notifier thread that touches no file, so a writer wedged in a hung filesystem cannot hold the warning back. There is exactly one queue and one writer thread for the whole process, not one per event loop: the two transports read on different threads and loops, and a writer bound to whichever loop recorded first would be replaced each time the other recorded, leaving two writers appending to the same file with two separate byte budgets. The writer is its own daemon thread, not a job on the shared subprocess executor, so it cannot be starved by tool subprocesses or starve them. It is started once, at import time on the main thread, by `start_recorder()`, and never from a reader loop: `Thread.start()` waits for the OS to schedule the new thread, which is unbounded on a starved host, and every lazy scheme (an executor hop, a private bootstrap pool) still paid that once on the loop. If the switch is set after import without `start_recorder()` being called, recording stands down with a line saying so. The queue is bounded by frame count and by wire bytes. If it fills, the frame is dropped and recording turns itself off for the process. Any error does the same, with one log line. The switch is stripped from the environment of every agent child the gateway spawns, so a nested Kiro Crew cannot record into the same file. The test suite strips it too, in the repo-root `conftest.py` before any `kiro_crew` import, so a developer who runs the suite with a live recording configured does not get fake frames appended to their real corpus from any testpath.

Redaction happens before the frame is serialised. `scrub_frame` walks the parsed frame and scrubs every string leaf, keys included, so a secret is replaced inside its own JSON string and never across a quote or a comma. A header map with a bearer token stays a valid header map with `[REDACTED]` as the value. Two keys that scrub to the same spelling (`/home/al/x` and a literal `~/x`) are kept apart with a `#2` suffix so no field is lost. Scrubbing the text after `json.dumps` could match across the `"key": "value"` boundary and leave a line that no longer parses, which would corrupt the corpus the frame was recorded for.

The recording holds redacted transcripts, so it is owner-only on disk and lands where the operator said. The destination is pinned through `kiro_crew.pinned_fs`, the module the repo keeps that mechanism in: `pinned_fs.pin_parent` opens every component of the parent relative to the previous descriptor with `O_DIRECTORY | O_NOFOLLOW`, and the leaf is created 0700 and opened through that pinned parent. The recorder hands `pin_parent` the lexical parent it has just checked, never a re-resolved one, so a link swapped in after the check fails `O_NOFOLLOW` instead of being followed. What stays in the recorder is policy, not mechanism: the owner/mode/ACL checks on the descriptor, a lexical-vs-physical comparison that refuses a destination already crossing a link (the env var is where the operator said transcripts sit, so a link there is refused rather than followed), and the file-side checks. A directory that already existed is checked, never changed: it must be owned by this user and grant nothing to group or other, or the recorder refuses it. An earlier draft tightened any directory to 0700, which would lock every other intended user out of a directory the operator shares on purpose. The file is opened relative to that descriptor with `O_NOFOLLOW`, opened non-blocking so a planted FIFO cannot wedge the writer, refused if it is not a regular file, refused if it was unlinked between open and append (`st_nlink == 0`, the write would vanish on close), refused if it is owned by another user (the same rule the directory is held to; an `fchmod` 0600 on a foreign-owned inode locks it to that owner, who then reads every frame), refused by `pinned_fs.refuse_hardlink_alias` if it is a planted hard link, and `fchmod`ed 0600. The mode is not the whole story: a 0700 directory can carry a POSIX ACL granting another account, and a file created inside inherits the directory's default ACL, which `fchmod` does not touch. So the directory descriptor (pre-existing or just created), and the file descriptor before it is tightened, are each checked with `listxattr` for `system.posix_acl_access` / `system.posix_acl_default` and refused if either is present, with the log line naming `setfacl -b` or a fresh path as the fix; a filesystem with no xattrs at all (`ENOTSUP`) has no ACLs and is accepted. Linux is the only platform that exposes ACLs through the xattr API CPython binds, so the recorder is Linux-only: macOS passes the POSIX gate but cannot prove the destination is owner-only, and `start_recorder` stands down there before any thread is started, the same way it does on Windows. Nothing on the way to the frame is resolved by name through a link, so a link swapped in at any ancestor cannot redirect the recording. When a component is refused because it is a link, the one log line names it and points at the physical path, since on macOS `/tmp` and `/var` are links.

The recorder is POSIX-only. Windows has neither `dir_fd` nor `O_NOFOLLOW`, and its DACL lockdown is applied by path after the open, so every check there leaves a window in which another account can swap a directory or hold an open handle. Review found four such windows in a row. Rather than ship a guarantee that holds on one platform and is best-effort on the other, a Windows process with the env var set stands down once with a log line saying so. The corpus is regenerated on a POSIX host. The corpus README stays with #9161, which owns the corpus.

## Tests

`test/test_acp_frame_record.py`, 147 tests (skipped on Windows), plus `test/test_acp_frame_record_windows.py`, 1 platform-neutral test that a Windows process stands down with the reason named, plus `test/test_acp_frame_record_provider_safety.py`, 70 tests that answer one question for EVERY known backend id (kiro-cli, kas, claude, codex): can the recorder ever take a live provider down? They drive both reader paths -- the per-session `AcpClient._read_message` and the multiplexed `AcpRuntime._reader_loop`, where an escaping exception would `_mark_dead` the runtime and every session on it -- with a frame on a fake stdout, and assert the frame still comes back (and, for the runtime, reaches its session queue with the runtime alive and the reader task still running, and a fault on session A does not cost session B its next frame) with the recorder off, on and healthy, never started, pointed at an unwritable destination, full by count, full by bytes, wedged inside the filesystem call (the read returns in well under a second), already stood down, and with `record_frame` itself raising an unexpected exception (contained, never propagated). A mutant that lets `record_frame` re-raise fails 24 of them across all four providers, 12 on each reader path. Off by default: unset and blank env write nothing; a blank destination never resolves to the CWD. Never waits: the write runs on a non-loop thread; no recorder thread is ever started from the event loop (every `Thread.start` is spied during a recording loop); recording stands down, naming `start_recorder`, if the writer was never started; two event loops share one writer and one byte budget; a full queue does not block test teardown; `record_frame` returns while the writer is wedged; a full queue (by count and by bytes) drops and stands down; released bytes are not double-counted. Never raises: an unwritable destination, an unknown backend, and a dead executor all stand down instead of raising; one failure logs once and discards the backlog; eight concurrent stand-downs log once. Owner-only: fresh recordings are 0700/0600; a pre-existing owner-only directory that carries a POSIX ACL (access or default) is refused, a leaf this run created that inherited a default ACL is refused, a recording file with an ACL is refused and left with its mode untouched, a recording file owned by another user is refused and left with its mode untouched, an `ENOTSUP` filesystem is accepted, and a platform that cannot inspect ACLs stands down without starting a thread; a pre-existing directory that is not owner-only (world, group-only, or other-only bits) is refused and left as it was; an owner-only one is reused and a loose file inside is tightened; the lockdown is by descriptor, not path. Home scrubbing replaces only a whole path component, so `/home/al` leaves `/home/alice/x` alone. Links: a linked leaf is refused with its target untouched; a linked ancestor is refused; an ancestor swapped for a link AFTER the lexical check is refused (a mutant that re-resolves the parent before pinning fails it); a `..` component cannot climb out through a link; a planted symlink, a planted hard link (in a 0700 directory, so the alias check and not the mode check is what refuses), a target unlinked between open and append, and a planted FIFO inside the directory are all refused, and a failure inside the hard-link helper closes the recording descriptor exactly once, the FIFO without blocking (and the FIFO test cannot wedge pytest, its worker is a daemon and a reader is opened on the way out); a refused link component is named in the stand-down line. Redaction: a credential inside a header map is replaced and the written line still parses as JSON; a credential nested inside a list or a deeper container under a sensitive key is still replaced (every enclosing key is carried down, so an inner `value` key does not hide an outer `Authorization`); any value, string or numeric, under a key whose canonical name ends in a credential noun (`Authorization`, `Cookie`, `accessToken`, `SLACK_BOT_TOKEN`, `clientSecret`, `password`, `apiKey`, `otp`, `pin`, npm's `_auth`, `proxyAuth`, ...) is replaced whatever it looks like, so `Authorization: Basic <base64>` is caught even though no shape detector knows it; usage counters (`inputTokens`, `max_tokens`), pagination cursors (`NextToken`), bare `code` fields and an `oauth` configuration block (its `clientId`, `issuer`, `scopes`) are not touched; a header written as a name/value pair (`[{"name": "Authorization", "value": "Basic ..."}]`, or a two-item `["Authorization", "Basic ..."]`, whatever the type of the second item) has its value replaced and its name kept; a secret used as a dict KEY under a credential-named ancestor (`{"Authorization": {"Basic ...": true}}`) is replaced too, while identifier-like sub-keys such as `value` or `expires_in` there are kept, so the recording still says where the value lived; many keys collapsing to one scrubbed spelling are suffixed in linear time, and the credential-bearing name lends context only to the pair's value fields, not to siblings like `enabled`; free text inside a leaf is scrubbed by the shared shape redactor only, guessing labels inside prose is that redactor's job and not a second engine here; colliding scrubbed keys both survive. Never waits, again: a busy backlog lock drops and stands down instead of blocking; a reader-side stand-down is logged from the notifier thread, even while the writer is wedged; a failed second thread start does not leak the first. Wiring: the env var is scrubbed from agent children; both transports await `record_frame`; the recorder is classified capture-side in `security_posture`.

## Manual verification

N/A — unit coverage sufficient. Every property is pinned by a test that fails when its guard is removed.

## Related Issues

no linked issue: follow-up to #9161 by maintainer ruling in that review; no tracked issue exists for the recorder.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
