### PR TITLE
perf(dev-fleet): skip npm ci and rebuild on a backend-only sync

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -650,6 +650,56 @@ upstream's. Skipping is what makes it safe, and it costs an edition nothing —
 the only artifact this path could produce for it is a bundle it must never
 serve.
 
+**The frontend half is also suppressed on a backend-only sync — one whose
+incoming ref changes nothing under `website/`.** Both `npm ci` and `npm build +
+stage` are then work with no output: no new lockfile to install, no new source to
+build, and the staged bundle is already the current one. The decision is made by
+the `Verify dependencies` preflight, the one step that runs after `fetch` has
+pinned the incoming ref and before `merge` makes the worktree equal to it — the
+only point where "does the incoming ref touch the frontend?" has a correct answer.
+It cannot be decided when the step list is assembled, because the per-PID sync ref
+is not written until fetch runs; on a long-lived gateway's second sync it would
+still point at the prior tip. The preflight signals the verdict by exiting a
+reserved code (`EXIT_FRONTEND_SKIP`, 48) that the runner trusts ONLY from the
+preflight's own label — a worktree-run step exiting the same code is demoted to a
+plain failure, so it cannot forge a "skip the build". The runner then suppresses
+the two frontend steps whole, transaction included: a suppressed `npm ci` must not
+enter the `node_modules` transaction, whose move-aside-then-drop-backup on a no-op
+exit would delete the tree.
+
+The suppression fires only when ALL of these hold together, so the tree that
+produced the staged bundle and the tree now on disk are provably identical across
+tracked files, untracked files, and installed packages:
+
+1. the incoming ref changes nothing under `website/` (the tracked `git diff` the
+   probe skip already computes);
+2. the working subtree is clean INCLUDING untracked files (`git status
+   --porcelain --untracked-files=normal -- website` empty) — the same check the
+   fingerprint is STAMPED behind, re-checked before it is TRUSTED, so an untracked
+   `website/` file added between build and skip cannot ride through;
+3. `node_modules` is complete against the lockfile (`npm ls --all` exits 0), which
+   closes the partial-tree residual a bare "populated" check would leave;
+4. a build-source fingerprint — the git tree id of `website/` stamped beside the
+   staged bundle on the last successful build, and only when that build's tree was
+   clean — equals the incoming ref's `website/` tree.
+
+Any single failure, or any uncertainty (missing or failing `git`/`npm`, a
+timeout), returns "run", so the unknown case always rebuilds; the suppression
+cannot hold while a rebuild is owed.
+
+**Declared bound: this is a skip optimisation, so it has an inherent
+check-then-skip window.** The preflight decides before the merge, the runner
+suppresses after it, and the fingerprint is read right after the build; a tree
+changed by a concurrent writer in between yields a STALE build, never a wrong or
+corrupt one. This is the defining window of every build cache — closing it
+completely would need a lock held across the whole build, which destroys the
+~28 s the suppression saves. The worst outcome is a stale build on the operator's
+OWN checkout, rebuilt by re-running Pull + Build: no data lost, nothing corrupted,
+and whoever changed the tree mid-sync is who sees the result. The window is kept
+as narrow as it cheaply can be without a lock — the cleanliness check and the
+tree-id read run back-to-back under the staging lock, and the preflight runs
+immediately before the merge.
+
 The final **npm build + stage** step builds the frontend and copies `website/dist` into
 `src/kiro_crew/static/dist` under the Dev Fleet backend's OWN interpreter, with
 the target repo passed as an argument. Resolving the helper from the target
