### PR TITLE
fix: gate adjudicator CLI floor, surface failed adjudication (#9216)

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -71,7 +71,27 @@ allow-dependencies-licenses:
   - pkg:npm/%40pierre/theme        # Apache-2.0 — https://github.com/pierrecomputer/pierre/blob/main/packages/theme/LICENSE
   - pkg:npm/%40pierre/theming      # Apache-2.0 — https://github.com/pierrecomputer/pierre/blob/main/packages/theming/LICENSE.md
   - pkg:npm/%40pierre/trees        # Apache-2.0 — https://github.com/pierrecomputer/pierre/blob/main/packages/trees/LICENSE.md
- 
+
+  # @anthropic-ai/claude-code and its platform binaries declare
+  # "SEE LICENSE IN README.md" (Anthropic's commercial terms), which is not an
+  # SPDX identifier, so the gate fails on license VALIDITY. These are CI-ONLY
+  # tools in .github/review-cli — installed on review runners for the AI-review
+  # adjudication stage (#9216), never shipped, linked, or distributed with the
+  # Apache-2.0 product. CI already runs this exact CLI via
+  # anthropics/claude-code-action's bundled installer; the lockfile pin only
+  # makes the version auditable and floor-checkable. Evidence:
+  # https://www.npmjs.com/package/@anthropic-ai/claude-code (README: Terms of
+  # Service link). Remove these if the adjudicator stops using Claude Code.
+  - pkg:npm/%40anthropic-ai/claude-code                    # Anthropic commercial terms — CI-only, not distributed
+  - pkg:npm/%40anthropic-ai/claude-code-darwin-arm64       # same — platform binary of the above
+  - pkg:npm/%40anthropic-ai/claude-code-darwin-x64         # same — platform binary of the above
+  - pkg:npm/%40anthropic-ai/claude-code-linux-arm64        # same — platform binary of the above
+  - pkg:npm/%40anthropic-ai/claude-code-linux-arm64-musl   # same — platform binary of the above
+  - pkg:npm/%40anthropic-ai/claude-code-linux-x64          # same — platform binary of the above
+  - pkg:npm/%40anthropic-ai/claude-code-linux-x64-musl     # same — platform binary of the above
+  - pkg:npm/%40anthropic-ai/claude-code-win32-arm64        # same — platform binary of the above
+  - pkg:npm/%40anthropic-ai/claude-code-win32-x64          # same — platform binary of the above
+
 
 # License gate only — vulnerability scanning is covered separately by the
 # nightly/release Dependency Audit and the Semgrep / CodeQL jobs, so we don't duplicate it here.

--- a/.github/review-cli/package-lock.json
+++ b/.github/review-cli/package-lock.json
@@ -8,8 +8,136 @@
       "name": "kirocrew-review-cli",
       "version": "0.0.0",
       "dependencies": {
+        "@anthropic-ai/claude-code": "2.1.263",
         "@openai/codex": "0.150.1"
       }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.263.tgz",
+      "integrity": "sha512-kvvBK6/69iTRYnq0TKVyxVZs1CxYCJGojshQSP+2qaDb66A2xtI4zbCuqkZUWLkFGmHSRqhFf/ATpzH2UNKcwg==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.263",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.263",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.263",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.263",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.263",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.263",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.263",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.263"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.263.tgz",
+      "integrity": "sha512-yLv8MtgulGMGCWTwDUSmlEL0+94sxKP3vJm0SAXZX+0qVQ09PrjVSRC0ibtVeW7xymyhvP1JaUimOyp+t2wO5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.263.tgz",
+      "integrity": "sha512-55AHarRoo10yV8qLRrtZiNfum0uLQ6FKtwQEGuahzXHUnBDDrQ56ejLZB/FSs+q2Nx3IFWEq9J/rNVfuX7oZ6w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.263.tgz",
+      "integrity": "sha512-RlJtLbl8xqFMf2zUdOKD4o5FkNhcgGjlS3Un8PNfSbv1fLQg3SqBQgEJhNEtSeKlEsOs26RnCG/jVk4yah8Udw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.263.tgz",
+      "integrity": "sha512-RxeDl9uWmj7FtghdtRImpWsGEEe8l05VoS9wt5vJAFVZFP6ZmyanS7b+1+STXW6F6QsEbVqbKF5R/HPz3dzW4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.263.tgz",
+      "integrity": "sha512-0IrvpLd/0FP0acQw59T4Cvx/r4nwAXKBrW0WyhIXymzYWurPCLztB+Icu9MkeewAUI+p3PTXsSfmilv/n6XlAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.263.tgz",
+      "integrity": "sha512-R6gtwGcW+sxoyANhikfUKPsat+mysEoLhl5rBUSaSHsey7x4oe/0zrWV2vbWw3t5X9XDsh0Bcl/n4/1Jgyc4vw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.263.tgz",
+      "integrity": "sha512-koscGNDJ0qMXQIAse9zqeQ70EL8qoMkDnMSrAbW8ussrLCyTvfgNny+N9GFic382XegSAIhcInF+oqJnaBSyxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.263",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.263.tgz",
+      "integrity": "sha512-P1LnudAWj2ptyE0IZzCZKAe7nU7LxqlkcLdBfp8FsHlH5dp75Og4JJ6TClvfjanHn3shYW4CYN6oI1vSqZlkHw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@openai/codex": {
       "version": "0.150.1",

--- a/.github/review-cli/package.json
+++ b/.github/review-cli/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Locked manifest for the AI review lanes' CLI. Not shipped, not part of the product build -- it exists so codex-review.yml and fork-gpt-review.yml install from a committed lockfile (npm ci) instead of resolving a floating registry version at job time. Those jobs hold Bedrock credentials and read PR content, so the exact code they execute must change only by a commit to this repo. Bump deliberately: edit the exact version below, run `npm install --package-lock-only` in this directory, and commit both files.",
   "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.263",
     "@openai/codex": "0.150.1"
   }
 }

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -982,6 +982,55 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
+      # The adjudicator model carries a MINIMUM Claude Code version, and the
+      # action's own bundled installer can lag it (#9216: the runner shipped
+      # 2.1.240 against Opus 4.8's 2.1.255 floor, so every adjudication call
+      # returned an API 400 and the stage silently never ran, once per PR
+      # forever). Resolve the CLI from the review-cli install -- the committed
+      # lockfile staged from the BASE commit, the same supply-chain posture as
+      # the codex binary -- and assert the floor HERE, at configuration time:
+      # a model bump that outruns the pin fails THIS step visibly, the
+      # adjudicate step below is skipped, and the verdict step reports an
+      # adjudication that did not run instead of one that declined to overturn.
+      # KEEP IN SYNC with fork-gpt-review.yml.
+      - name: Assert the adjudicator's Claude Code version floor
+        id: adj_cli
+        if: >-
+          github.event.pull_request.head.repo.full_name == github.repository
+          && (
+          (steps.adj_input.outputs.adjudicable != '' && steps.adj_input.outputs.adjudicable != '0')
+          || (steps.adj_input.outputs.fenced != '' && steps.adj_input.outputs.fenced != '0')
+          )
+        env:
+          # The minimum Claude Code the selected adjudicator model accepts
+          # (below it the API 400s the call). Bump this alongside any
+          # adjudicator model bump, and raise the @anthropic-ai/claude-code pin
+          # in .github/review-cli/package.json to satisfy it -- the assertion
+          # below is what turns a floor/pin mismatch into a configuration-time
+          # failure instead of a silent per-PR one.
+          ADJ_CLAUDE_CODE_FLOOR: "2.1.255"
+        run: |
+          set -euo pipefail
+          bin="$RUNNER_TEMP/review-cli/node_modules/.bin/claude"
+          if [ ! -x "$bin" ]; then
+            echo "::error::Claude Code is not in the review CLI install; add @anthropic-ai/claude-code to .github/review-cli/package.json (staged from the base commit). The adjudication stage cannot run."
+            exit 1
+          fi
+          # `|| true` keeps a failed or version-less `--version` from killing
+          # the step under `set -e` BEFORE the empty-value check below can name
+          # the real problem; every degraded path still exits 1.
+          installed="$("$bin" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
+          if [ -z "$installed" ]; then
+            echo "::error::could not read the installed Claude Code version; the adjudication stage cannot run."
+            exit 1
+          fi
+          if [ "$(printf '%s\n%s\n' "$ADJ_CLAUDE_CODE_FLOOR" "$installed" | sort -V | head -n1)" != "$ADJ_CLAUDE_CODE_FLOOR" ]; then
+            echo "::error::Claude Code $installed does not meet the adjudicator model's minimum $ADJ_CLAUDE_CODE_FLOOR; raise the @anthropic-ai/claude-code pin in .github/review-cli/package.json."
+            exit 1
+          fi
+          echo "Claude Code $installed satisfies the adjudicator's floor $ADJ_CLAUDE_CODE_FLOOR"
+          echo "path=$bin" >> "$GITHUB_OUTPUT"
+
       - name: Opus 4.8 adjudication (blocking findings only)
         id: adjudicate
         if: >-
