### PR TITLE
feat(wakatime): add coding-stats endpoint and JSON export variant

### DIFF
--- a/docs/feature-map/README.md
+++ b/docs/feature-map/README.md
@@ -134,7 +134,7 @@ Settings → Overview; the graph visualizer is a Developer internals view.
 | Embeddings | Enable the vector store and pick its model | Memory browser → vector card | `pages/overview/VectorMemoryCard.tsx` | `handlers/memory.py` | `GET /api/memory/embedding-status`, `POST /api/memory/enable-embeddings`, `POST /api/memory/embedding-model` |
 | Memory graph | Entity/relation visualizer over the memory store | `/developer?tab=memory` | `pages/overview/MemoryGraphTab.tsx` | `handlers/memory.py` | `GET /api/memory/graph`, `GET /api/memory/observability` |
 | Usage | Token and turn usage over time | `/settings/overview?view=usage` | `pages/overview/UsageTab.tsx` | `handlers/usage.py`, `handlers/telemetry.py` | `GET /api/usage`, `GET /api/usage/kiro`, `GET /api/usage/turns` |
-| WakaTime billable-hours export | Project-grouped hours over a date range as a CSV download for invoicing; the productivity view and stats read-back ship separately | API only | — | `handlers/wakatime.py` | `GET /api/wakatime/export` |
+| WakaTime coding stats and export | Aggregate coding stats for a named range, and project-grouped hours over a date range as a CSV download or JSON, for the productivity view and billable-hours invoicing; the productivity view UI that consumes these ships separately | API only | — | `handlers/wakatime.py` | `GET /api/wakatime/stats`, `GET /api/wakatime/export` |
 | Portability | Export and import the whole memory/config bundle | `/settings/imports` | `pages/overview/PortabilityTab.tsx` | `handlers/portability.py` | `GET /api/portability/export`, `POST /api/portability/import`, `POST /api/portability/preview` |
 
 ## Schedules and loops

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -523,6 +523,7 @@ from kiro_crew.dashboard.handlers.usage import (  # noqa: E402, F401
 )
 from kiro_crew.dashboard.handlers.wakatime import (  # noqa: E402, F401
     api_wakatime_export,
+    api_wakatime_stats,
 )
 
 # ── Themes: validation/parsing core (extracted to theme_validate.py) ──

--- a/src/kiro_crew/dashboard/handlers/wakatime.py
+++ b/src/kiro_crew/dashboard/handlers/wakatime.py
@@ -1,18 +1,18 @@
-"""Dashboard HTTP handler for the WakaTime integration.
+"""Dashboard HTTP handlers for the WakaTime integration.
 
