### PR TITLE
fix(acp): give session/set_mode the session-start budget (#9185)

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -2999,9 +2999,19 @@ class AcpRuntime:
             # "no report" for the rest of the session.
             staged_before_switch = handle.queued_frame_count()
             try:
+                # set_mode is a handshake request: switching to an agent boots
+                # THAT agent's MCP servers (see the mode_switched comment below),
+                # the same server (re-)initialization that gives session/new and
+                # session/load their 90s budget. A switched-to server pending
+                # OAuth holds the response for its full 30s wait, so the generic
+                # _REQUEST_TIMEOUT turns set_mode into the SAME race the
+                # session-start floor exists to prevent (see _SESSION_NEW_TIMEOUT
+                # and #9185). `budget` is already resolved for the session/new
+                # above, so reuse it rather than re-reading config.
                 await self._send_and_await(
                     METHOD_SET_MODE,
                     set_mode_params(session_id, mode_agent),
+                    timeout=budget,
                 )
             except Exception:
                 await self.terminate_session(session_id)
@@ -3271,9 +3281,15 @@ class AcpRuntime:
             # out, the only moment "queued" and "pre-switch" mean the same thing.
             staged_before_switch = handle.queued_frame_count()
             try:
+                # Same as create_session: set_mode on the resume path boots the
+                # switched-to agent's MCP servers, so it shares session/load's
+                # 90s budget rather than the generic _REQUEST_TIMEOUT that the
+                # backend's own 30s OAuth wait would race (#9185). `budget` is
+                # the session-start budget already resolved above.
                 await self._send_and_await(
                     METHOD_SET_MODE,
                     set_mode_params(resume_sid, agent),
+                    timeout=budget,
                 )
             except Exception:
                 await self.terminate_session(resume_sid)

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -6777,6 +6777,72 @@ async def test_session_load_call_site_passes_budget_above_request_timeout(monkey
 
 
 @pytest.mark.asyncio
+async def test_create_set_mode_call_site_passes_budget_above_request_timeout(
+    monkeypatch,
+):
+    """create_session's set_mode must carry the session-start budget, not the
+    generic _REQUEST_TIMEOUT. Switching to an agent boots THAT agent's MCP
+    servers (the same (re-)initialization session/new gets 90s for); a
+    switched-to server pending OAuth holds the response for its full 30s wait,
+    so the generic 30s budget races it exactly as it would session start
+    (#9185). set_mode fires here because the session/new response advertises
+    no `modes` list (older/fake backend -> attempt)."""
+    rt, _, _ = _make_runtime()
+    seen: dict[str, object] = {}
+
+    async def _fake_send(method, params, timeout=None):
+        if method == METHOD_SESSION_NEW:
+            return {"sessionId": "sid-setmode"}  # no `modes` -> set_mode attempts
+        if method == METHOD_SET_MODE:
+            seen["timeout"] = timeout
+        return {}
+
+    monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+
+    await rt.create_session(cwd="/w", agent="kirocrew")
+
+    assert seen["timeout"] == _SESSION_NEW_TIMEOUT
+    assert isinstance(seen["timeout"], float)
+    assert seen["timeout"] > _REQUEST_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_load_set_mode_call_site_passes_budget_above_request_timeout(
+    monkeypatch,
+):
+    """The resume path's set_mode is gated by the same switched-to-agent MCP
+    (re-)initialization as create_session's, so it must carry session/load's
+    budget rather than the generic _REQUEST_TIMEOUT (#9185). The session/load
+    response echoes `modes` (a genuine resume), which is also what makes
+    _mode_available admit the switch."""
+    rt, _, _ = _make_runtime()
+    rt._can_load_session = True
+    seen: dict[str, object] = {}
+
+    async def _fake_send(method, params, timeout=None):
+        if method == METHOD_SESSION_LOAD:
+            return {
+                "modes": {
+                    "currentModeId": "kiro",
+                    "availableModes": [{"id": "kirocrew"}],
+                }
+            }
+        if method == METHOD_SET_MODE:
+            seen["timeout"] = timeout
+        return {}
+
+    monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+
+    await rt.load_session(
+        "/home/u/.kiro/sessions/cli/sid-9.json", "sid-9", agent="kirocrew", cwd="/w"
+    )
+
+    assert seen["timeout"] == _SESSION_NEW_TIMEOUT
+    assert isinstance(seen["timeout"], float)
+    assert seen["timeout"] > _REQUEST_TIMEOUT
+
+
+@pytest.mark.asyncio
 async def test_session_start_budget_follows_config(monkeypatch):
     """agent.session_start_timeout_secs raises the session/new budget: the
     configured value is resolved lazily (off-loop, on first session start —


### PR DESCRIPTION
## Problem / Motivation

On Windows, creating an ACP session (even with the built-in minimal `kirocrew-lite`
agent) fails: `session/set_mode` hits a fixed 30s request budget and raises
`AcpRequestTimeout: Request session/set_mode timed out after 30s`. The reporter observed
it firing at ~42.7s while the gateway logged ~37.7s of event-loop lag, and confirmed the
knob `agent.session_start_timeout_secs` does not reach `set_mode`. Reported in #9185.

## Why it matters

A `set_mode` failure aborts the whole session creation: the just-created session is
terminated and no handle is returned to the caller, so the crew session never comes up.
On a host where the switched-to agent has any MCP server that is slow to initialize, this
turns normal session startup into a failure, and the reporter saw it reproduce across
restarts.

## What changed

Both `set_mode` call sites in `src/kiro_crew/acp/runtime.py` -- in `create_session`
(fresh sessions) and `load_session` (resumed sessions) -- called `_send_and_await` without
a `timeout`, so they took the generic `_REQUEST_TIMEOUT = 30.0`.

Chaining the symptom to the root cause: `session/set_mode` is a handshake request (the
module already lists it alongside `initialize` and `session/new` as an awaited handshake
request). Switching to an agent boots THAT agent's MCP servers -- the same server
(re-)initialization that already earns `session/new` and `session/load` the 90s
`_SESSION_NEW_TIMEOUT` budget (raised by `agent.session_start_timeout_secs`). The stated
reason that budget exists is that kiro-cli blocks the response while it initializes the
session's MCP servers, and a remote server pending OAuth holds it for its FULL 30s
authorization wait. `set_mode` on a real mode switch does the identical work, so the
generic 30s budget makes it lose the SAME race the session-start floor was created to
prevent (the client gives up a beat before the backend answers). `set_mode` was the only
one of the three handshake requests excluded from the handshake budget.

The fix reuses the session-start budget that both functions have already resolved into a
local `budget` a few lines above the `set_mode` call, passing `timeout=budget`. No new
config, no new knob: `set_mode` now shares `session/new` / `session/load`'s existing
budget and honours `agent.session_start_timeout_secs` the same way. This is scoped to the
budget asymmetry the issue's question 2 asks about; it does not attempt to fix the separate
event-loop stall (root cause unidentified; partly addressed by the unrelated #9172).

Two sibling operators verified the asymmetry against main before this change (the 30s
constant at runtime.py:159, both `set_mode` sites going through `_send_and_await` with no
timeout arg, and `set_mode` being the only handshake request excluded from the 90s budget).

## Tests

Added two regression tests to `test/test_acp_runtime.py`, direct siblings of the existing
`test_session_new_call_site_passes_budget_above_request_timeout` /
`test_session_load_call_site_passes_budget_above_request_timeout`:

- `test_create_set_mode_call_site_passes_budget_above_request_timeout`
- `test_load_set_mode_call_site_passes_budget_above_request_timeout`

Each drives the real `create_session` / `load_session` path, captures the `timeout` handed
to the `set_mode` `_send_and_await`, and asserts it equals `_SESSION_NEW_TIMEOUT` and
exceeds `_REQUEST_TIMEOUT`. Both were mutation-verified: removing `timeout=budget` reddens
them with `assert None == 90.0` (set_mode falling back to the 30s default). Verified locally
with `python3 -m pytest -n0 test/test_acp_runtime.py -k "set_mode ..."`; the 32-test
create/load/set_mode/budget subset stays green. Windows-specific behaviour is verified by
CI's `Backend Tests (Windows)` lanes, since this host is Linux.

## Pattern harvest

Defect class: a control-plane request that does the SAME expensive backend work as a
sibling request (here, MCP server (re-)initialization that can block on a 30s OAuth wait)
was given a different, tighter timeout than the sibling, so it silently loses a race the
sibling's larger budget was explicitly created to prevent. The give-away is a shared helper
(`_send_and_await`) whose `timeout` defaults to a generic value, with only SOME callers
overriding it -- and a module comment that groups the under-budgeted call with the
well-budgeted ones ("awaited handshake requests: initialize, session/new, set_mode").

Rule candidate: when several requests go through one shared send-and-await helper with a
default timeout, list every caller and check that requests doing the same class of blocking
backend work carry the same budget; a handshake/control-plane request grouped with the
session-start requests in the code's own comments should share their budget, not the
generic default.

Closes #9185