@@ -994,6 +1043,10 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The floor-asserted CLI from the step above; handing it over skips
+          # the action's own installer, whose bundled version is what fell
+          # behind the adjudicator model's minimum (#9216).
+          path_to_claude_code_executable: ${{ steps.adj_cli.outputs.path }}
           # Read the repo, return text. No `gh` anything: the PR body and comment
           # threads are attacker-controllable on a public repo and must never
           # enter an agentic reviewer's context, and this stage in particular
@@ -1083,10 +1136,21 @@ jobs:
             # /ai-review override; every later PR adjudicates normally once the
             # contract is on the base.
             note="The adjudication contract is absent on the base commit, so the blocking-finding adjudication pass was disabled and GPT's verdict stands. (Expected on the PR that introduces the contract; merging it requires a maintainer /ai-review override.)"
-          elif [ "$fenced" -gt 0 ]; then
-            note="$fenced of $count blocking finding(s) are security-class and were withheld from adjudication, so the blocking verdict stands."
           elif [ "$count" -eq 0 ]; then
             note="GPT emitted [BLOCK-MERGE] but no parseable BLOCKING finding, so there was nothing to adjudicate and the blocking verdict stands."
+          elif ! grep -Fq "[GPT-ADJUDICATED] $HEAD" "$parse" \
+            && ! grep -Fq "[GPT-ADJUDICATED-FENCED] $HEAD" "$parse"; then
+            # The stage was asked to rule (count > 0) but its output carries NO
+            # adjudication marker at all: it never ran to completion -- an API
+            # error, a skipped model step, or a crash, not a ruling. This branch
+            # sits ABOVE the fenced/uphold wording on purpose (#9216): those
+            # sentences describe a verdict, and rendering one for a stage that
+            # produced none reads like an adjudication that ran and declined to
+            # overturn. Surface the failure where the conclusion is read instead.
+            note="Adjudication produced no [GPT-ADJUDICATED] marker for $HEAD: the adjudication stage FAILED TO RUN (its raw output is in the Adjudication details block -- typically an API or setup error), so no proportionality review took place and GPT's blocking verdict stands unreviewed."
+            echo "::error::the Opus 4.8 adjudication stage produced no verdict for $HEAD -- inspect the 'Opus 4.8 adjudication' step output; GPT's blocking verdict stands unreviewed."
+          elif [ "$fenced" -gt 0 ]; then
+            note="$fenced of $count blocking finding(s) are security-class and were withheld from adjudication, so the blocking verdict stands."
           elif [ "$adjudicable" -eq 0 ]; then
             note="No blocking finding was adjudicable, so the blocking verdict stands."
           elif ! grep -Fq "[GPT-ADJUDICATED] $HEAD" "$parse"; then

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -893,6 +893,44 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
+      # The adjudicator model carries a MINIMUM Claude Code version, and the
+      # action's own bundled installer can lag it (#9216). Resolve the CLI from
+      # the review-cli install (committed lockfile staged from the trusted BASE)
+      # and assert the floor at configuration time. KEEP IN SYNC with
+      # codex-review.yml, which carries the full reasoning.
+      - name: Assert the adjudicator's Claude Code version floor
+        id: adj_cli
+        if: >-
+          (steps.adj_input.outputs.adjudicable != '' && steps.adj_input.outputs.adjudicable != '0')
+          || (steps.adj_input.outputs.fenced != '' && steps.adj_input.outputs.fenced != '0')
+        env:
+          # The minimum Claude Code the selected adjudicator model accepts.
+          # Bump alongside any adjudicator model bump, with the
+          # @anthropic-ai/claude-code pin in .github/review-cli/package.json
+          # raised to satisfy it.
+          ADJ_CLAUDE_CODE_FLOOR: "2.1.255"
+        run: |
+          set -euo pipefail
+          bin="$RUNNER_TEMP/review-cli/node_modules/.bin/claude"
+          if [ ! -x "$bin" ]; then
+            echo "::error::Claude Code is not in the review CLI install; add @anthropic-ai/claude-code to .github/review-cli/package.json (staged from the base commit). The adjudication stage cannot run."
+            exit 1
+          fi
+          # `|| true` keeps a failed or version-less `--version` from killing
+          # the step under `set -e` BEFORE the empty-value check below can name
+          # the real problem; every degraded path still exits 1.
+          installed="$("$bin" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
+          if [ -z "$installed" ]; then
+            echo "::error::could not read the installed Claude Code version; the adjudication stage cannot run."
+            exit 1
+          fi
+          if [ "$(printf '%s\n%s\n' "$ADJ_CLAUDE_CODE_FLOOR" "$installed" | sort -V | head -n1)" != "$ADJ_CLAUDE_CODE_FLOOR" ]; then
+            echo "::error::Claude Code $installed does not meet the adjudicator model's minimum $ADJ_CLAUDE_CODE_FLOOR; raise the @anthropic-ai/claude-code pin in .github/review-cli/package.json."
+            exit 1
+          fi
+          echo "Claude Code $installed satisfies the adjudicator's floor $ADJ_CLAUDE_CODE_FLOOR"
+          echo "path=$bin" >> "$GITHUB_OUTPUT"
+
       - name: Opus 4.8 adjudication (blocking findings only)
         id: adjudicate
         if: >-
