### PR TITLE
refactor(electron): share typed preload bridge contracts

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -976,7 +976,7 @@ function NotificationsBellButton() {
 
   // RFC Phase 4: mirror the unread count onto the desktop dock/taskbar badge.
   useEffect(() => {
-    const api = (window as Window & { electronAPI?: { setBadgeCount?: (n: number) => void } }).electronAPI
+    const api = window.electronAPI
     api?.setBadgeCount?.(unacked.length)
   }, [unacked.length])
   const selected = selectedTs ? items.find(n => n.ts === selectedTs) || null : null
@@ -1661,7 +1661,7 @@ export default function App() {
     // header's is: both stay MOUNTED and slide, so a shadow that is always on
     // paints its tail into the content while the surface itself is off screen.
     document.body.classList.toggle('mc-focus-rail', railPeek.open)
-    const api = (window as Window & { electronAPI?: { setFocusModeChrome?: (v: boolean) => void } }).electronAPI
+    const api = window.electronAPI
     api?.setFocusModeChrome?.(focusChromeVisible)
   }, [focusActive, focusChromeVisible, railPeek.open])
   // Same re-assert on window focus. Button visibility is window state this
@@ -1670,7 +1670,7 @@ export default function App() {
   useEffect(() => {
     if (!focusActive) return
     const reassert = () => {
-      const api = (window as Window & { electronAPI?: { setFocusModeChrome?: (v: boolean) => void } }).electronAPI
+      const api = window.electronAPI
       api?.setFocusModeChrome?.(focusChromeVisible)
     }
     window.addEventListener('focus', reassert)
@@ -1681,7 +1681,7 @@ export default function App() {
   // between the two commits.
   useEffect(() => () => {
     document.body.classList.remove('mc-focus-mode', 'mc-focus-chrome', 'mc-focus-rail')
-    const api = (window as Window & { electronAPI?: { setFocusModeChrome?: (v: boolean) => void } }).electronAPI
+    const api = window.electronAPI
     api?.setFocusModeChrome?.(true)
   }, [])
   const [sidePanelDock] = useSidePanelDock()
@@ -1709,7 +1709,7 @@ export default function App() {
   // had not: the traffic lights came back.
   useEffect(() => {
     if (!focusActive) return
-    const api = (window as Window & { electronAPI?: { setFocusModeChrome?: (v: boolean) => void } }).electronAPI
+    const api = window.electronAPI
     api?.setFocusModeChrome?.(focusChromeVisible)
   }, [activeInstanceId, focusActive, focusChromeVisible])
   // Whether the shell's one-shot entrance animation has already played.
@@ -2634,7 +2634,7 @@ export default function App() {
   }, [])
   // Sync dev-mode state to Electron on startup (so View > DevTools menu is correct)
   useEffect(() => {
-    const electronAPI = (window as Window & { electronAPI?: { setDevMode?: (v: boolean) => void } }).electronAPI
+    const electronAPI = window.electronAPI
     electronAPI?.setDevMode?.(devMode)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
   // Native app-menu navigation (Settings…, About) and the Crew Companion's "Open
@@ -2648,7 +2648,7 @@ export default function App() {
   // would surface the dashboard with the previous session still on screen: the
   // window comes forward and the notification appears to have opened nothing.
   useEffect(() => {
-    const electronAPI = (window as Window & { electronAPI?: { onNavigate?: (cb: (path: string) => void) => () => void } }).electronAPI
+    const electronAPI = window.electronAPI
     if (!electronAPI?.onNavigate) return
     return electronAPI.onNavigate(path => {
       if (typeof path !== 'string' || !/^\/(?!\/)/.test(path)) return

--- a/website/src/components/CrashReportNotice.tsx
+++ b/website/src/components/CrashReportNotice.tsx
@@ -37,12 +37,7 @@ import { i18nT } from '../i18n/t'
  * where there is no local disk holding crash artifacts to reveal — the banner
  * simply never renders, rather than offering an action that cannot work.
  */
-type CrashReportsAPI = {
-  get(): Promise<{ newCount: number }>
-  reveal(): Promise<{ ok: boolean; error?: string }>
-}
-const crashReportsAPI = (): CrashReportsAPI | undefined =>
-  (window as { crashReportsAPI?: CrashReportsAPI }).crashReportsAPI
+const crashReportsAPI = (): CrashReportsAPI | undefined => window.crashReportsAPI
 
 export default function CrashReportNotice() {
   const [count, setCount] = useState(0)

--- a/website/src/components/UpdateFoundModal.tsx
+++ b/website/src/components/UpdateFoundModal.tsx
@@ -41,10 +41,8 @@ import type { UpdateState } from '../hooks/useUpdateSubscription'
  * installs from merely showing this modal.
  */
 
-type UpdateAPI = { download?: () => Promise<unknown> }
-
 function getUpdateApi(): UpdateAPI | undefined {
-  return (window as unknown as { updateAPI?: UpdateAPI }).updateAPI
+  return window.updateAPI
 }
 
 /**
@@ -102,8 +100,7 @@ export default function UpdateFoundModal() {
   const { data: bridgeInfo } = useQuery({
     queryKey: ['update-info'],
     queryFn: async () =>
-      (window as unknown as { updateAPI?: { getInfo?: () => Promise<{ autoDownload?: boolean; channel?: string | null }> } })
-        .updateAPI?.getInfo?.() ?? null,
+      window.updateAPI?.getInfo?.() ?? null,
     enabled: !!desktop && (desktop.state === 'found' || desktop.state === 'available'),
     staleTime: Infinity,
   })

--- a/website/src/components/UpdateModal.tsx
+++ b/website/src/components/UpdateModal.tsx
@@ -23,12 +23,8 @@ import type { UpdateState } from '../hooks/useUpdateSubscription'
  * the Electron preload), so it's safe to mount unconditionally in App.
  */
 
-type UpdateAPI = {
-  install: () => Promise<unknown>
-}
-
 function getUpdateApi(): UpdateAPI | undefined {
-  return (window as unknown as { updateAPI?: UpdateAPI }).updateAPI
+  return window.updateAPI
 }
 
 export default function UpdateModal() {

--- a/website/src/components/WindowsTitlebarMenu.tsx
+++ b/website/src/components/WindowsTitlebarMenu.tsx
@@ -20,21 +20,7 @@ const formatWindowsAccelerator = (accelerator: string) => accelerator
   .replaceAll('CommandOrControl', 'Ctrl')
   .replaceAll('CmdOrCtrl', 'Ctrl')
 
-type ElectronMenuAPI = {
-  getAppMenuItems?: (id: string) => Promise<AppMenuItem[]>
-  executeAppMenuItem?: (id: string, index: number) => void
-}
-
-type AppMenuItem =
-  | { type: 'separator'; index: number }
-  | {
-      type: 'normal' | 'checkbox' | 'radio'
-      index: number
-      label: string
-      accelerator: string
-      enabled: boolean
-      checked: boolean
-    }
+type AppMenuItem = ElectronAppMenuItem
 
 /**
  * Zed-style Windows application menu. It rests as a compact hamburger, expands
@@ -106,7 +92,7 @@ export default function WindowsTitlebarMenu() {
   }, [collapseMenu, expanded])
 
   const openMenu = useCallback(async (id: string, target: HTMLElement) => {
-    const api = (window as Window & { electronAPI?: ElectronMenuAPI }).electronAPI
+    const api = window.electronAPI
     if (!api?.getAppMenuItems) return
     const rect = target.getBoundingClientRect()
     const titlebarBottom = target.closest('header')?.getBoundingClientRect().bottom
@@ -138,7 +124,7 @@ export default function WindowsTitlebarMenu() {
   }, [activeMenuId, collapseMenu, openMenu])
 
   const executeItem = useCallback((item: Exclude<AppMenuItem, { type: 'separator' }>) => {
-    const api = (window as Window & { electronAPI?: ElectronMenuAPI }).electronAPI
+    const api = window.electronAPI
     if (activeMenuId && item.enabled) api?.executeAppMenuItem?.(activeMenuId, item.index)
     collapseMenu(true)
   }, [activeMenuId, collapseMenu])

--- a/website/src/hooks/useGlobalHotkey.ts
+++ b/website/src/hooks/useGlobalHotkey.ts
@@ -2,8 +2,6 @@ import { useQuery } from '@tanstack/react-query'
 import { isElectron } from '../lib/electron'
 import type { GlobalHotkeyInfo } from '../lib/globalHotkey'
 
-type HotkeyBridge = { getGlobalHotkey?: () => Promise<GlobalHotkeyInfo> }
-
 /**
  * The desktop shell's system-wide summon hotkey, as ACTUALLY bound by the main
  * process (registration can degrade to the platform default or to nothing when
@@ -15,7 +13,7 @@ type HotkeyBridge = { getGlobalHotkey?: () => Promise<GlobalHotkeyInfo> }
  * lifetime (registered once on app ready), hence `staleTime: Infinity`.
  */
 export function useGlobalHotkey(): GlobalHotkeyInfo | null {
-  const api = (window as Window & { electronAPI?: HotkeyBridge }).electronAPI
+  const api = window.electronAPI
   const available = isElectron && typeof api?.getGlobalHotkey === 'function'
   const { data } = useQuery({
     queryKey: ['global-hotkey'],

--- a/website/src/hooks/useLocalGateway.ts
+++ b/website/src/hooks/useLocalGateway.ts
@@ -6,12 +6,7 @@ import { useState, useEffect, useCallback } from 'react'
 // the client asking it. In a plain browser or the PWA the bridge is absent and
 // there is nothing to manage, so `supported` is false and the UI hides the
 // control rather than showing one that cannot work.
-type LocalGatewayAPI = {
-  get(): Promise<boolean>
-  set(enabled: boolean): Promise<boolean>
-}
-const localGatewayAPI = (): LocalGatewayAPI | undefined =>
-  (window as { localGatewayAPI?: LocalGatewayAPI }).localGatewayAPI
+const localGatewayAPI = (): LocalGatewayAPI | undefined => window.localGatewayAPI
 
 /**
  * Read/write the desktop app's "run a local gateway" choice.

--- a/website/src/hooks/useNativeBrowser.ts
+++ b/website/src/hooks/useNativeBrowser.ts
@@ -1,36 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 /** State mirrored back from the main process's per-panel browser manager. */
-export interface NativeBrowserState {
-  open: boolean
-  visible: boolean
-  url: string
-  bounds: { x: number; y: number; width: number; height: number } | null
-  overlayActive?: boolean
-  refused?: boolean
-}
+export type NativeBrowserState = globalThis.NativeBrowserState
 
-interface NativeBrowserBridge {
-  open: (panelId: string, url: string) => Promise<NativeBrowserState | null>
-  navigate: (panelId: string, url: string) => Promise<NativeBrowserState | null>
-  setBounds: (
-    panelId: string,
-    rect: { x: number; y: number; width: number; height: number },
-    viewport: { width: number; height: number },
-  ) => Promise<NativeBrowserState | null>
-  setOverlayActive: (panelId: string, active: boolean) => Promise<NativeBrowserState | null>
-  setInactive: (panelId: string, value: boolean) => Promise<NativeBrowserState | null>
-  close: (panelId: string) => Promise<NativeBrowserState | null>
-  getState: (panelId: string) => Promise<NativeBrowserState | null>
-  setAgentAct: (panelId: string, enabled: boolean) => Promise<{ ok: boolean } | null>
-  setControlOwner: (panelId: string, owner: string) => Promise<unknown>
-  onDidNavigate: (cb: (p: { panelId?: string; url: string; title: string }) => void) => () => void
-  onTitleUpdated: (cb: (p: { panelId?: string; url: string; title: string }) => void) => () => void
-}
-
-function bridge(): NativeBrowserBridge | null {
-  const w = window as unknown as { browserAPI?: NativeBrowserBridge }
-  return w.browserAPI ?? null
+function bridge(): BrowserAPI | null {
+  return window.browserAPI ?? null
 }
 
 /** Selector for SPA chrome that would be occluded by the native layer. */

--- a/website/src/hooks/useTheme.tsx
+++ b/website/src/hooks/useTheme.tsx
@@ -747,9 +747,7 @@ function useThemeState(): ThemeContextValue {
   // `prefers-color-scheme` immediately; Chromium then fires a change event on
   // the media query below if the effective value moved. No-op in a browser.
   useEffect(() => {
-    const bridge = (window as unknown as {
-      electronAPI?: { setThemeMode?: (pref: string) => void }
-    }).electronAPI
+    const bridge = window.electronAPI
     bridge?.setThemeMode?.(mode)
   }, [mode])
 
@@ -757,9 +755,7 @@ function useThemeState(): ThemeContextValue {
   // mode changes. The overlay strip must match the dashboard chrome at all
   // times; sending on `resolved` (not `mode`) handles Auto switching correctly.
   useEffect(() => {
-    const bridge = (window as unknown as {
-      electronAPI?: { setTitleBarOverlayTheme?: (mode: string) => void }
-    }).electronAPI
+    const bridge = window.electronAPI
     bridge?.setTitleBarOverlayTheme?.(resolved)
   }, [resolved])
 
@@ -767,9 +763,7 @@ function useThemeState(): ThemeContextValue {
   // launch's boot splash (loading.html) paints in the user's chosen colour.
   // Reads the computed --accent after paint; a no-op in a plain browser.
   useEffect(() => {
-    const bridge = (window as unknown as {
-      electronAPI?: { setThemeAccent?: (hex: string) => void }
-    }).electronAPI
+    const bridge = window.electronAPI
     if (!bridge?.setThemeAccent) return
     const id = requestAnimationFrame(() => {
       const hex = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim()

--- a/website/src/hooks/useUpdateSubscription.ts
+++ b/website/src/hooks/useUpdateSubscription.ts
@@ -3,6 +3,8 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useAppDispatch } from '../store'
 import { setDesktopUpdateAvailable } from '../store/dashboardSlice'
 
+export type UpdateState = globalThis.UpdateState
+
 /**
  * The update lifecycle payload pushed by the Electron main process.
  *
@@ -11,50 +13,6 @@ import { setDesktopUpdateAvailable } from '../store/dashboardSlice'
  * absent at another — a missing optional field here reads as "never sent" at
  * the consumer that nobody remembered to edit.
  */
-export type UpdateState = {
-  state: 'checking' | 'found' | 'available' | 'downloading' | 'downloaded' | 'installing' | 'not-available' | 'error'
-  version?: string
-  notes?: string
-  pubDate?: string
-  channel?: string
-  message?: string
-  /** Which stage failed. Absent on builds older than the phase-aware emit. */
-  phase?: 'check' | 'download' | 'install'
-  /** Stable failure class; the user-facing copy is chosen from this, not from `message`. */
-  code?: string
-  httpStatus?: number
-  /** Download progress, 0-100. Absent until the first progress event arrives. */
-  percent?: number
-  bytesPerSecond?: number
-  /** Platform handoff the ready/installing UI should explain. */
-  installHandoff?: 'windows-installer' | 'automatic-relaunch'
-  /**
-   * What the FOLLOWED channel's feed reported and whether these bytes are ahead
-   * of it, carried on every lifecycle payload so a renderer that mounted before
-   * the latest check does not keep rendering `getInfo()`'s older answer. `''` /
-   * `null` means no usable answer — never "ahead". See auto-update.js
-   * `laneSnapshot`.
-   */
-  laneVersion?: string
-  runningAheadOfLane?: boolean | null
-  /**
-   * True when this payload was replayed from getInfo() on a fresh mount rather
-   * than pushed live. Restoration surfaces (the About card) render it like any
-   * other state; interruption surfaces (the UpdateModal) ignore it, so a
-   * dismissed modal is not resurrected by every renderer reload.
-   */
-  replayed?: boolean
-}
-
-type UpdateAPI = {
-  onState: (cb: (payload: UpdateState) => void) => (() => void)
-  /**
-   * Optional: the preload bridge exposes it, but an older bundle paired with a
-   * newer renderer may not — replay then degrades to the pre-replay behaviour.
-   */
-  getInfo?: () => Promise<{ lastState?: UpdateState | null } | undefined>
-}
-
 /**
  * Subscribes to the Electron main process's update lifecycle events and mirrors
  * each one into the shared ['update-state'] React Query cache.
@@ -86,7 +44,7 @@ export function useUpdateSubscription() {
   const queryClient = useQueryClient()
   const dispatch = useAppDispatch()
   useEffect(() => {
-    const api = (window as unknown as { updateAPI?: UpdateAPI }).updateAPI
+    const api = window.updateAPI
     if (!api?.onState) return
     const apply = (payload: UpdateState) => {
       queryClient.setQueryData(['update-state'], payload)

--- a/website/src/hooks/useZoom.ts
+++ b/website/src/hooks/useZoom.ts
@@ -29,12 +29,7 @@ const FAMILY_MAP: Record<FontFamily, string> = {
 // itself persists the factor per-origin across launches. In a plain browser
 // the bridge is absent — a web page cannot drive the browser's native zoom —
 // so the UI falls back to a keyboard-shortcut hint (`zoomSupported: false`).
-type ZoomAPI = {
-  get(): Promise<number>
-  set(factor: number): Promise<number>
-  step(dir: 1 | -1): Promise<number>
-}
-const zoomAPI = (): ZoomAPI | undefined => (window as { zoomAPI?: ZoomAPI }).zoomAPI
+const zoomAPI = (): ZoomAPI | undefined => window.zoomAPI
 
 // Legacy page-side scaling (removed): a CSS `zoom` on #root ('mc-zoom') and an
 // html font-size scale ('mc-font-scale') that stacked with native zoom into

--- a/website/src/lib/electron.ts
+++ b/website/src/lib/electron.ts
@@ -15,7 +15,7 @@
  * neither `.mac-electron` nor `.win-electron` applies, which is the correct
  * zero-inset layout, locked in by App.linuxElectron.test.tsx.
  */
-const mc = (window as { kirocrew?: { isElectron?: boolean; platform?: string; linuxFrameless?: boolean } }).kirocrew
+const mc = window.kirocrew
 
 export const isElectron = !!mc?.isElectron
 export const isMacElectron = isElectron && mc?.platform === 'darwin'
@@ -48,7 +48,7 @@ export const LINUX_CAPTION_CONTROLS_WIDTH = 108
  * does.
  */
 export function electronPlatform(): string | undefined {
-  return (window as { kirocrew?: { platform?: string } }).kirocrew?.platform
+  return window.kirocrew?.platform
 }
 
 /**
@@ -61,7 +61,7 @@ export function electronPlatform(): string | undefined {
  * `window.kirocrew` per-case without import-order coupling.
  */
 export function pathForFile(file: File): string {
-  const k = (window as { kirocrew?: { getPathForFile?: (f: File) => string } }).kirocrew
+  const k = window.kirocrew
   try {
     return k?.getPathForFile?.(file) || ''
   } catch {

--- a/website/src/lib/memoryWatch.ts
+++ b/website/src/lib/memoryWatch.ts
@@ -70,19 +70,11 @@ export interface MemorySample {
  *  is unchanged while the quantity measured is not. */
 const SAMPLE_MS = 5000
 
-interface Bridge {
-  reportMemorySample?: (s: MemorySample) => void
-  /** Electron's `process.getHeapStatistics()` surfaced through the preload. The
-   *  main world has no `process` under contextIsolation, so the object-heap half
-   *  of the subtraction has to be handed over the bridge. */
-  heapStatisticsKB?: () => { usedHeapKB: number | null } | null
-}
-
 let timer: ReturnType<typeof setInterval> | null = null
 let realmLabel = 'main'
 
-function bridge(): Bridge | undefined {
-  return (globalThis as unknown as { electronAPI?: Bridge }).electronAPI
+function bridge(): ElectronAPI | undefined {
+  return window.electronAPI
 }
 
 /** Reads `performance.memory` defensively. It is a non-standard Chromium

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -3889,9 +3889,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // Same active-slot guard as the mirror path: a background session's page must
   // not open another session's panel.
   useEffect(() => {
-    const api = (window as unknown as {
-      browserAPI?: { onAgentOpened?: (cb: (p: { panelId?: string }) => void) => () => void }
-    }).browserAPI
+    const api = window.browserAPI
     if (!api?.onAgentOpened) return      // plain browser (no preload bridge)
     return api.onAgentOpened(({ panelId }) => {
       if (!panelId || panelId !== activeSlotRef.current) return

--- a/website/src/pages/settings/AboutPanel.tsx
+++ b/website/src/pages/settings/AboutPanel.tsx
@@ -122,52 +122,8 @@ function updateErrorText(st: UpdateState | null | undefined): string {
   }
 }
 
-type UpdateInfo = {
-  version?: string
-  channel?: string
-  stampedChannel?: string | null
-  channelSwitchable?: boolean
-  channelPreference?: string
-  /**
-   * Whether a discovered update downloads without a click. ON by default in the
-   * desktop shell; `undefined` from a shell that predates the preference, which
-   * is why the toggle reads it as `!== false` rather than truthy.
-   */
-  autoDownload?: boolean
-  platform?: string
-  /** Manual-reinstall permalink from the main process; absent when no lane. */
-  downloadUrl?: string | null
-  packaged?: boolean
-  disabled?: string
-  /** Externally-managed metadata; both empty on a self-updating install. */
-  managedBy?: string
-  updateCommand?: string
-  /**
-   * What the FOLLOWED channel's feed last reported, and whether these bytes are
-   * ahead of it (that lane never published this build, so the install is not on
-   * it). Both come from the feed, because `stampedChannel` cannot answer it: a
-   * promoted stable release ships the soaked candidate's bytes unchanged, so its
-   * version keeps an insider stamp. `''` / `null` / `undefined` = no check has
-   * completed yet, which consumers must treat as UNKNOWN, never as "ahead".
-   */
-  laneVersion?: string
-  runningAheadOfLane?: boolean | null
-}
-
-type UpdateAPI = {
-  onState: (cb: (payload: UpdateState) => void) => (() => void)
-  check: () => Promise<unknown>
-  download: () => Promise<unknown>
-  install: () => Promise<unknown>
-  getInfo: () => Promise<UpdateInfo>
-  setChannel?: (channel: string) => Promise<{ ok: boolean; error?: string }>
-  // Optional so the panel still renders against an older desktop shell whose
-  // preload has no such bridge: the toggle is hidden rather than throwing.
-  setAutoDownload?: (enabled: boolean) => Promise<{ ok: boolean; error?: string }>
-}
-
 function getUpdateApi(): UpdateAPI | undefined {
-  return (window as unknown as { updateAPI?: UpdateAPI }).updateAPI
+  return window.updateAPI
 }
 
 // Subtle accent tint for the version pill + build chips (works with any theme's
@@ -624,7 +580,7 @@ export function AboutPanel() {
   // Desktop (Electron) app info (version, channel, platform)
   const { data: info, isError: infoError } = useQuery({
     queryKey: ['update-info'],
-    queryFn: () => desktopApi!.getInfo(),
+    queryFn: () => desktopApi!.getInfo!(),
     enabled: isDesktop,
     staleTime: Infinity, // static per session
   })
@@ -645,7 +601,7 @@ export function AboutPanel() {
   })
   // Explicit consent actions (macOS Software Update semantics): downloading
   // and installing each happen only when the user clicks.
-  const downloadMutation = useMutation({ mutationFn: () => desktopApi!.download() })
+  const downloadMutation = useMutation({ mutationFn: () => desktopApi!.download!() })
   const installMutation = useMutation({ mutationFn: () => desktopApi!.install() })
   // Install is a ONE-WAY door, so the control must never become actionable
   // again. Note isSuccess, not just isPending: `update:install` resolves as soon

--- a/website/src/pages/settings/DeveloperPanel.tsx
+++ b/website/src/pages/settings/DeveloperPanel.tsx
@@ -39,7 +39,7 @@ export function DeveloperPanel() {
     setDevMode(v)
     window.dispatchEvent(new CustomEvent(DEV_MODE_EVENT, { detail: v }))
     // Notify Electron main process to show/hide DevTools menu item
-    ;(window as Window & { electronAPI?: { setDevMode?: (v: boolean) => void } }).electronAPI?.setDevMode?.(v)
+    window.electronAPI?.setDevMode?.(v)
   }
 
   return (

--- a/website/src/pages/system/HostRuntimeCard.tsx
+++ b/website/src/pages/system/HostRuntimeCard.tsx
@@ -17,28 +17,8 @@ import { Card, CardTitle } from '../../components/ui'
 import { electronPlatform } from '../../lib/electron'
 import { i18nT } from '../../i18n/t'
 
-interface WslDistro {
-  name: string
-  /** Stable enum — never branch on the raw localized text. */
-  state: 'running' | 'stopped' | 'unknown'
-  /** The OS's own word for the state, in the OS language, for display. */
-  stateLabel: string
-  version: number
-  isDefault: boolean
-}
-
-interface WslDetectResult {
-  available: boolean
-  distros: WslDistro[]
-  defaultDistro: string | null
-  error?: string
-  reason?: string
-}
-
 /** Present only in the desktop shell (see electron/preload.js). */
-const resolveDetect =
-  (): (() => Promise<WslDetectResult>) | undefined =>
-    (window as { wslAPI?: { detect: () => Promise<WslDetectResult> } }).wslAPI?.detect
+const resolveDetect = (): (() => Promise<WslDetectResult>) | undefined => window.wslAPI?.detect
 
 export default function HostRuntimeCard() {
   const detect = resolveDetect()

--- a/website/src/test/electronBridgeContract.test.ts
+++ b/website/src/test/electronBridgeContract.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PRELOAD_PATH = resolve(process.cwd(), 'electron/preload.js')
+const CONTRACT_PATH = resolve(process.cwd(), 'src/types/electron-bridge.d.ts')
+
+const preloadSource = readFileSync(PRELOAD_PATH, 'utf8')
+
+const dashboardBridges = [
+  'kirocrew',
+  'electronAPI',
+  'localGatewayAPI',
+  'crashReportsAPI',
+  'wslAPI',
+  'zoomAPI',
+  'browserAPI',
+  'updateAPI',
+] as const
+
+const bridgeContracts = {
+  kirocrew: { name: 'KiroCrewBridge', methods: ['getPathForFile', 'windowControl'] },
+  electronAPI: { name: 'ElectronAPI', methods: ['onStatus', 'getAppMenuItems', 'setBadgeCount', 'getGlobalHotkey'] },
+  localGatewayAPI: { name: 'LocalGatewayAPI', methods: ['get', 'set'] },
+  crashReportsAPI: { name: 'CrashReportsAPI', methods: ['get', 'reveal'] },
+  wslAPI: { name: 'WslAPI', methods: ['detect'] },
+  zoomAPI: { name: 'ZoomAPI', methods: ['get', 'set', 'step'] },
+  browserAPI: { name: 'BrowserAPI', methods: ['open', 'navigate', 'setBounds', 'getState', 'control', 'onDidNavigate'] },
+  updateAPI: { name: 'UpdateAPI', methods: ['onState', 'check', 'download', 'install', 'getInfo'] },
+} as const
+
+function interfaceBody(contract: string, name: string): string {
+  const match = contract.match(new RegExp(`interface ${name} \\{([\\s\\S]*?)\\n  \\}`))
+  expect(match, `${name} declaration is missing`).not.toBeNull()
+  return match?.[1] ?? ''
+}
+
+describe('Electron preload bridge contract', () => {
+  it('declares every dashboard bridge exposed by preload.js', () => {
+    const contract = readFileSync(CONTRACT_PATH, 'utf8')
+    const exposed = [...preloadSource.matchAll(/exposeInMainWorld\("([^"]+)"/g)].map(m => m[1])
+
+    expect(exposed).toEqual(expect.arrayContaining(dashboardBridges))
+    for (const bridge of dashboardBridges) {
+      expect(contract).toMatch(new RegExp(`\\b${bridge}\\?:`))
+      const bridgeContract = bridgeContracts[bridge]
+      const body = interfaceBody(contract, bridgeContract.name)
+      for (const method of bridgeContract.methods) {
+        expect(body).toMatch(new RegExp(`\\b${method}\\b`))
+      }
+    }
+  })
+
+  it('keeps the browser-facing bridge properties optional', () => {
+    const contract = readFileSync(CONTRACT_PATH, 'utf8')
+
+    for (const bridge of dashboardBridges) {
+      expect(contract).toMatch(new RegExp(`\\b${bridge}\\?:`))
+    }
+  })
+})

--- a/website/src/types/electron-bridge.d.ts
+++ b/website/src/types/electron-bridge.d.ts
@@ -1,0 +1,201 @@
+/**
+ * Type contract for the dashboard bridges exposed by electron/preload.js.
+ *
+ * Every property is optional because the same renderer bundle also runs in a
+ * browser, where no Electron preload is present.
+ */
+
+declare global {
+  interface KiroCrewBridge {
+    platform?: string
+    isElectron?: boolean
+    linuxFrameless?: boolean
+    getPathForFile?: (file: File) => string
+    windowControl?: (action: string) => void
+  }
+
+  interface ElectronMemorySample {
+    realm: string
+    usedHeapKB: number | null
+    limitHeapKB: number | null
+    externalKB: number | null
+  }
+
+  interface ElectronMenuSeparator {
+    type: 'separator'
+    index: number
+  }
+
+  interface ElectronMenuItem {
+    type: 'normal' | 'checkbox' | 'radio'
+    index: number
+    label: string
+    accelerator: string
+    enabled: boolean
+    checked: boolean
+  }
+
+  type ElectronAppMenuItem = ElectronMenuSeparator | ElectronMenuItem
+
+  interface ElectronGlobalHotkeyInfo {
+    accelerator: string
+    default: string
+  }
+
+  interface ElectronAPI {
+    onStatus: (cb: (msg: unknown) => void) => () => void
+    onBootReady: (cb: () => void) => () => void
+    bootComplete: () => void
+    setThemeAccent: (hex: string) => void
+    setThemeMode: (pref: string) => void
+    setTitleBarOverlayTheme: (mode: string) => void
+    setFocusModeChrome: (visible: boolean) => void
+    setDevMode: (enabled: boolean) => void
+    getAppMenuItems: (id: string) => Promise<ElectronAppMenuItem[]>
+    executeAppMenuItem: (id: string, index: number) => void
+    onNavigate: (cb: (path: string) => void) => () => void
+    onFullScreenChanged: (cb: (isFullScreen: boolean) => void) => () => void
+    setBadgeCount: (count: number) => void
+    reportMicDenied: () => void
+    reportMemorySample: (sample: ElectronMemorySample) => void
+    heapStatisticsKB: () => { usedHeapKB: number | null } | null
+    getGlobalHotkey: () => Promise<ElectronGlobalHotkeyInfo>
+  }
+
+  interface LocalGatewayAPI {
+    get: () => Promise<boolean>
+    set: (enabled: boolean) => Promise<boolean>
+  }
+
+  interface CrashReportsAPI {
+    get: () => Promise<{ newCount: number }>
+    reveal: () => Promise<{ ok: boolean; error?: string }>
+  }
+
+  interface WslDistro {
+    name: string
+    state: 'running' | 'stopped' | 'unknown'
+    stateLabel: string
+    version: number
+    isDefault: boolean
+  }
+
+  interface WslDetectResult {
+    available: boolean
+    distros: WslDistro[]
+    defaultDistro: string | null
+    error?: string
+    reason?: string
+  }
+
+  interface WslAPI {
+    detect: () => Promise<WslDetectResult>
+  }
+
+  interface ZoomAPI {
+    get: () => Promise<number>
+    set: (factor: number) => Promise<number>
+    step: (direction: 1 | -1) => Promise<number>
+  }
+
+  interface NativeBrowserState {
+    open: boolean
+    visible: boolean
+    url: string
+    bounds: { x: number; y: number; width: number; height: number } | null
+    overlayActive?: boolean
+    refused?: boolean
+  }
+
+  interface NativeBrowserEvent {
+    panelId?: string
+    url: string
+    title: string
+  }
+
+  interface BrowserAPI {
+    open: (panelId: string, url: string) => Promise<NativeBrowserState | null>
+    navigate: (panelId: string, url: string) => Promise<NativeBrowserState | null>
+    setBounds: (
+      panelId: string,
+      rect: { x: number; y: number; width: number; height: number },
+      viewport: { width: number; height: number },
+    ) => Promise<NativeBrowserState | null>
+    setOverlayActive: (panelId: string, active: boolean) => Promise<NativeBrowserState | null>
+    setInactive: (panelId: string, inactive: boolean) => Promise<NativeBrowserState | null>
+    close: (panelId: string) => Promise<NativeBrowserState | null>
+    getState: (panelId: string) => Promise<NativeBrowserState | null>
+    setAgentAct: (panelId: string, enabled: boolean) => Promise<{ ok: boolean } | null>
+    setControlOwner: (panelId: string, owner: string) => Promise<unknown>
+    getControl: (panelId: string) => Promise<unknown>
+    control: (panelId: string, operation: string, args: unknown) => Promise<unknown>
+    trackSession: (panelId: string, tracked: boolean) => Promise<unknown>
+    onAgentOpened: (cb: (event: NativeBrowserEvent) => void) => () => void
+    onDidNavigate: (cb: (event: NativeBrowserEvent) => void) => () => void
+    onTitleUpdated: (cb: (event: NativeBrowserEvent) => void) => () => void
+  }
+
+  interface UpdateState {
+    state: 'checking' | 'found' | 'available' | 'downloading' | 'downloaded' | 'installing' | 'not-available' | 'error'
+    version?: string
+    notes?: string
+    pubDate?: string
+    channel?: string
+    message?: string
+    phase?: 'check' | 'download' | 'install'
+    code?: string
+    httpStatus?: number
+    percent?: number
+    bytesPerSecond?: number
+    installHandoff?: 'windows-installer' | 'automatic-relaunch'
+    laneVersion?: string
+    runningAheadOfLane?: boolean | null
+    replayed?: boolean
+  }
+
+  interface UpdateInfo {
+    version?: string
+    channel?: string
+    stampedChannel?: string | null
+    channelSwitchable?: boolean
+    channelPreference?: string
+    autoDownload?: boolean
+    platform?: string
+    downloadUrl?: string | null
+    packaged?: boolean
+    disabled?: string
+    managedBy?: string
+    updateCommand?: string
+    laneVersion?: string
+    runningAheadOfLane?: boolean | null
+  }
+
+  interface UpdateResult {
+    ok: boolean
+    error?: string
+    info?: UpdateInfo
+  }
+
+  interface UpdateAPI {
+    onState: (cb: (state: UpdateState) => void) => () => void
+    check: () => Promise<UpdateResult>
+    download?: () => Promise<UpdateResult>
+    install: () => Promise<UpdateResult>
+    getInfo?: () => Promise<(UpdateInfo & { lastState?: UpdateState | null }) | undefined>
+    setChannel?: (channel: string) => Promise<UpdateResult>
+    setAutoDownload?: (enabled: boolean) => Promise<UpdateResult>
+  }
+
+  interface Window {
+    kirocrew?: KiroCrewBridge
+    electronAPI?: ElectronAPI
+    localGatewayAPI?: LocalGatewayAPI
+    crashReportsAPI?: CrashReportsAPI
+    wslAPI?: WslAPI
+    zoomAPI?: ZoomAPI
+    browserAPI?: BrowserAPI
+    updateAPI?: UpdateAPI
+  }
+}
+
+export {}


### PR DESCRIPTION
## Problem / Motivation

The dashboard and Electron shell share a runtime bridge through `website/electron/preload.js`, but the renderer did not have one shared TypeScript contract for that boundary. Instead, components and hooks repeated small `Window & { ... }` casts or private bridge interfaces for `electronAPI`, `browserAPI`, `updateAPI`, `zoomAPI`, `wslAPI`, and the other preload surfaces. That made the contract easy to drift: a preload method could be renamed or reshaped while different renderer files continued compiling against different local copies.

The duplication also made the browser fallback harder to reason about. The same renderer bundle runs in ordinary browser tabs and in Electron windows, so every bridge must remain optional at runtime. That behavior was already present, but it was encoded independently in many consumers instead of being represented once in the renderer's type system.

## Why it matters

The preload is the boundary between the browser-facing React application and Electron's IPC APIs. When that boundary is described in several unrelated files, a change can compile in one consumer and remain stale in another until a specific desktop flow is exercised. The failure is especially easy to miss because browser builds do not expose any of these properties at runtime.

A shared contract makes the intended behavior explicit. The `Window` properties remain optional, so browser and PWA sessions keep their existing no-op fallbacks. Once a bridge exists, its methods and payloads have one shared definition, which lets TypeScript catch drift across the app shell, settings pages, browser panels, update flows, and Electron-specific hooks.

## What changed (motivation → approach → change)

The runtime bridge itself is unchanged. `website/electron/preload.js` remains JavaScript, keeps the same `contextBridge.exposeInMainWorld()` objects, and keeps the same IPC channel names and method behavior. This PR changes only how the TypeScript renderer describes and consumes that existing surface.

Added `website/src/types/electron-bridge.d.ts` as the shared ambient contract for the dashboard bridges: `kirocrew`, `electronAPI`, `localGatewayAPI`, `crashReportsAPI`, `wslAPI`, `zoomAPI`, `browserAPI`, and `updateAPI`. The contract also owns the shared payload shapes used by those bridges, including browser panel state, update state and update info, Windows menu items, WSL detection results, global hotkey information, and memory samples. The top-level `Window` properties stay optional because the renderer also runs without Electron. Compatibility points such as older update shells that do not expose `getInfo`, `download`, `setChannel`, or `setAutoDownload` remain optional where existing consumers already handle that skew.

The renderer consumers now read `window.<bridge>` directly instead of rebuilding a local type for each use. This covers the main app shell, ChatPage, update modals and About settings, browser-panel hooks, theme and zoom hooks, local-gateway settings, crash reports, WSL host status, Windows titlebar menus, memory diagnostics, Electron platform helpers, and the Developer panel. Existing optional chaining and browser fallbacks remain in place, so a normal browser tab behaves exactly as before.

Added `website/src/test/electronBridgeContract.test.ts` as a source-level drift guard. It reads the actual preload file, checks that all dashboard bridge names are exposed there, and checks that the shared declaration contains the important methods for each bridge. This prevents the type contract from becoming a second stale copy that only happens to compile.

## Tests

- `npx vitest run src/test/electronBridgeContract.test.ts` — 2 tests passed, including the preload bridge and method coverage checks.
- Targeted bridge consumer tests — 57 tests passed across `useNativeBrowser`, `HostRuntimeCard`, `CrashReportNotice`, `useZoom`, `useLocalGateway`, and `electronBridgeContract`.
- `npm run lint` — passed with no ESLint errors.
- `npm run jscpd` — passed with 0 clones.
- `npm run lint:i18n` — passed; the existing stale ceiling report remains advisory.
- `npm run lint:phantom-classes` — passed; existing ambiguous Tailwind utility warnings remain advisory.
- `npm run typecheck` — attempted, but the current checkout remains blocked by existing dependency and unrelated component errors involving `@radix-ui/react-tabs`, `@excalidraw/excalidraw`, `yaml`, `html-to-image`, graphology packages, Storybook packages, and their dependent type errors. No remaining typecheck errors were reported from the shared Electron bridge contract or the migrated bridge consumers.
- `npm run test:electron` — attempted. The suite reached 1,741 tests with 1,693 passing; the remaining failures were environment/package setup failures caused by missing `electron-store` and patched `app-builder-lib` NSIS templates, not by the renderer bridge changes.

## Manual verification

N/A — this is a type and contract refactor with no rendered layout, interaction, IPC channel, or preload runtime behavior change. The affected browser and Electron consumers are covered by the focused Vitest tests, while the preload source contract is checked directly against the renderer declaration.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** This PR changes TypeScript declarations and removes duplicated casts without changing rendered UI, layout, themes, user-facing strings, or runtime Electron behavior.

## Related Issues

no linked issue: this is a standalone type-safety and maintenance refactor that does not change user-visible behavior or close a tracked bug.

## Checklist

- [x] One Conventional Commits commit with the `refactor(electron): ...` title.
- [x] Shared renderer declarations cover the dashboard bridges exposed by `website/electron/preload.js`.
- [x] Focused contract and bridge consumer tests pass.
- [x] Frontend lint and jscpd pass.
- [x] Self-review completed with project-only files in the diff.
- [ ] Full frontend typecheck is still blocked by the existing dependency/component errors listed above.
- [ ] Full Electron suite is still blocked by the missing local Electron package/template dependencies listed above.
- [x] No secrets, credentials, internal URLs, or private process references are included in the diff.