### PR TITLE
fix: model parameter expansion and comments in shell char walk

### DIFF
--- a/src/kiro_crew/security/shell_normalizer.py
+++ b/src/kiro_crew/security/shell_normalizer.py
@@ -1561,23 +1561,37 @@ def _iter_shell_chars(text: str, state: int = 0, ansi: bool = False) -> "Iterato
                 # inactive; brace depth handles nesting, a backslash pair never
                 # closes, and an unclosed expansion simply runs out (malformed
                 # input bash would not execute; the walk keeps failing closed).
-                # Quote state is frozen across the span so an exotic interior
-                # cannot corrupt the rest of the walk.
+                # Quote state runs THROUGH the span, not frozen across it:
+                # POSIX 2.6.2 skips quoted strings when finding the matching
+                # ``}``, so only an UNQUOTED, unescaped ``}`` decrements depth
+                # (``: ${v:-"}"}; ...`` closes at the second ``}``, and the
+                # quoted ``}`` in ``${v:-'}X)Y'}`` is literal). The tracked
+                # quotes stay local to the span -- they decide depth only and
+                # never leak into the outer walk.
                 yield _ShellChar(i, ch, ch, True, state, ansi, False)
                 yield _ShellChar(i + 1, "{", "{", True, state, ansi, False)
                 i += 2
                 dollar_run = 0
                 at_word_start = False
                 depth = 1
+                qstate = 0
                 while i < n and depth > 0:
                     c = text[i]
-                    if c == "\\" and i + 1 < n:
+                    if c == "\\" and qstate != 1 and i + 1 < n:
                         yield _ShellChar(i, text[i : i + 2], text[i + 1], False, state, ansi, False)
                         i += 2
                         continue
-                    if c == "{":
+                    if qstate == 0 and c == "'":
+                        qstate = 1
+                    elif qstate == 1 and c == "'":
+                        qstate = 0
+                    elif qstate == 0 and c == '"':
+                        qstate = 2
+                    elif qstate == 2 and c == '"':
+                        qstate = 0
+                    elif qstate == 0 and c == "{":
                         depth += 1
-                    elif c == "}":
+                    elif qstate == 0 and c == "}":
                         depth -= 1
                         if depth == 0:
                             yield _ShellChar(i, c, c, True, state, ansi, False)

--- a/src/kiro_crew/security/shell_normalizer.py
+++ b/src/kiro_crew/security/shell_normalizer.py
@@ -1504,16 +1504,32 @@ def _iter_shell_chars(text: str, state: int = 0, ansi: bool = False) -> "Iterato
     program anchor read this state in the allow direction: a walk that ends
     "still open" where bash closed hides a separator or a ``git`` word.
 