@@ -902,6 +940,10 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The floor-asserted CLI from the step above; handing it over skips
+          # the action's own installer, whose bundled version is what fell
+          # behind the adjudicator model's minimum (#9216).
+          path_to_claude_code_executable: ${{ steps.adj_cli.outputs.path }}
           # workflow_run runs as the fork contributor, who lacks repo write;
           # claude-code-action >=1.0.194 rejects that actor before the model call
           # unless it is allow-listed here. See fork-opus-review.yml / issue #6116.
@@ -982,10 +1024,17 @@ jobs:
           vline='^(UPHOLD|DOWNGRADE) F[0-9]+ [^[:space:]]+ reason=('"$REASONS"')$'
 
           decision="uphold"
-          if [ "$fenced" -gt 0 ]; then
-            note="$fenced of $count blocking finding(s) are security-class and were withheld from adjudication, so the blocking verdict stands."
-          elif [ "$count" -eq 0 ]; then
+          if [ "$count" -eq 0 ]; then
             note="GPT emitted [BLOCK-MERGE] but no parseable BLOCKING finding, so there was nothing to adjudicate and the blocking verdict stands."
+          elif ! grep -Fq "[GPT-ADJUDICATED] $HEAD" "$parse" \
+            && ! grep -Fq "[GPT-ADJUDICATED-FENCED] $HEAD" "$parse"; then
+            # No adjudication marker at all: the stage never ran to completion
+            # (#9216). Sits ABOVE the fenced wording so a stage that produced
+            # no ruling is never reported in words that read like one.
+            note="Adjudication produced no [GPT-ADJUDICATED] marker for $HEAD: the adjudication stage FAILED TO RUN (its raw output is in the Adjudication details block -- typically an API or setup error), so no proportionality review took place and GPT's blocking verdict stands unreviewed."
+            echo "::error::the Opus 4.8 adjudication stage produced no verdict for $HEAD -- inspect the 'Opus 4.8 adjudication' step output; GPT's blocking verdict stands unreviewed."
+          elif [ "$fenced" -gt 0 ]; then
+            note="$fenced of $count blocking finding(s) are security-class and were withheld from adjudication, so the blocking verdict stands."
           elif [ "$adjudicable" -eq 0 ]; then
             note="No blocking finding was adjudicable, so the blocking verdict stands."
           elif ! grep -Fq "[GPT-ADJUDICATED] $HEAD" "$parse"; then

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -4636,6 +4636,242 @@ class TestBlockAdjudicationArithmetic:
         assert "contract is absent on the base commit" in parsed["note"]
         assert "/ai-review override" in parsed["note"]
 
