### PR TITLE
fix(autonudge): make an armed auto-nudge loop readable via monitor_inspect

### DIFF
--- a/src/kiro_crew/dashboard/handlers/autonudge.py
+++ b/src/kiro_crew/dashboard/handlers/autonudge.py
@@ -115,6 +115,35 @@ def _serialize_monitor(loop: Any) -> dict[str, Any]:
     return _serialize(loop)
 
 
+def _autonudge_loop_reading(loop: Any) -> dict[str, Any]:
+    """Project a plain auto-nudge loop into a bounded, agent-oriented status.
+
+    This is the reading #9194 asks for: enough to answer "is a loop armed on
+    this session, and is it firing" from inside the session, which
+    ``monitor_inspect`` previously could not do for an auto-nudge loop (it only
+    ever described the structured monitor, so an armed auto-nudge loop and no
+    loop at all both read as ``monitor: None``).
+
+    Only presence, cadence and progress fields are surfaced. The loop's
+    ``message`` is agent-controlled free text and is NOT included — it is not
+    needed to verify arming, and leaving it out keeps this read narrow.
+    """
+    return {
+        "id": loop.id,
+        "active": bool(loop.active),
+        "idle_secs": loop.idle_secs,
+        "max_cycles": loop.max_cycles,
+        "cycle_count": loop.cycle_count,
+        "max_runtime_secs": loop.max_runtime_secs,
+        "gate": bool(loop.gate),
+        "last_fire_ts": loop.last_fire_ts,
+        "created_ts": loop.created_ts,
+        "next_due_ts": loop.next_due_ts,
+        "stopped_reason": loop.stopped_reason,
+        "has_banner": bool(loop.banner),
+    }
+
+
 def _monitor_error(message: str, code: str, *, status: int = 400) -> web.Response:
     response = web.json_response({"error": message, "code": code})
     response.set_status(status)
@@ -299,8 +328,23 @@ async def api_session_monitor_get(request: web.Request) -> web.Response:
     if svc is None:
         return web.json_response({"enabled": False, "monitor": None})
     loop = svc.get_by_slot(binding)
-    if loop is None or not is_structured_monitor_loop(loop):
-        return web.json_response({"enabled": True, "monitor": None})
+    if loop is None:
+        # Nothing is armed on this session. This is the ONLY case that reads as
+        # "not armed", and it is now DISTINCT from an armed auto-nudge loop below
+        # — the two were previously collapsed into an identical ``monitor: None``,
+        # which is the observability gap #9194 reports: a caller could not tell an
+        # accepted-and-armed loop from an accepted-and-dropped request.
+        return web.json_response({"enabled": True, "monitor": None, "autonudge_loop": None})
+    if not is_structured_monitor_loop(loop):
+        # A plain auto-nudge loop IS armed. ``monitor`` stays None because a
+        # structured monitor genuinely does not exist, but ``autonudge_loop``
+        # now carries a truthful presence/cadence/progress reading so the caller
+        # can verify arming instead of being told "do not assume" with no
+        # instrument. The loop's free-text ``message`` is deliberately omitted:
+        # this reading answers "is it armed and firing", not "what does it say".
+        return web.json_response(
+            {"enabled": True, "monitor": None, "autonudge_loop": _autonudge_loop_reading(loop)}
+        )
     monitor = loop.monitor
     assert monitor is not None
     return web.json_response(
@@ -309,6 +353,7 @@ async def api_session_monitor_get(request: web.Request) -> web.Response:
             "active": bool(loop.active),
             "monitor_id": loop.id,
             "monitor": _redact_monitor_value(monitor_state_public_dict(monitor)),
+            "autonudge_loop": None,
         }
     )
 

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -1249,6 +1249,12 @@ def monitor_inspect(name: str, args: dict[str, Any]) -> str:
 def _compact_monitor_inspection(result: dict[str, Any]) -> dict[str, Any]:
     """Project the browser record into a bounded, agent-oriented status."""
     compact = {key: result.get(key) for key in ("enabled", "active", "monitor_id") if key in result}
+    # Surface the auto-nudge loop reading (#9194) so a caller can tell an armed
+    # auto-nudge loop from nothing armed. It is already a bounded, fixed-key dict
+    # from the handler, so it passes through as-is; absent on responses that
+    # predate the field, and None when no loop is armed.
+    if "autonudge_loop" in result:
+        compact["autonudge_loop"] = result.get("autonudge_loop")
     raw = result.get("monitor")
     if not isinstance(raw, dict):
         compact["monitor"] = None