+    Two more bash rules live here, because a literal ``)`` inside either used
+    to arrive ``active`` and truncate every substitution span
+    (``$(echo ${v:-)}; ...)`` extracted ``echo ${v:-`` while bash runs the
+    rest): ``${...}`` parameter expansion, whose interior is data as far as
+    paren counting goes, and ``#`` comments, which run to the newline. Both
+    yield their interior ``active=False``. Anything this misses (an exotic
+    nesting, a ``#`` after ``)``) errs toward scanning MORE, never less --
+    the fail-closed direction for every consumer.
+
     *state* and *ansi* resume a walk, which is what lets a quoted word spanning
     whitespace be read without desyncing.
     """
     i = 0
     n = len(text)
     dollar_run = 0  # consecutive LITERAL ``$`` immediately before this char
+    # A ``#`` starts a comment only at the start of a word (bash: ``echo a#b``
+    # is one word). The set below is deliberately NARROW -- start of input,
+    # whitespace, newline and the separators that open a new word. A ``#``
+    # anywhere else stays ordinary (scanned) text: missing a real comment
+    # over-scans, while treating code as comment would hide it.
+    at_word_start = True
     while i < n:
         ch = text[i]
         if ch == "\\" and (state != 1 or ansi):
             dollar_run = 0  # an escaped ``$`` is data and introduces nothing
+            at_word_start = False
             if i + 1 >= n:
                 yield _ShellChar(i, ch, ch, False, state, ansi, True)
                 return
@@ -1536,11 +1552,68 @@ def _iter_shell_chars(text: str, state: int = 0, ansi: bool = False) -> "Iterato
                 ansi = dollar_run % 2 == 1
             elif ch == '"':
                 state = 2
+            elif ch == "$" and i + 1 < n and text[i + 1] == "{" and dollar_run % 2 == 0:
+                # ``${...}`` parameter expansion: this ``$`` is unpaired (an
+                # even run before it, so no ``$$`` PID pairing consumes it) and
+                # opens an expansion closed by the matching ``}``. The interior
+                # is data -- a ``)`` inside must not count as a substitution
+                # closer. Yield the delimiters as usual and the interior
+                # inactive; brace depth handles nesting, a backslash pair never
+                # closes, and an unclosed expansion simply runs out (malformed
+                # input bash would not execute; the walk keeps failing closed).
+                # Quote state is frozen across the span so an exotic interior
+                # cannot corrupt the rest of the walk.
+                yield _ShellChar(i, ch, ch, True, state, ansi, False)
+                yield _ShellChar(i + 1, "{", "{", True, state, ansi, False)
+                i += 2
+                dollar_run = 0
+                at_word_start = False
+                depth = 1
+                while i < n and depth > 0:
+                    c = text[i]
+                    if c == "\\" and i + 1 < n:
+                        yield _ShellChar(i, text[i : i + 2], text[i + 1], False, state, ansi, False)
+                        i += 2
+                        continue
+                    if c == "{":
+                        depth += 1
+                    elif c == "}":
+                        depth -= 1
+                        if depth == 0:
+                            yield _ShellChar(i, c, c, True, state, ansi, False)
+                            i += 1
+                            break
+                    yield _ShellChar(i, c, c, False, state, ansi, False)
+                    i += 1
+                continue
+            elif ch == "#" and at_word_start:
+                # Comment to end of line: the ``#`` itself reads as usual, the
+                # interior is inert so a ``)`` inside cannot close a span, and
+                # the newline resumes the walk (a backslash-newline continues
+                # the comment, as in bash).
+                yield _ShellChar(i, ch, ch, True, state, ansi, False)
+                i += 1
+                dollar_run = 0
+                at_word_start = False
+                while i < n and text[i] != "\n":
+                    if text[i] == "\\" and i + 1 < n and text[i + 1] == "\n":
+                        yield _ShellChar(i, "\\\n", "\n", False, state, ansi, False)
+                        i += 2
+                        continue
+                    yield _ShellChar(i, text[i], text[i], False, state, ansi, False)
+                    i += 1
+                continue
         elif state == 1:
             if ch == "'":
                 state = 0
         elif ch == '"':
             state = 0
+        # A lone CR is deliberately absent from the word-start set: it is not
+        # a bash word boundary (``echo a\rb`` is one word).
+        if was_unquoted and ch in " \t\n;&|(":
+            at_word_start = True
+        else:
+            at_word_start = False
         dollar_run = dollar_run + 1 if was_unquoted and ch == "$" else 0
         yield _ShellChar(i, ch, ch, was_unquoted, state, ansi, False)
         i += 1

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -1894,6 +1894,28 @@ class TestBuiltinDenyPatterns:
         # Nested expansion still extracts whole.
         assert _substitution_bodies("kill $(echo ${a:-${b}} done)") == ["echo ${a:-${b}} done"]
 
+    def test_expansion_close_ignores_quoted_braces(self) -> None:
+        """A quoted ``}`` inside ``${...}`` is literal per POSIX 2.6.2 and must
+        not close the expansion (Design + Opus blocking findings on the
+        frozen-quote interior loop).
+
+        Closing early desyncs the outer walk from bash: the stray quote flips
+        the walker into a quote state bash never enters, hiding the ``;`` and
+        the ``git`` word that follow -- an allow-direction miss.
+        """
+        from kiro_crew.security import _iter_shell_chars, _substitution_bodies
+
+        # Double-quoted ``}``: the expansion closes at the second brace, so
+        # the ``;`` separator stays active and visible to the segment split.
+        steps = list(_iter_shell_chars(': ${v:-"}"}; git push origin main'))
+        semi = next(s for s in steps if s.char == ";")
+        assert semi.active
+        # Single-quoted ``}`` around a quoted paren: the full outer body
+        # survives instead of truncating at the quoted ``)``.
+        assert _substitution_bodies("kill $(echo ${v:-'}X)Y'} ; git push origin main)") == [
+            "echo ${v:-'}X)Y'} ; git push origin main"
+        ]
+
     def test_blocks_background_operator_bypass(self) -> None:
         """``&`` (single ampersand, the bash background operator) must split
         segments like ``;`` and ``&&``.

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -1871,6 +1871,29 @@ class TestBuiltinDenyPatterns:
         assert is_denied("git`echo`push origin main") is not None
         assert is_denied("git$()push origin") is not None
 