-One read endpoint, single-owner (no per-user identity: this is the local
+Two read endpoints, both single-owner (no per-user identity: this is the local
 dashboard owner's own configured WakaTime account):
 
+- ``GET /api/wakatime/stats`` — aggregate stats for a named range, for the
+  productivity view (coding time, language/project breakdown).
 - ``GET /api/wakatime/export`` — hours grouped by project over a date range,
-  as a CSV download, for billable-hours export.
+  as CSV (a download) or JSON, for billable-hours export.
 
-When the integration is disabled or unconfigured the endpoint returns a 200 with
+When the integration is disabled or unconfigured the endpoints return a 200 with
 ``{"configured": false}`` rather than an error, so the frontend renders an
-ordinary "connect WakaTime" empty state instead of an error banner.
-
-The stats endpoint and a JSON export variant are deferred to the dashboard
-productivity-view change that consumes them, so this ships only the surface with
-a use today: the CSV invoicing export.
+ordinary "connect WakaTime" empty state instead of an error banner. When the
+range is empty but the upstream call itself failed, they return a 502 rather
+than a false-empty result, so an outage is never mistaken for real zero data.
 """
 
 from __future__ import annotations
@@ -29,6 +29,20 @@ from typing import Any
 from aiohttp import web
 
 logger = logging.getLogger(__name__)
+
+# Ranges the WakaTime stats endpoint accepts. Guard the query param against this
+# allowlist so an arbitrary value is never interpolated into the upstream path.
+_ALLOWED_RANGES = frozenset(
+    {
+        "last_7_days",
+        "last_30_days",
+        "last_6_months",
+        "last_year",
+        "today",
+        "yesterday",
+    }
+)
+_DEFAULT_RANGE = "last_7_days"
 
 # YYYY-MM-DD is the only date shape WakaTime's summaries endpoint accepts.
 
@@ -56,6 +70,45 @@ def _upstream_error() -> web.Response:
         },
         status=502,
     )
+
+
+async def api_wakatime_stats(request: web.Request) -> web.Response:
+    """GET /api/wakatime/stats?range=last_7_days — aggregate coding stats.
+
+    Returns the WakaTime ``stats`` payload (languages, projects, totals) for the
+    range, ``{"configured": false}`` when the integration is off, or a 502 when
+    the upstream call fails (never a false-empty payload).
+    """
+    range_param = request.query.get("range", _DEFAULT_RANGE)
+    if range_param not in _ALLOWED_RANGES:
+        return web.json_response(
+            {
+                "error": f"unsupported range; allowed: {sorted(_ALLOWED_RANGES)}",
+                "code": "invalid_range",
+            },
+            status=400,
+        )
+
+    # Import the optional WakaTime subsystem lazily, on first request, so it
+    # stays off the gateway boot path (handlers/__init__ is imported at startup).
+    from kiro_crew.wakatime import WakaTimeUnavailableError, service
+
+    # build_client() does synchronous config-load + vault-decrypt I/O; run it off
+    # the event loop so a request never stalls the loop on filesystem reads.
+    client = await asyncio.to_thread(service.build_client)
+    if client is None:
+        return web.json_response({"configured": False})
+
+    try:
+        # fetch_stats RAISES on an upstream failure rather than degrading to {},
+        # so an outage is reported as a 502, never a false-empty stats payload.
+        data = await client.fetch_stats(range_param)
+    except WakaTimeUnavailableError:
+        return _upstream_error()
+    finally:
+        await client.close()
+
+    return web.json_response({"configured": True, "range": range_param, "stats": data})
 
 
 # Characters a spreadsheet treats as the start of a formula. A project name
@@ -99,12 +152,14 @@ def _rows_by_project(summaries: list[dict]) -> list[dict[str, Any]]:
 
 
 async def api_wakatime_export(request: web.Request) -> web.Response:
-    """GET /api/wakatime/export?start=&end= — billable hours as a CSV download.
+    """GET /api/wakatime/export?start=&end=&format=csv|json — billable hours.
 
     Hours grouped by project over ``start``..``end`` (inclusive, YYYY-MM-DD).
+    ``format`` is ``csv`` (default, a download) or ``json``.
     """
     start = request.query.get("start", "")
     end = request.query.get("end", "")
+    fmt = request.query.get("format", "csv").lower()
 
     if not _valid_date(start) or not _valid_date(end):
         return web.json_response(
@@ -114,6 +169,11 @@ async def api_wakatime_export(request: web.Request) -> web.Response:
     if start > end:
         return web.json_response(
             {"error": "start must not be after end", "code": "invalid_range"},
+            status=400,
+        )
+    if fmt not in ("csv", "json"):
+        return web.json_response(
+            {"error": "format must be csv or json", "code": "invalid_format"},
             status=400,
         )
 
@@ -139,6 +199,9 @@ async def api_wakatime_export(request: web.Request) -> web.Response:
         await client.close()
 
     rows = _rows_by_project(summaries)
+
+    if fmt == "json":
+        return web.json_response({"configured": True, "start": start, "end": end, "projects": rows})
 
     # CSV: generated in-memory, returned with a download disposition.
     buf = io.StringIO()

--- a/src/kiro_crew/dashboard/routes/system.py
+++ b/src/kiro_crew/dashboard/routes/system.py
@@ -67,6 +67,7 @@ def register(app: web.Application) -> None:
     app.router.add_get("/api/telemetry/startup", handlers.api_telemetry_startup)
     app.router.add_get("/api/telemetry/context-trace", handlers.api_context_trace)
     app.router.add_get("/api/usage/turns", handlers.api_usage_turns)
+    app.router.add_get("/api/wakatime/stats", handlers.api_wakatime_stats)
     app.router.add_get("/api/wakatime/export", handlers.api_wakatime_export)
     app.router.add_get("/api/telemetry/beacon", handlers.api_beacon_status)
     app.router.add_get("/api/telemetry/collection", handlers.api_collection_status)

--- a/src/kiro_crew/wakatime/client.py
+++ b/src/kiro_crew/wakatime/client.py
@@ -251,6 +251,23 @@ class WakaTimeClient:
                 return data
         return {}
 
+    async def fetch_stats(self, wakatime_range: str = "last_7_days") -> dict[str, Any]:
+        """Like :meth:`get_stats`, but RAISE on an upstream failure.
+
+        Same contract as :meth:`fetch_summaries`: a successful stats response
+        always carries a ``data`` dict (its fields empty for a range with no
+        activity), so anything without one — ``None`` from ``_api`` on a failure,
+        or the ``{}`` ``_api`` returns for a non-JSON 200 body — is a failure and
+        raises :class:`WakaTimeUnavailableError` rather than degrading to a false
+        empty result. Used where an empty payload must not be mistaken for real
+        zero data.
+        """
+        result = await self._api("GET", f"/users/current/stats/{wakatime_range}")
+        data = result.get("data") if isinstance(result, dict) else None
+        if not isinstance(data, dict):
+            raise WakaTimeUnavailableError("WakaTime stats request failed or returned no data")
+        return data
+
     async def get_durations(self, date: str, *, project: str | None = None) -> list[dict]:
         """GET the duration blocks for a single ``date`` (YYYY-MM-DD).
 

--- a/test/test_wakatime_client.py
+++ b/test/test_wakatime_client.py
@@ -169,6 +169,29 @@ async def test_fetch_summaries_raises_when_response_has_no_data_list() -> None:
         await client.fetch_summaries("2026-09-01", "2026-09-03")
 
 
+async def test_fetch_stats_returns_data_dict_on_success() -> None:
+    session = _FakeSession([_FakeResp(200, {"data": {"languages": [{"name": "Python"}]}})])
+    client = _client_with(session)
+    result = await client.fetch_stats("last_7_days")
+    assert result == {"languages": [{"name": "Python"}]}
+
+
+async def test_fetch_stats_raises_on_server_error() -> None:
+    session = _FakeSession([_FakeResp(500)])
+    client = _client_with(session)
+    with pytest.raises(WakaTimeUnavailableError):
+        await client.fetch_stats("last_7_days")
+
+
+async def test_fetch_stats_raises_when_response_has_no_data_dict() -> None:
+    # A non-JSON 200 coerces to {} in _api; no data dict means failure, not a
+    # false-empty stats payload.
+    session = _FakeSession([_FakeResp(200, {})])
+    client = _client_with(session)
+    with pytest.raises(WakaTimeUnavailableError):
+        await client.fetch_stats("last_7_days")
+
+
 async def test_verify_raises_on_rejected_key() -> None:
     session = _FakeSession([_FakeResp(401)])
     client = _client_with(session)

--- a/test/test_wakatime_handlers.py
+++ b/test/test_wakatime_handlers.py
@@ -26,9 +26,11 @@ class _StubClient:
         self,
         *,
         summaries: list | None = None,
+        stats: dict | None = None,
         fail: bool = False,
     ) -> None:
         self._summaries = summaries or []
+        self._stats = stats or {}
         self._fail = fail
         self.closed = False
 
@@ -39,12 +41,20 @@ class _StubClient:
             raise WakaTimeUnavailableError("stub: summaries request failed")
         return self._summaries
 
+    async def fetch_stats(self, wakatime_range: str = "last_7_days") -> dict:
+        if self._fail:
+            from kiro_crew.wakatime import WakaTimeUnavailableError
+
+            raise WakaTimeUnavailableError("stub: stats request failed")
+        return self._stats
+
     async def close(self) -> None:
         self.closed = True
 
 
 def _app() -> web.Application:
     app = web.Application()
+    app.router.add_get("/api/wakatime/stats", wt.api_wakatime_stats)
     app.router.add_get("/api/wakatime/export", wt.api_wakatime_export)
     return app
 
@@ -73,6 +83,69 @@ async def test_export_csv_groups_by_project() -> None:
     assert lines[1].startswith("oneka,1.5,5400")
     assert lines[2].startswith("noscere,0.5,1800")
     assert stub.closed is True
+
+
+async def test_stats_returns_payload_when_configured() -> None:
+    stub = _StubClient(stats={"languages": [{"name": "Python", "total_seconds": 3600}]})
+    with patch.object(wt_service, "build_client", return_value=stub):
+        async with TestClient(TestServer(_app())) as client:
+            resp = await client.get("/api/wakatime/stats?range=last_7_days")
+            assert resp.status == 200
+            data = await resp.json()
+    assert data == {
+        "configured": True,
+        "range": "last_7_days",
+        "stats": {"languages": [{"name": "Python", "total_seconds": 3600}]},
+    }
+    assert stub.closed is True
+
+
+async def test_stats_empty_state_when_unconfigured() -> None:
+    with patch.object(wt_service, "build_client", return_value=None):
+        async with TestClient(TestServer(_app())) as client:
+            resp = await client.get("/api/wakatime/stats")
+            assert resp.status == 200
+            assert await resp.json() == {"configured": False}
+
+
+async def test_stats_rejects_unknown_range() -> None:
+    with patch.object(wt_service, "build_client", return_value=_StubClient()):
+        async with TestClient(TestServer(_app())) as client:
+            resp = await client.get("/api/wakatime/stats?range=all_time")
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "invalid_range"
+
+
+async def test_stats_returns_502_when_upstream_fails() -> None:
+    stub = _StubClient(fail=True)
+    with patch.object(wt_service, "build_client", return_value=stub):
+        async with TestClient(TestServer(_app())) as client:
+            resp = await client.get("/api/wakatime/stats?range=last_7_days")
+            assert resp.status == 502
+            assert (await resp.json())["code"] == "upstream_unavailable"
+
+
+async def test_export_json_format() -> None:
+    summaries = [{"projects": [{"name": "oneka", "total_seconds": 7200}]}]
+    with patch.object(wt_service, "build_client", return_value=_StubClient(summaries=summaries)):
+        async with TestClient(TestServer(_app())) as client:
+            resp = await client.get(
+                "/api/wakatime/export?start=2026-09-01&end=2026-09-02&format=json"
+            )
+            assert resp.status == 200
+            data = await resp.json()
+    assert data["configured"] is True
+    assert data["projects"] == [{"project": "oneka", "seconds": 7200.0, "hours": 2.0}]
+
+
+async def test_export_rejects_bad_format() -> None:
+    with patch.object(wt_service, "build_client", return_value=_StubClient()):
+        async with TestClient(TestServer(_app())) as client:
+            resp = await client.get(
+                "/api/wakatime/export?start=2026-09-01&end=2026-09-02&format=pdf"
+            )
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "invalid_format"
 
 
 async def test_export_rejects_bad_date() -> None:


### PR DESCRIPTION
## Problem / Motivation

The WakaTime export endpoint landed on its own; the aggregate coding-stats endpoint and the JSON export variant were deferred because they had no consumer yet. The dashboard productivity view (a follow-up PR) needs both: the stats payload to render the coding-time breakdown, and a JSON export shape so a component can read the rows without parsing CSV.

## Why it matters

The productivity view builds against these two surfaces. Landing them as their own small backend PR keeps that surface reviewable on its own and lets the frontend build against a settled contract, rather than bundling backend and UI into one large change.

## What changed (motivation → approach → change)

The client already exposes `get_summaries`/`get_stats`; this wires the stats read to a dashboard handler and restores the JSON export branch, following the existing export handler's shape.

- `GET /api/wakatime/stats?range=<named-range>` returns the aggregate stats payload (languages, projects, totals). `range` is validated against an allowlist (`last_7_days`, `last_30_days`, `last_6_months`, `last_year`, `today`, `yesterday`) so an arbitrary value is never interpolated into the upstream path.
- `GET /api/wakatime/export` gains `format=json` beside the CSV download, with `invalid_format` validation.
- Both fail closed like the CSV export already does. `get_stats` swallows an upstream failure into `{}`, indistinguishable from a range with no activity, so this adds a strict `fetch_stats` companion (mirroring `fetch_summaries`) that raises `WakaTimeUnavailableError` unless the response carries a `data` dict. The stats endpoint uses it and returns `502 upstream_unavailable` on failure, never a false-empty payload. `get_stats` keeps its swallow-to-`{}` behavior for the agent-turn callers that rely on it.
- The optional subsystem is imported lazily inside the handler and `build_client` runs via `asyncio.to_thread`, so nothing touches the gateway boot path or blocks the event loop.

Single-owner: no per-user identity, matching the existing usage endpoints.

## Tests

- Handler (`test_wakatime_handlers.py`): stats happy path, unconfigured empty state, `invalid_range` 400, `502` on upstream failure; export `format=json` shape and `invalid_format` 400.
- Client (`test_wakatime_client.py`): `fetch_stats` returns the data dict on success, raises on a 5xx, and raises on a non-JSON 200 (no data dict).

## Manual verification

N/A — unit coverage is sufficient. Handlers are exercised end to end through an aiohttp TestClient against a stubbed client; a live WakaTime call is covered by the client's own tests.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (one aiohttp handler, one route, one client method); no frontend paths touched and nothing renders.

## Related Issues

Part of #8094

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
