### PR TITLE
fix(work-ledger): stop the lock-file open from truncating on Windows

### DIFF
--- a/src/kiro_crew/work_ledger.py
+++ b/src/kiro_crew/work_ledger.py
@@ -535,9 +535,21 @@ def _open_lock(path: Path) -> Iterator[None]:
     ``file_lock`` takes an already-open descriptor and fails CLOSED — it raises
     rather than entering the critical section unserialised — which is why nothing
     here has a lock-less fallback.
+
+    The lock file is created with ``touch`` and opened ``"r+"`` — WRITABLE, and
+    crucially WITHOUT truncation. ``msvcrt.locking`` needs a writable handle, so
+    ``"r"`` is not an option; but ``"w"`` TRUNCATES on open, and on Windows a
+    truncating open of a file whose first byte another thread or process already
+    holds under ``msvcrt.locking`` raises a sharing violation (``PermissionError``)
+    rather than waiting for the lock — so a second, contending acquirer crashes
+    before it ever reaches ``file_lock``, defeating the serialisation this lock
+    exists to provide. POSIX ``flock`` tolerates the truncate, which is why the bug
+    is Windows-only. Same reasoning, same fix as ``dashboard/handlers/mcp.py``'s
+    ``_McpFileLock``.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as handle:
+    path.touch(exist_ok=True)
+    with open(path, "r+") as handle:
         with file_lock(handle.fileno(), exclusive=True):
             yield
 

--- a/test/test_work_ledger.py
+++ b/test/test_work_ledger.py
@@ -1375,6 +1375,35 @@ def test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding():
         assert (item.worker_session_key == WORKER) == ((key, item_id) == binding)
 
 
+def test_acquiring_a_lock_does_not_truncate_the_lock_file():
+    """The lock-file open must be WRITABLE but MUST NOT truncate.
+
+    This is the property whose absence made
+    ``test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding``
+    fail on Windows only. ``msvcrt.locking`` needs a writable handle, so the fd
+    cannot be opened ``"r"``; but ``"w"`` truncates on open, and on Windows a
+    truncating open of a lock file whose first byte another holder already locked
+    raises a sharing violation instead of waiting — so the second, contending
+    acquirer crashes with a bare ``OSError`` before it reaches ``file_lock`` and
+    the bind it was serialising is never mutually excluded. POSIX ``flock``
+    tolerates the truncate, which is why the defect was invisible on Linux.
+
+    Truncation is the direct, platform-independent observable: seed the lock file
+    with bytes, acquire and release the lock, and assert the bytes survived. Under
+    the old ``open(path, "w")`` this test fails on every platform (the file is
+    emptied); under the ``touch`` + ``"r+"`` open it passes, and the same
+    non-truncating open is what stops the Windows sharing violation.
+    """
+    wl.ensure_conductor(CONDUCTOR, goal="g")
+    lock_path = wl.conductor_dir(CONDUCTOR) / wl._LOCK_FILE
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    sentinel = b"held by a prior acquirer\n"
+    lock_path.write_bytes(sentinel)
+    with wl.conductor_lock(CONDUCTOR):
+        pass
+    assert lock_path.read_bytes() == sentinel
+
+
 # ── revertability ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What is the problem?

`test/test_work_ledger.py::test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding`
fails on `Backend Tests (Windows) (4)` and nowhere else, with `assert 2 == 3`: two
threads got `already_bound` where three were expected. This is base maintenance, not
any one PR's fault. Four separate open PRs fail the identical lane on the identical
test (9222, 9225, 9215, 9234); two of those (9215, 9234) are unrelated to the pipeline
that found this, so other operators are blocked too. The failing file is absent from
every affected diff (9222 touches 12 files, 9225 touches 2, none contain
`test_work_ledger.py`), its only two commits are #9152 and #8855 (neither in any
affected diff), and it is green on the Linux 3.12 shards.

## Why it matters to the user

`assert 2 == 3` is the tell of a real durability defect, not a flaky test. In the
contended case one thread produced neither `bound` nor `already_bound` -- it crashed
with a bare exception the test's `except wl.WorkLedgerError` never caught, so it
appended nothing to `outcomes`. A thread crashing inside the very critical section that
is supposed to serialise `bind` means the work-ledger store does NOT reliably mutually
exclude two conductors binding one worker on Windows: the guarantee "exactly one
binding wins" can be lost. Weakening the assertion (`>= 2`, `skip on Windows`, mark
flaky) would have turned a green board into a lie. The test was right to fail.

## How the fix solves it (symptom -> root cause)

Symptom: one contending thread raises an unhandled `OSError` before it can bind.

