### PR TITLE
fix: extract pptx text in presentation order

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -817,6 +817,18 @@ flow again. Replay remains merge-only and idempotent.
 
 ## Dashboard (`dashboard/`)
 
+Office text previews use `doc_parser.extract_text`. For PPTX, slide order and
+`Slide N` labels come from `ppt/presentation.xml`'s `p:sldIdLst`, resolved through
+its internal slide relationships. ZIP filenames do not determine presentation
+positions. Blank or unresolved slides retain their positions, unreferenced slide
+parts are omitted, and the text budget stops extraction in presentation order.
+Each resolved slide part is extracted at most once, even if malformed metadata
+references it repeatedly.
+Ordering metadata uses the same bounded ZIP reads and hardened XML parser as slide
+content, including when the caller supplies an already-open archive. Incomplete
+containers without `ppt/presentation.xml` retain numeric-filename best-effort
+extraction; a present but unreadable ordering manifest does not fall back to it.
+
 Modular aiohttp package at `127.0.0.1:5476` (configurable). Split into:
 - `folder_repository.py` — chat-folder load, serialized read-modify-write, rollback,
   full-value write confirmation, and breadcrumb traversal. `DashboardState` keeps

--- a/src/kiro_crew/doc_parser.py
+++ b/src/kiro_crew/doc_parser.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import os
+import posixpath
 import re
 import zipfile
 import zlib