+    def test_substitution_span_survives_expansion_and_comment_parens(self) -> None:
+        """A literal ``)`` inside ``${...}`` or a ``#`` comment must not close
+        the substitution span (issue #9181).
+
+        ``_substitution_bodies`` feeds the nested-payload extractor: truncating
+        at such a paren hands every downstream scan a fragment while bash runs
+        the whole body, so a nested publish hides below the truncation point.
+        """
+        from kiro_crew.security import _substitution_bodies
+
+        # ``${v:-)}`` prints a literal ``)``; the span must cover the rest.
+        assert _substitution_bodies("kill $(echo ${v:-)}; pgrep -f kirocrew)") == [
+            "echo ${v:-)}; pgrep -f kirocrew"
+        ]
+        # The ``)`` after ``# `` is comment text; the span runs past the newline.
+        assert _substitution_bodies("kill $(echo x # )\npgrep -f kirocrew)") == [
+            "echo x # )\npgrep -f kirocrew"
+        ]
+        # A ``#`` mid-word is literal (``echo a#b`` is one word), not a comment.
+        assert _substitution_bodies("echo a#b") == []
+        # Nested expansion still extracts whole.
+        assert _substitution_bodies("kill $(echo ${a:-${b}} done)") == ["echo ${a:-${b}} done"]
+
     def test_blocks_background_operator_bypass(self) -> None:
         """``&`` (single ampersand, the bash background operator) must split
         segments like ``;`` and ``&&``.


### PR DESCRIPTION
## Problem / Motivation

`_iter_shell_chars` (`src/kiro_crew/security/shell_normalizer.py`) models shell quote and
escape handling, but did not handle two additional bash syntax categories:

* `${...}` parameter expansion
* `#` comments

A literal `)` inside `$(echo ${v:-})` or after a `#` comment arrived with
`active=True`, so `_matching_close_paren` counted it as the substitution
closer and truncated the extracted body. The nested-payload extractor then
handed every downstream scan a fragment while bash runs the whole body, so a
nested publish hides below the truncation point -- `is_denied` allows a command
bash executes (same shape as the documented quoted-paren truncation behind
`_matching_close_paren`).

## Why it matters

The `_iter_shell_chars` generator is the **single source of truth** for shell
quote/escape state walked by every consumer: the boundary walk, the git-publish
border walk, the nested-payload extractor, and `is_denied`/`is_sensitive_bash_command`.
When the machine did not know about `${...}` or `#`, those constructs were
invisible to it, and a `)` inside them was treated as a bare `)` -- a
false-allow of the class security reviews have caught before.

## What changed (motivation → approach → change)

Extended `_iter_shell_chars` with two new syntax branches:

1. **`${...}` parameter expansion**: when `$` is followed by `{` in the
   *unquoted* state (`state == 0`, unpaired `$`), the generator enters an
   expansion closed by the matching `}`. Interior steps yield `active=False`
   so `_matching_close_paren` ignores them, while quote state runs *through*
   the span per POSIX 2.6.2 -- only an unquoted, unescaped `}` decrements
   brace depth, so a quoted `}` (`${v:-"}"}`, `${v:-'}X)Y'}`) cannot close
   early and desync the outer walk. Tracked quotes stay local to the span.
   Nested `$(...)` inside still resolves via the raw-text descent in
   `_substitution_bodies`.

2. **`#` comments**: a `#` at word start (bash: `echo a#b` is one word) starts
   a comment running to the newline; interior steps yield `active=False`, and a
   backslash-newline continues the comment as in bash.

## Tests

- `test/test_security.py`: `test_substitution_span_survives_expansion_and_comment_parens`
  and the new `test_expansion_close_ignores_quoted_braces` (pins the two
  reviewer repros) pass
- `test/test_push_branch_gate.py::test_every_bash_metacharacter_is_accounted_for`
  passes -- `${` and `#` keep their existing accounting rows, so no spec move
- `black --target-version py310`, `flake8`, `isort`: clean on both touched files;
  `mypy` on `shell_normalizer.py`: clean

## Pattern harvest

Not generalizable: one-off bash-fidelity gap in a single state machine plus its
regression pins; the review lesson (never freeze quote state across a span you
close by delimiter) is already stated in the code comment.

## Related Issues

Fixes #9181. Note: #8830 (case-pattern terminators) is intentionally not cited --
that is #9164's scope, already merged.

## Checklist

- [x] At most 2 commits with Conventional Commits titles
- [x] Regression tests added and passing; spec accounting verified unchanged
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
