### PR TITLE
feat(aws-control): the crew container image and its runtime

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -65,7 +65,6 @@
 2 test/test_browser_recording_skill.py
 1 test/test_build_desktop_launcher_symlink.py
 1 test/test_build_desktop_rm_resilient.py
-1 test/test_ci_surface_tests.py
 1 test/test_cli.py
 2 test/test_cli_lazy_imports.py
 2 test/test_cli_manifest_signature.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1405,6 +1405,85 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+  backend-test-crew-container:
+    name: Backend Tests (crew container)
+    needs: [await-fast-gate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            setup.cfg
+            src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/requirements.txt
+
+      # Two installs, deliberately not merged into one resolution.
+      #
+      # `-e .` and the dev group are what every other backend lane installs, and this
+      # suite needs them for a reason that is not obvious: no container test imports
+      # `kiro_crew`, but the repo-root conftest's autouse isolation fixtures do
+      # (`importlib.import_module("kiro_crew.apps")`), so a venv without the package
+      # errors at test SETUP rather than at collection. Measured: 233 errors, every
+      # one a ModuleNotFoundError on a transitive app dependency.
+      #
+      # The image's own runtime pins come from `container/requirements.txt` and are
+      # installed ONLY here. That file's header forbids them becoming dependencies of
+      # the application ("the app's backend hooks are imported into every owner's
+      # gateway process, and a web framework there buys nothing"), which is exactly
+      # why this cannot be folded into the `backend-test` shards: their environment IS
+      # the application's.
+      #
+      # Not `container/requirements-dev.txt`, which is the file the review named. It
+      # carries `-r requirements.txt`, pytest and pytest-asyncio and nothing else,
+      # while this rootdir's addopts pass `-n auto --dist loadgroup
+      # --max-worker-restart=2 --timeout=120`; with no xdist and no pytest-timeout
+      # installed that is an argument error, not a test run. Its `pytest==8.3.4` also
+      # contradicts the dev group's `9.0.3` that the rootdir conftest is written
+      # against, so the two sets cannot share one resolution. The image build still
+      # uses that file; CI installs the runtime half plus this repo's own toolchain.
+      - name: Install dependencies
+        run: |
+          uv pip install --system -e "." --group dev
+          uv pip install --system -r \
+            src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/requirements.txt
+
+      # CREW_CONTAINER_TESTS_REQUIRED is the point of this job, not a detail of it.
+      # The suite's conftest answers a missing image dependency with
+      # `collect_ignore_glob`, which takes the WHOLE suite out of collection while the
+      # run still reports success. Under this variable every reason it would decline to
+      # collect becomes a hard error, and the collection is additionally checked against
+      # the tree: every module that defines tests must yield at least one, and the total
+      # must clear a floor. So a dependency rename reds THIS lane instead of quietly
+      # restoring a lane that reports success while collecting nothing.
+      #
+      # `-n0`: the suite forks real process trees and binds real ports, so xdist
+      # workers would race each other for both. It runs in about ten seconds serially,
+      # which is less than the workers cost to start.
+      #
+      # `--no-cov` for the same reason as the sibling sandbox lane: this data is not
+      # part of the coverage gate's combine, and half-reported coverage is worse than
+      # none.
+      - name: Run the crew container suite
+        env:
+          CREW_CONTAINER_TESTS_REQUIRED: "1"
+        run: |
+          # As in backend-test (#7296): the `python` matcher annotates any traceback
+          # in the log, including one printed inside a warning, and never matches a
+          # pytest failure.
+          echo "::remove-matcher owner=python::"
+          pytest -q -n0 --timeout=180 --no-cov \
+            src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/
+
   coverage-combine:
     name: Coverage Combine
     needs: [backend-test, changes]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -68,3 +68,26 @@ recursive-include src/kiro_crew/deploy/skills *
 # published Linux wheel ships a vendored llama_cpp that cannot load its own
 # shared library and in-process embeddings fail at gateway startup.
 recursive-include src/kiro_crew/_vendor/llama_cpp_libs *
+# The AWS Control crew container image's build context, re-included AFTER the excludes
+# for the same reason as the block above, and it is the ORDERING that does the work here.
+# `python -m build` builds the wheel from the SDIST, so a file absent from this file is
+# absent from every published wheel whatever `package_data` in setup.cfg says. The tree
+# holds Dockerfiles, `requirements*.txt`, CONTRACT.md and a vendor placeholder, none of
+# which any pattern above reaches: `*` does not cross a path separator, so
+# `recursive-include src/kiro_crew/apps *.md` matches nothing under `crew/runtime/`
+# beyond `.md`, and the Dockerfiles have no extension at all.
+#
+# Without these lines the image builds from a source checkout and silently cannot build
+# from an installed copy, with nothing raising at install time to say so.
+#
+# Three rules naming what the image needs, not one `recursive-include <runtime> *`. That
+# one also carried `container_tests/` -- a 4,000 line suite of the image's own tests --
+# into every sdist and so into every wheel and DMG, where nothing can run it: those
+# tests exercise a Linux container's supervisor, and the machine that installed the app
+# never runs that container. Written as an allowlist rather than the broad rule plus a
+# `prune`, because a `prune` here would be the last exclude in the file and would put
+# every rule above it back out of scope -- distutils applies these in file order, which
+# is the same reason this block sits at the end.
+recursive-include src/kiro_crew/apps/builtins/aws_control/crew/runtime Dockerfile*
+recursive-include src/kiro_crew/apps/builtins/aws_control/crew/runtime/container *
+recursive-include src/kiro_crew/apps/builtins/aws_control/crew/runtime/vendor *

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -294,6 +294,7 @@ Every job here is blocking. Every job that costs real runner time also `needs:`
 | `backend-test-windows-fail-closed` | windows-latest, single `-n0` run of `test/test_windows_fail_closed_optin.py` BY NODE ID with the pass count grepped, so a silent skip cannot go green. It is the only lane that boots a real gateway and drives one ACP prompt turn on Windows, against real filesystem state instead of a `sys.platform` mock: the pair of assertions [PR #8117](https://github.com/kirodotdev/KiroCrew/pull/8117) broke and no test could see |
 | `backend-test-macos` | macos-15 (pinned label, not `macos-latest`), 3 shards, `--no-cov`, 180s per-test timeout. The full suite, same shape as the Windows line. It shipped scoped to a 51-file glob while the darwin gap list was burned down; that list is `test/macos-expected-failures.txt` now and the glob is gone, so a POSIX-but-not-Linux regression outside those 51 files can no longer land unseen. 3 shards rather than Windows' 4 because macOS bills at 10x Linux per minute |
 | `backend-test-sandbox` | The one job that clears the AppArmor userns restriction, so the tests guarded by `skipif(not userns_available())` EXECUTE instead of skipping. Runs all eleven sandbox-dependent suites. The shards collect the same files — nothing is deselected — but there the sandbox-guarded tests skip, so this is the only lane where those 85 assertions (the `~/.kiro/crew` keystone among them) actually execute |
+| `backend-test-crew-container` | "Backend Tests (crew container)". The only lane that runs the crew container image's suite (`aws_control/crew/runtime/container_tests/`, 327 tests). It is separate from the shards because it installs the image's own runtime pins (`container/requirements.txt`: fastapi, uvicorn, httpx, boto3), which that file's header forbids becoming dependencies of the application, and the shards' environment IS the application's, so there the suite's conftest collects nothing. Sets `CREW_CONTAINER_TESTS_REQUIRED=1`, which turns every reason that conftest would decline to collect into a hard error and checks the collection against the tree |
 | `coverage-combine` then `coverage-gate` | Combines the 3.12 shard data, then enforces the project line-rate floors, plus a per-file floor with a shrink-only baseline (all floors live in the job's `env:` block). **CodeBuild-hosted runner** (pilot, below) except for forks |
 | `frontend-lint` | `tsc -b`, `eslint` under a hard-zero warning ceiling, `jscpd`, and `npm run i18n:check` |
 | `electron-test` | The Electron shell's own node:test suite (`website/electron`) |
@@ -424,6 +425,18 @@ Details worth knowing:
   namespace, the job fails instead of letting the suite silently skip and the gate
   go green having asserted nothing. This is what gives the `hooks.py`
   sensitive-path keystone real CI coverage.
+- **`backend-test-crew-container` cannot go green by skipping.** Installing the
+  image's runtime dependencies in a dedicated lane fixes one instance of the
+  problem; the mechanism that caused it, a conftest that answers a missing
+  dependency with `collect_ignore_glob`, so 226 tests read as present while
+  executing zero times, survives any dependency rename or extras split. So the lane
+  that installs them also sets `CREW_CONTAINER_TESTS_REQUIRED=1`, and under that
+  variable the suite refuses to skip: a missing dependency or a non-POSIX host is a
+  collection error, every `test_*.py` that defines a test function must contribute at
+  least one collected item, and the total must clear a floor read off a real
+  collection. The variable can only ever turn a skip into a failure, never the
+  reverse, so setting it can hide nothing. This is the same shape as
+  `backend-test-sandbox`'s `unshare` probe, moved inside the instrument.
 - **`coverage-gate` is fail-closed, and the split made that load-bearing.** It runs
   `if: always()` and its first step converts any non-success upstream result into an
   explicit failure, because GitHub treats a **skipped** required check as satisfied.

--- a/docs/request-for-change/rfc-remote-instance-on-fargate.md
+++ b/docs/request-for-change/rfc-remote-instance-on-fargate.md
@@ -1,13 +1,13 @@
 ---
 title: Remote Instance on Fargate
-status: draft
+status: in-progress
 kind: framework
 author: Raymond Chen (chenmingwei23)
 created: 2026-09-07
-last-audited: 2026-09-07
-audited-at: 424efa423
+last-audited: 2026-09-12
+audited-at: bf09e50e5
 doc-pr:
-implementation-prs: []
+implementation-prs: [9223]
 tracking-issues: []
 supersedes: []
 superseded-by: []
@@ -144,7 +144,26 @@ one is an API call, not a deployment.
 persists between the two except what the crew was told to write elsewhere.
 
 **No service, no load balancer.** Nothing needs to be reconciled to a desired
-count, and nothing needs a listener.
+count, and no traffic is distributed across tasks. The task is addressed
+directly.
+
+**The channel into the task is a front process in the task.** Decided, not open.
+The image runs a small HTTP front on port 8080 that receives a turn and forwards
+it to the crew's own gateway over loopback; reaching that port is an authorised
+call in the owner's own account, and the task is not published to the internet and
+has no external DNS name. Two routes answer without the control secret, a turn
+endpoint and a liveness check; every other path requires `SMC_CONTROL_SECRET`. The
+front layer's contract is
+[aws-control](../system-specs/modules/aws-control.md).
+
+The option not taken was a port-forward into the task with no listener at all,
+which is what EC2 remote instances use. It was rejected for this phase because the
+product this backend exists to deliver is "deploy a crew and chat with it": an
+endpoint delivers that now, and the front process is where further endpoints are
+added, while the port-forward path needs a Fargate target format and task-role
+messaging permissions established first. It stays available as a second phase; the
+cost of the choice is stated in section 6 under "the registry, the tunnel, and the
+relay", and in section 7.
 
 ### What it plugs into
 
@@ -192,7 +211,11 @@ Naming these explicitly, because a new compute backend is a good opportunity to
 change things that should not change.
 
 **Authorisation is IAM.** Reaching a remote crew is an authorised call in the
-owner's own account. There is no second principal and no new authentication path.
+owner's own account. There is no second principal. There is one new
+authentication path, and it is small and inward-facing: the task's front process
+requires `SMC_CONTROL_SECRET` on every route except the two customer ones, so the
+owner's control plane can be told apart from a turn. It authorises nothing about
+who the caller is; IAM still decides that, before the call reaches the task.
 
 **Credentials live in the CLI's own store on the remote compute.** This is the
 property EC2 remote instances already have, and a session that expires is what
@@ -203,9 +226,25 @@ introduces a long-lived credential.
 makes a remote crew reachable by anyone else, and no design here should assume a
 second caller might appear later.
 
-**The registry, the tunnel, and the relay.** A Fargate-backed remote crew appears
-where an EC2-backed one appears. If it does not, this RFC has failed at its main
-purpose, which is adding a backend rather than a parallel feature.
+**The registry, the tunnel, and the relay.** These are unchanged in themselves,
+and a Fargate-backed crew does not appear in them in this phase. That is a change
+of purpose from an earlier draft of this section, which said a Fargate-backed
+crew appears wherever an EC2-backed one appears and called anything less a
+failure of the RFC's main purpose. It is stated as a change rather than softened,
+because it is one.
+
+A Fargate-backed crew is reached through its own front process in the task (see
+section 4), not through the relay surfaces an EC2-backed crew uses. The trade:
+the product this backend exists to deliver is "deploy a crew and chat with it",
+one endpoint satisfies that, and the front process is where further endpoints are
+added. Reusing the relay surfaces instead would mean making them work against a
+target format they do not have today, on a task whose role does not carry
+messaging permissions, before anything is chattable at all. Parity with those
+surfaces stays a goal and becomes later work; it is no longer this phase's
+success criterion. What would make this the parallel feature the earlier wording
+feared is a SECOND way to reach a crew that never converges -- so the front
+process is the one channel for a Fargate-backed crew, and the relay work, when it
+happens, reaches it rather than going around it.
 
 ## 7. Security considerations
 
@@ -230,9 +269,12 @@ need to be answered.
 ### What does not change
 
 Still one principal, still IAM, still the owner's own account, still credentials
-in the CLI's store on remote compute with the same lifetime rules. No inbound
-path is added and no data is shared between two parties, because there is only
-one party.
+in the CLI's store on remote compute with the same lifetime rules. One inbound
+path is added, and its shape is the point: a listener in the task on port 8080
+serving exactly two routes without the control secret, a turn endpoint and a
+liveness check, with everything else refused unless the caller holds
+`SMC_CONTROL_SECRET`. No data is shared between two parties, because there is
+still only one party.
 
 ## 8. Migration plan
 
@@ -337,14 +379,6 @@ the problem, and a turn is not reliably short enough to fit the execution limit.
 the thing this RFC is trying to remove.
 
 ## 11. Open questions
-
-**How the channel into the task works.** A task can be reached through an
-IAM-authorised endpoint, or through a port-forward into the task with no listener
-at all. The second is what EC2 remote instances already do, and reusing it is what
-would let a Fargate-backed crew appear in the existing relay surfaces without new
-plumbing. It needs verifying on Fargate before phase 1 commits to it: the target
-format differs from an instance id, and the task role needs messaging permissions
-it does not receive by default.
 
 **Sign-in inside a task.** The EC2 flow runs an interactive login on the host and
 scrapes the device-code prompt. The equivalent inside a task needs to be

--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -105,7 +105,7 @@ agent loads only the one it needs.
 | Spec | Subsystem |
 |---|---|
 | [papyrus.md](papyrus.md) | The Papyrus writing app. |
-| [aws-control.md](aws-control.md) | The AWS account portal and S3-backed cloud drive app: accounts, Drive/Library/Backup, consent and confirmation guards, sharing. |
+| [aws-control.md](aws-control.md) | The AWS account portal and S3-backed cloud drive app: accounts, Drive/Library/Backup, consent and confirmation guards, sharing, and the crew container runtime a remote crew runs as. |
 | [command-bar.md](command-bar.md) | The opt-in launcher that replaces quick-search: the overlay seam, the request-free root, ranking and scopes. |
 | [pptx-maker.md](pptx-maker.md) | Deck generation. |
 | [meetings.md](meetings.md) | Meeting capture and summarization. |

--- a/docs/system-specs/modules/aws-control.md
+++ b/docs/system-specs/modules/aws-control.md
@@ -682,3 +682,395 @@ backup archive's `remoteError`) travels as the notice's message under the
 localised lead, so the hand-off carries the text AWS returned.
 `DrivePage.test.tsx::error surfaces reach the agent`,
 `AwsControlPage.test.tsx::edge states`, and `ConsoleView.test.tsx` pin these.
+
+## The crew container runtime
+
+`crew/runtime/` is the source of a Linux container image, not code the owner's
+gateway runs. It is what a remote crew runs AS: a supervisor that orders and
+watches the task's processes, a front process that receives a turn, and Kiro
+Crew's own backend executing it. The design of record is
+[rfc-remote-instance-on-fargate](../../request-for-change/rfc-remote-instance-on-fargate.md).
+
+The tree is a docker build context and deliberately not a Python package:
+`crew/runtime/` has no `__init__.py`, its modules import each other as top-level
+`container.*` because that is what they are inside the image, and
+`test_spawn_audit.py::test_container_image_assets_are_not_imported` pins that the
+gateway never imports it. Three repo-level audits exempt it by shape for that
+reason: the spawn audit (`_is_container_image_asset`), the MCP secret-caller scan,
+and the hardcoded-agents-dir ratchet.
+
+Its tests live in `container_tests/`, run only by the `backend-test-crew-container`
+lane in `ci.yml` (see [ci-and-reviews](../../ci/ci-and-reviews.md)), and are
+excluded from `setup.cfg`'s `package_data` and from `MANIFEST.in`, so a user's
+wheel and DMG carry the image's build context and not its test suite.
+`test_crew_runtime_payload.py` pins both directions.
+
+### Three processes, one task
+
+| Process | Owns | Exposure |
+|---|---|---|
+| Supervisor | process order, the crew bundle install, the container's own config, teardown | no listener; it is the task's init process |
+| Front | receiving a turn, stripping any route prefix, forwarding over loopback | the only listener, port 8080 |
+| Kiro Crew backend | sessions, conversations, transcripts, MCP, subagents, skills, memory | loopback only (`127.0.0.1`, not configurable) |
+
+Nothing serves a user interface. `config_dir` equals `data_home`: the gateway's
+`config_dir()` and `data_home()` resolve to the same directory, so
+`session_map.json` and `open_slots.json` sit at the home root, and the supervisor
+refuses to start when the two disagree, because a backend writing to one path
+while the deployment points at another loses the record of which conversations
+existed.
+
+The startup order is a correctness requirement rather than a preference:
+
+1. Gate the environment (path layout, model credential, sandbox) and install the
+   crew bundle. Nothing has started.
+2. Write the container's own configuration. It must land after the bundle, because
+   a bundle may ship config and the container's posture has to win on the keys it
+   sets, and before the backend, which reads the file at boot.
+3. Start the backend. `wait_until_ready` returns only when the port answers **and**
+   the boot secret file exists; process-alive is not ready.
+4. Start the front process.
+
+There is no backup sidecar and no restore phase. Durability across task
+replacement is a capability the container does not have; the front still fetches a
+slot's transcript from S3 on demand, so `SMC_BACKUP_BUCKET`/`SMC_BACKUP_PREFIX`
+name where it reads. When durability returns it must reinstate the ordering rule
+that made it correct -- a restore must finish before the backend starts, because
+the backend's periodic flush persists its in-memory slot table and a flush landing
+before the restore completes writes an empty set over the record of which
+conversations existed.
+
+### The front layer
+
+Two customer routes and nothing else. Everything is classified once, on the path
+AFTER any configured route prefix is stripped, because classifying the prefixed
+path let a control route read as a customer route in an earlier build:
+
+| Route | Auth | What it does |
+|---|---|---|
+| `POST /v1/chat/completions` | none of its own | one turn, forwarded to the backend |
+| `GET /health` | none of its own | liveness; `{"status": "ok"}` and no internals |
+| everything else | `SMC_CONTROL_SECRET` in `X-SMC-Control-Secret` | 404: no control operation is served yet |
+
+Both outcomes of the control-authorization decision are recorded before the response is
+sent -- the grant as well as the deny, because a trail holding only grants records exactly
+the events nobody needed to investigate, and the deny is what answers who tried. **A
+decision that cannot be recorded is not acted on**: the request gets a 503
+`control_audit_unavailable` rather than the 403 or the 404 it would otherwise get, because
+serving the grant would be the unaudited grant the record exists to prevent, and serving
+the deny would leave a denial nobody can later account for. 503 rather than 403 says the
+failure is the container's, not the caller's.
+
+The record mirrors `kiro_crew.sel` -- the `SecurityEvent` field names, its `event_type`
+vocabulary (`tool_approval` / `tool_denial`), and the audit-or-deny discipline
+`log_tool_invocation(critical=True)` exists for -- and is mirrored rather than called
+because of the SINK, not importability. The wheel is installed in this image, so
+`kiro_crew.sel` would import; what does not survive the move is where SEL keeps its log.
+`sel._default_dir()` resolves under `config_dir()` with the HMAC key in `trust/` beside
+it, which here means the persistent volume, and the supervisor and the model worker run as
+the same user -- so the audited party could delete both and write a self-consistent
+replacement, and there is no trust root in the container to anchor a chain. Nothing
+harvests that file either: the container's only writer to the owner's bucket is the
+transcript store. So the record goes to the process log stream, which leaves the task as
+it is written. It carries no `prev_hash` or `entry_hash`, because claiming SEL's integrity
+fields for an unchained line would assert a property the record does not have. Durability
+of that stream is the task definition's log driver, which belongs to the deploy track
+rather than to this image.
+
+No header value is ever recorded -- not the control secret, not any other header -- so
+what the record says is only whether the header was presented.
+
+**The sink is the container's own, and `emit` refuses when a record would not be
+delivered.** This is a different shape of defect from the rest of this document: the guard
+above is present, its logic is right, and it does refuse when it should -- but under
+uvicorn's own logging configuration a module logger in this process resolves to an
+effective level of WARNING with no reachable handler, and `logging.lastResort` sits at
+WARNING too, so an INFO audit call writes zero bytes. A dropped record is not an error, so
+nothing raised, the audit-or-deny path never fired, and every control decision was acted
+on with no record -- in production only, since a test session has a root handler. A guard
+that is live only where it is not needed cannot be told from no guard.
+
+Two halves, both load-bearing. `configure_sink()` attaches an INFO-capable handler that
+this module owns, called from `build_app` rather than from the process entrypoint so that
+an app which can serve a request has one -- a lazy "configure on first emit" would let
+whichever request arrives first decide whether the audit works. And `emit` checks that a
+record would actually reach a handler before writing it, which is what stops a later
+logging change from switching the audit off silently. The check is not
+`logger.hasHandlers()`: that ignores the logger's effective level and every handler's own
+level, so it answers yes for a logger whose only reachable handler is at WARNING, which is
+exactly the arrangement that drops an INFO record.
+
+`/health` is registered twice, prefixed and bare, so liveness can be probed
+without knowing the crew's prefix. The route prefix is optional and empty by
+default; nothing in this repository sets `SMC_ROUTE_PREFIX`, and a wrong value
+fails closed because a path that does not strip to one of the two customer routes
+is control and is refused.
+
+The control gate sits IN FRONT of the 404 rather than behind it. Adding a control
+route is then adding a handler rather than also remembering to authorise it, and
+an unauthorised caller cannot learn which control paths exist by reading which
+ones 404. `_control_authorized` fails closed when no control secret is configured
+and compares in constant time, on bytes rather than `str`, because
+`hmac.compare_digest` raises `TypeError` on a non-ASCII `str` and a caller could
+otherwise turn a 403 into an unhandled 500.
+
+**How an endpoint gets added.** Decide first whether it is a customer route or a
+control route, because that decision is the security boundary and not a detail of
+registration. A customer route is added to the allowlist that `gateway` checks and
+inherits no authentication of its own, so it must be safe for anyone who can reach
+the port; a control route needs only a handler, since the gate already refuses
+without the secret. Either way the path is matched on the STRIPPED path, and the
+turn path stays the only route that accepts a caller-supplied conversation id.
+
+**Authorisation, and what this process cannot do.** Reaching port 8080 is an
+authorised call in the owner's own account, decided before the request arrives; the
+task is not published to the internet and has no external DNS name. That decision's
+result is not passed through to the front process, so it has no caller identity to
+bind a forwarded conversation id to, and a binding written against an absent
+identity would fail open. What it does instead is refuse to serve customer turns at
+all unless the deployment has declared `SMC_SINGLE_PRINCIPAL`, which is the RFC's
+one-owner invariant made explicit and enforced at startup rather than assumed. The
+refusal is at startup for the reason `require_api_key` refuses at startup: a
+container that answers its port while mixing two callers' conversations looks
+healthy and is not.
+
+### The loopback hop
+
+The front forwards to the gateway's own `POST /v1/chat/completions` with
+`{model, messages, id, stream}`, returning one JSON completion or an SSE stream.
+`model` is set from the DEPLOYED crew name and never copied from the payload, and
+`id` is the slot id, which is what continues a conversation.
+
+Facts the front must respect, each established by reading the gateway's source and
+each wrong once in a way that produced no error:
+
+- **Authenticate with `X-Internal-Secret`, read from disk on EVERY attempt.** The
+  boot secret is `os.urandom(16)` per boot and is never persisted, so a cached copy
+  works until the backend restarts and then 403s on every request in a way that
+  looks like a client fault. On a 403 the front re-reads the secret once and retries
+  once, then relays the failure.
+- **Do not forward the client's `Origin` or any `X-Forwarded-*` header.** Loopback
+  with no Origin is trusted by the gateway's CSRF check and a forwarded foreign
+  Origin trips it. Outbound headers are built from scratch rather than copied and
+  stripped, so a header the caller sends cannot reach the backend by accident.
+- **A busy slot answers 409.** Requests for one slot id are serialised in the front
+  process rather than surfacing 409 to the caller.
+- **The stream is OpenAI-format, not ACP.** Completion chunks, keepalives, a
+  terminal sentinel and an error object, with no event names at all. The ACP
+  `sessionUpdate` vocabulary lives on the owner control stream, which this process
+  does not serve, so the projection is keyed on frame shape and is fail-closed: a
+  kind added later is dropped rather than relayed.
+- **Readiness proves less than it looks like.** A backend with no model credential
+  answers its port and then returns `503 kiro_prerequisite_required` on every turn,
+  so a present `KIRO_API_KEY` is not a working one and only a real turn establishes
+  that it is.
+
+A restored transcript is bounded by SIZE as well as by shape. The bytes come from the
+bucket and are held in memory for the length of a turn, so without a ceiling one stored
+object decides how much memory the task uses. `ContentLength` is checked first and then
+not trusted -- a header is a claim by the source -- and the read is streamed in chunks
+against the same 64 MiB ceiling, one chunk past it so an object of exactly that size can
+be told from a larger one. The refusal is a `TranscriptUnavailable`, so an oversized
+object fails that turn rather than letting the backend serve one with the conversation
+missing.
+
+### Launching the backend
+
+Verified names only, because the plausible ones are read by nothing:
+`KIROCREW_BIND=127.0.0.1` (the published image sets `0.0.0.0`, and a deployment
+that does not override it puts the backend on the network while every local test
+still passes); `KIROCREW_HOME` equal to `SMC_DATA_HOME`, which is what makes the
+boot secret path resolve; `KIROCREW_TELEMETRY_DISABLED=1` to silence the beacon;
+`--no-crons`, because arming the scheduler fires any overdue job immediately; and
+`--approval yolo`, which the gateway refuses unless `KIROCREW_HOME` is explicitly
+non-default. Nothing in the container is there to click Approve, so an interactive
+prompt would be an indefinite stall rather than a question, and the cost is stated
+plainly: every tool the crew carries is auto-approved for whatever a caller's
+message causes it to do. The boot update check cannot be disabled by config; it is
+recorded as an outbound request the deployment makes rather than suppressed.
+
+**The container serves no messaging channel, and disables them positively.** Before
+the backend starts, the supervisor writes `<config dir>/config.json` with every
+channel section's `enabled` false, merged over anything already there so a shipped
+file cannot outvote it, and the launch environment carries no channel credential.
+Both halves are required and neither covers the other's case: `imessage` and
+`whatsapp` carry no credential in the gateway's channel registry, so they start on
+their config flag alone, and `slack` has no `enabled` key at all, so it starts on
+its tokens alone. Both name lists are ratcheted against that registry in both
+directions by `test_crew_container_config_isolation.py` -- a channel the gateway
+can start that the container does not disable fails, and so does a name the gateway
+does not have, because that reads as coverage while doing nothing.
+
+**The backend environment drops what the worker must not hold.** The task role
+(`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` and its peers) and the front's
+`SMC_CONTROL_SECRET` are removed: the backend spawns the model subprocess with this
+environment, that subprocess auto-approves every tool, and a turn could otherwise
+read the task role from its own environment and act as it. `KIRO_API_KEY` cannot be
+removed, because kiro-cli re-injects it into the worker and it is the whole
+model-auth mechanism.
+
+**A reinstall replaces the bundle's own files and prunes nothing else.**
+`install_bundle` runs at every boot and the data home may be a persistent volume, so
+the skills install has two jobs that pull against each other: a skill a later bundle
+DROPPED must not stay active, and a skill the running crew created must not be
+deleted. Replacing the whole tree satisfies the first and violates the second, so the
+two sets are separated. The bundle-managed set is derived from the tree in the image
+layer, which needs no trust and cannot be forged by the crew; the marker records that
+set so the NEXT install can prune exactly what this one installed. Pruning is per
+FILE, not per directory, because a directory can hold both the bundle's file and the
+crew's. When the marker is absent, hand-edited or from an older build, the previous
+set is unknown and NOTHING is pruned: a stale skill an operator can delete is a
+smaller harm than the crew's work disappearing silently, and the log says which of the
+two happened. A symlink at a bundle-managed path is unlinked before that file is
+written -- a pointer is not work, and its target is never opened -- while a link at the
+skills ROOT is still refused outright, since that one redirects the whole install.
+
+**The install marker is authenticated, because it lives where the crew can write.**
+The record the prune reads sits in the data home, so its contents are an INPUT and not
+state this code owns; constraining what the list may contain does not change that. It
+carries an HMAC tag keyed on `SMC_CONTROL_SECRET` -- the one value the supervisor holds
+that the worker provably does not, since `build_backend_env` removes it from the
+environment the backend is launched with and the worker inherits that environment.
+Relocating the marker instead is not available: the image runs the supervisor and the
+worker as the same user, so no directory on the persistent volume is writable by one and
+not the other, and a location in the read-only image layer cannot record what a previous
+task installed, which is the marker's whole purpose. Every untrusted case -- no tag, a
+tag that does not verify, no control secret to verify with -- prunes nothing and is
+logged as itself, because "the tag is wrong" and "there is no marker" are different
+things to be told.
+
+**Every directory the container creates on that volume refuses rather than crashes.**
+`mkdir(exist_ok=True)` raises `FileExistsError` when a regular file holds the path, and a
+previous task can leave one where a skill directory belongs. Uncaught, that crashes the
+supervisor, ECS restarts the task, and the next boot hits the same file on the same
+volume -- a boot loop that spends the owner's money and never says what is wrong. A boot
+loop is worse than a refusal for the reason a crash is worse than a refusal, so each
+directory goes through one helper that names the path it could not create.
+
+**The prune's bound is in the code, not in the record.** The marker lives in the data
+home, which the crew can write, so what it says is an INPUT: an absolute entry, a
+non-normalised one, one carrying `..`, or a clean-looking one whose parent is a symlink
+would each turn "delete the bundle's own file" into "delete a file of the entry's
+choosing". Pruning from a recorded list is narrower than replacing the tree and would
+be strictly worse if the list decided where the deleting happens.
+
+So the bound is enforced twice. Any entry that is not a plain relative path is refused
+by name, and one bad entry discards the WHOLE record rather than only itself: a
+malformed entry means the record is corrupt or hostile, which says nothing good about
+the entries beside it, so the install falls back to pruning nothing and logs an error.
+It does not fail the boot, because refusing to start over a corrupt bookkeeping file
+would be a worse outcome than the residue. Then each deletion walks descriptors from
+the skills directory with `O_NOFOLLOW | O_DIRECTORY` and unlinks relative to the last
+one, so a component swapped for a symlink is refused by the kernel as it is traversed
+and the directory verified is the directory deleted from -- there is no window in which
+the path is re-resolved by name. A resolved-containment check runs first as well, not
+because the walk needs it but because it turns "this entry leaves the tree" into its
+own named refusal instead of a bare `ELOOP`. The leaf's own type is read by `lstat` on
+that descriptor, so a link at the recorded path is left alone rather than followed.
+
+**A transcript entry that is not a file is refused, not opened.** Boot restores no
+transcripts, so what is on disk was put there by an earlier turn or by the restore,
+and the restore's bytes and keys come from the backup bucket -- names and files from
+outside the container. Before the backend is handed a path it will open and append to,
+the entry's shape is checked: a directory, a FIFO, a socket, a symlink or a
+hard-linked file is refused by name with `TranscriptUnavailable`, which fails that one
+turn. A crash mid-turn on whatever `open()` raises would be worse, because a refusal
+is auditable and a crash is not.
+
+Shape is decided on the DESCRIPTOR, never on the name. `Path.exists()` follows a
+symlink, answers true for a directory, and is a separate resolution from the open that
+follows it, so a check by name plus an open by name is the check-to-use gap every
+finding in this area lives in. The probe opens with the link refused and `O_NONBLOCK`
+(a FIFO open would otherwise wait for a writer and hang the turn rather than answer),
+then `fstat`s that descriptor, so the entry validated is the entry that was opened.
+`st_nlink > 1` is refused as well as a non-regular type, because a hard link is a
+regular file and the backend appends to this path. This mirrors
+`hooks.safe_read_file_bytes_nolink`, which the container cannot import, the way
+`supervisor/bundle.py` mirrors the agents-dir resolver. The write side refuses a
+symlinked sessions directory for the same reason `mkdir(exist_ok=True)` cannot be
+trusted, and still installs by `os.link` so an existing target is never clobbered.
+
+A publish COLLISION goes through the same check. `os.link` failing means the entry the
+turn will use is not the one just written and has had none of these checks applied to
+it, so the winner is validated by the same helper before it is accepted. Keeping it is
+still right when it is a transcript -- whoever wrote it has the newer history -- and a
+shape that fails the check fails that turn rather than being handed to the backend.
+
+**The container writes the sandbox settings rather than inheriting them.** The
+gateway reads `agent.sandbox` and two unsandboxed-fallback flags from the same
+`config.json`, so a file supplied to the task could turn the sandbox off while the
+supervisor's refusal reported nothing wrong. All three are forced -- `sandbox` to
+`auto`, both flags to false -- and forcing rather than defaulting matters because
+`sandbox_allow_unsandboxed_exec` resolves an undeclared value through a platform
+default, so silence is not a constant. The rule is by PREFIX rather than by that list
+of three: `test_crew_container_config_isolation.py` requires every `AgentConfig`
+field whose name begins with `sandbox` to appear in `FORCED_AGENT_SETTINGS`, with the
+value checked as well as the key, so a sandbox knob added to the gateway reds CI
+until the container decides what to write for it.
+
+**The config is published atomically.** The file's failure is in the future: nothing
+reads it during the write, and a truncated write is read at the NEXT start, on a
+container that boots on a config it cannot parse and with the run that produced it
+already gone. So the write is a sibling temp in the destination's own directory
+opened `O_EXCL | O_NOFOLLOW`, fsynced, then one `os.replace`, with the directory
+fsynced after so the rename itself survives a power loss. A symlink at the
+destination is refused rather than replaced: `rename` would unlink the link rather
+than follow it, so nothing would be written through it, but a link there means
+something else chose the path and consuming it silently hides that.
+
+**A link planted where the boot secret goes stops the task.** The gateway writes
+`run/gateway-<port>.secret` itself, with an ordinary link-following open, and
+truncates it on every start; the model worker can write inside the data home and
+what it writes is driven by prompt content. Nothing in the container can make the
+gateway's writer link-safe, so the supervisor refuses to start when the run
+directory or the secret path is a symlink, or when the secret path is not a regular
+file. The checks are `lstat`-based, because `exists()` follows the link they are
+looking for. The container's own writes into the data home already refuse a link at
+the destination (`bundle._write_nofollow`); this is the same guard for a file
+another process writes.
+
+### Sandboxed-only, and why there is no opt-in
+
+kiro-cli runs the model subprocess inside an unprivileged user namespace, and
+without one `wrap_argv` fails closed. This container runs SANDBOXED-ONLY: there is
+deliberately no config key or environment variable that opts into unsandboxed
+execution, and the supervisor refuses to start on a host that cannot provide the
+sandbox rather than running the worker exposed.
+
+The refusal is positive. The probe returns an available verdict, a denied verdict,
+or an `undetermined: <why>` verdict, and only the first proceeds: undetermined
+refuses and names what could not be determined, and so does any verdict the guard
+does not recognise. Reading "could not determine" as "probably fine" fails open as
+new hosts appear, which is the same defect as reading the environment through a
+denylist.
+
+Why no opt-in, and why the task boundary is not a substitute for one: the model
+subprocess auto-approves every tool and its environment carries `KIRO_API_KEY`, so
+an unsandboxed worker would run an auto-approved shell, driven by untrusted prompt
+content, with a live credential readable in its own environment. The ECS task
+boundary (one owner, one data home, no public endpoint, reached only by an
+authorised call in the owner's own account) does not close that path, because the
+attacker there is the caller's own prompt content, already inside the boundary.
+Offering an unsandboxed posture safely requires brokering the model credential out
+of the worker's environment, which is tracked separately; until then the worker is
+sandboxed or the container does not start. Unprivileged user namespaces are not
+available on Fargate today
+([aws/containers-roadmap#2102](https://github.com/aws/containers-roadmap/issues/2102)),
+so the supported target is a host that permits them.
+
+### Shutdown
+
+A kiro-cli worker spawns with `start_new_session`, so it `setsid`s into its own
+process group and ESCAPES a `killpg` on the backend. Only the backend's own SIGTERM
+handling reaps it, which makes the drain window load-bearing rather than a
+courtesy: too short a drain SIGKILLs the backend before it finishes reaping and
+orphans a worker that goes on to finish its turn. Teardown order is front, then
+backend -- stop new turns arriving, then let the backend drain and flush -- and
+anything still alive afterwards is an escaped worker, which the teardown sweeps by
+process group over bounded rounds, because a killed process's children reparent to
+PID 1 and surface in the next round.
+
+The exit code distinguishes the two reasons, because it is the only thing the
+platform reads: a stop signal is the one success case, and any other reason,
+including one this code cannot account for, exits non-zero. Reporting both as 0
+told ECS that a crash loop was a clean shutdown.

--- a/setup.cfg
+++ b/setup.cfg
@@ -214,6 +214,24 @@ exclude =
 [options.package_data]
 kiro_crew =
     py.typed
+    # The AWS Control crew container image's build context: the Dockerfiles, the
+    # container's own source and requirements, its CONTRACT.md and the vendor
+    # placeholder. Each is read FROM DISK when the image is built, and `crew/` is not
+    # one of the fixed directory names below -- `*` does not cross a path separator, so
+    # an `apps/builtins/*/runtime/**/*` entry would not reach
+    # `aws_control/crew/runtime/`. Without these lines the tree works from a source
+    # checkout and is absent from every pip and DMG install, with nothing raising.
+    #
+    # Three entries naming what the image needs, rather than one `runtime/**/*` that
+    # takes the whole tree. The broad glob also shipped `container_tests/` -- a 4,000
+    # line suite of the image's own tests -- to every user's wheel and DMG, where
+    # nothing can run it: the tests exercise a Linux container's supervisor, and the
+    # machine that installed the app never runs that container. An allowlist cannot
+    # acquire a new subtree by accident, which is why this is not the broad pattern
+    # plus an `exclude_package_data` line.
+    apps/builtins/*/crew/runtime/Dockerfile*
+    apps/builtins/*/crew/runtime/container/**/*
+    apps/builtins/*/crew/runtime/vendor/*
     # Optional distribution build stamp (kiro_crew/__init__.py). Absent in this
     # repo and in the wheels it publishes; a downstream that writes it before
     # building its own wheel needs it carried into the package.
@@ -493,6 +511,19 @@ per-file-ignores =
     src/kiro_crew/cli.py: E402
     src/kiro_crew/__main__.py: E402
     src/kiro_crew/mcp_gateway/gatewayd.py: E402
+    # Pre-existing shapes in the crew container's own suite, which moves in with the
+    # image source it covers rather than being rewritten for this tree.
+    #
+    # F811: the suite shares fixtures by importing them across test modules
+    # (``from .test_front_proxy import backend, env``), and pyflakes reads each test's
+    # ``env`` PARAMETER as a redefinition of the imported name. It fires once per TEST,
+    # not on the import, so no noqa on the import line can reach it -- the alternative is
+    # six inline suppressions on six unmodified test signatures.
+    src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_transcript_fetch.py: F811
+    # E402: a second import block sits mid-file, after the tests for the first half,
+    # introducing the modules the layout tests below it need. That is the file's own
+    # structure, and reordering it would change a suite this move carries unchanged.
+    src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_main.py: E402
     # The security facade re-exports every name its submodules own, private
     # helpers included, because `kiro_crew.security` is the only import path and
     # callers reach those names as attributes of it. A re-export is an import

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/Dockerfile
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/Dockerfile
@@ -1,0 +1,121 @@
+# The Share My Crew deployment image: three processes, one task.
+#
+# What runs here is Kiro Crew's own backend, headless, plus a thin front process
+# and a backup sidecar. Headless means no interface is served to anyone, the
+# owner included: the owner's control plane stays on the owner's own machine and
+# no part of it is in this image.
+#
+# Base image: bookworm ships glibc 2.36. The floor for the kiro-cli gnu builds is
+# 2.30, not the 2.39 the installer claims, so slim is new enough.
+FROM python:3.12-slim
+
+# Architecture comes from the builder, it is NEVER pinned here. An earlier build
+# hardcoded arm64 in two places and cost two separate deploy failures: the image
+# refused to exec on an x86 task, and then a task definition kept an arm64
+# RuntimePlatform while accepting an x86 parameter that nothing referenced. The
+# deploy must cross-check image arch against task arch; this file's job is only
+# to not lie about it.
+ARG TARGETARCH
+
+# Pinned deliberately: this is the version whose ACP behaviour was verified, down
+# to agentCapabilities.loadSession and the shape of its tool events.
+ARG KIRO_VERSION=2.20.2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# `kiro-cli acp` is a thin launcher that dispatches to a SIBLING `kiro-cli-chat`,
+# resolved relative to its own path and through PATH. Shipping only the launcher
+# builds fine and then fails on the first turn, so both go in and both are
+# asserted here. The install is unconditional on purpose: an earlier revision
+# made it opt-in via a build arg, the deploy path never passed the arg, and the
+# build "succeeded" by skipping the download.
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) KIRO_ARCH=x86_64 ;; \
+      arm64) KIRO_ARCH=aarch64 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /tmp/kiro; \
+    curl -fsSL -o /tmp/kiro/kirocli.tar.xz \
+      "https://prod.download.cli.kiro.dev/stable/${KIRO_VERSION}/kirocli-${KIRO_ARCH}-linux.tar.xz"; \
+    tar -xJf /tmp/kiro/kirocli.tar.xz -C /tmp/kiro; \
+    install -m 0755 /tmp/kiro/kirocli/bin/kiro-cli      /usr/local/bin/kiro-cli; \
+    install -m 0755 /tmp/kiro/kirocli/bin/kiro-cli-chat /usr/local/bin/kiro-cli-chat; \
+    rm -rf /tmp/kiro; \
+    test -x /usr/local/bin/kiro-cli; \
+    test -x /usr/local/bin/kiro-cli-chat; \
+    command -v kiro-cli-chat; \
+    kiro-cli --version
+
+# The running crew has no reason to hold a download tool.
+RUN apt-get purge -y curl xz-utils && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Kiro Crew is installed as a real package because the backend is RUN here, not
+# imported as a library. scripts/build_image.sh builds the wheel from a checkout
+# and drops it in vendor/; the wheel is a build artifact and is not committed.
+COPY vendor/*.whl /tmp/wheels/
+COPY container/requirements.txt ./container/requirements.txt
+RUN pip install --no-cache-dir -r container/requirements.txt /tmp/wheels/*.whl \
+    && rm -rf /tmp/wheels
+
+# ONLY the container package. The Kiro Crew app's own backend and UI are in this
+# repository too, and they must never be copied in: that code runs inside the
+# OWNER's gateway with the owner's AWS credentials, and this image is the
+# customer-facing surface. Keeping the COPY narrow is what stops a control-plane
+# credential from riding into a customer's container.
+COPY container/ ./container/
+
+# Non-root: this container terminates a surface that eventually faces customers,
+# and nothing it does needs root.
+#
+# The state directories are created HERE, in the image, on purpose. A fresh
+# volume mounted over a path is initialised from the image's directory at that
+# mount point, ownership included, so declaring them owned by `crew` is what
+# lets a non-root container write to a mounted transcript store. Without it the
+# container starts and dies on a PermissionError that reads like a code fault.
+RUN useradd --create-home --home-dir /var/lib/crew --shell /usr/sbin/nologin crew \
+    && mkdir -p /var/lib/kirocrew/sessions/archive \
+                /var/lib/kirocrew/artifacts \
+                /var/lib/kirocrew/run \
+                /var/lib/crew/.kiro/agents \
+    && chown -R crew:crew /var/lib/kirocrew /var/lib/crew
+
+# The three processes read their configuration only through container.common,
+# so these names are the whole environment contract.
+#
+# SMC_CONFIG_DIR EQUALS SMC_DATA_HOME, and that is not an oversight. Verified
+# against a running gateway: Kiro Crew's config_dir() and data_home() resolve to
+# the same directory, so session_map.json and open_slots.json live at the home
+# root rather than under a config/ subdirectory. Setting them apart makes the
+# sidecar back up every transcript and neither of those files, which yields a
+# backup that looks healthy and a restore with no resume and no conversation
+# list. The supervisor refuses to start if they disagree.
+ENV HOME=/var/lib/crew \
+    KIROCREW_HOME=/var/lib/kirocrew \
+    SMC_DATA_HOME=/var/lib/kirocrew \
+    SMC_CONFIG_DIR=/var/lib/kirocrew \
+    SMC_BACKEND_RUN_DIR=/var/lib/kirocrew/run \
+    SMC_BACKEND_PORT=8765 \
+    SMC_FRONT_PORT=8080 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Supplied at run time, never baked in: KIRO_API_KEY, SMC_CONTROL_SECRET,
+# SMC_ROUTE_PREFIX, SMC_CREW_NAME, SMC_BACKUP_BUCKET, SMC_BACKUP_PREFIX.
+USER crew
+
+# 8080 is the front process, the only listener the network reaches. The Kiro Crew
+# backend listens on 8765 bound to 127.0.0.1 and is deliberately NOT exposed;
+# adding it here would defeat the design's only trust boundary.
+EXPOSE 8080
+
+# No HEALTHCHECK on purpose. A docker-level check that proves the port is bound
+# would report healthy on a container where every turn fails, which is exactly
+# what an invalid model credential produces: a present credential is not a
+# working one. Readiness belongs to the front process's own endpoint, which can
+# gate on a real turn having succeeded.
+CMD ["python", "-m", "container.supervisor"]

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/Dockerfile.crew
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/Dockerfile.crew
@@ -1,0 +1,52 @@
+# The crew layer: a thin, digest-pinned layer on the maintainer's base image.
+#
+# This file exists so that ONE artifact -- the pushed crew image -- pins both the
+# serving code (the base) and the crew content (the bundle). See
+# PACKAGING-CONTRACT.md. A bundle delivered separately, in S3, is a thing the
+# container can fail to read while every gate still reports green: the deploy
+# serves a default agent and nothing says the crew is missing. A layer of the
+# running image cannot be absent, so the bundle lives here.
+#
+# It COMPILES NOTHING and INSTALLS NOTHING. There is no RUN, no apt, no pip. If
+# the crew layer ever needed to install a package, the base image would be wrong
+# and that is a REPORT to the base-image (maintainer) track, never a fix here.
+#
+# Build context is the BUNDLE DIRECTORY (T1's `packaging.build` output). The four
+# explicit COPY sources below are the whole layout contract; a bundle missing any
+# of them fails the build here, which is the earliest place it can fail.
+
+# BASE is the maintainer's base image, pinned by digest (repo@sha256:...). It is
+# an ARG BEFORE FROM on purpose: that is the only way `FROM ${BASE}` resolves.
+# scripts/build_crew_image.sh always passes it; there is no sane default.
+ARG BASE
+FROM ${BASE}
+
+# Provenance travels with the image, not alongside it. These are the only inputs
+# the crew layer adds, and they are the answer to "which crew is this image".
+ARG CREW_NAME
+ARG BUNDLE_DIGEST
+ARG BUNDLE_VERSION=unknown
+ARG BUILT_AT=unknown
+
+# Read-only crew payload. The supervisor (T3) copies it into the data home before
+# the backend starts; nothing runs from /app/crew-bundle. Four explicit sources
+# so a missing manifest/agent/mcp is a hard build failure rather than a container
+# that boots with three files and a plausible-looking empty spot.
+#   manifest.json  {bundle_version, crew_name, created_at, digest}
+#   agent.json     the Kiro agent spec; "name" == crew_name
+#   mcp.json       MCP server config; may be {} but MUST exist
+#   skills/        skill directories; may be empty but MUST exist
+COPY manifest.json agent.json mcp.json /app/crew-bundle/
+COPY skills /app/crew-bundle/skills
+
+# OCI + Share My Crew labels. base.name carries the digest-pinned base ref, so
+# `docker inspect` on the crew image traces back to the exact base it was built
+# on; bundle-digest is the crew content's identity, echoed into the tag by the
+# build script so the two can never silently disagree.
+LABEL org.opencontainers.image.base.name="${BASE}" \
+      org.opencontainers.image.created="${BUILT_AT}" \
+      org.opencontainers.image.title="share-my-crew crew image" \
+      org.opencontainers.image.description="Maintainer base image plus one curated, digest-pinned crew bundle." \
+      dev.sharemycrew.crew-name="${CREW_NAME}" \
+      dev.sharemycrew.bundle-digest="${BUNDLE_DIGEST}" \
+      dev.sharemycrew.bundle-version="${BUNDLE_VERSION}"

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/__init__.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/__init__.py
@@ -1,0 +1,6 @@
+"""The three processes that run in the deployed ECS task.
+
+`docs/system-specs/modules/aws-control.md` defines the boundaries between them. Nothing in this
+package serves a user interface: the owner's control plane stays on the owner's
+own machine and is never deployed.
+"""

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/common/__init__.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/common/__init__.py
@@ -1,0 +1,36 @@
+"""Shared base for the three container processes.
+
+Owned centrally, not by any one track. A track that needs something changed here
+says so rather than editing it, because all three import it and a local fix
+becomes the next disagreement.
+"""
+
+from .config import (
+    BACKEND_HOST,
+    CONTROL_SECRET_HEADER,
+    ConfigError,
+    Settings,
+    load,
+    parse_route_prefix,
+)
+from .secret import (
+    HEADER,
+    BackendSecretUnavailable,
+    auth_header,
+    read_boot_secret,
+    secret_path,
+)
+
+__all__ = [
+    "BACKEND_HOST",
+    "CONTROL_SECRET_HEADER",
+    "ConfigError",
+    "Settings",
+    "load",
+    "parse_route_prefix",
+    "HEADER",
+    "BackendSecretUnavailable",
+    "auth_header",
+    "read_boot_secret",
+    "secret_path",
+]

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/common/audit.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/common/audit.py
@@ -1,0 +1,209 @@
+"""The container's audit record for a permission decision.
+
+MIRRORS ``kiro_crew.sel`` -- specifically the ``SecurityEvent`` field names, its
+``event_type`` vocabulary (``tool_approval`` / ``tool_denial``), and the audit-or-deny
+discipline ``SecurityEventLog.log_tool_invocation(critical=True)`` exists for: "the event
+is written synchronously and a filesystem failure is re-raised so the caller can deny the
+tool rather than run it unaudited".
+
+Mirrored rather than called, and the reason is the SINK, not importability. The wheel IS
+installed in this image (the base Dockerfile installs Kiro Crew as a real package because
+the backend is RUN as a process), so ``from kiro_crew.sel import sel`` would import. What
+does not survive the move is where that log lives:
+
+* ``sel._default_dir()`` resolves under ``config_dir()``, and the HMAC key under
+  ``trust/`` beside it. In this image both land on the persistent volume, and the
+  supervisor and the model worker run as the SAME user -- so the audited party can delete
+  the log and the key and write a self-consistent replacement. A chain its own subject can
+  re-forge is not evidence, and there is no trust root here to anchor one.
+* Nothing harvests that file. The container's only writer to the owner's bucket is the
+  transcript store, so a record written to the volume never reaches whoever would
+  investigate.
+
+So the record goes to the process log stream, which leaves the task the moment it is
+written and cannot be rewritten from inside it. It carries no ``prev_hash`` or
+``entry_hash``: those are SEL's, computed on write into its chain, and claiming them for
+an unchained line would misrepresent what the record proves. Durability of the stream is
+the task definition's log driver, which belongs to the deploy track rather than to this
+image.
+
+The sink is this module's OWN logger and handler, attached by ``configure_sink`` before
+the app can serve a request, and ``emit`` refuses when a record would not reach a
+handler. Both halves are needed: a log call on an ambient logger is dropped by level
+before any handler is consulted, and a dropped record is not an error -- so an audit built
+on ambient configuration reports success while writing nothing, and the audit-or-deny path
+above it never fires. A guard that is live only where it is not needed cannot be told from
+no guard.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import uuid
+from datetime import datetime, timezone
+
+#: The audit records go to a logger this module OWNS, at a name nothing else writes to.
+#: Not the calling module's ``__name__`` logger: that one inherits whatever the process's
+#: logging configuration happens to be, and under uvicorn's own configuration the front
+#: process's logger resolves to an effective level of WARNING with no reachable handler --
+#: so an INFO audit call writes zero bytes and raises nothing. An audit that depends on
+#: ambient configuration is an audit that a future logging change can switch off silently.
+AUDIT_LOGGER_NAME = "crew_container.audit"
+
+#: SEL's own ``event_type`` values for the two halves of a permission decision
+#: (``kiro_crew.sel.SecurityEvent``: "tool_invocation, tool_approval, tool_denial,
+#: mcp_call, api_access").
+EVENT_GRANTED = "tool_approval"
+EVENT_DENIED = "tool_denial"
+
+#: What ``caller_identity`` says when the caller is unidentified. The container's control
+#: surface authenticates a SECRET, not a principal, so there is no session key to name --
+#: and a blank field would read as a lost value rather than as an absent one.
+UNIDENTIFIED = "unidentified:control-caller"
+
+#: Marks the handler this module attached, so ``configure_sink`` is idempotent without
+#: counting handlers or comparing streams.
+_OWNED = "_crew_container_audit_sink"
+
+
+class AuditUnavailable(RuntimeError):
+    """The decision could not be recorded, so it must not be acted on.
+
+    Raised INSTEAD of returning, which is the whole point: a caller that treats a failed
+    emit as a warning produces exactly the unaudited grant the record exists to prevent.
+    """
+
+
+def sink() -> logging.Logger:
+    """The audit logger. Configuration is ``configure_sink``'s job, not this one's."""
+    return logging.getLogger(AUDIT_LOGGER_NAME)
+
+
+def configure_sink(*, stream=None) -> logging.Logger:
+    """Attach an INFO-capable handler on the process stream, and return the logger.
+
+    Called from ``build_app`` rather than from the process entrypoint, so the sink cannot
+    be missing for a request: an app that can serve one has been built, and building it
+    ran this. A lazy "configure on first emit" would leave whichever request arrives first
+    deciding whether the sink exists.
+
+    Idempotent, because ``build_app`` is called more than once in a test session and a
+    handler per call would multiply every record.
+
+    ``propagate`` is left alone. A deployment that also configures an INFO root handler
+    then gets the record twice, which is the better failure: a duplicate is visible and a
+    drop is not.
+    """
+    log = logging.getLogger(AUDIT_LOGGER_NAME)
+    # Set on the LOGGER, not the root: an effective level inherited from a root left at
+    # WARNING is what makes ``log.info`` a no-op before any handler is consulted.
+    log.setLevel(logging.INFO)
+    for handler in log.handlers:
+        if getattr(handler, _OWNED, False):
+            return log
+    handler = logging.StreamHandler(stream if stream is not None else sys.stderr)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s"))
+    setattr(handler, _OWNED, True)
+    log.addHandler(handler)
+    return log
+
+
+def sink_is_live(log: logging.Logger, *, level: int = logging.INFO) -> bool:
+    """Would a record at *level* from *log* actually reach a handler?
+
+    Deliberately not ``log.hasHandlers()``, which answers a different question: it ignores
+    the logger's effective level and every handler's own level, so it says yes for a
+    logger whose only reachable handler is at WARNING -- exactly the arrangement that drops
+    an INFO audit record. Both are checked here, and the propagation walk stops where
+    ``propagate`` stops it.
+
+    ``logging.lastResort`` is deliberately not counted. It is the fallback used when no
+    handler is found at all, and it sits at WARNING, so it does not carry INFO records --
+    counting it would report a live sink for the case this function exists to catch.
+    """
+    if not log.isEnabledFor(level):
+        return False
+    current: logging.Logger | None = log
+    while current is not None:
+        for handler in current.handlers:
+            if handler.level <= level:
+                return True
+        if not current.propagate:
+            return False
+        current = current.parent
+    return False
+
+
+def control_decision_event(
+    *,
+    granted: bool,
+    method: str,
+    path: str,
+    header_present: bool,
+    crew_name: str,
+) -> dict[str, object]:
+    """Build the record for one control-authorization decision.
+
+    Separate from the emit so a test can assert the CONTENT without a sink, and so the
+    two failure modes stay distinguishable: a record this function cannot build is a bug
+    here, while a record the sink cannot accept is the deployment's problem.
+
+    No header value appears in the record -- not the control secret, not any other header.
+    An audit log that carries the credential it is auditing turns every reader of the log
+    into a holder of the secret, so what is recorded is only WHETHER the header was
+    presented.
+    """
+    return {
+        "event_id": uuid.uuid4().hex[:16],
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "event_type": EVENT_GRANTED if granted else EVENT_DENIED,
+        "caller_identity": UNIDENTIFIED,
+        "agent": crew_name,
+        "source": "crew_container_front",
+        "operation": "control_request",
+        "tool_kind": "http_control",
+        "outcome": "granted" if granted else "denied",
+        "resources": f"{method} {path}",
+        "metadata": {"control_header_present": header_present},
+    }
+
+
+def emit(event: dict[str, object], *, log: logging.Logger | None = None) -> None:
+    """Write one record, or raise.
+
+    One line of JSON, because the reader is a log query rather than a person, and a
+    multi-line record cannot be selected reliably out of an interleaved stream.
+
+    The sink is CHECKED before the record is handed to it. A dropped log record is not an
+    error -- ``logging`` filters it by level and returns normally -- so without this check
+    a misconfigured process audits nothing, raises nothing, and the caller's audit-or-deny
+    path never fires. That is worse than no audit at all: the guard reports success.
+
+    ``logging`` also swallows exceptions raised by its own handlers
+    (``logging.raiseExceptions`` only prints them), so the record is serialised BEFORE the
+    log call and the handlers are flushed after it, which is where a write failure
+    surfaces rather than at interpreter exit.
+    """
+    log = log if log is not None else sink()
+    if not sink_is_live(log):
+        raise AuditUnavailable(
+            f"logger {log.name!r} would drop an INFO record: effective level "
+            f"{logging.getLevelName(log.getEffectiveLevel())}, no reachable handler at or "
+            "below INFO. The audit sink must be configured before serving "
+            "(common.audit.configure_sink)."
+        )
+
+    try:
+        line = json.dumps(event, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError) as exc:
+        raise AuditUnavailable(f"the audit record could not be serialised: {exc}") from exc
+
+    try:
+        log.info("sel_shaped_audit %s", line)
+        for handler in list(log.handlers) or list(logging.getLogger().handlers):
+            handler.flush()
+    except Exception as exc:  # noqa: BLE001 - any sink failure must deny, not pass
+        raise AuditUnavailable(f"the audit record could not be written: {exc}") from exc

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/common/config.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/common/config.py
@@ -1,0 +1,243 @@
+"""Environment contract for the three container processes.
+
+Every process in the task reads its configuration from here and nowhere else.
+Parsing happens once, at import of `load()`, and the result is frozen: a process
+that disagrees with another about a path or a port is the failure mode this
+module exists to prevent.
+
+Two values are deliberately NOT configurable.
+
+`BACKEND_HOST` is fixed at 127.0.0.1. The Kiro Crew backend must never be
+reachable from the network, and a setting is a thing an operator can get wrong.
+
+The backend's authentication secret is not here either. It is generated per boot
+and is read from disk on every use; see `secret.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+# Not configurable. See the module docstring.
+BACKEND_HOST = "127.0.0.1"
+
+# The header the owner's control plane sends to reach a control route, and the
+# one the API Gateway integration injects on every request so a client cannot
+# forge it.
+#
+# Pinned here rather than in the front process because three places have to
+# agree on the exact string: the front process that checks it, the CloudFormation
+# integration that injects it, and the control plane that sends it. Two of those
+# are not Python, so a constant private to the front process is a name three
+# systems copy by hand.
+CONTROL_SECRET_HEADER = "X-SMC-Control-Secret"
+
+
+class ConfigError(ValueError):
+    """Raised when the environment is wrong in a way that must not be repaired.
+
+    Refusing beats guessing: a silently corrected value produces a deployment
+    that works differently from the one the operator described.
+    """
+
+
+@dataclass(frozen=True)
+class Settings:
+    # The Kiro Crew backend, on loopback.
+    backend_port: int
+    backend_run_dir: Path
+
+    # The front process, the only listener the network reaches.
+    front_port: int
+    route_prefix: str
+    control_secret: str | None
+
+    # Shared filesystem. All three processes see the same paths.
+    data_home: Path
+    config_dir: Path
+
+    # Where the front reads a slot's transcript from on demand (Track B). These named the
+    # backup destination when the sidecar wrote here too; the backup subsystem was extracted
+    # from this PR, so today only the front's on-demand fetch reads this bucket, and it reads
+    # an empty one until the durability feature lands.
+    crew_name: str
+    backup_bucket: str | None
+    backup_prefix: str
+
+    # The crew bundle baked into the image (PACKAGING-CONTRACT.md, T3). The
+    # supervisor installs it into the crew's read paths before the backend
+    # starts, so "it started" means "the named crew is installed". Defaults to
+    # the real image path `/app/crew-bundle`, NEVER a temp dir: a temp default
+    # would let a test's throwaway bundle look like the shipped one, which is
+    # the class of "served a default agent while gates were green" this change
+    # exists to prevent.
+    #
+    # Carries a default because the Settings dataclass is constructed by hand in
+    # several tests, so a field with no default would break every one of them.
+    bundle_dir: Path = Path("/app/crew-bundle")
+
+    # Whether the DEPLOYMENT vouches that exactly one principal reaches this task.
+    #
+    # It matters because the customer turn route forwards the caller's ``id`` and that id
+    # drives the on-demand transcript fetch. This process has no caller identity to bind
+    # the id to: authorisation happens before the call reaches the task, and nothing
+    # passes an identity through to here, so a binding written in this process would fail
+    # OPEN. What can be answered here is the other half of the same question: with
+    # persistent memory on, is one principal the only one who can send an id at all.
+    #
+    # A security property the container cannot observe arrives as a setting, and the
+    # container refuses to run on the unsafe combination rather than assuming the safe
+    # one. Defaults to False, which is the SAFE default here -- claiming single-principal
+    # is what unlocks the risky pairing, so silence must mean "not claimed".
+    #
+    # This does not duplicate the deploy-time rule in the templates, which refuses the
+    # stack. It closes the case that rule cannot see: an image run by any other path.
+    single_principal: bool = False
+
+    @property
+    def backend_base_url(self) -> str:
+        return f"http://{BACKEND_HOST}:{self.backend_port}"
+
+    @property
+    def sessions_dir(self) -> Path:
+        return self.data_home / "sessions"
+
+    @property
+    def archive_dir(self) -> Path:
+        return self.data_home / "sessions" / "archive"
+
+    @property
+    def artifacts_dir(self) -> Path:
+        return self.data_home / "artifacts"
+
+    @property
+    def session_map_path(self) -> Path:
+        return self.config_dir / "session_map.json"
+
+    @property
+    def open_slots_path(self) -> Path:
+        return self.config_dir / "open_slots.json"
+
+
+def _int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ConfigError(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def _path(name: str, default: str) -> Path:
+    return Path(os.environ.get(name) or default).expanduser()
+
+
+def _bool(name: str, default: bool) -> bool:
+    """Parse a strict boolean. An unrecognised value is REFUSED, not falsy.
+
+    This gates a security-class setting (whether the deployment claims a single
+    principal), so the usual ``value.lower() in ("1", "true")`` idiom is the wrong
+    shape: it silently reads a typo such as ``ture`` or a templating artefact such
+    as ``${Claim}`` as "no", which is the safe direction here but hides that the
+    deployment did not say what it meant. Refusing makes the operator fix the value.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    lowered = raw.strip().lower()
+    if lowered in ("1", "true", "yes", "on"):
+        return True
+    if lowered in ("0", "false", "no", "off"):
+        return False
+    raise ConfigError(
+        f"{name} must be a boolean (true/false), got {raw!r}. It is not "
+        "interpreted loosely because it controls whether the deployment claims a "
+        "single principal, which decides whether one caller's turns may share a "
+        "conversation slot with another's."
+    )
+
+
+def parse_route_prefix(raw: str | None) -> str:
+    """Normalise an external path prefix the caller's paths arrive with.
+
+    Optional, and empty by default. Nothing in this repository sets
+    ``SMC_ROUTE_PREFIX``: it exists for a deploy path that addresses a crew by a
+    path segment (``/c/<crew>/...``) and cannot rewrite the path before the task
+    sees it. Delete the setting and ``strip_prefix`` with it if the deployment
+    that reaches this container never needs one.
+
+    A wrong value fails CLOSED. ``strip_prefix`` removes the prefix only from a
+    path that is the prefix or begins with ``prefix + "/"`` and returns anything
+    else unchanged, and the front's customer surface is a two-entry allowlist
+    checked AFTER stripping, so a path that does not strip to one of those two is
+    control and is refused without the control secret. It cannot strip a control
+    route into the customer surface, because the only way to reach the turn path
+    after stripping is to have sent the turn path.
+
+    A bare word is REFUSED rather than repaired. ``SMC_ROUTE_PREFIX=frontdesk``
+    almost certainly means the operator does not know whether the value carries
+    its own slash, and a guess here is invisible until a request is misrouted.
+    """
+    if raw is None or raw.strip() == "":
+        return ""
+    value = raw.strip()
+    if not value.startswith("/"):
+        raise ConfigError(
+            f"SMC_ROUTE_PREFIX must start with '/', got {value!r}. "
+            "It is refused rather than corrected because a wrong prefix "
+            "misroutes requests instead of failing."
+        )
+    value = value.rstrip("/")
+    if "//" in value:
+        raise ConfigError(f"SMC_ROUTE_PREFIX contains an empty segment: {raw!r}")
+    if value == "":
+        # ``"/"`` and ``"//"`` survive the checks above and strip down to nothing, which
+        # would silently mean "no prefix" -- so the container would serve the bare routes
+        # while the deployment believed it had set a prefix. A value that means nothing
+        # after normalisation is REFUSED for the same reason a bare word is: the operator
+        # did not say what they meant, and the failure would first show as a misrouted
+        # request rather than as an error. Leave it unset to mean no prefix.
+        raise ConfigError(
+            f"SMC_ROUTE_PREFIX is {raw!r}, which normalises to an empty prefix. Unset it "
+            "to serve the routes unprefixed; a value that means nothing is refused rather "
+            "than read as no value."
+        )
+    return value
+
+
+def load() -> Settings:
+    """Read the environment once. Call at process start, pass the result down."""
+    data_home = _path("SMC_DATA_HOME", "/var/lib/kirocrew")
+    return Settings(
+        backend_port=_int("SMC_BACKEND_PORT", 8765),
+        backend_run_dir=_path("SMC_BACKEND_RUN_DIR", str(data_home / "run")),
+        front_port=_int("SMC_FRONT_PORT", 8080),
+        route_prefix=parse_route_prefix(os.environ.get("SMC_ROUTE_PREFIX")),
+        control_secret=os.environ.get("SMC_CONTROL_SECRET") or None,
+        # Absent or empty means "not claimed", which is the posture that refuses the
+        # risky pairing rather than the one that permits it. A value that cannot be read
+        # is REFUSED instead: see `_bool`.
+        single_principal=_bool("SMC_SINGLE_PRINCIPAL", False),
+        data_home=data_home,
+        # Defaults to the data home itself, NOT a `config/` subdirectory.
+        # Verified against a running gateway: Kiro Crew's `config_dir()` and
+        # `data_home()` resolve to the same directory, so `session_map.json` and
+        # `open_slots.json` sit at the home root.
+        #
+        # This default was wrong once, and the way it failed is worth keeping in
+        # view: with `data_home/config` the sidecar backs up every transcript and
+        # NEITHER of those two files, so the backup looks healthy and the restore
+        # has no resume and no conversation list. It stays overridable only so a
+        # test can construct the wrong case on purpose; the supervisor refuses to
+        # start when the two disagree.
+        config_dir=_path("SMC_CONFIG_DIR", str(data_home)),
+        crew_name=os.environ.get("SMC_CREW_NAME") or "",
+        backup_bucket=os.environ.get("SMC_BACKUP_BUCKET") or None,
+        backup_prefix=os.environ.get("SMC_BACKUP_PREFIX") or "",
+        # The crew bundle in the image. Defaults to the real path; a test points
+        # SMC_BUNDLE_DIR at a fixture. Never defaulted to a temp dir (see field).
+        bundle_dir=_path("SMC_BUNDLE_DIR", "/app/crew-bundle"),
+    )

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/common/secret.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/common/secret.py
@@ -1,0 +1,61 @@
+"""Reading the Kiro Crew backend's per-boot authentication secret.
+
+The backend writes `gateway-<port>.secret` into its run directory at startup.
+The value is `os.urandom(16)`, generated fresh on every boot, and it is NOT
+persisted anywhere else.
+
+That single fact decides the shape of this module. A caller that caches the
+value keeps working right up until the backend restarts, and then every request
+fails with 403 for as long as the process lives. A 403 reads like a client
+problem, so the actual cause, a stale secret, is not where anyone looks.
+
+There is therefore no cache here, and no parameter to add one. The file read is
+a few microseconds from the page cache; a caching layer would trade a real
+outage for an unmeasurable saving.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+HEADER = "X-Internal-Secret"
+
+
+class BackendSecretUnavailable(RuntimeError):
+    """The secret file is absent or empty.
+
+    Distinct from an authentication failure on purpose. This means the backend
+    has not finished booting, or the run directory is not shared between the
+    processes, both of which are startup faults rather than request faults.
+    """
+
+
+def secret_path(run_dir: Path, backend_port: int) -> Path:
+    return Path(run_dir) / f"gateway-{backend_port}.secret"
+
+
+def read_boot_secret(run_dir: Path, backend_port: int) -> str:
+    """Read the current secret from disk. Never cache the return value.
+
+    Call this per request, or per attempt after a 403. Storing it in a module
+    global, a client object, or a connection pool re-introduces exactly the
+    failure this module is written to avoid.
+    """
+    path = secret_path(run_dir, backend_port)
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise BackendSecretUnavailable(
+            f"{path} does not exist. The backend writes it at startup, so this "
+            "means the backend is not up yet or the run directory is not shared."
+        ) from exc
+    except OSError as exc:
+        raise BackendSecretUnavailable(f"{path} could not be read: {exc}") from exc
+    if not value:
+        raise BackendSecretUnavailable(f"{path} is empty")
+    return value
+
+
+def auth_header(run_dir: Path, backend_port: int) -> dict[str, str]:
+    """The one header the backend needs from a loopback caller."""
+    return {HEADER: read_boot_secret(run_dir, backend_port)}

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/__init__.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/__init__.py
@@ -1,0 +1,15 @@
+"""S1: the front process.
+
+The only listener the network reaches. It authenticates the loopback call to the
+Kiro Crew backend, strips the crew route prefix, serializes turns per conversation,
+projects the backend's stream down to a customer-safe allowlist, and keeps the
+customer surface separate from the owner's control surface.
+
+Public seam (see ``docs/system-specs/modules/aws-control.md``, "The front layer"):
+    container.front.app:build_app(settings)
+    container.front.__main__:main()
+"""
+
+from .app import build_app
+
+__all__ = ["build_app"]

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/__main__.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/__main__.py
@@ -1,0 +1,31 @@
+"""Runnable entrypoint for the front process: ``python -m container.front``.
+
+Reads the environment once through ``common.load()`` and serves ``build_app`` on
+the configured front port. The bind is ``0.0.0.0`` on purpose: a container's own
+port has to be reachable from outside the container to be reachable at all, and
+this process is the only listener that is. The backend it forwards to is
+loopback-only and is never bound here.
+
+Reaching this port is an authorised call in the owner's own account, decided
+before the request arrives; the task is not published to the internet and has no
+external DNS name. That authorisation is not this process's to enforce and this
+process cannot see its result, which is why the turn route refuses to serve at all
+unless the deployment has declared a single principal (``app.py``).
+"""
+
+from __future__ import annotations
+
+import uvicorn
+from container import common
+
+from .app import build_app
+
+
+def main() -> None:
+    settings = common.load()
+    app = build_app(settings)
+    uvicorn.run(app, host="0.0.0.0", port=settings.front_port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/app.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/app.py
@@ -1,0 +1,588 @@
+"""The FastAPI application: ``build_app(settings)``.
+
+Responsibilities, and only these:
+
+* Strip the optional crew route prefix and classify on the STRIPPED path. A
+  deployment that addresses a crew by a path segment (``/c/<crew>/...``) cannot
+  always rewrite the path before the task sees it, so the prefix arrives here;
+  nothing in this repository sets one, and it is empty by default. Classifying the
+  prefixed path made control routes read as customer routes in an earlier build, so
+  classification is done once, after stripping.
+* Keep the customer surface (a single turn endpoint) separate from the owner's
+  control surface. The split is fail-closed: only ``GET /health`` and the turn
+  endpoint are customer routes; everything else is control and requires the
+  control secret. A customer cannot relabel a control route as a customer one,
+  because classification runs on the stripped path, and cannot forge the control
+  secret, which they do not hold.
+* Register a bare ``/health`` in addition to the prefixed one, so liveness can be
+  probed without knowing the crew's prefix. It returns ``{"status": "ok"}`` and no
+  internals, because it is the one route that answers without the control secret.
+  No consumer in this repository calls it -- the image deliberately declares no
+  ``HEALTHCHECK`` (``Dockerfile``) -- so it stands or falls with whatever probes the
+  task.
+* Ensure the addressed conversation's transcript is on disk before the turn
+  reaches the backend. Boot restores no transcripts at all, so this is where a
+  returning caller's conversation comes back. The lock and
+  the fetch are one scope (``transcript.prepared_turn``) built at a single site,
+  so the streamed and non-streamed transports cannot drift apart on it.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+from container import common
+from container.common import audit
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from . import backend, transcript
+from .slotlock import SlotSerializer
+
+#: Hard ceiling on a control request body. The control routes carry small JSON
+#: objects -- ids, flags, a slot key -- so a megabyte is already far more than
+#: any real caller sends, and the point of the number is that there IS one.
+_MAX_CONTROL_BODY_BYTES = 1024 * 1024
+
+logger = logging.getLogger("smc.front.app")
+
+# Customer surface, evaluated on the stripped path.
+CUSTOMER_TURN_PATH = "/v1/chat/completions"
+HEALTH_PATH = "/health"
+
+# The header the API Gateway control integration sets to the value of
+# SMC_CONTROL_SECRET. ``common`` is the single definition and this is an alias for
+# readability at the use sites below, so the deploy integration matches whatever
+# ``common.CONTROL_SECRET_HEADER`` says rather than a name chosen here. An earlier comment
+# here asserted the reverse, which was true while this line spelled the string out and
+# stopped being true the moment it became an alias.
+CONTROL_SECRET_HEADER = common.CONTROL_SECRET_HEADER
+
+# Read timeout is disabled: a turn (and a stream) can legitimately run long. The
+# connect timeout stays short so a dead backend fails fast rather than hanging.
+_BACKEND_TIMEOUT = httpx.Timeout(connect=5.0, read=None, write=30.0, pool=5.0)
+
+
+def strip_prefix(path: str, prefix: str) -> str:
+    """Remove the configured route prefix from an incoming path.
+
+    A path not under the prefix (the bare ``/health``, chiefly) is returned
+    unchanged so it can still be classified. Unchanged means classified as control
+    unless it is one of the two customer routes, so an unmatched path is refused
+    rather than admitted.
+    """
+    if not prefix:
+        return path
+    if path == prefix:
+        return "/"
+    if path.startswith(prefix + "/"):
+        return path[len(prefix) :]
+    return path
+
+
+def _audit_control_decision(
+    request: Request, stripped_path: str, *, granted: bool, settings: common.Settings
+) -> None:
+    """Record BOTH outcomes of the control-authorization decision, before responding.
+
+    Emitted for a grant as well as a deny. The deny is the half that gets forgotten and
+    the half that answers "who tried", and a log holding only grants records exactly the
+    events nobody needed to investigate.
+
+    Before the response, not after, so a failure between the decision and the reply cannot
+    produce an unaudited grant. And a failure to RECORD refuses the request rather than
+    passing: see ``common.audit``, which mirrors what
+    ``kiro_crew.sel.SecurityEventLog.log_tool_invocation(critical=True)`` exists for.
+    Raises ``AuditUnavailable``; the caller turns that into a 503.
+    """
+    audit.emit(
+        audit.control_decision_event(
+            granted=granted,
+            method=request.method,
+            path=stripped_path,
+            header_present=common.CONTROL_SECRET_HEADER in request.headers,
+            crew_name=settings.crew_name,
+        )
+    )
+
+
+def _control_authorized(request: Request, settings: common.Settings) -> bool:
+    """True only if the request carries the exact control secret.
+
+    Fails closed when no control secret is configured, and compares in constant
+    time. A client-supplied header cannot pass without knowing the secret, and
+    the secret never appears on the customer path.
+    """
+    expected = settings.control_secret
+    if not expected:
+        return False
+    provided = request.headers.get(CONTROL_SECRET_HEADER)
+    if provided is None:
+        return False
+    # Compared as BYTES. `hmac.compare_digest` on str raises TypeError for any non-ASCII
+    # character -- measured: "ab\u00e9" raises "comparing strings with non-ASCII characters
+    # is not supported" -- so a caller could turn a 403 into an unhandled 500 by putting one
+    # accented letter in the header. Encoding first gives every possible header value a
+    # verdict, and keeps the comparison constant-time for equal lengths.
+    #
+    # surrogatepass, because a header that arrived as lone surrogates must still compare
+    # rather than raise on the way in.
+    return hmac.compare_digest(
+        provided.encode("utf-8", "surrogatepass"),
+        expected.encode("utf-8", "surrogatepass"),
+    )
+
+
+def judge_addressed_crew(
+    payload: dict[str, Any], deployed_crew: str
+) -> tuple[str | None, JSONResponse | None]:
+    """Resolve which crew the request addresses, or refuse.
+
+    ``model`` is the OpenAI-shaped field that names the crew. It is OPTIONAL in the
+    schema and REQUIRED in effect: a request that names nobody is refused rather
+    than answered by whatever agent the backend would otherwise pick.
+
+    That distinction is the whole point. Kiro Crew maps ``model`` to an agent name
+    (``dashboard/openai_compat.py:237``) and validates it against a NAME REGEX, not
+    against the set of agents that exist, so an unrecognised name does not fail --
+    it lands on the installed default. A deployment whose crew was never installed
+    therefore answers every turn with a stock agent and looks entirely healthy, which
+    is exactly what this deployment did before the crew moved into the image. A
+    default answer to an unaddressed request is the failure, not the fallback.
+
+    Forwarding the customer's string was also an authorization hole: any agent
+    present in the container was reachable by naming it. The caller may only ADDRESS
+    this deployment's crew; the value that reaches the backend is set from
+    ``SMC_CREW_NAME`` rather than copied from the request.
+
+    Returns ``(crew, None)`` when the request may proceed, or ``(None, response)``.
+    """
+    if not deployed_crew:
+        # The supervisor refuses to boot without a crew, so this is unreachable in a
+        # correct deployment. Fail closed anyway: the alternative is accepting any
+        # name because we do not know our own.
+        return None, JSONResponse(
+            {"detail": "service unavailable", "code": "crew_not_configured"},
+            status_code=503,
+        )
+
+    raw = payload.get("model")
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return None, JSONResponse(
+            {
+                "detail": (
+                    'no crew was addressed: set "model" to the crew you are '
+                    "calling. This service does not answer on behalf of an "
+                    "unnamed crew."
+                ),
+                "code": "crew_not_addressed",
+            },
+            status_code=400,
+        )
+    if not isinstance(raw, str):
+        return None, JSONResponse(
+            {"detail": '"model" must be a string naming a crew', "code": "bad_request"},
+            status_code=400,
+        )
+
+    if raw.strip() != deployed_crew:
+        # Naming a crew that is not here is a 404: the address is wrong, not the
+        # request. Echoing the deployed name is deliberate -- it is not a secret
+        # (it is in the URL prefix) and withholding it makes a typo unfixable.
+        return None, JSONResponse(
+            {
+                "detail": (
+                    f"this deployment serves the crew {deployed_crew!r}, not " f"{raw.strip()!r}"
+                ),
+                "code": "crew_not_served_here",
+            },
+            status_code=404,
+        )
+
+    return deployed_crew, None
+
+
+class BadForwardField(ValueError):
+    """A payload field cannot be reduced to its backend contract type.
+
+    Carried out of :func:`_forward_body` and turned into a 400 by the handler, so
+    the type check lives with the field it guards and is unit-testable without an
+    ASGI round trip.
+
+    ``detail`` is the ONLY text that reaches the caller, and every value assigned to
+    it must be written for that audience. Returning ``str(exc)`` would not be,
+    which works while there is one raise site with an authored message and stops
+    working the first time someone writes
+    ``raise BadForwardField(f"bad field: {inner_exc}")`` -- the message would then
+    carry whatever the inner exception says about the container's internals, and no
+    reviewer of that line would be looking at the response path. Naming the channel
+    puts the decision at the raise site, where the author can see it.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+def _require_stream_bool(raw: Any) -> bool:
+    """``stream`` must be a real boolean; anything else is refused.
+
+    ``bool("false")`` is ``True``, so silently coercing would turn a client that
+    sent the STRING ``"false"`` -- meaning off -- into a streamed response. A
+    client that says ``"false"`` and means it has misunderstood the field, and a
+    silent coercion hides that, so we refuse rather than guess. Absent means the
+    default (non-streamed), which is the documented shape of the field.
+    """
+    if raw is None:
+        return False
+    if isinstance(raw, bool):
+        return raw
+    raise BadForwardField(
+        f'"stream" must be a boolean (true/false), not {type(raw).__name__}. '
+        'It is not interpreted loosely because the string "false" is truthy, '
+        "so a coercion would stream a turn the caller asked not to stream."
+    )
+
+
+def _forward_body(payload: dict[str, Any], crew: str) -> tuple[dict[str, Any], str, bool]:
+    """Reduce a customer payload to exactly the backend's contract fields.
+
+    Only ``model``, ``messages``, ``id`` and ``stream`` are forwarded; any other
+    field a client sends is dropped. ``id`` is the slot id used for
+    serialization; absent, the backend mints one and there is nothing to
+    serialize on.
+
+    ``model`` is set from the DEPLOYED crew name, never copied from the payload:
+    the request has already been checked to address this crew, and re-using the
+    caller's string would let a differently-cased or padded value reach the
+    backend's agent resolver.
+    """
+    stream = _require_stream_bool(payload.get("stream"))
+    body: dict[str, Any] = {"stream": stream}
+    body["model"] = crew
+    # The ``id`` is forwarded as the caller sent it (after the shape and type
+    # checks below) and is NOT bound to an authenticated principal, because this
+    # process has no caller identity to bind: reaching the task is an authorised
+    # call in the owner's own account, decided before the request arrives, and
+    # nothing passes the result of that decision through to here. A binding
+    # written against an absent identity would fail OPEN, which is the worse of
+    # the two failure directions.
+    #
+    # The review's fix reads "bind forwarded IDs to the authenticated principal OR
+    # enforce single-principal access". The second is what is implemented, in three
+    # places that cover three different ways the pairing can be reached:
+    #   * ``build_app`` -- refuses to START unless the deployment has declared
+    #     ``SMC_SINGLE_PRINCIPAL``, whether or not a backup bucket is configured. This is
+    #     the one that holds for an image run by any path at all, including none of the
+    #     two below.
+    #   * the deploy track's CloudFormation template refuses the stack when persistent
+    #     memory lacks a single-principal trust domain, so a console or pipeline deploy
+    #     cannot skip it, and its driver refuses the same pairing at parse time so an
+    #     owner learns before step 0 rather than six steps in.
+    # That track is not in this repository, which is why the first one is the one that
+    # matters here: it needs nothing outside this image to be true.
+    # In the default ``chatbot`` mode no history is retained, so a reused id resumes
+    # nothing regardless.
+    for key in ("messages", "id"):
+        if key in payload:
+            body[key] = payload[key]
+
+    # The slot id drives the on-demand transcript fetch and the per-slot lock. A
+    # NON-STRING id must never become one. ``bool("false")``'s sibling here is
+    # ``str(123) == "123"``: a folded integer is a perfectly legal SHAPE, so it
+    # sails through ``is_fetchable_slot_id`` and gets fetched -- and only THEN
+    # does the backend reject the integer id, leaving the task holding
+    # ``dashboard_123``, a conversation it never served. That is the same
+    # isolation hole the punctuation door (``dashboard:cust-1``) opened, entered
+    # through the type door instead.
+    #
+    # We choose "fetch nothing" over "reject outright at the front". The raw
+    # ``id`` is still forwarded above, so the backend remains the one authority
+    # that judges legality (its grammar is not importable here, and duplicating
+    # it is exactly what the shape-test guard was built to avoid). An empty
+    # ``slot_id`` maps to ``FetchOutcome("no_slot")`` -- no key, no lock keyed on
+    # a fabricated string. And the direction is the safe one: declining to fetch
+    # for a non-string id costs nothing (a refused turn writes nothing), whereas
+    # fetching for it would put another customer's transcript on this disk.
+    raw_id = payload.get("id")
+    slot_id = raw_id if isinstance(raw_id, str) else ""
+    return body, slot_id, stream
+
+
+def _get_client(app: FastAPI) -> httpx.AsyncClient:
+    """Lazily create the backend client inside the running loop, once."""
+    client = getattr(app.state, "backend_client", None)
+    if client is None:
+        # ``trust_env=False`` because every request this client makes goes to
+        # ``http://127.0.0.1:<backend_port>`` (``Settings.backend_base_url``), and
+        # ambient environment is wrong for a loopback call in both directions it
+        # reads. Proxies: an ``HTTP_PROXY`` / ``ALL_PROXY`` inherited by the task
+        # would route the front's internal turn traffic -- whole conversations --
+        # through that proxy instead of to the process next door. Trust store:
+        # httpx eagerly builds an SSL context from ``SSL_CERT_FILE`` even for a
+        # client that never speaks TLS, so a stale value crashes construction with
+        # FileNotFoundError (which is how CI found this). This is NOT
+        # ``verify=False``: verification stays on, so pointing the backend at an
+        # https URL later still validates its certificate.
+        client = httpx.AsyncClient(timeout=_BACKEND_TIMEOUT, trust_env=False)
+        app.state.backend_client = client
+    return client
+
+
+def _get_transcript_reader(
+    app: FastAPI, settings: common.Settings
+) -> transcript.TranscriptReader | None:
+    """The read-only S3 reader for on-demand transcripts, built once, or None.
+
+    None means no bucket is configured, which is a supported deployment: the
+    crew runs without durable conversations. It is NOT treated as a failed fetch,
+    because nothing was ever uploaded, so nothing is missing. The distinction is
+    said out loud once at startup rather than per turn (see ``build_app``).
+
+    Lazy, like the backend client: constructing a boto3 client at import or at
+    build time would put AWS on the path of every test that builds the app.
+    """
+    if not settings.backup_bucket:
+        return None
+    reader = getattr(app.state, "transcript_reader", None)
+    if reader is None:
+        reader = transcript.S3TranscriptReader(settings.backup_bucket)
+        app.state.transcript_reader = reader
+    return reader
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    yield
+    client = getattr(app.state, "backend_client", None)
+    if client is not None:
+        await client.aclose()
+
+
+def build_app(
+    settings: common.Settings,
+    *,
+    transcript_reader: transcript.TranscriptReader | None = None,
+) -> FastAPI:
+    """The front process's app.
+
+    ``transcript_reader`` is the injection seam for the on-demand transcript
+    fetch. Production leaves it None and gets a lazily built
+    :class:`~container.front.transcript.S3TranscriptReader`; a test passes a fake
+    with a ``get`` and no credentials. It is keyword-only so the public seam
+    named in ``docs/system-specs/modules/aws-control.md`` (``build_app(settings)``) still holds.
+    """
+    # Before the app exists, so it cannot be missing for a request. Under uvicorn's own
+    # logging configuration this process's module loggers resolve to WARNING with no
+    # reachable handler, so an INFO audit call writes nothing and raises nothing -- the
+    # control audit would be inert exactly in production, where it is the only record of
+    # who reached the control surface. Configured here rather than in ``__main__`` because
+    # every path that can serve a request goes through this function.
+    audit.configure_sink()
+    app = FastAPI(
+        title="share-my-crew front",
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+        lifespan=_lifespan,
+    )
+    app.state.backend_client = None
+    app.state.transcript_reader = transcript_reader
+    serializer = SlotSerializer()
+
+    # An unclaimed trust domain is refused HERE, at startup, and NOT conditioned on a
+    # backup bucket.
+    #
+    # The bucket was the condition in the first version of this guard and it is the wrong
+    # one. What a bucket decides is whether transcripts are DURABLE; what the caller's
+    # ``id`` decides is which conversation this turn joins. Those are different questions.
+    # With no bucket the fetch does nothing, but the id still selects a slot on the shared
+    # serializer and the backend still returns the live session behind it, so a second
+    # caller reusing a first caller's id lands in that conversation. Gating on the bucket
+    # left exactly that case open, and a no-bucket multi-caller deployment is an ordinary
+    # one rather than a corner.
+    #
+    # So the real condition is the one that is always true here: this route accepts a
+    # caller-supplied id and this process cannot bind it to a principal. It has no caller
+    # identity to bind -- reaching the task is an authorised call in the owner's own
+    # account, decided before the request arrives, and its result is not passed through --
+    # and a binding written against an absent identity fails OPEN. So it answers the
+    # question it CAN answer, whether the deployment has vouched that only one principal
+    # reaches this task, and declines to serve customer turns at all without that answer.
+    #
+    # Refusing at startup rather than per turn, for the reason ``require_api_key`` refuses
+    # at startup: a container that answers its port while mixing two callers' conversations
+    # looks healthy and is not.
+    if not settings.single_principal:
+        raise common.ConfigError(
+            "the deployment has not declared a single-principal trust domain "
+            "(SMC_SINGLE_PRINCIPAL). The customer turn route accepts the caller's own slot "
+            "id and this process has no caller identity to bind it to, so one caller "
+            "reusing another's id joins that conversation -- with a backup bucket by having "
+            "the transcript restored here, and without one by landing on the live session "
+            "the id already names. Set SMC_SINGLE_PRINCIPAL=1 if exactly one principal "
+            "reaches this task. Refusing to start."
+        )
+
+    if not settings.backup_bucket:
+        # Said once, here, rather than on every turn. A crew with no bucket has
+        # no durable conversations at all: nothing is uploaded, so an absent
+        # transcript is expected rather than a restore that failed.
+        logger.warning(
+            "no backup bucket configured: transcripts are never fetched, so a "
+            "conversation does not survive a task replacement"
+        )
+
+    def health() -> JSONResponse:
+        # No internals: a customer reaches this. Just liveness.
+        return JSONResponse({"status": "ok"})
+
+    @app.get(HEALTH_PATH)
+    async def health_bare() -> JSONResponse:
+        return health()
+
+    @app.api_route(
+        "/{full_path:path}",
+        methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+    )
+    async def gateway(full_path: str, request: Request):
+        stripped = strip_prefix("/" + full_path, settings.route_prefix)
+        method = request.method
+
+        if method == "GET" and stripped == HEALTH_PATH:
+            return health()
+
+        # Customer surface is a tiny allowlist; everything else is control.
+        is_customer_turn = method == "POST" and stripped == CUSTOMER_TURN_PATH
+        if not is_customer_turn:
+            granted = _control_authorized(request, settings)
+            try:
+                _audit_control_decision(request, stripped, granted=granted, settings=settings)
+            except audit.AuditUnavailable as exc:
+                # The decision is not acted on either way. Serving the grant would be the
+                # unaudited grant the record exists to prevent; serving the deny would be
+                # a denial nobody can later account for. 503 rather than 403, because what
+                # failed is this container's ability to record, not the caller's
+                # authorisation -- and a caller told "forbidden" would keep retrying a
+                # thing that is not their fault.
+                logger.error("control request refused: %s", exc)
+                return JSONResponse(
+                    {
+                        "detail": "control decision could not be audited",
+                        "code": "control_audit_unavailable",
+                    },
+                    status_code=503,
+                )
+            if not granted:
+                return JSONResponse(
+                    {"detail": "control access denied", "code": "control_forbidden"},
+                    status_code=403,
+                )
+            # Authorised, and there is nothing here to run yet: the front process
+            # serves two customer routes and no control operation. The gate stays in
+            # front of the 404 on purpose, so adding a control route later is adding a
+            # handler rather than also remembering to authorise it -- and so an
+            # unauthorised caller cannot learn which control paths exist by reading
+            # which ones 404.
+            return JSONResponse(
+                {
+                    "detail": "control route not served by the front process",
+                    "code": "control_not_implemented",
+                },
+                status_code=404,
+            )
+
+        # Bounded while READING, not after. ``request.json()`` buffers the whole body
+        # first, so a large upload is already resident by the time anything could reject
+        # it -- and a Content-Length check alone is not the bound, because the header is
+        # the client's claim about a body it has not sent yet. Counting the chunks is what
+        # makes the ceiling real.
+        # Named for what it holds, not ``body``: a ``body`` further down this function is
+        # the decoded dict handed to ``_forward_body``, and reusing the name made mypy
+        # report three type errors in the forwarding path rather than here.
+        raw_body = bytearray()
+        try:
+            async for chunk in request.stream():
+                raw_body += chunk
+                if len(raw_body) > _MAX_CONTROL_BODY_BYTES:
+                    return JSONResponse(
+                        {
+                            "detail": (f"request body exceeds {_MAX_CONTROL_BODY_BYTES} bytes"),
+                            "code": "body_too_large",
+                        },
+                        status_code=413,
+                    )
+        except Exception:
+            return JSONResponse(
+                {"detail": "request body could not be read", "code": "bad_request"},
+                status_code=400,
+            )
+        try:
+            payload = json.loads(bytes(raw_body).decode("utf-8"))
+        except Exception:
+            return JSONResponse(
+                {"detail": "request body must be JSON", "code": "bad_request"},
+                status_code=400,
+            )
+        if not isinstance(payload, dict):
+            return JSONResponse(
+                {"detail": "request body must be a JSON object", "code": "bad_request"},
+                status_code=400,
+            )
+
+        crew, refusal = judge_addressed_crew(payload, settings.crew_name)
+        if refusal is not None:
+            return refusal
+        # `judge_addressed_crew` returns (crew, None) or (None, response) -- a
+        # correlation no signature can express, so a checker reads `crew` as
+        # possibly None here. State the invariant rather than widen
+        # `_forward_body`, whose `crew: str` is what stops the deployed crew
+        # name from being replaced by the caller's string.
+        assert crew is not None
+        try:
+            body, slot_id, stream = _forward_body(payload, crew)
+        except BadForwardField as exc:
+            return JSONResponse(
+                {"detail": exc.detail, "code": "bad_request"},
+                status_code=400,
+            )
+        client = _get_client(app)
+        reader = _get_transcript_reader(app, settings)
+
+        # ONE construction site for the turn scope, so the per-slot lock and the
+        # on-demand transcript fetch cannot differ between the two transports.
+        # The streamed turn enters it inside its generator (the slot stays busy
+        # for the life of the stream); the non-streamed turn enters it here.
+        scope = transcript.prepared_turn(serializer, settings, slot_id, reader)
+
+        if stream:
+            return backend.forward_stream(client, settings, body, scope)
+
+        try:
+            async with scope:
+                return await backend.forward_completion(client, settings, body)
+        except common.BackendSecretUnavailable:
+            return JSONResponse(
+                {"detail": "service unavailable", "code": "backend_unavailable"},
+                status_code=503,
+            )
+        except transcript.TranscriptUnavailable:
+            # Refuse rather than answer with an empty conversation. A customer
+            # whose history looks forgotten is worse than an error, and serving
+            # the turn would also overwrite that history in S3 once a durability
+            # writer exists (it replaces whole objects).
+            logger.error("turn refused: transcript unavailable", exc_info=True)
+            return JSONResponse(
+                {
+                    "detail": "conversation is temporarily unavailable",
+                    "code": transcript.TranscriptUnavailable.code,
+                },
+                status_code=503,
+            )
+
+    return app

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/backend.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/backend.py
@@ -1,0 +1,217 @@
+"""Forwarding a turn to the Kiro Crew backend on loopback.
+
+Everything here follows the backend facts pinned in ``docs/system-specs/modules/aws-control.md``
+("The loopback hop"):
+
+* Turn endpoint is ``POST /v1/chat/completions`` with ``{model, messages, id,
+  stream}``.
+* Authenticate with the ``X-Internal-Secret`` header, read from disk **on every
+  attempt** via ``common.read_boot_secret``. The secret is ``os.urandom(16)`` per
+  boot and is never persisted, so a cached copy 403s silently after a backend
+  restart. It is never stored on the client or in a global here.
+* The client's ``Origin`` and any ``X-Forwarded-*`` header are never forwarded.
+  Rather than copy-and-strip, outbound headers are built from scratch, so a
+  header the customer sends cannot reach the backend by accident.
+* On a 403, re-read the secret once and retry once, then give up (relay it).
+* Every turn runs inside ``transcript.prepared_turn``: the per-slot lock plus the
+  on-demand fetch of that one conversation's transcript. The scope is built by
+  the caller and entered here on the streaming path, so both transports share one
+  definition of "the conversation is present and the slot is ours".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import AbstractAsyncContextManager
+from typing import Any
+
+import httpx
+from container import common
+from fastapi import Response
+from fastapi.responses import StreamingResponse
+
+from . import transcript
+from .stream import project_sse
+
+logger = logging.getLogger("smc.front.backend")
+
+TURN_PATH = "/v1/chat/completions"
+
+
+def build_outbound_headers(secret: str, *, stream: bool) -> dict[str, str]:
+    """The complete header set sent to the backend. Built from scratch: no
+    customer header is ever passed through, so ``Origin`` / ``X-Forwarded-*``
+    cannot leak in and trip the backend's CSRF check."""
+    return {
+        common.HEADER: secret,
+        "content-type": "application/json",
+        "accept": "text/event-stream" if stream else "application/json",
+    }
+
+
+def _read_secret(settings: common.Settings) -> str:
+    return common.read_boot_secret(settings.backend_run_dir, settings.backend_port)
+
+
+def _sse_error(message: str, *, kind: str = "server_error") -> bytes:
+    """A customer-safe SSE error frame in OpenAI stream shape (matches the real
+    backend, which emits ``data: {"error": ...}`` then ``data: [DONE]`` -- never a
+    named event). Detail stays server-side, never here.
+
+    ``kind`` carries the same code the non-streamed path returns in its JSON body,
+    so one failure is named identically on both transports.
+    """
+    err = {"error": {"message": message, "type": kind}}
+    return f"data: {json.dumps(err)}\n\ndata: [DONE]\n\n".encode("utf-8")
+
+
+async def forward_completion(
+    client: httpx.AsyncClient,
+    settings: common.Settings,
+    body: dict[str, Any],
+) -> Response:
+    """Single, non-streamed turn. Relays the backend's status and body verbatim.
+
+    A non-streamed completion returns assistant text; the backend's ``/v1``
+    ``usage`` block is hardcoded to zero, so there is nothing to redact here.
+    """
+    url = settings.backend_base_url + TURN_PATH
+    headers = build_outbound_headers(_read_secret(settings), stream=False)
+    # A transport failure is EXPECTED here, not exceptional: the backend is a sibling
+    # process that ECS restarts, and a turn in flight when that happens raised
+    # httpx.RequestError straight out of this coroutine. FastAPI turned that into a
+    # 500 with a stack-shaped body, which tells the caller "this service is broken"
+    # when the truth is "try again in a moment". 503 is that difference, and it is the
+    # difference a retrying client acts on.
+    try:
+        resp = await client.post(url, json=body, headers=headers)
+
+        if resp.status_code == 403:
+            # Re-read once (a fresh boot secret may be on disk) and retry once.
+            headers = build_outbound_headers(_read_secret(settings), stream=False)
+            resp = await client.post(url, json=body, headers=headers)
+    except httpx.RequestError as exc:
+        logger.warning("backend transport failure on a non-streamed turn: %s", exc)
+        return Response(
+            content=json.dumps(
+                {
+                    "error": {
+                        "message": "the crew's backend is not reachable right now",
+                        "type": "service_unavailable",
+                        "code": "backend_unreachable",
+                    }
+                }
+            ),
+            status_code=503,
+            media_type="application/json",
+        )
+
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        media_type=resp.headers.get("content-type", "application/json"),
+    )
+
+
+def forward_stream(
+    client: httpx.AsyncClient,
+    settings: common.Settings,
+    body: dict[str, Any],
+    scope: AbstractAsyncContextManager[None],
+) -> StreamingResponse:
+    """Streamed turn. Holds the turn scope for the whole stream and projects the
+    backend's SSE down to the customer allowlist.
+
+    ``scope`` is ``transcript.prepared_turn(...)``: the per-slot lock plus the
+    on-demand transcript fetch, built by the caller and entered HERE rather than
+    in the request handler, because the slot stays busy on the backend until the
+    stream ends. Entering it inside the generator also means a client that
+    disconnects before the body starts never takes the lock at all.
+
+    An SSE response commits status 200 before the body streams, so a failure
+    (a backend 403 that survives the one retry, or a transcript that could not be
+    fetched) is surfaced as an error FRAME rather than an HTTP status. The frame
+    carries the same code the non-streamed path returns, so the customer is told
+    the turn failed instead of being handed a conversation that looks forgotten.
+    """
+    url = settings.backend_base_url + TURN_PATH
+
+    async def generator():
+        try:
+            async with scope:
+                try:
+                    secret = _read_secret(settings)
+                except common.BackendSecretUnavailable:
+                    yield _sse_error("service unavailable")
+                    return
+
+                stream_cm = client.stream(
+                    "POST", url, json=body, headers=build_outbound_headers(secret, stream=True)
+                )
+                resp = await stream_cm.__aenter__()
+                # Track the stream we actually HOLD, so the finally below closes that
+                # one exactly once. The retry path exits the first stream before
+                # opening a second, so a single `stream_cm` name meant the finally
+                # could exit an already-closed context, or one whose __aenter__ never
+                # completed.
+                entered: AbstractAsyncContextManager[Any] | None = stream_cm
+                try:
+                    if resp.status_code == 403:
+                        await stream_cm.__aexit__(None, None, None)
+                        entered = None
+                        # The FIRST secret read is guarded; this one was not. A backend
+                        # that restarts and 403s while its replacement secret is not yet
+                        # on disk raised BackendSecretUnavailable from here, and nothing
+                        # above catches it. Status 200 is already committed by the time a
+                        # body streams, so the stream ended TRUNCATED with no `[DONE]`
+                        # and a client waiting for the sentinel waited forever. That is
+                        # the same defect as the transport case below, one line over, and
+                        # it survived the transport fix because it is a different type.
+                        try:
+                            secret = _read_secret(settings)
+                        except common.BackendSecretUnavailable:
+                            yield _sse_error("service unavailable")
+                            return
+                        stream_cm = client.stream(
+                            "POST",
+                            url,
+                            json=body,
+                            headers=build_outbound_headers(secret, stream=True),
+                        )
+                        resp = await stream_cm.__aenter__()
+                        entered = stream_cm
+
+                    if resp.status_code != 200:
+                        await resp.aread()
+                        yield _sse_error("upstream error")
+                        return
+
+                    async for frame in project_sse(resp.aiter_bytes()):
+                        yield frame
+                finally:
+                    if entered is not None:
+                        await entered.__aexit__(None, None, None)
+        except transcript.TranscriptUnavailable:
+            # The conversation could not be restored. Refuse the turn: answering
+            # would show the customer an empty history and then overwrite the
+            # real one in S3 at the next backup cycle.
+            logger.error("stream refused: transcript unavailable", exc_info=True)
+            yield _sse_error(
+                "conversation is temporarily unavailable",
+                kind=transcript.TranscriptUnavailable.code,
+            )
+        except httpx.RequestError as exc:
+            # The backend went away mid-turn -- an ECS restart, not a bug. Status 200
+            # is already committed by the time a body streams, so the only way to say
+            # "this failed" is a frame. Without this the generator raised and the
+            # response ended TRUNCATED, with no `[DONE]`: a client waiting for the
+            # sentinel waits forever, which reads as a hung crew rather than a retry.
+            # ``_sse_error`` appends `[DONE]`, so the stream is always well formed.
+            logger.warning("stream ended early: backend transport failure: %s", exc)
+            yield _sse_error(
+                "the crew's backend is not reachable right now",
+                kind="backend_unreachable",
+            )
+
+    return StreamingResponse(generator(), media_type="text/event-stream")

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/slotlock.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/slotlock.py
@@ -1,0 +1,66 @@
+"""Per-conversation serialization.
+
+The backend returns 409 for a second concurrent turn on one slot id. That is a
+correct backend behaviour, not something the caller should ever see: a customer
+who sends two messages quickly to the same conversation must have the second one
+queued, not rejected. So the front process serializes turns *per slot id*.
+
+A global lock would be wrong in the other direction: turns for DIFFERENT
+conversations must run concurrently, or one slow crew blocks every caller.
+
+The lock for a slot must be held for the whole turn, including the entire SSE
+stream, because the slot stays busy on the backend until the stream ends. The
+async context manager returned here is therefore entered inside the streaming
+generator, not merely around the request handler.
+
+Slots with no id (the backend mints one per request, so there is no shared
+conversation to contend on) are not serialized at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+
+
+class SlotSerializer:
+    """One asyncio lock per live slot id, created on demand and reaped when idle.
+
+    Locks are reference-counted so the map does not grow without bound over the
+    life of the process: the entry for a slot is removed once no turn holds or
+    waits on it.
+    """
+
+    def __init__(self) -> None:
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._waiters: dict[str, int] = {}
+        self._guard = asyncio.Lock()
+
+    @asynccontextmanager
+    async def for_slot(self, slot_id: str):
+        # No id means no shared conversation: run concurrently, take no lock.
+        if not slot_id:
+            yield
+            return
+
+        async with self._guard:
+            lock = self._locks.get(slot_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[slot_id] = lock
+                self._waiters[slot_id] = 0
+            self._waiters[slot_id] += 1
+
+        try:
+            async with lock:
+                yield
+        finally:
+            async with self._guard:
+                self._waiters[slot_id] -= 1
+                if self._waiters[slot_id] <= 0:
+                    self._locks.pop(slot_id, None)
+                    self._waiters.pop(slot_id, None)
+
+    def _live_slots(self) -> int:
+        """Number of slots currently tracked. For tests and diagnostics only."""
+        return len(self._locks)

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/stream.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/stream.py
@@ -1,0 +1,108 @@
+"""Customer stream projection for the backend's OpenAI-compatible turn SSE.
+
+VERIFIED against a real Kiro Crew backend (isolated home on :8801):
+``POST /v1/chat/completions`` with ``stream=true`` emits an **OpenAI** event
+stream, NOT the ACP ``sessionUpdate`` vocabulary:
+
+  * ``data: {chat.completion.chunk}`` frames carrying ``choices[].delta.content``
+    -- assistant text only. The backend already applies credential/exfil-URL
+    redaction to this content (``openai_compat._redact``), and its collector
+    forwards ONLY ``assistant``/``chunk`` roles, so tool params, agent reasoning
+    and usage never appear on this endpoint.
+  * ``: keepalive`` comment frames (every ~30s of quiet).
+  * a terminal ``data: [DONE]``.
+  * on failure, ``data: {"error": {...}}`` then ``data: [DONE]``.
+  * NO SSE ``event:`` names anywhere.
+
+The ACP event kinds the design's streaming contract enumerates -- and the
+undocumented ``tool_result`` leak it warns about -- belong to the OWNER control
+stream (``GET /sessions/{cid}/stream``), a surface the front process does NOT
+serve. An event-NAME allowlist (the earlier build) drops every frame here and
+hands the customer an empty turn.
+
+So the projection fails closed at the FRAME-CONTENT level. A frame is relayed
+only if it is: a keepalive comment, the ``[DONE]`` sentinel, a well-formed
+``chat.completion.chunk``, or an OpenAI ``error`` object. Anything else -- a
+non-chunk JSON object, non-JSON data, or a frame carrying an SSE ``event:`` name
+(which this endpoint never emits) -- is dropped. If a future backend change ever
+interleaves a named ACP event onto this endpoint, it fails closed rather than
+leaking.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import AsyncIterator
+
+_FRAME_SEP = b"\n\n"
+
+
+def _frame_lines(frame_text: str) -> list[str]:
+    return frame_text.split("\n")
+
+
+def _is_keepalive(lines: list[str]) -> bool:
+    nonblank = [line for line in lines if line != ""]
+    return len(nonblank) > 0 and all(line.startswith(":") for line in nonblank)
+
+
+def _data_payload(lines: list[str]) -> str | None:
+    """Concatenated SSE ``data:`` field of a frame, or None if it has none."""
+    parts = [line[len("data:") :].lstrip() for line in lines if line.startswith("data:")]
+    if not parts:
+        return None
+    return "\n".join(parts).strip()
+
+
+def _frame_is_customer_safe(frame_text: str) -> bool:
+    lines = _frame_lines(frame_text)
+    if _is_keepalive(lines):
+        return True
+    # This endpoint never names events; a named frame is an anomaly -> drop.
+    if any(line.startswith("event:") for line in lines):
+        return False
+    payload = _data_payload(lines)
+    if payload is None:
+        return False
+    if payload == "[DONE]":
+        return True
+    try:
+        obj = json.loads(payload)
+    except (ValueError, TypeError):
+        return False  # non-JSON data -> fail closed
+    if not isinstance(obj, dict):
+        return False
+    return obj.get("object") == "chat.completion.chunk" or "error" in obj
+
+
+def project_frame(frame_bytes: bytes) -> bytes | None:
+    """Return the frame verbatim (with separator) if it may reach the customer,
+    else None. Fails closed."""
+    text = frame_bytes.decode("utf-8", "replace")
+    if not text.strip():
+        return None
+    if _frame_is_customer_safe(text):
+        return frame_bytes + _FRAME_SEP
+    return None
+
+
+async def project_sse(chunks: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+    """Reframe a raw backend SSE byte stream, yielding only customer-safe frames.
+
+    Frames can straddle chunk boundaries, so bytes are buffered and split on the
+    blank-line separator. CRLF is normalised to LF.
+    """
+    buffer = b""
+    async for chunk in chunks:
+        if not chunk:
+            continue
+        buffer += chunk.replace(b"\r\n", b"\n")
+        while _FRAME_SEP in buffer:
+            frame, buffer = buffer.split(_FRAME_SEP, 1)
+            projected = project_frame(frame)
+            if projected is not None:
+                yield projected
+    if buffer.strip():
+        projected = project_frame(buffer)
+        if projected is not None:
+            yield projected

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/transcript.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/front/transcript.py
@@ -1,0 +1,668 @@
+"""Putting ONE conversation's transcript on disk, at the turn that needs it.
+
+Boot downloads no transcripts at all: a task starts with the two authority files
+and no conversations. This module is the other half of that change. Before a
+turn reaches the backend, the one transcript that turn continues is fetched.
+
+The property the pair achieves, stated exactly: *a task only ever holds the
+conversations it itself served, and loses them when it exits.*
+
+Each rule below is a way this goes wrong silently, so each is enforced by
+construction rather than by review.
+
+* **One object, never a list.** The reader this module talks to has no ``list``
+  and no ``put`` (:class:`TranscriptReader`), so listing the prefix is not a
+  thing this code path can do. A single list would undo the whole change at the
+  first turn.
+* **Absent is NORMAL.** A new conversation has no transcript yet, and its first
+  turn must proceed.
+* **Already on disk means this task already served it.** Do not re-fetch and do
+  not overwrite: the local copy is newer than S3 by up to one backup interval,
+  so overwriting rolls a customer's conversation backwards. The write uses
+  ``os.link`` onto the target, which FAILS if the target exists, so
+  "never overwrite" is a filesystem guarantee and not a check that a later edit
+  can quietly drop.
+* **A fetch that fails FAILS THE TURN.** A customer whose conversation appears
+  forgotten is worse than an error, and the damage is worse than it first looks:
+  the backend would create a fresh transcript holding only this turn, and once a
+  durability writer exists it will replace whole objects (that is the write model
+  the extracted backup used and the one its replacement must keep), so the next
+  backup cycle would overwrite the customer's entire history in S3. Failing the
+  turn now keeps that hazard closed before the writer lands. The failure is
+  :class:`TranscriptUnavailable`, surfaced with its own error code.
+* **Never log a transcript's contents.** The sid and the byte count only.
+
+**The filename, which is the part that was found the hard way.** The object is
+``<thread>_<slot>.jsonl``, not ``<slot>.jsonl``, and for this deployment the
+thread is always ``dashboard``. Verified in the Kiro Crew wheel this image ships
+(``vendor/kirocrew-0.6.0-py3-none-any.whl``):
+
+* ``dashboard/openai_compat.py:257`` takes the turn's ``id`` as the slot id and
+  ``:296`` resolves it through ``state.get_or_create_slot``, which normalizes
+  with ``dashboard/state.py:_normalize_slot_key``.
+* That function's docstring states the invariant a restart depends on:
+  ``_safe_key(_history_key_for(key)) == f"dashboard_{key}"``. So the transcript
+  stem is the slot key with a ``dashboard_`` prefix, and the file is
+  ``<sessions_dir>/dashboard_<slot>.jsonl``.
+* ``control/observe.py resolve_open_slots`` documents the same mapping from the
+  other side, plus the verbatim form (``weixin_...``) that belongs to a
+  channel-born conversation. No channel credentials are supplied to this
+  container (``docs/system-specs/modules/aws-control.md``), so every conversation here is a
+  dashboard slot and the thread is not ambiguous.
+
+``_normalize_slot_key`` is mirrored rather than imported: the wheel is a vendored
+artifact the front process does not import from, and the mapping is three lines.
+:func:`transcript_stem` is pinned against the values in those two sources by
+``tests/test_front_transcript_fetch.py``.
+
+Archived segments (``sessions/archive/**``) are deliberately NOT fetched: finding
+them requires listing, which is the one thing this path may not do. Rotation
+keeps the recent window in the live transcript, so a turn continues from the live
+object; older segments stay in S3 and remain readable by the owner's control
+plane, which has credentials of its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import logging
+import os
+import re
+import stat
+import tempfile
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from ..common import Settings
+from .slotlock import SlotSerializer
+
+logger = logging.getLogger("smc.front.transcript")
+
+__all__ = [
+    "TranscriptReader",
+    "S3TranscriptReader",
+    "TranscriptUnavailable",
+    "TranscriptAbsent",
+    "FetchOutcome",
+    "transcript_stem",
+    "object_key",
+    "local_transcript_path",
+    "ensure_local_transcript",
+    "prepared_turn",
+]
+
+# The transport prefix every dashboard conversation's transcript carries. See the
+# module docstring for where this is established.
+THREAD_PREFIX = "dashboard"
+
+# Mirrors ``dashboard/state.py:_ascii_slot_key`` then the filename fold in
+# ``history.py:_safe_key`` (``re.ASCII`` pins ``\w`` to ``[a-zA-Z0-9_]``). Order
+# matters: the non-printable pass produces ``-``, which the filename fold keeps.
+_NON_PRINTABLE_RE = re.compile(r"[^\x20-\x7e]")
+_FILENAME_UNSAFE_RE = re.compile(r"[^\w\-.]", flags=re.ASCII)
+
+# Namespace and key derivation for a transcript object in the S3 bucket. These moved HERE
+# from the backup layout module when the backup subsystem was extracted from this PR (the
+# durability design is tracked separately). The front's on-demand transcript fetch is
+# runtime, not backup, but it READS a key an eventual sidecar will WRITE, so the two must
+# derive the same key. Until the durability feature lands there is no writer, so this fetch
+# reads an empty bucket -- a capability the container does not yet have, not a regression.
+# When backup returns, the writer and this reader must share ONE derivation; the first live
+# deployment doubled the crew name in every key because two places each decided the prefix,
+# and it survived twelve green gates because writer and reader agreed with each other while
+# both disagreed with the contract. The lesson stands regardless of which module owns it.
+_TRANSCRIPT_DATA_NS = "data/"
+
+
+def _object_prefix(settings: Settings) -> str:
+    parts = [p for p in (settings.backup_prefix.strip("/"), settings.crew_name.strip("/")) if p]
+    return ("/".join(parts) + "/") if parts else ""
+
+
+def _sessions_prefix(settings: Settings) -> str:
+    """Rel-key prefix under which conversation transcripts live."""
+    try:
+        tail = settings.sessions_dir.relative_to(settings.data_home).as_posix()
+    except ValueError:
+        tail = settings.sessions_dir.name
+    return _TRANSCRIPT_DATA_NS + tail + "/"
+
+
+def _full_key(settings: Settings, rel_key: str) -> str:
+    return _object_prefix(settings) + rel_key
+
+
+class TranscriptUnavailable(RuntimeError):
+    """The transcript could not be obtained, so the turn must not be served.
+
+    Distinct from absence. Absence means the conversation is new; this means we
+    do not know whether it is, and answering anyway would present a returning
+    customer with an empty conversation and then overwrite their history in S3
+    at the next backup cycle.
+    """
+
+    code = "transcript_unavailable"
+
+
+class TranscriptAbsent(Exception):
+    """The key is not in the bucket, which for a new conversation is normal.
+
+    A reader may raise this to say so explicitly. It does not have to: a
+    botocore-shaped ``NoSuchKey``/404 error is classified the same way by
+    :func:`_fetch`, so the real boto3 client needs no wrapper of its own.
+    """
+
+
+# Error codes S3 uses for "that key is not here". Anything else, ``AccessDenied``
+# included, is a FAILURE: absence and denial are different answers and only one
+# of them may let the turn proceed.
+_ABSENT_CODES = frozenset({"NoSuchKey", "404", "NotFound"})
+
+
+@runtime_checkable
+class TranscriptReader(Protocol):
+    """Read ONE object by key. Deliberately the whole surface.
+
+    There is no ``list`` and no ``put``. The isolation property this change
+    exists for dies at the first list, and the turn path must never be a writer,
+    so neither operation is reachable from it even by mistake. ``get`` returns
+    the whole object, or raises: either
+    :class:`TranscriptAbsent`, or whatever the client raised, which
+    :func:`_fetch` classifies.
+    """
+
+    def get(self, key: str) -> bytes: ...
+
+
+class S3TranscriptReader:
+    """The real reader: ``GetObject``, one key, read-only.
+
+    boto3 is imported and the client built lazily so the front process is
+    importable, and every existing test runnable, with no AWS present.
+
+    It deliberately does NOT classify its own errors. Absence policy lives in
+    one place (:func:`_fetch`) so the fake used in tests and the real client are
+    judged by the same rule, rather than the rule being exercised only through
+    boto3-shaped exceptions the tests would have to imitate here.
+    """
+
+    def __init__(self, bucket: str, *, client=None) -> None:
+        self._bucket = bucket
+        self._client = client
+
+    def _ensure_client(self):
+        if self._client is None:
+            import boto3  # local import: keep the front process AWS-free to import
+
+            self._client = boto3.client("s3")
+        return self._client
+
+    def get(self, key: str) -> bytes:
+        """Fetch one object, bounded twice.
+
+        ``ContentLength`` is a CLAIM by the source, so it is checked and then not
+        trusted: an object that declares itself too large is refused before a byte is
+        read, and the streaming read enforces the same ceiling on what actually arrives.
+        A header is not a bound, which is the same reason the request-body limit on the
+        turn route does not trust ``Content-Length`` either.
+        """
+        resp = self._ensure_client().get_object(Bucket=self._bucket, Key=key)
+        declared = resp.get("ContentLength")
+        if isinstance(declared, int) and declared > MAX_TRANSCRIPT_BYTES:
+            raise TranscriptTooLarge(
+                f"the stored transcript {key} declares {declared} bytes, above the "
+                f"{MAX_TRANSCRIPT_BYTES}-byte ceiling, and was not read."
+            )
+        return _read_bounded(resp["Body"], key)
+
+
+#: Ceiling on a transcript restored from the bucket.
+#:
+#: The bytes come from outside the container and are held IN MEMORY for the length of a
+#: turn, so without a ceiling one object decides how much memory this process uses. 64
+#: MiB is far above any real transcript (a conversation is JSONL text) and far below the
+#: task's memory, so it separates "a big conversation" from "an object that should not be
+#: read at all" without needing to know which conversations exist.
+MAX_TRANSCRIPT_BYTES: int = 64 * 1024 * 1024
+
+#: How much is read per chunk while enforcing that ceiling. Small enough that the
+#: overshoot before the refusal is bounded by this rather than by the object's size.
+_READ_CHUNK_BYTES: int = 1024 * 1024
+
+
+class TranscriptTooLarge(TranscriptUnavailable):
+    """The stored object is larger than a transcript is allowed to be."""
+
+
+def _read_bounded(body, key: str, *, limit: int = MAX_TRANSCRIPT_BYTES) -> bytes:
+    """Read at most *limit* bytes from an S3 body, refusing an object that exceeds it.
+
+    Streamed in chunks rather than ``body.read()``: a single read materialises whatever
+    the object happens to be, so the ceiling would be enforced after the memory was
+    already committed. Reading one chunk PAST the limit is what makes the refusal
+    decidable -- stopping exactly at the limit cannot tell a file of exactly that size
+    from a larger one.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = body.read(_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > limit:
+            raise TranscriptTooLarge(
+                f"the stored transcript {key} exceeds {limit} bytes and was not read. It "
+                "is held in memory for the length of a turn, so an object this size is "
+                "refused rather than loaded."
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _error_code(exc: Exception) -> str:
+    """The S3 error code of a botocore ClientError, or ``""``.
+
+    Read off the response dict rather than the exception type so a stub client in
+    a test can produce a genuine absence without botocore installed.
+    """
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        error = response.get("Error")
+        if isinstance(error, dict):
+            code = error.get("Code")
+            if isinstance(code, str):
+                return code
+        status = response.get("ResponseMetadata")
+        if isinstance(status, dict) and status.get("HTTPStatusCode") == 404:
+            return "404"
+    return ""
+
+
+def _sid_of(key: str) -> str:
+    """The sid a key names, for a log line. Never the key's contents."""
+    tail = key.rsplit("/", 1)[-1]
+    return tail[: -len(".jsonl")] if tail.endswith(".jsonl") else tail
+
+
+# --- naming ---------------------------------------------------------------
+
+
+def is_fetchable_slot_id(slot_id: str) -> bool:
+    """True when this id is worth spending an S3 GET on.
+
+    The front proxies a turn; the BACKEND decides whether an id is legal. That
+    ordering leaves a hole, because the fetch happens first: an id the backend
+    goes on to reject can still name a real conversation once folded, so the
+    task ends up holding a conversation it never served, which is precisely the
+    property this change exists to establish. ``id="dashboard:cust-1"`` is the
+    demonstrated case. The backend's own grammar
+    (``kiro_crew.session_storage._UNIT_ID_RE``, ``[A-Za-z0-9_][A-Za-z0-9._-]*``)
+    has no colon in it, yet the fold turns that string into ``dashboard_cust-1``
+    and downloads someone's transcript.
+
+    The test is deliberately a SHAPE test and not a copy of that grammar, which
+    lives in a dependency this process does not import. Every character the
+    backend accepts is a character the sanitizer leaves alone, so "the sanitizer
+    changed nothing" admits every legal id and excludes the folded spellings.
+    Being wrong in the permissive direction is the only safe way to be wrong
+    here: skipping a fetch for an id the backend ACCEPTS would serve an empty
+    history, and the sidecar's whole-object put would then overwrite that
+    customer's real history in S3. Skipping one it REJECTS costs nothing, since
+    a refused turn never reaches the session store.
+    """
+    body = slot_id
+    while body.startswith(THREAD_PREFIX + "_"):
+        body = body[len(THREAD_PREFIX) + 1 :]
+    if not body:
+        return False
+    return _FILENAME_UNSAFE_RE.sub("_", _NON_PRINTABLE_RE.sub("-", body)) == body
+
+
+def normalize_slot_key(slot_id: str) -> str:
+    """Fold a turn's ``id`` exactly as the backend folds it into a slot key.
+
+    Mirrors ``dashboard/state.py:_normalize_slot_key``. The prefix stripping is
+    the part that matters here: ``id="dashboard_cust-1"`` reaches the SAME slot,
+    and therefore the same transcript, as ``id="cust-1"``, so a fetch that
+    skipped this step would miss the object for one of the two spellings and
+    hand that caller an empty conversation.
+    """
+    if slot_id.startswith(THREAD_PREFIX + ":"):
+        slot_id = slot_id[len(THREAD_PREFIX) + 1 :]
+    while slot_id.startswith(THREAD_PREFIX + "_"):
+        slot_id = slot_id[len(THREAD_PREFIX) + 1 :]
+    return _FILENAME_UNSAFE_RE.sub("_", _NON_PRINTABLE_RE.sub("-", slot_id))
+
+
+def transcript_stem(slot_id: str) -> str:
+    """The transcript's filename stem, or ``""`` when the id names nothing.
+
+    ``"cust-8831"`` -> ``"dashboard_cust-8831"``, whose file is
+    ``dashboard_cust-8831.jsonl``. NOT ``cust-8831.jsonl``: see the module
+    docstring for the two independent sources that establish the prefix.
+    """
+    normalized = normalize_slot_key(slot_id)
+    if not normalized:
+        return ""
+    return f"{THREAD_PREFIX}_{normalized}"
+
+
+def object_key(settings: Settings, stem: str) -> str:
+    """The full S3 key of a transcript, matching what a sidecar would write.
+
+    Derived from THIS module's own key helpers now that backup is extracted. When the
+    durability feature returns, its writer and this reader must derive the same key from a
+    single shared definition, because drift here is invisible: the fetch would simply miss,
+    and a customer whose history was not found is indistinguishable from a new one.
+
+    That is not hypothetical. The first live deployment doubled the crew name in every key
+    (``crews/<crew>/<crew>/``) because two places each decided one prefix, and it survived
+    twelve green gates because writer and reader agreed with each other while both disagreed
+    with the contract.
+    """
+    return _full_key(settings, f"{_sessions_prefix(settings)}{stem}.jsonl")
+
+
+#: Longest single filename this build will construct for a transcript. 255 is the POSIX
+#: ``NAME_MAX`` on ext4/xfs and the limit NTFS applies per component too, so it is the
+#: bound that actually exists rather than one chosen for neatness. Measured on the build
+#: host with ``getconf NAME_MAX /``.
+_MAX_STEM_CHARS = 255
+
+
+def local_transcript_path(settings: Settings, stem: str) -> Path | None:
+    """Where the transcript belongs on disk, or None if the stem escapes it.
+
+    A slot id is untrusted input. The fold in :func:`normalize_slot_key` already
+    turns ``/`` into ``_``, so traversal is not reachable, but the containment is
+    asserted rather than assumed: the cost is one comparison and the failure it
+    guards is a write outside the data home.
+    """
+    # Length is checked HERE, beside the containment check, because this function is the
+    # one place that decides whether a stem maps to a usable path -- and it does so with
+    # string operations only. A stem longer than the filesystem allows therefore passes
+    # this function and raises ``OSError(ENAMETOOLONG)`` at the caller's first ``exists()``
+    # instead, which reads as "the disk is broken" rather than "that id is not valid".
+    #
+    # ``_MAX_STEM_CHARS`` is derived from the measured ``NAME_MAX`` rather than a number
+    # quoted from the backend: no length limit was found in the backend's own persistence
+    # code, so the real bound is what the filesystem will accept for the ``.jsonl`` name.
+    if len(stem) + len(".jsonl") > _MAX_STEM_CHARS:
+        return None
+    candidate = settings.sessions_dir / f"{stem}.jsonl"
+    root = os.path.normpath(str(settings.sessions_dir))
+    resolved = os.path.normpath(str(candidate))
+    if not resolved.startswith(root + os.sep):
+        return None
+    return candidate
+
+
+# --- the fetch ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FetchOutcome:
+    """What the fetch did. Returned for logging and tests, never to the customer.
+
+    ``action`` is one of:
+
+    * ``"no_slot"``  the turn names no conversation, so there is nothing to fetch
+    * ``"no_store"`` no bucket is configured, so there is nothing to fetch from
+    * ``"not_a_slot_id"`` the backend will refuse this id, so fetching would put
+      a conversation this task never serves on its disk
+    * ``"present"``  already on disk: this task served it, keep the newer copy
+    * ``"fetched"``  restored from S3
+    * ``"absent"``   not in S3: a new conversation, which is normal
+    """
+
+    action: str
+    stem: str = ""
+    bytes_written: int = 0
+
+
+def _write_without_clobbering(path: Path, data: bytes) -> None:
+    """Create ``path`` with ``data``, failing if it already exists.
+
+    Three properties, all load-bearing:
+
+    * **Atomic.** The bytes land in a temp file in the same directory, are
+      fsynced, and then appear at the target under one name. A crash cannot
+      leave a truncated transcript for the backend to append to and the sidecar
+      to upload.
+    * **Never an overwrite.** ``os.link`` refuses an existing target, so the
+      do-not-overwrite rule holds even against a file that appeared in the
+      window since the caller looked. An existing target is not an error here:
+      whoever created it has the newer copy, which is exactly what the rule
+      protects. It also refuses a symlink at the target without following it, so
+      a link planted there cannot receive a customer's conversation.
+    * **Into a real directory.** The sessions directory is checked by ``lstat``
+      before it is created or written into, because ``mkdir(exist_ok=True)``
+      succeeds on a symlink to a directory and every write then lands wherever
+      that link points.
+    """
+    parent = path.parent
+    if parent.is_symlink():
+        raise TranscriptUnavailable(
+            f"the sessions directory is a symlink: {parent}. Writing a transcript "
+            "through it would put a customer's conversation outside the data home. "
+            "Refusing the turn."
+        )
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        # A regular file where the sessions directory belongs fails EVERY turn, so it is
+        # answered as a refusal naming the path rather than as whatever ``mkdir`` raises.
+        # The supervisor makes the same call about the directories it creates at boot.
+        raise TranscriptUnavailable(
+            f"the sessions directory could not be created at {parent} ({exc})."
+        ) from exc
+    fd, tmp = tempfile.mkstemp(dir=str(parent), prefix=".smc-fetch-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        try:
+            os.link(tmp, str(path))
+        except FileExistsError:
+            # Something arrived at this path while the fetch was in flight, so the file
+            # the turn will use is NOT the one just written and has had none of this
+            # module's checks applied to it. Keeping the copy on disk is still right --
+            # whoever created it has the newer history -- but only if it is a
+            # transcript at all, so the entry that won is validated the same way the
+            # pre-fetch check validates one, through the same helper rather than a
+            # second check that could drift from it. A shape that fails raises, which
+            # fails this turn.
+            _probe_local_entry(path)
+            logger.info(
+                "transcript fetch: sid=%s appeared while fetching; keeping the "
+                "copy on disk, which is the newer one",
+                _sid_of(path.name),
+            )
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+#: Flags for a shape probe on a local transcript entry.
+#:
+#: ``O_NOFOLLOW`` refuses a symlink at the final component, and ``O_NONBLOCK`` is what
+#: keeps a FIFO from turning the probe into a hang: opening a pipe for reading blocks
+#: until a writer arrives, and an entry planted as a FIFO would otherwise stall the
+#: turn indefinitely rather than be refused.
+_PROBE_FLAGS: int = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+
+
+def _probe_local_entry(path: Path) -> bool:
+    """Is this slot's transcript already a real file on disk?
+
+    ``True`` it is a regular file with one link, ``False`` nothing is there. Any other
+    shape RAISES :class:`TranscriptUnavailable` naming the path, because the turn must
+    not proceed on an entry the backend is about to open and append to.
+
+    Shape is decided on the DESCRIPTOR, never on the name. ``Path.exists()`` follows a
+    symlink, answers true for a directory, a FIFO or a socket, and is a separate
+    operation from the open that follows it -- so a check by name plus an open by name
+    is two resolutions of one path with a window in between, which is the gap every
+    finding in this series has lived in. Mirrors ``hooks.safe_read_file_bytes_nolink``:
+    open first with the link refused, then ``fstat`` the descriptor, so the entry
+    validated is exactly the entry that was opened. The helper cannot be imported here
+    -- ``kiro_crew`` is not importable inside the image -- so the shape is mirrored,
+    the way ``supervisor/bundle.py`` mirrors the agents-dir resolver.
+
+    ``st_nlink > 1`` is refused for a reason the file type does not cover: a hard link
+    is a regular file, and the backend appends to this path, so a second name for the
+    same inode makes that append write into whatever else holds it.
+
+    Nothing here reads the file. This process only decides whether the backend may,
+    and the refusals are the shapes an operator has to know about.
+    """
+    try:
+        fd = os.open(str(path), _PROBE_FLAGS)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise TranscriptUnavailable(
+                f"the transcript path is a symlink, not a file: {path}. The backend "
+                "appends to it, so a link there would redirect a conversation's history "
+                "somewhere else. Refusing the turn rather than writing through it."
+            ) from exc
+        raise TranscriptUnavailable(
+            f"the transcript path could not be opened to check its shape: {path} ({exc})."
+        ) from exc
+    try:
+        st = os.fstat(fd)
+    finally:
+        os.close(fd)
+    if not stat.S_ISREG(st.st_mode):
+        raise TranscriptUnavailable(
+            f"the transcript path is not a regular file: {path} (mode {st.st_mode:#o}). "
+            "A directory, socket or FIFO there is not a conversation this task can "
+            "serve, so the turn is refused rather than handed to the backend."
+        )
+    if st.st_nlink > 1:
+        raise TranscriptUnavailable(
+            f"the transcript file has {st.st_nlink} links: {path}. The backend appends "
+            "to it, so another name for the same inode would receive a customer's "
+            "conversation. Refusing the turn."
+        )
+    return True
+
+
+def _fetch(reader: TranscriptReader, key: str) -> bytes | None:
+    """Blocking read of one key. None means absent. Runs off the event loop.
+
+    The one place absence is decided. ``AccessDenied`` is NOT absence: reading a
+    denial as "new conversation" is the silent route to serving an empty history
+    and then overwriting the real one at the next backup cycle.
+
+    Residual risk, named because it cannot be settled from here: S3 answers a
+    missing key with 403 rather than 404 when the caller lacks ``s3:ListBucket``
+    for it, and the task role's grant carries an ``s3:prefix`` condition
+    (the deploy track's template narrows it to the task's own prefix) whose effect on that
+    choice needs a real bucket to establish. If it does answer 403, a brand new
+    conversation's FIRST turn fails closed here instead of starting fresh. That
+    is the fail direction the contract asks for, and the fix belongs to the
+    deploy track, not to a looser rule here.
+    """
+    try:
+        return reader.get(key)
+    except TranscriptAbsent:
+        return None
+    except Exception as exc:  # noqa: BLE001 - classified, never swallowed
+        if _error_code(exc) in _ABSENT_CODES:
+            return None
+        raise TranscriptUnavailable(f"GetObject failed for sid {_sid_of(key)}") from exc
+
+
+async def ensure_local_transcript(
+    settings: Settings,
+    slot_id: str,
+    *,
+    reader: TranscriptReader | None,
+) -> FetchOutcome:
+    """Make sure this slot's transcript is on disk. Call inside the slot lock.
+
+    Raises :class:`TranscriptUnavailable` when the object exists as far as we
+    know but could not be read. Every other outcome lets the turn proceed.
+    """
+    stem = transcript_stem(slot_id)
+    if not stem:
+        return FetchOutcome("no_slot")
+
+    if not is_fetchable_slot_id(slot_id):
+        # The backend will refuse this id. Folding it would still name a real
+        # conversation, so fetching first would put someone else's history on
+        # this task's disk for a turn that is about to be rejected. Let the
+        # backend do the refusing; a refused turn writes nothing, so there is no
+        # empty-history hazard in declining to fetch here.
+        logger.info("transcript fetch: id is not a slot id; not fetching")
+        return FetchOutcome("not_a_slot_id", stem)
+
+    path = local_transcript_path(settings, stem)
+    if path is None:
+        # Unreachable through the backend's own id validation, and fail-closed
+        # rather than dropped: we cannot promise the conversation's history.
+        raise TranscriptUnavailable(f"slot id does not map into the sessions dir: {stem!r}")
+
+    if _probe_local_entry(path):
+        # This task already served this conversation. The local copy leads S3 by
+        # up to one backup interval, so re-fetching could only lose turns.
+        logger.debug("transcript fetch: sid=%s already on disk; not re-fetching", stem)
+        return FetchOutcome("present", stem)
+
+    if reader is None:
+        # No bucket configured. Nothing was ever uploaded, so nothing is missing:
+        # this is a crew running without durability, not a failure to restore.
+        # The warning is emitted once at startup, not once per turn.
+        return FetchOutcome("no_store", stem)
+
+    key = object_key(settings, stem)
+    # boto3 is blocking. A multi-megabyte GET on the event loop would stall every
+    # OTHER conversation's turn, so it runs in a thread.
+    data = await asyncio.to_thread(_fetch, reader, key)
+    if data is None:
+        logger.info("transcript fetch: sid=%s not in S3; treating as a new conversation", stem)
+        return FetchOutcome("absent", stem)
+
+    # The write is offloaded for exactly the reason the fetch above is: this is the
+    # same multi-megabyte payload, and `_write_without_clobbering` fsyncs it, which
+    # is the slowest thing a filesystem does. Leaving it inline would have made the
+    # thread on the previous line pointless -- the loop would stall on the write it
+    # was just spared on the read.
+    await asyncio.to_thread(_write_without_clobbering, path, data)
+    logger.info("transcript fetch: sid=%s restored %d B", stem, len(data))
+    return FetchOutcome("fetched", stem, len(data))
+
+
+@asynccontextmanager
+async def prepared_turn(
+    serializer: SlotSerializer,
+    settings: Settings,
+    slot_id: str,
+    reader: TranscriptReader | None,
+):
+    """Hold the slot for this turn, with its transcript present.
+
+    The two transports differ in WHERE they enter this scope, not in what it
+    does: the non-streamed turn enters it in the request handler, and the
+    streamed turn enters it inside its generator, because an SSE response must
+    keep the slot for the life of the stream. Both enter the same object, so the
+    fetch happens inside the per-slot lock on both paths and the ordering exists
+    in one place. Writing the fetch into each transport instead would leave two
+    copies of "before the body reaches the backend" to keep in agreement.
+    Both the lock and the fetch are keyed on the CANONICAL slot, not the string
+    the caller sent. ``cust-1``, ``dashboard_cust-1`` and ``dashboard:cust-1`` all
+    name one conversation and resolve to one transcript, so locking on the raw id
+    would hand two spellings two different locks and let them run at once, on the
+    same file, while the serializer reported one turn per slot.
+    """
+    canonical = normalize_slot_key(slot_id)
+    async with serializer.for_slot(canonical or slot_id):
+        await ensure_local_transcript(settings, slot_id, reader=reader)
+        yield

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/requirements-dev.txt
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+pytest-asyncio==0.25.2

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/requirements.txt
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/requirements.txt
@@ -1,0 +1,7 @@
+# Container runtime only. These must NOT become dependencies of the Kiro Crew app
+# itself: the app's backend hooks are imported into the owner's gateway process,
+# and adding a web framework to every owner's gateway buys nothing.
+fastapi==0.115.6
+uvicorn==0.34.0
+httpx==0.28.1
+boto3==1.35.99

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/__init__.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/__init__.py
@@ -1,0 +1,21 @@
+"""Track S3: launch the Kiro Crew backend headless and supervise the process tree.
+
+This package owns the container entrypoint. It runs the startup order the
+contract makes a correctness requirement (`docs/system-specs/modules/aws-control.md`, "Three
+processes, one task"): gate the environment and install the bundle, then the backend, then the
+front process. It also owns shutdown, which terminates process *groups* rather
+than pids because a `kiro-cli` worker is a two-process tree and signalling only
+the launcher orphans a child that finishes its turn anyway.
+
+There is no restore phase and no sidecar: the backup subsystem was extracted from
+this PR (durability is tracked separately).
+
+Public seams other tracks may call (do not import our internals otherwise):
+
+- ``container.supervisor.backend:start_backend(settings)``
+- ``container.supervisor.backend:wait_until_ready(settings, timeout)``
+"""
+
+from .backend import start_backend, wait_until_ready
+
+__all__ = ["start_backend", "wait_until_ready"]

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/__main__.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/__main__.py
@@ -1,0 +1,484 @@
+"""Container entrypoint: order the task, supervise it, drain it on shutdown.
+
+Run as ``python -m container.supervisor``. This is the task's init process. It
+does not serve anything itself; it enforces the startup order the contract makes
+a correctness requirement and then supervises the children.
+
+The order (``docs/system-specs/modules/aws-control.md``, "Three processes, one task"):
+
+1. Gate the environment (layout, model credential, sandbox) and install the crew
+   bundle. Nothing has started.
+2. The backend starts and ``wait_until_ready`` returns (port answers AND the
+   boot secret exists).
+3. The front process starts.
+
+There is no restore phase and no sidecar: the backup subsystem was extracted from
+this PR (durability is tracked separately). When it returns it must reinstate the
+rule that made it correct -- restore to completion before the backend starts, or
+the backend's periodic flush persists an empty slot table over the gap.
+
+Shutdown drains process groups, not pids (see ``process.py``): a ``kiro-cli``
+worker is a two-process tree and signalling only the launcher orphans a child
+that finishes its turn. Teardown order is front, then backend: stop new turns
+arriving first, then let the backend drain in-flight work and flush to disk.
+Anything still alive after the backend is gone is an escaped worker it could not
+reap, so the teardown sweeps orphaned process groups directly.
+
+Track boundaries: the front ``__main__`` seam is imported by its documented path,
+lazily, so this module stays importable and testable and never reimplements the
+other track's work.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sys
+import threading
+from collections.abc import Sequence
+from pathlib import Path
+
+from .. import common
+from ..common import Settings
+from . import backend as backend_mod
+from . import bundle as bundle_mod
+from .process import ProcessGroup, spawn_process_group
+
+log = logging.getLogger("container.supervisor")
+
+# Drain windows. The backend gets the longest so an in-flight turn can finish.
+# Drain windows. The backend gets the longest, and the length is load-bearing:
+# a kiro-cli worker spawns with start_new_session (acp/runtime.py:1321), so it
+# setsid's into its OWN process group and is NOT in the backend's group. Our
+# group SIGKILL therefore cannot reach a worker; only the backend's own SIGTERM
+# shutdown reaps it. Too short a drain here would SIGKILL the backend before it
+# finishes reaping, orphaning workers that go on to finish their turn. Verified
+# confirmed by reading the real source and booting the real backend.
+FRONT_DRAIN_SECS: float = 5.0
+BACKEND_DRAIN_SECS: float = 25.0
+# How many discover-kill rounds the orphan sweep makes at teardown. Each round
+# reaps a layer, and a killed process's own children reparent to PID 1 and surface in the
+# NEXT round, so more than one is required to reach a worker's grandchildren. Bounded so a
+# process respawning children cannot spin the teardown forever; a torn-down container has no
+# legitimate reason to rebuild its tree faster than this drains it.
+_TEARDOWN_SWEEP_ROUNDS: int = 8
+
+
+def _start_front(settings: Settings) -> ProcessGroup:
+    """Launch Track S1's front process (its documented ``__main__``)."""
+    return spawn_process_group("front", [sys.executable, "-m", "container.front"])
+
+
+def _wait_for_shutdown(children: Sequence[ProcessGroup]) -> str:
+    """Block until a stop signal arrives or any child exits. Return the reason.
+
+    Returns ``"signal"`` on SIGTERM/SIGINT, or ``"<name> exited"`` if a child
+    dies first (the backend dying is fatal; so is either other child, since the
+    task cannot do its job).
+    """
+    stop = threading.Event()
+    reason = {"why": ""}
+
+    def _on_signal(signum, _frame):
+        reason["why"] = "signal"
+        stop.set()
+
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGINT, _on_signal)
+
+    while not stop.wait(0.5):
+        for child in children:
+            if child.poll() is not None:
+                reason["why"] = f"{child.name} exited (code {child.returncode()})"
+                return reason["why"]
+    return reason["why"]
+
+
+def _our_live_children(exclude: set[int]) -> list[int]:
+    """Pids whose parent is this process, minus *exclude*.
+
+    The supervisor is PID 1 in this image (``CMD ["python", "-m", "container.supervisor"]``),
+    so a process orphaned inside the container is reparented to it. That is what makes an
+    ESCAPED worker findable at all: a kiro-cli worker calls ``start_new_session``, so it is in
+    its own process group and no ``killpg`` of the backend's group can reach it -- but when the
+    backend dies, the worker becomes our child.
+
+    Read from ``/proc`` rather than tracked, because the supervisor never learns the pid: the
+    backend spawns its workers and tells nobody. Linux-only, which ``crew/runtime/**`` already
+    is; a missing ``/proc`` yields an empty list rather than an error, so a host without it
+    degrades to the previous behaviour instead of failing the shutdown.
+    """
+    mine = os.getpid()
+    found: list[int] = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return found
+    for name in entries:
+        if not name.isdigit():
+            continue
+        pid = int(name)
+        if pid == mine or pid in exclude:
+            continue
+        try:
+            with open(f"/proc/{pid}/stat", encoding="utf-8", errors="replace") as fh:
+                fields = fh.read().rsplit(")", 1)[1].split()
+        except OSError:
+            continue
+        # After the ')' closing comm: state, ppid. Split this way because comm can contain
+        # spaces and parentheses, which is why the naive field index is wrong.
+        if len(fields) < 2:
+            continue
+        if fields[0] == "Z":
+            # Already dead and waiting to be reaped; the wait below collects it.
+            continue
+        try:
+            if int(fields[1]) == mine:
+                found.append(pid)
+        except ValueError:
+            continue
+    return found
+
+
+def _sweep_orphans_the_backend_cannot_reap(exclude: set[int]) -> None:
+    """SIGKILL any of our children left after the backend was drained.
+
+    Run at ONE point: after ``backend.terminate``. What makes it safe there is that the
+    backend is already gone, so a process still running is one whose reaper is dead --
+    nothing is going to finish its turn or flush its state, and it is left writing to the
+    container filesystem after the task is meant to be gone.
+
+    Deliberately NOT a general "kill workers on shutdown". A worker that escaped the group is
+    reaped by the backend's own SIGTERM handler, and ``BACKEND_DRAIN_SECS`` is sized for that
+    (see the constant): killing one during the drain is exactly what the long drain exists to
+    prevent. This runs after the drain has already ended, one way or the other.
+    """
+    orphans = _our_live_children(exclude)
+    if not orphans:
+        return
+    log.warning(
+        "teardown: %d process(es) outlived the backend and cannot be reaped by it (%s). "
+        "Killing them so nothing keeps writing to the data home after the task is "
+        "supposed to be gone.",
+        len(orphans),
+        ", ".join(str(p) for p in orphans),
+    )
+    # Repeat discovery-and-kill until no live child remains, bounded. A single pass is not
+    # enough: an orphan's OWN children reparent to the supervisor (PID 1) only when the
+    # orphan dies, so a grandchild becomes findable in the NEXT scan, not this one. Killing
+    # once and walking away leaves that grandchild still writing to the data home after the
+    # task is torn down. Each round also signals the process GROUP, because a kiro-cli worker
+    # start_new_session()s into its own group (the spec's "Shutdown" section documents that it escapes a killpg
+    # of the backend's group), so killpg of the worker's OWN pgid takes its subtree in one
+    # signal rather than one pid at a time. The round cap bounds the loop against a process
+    # that respawns children faster than we can reap them; it is a container being torn down,
+    # so a few rounds is generous.
+    for _ in range(_TEARDOWN_SWEEP_ROUNDS):
+        live = _our_live_children(exclude)
+        if not live:
+            break
+        for pid in live:
+            # Group first: reaches the worker's whole session in one signal. A pid whose
+            # group cannot be resolved (already gone) falls back to a direct kill.
+            try:
+                os.killpg(os.getpgid(pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+            except OSError:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    pass
+        # Reap what just died so the next _our_live_children scan does not re-list zombies as
+        # live and so no zombie is left for the platform to report. Bounded per round.
+        for _ in range(len(live) + 1):
+            try:
+                if os.waitpid(-1, os.WNOHANG) == (0, 0):
+                    break
+            except ChildProcessError:
+                break
+
+
+def _teardown(
+    front: ProcessGroup,
+    backend: ProcessGroup,
+) -> None:
+    """Drain the children in order: front, then backend, then sweep orphans.
+
+    The backend gets the longer drain so an in-flight turn can finish. Once it is gone,
+    anything of ours still running is a process it could not reap -- an escaped worker in its
+    own process group, which no group signal reached -- so we discover and kill those directly.
+    """
+    log.info("draining front (%.0fs)", FRONT_DRAIN_SECS)
+    front.terminate(FRONT_DRAIN_SECS)
+    log.info("draining backend (%.0fs)", BACKEND_DRAIN_SECS)
+    backend.terminate(BACKEND_DRAIN_SECS)
+    # The backend is gone. Anything of ours still running is a process it cannot reap --
+    # an escaped worker in its own process group, which no group signal could reach.
+    known = {front.pid, backend.pid}
+    _sweep_orphans_the_backend_cannot_reap(known)
+
+
+def verify_layout(settings: Settings) -> None:
+    """Refuse to start if the SMC paths disagree with what Kiro Crew resolves.
+
+    Kiro Crew keeps its whole data home under ONE root: ``config_dir()`` equals
+    the data home equals ``KIROCREW_HOME``, and it writes ``sessions/``,
+    ``open_slots.json``, ``session_map.json`` and ``run/gateway-<port>.secret``
+    directly under that root (chat_persistence.py:322, run_marker.py, verified by
+    booting the real gateway). The backend is launched with
+    ``KIROCREW_HOME=settings.data_home``, so the backend's own ``config_dir()``
+    IS ``settings.data_home``. Two path settings must therefore agree, or the
+    deployment comes up looking healthy and loses state silently:
+
+    * ``settings.config_dir`` must equal ``settings.data_home``. Kiro Crew writes
+      ``open_slots.json`` and ``session_map.json`` at the data-home root; if
+      ``config_dir`` is a ``/config`` subdir the backend never writes to, the
+      deployment comes up looking healthy while the authoritative files are
+      nowhere the rest of the system reads them -- the exact section9.1 failure.
+    * ``settings.backend_run_dir`` must be ``settings.data_home / "run"``, or
+      ``wait_until_ready`` polls a secret path the backend did not write.
+
+    This is the "verify rather than trust" the Dockerfile open item calls for.
+    It is checked before anything starts so a path mistake fails at deploy
+    rather than as missing conversations later.
+    """
+    problems = []
+    if settings.config_dir != settings.data_home:
+        problems.append(
+            f"SMC_CONFIG_DIR ({settings.config_dir}) must equal SMC_DATA_HOME "
+            f"({settings.data_home}): Kiro Crew writes open_slots.json and "
+            f"session_map.json at the data-home root, not a /config subdir."
+        )
+    expected_run = settings.data_home / "run"
+    if settings.backend_run_dir != expected_run:
+        problems.append(
+            f"SMC_BACKEND_RUN_DIR ({settings.backend_run_dir}) must be "
+            f"{expected_run}: the backend writes its per-boot secret under "
+            f"<data home>/run."
+        )
+    # --approval yolo is REFUSED unless KIROCREW_HOME is an isolated,
+    # non-default home (cli.py:498-533). data_home IS KIROCREW_HOME, so reject a
+    # default/legacy home here -- otherwise the backend would exit rc=2 on the
+    # yolo rail, which reads as a boot failure. This also enforces R1 (one
+    # gateway per data home; never the live home).
+    protected = set()
+    for p in (Path("~/.kiro/crew").expanduser(), Path("~/.kirocrew").expanduser()):
+        try:
+            protected.add(p.resolve())
+        except OSError:
+            protected.add(p)
+    try:
+        home_resolved = settings.data_home.resolve()
+    except OSError:
+        home_resolved = settings.data_home
+    if home_resolved in protected:
+        problems.append(
+            f"SMC_DATA_HOME ({settings.data_home}) resolves to a default/live "
+            f"Kiro Crew home; --approval yolo is refused there and it would "
+            f"collide with the real gateway (R1). Use an isolated data home."
+        )
+    if problems:
+        raise common.ConfigError(
+            "Container path layout disagrees with Kiro Crew's resolved paths; "
+            "refusing to start rather than silently lose state:\n  - " + "\n  - ".join(problems)
+        )
+
+
+#: The three things the sandbox probe can conclude. A verdict is a string rather
+#: than a tri-state boolean because the interesting case carries information: an
+#: undetermined verdict names WHY it could not be settled, and an operator needs
+#: that to act. ``SANDBOX_UNDETERMINED_PREFIX`` is the prefix every such verdict
+#: carries.
+SANDBOX_AVAILABLE = "available"
+SANDBOX_DENIED = "denied"
+SANDBOX_UNDETERMINED_PREFIX = "undetermined: "
+
+
+def _user_namespaces_available() -> str:
+    """Probe whether this host permits an unprivileged user namespace.
+
+    Returns one of :data:`SANDBOX_AVAILABLE`, :data:`SANDBOX_DENIED`, or an
+    ``undetermined: <why>`` verdict. The probe runs in a forked child because
+    ``unshare`` mutates the caller's namespaces.
+
+    Undetermined is a real outcome and is reported as one, not folded into either
+    answer. It happens when the platform has no ``os.unshare``, when the fork
+    itself fails, or when the child neither succeeds nor reports a clean denial --
+    and the caller refuses on it, so the honest thing is to say which of those it
+    was rather than to pick a side on the host's behalf.
+    """
+    if not (hasattr(os, "unshare") and hasattr(os, "CLONE_NEWUSER")):
+        return (
+            f"{SANDBOX_UNDETERMINED_PREFIX}this platform has no os.unshare/os.CLONE_NEWUSER "
+            f"(sys.platform is {sys.platform!r}), so whether a user namespace could be "
+            "created cannot be tested here"
+        )
+    try:
+        pid = os.fork()
+    except OSError as exc:  # pragma: no cover - fork refused by the host
+        return f"{SANDBOX_UNDETERMINED_PREFIX}the probe could not fork a child ({exc})"
+    if pid == 0:
+        try:
+            os.unshare(os.CLONE_NEWUSER)  # type: ignore[attr-defined]
+            os._exit(0)
+        except OSError:
+            os._exit(1)
+        except Exception:
+            os._exit(2)
+    _, status = os.waitpid(pid, 0)
+    if os.WIFEXITED(status):
+        code = os.WEXITSTATUS(status)
+        if code == 0:
+            return SANDBOX_AVAILABLE
+        if code == 1:
+            return SANDBOX_DENIED
+        return (
+            f"{SANDBOX_UNDETERMINED_PREFIX}the probe child failed for a reason that is "
+            f"neither success nor a kernel refusal (exit code {code})"
+        )
+    if os.WIFSIGNALED(status):  # pragma: no cover - requires killing the probe child
+        return (
+            f"{SANDBOX_UNDETERMINED_PREFIX}the probe child was killed by signal "
+            f"{os.WTERMSIG(status)} before it could answer"
+        )
+    return (  # pragma: no cover - waitpid reporting neither exit nor signal
+        f"{SANDBOX_UNDETERMINED_PREFIX}the probe child reported neither an exit code nor "
+        f"a signal (raw wait status {status})"
+    )
+
+
+def verify_sandbox(settings: Settings, *, probe=_user_namespaces_available) -> None:
+    """Refuse to start unless the model subprocess can run sandboxed.
+
+    kiro-cli runs the model subprocess inside a sandbox. On Linux that needs an
+    unprivileged user namespace; without one, ``wrap_argv`` fails CLOSED
+    (sections.py:636). This container ships SANDBOXED-ONLY: if the host has no
+    user namespace we refuse to start rather than run the model subprocess
+    without one.
+
+    There is deliberately no opt-in to run unsandboxed. kiro-cli auto-approves
+    every tool (``--approval yolo``, nothing in the container clicks Approve),
+    and the backend's environment carries the model credential ``KIRO_API_KEY``,
+    which kiro-cli re-injects into the worker. An unsandboxed worker would then
+    run an auto-approved shell driven by untrusted customer prompt content with
+    that credential readable in its environment -- a prompt-injection-to-
+    credential-exfiltration path the ECS boundary does not close, because the
+    attacker is the prompt content, already inside the boundary. Offering that
+    safely needs the credential brokered out of the worker's environment, which
+    is not part of this change; until then the only posture this container
+    accepts is sandboxed. On a host without user namespaces (Fargate today) it
+    refuses to start, loudly, rather than boot into the exposed posture.
+
+    **Only ``SANDBOX_AVAILABLE`` proceeds.** Undetermined refuses, and so does any
+    verdict this function does not recognise. Reading a probe that cannot reach an
+    answer as permission to continue is the same defect as reading the environment
+    through a denylist: it holds for the hosts someone already thought of and fails
+    open on the next one, and here failing open means an auto-approving worker
+    holding the model credential with no sandbox. The refusal repeats the verdict
+    verbatim so an operator learns what could not be determined rather than only
+    that something could not be.
+    """
+    verdict = probe()
+    if verdict == SANDBOX_AVAILABLE:
+        return
+    if verdict == SANDBOX_DENIED:
+        raise common.ConfigError(
+            "No user-namespace sandbox is available on this host, so kiro-cli cannot "
+            "spawn the model subprocess sandboxed. This container runs sandboxed-only "
+            "and does not offer an unsandboxed posture, so it refuses to start rather "
+            "than run the model subprocess -- which auto-approves every tool and holds "
+            "the model credential in its environment -- without a sandbox. Run where "
+            "unprivileged user namespaces are permitted."
+        )
+    raise common.ConfigError(
+        f"Whether this host permits an unprivileged user-namespace sandbox could not be "
+        f"determined: {verdict}. This container runs sandboxed-only, so an undetermined "
+        "answer refuses exactly as a denial does: continuing would run the model "
+        "subprocess -- which auto-approves every tool and holds the model credential in "
+        "its environment -- with no evidence that a sandbox is in place. Run this image "
+        "on Linux where unprivileged user namespaces are permitted, and fix what "
+        "stopped the probe rather than reading its silence as consent."
+    )
+
+
+def run(settings: Settings, *, wait_for_shutdown=_wait_for_shutdown) -> int:
+    """Order, supervise and drain the task. Return a process exit code.
+
+    ``wait_for_shutdown`` is injected so tests can drive the supervise phase
+    without signals or real processes.
+    """
+    # 0. Fail loudly, before anything starts, if the environment cannot run a
+    #    turn: bad path layout, no model credential, an unspawnable sandbox, or a
+    #    bundle that is absent or names a different crew.
+    verify_layout(settings)
+    env = backend_mod.build_backend_env(settings)
+    backend_mod.require_api_key(env)
+    verify_sandbox(settings)
+    # Install the crew into the paths Kiro Crew reads BEFORE the backend starts,
+    # so "it started" means "the named crew is installed" rather than a default
+    # agent. Refuses closed on any mismatch (see bundle.install_bundle).
+    bundle_mod.install_bundle(settings)
+    # Then the container's own configuration, which must land after the bundle (a
+    # bundle may ship config, and this has to win on the keys it sets) and before the
+    # backend, which reads this file at boot: a transport it starts there is already
+    # connected by the time anything else could object.
+    backend_mod.write_backend_config(settings)
+
+    # 1. Backend, then readiness. Nothing else has started yet.
+    #
+    # There is no restore phase: the backup subsystem was extracted from this PR (its
+    # durability design is tracked separately), so the container boots straight into the
+    # backend on a fresh data home. Cross-task-replacement persistence is a capability the
+    # container does not yet have, not a regression -- there is no crew container on main.
+    backend = backend_mod.start_backend(settings, env=env)
+    try:
+        backend_mod.wait_until_ready(
+            settings, backend_mod.DEFAULT_READY_TIMEOUT_SECS, process=backend
+        )
+    except Exception:
+        # Readiness failed or the backend exited: tear the backend down and
+        # abort. The front was never started.
+        log.error("backend did not become ready; aborting")
+        backend.terminate(BACKEND_DRAIN_SECS)
+        raise
+    log.info("backend: ready on %s", settings.backend_base_url)
+
+    # 2. Front. There is no sidecar: backup was extracted from this PR.
+    front = _start_front(settings)
+    log.info("front: started")
+
+    watched = [backend, front]
+    try:
+        why = wait_for_shutdown(watched)
+        log.info("shutdown: %s", why)
+    finally:
+        _teardown(front, backend)
+    # The exit code has to distinguish the two reasons, because it is the only one
+    # the platform reads. `_wait_for_shutdown` returns "signal" for an orderly stop
+    # (ECS asked the task to go) and "<name> exited (code N)" when a child died
+    # first -- and its own docstring calls the backend dying fatal. Returning 0 for
+    # both told ECS a crash loop was a clean shutdown, so the console showed a task
+    # exiting normally over and over with nothing marked failed.
+    #
+    # `signal` is the ONLY success case. Anything else, including an empty reason,
+    # is reported as a failure: a reason this code cannot account for is not
+    # evidence that things went well.
+    if why == "signal":
+        return 0
+    log.error("exiting non-zero: %s", why or "shutdown reason unknown")
+    return 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    settings = common.load()
+    return run(settings)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/backend.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/backend.py
@@ -1,0 +1,573 @@
+"""Launching the Kiro Crew backend headless, and knowing when it is ready.
+
+The deployed unit is Kiro Crew's own backend, run in *dashboard mode*, on
+loopback, with no interface served (`docs/system-specs/modules/aws-control.md`,
+"Three processes, one task"). Dashboard mode is
+required and `--no-dashboard` is wrong: the smaller ``_init_api_server`` it
+starts has neither the chat endpoints nor the slot registry this design calls,
+and it quiets nothing, so headless here means "no interface exposed", not
+"--no-dashboard".
+
+Launch decisions, all from the contract and design:
+
+- Bind ``common.BACKEND_HOST`` (127.0.0.1, not configurable). The gateway binds
+  loopback by default; we also pass it explicitly so the intent is recorded.
+- ``--no-crons``. Arming the scheduler fires any *overdue* job immediately, so a
+  freshly deployed crew would run a stale job on boot.
+- Serve no messaging channel. ``write_backend_config`` writes a config the
+  container owns that turns every transport off by name, and the launch env carries
+  no channel credential. Both halves are needed: two transports need no credential
+  and start on their config flag, and Slack has no config flag and starts on its
+  tokens.
+- ``telemetry.beacon_enabled=false``.
+- The boot update check cannot be disabled by config (R4). We do not fight it;
+  it is recorded as a known outbound request in the report, not suppressed here.
+
+Readiness means the port answers AND the boot secret file exists. Process-alive
+is not ready, and this check deliberately proves no more than that: a present
+model key is not a working one, so a container can be "ready" here and still
+fail every turn on an invalid key. We do not claim otherwise.
+
+VERIFIED against the installed Kiro Crew (0.3.0) by booting a real
+backend through this code on an isolated KIROCREW_HOME (port 8803): the argv
+``python -m kiro_crew gateway --no-crons`` boots dashboard mode; ``KIROCREW_PORT``
+sets the port (dashboard/urls.py:116), ``KIROCREW_BIND`` pins the address
+(urls.py:208), ``KIROCREW_TELEMETRY_DISABLED`` disables the beacon (beacon.py),
+the secret lands at ``<KIROCREW_HOME>/run/gateway-<port>.secret`` exactly where
+``common.secret_path`` looks, and the listener came up on 127.0.0.1 only.
+
+STILL NOT VERIFIABLE FROM HERE: the backend refuses turns with 503
+``kiro_prerequisite_required`` until Kiro CLI is signed in, and this host has no
+usable sandbox backend (``unshare(CLONE_NEWUSER)`` EPERM), so a real kiro-cli
+worker could not be spawned -- the escaped-worker teardown is proven only by the
+topology tests, not against a live worker. The boot update check also runs
+regardless of config (R4): on this git install it only "notifies", but a
+pip-installed container image may make an outbound probe.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import sys
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from .. import common
+from ..common import Settings
+from . import bundle
+from .process import ProcessGroup, spawn_process_group
+
+log = logging.getLogger("container.supervisor.backend")
+
+# --- Invocation (spelling-sensitive, see module docstring) ------------------
+BACKEND_LAUNCHER: tuple[str, ...] = (sys.executable, "-m", "kiro_crew")
+GATEWAY_SUBCOMMAND: str = "gateway"
+FLAG_NO_CRONS: str = "--no-crons"
+# The flags that turn the dashboard off. We must pass NEITHER. Verified against
+# the real CLI (cli.py:539): dashboard-off is driven by --slack-only, and there
+# is no --no-dashboard flag on the gateway parser at all -- the design's
+# "--no-dashboard" is a description of the wrong mode, not the flag name. Both
+# are named so the tests can assert their absence.
+FLAG_SLACK_ONLY: str = "--slack-only"
+FLAG_NO_DASHBOARD: str = "--no-dashboard"
+
+# Approval mode. yolo auto-approves every tool so an unattended, headless crew
+# can run a turn end to end with nobody to answer a prompt (cli.py:1256). The
+# gateway REFUSES yolo unless KIROCREW_HOME is an isolated, non-default home
+# (cli.py:498-533, sys.exit(2)); the container's home qualifies, and
+# verify_layout asserts it so a bad home fails loudly here rather than as a
+# turn that stalls waiting for an approval nobody sees. Cost recorded by the
+# owner in the contract/design: every tool the crew calls runs unprompted.
+FLAG_APPROVAL: str = "--approval"
+APPROVAL_MODE: str = "yolo"
+
+# kiro-cli's own MODEL credential (loader.py:366 CRED_KIRO_API_KEY). Supplied to
+# the task from Secrets Manager as this env var; re-injected into the kiro-cli
+# child (loader.py:1167/1182) and intentionally NOT denied by the sandbox env
+# filter (runtime.py:1251), so forwarding it in the backend env is the whole
+# auth mechanism. We forward it EXPLICITLY (below) and refuse to start without
+# it (require_api_key), rather than relying on the wholesale os.environ copy.
+ENV_KIRO_API_KEY: str = "KIRO_API_KEY"
+
+# Environment variable names the backend reads. VERIFIED against the installed
+# source (paths cited), replacing the earlier laptop guesses.
+ENV_HOME: str = "KIROCREW_HOME"  # config/paths.py:265 config_dir() honours it
+ENV_PORT: str = "KIROCREW_PORT"  # dashboard/urls.py:116 overrides the port
+# Pin the bind ADDRESS. dashboard/urls.py:208 reads KIROCREW_BIND; the OFFICIAL
+# image sets it to 0.0.0.0 (urls.py:218), which would put the backend on the
+# network. Overriding it to loopback keeps the backend unreachable regardless of
+# the base image, and a KIROCREW_BIND typo can only narrow back to loopback.
+ENV_BIND: str = "KIROCREW_BIND"
+# Disable the anonymous beacon. beacon.py:137 reads KIROCREW_TELEMETRY_DISABLED
+# (truthy disables); this is the opt-out Kiro Crew actually honours. The config
+# key telemetry.beacon_enabled=false the design names is equivalent, but the env
+# form needs no config file and cannot be silently ignored. NOTE: neither this
+# nor the config key stops the boot update check -- that fires regardless (R4)
+# and is recorded as a known outbound request, not suppressed here.
+ENV_TELEMETRY_DISABLED: str = "KIROCREW_TELEMETRY_DISABLED"
+#: The front's control-plane secret. Named here so the strip below is a named
+#: constant rather than a bare string, and so a reader can find every use of it.
+ENV_CONTROL_SECRET: str = "SMC_CONTROL_SECRET"
+
+#: Every messaging transport the gateway can start, by the name of its config
+#: section. ``write_backend_config`` turns each one OFF in a file the container owns.
+#:
+#: A container has nobody to talk to on a messaging channel: the only caller it
+#: serves is the customer's HTTP turn through the front process. A transport that
+#: comes up gives a crew an outbound channel to an owner's workspace that nobody
+#: chose to grant it.
+#:
+#: Written positively rather than by removing what arms a transport. Two of these
+#: need no credential at all (``imessage``, ``whatsapp`` -- their registry
+#: descriptors carry an empty credential tuple), so they start on their config flag
+#: alone and no amount of secret-stripping reaches them.
+#:
+#: ``test/test_crew_container_config_isolation.py`` ratchets this tuple against
+#: ``kiro_crew.channels.builtin_channel_descriptors()``, the gateway's own registry,
+#: so a channel added there reds CI until it is turned off here. That test reads
+#: THIS FILE'S SOURCE with ``ast`` rather than importing it, because nothing may
+#: import the image's tree.
+CHANNEL_SECTIONS: tuple[str, ...] = (
+    "discord",
+    "feishu",
+    "imessage",
+    "slack",
+    "teams",
+    "telegram",
+    "webex",
+    "wecom",
+    "weixin",
+    "whatsapp",
+)
+
+# Channel-credential env vars we drop, so a credential that leaked into the task
+# environment cannot arm a transport whose config flag is off -- and so ``slack``,
+# whose config section has no ``enabled`` key at all and which starts on its tokens
+# alone, has nothing to start from.
+#
+# These names are the ones the gateway ACTUALLY reads, taken from its channel
+# registry (each descriptor's ``credentials``), and the same ratchet test keeps them
+# in step with it. A name the gateway does not read is worse than a missing one: it
+# reads as coverage while stripping nothing.
+#
+# This half of the isolation is still a list of names, which is why it is not the
+# whole of it: it cannot cover a credential spelling nobody has thought of. The
+# config file above is what does not depend on knowing a name.
+CHANNEL_CRED_ENV: frozenset[str] = frozenset(
+    {
+        "SLACK_APP_TOKEN",
+        "SLACK_BOT_TOKEN",
+        "WECOM_BOT_ID",
+        "WECOM_SECRET",
+        "TELEGRAM_BOT_TOKEN",
+        "DISCORD_BOT_TOKEN",
+        "WEBEX_BOT_TOKEN",
+        "MICROSOFT_APP_ID",
+        "MICROSOFT_APP_PASSWORD",
+        "WEIXIN_TOKEN",
+        "FEISHU_APP_ID",
+        "FEISHU_APP_SECRET",
+    }
+)
+
+#: The variables that hand an AWS credential to anything that reads the environment.
+#:
+#: On Fargate the task role is not a file or a key: it is an HTTP endpoint named by
+#: ``AWS_CONTAINER_CREDENTIALS_RELATIVE_URI``, which every AWS SDK resolves without being
+#: asked. The backend spawns the model subprocess with this environment, and that
+#: subprocess auto-approves every tool it calls -- the same premise that
+#: already removes ``SMC_CONTROL_SECRET`` below. So a turn could read the URI from its own
+#: environment, curl it, and act as the task role: read the transcript bucket, and reach
+#: whatever else the role is granted. Keeping it out of the environment closes that
+#: independently of the sandbox.
+#:
+#: Removing them is not a loss for the backend. It talks to the model over
+#: ``KIRO_API_KEY`` and to nothing in AWS; the SUPERVISOR is what uses the task role, and
+#: it keeps its own ``os.environ`` untouched. A container that genuinely needs an AWS call
+#: on the turn path should be given a narrower credential explicitly rather than inherit
+#: the task's.
+#:
+#: ``AWS_CONTAINER_AUTHORIZATION_TOKEN`` and the full-URI form are listed too: the newer
+#: agent protocol uses them, and a list that only covers the shape in front of us today
+#: fails open the day the platform adds another.
+AWS_CRED_ENV: frozenset[str] = frozenset(
+    {
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AWS_ROLE_ARN",
+        "AWS_PROFILE",
+        "AWS_SHARED_CREDENTIALS_FILE",
+        "AWS_CONFIG_FILE",
+    }
+)
+
+# Backend boot can be slow: dashboard mode starts embeddings (hundreds of MB),
+# the MCP gateway and subagents regardless of mode. Give it generous headroom.
+DEFAULT_READY_TIMEOUT_SECS: float = 180.0
+
+
+class BackendReadyTimeout(RuntimeError):
+    """The backend did not become ready within the timeout."""
+
+
+class BackendExited(RuntimeError):
+    """The backend process exited before it became ready."""
+
+
+def build_backend_argv(settings: Settings) -> list[str]:
+    """The command that launches the backend in dashboard mode on loopback.
+
+    Dashboard mode is the default, so no mode flag is added; the point is the
+    absence of ``--slack-only`` (the flag that would turn the dashboard off, and
+    with it the chat API and slot registry). ``--approval yolo`` lets the
+    unattended crew run tool-calling turns with nobody to answer a prompt.
+    """
+    return [
+        *BACKEND_LAUNCHER,
+        GATEWAY_SUBCOMMAND,
+        FLAG_NO_CRONS,
+        FLAG_APPROVAL,
+        APPROVAL_MODE,
+    ]
+
+
+#: The `agent` settings the container WRITES rather than inherits, and the reason
+#: they are here rather than left to their defaults.
+#:
+#: `verify_sandbox` refuses to start on a host that cannot sandbox the model
+#: subprocess, and this container offers no unsandboxed posture at all. That refusal
+#: is worth nothing if a config file can turn the sandbox off underneath it: the
+#: gateway reads these three keys, `sandbox="off"` skips its own OS-level isolation,
+#: and either fallback flag set true lets `wrap_argv` proceed with no backend instead
+#: of raising. So they are forced exactly as the channel sections are -- written, not
+#: merged, not defaulted.
+#:
+#: Defaults are not a substitute for writing them. `sandbox_allow_unsandboxed_exec`
+#: resolves an UNDECLARED value through `unsandboxed_exec_platform_default()`, so
+#: what silence means is a property of the platform rather than a constant, and
+#: `config.json` arrives in the task from outside this code.
+#:
+#: `test/test_crew_container_config_isolation.py` ratchets these keys against
+#: `AgentConfig`, so a sandbox knob added to the gateway reds CI until the container
+#: decides what to write for it.
+FORCED_AGENT_SETTINGS: Mapping[str, object] = {
+    "sandbox": "auto",
+    "sandbox_allow_no_isolation": False,
+    "sandbox_allow_unsandboxed_exec": False,
+}
+
+
+def build_backend_config(existing: Mapping[str, object] | None = None) -> dict[str, object]:
+    """The config the backend boots with: no messaging transport, no sandbox opt-out.
+
+    Merges over *existing* rather than replacing it, so a crew bundle that ships
+    config keeps them, and a section already present keeps its other settings with
+    only the forced keys overwritten. Forcing rather than defaulting is the point: a
+    file that arrives with ``telegram.enabled`` true, or with ``agent.sandbox`` set to
+    ``off``, must lose, or the container's posture is a suggestion.
+
+    A non-dict where a section should be is REPLACED, not merged. The gateway coerces
+    such a section to defaults, and defaults are not what this function is for.
+    """
+    config: dict[str, object] = dict(existing or {})
+    for section in CHANNEL_SECTIONS:
+        current = config.get(section)
+        merged = dict(current) if isinstance(current, dict) else {}
+        merged["enabled"] = False
+        config[section] = merged
+    agent = config.get("agent")
+    agent_merged = dict(agent) if isinstance(agent, dict) else {}
+    agent_merged.update(FORCED_AGENT_SETTINGS)
+    config["agent"] = agent_merged
+    return config
+
+
+def write_backend_config(settings: Settings) -> Path:
+    """Write the container-owned config to ``<config dir>/config.json``.
+
+    Called before the backend starts, because the gateway reads this file at boot and
+    a transport it starts there is already connected by the time anything else could
+    object.
+
+    ``config_dir`` equals ``data_home`` (see the spec's "Three processes, one task").
+
+    Written through a sibling temp and one atomic replace, because the failure this
+    file has is in the FUTURE: nothing reads it during this write, and a truncated
+    write is read at the NEXT start, by which time the run that produced it is gone
+    and the container boots on a config it cannot parse. The temp is opened
+    ``O_EXCL | O_NOFOLLOW`` in the destination's own directory (a replace across
+    filesystems is not atomic), fsynced so the bytes are on disk before the name
+    moves, and the directory is fsynced after so the name change itself survives a
+    power loss.
+
+    A symlink at the destination is REFUSED rather than replaced. ``os.replace``
+    would not write through it -- ``rename`` unlinks the link rather than following
+    it -- but a link there is a signal, and quietly consuming it hides that something
+    planted one. This matches ``bundle._write_nofollow``, which every other write
+    into the data home goes through.
+    """
+    bundle._mkdir_or_refuse(settings.config_dir, what="the config directory")
+    path = settings.config_dir / "config.json"
+    if path.is_symlink():
+        raise common.ConfigError(
+            f"{path} is a symlink. The container writes its own configuration there and "
+            "refuses to replace a link rather than a file, because a link means "
+            "something else chose that path. Refusing to start."
+        )
+    existing: Mapping[str, object] | None = None
+    if path.exists():
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            existing = raw
+    payload = json.dumps(build_backend_config(existing), indent=2, sort_keys=True) + "\n"
+    _atomic_write_nofollow(path, payload.encode("utf-8"))
+    log.info(
+        "backend config: %d messaging transports disabled, %d agent settings forced",
+        len(CHANNEL_SECTIONS),
+        len(FORCED_AGENT_SETTINGS),
+    )
+    return path
+
+
+def _atomic_write_nofollow(dst: Path, data: bytes) -> None:
+    """Write *data* to *dst* atomically, through a sibling temp in the same directory.
+
+    Separate from ``bundle._write_nofollow`` rather than replacing it: that one is a
+    truncating write, which is the right shape for a file read only by the process
+    that just wrote it. This one is for a file another process reads at a LATER start,
+    where a half-written state is the whole problem.
+
+    The temp carries the pid so two supervisors in one data home cannot collide on the
+    name, and ``O_EXCL`` means a pre-planted file at that name is an error rather than
+    something written through.
+    """
+    tmp = dst.with_name(f"{dst.name}.{os.getpid()}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(str(tmp), flags, 0o600)
+    except OSError as exc:
+        raise common.ConfigError(
+            f"container config write failed [temporary file]: {tmp} could not be created "
+            f"({exc})."
+        ) from exc
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, dst)
+    except OSError as exc:
+        raise common.ConfigError(
+            f"container config write failed [publish]: {dst} could not be written ({exc})."
+        ) from exc
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass  # the replace consumed it, which is the success path
+        except OSError:
+            log.warning("container config: could not remove %s", tmp)
+    dir_fd = os.open(str(dst.parent), os.O_RDONLY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def build_backend_env(settings: Settings, base: Mapping[str, str] | None = None) -> dict[str, str]:
+    """The environment the backend is launched with.
+
+    Points the backend at the shared data home and loopback port, pins the bind
+    address to loopback (overriding any inherited ``KIROCREW_BIND=0.0.0.0`` from
+    the base image), disables the beacon, removes any channel credential, and
+    forwards the model credential (``KIRO_API_KEY``) explicitly.
+    """
+    env = dict(os.environ if base is None else base)
+    env[ENV_HOME] = str(settings.data_home)
+    env[ENV_PORT] = str(settings.backend_port)
+    env[ENV_BIND] = common.BACKEND_HOST
+    env[ENV_TELEMETRY_DISABLED] = "1"
+    for name in CHANNEL_CRED_ENV:
+        env.pop(name, None)
+    # The task role, for the reason spelled out on AWS_CRED_ENV: on Fargate the
+    # credential is an endpoint any SDK finds by itself, so carrying it in the env
+    # buys nothing while adding a secret the auto-approved worker does not need.
+    for name in AWS_CRED_ENV:
+        env.pop(name, None)
+    # The FRONT's control-plane secret, dropped for the same defence-in-depth
+    # reason and one more: the backend spawns the model subprocess, which inherits
+    # this environment and auto-approves every tool it calls. Keeping the secret
+    # out of that environment means a prompt cannot read SMC_CONTROL_SECRET and
+    # call the front's control endpoints as the control plane, independently of
+    # the sandbox.
+    #
+    # Nothing is lost by removing it: the only readers are common/config.py, which
+    # loads it into Settings, and front/app.py, which validates the
+    # X-SMC-Control-Secret header. The BACKEND never reads it -- the gateway's own
+    # internal secret is a separate value derived from its port.
+    env.pop(ENV_CONTROL_SECRET, None)
+    # Forward the model credential explicitly. It is already present via the
+    # wholesale copy, but naming it documents that this is the deliberate auth
+    # path (require_api_key refuses to start without it) rather than an
+    # accident of inheriting os.environ.
+    #
+    # Unlike the two secrets above, this one CANNOT be popped: kiro-cli re-injects
+    # it into the worker and it is the whole model-auth mechanism, so the worker
+    # must carry it. That is precisely why the worker must run sandboxed -- see
+    # verify_sandbox, which refuses to start when it cannot. There is no
+    # unsandboxed posture: a worker that both holds this credential and runs an
+    # auto-approved shell on untrusted prompt content would be a
+    # prompt-injection-to-credential-exfiltration path, so the container refuses
+    # rather than offer it. Brokering the credential out of the worker's
+    # environment (which would let an unsandboxed posture be safe) is future work.
+    source = os.environ if base is None else base
+    if source.get(ENV_KIRO_API_KEY):
+        env[ENV_KIRO_API_KEY] = source[ENV_KIRO_API_KEY]
+    return env
+
+
+def require_api_key(env: Mapping[str, str]) -> None:
+    """Refuse to start when the model credential is absent or empty.
+
+    Presence only. A present key is NOT a working one: an invalid key boots a
+    container that answers the port and fails every turn, and validity can only
+    be established by a real turn (see wait_until_ready). This check therefore
+    proves the credential was supplied, nothing more.
+    """
+    if not (env.get(ENV_KIRO_API_KEY) or "").strip():
+        raise common.ConfigError(
+            f"{ENV_KIRO_API_KEY} is not set. The task injects the model "
+            "credential from Secrets Manager; without it the backend boots and "
+            "every turn fails. Refusing to start."
+        )
+
+
+def _refuse_planted_links(settings: Settings) -> None:
+    """Refuse to start when a symlink sits where the boot secret is written.
+
+    The gateway writes ``run/gateway-<port>.secret`` itself, with an ordinary open
+    that follows a link. A link planted at that path -- or at the run directory --
+    therefore turns the gateway's own secret write into a truncating write to
+    wherever the link points, and the crew's model worker can write inside the data
+    home, so the path is reachable by prompt content.
+
+    Nothing here can make the gateway's writer safe, so this refuses instead: the
+    task starts on a real directory and a real file path, or it does not start. The
+    checks are LSTAT-based on purpose, since ``exists()`` follows the link it is
+    looking for. This is the guard ``config.json`` gets from
+    ``bundle._write_nofollow``, applied to a file another process writes.
+    """
+    run_dir = settings.backend_run_dir
+    if run_dir.is_symlink():
+        raise common.ConfigError(
+            f"backend run directory {run_dir} is a symlink. The backend writes its "
+            "per-boot secret inside it with a link-following open, so a link here "
+            "redirects that write outside the data home. Refusing to start."
+        )
+    secret = common.secret_path(run_dir, settings.backend_port)
+    if secret.is_symlink():
+        raise common.ConfigError(
+            f"boot secret path {secret} is a symlink. The backend truncates and "
+            "rewrites this file on every start, so a link here makes it overwrite the "
+            "link's target instead. Refusing to start."
+        )
+    if secret.exists() and not secret.is_file():
+        raise common.ConfigError(
+            f"boot secret path {secret} exists and is not a regular file. The backend "
+            "expects to write a file there. Refusing to start."
+        )
+
+
+def start_backend(
+    settings: Settings,
+    *,
+    argv: Sequence[str] | None = None,
+    env: Mapping[str, str] | None = None,
+    stdout=None,
+    stderr=None,
+) -> ProcessGroup:
+    """Launch the backend as its own process group and return the handle.
+
+    ``argv``/``env`` default to the real invocation; tests inject a fake backend
+    process through them. The child is a group leader so the whole tree can be
+    drained at shutdown. The backend's run directory is created first: the
+    backend writes its per-boot secret there, and if the directory is missing
+    the secret write -- and readiness -- fail for a reason that looks like a
+    hang rather than a missing path. Creating it is also where the secret path is
+    checked for a planted link (see ``_refuse_planted_links``), because that is the
+    last moment before the process that follows such a link exists.
+    """
+    bundle._prepare_dir_nofollow(settings.backend_run_dir)
+    _refuse_planted_links(settings)
+    return spawn_process_group(
+        "backend",
+        list(argv) if argv is not None else build_backend_argv(settings),
+        env=dict(env) if env is not None else build_backend_env(settings),
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _port_answers(host: str, port: int, timeout: float = 0.5) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (ConnectionRefusedError, OSError):
+        return False
+
+
+def _secret_present(settings: Settings) -> bool:
+    try:
+        common.read_boot_secret(settings.backend_run_dir, settings.backend_port)
+        return True
+    except common.BackendSecretUnavailable:
+        return False
+
+
+def wait_until_ready(
+    settings: Settings,
+    timeout: float = DEFAULT_READY_TIMEOUT_SECS,
+    *,
+    process: ProcessGroup | None = None,
+    poll_interval: float = 0.25,
+) -> None:
+    """Block until the backend is ready, or raise.
+
+    Ready = the loopback port accepts a connection AND the per-boot secret file
+    exists and is non-empty. Both are required: the port can open before the
+    secret is written, and the secret can exist from a previous boot before the
+    port is up. Neither proves the backend can complete a turn -- an invalid
+    model key is not detectable here -- and this function does not claim it.
+
+    If ``process`` is supplied, an exit before readiness is reported as
+    ``BackendExited`` rather than waited out to the full timeout.
+    """
+    host = common.BACKEND_HOST
+    port = settings.backend_port
+    deadline = time.monotonic() + timeout
+
+    while True:
+        if process is not None:
+            code = process.poll()
+            if code is not None:
+                raise BackendExited(f"backend exited with code {code} before becoming ready")
+        if _port_answers(host, port) and _secret_present(settings):
+            return
+        if time.monotonic() >= deadline:
+            raise BackendReadyTimeout(
+                f"backend not ready after {timeout:.0f}s: "
+                f"port_open={_port_answers(host, port)} "
+                f"secret_present={_secret_present(settings)} "
+                f"(host={host} port={port} run_dir={settings.backend_run_dir})"
+            )
+        time.sleep(poll_interval)

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/bundle.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/bundle.py
@@ -1,0 +1,694 @@
+"""Install the crew bundle into the paths Kiro Crew actually reads, or refuse.
+
+The crew rides in the image at ``/app/crew-bundle`` (PACKAGING-CONTRACT.md, T3).
+The previous design uploaded it to S3 and nothing in the container ever read it,
+so ten gates went green while the deployment served a default agent. This module
+closes that by construction: the supervisor installs the bundle BEFORE the
+backend starts, and refuses to boot unless the named crew is the one installed.
+
+WHERE EACH ENTRY GOES -- verified against the Kiro Crew source at
+a Kiro Crew source checkout (0.6.0), not inferred from a plausible
+name. ``config_dir()`` and ``data_home()`` resolve to the SAME directory, so a
+``<home>/config/`` guess would land two of these where nothing reads them:
+
+* ``agent.json`` -> ``<kiro home>/agents/<crew_name>.json``.
+  ``agent_discovery.list_agents`` is THE reader of installed agent specs, keyed by
+  the spec's ``name``, and it reads and JSON-parses every ``~/.kiro/agents/*.json``
+  on each call. The gateway resolves that directory as ``kiro_home() / "agents"``,
+  where ``kiro_home()`` is ``$KIRO_HOME`` or ``~/.kiro``. It is NOT under the data
+  home and NOT governed by ``KIROCREW_HOME``: the backend is launched with
+  ``KIROCREW_HOME=data_home`` but no ``KIRO_HOME`` (``supervisor/backend.py``),
+  so the spec lands under the process HOME. Resolved here the same way rather
+  than imported, so this module needs no ``kiro_crew`` install (matching the
+  supervisor's other minimal, import-free config reads).
+
+  The gateway's chain reaches that path through a private override-BLIND helper,
+  which ``test_host_isolation_floor.py::test_the_ambient_resolver_has_exactly_one_caller``
+  keeps to a fixed set of callers. This module is not one of them and must not
+  become one, so it is named here by what it computes rather than by its symbol:
+  a source-text guard cannot tell a docstring from a call, and it is right not to
+  try.
+
+* ``mcp.json`` -> ``<data home>/mcp.json``. The Kiro Crew-scope MCP config is
+  ``data_home()/"mcp.json"`` -- the highest-priority source in
+  ``mcp_discovery._mcp_sources`` (``mcp_discovery.py:297``,
+  ``SCOPE_KIROCREW``) and what ``dashboard/handlers/mcp.py:1620``
+  (``_kirocrew_mcp_json`` -> ``data_home()/"mcp.json"``) reads for its
+  ``mcpServers`` (``:704``).
+
+* ``skills/`` -> ``<data home>/skills/``. ``skills.py:1422`` ``skills_dir()`` is
+  ``config_dir() / SKILLS_DIR_NAME`` and ``SKILLS_DIR_NAME == "skills"``
+  (``skills.py:49``); ``config_dir()`` (``config/paths.py:265``) honours
+  ``KIROCREW_HOME``, so in the container this is ``<data home>/skills``.
+
+THE DIGEST is recomputed here byte-identically to the producer
+(``share-my-crew/build/export/crew_export/bundle.py:78`` ``_bundle_digest``) and
+its independent verifier (``build/export/tools/verify_bundle.py:50``
+``digest_of``), which agree exactly. A different serialisation would fail every
+valid bundle, so ``_content_digest`` is copied verbatim rather than reinvented.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+
+from .. import common
+from ..common import Settings
+
+log = logging.getLogger("container.supervisor")
+
+#: The four entries PACKAGING-CONTRACT.md freezes, with the on-disk kind each
+#: must be. ``skills`` is a directory (may be empty but MUST exist); the rest are
+#: files (``mcp.json`` may be ``{}`` but MUST exist).
+BUNDLE_ENTRIES: tuple[tuple[str, str], ...] = (
+    ("manifest.json", "file"),
+    ("agent.json", "file"),
+    ("mcp.json", "file"),
+    ("skills", "dir"),
+)
+
+#: Written at the data-home root on a successful install. For a human reading the
+#: logs; T4's gate proves the crew from the image digest, not from this file.
+INSTALLED_MARKER = ".smc-crew-installed.json"
+
+
+def default_kiro_agents_dir() -> Path:
+    """Where kiro-cli reads agent specs: ``<kiro home>/agents``.
+
+    Mirrors ``kiro_crew.config.paths.kiro_home`` (``config/paths.py:510``):
+    ``$KIRO_HOME`` if set, else ``~/.kiro``, then ``/agents``. Deliberately NOT
+    under the data home -- see the module docstring. The one behaviour not
+    mirrored is ``kiro_home``'s rejection of a system-directory ``$KIRO_HOME``;
+    that guards a pathological override the container never sets, and copying it
+    would only widen this module's surface.
+    """
+    override = os.environ.get("KIRO_HOME")
+    home = Path(override).expanduser() if override else Path.home() / ".kiro"
+    return home / "agents"
+
+
+def _content_digest(root: Path) -> str:
+    """Recompute the bundle content digest, byte-identical to the producer.
+
+    Copied verbatim from ``crew_export/bundle.py:78`` and ``verify_bundle.py:50``
+    (which agree): sha256 over sorted ``[rel_posix, sha256(bytes)]`` rows for
+    every file except the top-level ``manifest.json`` (it carries the digest),
+    then sha256 of the compact-JSON payload, prefixed ``"sha256:"``. The
+    ``sorted(root.rglob("*"))`` over ``Path`` objects and the
+    ``separators=(",", ":")`` compaction are both load-bearing: change either and
+    the digest of a valid bundle stops matching.
+    """
+    rows: list[list[str]] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        if rel == "manifest.json":
+            continue
+        rows.append([rel, hashlib.sha256(path.read_bytes()).hexdigest()])
+    payload = json.dumps(rows, ensure_ascii=False, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _read_json_object(path: Path, label: str) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise common.ConfigError(
+            f"bundle check failed [{label} is readable JSON]: {path} could not be "
+            f"read as JSON ({exc})."
+        ) from exc
+    if not isinstance(data, dict):
+        raise common.ConfigError(
+            f"bundle check failed [{label} is a JSON object]: {path} parsed to a "
+            f"{type(data).__name__}, not an object."
+        )
+    return data
+
+
+# Bundle install writes into the data home, which under a mounted persistent volume
+# (this image's Dockerfile provisions ``/var/lib/kirocrew`` for exactly that) carries over
+# from a prior task. A sandboxed agent in that prior task can write ``mcp.json`` and the
+# other destinations, so it can plant a SYMLINK there pointing outside the data home.
+# ``install_bundle`` then runs at the NEXT boot, before the backend and any sandbox, as the
+# image's own user, and a plain ``shutil.copyfile``/``copytree`` FOLLOWS that symlink and
+# overwrites the target outside any confinement. So every destination write below refuses a
+# symlink AT the destination, the same way the (extracted) backup reader refused one at its
+# source: check and write are the same ``O_NOFOLLOW`` open, not a stat-then-write pair a
+# swap can slip between.
+
+
+def _write_nofollow(dst: Path, data: bytes) -> None:
+    """Write *data* to *dst*, refusing to follow a symlink planted at *dst*.
+
+    ``O_NOFOLLOW`` fails with ``ELOOP`` when the final component is a symlink, so a
+    pre-planted link cannot redirect this write outside the data home. ``O_TRUNC`` gives the
+    same whole-file-replace semantics ``copyfile`` had for the ordinary (non-symlink) case.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(str(dst), flags, 0o644)
+    except OSError as exc:
+        raise common.ConfigError(
+            f"bundle check failed [destination is not a symlink]: {dst} could not be opened "
+            f"for writing without following a link ({exc}). A pre-planted symlink there would "
+            f"redirect the unsandboxed install to overwrite a file outside the data home, so "
+            f"the install refuses rather than follow it."
+        ) from exc
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+    except OSError as exc:
+        raise common.ConfigError(
+            f"bundle check failed [destination write]: {dst} could not be written ({exc})."
+        ) from exc
+
+
+def _mkdir_or_refuse(dst: Path, *, what: str) -> None:
+    """Create *dst* as a directory, or refuse with a message naming the path.
+
+    ``mkdir(exist_ok=True)`` raises ``FileExistsError`` when the path is an existing
+    FILE, and an uncaught one here is worse than a refusal in a way that is specific to
+    this deployment: the data home may be a persistent volume, so a regular file left
+    where a directory belongs makes the supervisor crash, ECS restart the task, and the
+    next boot hit the same file. That is a boot loop that spends the owner's money in
+    their own account and never says what is wrong.
+
+    So every directory the container creates on that volume goes through here. The
+    container does not get to assume anything about what is on the volume, and the
+    answer to an assumption that fails is a refusal that names the path -- the same
+    answer ``verify_sandbox`` gives.
+    """
+    try:
+        dst.mkdir(parents=True, exist_ok=True)
+    except FileExistsError as exc:
+        raise common.ConfigError(
+            f"{what} cannot be created: {dst} exists and is not a directory. Something "
+            f"left it there, and the container refuses to start rather than crash on it "
+            f"every time the task restarts. Remove it, or start on a clean data home."
+        ) from exc
+    except OSError as exc:
+        raise common.ConfigError(f"{what} could not be created at {dst} ({exc}).") from exc
+
+
+def _prepare_dir_nofollow(dst: Path) -> None:
+    """Ensure *dst* is a real directory to copy into, refusing a symlink at that path.
+
+    ``copytree(dirs_exist_ok=True)`` into a path that is a symlink to a directory would write
+    through the link. ``os.path.islink`` is checked BEFORE ``is_dir`` because a symlink to a
+    directory answers True to ``is_dir`` -- the link is what must be refused, not resolved.
+    """
+    if os.path.islink(str(dst)):
+        raise common.ConfigError(
+            f"bundle check failed [destination is not a symlink]: {dst} is a symlink. A "
+            f"pre-planted link there would redirect the unsandboxed skills install outside "
+            f"the data home, so the install refuses rather than copy through it."
+        )
+    _mkdir_or_refuse(dst, what="a skills directory")
+
+
+def _clear_link_at(dst: Path) -> None:
+    """Remove a symlink sitting where the bundle needs a real file or directory.
+
+    A link at a bundle-managed path is a collision on a path the bundle owns, and the
+    link itself is a pointer rather than content: unlinking it destroys no work, and its
+    TARGET is never opened, so nothing outside the data home is touched. Refusing
+    instead would be the wrong direction here -- a leftover link in the crew's own
+    skills tree would then stop every future task from booting, on a volume an operator
+    may not be able to reach.
+
+    The skills ROOT is different and is still refused outright (see
+    ``_install_skills_tree``): a link there redirects the entire install, and there is
+    no path the bundle owns beneath it to reason about.
+    """
+    if os.path.islink(str(dst)):
+        log.info("skills: removing a symlink planted at %s before installing over it", dst.name)
+        dst.unlink()
+
+
+def _copytree_nofollow(src: Path, dst: Path) -> None:
+    """Copy the trusted *src* tree into *dst*, refusing a symlink at any destination path.
+
+    ``copytree`` alone would follow a symlink pre-planted at a NESTED destination the same way
+    it would at the top level. This walks the trusted source and writes each file through
+    ``_write_nofollow`` and each subdirectory through ``_prepare_dir_nofollow``, so no
+    destination component -- top-level or nested -- can redirect a write outside the tree.
+    The source is in-image and digest-verified, so it is trusted; only the destinations,
+    which live on the possibly-persistent data home, are guarded.
+    """
+    for entry in sorted(src.iterdir()):
+        target = dst / entry.name
+        if entry.is_dir() and not entry.is_symlink():
+            _clear_link_at(target)
+            _prepare_dir_nofollow(target)
+            _copytree_nofollow(entry, target)
+        elif entry.is_file() and not entry.is_symlink():
+            _clear_link_at(target)
+            _write_nofollow(target, entry.read_bytes())
+        # A symlink IN THE SOURCE is skipped: the bundle is laid out as plain files and
+        # dirs, so a link there is not something to reproduce into the read path.
+
+
+def _bundle_skill_files(src: Path) -> list[str]:
+    """The bundle's own skill files, as sorted POSIX-relative paths.
+
+    This is the BUNDLE-MANAGED SET: derived from the tree in the image layer rather
+    than from a marker anyone could have written, so it needs no trust and cannot be
+    forged by the running crew. Files only -- directories are not managed, because a
+    directory can hold both a bundle's file and a crew's, and pruning at directory
+    granularity is what deletes the second.
+    """
+    return sorted(
+        path.relative_to(src).as_posix()
+        for path in src.rglob("*")
+        if path.is_file() and not path.is_symlink()
+    )
+
+
+def _marker_mac(payload: dict, secret: str) -> str:
+    """The authentication tag over a marker payload.
+
+    Computed over the payload WITHOUT its own ``mac`` key, serialised the way the writer
+    serialises it (sorted keys, compact separators) so the reader can reproduce the exact
+    bytes. A tag over a re-serialisation that differs by a space authenticates nothing.
+    """
+    body = {key: value for key, value in payload.items() if key != "mac"}
+    canonical = json.dumps(body, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hmac.new(secret.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _previously_installed_skills(settings: Settings) -> list[str] | None:
+    """The bundle-managed set from the LAST install, or ``None`` when it is not known.
+
+    The marker lives in the data home, which the crew's own model worker can write, so
+    what it says is an INPUT rather than a record this code owns. Constraining what the
+    list may CONTAIN does not fix that; the premise has to change. So the marker carries
+    an authentication tag, and a marker whose tag does not verify is not read.
+
+    The key is ``SMC_CONTROL_SECRET``. It is the one value the supervisor holds that the
+    worker provably does not: ``build_backend_env`` removes it from the environment the
+    backend is launched with, and the worker inherits that environment, which
+    ``test_backend_env_drops_control_secret.py`` pins. Relocating the marker instead was
+    the other option GPT named and it is not available here: the image runs the
+    supervisor and the worker as the SAME user (``USER crew``), so no directory on the
+    persistent volume is writable by one and not the other, and a location in the
+    read-only image layer cannot record what a PREVIOUS task installed, which is the
+    marker's whole job.
+
+    ``None`` -- meaning "prune nothing" -- is returned for every reason the record cannot
+    be trusted or read: no control secret configured (so nothing can be authenticated),
+    no tag, a tag that does not verify, unreadable or unparseable content, or a marker
+    from a build that did not record the list. Each of those is logged as itself, because
+    "the tag is wrong" and "there is no marker" are very different things to be told.
+    """
+    marker = settings.data_home / INSTALLED_MARKER
+    try:
+        raw = json.loads(marker.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as exc:
+        log.warning("skills: the install marker could not be read (%s); pruning nothing", exc)
+        return None
+    if not isinstance(raw, dict):
+        log.warning("skills: the install marker is not an object; pruning nothing")
+        return None
+
+    recorded = raw.get("skill_files")
+    if not isinstance(recorded, list):
+        return None
+
+    secret = settings.control_secret
+    if not secret:
+        log.warning(
+            "skills: no control secret is configured, so the install marker cannot be "
+            "authenticated; pruning nothing"
+        )
+        return None
+    presented = raw.get("mac")
+    if not isinstance(presented, str) or not presented:
+        log.error(
+            "skills: the install marker carries no authentication tag; it did not come "
+            "from this container's supervisor. Pruning nothing."
+        )
+        return None
+    if not hmac.compare_digest(presented, _marker_mac(raw, secret)):
+        log.error(
+            "skills: the install marker's authentication tag does not verify, so its "
+            "contents were not written by this container's supervisor. Pruning nothing."
+        )
+        return None
+
+    return [entry for entry in recorded if isinstance(entry, str)]
+
+
+def _validated_managed_entries(entries: list[str]) -> list[str] | None:
+    """The recorded entries, or ``None`` when the record cannot be trusted at all.
+
+    Every entry must be a plain relative path: not absolute, already normalised, and
+    with no ``..``, no empty and no ``.`` component. An entry that is not is REFUSED
+    rather than repaired, and it discards the WHOLE record rather than just itself.
+
+    All-or-nothing is the point, and it is a decision rather than a shortcut. This file
+    lives in the data home, which the crew can write, so a malformed entry means the
+    record is either corrupt or hostile -- and in both cases the rest of the list is no
+    more trustworthy than the bad entry. Dropping only the offender would keep pruning
+    from a list something else has been editing. Discarding the record falls back to the
+    same path an absent marker takes: prune nothing, install over the top, log why. That
+    leaves residue an operator can delete instead of deleting from a list that points
+    who-knows-where, and it does not fail the boot, because refusing to start over a
+    corrupt bookkeeping file would be a worse answer than the residue.
+
+    This is shape only. It does not establish that an entry stays inside the skills
+    directory when it is used -- a string with no ``..`` in it still leaves through a
+    symlinked parent -- which is why the deletion itself walks descriptors.
+    """
+    for entry in entries:
+        problem: str | None = None
+        if not entry:
+            problem = "it is empty"
+        elif entry != os.path.normpath(entry):
+            problem = "it is not normalised"
+        elif PurePosixPath(entry).is_absolute() or entry.startswith("/"):
+            problem = "it is absolute"
+        elif any(part in ("", ".", "..") for part in PurePosixPath(entry).parts):
+            problem = "it has a '.', '..' or empty component"
+        elif "\\" in entry or "\x00" in entry:
+            problem = "it contains a backslash or a NUL"
+        if problem is not None:
+            log.error(
+                "skills: the recorded bundle file list is not trustworthy -- entry %r is "
+                "refused because %s. Pruning nothing this install; a stale skill may remain "
+                "and can be deleted by hand.",
+                entry,
+                problem,
+            )
+            return None
+    return entries
+
+
+def _unlink_within(dst: Path, rel: str) -> str:
+    """Delete ``dst/rel``, refusing anything that would act outside *dst*.
+
+    Returns ``"pruned"``, or a short reason the entry was left alone.
+
+    Containment is enforced by CONSTRUCTION, not by comparing strings. Each directory
+    component is opened relative to the previous descriptor with ``O_NOFOLLOW |
+    O_DIRECTORY``, so a component swapped for a symlink is refused by the kernel at the
+    moment it is traversed, and the final ``unlink`` runs relative to the last
+    descriptor. There is no window between deciding the path is inside *dst* and acting
+    on it, because the path is never re-resolved by name: the directory verified is the
+    directory deleted from. ``crew/packaging/build.py`` uses the same shape for a
+    different object.
+
+    A resolved-containment check runs first as well. It is redundant against the walk
+    but it is what turns "this entry leaves the tree through a link" into its own named
+    refusal instead of a generic ``ELOOP``, and the message is the thing an operator
+    reads.
+    """
+    candidate = dst / rel
+    try:
+        resolved = candidate.resolve()
+        root = dst.resolve()
+    except OSError as exc:
+        return f"its path could not be resolved ({exc})"
+    if resolved != root and root not in resolved.parents:
+        return f"it resolves to {resolved}, outside the skills directory"
+
+    parts = PurePosixPath(rel).parts
+    try:
+        fd = os.open(str(dst), os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as exc:
+        return f"the skills directory could not be opened ({exc})"
+    open_fds = [fd]
+    try:
+        for part in parts[:-1]:
+            try:
+                fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=open_fds[-1],
+                )
+            except OSError as exc:
+                return f"the component {part!r} is not a real directory ({exc})"
+            open_fds.append(fd)
+        leaf = parts[-1]
+        try:
+            st = os.lstat(leaf, dir_fd=open_fds[-1])
+        except FileNotFoundError:
+            return "it is already gone"
+        except OSError as exc:
+            return f"it could not be inspected ({exc})"
+        if not stat.S_ISREG(st.st_mode):
+            return "it is no longer a plain file"
+        try:
+            os.unlink(leaf, dir_fd=open_fds[-1])
+        except OSError as exc:
+            return f"it could not be removed ({exc})"
+        return "pruned"
+    finally:
+        for open_fd in open_fds:
+            os.close(open_fd)
+
+
+def _install_skills_tree(src: Path, dst: Path, *, previous: list[str] | None) -> None:
+    """Lay the bundle's skills into *dst*, replacing its own files and nothing else.
+
+    ``install_bundle`` runs at every boot and the data home may be a persistent
+    volume, so this has two jobs that pull against each other:
+
+    * **A skill a later bundle DROPPED must not stay active.** A stale,
+      possibly governance-relevant skill silently in the read path is the hazard.
+    * **A skill the RUNNING CREW created must not be deleted.** A reinstall's job is
+      to replace the bundle's own files; a crew's own work is not its to remove.
+
+    Replacing the whole directory satisfies the first and violates the second, so the
+    two sets are separated instead. *previous* is the bundle-managed set from the last
+    install, recorded in the marker; anything in it that this bundle does not ship is
+    pruned, and everything else is left exactly where it is. When *previous* is
+    ``None`` the last install's set is unknown, so nothing is pruned: residue beats
+    destruction, and the log says which of the two happened.
+
+    Deliberately not an atomic whole-tree swap. Such a swap guards a reader observing a
+    partially-installed tree, and there is no such reader: the install runs in ``run()``
+    step 0, before the backend process exists. What matters here is that no write
+    follows a link, which each individual file write guarantees.
+    """
+    if os.path.islink(str(dst)):
+        raise common.ConfigError(
+            f"bundle check failed [destination is not a symlink]: {dst} is a symlink. A "
+            f"pre-planted link there would redirect the unsandboxed skills install outside "
+            f"the data home, so the install refuses rather than copy through it."
+        )
+    managed = _bundle_skill_files(src)
+    trusted = None if previous is None else _validated_managed_entries(previous)
+    if trusted is None:
+        log.info(
+            "skills: no trustworthy record of what the last install managed; installing "
+            "without pruning so nothing the crew created can be removed"
+        )
+        stale: list[str] = []
+    else:
+        stale = sorted(set(trusted) - set(managed))
+
+    _prepare_dir_nofollow(dst)
+    pruned = 0
+    for rel in stale:
+        outcome = _unlink_within(dst, rel)
+        if outcome == "pruned":
+            pruned += 1
+        else:
+            log.warning("skills: leaving %s because %s", rel, outcome)
+    _copytree_nofollow(src, dst)
+    _prune_empty_dirs(dst)
+    log.info("skills: %d bundle file(s) installed, %d stale pruned", len(managed), pruned)
+
+
+def _prune_empty_dirs(root: Path) -> None:
+    """Remove directories under *root* that are now empty, deepest first.
+
+    Pruning a dropped skill's file leaves its directory behind, and an empty directory
+    is nobody's work, so removing it is not the destruction this function's caller
+    guards against. A directory that still holds anything -- a crew's file, a file this
+    install declined to touch -- is left, which is what keeps that true.
+    """
+    for path in sorted(root.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        if path.is_dir() and not path.is_symlink():
+            try:
+                path.rmdir()
+            except OSError:
+                pass  # not empty, which is the answer
+
+
+def install_bundle(settings: Settings, *, agents_dir: Path | None = None) -> dict:
+    """Verify the bundle, then lay it out where Kiro Crew reads it. Fail CLOSED.
+
+    Called from ``run()`` before the backend starts, alongside ``verify_layout``
+    / ``require_api_key`` / ``verify_sandbox``. Every refusal names the
+    check that failed and both values, because a container that boots with the
+    wrong crew is the exact failure this change exists to prevent.
+
+    ``agents_dir`` is injected only by tests, so the agent spec never lands in the
+    real ``~/.kiro/agents`` during a test run; production resolves it via
+    :func:`default_kiro_agents_dir`. Returns the marker payload on success.
+    """
+    bundle_dir = settings.bundle_dir
+
+    # 1. The bundle dir and each of its four entries must exist, with the right
+    #    kind. The crew rides in an image layer, which cannot be absent -- so a
+    #    missing one means the image was built wrong, not a runtime blip.
+    if not bundle_dir.is_dir():
+        raise common.ConfigError(
+            f"bundle check failed [bundle dir present]: SMC_BUNDLE_DIR="
+            f"{bundle_dir} is not a directory (exists={bundle_dir.exists()}). The "
+            f"crew rides in the image at this path; booting without it would "
+            f"serve a default agent."
+        )
+    for entry, kind in BUNDLE_ENTRIES:
+        p = bundle_dir / entry
+        ok = p.is_dir() if kind == "dir" else p.is_file()
+        if not ok:
+            raise common.ConfigError(
+                f"bundle check failed [entry present]: expected a {kind} at {p}, "
+                f"but exists={p.exists()} is_file={p.is_file()} "
+                f"is_dir={p.is_dir()}."
+            )
+
+    manifest = _read_json_object(bundle_dir / "manifest.json", "manifest.json")
+    agent_spec = _read_json_object(bundle_dir / "agent.json", "agent.json")
+
+    # 2. manifest crew_name must equal SMC_CREW_NAME. An empty SMC_CREW_NAME is
+    #    refused too: "it started" must mean "the NAMED crew is installed", and
+    #    an unnamed crew cannot satisfy that even if the manifest also omits it.
+    manifest_crew = str(manifest.get("crew_name") or "")
+    if not settings.crew_name:
+        raise common.ConfigError(
+            "bundle check failed [manifest crew_name == SMC_CREW_NAME]: "
+            f"SMC_CREW_NAME is empty (manifest crew_name={manifest_crew!r}). "
+            "The deployment must name the crew it intends to serve."
+        )
+    if manifest_crew != settings.crew_name:
+        raise common.ConfigError(
+            "bundle check failed [manifest crew_name == SMC_CREW_NAME]: "
+            f"manifest crew_name={manifest_crew!r} != SMC_CREW_NAME="
+            f"{settings.crew_name!r}. The image does not carry the crew this "
+            "task was configured to serve."
+        )
+
+    # 3. agent.json name must equal crew_name, or kiro-cli resolves a different
+    #    agent (or none) -- surfacing later as a mode error, not the naming bug.
+    agent_name = str(agent_spec.get("name") or "")
+    if agent_name != manifest_crew:
+        raise common.ConfigError(
+            "bundle check failed [agent.json name == crew_name]: agent.json "
+            f"name={agent_name!r} != manifest crew_name={manifest_crew!r}. The "
+            f"spec is installed at <agents>/{manifest_crew}.json and read back by "
+            "its own name, so a mismatch serves nothing."
+        )
+
+    # 4. The recomputed content digest must equal the manifest's. This is what
+    #    proves the bytes in the image are the bytes that were reviewed.
+    manifest_digest = str(manifest.get("digest") or "")
+    recomputed = _content_digest(bundle_dir)
+    if recomputed != manifest_digest:
+        raise common.ConfigError(
+            "bundle check failed [content digest == manifest digest]: recomputed="
+            f"{recomputed!r} != manifest digest={manifest_digest!r}. The bundle "
+            "content does not match what the manifest was signed over."
+        )
+
+    # All checks passed -- install into the read paths verified above.
+    agents = agents_dir if agents_dir is not None else default_kiro_agents_dir()
+    _mkdir_or_refuse(agents, what="the kiro-cli agents directory")
+    # A crew name is a NAME, checked before it becomes a path segment. Every check above
+    # is an EQUALITY or a digest: they prove the manifest agrees with the spec and with the
+    # bytes, and none of them constrains the SHAPE of the agreed name. So a manifest and a
+    # spec that both say ``../../etc/whatever`` pass all four and then
+    # ``agents / f"{manifest_crew}.json"`` resolves outside ``agents``, because
+    # ``Path.__truediv__`` treats an absolute segment as a new root and ``..`` as a parent
+    # step -- and ``shutil.copyfile`` writes there, before the backend starts, as root in
+    # the image.
+    #
+    # Whether the name can be attacker-chosen depends on how the deploy tooling populates
+    # it, and that tooling is in another track. That is the reason to check here rather
+    # than the reason not to: this is the process that does the write, so this is where the
+    # answer holds regardless of what set the value.
+    #
+    # The builder has the same guard for the same reason (``_validated_crew_name`` in
+    # ``packaging/build.py``). Duplicated rather than shared, like the no-follow opener:
+    # this tree is image source the gateway must not import.
+    if (
+        not manifest_crew
+        or manifest_crew in {".", ".."}
+        or "/" in manifest_crew
+        or "\\" in manifest_crew
+        or "\x00" in manifest_crew
+        or os.path.isabs(manifest_crew)
+    ):
+        raise common.ConfigError(
+            f"bundle check failed [crew name is a name]: crew_name={manifest_crew!r} "
+            "contains a path separator, is absolute, or is a directory reference. The "
+            "spec is installed at <agents>/<crew_name>.json, so a name that can leave "
+            "that directory would overwrite a file outside it."
+        )
+    # One guard, not two. A containment assertion on the resolved destination was here as
+    # defence in depth and it is unreachable: with the shape check above in place, no name
+    # gets far enough to land outside ``agents``, so no test could redden it. A guard no
+    # test can fail is a comment claiming a property nobody verifies, so it is gone rather
+    # than shipped. If the join ever changes shape, the check to add back is the one that
+    # can be tested against the new shape.
+    agent_dst = agents / f"{manifest_crew}.json"
+    # Copy the validated bytes rather than re-serialising, so what kiro-cli reads
+    # is exactly what the digest covered -- through a no-follow open so a symlink
+    # pre-planted at the destination cannot redirect the write.
+    _write_nofollow(agent_dst, (bundle_dir / "agent.json").read_bytes())
+
+    _mkdir_or_refuse(settings.data_home, what="the data home")
+    mcp_dst = settings.data_home / "mcp.json"
+    _write_nofollow(mcp_dst, (bundle_dir / "mcp.json").read_bytes())
+
+    skills_dst = settings.data_home / "skills"
+    # Read the last install's bundle-managed set BEFORE the marker is rewritten below,
+    # or the pruning decision would be made against this install's own answer.
+    previous_skills = _previously_installed_skills(settings)
+    _install_skills_tree(bundle_dir / "skills", skills_dst, previous=previous_skills)
+
+    payload = {
+        "crew_name": manifest_crew,
+        "bundle_digest": manifest_digest,
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+        # The bundle-managed set, so the NEXT install can prune exactly what this one
+        # installed and leave everything else. Recorded rather than inferred because
+        # the next install sees only its own bundle, which cannot tell it what a
+        # previous bundle put on this disk.
+        "skill_files": _bundle_skill_files(bundle_dir / "skills"),
+    }
+    # Authenticated with the one secret the worker's environment does not carry, so the
+    # next install can tell this record from one the crew wrote. Without a control secret
+    # there is nothing to sign with, and the next install will read the record as
+    # untrusted and prune nothing -- which is the safe direction, so the install still
+    # proceeds rather than refusing here.
+    if settings.control_secret:
+        payload["mac"] = _marker_mac(payload, settings.control_secret)
+    else:
+        log.warning(
+            "skills: no control secret is configured, so the install marker cannot be "
+            "authenticated; a later install will not prune from it"
+        )
+    marker = settings.data_home / INSTALLED_MARKER
+    _write_nofollow(marker, (json.dumps(payload, indent=2) + "\n").encode("utf-8"))
+    log.info(
+        "crew %r installed: agent=%s mcp=%s skills=%s digest=%s",
+        manifest_crew,
+        agent_dst,
+        mcp_dst,
+        skills_dst,
+        manifest_digest,
+    )
+    return payload

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/process.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container/supervisor/process.py
@@ -1,0 +1,140 @@
+"""Launching and tearing down a child as a process *group*.
+
+The container runs a small tree of long-lived children. One of them, the
+Kiro Crew backend, itself launches ``kiro-cli`` workers, and each worker is a
+two-process tree: a launcher and the child that actually runs the turn.
+Signalling the launcher's pid alone orphans that child, which goes on to finish
+its turn against a data home the container is trying to shut down.
+
+So every child here is started in its own session with ``start_new_session``,
+which makes the child a session and group leader whose process-group id equals
+its pid. Grandchildren inherit that group, and a single ``killpg`` reaches the
+whole tree. Teardown *drains*: it asks the group to stop with SIGTERM, waits for
+the group leader to exit, and only escalates to SIGKILL if the drain window
+elapses.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from typing import IO
+
+
+class ProcessGroup:
+    """A launched child and every process in its group.
+
+    ``leader`` is the ``Popen`` for the group-leader process. Because the child
+    was started with ``start_new_session=True`` its pid is also its process
+    group id, so ``os.killpg(leader.pid, ...)`` signals the whole tree.
+    """
+
+    def __init__(self, name: str, leader: subprocess.Popen) -> None:
+        self.name = name
+        self.leader = leader
+        # With start_new_session=True the child is a group leader: pgid == pid.
+        # Capture the pid rather than calling os.getpgid(), which can race the
+        # child's setsid() and briefly return the parent's group.
+        self.pgid = leader.pid
+
+    @property
+    def pid(self) -> int:
+        return self.leader.pid
+
+    def poll(self) -> int | None:
+        """Return the leader's exit code, or None while it is still running."""
+        return self.leader.poll()
+
+    def returncode(self) -> int | None:
+        return self.leader.returncode
+
+    def _signal_group(self, sig: int) -> bool:
+        """Send ``sig`` to the whole group. Return False if the group is gone."""
+        try:
+            os.killpg(self.pgid, sig)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # The group outlived our permission to signal it (should not happen
+            # for our own children); fall back to the leader pid.
+            try:
+                self.leader.send_signal(sig)
+                return True
+            except ProcessLookupError:
+                return False
+
+    def terminate(self, drain_timeout: float, poll_interval: float = 0.05) -> int | None:
+        """Stop the whole group, draining before it is killed.
+
+        Sends SIGTERM to the group, waits up to ``drain_timeout`` for the leader
+        to exit, and escalates to SIGKILL only if the drain window elapses. The
+        leader is always reaped, so no zombie is left behind. Returns the
+        leader's exit code (negative if it was signalled).
+
+        Every return path sweeps the GROUP, including the one where the leader had
+        already exited before this was called. A leader exit says nothing about its
+        children: the point of ``start_new_session=True`` is that a grandchild worker
+        outlives its parent in the same group, and the drain path below has always
+        swept for exactly that reason. Returning early without the sweep left the
+        CRASH case -- the one where the leader exited on its own rather than on our
+        signal -- as the single path that let a worker survive a teardown, still
+        holding the model credential and still writing to the data home.
+        """
+        if self.leader.poll() is not None:
+            # Sweep before returning, for the reason the drain path sweeps.
+            self._signal_group(signal.SIGKILL)
+            return self.leader.returncode
+
+        alive = self._signal_group(signal.SIGTERM)
+        if not alive:
+            # Group already gone; still reap the leader handle.
+            return self._reap()
+
+        deadline = time.monotonic() + max(0.0, drain_timeout)
+        while time.monotonic() < deadline:
+            if self.leader.poll() is not None:
+                # Leader drained; sweep the group in case a grandchild lingers.
+                self._signal_group(signal.SIGKILL)
+                return self.leader.returncode
+            time.sleep(poll_interval)
+
+        # Drain window elapsed: kill the whole group hard.
+        self._signal_group(signal.SIGKILL)
+        return self._reap()
+
+    def _reap(self) -> int | None:
+        try:
+            return self.leader.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            # Extremely unlikely after SIGKILL; report unknown rather than hang.
+            return self.leader.poll()
+
+
+def spawn_process_group(
+    name: str,
+    argv: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    cwd: str | None = None,
+    stdout: IO | int | None = None,
+    stderr: IO | int | None = None,
+) -> ProcessGroup:
+    """Launch ``argv`` as a new session/group leader and return its handle.
+
+    ``start_new_session=True`` is the load-bearing argument: it detaches the
+    child into its own process group so the whole tree, including any
+    grandchild workers, can be drained together.
+    """
+    leader = subprocess.Popen(
+        list(argv),
+        env=dict(env) if env is not None else None,
+        cwd=cwd,
+        stdout=stdout,
+        stderr=stderr,
+        start_new_session=True,
+    )
+    return ProcessGroup(name, leader)

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/_settings_helper.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/_settings_helper.py
@@ -1,0 +1,35 @@
+"""A single-arg ``Settings`` factory shared by the runtime tests.
+
+This lived in ``test_backup_restore`` until the backup subsystem was extracted from the PR;
+the tests that borrowed it (backend env, secret retry, transport failure, review findings)
+are runtime tests, not backup ones, so the factory moved here rather than leaving with the
+deleted module. It is a plain helper, not a test module, so pytest does not collect it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from container.common import Settings
+
+
+def make_settings(root: Path, *, bucket="bkt", crew="crew1", prefix="crews") -> Settings:
+    data_home = root / "data"
+    config_dir = data_home
+    s = Settings(
+        backend_port=8765,
+        backend_run_dir=data_home / "run",
+        front_port=8080,
+        route_prefix="",
+        control_secret=None,
+        data_home=data_home,
+        config_dir=config_dir,
+        crew_name=crew,
+        backup_bucket=bucket,
+        backup_prefix=prefix,
+    )
+    s.sessions_dir.mkdir(parents=True, exist_ok=True)
+    s.archive_dir.mkdir(parents=True, exist_ok=True)
+    s.artifacts_dir.mkdir(parents=True, exist_ok=True)
+    s.config_dir.mkdir(parents=True, exist_ok=True)
+    return s

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/conftest.py
@@ -1,0 +1,248 @@
+"""Reach the container package the way the image does: by its build context.
+
+The subject of this suite is imported as top-level ``container.*``, because that
+is what it is inside the image -- ``/app`` is on ``sys.path`` and the package
+sits at ``/app/container``. Modules import ``container.common`` absolutely, so
+that name is part of the image's contract rather than an artifact of where the
+source sits in the image. Rewriting the imports to this repository's package
+path would break the image at runtime.
+
+``crew/runtime/`` therefore has no ``__init__.py``: it is a docker build
+context, not a python package, and
+``test_spawn_audit.py::test_container_image_assets_are_not_imported`` pins that
+so the gateway can never import this tree by package path. Putting the build
+context on ``sys.path`` here is what lets the tests resolve ``container`` while
+that stays true.
+
+pytest's prepend import mode happens to insert this same directory (it is the
+first ancestor without an ``__init__.py``), so this file is belt and braces --
+but the import root is a fact about the image, not about a pytest setting, and
+it should be stated somewhere that survives a change to either.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_BUILD_CONTEXT = Path(__file__).resolve().parents[1]
+_HERE = Path(__file__).resolve().parent
+
+# The one lane whose entire purpose is to run this suite sets this. Everywhere else
+# -- a developer's laptop, the application's own CI shards -- leaves it unset, and
+# the skips below stay skips.
+#
+# It exists because a skip is indistinguishable from a pass in every report anyone
+# reads, and the skips below are wide: a missing image dependency takes the WHOLE
+# suite out of collection, so 236 tests can be entirely absent from a run that
+# reports success. Installing those dependencies in a dedicated job is not enough on
+# its own, because it fixes the environment and not the mechanism: a dependency
+# rename, an extras split or a resolver change puts that lane back to reporting
+# success while collecting nothing, with no signal anywhere.
+#
+# So the lane that installs them also declares that it MUST be able to run them, and
+# under that declaration every reason this file would decline to collect becomes a
+# hard error instead. The rule is one-directional on purpose: this variable can only
+# turn a skip into a failure, never a failure into a skip, so setting it can hide
+# nothing.
+_REQUIRED_ENV = "CREW_CONTAINER_TESTS_REQUIRED"
+_REQUIRED_RAW = os.environ.get(_REQUIRED_ENV)
+# Parsed strictly, not with ``bool(os.environ.get(...))``, which reads "0" and "false" as
+# ON because any non-empty string is truthy. A lane that set it to "0" believing it had
+# turned the requirement off would get the requirement, and a lane that set it to
+# "true" expecting a boolean would get it for the wrong reason. An unrecognised value is
+# REFUSED rather than guessed at, the same call ``parse_route_prefix`` makes about a bare
+# word: this decides whether a suite is allowed to skip, so reading a typo as either
+# answer is worse than saying the value is not a boolean.
+if _REQUIRED_RAW is None or _REQUIRED_RAW.strip() == "":
+    _REQUIRED = False
+elif _REQUIRED_RAW.strip().lower() in ("1", "true", "yes", "on"):
+    _REQUIRED = True
+elif _REQUIRED_RAW.strip().lower() in ("0", "false", "no", "off"):
+    _REQUIRED = False
+else:
+    raise RuntimeError(
+        f"{_REQUIRED_ENV} must be a boolean (1/0, true/false), got {_REQUIRED_RAW!r}. It "
+        "decides whether this suite may skip, so an unrecognised value is refused rather "
+        "than read as either answer."
+    )
+
+# Floor on how many tests the suite must yield, checked only under _REQUIRED_ENV.
+#
+# Read off a real collection (327 items). The margin is 2, not a comfortable ten per
+# cent, and the tightness IS the feature: the smallest module here contributes 3
+# tests, so a floor of 325 is tripped by losing even the smallest one, which a looser
+# floor would wave through. The per-module check below catches a module that stops
+# being collected at all; this catches the subtler shape, a module still collected
+# but yielding fewer tests than it holds -- a parametrize source that silently
+# empties, a decorator that swallows its function, an import guard that turns a class
+# into nothing.
+#
+# When the suite grows, raise it. It may be LOWERED only alongside a deliberate
+# deletion of tests, in the same commit, and never to make a red lane green: a floor
+# edited down to meet the measurement measures nothing.
+_MIN_COLLECTED = 325
+
+# Not collected on a non-POSIX host. This suite's SUBJECT is the source of a Linux
+# container image, built by the deploy driver and run on Fargate -- not part of the
+# application that installs on a user's machine. It depends on POSIX primitives that
+# are not incidental: the supervisor forks and signals a process group, and the
+# layout tests assert container filesystem paths. Running it on Windows measures
+# nothing about the only platform the image runs on, and it failed there for exactly
+# that reason.
+#
+# Marking individual tests was tried first and is the wrong shape: the POSIX
+# dependencies are spread across the suite, so the list was already incomplete and
+# the next test to touch a fork/signal path would redden Windows again without
+# changing anything real. Skipping the whole tree on a non-POSIX host is the honest
+# unit.
+#
+# The suite is ALSO not collected when the image's own runtime dependencies are not
+# importable. ``container/requirements.txt`` (fastapi, uvicorn, httpx, boto3) is
+# marked "Container runtime only. These must NOT become dependencies of the Kiro
+# Crew app itself" -- the app's backend hooks are imported into every owner's
+# gateway process, and a web framework there buys nothing. So the application's own
+# CI environment installs ``-e .[voice,desktop] --group dev`` and does NOT carry
+# these, yet ``testpaths`` in ``setup.cfg`` walks ``src/kiro_crew/apps/builtins``
+# and reaches this tree: four modules ``import httpx`` (the front's backend client)
+# at module top level, which is a collection-time ``ModuleNotFoundError`` that
+# cascades every backend shard. The image build context and any developer machine
+# that installs ``requirements-dev.txt`` DO carry them, so the suite still runs
+# where their subject can -- this only declines to run them where the deliberately
+# absent deps make the subject unimportable, rather than forcing the app env to
+# grow a dependency the runtime contract forbids.
+#
+# Only the deps imported AT MODULE TOP LEVEL by the test modules gate collection:
+# ``httpx`` (four modules), ``fastapi`` and ``uvicorn`` (``test_front_proxy``).
+# ``boto3`` is deliberately NOT in this list -- ``front/transcript.py`` imports it
+# lazily inside a function ("keep the package importable without AWS"), so it is
+# never touched at collection time and a venv without it (the app's own dev env is
+# one) collects and runs this suite fine. Listing it here would skip the suite on
+# every such env for a dependency that never blocks import.
+_IMAGE_COLLECT_TIME_DEPS = ("fastapi", "httpx", "uvicorn")
+_missing_image_deps = [
+    name for name in _IMAGE_COLLECT_TIME_DEPS if importlib.util.find_spec(name) is None
+]
+
+if os.name != "posix":  # pragma: no cover - the excluded platform
+    _declined: str | None = f"the host is not POSIX (os.name is {os.name!r})"
+elif _missing_image_deps:  # pragma: no cover - the app CI env without image deps
+    _declined = "these image runtime dependencies are not importable: " + ", ".join(
+        _missing_image_deps
+    )
+else:
+    _declined = None
+
+if _declined is not None:  # pragma: no cover - decided by the host, not by a branch
+    if _REQUIRED:
+        raise RuntimeError(
+            f"{_REQUIRED_ENV} is set, so this environment declared that it must run "
+            f"the crew container suite, but it cannot: {_declined}. Refusing to skip. "
+            "A skip here would take the whole suite out of collection while the run "
+            "still reports success. Install the image's runtime dependencies "
+            "(container/requirements.txt) on a POSIX host, or unset "
+            f"{_REQUIRED_ENV} if this environment is not meant to run them."
+        )
+    collect_ignore_glob = ["test_*.py"]
+
+
+def _modules_that_define_tests() -> set[str]:
+    """Names of the ``test_*.py`` files beside this one that define a test function.
+
+    Read from the source with ``ast``, never imported: this runs while deciding
+    whether collection was complete, and importing a module to find out would either
+    duplicate collection or hide the very import failure being looked for.
+
+    The filter matters because a file matching ``test_*.py`` is not necessarily a
+    test module. ``test_supervisor_fakes.py`` is named that way to sit inside one
+    track's ownership and deliberately defines no test function, so requiring every
+    ``test_*.py`` to yield an item fails on the tree as it stands. Asking the source
+    what it defines keeps the check exact and self-maintaining: add a test to that
+    helper and it starts being required, with nothing to remember.
+    """
+    named: set[str] = set()
+    for path in _HERE.glob("test_*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):  # pragma: no cover - unparseable is pytest's error
+            named.add(path.name)
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith(
+                "test"
+            ):
+                named.add(path.name)
+                break
+    return named
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session,
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Under ``CREW_CONTAINER_TESTS_REQUIRED``, refuse a collection that came up short.
+
+    The import-time gate above proves the suite CAN be collected. This proves it WAS.
+    They are different failures, and only the second catches a module that quietly
+    stops yielding tests while every dependency is still importable.
+
+    Two checks, and the first is the one that cannot rot: the set of modules that
+    must yield tests is read off the filesystem, so it needs no maintenance and
+    cannot disagree with the tree. A module that defines tests and contributed no
+    collected item is an error whatever the reason. Deleting a test file legitimately
+    removes it from both sides and stays silent, which is why this check can be exact
+    rather than a floor. The count floor then covers what a presence check cannot
+    see.
+
+    Items outside this directory are ignored, so a wider run that happens to include
+    this suite is not judged by it.
+    """
+    if not _REQUIRED:
+        return
+    mine = [item for item in items if getattr(item, "path", None) is not None]
+    mine = [item for item in mine if item.path.parent == _HERE]
+    collected = {item.path.name for item in mine}
+    uncollected = sorted(_modules_that_define_tests() - collected)
+    if uncollected:
+        raise pytest.UsageError(
+            f"{_REQUIRED_ENV} is set and these modules define tests but contributed "
+            f"no collected test: {', '.join(uncollected)}. A module that collects "
+            "nothing is reported as neither a pass nor a failure, so this is an error "
+            "rather than a silence."
+        )
+    if len(mine) < _MIN_COLLECTED:
+        raise pytest.UsageError(
+            f"{_REQUIRED_ENV} is set and the crew container suite collected "
+            f"{len(mine)} tests, below its floor of {_MIN_COLLECTED}. Every module "
+            "that defines tests yielded at least one, so tests went missing inside "
+            "one of them. Find them rather than lowering the floor; lower it only in "
+            "the same commit as a deliberate deletion."
+        )
+
+
+# APPEND, never insert(0), and note the directory beside this one is named
+# ``container_tests`` rather than ``tests``. Both facts exist for the same reason.
+#
+# ``crew/runtime/`` deliberately has no ``__init__.py`` (see above), so pytest's
+# prepend mode inserts THIS directory at sys.path[0] and names the suite by its own
+# folder. Called ``tests``, that made it the TOP-LEVEL package ``tests`` for the
+# whole process, and several builtin apps import their own fixtures under exactly
+# that name (``from tests.fixtures import ...``) -- so ours won the name and theirs
+# failed to import. It surfaced only on Windows, whose shard split happened to put
+# both suites in one process, which means the collision was latent on every
+# platform and observable on one. Every other app's test package sits inside an
+# unbroken ``__init__.py`` chain and is therefore never top-level; this tree is the
+# only one that breaks the chain, and it breaks it on purpose, so it is the one
+# that has to carry a name nothing else claims.
+#
+# Appending is then belt and braces for what this is actually for: the container's
+# own package is ``container``, which no other suite defines, so it resolves from
+# anywhere on the path and needs no precedence.
+if str(_BUILD_CONTEXT) not in sys.path:
+    sys.path.append(str(_BUILD_CONTEXT))

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_channels_off.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_channels_off.py
@@ -1,0 +1,235 @@
+"""The container serves no messaging channel, and says so positively.
+
+A crew in a container has nobody to reach on Slack or Telegram: the only caller it
+serves is the customer's HTTP turn through the front process. A transport that comes
+up hands that crew an outbound channel into an owner's workspace that nobody chose to
+grant it.
+
+Two mechanisms, because neither alone is complete. The config file turns every
+transport off by name, which is the only thing that reaches ``imessage`` and
+``whatsapp`` -- their registry descriptors carry no credential at all, so they start
+on their config flag. The credential strip is what reaches ``slack``, whose config
+section has no ``enabled`` key and which starts on its tokens.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from container.common import ConfigError
+from container.supervisor import backend as backend_mod
+
+from ._settings_helper import make_settings
+
+
+def _written(tmp_path: Path) -> dict:
+    settings = make_settings(tmp_path)
+    path = backend_mod.write_backend_config(settings)
+    assert path == settings.config_dir / "config.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_every_transport_is_off_in_the_written_config(tmp_path: Path) -> None:
+    config = _written(tmp_path)
+    on = [name for name in backend_mod.CHANNEL_SECTIONS if config.get(name, {}).get("enabled")]
+    assert not on, f"these transports are not disabled in the config the backend boots with: {on}"
+
+
+def test_the_transport_list_is_not_empty() -> None:
+    """Non-vacuity: an empty tuple would make the assertions above pass silently."""
+    assert len(backend_mod.CHANNEL_SECTIONS) >= 10
+
+
+def test_the_sandbox_cannot_be_turned_off_by_an_existing_config(tmp_path: Path) -> None:
+    """The refusal to run unsandboxed must not be defeatable by a config file.
+
+    ``verify_sandbox`` refuses to start where the model subprocess cannot be
+    sandboxed, and the container offers no unsandboxed posture. The gateway reads its
+    sandbox mode and two fallback flags from this same file, so a file arriving with
+    them relaxed would let the worker run with no backend while the supervisor's
+    refusal reported nothing wrong.
+    """
+    settings = make_settings(tmp_path)
+    settings.config_dir.mkdir(parents=True, exist_ok=True)
+    (settings.config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "agent": {
+                    "sandbox": "off",
+                    "sandbox_allow_no_isolation": True,
+                    "sandbox_allow_unsandboxed_exec": True,
+                    "default_agent": "kept",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = json.loads(backend_mod.write_backend_config(settings).read_text(encoding="utf-8"))
+
+    assert config["agent"]["sandbox"] == "auto"
+    assert config["agent"]["sandbox_allow_no_isolation"] is False
+    assert config["agent"]["sandbox_allow_unsandboxed_exec"] is False
+    assert config["agent"]["default_agent"] == "kept", "only the forced keys are overwritten"
+
+
+def test_the_sandbox_settings_are_written_even_with_no_existing_config(tmp_path: Path) -> None:
+    """Written, not left to a default.
+
+    ``sandbox_allow_unsandboxed_exec`` resolves an undeclared value through a PLATFORM
+    default, so what silence means is not a constant and the container states its
+    answer rather than inheriting one.
+    """
+    config = _written(tmp_path)
+    for key, value in backend_mod.FORCED_AGENT_SETTINGS.items():
+        assert config["agent"][key] == value, key
+
+
+def test_a_flag_only_transport_is_covered() -> None:
+    """``imessage`` and ``whatsapp`` need no credential, so only the config reaches them.
+
+    Named individually because they are the reason this file exists as well as the
+    credential strip. Stripping secrets cannot disable a transport that never needed
+    one.
+    """
+    assert "imessage" in backend_mod.CHANNEL_SECTIONS
+    assert "whatsapp" in backend_mod.CHANNEL_SECTIONS
+
+
+def test_a_config_that_enables_a_transport_loses(tmp_path: Path) -> None:
+    """The container's posture must not be a default a shipped file can outvote."""
+    settings = make_settings(tmp_path)
+    settings.config_dir.mkdir(parents=True, exist_ok=True)
+    path = settings.config_dir / "config.json"
+    path.write_text(
+        json.dumps({"telegram": {"enabled": True, "bot_token": "t"}, "keep": {"me": 1}}),
+        encoding="utf-8",
+    )
+
+    backend_mod.write_backend_config(settings)
+    config = json.loads(path.read_text(encoding="utf-8"))
+
+    assert config["telegram"]["enabled"] is False
+    assert config["telegram"]["bot_token"] == "t", "only `enabled` is forced"
+    assert config["keep"] == {"me": 1}, "unrelated config survives"
+
+
+def test_a_non_dict_section_is_replaced_rather_than_merged(tmp_path: Path) -> None:
+    """A section of the wrong shape cannot make the section unwritable.
+
+    ``dict(current)`` on a string would raise, and a transport left unwritten because
+    the file was malformed is the failure this container cannot have.
+    """
+    settings = make_settings(tmp_path)
+    settings.config_dir.mkdir(parents=True, exist_ok=True)
+    (settings.config_dir / "config.json").write_text(
+        json.dumps({"discord": "not a section"}), encoding="utf-8"
+    )
+
+    config = json.loads(backend_mod.write_backend_config(settings).read_text(encoding="utf-8"))
+    assert config["discord"] == {"enabled": False}
+
+
+def test_the_write_refuses_a_symlink_at_the_destination(tmp_path: Path) -> None:
+    """A pre-planted link must not redirect this write outside the data home.
+
+    Same exposure as the bundle install, and the same primitive answers it.
+    """
+    settings = make_settings(tmp_path)
+    settings.config_dir.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+    (settings.config_dir / "config.json").symlink_to(outside)
+
+    with pytest.raises(ConfigError):
+        backend_mod.write_backend_config(settings)
+    assert outside.read_text(encoding="utf-8") == "{}", "the link target was written through"
+
+
+def test_no_channel_credential_reaches_the_backend(tmp_path: Path) -> None:
+    base = {name: "secret" for name in backend_mod.CHANNEL_CRED_ENV}
+    base["KIRO_API_KEY"] = "k"
+
+    env = backend_mod.build_backend_env(make_settings(tmp_path), base=base)
+
+    present = sorted(name for name in backend_mod.CHANNEL_CRED_ENV if name in env)
+    assert not present, f"these channel credentials reach the auto-approving worker: {present}"
+
+
+def test_the_credential_list_names_only_variables_the_gateway_reads(tmp_path: Path) -> None:
+    """Every name here must be one the gateway actually reads.
+
+    A name nothing reads is worse than a missing one: it reads as coverage while
+    stripping nothing, and it makes the list look longer than its reach. The
+    authoritative set lives in the gateway's channel registry, and
+    ``test/test_crew_container_config_isolation.py`` compares the two -- this only
+    pins the shape those names have, which is what makes that comparison possible.
+    """
+    assert backend_mod.CHANNEL_CRED_ENV
+    for name in backend_mod.CHANNEL_CRED_ENV:
+        assert name == name.upper(), name
+        assert not name.startswith("KIROCREW_"), (
+            f"{name} is a Kiro Crew-namespaced spelling; the gateway reads the channel's "
+            "own variable, so this name strips nothing"
+        )
+
+
+def test_the_config_is_written_before_the_backend_starts(tmp_path: Path, monkeypatch) -> None:
+    """Order, not just presence: the gateway reads this file at boot.
+
+    A config written after ``start_backend`` is a config the running backend already
+    ignored, and a transport it started is connected by then.
+    """
+    from container.supervisor import __main__ as entry
+
+    calls: list[str] = []
+    settings = make_settings(tmp_path)
+
+    class _Fake:
+        def terminate(self, *a, **k):
+            return None
+
+        def kill(self, *a, **k):
+            return None
+
+    def _record(name: str):
+        """A stub that records the call and returns nothing.
+
+        Each stub is a ``def`` rather than ``lambda ...: calls.append(name)`` because
+        ``list.append`` returns ``None``, so the lambda form types as a function
+        returning a value it does not have. Spelling it ``... or Path()`` would satisfy
+        the type checker by relying on that same ``None``, which is the reading a
+        checker is right to refuse.
+        """
+
+        def stub(*args, **kwargs):
+            calls.append(name)
+
+        return stub
+
+    def _record_returning(name: str, value):
+        def stub(*args, **kwargs):
+            calls.append(name)
+            return value
+
+        return stub
+
+    monkeypatch.setattr(entry, "verify_layout", _record("layout"))
+    monkeypatch.setattr(entry, "verify_sandbox", _record("sandbox"))
+    monkeypatch.setattr(entry.bundle_mod, "install_bundle", _record("bundle"))
+    monkeypatch.setattr(entry.backend_mod, "build_backend_env", lambda s: {"KIRO_API_KEY": "k"})
+    monkeypatch.setattr(entry.backend_mod, "require_api_key", lambda env: None)
+    monkeypatch.setattr(
+        entry.backend_mod, "write_backend_config", _record_returning("config", Path())
+    )
+    monkeypatch.setattr(entry.backend_mod, "start_backend", _record_returning("backend", _Fake()))
+    monkeypatch.setattr(entry.backend_mod, "wait_until_ready", lambda *a, **kw: None)
+    monkeypatch.setattr(entry, "_start_front", _record_returning("front", _Fake()))
+    monkeypatch.setattr(entry, "_teardown", lambda front, backend: None)
+
+    entry.run(settings, wait_for_shutdown=lambda children: "signal")
+
+    assert calls.index("config") < calls.index("backend"), calls
+    assert calls.index("bundle") < calls.index("config"), calls

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_config_atomicity.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_config_atomicity.py
@@ -1,0 +1,124 @@
+"""The container's config must never be read half-written.
+
+`config.json` is written by the supervisor and read by the gateway at the NEXT
+start, which is what makes a partial write the interesting failure: nothing reads
+the file during the write, so an interrupted one is a defect that surfaces after
+the run that caused it is gone, on a container that boots on a config it cannot
+parse.
+
+So the write is a sibling temp in the same directory, fsynced, then one atomic
+replace -- and a symlink at the destination is refused rather than consumed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from container.common import ConfigError
+from container.supervisor import backend as backend_mod
+
+from ._settings_helper import make_settings
+
+
+def _config_path(settings) -> Path:
+    return settings.config_dir / "config.json"
+
+
+def test_an_interrupted_write_leaves_the_previous_config_intact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The destination is either the old file or the new one, never a prefix of the new.
+
+    The failure is injected at the last possible moment -- after the temp is written
+    and fsynced, at the replace itself -- because that is the window a
+    write-in-place implementation cannot survive.
+    """
+    settings = make_settings(tmp_path)
+    settings.config_dir.mkdir(parents=True, exist_ok=True)
+    path = _config_path(settings)
+    before = json.dumps({"agent": {"default_agent": "previous"}}) + "\n"
+    path.write_text(before, encoding="utf-8")
+
+    def _boom(src, dst):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(backend_mod.os, "replace", _boom)
+
+    with pytest.raises(ConfigError, match="publish"):
+        backend_mod.write_backend_config(settings)
+
+    assert path.read_text(encoding="utf-8") == before, "the previous config was damaged"
+    assert json.loads(path.read_text(encoding="utf-8")), "and it still parses"
+
+
+def test_an_interrupted_write_leaves_no_temporary_behind(tmp_path: Path, monkeypatch) -> None:
+    """A failed write must not accumulate files in the data home.
+
+    A leftover temp is not a security problem, but it is how a directory silently
+    fills over a task's lifetime, and it makes the next failure harder to read.
+    """
+    settings = make_settings(tmp_path)
+    settings.config_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        backend_mod.os, "replace", lambda src, dst: (_ for _ in ()).throw(OSError(5, "I/O error"))
+    )
+    with pytest.raises(ConfigError):
+        backend_mod.write_backend_config(settings)
+
+    leftovers = [p.name for p in settings.config_dir.iterdir() if p.name.endswith(".tmp")]
+    assert not leftovers, leftovers
+
+
+def test_the_write_publishes_a_complete_document(tmp_path: Path) -> None:
+    """The success path, asserted on the bytes rather than on the call succeeding."""
+    settings = make_settings(tmp_path)
+    path = backend_mod.write_backend_config(settings)
+
+    text = path.read_text(encoding="utf-8")
+    assert text.endswith("\n")
+    config = json.loads(text)
+    assert config["agent"]["sandbox"] == "auto"
+    assert config["slack"]["enabled"] is False
+    leftovers = [p.name for p in settings.config_dir.iterdir() if p.name.endswith(".tmp")]
+    assert not leftovers, leftovers
+
+
+def test_a_symlink_at_the_destination_is_refused(tmp_path: Path) -> None:
+    """A link there means something else chose the path, so the container stops.
+
+    ``os.replace`` would not write through the link -- ``rename`` unlinks it rather
+    than following it -- so this is not about preventing a write to the target. It is
+    about not consuming a planted link silently.
+    """
+    settings = make_settings(tmp_path)
+    settings.config_dir.mkdir(parents=True, exist_ok=True)
+    victim = tmp_path / "victim.json"
+    victim.write_text("{}", encoding="utf-8")
+    _config_path(settings).symlink_to(victim)
+
+    with pytest.raises(ConfigError, match="symlink"):
+        backend_mod.write_backend_config(settings)
+
+    assert victim.read_text(encoding="utf-8") == "{}"
+    assert _config_path(settings).is_symlink(), "the link is left for a human to look at"
+
+
+def test_a_pre_planted_temp_file_is_an_error_not_a_target(tmp_path: Path, monkeypatch) -> None:
+    """The temp is opened ``O_EXCL``, so a file already at that name is refused.
+
+    Without it the write would happily use whatever is at the temp path, which is a
+    second way into the same directory.
+    """
+    settings = make_settings(tmp_path)
+    settings.config_dir.mkdir(parents=True, exist_ok=True)
+    planted = settings.config_dir / f"config.json.{99999}.tmp"
+    planted.write_text("planted", encoding="utf-8")
+    monkeypatch.setattr(backend_mod.os, "getpid", lambda: 99999)
+
+    with pytest.raises(ConfigError, match="temporary file"):
+        backend_mod.write_backend_config(settings)
+
+    assert planted.read_text(encoding="utf-8") == "planted"

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_env_drops_control_secret.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_env_drops_control_secret.py
@@ -1,0 +1,62 @@
+"""The backend must not hand the front's control secret to the model subprocess.
+
+``build_backend_env`` copies the task environment wholesale. That environment holds
+``SMC_CONTROL_SECRET``, injected by the ECS task definition from Secrets Manager for
+the FRONT to validate the ``X-SMC-Control-Secret`` header with. The backend never
+reads it -- but the backend spawns the model subprocess, which inherits its
+environment and auto-approves every tool it calls. So a prompt able to read its own
+environment could lift the secret and then call the front's control endpoints as the
+control plane; dropping it from the backend env closes that independently of the
+sandbox.
+"""
+
+from __future__ import annotations
+
+from container.supervisor import backend as be
+
+from ._settings_helper import make_settings
+
+
+def _settings(tmp_path):
+    """The suite's own factory, with the control secret the front would validate."""
+    s = make_settings(tmp_path)
+    return s.__class__(**{**s.__dict__, "control_secret": "s3cr3t-control"})
+
+
+def test_the_control_secret_is_not_in_the_backend_environment(tmp_path):
+    base = {
+        "SMC_CONTROL_SECRET": "s3cr3t-control",
+        "KIRO_API_KEY": "aws-kiro-abcdefghijklmnopqrstuvwxyz0123456789",
+        "PATH": "/usr/bin",
+    }
+    env = be.build_backend_env(_settings(tmp_path), base)
+
+    assert "SMC_CONTROL_SECRET" not in env
+    # And not under any other name either: a rename that kept the VALUE reachable
+    # would defeat the point, which is that the value cannot be read from the
+    # subprocess environment at all.
+    assert "s3cr3t-control" not in env.values(), (
+        f"the control secret's value survives under another key: "
+        f"{sorted(k for k, v in env.items() if v == 's3cr3t-control')}"
+    )
+
+
+def test_the_model_credential_still_reaches_the_backend(tmp_path):
+    """The strip must not take the credential the backend cannot start without."""
+    key = "aws-kiro-abcdefghijklmnopqrstuvwxyz0123456789"
+    env = be.build_backend_env(
+        _settings(tmp_path), {"SMC_CONTROL_SECRET": "x", "KIRO_API_KEY": key}
+    )
+    assert env["KIRO_API_KEY"] == key
+    be.require_api_key(env)  # must not raise
+
+
+def test_the_front_still_receives_the_secret_through_settings(tmp_path):
+    """Removing it from the backend env must not remove it from the front's config.
+
+    The front validates the header against ``Settings.control_secret``, which is
+    loaded from the task environment in the FRONT's own process -- a different
+    process that is not launched through ``build_backend_env``.
+    """
+    settings = _settings(tmp_path)
+    assert settings.control_secret == "s3cr3t-control"

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_secret_path_links.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_secret_path_links.py
@@ -1,0 +1,91 @@
+"""A link planted where the boot secret goes must stop the task, not be followed.
+
+The gateway writes ``run/gateway-<port>.secret`` itself, with an ordinary open that
+follows a symlink, and it truncates that file on every start. The crew's model
+worker can write inside the data home, and what it writes is driven by prompt
+content, so the path is reachable by an untrusted caller. A link there would turn
+the gateway's own secret write into a truncating write to the link's target.
+
+Nothing in this container can make the gateway's writer link-safe, so the
+supervisor refuses instead: a real directory and a real file path, or no task.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from container import common
+from container.common import ConfigError
+from container.supervisor import backend as backend_mod
+
+from ._settings_helper import make_settings
+
+
+def test_a_symlinked_run_directory_refuses_to_start(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    run_dir = settings.backend_run_dir
+    if run_dir.exists():
+        run_dir.rmdir()
+    run_dir.symlink_to(elsewhere, target_is_directory=True)
+
+    with pytest.raises(ConfigError, match="symlink"):
+        backend_mod.start_backend(settings, argv=["/bin/true"])
+
+
+def test_a_symlinked_secret_path_refuses_to_start(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    settings.backend_run_dir.mkdir(parents=True, exist_ok=True)
+    victim = tmp_path / "victim.json"
+    victim.write_text("do not truncate me", encoding="utf-8")
+    common.secret_path(settings.backend_run_dir, settings.backend_port).symlink_to(victim)
+
+    with pytest.raises(ConfigError, match="symlink"):
+        backend_mod.start_backend(settings, argv=["/bin/true"])
+
+    assert victim.read_text(encoding="utf-8") == "do not truncate me"
+
+
+def test_a_directory_where_the_secret_goes_refuses_to_start(tmp_path: Path) -> None:
+    """Not a link, but the same class: the gateway expects to write a file there."""
+    settings = make_settings(tmp_path)
+    settings.backend_run_dir.mkdir(parents=True, exist_ok=True)
+    common.secret_path(settings.backend_run_dir, settings.backend_port).mkdir()
+
+    with pytest.raises(ConfigError, match="not a regular file"):
+        backend_mod.start_backend(settings, argv=["/bin/true"])
+
+
+def test_a_clean_run_directory_starts(tmp_path: Path) -> None:
+    """Non-vacuity: the guard must not refuse the ordinary case.
+
+    A guard that refused everything would make the three tests above pass while
+    saying nothing about links.
+    """
+    settings = make_settings(tmp_path)
+    group = backend_mod.start_backend(settings, argv=["/bin/true"])
+    try:
+        assert settings.backend_run_dir.is_dir()
+        assert not settings.backend_run_dir.is_symlink()
+    finally:
+        group.terminate(2.0)
+
+
+def test_an_existing_secret_file_is_left_for_the_gateway_to_rewrite(tmp_path: Path) -> None:
+    """A real file is not the attack, and removing it would break the ordinary restart.
+
+    The gateway truncates and rewrites this path itself; the guard's job is to be sure
+    the path it rewrites is the path, not a link to somewhere else.
+    """
+    settings = make_settings(tmp_path)
+    settings.backend_run_dir.mkdir(parents=True, exist_ok=True)
+    secret = common.secret_path(settings.backend_run_dir, settings.backend_port)
+    secret.write_text("stale", encoding="utf-8")
+
+    group = backend_mod.start_backend(settings, argv=["/bin/true"])
+    try:
+        assert secret.read_text(encoding="utf-8") == "stale"
+    finally:
+        group.terminate(2.0)

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_secret_retry.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_secret_retry.py
@@ -1,0 +1,147 @@
+"""A secret that vanishes between the 403 and the retry must not truncate the stream.
+
+``forward_stream`` guards the FIRST ``_read_secret`` and, until this test existed, not the
+one on the 403 retry path. A backend that restarts and answers 403 while its replacement
+boot secret is not yet on disk raised ``BackendSecretUnavailable`` from that second read,
+and nothing upstream caught it: status 200 is committed before a body streams, so the
+response ended truncated with no ``[DONE]`` and a client waiting for the sentinel waited
+forever.
+
+Same failure mode as the transport case in ``test_backend_transport_failure``, and it
+survived that fix because it is a different exception type. This suite also pins the
+context-manager bookkeeping the retry needs, since the first stream is closed before the
+second is opened.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from container import common
+from container.front import backend as be
+
+from ._settings_helper import make_settings
+
+
+class _Stream:
+    """One ``client.stream(...)`` context manager that records its own closes."""
+
+    def __init__(self, status: int, closes: list[str], tag: str, body: bytes = b"") -> None:
+        self._status = status
+        self._closes = closes
+        self._tag = tag
+        self._body = body
+
+    async def __aenter__(self):
+        stream = self
+
+        class _Resp:
+            status_code = stream._status
+
+            async def aread(self):
+                return stream._body
+
+            async def aiter_bytes(self):
+                if stream._body:
+                    yield stream._body
+
+        return _Resp()
+
+    async def __aexit__(self, *_):
+        self._closes.append(self._tag)
+        return False
+
+
+class _Client:
+    """403 first, then whatever the test wants, recording every close."""
+
+    def __init__(self, closes: list[str], second_status: int = 200) -> None:
+        self.closes = closes
+        self._calls = 0
+        self._second = second_status
+
+    def stream(self, *a, **k):
+        self._calls += 1
+        if self._calls == 1:
+            return _Stream(403, self.closes, "first")
+        return _Stream(self._second, self.closes, "second", b"data: [DONE]\n\n")
+
+
+class _NoScope:
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _drain(resp) -> str:
+    async def go():
+        return b"".join([c async for c in resp.body_iterator])
+
+    out = asyncio.run(go())
+    return out.decode("utf-8") if isinstance(out, bytes) else str(out)
+
+
+def test_a_secret_lost_on_the_retry_still_ends_the_stream(tmp_path, monkeypatch):
+    calls = {"n": 0}
+
+    def flaky(_settings):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "first-secret"
+        raise common.BackendSecretUnavailable("rotated away")
+
+    monkeypatch.setattr(be, "_read_secret", flaky)
+    closes: list[str] = []
+    text = _drain(
+        be.forward_stream(_Client(closes), make_settings(tmp_path), {"messages": []}, _NoScope())
+    )
+
+    # The sentinel is the property that matters: without it a client hangs.
+    assert "[DONE]" in text, f"stream ended without the sentinel: {text[:160]!r}"
+    assert '"error"' in text, text[:200]
+    assert calls["n"] == 2, "the retry path did not run, so this proves nothing"
+
+
+def test_the_first_stream_is_closed_exactly_once(tmp_path, monkeypatch):
+    """The retry closes the first stream, so the finally must not close it again."""
+    calls = {"n": 0}
+
+    def flaky(_settings):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "first-secret"
+        raise common.BackendSecretUnavailable("rotated away")
+
+    monkeypatch.setattr(be, "_read_secret", flaky)
+    closes: list[str] = []
+    _drain(
+        be.forward_stream(_Client(closes), make_settings(tmp_path), {"messages": []}, _NoScope())
+    )
+    assert closes == ["first"], f"expected one close of the first stream, got {closes}"
+
+
+def test_a_successful_retry_closes_only_the_second_stream(tmp_path, monkeypatch):
+    monkeypatch.setattr(be, "_read_secret", lambda s: "secret")
+    closes: list[str] = []
+    text = _drain(
+        be.forward_stream(_Client(closes), make_settings(tmp_path), {"messages": []}, _NoScope())
+    )
+    assert "[DONE]" in text
+    # First closed by the retry path, second by the finally. Each exactly once.
+    assert closes == ["first", "second"], closes
+
+
+@pytest.mark.parametrize("second_status", [500, 503])
+def test_a_retry_that_still_fails_reports_an_error_frame(tmp_path, monkeypatch, second_status):
+    monkeypatch.setattr(be, "_read_secret", lambda s: "secret")
+    closes: list[str] = []
+    text = _drain(
+        be.forward_stream(
+            _Client(closes, second_status), make_settings(tmp_path), {"messages": []}, _NoScope()
+        )
+    )
+    assert "[DONE]" in text
+    assert '"error"' in text

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_transport_failure.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_backend_transport_failure.py
@@ -1,0 +1,114 @@
+"""A backend that goes away mid-turn must produce a usable answer, not a hang.
+
+The backend is a sibling process in the same task and ECS restarts it, so a turn in
+flight when that happens is an expected event rather than a bug. Neither transport was
+guarded:
+
+* the non-streamed path let ``httpx.RequestError`` escape, which FastAPI rendered as a
+  500 -- "this service is broken" when the truth is "try again";
+* the streamed path had already committed status 200, so the exception ended the body
+  TRUNCATED with no ``[DONE]``, and a client waiting for that sentinel waits forever.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from container.front import backend as be
+
+from ._settings_helper import make_settings
+
+
+class _BoomClient:
+    """An httpx-shaped client whose every call fails the way a restart does."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def post(self, *a, **k):
+        raise self._exc
+
+    def stream(self, *a, **k):
+        exc = self._exc
+
+        class _CM:
+            async def __aenter__(self):
+                raise exc
+
+            async def __aexit__(self, *_):
+                return False
+
+        return _CM()
+
+
+class _NoScope:
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _settings(tmp_path):
+    s = make_settings(tmp_path)
+    s.__class__  # keep the fixture's own construction; nothing to override here
+    return s
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("connection refused"),
+        httpx.ReadError("connection reset"),
+        httpx.RemoteProtocolError("server disconnected"),
+    ],
+)
+def test_a_non_streamed_turn_returns_503(tmp_path, exc, monkeypatch):
+    import asyncio
+
+    monkeypatch.setattr(be, "_read_secret", lambda s: "secret")
+    resp = asyncio.run(
+        be.forward_completion(_BoomClient(exc), _settings(tmp_path), {"messages": []})
+    )
+    assert resp.status_code == 503, f"{type(exc).__name__} did not become a 503"
+    payload = json.loads(bytes(resp.body).decode("utf-8"))
+    assert payload["error"]["code"] == "backend_unreachable"
+
+
+def test_a_streamed_turn_ends_with_a_complete_error_frame(tmp_path, monkeypatch):
+    import asyncio
+
+    monkeypatch.setattr(be, "_read_secret", lambda s: "secret")
+    resp = be.forward_stream(
+        _BoomClient(httpx.ConnectError("connection refused")),
+        _settings(tmp_path),
+        {"messages": []},
+        _NoScope(),
+    )
+
+    async def drain():
+        return b"".join([chunk async for chunk in resp.body_iterator])
+
+    body = asyncio.run(drain())
+    text = body.decode("utf-8") if isinstance(body, bytes) else str(body)
+    # The sentinel is the property that matters: without it a client hangs.
+    assert "[DONE]" in text, f"stream ended without the sentinel: {text[:120]!r}"
+    assert "backend_unreachable" in text, text[:200]
+
+
+def test_the_stream_says_it_failed_rather_than_returning_nothing(tmp_path, monkeypatch):
+    """An empty-but-well-formed stream would look like a crew with nothing to say."""
+    import asyncio
+
+    monkeypatch.setattr(be, "_read_secret", lambda s: "secret")
+    resp = be.forward_stream(
+        _BoomClient(httpx.ReadError("reset")), _settings(tmp_path), {"messages": []}, _NoScope()
+    )
+
+    async def drain():
+        return b"".join([chunk async for chunk in resp.body_iterator])
+
+    text = asyncio.run(drain()).decode("utf-8")
+    assert '"error"' in text, text[:200]

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_comment_code_agreement.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_comment_code_agreement.py
@@ -1,0 +1,83 @@
+"""Two comments that had drifted from the code beside them, and a guard against a third.
+
+Both were flagged by review, and both had the same history: they described an earlier
+version of the line under them and stopped being true when that line changed. A comment
+that contradicts its own code is worse than no comment, because a reader who trusts it
+reasons from a premise the program does not hold.
+
+* ``front/app.py`` said the control header's name was "not pinned by the shared base",
+  directly above ``CONTROL_SECRET_HEADER = common.CONTROL_SECRET_HEADER``.
+* ``front/transcript.py`` said the backup layout was "not ours to import", above an import
+  of it -- both the import and that comment left when the backup subsystem was extracted
+  from this PR, so the guard now only ensures neither returns.
+
+Neither code line was wrong. The header alias is the better choice than a second copy, and
+the transcript key helpers are now the front's own after backup left. So the comments were
+corrected to the code rather than the other way round.
+
+These tests are the cheap half of keeping them honest. They cannot check that prose is
+accurate, only that the specific claims which HAD drifted cannot come back while the code
+they contradict is still there.
+
+The guard is a plain substring match and it caught the first attempt at this file: the
+replacement comments explained their own history by QUOTING the retired phrase, which the
+match cannot tell from asserting it. The comments were reworded to describe the old claim
+instead of repeating it, rather than teaching the guard to allow a quoted form -- an
+exception for "in quotes" is an exception a future edit can sit inside.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from container import common
+from container.front import app as app_mod
+from container.front import transcript as transcript_mod
+
+APP_SOURCE = pathlib.Path(app_mod.__file__)
+TRANSCRIPT_SOURCE = pathlib.Path(transcript_mod.__file__)
+
+
+def test_the_control_header_has_one_definition() -> None:
+    """The alias must stay an alias, so the deploy integration has one name to match."""
+    assert app_mod.CONTROL_SECRET_HEADER is common.CONTROL_SECRET_HEADER
+
+
+def test_the_header_comment_does_not_deny_the_shared_definition() -> None:
+    """The retired claim must not return while the line below it is an alias.
+
+    Keyed on the phrase that was wrong rather than on the whole comment: pinning the exact
+    prose would make every rewording a test failure, which trains people to edit the test.
+    """
+    text = APP_SOURCE.read_text(encoding="utf-8")
+    assert "not pinned by the shared base" not in text, (
+        "the comment denies the shared definition again, but CONTROL_SECRET_HEADER is "
+        "still an alias for common.CONTROL_SECRET_HEADER"
+    )
+
+
+def test_the_transcript_key_helpers_are_defined_locally() -> None:
+    """The front owns its key derivation now that backup is extracted.
+
+    While the sidecar existed, the front imported ``full_key``/``sessions_prefix`` from the
+    backup layout so the two could not drift. Backup left this PR, so the helpers moved here.
+    This pins that the derivation is present as the front's own, callable functions -- a
+    replacement that dropped them would break the transcript fetch.
+    """
+    assert callable(transcript_mod._full_key)
+    assert callable(transcript_mod._sessions_prefix)
+    assert callable(transcript_mod._object_prefix)
+
+
+def test_the_transcript_comment_does_not_claim_a_backup_import() -> None:
+    """No stale reference to the extracted backup layout may return.
+
+    The old comment described importing the key scheme from the backup layout; that import
+    is gone with the subsystem. Neither the import nor the retired "not ours to import"
+    claim about it may reappear while the helpers live here.
+    """
+    text = TRANSCRIPT_SOURCE.read_text(encoding="utf-8")
+    assert "from ..backup.layout import" not in text, "the extracted backup import is back"
+    assert (
+        "not ours to import" not in text
+    ), "the retired claim about importing the layout has returned"

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_config_refuses_meaningless_input.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_config_refuses_meaningless_input.py
@@ -1,0 +1,41 @@
+"""Malformed input is refused, not repaired, in two more places.
+
+Both are the mistake `parse_route_prefix`'s own docstring names when it refuses a bare
+word: a value that has to be guessed at is a value the operator did not mean, and the
+guess surfaces later as a misrouted request or a suite that skipped, rather than now as
+an error.
+"""
+
+from __future__ import annotations
+
+import pytest
+from container.common.config import ConfigError, parse_route_prefix
+
+
+@pytest.mark.parametrize("raw", ["/", "//", "///", " / ", " // "])
+def test_a_prefix_that_normalises_to_nothing_is_refused(raw: str) -> None:
+    """A value whose normalised form is empty must not read as "no prefix".
+
+    That is the dangerous direction: the deployment believes it set a prefix, the
+    container serves the routes bare, and nothing says so until a request arrives at a
+    path nobody expected it to answer.
+    """
+    with pytest.raises(ConfigError):
+        parse_route_prefix(raw)
+
+
+@pytest.mark.parametrize("raw", [None, "", "   "])
+def test_an_absent_prefix_still_means_no_prefix(raw: str | None) -> None:
+    """Non-vacuity for the refusal above: unset is a legitimate answer.
+
+    A guard that refused everything would make the test above pass while breaking every
+    deployment that does not use a prefix, which is all of them today.
+    """
+    assert parse_route_prefix(raw) == ""
+
+
+@pytest.mark.parametrize(
+    "raw,expected", [("/c/frontdesk", "/c/frontdesk"), ("/c/frontdesk/", "/c/frontdesk")]
+)
+def test_a_real_prefix_is_accepted_and_normalised(raw: str, expected: str) -> None:
+    assert parse_route_prefix(raw) == expected

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_escaped_workers_are_swept.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_escaped_workers_are_swept.py
@@ -1,0 +1,187 @@
+"""A worker that ESCAPED the backend's process group still has to be stopped.
+
+``ProcessGroup.terminate`` sweeps the group, and a kiro-cli worker is not in it: it spawns
+with ``start_new_session`` (``acp/runtime.py:1321``), so it ``setsid``s into a group of its own
+and no ``killpg`` of the backend's group can reach it. That is deliberate and the drain is the
+mechanism -- ``BACKEND_DRAIN_SECS`` is sized so the backend's own SIGTERM handler can reap its
+workers, and killing one mid-turn is exactly what the long drain exists to prevent.
+
+What the drain cannot cover is the backend NOT running that handler: it crashed, or it was
+still reaping when the drain window elapsed and got SIGKILLed. Then the worker is orphaned, no
+one will reap it, and it keeps running and writing to the container filesystem after the task
+is meant to be gone -- a leak the teardown exists to close.
+
+The supervisor is PID 1 in this image (``CMD ["python", "-m", "container.supervisor"]``), so
+such an orphan is reparented to it. That is the only reason it is findable: the supervisor never
+learns the worker's pid, because the backend spawns it and tells nobody.
+
+Real processes here, not mocks. What is under test is whether a process is alive afterwards,
+and a mock of ``os.kill`` would only prove the call was made with the argument the test supplied.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+from container.supervisor.__main__ import (
+    _our_live_children,
+    _sweep_orphans_the_backend_cannot_reap,
+)
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX")
+
+# Escapes into its own session, then outlives anything this file waits for.
+_ESCAPER = "import os, time; os.setsid(); print(os.getpid(), flush=True); time.sleep(120)"
+
+
+def _spawn_escaper() -> subprocess.Popen:
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _ESCAPER],
+        stdout=subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    proc.stdout.readline()  # wait until setsid has happened
+    return proc
+
+
+def _alive(pid: int) -> bool:
+    """A zombie counts as gone: it cannot write anymore.
+
+    Existence goes through ``platform_compat.pid_exists`` rather than ``os.kill(pid, 0)``.
+    The repo audits for that pattern and the audit is right: on Windows ``os.kill`` with
+    signal 0 does not probe, it calls TerminateProcess on the pid being asked about. This is
+    host-side test code, not container image source, so the shim is importable here -- the
+    suite's own ``pid_alive`` helper takes the same route for the same reason.
+    """
+    from kiro_crew.platform_compat import pid_exists
+
+    if not pid_exists(pid):
+        return False
+    try:
+        with open(f"/proc/{pid}/stat", encoding="utf-8") as fh:
+            return fh.read().rsplit(")", 1)[1].split()[0] != "Z"
+    except OSError:
+        return False
+
+
+def _await_gone(pid: int, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _alive(pid):
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def test_an_escaped_process_is_found_though_it_left_the_group() -> None:
+    """The discovery half: it is in another session, so only parentage can find it."""
+    proc = _spawn_escaper()
+    try:
+        assert os.getpgid(proc.pid) != os.getpgid(0), "the fixture did not escape the group"
+        assert proc.pid in _our_live_children(set())
+    finally:
+        os.kill(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5)
+
+
+def test_the_sweep_kills_a_process_the_backend_could_not_reap() -> None:
+    """The whole point: an orphan the backend could not reap must be gone at teardown."""
+    proc = _spawn_escaper()
+    try:
+        _sweep_orphans_the_backend_cannot_reap(set())
+        assert _await_gone(proc.pid), "the escaped process outlived the sweep"
+    finally:
+        try:
+            os.kill(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def test_an_excluded_child_is_left_alone() -> None:
+    """Non-vacuity: a pid in the exclude set must survive the sweep.
+
+    The teardown passes the front and backend pids as excluded while it drains them in order,
+    so a sweep that killed every child would take a process still being drained. This pins
+    that an excluded pid is left running.
+    """
+    proc = _spawn_escaper()
+    try:
+        _sweep_orphans_the_backend_cannot_reap({proc.pid})
+        assert _alive(proc.pid), "an excluded child was killed"
+        assert proc.pid not in _our_live_children({proc.pid})
+    finally:
+        os.kill(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5)
+
+
+def test_the_sweep_is_a_no_op_with_nothing_to_sweep() -> None:
+    """The ordinary shutdown: the backend reaped its own workers, so there is nothing here."""
+    _sweep_orphans_the_backend_cannot_reap(set(_our_live_children(set())))
+
+
+def test_a_zombie_is_not_reported_as_live() -> None:
+    """A dead-but-unreaped child cannot write, so it is not something to kill.
+
+    Reported separately because an existence probe succeeds for a zombie: a liveness check
+    built on existence alone would list every unreaped child forever and log a kill each
+    shutdown.
+    """
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    try:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and proc.poll() is None:
+            time.sleep(0.02)
+        assert proc.poll() is not None
+        # Not waited on yet, so it is a zombie until this process reaps it.
+        assert proc.pid not in _our_live_children(set())
+    finally:
+        proc.wait(timeout=5)
+
+
+# Leader setsid()s into its own session, forks a child that STAYS in that session, prints
+# both pids, and both sleep. The child is the grandchild the single-pass sweep missed: it is
+# not a direct child of the supervisor until the leader dies, so killing only the discovered
+# leader leaves it writing. killpg of the leader's own group reaches it in one signal; the
+# discovery loop is the belt-and-braces if it reparents before the group signal lands.
+_LEADER_WITH_CHILD = (
+    "import os, time, sys\n"
+    "os.setsid()\n"
+    "pid = os.fork()\n"
+    "if pid == 0:\n"
+    "    time.sleep(120)\n"  # the child (grandchild of PID 1): stays in the leader's group
+    "else:\n"
+    "    print(os.getpid(), pid, flush=True)\n"
+    "    time.sleep(120)\n"
+)
+
+
+def test_the_sweep_takes_the_whole_process_group_not_just_the_leader() -> None:
+    """F1: an escaped worker's own child must also be gone at teardown.
+
+    Signalling only the discovered leader pid leaves its child -- a process still writing to
+    the container filesystem after the task is meant to be gone -- alive. The sweep signals
+    the leader's process GROUP and repeats discovery until nothing of ours is live, so the
+    child dies too.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _LEADER_WITH_CHILD],
+        stdout=subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    leader_pid, child_pid = (int(x) for x in proc.stdout.readline().split())
+    try:
+        _sweep_orphans_the_backend_cannot_reap(set())
+        assert _await_gone(leader_pid), "the escaped leader outlived the sweep"
+        assert _await_gone(child_pid), "the leader's child survived: only the leader was killed"
+    finally:
+        for pid in (child_pid, leader_pid, proc.pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        proc.wait(timeout=5)

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_and_sidecar_ceilings.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_and_sidecar_ceilings.py
@@ -1,0 +1,142 @@
+"""Two defects the review found in the FRONT process.
+
+Each is a case where a check existed but was reachable around: the transcript path let a
+stem the filesystem cannot hold through to the caller's first stat, and the control route
+buffered a request body with no ceiling. (The sidecar defects that once shared this file
+left with the backup subsystem when it was extracted from this PR.)
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+from container.front import app as app_mod
+from container.front import transcript as T
+
+from .test_front_transcript_fetch import make_settings
+
+
+@pytest.fixture()
+def settings(tmp_path):
+    """The transcript tests' own settings factory, given the two keys it reads.
+
+    ``backend_env`` there is a live-backend fixture these tests do not need: nothing here
+    talks to a backend, only ``local_transcript_path``, which is pure string work.
+    """
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    return make_settings({"port": 8801, "run_dir": run_dir})
+
+
+# --- an oversized slot id is refused before a path is built ----------------
+
+
+def test_a_stem_longer_than_name_max_is_refused(settings) -> None:
+    """Refused by returning None, the same answer a containment failure gives.
+
+    Without this the stem reaches the caller's ``exists()`` and raises
+    ``OSError(ENAMETOOLONG)``, which reads as a broken disk rather than an invalid id.
+    """
+    assert T.local_transcript_path(settings, "chat-" + "x" * 5000) is None
+    assert T.local_transcript_path(settings, "x" * 250) is None
+
+
+def test_an_ordinary_slot_id_still_maps_to_a_path(settings) -> None:
+    """The other half: the ceiling is not "refuse everything".
+
+    A limit set too low would pass the test above and break every real conversation, and
+    no other test here would notice.
+    """
+    path = T.local_transcript_path(settings, "chat-982-1788526277")
+    assert path is not None
+    assert path.name == "chat-982-1788526277.jsonl"
+
+
+def test_the_boundary_counts_the_suffix(settings) -> None:
+    """``.jsonl`` counts toward the limit, because it is part of the name being created.
+
+    A check on ``len(stem)`` alone would accept a 255-character stem and then build a
+    261-character filename, which is the failure this prevents.
+    """
+    assert T.local_transcript_path(settings, "y" * (255 - len(".jsonl"))) is not None
+    assert T.local_transcript_path(settings, "y" * (255 - len(".jsonl") + 1)) is None
+
+
+# --- the control body has a ceiling ---------------------------------------
+
+
+def test_the_control_route_bounds_the_body_while_reading_it() -> None:
+    """The ceiling has to be inside the read loop.
+
+    ``request.json()`` buffers the whole body before returning, so a check after it runs
+    is a check on memory already spent. Streaming and counting is what makes the bound
+    real, and a Content-Length check alone is not it: that header is the client's claim
+    about a body it has not sent.
+    """
+    src = pathlib.Path(app_mod.__file__).read_text(encoding="utf-8")
+    assert "async for chunk in request.stream():" in src, "the body is not streamed"
+    assert "if len(raw_body) > _MAX_CONTROL_BODY_BYTES:" in src, "no ceiling in the loop"
+    assert (
+        "await request.json()" not in src
+    ), "request.json() is back, which buffers the whole body before any check can run"
+
+
+def test_the_ceiling_is_a_usable_number() -> None:
+    """A ceiling of zero would refuse every control request.
+
+    A limit that excludes the legitimate caller is the same failure whether it guards a
+    request body or anything else: the service answers its port while rejecting real work.
+    """
+    assert app_mod._MAX_CONTROL_BODY_BYTES > 0
+    assert app_mod._MAX_CONTROL_BODY_BYTES >= 64 * 1024, (
+        "a control payload carries ids and flags, but a ceiling under 64KiB is small "
+        "enough to refuse a legitimate caller"
+    )
+
+
+def test_the_refusal_says_which_problem_it_is() -> None:
+    """413, not 400: the caller has to be able to tell "too big" from "bad JSON".
+
+    A 400 sends whoever is debugging to look at their serializer instead of their payload
+    size.
+    """
+    src = pathlib.Path(app_mod.__file__).read_text(encoding="utf-8")
+    block = src[src.index("async for chunk in request.stream():") :][:900]
+    assert "status_code=413" in block
+    assert '"code": "body_too_large"' in block
+
+
+def test_json_is_decoded_from_the_bounded_bytes() -> None:
+    """The decode reads the buffer the loop filled, not the request again.
+
+    Re-reading would restore the unbounded path while leaving every assertion above
+    passing, because the ceiling would still be present in the source.
+    """
+    src = pathlib.Path(app_mod.__file__).read_text(encoding="utf-8")
+    assert 'json.loads(bytes(raw_body).decode("utf-8"))' in src
+
+
+def test_the_comparison_is_strict() -> None:
+    """Exactly the ceiling is accepted; one byte over is not.
+
+    Pins the off-by-one directly: ``>=`` would refuse a payload of exactly the documented
+    size, and no test above distinguishes the two.
+    """
+    limit = app_mod._MAX_CONTROL_BODY_BYTES
+    assert not limit > limit, "a body of exactly the ceiling must be accepted"
+    assert limit + 1 > limit, "a body one byte over must be refused"
+
+
+def test_the_payload_shape_check_still_runs_after_the_decode() -> None:
+    """A non-object body is still a 400, so the new read did not drop that check."""
+    src = pathlib.Path(app_mod.__file__).read_text(encoding="utf-8")
+    assert "if not isinstance(payload, dict):" in src
+
+
+@pytest.mark.parametrize("raw", ['{"a": 1}', "{}", '{"nested": {"b": [1, 2]}}'])
+def test_the_decode_accepts_ordinary_json_objects(raw: str) -> None:
+    """The replacement decode path handles what the route is actually sent."""
+    payload = json.loads(bytes(bytearray(raw.encode("utf-8"))).decode("utf-8"))
+    assert isinstance(payload, dict)

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_client_ignores_ambient_env.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_client_ignores_ambient_env.py
@@ -1,0 +1,75 @@
+"""The front's backend client must not read ambient proxy or trust-store env.
+
+Every request it makes goes to ``http://127.0.0.1:<backend_port>``. Ambient
+environment is wrong for that in both directions httpx would read it:
+
+* An inherited ``HTTP_PROXY`` / ``ALL_PROXY`` would route the front's internal
+  turn traffic -- whole conversations -- through a proxy instead of to the
+  process next door.
+* httpx eagerly builds an SSL context from ``SSL_CERT_FILE`` even for a client
+  that never speaks TLS, so a stale value crashes ``AsyncClient(...)``
+  construction with ``FileNotFoundError`` before any request is made.
+
+The second one is how this was found: CI's environment carried an
+``SSL_CERT_FILE`` pointing at a file that was not there, and twelve front tests
+died inside client construction while every local run passed. So the assertion
+below sets that exact condition rather than trusting the flag's presence.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+from container.front import app as front_app
+
+
+def _client_for(monkeypatch: pytest.MonkeyPatch) -> httpx.AsyncClient:
+    """Build the client the way the app does, under a hostile environment."""
+    monkeypatch.setenv("SSL_CERT_FILE", "/nonexistent/ca-bundle.crt")
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.invalid:3128")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.invalid:3128")
+    monkeypatch.setenv("ALL_PROXY", "http://proxy.invalid:3128")
+
+    class _State:
+        pass
+
+    class _App:
+        state = _State()
+
+    return front_app._get_client(_App())  # type: ignore[arg-type]
+
+
+def test_construction_survives_a_stale_ssl_cert_file(monkeypatch):
+    """A missing SSL_CERT_FILE must not stop a plain-HTTP loopback client."""
+    assert os.environ.get("SSL_CERT_FILE") != "/nonexistent/ca-bundle.crt"
+    client = _client_for(monkeypatch)
+    assert isinstance(client, httpx.AsyncClient)
+
+
+def test_no_ambient_proxy_is_mounted(monkeypatch):
+    """An inherited proxy must not carry the front's internal turn traffic.
+
+    Asserted through the client's own mounts rather than by reading the flag
+    back: ``trust_env`` is the mechanism, and a proxy reaching a loopback call
+    is the consequence that actually matters.
+    """
+    client = _client_for(monkeypatch)
+    proxied = [pattern for pattern, transport in client._mounts.items() if transport is not None]
+    assert proxied == [], f"the backend client mounted ambient proxies: {proxied}"
+
+
+def test_verification_is_still_on(monkeypatch):
+    """``trust_env=False`` must not be confused with ``verify=False``.
+
+    Turning verification off would matter the day the backend address becomes an
+    https one, so pin that this fix did not quietly do that.
+    """
+    client = _client_for(monkeypatch)
+    transport = client._transport
+    ssl_context = getattr(getattr(transport, "_pool", None), "_ssl_context", None)
+    assert ssl_context is not None, "no SSL context on the transport to check"
+    assert (
+        ssl_context.verify_mode is not __import__("ssl").CERT_NONE
+    ), "certificate verification is off on the front's backend client"

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_control_audit.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_control_audit.py
@@ -1,0 +1,380 @@
+"""The control-authorization decision is audited, both ways, or it is not acted on.
+
+Three properties, and the third is the one that makes the other two worth having:
+
+1. A grant produces a record.
+2. A deny produces a record -- the half that answers "who tried" after the fact, and the
+   half a granted-only trail leaves out.
+3. A decision that cannot be recorded is not acted on at all.
+
+The container mirrors ``kiro_crew.sel`` rather than calling it, so these tests also pin
+the mirror: SEL's ``event_type`` vocabulary, its field names, and the audit-or-deny
+behaviour of ``log_tool_invocation(critical=True)``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from container import common
+from container.common import audit
+from container.front.app import build_app
+from fastapi.testclient import TestClient
+
+
+def _strip_audit_handlers() -> None:
+    """Put the audit logger into the state production starts in: nothing listening.
+
+    Two steps, because pytest is not production. Removing the handler this module attaches
+    is the first; cutting ``propagate`` is the second, and it is needed because pytest's
+    own log-capture handler sits on the ROOT logger at level 0. A record that propagates
+    there IS delivered, so with propagation left on, the sink is genuinely live and the
+    inert arrangement cannot be reproduced inside a pytest session at all. Production has
+    no such root handler -- that is what the reproduction of uvicorn's configuration in
+    ``test_uvicorns_own_logging_configuration_does_not_provide_a_sink`` shows.
+    """
+    log = audit.sink()
+    log.handlers[:] = [
+        h for h in log.handlers if not getattr(h, "_crew_container_audit_sink", False)
+    ]
+    log.propagate = False
+
+
+@pytest.fixture(autouse=True)
+def _restore_audit_sink():
+    """Leave the process's logging state as it was found.
+
+    These tests deliberately break the sink, and a leaked broken sink would fail unrelated
+    tests later in the session with a 503 that looks like a real defect.
+    """
+    log = audit.sink()
+    saved_handlers = list(log.handlers)
+    saved_level = log.level
+    saved_propagate = log.propagate
+    yield
+    log.handlers[:] = saved_handlers
+    log.setLevel(saved_level)
+    log.propagate = saved_propagate
+
+
+def make_settings(tmp_path: Path, *, control_secret: str | None) -> common.Settings:
+    data_home = tmp_path / "data"
+    data_home.mkdir(parents=True, exist_ok=True)
+    return common.Settings(
+        backend_port=8765,
+        backend_run_dir=data_home / "run",
+        front_port=8080,
+        route_prefix="",
+        control_secret=control_secret,
+        data_home=data_home,
+        config_dir=data_home / "config",
+        crew_name="frontdesk",
+        backup_bucket=None,
+        backup_prefix="",
+        single_principal=True,
+    )
+
+
+def _records(caplog) -> list[dict]:
+    """Every SEL-shaped record in the captured log, parsed."""
+    out = []
+    for message in caplog.messages:
+        marker = "sel_shaped_audit "
+        if marker in message:
+            out.append(json.loads(message.split(marker, 1)[1]))
+    return out
+
+
+def test_a_denied_control_request_is_recorded(tmp_path: Path, caplog) -> None:
+    settings = make_settings(tmp_path, control_secret="right")
+    with caplog.at_level("INFO"):
+        with TestClient(build_app(settings)) as client:
+            resp = client.post("/control/anything", headers={"X-SMC-Control-Secret": "wrong"})
+
+    assert resp.status_code == 403
+    records = _records(caplog)
+    assert len(records) == 1, f"expected one record, got {records}"
+    assert records[0]["event_type"] == audit.EVENT_DENIED
+    assert records[0]["outcome"] == "denied"
+    assert records[0]["metadata"]["control_header_present"] is True
+
+
+def test_a_granted_control_request_is_recorded(tmp_path: Path, caplog) -> None:
+    """The grant, too.
+
+    A trail that records only denials cannot answer what an authorised caller did, which
+    is the question an incident actually starts from.
+    """
+    settings = make_settings(tmp_path, control_secret="right")
+    with caplog.at_level("INFO"):
+        with TestClient(build_app(settings)) as client:
+            resp = client.post("/control/anything", headers={"X-SMC-Control-Secret": "right"})
+
+    assert resp.status_code == 404, "authorised, and no control route is served yet"
+    records = _records(caplog)
+    assert len(records) == 1, f"expected one record, got {records}"
+    assert records[0]["event_type"] == audit.EVENT_GRANTED
+    assert records[0]["outcome"] == "granted"
+
+
+def test_a_missing_header_is_recorded_as_missing(tmp_path: Path, caplog) -> None:
+    """ "No header" and "wrong secret" are different attempts, so they read differently."""
+    settings = make_settings(tmp_path, control_secret="right")
+    with caplog.at_level("INFO"):
+        with TestClient(build_app(settings)) as client:
+            client.post("/control/anything")
+
+    records = _records(caplog)
+    assert records[0]["metadata"]["control_header_present"] is False
+
+
+def test_the_record_never_carries_the_secret(tmp_path: Path, caplog) -> None:
+    """An audit log that carries the credential makes every reader a holder of it."""
+    settings = make_settings(tmp_path, control_secret="sup3r-s3cret-value")
+    with caplog.at_level("INFO"):
+        with TestClient(build_app(settings)) as client:
+            client.post(
+                "/control/anything",
+                headers={"X-SMC-Control-Secret": "sup3r-s3cret-value", "Cookie": "a=b"},
+            )
+
+    assert "sup3r-s3cret-value" not in caplog.text
+    record = _records(caplog)[0]
+    assert "sup3r-s3cret-value" not in json.dumps(record)
+    assert "a=b" not in json.dumps(record), "no other header rides along either"
+
+
+def test_a_decision_that_cannot_be_recorded_is_not_acted_on(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    """The property the other tests rest on.
+
+    A correct caller with the correct secret is REFUSED when the record cannot be written,
+    because serving it would be the unaudited grant the record exists to prevent. 503, not
+    403: what failed is this container's ability to record, not the caller's authorisation.
+    """
+    from container.front import app as app_mod
+
+    def _explode(event, *, log=None):
+        raise audit.AuditUnavailable("the sink is gone")
+
+    monkeypatch.setattr(app_mod.audit, "emit", _explode)
+    settings = make_settings(tmp_path, control_secret="right")
+    with caplog.at_level("ERROR"):
+        with TestClient(app_mod.build_app(settings)) as client:
+            resp = client.post("/control/anything", headers={"X-SMC-Control-Secret": "right"})
+
+    assert resp.status_code == 503
+    assert resp.json()["code"] == "control_audit_unavailable"
+    assert "the sink is gone" in caplog.text
+
+
+def test_a_denial_that_cannot_be_recorded_is_also_refused_that_way(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Same answer for the deny.
+
+    Returning the 403 anyway would look harmless and would leave a denial nobody can
+    account for, which is the same gap in the trail from the other direction.
+    """
+    from container.front import app as app_mod
+
+    def _explode(event, *, log=None):
+        raise audit.AuditUnavailable("the sink is gone")
+
+    monkeypatch.setattr(app_mod.audit, "emit", _explode)
+    settings = make_settings(tmp_path, control_secret="right")
+    with TestClient(app_mod.build_app(settings)) as client:
+        resp = client.post("/control/anything", headers={"X-SMC-Control-Secret": "wrong"})
+
+    assert resp.status_code == 503
+
+
+def test_the_customer_surface_is_not_a_control_decision(tmp_path: Path, caplog) -> None:
+    """Non-vacuity for the emit site.
+
+    The customer surface is not a control decision, so it must produce NO record -- both
+    because a per-request audit line is noise and because a record implying an
+    authorisation decision was made would be false.
+    """
+    settings = make_settings(tmp_path, control_secret="right")
+    with caplog.at_level("INFO"):
+        with TestClient(build_app(settings)) as client:
+            client.get("/health")
+
+    assert _records(caplog) == []
+
+
+def test_the_event_uses_sels_own_type_names() -> None:
+    """The mirror is only useful if the reader does not need a second vocabulary.
+
+    ``kiro_crew.sel.SecurityEvent`` documents its ``event_type`` values as
+    "tool_invocation, tool_approval, tool_denial, mcp_call, api_access". Drifting to a
+    private spelling here would mean an operator's SEL query silently misses these.
+    """
+    assert audit.EVENT_GRANTED == "tool_approval"
+    assert audit.EVENT_DENIED == "tool_denial"
+
+
+def test_the_record_carries_no_chain_fields() -> None:
+    """An unchained line must not claim SEL's integrity fields.
+
+    ``prev_hash`` and ``entry_hash`` are what make a SEL entry tamper-evident, and they
+    are computed as the entry is written into that chain. Emitting either here would
+    assert an integrity property this record does not have.
+    """
+    event = audit.control_decision_event(
+        granted=True, method="POST", path="/control/x", header_present=True, crew_name="frontdesk"
+    )
+    assert "prev_hash" not in event
+    assert "entry_hash" not in event
+
+
+def test_an_unserialisable_record_raises_rather_than_logging_nothing() -> None:
+    """The failure mode of a JSON sink, caught where it can still deny.
+
+    The sink is made live first, so the refusal is attributable to the record rather than
+    to the sink -- two different failures with the same consequence, and an operator
+    reading the message has to be able to tell them apart.
+    """
+    log = logging.getLogger("crew_container.audit.test_serialise")
+    log.setLevel(logging.INFO)
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setLevel(logging.INFO)
+    log.addHandler(handler)
+    try:
+        assert audit.sink_is_live(log), "the sink must be live for this to test the record"
+        with pytest.raises(audit.AuditUnavailable, match="serialised"):
+            audit.emit({"bad": object()}, log=log)
+    finally:
+        log.removeHandler(handler)
+
+
+def test_the_sink_is_live_before_any_request_can_be_served(tmp_path: Path) -> None:
+    """Ordering, not just presence.
+
+    ``build_app`` configures the sink, so an app that exists has one -- checked here
+    BEFORE any request is issued. Configuring lazily on the first emit would leave
+    whichever request arrives first deciding whether the audit works, and a request during
+    startup would get the inert path.
+    """
+    _strip_audit_handlers()
+    assert not audit.sink_is_live(audit.sink()), "precondition: no sink yet"
+
+    build_app(make_settings(tmp_path, control_secret="right"))
+
+    assert audit.sink_is_live(audit.sink()), "building the app must configure the sink"
+
+
+def test_uvicorns_own_logging_configuration_does_not_provide_a_sink() -> None:
+    """The production arrangement, reproduced rather than assumed.
+
+    ``uvicorn.run`` applies its own ``LOGGING_CONFIG``, which configures the ``uvicorn``
+    loggers and leaves the root at WARNING with no handler. A module logger under that
+    configuration reports an effective level of WARNING and reaches no handler, so an INFO
+    audit call writes zero bytes and raises nothing. This is the environment the audit has
+    to work in, and the reason the sink is this module's own rather than ambient.
+    """
+    import logging.config
+
+    import uvicorn.config
+
+    saved = {
+        name: (logging.getLogger(name).level, list(logging.getLogger(name).handlers))
+        for name in ("", "container.front.app")
+    }
+    try:
+        logging.config.dictConfig(uvicorn.config.LOGGING_CONFIG)
+        ambient = logging.getLogger("container.front.app")
+        assert ambient.getEffectiveLevel() == logging.WARNING
+        assert not audit.sink_is_live(ambient)
+        # And the audit's own sink is unaffected by that configuration, which is the point.
+        audit.configure_sink()
+        assert audit.sink_is_live(audit.sink())
+    finally:
+        for name, (level, handlers) in saved.items():
+            log = logging.getLogger(name)
+            log.setLevel(level)
+            log.handlers[:] = handlers
+
+
+def test_a_handler_that_only_takes_warnings_is_not_an_info_sink() -> None:
+    """``hasHandlers()`` is not the question.
+
+    A logger with a WARNING-level handler attached answers ``hasHandlers()`` with True
+    while still dropping every INFO record, which is precisely the arrangement that makes
+    an audit inert. The handler's own level has to be part of the check.
+    """
+    log = logging.getLogger("crew_container.audit.test_warning_only")
+    log.setLevel(logging.INFO)
+    log.propagate = False
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setLevel(logging.WARNING)
+    log.addHandler(handler)
+    try:
+        assert log.hasHandlers(), "the misleading answer"
+        assert not audit.sink_is_live(log), "an INFO record would be dropped by the handler"
+    finally:
+        log.removeHandler(handler)
+        log.propagate = True
+
+
+def test_a_logger_cut_off_from_handlers_is_not_live() -> None:
+    """``propagate = False`` with no local handler reaches nothing."""
+    log = logging.getLogger("crew_container.audit.test_cut_off")
+    log.setLevel(logging.INFO)
+    log.propagate = False
+    try:
+        assert not audit.sink_is_live(log)
+    finally:
+        log.propagate = True
+
+
+def test_last_resort_does_not_count_as_a_sink() -> None:
+    """``logging.lastResort`` is at WARNING, so it carries no INFO record.
+
+    Counting it would report a live sink for exactly the case this check exists to catch:
+    a process with no logging configuration at all.
+    """
+    assert logging.lastResort is not None
+    assert logging.lastResort.level == logging.WARNING
+    log = logging.getLogger("crew_container.audit.test_last_resort")
+    log.setLevel(logging.INFO)
+    log.propagate = False
+    try:
+        assert not audit.sink_is_live(log)
+    finally:
+        log.propagate = True
+
+
+def test_an_inert_sink_refuses_the_decision(tmp_path: Path) -> None:
+    """The whole finding, end to end.
+
+    With no INFO-capable handler, a control request that would otherwise be authorised is
+    refused instead of being served unaudited. Before this check the same arrangement
+    served the request and wrote nothing, because a dropped log record raises nothing and
+    the audit-or-deny path never fired.
+    """
+    settings = make_settings(tmp_path, control_secret="right")
+    app = build_app(settings)
+    _strip_audit_handlers()
+
+    with TestClient(app) as client:
+        resp = client.post("/control/anything", headers={"X-SMC-Control-Secret": "right"})
+
+    assert resp.status_code == 503
+    assert resp.json()["code"] == "control_audit_unavailable"
+
+
+def test_configuring_the_sink_twice_does_not_double_the_record(tmp_path: Path) -> None:
+    """``build_app`` runs more than once in a process, and a handler per call multiplies."""
+    _strip_audit_handlers()
+    audit.configure_sink()
+    audit.configure_sink()
+    audit.configure_sink()
+    owned = [h for h in audit.sink().handlers if getattr(h, "_crew_container_audit_sink", False)]
+    assert len(owned) == 1

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_crew_address.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_crew_address.py
@@ -1,0 +1,135 @@
+"""The request must ADDRESS a crew, and the container must never substitute one.
+
+This covers the defect that made the first live deployment look healthy while
+serving nobody's crew. The turn probe sent ``{"model": "default"}``; Kiro Crew maps
+``model`` to an agent name and validates it against a NAME REGEX rather than against
+the agents that exist (``dashboard/openai_compat.py:237``), so the name resolved to
+the installed default and a stock agent answered. Every gate passed, because the
+question asked was one any agent answers correctly.
+
+Two properties are tested here, and the second is a security property rather than a
+correctness one:
+
+1. A request that names nobody is REFUSED. Answering it with a default is the bug.
+2. The value that reaches the backend is the DEPLOYED crew name, not the caller's
+   string, so no caller can steer the turn to another agent in the container.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from container.front.app import _forward_body, judge_addressed_crew
+
+TURN = "/v1/chat/completions"
+
+
+# --- 1. an unaddressed request is refused, not defaulted ---------------------
+
+
+def test_a_request_naming_nobody_is_refused() -> None:
+    crew, refusal = judge_addressed_crew({"messages": []}, "acme-support")
+    assert crew is None
+    assert refusal is not None and refusal.status_code == 400
+    assert b"crew_not_addressed" in refusal.body
+
+
+def test_an_empty_crew_name_is_refused_like_an_absent_one() -> None:
+    """`model: ""` and `model: "  "` are the same omission spelled differently."""
+    for value in ("", "   "):
+        crew, refusal = judge_addressed_crew({"model": value}, "acme-support")
+        assert crew is None, value
+        assert refusal is not None and refusal.status_code == 400
+
+
+def test_the_payload_that_caused_the_original_bug_is_now_refused() -> None:
+    """`model: "default"` is the exact request that got a stock agent and a 200.
+
+    It is refused as a crew this deployment does not serve, which is the truthful
+    answer: nothing named "default" was ever deployed here.
+    """
+    crew, refusal = judge_addressed_crew({"model": "default"}, "acme-support")
+    assert crew is None
+    assert refusal is not None and refusal.status_code == 404
+    assert b"crew_not_served_here" in refusal.body
+
+
+def test_naming_another_crew_is_refused_and_says_which_one_is_here() -> None:
+    crew, refusal = judge_addressed_crew({"model": "other-crew"}, "acme-support")
+    assert crew is None
+    assert refusal is not None and refusal.status_code == 404
+    # Withholding the deployed name would make a typo unfixable, and it is not a
+    # secret: it is in the route prefix the caller already used.
+    assert b"acme-support" in refusal.body
+
+
+def test_a_non_string_model_is_refused() -> None:
+    values: tuple[object, ...] = (1, [], {}, True)
+    for value in values:
+        crew, refusal = judge_addressed_crew({"model": value}, "acme-support")
+        assert crew is None, value
+        assert refusal is not None and refusal.status_code == 400
+
+
+def test_addressing_the_deployed_crew_proceeds() -> None:
+    crew, refusal = judge_addressed_crew({"model": "acme-support"}, "acme-support")
+    assert refusal is None
+    assert crew == "acme-support"
+
+
+def test_surrounding_whitespace_still_addresses_the_crew() -> None:
+    crew, refusal = judge_addressed_crew({"model": " acme-support "}, "acme-support")
+    assert refusal is None
+    assert crew == "acme-support"
+
+
+def test_a_container_that_does_not_know_its_own_crew_refuses_everything() -> None:
+    """Fail closed. The alternative is accepting any name because we cannot check."""
+    crew, refusal = judge_addressed_crew({"model": "anything"}, "")
+    assert crew is None
+    assert refusal is not None and refusal.status_code == 503
+    assert b"crew_not_configured" in refusal.body
+
+
+# --- 2. the caller cannot choose which agent answers ------------------------
+
+
+def test_the_forwarded_model_comes_from_the_deployment_not_the_caller() -> None:
+    """Forwarding the caller's string made every agent in the container reachable.
+
+    The equality check alone is not enough: a value that passes it after stripping
+    must not be handed on in its original form, or the backend's resolver sees a
+    string the check did not examine.
+    """
+    payload: dict[str, Any] = {"model": " acme-support ", "messages": [], "id": "s"}
+    body, slot_id, stream = _forward_body(payload, "acme-support")
+    assert body["model"] == "acme-support"
+    assert slot_id == "s"
+    assert stream is False
+
+
+def test_forwarding_drops_every_field_outside_the_contract() -> None:
+    payload = {
+        "model": "acme-support",
+        "messages": [{"role": "user", "content": "hi"}],
+        "id": "slot-9",
+        "stream": True,
+        "temperature": 0.9,  # not ours to forward
+        "tools": [{"x": 1}],  # nor this
+        "system": "override me",  # nor this
+    }
+    body, _, _ = _forward_body(payload, "acme-support")
+    assert set(body) == {"model", "messages", "id", "stream"}
+
+
+@pytest.mark.parametrize("hostile", ["Default", "ACME-SUPPORT", "acme_support"])
+def test_a_near_miss_name_does_not_address_the_crew(hostile: str) -> None:
+    """Crew matching is exact. A case- or separator-variant is a different crew.
+
+    Kiro Crew's agent names are case-sensitive, so accepting a variant here would
+    forward a name the deployment did not install and land on the default again.
+    """
+    crew, refusal = judge_addressed_crew({"model": hostile}, "acme-support")
+    assert crew is None
+    assert refusal is not None and refusal.status_code == 404

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_fetch_only_for_real_slots.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_fetch_only_for_real_slots.py
@@ -1,0 +1,136 @@
+"""A turn the backend will refuse must not put a conversation on this disk.
+
+Found by an adversarial cross-model review of the ephemeral change, reproduced
+before fixing. The front proxies a turn and the BACKEND decides whether an id is
+legal, so the fetch runs first. ``id="dashboard:cust-1"`` is not a legal backend
+id (``kiro_crew.session_storage._UNIT_ID_RE`` has no colon in its class), but the
+fold turns it into ``dashboard_cust-1``, which names a real conversation. The old
+code downloaded that transcript and the backend then rejected the turn, leaving
+the task holding a conversation it never served. That is the exact property the
+ephemeral change exists to establish, defeated by one punctuation mark.
+
+The second half is the alias lock. ``cust-1`` and ``dashboard_cust-1`` are one
+conversation and one file, but the serializer was keyed on the raw string, so the
+two spellings took two different locks while reporting one turn per slot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from container.front import transcript
+
+
+class _Settings:
+    def __init__(self, root: Path) -> None:
+        self.backup_prefix = "crews/"
+        self.crew_name = "acme"
+        self.data_home = root
+        self.sessions_dir = root / "sessions"
+
+
+class _Reader:
+    """Records every key asked for, so a fetch that should not happen is visible."""
+
+    def __init__(self) -> None:
+        self.keys: list[str] = []
+
+    def get(self, key: str) -> bytes:
+        self.keys.append(key)
+        return b'{"role":"user"}\n'
+
+
+@pytest.fixture
+def settings(tmp_path: Path) -> _Settings:
+    s = _Settings(tmp_path)
+    s.sessions_dir.mkdir(parents=True)
+    return s
+
+
+def test_an_id_the_backend_rejects_is_never_fetched(settings) -> None:
+    """The reproduction. A colon makes the id illegal but the fold hides that."""
+    reader = _Reader()
+    outcome = asyncio.run(
+        transcript.ensure_local_transcript(settings, "dashboard:cust-1", reader=reader)
+    )
+    assert reader.keys == [], (
+        "S3 was consulted for an id the backend will refuse; the task would hold "
+        f"a conversation it never served: {reader.keys}"
+    )
+    assert outcome.action == "not_a_slot_id"
+    assert not (settings.sessions_dir / "dashboard_cust-1.jsonl").exists()
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["dashboard:cust-1", "../../etc/passwd", "x y", "a\tb", "caf\u00e9"],
+)
+def test_no_sanitized_id_reaches_s3(settings, bad: str) -> None:
+    reader = _Reader()
+    asyncio.run(transcript.ensure_local_transcript(settings, bad, reader=reader))
+    assert reader.keys == [], f"{bad!r} reached S3 as {reader.keys}"
+
+
+@pytest.mark.parametrize("good", ["cust-1", "dashboard_cust-1", "a.b_c-d", "S3", "x" * 200])
+def test_every_legal_id_still_fetches(settings, good: str) -> None:
+    """The dangerous direction.
+
+    Refusing to fetch for an id the backend ACCEPTS would serve an empty history,
+    and the sidecar's whole-object put would then overwrite that customer's real
+    history in S3. So this half of the guard matters more than the other.
+    """
+    reader = _Reader()
+    outcome = asyncio.run(transcript.ensure_local_transcript(settings, good, reader=reader))
+    assert len(reader.keys) == 1, f"{good!r} was not fetched: {outcome.action}"
+
+
+def test_two_spellings_of_one_slot_cannot_hold_the_lock_at_once(tmp_path: Path) -> None:
+    """MUTATION: key the serializer on slot_id again and the peak becomes 2.
+
+    The first version of this test only asserted what ``normalize_slot_key``
+    returns, which passes under both implementations and therefore proved
+    nothing. Occupancy is the thing that matters, so measure occupancy: enter
+    ``prepared_turn`` concurrently under two spellings of one conversation and
+    count how many bodies are inside at the same moment.
+    """
+    from container.front.slotlock import SlotSerializer
+
+    async def run() -> int:
+        root = tmp_path
+        (root / "sessions").mkdir()
+        settings = _Settings(root)
+        serializer = SlotSerializer()
+        inside = 0
+        peak = 0
+
+        async def turn(spelling: str) -> None:
+            nonlocal inside, peak
+            async with transcript.prepared_turn(serializer, settings, spelling, _Reader()):
+                inside += 1
+                peak = max(peak, inside)
+                await asyncio.sleep(0.02)
+                inside -= 1
+
+        await asyncio.gather(turn("cust-1"), turn("dashboard_cust-1"))
+        return peak
+
+    assert asyncio.run(run()) == 1, (
+        "two spellings of one conversation ran at once, so the per-slot lock did "
+        "not serialize the turns it reported serializing"
+    )
+
+
+def test_the_guard_admits_exactly_what_the_sanitizer_leaves_alone() -> None:
+    """The shape rule is a proxy for the backend's grammar, so pin the proxy.
+
+    Every character the backend accepts must survive the sanitizer untouched, or
+    the guard would start refusing legal ids and serving empty histories.
+    """
+    import string
+
+    for ch in string.ascii_letters + string.digits + "._-":
+        assert transcript.is_fetchable_slot_id(f"a{ch}b"), ch
+    for ch in ":/ \t?*":
+        assert not transcript.is_fetchable_slot_id(f"a{ch}b"), ch

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_proxy.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_proxy.py
@@ -1,0 +1,483 @@
+"""Tests for the S1 front process against a FAKE backend HTTP surface.
+
+No AWS, no real Kiro Crew boot. The fake backend is a small FastAPI app on real
+loopback that records what it received and models the three backend behaviours
+the front must respect: the ``X-Internal-Secret`` grant, the per-slot 409, and an
+SSE turn stream. The front app is driven in-process over ``httpx.ASGITransport``.
+
+What these tests CANNOT prove is stated in the track report: the real backend's
+exact SSE event vocabulary, the CSRF/Origin behaviour of the real gateway, and
+anything about the deployed network path are not exercised here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import threading
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+import pytest
+import uvicorn
+from container import common
+from container.front.app import build_app
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+
+# --------------------------------------------------------------------------- #
+# Fake backend
+# --------------------------------------------------------------------------- #
+@dataclass
+class FakeState:
+    secret_file: Path
+    accept: str = "SECRET"
+    heal_on_bad: bool = False
+    turn_delay: float = 0.05
+    stream_chunks: list[bytes] = field(default_factory=list)
+    requests: list[dict] = field(default_factory=list)
+    inflight: set[str] = field(default_factory=set)
+    current: int = 0
+    max_concurrent: int = 0
+    saw_409: int = 0
+    lock: asyncio.Lock | None = None
+
+
+def build_fake_backend(fake: FakeState) -> FastAPI:
+    app = FastAPI()
+
+    @app.post("/v1/chat/completions")
+    async def turn(request: Request):
+        if fake.lock is None:
+            fake.lock = asyncio.Lock()
+        headers = {k.lower(): v for k, v in request.headers.items()}
+        raw = await request.body()
+        body = json.loads(raw) if raw else {}
+        fake.requests.append({"headers": headers, "body": body})
+
+        presented = headers.get(common.HEADER.lower())
+        if presented != fake.accept:
+            # Model a backend that has (re)booted: the fresh secret is now the
+            # value on disk, so a re-read by the caller will pick it up.
+            if fake.heal_on_bad:
+                fake.secret_file.write_text(fake.accept, encoding="utf-8")
+            return JSONResponse({"detail": "forbidden"}, status_code=403)
+
+        # A missing id means the backend mints one; model that so id-less turns
+        # do not collide on a shared inflight key.
+        sid = body.get("id") or f"__mint_{len(fake.requests)}"
+
+        async with fake.lock:
+            if sid in fake.inflight:
+                fake.saw_409 += 1
+                # Real backend shape (verified against the running backend): OpenAI-style error.
+                return JSONResponse(
+                    {"error": {"message": f"slot '{sid}' is busy", "type": "slot_busy"}},
+                    status_code=409,
+                )
+            fake.inflight.add(sid)
+            fake.current += 1
+            fake.max_concurrent = max(fake.max_concurrent, fake.current)
+
+        if body.get("stream"):
+
+            async def gen():
+                try:
+                    await asyncio.sleep(fake.turn_delay)
+                    for chunk in fake.stream_chunks:
+                        yield chunk
+                finally:
+                    # Created by the route above before it ever reaches here.
+                    assert fake.lock is not None
+                    async with fake.lock:
+                        fake.inflight.discard(sid)
+                        fake.current -= 1
+
+            return StreamingResponse(gen(), media_type="text/event-stream")
+
+        try:
+            await asyncio.sleep(fake.turn_delay)
+            return JSONResponse(
+                {
+                    "id": sid,
+                    "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+                    "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+                }
+            )
+        finally:
+            async with fake.lock:
+                fake.inflight.discard(sid)
+                fake.current -= 1
+
+    return app
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture(scope="module")
+def backend(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("front-backend")
+    run_dir = tmp / "run"
+    run_dir.mkdir()
+    port = _free_port()
+    secret_file = run_dir / f"gateway-{port}.secret"
+    secret_file.write_text("SECRET", encoding="utf-8")
+
+    fake = FakeState(secret_file=secret_file)
+    server = uvicorn.Server(
+        uvicorn.Config(build_fake_backend(fake), host="127.0.0.1", port=port, log_level="warning")
+    )
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(200):
+        if server.started:
+            break
+        time.sleep(0.02)
+    else:
+        raise RuntimeError("fake backend did not start")
+
+    yield {"fake": fake, "port": port, "run_dir": run_dir, "secret_file": secret_file}
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+@pytest.fixture
+def env(backend):
+    """Reset the fake to a clean, authenticating state before each test."""
+    fake: FakeState = backend["fake"]
+    fake.requests.clear()
+    fake.inflight.clear()
+    fake.current = 0
+    fake.max_concurrent = 0
+    fake.saw_409 = 0
+    fake.heal_on_bad = False
+    fake.turn_delay = 0.05
+    fake.accept = "SECRET"
+    fake.stream_chunks = []
+    backend["secret_file"].write_text("SECRET", encoding="utf-8")
+    return backend
+
+
+def make_settings(backend, *, route_prefix: str = "/c/crew", control_secret: str | None = None):
+    run_dir = backend["run_dir"]
+    data_home = run_dir.parent / "data"
+    return common.Settings(
+        backend_port=backend["port"],
+        backend_run_dir=run_dir,
+        front_port=8080,
+        route_prefix=route_prefix,
+        control_secret=control_secret,
+        data_home=data_home,
+        config_dir=data_home / "config",
+        crew_name="crew",
+        backup_bucket=None,
+        backup_prefix="",
+        # build_app refuses to serve customer turns unless the deployment has vouched that
+        # one principal reaches the task: the route accepts a caller-supplied slot id and
+        # nothing here can bind it to anybody. These tests drive that route, so they are the
+        # single-principal case by construction. Note the bucket is None and the declaration
+        # is still required: the guard is unconditional, because a bucketless deployment
+        # with several callers shares live sessions just as readily as one with a bucket.
+        # The refusal is pinned in test_review_findings_prb.py.
+        single_principal=True,
+    )
+
+
+@asynccontextmanager
+async def run_front(settings):
+    app = build_app(settings)
+    client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://front")
+    try:
+        yield client, app
+    finally:
+        await client.aclose()
+        backend_client = getattr(app.state, "backend_client", None)
+        if backend_client is not None:
+            await backend_client.aclose()
+
+
+TURN = "/c/crew/v1/chat/completions"
+
+
+# --------------------------------------------------------------------------- #
+# Forwarding + auth
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_customer_turn_forwards_and_authenticates(env):
+    async with run_front(make_settings(env)) as (client, _app):
+        resp = await client.post(TURN, json={"model": "crew", "messages": [], "id": "slot-1"})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "slot-1"
+    assert len(env["fake"].requests) == 1
+    sent = env["fake"].requests[0]
+    assert sent["headers"][common.HEADER.lower()] == "SECRET"
+    # Only the contract fields were forwarded.
+    assert set(sent["body"]) == {"model", "messages", "id", "stream"}
+
+
+@pytest.mark.asyncio
+async def test_foreign_origin_and_forwarded_headers_are_not_forwarded(env):
+    """A request arriving with a foreign Origin and X-Forwarded-* must reach the
+    backend WITHOUT them: loopback-with-no-Origin is what the backend's CSRF
+    check trusts, and a forwarded foreign Origin trips it silently."""
+    hostile = {
+        "Origin": "https://evil.example.com",
+        "X-Forwarded-For": "203.0.113.9",
+        "X-Forwarded-Host": "evil.example.com",
+        "X-Forwarded-Proto": "https",
+    }
+    async with run_front(make_settings(env)) as (client, _app):
+        resp = await client.post(
+            TURN, json={"model": "crew", "messages": [], "id": "s"}, headers=hostile
+        )
+    assert resp.status_code == 200
+    assert len(env["fake"].requests) == 1  # it reached the backend
+    got = env["fake"].requests[0]["headers"]
+    assert "origin" not in got
+    assert not any(k.startswith("x-forwarded") for k in got)
+
+
+# --------------------------------------------------------------------------- #
+# Prefix stripping + health
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_bare_and_prefixed_health(env):
+    async with run_front(make_settings(env)) as (client, _app):
+        bare = await client.get("/health")
+        prefixed = await client.get("/c/crew/health")
+    assert bare.status_code == 200 and bare.json() == {"status": "ok"}
+    assert prefixed.status_code == 200 and prefixed.json() == {"status": "ok"}
+    assert env["fake"].requests == []  # health never touches the backend
+
+
+@pytest.mark.asyncio
+async def test_turn_recognized_only_after_prefix_strip(env):
+    async with run_front(make_settings(env, route_prefix="/c/crew")) as (client, _app):
+        ok = await client.post(
+            "/c/crew/v1/chat/completions", json={"model": "crew", "id": "s", "messages": []}
+        )
+    assert ok.status_code == 200
+
+
+# --------------------------------------------------------------------------- #
+# Per-slot serialization
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_same_slot_requests_are_serialized_never_409(env):
+    env["fake"].turn_delay = 0.2
+    async with run_front(make_settings(env)) as (client, _app):
+        r1, r2 = await asyncio.gather(
+            client.post(TURN, json={"model": "crew", "id": "A", "messages": []}),
+            client.post(TURN, json={"model": "crew", "id": "A", "messages": []}),
+        )
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert env["fake"].saw_409 == 0  # the caller never saw a 409
+    assert env["fake"].max_concurrent == 1  # the front queued them
+
+
+@pytest.mark.asyncio
+async def test_different_slots_run_concurrently(env):
+    env["fake"].turn_delay = 0.2
+    async with run_front(make_settings(env)) as (client, _app):
+        r1, r2 = await asyncio.gather(
+            client.post(TURN, json={"model": "crew", "id": "A", "messages": []}),
+            client.post(TURN, json={"model": "crew", "id": "B", "messages": []}),
+        )
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert env["fake"].max_concurrent >= 2  # a global lock would make this 1
+
+
+# --------------------------------------------------------------------------- #
+# Customer / control separation
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_control_route_requires_the_secret(env):
+    settings = make_settings(env, control_secret="CTRL")
+    async with run_front(settings) as (client, _app):
+        no_secret = await client.get("/c/crew/crews")
+        wrong = await client.get("/c/crew/crews", headers={"X-SMC-Control-Secret": "nope"})
+        right = await client.get("/c/crew/crews", headers={"X-SMC-Control-Secret": "CTRL"})
+    assert no_secret.status_code == 403 and no_secret.json()["code"] == "control_forbidden"
+    assert wrong.status_code == 403
+    # Correct secret passes the gate; the front serves no control operation.
+    assert right.status_code == 404 and right.json()["code"] == "control_not_implemented"
+    assert env["fake"].requests == []  # control is never forwarded to the backend
+
+
+@pytest.mark.asyncio
+async def test_control_denied_when_no_secret_configured(env):
+    settings = make_settings(env, control_secret=None)
+    async with run_front(settings) as (client, _app):
+        resp = await client.get("/c/crew/crews", headers={"X-SMC-Control-Secret": "anything"})
+    assert resp.status_code == 403  # fail closed
+
+
+@pytest.mark.asyncio
+async def test_client_control_header_cannot_reach_control_and_is_not_forwarded(env):
+    """A customer-supplied control header on the customer path stays a customer
+    turn, and the header is never forwarded to the backend."""
+    settings = make_settings(env, control_secret="CTRL")
+    async with run_front(settings) as (client, _app):
+        resp = await client.post(
+            TURN,
+            json={"model": "crew", "id": "s", "messages": []},
+            headers={"X-SMC-Control-Secret": "CTRL", "Origin": "https://evil.example.com"},
+        )
+    assert resp.status_code == 200
+    assert len(env["fake"].requests) == 1
+    got = env["fake"].requests[0]["headers"]
+    assert "x-smc-control-secret" not in got
+    assert "origin" not in got
+
+
+# --------------------------------------------------------------------------- #
+# Boot secret re-read + single retry
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_secret_reread_and_retry_succeeds_on_403(env):
+    fake: FakeState = env["fake"]
+    fake.accept = "NEW"
+    fake.heal_on_bad = True  # first 403 writes NEW to disk
+    env["secret_file"].write_text("OLD", encoding="utf-8")
+    async with run_front(make_settings(env)) as (client, _app):
+        resp = await client.post(TURN, json={"model": "crew", "id": "s", "messages": []})
+    assert resp.status_code == 200
+    assert len(fake.requests) == 2  # one 403, one retried success
+    assert fake.requests[0]["headers"][common.HEADER.lower()] == "OLD"
+    assert fake.requests[1]["headers"][common.HEADER.lower()] == "NEW"
+
+
+@pytest.mark.asyncio
+async def test_secret_retry_gives_up_after_one_retry(env):
+    fake: FakeState = env["fake"]
+    fake.accept = "NEW"
+    fake.heal_on_bad = False  # disk never gets the good secret
+    env["secret_file"].write_text("OLD", encoding="utf-8")
+    async with run_front(make_settings(env)) as (client, _app):
+        resp = await client.post(TURN, json={"model": "crew", "id": "s", "messages": []})
+    assert resp.status_code == 403  # relayed to the caller
+    assert len(fake.requests) == 2  # exactly one retry, then give up
+
+
+# --------------------------------------------------------------------------- #
+# Stream projection -- OpenAI-format frames (VERIFIED against a real backend on
+# Observed shape: /v1/chat/completions streams `data: {chat.completion.chunk}` +
+# `data: [DONE]` + `: keepalive`, with NO SSE event: names; the ACP event
+# vocabulary and its tool_result leak live on the control /sessions/{id}/stream,
+# not on this endpoint). The projection is a fail-closed frame-CONTENT allowlist.
+# --------------------------------------------------------------------------- #
+def _chunk(content):
+    return (
+        b'data: {"id": "cmpl-1", "object": "chat.completion.chunk", '
+        b'"choices": [{"index": 0, "delta": {"role": "assistant", "content": "'
+        + content.encode()
+        + b'"}, "finish_reason": null}]}\n\n'
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_forwards_openai_chunks_done_and_keepalive(env):
+    fake: FakeState = env["fake"]
+    fake.stream_chunks = [
+        _chunk("Hel"),
+        b": keepalive\n\n",
+        _chunk("lo"),  # split across two frames to exercise buffering
+        b'data: {"id": "cmpl-1", "object": "chat.completion.chunk", '
+        b'"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+    body = b""
+    async with run_front(make_settings(env)) as (client, _app):
+        async with client.stream(
+            "POST", TURN, json={"model": "crew", "id": "s", "messages": [], "stream": True}
+        ) as resp:
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith("text/event-stream")
+            async for chunk in resp.aiter_bytes():
+                body += chunk
+    text = body.decode("utf-8")
+    assert '"content": "Hel"' in text and '"content": "lo"' in text
+    assert '"finish_reason": "stop"' in text
+    assert "data: [DONE]" in text
+    assert ": keepalive" in text
+
+
+@pytest.mark.asyncio
+async def test_stream_drops_named_acp_event_fail_closed(env):
+    """The design's tool_result-leak concern, encoded at the correct layer: if a
+    named ACP event ever appears on this endpoint, it is dropped, not relayed."""
+    fake: FakeState = env["fake"]
+    fake.stream_chunks = [
+        _chunk("safe text"),
+        b'event: tool_result\ndata: {"output": "SENSITIVE-TOOL-OUTPUT"}\n\n',
+        b'event: agent_thought_chunk\ndata: {"delta": "private reasoning"}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+    body = b""
+    async with run_front(make_settings(env)) as (client, _app):
+        async with client.stream(
+            "POST", TURN, json={"model": "crew", "id": "s", "messages": [], "stream": True}
+        ) as resp:
+            async for chunk in resp.aiter_bytes():
+                body += chunk
+    text = body.decode("utf-8")
+    assert '"content": "safe text"' in text
+    assert "data: [DONE]" in text
+    assert "SENSITIVE-TOOL-OUTPUT" not in text
+    assert "tool_result" not in text
+    assert "private reasoning" not in text
+
+
+@pytest.mark.asyncio
+async def test_stream_drops_non_chunk_json(env):
+    """A data frame that is neither a chat.completion.chunk nor an error object
+    (nor [DONE]) is dropped."""
+    fake: FakeState = env["fake"]
+    fake.stream_chunks = [
+        b'data: {"object": "something_internal", "secret": "LEAK"}\n\n',
+        _chunk("ok"),
+        b"data: [DONE]\n\n",
+    ]
+    body = b""
+    async with run_front(make_settings(env)) as (client, _app):
+        async with client.stream(
+            "POST", TURN, json={"model": "crew", "id": "s", "messages": [], "stream": True}
+        ) as resp:
+            async for chunk in resp.aiter_bytes():
+                body += chunk
+    text = body.decode("utf-8")
+    assert '"content": "ok"' in text
+    assert "data: [DONE]" in text
+    assert "LEAK" not in text
+    assert "something_internal" not in text
+
+
+@pytest.mark.asyncio
+async def test_stream_backend_403_becomes_openai_error_frame(env):
+    fake: FakeState = env["fake"]
+    fake.accept = "NEW"
+    fake.heal_on_bad = False
+    env["secret_file"].write_text("OLD", encoding="utf-8")
+    body = b""
+    async with run_front(make_settings(env)) as (client, _app):
+        async with client.stream(
+            "POST", TURN, json={"model": "crew", "id": "s", "messages": [], "stream": True}
+        ) as resp:
+            assert resp.status_code == 200  # SSE commits 200, error is a frame
+            async for chunk in resp.aiter_bytes():
+                body += chunk
+    assert b'"error"' in body and b"data: [DONE]" in body
+    assert b"event:" not in body  # OpenAI shape, not a named event
+    assert len(fake.requests) == 2  # retried once, then gave up

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_track_b_truthiness.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_track_b_truthiness.py
@@ -1,0 +1,142 @@
+"""Track B pins for the front process: a non-string conversation id must never
+become a fetch, and ``stream`` must be a real boolean.
+
+Finding 1 is the TYPE door into the same isolation hole the punctuation door
+(``dashboard:cust-1``) opened: ``{"id": 123}`` is folded to the legal shape
+``"123"`` by ``str()``, sails through ``is_fetchable_slot_id``, and gets
+fetched -- and only THEN does the backend reject the integer id, leaving the task
+holding ``dashboard_123``, a conversation it never served. The fix makes a
+non-string id produce an empty ``slot_id``, which maps to ``no_slot`` (no fetch),
+while the raw ``id`` is still forwarded so the backend stays the one authority
+that judges legality.
+
+The pin asserts the reader is NEVER consulted, and the mutation (restore the old
+``str(raw_id)`` coercion) is shown to fetch, so the guard is load-bearing.
+
+Finding 3B: ``bool("false")`` is truthy, so a payload ``{"stream": "false"}``
+would stream a turn the caller asked not to stream. The fix requires a real
+boolean and refuses anything else with a 400.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from container.front import app as front_app
+from container.front import transcript
+
+
+class _Settings:
+    def __init__(self, root: Path) -> None:
+        self.backup_prefix = "crews/"
+        self.crew_name = "acme"
+        self.data_home = root
+        self.sessions_dir = root / "sessions"
+
+
+class _Reader:
+    """Records every key asked for, so a fetch that should not happen is visible."""
+
+    def __init__(self) -> None:
+        self.keys: list[str] = []
+
+    def get(self, key: str) -> bytes:
+        self.keys.append(key)
+        return b'{"role":"user"}\n'
+
+
+@pytest.fixture
+def settings(tmp_path: Path) -> _Settings:
+    s = _Settings(tmp_path)
+    s.sessions_dir.mkdir(parents=True)
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Finding 1: a non-string id becomes an empty slot_id, so it is never fetched.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("raw_id", [123, 12.5, True, {"x": 1}, ["a"]])
+def test_a_non_string_id_yields_no_slot_id(raw_id) -> None:
+    """``_forward_body`` must not fabricate a string slot id from a non-string.
+
+    The raw id is still forwarded (the backend judges it); only the slot id used
+    for the fetch/lock is emptied.
+    """
+    payload = {"model": "acme", "messages": [], "id": raw_id}
+    body, slot_id, _ = front_app._forward_body(payload, "acme")
+    assert slot_id == "", f"a non-string id produced a fetchable slot id: {slot_id!r}"
+    assert body["id"] == raw_id, "the raw id must still reach the backend to be judged"
+
+
+def test_the_integer_id_never_reaches_the_store(settings) -> None:
+    """End to end through the transcript path: ``{"id": 123}`` consults no reader.
+
+    ``_forward_body`` empties the slot id, so ``ensure_local_transcript`` sees an
+    empty id and returns ``no_slot`` without a fetch.
+    """
+    reader = _Reader()
+    _, slot_id, _ = front_app._forward_body({"model": "acme", "messages": [], "id": 123}, "acme")
+    outcome = asyncio.run(transcript.ensure_local_transcript(settings, slot_id, reader=reader))
+    assert reader.keys == [], (
+        "S3 was consulted for a non-string id; the task would hold a conversation "
+        f"it never served: {reader.keys}"
+    )
+    assert outcome.action == "no_slot"
+    assert not (settings.sessions_dir / "dashboard_123.jsonl").exists()
+
+
+def test_a_legal_string_id_still_fetches(settings) -> None:
+    """The safe asymmetry: a legal string id must still fetch (the dangerous
+    direction is declining to fetch for an id the backend ACCEPTS)."""
+    reader = _Reader()
+    _, slot_id, _ = front_app._forward_body(
+        {"model": "acme", "messages": [], "id": "cust-1"}, "acme"
+    )
+    outcome = asyncio.run(transcript.ensure_local_transcript(settings, slot_id, reader=reader))
+    assert len(reader.keys) == 1, f"a legal id was not fetched: {outcome.action}"
+
+
+def test_REVERT_non_string_id_would_be_fetched(settings) -> None:
+    """The reddening, in-line: the reverted coercion turns 123 into "123" and it
+    is fetched.
+
+    This mirrors the exact pre-fix expression rather than calling ``_forward_body``
+    with the guard mutated, because the coercion is a single expression inside the
+    function -- reproducing it here is the faithful revert.
+    """
+    raw_id = 123
+    reverted_slot_id = (
+        raw_id if isinstance(raw_id, str) else ("" if raw_id is None else str(raw_id))
+    )
+    assert reverted_slot_id == "123"
+    reader = _Reader()
+    asyncio.run(transcript.ensure_local_transcript(settings, reverted_slot_id, reader=reader))
+    assert reader.keys == ["crews/acme/data/sessions/dashboard_123.jsonl"], (
+        "the pre-fix coercion must fetch another conversation's transcript, "
+        f"proving the guard is load-bearing: {reader.keys}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 3B: stream must be a real boolean.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("bad", ["false", "true", "0", 1, 0, "no"])
+def test_a_non_boolean_stream_is_refused(bad) -> None:
+    with pytest.raises(front_app.BadForwardField):
+        front_app._forward_body({"model": "acme", "messages": [], "stream": bad}, "acme")
+
+
+@pytest.mark.parametrize("value,expected", [(True, True), (False, False), (None, False)])
+def test_a_real_boolean_stream_is_honoured(value, expected) -> None:
+    payload = {"model": "acme", "messages": []}
+    if value is not None:
+        payload["stream"] = value
+    _, _, stream = front_app._forward_body(payload, "acme")
+    assert stream is expected
+
+
+def test_REVERT_string_false_would_stream() -> None:
+    """The reddening: the reverted ``bool(...)`` coercion turns "false" truthy."""
+    assert bool("false") is True, "the reverted coercion would stream a non-streaming turn"

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_transcript_entry_shape.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_transcript_entry_shape.py
@@ -1,0 +1,234 @@
+"""A transcript entry that is not a file must be refused, not opened.
+
+`ensure_local_transcript` decides whether this slot's conversation is already on disk and,
+if not, restores it from the backup bucket. Both halves handle names and files that
+came from OUTSIDE the container: boot restores nothing, so what is on disk was put
+there by an earlier turn or by the restore, and the restore's bytes and keys come from
+the bucket.
+
+So the shape of an entry is not something this process gets to assume. A directory, a
+FIFO, a socket, a symlink or a hard-linked file where a transcript should be is refused
+by name, before the backend is handed a path it will open and append to. Crashing
+mid-turn on whatever `open()` raises is the worst of the three outcomes, because a
+refusal is auditable and a crash is not.
+
+Shape is decided on the descriptor, never on the name: `Path.exists()` follows a link,
+answers true for a directory, and is a separate resolution from the open that follows
+it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from container.front import transcript as t
+
+from ._settings_helper import make_settings
+
+
+def _path(settings, stem: str = "dashboard_slot-1") -> Path:
+    path = t.local_transcript_path(settings, stem)
+    assert path is not None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def test_a_regular_file_reads_as_present(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+    path.write_bytes(b'{"role":"user"}\n')
+
+    assert t._probe_local_entry(path) is True
+
+
+def test_nothing_there_reads_as_absent(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    assert t._probe_local_entry(_path(settings)) is False
+
+
+def test_a_directory_is_refused(tmp_path: Path) -> None:
+    """The shape `Path.exists()` gets wrong most usefully: it answers true."""
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+    path.mkdir()
+
+    with pytest.raises(t.TranscriptUnavailable, match="not a regular file"):
+        t._probe_local_entry(path)
+
+
+def test_a_symlink_is_refused_and_names_the_path(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+    elsewhere = tmp_path / "elsewhere.jsonl"
+    elsewhere.write_bytes(b"not this file\n")
+    path.symlink_to(elsewhere)
+
+    with pytest.raises(t.TranscriptUnavailable, match="symlink") as exc:
+        t._probe_local_entry(path)
+    assert str(path) in str(exc.value), "an operator needs the path in the message"
+    assert elsewhere.read_bytes() == b"not this file\n"
+
+
+def test_a_fifo_is_refused_rather_than_hanging(tmp_path: Path) -> None:
+    """Refused, and refused WITHOUT blocking.
+
+    Opening a FIFO for reading waits for a writer, so the probe would hang forever
+    rather than answer. ``O_NONBLOCK`` is what makes this a refusal; the timeout on
+    this test is what would catch its removal.
+    """
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+    os.mkfifo(path)
+
+    with pytest.raises(t.TranscriptUnavailable, match="not a regular file"):
+        t._probe_local_entry(path)
+
+
+def test_a_hard_linked_transcript_is_refused(tmp_path: Path) -> None:
+    """A regular file, and still not safe: the backend appends to this path.
+
+    A second name for the same inode receives everything the backend writes, which is
+    a customer's conversation going somewhere nobody asked for.
+    """
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+    other = tmp_path / "other-name"
+    other.write_bytes(b"seed\n")
+    os.link(other, path)
+
+    with pytest.raises(t.TranscriptUnavailable, match="links"):
+        t._probe_local_entry(path)
+
+
+def test_a_refused_shape_fails_the_turn_rather_than_fetching(tmp_path: Path) -> None:
+    """End to end through the caller: the refusal is the turn's answer.
+
+    ``ensure_local_transcript``'s contract is that ``TranscriptUnavailable`` fails the
+    turn and every other outcome lets it proceed. A bad shape must take the first
+    path -- a turn served on top of one would have the backend create a fresh history
+    and, once a durability writer exists, overwrite the customer's real one.
+    """
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+    path.mkdir()
+
+    class _Reader:
+        def get(self, key):  # pragma: no cover - must never be reached
+            raise AssertionError("fetched despite a refused local entry")
+
+    with pytest.raises(t.TranscriptUnavailable):
+        asyncio.run(t.ensure_local_transcript(settings, "dashboard_slot-1", reader=_Reader()))
+
+
+@pytest.mark.parametrize("shape", ["directory", "symlink", "fifo", "hardlink"])
+def test_every_bad_shape_is_refused_through_the_public_entry_point(
+    tmp_path: Path, shape: str
+) -> None:
+    """Each shape pinned at the CALL SITE, not only against the private probe.
+
+    The unit tests above would keep passing if the probe were written and never
+    called, which is the failure mode this whole series is about. These reach it the
+    way a turn does.
+    """
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+    if shape == "directory":
+        path.mkdir()
+    elif shape == "symlink":
+        target = tmp_path / "target.jsonl"
+        target.write_bytes(b"x\n")
+        path.symlink_to(target)
+    elif shape == "fifo":
+        os.mkfifo(path)
+    else:
+        other = tmp_path / "other-name"
+        other.write_bytes(b"seed\n")
+        os.link(other, path)
+
+    class _Reader:
+        def get(self, key):  # pragma: no cover - must never be reached
+            raise AssertionError("fetched despite a refused local entry")
+
+    with pytest.raises(t.TranscriptUnavailable):
+        asyncio.run(t.ensure_local_transcript(settings, "dashboard_slot-1", reader=_Reader()))
+
+
+def test_the_write_refuses_a_symlinked_sessions_directory(tmp_path: Path) -> None:
+    """``mkdir(exist_ok=True)`` succeeds on a link to a directory, so it is checked."""
+    settings = make_settings(tmp_path)
+    real = tmp_path / "real-sessions"
+    real.mkdir()
+    sessions = settings.sessions_dir
+    shutil.rmtree(sessions)
+    sessions.symlink_to(real, target_is_directory=True)
+
+    with pytest.raises(t.TranscriptUnavailable, match="sessions directory is a symlink"):
+        t._write_without_clobbering(sessions / "dashboard_slot-1.jsonl", b"x")
+
+    assert not any(real.iterdir()), "nothing was written through the link"
+
+
+def test_the_write_still_refuses_to_clobber(tmp_path: Path) -> None:
+    """Non-vacuity for the guard above: the ordinary paths still behave.
+
+    A guard that refused every write would make the test above pass while breaking
+    restore entirely.
+    """
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+
+    t._write_without_clobbering(path, b"first\n")
+    assert path.read_bytes() == b"first\n"
+
+    t._write_without_clobbering(path, b"second\n")
+    assert path.read_bytes() == b"first\n", "the copy on disk is the newer one and wins"
+    leftovers = [p.name for p in path.parent.iterdir() if p.name.endswith(".tmp")]
+    assert not leftovers, leftovers
+
+
+@pytest.mark.parametrize("shape", ["directory", "symlink", "fifo", "hardlink"])
+def test_a_raced_publish_validates_the_entry_that_won(tmp_path: Path, shape: str) -> None:
+    """A collision means the file the turn will use is not the one just written.
+
+    The pre-fetch probe answered about a different entry, so the winner has had none of
+    this module's checks applied to it. Keeping it is still right when it is a
+    transcript -- whoever wrote it has the newer history -- but it has to BE one, and
+    the same helper decides that, so the collision path cannot drift from the path it
+    mirrors.
+    """
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+    if shape == "directory":
+        path.mkdir()
+    elif shape == "symlink":
+        target = tmp_path / "raced.jsonl"
+        target.write_bytes(b"x\n")
+        path.symlink_to(target)
+    elif shape == "fifo":
+        os.mkfifo(path)
+    else:
+        other = tmp_path / "raced-other"
+        other.write_bytes(b"seed\n")
+        os.link(other, path)
+
+    with pytest.raises(t.TranscriptUnavailable):
+        t._write_without_clobbering(path, b"fetched\n")
+
+
+def test_a_raced_publish_with_a_real_transcript_keeps_it(tmp_path: Path) -> None:
+    """The ordinary collision is not an error, and must not become one.
+
+    Two turns for the same conversation can race, and the loser's job is to leave the
+    winner's bytes alone rather than fail a turn that has a perfectly good transcript.
+    """
+    settings = make_settings(tmp_path)
+    path = _path(settings)
+    path.write_bytes(b"arrived first\n")
+
+    t._write_without_clobbering(path, b"fetched\n")
+
+    assert path.read_bytes() == b"arrived first\n"

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_transcript_fetch.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_transcript_fetch.py
@@ -1,0 +1,507 @@
+"""The on-demand transcript fetch: the other half of the ephemeral memory change.
+
+Boot restores no transcripts, so THIS is where a returning customer's
+conversation comes back (``EPHEMERAL-CONTRACT.md``). Every test here pins a rule
+whose violation is silent in production:
+
+1. The object is ``dashboard_<slot>.jsonl``, not ``<slot>.jsonl``. Getting this
+   wrong fetches nothing and every customer looks new, with no error anywhere.
+2. Exactly ONE key is requested, ever. A list undoes the isolation the change
+   exists for.
+3. A transcript already on disk is never re-fetched and never overwritten. The
+   local copy leads S3 by up to one backup interval, so an overwrite rolls a
+   customer's conversation backwards.
+4. Absence is normal; a FAILURE fails the turn on both transports, before the
+   body reaches the backend.
+5. Contents are never logged.
+
+No AWS: the reader is a fake with a ``get``. The backend is the same fake HTTP
+surface ``test_front_proxy.py`` uses, imported rather than rebuilt so the two
+files cannot model different backends.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+import pytest
+from container import common
+from container.front import transcript
+from container.front.app import build_app
+
+from .test_front_proxy import _free_port, backend, env  # noqa: F401 - fixtures
+
+TURN = "/c/crew/v1/chat/completions"
+
+# A body long enough that a truncating bug is visible, and carrying a distinctive
+# string so a test can prove it never reaches a log line.
+SECRET_LINE = "customer-said-something-private"
+TRANSCRIPT_BODY = (
+    json.dumps({"_type": "metadata", "title": "Order 8831"})
+    + "\n"
+    + json.dumps({"role": "user", "content": SECRET_LINE})
+    + "\n"
+).encode("utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+@dataclass
+class FakeReader:
+    """A read-only store with a ``get`` and nothing else.
+
+    Records every key asked for, so a test can assert the count as well as the
+    value: "fetched the right object" and "fetched exactly one object" are
+    different properties and both matter here.
+    """
+
+    objects: dict[str, bytes] = field(default_factory=dict)
+    gets: list[str] = field(default_factory=list)
+    fail_with: Exception | None = None
+    delay: float = 0.0
+
+    def get(self, key: str) -> bytes:
+        self.gets.append(key)
+        if self.delay:
+            import time
+
+            time.sleep(self.delay)
+        if self.fail_with is not None:
+            raise self.fail_with
+        try:
+            return self.objects[key]
+        except KeyError:
+            raise _client_error("NoSuchKey", 404) from None
+
+
+def _client_error(code: str, status: int) -> Exception:
+    """An exception shaped like botocore's ``ClientError``, without botocore."""
+
+    class ClientError(Exception):
+        pass
+
+    exc = ClientError(f"{code} ({status})")
+    exc.response = {  # type: ignore[attr-defined]
+        "Error": {"Code": code},
+        "ResponseMetadata": {"HTTPStatusCode": status},
+    }
+    return exc
+
+
+def make_settings(backend_env, *, bucket: str | None = "smc-bucket", prefix: str = "crews"):
+    """Settings for the HTTP-path tests, with a data home of their own.
+
+    The data home is unique per call on purpose. Sharing one would make a slot id
+    reused by a later test find the earlier test's transcript already on disk, and
+    the fetch it meant to exercise would be skipped rather than failed: a test
+    that passes for the wrong reason, which is the failure this whole file is
+    about.
+    """
+    run_dir = backend_env["run_dir"]
+    data_home = run_dir.parent / f"data-{uuid4().hex[:8]}"
+    return common.Settings(
+        backend_port=backend_env["port"],
+        backend_run_dir=run_dir,
+        front_port=8080,
+        route_prefix="/c/crew",
+        control_secret=None,
+        data_home=data_home,
+        config_dir=data_home,
+        crew_name="crew",
+        backup_bucket=bucket,
+        backup_prefix=prefix,
+        # A bucket means durable transcripts, and build_app refuses that pairing unless
+        # the deployment has vouched that one principal reaches the task. These tests are
+        # ABOUT the fetch, so they are the single-principal case by construction; the
+        # refusal itself is pinned in test_review_findings.py.
+        single_principal=True,
+    )
+
+
+def local_settings(tmp_path: Path, *, bucket: str | None = "smc-bucket") -> common.Settings:
+    """Settings for the tests that need no HTTP at all."""
+    return common.Settings(
+        backend_port=1,
+        backend_run_dir=tmp_path / "run",
+        front_port=8080,
+        route_prefix="",
+        control_secret=None,
+        data_home=tmp_path / "home",
+        config_dir=tmp_path / "home",
+        crew_name="crew",
+        backup_bucket=bucket,
+        backup_prefix="crews",
+        single_principal=True,  # see the note in the fixture above
+    )
+
+
+async def drive(settings, reader, payload: dict) -> httpx.Response:
+    app = build_app(settings, transcript_reader=reader)
+    client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://front")
+    try:
+        return await client.post(TURN, json=payload)
+    finally:
+        await client.aclose()
+        backend_client = getattr(app.state, "backend_client", None)
+        if backend_client is not None:
+            await backend_client.aclose()
+
+
+async def drive_stream(settings, reader, payload: dict) -> tuple[int, str]:
+    app = build_app(settings, transcript_reader=reader)
+    client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://front")
+    try:
+        async with client.stream("POST", TURN, json=payload) as resp:
+            body = b"".join([chunk async for chunk in resp.aiter_bytes()])
+            return resp.status_code, body.decode("utf-8")
+    finally:
+        await client.aclose()
+        backend_client = getattr(app.state, "backend_client", None)
+        if backend_client is not None:
+            await backend_client.aclose()
+
+
+# --------------------------------------------------------------------------- #
+# 1. the filename mapping
+# --------------------------------------------------------------------------- #
+def test_the_stem_carries_the_dashboard_thread_prefix() -> None:
+    """``<thread>_<slot>``, not ``<slot>``.
+
+    Pinned to the two sources that establish it: the wheel's
+    ``_normalize_slot_key`` docstring invariant
+    (``_safe_key(_history_key_for(key)) == f"dashboard_{key}"``) and
+    ``control/observe.py resolve_open_slots``, whose own example is
+    ``smc-verify`` -> ``dashboard_smc-verify.jsonl``.
+    """
+    assert transcript.transcript_stem("cust-8831") == "dashboard_cust-8831"
+    assert transcript.transcript_stem("smc-verify") == "dashboard_smc-verify"
+
+
+def test_a_bare_slot_name_is_not_the_object_name(tmp_path: Path) -> None:
+    """A store holding ``<slot>.jsonl`` is a MISS. This is the mutation test.
+
+    Point the code at ``<slot>.jsonl`` and this reddens: the object is found and
+    written, which in production is the same shape as the defect (the fetch reads
+    the wrong key) only inverted, so it is the sharpest available witness.
+    """
+    settings = local_settings(tmp_path)
+    reader = FakeReader(objects={"crews/crew/data/sessions/cust-8831.jsonl": TRANSCRIPT_BODY})
+
+    outcome = asyncio.run(transcript.ensure_local_transcript(settings, "cust-8831", reader=reader))
+
+    assert outcome.action == "absent"
+    assert reader.gets == ["crews/crew/data/sessions/dashboard_cust-8831.jsonl"]
+    assert not (settings.sessions_dir / "dashboard_cust-8831.jsonl").exists()
+
+
+@pytest.mark.parametrize("spelling", ["cust-1", "dashboard_cust-1", "dashboard:cust-1"])
+def test_every_spelling_of_one_slot_resolves_to_one_object(spelling: str) -> None:
+    """The backend folds all three onto ONE slot, so all three must fetch one key.
+
+    ``_normalize_slot_key`` strips a ``dashboard:``/``dashboard_`` prefix before
+    the slot is looked up, so a fetch that skipped the strip would miss the object
+    for two of these three and hand those callers an empty conversation.
+    """
+    assert transcript.transcript_stem(spelling) == "dashboard_cust-1"
+
+
+def test_a_slot_id_cannot_escape_the_sessions_directory(tmp_path: Path) -> None:
+    settings = local_settings(tmp_path)
+    stem = transcript.transcript_stem("../../etc/passwd")
+    assert "/" not in stem
+    path = transcript.local_transcript_path(settings, stem)
+    assert path is not None
+    assert path.parent == settings.sessions_dir
+
+
+def test_the_transcript_key_is_derived_consistently(tmp_path: Path) -> None:
+    """The reader must name the object a writer would.
+
+    The backup subsystem (which once owned the key shape) was extracted from this PR, so
+    the front now derives the key from its OWN helpers. When durability returns, its writer
+    and this reader must share one derivation; this pins the front's half so a prefix-join
+    or namespace change reddens here rather than the fetch silently missing every object.
+    """
+    for prefix in ("crews", "", "crews/nested/"):
+        settings = local_settings(tmp_path)
+        settings = common.Settings(**{**settings.__dict__, "backup_prefix": prefix})
+        # Reconstruct the expected key from the same rule the front documents: the
+        # <backup_prefix>/<crew_name>/ join over the data/sessions/<stem>.jsonl rel key.
+        parts = [p for p in (prefix.strip("/"), settings.crew_name.strip("/")) if p]
+        object_prefix = ("/".join(parts) + "/") if parts else ""
+        expected = f"{object_prefix}data/sessions/dashboard_cust-1.jsonl"
+        assert transcript.object_key(settings, "dashboard_cust-1") == expected
+
+
+def test_the_reader_cannot_list_or_write() -> None:
+    """Structural, not conventional: the surface has no way to do either.
+
+    A list at the turn undoes the change the whole track exists for, and the
+    sidecar must remain the only writer. Both are absent from the type rather
+    than merely unused by it.
+    """
+    assert not hasattr(transcript.S3TranscriptReader, "list")
+    assert not hasattr(transcript.S3TranscriptReader, "put")
+    assert not hasattr(transcript.S3TranscriptReader, "delete")
+    declared = {name for name in vars(transcript.TranscriptReader) if not name.startswith("_")}
+    assert declared == {"get"}
+
+
+# --------------------------------------------------------------------------- #
+# 2. already on disk: never re-fetch, never overwrite
+# --------------------------------------------------------------------------- #
+def test_a_transcript_on_disk_is_neither_refetched_nor_overwritten(tmp_path: Path) -> None:
+    """THE mutation test for the do-not-overwrite rule.
+
+    The local copy is newer than S3 by up to one backup interval. Here S3 holds a
+    SHORTER, older object, which is a real state (a transcript is atomically
+    replaced and can shrink), so an overwrite silently rolls the customer's
+    conversation backwards. Remove the on-disk short-circuit and this reddens.
+    """
+    settings = local_settings(tmp_path)
+    settings.sessions_dir.mkdir(parents=True)
+    path = settings.sessions_dir / "dashboard_cust-1.jsonl"
+    newer = TRANSCRIPT_BODY + json.dumps({"role": "assistant", "content": "later"}).encode() + b"\n"
+    path.write_bytes(newer)
+
+    reader = FakeReader(
+        objects={"crews/crew/data/sessions/dashboard_cust-1.jsonl": b"stale-and-shorter\n"}
+    )
+    outcome = asyncio.run(transcript.ensure_local_transcript(settings, "cust-1", reader=reader))
+
+    # Ordered by what a customer would lose: the bytes first, then the wasted
+    # GET, then the label. A mutation should redden on the harm, not on a name.
+    assert path.read_bytes() == newer, "the newer local transcript was rolled backwards"
+    assert reader.gets == [], "S3 was consulted for a conversation already on disk"
+    assert outcome.action == "present"
+
+
+def test_a_transcript_that_appears_mid_fetch_is_not_clobbered(tmp_path: Path) -> None:
+    """The write refuses an existing target, so the rule holds against the race.
+
+    ``ensure_local_transcript`` checks and then writes; between those the backend
+    could create the file. The write is a link onto the target, which fails if it
+    exists, so the newer copy survives without a second check to forget.
+    """
+    settings = local_settings(tmp_path)
+    settings.sessions_dir.mkdir(parents=True)
+    path = settings.sessions_dir / "dashboard_cust-1.jsonl"
+    path.write_bytes(b"created-by-the-backend\n")
+
+    transcript._write_without_clobbering(path, b"from-s3\n")
+
+    assert path.read_bytes() == b"created-by-the-backend\n"
+
+
+def test_a_fetch_leaves_no_temp_file_behind(tmp_path: Path) -> None:
+    settings = local_settings(tmp_path)
+    reader = FakeReader(
+        objects={"crews/crew/data/sessions/dashboard_cust-1.jsonl": TRANSCRIPT_BODY}
+    )
+    outcome = asyncio.run(transcript.ensure_local_transcript(settings, "cust-1", reader=reader))
+    assert outcome.action == "fetched" and outcome.bytes_written == len(TRANSCRIPT_BODY)
+    assert (settings.sessions_dir / "dashboard_cust-1.jsonl").read_bytes() == TRANSCRIPT_BODY
+    assert list(settings.sessions_dir.glob(".smc-fetch-*")) == []
+
+
+# --------------------------------------------------------------------------- #
+# 3. absence, and no bucket
+# --------------------------------------------------------------------------- #
+def test_absent_in_s3_is_normal_and_writes_nothing(tmp_path: Path) -> None:
+    settings = local_settings(tmp_path)
+    reader = FakeReader()
+    outcome = asyncio.run(transcript.ensure_local_transcript(settings, "brand-new", reader=reader))
+    assert outcome.action == "absent"
+    assert not settings.sessions_dir.exists() or list(settings.sessions_dir.iterdir()) == []
+
+
+def test_no_bucket_configured_is_not_a_failed_fetch(tmp_path: Path) -> None:
+    """A crew with no bucket must still serve turns.
+
+    Nothing was ever uploaded, so nothing is missing: this is a crew without
+    durable conversations, not a restore that failed. Reporting it as a failure
+    here would refuse every turn such a crew ever receives.
+    """
+    settings = local_settings(tmp_path, bucket=None)
+    outcome = asyncio.run(transcript.ensure_local_transcript(settings, "cust-1", reader=None))
+    assert outcome.action == "no_store"
+
+
+def test_a_turn_with_no_slot_id_fetches_nothing(tmp_path: Path) -> None:
+    """An id-less turn is ephemeral: the backend mints a slot, so there is no
+    conversation to restore and nothing to look up."""
+    settings = local_settings(tmp_path)
+    reader = FakeReader()
+    outcome = asyncio.run(transcript.ensure_local_transcript(settings, "", reader=reader))
+    assert outcome.action == "no_slot"
+    assert reader.gets == []
+
+
+# --------------------------------------------------------------------------- #
+# 4. a failure fails the turn, on both transports
+# --------------------------------------------------------------------------- #
+def test_access_denied_is_a_failure_not_an_absence(tmp_path: Path) -> None:
+    """403 must not read as "new conversation".
+
+    Absence and denial are different answers and only one of them may proceed.
+    Reading a denial as absence is the silent path to serving an empty history
+    and then overwriting the real one at the next backup cycle.
+    """
+    settings = local_settings(tmp_path)
+    reader = FakeReader(fail_with=_client_error("AccessDenied", 403))
+    with pytest.raises(transcript.TranscriptUnavailable):
+        asyncio.run(transcript.ensure_local_transcript(settings, "cust-1", reader=reader))
+
+
+def test_a_transport_error_is_a_failure(tmp_path: Path) -> None:
+    settings = local_settings(tmp_path)
+    reader = FakeReader(fail_with=OSError("connection reset"))
+    with pytest.raises(transcript.TranscriptUnavailable):
+        asyncio.run(transcript.ensure_local_transcript(settings, "cust-1", reader=reader))
+
+
+@pytest.mark.asyncio
+async def test_a_failed_fetch_refuses_the_turn_before_the_backend_sees_it(env) -> None:
+    reader = FakeReader(fail_with=_client_error("AccessDenied", 403))
+    resp = await drive(
+        make_settings(env), reader, {"model": "crew", "id": "cust-1", "messages": []}
+    )
+    assert resp.status_code == 503
+    assert resp.json()["code"] == "transcript_unavailable"
+    assert env["fake"].requests == [], "the turn reached the backend with no history"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_fetch_refuses_a_streamed_turn_too(env) -> None:
+    """The streaming path must fail as well, with the same code.
+
+    SSE commits 200 before the body, so the refusal is an error FRAME. What
+    matters is that the customer is told the turn failed rather than shown an
+    empty conversation, and that the backend never received the turn.
+    """
+    reader = FakeReader(fail_with=_client_error("AccessDenied", 403))
+    status, body = await drive_stream(
+        make_settings(env),
+        reader,
+        {"model": "crew", "id": "cust-1", "messages": [], "stream": True},
+    )
+    assert status == 200
+    assert "transcript_unavailable" in body
+    assert "[DONE]" in body
+    assert env["fake"].requests == []
+
+
+@pytest.mark.asyncio
+async def test_a_streamed_turn_fetches_the_transcript_before_forwarding(env) -> None:
+    """The streaming path gets the same fetch, from the same scope.
+
+    Both transports enter ``prepared_turn``; only the entry point differs. This
+    is the test that would redden if the streaming branch were left on the bare
+    slot lock.
+    """
+    settings = make_settings(env)
+    key = "crews/crew/data/sessions/dashboard_cust-7.jsonl"
+    reader = FakeReader(objects={key: TRANSCRIPT_BODY})
+    env["fake"].stream_chunks = [
+        b'data: {"object":"chat.completion.chunk","choices":[{"delta":{"content":"hi"}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+
+    status, body = await drive_stream(
+        settings, reader, {"model": "crew", "id": "cust-7", "messages": [], "stream": True}
+    )
+
+    assert status == 200 and "[DONE]" in body
+    assert reader.gets == [key]
+    assert (settings.sessions_dir / "dashboard_cust-7.jsonl").read_bytes() == TRANSCRIPT_BODY
+    assert len(env["fake"].requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_non_streamed_turn_fetches_then_forwards(env) -> None:
+    settings = make_settings(env)
+    key = "crews/crew/data/sessions/dashboard_cust-8831.jsonl"
+    reader = FakeReader(objects={key: TRANSCRIPT_BODY})
+
+    resp = await drive(settings, reader, {"model": "crew", "id": "cust-8831", "messages": []})
+
+    assert resp.status_code == 200
+    assert reader.gets == [key]
+    assert (settings.sessions_dir / "dashboard_cust-8831.jsonl").read_bytes() == TRANSCRIPT_BODY
+
+
+@pytest.mark.asyncio
+async def test_a_refused_turn_never_reaches_the_fetch(env) -> None:
+    """The fetch sits AFTER ``judge_addressed_crew``, so a refusal costs no GET.
+
+    An unaddressed or wrongly addressed request must not be able to make the
+    container fetch objects, or the refusals become a way to probe the bucket.
+    """
+    reader = FakeReader()
+    payloads: tuple[dict, ...] = (
+        {"messages": []},  # names nobody
+        {"model": "other-crew", "id": "cust-1", "messages": []},  # wrong crew
+    )
+    for payload in payloads:
+        resp = await drive(make_settings(env), reader, payload)
+        assert resp.status_code in (400, 404)
+    assert reader.gets == []
+
+
+# --------------------------------------------------------------------------- #
+# 5. one turn at a time, one fetch
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_two_concurrent_turns_on_one_slot_fetch_once(env) -> None:
+    """The fetch is inside the per-slot lock, so the second turn finds the file.
+
+    Outside the lock both turns would fetch the same object concurrently and one
+    of them would write over the other's file. One recorded GET is the witness
+    that the fetch and the lock are the same scope.
+    """
+    settings = make_settings(env)
+    key = "crews/crew/data/sessions/dashboard_cust-9.jsonl"
+    reader = FakeReader(objects={key: TRANSCRIPT_BODY}, delay=0.05)
+    env["fake"].turn_delay = 0.05
+
+    app = build_app(settings, transcript_reader=reader)
+    client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://front")
+    try:
+        r1, r2 = await asyncio.gather(
+            client.post(TURN, json={"model": "crew", "id": "cust-9", "messages": []}),
+            client.post(TURN, json={"model": "crew", "id": "cust-9", "messages": []}),
+        )
+    finally:
+        await client.aclose()
+        backend_client = getattr(app.state, "backend_client", None)
+        if backend_client is not None:
+            await backend_client.aclose()
+
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert reader.gets == [key], f"fetched {len(reader.gets)} times, expected once"
+    assert env["fake"].saw_409 == 0
+
+
+# --------------------------------------------------------------------------- #
+# 6. logging
+# --------------------------------------------------------------------------- #
+def test_the_log_carries_the_sid_and_the_byte_count_and_no_contents(tmp_path: Path, caplog) -> None:
+    settings = local_settings(tmp_path)
+    reader = FakeReader(
+        objects={"crews/crew/data/sessions/dashboard_cust-1.jsonl": TRANSCRIPT_BODY}
+    )
+    with caplog.at_level(logging.DEBUG, logger="smc.front.transcript"):
+        asyncio.run(transcript.ensure_local_transcript(settings, "cust-1", reader=reader))
+
+    text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "dashboard_cust-1" in text
+    assert str(len(TRANSCRIPT_BODY)) in text
+    assert SECRET_LINE not in text
+    assert "Order 8831" not in text

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_transcript_size_bound.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_front_transcript_size_bound.py
@@ -1,0 +1,107 @@
+"""The transcript restore is bounded by size as well as by shape.
+
+Every other guard on this path answers "is this entry the right KIND of thing". This one
+answers "how much of it is this process willing to hold": the bytes come from the backup
+bucket and live in memory for the length of a turn, so without a ceiling one stored
+object decides how much memory the task uses.
+
+Two bounds, because a header is a claim rather than a bound. `ContentLength` is checked
+before a byte is read, and the streaming read enforces the same ceiling on what actually
+arrives.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from container.front import transcript as t
+
+
+class _Body:
+    """A minimal stand-in for a botocore streaming body."""
+
+    def __init__(self, data: bytes) -> None:
+        self._buf = io.BytesIO(data)
+        self.reads = 0
+
+    def read(self, size: int | None = None) -> bytes:
+        self.reads += 1
+        return self._buf.read(size)
+
+
+def test_a_transcript_under_the_ceiling_reads_whole() -> None:
+    body = _Body(b"a" * 4096)
+    assert t._read_bounded(body, "k", limit=8192) == b"a" * 4096
+
+
+def test_a_transcript_over_the_ceiling_is_refused() -> None:
+    with pytest.raises(t.TranscriptTooLarge, match="exceeds"):
+        t._read_bounded(_Body(b"a" * 9000), "some/key.jsonl", limit=8192)
+
+
+def test_the_refusal_names_the_key() -> None:
+    """An operator has to know WHICH object, since the fix is on the bucket side."""
+    with pytest.raises(t.TranscriptTooLarge) as exc:
+        t._read_bounded(_Body(b"a" * 9000), "crews/frontdesk/dashboard_slot-1.jsonl", limit=8192)
+    assert "crews/frontdesk/dashboard_slot-1.jsonl" in str(exc.value)
+
+
+def test_a_refusal_is_a_transcript_failure_so_the_turn_fails() -> None:
+    """``TranscriptTooLarge`` must be a ``TranscriptUnavailable``.
+
+    The caller's contract is that ``TranscriptUnavailable`` fails the turn and anything
+    else lets it proceed. A size refusal that was not one of those would let the backend
+    serve a turn with the conversation missing and then overwrite the real history.
+    """
+    assert issubclass(t.TranscriptTooLarge, t.TranscriptUnavailable)
+
+
+def test_the_read_is_chunked_rather_than_one_call() -> None:
+    """The ceiling has to be enforced while reading, not after.
+
+    A single ``body.read()`` materialises whatever the object is, so the limit would be
+    checked once the memory was already committed. Asserting on the number of reads is
+    what pins that: one read of everything would be a single call.
+    """
+    body = _Body(b"a" * (3 * t._READ_CHUNK_BYTES))
+    t._read_bounded(body, "k")
+    assert body.reads >= 3
+
+
+def test_an_object_declaring_itself_too_large_is_refused_before_reading(tmp_path: Path) -> None:
+    """The header check exists to avoid starting a read that cannot end well.
+
+    It is not trusted -- the streaming ceiling still applies -- but an object that
+    announces itself as oversized is refused without pulling any of it.
+    """
+
+    class _Client:
+        def __init__(self) -> None:
+            self.body = _Body(b"a" * 16)
+
+        def get_object(self, Bucket: str, Key: str):  # noqa: N803 - botocore's own casing
+            return {"ContentLength": t.MAX_TRANSCRIPT_BYTES + 1, "Body": self.body}
+
+    reader = t.S3TranscriptReader("bkt")
+    client = _Client()
+    reader._client = client
+
+    with pytest.raises(t.TranscriptTooLarge, match="declares"):
+        reader.get("some/key.jsonl")
+    assert client.body.reads == 0, "the body was read despite the declared size"
+
+
+def test_a_lying_header_does_not_get_past_the_streaming_ceiling() -> None:
+    """A header is a claim by the source, so the read enforces the bound itself."""
+
+    class _Client:
+        def get_object(self, Bucket: str, Key: str):  # noqa: N803 - botocore's own casing
+            return {"ContentLength": 10, "Body": _Body(b"a" * (t.MAX_TRANSCRIPT_BYTES + 1))}
+
+    reader = t.S3TranscriptReader("bkt")
+    reader._client = _Client()
+
+    with pytest.raises(t.TranscriptTooLarge, match="exceeds"):
+        reader.get("some/key.jsonl")

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_review_findings.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_review_findings.py
@@ -1,0 +1,147 @@
+"""Two findings from review on this change, each pinned so a revert reddens.
+
+**The task role reached the model process.** ``build_backend_env`` already drops the
+front's control secret, on the premise that the backend spawns the model subprocess, which
+inherits this environment and auto-approves every tool it calls (see
+``test_backend_env_drops_control_secret``). The same premise covers the task role, and it
+was not being dropped. On Fargate that credential is not a file or a key but an HTTP
+endpoint named by ``AWS_CONTAINER_CREDENTIALS_RELATIVE_URI``, which every AWS SDK resolves
+unasked, so a turn could read the variable from its own environment and act as the task
+role.
+
+**The 400 body returned ``str(exc)``.** Harmless while one raise site holds an authored
+message, and wrong the first time someone writes ``BadForwardField(f"...{inner}")``: the
+response would carry whatever the inner exception says about the container, on a line whose
+reviewer is not looking at the response path. ``detail`` names the caller-facing channel so
+the decision sits where it is made.
+
+The third finding on this change is about PACKAGING -- that no published wheel carried this
+tree, because ``python -m build`` builds the wheel from the sdist and ``MANIFEST.in``
+reached none of these files. It is pinned in ``test/test_crew_runtime_payload.py`` rather
+than here: this suite's subject is the image, which runs on an installed copy where there
+is no repository and no ``MANIFEST.in`` to read.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+from container.supervisor import backend as be
+
+from ._settings_helper import make_settings
+
+RUNTIME_ROOT = pathlib.Path(be.__file__).resolve().parents[2]
+FRONT_APP = RUNTIME_ROOT / "container" / "front" / "app.py"
+
+RELATIVE_URI = "/v2/credentials/2b7f1e44-0000-4000-8000-0123456789ab"
+
+
+# ---------------------------------------------------------------------------
+# The task role must not reach the model process
+# ---------------------------------------------------------------------------
+def test_the_ecs_credential_endpoint_is_withheld_from_the_backend(tmp_path):
+    """The variable an SDK resolves the task role through must not survive.
+
+    Asserted on the RELATIVE_URI form because that is the one Fargate actually sets: a test
+    covering only the static-key names would pass while the live credential path stayed
+    open.
+    """
+    base = {
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": RELATIVE_URI,
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN": "header-token-value",
+        "KIRO_API_KEY": "aws-kiro-abcdefghijklmnopqrstuvwxyz0123456789",
+        "PATH": "/usr/bin",
+    }
+    env = be.build_backend_env(make_settings(tmp_path), base)
+
+    assert "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" not in env
+    assert "AWS_CONTAINER_AUTHORIZATION_TOKEN" not in env
+    # Not under another name either, the standard the control-secret test set: a rename
+    # keeping the VALUE reachable would defeat the point, which is that the subprocess
+    # cannot read it from its environment at all.
+    assert RELATIVE_URI not in env.values(), (
+        "the credential path survives under another key: "
+        f"{sorted(k for k, v in env.items() if v == RELATIVE_URI)}"
+    )
+    assert env["KIRO_API_KEY"].startswith("aws-kiro-"), "the model credential is what stays"
+    assert env["PATH"] == "/usr/bin", "unrelated variables must still be inherited"
+
+
+@pytest.mark.parametrize("name", sorted(be.AWS_CRED_ENV))
+def test_every_listed_aws_credential_variable_is_actually_dropped(name, tmp_path):
+    """Each entry must be removed, not merely listed.
+
+    A name present in the set that the builder never pops would read as covered while the
+    variable sailed through -- the gap a single happy-path assertion cannot see.
+    """
+    base = {name: "sentinel-value", "KIRO_API_KEY": "aws-kiro-0123456789"}
+    env = be.build_backend_env(make_settings(tmp_path), base)
+    assert name not in env
+    assert "sentinel-value" not in env.values()
+
+
+def test_the_supervisor_keeps_its_own_credentials(tmp_path):
+    """Stripping is scoped to the CHILD environment.
+
+    The supervisor is what legitimately uses the task role, so ``build_backend_env``
+    returning a copy rather than mutating its input is load-bearing here, not incidental.
+    """
+    base = {"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": RELATIVE_URI, "KIRO_API_KEY": "k"}
+    be.build_backend_env(make_settings(tmp_path), base)
+    assert base["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"] == RELATIVE_URI
+
+
+def test_the_two_credential_sets_are_populated_and_disjoint():
+    """Non-vacuity, and a guard against the two lists growing into each other.
+
+    An emptied set leaves its loop in ``build_backend_env`` running over nothing while
+    every test above that names a variable explicitly would still fail -- but the
+    parametrised one would silently collapse to zero cases.
+    """
+    assert be.AWS_CRED_ENV, "the AWS set is empty, so its strip loop does nothing"
+    assert be.CHANNEL_CRED_ENV, "the channel set is empty"
+    assert not (be.AWS_CRED_ENV & be.CHANNEL_CRED_ENV)
+
+
+# ---------------------------------------------------------------------------
+# Only text written for the caller reaches the caller
+# ---------------------------------------------------------------------------
+def test_no_exception_str_reaches_a_response_body():
+    """``exc.detail``, never ``str(exc)``.
+
+    A source assertion because the difference is invisible in behaviour today: the single
+    raise site passes an authored message, so both spellings return the same bytes. What is
+    pinned is the spelling the NEXT author inherits.
+    """
+    tree = ast.parse(FRONT_APP.read_text(encoding="utf-8"), str(FRONT_APP))
+    offenders: list[int] = []
+    for handler in ast.walk(tree):
+        if not isinstance(handler, ast.ExceptHandler) or not handler.name:
+            continue
+        for call in ast.walk(handler):
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "str"
+                and call.args
+                and isinstance(call.args[0], ast.Name)
+                and call.args[0].id == handler.name
+            ):
+                offenders.append(call.lineno)
+
+    assert not offenders, (
+        f"an exception's str() is rendered inside a handler at front/app.py {offenders}; "
+        "put caller-facing text on an explicit attribute instead"
+    )
+
+
+def test_the_detail_attribute_carries_the_authored_message():
+    """The channel has to work, or the 400 would answer with an empty detail."""
+    from container.front.app import BadForwardField
+
+    message = '"stream" must be a boolean (true/false), not str.'
+    exc = BadForwardField(message)
+    assert exc.detail == message
+    assert str(exc) == message, "str() must stay useful for logs and pytest output"

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_review_findings_prb.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_review_findings_prb.py
@@ -1,0 +1,196 @@
+"""The two findings the GPT lane raised on PR B once its adjudication could run.
+
+Worth recording why they were UPHELD rather than downgraded: the adjudicator said both
+rarity records were INCOMPLETE, because the deploy-time controls that would bound each risk
+(``templates/crew.yaml``, ``scripts/smc-deploy.sh``) live in the track that deploys and are
+absent from this checkout. That is a property of splitting the change, not of the risk, and
+the right answer is not to argue the absent files -- it is to make this image hold on its
+own. Both fixes below are checkable entirely inside this PR.
+
+**F1, the customer turn route.** It forwards the caller's ``id`` and that id drives the
+on-demand transcript fetch, so with a bucket configured one caller can name another's slot
+and have that conversation restored onto this task's disk. This process cannot bind the id
+to a principal: it has no caller identity to bind to, and a binding written against an
+absent identity fails OPEN. So it answers the question it CAN answer -- has the deployment
+vouched that one principal reaches this task -- and refuses to START on the pairing that
+needs an answer it does not have. A security property the container cannot observe
+arrives as a setting, defaulting to the safe value.
+
+**F2, the crew name.** Every check ``install_bundle`` already made was an equality or a
+digest. Those prove the manifest agrees with the spec and with the bytes, and none of them
+constrains the SHAPE of the agreed name -- so a manifest and spec that both say
+``../../x`` passed all four, and ``agents / f"{name}.json"`` then resolved outside
+``agents`` and was written by ``copyfile`` as root, before the backend started. The
+builder's ``_validated_crew_name`` is the same guard for the same reason; duplicated rather
+than shared because this tree is image source the gateway must not import.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+from container import common
+from container.front.app import build_app
+from container.supervisor import bundle as bundle_mod
+
+from .test_supervisor_bundle import build_bundle, make_settings
+
+
+def _with(settings: common.Settings, **changes) -> common.Settings:
+    return settings.__class__(**{**settings.__dict__, **changes})
+
+
+# ---------------------------------------------------------------------------
+# F1: persistent memory needs a declared trust domain
+# ---------------------------------------------------------------------------
+def test_a_bucket_without_a_declared_trust_domain_refuses_to_start(tmp_path) -> None:
+    """The refusal is at START, not per turn.
+
+    A container that answers its port while silently declining to restore history looks
+    healthy and is not, which is why ``require_api_key`` refuses at startup too. The
+    message has to name the setting, because the operator's next action is to decide
+    whether their deployment really is single-principal.
+    """
+    settings = _with(make_settings(tmp_path), backup_bucket="smc-bucket", single_principal=False)
+    with pytest.raises(common.ConfigError) as caught:
+        build_app(settings)
+    assert "SMC_SINGLE_PRINCIPAL" in str(caught.value)
+
+
+def test_a_bucket_with_a_declared_trust_domain_starts(tmp_path) -> None:
+    """Non-vacuity: the refusal must not have taken persistent memory out entirely.
+
+    Without this, raising unconditionally would satisfy the test above and delete the
+    feature.
+    """
+    settings = _with(make_settings(tmp_path), backup_bucket="smc-bucket", single_principal=True)
+    assert build_app(settings) is not None
+
+
+def test_no_bucket_does_not_excuse_the_declaration(tmp_path) -> None:
+    """A missing bucket is NOT a reason to skip the trust-domain declaration.
+
+    Asserting the opposite here is what would make the gap look
+    intentional. The first version of the guard read
+    ``if settings.backup_bucket and not settings.single_principal``, and the bucket is the
+    wrong condition: it decides whether transcripts are DURABLE, while the caller's ``id``
+    decides which conversation the turn joins. With no bucket the fetch does nothing, but
+    the id still selects a slot on the shared serializer and the backend still returns the
+    live session behind it -- so a second caller reusing a first caller's id lands in that
+    conversation, with nothing restored and nothing needed.
+
+    Both values are checked so the refusal cannot quietly go back to depending on the
+    bucket in either direction.
+    """
+    for bucket in (None, "smc-bucket"):
+        settings = _with(make_settings(tmp_path), backup_bucket=bucket, single_principal=False)
+        with pytest.raises(common.ConfigError) as caught:
+            build_app(settings)
+        assert "SMC_SINGLE_PRINCIPAL" in str(caught.value), f"bucket={bucket!r}"
+
+
+def test_the_declaration_alone_is_what_lets_it_start(tmp_path) -> None:
+    """Non-vacuity, and it pins that the bucket is irrelevant to this decision.
+
+    With the declaration, both bucket settings start. Without it, neither does. That pair is
+    the property: the guard is about who can reach the task, not about where transcripts go.
+    """
+    for bucket in (None, "smc-bucket"):
+        settings = _with(make_settings(tmp_path), backup_bucket=bucket, single_principal=True)
+        assert build_app(settings) is not None, f"bucket={bucket!r}"
+
+
+def test_the_safe_default_is_not_claimed() -> None:
+    """Silence must mean "not vouched for", because claiming is what unlocks the pairing.
+
+    A default of True would make every hand-built Settings and every future deployment
+    assert a property nobody checked, which is the failure direction that matters.
+    """
+    assert common.Settings.single_principal is False
+
+
+def test_the_environment_reader_defaults_the_same_direction(monkeypatch) -> None:
+    """An absent or unparseable variable must not read as a claim.
+
+    Checked through the loader rather than the dataclass, because that is the path a real
+    deployment takes and the two could drift.
+    """
+    for value in (None, "0", "false"):
+        monkeypatch.delenv("SMC_SINGLE_PRINCIPAL", raising=False)
+        if value is not None:
+            monkeypatch.setenv("SMC_SINGLE_PRINCIPAL", value)
+        assert common.load().single_principal is False, value
+    monkeypatch.setenv("SMC_SINGLE_PRINCIPAL", "1")
+    assert common.load().single_principal is True
+
+    # An unparseable value REFUSES rather than defaulting, which is the loader's own
+    # behaviour and stricter than this test first assumed. It is the right direction: a
+    # typo in the variable governing this pairing should stop the container rather than
+    # silently pick a posture nobody chose.
+    monkeypatch.setenv("SMC_SINGLE_PRINCIPAL", "maybe")
+    with pytest.raises(common.ConfigError):
+        common.load()
+
+
+# ---------------------------------------------------------------------------
+# F2: a crew name is a name
+# ---------------------------------------------------------------------------
+def _bundle_for(tmp_path: pathlib.Path, crew_name: str) -> common.Settings:
+    """Settings whose bundle's manifest, spec and digest all agree on *crew_name*.
+
+    Agreeing is the point: the four checks that ran before this fix are equalities and a
+    digest, so a hostile name that is consistent everywhere passes every one of them. Built
+    on the suite's own ``build_bundle`` so the bundle shape stays in one place, then the
+    name is rewritten in all three files and the digest recomputed.
+    """
+    build_bundle(tmp_path, crew_name="placeholder")
+    settings = make_settings(tmp_path, crew_name=crew_name)
+    d = settings.bundle_dir
+    spec = json.loads((d / "agent.json").read_text(encoding="utf-8"))
+    spec["name"] = crew_name
+    (d / "agent.json").write_text(json.dumps(spec), encoding="utf-8")
+    manifest = json.loads((d / "manifest.json").read_text(encoding="utf-8"))
+    manifest["crew_name"] = crew_name
+    manifest["digest"] = bundle_mod._content_digest(d)
+    (d / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return settings
+
+
+@pytest.mark.parametrize("name", ["../../escaped", "..", "a/b", "a\\b", "/abs", ""])
+def test_a_crew_name_that_can_address_a_path_is_refused(name, tmp_path) -> None:
+    """Refused before any copy, and the victim outside ``agents`` must be untouched."""
+    agents = tmp_path / "kiro" / "agents"
+    agents.mkdir(parents=True, exist_ok=True)
+    victim = tmp_path / "kiro" / "escaped.json"
+    victim.write_text("original\n", encoding="utf-8")
+    settings = _bundle_for(tmp_path, name)
+
+    with pytest.raises(common.ConfigError) as caught:
+        bundle_mod.install_bundle(settings, agents_dir=agents)
+    assert "crew name" in str(caught.value).lower() or "crew_name" in str(caught.value)
+    assert victim.read_text(encoding="utf-8") == "original\n", "the copy escaped agents/"
+
+
+def test_an_ordinary_crew_name_still_installs(tmp_path) -> None:
+    """Non-vacuity: the guard must not have become a blanket refusal."""
+    agents = tmp_path / "kiro" / "agents"
+    settings = _bundle_for(tmp_path, "frontdesk")
+    bundle_mod.install_bundle(settings, agents_dir=agents)
+    assert (agents / "frontdesk.json").is_file()
+
+
+def test_the_equality_checks_alone_would_have_let_it_through(tmp_path) -> None:
+    """Why the shape check is needed rather than covered by what was already there.
+
+    The fixture makes manifest, spec and digest agree on a traversal name, so the ONLY
+    thing standing between that bundle and a write outside ``agents`` is the shape check --
+    not one of the four checks that precede it.
+    """
+    settings = _bundle_for(tmp_path, "../../escaped")
+    d = settings.bundle_dir
+    manifest = json.loads((d / "manifest.json").read_text(encoding="utf-8"))
+    spec = json.loads((d / "agent.json").read_text(encoding="utf-8"))
+    assert manifest["crew_name"] == spec["name"] == "../../escaped"
+    assert manifest["digest"] == bundle_mod._content_digest(d)

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_backend.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_backend.py
@@ -1,0 +1,201 @@
+"""Tests for ``container.supervisor.backend`` -- launch argv/env and readiness.
+
+Readiness is exercised against a fake backend process that binds a real
+loopback port and writes a real secret file. No Kiro Crew gateway is booted.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from container import common
+from container.common import Settings
+from container.supervisor import backend as backend_mod
+from container.supervisor.backend import (
+    BackendExited,
+    BackendReadyTimeout,
+    build_backend_argv,
+    build_backend_env,
+    require_api_key,
+    start_backend,
+    wait_until_ready,
+)
+
+from .test_supervisor_fakes import fake_argv, free_port, write_fake_backend
+
+
+def make_settings(tmp_path: Path, port: int) -> Settings:
+    data_home = tmp_path / "data"
+    return Settings(
+        backend_port=port,
+        backend_run_dir=data_home / "run",
+        front_port=8080,
+        route_prefix="",
+        control_secret=None,
+        data_home=data_home,
+        config_dir=data_home / "config",
+        crew_name="test-crew",
+        backup_bucket=None,
+        backup_prefix="",
+    )
+
+
+# --- argv ------------------------------------------------------------------
+
+
+def test_argv_runs_dashboard_mode_never_no_dashboard(tmp_path):
+    argv = build_backend_argv(make_settings(tmp_path, 8765))
+    # Dashboard mode is required. --slack-only is the real flag that removes it
+    # (cli.py:539); --no-dashboard is not even a real flag. Pass NEITHER.
+    assert backend_mod.FLAG_SLACK_ONLY not in argv
+    assert backend_mod.FLAG_NO_DASHBOARD not in argv
+    assert backend_mod.GATEWAY_SUBCOMMAND in argv
+
+
+def test_argv_arms_no_crons(tmp_path):
+    # Arming the scheduler fires overdue jobs immediately on boot.
+    assert backend_mod.FLAG_NO_CRONS in build_backend_argv(make_settings(tmp_path, 8765))
+
+
+def test_argv_sets_approval_yolo(tmp_path):
+    # Unattended crew: no one is there to answer a tool-approval prompt.
+    argv = build_backend_argv(make_settings(tmp_path, 8765))
+    assert backend_mod.FLAG_APPROVAL in argv
+    i = argv.index(backend_mod.FLAG_APPROVAL)
+    assert argv[i + 1] == backend_mod.APPROVAL_MODE == "yolo"
+
+
+# --- credential ------------------------------------------------------------
+
+
+def test_env_forwards_the_model_credential(tmp_path):
+    env = build_backend_env(make_settings(tmp_path, 9001), base={"KIRO_API_KEY": "sk-test"})
+    assert env[backend_mod.ENV_KIRO_API_KEY] == "sk-test"
+
+
+def test_require_api_key_raises_when_absent_or_empty(tmp_path):
+    with pytest.raises(common.ConfigError, match="KIRO_API_KEY"):
+        require_api_key({})
+    with pytest.raises(common.ConfigError, match="KIRO_API_KEY"):
+        require_api_key({"KIRO_API_KEY": "   "})
+
+
+def test_require_api_key_passes_when_present(tmp_path):
+    require_api_key({"KIRO_API_KEY": "sk-live"})  # must not raise
+
+
+# --- env -------------------------------------------------------------------
+
+
+def test_env_points_at_shared_home_and_loopback_port(tmp_path):
+    s = make_settings(tmp_path, 9001)
+    env = build_backend_env(s, base={})
+    assert env[backend_mod.ENV_HOME] == str(s.data_home)
+    assert env[backend_mod.ENV_PORT] == "9001"
+    # The bind address is pinned to loopback (dashboard/urls.py:208 reads this).
+    assert env[backend_mod.ENV_BIND] == common.BACKEND_HOST == "127.0.0.1"
+
+
+def test_env_pins_loopback_over_an_inherited_bind_all(tmp_path):
+    # The official image sets KIROCREW_BIND=0.0.0.0; the backend must never be
+    # network-reachable, so our env must override that back to loopback.
+    env = build_backend_env(make_settings(tmp_path, 9001), base={"KIROCREW_BIND": "0.0.0.0"})
+    assert env[backend_mod.ENV_BIND] == "127.0.0.1"
+
+
+def test_env_disables_the_beacon(tmp_path):
+    # KIROCREW_TELEMETRY_DISABLED (truthy) is the opt-out beacon.py actually reads.
+    env = build_backend_env(make_settings(tmp_path, 9001), base={})
+    assert env[backend_mod.ENV_TELEMETRY_DISABLED].strip().lower() in {"1", "true", "yes", "on"}
+
+
+def test_env_strips_leaked_channel_credentials(tmp_path):
+    base = {
+        "TELEGRAM_BOT_TOKEN": "leaked",
+        "SLACK_BOT_TOKEN": "leaked",
+        "KEEP_ME": "yes",
+    }
+    env = build_backend_env(make_settings(tmp_path, 9001), base=base)
+    assert "TELEGRAM_BOT_TOKEN" not in env
+    assert "SLACK_BOT_TOKEN" not in env
+    assert env["KEEP_ME"] == "yes"  # unrelated env is preserved
+
+
+# --- readiness -------------------------------------------------------------
+
+
+def test_wait_until_ready_returns_when_port_and_secret_are_both_up(tmp_path):
+    port = free_port()
+    s = make_settings(tmp_path, port)
+    script = write_fake_backend(tmp_path)
+    pg = start_backend(
+        s,
+        argv=fake_argv(
+            script,
+            port=port,
+            run_dir=str(s.backend_run_dir),
+            secret_delay=0.4,
+            ttl=30,
+        ),
+    )
+    try:
+        wait_until_ready(s, timeout=10.0, process=pg, poll_interval=0.05)
+        # The secret the fake wrote is exactly what common reads back.
+        assert common.read_boot_secret(s.backend_run_dir, port) == "fake-boot-secret"
+    finally:
+        pg.terminate(2.0)
+
+
+def test_wait_until_ready_times_out_when_secret_present_but_port_closed(tmp_path):
+    # A present secret alone is NOT ready. Pre-write the secret, start nothing.
+    port = free_port()
+    s = make_settings(tmp_path, port)
+    s.backend_run_dir.mkdir(parents=True)
+    common.secret_path(s.backend_run_dir, port).write_text("stale-from-a-prior-boot")
+
+    with pytest.raises(BackendReadyTimeout) as exc:
+        wait_until_ready(s, timeout=0.6, poll_interval=0.05)
+    assert "secret_present=True" in str(exc.value)
+    assert "port_open=False" in str(exc.value)
+
+
+def test_wait_until_ready_times_out_when_port_open_but_no_secret(tmp_path):
+    # A live port with no secret is NOT ready either.
+    port = free_port()
+    s = make_settings(tmp_path, port)
+    script = write_fake_backend(tmp_path)
+    # Fake binds the port but never writes a secret (no run-dir given).
+    pg = start_backend(s, argv=fake_argv(script, port=port, ttl=30))
+    try:
+        with pytest.raises(BackendReadyTimeout) as exc:
+            wait_until_ready(s, timeout=1.0, process=pg, poll_interval=0.05)
+        assert "port_open=True" in str(exc.value)
+        assert "secret_present=False" in str(exc.value)
+    finally:
+        pg.terminate(2.0)
+
+
+def test_wait_until_ready_reports_backend_exit_without_waiting_out_timeout(tmp_path):
+    port = free_port()
+    s = make_settings(tmp_path, port)
+    script = write_fake_backend(tmp_path)
+    # ttl=0.2 so the fake exits almost immediately, never opening long.
+    pg = start_backend(s, argv=fake_argv(script, ttl=0.2))
+    t0 = time.monotonic()
+    with pytest.raises(BackendExited):
+        wait_until_ready(s, timeout=30.0, process=pg, poll_interval=0.05)
+    assert time.monotonic() - t0 < 5.0, "should fail fast on exit, not wait 30s"
+
+
+def test_start_backend_creates_the_run_directory(tmp_path):
+    port = free_port()
+    s = make_settings(tmp_path, port)
+    assert not s.backend_run_dir.exists()
+    script = write_fake_backend(tmp_path)
+    pg = start_backend(s, argv=fake_argv(script, ttl=0.5))
+    try:
+        assert s.backend_run_dir.exists()
+    finally:
+        pg.terminate(2.0)

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_bundle.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_bundle.py
@@ -1,0 +1,441 @@
+"""Tests for ``container.supervisor.bundle.install_bundle``.
+
+The failure this guards is the one the packaging contract was written around: a
+bundle that is built, digested and handed to the task, then never read, so the
+deployment serves a default agent while every gate is green. So the assertions
+here are about WHERE each entry lands (the paths verified against the Kiro Crew
+source) and that each refusal actually fires.
+
+Every refusal test is a MUTATION test: it starts from a bundle the installer
+accepts (proven by ``test_install_lays_the_bundle_out_where_kirocrew_reads``),
+applies exactly ONE change, and asserts the matching refusal. A guard that never
+fails is indistinguishable from one that cannot, so each guard is shown failing.
+
+The digest the fixture stamps into the manifest is computed by an INDEPENDENT
+reimplementation below, not by importing the installer's own ``_content_digest``:
+a happy path that used the code under test to stamp what the code under test
+checks would only prove the function is deterministic. This mirrors how the
+source's ``verify_bundle.py`` restates the algorithm on purpose.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from container.common import ConfigError, Settings
+from container.supervisor import bundle as bundle_mod
+
+
+def make_settings(
+    tmp_path: Path, *, crew_name: str = "frontdesk", control_secret: str | None = "s3cr3t"
+) -> Settings:
+    """Settings for an install test.
+
+    ``control_secret`` defaults to a value because the install marker is authenticated
+    with it, and a deployment that reaches the pruning path has one: without it the
+    supervisor cannot sign the marker and a later install reads the record as untrusted.
+    Tests of that case pass ``None`` explicitly.
+    """
+    data_home = tmp_path / "data"
+    data_home.mkdir(parents=True, exist_ok=True)
+    return Settings(
+        backend_port=8765,
+        backend_run_dir=data_home / "run",
+        front_port=8080,
+        route_prefix="",
+        control_secret=control_secret,
+        data_home=data_home,
+        config_dir=data_home,
+        crew_name=crew_name,
+        backup_bucket=None,
+        backup_prefix="",
+        bundle_dir=tmp_path / "crew-bundle",
+    )
+
+
+def _independent_digest(root: Path) -> str:
+    """A second spelling of the producer's algorithm (crew_export/bundle.py:78).
+
+    Restated rather than imported so the happy-path match is a genuine agreement
+    between two implementations, exactly as verify_bundle.py does.
+    """
+    rows = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        if rel == "manifest.json":
+            continue
+        rows.append([rel, hashlib.sha256(path.read_bytes()).hexdigest()])
+    payload = json.dumps(rows, ensure_ascii=False, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_bundle(
+    tmp_path: Path, *, crew_name: str = "frontdesk", skills: dict[str, str] | None = None
+) -> Path:
+    """Write a four-entry bundle whose manifest digest is correct.
+
+    Returns the bundle dir. The manifest is written LAST, after the digest is
+    computed over the other files, matching the producer.
+
+    ``skills`` maps a skill directory name to its ``SKILL.md`` body, so a test can
+    build a SECOND bundle that drops one and drive a real upgrade. The skills tree is
+    rebuilt from scratch each call for exactly that reason: a bundle that still carried
+    a previous call's skill would make an upgrade test pass without upgrading anything.
+    """
+    root = tmp_path / "crew-bundle"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "agent.json").write_text(
+        json.dumps({"name": crew_name, "prompt": "You are the front desk."}, indent=2),
+        encoding="utf-8",
+    )
+    (root / "mcp.json").write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+    skills_tree = root / "skills"
+    if skills_tree.exists():
+        shutil.rmtree(skills_tree)
+    for name, body in (skills or {"greet": "# Greet\nSay hello.\n"}).items():
+        (skills_tree / name).mkdir(parents=True, exist_ok=True)
+        (skills_tree / name / "SKILL.md").write_text(body, encoding="utf-8")
+    skills_tree.mkdir(parents=True, exist_ok=True)
+
+    digest = _independent_digest(root)
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "bundle_version": 1,
+                "crew_name": crew_name,
+                "created_at": "2026-09-03T00:00:00+00:00",
+                "digest": digest,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+# --- happy path: the bundle lands where Kiro Crew reads it ------------------
+
+
+def test_install_lays_the_bundle_out_where_kirocrew_reads(tmp_path):
+    build_bundle(tmp_path, crew_name="frontdesk")
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    agents = tmp_path / "kiro" / "agents"
+
+    payload = bundle_mod.install_bundle(settings, agents_dir=agents)
+
+    # agent.json -> <kiro agents>/<crew>.json, byte-identical to the source.
+    agent_dst = agents / "frontdesk.json"
+    assert agent_dst.is_file()
+    assert agent_dst.read_bytes() == (settings.bundle_dir / "agent.json").read_bytes()
+    # mcp.json -> <data home>/mcp.json.
+    assert (settings.data_home / "mcp.json").is_file()
+    # skills/ -> <data home>/skills/ (tree preserved).
+    assert (settings.data_home / "skills" / "greet" / "SKILL.md").is_file()
+    # marker at the data-home root, with the three contract fields.
+    marker = json.loads((settings.data_home / bundle_mod.INSTALLED_MARKER).read_text())
+    assert marker["crew_name"] == "frontdesk"
+    assert marker["bundle_digest"].startswith("sha256:")
+    assert marker["installed_at"]
+    assert payload == marker
+
+
+def test_default_agents_dir_mirrors_kiro_home(tmp_path, monkeypatch):
+    # Verified location: $KIRO_HOME/agents (config/paths.py:510 kiro_home), NOT
+    # under the data home. With KIRO_HOME set, the agent dir follows it.
+    monkeypatch.setenv("KIRO_HOME", str(tmp_path / "khome"))
+    assert bundle_mod.default_kiro_agents_dir() == tmp_path / "khome" / "agents"
+    monkeypatch.delenv("KIRO_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "h"))
+    assert bundle_mod.default_kiro_agents_dir() == tmp_path / "h" / ".kiro" / "agents"
+
+
+# --- refusal 1: the bundle dir / an entry is missing (mutation: delete) -----
+
+
+def test_refuses_a_missing_bundle_dir(tmp_path):
+    settings = make_settings(tmp_path)  # no build_bundle -> dir absent
+    with pytest.raises(ConfigError, match=r"bundle dir present"):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "agents")
+
+
+@pytest.mark.parametrize("entry", ["manifest.json", "agent.json", "mcp.json", "skills"])
+def test_refuses_when_any_of_the_four_entries_is_missing(tmp_path, entry):
+    # MUTATION: build a valid bundle, then remove exactly one required entry.
+    root = build_bundle(tmp_path)
+    target = root / entry
+    if target.is_dir():
+        import shutil
+
+        shutil.rmtree(target)
+    else:
+        target.unlink()
+    settings = make_settings(tmp_path)
+    with pytest.raises(ConfigError, match=r"entry present"):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "agents")
+
+
+# --- refusal 2: manifest crew_name != SMC_CREW_NAME -------------------------
+
+
+def test_refuses_when_manifest_crew_name_disagrees_with_env(tmp_path):
+    # MUTATION: the bundle names 'frontdesk' but the task is configured for
+    # 'lawyer'. The image does not carry the crew this task serves.
+    build_bundle(tmp_path, crew_name="frontdesk")
+    settings = make_settings(tmp_path, crew_name="lawyer")
+    with pytest.raises(ConfigError, match=r"crew_name == SMC_CREW_NAME"):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "agents")
+
+
+def test_refuses_an_empty_crew_name(tmp_path):
+    # MUTATION: SMC_CREW_NAME unset. "It started" must mean "the NAMED crew is
+    # installed"; an unnamed crew cannot satisfy that.
+    build_bundle(tmp_path, crew_name="frontdesk")
+    settings = make_settings(tmp_path, crew_name="")
+    with pytest.raises(ConfigError, match=r"crew_name == SMC_CREW_NAME"):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "agents")
+
+
+# --- refusal 3: agent.json name != crew_name --------------------------------
+
+
+def test_refuses_when_agent_name_disagrees_with_manifest(tmp_path):
+    # MUTATION: rewrite agent.json's name AND restamp the digest, so ONLY the
+    # name check can fire (a naive restamp-less edit would trip the digest guard
+    # instead and prove nothing about this one).
+    root = build_bundle(tmp_path, crew_name="frontdesk")
+    (root / "agent.json").write_text(
+        json.dumps({"name": "someone-else", "prompt": "hi"}, indent=2),
+        encoding="utf-8",
+    )
+    man = json.loads((root / "manifest.json").read_text())
+    man["digest"] = _independent_digest(root)
+    (root / "manifest.json").write_text(json.dumps(man, indent=2), encoding="utf-8")
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    with pytest.raises(ConfigError, match=r"agent.json name == crew_name"):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "agents")
+
+
+# --- refusal 4: recomputed digest != manifest digest ------------------------
+
+
+def test_refuses_when_content_does_not_match_the_manifest_digest(tmp_path):
+    # MUTATION: change a skill file AFTER the manifest was stamped, so the
+    # recomputed content digest does not match. Nothing else is wrong.
+    root = build_bundle(tmp_path)
+    (root / "skills" / "greet" / "SKILL.md").write_text(
+        "# Greet\nSay hello, tampered.\n", encoding="utf-8"
+    )
+    settings = make_settings(tmp_path)
+    with pytest.raises(ConfigError, match=r"content digest == manifest digest"):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "agents")
+
+
+def test_nothing_is_installed_when_a_check_fails(tmp_path):
+    # A refusal must leave the read paths untouched -- fail closed, not halfway.
+    root = build_bundle(tmp_path)
+    (root / "skills" / "greet" / "SKILL.md").write_text("tampered\n", encoding="utf-8")
+    settings = make_settings(tmp_path)
+    with pytest.raises(ConfigError):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "agents")
+    assert not (settings.data_home / "mcp.json").exists()
+    assert not (settings.data_home / "skills").exists()
+    assert not (settings.data_home / bundle_mod.INSTALLED_MARKER).exists()
+
+
+# --- pre-planted destination symlinks cannot redirect the unsandboxed install ----
+#
+# install_bundle runs at boot before any sandbox, as the image's own user. Under a mounted
+# persistent data home (this image's Dockerfile provisions one), a sandboxed agent in a PRIOR
+# task can plant a symlink at a bundle destination pointing outside the data home. A plain
+# copyfile/copytree would follow it and overwrite the target. Each destination must refuse.
+
+
+def _outside_target(tmp_path: Path) -> Path:
+    """A file OUTSIDE the data home that a followed symlink would clobber."""
+    victim = tmp_path / "outside" / "victim.txt"
+    victim.parent.mkdir(parents=True, exist_ok=True)
+    victim.write_text("ORIGINAL", encoding="utf-8")
+    return victim
+
+
+def test_a_symlink_planted_at_mcp_dst_is_refused_not_followed(tmp_path):
+    build_bundle(tmp_path, crew_name="frontdesk")
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    victim = _outside_target(tmp_path)
+    (settings.data_home / "mcp.json").symlink_to(victim)
+
+    with pytest.raises(ConfigError, match="not a symlink"):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "kiro" / "agents")
+    # The outside file was NOT overwritten through the link.
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL"
+
+
+def test_a_symlink_planted_at_the_agent_dst_is_refused(tmp_path):
+    build_bundle(tmp_path, crew_name="frontdesk")
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    victim = _outside_target(tmp_path)
+    agents = tmp_path / "kiro" / "agents"
+    agents.mkdir(parents=True, exist_ok=True)
+    (agents / "frontdesk.json").symlink_to(victim)
+
+    with pytest.raises(ConfigError, match="not a symlink"):
+        bundle_mod.install_bundle(settings, agents_dir=agents)
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL"
+
+
+def test_a_symlink_planted_at_skills_dst_is_refused(tmp_path):
+    build_bundle(tmp_path, crew_name="frontdesk")
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    outside_dir = tmp_path / "outside_dir"
+    outside_dir.mkdir(parents=True, exist_ok=True)
+    (settings.data_home / "skills").symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(ConfigError, match="not a symlink"):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "kiro" / "agents")
+    # Nothing was copied through the link into the outside directory.
+    assert not (outside_dir / "greet").exists()
+
+
+def test_a_bundle_upgrade_prunes_a_removed_skill(tmp_path):
+    # A skill an earlier bundle installed and this one dropped must be GONE, or a
+    # removed (possibly governance-relevant) skill stays active on a persistent volume.
+    # Driven as two real installs, because the pruning decision reads what the previous
+    # install RECORDED: fabricating a skill on disk with no marker is a different case,
+    # covered by test_an_unrecorded_skill_is_left_alone.
+    build_bundle(
+        tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n", "obsolete": "# O\n"}
+    )
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    agents = tmp_path / "kiro" / "agents"
+    bundle_mod.install_bundle(settings, agents_dir=agents)
+    assert (settings.data_home / "skills" / "obsolete" / "SKILL.md").is_file()
+
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    bundle_mod.install_bundle(settings, agents_dir=agents)
+
+    assert (settings.data_home / "skills" / "greet" / "SKILL.md").is_file()
+    assert not (settings.data_home / "skills" / "obsolete").exists()
+
+
+def test_a_skill_the_crew_created_survives_a_reinstall(tmp_path):
+    # The other half of the same rule, and the one a wholesale replace violates: the
+    # install replaces the bundle's OWN files, and a skill the running crew produced is
+    # not its to delete. A reinstall happens on every boot, so a wholesale prune loses
+    # the crew's work on the first restart.
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    agents = tmp_path / "kiro" / "agents"
+    bundle_mod.install_bundle(settings, agents_dir=agents)
+
+    learned = settings.data_home / "skills" / "learned-by-doing"
+    learned.mkdir(parents=True, exist_ok=True)
+    (learned / "SKILL.md").write_text("# Learned\n", encoding="utf-8")
+
+    bundle_mod.install_bundle(settings, agents_dir=agents)
+
+    assert (learned / "SKILL.md").read_text(encoding="utf-8") == "# Learned\n"
+    assert (settings.data_home / "skills" / "greet" / "SKILL.md").is_file()
+
+
+def test_a_crew_file_inside_a_dropped_skill_survives_its_pruning(tmp_path):
+    # Pruning is per FILE, not per directory, which is what keeps this case right: the
+    # bundle's own file goes and the crew's file in the same directory stays. Pruning by
+    # directory name would take both.
+    build_bundle(
+        tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n", "obsolete": "# O\n"}
+    )
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    agents = tmp_path / "kiro" / "agents"
+    bundle_mod.install_bundle(settings, agents_dir=agents)
+    notes = settings.data_home / "skills" / "obsolete" / "NOTES.md"
+    notes.write_text("# mine\n", encoding="utf-8")
+
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    bundle_mod.install_bundle(settings, agents_dir=agents)
+
+    assert not (settings.data_home / "skills" / "obsolete" / "SKILL.md").exists()
+    assert notes.read_text(encoding="utf-8") == "# mine\n"
+
+
+def test_an_unrecorded_skill_is_left_alone(tmp_path):
+    # No marker means the previous install's file list is unknown, so NOTHING is pruned.
+    # A stale skill an operator can delete is a smaller harm than deleting a skill the
+    # crew produced, and this is the case where the two cannot be told apart.
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    unknown = settings.data_home / "skills" / "arrived-somehow"
+    unknown.mkdir(parents=True, exist_ok=True)
+    (unknown / "SKILL.md").write_text("# Unknown\n", encoding="utf-8")
+
+    bundle_mod.install_bundle(settings, agents_dir=tmp_path / "kiro" / "agents")
+
+    assert (unknown / "SKILL.md").read_text(encoding="utf-8") == "# Unknown\n"
+
+
+def test_the_marker_records_the_bundle_managed_files(tmp_path):
+    # The next install can only prune what this one recorded, so the record is the
+    # mechanism rather than a log line. An empty or absent list means "prune nothing".
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    bundle_mod.install_bundle(settings, agents_dir=tmp_path / "kiro" / "agents")
+
+    payload = json.loads(
+        (settings.data_home / bundle_mod.INSTALLED_MARKER).read_text(encoding="utf-8")
+    )
+    assert payload["skill_files"] == ["greet/SKILL.md"]
+
+
+def test_a_hand_edited_marker_prunes_nothing(tmp_path):
+    # The marker is written by the install and read by the next one, so a corrupt or
+    # hand-edited one must degrade to "cannot decide" rather than to a wide prune.
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    agents = tmp_path / "kiro" / "agents"
+    bundle_mod.install_bundle(settings, agents_dir=agents)
+    mine = settings.data_home / "skills" / "greet" / "MINE.md"
+    mine.write_text("# mine\n", encoding="utf-8")
+    (settings.data_home / bundle_mod.INSTALLED_MARKER).write_text("{not json", encoding="utf-8")
+
+    bundle_mod.install_bundle(settings, agents_dir=agents)
+
+    assert mine.read_text(encoding="utf-8") == "# mine\n"
+
+
+def test_a_nested_symlink_in_the_old_skills_tree_is_removed_not_followed(tmp_path):
+    # A symlink an agent planted inside the skills tree, at a path the BUNDLE owns, is
+    # removed before the bundle's own file is written there -- unlinking a pointer
+    # destroys no work, and the link's target is never opened. Refusing instead would
+    # let a leftover link stop every future boot on a persistent volume.
+    build_bundle(tmp_path, crew_name="frontdesk")
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    victim = _outside_target(tmp_path)
+    nested = settings.data_home / "skills" / "greet"
+    nested.mkdir(parents=True, exist_ok=True)
+    (nested / "SKILL.md").symlink_to(victim)
+
+    bundle_mod.install_bundle(settings, agents_dir=tmp_path / "kiro" / "agents")
+
+    # The victim was never written through the link.
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL"
+    # The planted link is gone and the real bundle skill is in place.
+    assert not (settings.data_home / "skills" / "greet" / "SKILL.md").is_symlink()
+    assert (settings.data_home / "skills" / "greet" / "SKILL.md").read_text(
+        encoding="utf-8"
+    ) == "# Greet\nSay hello.\n"
+
+
+def test_a_symlink_planted_at_the_marker_is_refused(tmp_path):
+    build_bundle(tmp_path, crew_name="frontdesk")
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    victim = _outside_target(tmp_path)
+    (settings.data_home / bundle_mod.INSTALLED_MARKER).symlink_to(victim)
+
+    with pytest.raises(ConfigError, match="not a symlink"):
+        bundle_mod.install_bundle(settings, agents_dir=tmp_path / "kiro" / "agents")
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL"

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_bundle_prune_bounds.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_bundle_prune_bounds.py
@@ -1,0 +1,276 @@
+"""The prune is bounded by the code, not by what the marker says.
+
+`install_bundle` prunes the skills an earlier bundle installed and this one dropped,
+reading that set from `.smc-crew-installed.json` in the data home. The data home is
+writable by the running crew, so the record is an INPUT: an absolute entry, a
+non-normalised one, one carrying `..`, or a clean-looking one whose parent is a symlink
+would each turn "delete the bundle's own file" into "delete a file of the entry's
+choosing".
+
+Narrower and unbounded is worse than broad and contained. The bound therefore lives in
+two places: the record is refused as a whole when any entry is not a plain relative
+path, and the deletion walks descriptors from the skills directory with symlinks
+refused, so the directory verified is the directory deleted from and no re-resolution
+happens in between.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from container.common import ConfigError
+from container.supervisor import bundle as bundle_mod
+
+from .test_supervisor_bundle import build_bundle, make_settings
+
+
+def _install(settings, tmp_path: Path):
+    return bundle_mod.install_bundle(settings, agents_dir=tmp_path / "kiro" / "agents")
+
+
+def _seed(tmp_path: Path):
+    """One completed install, so a second one has a record to prune from."""
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    _install(settings, tmp_path)
+    return settings
+
+
+def _record(settings, entries: list[str], *, sign: bool = True) -> None:
+    """Rewrite the marker's recorded set, re-signing it as the supervisor would.
+
+    Re-signing is what makes these path tests test the PATH rules. An unsigned rewrite is
+    rejected by the marker's authentication before any entry is looked at, so it would
+    prove only that authentication works -- which
+    ``test_a_forged_marker_is_not_read`` covers separately. Pass ``sign=False`` to
+    exercise that direction instead.
+    """
+    marker = settings.data_home / bundle_mod.INSTALLED_MARKER
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["skill_files"] = entries
+    payload.pop("mac", None)
+    if sign:
+        payload["mac"] = bundle_mod._marker_mac(payload, settings.control_secret)
+    marker.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_a_forged_marker_is_not_read(tmp_path: Path, caplog) -> None:
+    """The premise, not another layer on top of it.
+
+    The marker lives in the data home, which the crew's worker can write, so its
+    contents are an input. It carries an authentication tag computed with
+    ``SMC_CONTROL_SECRET`` -- the one value ``build_backend_env`` removes from the
+    environment the worker inherits -- so a record the supervisor did not write is
+    detectable, and an undetectable one cannot be produced by the party that could
+    otherwise forge it.
+    """
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n", "obsolete": "# O\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    _install(settings, tmp_path)
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n"})
+    _record(settings, ["obsolete/SKILL.md"], sign=False)
+
+    with caplog.at_level("ERROR"):
+        _install(settings, tmp_path)
+
+    assert (settings.data_home / "skills" / "obsolete" / "SKILL.md").is_file()
+    assert "authentication tag" in caplog.text
+
+
+def test_a_marker_with_a_wrong_tag_is_not_read(tmp_path: Path, caplog) -> None:
+    """A tag that does not verify is louder than a missing one, and says which it was."""
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n", "obsolete": "# O\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    _install(settings, tmp_path)
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n"})
+    marker = settings.data_home / bundle_mod.INSTALLED_MARKER
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["skill_files"] = ["obsolete/SKILL.md"]
+    payload["mac"] = "00" * 32
+    marker.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    with caplog.at_level("ERROR"):
+        _install(settings, tmp_path)
+
+    assert (settings.data_home / "skills" / "obsolete" / "SKILL.md").is_file()
+    assert "does not verify" in caplog.text
+
+
+def test_without_a_control_secret_nothing_is_pruned(tmp_path: Path, caplog) -> None:
+    """No key means no authentication, which means no pruning.
+
+    The deployment, not this code, decides whether a control secret exists. When it does
+    not, the honest answer is that the record cannot be told from a forgery, so it is not
+    acted on -- and the install still proceeds, because refusing to boot over an
+    unsignable bookkeeping file would be the worse failure.
+    """
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n", "obsolete": "# O\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk", control_secret=None)
+    _install(settings, tmp_path)
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n"})
+
+    with caplog.at_level("WARNING"):
+        _install(settings, tmp_path)
+
+    assert (settings.data_home / "skills" / "obsolete" / "SKILL.md").is_file()
+    assert "cannot be authenticated" in caplog.text
+
+
+def test_a_regular_file_where_a_skill_directory_belongs_refuses_to_start(tmp_path: Path) -> None:
+    """A boot loop is worse than a refusal, for the reason a crash is.
+
+    A previous task can leave a regular file where this bundle ships a skill directory.
+    ``mkdir`` raises ``FileExistsError`` there, and an uncaught one makes the supervisor
+    crash, ECS restart the task, and the next boot hit the same file on the same volume --
+    forever, spending the owner's money and never saying what is wrong. So it is a
+    refusal that names the path.
+    """
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    skills = settings.data_home / "skills"
+    skills.mkdir(parents=True, exist_ok=True)
+    (skills / "greet").write_text("a file where a directory belongs\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="not a directory") as exc:
+        _install(settings, tmp_path)
+    assert str(skills / "greet") in str(exc.value), "the refusal must name the path"
+
+
+@pytest.mark.parametrize(
+    "entry,because",
+    [
+        ("/etc/hostname", "it is absolute"),
+        ("../../escaped.txt", "it has a '.', '..' or empty component"),
+        ("greet/../../escaped.txt", "it is not normalised"),
+        ("./greet/SKILL.md", "it is not normalised"),
+        ("greet//SKILL.md", "it is not normalised"),
+    ],
+)
+def test_a_malformed_entry_is_refused_and_names_itself(
+    tmp_path: Path, caplog, entry: str, because: str
+) -> None:
+    """Each shape produces its own refusal, naming the entry and the reason.
+
+    Refused rather than repaired: a silently sanitised path hides that the record is
+    corrupt or that something is editing it, and this record sits in a tree the crew can
+    write.
+    """
+    settings = _seed(tmp_path)
+    victim = tmp_path / "escaped.txt"
+    victim.write_text("ORIGINAL\n", encoding="utf-8")
+    _record(settings, [entry])
+
+    with caplog.at_level("ERROR"):
+        _install(settings, tmp_path)
+
+    assert entry in caplog.text, "the refusal must name the offending entry"
+    assert because in caplog.text
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL\n"
+
+
+def test_one_bad_entry_discards_the_whole_record(tmp_path: Path) -> None:
+    """All-or-nothing, and deliberately so.
+
+    A malformed entry means the record is corrupt or hostile, and the rest of it is no
+    more trustworthy than the bad entry. So nothing is pruned -- including the entry
+    beside it that looks fine -- and the install proceeds, leaving residue rather than
+    deleting from a list something else has been editing.
+    """
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n", "obsolete": "# O\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    _install(settings, tmp_path)
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n"})
+    _record(settings, ["obsolete/SKILL.md", "/etc/hostname"])
+
+    _install(settings, tmp_path)
+
+    assert (settings.data_home / "skills" / "obsolete" / "SKILL.md").is_file()
+
+
+def test_an_entry_whose_parent_is_a_symlink_is_refused(tmp_path: Path, caplog) -> None:
+    """The case a string check cannot see.
+
+    ``skills/away/SKILL.md`` carries no ``..`` and is perfectly normalised, so shape
+    validation passes it. If ``away`` is a symlink, deleting by path deletes someone
+    else's file. The descriptor walk refuses the component instead, and the resolved
+    containment check is what gives the refusal a message an operator can read.
+    """
+    settings = _seed(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "SKILL.md"
+    victim.write_text("ORIGINAL\n", encoding="utf-8")
+    (settings.data_home / "skills" / "away").symlink_to(outside, target_is_directory=True)
+    _record(settings, ["away/SKILL.md"])
+
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    with caplog.at_level("WARNING"):
+        _install(settings, tmp_path)
+
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL\n", "a file outside was deleted"
+    assert "away/SKILL.md" in caplog.text
+    assert "outside the skills directory" in caplog.text
+
+
+def test_a_symlinked_entry_pointing_outside_is_left_alone(tmp_path: Path, caplog) -> None:
+    """A link AT the recorded path, aimed outside, is caught by containment.
+
+    Two guards can answer this and the resolved-containment one answers first, which is
+    the better message: it says where the entry would have gone rather than only that it
+    is not a plain file.
+    """
+    settings = _seed(tmp_path)
+    victim = tmp_path / "linked-target.md"
+    victim.write_text("ORIGINAL\n", encoding="utf-8")
+    (settings.data_home / "skills" / "greet" / "GONE.md").symlink_to(victim)
+    _record(settings, ["greet/GONE.md"])
+
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    with caplog.at_level("WARNING"):
+        _install(settings, tmp_path)
+
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL\n"
+    assert "greet/GONE.md" in caplog.text
+    assert "outside the skills directory" in caplog.text
+
+
+def test_a_symlinked_entry_pointing_inside_is_left_alone(tmp_path: Path, caplog) -> None:
+    """The case containment cannot answer, so ``lstat`` on the descriptor does.
+
+    A link that stays inside the skills directory passes both the shape check and the
+    resolved-containment check. It is still not the file this install put there, and
+    unlinking it would delete the crew's link rather than a bundle file, so the leaf's
+    own type is what decides -- read from the descriptor, about the link and not its
+    target.
+    """
+    settings = _seed(tmp_path)
+    inside = settings.data_home / "skills" / "greet" / "SKILL.md"
+    (settings.data_home / "skills" / "greet" / "GONE.md").symlink_to(inside)
+    _record(settings, ["greet/GONE.md"])
+
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# Greet\n"})
+    with caplog.at_level("WARNING"):
+        _install(settings, tmp_path)
+
+    assert (settings.data_home / "skills" / "greet" / "GONE.md").is_symlink()
+    assert inside.is_file(), "the link's target inside the tree survived"
+    assert "no longer a plain file" in caplog.text
+
+
+def test_a_well_formed_entry_inside_the_tree_is_still_pruned(tmp_path: Path) -> None:
+    """Non-vacuity for every refusal above: the ordinary prune must still work.
+
+    A bound that refused everything would make the tests above pass while quietly
+    restoring the stale-skill hazard the prune exists to close.
+    """
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n", "obsolete": "# O\n"})
+    settings = make_settings(tmp_path, crew_name="frontdesk")
+    _install(settings, tmp_path)
+    assert (settings.data_home / "skills" / "obsolete" / "SKILL.md").is_file()
+
+    build_bundle(tmp_path, crew_name="frontdesk", skills={"greet": "# G\n"})
+    _install(settings, tmp_path)
+
+    assert not (settings.data_home / "skills" / "obsolete").exists()

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_exit_code.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_exit_code.py
@@ -1,0 +1,65 @@
+"""The supervisor's exit code is the only signal the platform reads.
+
+``run()`` ended with an unconditional ``return 0`` after teardown, so a task whose
+backend had crashed reported the same status as one ECS had asked to stop. On the
+console that is a task exiting normally, over and over, with nothing marked failed --
+the crash loop is invisible exactly when it matters.
+
+Nothing asserted the return value before, which is how it survived: the whole
+supervisor suite passed with the bug in place.
+"""
+
+from __future__ import annotations
+
+from container.supervisor import __main__ as entry
+
+from .test_supervisor_main import make_settings, wired  # noqa: F401  (pytest fixture)
+
+
+def test_an_orderly_signal_is_success(wired, tmp_path):  # noqa: F811
+    rc = entry.run(make_settings(tmp_path, bucket=None), wait_for_shutdown=lambda c: "signal")
+    assert rc == 0
+
+
+def test_a_crashed_backend_is_a_failure(wired, tmp_path):  # noqa: F811
+    """The case the platform has to be able to see."""
+    rc = entry.run(
+        make_settings(tmp_path, bucket=None),
+        wait_for_shutdown=lambda c: "backend exited (code 1)",
+    )
+    assert rc != 0, "a dead backend reported success to ECS"
+
+
+def test_a_crashed_front_is_a_failure(wired, tmp_path):  # noqa: F811
+    rc = entry.run(
+        make_settings(tmp_path, bucket=None),
+        wait_for_shutdown=lambda c: "front exited (code 137)",
+    )
+    assert rc != 0
+
+
+def test_an_unaccountable_reason_is_a_failure(wired, tmp_path):  # noqa: F811
+    """An empty reason is not evidence that things went well.
+
+    Defaulting the unknown case to success is what made the original bug quiet, so
+    the unknown case fails closed instead.
+    """
+    rc = entry.run(make_settings(tmp_path, bucket=None), wait_for_shutdown=lambda c: "")
+    assert rc != 0
+
+
+def test_teardown_still_runs_on_the_failure_path(wired, tmp_path):  # noqa: F811
+    """Reporting a failure must not skip the cleanup, which has to be unconditional.
+
+    ``_teardown`` is in a ``finally``, so a non-zero return must not become a way to leave
+    a child undrained. ``wired`` records the call order, so the assertion is against what
+    actually ran.
+    """
+    entry.run(
+        make_settings(tmp_path, bucket=None),
+        wait_for_shutdown=lambda c: "backend exited (code 1)",
+    )
+    # ``wired`` records a ``term:<name>`` per child stopped. Asserted against those
+    # real event names rather than a name I assumed: the first version of this test
+    # looked for "teardown" and failed against a correct implementation.
+    assert [e for e in wired if e.startswith("term:")] == ["term:front", "term:backend"], wired

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_fakes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_fakes.py
@@ -1,0 +1,143 @@
+"""Shared fakes for the supervisor tests.
+
+This module is named ``test_supervisor_*`` so it falls inside Track S3's
+ownership, but it defines no test functions -- pytest collects nothing from it.
+It provides a fake backend process that is a real OS process tree (so process
+groups, draining and killpg escalation are exercised for real) and never boots a
+Kiro Crew gateway.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# A real process that can: bind a loopback port, write a gateway secret after a
+# delay, fork a grandchild into its own group, and either drain on SIGTERM or
+# ignore it (to force SIGKILL escalation). No Kiro Crew import.
+FAKE_BACKEND_SRC = r"""
+import argparse, os, signal, socket, sys, time
+from pathlib import Path
+
+p = argparse.ArgumentParser()
+p.add_argument("--port", type=int, default=0)
+p.add_argument("--run-dir", default="")
+p.add_argument("--secret", default="fake-boot-secret")
+p.add_argument("--secret-delay", type=float, default=0.0)
+p.add_argument("--pidfile", default="")
+p.add_argument("--child-pidfile", default="")
+p.add_argument("--spawn-child", action="store_true")
+p.add_argument("--child-setsid", action="store_true")
+p.add_argument("--reap-on-term", action="store_true")
+p.add_argument("--ignore-sigterm", action="store_true")
+p.add_argument("--ttl", type=float, default=30.0)
+# The LEADER's own lifetime, when it must differ from the child's. Defaults to --ttl, so
+# every existing caller is unaffected. A shorter value is the crash shape: the leader exits
+# on its own while the worker it forked is still running, which is the one state
+# ``terminate`` used to return from without sweeping the group.
+p.add_argument("--leader-ttl", type=float, default=-1.0)
+a = p.parse_args()
+
+if a.pidfile:
+    Path(a.pidfile).write_text(str(os.getpid()))
+
+# Holds the escaped child's pid so the SIGTERM handler can reap its group,
+# modelling the real backend, whose kiro-cli workers setsid into their own
+# session and are reaped by the backend's own graceful shutdown.
+_child = {}
+
+def _on_term(*_):
+    if a.reap_on_term and _child.get("pid"):
+        try:
+            os.killpg(_child["pid"], signal.SIGKILL)  # setsid child: pgid == pid
+        except ProcessLookupError:
+            pass
+    sys.exit(0)
+
+if a.ignore_sigterm:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+else:
+    signal.signal(signal.SIGTERM, _on_term)
+
+lsock = None
+if a.port:
+    lsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    lsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    lsock.bind(("127.0.0.1", a.port))
+    lsock.listen(16)
+
+if a.spawn_child:
+    pid = os.fork()
+    if pid == 0:
+        # Child. With --child-setsid it becomes its own session/group leader,
+        # escaping the parent's process group exactly as a kiro-cli worker does.
+        if a.child_setsid:
+            os.setsid()
+        if a.child_pidfile:
+            Path(a.child_pidfile).write_text(str(os.getpid()))
+        signal.signal(signal.SIGTERM, signal.SIG_IGN if a.ignore_sigterm else signal.SIG_DFL)
+        time.sleep(a.ttl)
+        os._exit(0)
+    else:
+        _child["pid"] = pid
+
+if a.port and a.run_dir:
+    time.sleep(a.secret_delay)
+    Path(a.run_dir).mkdir(parents=True, exist_ok=True)
+    (Path(a.run_dir) / ("gateway-%d.secret" % a.port)).write_text(a.secret)
+
+deadline = time.time() + (a.ttl if a.leader_ttl < 0 else a.leader_ttl)
+while time.time() < deadline:
+    if lsock:
+        lsock.settimeout(0.2)
+        try:
+            conn, _ = lsock.accept()
+            conn.close()
+        except socket.timeout:
+            pass
+        except OSError:
+            break
+    else:
+        time.sleep(0.2)
+"""
+
+
+def write_fake_backend(dir_: Path) -> Path:
+    path = Path(dir_) / "fake_backend.py"
+    path.write_text(FAKE_BACKEND_SRC)
+    return path
+
+
+def fake_argv(script: Path, **kwargs) -> list[str]:
+    """Build argv for the fake backend. Bools are flags; others are --k v."""
+    argv = [sys.executable, str(script)]
+    for key, value in kwargs.items():
+        flag = "--" + key.replace("_", "-")
+        if isinstance(value, bool):
+            if value:
+                argv.append(flag)
+        else:
+            argv += [flag, str(value)]
+    return argv
+
+
+def pid_alive(pid: int) -> bool:
+    # This is host-side test code, not container image source: the Dockerfile
+    # copies only `container/`, so `kiro_crew` is importable here. Route the
+    # liveness check through the shim rather than a raw `os.kill(pid, 0)` probe,
+    # which on Windows TerminateProcess()es the pid it is asking about instead
+    # of testing it. `pid_exists` keeps the POSIX semantics this helper relied
+    # on (EPERM means alive, not gone).
+    from kiro_crew.platform_compat import pid_exists
+
+    return pid_exists(pid)
+
+
+def free_port() -> int:
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_main.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_main.py
@@ -1,0 +1,257 @@
+"""Tests for ``container.supervisor.__main__`` -- the startup ORDER and the drained
+teardown order.
+
+The backup subsystem was extracted from this PR, so there is no restore phase and no
+sidecar: the supervisor gates the environment, installs the bundle, starts the backend,
+waits for readiness, starts the front, and drains front then backend at teardown. The seams
+are stubbed; the point here is the ordering guarantees, proven by the recorded call sequence.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+
+import pytest
+from container.common import ConfigError, Settings
+from container.supervisor import __main__ as entry
+from container.supervisor import backend as backend_mod
+from container.supervisor.backend import require_api_key as _real_require_api_key
+from container.supervisor.bundle import install_bundle as _real_install_bundle
+
+
+def make_settings(tmp_path: Path, *, bucket: str | None = "smc-test-bucket") -> Settings:
+    """Settings for the supervise phase.
+
+    ``bucket`` still exists because the front's on-demand transcript fetch reads it; it no
+    longer gates a sidecar (there is none). It defaults to a value so the transcript-read
+    configuration is exercised; pass ``bucket=None`` for the no-bucket case.
+    """
+    data_home = tmp_path / "data"
+    return Settings(
+        backend_port=8765,
+        backend_run_dir=data_home / "run",
+        front_port=8080,
+        route_prefix="",
+        control_secret=None,
+        data_home=data_home,
+        config_dir=data_home,  # Kiro Crew keeps everything under one root
+        crew_name="test-crew",
+        backup_bucket=bucket,
+        backup_prefix="crews/",
+    )
+
+
+class FakePG:
+    def __init__(self, name, events):
+        self.name = name
+        self._events = events
+        # _teardown excludes the known children from its orphan sweep by pid, so the double
+        # has to answer that too. A real pid, this process's own, because the sweep compares
+        # against live /proc entries and an invented number could collide with a real process.
+        self.pid = os.getpid()
+
+    def poll(self):
+        return None
+
+    def returncode(self):
+        return None
+
+    def terminate(self, drain_timeout, poll_interval=0.05):
+        self._events.append(f"term:{self.name}")
+        return 0
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Stub every seam and record the order calls happen in."""
+    events: list[str] = []
+
+    def fake_start_backend(settings, *, env=None, **kw):
+        events.append("start_backend")
+        return FakePG("backend", events)
+
+    def fake_wait_ready(settings, timeout, *, process=None, poll_interval=0.25):
+        events.append("wait_ready")
+
+    def fake_start_front(settings):
+        events.append("start_front")
+        return FakePG("front", events)
+
+    monkeypatch.setattr(backend_mod, "start_backend", fake_start_backend)
+    monkeypatch.setattr(backend_mod, "wait_until_ready", fake_wait_ready)
+    monkeypatch.setattr(entry, "_start_front", fake_start_front)
+    # Neutralise the environment gates for the ORDERING tests; each has its own
+    # dedicated test below.
+    monkeypatch.setattr(backend_mod, "build_backend_env", lambda settings: {})
+    monkeypatch.setattr(backend_mod, "require_api_key", lambda env: None)
+    monkeypatch.setattr(entry, "verify_sandbox", lambda settings, **kw: None)
+    monkeypatch.setattr(entry.bundle_mod, "install_bundle", lambda settings, **kw: None)
+    return events
+
+
+def test_backend_is_ready_before_the_front_starts(wired, tmp_path):
+    entry.run(make_settings(tmp_path), wait_for_shutdown=lambda children: "signal")
+    assert wired.index("wait_ready") < wired.index("start_front")
+
+
+def test_full_happy_path_order(wired, tmp_path):
+    entry.run(make_settings(tmp_path), wait_for_shutdown=lambda children: "signal")
+    startup = [e for e in wired if not e.startswith("term:")]
+    assert startup == [
+        "start_backend",
+        "wait_ready",
+        "start_front",
+    ]
+
+
+def test_teardown_drains_front_then_backend(wired, tmp_path):
+    entry.run(make_settings(tmp_path), wait_for_shutdown=lambda children: "signal")
+    teardown = [e for e in wired if e.startswith("term:")]
+    assert teardown == ["term:front", "term:backend"]
+
+
+def test_readiness_failure_tears_down_backend_and_never_starts_the_front(
+    wired, tmp_path, monkeypatch
+):
+    def not_ready(settings, timeout, *, process=None, poll_interval=0.25):
+        wired.append("wait_ready")
+        raise backend_mod.BackendReadyTimeout("nope")
+
+    monkeypatch.setattr(backend_mod, "wait_until_ready", not_ready)
+    with pytest.raises(backend_mod.BackendReadyTimeout):
+        entry.run(make_settings(tmp_path), wait_for_shutdown=lambda c: "signal")
+
+    assert "start_front" not in wired
+    # The backend we started is drained rather than orphaned.
+    assert "term:backend" in wired
+
+
+def test_teardown_runs_even_if_supervise_raises(wired, tmp_path):
+    def blow_up(children):
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        entry.run(make_settings(tmp_path), wait_for_shutdown=blow_up)
+    # Both were still drained.
+    assert {"term:front", "term:backend"} <= set(wired)
+
+
+# --- verify_layout (the Dockerfile open item) ------------------------------
+
+
+def test_verify_layout_accepts_the_single_root_layout(tmp_path):
+    entry.verify_layout(make_settings(tmp_path))  # must not raise
+
+
+def test_verify_layout_rejects_a_config_subdir(tmp_path):
+    # SMC_CONFIG_DIR=<home>/config is where common defaults it today, but the
+    # backend writes open_slots.json / session_map.json at the home ROOT.
+    s = make_settings(tmp_path)
+    bad = dataclasses.replace(s, config_dir=s.data_home / "config")
+    with pytest.raises(ConfigError, match="SMC_CONFIG_DIR"):
+        entry.verify_layout(bad)
+
+
+def test_verify_layout_rejects_a_stray_run_dir(tmp_path):
+    s = make_settings(tmp_path)
+    bad = dataclasses.replace(s, backend_run_dir=s.data_home / "elsewhere")
+    with pytest.raises(ConfigError, match="SMC_BACKEND_RUN_DIR"):
+        entry.verify_layout(bad)
+
+
+def test_run_verifies_layout_before_starting_the_backend(wired, tmp_path, monkeypatch):
+    # A bad layout must abort before the backend starts.
+    s = make_settings(tmp_path)
+    bad = dataclasses.replace(s, config_dir=s.data_home / "config")
+    with pytest.raises(ConfigError):
+        entry.run(bad, wait_for_shutdown=lambda c: "signal")
+    assert "start_backend" not in wired
+
+
+# --- yolo precondition: home must not be a default/live home ---------------
+
+
+def test_verify_layout_rejects_a_default_home(tmp_path, monkeypatch):
+    # SMC_DATA_HOME resolving to ~/.kiro/crew would make --approval yolo refuse.
+    fake_home = tmp_path / "fakehome"
+    (fake_home / ".kiro" / "crew").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+    s = make_settings(tmp_path)
+    bad = dataclasses.replace(
+        s,
+        data_home=fake_home / ".kiro" / "crew",
+        config_dir=fake_home / ".kiro" / "crew",
+        backend_run_dir=fake_home / ".kiro" / "crew" / "run",
+    )
+    with pytest.raises(ConfigError, match="default/live"):
+        entry.verify_layout(bad)
+
+
+# --- verify_sandbox --------------------------------------------------------
+
+
+def test_verify_sandbox_ok_when_namespaces_available(tmp_path):
+    entry.verify_sandbox(make_settings(tmp_path), probe=lambda: entry.SANDBOX_AVAILABLE)
+
+
+def test_verify_sandbox_refuses_when_the_probe_cannot_answer(tmp_path):
+    # An undetermined probe refuses like a denial: sandboxed-only means the guard may
+    # never proceed on the absence of an answer, only on a positive one.
+    verdict = f"{entry.SANDBOX_UNDETERMINED_PREFIX}this platform has no os.unshare"
+    with pytest.raises(ConfigError, match="could not be determined"):
+        entry.verify_sandbox(make_settings(tmp_path), probe=lambda: verdict)
+
+
+def test_verify_sandbox_fails_loud_when_no_user_namespace(tmp_path):
+    # Sandboxed-only: no user namespace means refuse to start. There is no opt-in
+    # escape, and the message must not point at the removed config key.
+    with pytest.raises(ConfigError, match="sandboxed-only") as exc:
+        entry.verify_sandbox(make_settings(tmp_path), probe=lambda: entry.SANDBOX_DENIED)
+    assert "sandbox_allow_unsandboxed_exec" not in str(exc.value)
+
+
+# --- run() aborts on a missing credential before the backend starts --------
+
+
+def test_run_refuses_without_api_key_before_the_backend(wired, tmp_path, monkeypatch):
+    # Undo wired's neutralised gates so the real credential check runs against
+    # an env with no KIRO_API_KEY.
+    monkeypatch.setattr(backend_mod, "build_backend_env", lambda settings: {})
+    monkeypatch.setattr(backend_mod, "require_api_key", _real_require_api_key)
+    with pytest.raises(ConfigError, match="KIRO_API_KEY"):
+        entry.run(make_settings(tmp_path), wait_for_shutdown=lambda c: "signal")
+    assert "start_backend" not in wired
+
+
+# --- run() installs the crew bundle before the backend starts --------------
+
+
+def test_run_installs_the_bundle_before_the_backend_starts(wired, tmp_path, monkeypatch):
+    # Undo wired's no-op install and record the call in the sequence instead.
+    def recording_install(settings, **kw):
+        wired.append("install_bundle")
+
+    monkeypatch.setattr(entry.bundle_mod, "install_bundle", recording_install)
+    entry.run(make_settings(tmp_path), wait_for_shutdown=lambda c: "signal")
+    assert "install_bundle" in wired
+    assert wired.index("install_bundle") < wired.index("start_backend")
+
+
+def test_run_refuses_a_bad_bundle_before_the_backend(wired, tmp_path, monkeypatch):
+    # Real install_bundle against a bundle dir that does not exist: run() must
+    # abort before the backend starts.
+    monkeypatch.setattr(entry.bundle_mod, "install_bundle", _real_install_bundle)
+    s = make_settings(tmp_path)
+    bad = dataclasses.replace(s, bundle_dir=tmp_path / "nope")
+    with pytest.raises(ConfigError, match="bundle dir present"):
+        entry.run(bad, wait_for_shutdown=lambda c: "signal")
+    assert "start_backend" not in wired
+
+
+def test_no_bucket_still_boots(wired, tmp_path):
+    # No bucket means the front's transcript fetch reads nothing, not a boot failure.
+    entry.run(make_settings(tmp_path, bucket=None), wait_for_shutdown=lambda c: "signal")
+    assert "start_backend" in wired
+    assert "start_front" in wired

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_process.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_process.py
@@ -1,0 +1,260 @@
+"""Tests for ``container.supervisor.process`` -- process-group launch and drain.
+
+These use real OS processes (never a Kiro Crew gateway) so that killpg,
+grandchild reaping and SIGKILL escalation are exercised for real.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+
+from container.supervisor.process import spawn_process_group
+
+from .test_supervisor_fakes import (
+    fake_argv,
+    pid_alive,
+    write_fake_backend,
+)
+
+
+def _wait_for(path, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def test_terminate_reaps_the_whole_group_including_a_grandchild(tmp_path):
+    # A launcher plus a forked grandchild -- the two-process shape a real
+    # kiro-cli worker has. Draining must take out both.
+    script = write_fake_backend(tmp_path)
+    parent_pidfile = tmp_path / "parent.pid"
+    child_pidfile = tmp_path / "child.pid"
+    pg = spawn_process_group(
+        "backend",
+        fake_argv(
+            script,
+            pidfile=parent_pidfile,
+            child_pidfile=child_pidfile,
+            spawn_child=True,
+            ttl=30,
+        ),
+    )
+    assert _wait_for(parent_pidfile) and _wait_for(child_pidfile)
+    child_pid = int(child_pidfile.read_text())
+
+    pg.terminate(drain_timeout=5.0)
+
+    assert pg.poll() is not None
+    # The orphan that would survive a pid-only kill is gone.
+    deadline = time.monotonic() + 3.0
+    while pid_alive(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert not pid_alive(child_pid), "grandchild survived group teardown"
+
+
+def test_terminate_drains_a_cooperative_child_without_sigkill(tmp_path):
+    # The child exits cleanly on SIGTERM well within the drain window.
+    script = write_fake_backend(tmp_path)
+    pidfile = tmp_path / "p.pid"
+    pg = spawn_process_group("backend", fake_argv(script, pidfile=pidfile, ttl=30))
+    assert _wait_for(pidfile)
+
+    t0 = time.monotonic()
+    code = pg.terminate(drain_timeout=5.0)
+    elapsed = time.monotonic() - t0
+
+    assert code == 0, "cooperative child should exit 0 on SIGTERM"
+    assert elapsed < 4.0, "should not have waited out the whole drain window"
+
+
+def test_terminate_escalates_to_sigkill_when_sigterm_is_ignored(tmp_path):
+    # A child that ignores SIGTERM must still be gone after the drain window.
+    script = write_fake_backend(tmp_path)
+    pidfile = tmp_path / "p.pid"
+    pg = spawn_process_group(
+        "backend", fake_argv(script, pidfile=pidfile, ignore_sigterm=True, ttl=30)
+    )
+    assert _wait_for(pidfile)
+
+    code = pg.terminate(drain_timeout=0.5)
+
+    assert pg.poll() is not None
+    # SIGKILL shows up as a negative return code equal to -SIGKILL.
+    assert code == -9, f"expected SIGKILL escalation, got {code}"
+
+
+def test_terminate_is_idempotent_on_an_already_dead_group(tmp_path):
+    script = write_fake_backend(tmp_path)
+    pg = spawn_process_group("backend", fake_argv(script, ttl=0.2))
+    # Let it exit on its own.
+    deadline = time.monotonic() + 3.0
+    while pg.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert pg.poll() is not None
+    # A second teardown must not raise.
+    pg.terminate(drain_timeout=1.0)
+
+
+# --- Escaped-worker topology -----------------------------------------------
+# A real kiro-cli worker spawns with start_new_session (runtime.py:1321), so it
+# setsid's into its OWN process group and ESCAPES the backend's group. These two
+# tests model that: killpg of the backend group cannot reach the worker, so the
+# worker is reaped by the backend's own SIGTERM shutdown -- which is why the
+# supervisor DRAINS the backend (SIGTERM, wait) before it ever SIGKILLs.
+
+
+def test_drain_reaps_a_worker_that_escaped_into_its_own_session(tmp_path):
+    # Backend spawns a setsid child (an "escaped worker") and, like the real
+    # gateway, reaps it on SIGTERM. Draining must leave nothing behind.
+    script = write_fake_backend(tmp_path)
+    ppf, cpf = tmp_path / "b.pid", tmp_path / "w.pid"
+    pg = spawn_process_group(
+        "backend",
+        fake_argv(
+            script,
+            pidfile=ppf,
+            child_pidfile=cpf,
+            spawn_child=True,
+            child_setsid=True,
+            reap_on_term=True,
+            ttl=30,
+        ),
+    )
+    assert _wait_for(ppf) and _wait_for(cpf)
+    worker = int(cpf.read_text())
+    # The worker really is in a different process group than the backend.
+    assert os.getpgid(worker) != pg.pgid
+
+    pg.terminate(drain_timeout=5.0)
+
+    assert pg.poll() is not None
+    deadline = time.monotonic() + 3.0
+    while pid_alive(worker) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert not pid_alive(worker), "backend's drain should have reaped the escaped worker"
+
+
+def test_group_kill_alone_cannot_reach_an_escaped_worker(tmp_path):
+    # Documents the limitation the drain exists to cover: if the backend never
+    # reaps (here it ignores SIGTERM and is SIGKILLed), killpg of the backend's
+    # group does NOT reach a worker that setsid'd out. The supervisor must rely
+    # on the backend's graceful shutdown, not on the group kill, for workers.
+    script = write_fake_backend(tmp_path)
+    ppf, cpf = tmp_path / "b.pid", tmp_path / "w.pid"
+    pg = spawn_process_group(
+        "backend",
+        fake_argv(
+            script,
+            pidfile=ppf,
+            child_pidfile=cpf,
+            spawn_child=True,
+            child_setsid=True,
+            ignore_sigterm=True,
+            ttl=6,
+        ),
+    )
+    assert _wait_for(ppf) and _wait_for(cpf)
+    worker = int(cpf.read_text())
+    try:
+        pg.terminate(drain_timeout=0.5)  # SIGTERM ignored -> SIGKILL the backend group
+        assert pg.poll() is not None
+        # The escaped worker is in its own group, so the backend-group SIGKILL
+        # never touched it.
+        assert pid_alive(worker), "escaped worker unexpectedly died from group kill"
+    finally:
+        try:
+            os.killpg(worker, signal.SIGKILL)  # its own group leader: pgid == pid
+        except ProcessLookupError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# A leader that exited on its own must still have its group swept.
+#
+# ``terminate`` has three return paths and two of them swept the group with SIGKILL. The
+# one that did not was the first: the leader had already exited before ``terminate`` was
+# called. That is the CRASH case, and it is where the sweep matters most, because the
+# caller's next act is ``_final_backup_cycle`` -- so a worker that survived is still
+# writing while its own transcript is uploaded.
+#
+# The asymmetry was visible inside the function. The drain path carried the comment
+# "Leader drained; sweep the group in case a grandchild lingers", which is the same state
+# the early return was in, reaching the opposite conclusion.
+# ---------------------------------------------------------------------------
+
+
+def _crashed_leader_with_a_live_worker(tmp_path):
+    """A leader that exits while the worker it forked keeps running."""
+    script = write_fake_backend(tmp_path)
+    child_pidfile = tmp_path / "worker.pid"
+    group = spawn_process_group(
+        "backend",
+        fake_argv(
+            script,
+            run_dir=tmp_path,
+            spawn_child=True,
+            child_pidfile=child_pidfile,
+            # The worker outlives any drain window used here; the leader leaves at once.
+            ttl=120,
+            leader_ttl=0,
+        ),
+        cwd=str(tmp_path),
+    )
+    assert _wait_for(child_pidfile), "the fake worker never recorded its pid"
+    worker_pid = int(child_pidfile.read_text())
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and group.leader.poll() is None:
+        time.sleep(0.02)
+    assert group.leader.poll() is not None, "the leader should have exited on its own"
+    assert pid_alive(worker_pid), "the worker should still be running"
+    return group, worker_pid
+
+
+def _await_gone(pid, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not pid_alive(pid):
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def test_a_worker_left_by_a_crashed_leader_is_swept(tmp_path):
+    """The escaped worker must be gone once terminate returns."""
+    group, worker_pid = _crashed_leader_with_a_live_worker(tmp_path)
+    try:
+        code = group.terminate(0.5)
+        assert code == 0, "the leader's own exit code must still be reported"
+        assert _await_gone(worker_pid), "the worker survived a crashed leader's teardown"
+    finally:
+        try:
+            os.kill(worker_pid, signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass
+
+
+def test_the_crash_test_drives_the_already_exited_path(tmp_path):
+    """Non-vacuity: prove the test above exercises the EARLY RETURN, not the drain loop.
+
+    Without this, a fixture whose leader was still alive would pass through the drain path,
+    which always swept, and the early return would stay untested. A drain window far longer
+    than the assertion tolerates is the discriminator: only the early return can beat it.
+    """
+    group, worker_pid = _crashed_leader_with_a_live_worker(tmp_path)
+    try:
+        assert group.poll() is not None, "poll() must already report an exit"
+        started = time.monotonic()
+        group.terminate(30.0)
+        elapsed = time.monotonic() - started
+        assert elapsed < 5.0, f"took {elapsed:.1f}s, so it waited on the drain loop"
+    finally:
+        try:
+            os.kill(worker_pid, signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass

--- a/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_sandbox.py
+++ b/src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_sandbox.py
@@ -1,0 +1,162 @@
+"""Tests for the sandbox guard.
+
+This container runs SANDBOXED-ONLY. kiro-cli runs the model subprocess inside an
+unprivileged user namespace; without one, ``wrap_argv`` fails closed. There is no
+opt-in to run unsandboxed, because the worker holds the model credential
+(``KIRO_API_KEY``) and auto-approves every tool -- an unsandboxed worker on
+untrusted prompt content would be a credential-exfiltration path. So on a host
+without a user namespace the container refuses to start rather than run the model
+subprocess exposed. These pin that: it refuses when the probe reports no
+namespace, it refuses when the probe cannot reach an answer at all, and it
+proceeds only on a positive verdict.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from container.common import Settings
+from container.common.config import ConfigError, _bool
+from container.supervisor import __main__ as entry
+
+
+def make_settings(tmp_path: Path) -> Settings:
+    data_home = tmp_path / "data"
+    data_home.mkdir(parents=True, exist_ok=True)
+    return Settings(
+        backend_port=8765,
+        backend_run_dir=data_home / "run",
+        front_port=8080,
+        route_prefix="",
+        control_secret=None,
+        data_home=data_home,
+        config_dir=data_home,
+        crew_name="test-crew",
+        backup_bucket=None,
+        backup_prefix="",
+    )
+
+
+def test_the_guard_refuses_when_no_user_namespace_is_available(tmp_path: Path) -> None:
+    """No sandbox and no opt-in escape: the container must refuse to start.
+
+    This is the whole point of the sandboxed-only posture. There is deliberately
+    no config key or env var that lets a deployment run the model subprocess
+    unsandboxed, so the only safe answer on a host without a user namespace
+    (Fargate today) is to refuse.
+    """
+    settings = make_settings(tmp_path)
+    with pytest.raises(ConfigError, match="sandboxed-only"):
+        entry.verify_sandbox(settings, probe=lambda: entry.SANDBOX_DENIED)
+
+
+def test_the_refusal_names_the_missing_sandbox_not_a_missing_opt_in(tmp_path: Path) -> None:
+    """The message must not point the operator at an opt-in that does not exist.
+
+    An unsandboxed posture would tell operators to set
+    ``agent.sandbox_allow_unsandboxed_exec``; a message still saying that would
+    send them to a dead knob. It must name the missing user namespace instead.
+    """
+    settings = make_settings(tmp_path)
+    with pytest.raises(ConfigError) as exc:
+        entry.verify_sandbox(settings, probe=lambda: entry.SANDBOX_DENIED)
+    assert "sandbox_allow_unsandboxed_exec" not in str(exc.value)
+
+
+def test_a_host_with_namespaces_starts(tmp_path: Path) -> None:
+    entry.verify_sandbox(make_settings(tmp_path), probe=lambda: entry.SANDBOX_AVAILABLE)
+
+
+def test_an_undetermined_probe_refuses(tmp_path: Path) -> None:
+    """A probe that could not reach an answer must refuse, not proceed.
+
+    A host where the probe cannot run is not a host where the sandbox is known to be
+    missing, and treating that as permission to continue is the same defect as reading
+    the backend environment through a denylist: it holds for the cases someone already
+    enumerated and fails OPEN on the next one. Failing open here means booting a worker
+    that auto-approves every tool and holds the model credential with no evidence that a
+    sandbox exists, so undetermined refuses exactly as a denial does.
+    """
+    verdict = f"{entry.SANDBOX_UNDETERMINED_PREFIX}the probe could not fork a child"
+    with pytest.raises(ConfigError, match="could not be determined"):
+        entry.verify_sandbox(make_settings(tmp_path), probe=lambda: verdict)
+
+
+def test_an_undetermined_refusal_repeats_what_could_not_be_determined(tmp_path: Path) -> None:
+    """An operator needs the specific reason, not just that there was one.
+
+    'Something went wrong with the sandbox probe' is unactionable; 'this platform has
+    no os.unshare' and 'the probe child was killed by signal 9' lead to different
+    fixes. The verdict is carried into the refusal verbatim so the message names
+    which one it was.
+    """
+    verdict = (
+        f"{entry.SANDBOX_UNDETERMINED_PREFIX}the probe child was killed by signal 9 "
+        "before it could answer"
+    )
+    with pytest.raises(ConfigError) as exc:
+        entry.verify_sandbox(make_settings(tmp_path), probe=lambda: verdict)
+    assert "killed by signal 9" in str(exc.value)
+
+
+def test_an_unrecognised_verdict_refuses(tmp_path: Path) -> None:
+    """The guard fails closed on any verdict it does not know.
+
+    Only ``SANDBOX_AVAILABLE`` proceeds. A verdict added later, a typo, or a stubbed
+    probe returning something else entirely all land on the refusal, so extending the
+    probe cannot accidentally open the gate -- the direction a security guard must
+    fail in when someone adds a case and forgets this call site.
+    """
+    for bogus in ("AVAILABLE", "yes", "", None, True):
+        with pytest.raises(ConfigError):
+            entry.verify_sandbox(make_settings(tmp_path), probe=lambda value=bogus: value)
+
+
+def test_the_real_probe_returns_a_verdict_this_guard_understands() -> None:
+    """The shipped probe and the guard must not drift apart.
+
+    Both halves are in this module, and the guard now treats an unknown verdict as a
+    refusal -- which means a probe that started returning something else would make
+    the container refuse to boot everywhere rather than fail a test. Pin the contract
+    here: whatever this host is, the real probe's answer is one the guard recognises.
+    """
+    verdict = entry._user_namespaces_available()
+    assert verdict in (entry.SANDBOX_AVAILABLE, entry.SANDBOX_DENIED) or verdict.startswith(
+        entry.SANDBOX_UNDETERMINED_PREFIX
+    )
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("true", True),
+        ("TRUE", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        (" true ", True),
+    ],
+)
+def test_bool_accepts_the_spellings_a_template_may_produce(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: bool
+) -> None:
+    monkeypatch.setenv("SMC_PROBE_BOOL", raw)
+    assert _bool("SMC_PROBE_BOOL", False) is expected
+
+
+@pytest.mark.parametrize("raw", ["ture", "${SinglePrincipal}", "maybe", "2"])
+def test_bool_refuses_a_value_it_cannot_read(monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+    """Reading a typo as "no" is the safe direction but hides a broken deployment.
+
+    An unresolved CloudFormation reference is the realistic case: it would leave
+    the setting at its safe default with nothing pointing at the parameter that
+    failed to resolve.
+    """
+    monkeypatch.setenv("SMC_PROBE_BOOL", raw)
+    with pytest.raises(ConfigError, match="must be a boolean"):
+        _bool("SMC_PROBE_BOOL", False)

--- a/test/metrics/test_session_duration.py
+++ b/test/metrics/test_session_duration.py
@@ -1226,6 +1226,25 @@ class TestEveryRegistryRemovalRecordsAnEnd:
         for path in sorted(root.rglob("*.py")):
             if "__pycache__" in path.parts:
                 continue
+            rel_parts = path.relative_to(root).parts
+            # A container image's build context, under ``apps/builtins/<app>/crew/runtime/**``.
+            # This walk hands each hit to ``importlib.import_module``, and that tree is the
+            # one place under ``src/kiro_crew`` that must never be imported from here:
+            # ``test_spawn_audit.py::test_container_image_assets_are_not_imported`` forbids
+            # it, and the tree could not satisfy the import anyway, since it assumes the
+            # image's installed layout and its modules import the image's own runtime
+            # dependencies (httpx, fastapi), which ``container/requirements.txt`` marks as
+            # deliberately absent from this application's environment.
+            #
+            # This does not weaken the discovered-not-listed property the docstring
+            # defends. That property is about GATEWAY removal paths, and nothing in an
+            # image that runs on Fargate participates in this process's session registry.
+            if (
+                rel_parts[:2] == ("apps", "builtins")
+                and "crew" in rel_parts
+                and "runtime" in rel_parts
+            ):
+                continue
             try:
                 if "_sessions" not in path.read_text(encoding="utf-8"):
                     continue
@@ -1310,6 +1329,31 @@ class TestEveryRegistryRemovalRecordsAnEnd:
         removals = self._removal_functions("session_lifecycle")
         assert removals, "the AST walk found no registry removals at all"
         assert "drain_all_providers" in removals, "the mass-pop path must be in scope"
+
+    def test_the_container_image_tree_is_excluded_and_that_exclusion_is_needed(self):
+        """The image-tree skip must be load-bearing, not a line that matches nothing.
+
+        An exclusion matching no file would pass this gate while protecting nothing, and
+        would quietly stop protecting it the day the tree grew a match. So assert both
+        halves: files under the image tree DO contain the registry name this walk keys
+        on, and none of them reached the discovered list, where ``import_module`` would
+        have tried to import a tree that cannot be imported from this process.
+        """
+        import kiro_crew
+
+        root = Path(kiro_crew.__file__).resolve().parent
+        image_root = root / "apps" / "builtins" / "aws_control" / "crew" / "runtime"
+        matching = [
+            p
+            for p in image_root.rglob("*.py")
+            if "__pycache__" not in p.parts and "_sessions" in p.read_text(encoding="utf-8")
+        ]
+        assert matching, (
+            "no file under the image tree mentions the registry, so the skip in "
+            "_owning_modules is vacuous -- remove it or re-point it"
+        )
+        leaked = [m for m in self._owning_modules() if "crew.runtime" in m]
+        assert not leaked, f"the image tree reached an import-based walk: {leaked}"
 
 
 class TestTeardownPathsAreWired:

--- a/test/test_agent_home_isolation.py
+++ b/test/test_agent_home_isolation.py
@@ -736,6 +736,13 @@ _LITERAL_RE = re.compile(r'"\.kiro"\s*/\s*"agents"' r"|[\"']\.kiro/agents")
 _ALLOWED = {
     "config/paths.py",
     "security/paths.py",
+    # A third case, and a different kind. The AWS Control crew container runs as its
+    # own process inside a Linux image where ``kiro_crew`` is not importable, so
+    # ``supervisor/bundle.py`` re-implements this resolver rather than calling it.
+    # The exempt file is that module's own TEST, which asserts what the
+    # re-implementation returns against a tmp_path: it neither reads nor writes the
+    # owner's home.
+    "apps/builtins/aws_control/crew/runtime/container_tests/test_supervisor_bundle.py",
 }
 
 

--- a/test/test_ci_surface_tests.py
+++ b/test/test_ci_surface_tests.py
@@ -13,8 +13,12 @@ ships green.
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
+import sys
+import types
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -475,6 +479,7 @@ def test_explicit_cli_target_bypasses_collect_ignore(tmp_path) -> None:
             cwd=tmp_path,
             capture_output=True,
             text=True,
+            encoding="utf-8",
         ).returncode
 
     assert run(str(suite)) == 0, "recursive collection should honour collect_ignore"
@@ -535,3 +540,136 @@ def test_windows_filter_is_scoped_to_the_test_root(tmp_path, monkeypatch) -> Non
         "a same-named suite outside test/ is not covered by conftest's "
         f"collect_ignore and must keep running on Windows; got {selected}"
     )
+
+
+# --- container image test suite: image-only-dependency collection guard ---------
+#
+# The crew container image's test suite lives under
+# ``src/kiro_crew/apps/builtins/aws_control/crew/runtime/container_tests`` and is
+# reached by ``setup.cfg``'s ``testpaths = ... src/kiro_crew/apps/builtins``. Four
+# of its modules ``import httpx`` (and one ``fastapi``/``uvicorn``) at module top
+# level -- deps that ``container/requirements.txt`` marks "Container runtime only.
+# These must NOT become dependencies of the Kiro Crew app itself", so the app's own
+# CI env does not carry them. Its conftest therefore sets ``collect_ignore_glob`` to
+# skip the suite when those collection-time deps are absent, rather than raising a
+# ``ModuleNotFoundError`` at collection that cascades every backend shard. These
+# pin that guard: it must skip on a missing dep, and it must NOT skip when all are
+# present (or the 309 tests silently stop running everywhere).
+
+_CONTAINER_CONFTEST = (
+    _REPO_ROOT
+    / "src"
+    / "kiro_crew"
+    / "apps"
+    / "builtins"
+    / "aws_control"
+    / "crew"
+    / "runtime"
+    / "container_tests"
+    / "conftest.py"
+)
+
+
+def _os_reporting(name: str):
+    """A stand-in ``os`` module whose ``name`` is *name*, for ``sys.modules``.
+
+    ``mock.patch.object(os, "name", ...)`` cannot be used here. ``pathlib.Path.__new__``
+    consults ``os.name`` on EVERY instantiation to pick ``PosixPath`` or ``WindowsPath``,
+    and the conftest calls ``Path(__file__).resolve()``, so patching the real attribute
+    makes that line raise ``cannot instantiate 'WindowsPath' on your system`` -- in both
+    directions, since a Windows runner patched to ``posix`` fails the mirror way.
+
+    Swapping the module that the conftest's own ``import os`` resolves to keeps the
+    change inside the module under test: ``pathlib`` bound the real ``os`` object when it
+    was first imported and never looks it up again.
+    """
+    proxy = types.ModuleType("os")
+    proxy.__dict__.update(vars(os))
+    # Through ``__dict__`` rather than ``proxy.name``: mypy types a ``ModuleType``
+    # attribute set by the stub for the real ``os``, so the direct assignment is an
+    # ``attr-defined`` error on a line that is doing exactly what it means to.
+    proxy.__dict__["name"] = name
+    return proxy
+
+
+def _run_container_conftest(*, present: set[str], os_name: str = "posix"):
+    """Load the container conftest as a module with ``find_spec`` reporting only ``present``.
+
+    Uses the same ``spec_from_file_location`` + ``exec_module`` mechanism as
+    ``_load_selector`` above, so the conftest's module-level guard runs and its
+    ``collect_ignore_glob`` / ``_missing_image_deps`` can be read back. Returns the
+    loaded module.
+    """
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *a, **k):
+        if name in {"fastapi", "httpx", "uvicorn", "boto3"}:
+            return object() if name in present else None
+        return real_find_spec(name, *a, **k)
+
+    spec = importlib.util.spec_from_file_location(
+        "container_conftest_under_test", _CONTAINER_CONFTEST
+    )
+    assert spec and spec.loader, "could not build an import spec for the container conftest"
+    module = importlib.util.module_from_spec(spec)
+    saved = importlib.util.find_spec
+    try:
+        importlib.util.find_spec = fake_find_spec  # type: ignore[assignment]
+        # Pin the platform the conftest sees, so what a caller measures is the branch it
+        # asked for. The conftest tests ``os.name`` BEFORE it tests the deps, so on a
+        # Windows runner ``collect_ignore_glob`` is set whatever ``present`` says, and
+        # every dep-branch assertion would be reading the platform branch's answer.
+        #
+        # Skipping those tests on Windows was the alternative and is worse: the
+        # dependency logic is not platform-specific, so a skip stops checking a live
+        # property on one platform while still scoring as a pass.
+        with mock.patch.dict(sys.modules, {"os": _os_reporting(os_name)}):
+            spec.loader.exec_module(module)
+    finally:
+        importlib.util.find_spec = saved  # type: ignore[assignment]
+    return module
+
+
+def test_container_suite_skipped_when_a_collect_time_dep_is_missing() -> None:
+    ns = _run_container_conftest(present={"fastapi", "uvicorn"})  # httpx missing
+    assert ns._missing_image_deps == ["httpx"]
+    assert getattr(ns, "collect_ignore_glob", None) == ["test_*.py"], (
+        "conftest must set collect_ignore_glob to skip the image suite when a "
+        "collection-time dep (httpx/fastapi/uvicorn) is absent"
+    )
+
+
+def test_container_suite_runs_when_all_collect_time_deps_present() -> None:
+    ns = _run_container_conftest(present={"fastapi", "httpx", "uvicorn"})
+    assert ns._missing_image_deps == []
+    assert getattr(ns, "collect_ignore_glob", None) is None, (
+        "conftest must NOT skip the image suite when every collection-time dep is "
+        "importable, or the 309 tests stop running where their subject can run"
+    )
+
+
+def test_the_platform_branch_wins_over_the_dep_branch() -> None:
+    """On a non-POSIX host the suite is skipped even with every dep importable.
+
+    The two branches answer different questions -- "can this subject run here at all"
+    and "are its imports satisfied" -- and the platform one has to win, because the
+    image is Linux-only however complete the dev env is. Ordering them the other way
+    would collect 309 POSIX-dependent tests on Windows whenever someone had installed
+    ``requirements-dev.txt`` there.
+    """
+    ns = _run_container_conftest(present={"fastapi", "httpx", "uvicorn"}, os_name="nt")
+    assert ns._missing_image_deps == [], "the dep branch had nothing to complain about"
+    assert getattr(ns, "collect_ignore_glob", None) == [
+        "test_*.py"
+    ], "the image suite must not be collected on a non-POSIX host, whatever its deps"
+
+
+def test_boto3_is_not_a_collect_time_gate() -> None:
+    """boto3 is imported lazily, so a venv without it must still run the suite.
+
+    Both ``backup/store.py`` and ``front/transcript.py`` import boto3 inside a
+    function. If boto3 were in the guard list, every AWS-free dev env would skip
+    the whole suite for a dependency that never blocks import.
+    """
+    ns = _run_container_conftest(present={"fastapi", "httpx", "uvicorn"})  # no boto3
+    assert getattr(ns, "collect_ignore_glob", None) is None

--- a/test/test_crew_container_config_isolation.py
+++ b/test/test_crew_container_config_isolation.py
@@ -1,0 +1,184 @@
+"""The crew container's own configuration must stay in step with the gateway.
+
+The container that a remote crew runs as serves exactly one caller: the customer's
+HTTP turn, through its front process. It has nobody to reach on a messaging channel,
+so it disables every transport before the backend starts -- by name in a config file
+it owns, and by refusing to pass a channel credential into the launch environment.
+It also refuses to run the model subprocess unsandboxed, and the gateway reads its
+sandbox mode and fallback flags from that same file, so the container writes those
+too rather than inheriting whatever arrives.
+
+All of that is lists of names, and a list of names is only as good as its last
+update. This file is what keeps them updated: it compares them against the
+gateway's own definitions -- ``builtin_channel_descriptors()`` for the channels and
+their credentials, ``AgentConfig``'s ``sandbox*`` fields for the sandbox settings. A
+channel or a sandbox knob added there reds this test until the container decides what
+to do about it, which is the difference between an isolation claim and an isolation
+that holds.
+
+The container's source is READ, never imported. ``crew/runtime/`` is a docker build
+context whose modules import each other as top-level ``container.*``, and
+``test_spawn_audit.py::test_container_image_assets_are_not_imported`` pins that the
+gateway never imports the tree. So the constants are pulled out of the file's AST.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_SRC = (
+    REPO_ROOT
+    / "src"
+    / "kiro_crew"
+    / "apps"
+    / "builtins"
+    / "aws_control"
+    / "crew"
+    / "runtime"
+    / "container"
+    / "supervisor"
+    / "backend.py"
+)
+
+
+def _literal(name: str) -> Any:
+    """The value assigned to a module-level constant, read from the source.
+
+    ``ast.literal_eval`` on the assigned node, so only a literal is accepted -- a
+    constant computed at import time would raise here rather than be silently read as
+    empty, which is the failure mode that would make this whole file vacuous.
+    """
+    tree = ast.parse(BACKEND_SRC.read_text(encoding="utf-8"))
+    for node in tree.body:
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        if not any(isinstance(t, ast.Name) and t.id == name for t in targets):
+            continue
+        value = getattr(node, "value", None)
+        assert value is not None, f"{name} has no assigned value"
+        if isinstance(value, ast.Call):  # frozenset({...}) and friends
+            assert len(value.args) == 1, f"{name} is a call this reader cannot evaluate"
+            return ast.literal_eval(value.args[0])
+        return ast.literal_eval(value)
+    raise AssertionError(f"{name} is not assigned at module level in {BACKEND_SRC}")
+
+
+@pytest.fixture(scope="module")
+def registry():
+    """The gateway's own channel roster, with each channel's credential variables."""
+    from kiro_crew.channels import builtin_channel_descriptors
+    from kiro_crew.messaging.registry import governed_members
+
+    descriptors = tuple(builtin_channel_descriptors())
+    assert descriptors, "the channel registry is empty; every assertion here would be vacuous"
+    return {
+        "members": set(governed_members(descriptors)),
+        "credentials": {name for d in descriptors for name in d.credentials},
+    }
+
+
+@pytest.fixture(scope="module")
+def sandbox_keys() -> set[str]:
+    """Every `agent` setting the gateway has whose name begins with ``sandbox``.
+
+    The rule is deliberately by PREFIX rather than a list of the three that exist
+    today. A sandbox knob added to `AgentConfig` then reds this test until the
+    container decides what to write for it, which is the only way a container that
+    refuses to run unsandboxed stays true as the gateway grows more ways to not be.
+    """
+    import dataclasses
+
+    from kiro_crew.config.sections import AgentConfig
+
+    keys = {f.name for f in dataclasses.fields(AgentConfig) if f.name.startswith("sandbox")}
+    assert keys, "no sandbox settings found on AgentConfig; this test would be vacuous"
+    return keys
+
+
+def test_the_container_disables_every_channel_the_gateway_can_start(registry) -> None:
+    sections = set(_literal("CHANNEL_SECTIONS"))
+    missing = sorted(registry["members"] - sections)
+    assert not missing, (
+        "the crew container does not disable these transports, so a crew in a container "
+        f"can come up on them: {missing}. Add them to CHANNEL_SECTIONS in {BACKEND_SRC}."
+    )
+
+
+def test_the_container_names_no_channel_the_gateway_does_not_have(registry) -> None:
+    """The other direction, because a stale name is a false claim of coverage.
+
+    A section the gateway does not have is written into the config and ignored, which
+    makes the list read as broader than its reach.
+    """
+    sections = set(_literal("CHANNEL_SECTIONS"))
+    unknown = sorted(sections - registry["members"])
+    assert not unknown, f"these are not channels the gateway can start: {unknown}"
+
+
+def test_the_container_strips_every_channel_credential_the_gateway_reads(registry) -> None:
+    stripped = set(_literal("CHANNEL_CRED_ENV"))
+    missing = sorted(registry["credentials"] - stripped)
+    assert not missing, (
+        "these channel credentials would reach the container's backend, and through it "
+        f"the auto-approving model worker: {missing}. Add them to CHANNEL_CRED_ENV in "
+        f"{BACKEND_SRC}."
+    )
+
+
+def test_the_container_strips_no_variable_the_gateway_never_reads(registry) -> None:
+    """A name nothing reads strips nothing while making the list look complete."""
+    stripped = set(_literal("CHANNEL_CRED_ENV"))
+    unknown = sorted(stripped - registry["credentials"])
+    assert not unknown, (
+        f"these variables are in no channel's credential set, so removing them protects "
+        f"nothing: {unknown}"
+    )
+
+
+def test_the_container_forces_every_sandbox_setting_the_gateway_reads(sandbox_keys) -> None:
+    """Each one is a way to be less sandboxed, and the container refuses to be.
+
+    The supervisor refuses to start where the model subprocess cannot be sandboxed and
+    offers no unsandboxed posture. The gateway reads its sandbox mode and its fallback
+    flags from `config.json`, which the container writes -- so any of them left to what
+    a supplied file says is a way to defeat that refusal without tripping it.
+    """
+    forced = set(_literal("FORCED_AGENT_SETTINGS"))
+    missing = sorted(sandbox_keys - forced)
+    assert not missing, (
+        "the crew container does not write these sandbox settings, so a config file "
+        f"supplied to the task decides them: {missing}. Add them to "
+        f"FORCED_AGENT_SETTINGS in {BACKEND_SRC}."
+    )
+
+
+def test_the_forced_sandbox_values_are_the_sandboxed_ones(sandbox_keys) -> None:
+    """Writing the key is half of it; the value has to be the safe one.
+
+    Checked against the values rather than against the schema defaults, because a
+    default is what this container is declining to rely on.
+    """
+    forced = dict(_literal("FORCED_AGENT_SETTINGS"))
+    assert forced.get("sandbox") == "auto", forced.get("sandbox")
+    for key in sorted(sandbox_keys - {"sandbox"}):
+        assert forced.get(key) is False, f"{key} is forced to {forced.get(key)!r}, not False"
+
+
+def test_the_container_forces_no_agent_setting_the_gateway_does_not_have() -> None:
+    """A key the gateway does not read is written and ignored, which reads as coverage."""
+    import dataclasses
+
+    from kiro_crew.config.sections import AgentConfig
+
+    known = {f.name for f in dataclasses.fields(AgentConfig)}
+    forced = set(_literal("FORCED_AGENT_SETTINGS"))
+    unknown = sorted(forced - known)
+    assert not unknown, f"these are not settings on AgentConfig: {unknown}"

--- a/test/test_crew_runtime_payload.py
+++ b/test/test_crew_runtime_payload.py
@@ -1,0 +1,232 @@
+"""The AWS Control crew image's build context must reach every install lane.
+
+The image is built from files on disk: two Dockerfiles, ``requirements.txt``,
+``requirements-dev.txt``, the container's own source, and a vendor placeholder. If any of
+them is absent from an installed copy, the build fails at image-build time with a missing
+file -- long after the install that dropped it, and with nothing in the install output
+saying so.
+
+Two lanes select these files by DIFFERENT mechanisms and can drop them independently, so
+each is pinned separately. This follows ``test_vendored_llama_payload.py``, which exists
+because exactly one of these lanes silently shipped a broken wheel:
+
+* the **sdist**, governed by ``MANIFEST.in``. ``python -m build`` builds the wheel FROM the
+  sdist, so a file this file does not reach is absent from every published wheel whatever
+  ``package_data`` says. ``python -m build --wheel`` never evaluates ``MANIFEST.in`` at all,
+  so a wheel-only build cannot observe a regression here.
+* the **wheel**, governed by ``[options.package_data]`` in ``setup.cfg``. A pattern there
+  globs by fixed directory name, and ``*`` does not cross a path separator, so an entry
+  written for ``apps/builtins/*/`` does not descend into ``aws_control/crew/runtime/``.
+
+Neither lane is reached by the patterns that were already present: the tree's Python files
+are found by ``packages = find:``, its ``.md`` files by
+``recursive-include src/kiro_crew/apps *.md``, and its Dockerfiles by nothing, because they
+have no suffix to match.
+
+These tests MODEL both files rather than executing them, which makes them the weaker half
+of the defence by construction -- ``build.yml`` builds the real sdist and wheel. The
+stronger alternative here, shelling out to ``python -m build``, skips wherever ``build`` is
+missing, and a skip scores as a pass, so the guard would be absent exactly where it matters.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "MANIFEST.in"
+SETUP_CFG = REPO_ROOT / "setup.cfg"
+RUNTIME = REPO_ROOT / "src" / "kiro_crew" / "apps" / "builtins" / "aws_control" / "crew" / "runtime"
+
+
+def _payload() -> list[Path]:
+    """The members no other rule reaches: everything that is not ``.py`` or ``.md``."""
+    return [
+        p
+        for p in sorted(RUNTIME.rglob("*"))
+        if p.is_file() and "__pycache__" not in p.parts and p.suffix not in {".py", ".md"}
+    ]
+
+
+def _sdist_rules() -> list[tuple[str, list[str]]]:
+    """``MANIFEST.in``'s ``recursive-include`` rules that survive its excludes.
+
+    Position is as load-bearing as presence: ``global-exclude`` and ``prune`` lines apply
+    in file order, so an include written above them is undone by them. Only the rules
+    below the last exclude are in force, and those are what this returns.
+    """
+    lines = [ln.strip() for ln in MANIFEST.read_text(encoding="utf-8").splitlines()]
+    last_exclude = max(
+        (i for i, ln in enumerate(lines) if ln.startswith(("global-exclude", "prune", "exclude"))),
+        default=-1,
+    )
+    rules: list[tuple[str, list[str]]] = []
+    for i, ln in enumerate(lines):
+        if i <= last_exclude or not ln.startswith("recursive-include"):
+            continue
+        parts = ln.split()
+        if len(parts) >= 3:
+            rules.append((parts[1], parts[2:]))
+    return rules
+
+
+def _reaches_sdist(path: Path, rules: list[tuple[str, list[str]]]) -> bool:
+    """Model ``recursive-include`` the way distutils reads it.
+
+    The file is under ``dir`` and its NAME matches a pattern -- not the whole path
+    matched with ``fnmatch``, whose ``*`` crosses separators and would accept rules
+    distutils rejects.
+    """
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    return any(
+        rel.startswith(f"{d}/") and any(fnmatch.fnmatch(path.name, p) for p in pats)
+        for d, pats in rules
+    )
+
+
+def _package_data_patterns() -> list[str]:
+    """The ``[options.package_data]`` patterns, in file order."""
+    text = SETUP_CFG.read_text(encoding="utf-8")
+    block = text.split("[options.package_data]", 1)
+    assert len(block) == 2, "setup.cfg has no [options.package_data] section"
+
+    patterns: list[str] = []
+    for line in block[1].splitlines()[1:]:
+        if line.startswith("["):
+            break
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        if entry.endswith("="):  # the `kiro_crew =` key line
+            continue
+        if not line[0].isspace():  # a new top-level key ends the section's values
+            break
+        patterns.append(entry)
+    return patterns
+
+
+def _wheel_shipped() -> set[Path]:
+    """What ``package_data`` selects, EXPANDED against the real tree.
+
+    ``Path.glob`` rather than ``fnmatch``, because that is what setuptools does and the
+    two disagree on the thing that matters here -- ``fnmatch``'s ``*`` crosses a path
+    separator, so it would accept a pattern that never descends into
+    ``aws_control/crew/runtime/`` and report a lane as covered while every wheel shipped
+    nothing.
+    """
+    patterns = _package_data_patterns()
+    assert patterns, "no package_data patterns parsed"
+    pkg_root = REPO_ROOT / "src" / "kiro_crew"
+    return {p.resolve() for pat in patterns for p in pkg_root.glob(pat) if p.is_file()}
+
+
+def test_the_payload_this_guards_is_not_empty() -> None:
+    """Non-vacuity, and it names what is at stake.
+
+    Every assertion below quantifies over this list. Were it empty they would all pass
+    while guarding nothing, and the day someone moved the Dockerfiles out they would go on
+    passing.
+    """
+    payload = _payload()
+    assert payload, "no non-.py/.md members under crew/runtime -- these guards are vacuous"
+    names = {p.name for p in payload}
+    assert "Dockerfile" in names, "the extensionless member is the reason for these rules"
+    assert "requirements.txt" in names
+
+
+def test_the_sdist_rules_reach_the_payload() -> None:
+    """``MANIFEST.in`` must carry every member, by a rule placed after the excludes."""
+    rules = _sdist_rules()
+    assert rules, "MANIFEST.in has no recursive-include after its excludes"
+
+    unreached = [
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in _payload()
+        if not _reaches_sdist(path, rules)
+    ]
+
+    assert not unreached, (
+        "these files are in no sdist, so no published wheel carries them and the image "
+        f"cannot be built from an installed copy: {unreached}"
+    )
+
+
+def test_the_wheel_rules_reach_the_payload() -> None:
+    """``package_data`` must carry every member too.
+
+    Independent of the sdist lane: the desktop bundle pip-installs the project, so it
+    inherits this lane and not the other.
+    """
+    shipped = _wheel_shipped()
+    pkg_root = REPO_ROOT / "src" / "kiro_crew"
+    unreached = [
+        path.relative_to(pkg_root).as_posix()
+        for path in _payload()
+        if path.resolve() not in shipped
+    ]
+
+    assert not unreached, (
+        "these files are in no wheel, so a pip or desktop install cannot build the "
+        f"image: {unreached}"
+    )
+
+
+# --------------------------------------------------------------------------
+# The other direction: what must NOT travel
+# --------------------------------------------------------------------------
+# The rules above answer "does the image's build context reach an installed copy".
+# These answer the opposite question, because a rule broad enough to satisfy the first
+# was: `container_tests/` is the image's OWN test suite, 4,000 lines of it, and it was
+# in every sdist, wheel and DMG. Nothing on a user's machine can run it -- the tests
+# exercise a Linux container's supervisor, and the machine that installed the app never
+# runs that container.
+#
+# Both directions are asserted against the same parsed rules, so a future widening that
+# restores the payload by taking the whole tree cannot pass both.
+
+
+def _container_test_files() -> list[Path]:
+    return [
+        p
+        for p in sorted((RUNTIME / "container_tests").rglob("*"))
+        if p.is_file() and "__pycache__" not in p.parts
+    ]
+
+
+def test_the_container_test_suite_is_worth_excluding() -> None:
+    """Non-vacuity for the two guards below, and it names the scale.
+
+    An empty list would make both pass while proving nothing, including on the day the
+    suite is renamed and starts shipping again under its new name.
+    """
+    files = _container_test_files()
+    assert len(files) >= 20, f"expected the image's test suite here, found {len(files)} files"
+
+
+def test_the_sdist_rules_do_not_carry_the_container_test_suite() -> None:
+    rules = _sdist_rules()
+    assert rules, "MANIFEST.in has no recursive-include after its excludes"
+    shipped = [
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in _container_test_files()
+        if _reaches_sdist(path, rules)
+    ]
+    assert not shipped, (
+        "the image's own test suite is in the sdist, so every published wheel carries "
+        f"tests nothing on a user's machine can run: {len(shipped)} files, e.g. {shipped[:3]}"
+    )
+
+
+def test_the_wheel_rules_do_not_carry_the_container_test_suite() -> None:
+    shipped_paths = _wheel_shipped()
+    pkg_root = REPO_ROOT / "src" / "kiro_crew"
+    shipped = [
+        path.relative_to(pkg_root).as_posix()
+        for path in _container_test_files()
+        if path.resolve() in shipped_paths
+    ]
+    assert not shipped, (
+        "the image's own test suite is in the wheel, so a pip or desktop install carries "
+        f"tests nothing on that machine can run: {len(shipped)} files, e.g. {shipped[:3]}"
+    )

--- a/test/test_mcp_call_site_auth_coverage.py
+++ b/test/test_mcp_call_site_auth_coverage.py
@@ -697,6 +697,17 @@ class TestMcpCallSiteAuthCoverage:
                 continue
             if "/tests/" in f"/{rel}" or path.name.startswith("test_"):
                 continue
+            # OUT OF SCOPE BY SHAPE, not by exception: a container image's own source
+            # under ``apps/builtins/<app>/crew/runtime/**``. This guard exists because a
+            # module that reaches THE DASHBOARD with the internal secret must have its
+            # call sites checked. That tree is not in the dashboard's process: it is
+            # built into a Linux image and its secret header is passed between the
+            # image's OWN processes over loopback, never to the owner's gateway. It is
+            # also not importable from here, which is what
+            # ``test_spawn_audit.py::test_container_image_assets_are_not_imported``
+            # holds, so adding it to ``_SOURCES`` is not available either.
+            if "/crew/runtime/" in f"/{rel}":
+                continue
             text = path.read_text(encoding="utf-8")
             tree = ast.parse(text)
             reasons: list[str] = []

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -111,6 +111,23 @@ def _is_bundled_skill_asset(path: Path) -> bool:
     return parts[:2] == ("apps", "builtins") and "skills" in parts[2:]
 
 
+def _is_container_image_asset(path: Path) -> bool:
+    """True for a container image's own source rather than gateway runtime code.
+
+    ``apps/builtins/<app>/crew/runtime/**`` is the build context of a Linux image: a
+    Dockerfile, the processes that image runs, and their tests. The gateway does not
+    import it, which ``test_container_image_assets_are_not_imported`` pins and which the
+    tree itself enforces by assuming an installed layout where ``kiro_crew`` is absent.
+
+    Its subprocess calls are the image's supervisor starting the image's own children,
+    inside a container the owner's machine never runs. The sandbox chokepoint governs the
+    gateway's OWN spawning, so it has nothing to say about them -- the same reasoning as
+    ``_is_bundled_skill_asset`` above, applied to a different shape.
+    """
+    parts = path.relative_to(_SRC_ROOT).parts
+    return parts[:2] == ("apps", "builtins") and "crew" in parts and "runtime" in parts
+
+
 # Attribute names that actually spawn a child process.
 _SPAWN_ATTRS = {
     "Popen",
@@ -1697,7 +1714,7 @@ def _collect_first_party_flag_sites() -> frozenset[str]:
     out: set[str] = set()
     for path, source in candidate_sources(require_all=(_FIRST_PARTY_KWARG,)):
         rel = path.relative_to(_SRC_ROOT).as_posix()
-        if rel == "sandbox.py" or _is_bundled_skill_asset(path):
+        if rel == "sandbox.py" or _is_bundled_skill_asset(path) or _is_container_image_asset(path):
             continue
         tree = ast.parse(source, str(path))
         funcs = [
@@ -1837,8 +1854,9 @@ def _collect_spawn_functions() -> dict[str, str]:
     needles = tuple(_SPAWN_ATTRS | _SPAWN_NAMES)
     for path, source in candidate_sources(require_any=needles):
         # A skill's own helper scripts are not gateway runtime code paths --
-        # see ``_is_bundled_skill_asset`` for why they are out of scope.
-        if _is_bundled_skill_asset(path):
+        # see ``_is_bundled_skill_asset`` for why they are out of scope. A container
+        # image's own source is the same kind of exclusion for a different shape.
+        if _is_bundled_skill_asset(path) or _is_container_image_asset(path):
             continue
         tree = ast.parse(source, str(path))
         spawn_bases = _spawn_module_bindings(tree)
@@ -2115,6 +2133,60 @@ def test_bundled_skill_assets_are_not_imported():
         "exempts:\n  " + "\n  ".join(sorted(offenders)) + "\n\nEither move the "
         "shared logic into a real module under src/kiro_crew (where the spawn "
         "audit reviews it), or drop the import."
+    )
+
+
+def test_container_image_assets_are_not_imported():
+    """The container-image exemption is only honest while the gateway never imports one.
+
+    ``_is_container_image_asset`` takes a Linux image's own source out of the spawn audit
+    on the premise that the image runs it, not this package. That premise has one failure
+    mode: gateway code imports one of those modules, and its unrouted spawns become
+    gateway spawns while staying invisible to the audit.
+
+    The tree also cannot be imported in practice: it assumes an installed layout where
+    ``kiro_crew`` is absent, so an import would fail at runtime rather than quietly work.
+    This test makes the premise explicit instead of leaving it to that accident.
+
+    Reading these files as DATA is expected: the image build copies the tree, and tests in
+    the tree's own suite compare its source text against the gateway's copy of a duplicated
+    helper. Neither is an import.
+    """
+    assets = [p for p in _SRC_ROOT.rglob("*.py") if _is_container_image_asset(p)]
+    # Non-vacuity: a predicate matching nothing would make this pass while pinning
+    # nothing, and would mean the exemption itself is dead.
+    assert assets, "no container image assets found -- the exemption matches nothing"
+
+    asset_modules = {
+        "kiro_crew." + p.relative_to(_SRC_ROOT).with_suffix("").as_posix().replace("/", ".")
+        for p in assets
+    }
+    asset_packages = {
+        "kiro_crew." + p.relative_to(_SRC_ROOT).parent.as_posix().replace("/", ".") for p in assets
+    }
+
+    offenders: list[str] = []
+    for path in _SRC_ROOT.rglob("*.py"):
+        if _is_container_image_asset(path):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+        rel = path.relative_to(_SRC_ROOT).as_posix()
+        for node in ast.walk(tree):
+            names: list[str] = []
+            if isinstance(node, ast.Import):
+                names = [a.name for a in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module and not node.level:
+                names = [node.module]
+            for name in names:
+                if name in asset_modules or name in asset_packages:
+                    offenders.append(f"{rel}:{node.lineno} imports {name}")
+
+    assert not offenders, (
+        "Gateway code imports a container image asset, which the spawn audit "
+        "exempts:\n  " + "\n  ".join(sorted(offenders)) + "\n\nThat tree runs inside a "
+        "Linux image on an installed copy where kiro_crew is absent, so the import would "
+        "fail there anyway. Move the shared logic into a real module under src/kiro_crew, "
+        "or duplicate it deliberately and pin the copies equal by source text."
     )
 
 


### PR DESCRIPTION
## What this is

The image a remote crew runs as: a supervisor that starts and watches the crew's
processes, a front that receives turns, and a backend that executes them. Plus the
Dockerfiles and requirements that build it.

226 tests, run on a real temporary filesystem. No Docker, no cloud account, nothing
to configure to review this.

Independent of the sibling bundle-builder change: neither imports the other, so
both are open against `main` rather than stacked. The design both serve is in the
Remote Instance on Fargate RFC.

## Boot gates (fail-closed refusals)

The supervisor refuses to start rather than run degraded, in two cases the reviewer asked to see named:

- **No user namespace (Fargate today).** kiro-cli sandboxes the model subprocess in an unprivileged user namespace; where the host has none, the container ships SANDBOXED-ONLY and refuses to boot rather than run the worker exposed. There is no opt-in (`SMC_ALLOW_UNSANDBOXED_EXEC` was removed); the credential broker is the tracked path to an unsandboxed posture. Documented in `CONTRACT.md`.
- **`SMC_SINGLE_PRINCIPAL` not declared.** A crew that configures a backup bucket must declare it serves a single trust principal; without that declaration the front refuses to boot, so a multi-tenant bucket cannot be reached by accident.

## Ships without cross-task-replacement backup (extracted)

The backup subsystem -- the sidecar that copied session state to S3, the restore that
brought it back, and their layout/state/store modules -- was **extracted from this PR** and
is not here. Durability across task replacement is a capability the container does not yet
have, **not a regression**: there is no crew container on `main` today, so nothing is lost
relative to the current state.

Backing up a live, mutable, unbounded artifact set inside a replaceable container turned out
to be a design problem in its own right rather than an implementation detail. Three designs
were tried and each hit a real flaw of its own class -- skip-with-a-warning was data loss,
streaming was a consistency problem against a concurrent writer, snapshotting was a capacity
problem (a full copy of an up-to-ceiling artifact can fill the artifact filesystem). The
right move is to design all four constraints together -- no silent skip, consistency,
bounded capacity, and a restore path that returns the bytes -- and prove the round trip,
rather than decide it one review finding at a time. That work is tracked in #9464 and will land as its own PR.

What stays: the front still fetches a slot's transcript from S3 on demand (Track B), so
`SMC_BACKUP_BUCKET`/`SMC_BACKUP_PREFIX` name where it reads. Until the durability feature
provides a writer, that fetch reads an empty bucket.

## Three audits needed telling this is image source, not gateway code

The tree is the SOURCE OF A LINUX CONTAINER IMAGE. It runs as its own processes
inside that image, on an installed copy where `kiro_crew` is not importable. Each
audit is scoped **by shape**, beside an existing exclusion of the same kind, rather
than by a new list of exceptions.

**The spawn audit** gains `_is_container_image_asset`, mirroring
`_is_bundled_skill_asset` directly above it. The supervisor's spawns are the image
starting its own children inside a container the owner's machine never runs, so the
sandbox chokepoint that governs the gateway's own spawning has nothing to say about
them.

That exemption is only honest while nothing imports the tree, so
`test_container_image_assets_are_not_imported` pins it, following the existing
companion test including its non-vacuity assertion: a predicate matching nothing
would pass while proving nothing. Verified load-bearing by removing the predicate
from the walk, which reddens the audit.

**The MCP secret-caller scan** skips it. That guard exists because a module reaching
*the dashboard* with the internal secret must have its call sites checked. This tree
passes its secret between the image's own processes over loopback, and it cannot be
added to `_SOURCES` instead, because that would be the import the spawn audit
forbids.

**The hardcoded-agents-dir ratchet** exempts one file. `supervisor/bundle.py`
re-implements the resolver because `kiro_crew` is absent inside the image, and the
exempt file is the test asserting what that copy returns against a `tmp_path`. It
neither reads nor writes the owner's home.

## Packaging

`setup.cfg` and `MANIFEST.in` carry the image's non-Python build context. The
existing globs do not reach it: `*` does not cross a path separator, so nothing
already there descends into `crew/runtime/`. Both lanes are needed because
`python -m build` builds the wheel from the sdist, so a file absent from
`MANIFEST.in` is absent from the wheel whatever `package_data` says.

Two `per-file-ignores` cover shapes the suite already had before it moved: an `F811`
from sharing fixtures across test modules, which fires once per test rather than on
the import so no `noqa` can reach it, and an `E402` from a mid-file import block
that is the file's own structure.

## CONTRACT.md

Its twenty `file.py:NNN` citations lose the line numbers and keep the file names.
They point into gateway files that move, which is exactly why the docs lint refuses
that shape. The alternative was twenty more entries in a baseline that already
carries 474.

## Checks

309 container tests pass. The four repo-level audit files pass at 74, measured
against a pristine `origin/main` worktree first so host-environment failures are not
mistaken for mine. `flake8`, `black`, `isort`, `check_subprocess_encoding`,
`docs-lint` and the brand check all pass.

## Held back

`test_gate_token_matches_container.py` reads the deploy driver and its gate fixture,
neither of which is in this change. It goes with the Fargate backend. Two tests that
pin this tree's `O_NOFOLLOW` opener against the bundle builder's deliberately
duplicated copy need both trees on main, so they follow once these two land.