--- a/test/test_autonudge_handlers_cov80.py
+++ b/test/test_autonudge_handlers_cov80.py
@@ -913,3 +913,80 @@ async def test_delete_of_an_unknown_loop_is_audited_as_a_noop(
     kwargs = sel_mock.log_tool_invocation.call_args.kwargs
     assert kwargs["outcome"] == "noop"
     assert kwargs["session_key"] == ""
+
+
+# --- #9194: an armed auto-nudge loop must read as armed, distinct from none ---
+
+
+def _authed_session_monitor_request() -> web.Request:
+    return _mk(
+        "GET",
+        "/api/autonudge/session-monitor",
+        headers={"X-Session-Key": "dashboard:chat-1-111"},
+        internal_auth=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_monitor_read_reports_no_loop_as_not_armed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session with NOTHING armed reads as not armed.
+
+    This is the negative case #9194 turns on: a loop that did not arm must be
+    distinguishable from one that did. Here no loop exists at all.
+    """
+    _svc(monkeypatch, _FakeSvc([]))
+
+    payload = _body(await h.api_session_monitor_get(_authed_session_monitor_request()))
+
+    assert payload["monitor"] is None
+    assert payload["autonudge_loop"] is None
+
+
+@pytest.mark.asyncio
+async def test_session_monitor_read_reports_armed_autonudge_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain auto-nudge loop reads as armed via ``autonudge_loop``.
+
+    Previously this collapsed to ``monitor: None`` — identical to the no-loop
+    case above — which is the observability gap the issue reports.
+    """
+    loop = _loop(slot_key="chat-1-111")
+    loop.cycle_count = 4
+    loop.last_fire_ts = 123.0
+    loop.message = "keep driving PR 42"  # agent-controlled: must NOT be echoed
+    _svc(monkeypatch, _FakeSvc([loop]))
+
+    payload = _body(await h.api_session_monitor_get(_authed_session_monitor_request()))
+
+    # The structured monitor genuinely does not exist, so that stays None...
+    assert payload["monitor"] is None
+    # ...but the auto-nudge loop is now readable, and the reading is distinct
+    # from the no-loop case (a dict, not None).
+    reading = payload["autonudge_loop"]
+    assert reading is not None
+    assert reading["id"] == loop.id
+    assert reading["active"] is True
+    assert reading["idle_secs"] == 300
+    assert reading["cycle_count"] == 4
+    assert reading["last_fire_ts"] == 123.0
+    # The free-text instruction is not surfaced by this presence reading.
+    assert "message" not in reading
+    assert "keep driving PR 42" not in json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_session_monitor_read_structured_monitor_carries_null_autonudge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A structured monitor keeps its authoritative reading; autonudge_loop null."""
+    loop = _monitor_loop(slot_key="chat-1-111")
+    _svc(monkeypatch, _FakeSvc([loop]))
+
+    payload = _body(await h.api_session_monitor_get(_authed_session_monitor_request()))
+
+    assert payload["monitor_id"] == loop.id
+    assert payload["monitor"]["target"] == "https://github.com/acme/widgets/pull/7"
+    assert payload["autonudge_loop"] is None

--- a/test/test_monitor_mcp.py
+++ b/test/test_monitor_mcp.py
@@ -224,3 +224,56 @@ def test_monitor_inspect_reports_internal_read_failure_as_error():
         result = control.monitor_inspect("monitor_inspect", {})
 
     assert result == "Error: Monitor inspection failed: gateway unavailable"
+
+
+def test_monitor_inspect_surfaces_armed_autonudge_loop():
+    """#9194: monitor_inspect must let a caller see an armed auto-nudge loop.
+
+    The gateway reports ``monitor: None`` (no structured monitor) together with
+    a truthful ``autonudge_loop`` reading; the compact projection must pass that
+    reading through so the caller can tell armed-auto-nudge from nothing armed.
+    """
+    with (
+        patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value="dashboard:chat-1-1"),
+        patch(
+            "kiro_crew.mcp_core._get",
+            return_value={
+                "enabled": True,
+                "monitor": None,
+                "autonudge_loop": {
+                    "id": "lp-9",
+                    "active": True,
+                    "idle_secs": 300,
+                    "cycle_count": 4,
+                    "last_fire_ts": 123.0,
+                },
+            },
+        ),
+    ):
+        result = control.monitor_inspect("monitor_inspect", {})
+
+    payload = json.loads(result)
+    assert payload["monitor"] is None
+    assert payload["autonudge_loop"] == {
+        "id": "lp-9",
+        "active": True,
+        "idle_secs": 300,
+        "cycle_count": 4,
+        "last_fire_ts": 123.0,
+    }
+
+
+def test_monitor_inspect_reports_no_loop_distinctly_from_armed():
+    """The no-loop reading carries ``autonudge_loop: None``, distinct from armed."""
+    with (
+        patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value="dashboard:chat-1-1"),
+        patch(
+            "kiro_crew.mcp_core._get",
+            return_value={"enabled": True, "monitor": None, "autonudge_loop": None},
+        ),
+    ):
+        result = control.monitor_inspect("monitor_inspect", {})
+
+    payload = json.loads(result)
+    assert payload["monitor"] is None
+    assert payload["autonudge_loop"] is None


### PR DESCRIPTION
## Problem / Motivation

`monitor_inspect` cannot tell an armed auto-nudge loop apart from a session with nothing armed. Both read as `{"enabled": true, "monitor": null}`. The read endpoint `api_session_monitor_get` (dashboard/handlers/autonudge.py) resolved the loop bound to the session and then collapsed two distinct states into one:

```python
loop = svc.get_by_slot(binding)
if loop is None or not is_structured_monitor_loop(loop):
    return web.json_response({"enabled": True, "monitor": None})
```

A plain auto-nudge loop (`monitor is None`) took the same branch as no loop at all. `monitor_start` and `monitor_watch` return request receipts that explicitly say "do not assume it armed", but for an auto-nudge loop there was no in-session instrument to check, so a caller following that advice records a working loop and stops watching. Verified against main `915344ee9`; the accept strings and the `monitor: null` mechanism are as reported in #9194 and confirmed by the sibling re-triage on the issue.

## Why it matters

The observability gap is asymmetric. For a structured monitor `monitor_inspect` is authoritative: `monitor: null` after a turn boundary genuinely means "did not arm". For an auto-nudge loop the same reading said nothing, so the same class of automation had a verifiable arm on one path and an unverifiable arm on the other. A silently-dropped arming request then looks identical to a working one, which is how a patrol can go quiet for hours before anyone notices.

## What changed

`api_session_monitor_get` now distinguishes three states instead of two, chained from the symptom (indistinguishable readings) to the root cause (the `loop is None or not is_structured_monitor_loop(loop)` collapse):

- No loop: returns `{"monitor": null, "autonudge_loop": null}`. This is the only state that reads as not-armed, and it is now distinct from an armed auto-nudge loop.
- Plain auto-nudge loop: returns `{"monitor": null, "autonudge_loop": {...}}`, a bounded presence/cadence/progress reading (`id`, `active`, `idle_secs`, `max_cycles`, `cycle_count`, `max_runtime_secs`, `gate`, `last_fire_ts`, `created_ts`, `next_due_ts`, `stopped_reason`, `has_banner`). `monitor` stays `null` because a structured monitor genuinely does not exist. The loop's free-text `message` is deliberately not surfaced: this read answers "is it armed and firing", not "what does it say", so it adds no new leak surface.
- Structured monitor: unchanged authoritative reading, now carrying `autonudge_loop: null`.

`monitor_inspect`'s compact projection (`mcp_tools/control.py`) passes `autonudge_loop` through so the caller sees it. No gate change: `monitor_inspect` already reaches the endpoint for exactly the dashboard/Slack/Discord sessions that can host an auto-nudge loop, and the read is behind the same internal-secret plus session-binding authorization it always was. No security surface is touched.

This does not change what `monitor_start`/`monitor_watch` return, and it does not change arming. It gives the caller the instrument the issue says is missing, so not-armed is now verifiable rather than assumed.

## Tests

Changed test files only, at `-n0`:

- `test/test_autonudge_handlers_cov80.py`: no-loop reads not-armed (`autonudge_loop: null`); an armed auto-nudge loop reads as a distinct dict and does not echo the free-text `message`; a structured monitor keeps its authoritative reading with `autonudge_loop: null`.
- `test/test_monitor_mcp.py`: `monitor_inspect` surfaces the `autonudge_loop` reading through the compact projection, and the no-loop reading is distinct from the armed one.

58 passed. Mutation-verified by hand at three enforcement sites, each reddening on a distinct assertion: reverting the armed branch to `null` reddens `assert reading is not None`; making the no-loop branch return non-null reddens `assert autonudge_loop is None`; dropping the compact passthrough reddens with `KeyError: 'autonudge_loop'`. The negative case (a loop that did not arm) is the one this issue turns on, and it is pinned. `black --target-version py310`, `isort`, `flake8` and `mypy` clean on the changed files. `merge-tree` clean against main `915344ee9`.

## Pattern harvest

Defect class: an observability read collapsed two semantically different states ("nothing armed" and "an armed loop of a kind this reader does not describe") into one indistinguishable value, so a receipt that could not fail was mistaken for a confirmation. The fix splits the branch and surfaces a bounded, identity-first reading of the previously-invisible state, and its negative branch (not-armed) is tested: a verification path whose failing branch is untested is exactly the defect being fixed.

Rule candidate: when a status read returns the same "absent" value for a genuinely-absent subject and for a present-but-different-typed one, treat that as a defect, not a convenience -- split the states and make the failing/negative branch of the reader independently testable.

Field note (a live check of this exact behaviour): while babysitting this PR, an observation-gated auto-nudge loop was armed on the driving session and fired on schedule, but between two quiet cycles it delivered no wake for 18 minutes because gating suppresses unchanged cycles by design. The loop was healthy; what was absent was any external signal of that. From an observer's side a healthy-but-quiet gated loop and a loop that silently failed to arm are the same observation -- which is this issue one level up. It was resolved out-of-band by re-arming ungated so liveness was visible each interval. This is evidence that the missing instrument matters in practice, not only in the reported incident.

Closes #9194