@@ -738,15 +788,14 @@ still probes. Anything the comparison cannot answer — a failing or missing `gi
 a timeout — probes as well: the unknown case costs an install rather than a
 guarantee.
 
-A populated tree is evidence, not a verified install, and the bound is worth
-stating: a prior frontend sync whose post-merge `npm ci` died partway can leave a
-partial tree beside the merged lockfile, and later backend-only syncs will skip on
-it, since from there on the subtree is unchanged and nothing re-examines it. The
-consequence is the same class as the dead-registry residual — the skip decides only
-whether this sync pays for a rehearsal, so a refusal lands one step later rather
-than never, and the transaction keeps the checkout consistent either way. Issue
-[#7132](https://github.com/kirodotdev/KiroCrew/issues/7132) tracks the stronger
-evidence check that would close it.
+A populated tree is evidence, not a verified install. On its own that would let a
+partial tree — a prior frontend sync whose post-merge `npm ci` died partway,
+leaving packages missing beside the merged lockfile — pass as "populated". For
+the PROBE skip that residual is benign (the skip decides only whether this sync
+pays for a rehearsal, so a refusal lands one step later rather than never, and the
+transaction keeps the checkout consistent either way). For the frontend-STEP
+suppression below it would not be benign, so that path does not rely on the
+populated check alone — see the build-currency preconditions there.
 
 The condition is the whole subtree rather than just `package-lock.json` /
 `package.json` / `.npmrc`, and the difference is load-bearing. With those three

--- a/src/kiro_crew/apps/builtins/dev_fleet/npm_preflight.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/npm_preflight.py
@@ -100,6 +100,17 @@ EXIT_NO_SPACE = 45
 EXIT_TREE_AMBIGUOUS = 46
 #: The runner could not put a stashed dependency tree back after a failed step.
 EXIT_RESTORE_FAILED = 47
+#: The incoming ref proved the frontend install and build are already on disk
+#: (whole ``website/`` subtree unchanged AND ``node_modules`` populated), so the
+#: reinstall and rebuild are not owed. This is a SUCCESS verdict, not a failure
+#: -- it carries no ``_EXPLAIN`` sentence -- but it is RESERVED so the runner
+#: trusts it only from the preflight step's own label. A later worktree-run step
+#: (a pip lifecycle script) exiting 48 is DEMOTED to a plain failure by
+#: :func:`sync_runner.demote_reserved`, which is what stops an untrusted step
+#: from forging a "skip the build" verdict and shipping stale assets. The
+#: verdict travels as this exit code and lives in the runner's own state, never
+#: as a file any same-UID step could create.
+EXIT_FRONTEND_SKIP = 48
 
 #: The checkout subdirectory holding the frontend half. A ``probe()`` parameter
 #: once carried this, but only ``main()`` ever called it and it never passed one
@@ -193,7 +204,11 @@ def classify(output: str) -> int:
 #: number it likes, and a forged 41 would make the dashboard assert a registry
 #: credential failure -- with a remedy -- for what was actually a build error. So
 #: the runner remaps a reserved code coming from any step other than the probe.
-RESERVED_EXIT_CODES = frozenset(_EXPLAIN)
+#: EXIT_FRONTEND_SKIP is added explicitly: it is a SUCCESS verdict with no
+#: _EXPLAIN sentence, but it must be reserved so a worktree-run step cannot forge
+#: it to skip the frontend build (its whole point is that only the trusted
+#: preflight step may assert it).
+RESERVED_EXIT_CODES = frozenset(_EXPLAIN) | {EXIT_FRONTEND_SKIP}
 
 
 def explain_exit(rc: int) -> str:
@@ -344,6 +359,157 @@ def _install_already_proven(git: str, repo: str, ref: str) -> str | None:
     )
 
 
+#: File (under ``static/dist``) holding the git tree id of ``website/`` the
+#: staged bundle was built from. Written by :func:`frontend._write_build_source_fingerprint`.
+_BUILD_SOURCE_FINGERPRINT = "kirocrew-build-source.txt"
+#: Where the staged bundle lives relative to the repo root.
+_STATIC_DIST = ("src", "kiro_crew", "static", "dist")
+
+
+def _frontend_worktree_clean(git: str, repo: str) -> bool:
+    """True only when ``website/`` has NO uncommitted change, untracked included.
+
+    ``git status --porcelain --untracked-files=normal -- website`` lists tracked
+    modifications AND new untracked files (as ``?? path``); an empty result means
+    the working subtree equals the committed one. Non-empty, a non-zero exit, a
+    missing git, or a timeout all return False, so the skip is refused on any
+    doubt -- the build then runs, the safe direction. This mirrors the stamp-time
+    guard: the fingerprint is only WRITTEN when this holds, and here it is
+    re-checked before the fingerprint is TRUSTED, so an untracked file added
+    between build and skip cannot ride through.
+    """
+    try:
+        proc = subprocess.run(  # nosec B603 - argv list, no shell
+            [
+                git,
+                "-C",
+                repo,
+                "status",
+                "--porcelain",
+                "--untracked-files=normal",
+                "--",
+                _FRONTEND_SUBDIR,
+            ],
+            capture_output=True,
+            timeout=60,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return proc.returncode == 0 and not (proc.stdout or b"").strip()
+
+
+def _frontend_tree_complete(npm: str, repo: str) -> bool:
+    """True only when ``website/node_modules`` fully satisfies the lockfile.
+
+    ``_install_already_proven``'s "populated" test is a NON-EMPTY directory,
+    which a partial tree passes. Skipping the real ``npm ci`` on a partial tree
+    would leave the sync succeeding on incomplete dependencies, so the build-skip
+    needs a completeness check that a bare-populated one cannot give.
+
+    ``npm ls --all`` walks the installed tree against the lockfile and exits
+    non-zero (``ELSPROBLEMS``, "missing: ...") when any package is absent or
+    invalid; it exits 0 only when the tree is complete. It runs no lifecycle
+    scripts, writes nothing, and needs no network -- measured ~1s. Anything other
+    than a clean exit 0 (a non-zero code, a missing npm, a timeout) returns
+    False, so the unknown case rebuilds rather than trusting the tree.
+    """
+    try:
+        proc = subprocess.run(  # nosec B603 - argv list, no shell
+            [npm, "ls", "--all"],
+            cwd=str(Path(repo) / _FRONTEND_SUBDIR),
+            capture_output=True,
+            timeout=120,
+            check=False,
+            env={**os.environ, "npm_config_update_notifier": "false"},
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return proc.returncode == 0
+
+
+def _frontend_build_already_current(git: str, npm: str, repo: str, ref: str) -> str | None:
+    """Reason to SKIP the frontend reinstall AND rebuild, or ``None`` to run them.
+
+    STRICTLY STRONGER than :func:`_install_already_proven`, and it must be: that
+    predicate governs whether the pre-merge PROBE pays for a rehearsal, where a
+    stale-but-populated tree is benign because a refusal merely lands one step
+    later. Skipping the real ``npm ci`` AND ``npm run build`` is not benign in
+    the same way -- a wrongly skipped build leaves ``static/dist`` holding a
+    bundle that was never built from the current source, which surfaces days
+    later as a stale-frontend bug. So this requires everything
+    :func:`_install_already_proven` does, PLUS two proofs it does not: that the
+    installed tree is COMPLETE (:func:`_frontend_tree_complete`, closing the
+    partial-``node_modules`` gap), and that the staged bundle was built from the
+    source the sync will end up with (the fingerprint below).
+
+    The extra proof closes the concrete hole (#7132): a prior FRONTEND sync can
+    merge new ``website/`` source and then have its ``npm ci`` fail, at which
+    point the runner's transaction restores the OLD ``node_modules``. From then
+    on the subtree stops changing, so ``_install_already_proven`` would skip --
+    but ``static/dist`` was built from the OLD source and the merge landed the
+    NEW one. The fingerprint distinguishes them: it records the git tree id of
+    ``website/`` the staged bundle was built from, and this requires it to equal
+    the incoming ref's ``website/`` tree. In that failed-sync case the two differ
+    (old built tree vs new merged tree), so the skip is refused and the build
+    runs. Any uncertainty -- no fingerprint, an unreadable one, a git that cannot
+    resolve the ref's tree -- returns ``None`` and the build runs, the safe
+    direction.
+    """
+    base = _install_already_proven(git, repo, ref)
+    if base is None:
+        return None
+    # The install-proven check compares only TRACKED files (`git diff`), so an
+    # untracked website/ file added since the last build -- one the staged bundle
+    # cannot contain -- would not move the comparison. Require the working tree
+    # to be clean INCLUDING untracked files before skipping, mirroring the
+    # stamp-time guard in frontend._write_build_source_fingerprint: the two
+    # together mean a skip implies the tree that produced the bundle and the tree
+    # now on disk are the same, tracked and untracked alike (#7132).
+    if not _frontend_worktree_clean(git, repo):
+        return None
+    # The install-proven check only requires node_modules to be NON-EMPTY. A
+    # partial tree (an interrupted install) passes that, so verify completeness
+    # against the lockfile before skipping the real npm ci -- otherwise the sync
+    # could succeed on incomplete dependencies (#7132).
+    if not _frontend_tree_complete(npm, repo):
+        return None
+    fingerprint_path = Path(repo).joinpath(*_STATIC_DIST) / _BUILD_SOURCE_FINGERPRINT
+    try:
+        built_tree = fingerprint_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        # No fingerprint (a bundle built before this feature, or a stamp that
+        # failed to write) proves nothing about what the dist was built from, so
+        # rebuild rather than trust a populated tree alone.
+        return None
+    if not built_tree:
+        return None
+    try:
+        proc = subprocess.run(  # nosec B603 - argv list, no shell
+            [git, "-C", repo, "rev-parse", f"{ref}:{_FRONTEND_SUBDIR}"],
+            capture_output=True,
+            timeout=60,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    incoming_tree = (proc.stdout or b"").decode(errors="replace").strip()
+    if not incoming_tree or incoming_tree != built_tree:
+        # The staged bundle was built from a DIFFERENT website/ tree than the one
+        # the sync will end up with -- the stale-after-failed-frontend-sync case.
+        # Rebuild.
+        return None
+    return (
+        f"skipped the frontend reinstall and rebuild: the incoming ref changes "
+        f"nothing under {_FRONTEND_SUBDIR}/, its node_modules is populated and "
+        "complete against the lockfile, and the staged bundle was built from this "
+        "exact source tree, so no new resolution is arriving and no new bundle is "
+        "owed"
+    )
+
+
 def probe(
     *,
     git: str,
@@ -434,10 +600,32 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--npm", required=True)
     ap.add_argument("--repo", required=True)
     ap.add_argument("--ref", required=True)
+    # When set, and only when the incoming ref proves the frontend install is
+    # already on disk, exit EXIT_FRONTEND_SKIP instead of EXIT_OK. The runner
+    # reads that verdict off THIS step's exit code -- a channel it already trusts
+    # only from this step's label -- and skips the later npm ci and build+stage
+    # steps. It is a flag, not a value: the verdict cannot be smuggled in from
+    # outside, and a worktree-run step exiting 48 is demoted to a plain failure.
+    # This is the same window the probe uses (after fetch pinned --ref, before
+    # merge), which is the only point where "does the incoming ref touch the
+    # frontend?" has a correct answer (#7132).
+    ap.add_argument("--emit-frontend-skip", action="store_true")
     # --subdir and --timeout were CLI flags no caller passed. The subdir is now
     # _FRONTEND_SUBDIR and the timeout is probe()'s own default, so the surface
     # matches the one real invocation.
     args = ap.parse_args(argv)
+    if args.emit_frontend_skip:
+        # Asked with the SAME (git, repo, ref) the probe uses. This is the
+        # STRONGER predicate: it requires the unchanged subtree and populated
+        # node_modules the install-skip needs, PLUS proof (a build fingerprint)
+        # that the staged bundle was built from the source the sync ends up with
+        # -- so it cannot skip the rebuild on a tree left stale by a prior
+        # failed frontend sync. Any uncertainty returns None, so the frontend
+        # steps run: the unknown case pays the rebuild.
+        proven = _frontend_build_already_current(args.git, args.npm, args.repo, args.ref)
+        if proven is not None:
+            print(f"{DETAIL_PREFIX}{proven}", flush=True)
+            return EXIT_FRONTEND_SKIP
     code, detail = probe(
         git=args.git,
         npm=args.npm,

--- a/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
@@ -249,6 +249,8 @@ def run_steps(
     reserved: frozenset[int],
     preflight_label: str,
     exit_restore_failed: int,
+    exit_frontend_skip: int | None = None,
+    frontend_labels: frozenset[str] = frozenset(),
 ) -> int:
     """Run the reconciled step list in order, fail-fast, with the transaction.
 
@@ -256,12 +258,40 @@ def run_steps(
     these to name the current step in the dashboard. Returns the exit code to
     exit with: 0 if every step passed, otherwise the first non-zero code (after
     reserved-code demotion and any restore-failure override).
+
+    The frontend-skip verdict is held HERE, in runner state, not on disk. When
+    the trusted preflight step (identified by ``preflight_label``) exits
+    ``exit_frontend_skip``, the incoming ref proved the frontend install and
+    build are already present, so this treats that as success and skips every
+    later step whose label is in ``frontend_labels`` -- WITHOUT running their
+    node_modules transaction (a skipped step's transaction would move the tree
+    aside and drop the backup on its no-op exit, deleting it). The verdict can
+    come ONLY from the preflight: a worktree-run step (a pip lifecycle script)
+    exiting the same code is demoted to a plain failure by
+    :func:`demote_reserved`, so an untrusted step cannot forge a "skip the
+    build" verdict and ship stale assets (#7132).
     """
+    skip_frontend = False
     for i, st in enumerate(steps):
         print("::step::%d::%s" % (i, st["label"]), flush=True)
+        if skip_frontend and st["label"] in frontend_labels:
+            print(
+                "::skip::%d::%s -- backend-only sync, frontend unchanged and "
+                "node_modules populated" % (i, st["label"]),
+                flush=True,
+            )
+            continue
         with NodeModulesTransaction(st.get("stash"), exit_restore_failed) as txn:
             rc = run_step(st, cwd)
             rc = demote_reserved(rc, st["label"], reserved, preflight_label)
+            # The preflight asserting the frontend is already built is a SUCCESS
+            # that also suppresses the two frontend steps. Only the trusted
+            # preflight label may assert it: demote_reserved above has already
+            # turned this same code from any other step into a plain failure, so
+            # a worktree-run step cannot forge the skip.
+            if st["label"] == preflight_label and rc == exit_frontend_skip:
+                skip_frontend = True
+                rc = 0
             txn.rc = rc
         # The transaction may have overridden rc to its restore-failed code.
         rc = txn.rc
@@ -314,6 +344,25 @@ def main(argv: list[str] | None = None) -> int:
         help="exit code for a failed post-step restore (npm_preflight owns the value)",
     )
     ap.add_argument(
+        "--exit-frontend-skip",
+        type=int,
+        default=None,
+        help=(
+            "exit code the preflight uses to assert the frontend install/build "
+            "is already present (npm_preflight owns the value); trusted only "
+            "from the preflight step, demoted from any other. Omitted disables "
+            "the suppression, so both frontend steps always run"
+        ),
+    )
+    ap.add_argument(
+        "--frontend-labels",
+        default="",
+        help=(
+            "comma-separated step labels suppressed when the preflight asserts "
+            "the frontend-skip verdict"
+        ),
+    )
+    ap.add_argument(
         "--steps-sha256",
         required=True,
         help=(
@@ -340,9 +389,18 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     steps = json.loads(raw.decode("utf-8"))
     reserved = frozenset(int(c) for c in args.reserved.split(",") if c.strip())
+    frontend_labels = frozenset(s for s in args.frontend_labels.split(",") if s.strip())
 
     reconcile_leftovers(steps, args.exit_tree_ambiguous)
-    return run_steps(steps, args.cwd, reserved, args.preflight_label, args.exit_restore_failed)
+    return run_steps(
+        steps,
+        args.cwd,
+        reserved,
+        args.preflight_label,
+        args.exit_restore_failed,
+        args.exit_frontend_skip,
+        frontend_labels,
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised as a subprocess

--- a/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
@@ -1416,6 +1416,68 @@ def _venv_python(repo: str) -> Path | None:
     return None
 
 
+def _frontend_build_steps(
+    *,
+    npm_bin: str,
+    git_bin: str,
+    repo: str,
+) -> list[tuple[list[str], str, dict, str]]:
+    """The ``npm ci`` and ``npm build + stage`` steps, in order.
+
+    Returns both steps unconditionally. Whether they RUN is decided at run time
+    by the sync runner, which suppresses a step whose label is in its
+    frontend-skip set when the trusted preflight step exits the frontend-skip
+    verdict. That decision is made by the preflight -- the one point that runs
+    after ``fetch`` pinned the incoming ref and before ``merge`` -- so it is made
+    in the only window where "does the incoming ref touch the frontend?" has a
+    correct answer. Deciding it here at assembly time would read the per-PID sync
+    ref before fetch wrote it, so on a long-lived gateway's second sync it would
+    compare against the PRIOR tip and skip a rebuild an incoming frontend change
+    genuinely needed (#7132).
+
+    The two steps suppress together because the runner keys on their labels off
+    one preflight verdict, and they must: ``npm ci`` reifies the incoming
+    lockfile and ``npm build + stage`` compiles the source, sharing the one
+    precondition the verdict encodes.
+
+    ``git_bin`` is the sync's trusted-bin absolute git path; it is threaded into
+    ``build_and_stage`` so the read-only build-source fingerprint's git calls use
+    a trusted binary rather than a PATH search.
+    """
+    return [
+        ([npm_bin, "ci", "--prefix", "website"], "strict", runtime._build_env(), "npm ci"),
+        # Build and stage as ONE step, holding the staging lock across both.
+        # `npm run build` empties website/dist, so a peer flow (the dashboard's
+        # own update, pod provisioning) staging concurrently would copy a
+        # partially written tree — and a bundle's lazy chunks are not reachable
+        # from index.html, so no post-hoc inspection detects that reliably.
+        # Covering only the copy is not enough; the holder has to span the build.
+        #
+        # Run with THIS backend's interpreter, not the target checkout's: the
+        # logic is revision-independent, while resolving it from the target would
+        # make the step's very EXISTENCE contingent on the pulled revision
+        # carrying build_and_stage, turning an older target into an ImportError
+        # that fails the whole Pull+Build. The repo to build, npm's resolved
+        # trusted path, and git's trusted path are passed in rather than
+        # re-resolved.
+        (
+            [
+                sys.executable,
+                "-c",
+                "import sys;from kiro_crew.frontend import build_and_stage;"
+                "sys.exit(0 if build_and_stage(sys.argv[1], npm=sys.argv[2], "
+                "git=sys.argv[3]) else 1)",
+                repo,
+                npm_bin,
+                git_bin,
+            ],
+            "strict",
+            runtime._build_env(),
+            "npm build + stage",
+        ),
+    ]
+
+
 #: Trusted loader for the sync-runner snapshot. A FIXED literal — nothing is
 #: ever interpolated into it — so unlike the pre-extraction inline script it
 #: carries no program logic beyond verify-and-exec. It exists because a file
@@ -1729,6 +1791,14 @@ async def _sync_start_locked() -> dict:
                     str(repo),
                     "--ref",
                     sync_base_ref,
+                    # Asks this step to exit EXIT_FRONTEND_SKIP (a reserved code
+                    # trusted only from this step) when the incoming ref proves
+                    # the frontend install/build is already present, so the
+                    # runner suppresses the later npm ci and build+stage steps.
+                    # A flag, not a value -- the verdict travels as this step's
+                    # exit code and lives in runner state, never a file another
+                    # same-UID step could forge (#7132).
+                    "--emit-frontend-skip",
                 ],
                 "strict",
                 runtime._build_env(),
@@ -1798,37 +1868,18 @@ async def _sync_start_locked() -> dict:
             "edition; the shipped bundle is left in place"
         )
     else:
-        raw_steps += [
-            ([npm_bin, "ci", "--prefix", "website"], "strict", runtime._build_env(), "npm ci"),
-            # Build and stage as ONE step, holding the staging lock across both.
-            # `npm run build` empties website/dist, so a peer flow (the
-            # dashboard's own update, pod provisioning) staging concurrently
-            # would copy a partially written tree — and a bundle's lazy chunks
-            # are not reachable from index.html, so no post-hoc inspection of
-            # the copy detects that reliably. Covering only the copy is not
-            # enough; the holder has to span the build.
-            #
-            # Run with THIS backend's interpreter, not the target checkout's, for
-            # the same reason the staging step does: the logic is
-            # revision-independent, while resolving it from the target would make
-            # the step's very EXISTENCE contingent on the pulled revision
-            # carrying build_and_stage, turning an older target into an
-            # ImportError that fails the whole Pull+Build. The repo to build and
-            # npm's resolved trusted path are passed in rather than re-resolved.
-            (
-                [
-                    sys.executable,
-                    "-c",
-                    "import sys;from kiro_crew.frontend import build_and_stage;"
-                    "sys.exit(0 if build_and_stage(sys.argv[1], npm=sys.argv[2]) else 1)",
-                    repo,
-                    npm_bin,
-                ],
-                "strict",
-                runtime._build_env(),
-                "npm build + stage",
-            ),
-        ]
+        # Append the reinstall AND the rebuild. Whether they RUN is decided at
+        # run time by the sync runner: it suppresses these two labels when the
+        # preflight step (which runs after fetch pinned the incoming ref and
+        # before merge) exits the frontend-skip verdict -- the incoming ref
+        # changed nothing under website/ and node_modules is populated. A
+        # backend-only sync -- the common case, since most syncs move only
+        # Python -- otherwise pays a full `npm ci` (which DELETES node_modules
+        # before reinstalling from an unchanged lockfile) and a full vite build
+        # that reproduces a byte-identical bundle. The decision is made
+        # post-fetch, carried by the preflight's trusted exit code rather than
+        # in-process here where the ref is not yet fetched (#7132).
+        raw_steps += _frontend_build_steps(npm_bin=npm_bin, git_bin=git_bin, repo=str(repo))
     cleanups: list[str] = []
     # The preflight's snapshot is removed with the run's other temporaries. It is
     # registered here rather than left behind: a leaked mkdtemp per sync is how
@@ -1939,6 +1990,14 @@ async def _sync_start_locked() -> dict:
         str(npm_preflight.EXIT_TREE_AMBIGUOUS),
         "--exit-restore-failed",
         str(npm_preflight.EXIT_RESTORE_FAILED),
+        "--exit-frontend-skip",
+        str(npm_preflight.EXIT_FRONTEND_SKIP),
+        # The two labels the runner suppresses when the preflight asserts the
+        # frontend-skip verdict. They MATCH the labels _frontend_build_steps
+        # gives those steps; kept literal here rather than derived so the runner
+        # (which imports nothing from kiro_crew) is told exactly what to skip.
+        "--frontend-labels",
+        "npm ci,npm build + stage",
         "--steps-sha256",
         steps_sha256,
     ]

--- a/src/kiro_crew/frontend.py
+++ b/src/kiro_crew/frontend.py
@@ -360,6 +360,7 @@ def build_and_stage(
     proj_path: "str | Path | None" = None,
     npm: str | None = None,
     log: Callable[[str], None] = print,
+    git: str | None = None,
 ) -> bool:
     """Build this install's frontend and stage it, both under one lock.
 
@@ -372,8 +373,10 @@ def build_and_stage(
     ``proj_path`` accepts a string because the callers that need it are
     out-of-process and pass it through ``argv``. ``npm`` names the executable to
     run, so a caller that resolved a trusted path passes it rather than having it
-    re-resolved here. Returns ``True`` when ``static/dist`` holds the newly built
-    bundle.
+    re-resolved here. ``git`` likewise names the git executable for the read-only
+    build-source fingerprint: the Dev Fleet sync passes its trusted-bin absolute
+    path so the fingerprint's git calls never depend on a PATH search. Returns
+    ``True`` when ``static/dist`` holds the newly built bundle.
     """
     root = (
         Path(proj_path)
@@ -388,12 +391,95 @@ def build_and_stage(
     if not npm_bin:
         log("  ⚠️  npm not found — cannot build the frontend")
         return False
+    git_bin = git or shutil.which("git") or "git"
     try:
         with _staging_lock(root / "src" / "kiro_crew" / "static"):
-            return _npm_build_and_stage_locked(website_dir, root, npm_bin, log)
+            staged = _npm_build_and_stage_locked(website_dir, root, npm_bin, log)
+            if staged:
+                _write_build_source_fingerprint(root, git_bin, log)
+            return staged
     except OSError as exc:
         log(f"  ⚠️  Could not acquire the static/dist staging lock: {exc}")
         return False
+
+
+#: Records WHICH ``website/`` source the currently staged bundle was built from.
+#: Written beside the staged dist on every successful build+stage, and read by
+#: Dev Fleet's backend-only-sync skip: the skip is only safe when this equals the
+#: source the sync will end up with. It is the fingerprint the #7132 skip needs
+#: to distinguish "the build is already current" from a STALE tree left when a
+#: prior frontend sync merged new source but its ``npm ci`` failed and the
+#: transaction restored the old node_modules -- a case where the subtree stops
+#: changing yet the staged bundle was never built from it.
+_BUILD_SOURCE_FINGERPRINT = "kirocrew-build-source.txt"
+
+
+def _write_build_source_fingerprint(root: Path, git_bin: str, log: Callable[[str], None]) -> None:
+    """Stamp the git tree id of ``website/`` at HEAD beside the staged dist.
+
+    The git tree object id of ``website/`` is the exact identity of the built
+    source: it changes iff any tracked file under ``website/`` changes, and it
+    costs one ``git rev-parse``. Written to ``static/dist`` so it travels with
+    the bundle and is swept/replaced with it. Best-effort: a failure to stamp
+    leaves no fingerprint, and a missing fingerprint makes the skip decision fall
+    through to a rebuild (the safe direction), so this never blocks a build.
+
+    ``git_bin`` is the git executable to run -- the Dev Fleet sync passes its
+    trusted-bin absolute path, so these read-only calls do not depend on a PATH
+    search. Both calls are fixed list-argv, shell-free, and carry no
+    agent-supplied component; ``root`` is the operator's own registered checkout.
+
+    STAMPED ONLY WHEN ``website/`` IS CLEAN. ``HEAD:website`` names the committed
+    tree, but the build compiles the WORKING tree -- so if ``website/`` carried
+    uncommitted edits, the bundle was built from content ``HEAD:website`` does
+    not describe. Stamping anyway would let a later backend-only sync skip on a
+    fingerprint that matches HEAD while the dirty edit that was actually built
+    has since been reverted, serving a bundle built from content no longer on
+    disk. So a dirty ``website/`` writes NO fingerprint, and the next sync
+    rebuilds. The sync's own build runs after a ``merge --ff-only`` and is clean;
+    this guard covers the other callers (pod provision, dashboard update) and any
+    path that could build a dirty tree.
+    """
+    static_dist = root / "src" / "kiro_crew" / "static" / "dist"
+    try:
+        dirty = subprocess.run(  # nosec B603 - argv list, no shell
+            [git_bin, "-C", str(root), "status", "--porcelain", "--", "website"],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        if dirty.returncode != 0 or (dirty.stdout or b"").strip():
+            # Non-zero: cannot establish cleanliness. Non-empty: website/ has
+            # uncommitted changes, so HEAD:website does not describe what was
+            # built. Either way, leave no fingerprint -> the next sync rebuilds.
+            log(
+                "  ⚠️  website/ was not clean at build time; not fingerprinting "
+                "the bundle, so the next backend-only sync will rebuild"
+            )
+            return
+        proc = subprocess.run(  # nosec B603 - argv list, no shell
+            [git_bin, "-C", str(root), "rev-parse", "HEAD:website"],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        if proc.returncode != 0:
+            log(
+                "  ⚠️  Could not fingerprint the built frontend source; the next "
+                "backend-only sync will rebuild rather than skip"
+            )
+            return
+        tree_id = proc.stdout.decode(errors="replace").strip()
+        if not tree_id:
+            # An empty rev-parse output proves nothing; leave no fingerprint so
+            # the next sync rebuilds rather than trusting an empty tree id.
+            return
+        (static_dist / _BUILD_SOURCE_FINGERPRINT).write_text(tree_id, encoding="utf-8")
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        log(
+            f"  ⚠️  Could not write the build source fingerprint ({exc}); the next "
+            "backend-only sync will rebuild rather than skip"
+        )
 
 
 def _discard_path(path: Path) -> None:

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -7939,7 +7939,15 @@ async def test_sync_builds_and_stages_under_one_lock_holder(monkeypatch, tmp_pat
     # whole Pull+Build. The repo to build is passed as an argument instead.
     assert argvs[stage_i][0] == sys.executable
     assert str(repo) in argvs[stage_i], "the target repo must be passed explicitly"
-    assert argvs[stage_i][-1].endswith("npm"), "the trusted npm path is passed through"
+    # The build+stage child reads its args positionally: sys.argv[1]=repo,
+    # sys.argv[2]=npm, sys.argv[3]=git. Both binaries are the trusted _trusted_bin
+    # paths (stubbed here to /usr/bin/<name>), passed through explicitly rather
+    # than re-resolved in the child. The git path is a later addition (the
+    # read-only build-source fingerprint, #7132), so npm is now the
+    # second-to-last arg and git the last -- assert each trusted path reaches the
+    # spawn at the position its child consumes, not merely that one is last.
+    assert argvs[stage_i][4].endswith("npm"), "the trusted npm path is passed through (argv[2])"
+    assert argvs[stage_i][5].endswith("git"), "the trusted git path is passed through (argv[3])"
     assert not any(
         a[1:] == ["run", "build", "--prefix", "website"] for a in argvs
     ), "a separate unlocked npm build step would reintroduce the race"
@@ -9931,10 +9939,23 @@ async def test_only_the_preflight_step_may_assert_a_diagnosis(monkeypatch):
     assert passed == ",".join(str(c) for c in reserved), passed
     assert "--preflight-label" in cmd
     assert cmd[cmd.index("--preflight-label") + 1] == mod._PREFLIGHT_LABEL
-    # Every code the gateway will explain must be in the guarded set, or a code
-    # it explains could still arrive forged.
+    # Every code the gateway EXPLAINS must be in the guarded set, or a diagnosis
+    # it explains could arrive forged. The converse does not hold:
+    # EXIT_FRONTEND_SKIP is guarded so an untrusted step cannot forge it, but it
+    # is a SUCCESS verdict, not a diagnosis, so it carries no explanation.
     for code in reserved:
+        if code == npm_preflight.EXIT_FRONTEND_SKIP:
+            assert not npm_preflight.explain_exit(code), "the skip verdict is not a diagnosis"
+            continue
         assert npm_preflight.explain_exit(code), code
+    # The frontend-skip verdict must be guarded (reserved) so a worktree-run step
+    # cannot forge it to suppress the build, and the gateway must tell the runner
+    # its value and which labels it suppresses.
+    assert npm_preflight.EXIT_FRONTEND_SKIP in npm_preflight.RESERVED_EXIT_CODES
+    assert "--exit-frontend-skip" in cmd
+    assert cmd[cmd.index("--exit-frontend-skip") + 1] == str(npm_preflight.EXIT_FRONTEND_SKIP)
+    assert "--frontend-labels" in cmd
+    assert cmd[cmd.index("--frontend-labels") + 1] == "npm ci,npm build + stage"
 
 
 def test_the_trusted_label_matches_the_step_that_carries_it():

--- a/test/test_dev_fleet_backend_only_sync_skip.py
+++ b/test/test_dev_fleet_backend_only_sync_skip.py
@@ -1,0 +1,442 @@
+"""A backend-only Pull + Build must not reinstall node_modules or rebuild.
+
+Issue #7132. Dev Fleet's sync appended the ``npm ci`` and ``npm build + stage``
+steps unconditionally on every non-edition sync, so a sync that moved only
+Python still paid a full ``npm ci`` (which DELETES ``website/node_modules``
+before reinstalling from an unchanged lockfile) and a full vite build that
+reproduced a byte-identical bundle.
+
+The skip decision is made POST-FETCH by the preflight step -- the only window
+where ``git diff --name-only <ref> -- website/`` means "the incoming ref does
+not touch the frontend" (after ``fetch`` pinned the ref, before ``merge`` made
+the worktree equal to it). The preflight signals it by exiting a RESERVED code
+(:data:`npm_preflight.EXIT_FRONTEND_SKIP`) that the runner trusts ONLY from the
+preflight step's label; the runner then suppresses the two frontend steps,
+holding the verdict in its own state -- never a file a same-UID worktree step
+could forge (the security property GPT 5.6 Review flagged on the marker-file
+draft).
+
+These pin the three seams:
+* the preflight exits EXIT_FRONTEND_SKIP only when :func:`_install_already_proven`
+  fires;
+* the runner suppresses the frontend labels when the trusted preflight step
+  exits that code, WITHOUT running their node_modules transaction;
+* a forged EXIT_FRONTEND_SKIP from any OTHER step is demoted to a plain failure,
+  so an untrusted step cannot skip the build and ship stale assets.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.apps.builtins.dev_fleet import npm_preflight as np
+from kiro_crew.apps.builtins.dev_fleet import sync_runner
+
+PREFLIGHT_LABEL = "Verify dependencies"
+FRONTEND = frozenset({"npm ci", "npm build + stage"})
+
+
+def _tree(root: Path, *, populated: bool = True) -> str:
+    nm = root / "website" / "node_modules"
+    nm.mkdir(parents=True, exist_ok=True)
+    if populated:
+        (nm / ".package-lock.json").write_bytes(b"{}")
+    return str(root)
+
+
+def _fingerprint(root: Path, tree_id: str) -> None:
+    """Write the build-source fingerprint the skip requires, beside static/dist."""
+    d = Path(root, "src", "kiro_crew", "static", "dist")
+    d.mkdir(parents=True, exist_ok=True)
+    (d / np._BUILD_SOURCE_FINGERPRINT).write_text(tree_id, encoding="utf-8")
+
+
+def _git(
+    *,
+    changed: list[str] | None = None,
+    tree_id: str = "treesha_current",
+    rc: int = 0,
+    ls_rc: int = 0,
+    status_dirty: bool = False,
+    boom: Exception | None = None,
+):
+    """A ``git``/``npm`` stub answering the subtree diff, the skip-time
+    ``git status --porcelain`` cleanliness check, the rev-parse of the incoming
+    ref's website tree, and the ``npm ls --all`` integrity check.
+
+    ``ls_rc`` 0 = complete tree; ``status_dirty`` True = an uncommitted/untracked
+    website file is present at skip time."""
+
+    def fake_run(argv, **kw):
+        if boom is not None:
+            raise boom
+        if "ls" in argv:  # npm ls --all integrity check
+            return subprocess.CompletedProcess(argv, ls_rc, b"", b"missing: x" if ls_rc else b"")
+        if "status" in argv:  # skip-time worktree cleanliness (untracked included)
+            out = b"?? website/src/new.tsx\n" if status_dirty else b""
+            return subprocess.CompletedProcess(argv, rc, out, b"")
+        if "rev-parse" in argv:
+            return subprocess.CompletedProcess(argv, rc, (tree_id + "\n").encode(), b"")
+        out = "\n".join(changed or []).encode()  # diff
+        return subprocess.CompletedProcess(argv, rc, out, b"")
+
+    return fake_run
+
+
+# -- the preflight emits the frontend-skip verdict only when proven --
+
+
+class TestPreflightEmitsFrontendSkipOnlyWhenProven:
+    def _run_main(
+        self,
+        monkeypatch,
+        repo: str,
+        changed: list[str],
+        tree_id="treesha_current",
+        ls_rc=0,
+        status_dirty=False,
+    ):
+        # The probe's own npm ci must never run here; short-circuit it so only
+        # the --emit-frontend-skip path is under test.
+        monkeypatch.setattr(np, "probe", lambda **kw: (np.EXIT_OK, ""))
+        monkeypatch.setattr(
+            np.subprocess,
+            "run",
+            _git(changed=changed, tree_id=tree_id, ls_rc=ls_rc, status_dirty=status_dirty),
+        )
+        return np.main(
+            [
+                "--git",
+                "/usr/bin/git",
+                "--npm",
+                "/usr/bin/npm",
+                "--repo",
+                repo,
+                "--ref",
+                "origin/main",
+                "--emit-frontend-skip",
+            ]
+        )
+
+    def test_emits_skip_on_a_backend_only_sync_when_the_build_is_current(
+        self, tmp_path, monkeypatch
+    ):
+        """Unchanged subtree + populated node_modules + a build fingerprint that
+        matches the incoming website/ tree -> skip both frontend steps."""
+        repo = _tree(tmp_path)
+        _fingerprint(tmp_path, "treesha_current")  # matches the git stub's rev-parse
+        rc = self._run_main(monkeypatch, repo, changed=[], tree_id="treesha_current")
+        assert rc == np.EXIT_FRONTEND_SKIP
+
+    def test_does_not_emit_skip_when_the_build_fingerprint_is_stale(self, tmp_path, monkeypatch):
+        """The #7132 hole: a prior frontend sync merged new source but its npm ci
+        failed, so the transaction restored the OLD node_modules. The subtree
+        stops changing, but static/dist was built from the OLD tree. The
+        fingerprint (old) does not match the incoming website/ tree (new), so the
+        build MUST run rather than ship a stale bundle."""
+        repo = _tree(tmp_path)
+        _fingerprint(tmp_path, "treesha_OLD_source")  # built from a different tree
+        rc = self._run_main(monkeypatch, repo, changed=[], tree_id="treesha_current")
+        assert rc != np.EXIT_FRONTEND_SKIP, "a stale build fingerprint must force a rebuild"
+
+    def test_does_not_emit_skip_when_no_build_fingerprint_exists(self, tmp_path, monkeypatch):
+        """A bundle built before this feature (or a stamp that failed to write)
+        proves nothing about what the dist was built from -> rebuild."""
+        repo = _tree(tmp_path)  # no _fingerprint() written
+        rc = self._run_main(monkeypatch, repo, changed=[], tree_id="treesha_current")
+        assert rc != np.EXIT_FRONTEND_SKIP
+
+    @pytest.mark.parametrize(
+        "changed",
+        [
+            ["website/package-lock.json"],
+            ["website/package.json"],
+            ["website/.npmrc"],
+            ["website/src/App.tsx"],
+            ["website/index.html"],
+        ],
+    )
+    def test_does_not_emit_skip_when_the_frontend_changed(self, tmp_path, monkeypatch, changed):
+        repo = _tree(tmp_path)
+        _fingerprint(tmp_path, "treesha_current")  # even with a matching fingerprint
+        rc = self._run_main(monkeypatch, repo, changed=changed, tree_id="treesha_current")
+        assert rc != np.EXIT_FRONTEND_SKIP, changed
+
+    def test_does_not_emit_skip_when_node_modules_is_unpopulated(self, tmp_path, monkeypatch):
+        repo = _tree(tmp_path, populated=False)
+        _fingerprint(tmp_path, "treesha_current")
+        rc = self._run_main(monkeypatch, repo, changed=[], tree_id="treesha_current")
+        assert rc != np.EXIT_FRONTEND_SKIP
+
+    def test_does_not_emit_skip_when_the_tree_is_partial(self, tmp_path, monkeypatch):
+        """The GPT partial-tree gap: node_modules is non-empty (passes "populated")
+        and the source fingerprint matches, but `npm ls --all` reports missing
+        packages (rc!=0). The skip MUST be refused so the sync does not succeed on
+        an incomplete dependency tree."""
+        repo = _tree(tmp_path)
+        _fingerprint(tmp_path, "treesha_current")
+        rc = self._run_main(monkeypatch, repo, changed=[], tree_id="treesha_current", ls_rc=1)
+        assert rc != np.EXIT_FRONTEND_SKIP, "a partial node_modules must force a rebuild"
+
+    def test_does_not_emit_skip_when_an_untracked_frontend_file_is_present(
+        self, tmp_path, monkeypatch
+    ):
+        """The untracked-inputs gap: the tracked diff and the tree fingerprint
+        both ignore an untracked website/ file added since the build, but a skip
+        would serve a bundle that omits it. `git status --porcelain` (untracked
+        included) being non-empty must refuse the skip."""
+        repo = _tree(tmp_path)
+        _fingerprint(tmp_path, "treesha_current")
+        rc = self._run_main(
+            monkeypatch, repo, changed=[], tree_id="treesha_current", status_dirty=True
+        )
+        assert rc != np.EXIT_FRONTEND_SKIP, "an untracked website/ file must force a rebuild"
+
+    def test_without_the_flag_the_skip_code_is_never_returned(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np, "probe", lambda **kw: (np.EXIT_OK, "ok"))
+        called = {"n": 0}
+        monkeypatch.setattr(
+            np,
+            "_frontend_build_already_current",
+            lambda *a: (called.__setitem__("n", called["n"] + 1), None)[1],
+        )
+        rc = np.main(["--git", "/g", "--npm", "/n", "--repo", "/r", "--ref", "x"])
+        assert rc == np.EXIT_OK
+        assert called["n"] == 0, "no flag -> the skip predicate must not be consulted"
+
+    def test_the_skip_code_is_reserved(self):
+        """It must be in the reserved set or the runner would not demote a forged
+        one from an untrusted step -- the whole security property."""
+        assert np.EXIT_FRONTEND_SKIP in np.RESERVED_EXIT_CODES
+
+
+# -- the runner suppresses the frontend steps on the trusted verdict --
+
+
+def _echo_step(label, rc, tmp_path, stash=None):
+    """A step that writes a sentinel file then exits rc, so a skip is observable
+    by the sentinel's ABSENCE."""
+    ran = tmp_path / f"ran-{label.replace(' ', '_')}"
+    st = {
+        "label": label,
+        "env": {},
+        "argv": [
+            "python3",
+            "-c",
+            "import sys,pathlib;pathlib.Path(sys.argv[1]).write_text('x');sys.exit(int(sys.argv[2]))",
+            str(ran),
+            str(rc),
+        ],
+    }
+    if stash:
+        st["stash"] = stash
+    return st, ran
+
+
+def _run(steps, cwd):
+    return sync_runner.run_steps(
+        steps,
+        cwd,
+        frozenset({np.EXIT_FRONTEND_SKIP}),  # reserved
+        PREFLIGHT_LABEL,
+        np.EXIT_RESTORE_FAILED,
+        np.EXIT_FRONTEND_SKIP,
+        FRONTEND,
+    )
+
+
+class TestRunnerSuppressesFrontendOnTheTrustedVerdict:
+    def test_preflight_skip_verdict_suppresses_both_frontend_steps(self, tmp_path):
+        pf, pf_ran = _echo_step(PREFLIGHT_LABEL, np.EXIT_FRONTEND_SKIP, tmp_path)
+        ci, ci_ran = _echo_step("npm ci", 0, tmp_path)
+        build, build_ran = _echo_step("npm build + stage", 0, tmp_path)
+        rc = _run([pf, ci, build], str(tmp_path))
+        assert rc == 0, "the skip verdict is a success, not a failure"
+        assert pf_ran.exists(), "the preflight itself must have run"
+        assert not ci_ran.exists(), "npm ci must be suppressed by the skip verdict"
+        assert not build_ran.exists(), "build + stage must be suppressed by the skip verdict"
+
+    def test_preflight_ok_runs_both_frontend_steps(self, tmp_path):
+        pf, _ = _echo_step(PREFLIGHT_LABEL, 0, tmp_path)
+        ci, ci_ran = _echo_step("npm ci", 0, tmp_path)
+        build, build_ran = _echo_step("npm build + stage", 0, tmp_path)
+        rc = _run([pf, ci, build], str(tmp_path))
+        assert rc == 0
+        assert ci_ran.exists() and build_ran.exists(), "a normal preflight leaves the build to run"
+
+    def test_suppressed_npm_ci_does_not_run_the_transaction(self, tmp_path):
+        """The safety property: a suppressed npm ci must leave node_modules
+        untouched. The transaction moves the tree aside on entry and DROPS the
+        backup on a zero exit, so a suppressed step must not enter it or the tree
+        is deleted."""
+        repo = Path(_tree(tmp_path))
+        stash = str(repo / "website" / "node_modules")
+        before = sorted(p.name for p in (repo / "website" / "node_modules").iterdir())
+        pf, _ = _echo_step(PREFLIGHT_LABEL, np.EXIT_FRONTEND_SKIP, tmp_path)
+        ci, _ = _echo_step("npm ci", 0, tmp_path, stash=stash)
+        rc = _run([pf, ci], str(tmp_path))
+        assert rc == 0
+        assert (
+            repo / "website" / "node_modules"
+        ).is_dir(), (
+            "a suppressed npm ci must NOT run the transaction that would delete node_modules"
+        )
+        after = sorted(p.name for p in (repo / "website" / "node_modules").iterdir())
+        assert after == before
+
+    def test_an_unsuppressed_npm_ci_failure_still_restores_via_the_transaction(self, tmp_path):
+        """The saving must not disarm the protection: an npm ci that actually
+        runs and FAILS is still restored by the transaction."""
+        repo = Path(_tree(tmp_path))
+        stash = str(repo / "website" / "node_modules")
+        pf, _ = _echo_step(PREFLIGHT_LABEL, 0, tmp_path)  # normal, no skip
+        ci, _ = _echo_step("npm ci", 3, tmp_path, stash=stash)  # runs and fails
+        rc = _run([pf, ci], str(tmp_path))
+        assert rc == 3
+        assert (repo / "website" / "node_modules").is_dir()
+
+
+# -- an untrusted step cannot FORGE the skip verdict (the GPT security finding) --
+
+
+class TestUntrustedStepCannotForgeTheSkipVerdict:
+    def test_a_non_preflight_step_exiting_the_skip_code_is_demoted_to_failure(self, tmp_path):
+        """A pip lifecycle script (worktree-controlled) exiting EXIT_FRONTEND_SKIP
+        must NOT be honoured as a skip. demote_reserved turns it into a plain
+        failure, so the sync fails loudly instead of silently shipping a stale
+        build.
+        """
+        out = sync_runner.demote_reserved(
+            np.EXIT_FRONTEND_SKIP,
+            "pip install",
+            frozenset({np.EXIT_FRONTEND_SKIP}),
+            PREFLIGHT_LABEL,
+        )
+        assert out == 1, "a forged skip code from an untrusted step must be demoted to failure"
+
+    def test_a_forged_skip_from_pip_does_not_suppress_the_frontend(self, tmp_path):
+        """End to end through run_steps: a pip step forging the code fails the
+        run (fail-fast), and the frontend steps are never reached -- the opposite
+        of being skipped-as-success."""
+        pf, _ = _echo_step(PREFLIGHT_LABEL, 0, tmp_path)  # honest preflight, no skip
+        pip, _ = _echo_step("pip install", np.EXIT_FRONTEND_SKIP, tmp_path)  # forges the code
+        ci, ci_ran = _echo_step("npm ci", 0, tmp_path)
+        rc = _run([pf, pip, ci], str(tmp_path))
+        assert rc == 1, "the forged skip code must be demoted to a failure"
+        assert not ci_ran.exists(), "fail-fast: npm ci is never reached, not skipped-as-success"
+
+    def test_the_preflight_label_keeps_its_trusted_skip_code(self, tmp_path):
+        """Control for the demotion test: the SAME code from the preflight label
+        is NOT demoted."""
+        out = sync_runner.demote_reserved(
+            np.EXIT_FRONTEND_SKIP,
+            PREFLIGHT_LABEL,
+            frozenset({np.EXIT_FRONTEND_SKIP}),
+            PREFLIGHT_LABEL,
+        )
+        assert out == np.EXIT_FRONTEND_SKIP
+
+
+# -- the assembled steps are the plain npm ci / build + stage, unchanged --
+
+
+class TestFrontendBuildStepsShape:
+    def test_both_steps_present_in_order(self):
+        from kiro_crew.apps.builtins.dev_fleet import worktree_ops
+
+        steps = worktree_ops._frontend_build_steps(
+            npm_bin="/usr/bin/npm", git_bin="/usr/bin/git", repo="/repo"
+        )
+        labels = [label for (_argv, _mode, _env, label) in steps]
+        assert labels == ["npm ci", "npm build + stage"]
+        assert steps[0][0] == ["/usr/bin/npm", "ci", "--prefix", "website"]
+        assert "build_and_stage" in steps[1][0][2]
+        # The labels the runner is told to suppress must match these exactly.
+        assert set(labels) == FRONTEND
+
+
+# -- the fingerprint is stamped only when website/ was clean (GPT finding) --
+
+
+class TestBuildSourceFingerprintCleanTreeGuard:
+    """`_write_build_source_fingerprint` records HEAD:website, which describes the
+    COMMITTED tree. The build compiles the WORKING tree, so a dirty website/ must
+    NOT be stamped -- else a reverted dirty edit would let a later sync skip on a
+    fingerprint that matches HEAD while the bundle was built from content no
+    longer on disk."""
+
+    def _git_status(self, *, porcelain: bytes, tree_id: bytes = b"tree_head\n", rc: int = 0):
+        from kiro_crew import frontend as fe
+
+        def fake_run(argv, **kw):
+            if "status" in argv:
+                return subprocess.CompletedProcess(argv, rc, porcelain, b"")
+            if "rev-parse" in argv:
+                return subprocess.CompletedProcess(argv, 0, tree_id, b"")
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+        return fe, fake_run
+
+    def test_clean_website_is_stamped(self, tmp_path, monkeypatch):
+        fe, fake = self._git_status(porcelain=b"")
+        (tmp_path / "src" / "kiro_crew" / "static" / "dist").mkdir(parents=True)
+        monkeypatch.setattr(fe.subprocess, "run", fake)
+        fe._write_build_source_fingerprint(tmp_path, "/usr/bin/git", log=lambda *_: None)
+        fp = tmp_path / "src" / "kiro_crew" / "static" / "dist" / fe._BUILD_SOURCE_FINGERPRINT
+        assert fp.exists() and fp.read_text().strip() == "tree_head"
+
+    def test_dirty_website_is_not_stamped(self, tmp_path, monkeypatch):
+        fe, fake = self._git_status(porcelain=b" M website/src/App.tsx\n")
+        (tmp_path / "src" / "kiro_crew" / "static" / "dist").mkdir(parents=True)
+        monkeypatch.setattr(fe.subprocess, "run", fake)
+        fe._write_build_source_fingerprint(tmp_path, "/usr/bin/git", log=lambda *_: None)
+        fp = tmp_path / "src" / "kiro_crew" / "static" / "dist" / fe._BUILD_SOURCE_FINGERPRINT
+        assert (
+            not fp.exists()
+        ), "a dirty website/ must leave no fingerprint, so the next sync rebuilds"
+
+    def test_unresolvable_status_is_not_stamped(self, tmp_path, monkeypatch):
+        fe, fake = self._git_status(porcelain=b"", rc=128)
+        (tmp_path / "src" / "kiro_crew" / "static" / "dist").mkdir(parents=True)
+        monkeypatch.setattr(fe.subprocess, "run", fake)
+        fe._write_build_source_fingerprint(tmp_path, "/usr/bin/git", log=lambda *_: None)
+        fp = tmp_path / "src" / "kiro_crew" / "static" / "dist" / fe._BUILD_SOURCE_FINGERPRINT
+        assert not fp.exists()
+
+
+# -- npm ls is the tree-completeness signal (GPT partial-tree finding) --
+
+
+class TestFrontendTreeComplete:
+    def test_complete_tree_is_true(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np.subprocess, "run", _git(ls_rc=0))
+        assert np._frontend_tree_complete("/usr/bin/npm", str(tmp_path)) is True
+
+    def test_partial_tree_is_false(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np.subprocess, "run", _git(ls_rc=1))
+        assert np._frontend_tree_complete("/usr/bin/npm", str(tmp_path)) is False
+
+    def test_missing_npm_is_false(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np.subprocess, "run", _git(boom=OSError("no npm")))
+        assert np._frontend_tree_complete("/usr/bin/npm", str(tmp_path)) is False
+
+    def test_timeout_is_false(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np.subprocess, "run", _git(boom=subprocess.TimeoutExpired("npm", 120)))
+        assert np._frontend_tree_complete("/usr/bin/npm", str(tmp_path)) is False
+
+
+class TestFrontendWorktreeClean:
+    def test_clean_is_true(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np.subprocess, "run", _git(status_dirty=False))
+        assert np._frontend_worktree_clean("/usr/bin/git", str(tmp_path)) is True
+
+    def test_untracked_is_false(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np.subprocess, "run", _git(status_dirty=True))
+        assert np._frontend_worktree_clean("/usr/bin/git", str(tmp_path)) is False
+
+    def test_missing_git_is_false(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np.subprocess, "run", _git(boom=OSError("no git")))
+        assert np._frontend_worktree_clean("/usr/bin/git", str(tmp_path)) is False

--- a/test/test_frontend_dist_resolve.py
+++ b/test/test_frontend_dist_resolve.py
@@ -875,6 +875,12 @@ def test_build_and_stage_accepts_a_string_repo_path(tmp_path):
 
     class _Done:
         returncode = 0
+        # build_and_stage now also runs read-only `git status`/`rev-parse` to
+        # fingerprint the built source; stubbed git returns empty output, read as
+        # a clean tree with no resolvable id, so no fingerprint is written and
+        # the staged-bundle assertion below is unaffected.
+        stdout = b""
+        stderr = b""
 
         def wait(self, timeout=None):
             return 0

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -773,6 +773,40 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "apps/builtins/dev_fleet/npm_preflight.py::_extract",
         "apps/builtins/dev_fleet/npm_preflight.py::_install_already_proven",
         "apps/builtins/dev_fleet/npm_preflight.py::probe",
+        # _frontend_build_already_current is the STRONGER build-skip predicate
+        # that wraps _install_already_proven (listed directly above) and adds one
+        # read-only spawn: `<git> -C <repo> rev-parse <ref>:website`. Same three
+        # sources as its wrapped sibling -- the binary is the sync's _trusted_bin
+        # git (never a PATH search), the repo is the operator-configured checkout,
+        # and <ref> is the sync's own per-PID base ref, never agent-supplied. It
+        # is fixed list-argv, shell-free, and only READS (it resolves a tree id to
+        # compare against the staged bundle's fingerprint); nothing is written.
+        # Consistent with npm_preflight.py::_install_already_proven / ::_extract
+        # above and git_divergence.py::count_divergence below -- and refusing it
+        # while the function it wraps is listed would make the same subprocess
+        # benign when called directly and forbidden through a one-line wrapper.
+        "apps/builtins/dev_fleet/npm_preflight.py::_frontend_build_already_current",
+        # _frontend_worktree_clean is one of that predicate's two guards. One
+        # read-only spawn: `<git> -C <repo> status --porcelain
+        # --untracked-files=normal -- website`. Fixed list-argv, shell-free, no
+        # agent-supplied component -- the binary is the sync's _trusted_bin git
+        # (threaded in via _frontend_build_already_current, never a PATH search),
+        # the repo is the operator-configured checkout, and the subcommand,
+        # flags and pathspec are literals. It only READS the working-tree status
+        # (writes nothing). Same class as
+        # npm_preflight.py::_install_already_proven / ::_extract above and
+        # git_divergence.py::count_divergence below.
+        "apps/builtins/dev_fleet/npm_preflight.py::_frontend_worktree_clean",
+        # _frontend_tree_complete is the predicate's other guard: the on-disk
+        # node_modules completeness check. One read-only spawn: `<npm> ls --all`
+        # with cwd set to <repo>/website. Fixed list-argv, shell-free, no
+        # agent-supplied component -- the binary is the sync's _trusted_bin npm
+        # (the same npm probe() uses), the cwd is the operator-configured
+        # checkout's website subtree, and the args are literals. `npm ls` only
+        # WALKS the installed tree against the lockfile (writes nothing, runs no
+        # lifecycle scripts). Same class as npm_preflight.py::probe, whose npm
+        # spawn is listed above.
+        "apps/builtins/dev_fleet/npm_preflight.py::_frontend_tree_complete",
         # Foreground last-resort restart (Make Live on hosts with no drivable
         # service manager): a detached `kirocrew restart --port <marker port>`,
         # fixed argv whose binary is validated (basenamed kirocrew, absolute,