Root cause: the store's lock primitive `work_ledger._open_lock` opened its lock file
with `open(path, "w")`, which TRUNCATES on open. `file_lock` then takes an
`msvcrt.locking` byte-range lock on byte 0 of that file. On Windows, a *truncating*
open of a file whose first byte another holder already locks raises a sharing violation
(`PermissionError`) rather than waiting for the lock -- so the second, contending
acquirer crashes before it ever reaches `file_lock`, and the serialisation the lock
exists to provide never happens. POSIX `flock` tolerates the truncate, which is exactly
why the defect is invisible on Linux and surfaces only on the Windows shard.

Fix: create the lock file with `touch(exist_ok=True)` and open it `"r+"` -- writable
(`msvcrt.locking` needs a writable handle) but WITHOUT truncation. This mirrors the
repository's own canonical safe pattern in `dashboard/handlers/mcp.py::_McpFileLock`,
whose comment states the same Windows requirement verbatim ("Open the lock fd WRITABLE
... `"r+"` keeps the shared file present (no truncate)"). Minimum change to make the
lane honest: two lines of code plus a docstring; no refactor of the store.

## What tests we did

- Added `test_acquiring_a_lock_does_not_truncate_the_lock_file`, which pins the exact
  invalid property: acquiring a lock must not empty an existing lock file. Truncation is
  the direct, platform-independent observable of the defect.
- Mutation-verified the test: reverting the source to `open(path, "w")` reddens it
  (`assert b'' == b'held by a prior acquirer\n'`); the `touch` + `"r+"` fix greens it.
- Full `test/test_work_ledger.py` under `-n0`: 123 passed.
- Cannot reproduce a Windows-only failure on this Linux host, so the Windows behaviour
  is REASONED from the code and the CI log; CI is the proof. On Linux the original test
  passes both before and after (POSIX tolerates the truncate).
- Lint battery on both changed files: black `--target-version py310`, isort, flake8 all
  clean; mypy reports zero errors in `work_ledger.py` (two pre-existing errors surface in
  `transcribe.py`, an imported file this diff never touches, identical on pristine main).

## Other suggestions

Scope note for this PR: within `work_ledger.py` the fixed `_open_lock` is the ONLY
lock-file opener. There are exactly two `open(` calls in the store -- the lock opener
(now `touch` + `"r+"`) and a read-only `open("r", ...)` in `_read_text_or_none` that
reads a data file for rollback (no truncate, not a lock file). All three lock context
managers (`conductor_lock`, `item_lock`, `binding_lock`) funnel through `_open_lock`,
and records are written via `atomic_write` (temp + rename), so there is no second
instance of this bug inside the store to fix or leave behind.

Correction to an earlier draft of this description: it claimed "every other lock-file
site in the tree already opens non-truncating." That is FALSE, and I am stating so
plainly. The identical defective pattern -- `open(<lockfile>, "w")` (which truncates)
immediately before a `platform_compat.file_lock` / `acquire_lock` acquire, which on
Windows routes to `msvcrt.locking` -- is LIVE at ~27 sites across at least 11 core
files, including `session_pid.py:148` and `:184`, `webhooks.py:189`,
`deploy/pending.py`, `deploy/profiles.py`, `mcp_tools/control.py`, `pod/runtime.py`,
`apps/builtins/issue_radar/backend/{store,crew_store}.py`, and three `aws_control`
backends. The same Windows durability defect this PR proves is real is live at every
one of them.

They are DELIBERATELY OUT OF SCOPE here: this PR is a fleet unblock that four PRs are
waiting behind (two belonging to other operators), and its value is that it merges
fast and touches two files. The sibling sites are a real defect class that deserves
its own PR -- ideally a shared non-truncating lock-open helper (matching this fix and
`dashboard/handlers/mcp.py`'s `_McpFileLock`) plus a lint that rejects
`open(<lockfile>, "w")`, so a future site cannot re-introduce it.

## Pattern harvest

Defect class: a cross-platform lock/atomic-file primitive that works on POSIX and fails
on Windows because Windows enforces sharing/lock semantics POSIX does not -- here, a
*truncating* open (`"w"`) of a byte-range-locked lock file trips a sharing violation
where `flock` simply waits. The tell is a concurrency test that passes on Linux shards
and fails only on `Backend Tests (Windows)`, with a count-off-by-one that means one
contending actor crashed out of the critical section rather than being serialised.

Rule candidate: A file used purely as a lock target must be opened WITHOUT truncation
(`"r+"`/`"a+b"` after ensuring it exists), never `"w"` -- on Windows a truncating open
of a byte-range-locked file raises a sharing violation instead of waiting, so a
contending acquirer crashes before it locks and the mutual exclusion is silently lost.

Refs #9222
Refs #9225
Refs #9215
Refs #9234