+    @pytest.mark.parametrize("lane", LANES)
+    def test_an_api_error_with_fenced_findings_reports_a_failed_stage_not_a_ruling(
+        self, tmp_path: Path, lane: str
+    ) -> None:
+        """#9216: the adjudicator returned an API 400 on every PR (the runner's
+        Claude Code sat below the model's version floor), and the fenced branch
+        still rendered "withheld from adjudication, so the blocking verdict
+        stands" -- words that read like an adjudication ran and declined to
+        overturn. A stage whose output carries no adjudication marker at all
+        must be reported as one that FAILED TO RUN, whatever the fence held
+        back, and the verdict must still stand (fail closed)."""
+        api_error = (
+            "API Error: 400 Claude Code 2.1.240 does not support this model; "
+            "version 2.1.255 or newer is required. Run 'claude update', or "
+            "update the Claude desktop app, then try again."
+        )
+        decision, note = self._run(
+            tmp_path,
+            lane,
+            api_error,
+            count=2,
+            adjudicable=1,
+            fenced=1,
+            ids="F1",
+            fenced_ids="F2",
+        )
+        assert decision == "uphold"
+        assert "FAILED TO RUN" in note
+        assert "stands unreviewed" in note
+        assert "withheld" not in note
+
+    @pytest.mark.parametrize("lane", LANES)
+    def test_a_crashed_annotate_only_pass_is_reported_as_failed(
+        self, tmp_path: Path, lane: str
+    ) -> None:
+        """Same defect, fenced-only population: every blocking finding was
+        security-class, so only the annotate-only pass was requested -- and it
+        produced nothing. The old chain's fenced branch masked that entirely."""
+        decision, note = self._run(
+            tmp_path,
+            lane,
+            None,
+            count=1,
+            adjudicable=0,
+            fenced=1,
+            ids="",
+            fenced_ids="F2",
+        )
+        assert decision == "uphold"
+        assert "FAILED TO RUN" in note
+        assert "withheld" not in note
+
+    @pytest.mark.parametrize("lane", LANES)
+    def test_a_completed_ruling_with_fenced_findings_keeps_the_withheld_wording(
+        self, tmp_path: Path, lane: str
+    ) -> None:
+        """The mirror case: when the stage DID produce a ruling, the fenced
+        sentence is an accurate statement about the gate and stays."""
+        output = _adjudication(
+            "[ADJUDICATION] deadbeef total=1 uphold=0 downgrade=1",
+            DOWN.format(fid="F1"),
+            MARKER,
+            FFOOTER.format(n=1, k=0),
+            UPFENCED.format(fid="F2"),
+            FMARKER,
+        )
+        decision, note = self._run(
+            tmp_path,
+            lane,
+            output,
+            count=2,
+            adjudicable=1,
+            fenced=1,
+            ids="F1",
+            fenced_ids="F2",
+        )
+        assert decision == "uphold"
+        assert "withheld from adjudication" in note
+
+
+class TestAdjudicatorVersionFloor:
+    """#9216: the adjudicator model requires a minimum Claude Code version, and
+    the action's bundled installer can lag it -- which made every adjudication
+    call 400 while the check-run concluded normally. The floor is now asserted
+    at CONFIGURATION time, against a CLI installed from the committed
+    review-cli lockfile, so a model bump that outruns the pin fails one visible
+    step instead of failing once per PR forever."""
+
+    LANES = ("codex-review.yml", "fork-gpt-review.yml")
+    FLOOR_STEP = "Assert the adjudicator's Claude Code version floor"
+
+    @staticmethod
+    def _ver(version: str) -> tuple[int, ...]:
+        return tuple(int(part) for part in version.split("."))
+
+    @pytest.mark.parametrize("lane", LANES)
+    def test_the_model_call_uses_the_floor_asserted_executable(self, lane: str) -> None:
+        """The floor step gates the model call: same trigger condition, and the
+        adjudicate step consumes ITS executable, skipping the action's own
+        installer (whose bundled version is what fell behind). A floor breach
+        fails the assert step, the model step is skipped by its implicit
+        success() dependency, and the verdict step reports an adjudication that
+        did not run."""
+        floor_step = _step(lane, self.FLOOR_STEP)
+        model_step = _step(lane, ADJ_MODEL)
+        assert floor_step["if"] == model_step["if"], lane
+        assert (
+            model_step["with"]["path_to_claude_code_executable"]
+            == "${{ steps.adj_cli.outputs.path }}"
+        ), lane
+        script = _step_script(_workflow(lane), self.FLOOR_STEP)
+        # The comparison is a version sort, not a string compare, and every
+        # degraded path (no binary, unreadable version, floor unmet) exits
+        # nonzero rather than letting the model call proceed and 400.
+        assert "sort -V" in script, lane
+        assert "exit 1" in script, lane
+
+    def test_the_lanes_agree_on_the_floor(self) -> None:
+        floors = {
+            lane: _step_env(lane, self.FLOOR_STEP)["ADJ_CLAUDE_CODE_FLOOR"] for lane in self.LANES
+        }
+        assert len(set(floors.values())) == 1, floors
+
+    def test_the_committed_pin_satisfies_the_floor(self) -> None:
+        """The configuration-time assertion, mirrored where it is cheapest: a
+        floor bump without a manifest bump (or a manifest downgrade below the
+        floor) reds this test before any workflow run pays for it. The lockfile
+        must agree with the manifest, or `npm ci` installs something other than
+        the version this test just approved."""
+        floor = _step_env("codex-review.yml", self.FLOOR_STEP)["ADJ_CLAUDE_CODE_FLOOR"]
+        manifest = json.loads(
+            (ROOT / ".github" / "review-cli" / "package.json").read_text(encoding="utf-8")
+        )
+        pin = manifest["dependencies"]["@anthropic-ai/claude-code"]
+        assert re.fullmatch(
+            r"\d+\.\d+\.\d+", pin
+        ), f"the adjudicator CLI must be an exact pin, got {pin!r}"
+        assert self._ver(pin) >= self._ver(
+            floor
+        ), f"@anthropic-ai/claude-code pin {pin} is below the adjudicator floor {floor}"
+        lock = json.loads(
+            (ROOT / ".github" / "review-cli" / "package-lock.json").read_text(encoding="utf-8")
+        )
+        locked = lock["packages"]["node_modules/@anthropic-ai/claude-code"]["version"]
+        assert locked == pin, f"lockfile holds {locked}, manifest pins {pin}"
+
+    def _run_floor(
+        self, tmp_path: Path, lane: str, claude_body: str | None
+    ) -> tuple[int, str, dict[str, str]]:
+        """Execute the ACTUAL floor-step script with a fake `claude` binary.
+
+        ``claude_body`` is the fake binary's shell source; ``None`` installs no
+        binary at all (the review-cli manifest predating the pin).
+        """
+        if os.name == "nt":
+            pytest.skip("the floor step runs only on the Linux CI runner; skip on Windows")
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the floor step executes only under Bash")
+        script = _step_script(_workflow(lane), self.FLOOR_STEP)
+        bin_dir = tmp_path / "review-cli" / "node_modules" / ".bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        if claude_body is not None:
+            fake = bin_dir / "claude"
+            fake.write_text(f"#!/bin/sh\n{claude_body}\n", encoding="utf-8")
+            fake.chmod(0o755)
+        outputs = tmp_path / "github-output"
+        outputs.touch()
+        env = dict(os.environ)
+        env.update(_step_env(lane, self.FLOOR_STEP))
+        env.update(RUNNER_TEMP=str(tmp_path), GITHUB_OUTPUT=str(outputs))
+        result = subprocess.run(
+            [bash, "-c", script],
+            cwd=tmp_path,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        parsed = dict(
+            line.split("=", 1)
+            for line in outputs.read_text(encoding="utf-8").splitlines()
+            if "=" in line
+        )
+        return result.returncode, result.stdout + result.stderr, parsed
+
+    @pytest.mark.parametrize("lane", LANES)
+    def test_a_version_above_the_floor_passes_and_exports_the_path(
+        self, tmp_path: Path, lane: str
+    ) -> None:
+        rc, out, parsed = self._run_floor(tmp_path, lane, 'echo "9.9.9 (Claude Code)"')
+        assert rc == 0, out
+        assert parsed["path"].endswith("node_modules/.bin/claude")
+
+    @pytest.mark.parametrize("lane", LANES)
+    def test_a_version_equal_to_the_floor_passes(self, tmp_path: Path, lane: str) -> None:
+        floor = _step_env(lane, self.FLOOR_STEP)["ADJ_CLAUDE_CODE_FLOOR"]
+        rc, out, _ = self._run_floor(tmp_path, lane, f'echo "{floor} (Claude Code)"')
+        assert rc == 0, out
+
+    @pytest.mark.parametrize("lane", LANES)
+    def test_a_version_below_the_floor_fails_naming_the_pin(
+        self, tmp_path: Path, lane: str
+    ) -> None:
+        """The #9216 shape itself: the installed CLI sits below the adjudicator
+        model's minimum. The step must fail (skipping the model call) and the
+        error must point at the pin to raise, not at the PR under review."""
+        rc, out, parsed = self._run_floor(tmp_path, lane, 'echo "2.1.240 (Claude Code)"')
+        assert rc != 0
+        assert "does not meet the adjudicator model's minimum" in out
+        assert "path" not in parsed
+
+    @pytest.mark.parametrize("lane", LANES)
+    def test_a_crashing_version_command_still_names_the_cause(
+        self, tmp_path: Path, lane: str
+    ) -> None:
+        """`set -e` must not kill the step before the empty-value check can emit
+        its diagnosis -- the extraction pipeline is `|| true`-guarded so the
+        friendly ::error:: is what a maintainer sees, not a bare nonzero exit."""
+        rc, out, _ = self._run_floor(tmp_path, lane, "exit 1")
+        assert rc != 0
+        assert "could not read the installed Claude Code version" in out
+
+    @pytest.mark.parametrize("lane", LANES)
+    def test_a_version_less_output_still_names_the_cause(self, tmp_path: Path, lane: str) -> None:
+        rc, out, _ = self._run_floor(tmp_path, lane, 'echo "no semver here"')
+        assert rc != 0
+        assert "could not read the installed Claude Code version" in out
+
+    @pytest.mark.parametrize("lane", LANES)
+    def test_a_missing_binary_points_at_the_manifest(self, tmp_path: Path, lane: str) -> None:
+        rc, out, _ = self._run_floor(tmp_path, lane, None)
+        assert rc != 0
+        assert "not in the review CLI install" in out
+
 
 class TestBlockAdjudicationExtraction:
     """What reaches the adjudicator is exactly the BLOCKING findings, one per id,


### PR DESCRIPTION
## Problem / Motivation

The AI review workflow's second-stage adjudication (the pass that decides whether blocking on each GPT finding is proportionate) never runs. The selected adjudicator model requires Claude Code >= 2.1.255, the claude-code-action's bundled installer ships 2.1.240, and every adjudication call returns an API 400. Measured on the twelve most recent PRs: six comments name the current adjudicator and none produced a verdict; all six carry the same runner=2.1.240 / required=2.1.255 error.

The failure is silent exactly where people look. The error lands inside a collapsed details block, the check-run concludes normally, and when a finding is security-fenced the comment says the blocking verdict stands "because the finding was withheld" - wording that reads as though an adjudication ran and declined to overturn.

## Why it matters

A PR held by a blocking verdict is entitled to the proportionality review the workflow promises; today nothing performs it, and nothing tells a reader that. A maintainer trusting the check conclusion or the standing-verdict sentence cannot distinguish a gate that ran and agreed from a gate that could not run at all. Worse, the mismatch is structural: any future adjudicator model bump that outruns the runner's Claude Code re-creates the same silent failure, once per PR, forever.

## What changed (motivation -> approach -> change)

Two changes, applied to both GPT lanes (`codex-review.yml` and `fork-gpt-review.yml`, kept in sync):

1. **Configuration-time version floor.** `@anthropic-ai/claude-code` is pinned (2.1.263) in the committed `.github/review-cli` lockfile both lanes already install from the trusted BASE commit via `npm ci` - the same supply-chain posture as the codex binary, no floating registry resolution. A new step, "Assert the adjudicator's Claude Code version floor" (same trigger condition as the model call), resolves that CLI, reads its version, and asserts the adjudicator's floor (2.1.255, kept identical across lanes) via `sort -V`. The adjudicate step consumes the asserted executable through `path_to_claude_code_executable`, skipping the action's own installer - the component whose bundled version fell behind. A model bump that outruns the pin now fails one visible step at configuration time; the model call is skipped by its implicit `success()` dependency and the verdict step reports an adjudication that did not run. Every degraded path exits nonzero and the gate stays blocked (fail closed).

2. **Verdict-dependent wording plus failure surfacing.** The "Adjudicate the blocking verdict" script gains a branch, ordered above the fenced/withheld wording, that detects output carrying neither `[GPT-ADJUDICATED]` nor `[GPT-ADJUDICATED-FENCED]` marker for the head: the stage was asked to rule but produced nothing (API error, skipped model step, crash). It reports the stage as FAILED TO RUN, emits an `::error::` annotation, and the note flows into the check-run summary and the comment headline. The "withheld from adjudication, so the blocking verdict stands" sentence now renders only when the stage actually produced a ruling. `decision` stays `uphold` on every degraded path - no change to gate semantics.

No adjudicator model reference moved; model ids stay in the workflow inputs as before.

## Tests

- 12 new executable floor-step tests (`TestAdjudicatorVersionFloor`): fake `claude` binaries covering above-floor, equal-floor (inclusive), below-floor (the #9216 shape - fails naming the pin to raise), a crashing `--version`, version-less output, and a missing binary; plus structural assertions that the floor step gates the model call with the identical trigger condition, the lanes agree on the floor, and the committed manifest pin and lockfile satisfy the floor (so a floor bump without a pin bump reds CI before any workflow run pays for it).
- 6 new adjudication-arithmetic tests: an API-error output with fenced findings must not render "withheld" (reports FAILED TO RUN, verdict stands unreviewed); a crashed annotate-only pass is reported as failed; a completed ruling with fenced findings keeps the withheld wording.
- Full workflow suite green: 464 passed in `test_ai_review_workflows.py`; 666 passed across all workflow-shape test files (permissions, secret/cache scope, checkout credentials, workflow security).
- Local gates: black, isort, flake8, subprocess-encoding, YAML parse of both workflows.

## Manual verification

Ran `npm ci` on the updated lockfile in a scratch directory: `node_modules/.bin/claude` resolves, `--version` reports 2.1.263, and the floor comparison passes. Executed the real floor-step script from both workflows against fake binaries for all six degraded/healthy paths (the executable tests above are exactly that harness).

## Related Issues

Closes #9216

## Pattern harvest

Rule candidate: review-prompt
Pattern: wording that reports a review must be conditional on the review having produced a verdict, not on one having been requested

A two-stage gate whose second stage fails open into text that reads like the first stage was reviewed is indistinguishable from a gate that ran and agreed. Wording that reports a review must be conditional on the review having produced an answer, and a version floor between a tool and its runner belongs at configuration time, not per invocation.
