### PR TITLE
test(acp): re-record frame-replay snapshots for the wire_title field

### DIFF
--- a/test/fixtures/acp_frames/claude/session.expected.json
+++ b/test/fixtures/acp_frames/claude/session.expected.json
@@ -64,7 +64,8 @@
         "title": "Echo the corpus marker",
         "tool_call_id": "toolu_01ReplayCorpus",
         "tool_input": "{\n  \"command\": \"echo acp-replay-corpus\",\n  \"description\": \"Echo the corpus marker\"\n}",
-        "tool_kind": "execute"
+        "tool_kind": "execute",
+        "wire_title": "Bash"
       }
     ],
     "frame": "session/update",

--- a/test/fixtures/acp_frames/codex/session.expected.json
+++ b/test/fixtures/acp_frames/codex/session.expected.json
@@ -76,7 +76,8 @@
         "title": "shell",
         "tool_call_id": "call_ReplayCorpus1",
         "tool_input": "{\n  \"command\": [\n    \"bash\",\n    \"-lc\",\n    \"echo acp-replay-corpus\"\n  ]\n}",
-        "tool_kind": "execute"
+        "tool_kind": "execute",
+        "wire_title": "shell"
       }
     ],
     "frame": "session/update",

--- a/test/fixtures/acp_frames/kas/session.expected.json
+++ b/test/fixtures/acp_frames/kas/session.expected.json
@@ -42,7 +42,8 @@
         "tool_call_id": "kas-tool-0001",
         "tool_input": "{\n  \"command\": \"echo acp-replay-corpus\",\n  \"__toolUsePurpose\": \"Echo the corpus marker\"\n}",
         "tool_kind": "execute",
-        "tool_purpose": "Echo the corpus marker"
+        "tool_purpose": "Echo the corpus marker",
+        "wire_title": "executeBash"
       }
     ],
     "frame": "session/update",

--- a/test/fixtures/acp_frames/kiro/notifications.expected.json
+++ b/test/fixtures/acp_frames/kiro/notifications.expected.json
@@ -92,7 +92,8 @@
         "tool_call_id": "kiro-tool-0002",
         "tool_input": "{\n  \"path\": \"~/notes.md\",\n  \"token\": \"[REDACTED: credential]\"\n}",
         "tool_input_redacted": true,
-        "tool_kind": "read"
+        "tool_kind": "read",
+        "wire_title": "read the deploy notes"
       }
     ],
     "frame": "session/update",

--- a/test/fixtures/acp_frames/kiro/session.expected.json
+++ b/test/fixtures/acp_frames/kiro/session.expected.json
@@ -68,7 +68,8 @@
         "tool_call_id": "kiro-tool-0001",
         "tool_input": "{\n  \"command\": \"echo acp-replay-corpus\",\n  \"__tool_use_purpose\": \"Echo the corpus marker\"\n}",
         "tool_kind": "execute",
-        "tool_purpose": "Echo the corpus marker"
+        "tool_purpose": "Echo the corpus marker",
+        "wire_title": "echo acp-replay-corpus"
       }
     ],
     "frame": "session/update",


### PR DESCRIPTION
## Problem / Motivation

`test/test_acp_frame_replay.py` is red on `main`, and because CI tests the merge
ref (current `main` merged into each branch), every open PR inherits the same six
failures on both Windows and Linux shard 1:

```
test/test_acp_frame_replay.py::test_the_snapshot_render_is_byte_stable
test/test_acp_frame_replay.py::test_replayed_events_match_snapshot[kiro/session.jsonl]
test/test_acp_frame_replay.py::test_replayed_events_match_snapshot[kiro/notifications.jsonl]
test/test_acp_frame_replay.py::test_replayed_events_match_snapshot[claude/session.jsonl]
test/test_acp_frame_replay.py::test_replayed_events_match_snapshot[kas/session.jsonl]
test/test_acp_frame_replay.py::test_replayed_events_match_snapshot[codex/session.jsonl]
```

The failing file appears in ZERO of the affected PRs' diffs (knowledge ingestion,
dev-fleet sync, a markdown card toggle, and others), which is the tell that this
is base-owned rather than any one PR's fault.

## Why it matters

This one stale corpus reds the tree gate on every open PR at once, so it blocks the
whole repository until it is fixed. This PR is a base unblock; there is no tracking
issue, so nobody should look for one.

## What changed

Regenerated the five ACP frame-replay snapshots with the repository's own writer,
`python3 scripts/update_acp_frame_snapshots.py`, and committed nothing else. The
diff is a single new key, `wire_title`, on each backend's `tool_call` event:

- `claude/session.expected.json`  -> `"wire_title": "Bash"`
- `codex/session.expected.json`   -> `"wire_title": "shell"`
- `kas/session.expected.json`     -> `"wire_title": "executeBash"`
- `kiro/session.expected.json`    -> `"wire_title": "echo acp-replay-corpus"`
- `kiro/notifications.expected.json` -> `"wire_title": "read the deploy notes"`

Chained from symptom to root cause: `wire_title` is the field that
`da3e6757c` (#9073, "claim the out-of-band record by the call's input, not the
result") added to the tool-call event -- it threads the backend's own frame title
through `acp/_dispatch.py` into `AcpEvent.wire_title` (`acp/types.py:506`) for
`session_directive.py` and `chat_runner.py` to read. `34d91273a` (#9161) recorded
the replay corpus 41 seconds to 3 minutes BEFORE that render change, so the
committed snapshots never carried the field. Each was green on its own merge ref;
their combination on `main` is red. This PR makes `main`'s own corpus match
`main`'s own render again, and nothing else: no event was dropped, reordered, or
re-redacted, and the sibling change `f79d00b28` (#9147, structured-refusal card)
did not alter these fixtures' `tool_call` events, so it produced no snapshot delta.

## Tests

- Reproduced on a fresh worktree at `main` (`3933456`):
  `timeout 900 python3 -m pytest -n0 test/test_acp_frame_replay.py -x -q` fails at
  `claude/session.jsonl` with an `index 4` `tool_call` diff.
- Ran the sanctioned writer, then read the diff before trusting it: the ONLY delta
  is the `wire_title` key, which is exactly what #9073 introduced, so the refresh
  absorbs an understood render change rather than hiding an unintended one.
- Re-ran the whole file: `19 passed`, including all six originally-failing IDs.
- Snapshot files only; no change to the test, the render, or the fixtures.

## Pattern harvest

Defect class: a merge-order collision on `main`. A test-and-corpus PR and a
render-change PR each pass on their own merge ref, but merging both leaves the
committed snapshot describing the old render, so the test reds on the combined
tree. `main` has no per-commit CI verdict here, so nothing caught the combination
until it was already on the default branch and fanning out to every open PR. The
remedy is the assertion's own named script, never a hand-edit of the JSON, and the
refresh must be read field-by-field so it cannot silently absorb an unintended
render change -- a snapshot that turns a visible red into an invisible pass is
worse than the red.

Rule candidate: when a snapshot/golden test reds on `main` and the failing file is
absent from every open PR's diff, treat it as base-owned; regenerate with the
repository's sanctioned writer, then diff the regenerated output against the commit
that changed the render and confirm every delta is explained by that commit before
committing -- if a delta is unexplained, stop rather than green the test.

Refs #9073 Refs #9147 Refs #9161