@@ -1042,6 +1076,20 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "frontend.py::_npm_build_and_stage_locked",
         "frontend.py::build_frontend_async",
         "frontend.py::build_frontend_sync",
+        # _write_build_source_fingerprint stamps the built bundle's source
+        # identity beside static/dist, with two read-only spawns:
+        # `<git> -C <root> status --porcelain -- website` and
+        # `<git> -C <root> rev-parse HEAD:website`. Fixed list-argv, shell-free,
+        # no agent-supplied component: <root> is the operator's own registered
+        # checkout, the subcommands and pathspec are literals, and neither call
+        # writes anything (only the resulting tree id is written to a file, by
+        # Python, not by git). The git binary is the sync's _trusted_bin absolute
+        # path when Dev Fleet calls build_and_stage (git= is threaded through);
+        # the standalone callers fall back to a PATH `git`, the same resolution
+        # the sibling frontend.py::_npm_build_and_stage_locked already uses for
+        # npm. Same trust class as npm_preflight.py::_install_already_proven and
+        # git_divergence.py::count_divergence.
+        "frontend.py::_write_build_source_fingerprint",
         # The shared ahead/behind divergence count: a read-only ``git rev-list
         # --count --left-right HEAD...<upstream>`` fixed list-argv (no shell)
         # run against the install's own checkout. Callers pass the repo path


