### PR TITLE
fix(dashboard): close three residual reload teardown races

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -7377,15 +7377,21 @@ async def api_chat_slot_reload(request: web.Request) -> web.Response:
     at session-init time; config that changes afterwards (a newly added MCP
     server, an env or agent-spec fix) never reaches it. Reload is the in-place
     remedy: tear the process down exactly like the agent/workspace switch
-    handlers do, then eagerly re-arm the resume spawn, so the relaunched
-    process re-reads its agent spec and environment and re-initializes MCP
-    servers via session/load -- with the conversation preserved.
+    handlers do, then eagerly re-arm the resume spawn for a session this slot
+    alone owns (a linked session suppresses it, see the respawn site), so the
+    relaunched process re-reads its agent spec and environment and
+    re-initializes MCP servers via session/load -- with the conversation
+    preserved.
 
     Refused with 409 while a turn is in flight (killing an in-flight ACP
     process orphans the streaming prompt: resume refusals, empty responses)
     and while sub-agent children are attached (their shared runtime is torn
     down with the parent session -- see ``SessionManager.reset`` -- so a
-    reload under a working child silently discards its work). The
+    reload under a working child silently discards its work). "A turn is in
+    flight" is a SESSION-scoped question, not a slot-scoped one, because an
+    alias pair can share one session: the guard reads this slot's ``running``,
+    the session-scoped running set, and the registered provider, so an alias
+    sibling's cold-starting turn refuses the reload too. The
     has_active_turn() check is a best-effort fast path; the authoritative
     guard is the reset's skip_if_busy, which evaluates busyness atomically
     with the session pop (see _reset_slot_session for why the unblock half of
@@ -7459,8 +7465,83 @@ async def api_chat_slot_reload(request: web.Request) -> web.Response:
         denied = _app_cancel_denied(request, slot, "chat.slot_reload", session_key)
         if denied is not None:
             return denied
+        # Cancel and AWAIT this slot's in-flight speculative session creation.
+        # schedule_eager_spawn cancels the slot's prior _eager_spawn_task as a
+        # side effect of scheduling a new one, but reload suppresses that call for
+        # a linked session (see the respawn site), so without cancelling here a
+        # focus prefetch already mid-handshake from an earlier signal survives the
+        # teardown and registers a stale-config session after the reload reports
+        # success. AWAIT, not just cancel: the prefetch can be mid get_or_create,
+        # so the reset must not run until the task has settled, or it registers in
+        # the window between the cancel and the pop. The delete path
+        # (api_chat_slot_delete) cancels the same task for the same class of race.
+        #
+        # Placed BEFORE the turn guard below on purpose: this is the only real
+        # suspension point between resolving the session and the reset, so a send
+        # could otherwise start a turn (and post an approval card) DURING the
+        # await, after the guard had already passed -- and _reset_slot_session
+        # runs _unblock_pending_waits unconditionally, BEFORE its skip_if_busy
+        # decline, so that card is discarded even though the decline then answers
+        # 409. Cancelling first, then reading the guard with no await before the
+        # reset, keeps the guard's answer true at the moment of the teardown.
+        #
+        # SCOPED TO THIS SLOT, deliberately. ``_eager_spawn_task`` is per-slot
+        # while the session can be SHARED, so an alias sibling's prefetch on this
+        # same key is NOT cancelled here. Cancelling every sharer cannot be made
+        # correct from inside this endpoint: ``schedule_eager_spawn`` is also
+        # reached from the WS focus path (``ws.py``), which holds neither of this
+        # handler's locks, so a focus frame arriving during such a scan re-arms a
+        # prefetch on a slot the scan has already passed. Closing that needs the
+        # prefetch mechanism itself to become session-aware -- refuse or defer a
+        # prefetch for a session whose teardown is in flight -- which belongs with
+        # that mechanism rather than here.
+        _eager = getattr(slot, "_eager_spawn_task", None)
+        if _eager is not None and not _eager.done():
+            _eager.cancel()
+            try:
+                await _eager
+            except (asyncio.CancelledError, Exception):
+                # The task's own post-create liveness re-check tears down any
+                # session it managed to register before the cancel landed; here
+                # we only need it to have STOPPED before the guard and reset.
+                pass
+        # Re-authorize across the await above, for the same reason the two checks
+        # before it exist: a same-name delete and re-create can land while this
+        # request is suspended, and the ownership decision above was made against
+        # the slot object read before it. The shared helper is the same decision
+        # the autocompact, context-inject, note and edit-resend paths make after
+        # their own awaits -- identity on the slot OBJECT, an indistinguishable
+        # 404, the SEL app_isolation denial record, and a re-run of the ownership
+        # gate.
+        stale = _reauthorize_after_await(
+            state, slot, name, request.get("app", ""), "chat.slot_reload"
+        )
+        if stale is not None:
+            return stale
+        # A turn in flight on THIS session must refuse the reload -- but the
+        # session can be SHARED (an alias pair, both slots carrying the same
+        # linked_session_key), so "is a turn running on this session" is a
+        # SESSION-scoped question, not a slot-scoped one. Three probes, each
+        # covering a gap the others leave:
+        #   * ``slot.running`` -- THIS slot's turn, set at dispatch BEFORE
+        #     provider.start() registers a session, so a cold-starting first
+        #     turn on this slot is invisible to get_provider but not to this.
+        #   * ``session_key in state.running_session_keys()`` -- an ALIAS slot's
+        #     turn on the same session. That slot's ``running`` is a different
+        #     object and its cold-starting turn has not registered a provider
+        #     yet, so neither ``slot.running`` here nor get_provider sees it;
+        #     the session-scoped set does (it folds every slot through
+        #     effective_session_key). Without this an alias reload tears down a
+        #     session a sibling slot is mid-cold-start on and returns 200, and
+        #     that sibling then registers its stale-config provider.
+        #   * ``provider.has_active_turn()`` -- a registered live turn.
+        # A 409 is retryable once the turn completes.
         provider = state.sessions.get_provider(session_key)
-        if provider is not None and provider.has_active_turn():
+        if (
+            slot.running
+            or session_key in state.running_session_keys()
+            or (provider is not None and provider.has_active_turn())
+        ):
             return web.json_response(
                 {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
             )
@@ -7481,7 +7562,15 @@ async def api_chat_slot_reload(request: web.Request) -> web.Response:
         reloaded = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
         if not reloaded:
             provider = state.sessions.get_provider(session_key)
-            if provider is not None and provider.has_active_turn():
+            # Session-scoped for the same reason as the pre-reset guard above:
+            # the decline can be a turn on an ALIAS slot sharing this session,
+            # which neither this slot's ``running`` nor get_provider observes
+            # while it is still cold-starting.
+            if (
+                slot.running
+                or session_key in state.running_session_keys()
+                or (provider is not None and provider.has_active_turn())
+            ):
                 return web.json_response(
                     {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
                 )
@@ -7540,7 +7629,24 @@ async def api_chat_slot_reload(request: web.Request) -> web.Response:
     )
     # Respawn + session/load now rather than on the next message, so the fresh
     # process (and its rebuilt toolset) is ready when the user comes back.
-    schedule_eager_spawn(state, slot, allow_resume=True)
+    #
+    # ONLY for a session this slot alone owns. The eager spawn is deliberately
+    # scheduled AFTER the locks release (it debounces, then handshakes for
+    # multiple seconds -- holding the session lock across it would serialize an
+    # unrelated switch behind work that does not race the teardown). But a LINKED
+    # session (``linked_session_key`` set -- a channel/cron slot, or an alias
+    # pair) can be shared by another slot, and that slot's per-slot lock is
+    # DISJOINT from this one's. So a respawn that escaped the session lock can
+    # win ``get_or_create``'s same-key race and bake THIS slot's bindings into a
+    # session an alias slot's switch just committed different bindings for, and
+    # the first turn then runs the wrong model and config.
+    # Suppressing it for a linked session is safe: reload has already torn the
+    # session down, so the next real turn cold-starts under whatever bindings are
+    # current at that moment, which is exactly the correct, race-free outcome.
+    # The common reload -- a plain ``dashboard:`` slot with no link -- keeps the
+    # speculative respawn.
+    if not getattr(slot, "linked_session_key", ""):
+        schedule_eager_spawn(state, slot, allow_resume=True)
     state.push_slots_update()
     return web.json_response({"ok": True})
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -20532,6 +20532,42 @@ class TestSessionReload:
         assert resp.status == 409
         state.sessions.reset.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_reload_suppresses_eager_respawn_for_a_linked_session(
+        self, tmp_path, monkeypatch
+    ):
+        """A LINKED (alias-shareable) session reloads but does NOT eager-respawn.
+
+        The eager spawn is scheduled after the session lock releases and then
+        handshakes for seconds, so it escapes the serialization. For a session
+        another slot can share (``linked_session_key`` set), that escaped respawn
+        could win get_or_create's same-key race and bake THIS slot's bindings
+        into a session an alias slot's switch just committed different bindings
+        for -- the first turn would run the wrong model and config. So reload
+        suppresses the speculative respawn for a linked
+        session; the next real turn cold-starts under the current bindings.
+        Removing the ``linked_session_key`` guard makes eager fire and reddens
+        the assert below.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.linked_session_key = "slack:123.456"
+        state.sessions.get_provider = MagicMock(return_value=self._idle_provider())
+        state.sessions.reset = AsyncMock(return_value=True)
+        eager = MagicMock(return_value=None)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.schedule_eager_spawn", eager)
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/reload")
+
+        assert resp.status == 200
+        # The teardown still happened on the linked key -- reload is not skipped,
+        # only its speculative respawn is.
+        state.sessions.reset.assert_awaited_once_with("slack:123.456", skip_if_busy=True)
+        # The escaped respawn is suppressed for the shareable session.
+        eager.assert_not_called()
+
 
 class TestCloseBroadcastDurability:
     """A slot-list frame must never omit a slot that is coming back.

--- a/test/test_slot_reset_interleaving_seam.py
+++ b/test/test_slot_reset_interleaving_seam.py
@@ -580,3 +580,228 @@ class TestReloadRacesSwitchCommitResetSpan:
             "reset:post_pop",
         ]
         assert state.sessions.reset.await_count == 2
+
+
+class TestReloadRefusesAnAliasColdStartOnTheSharedSession:
+    """The alias cold-start guard.
+
+    A reload's turn-in-flight guard is SESSION-scoped, not slot-scoped: the
+    session can be shared by an alias slot, whose cold-starting first turn is
+    invisible to THIS slot's ``slot.running`` (a different object) and to
+    ``get_provider`` (``provider.start()`` has not registered a session yet).
+    ``session_key in state.running_session_keys()`` is what sees it -- the set
+    folds every slot through effective_session_key. Without it, reload tears
+    down a session a sibling is mid-cold-start on and returns 200; the sibling
+    then registers its pre-reload provider with stale config.
+    """
+
+    @pytest.mark.asyncio
+    async def test_running_turn_on_the_shared_session_refuses_reload(
+        self, state, slot, monkeypatch
+    ):
+        # No turn on THIS slot (fresh fixture slot: task is None -> running
+        # False) and no registered provider -- the two probes that would
+        # otherwise catch a turn. Only the session-scoped set knows an alias
+        # slot is cold-starting a turn on the shared key.
+        state.sessions.get_provider = MagicMock(return_value=None)
+        state.running_session_keys = MagicMock(return_value=frozenset({_SESSION_KEY}))
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+            data = await resp.json()
+
+        # Reverting the session-scoped clause lets reload fall through to reset +
+        # 200 and reddens this on the status assertion.
+        assert resp.status == 409
+        assert data["code"] == "turn_in_flight"
+        # The teardown must NOT have run -- refused before reset.
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_running_session_reloads_normally(self, state, slot, monkeypatch):
+        """Control: an empty running set lets reload proceed to 200."""
+        state.sessions.get_provider = MagicMock(return_value=_idle_provider())
+        state.running_session_keys = MagicMock(return_value=frozenset())
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+
+        assert resp.status == 200
+        state.sessions.reset.assert_awaited_once_with(_SESSION_KEY, skip_if_busy=True)
+
+
+class TestReloadCancelsInFlightEagerSpawnBeforeReset:
+    """Reload cancels the slot's in-flight eager-spawn before tearing down.
+
+    ``schedule_eager_spawn`` cancels the slot's prior ``_eager_spawn_task`` as a
+    side effect of scheduling a new one. Reload SUPPRESSES that call for a linked
+    session, so a focus prefetch already mid-handshake from an earlier signal
+    would otherwise survive the teardown and register an old-config session AFTER
+    the reload reported success. Reload now cancels AND awaits the task before the
+    reset. Reverting the cancel leaves the task pending after reload and reddens
+    the assertion below.
+    """
+
+    @pytest.mark.asyncio
+    async def test_in_flight_eager_task_is_cancelled_and_awaited_before_reset(
+        self, state, slot, monkeypatch
+    ):
+        # A linked session, so reload takes the suppression branch and does NOT
+        # schedule a replacement spawn -- the only cancellation is the explicit
+        # pre-reset one under test.
+        slot.linked_session_key = _SESSION_KEY
+
+        started = asyncio.Event()
+        settled = {"cancelled": False}
+
+        async def _never_finishes() -> None:
+            # Stands in for an eager prefetch mid-handshake: runnable, not done,
+            # until cancelled.
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                settled["cancelled"] = True
+                raise
+
+        eager = asyncio.get_event_loop().create_task(_never_finishes())
+        await started.wait()  # ensure it is genuinely in flight, not just created
+        slot._eager_spawn_task = eager
+
+        # Order probe: the reset must run only AFTER the eager task has settled.
+        order: list[str] = []
+        orig_reset = state.sessions.reset
+
+        async def _record_reset(*a, **k):
+            order.append(f"reset:eager_done={eager.done()}")
+            return await orig_reset(*a, **k)
+
+        state.sessions.reset = _record_reset
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+
+        assert resp.status == 200
+        # Reverting the pre-reset cancel leaves this False (task still pending).
+        assert eager.done(), "in-flight eager task was not cancelled by reload"
+        assert eager.cancelled() or settled["cancelled"]
+        # And it was settled BEFORE the reset ran, not concurrently.
+        assert order == ["reset:eager_done=True"]
+
+
+class TestReloadRechecksTurnStateAfterEagerCancelAwait:
+    """A turn starting DURING the eager-cancel await is caught before the reset.
+
+    The eager cancel+await is the only real suspension point between resolving the
+    session and the reset. If the turn-in-flight guard ran BEFORE that await, a
+    send could start a turn (and post an approval card) during it, and
+    ``_reset_slot_session`` runs ``_unblock_pending_waits`` unconditionally --
+    before its ``skip_if_busy`` decline -- so the card would be discarded even as
+    the reset then declines and answers 409. Placing the eager cancel+await BEFORE
+    the guard, with no await between the guard and the reset, keeps the guard's
+    answer true at teardown. Reverting to guard-before-await lets the reset run and
+    reddens the ``reset.assert_not_awaited()`` below.
+    """
+
+    @pytest.mark.asyncio
+    async def test_turn_appearing_during_eager_await_answers_409_without_reset(
+        self, state, slot, monkeypatch
+    ):
+        started = asyncio.Event()
+
+        async def _turn_appears_mid_cancel() -> None:
+            # Stands in for an in-flight eager prefetch. When reload cancels+awaits
+            # it, a turn becomes visible on the session before control returns to
+            # the guard -- exactly the window under test.
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                # The turn is now in flight on the shared session key.
+                state.running_session_keys = MagicMock(return_value=frozenset({_SESSION_KEY}))
+                raise
+
+        eager = asyncio.get_event_loop().create_task(_turn_appears_mid_cancel())
+        await started.wait()
+        slot._eager_spawn_task = eager
+        # Guard reads empty until the cancel above flips it.
+        state.running_session_keys = MagicMock(return_value=frozenset())
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+            data = await resp.json()
+
+        assert resp.status == 409
+        assert data["code"] == "turn_in_flight"
+        # The teardown must NOT have run: the guard, read AFTER the await, saw the
+        # turn. Guard-before-await would miss it and reach the reset.
+        state.sessions.reset.assert_not_awaited()
+
+
+class TestReloadRevalidatesSlotIdentityAfterEagerCancel:
+    """A same-name slot replacement during the cancel-await answers 404.
+
+    ``slot`` is resolved from ``state._slots`` before this handler takes any lock,
+    and ``close_slot`` pops that mapping WITHOUT taking ``slot._lock``. So a
+    same-name delete can complete while reload holds the old slot's lock, and a
+    recreate can bind a NEW slot to the same session key. The app-ownership check
+    was decided against the slot read before the suspension, so proceeding would
+    apply that authorization to a different owner's session and tear down the
+    replacement's idle session. Reload revalidates the registry entry by IDENTITY
+    after the await and answers the same indistinguishable 404 a missing slot
+    gets. Dropping the identity check lets the teardown run and reddens the
+    assertions below.
+    """
+
+    @pytest.mark.asyncio
+    async def test_same_name_replacement_during_cancel_await_answers_404(
+        self, state, slot, monkeypatch
+    ):
+        started = asyncio.Event()
+        replacement = _ChatSlot(_SLOT)
+
+        async def _replace_slot_mid_cancel() -> None:
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                # A same-name delete + recreate lands while reload is suspended:
+                # the registry entry is now a DIFFERENT object under the same key.
+                state._slots[_SLOT] = replacement
+                raise
+
+        eager = asyncio.get_event_loop().create_task(_replace_slot_mid_cancel())
+        await started.wait()
+        slot._eager_spawn_task = eager
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+            data = await resp.json()
+
+        # The replacement really did take the name.
+        assert state._slots[_SLOT] is replacement
+        # Identity, not presence: a slot IS registered under this name, so a
+        # presence test would pass here and the teardown would proceed.
+        assert resp.status == 404
+        assert data["code"] == "slot_not_found"
+        # The replacement owner's session must be untouched.
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unreplaced_slot_reloads_normally(self, state, slot, monkeypatch):
+        """Control: the same registry entry after the await proceeds to 200."""
+        started = asyncio.Event()
+
+        async def _plain_prefetch() -> None:
+            started.set()
+            await asyncio.Event().wait()
+
+        eager = asyncio.get_event_loop().create_task(_plain_prefetch())
+        await started.wait()
+        slot._eager_spawn_task = eager
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+
+        assert resp.status == 200
+        state.sessions.reset.assert_awaited_once_with(_SESSION_KEY, skip_if_busy=True)


### PR DESCRIPTION
## What changed

The reload teardown is already serialized under the switch locks on main, so that
part of this work is done and is no longer in this diff. Three gaps that review of
this work surfaced are still open, and this PR closes those and nothing else.

**1. The turn-in-flight guard was slot-scoped on a session that can be shared.**
An alias pair carries the same `linked_session_key`, so two slots run their turns
on ONE session. A sibling's cold-starting turn is invisible to this slot's guard:
that slot's `running` is a different object, and its `provider.start()` has not
registered a session yet, so `get_provider` returns nothing either. Reload tore the
shared session down, answered 200, and the sibling then registered its stale-config
provider -- the exact failure this endpoint exists to prevent.

The guard now asks the session-scoped question at both decision points, the
pre-reset guard and the declined-reset ladder:

```python
if (
    slot.running
    or session_key in state.running_session_keys()
    or (provider is not None and provider.has_active_turn())
):
```

`running_session_keys()` folds every slot through `effective_session_key`, so it
sees the sibling's cold start that neither slot-scoped probe can.

**2. A speculative session creation already in flight outlived the teardown.**
`schedule_eager_spawn` cancels a slot's prior `_eager_spawn_task` as a side effect
of scheduling a new one, but reload suppresses that call for a linked session (see
3), so a focus prefetch already mid-handshake survived the reset and registered a
stale-config session AFTER reload reported success. Reload now cancels and AWAITS
that task before the reset -- awaits, because the prefetch can be mid
`get_or_create`, and a bare cancel leaves a window in which it still registers.

The cancel is placed BEFORE the turn guard deliberately. It is the only real
suspension point between resolving the session and the reset, so a send could
otherwise start a turn during the await, after the guard had already passed, and
`_reset_slot_session` runs `_unblock_pending_waits` unconditionally BEFORE its
`skip_if_busy` decline -- so that turn's approval card would be discarded even
though the decline then answers 409. Cancelling first, then reading the guard with
no await before the reset, keeps the guard's answer true at the moment of teardown.
Re-authorization across that new await goes through the existing
`_reauthorize_after_await` helper, which carries the identity check on the slot
OBJECT, the indistinguishable 404, the SEL `app_isolation` denial record, and a
re-run of the ownership gate.

**3. The eager respawn escaped the session lock for shareable sessions.**
It is scheduled after the locks release, on purpose -- it debounces and then
handshakes for seconds, and holding the session lock across that would serialize an
unrelated switch behind work that does not race the teardown. But for a LINKED
session another slot can share it, and that slot's per-slot lock is disjoint from
this one's, so the escaped respawn could win `get_or_create`'s same-key race and
bake this slot's bindings into a session an alias slot's switch just committed
different bindings for; the first turn then runs the wrong model and config. Reload
now suppresses the speculative respawn for a linked session. That is safe because
the session is already torn down, so the next real turn cold-starts under whatever
bindings are current at that moment -- the race-free outcome. A plain `dashboard:`
slot with no link keeps the speculative respawn.

## Tests

Each guard is pinned by a test that reddens when that guard alone is removed,
verified by disabling them one at a time:

- `TestReloadRefusesAnAliasColdStartOnTheSharedSession` -- a running turn on the
  shared key with no `slot.running` and no registered provider must answer 409 and
  must not reset. Removing the session-scoped clause reddens it.
- `TestReloadCancelsInFlightEagerSpawnBeforeReset` -- the prefetch is cancelled and
  awaited before the reset. Removing the cancel reddens it.
- `TestReloadRechecksTurnStateAfterEagerCancelAwait` -- a turn becoming busy DURING
  the cancel-await is still caught before the reset.
- `TestReloadRevalidatesSlotIdentityAfterEagerCancel` -- a same-name slot
  replacement during the cancel-await answers 404 and does not reset the
  replacement's session. It asserts a slot IS registered under the name, so it
  tests identity rather than presence.
- `test_reload_suppresses_eager_respawn_for_a_linked_session` -- removing the
  suppression reddens it.

120 pass across the seam file, `TestSessionReload`, and the switch-atomicity suite.

## Declared residuals

Neither is chased here, and both are tracked on #9255.

- The prefetch cancel is scoped to THIS slot. An alias sibling's prefetch on the
  same key is not cancelled, and cancelling every sharer cannot be made correct
  from inside this endpoint: `schedule_eager_spawn` is also reached from the WS
  focus path, which holds neither of this handler's locks, so a focus frame
  arriving during such a scan re-arms a prefetch on a slot the scan already passed.
  Closing it needs the prefetch mechanism itself to refuse or defer a prefetch for
  a session whose teardown is in flight.
- The same-name slot replacement window also exists in the four switch handlers.
  Its root cause is `close_slot` popping `state._slots` without taking
  `slot._lock`, so ordering that pop is the real fix rather than adding a re-check
  to each handler.

Refs #9019, #9255.