@@ -271,7 +272,49 @@ def _extract_docx(
 # ── PPTX parser (Office Open XML) ──
 
 _A_NS = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
+_P_NS = "{http://schemas.openxmlformats.org/presentationml/2006/main}"
+_R_NS = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
+_PACKAGE_R_NS = "{http://schemas.openxmlformats.org/package/2006/relationships}"
+_SLIDE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
 _SLIDE_RE = re.compile(r"^ppt/slides/slide(\d+)\.xml$")
+
+
+def _pptx_slide_order(zf: zipfile.ZipFile) -> list[tuple[int, str]]:
+    """Resolve presentation positions to internal ZIP members, never filesystem paths."""
+    assert _xml_fromstring is not None
+    names = set(zf.namelist())
+    if "ppt/presentation.xml" not in names:
+        # Keep best-effort extraction for incomplete containers without an order.
+        return sorted(
+            (int(match.group(1)), name)
+            for name in names
+            if (match := _SLIDE_RE.match(name))
+        )
+    presentation = _read_zip_entry(zf, "ppt/presentation.xml")
+    relationships = _read_zip_entry(zf, "ppt/_rels/presentation.xml.rels")
+    if presentation is None or relationships is None:
+        return []
+    root = _xml_fromstring(presentation)
+    rels = _xml_fromstring(relationships)
+    targets = {
+        rel.get("Id"): posixpath.normpath(posixpath.join("ppt", rel.attrib["Target"])).lstrip("/")
+        for rel in rels.findall(f"{_PACKAGE_R_NS}Relationship")
+        if rel.get("Type") == _SLIDE_REL_TYPE
+        and rel.get("TargetMode", "Internal") == "Internal"
+        and rel.get("Target")
+    }
+    # Part numbers and relationship IDs survive reordering; only sldIdLst gives
+    # the order a reader sees. Enumerate before skipping blank or missing slides.
+    ordered: list[tuple[int, str]] = []
+    seen: set[str] = set()
+    for number, slide in enumerate(root.iterfind(f"{_P_NS}sldIdLst/{_P_NS}sldId"), 1):
+        target = targets.get(slide.get(f"{_R_NS}id"))
+        if target is not None and target in names and target not in seen:
+            # A malformed manifest must not multiply decompression and retained
+            # text beyond the vetted inventory by referencing one part repeatedly.
+            seen.add(target)
+            ordered.append((number, target))
+    return ordered
 
 
 def _extract_pptx(
@@ -293,15 +336,10 @@ def _extract_pptx(
     slides: list[tuple[int, str]] = []
     collected = 0
     with zipfile.ZipFile(fileobj if fileobj is not None else path, "r") as zf:
-        slide_names = sorted(
-            (n for n in zf.namelist() if _SLIDE_RE.match(n)),
-            key=lambda n: int(_SLIDE_RE.match(n).group(1)),  # type: ignore[union-attr]
-        )
-        for slide_name in slide_names:
+        for num, slide_name in _pptx_slide_order(zf):
             data = _read_zip_entry(zf, slide_name)
             if data is None:
                 continue
-            num = int(_SLIDE_RE.match(slide_name).group(1))  # type: ignore[union-attr]
             root = _xml_fromstring(data)
             texts: list[str] = []
             for t_elem in root.iter(f"{_A_NS}t"):

--- a/test/test_doc_parser_pptx_order.py
+++ b/test/test_doc_parser_pptx_order.py
@@ -1,0 +1,184 @@
+"""Presentation metadata, not ZIP part names, defines slide order and numbers."""
+
+from __future__ import annotations
+
+import zipfile
+
+# Fixture construction/serialization only; all XML parsing stays in defusedxml.
+# nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from kiro_crew import doc_parser
+
+_P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+_A = "http://schemas.openxmlformats.org/drawingml/2006/main"
+_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+_PACKAGE_R = "http://schemas.openxmlformats.org/package/2006/relationships"
+_PRESENTATION = "ppt/presentation.xml"
+_RELS = "ppt/_rels/presentation.xml.rels"
+
+
+def _deck(tmp_path, *, order=(2, 3, 1), targets=None, blank=(), external=(), broken=()):
+    """Write the ordering parts of a deck with stable, independently named slides."""
+    targets = targets or {i: f"slides/slide{i}.xml" for i in (1, 2, 3)}
+    presentation = ET.Element(f"{{{_P}}}presentation")
+    slide_ids = ET.SubElement(presentation, f"{{{_P}}}sldIdLst")
+    relationships = ET.Element(f"{{{_PACKAGE_R}}}Relationships")
+    parts = {}
+    for i in order:
+        ET.SubElement(slide_ids, f"{{{_P}}}sldId", {"id": str(255 + i), f"{{{_R}}}id": f"rId{i}"})
+    for i, target in targets.items():
+        if i not in broken:
+            ET.SubElement(
+                relationships,
+                f"{{{_PACKAGE_R}}}Relationship",
+                {
+                    "Id": f"rId{i}",
+                    "Type": f"{_R}/slide",
+                    "Target": target,
+                    "TargetMode": "External" if i in external else "Internal",
+                },
+            )
+        slide = ET.Element(f"{{{_P}}}sld")
+        if i not in blank:
+            ET.SubElement(slide, f"{{{_A}}}t").text = f"Content {i}"
+        # Tests spell the member name independently of production URI resolution.
+        member = target.lstrip("/") if target.startswith("/") else f"ppt/{target}"
+        parts[member] = ET.tostring(slide)
+    parts[_PRESENTATION] = ET.tostring(presentation)
+    parts[_RELS] = ET.tostring(relationships)
+    path = tmp_path / "deck.pptx"
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in parts.items():
+            archive.writestr(name, data)
+    return path
+
+
+@pytest.mark.parametrize("fileobj", [False, True])
+def test_reordered_deck_uses_presentation_positions(tmp_path, fileobj):
+    path = _deck(tmp_path)
+    expected = (
+        "--- Slide 1 ---\nContent 2\n\n"
+        "--- Slide 2 ---\nContent 3\n\n"
+        "--- Slide 3 ---\nContent 1"
+    )
+    if fileobj:
+        with path.open("rb") as stream:
+            assert doc_parser.extract_text(str(path), fileobj=stream) == expected
+    else:
+        assert doc_parser.extract_text(str(path)) == expected
+
+
+def test_budget_keeps_the_actual_first_slide_and_never_reads_later_slides(tmp_path, monkeypatch):
+    path = _deck(tmp_path)
+    reads = []
+    original = doc_parser._read_zip_entry
+
+    def read(archive, name, *args, **kwargs):
+        reads.append(name)
+        return original(archive, name, *args, **kwargs)
+
+    monkeypatch.setattr(doc_parser, "_read_zip_entry", read)
+    assert doc_parser.extract_text(str(path), max_chars=1) == "--- Slide 1 ---\nContent 2"
+    assert "ppt/slides/slide1.xml" not in reads
+    assert "ppt/slides/slide3.xml" not in reads
+
+
+def test_unreferenced_slide_parts_are_not_in_the_presentation(tmp_path):
+    path = _deck(tmp_path, order=(2, 3))
+    assert doc_parser.extract_text(str(path)) == (
+        "--- Slide 1 ---\nContent 2\n\n--- Slide 2 ---\nContent 3"
+    )
+
+
+def test_blank_slide_keeps_the_following_presentation_number(tmp_path):
+    path = _deck(tmp_path, blank=(2,))
+    assert doc_parser.extract_text(str(path)) == (
+        "--- Slide 2 ---\nContent 3\n\n--- Slide 3 ---\nContent 1"
+    )
+
+
+@pytest.mark.parametrize("target", ["slides/overview.xml", "/ppt/slides/overview.xml"])
+def test_relationship_target_does_not_need_a_numeric_filename(tmp_path, target):
+    path = _deck(tmp_path, order=(1,), targets={1: target})
+    assert doc_parser.extract_text(str(path)) == "--- Slide 1 ---\nContent 1"
+
+
+@pytest.mark.parametrize("unreadable", [{"external": (2,)}, {"broken": (2,)}])
+def test_unresolvable_slide_does_not_reorder_the_remaining_slides(tmp_path, unreadable):
+    path = _deck(tmp_path, **unreadable)
+    assert doc_parser.extract_text(str(path)) == (
+        "--- Slide 2 ---\nContent 3\n\n--- Slide 3 ---\nContent 1"
+    )
+
+
+def test_empty_presentation_does_not_fall_back_to_orphan_parts(tmp_path):
+    path = _deck(tmp_path, order=())
+    assert doc_parser.extract_text(str(path)) == ""
+
+
+def test_repeated_references_read_each_slide_part_only_once(tmp_path, monkeypatch):
+    path = _deck(tmp_path, order=(2,) * 100 + (3, 1))
+    reads = []
+    original = doc_parser._read_zip_entry
+
+    def read(archive, name, *args, **kwargs):
+        reads.append(name)
+        return original(archive, name, *args, **kwargs)
+
+    monkeypatch.setattr(doc_parser, "_read_zip_entry", read)
+    assert doc_parser.extract_text(str(path)) == (
+        "--- Slide 1 ---\nContent 2\n\n"
+        "--- Slide 101 ---\nContent 3\n\n"
+        "--- Slide 102 ---\nContent 1"
+    )
+    assert reads.count("ppt/slides/slide2.xml") == 1
+
+
+def test_distinct_relationships_to_the_same_part_do_not_duplicate_text(tmp_path):
+    path = _deck(
+        tmp_path,
+        order=(2, 1, 3),
+        targets={1: "slides/shared.xml", 2: "slides/shared.xml", 3: "slides/slide3.xml"},
+    )
+    assert doc_parser.extract_text(str(path)) == (
+        "--- Slide 1 ---\nContent 2\n\n--- Slide 3 ---\nContent 3"
+    )
+
+
+@pytest.mark.parametrize("part", [_PRESENTATION, _RELS])
+def test_ordering_metadata_keeps_the_existing_read_cap(tmp_path, monkeypatch, part):
+    path = _deck(tmp_path)
+    original = doc_parser._read_zip_entry
+
+    def capped_read(archive, name, *args, **kwargs):
+        return original(archive, name, max_size=1 if name == part else None)
+
+    monkeypatch.setattr(doc_parser, "_read_zip_entry", capped_read)
+    assert doc_parser.extract_text(str(path)) == ""
+
+
+@pytest.mark.parametrize("part", [_PRESENTATION, _RELS])
+@pytest.mark.parametrize("xml", [b"<broken", b'<!DOCTYPE x [<!ENTITY e "expanded">]><x>&e;</x>'])
+def test_invalid_ordering_metadata_does_not_fall_back_to_filename_order(
+    tmp_path, monkeypatch, part, xml
+):
+    path = _deck(tmp_path)
+    original = doc_parser._read_zip_entry
+
+    def read(archive, name, *args, **kwargs):
+        return xml if name == part else original(archive, name, *args, **kwargs)
+
+    monkeypatch.setattr(doc_parser, "_read_zip_entry", read)
+    assert doc_parser.extract_text(str(path)) == ""
+
+
+def test_unchanged_order_is_a_control(tmp_path):
+    path = _deck(tmp_path, order=(1, 2, 3))
+    assert doc_parser.extract_text(str(path)) == (
+        "--- Slide 1 ---\nContent 1\n\n"
+        "--- Slide 2 ---\nContent 2\n\n"
+        "--- Slide 3 ---\nContent 3"
+    )


### PR DESCRIPTION
## Problem / Motivation

Reordering a PowerPoint deck does not rename its slide parts. `doc_parser` sorts
`ppt/slides/slideN.xml` and uses N as the displayed slide number, so the Office
text preview silently restores filename order instead of showing the presentation.

Reproduced on `main` at `91513fa01` with a valid three-slide deck, saved and
independently reopened using python-pptx:

```
Presentation order: Executive summary, Recommendation, Detailed appendix
Kiro Crew order:    Detailed appendix, Executive summary, Recommendation
```

With `max_chars=1`, extraction keeps only `Detailed appendix`. The fixed code
returns `Executive summary` as Slide 1 in both full and capped extraction.

## Why it matters

The dashboard's `/api/file-office-preview` uses this parser through an already-open
archive and a text budget. A reordered deck therefore has incorrect slide labels,
and a long preview can omit its actual opening slides. The shared attachment
extractor also uses this parser when supplying document text to the agent.

## What changed (motivation → approach → change)

Read `p:sldIdLst` from `ppt/presentation.xml`, resolve its internal slide
relationships, and number results by presentation position. This follows the
[PresentationML structure](https://learn.microsoft.com/en-us/office/open-xml/presentation/working-with-presentations).
The new metadata reads use the existing bounded ZIP reader and defusedxml parser.

Blank or unresolved entries keep their positions; unreferenced parts are omitted.
Each resolved ZIP part is extracted only once, so repeated references in malformed
metadata cannot multiply decompression or retained text beyond the vetted inventory.
The extraction budget still prevents later slides from being read. Incomplete
containers without a presentation manifest retain the existing best-effort
filename scan, while present-but-unreadable metadata does not fall back to an
invented order. No new dependency or endpoint change.

## Tests

- Before the production change: 12 new cases failed and the unchanged-order
  control passed against `main`.
- Parser and Office-preview endpoint suites: **70 passed**, covering reordered decks through path and open-handle
  callers, capped reads, blank and unreferenced slides, internal relationship
  targets, unreadable relationships, bounded metadata, and malformed/DTD XML.
- Repeated-reference regression failed before its repair; the final tests also
  cover distinct relationship IDs targeting the same slide part.
- Relevant isort, flake8, mypy, and repository Black gate pass.

The focused command was:

```
python -m pytest test/test_doc_parser.py test/test_doc_parser_pptx_order.py test/test_file_office_preview.py -q --override-ini="addopts=-n auto --dist loadgroup --max-worker-restart=2"
```

A broader local run was not clean: the full backend suite hit timeouts and was
stopped, and whole-tree lint/type runs reported findings in unchanged files with
newer local tool versions. This PR does not claim whole-repository validation.

## Manual verification

Generated a valid deck with python-pptx, moved its first slide to the end, saved
and reopened it with that independent reader, then ran the public `extract_text`
API against the same file before and after the fix. Both full and capped output
now agree with the reopened presentation. python-pptx was used only for this probe;
the committed regression fixtures use the standard library.

## Related Issues

Found by inspection. Checked all 371 open PRs at admission, refreshed the full
inventory after rebasing, and checked targeted issue/PR searches and local claims.
No open PR touches `doc_parser.py` or covers
presentation-order extraction. #4650 concerns a separate File Explorer viewer.

## Pattern harvest

Rule candidate: review-prompt
Pattern: an archive member's filename or identifier is not its display order;
follow the container's ordering metadata and test a reordered valid document.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