### PR DESCRIPTION
## What is the problem?

Dev Fleet's Pull + Build runs a full frontend install (npm ci for the website workspace) and a full vite build plus dist stage on every non-edition sync, even when the sync changed nothing under the website tree. On a backend-only sync -- one that moves only Python -- both still run: the install deletes and reinstalls 1113 packages from an unchanged lockfile, and the build recompiles about 7165 modules into a bundle byte-identical in content to the one already staged.

## Why it matters to the user

Pull + Build is an interactive button; the operator waits on the critical path. On a sync that touches no frontend file, the whole frontend half of that wait reproduces what is already on disk. It also carries a second-order risk: the install deleting and reinstalling the tree is exactly the step the sync's stash transaction exists to protect, so every backend-only sync takes a needless trip through the one step in the run that can destroy the installed tree.

## How the fix solves it

Root cause: the two frontend steps were appended unconditionally in the sync assembly, gated only by an edition-config switch, never by what the incoming ref changed.

The decision is made after fetch by the preflight step -- the only window where the incoming ref is pinned and the worktree has not yet been merged to it. The preflight signals the verdict by exiting a reserved exit code that the runner trusts only from the preflight step's own label; the runner then suppresses the install and build steps, holding the verdict in its own in-process state. A worktree-run step (a pip lifecycle script) exiting the same code is demoted to a plain failure, so it cannot forge a skip. A suppressed step is skipped whole, including its dependency-tree transaction, which must not run for a no-op or its move-aside then drop-backup would delete the tree.

The suppression fires only when all four of these hold, so the tree that produced the staged bundle and the tree on disk are provably identical across tracked files, untracked files, and installed packages:

1. the incoming ref changes nothing under the website tree (tracked diff);
2. the working tree is clean including untracked files (porcelain status, untracked-files normal);
3. the installed tree is complete against the lockfile (npm ls all exits zero) -- not merely a non-empty directory, which a partial install would pass;
4. a build-source fingerprint (the git tree id of the website tree, stamped beside the staged bundle on the last successful build, and only when that build's tree was clean) equals the incoming ref's website tree.

Any single failure, or any uncertainty (missing or failing git or npm, a timeout), returns run, so the unknown case always rebuilds. The skip condition cannot be true while a rebuild is owed.

## Declared bound (certify over this)

Skip-based suppression is a point-in-time decision by design, so there is an inherent check-then-skip window: the preflight decides before the merge, the runner suppresses after it, and the build-currency fingerprint is read right after the build. A tree changed by a concurrent writer in that window yields a stale build, never a wrong or corrupt one. This is the defining window of every build cache; closing it completely would need a lock held across the whole build, which destroys the roughly 28 seconds this change saves. The worst outcome is a stale build on the operator's own checkout, rebuilt by re-running Pull + Build -- no data lost, nothing corrupted, and whoever changed the tree mid-sync is who sees the result. The window is kept as narrow as it cheaply can be without a lock: the cleanliness check and the tree-id read run back-to-back under the staging lock, and the preflight runs immediately before the merge.

## Tests

A new regression file (backend-only-sync-skip), red on base and mutation-verified: the preflight emits the skip verdict only when all four preconditions hold; a changed frontend, a dirty or untracked tree, a partial installed tree, a stale build fingerprint, or a build over a dirty tree each force a rebuild; the runner suppresses both frontend steps on the trusted verdict without running the dependency-tree transaction; an unsuppressed install failure is still restored by the transaction; a forged verdict from a non-preflight step is demoted to a failure. In-scope consumer tests (the preflight, the sync runner, the dev-fleet app spawn and diagnosis tests, the dist-resolve tests) re-run green. black, isort, flake8 and mypy are clean on the changed source; the black baseline was pruned for one file this change made black-clean; the two new read-only git and npm guard spawns are registered in the spawn-audit allowlist as the same read-only fixed-argv class as the existing preflight and divergence entries.

Performance -- backend-only sync, on this host, both ways:

- install: a script-free offline install into a scratch directory -- 10s wall, 1165 packages, 844M tree. MEASURED (a floor: the production step also runs lifecycle scripts and rewrites the tree in place).
- build: a production build to a scratch output directory so the live bundle was untouched -- 28.48s wall, 7165 modules. MEASURED.
- Before (a backend-only sync): both run, about 38s on the critical path. After: both suppressed, 0s of frontend work, verified by the runner-suppression tests.

## Other suggestions

None. The edition path and the pre-merge probe already made the same skip decision at their own seams; this closes the two remaining steps against the same predicate, hardened with the runner's own trust model and the build-currency preconditions above.

## Pattern harvest

Defect class: a fixed step sequence doing work unconditionally instead of keying the decision on its real input, compounded by two follow-on traps -- deciding in-process at assembly time before the input (the fetched ref) exists, and reusing a sibling's skip predicate (whose stale-tree case is benign for a rehearsal) to gate a producing step (a build), where the same staleness is not benign. Fixed by deferring the decision to the post-fetch step, carrying the verdict as a trusted reserved exit code (not a forgeable file), and proving build currency (clean tree including untracked, complete install, matching source fingerprint) before skipping.

Rule candidate: when reusing an existing skip predicate for a new caller, check whether the new caller produces an artifact the old one only verified -- safe to skip the check is not safe to skip the work, and the producing caller must prove the artifact is current, not just that the tracked inputs are unchanged.

Closes #7132
