### PR TITLE
feat: deliver spawn approvals to the originating telegram channel

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -62,6 +62,7 @@ Slack's transport path is gated behind the `messaging.use_transport` config flag
 | `messaging/auto_title.py` | Conversation auto-titling — the claim-early LRU, the tool-free bounded background turn, the prompt, and the title-cleaning rules. Renaming the platform conversation is a caller-supplied callback. See [Auto-titling](#auto-titling-auto_titlepy) |
 | `messaging/upload_gate.py` | `session_is_restricted(dashboard_state, session_key, persisted_probe=, unknown_denies=True)` — the shared incognito/temporary decision, `session_blocks_reads(...)` — its READ counterpart (only `temporary` blocks reads; `incognito` still reads), plus `uploads_restricted(...)` which adds the per-channel upload audit, plus `live_dashboard_slot`. Three-state ladder (non-`dashboard:` key answers off `privacy_mode`, a LIVE slot answers off `is_restricted`/`blocks_reads`, otherwise the PERSISTED transcript mode answers). `unknown_denies` decides an unreadable mode: uploads DENY it outright (bytes cannot be recalled), while the durable-history gate denies only when a transcript EXISTS but its mode cannot be resolved (an ambiguous stem, a header no normal session wrote) — that is where an incognito session can hide. A legacy header with no `memory_mode` reads `persistent` rather than unknown, so the only unknown history allows is a truly ABSENT record, where nothing on disk claims the session is restricted. Discord and Telegram both route uploads here; both resumed-turn paths also use it to gate live projection and durable history, and Telegram uses it for `/title` |
 | `messaging/session_trust.py` | The per-session tool-Trust grant store: `is_session_trusted`, `add_trusted_session(key, sessions=)`, `clear_trusted_sessions`. In memory only, so an ad-hoc auto-approve grant dies with the process. The grant has TWO halves and both are load-bearing: the in-memory mapping the driver reads, and the session's approval policy set to `auto`, because a spawned subagent reads its parent's policy and never this mapping. So it is a `key -> SessionManager` MAPPING rather than a set, which is what lets `clear_trusted_sessions` undo the policy half too (back to `""`, the same value the dashboard's untrust toggle writes) without its caller having to hand a manager back. **Every mutation goes through the API**: reaching the container directly is how a revoke came to drop one half and leave subagents trusted, and a mapping has no `.add`, so a half-grant is not expressible either. Named `session_trust`, not `trust`, so it cannot be confused with a connection-admission roster: this grant is about what ONE session's tools may skip, not about which principals may attach. Consumed only through `TurnDriver`'s `auto_approve_session` predicate, which runs BEHIND the keystone, governance and deny-list gates, so a hard DENY still refuses |
+| `messaging/spawn_approval_delivery.py` | The channel-neutral spawn-approval delivery seam: a process-global registry (`register_channel_delivery` / `unregister_channel_delivery` / `resolve_channel_delivery` / `deliver_spawn_approval` / `clear_channel_delivery_hooks`) keyed by channel namespace. The single host-wide `on_spawn_approval` callback (`slack/gateway.py`) consults `deliver_spawn_approval` FIRST so a spawn parented on a live channel conversation is answered where the human already is, on that channel's own Approve/Deny/Trust keyboard. A hook returns `True`/`False` (the user's decision, used verbatim) or `None` (no hook for this channel, or it could not surface the prompt) to fall through to the Slack-DM/dashboard gate. Same inversion `session_trust` uses — `messaging` may not import a channel package, so the hook is a plain async callable the channel supplies. In memory only (a hook is a live object on a running dispatcher; the registry dies with the process and a channel re-registers on startup). See [Channel-neutral spawn-approval delivery](#channel-neutral-spawn-approval-delivery-spawn_approval_deliverypy) |
 | `messaging/link.py` | **Layer 3** — session-key namespacing (`session_key`/`canonical_key`/`legacy_key`/`is_legacy_slack_key`) + `ChannelLink` + DM-scope key derivation / `should_rotate_generation`, plus the in-channel `/link` ⇄ `/unlink` pair (`rebind_conversation_location` / `release_conversation_location`) |
 | `messaging/conversation.py` | `ConversationState` — per-conversation rotating *generation* bookkeeping (advanced by `/new` and idle/daily reset), seeded from the persisted session map |
 | `messaging/session_resume.py` | **Layer 3** — the channel-neutral half of dashboard-session resume. `SessionResumeController` consumes a bound `ResumeSurface` (including its exact durable expectation identity, which may be narrower than `ChannelLink.channel_id`) and owns the complete SHOW-PICKER flow (eligibility/search, audit, nonce/TTL/owner/message scoping, and registration only after a successful post) plus the CHOOSE/BIND transaction (history existence, conflict checks around the awaited settlement, durable expectation before success, atomic inbound claim, lost-claim/storage outcomes, dashboard push, and audit). `SessionBinder` owns inbound routing, settlement, and release. Discord, Telegram, and Teams retain only address/identity derivation, widgets/cards, exact wording and display redaction, callback parsing, and channel-local replay. |
@@ -311,6 +312,62 @@ is the point — a channel-local store would have had to reimplement every one o
 `decider: ApprovalDecider` (`Callable[[Any], Awaitable[bool]]`) supplies the interactive click; when omitted, interactive mode denies by default (so buttons are only rendered when a decider exists — otherwise the user would get dead controls). Every permission decision emits an `sel().log_api_access` event (`caller="turn_driver"`, `operation="tool_permission"`, `source="messaging"`, `outcome` one of `auto_approved` / `approved` / `denied`).
 
 **Deny-on-silence can be SPOKEN.** `open_approval(..., on_timeout=…)` takes an optional coroutine that `PendingApproval.wait` awaits when the window closes, before it returns `DENY`, so the channel can resolve the prompt still sitting on the user's screen: `approval.TIMEOUT_NOTICE` is the text. Without it the refusal is invisible: the turn moves on and a live-looking prompt remains, which a later `1` can no longer answer (it finds no open entry and gets `RECEIPT_EXPIRED`). It is a callback rather than a transport because this module never learns what a channel is, and only the renderer that posted the prompt knows which message to edit. It must not raise: the verdict is already `DENY`, and `_announce_timeout` logs and swallows anything but cancellation, because a notice that could not be posted must never become an approval. WhatsApp is the first channel wired onto it.
+
+### Channel-neutral spawn-approval delivery (`spawn_approval_delivery.py`)
+
+The ladder above governs a MID-RUN tool prompt, which every channel's `TurnDriver`
+already renders through its own `decider`. The HOST **spawn** gate is different: the
+single host-wide `SubagentManager` owns ONE `on_spawn_approval` callback, built in
+`slack/gateway.py`, and that callback historically raced only a Slack owner DM and
+an attached dashboard client. A spawn parented on a Telegram (or any other channel)
+conversation therefore reached no surface at all, and post-#8914 the gate refuses it
+fast (`no_approval_surface`) rather than parking to the reaper's deadline. The
+driver's per-turn `decider` cannot help here — it is wired to the main-agent tool
+ladder, not to this host callback.
+
+`spawn_approval_delivery.py` is the seam that lets the host gate reach the
+originating channel's own inline keyboard, mirroring how `session_trust` lets a
+channel write an auto-approve grant the driver reads without `messaging` importing
+any channel package. It is a process-global registry of async delivery hooks keyed
+by channel namespace:
+
+- `register_channel_delivery(channel, hook)` / `unregister_channel_delivery(channel)`
+  — a channel dispatcher opts in on startup and drops out on shutdown. `channel` is
+  the channel namespace (`"telegram"`), the same token `messaging.link.channel_namespace_of`
+  returns for that channel's session keys. Idempotent: a restart replaces the
+  channel's own prior hook, so a stale registration can never shadow the live
+  dispatcher.
+- `deliver_spawn_approval(request_id, description, parent_session_key)` — what the
+  host callback calls FIRST. It resolves the hook whose channel owns
+  `parent_session_key` (via `channel_namespace_of`) and returns the hook's
+  `True`/`False` decision verbatim, or `None` to fall through. `None` means the key
+  is unowned (the CLI spawns with no parent), sits in a non-channel namespace
+  (`dashboard:`, `cron:`, `subagent:`), the channel registered no hook, or the hook
+  itself could not surface the prompt for this session. A hook that RAISES is
+  contained and read as `None`: a channel-delivery bug must degrade to the existing
+  Slack/dashboard fallback, never turn a spawn the operator could still answer into
+  a hard failure.
+
+The hook signature `async def(request_id, description, parent_session_key) -> bool | None`
+is the SAME three arguments the host `SpawnApprovalCallback` receives, so a channel
+posts its prompt and awaits the press without the seam reshaping anything. Keyed by
+channel namespace rather than by full session key on purpose: a channel runs one
+dispatcher per process, the session's channel is already recoverable from its key
+prefix, and keying by the full key would force the gate to know every live session —
+exactly the coupling the seam avoids. In memory only, like `session_trust`: a hook
+is a live object on a running dispatcher, so a registration surviving a restart would
+name a dispatcher that no longer exists; the registry dies with the process and a
+channel re-registers on its next startup.
+
+**Telegram is the reference opt-in.** `TelegramDispatcher.deliver_spawn_approval`
+posts the existing Approve/Deny/Trust inline keyboard and awaits the press through
+the same `on_callback` `a:` path a mid-run tool approval uses, so **Trust** grants
+parent-session trust via the shared `add_trusted_session` and a later spawn from that
+session is auto-approved by the parent-trusted rung. The hook is registered in
+`telegram/gateway.py` on startup and unregistered on client close. The full delivery
+order (channel hook → Slack-DM/dashboard fallback → the #8914 fast-fail backstop) and
+the operator-log-vs-agent-error security split are documented in
+[`subagent.md`](subagent.md).
 
 ## Layer 2b — `Renderer` + `OutputEvent` (`renderer.py`)
 

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -74,6 +74,25 @@ Spawn flow:
    approval with a 2-minute timeout. Timeout or rejection frees the
    concurrency slot.
 
+**Channel-side approval delivery (issue #2381 item 1).** The single host-wide
+`on_spawn_approval` callback (built in `slack/gateway.py`) consults a
+channel-neutral delivery seam (`messaging/spawn_approval_delivery.py`) FIRST,
+given the spawn's `parent_session_key`. A channel dispatcher registers a delivery
+hook keyed by its channel namespace (`register_channel_delivery("telegram", …)`);
+the seam resolves the hook whose channel owns the parent session
+(`messaging.link.channel_namespace_of`). A hook that returns `True`/`False` is the
+user's in-channel decision; `None` (no hook registered for that channel, or the
+hook could not surface the prompt) falls through to the pre-existing
+Slack-DM/dashboard gate, which still raises `SpawnApprovalUnreachable` when no
+surface is attached. Telegram implements the hook over its existing
+Approve/Deny/Trust inline keyboard (`TelegramDispatcher.deliver_spawn_approval`):
+the press resolves through the same `on_callback` `a:` path as a tool approval, so
+**Trust** grants parent-session trust via `add_trusted_session` and a later spawn
+from that session is auto-approved by the parent-trusted rung. The seam is
+in-memory only (dies with the process); the hook is registered on Telegram startup
+and unregistered on client shutdown. The per-agent `auto_approve_spawn` rung
+(issue #2381 item 2) is deferred to #4751/#4693 and is NOT added here.
+
 ### Tool Approval Cascade
 
 When a subagent's tool call triggers `EVENT_PERMISSION_REQUEST`, approval

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -93,6 +93,39 @@ in-memory only (dies with the process); the hook is registered on Telegram start
 and unregistered on client shutdown. The per-agent `auto_approve_spawn` rung
 (issue #2381 item 2) is deferred to #4751/#4693 and is NOT added here.
 
+**Delivery order.** A spawn-approval prompt that reaches `_spawn_with_approval`
+is offered to surfaces in this fixed order, and the search stops at the first one
+that answers:
+
+1. **Originating channel hook** — the channel-neutral seam above. A `True`/`False`
+   return is the user's in-channel decision and is used verbatim; `None` (no hook
+   for that channel, or it could not surface the prompt) falls through.
+2. **Slack owner DM / dashboard fallback** — the pre-existing gate in
+   `slack/gateway.py` (`_interactive_approval`), which races a Slack owner DM
+   against an attached dashboard client. A configured-but-unpostable Slack DM and
+   an unattached dashboard both count as "no surface".
+3. **`#8914` fast-fail backstop** — reached only when neither a channel hook nor a
+   Slack/dashboard surface could show the prompt. Rather than park the run at
+   turn 0 until the reaper's ~30-minute deadline, the gate (`raise_when_unreachable=True`)
+   raises `SpawnApprovalUnreachable`, and `subagent_manager/admission.py`
+   turns it into an immediate refusal audited with `reason="no_approval_surface"`.
+
+The backstop keeps two audiences apart on purpose (Design Review r3, PR #8914).
+The **operator** WARNING log names every auto-approve rung that would have let the
+spawn through (`approval_mode="auto"`, parent-session **Trust**,
+`hooks.auto_approve_subagent_spawn`, `hooks.auto_approve_sources`). The
+**agent-facing** `info.error` names none of them: two of those rungs are
+`config.json` edits, and `config.json` is writable by any auto-approved agent
+shell, so a bypass recipe in the completion event would hand an unattended or
+prompt-injected agent the steps to remove its own gate. The agent error stays
+terse ("ask the operator to open the dashboard and spawn again, or to enable spawn
+auto-approval"). Because the channel hook and the Slack/dashboard gate own the
+"which surface was missing" half while the backstop owns the rung list, the
+refusal wording stays truthful as channels learn to deliver the prompt: the gate
+never names a surface it does not know about, and the fast-fail sentence ("no
+surface could show the approval prompt") is only ever emitted once every surface
+above has genuinely declined to carry it.
+
 ### Tool Approval Cascade
 
 When a subagent's tool call triggers `EVENT_PERMISSION_REQUEST`, approval

--- a/src/kiro_crew/messaging/spawn_approval_delivery.py
+++ b/src/kiro_crew/messaging/spawn_approval_delivery.py
@@ -1,0 +1,138 @@
+"""Channel-side delivery for the host spawn-approval prompt — one seam, every channel.
+
+The single host-wide ``SubagentManager`` owns ONE ``on_spawn_approval`` callback,
+built in ``slack/gateway.py``. Before this seam that callback raced only a Slack
+owner DM and the dashboard, so a spawn parented on a Telegram (or any other)
+conversation reached no surface at all: post-#8914 the gate refuses it fast with
+``no_approval_surface`` rather than parking to the reaper's deadline. The ideal
+fix named on issue #2381 is to deliver the prompt to the ORIGINATING channel's
+own inline keyboard, which each channel already renders for mid-run tool prompts
+but which the host spawn gate cannot reach — the driver's per-turn ``decider`` is
+wired to the main-agent tool ladder, not to this callback.
+
+This module is that reach: a process-global registry a channel dispatcher
+registers a delivery hook into, keyed by the channel namespace it owns
+(``telegram``, ``slack``, …). The spawn-approval callback consults it FIRST,
+given the spawn's ``parent_session_key``, and:
+
+* a hook returning ``True``/``False`` is the user's in-channel decision — run or
+  reject — and the callback returns it verbatim;
+* a hook returning ``None`` means "this channel is registered but could not
+  surface the prompt for THIS session" (an unroutable key, a send that failed),
+  so the callback falls through to the existing Slack-DM/dashboard path exactly
+  as before;
+* no hook registered for the session's channel is the same fall-through.
+
+Why a registry keyed by channel namespace rather than by ``parent_session_key``:
+a channel runs one dispatcher for the whole process, and the session's channel is
+already recoverable from its key prefix (``messaging.link.channel_namespace_of``),
+which is the authoritative classifier the rest of the system uses. Keying by the
+full session key would need the gate to know every live session, which is exactly
+the coupling the seam exists to avoid.
+
+In memory only, deliberately, and modelled on ``messaging/session_trust.py``: a
+delivery hook is a live object on a running dispatcher, so a registration that
+survived a restart would name a dispatcher that no longer exists. The registry
+dies with the process; a channel re-registers on its next startup.
+
+``messaging`` may not import a channel package, so the hook is a plain async
+callable the channel supplies — the same inversion ``session_trust`` uses to let
+a Slack widget write a grant a Telegram turn can read.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable
+
+from kiro_crew.messaging.link import channel_namespace_of
+
+logger = logging.getLogger(__name__)
+
+#: A channel's spawn-approval delivery hook.
+#:
+#: ``async def(request_id, description, parent_session_key) -> bool | None`` — the
+#: SAME three arguments the host ``SpawnApprovalCallback`` receives, so a channel
+#: can post its prompt and await the press without the seam reshaping anything.
+#: ``True``/``False`` is the user's decision; ``None`` means "not surfaced here,
+#: fall through" (see the module docstring).
+SpawnApprovalDeliveryHook = Callable[[str, str, str], Awaitable["bool | None"]]
+
+#: Channel namespace (``telegram``, ``slack``, …) -> its live delivery hook. One
+#: dispatcher per channel per process, so a namespace maps to at most one hook.
+#: In memory only: a hook is a live object on a running dispatcher.
+_HOOKS: dict[str, SpawnApprovalDeliveryHook] = {}
+
+
+def register_channel_delivery(channel: str, hook: SpawnApprovalDeliveryHook) -> None:
+    """Register *hook* as the spawn-approval delivery surface for *channel*.
+
+    *channel* is a channel namespace (``telegram``), the same token
+    :func:`channel_namespace_of` returns for that channel's session keys — that is
+    what lets :func:`resolve_channel_delivery` find the hook from a bare
+    ``parent_session_key``. Idempotent by construction: a channel that restarts
+    replaces its own prior hook, so a stale registration can never shadow the live
+    dispatcher.
+    """
+    if not channel:
+        return
+    _HOOKS[channel] = hook
+
+
+def unregister_channel_delivery(channel: str) -> None:
+    """Drop *channel*'s delivery hook (idempotent).
+
+    Called on a channel's shutdown so the gate stops routing to a dispatcher that
+    is going away. Absent-key safe: a channel that failed to start never
+    registered, and its shutdown path still calls this.
+    """
+    _HOOKS.pop(channel, None)
+
+
+def resolve_channel_delivery(parent_session_key: str) -> "SpawnApprovalDeliveryHook | None":
+    """The delivery hook whose channel owns *parent_session_key*, or ``None``.
+
+    ``None`` when the key is unowned (the CLI spawns with no parent), sits in a
+    non-channel namespace (``dashboard:``, ``cron:``, ``subagent:``), or its
+    channel has registered no hook. The caller treats every ``None`` the same way:
+    fall through to the Slack-DM/dashboard path.
+    """
+    channel = channel_namespace_of(parent_session_key)
+    if not channel:
+        return None
+    return _HOOKS.get(channel)
+
+
+async def deliver_spawn_approval(
+    request_id: str, description: str, parent_session_key: str
+) -> "bool | None":
+    """Offer the spawn prompt to the originating channel; ``None`` = fall through.
+
+    Consulted FIRST by the host spawn-approval callback. Returns the channel's
+    ``True``/``False`` decision when a hook answered, or ``None`` when no hook is
+    registered for the session's channel or the hook itself returned ``None`` (it
+    could not surface the prompt here). A hook that RAISES is contained and read as
+    ``None``: a channel-delivery bug must degrade to the existing fallback, never
+    turn a spawn the operator could still answer on Slack/dashboard into a hard
+    failure.
+    """
+    hook = resolve_channel_delivery(parent_session_key)
+    if hook is None:
+        return None
+    try:
+        return await hook(request_id, description, parent_session_key)
+    except Exception:
+        # The surface, not the key: the channel is what an operator acts on, and a
+        # raw session key can carry the peer's platform id.
+        logger.warning(
+            "Spawn-approval channel delivery failed on %s; falling through to "
+            "the Slack/dashboard path",
+            channel_namespace_of(parent_session_key) or "unknown",
+            exc_info=True,
+        )
+        return None
+
+
+def clear_channel_delivery_hooks() -> None:
+    """Drop every registered hook. For test isolation and a full gateway teardown."""
+    _HOOKS.clear()

--- a/src/kiro_crew/messaging/spawn_approval_delivery.py
+++ b/src/kiro_crew/messaging/spawn_approval_delivery.py
@@ -123,11 +123,14 @@ async def deliver_spawn_approval(
         return await hook(request_id, description, parent_session_key)
     except Exception:
         # The surface, not the key: the channel is what an operator acts on, and a
-        # raw session key can carry the peer's platform id.
+        # raw session key can carry the peer's platform id. The request id is named
+        # too so this seam-level warning matches the granularity of the
+        # dispatcher-level one (which also logs the ``rid``) when both fire.
         logger.warning(
-            "Spawn-approval channel delivery failed on %s; falling through to "
-            "the Slack/dashboard path",
+            "Spawn-approval channel delivery failed on %s for %s; falling through "
+            "to the Slack/dashboard path",
             channel_namespace_of(parent_session_key) or "unknown",
+            request_id,
             exc_info=True,
         )
         return None

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -219,6 +219,7 @@ from kiro_crew.messaging.link import (
     parse_session_key,
 )
 from kiro_crew.messaging.renderer import SilentRenderer, chunk_for_transport
+from kiro_crew.messaging.spawn_approval_delivery import deliver_spawn_approval
 from kiro_crew.messaging.transport import InboundMessage, delivery_confirmed
 from kiro_crew.monitoring.completion import (
     MonitorCompletionHook,
@@ -8386,6 +8387,19 @@ class GatewayOrchestrator:
         async def _spawn_approve(
             request_id: str, description: str, parent_session_key: str = ""
         ) -> bool:
+            # Channel-side delivery FIRST (issue #2381 item 1). A spawn parented on
+            # a live channel conversation (Telegram, …) is best answered where the
+            # human already is, with that channel's own Approve/Deny/Trust
+            # keyboard. The seam returns True/False when the channel surfaced the
+            # prompt and got a press; None means no channel hook owns this session,
+            # or the hook could not surface it here — either way, fall through to
+            # the unchanged Slack-DM/dashboard gate below (which still raises
+            # SpawnApprovalUnreachable when no surface is attached).
+            channel_decision = await deliver_spawn_approval(
+                request_id, description, parent_session_key
+            )
+            if channel_decision is not None:
+                return channel_decision
             event = LLMEvent(kind="permission_request", request_id=request_id, title=description)
             return await _approve_spawn_gate(event, parent_session_key)
 

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -616,6 +616,12 @@ class TelegramClient:
         # transitions to persistently-failing or recovers. Set by the gateway
         # to keep the settings status badge truthful after startup.
         self.on_status: Callable[[bool, str], None] | None = None
+        #: Optional teardown callback: called once from :meth:`close`, best-effort.
+        #: The gateway sets it to unregister the dispatcher's spawn-approval
+        #: delivery hook so the host gate stops routing to a channel that is going
+        #: away (the registration is process-global; see
+        #: ``messaging/spawn_approval_delivery.py``).
+        self.on_close: Callable[[], None] | None = None
         #: Last health state reported through on_status (None = never
         #: reported). The gateway seeds this with the startup getMe outcome so
         #: transitions are relative to the boot state.
@@ -717,6 +723,14 @@ class TelegramClient:
     async def close(self) -> None:
         """Gracefully shut down."""
         self._closed = True
+        # Retire any process-global registration this channel holds (the
+        # spawn-approval delivery hook) BEFORE tearing the transport down, so the
+        # host spawn gate stops routing to a dispatcher that is going away.
+        if self.on_close is not None:
+            try:
+                self.on_close()
+            except Exception:
+                logger.debug("Telegram on_close callback failed", exc_info=True)
         # Best-effort flush of buffered albums BEFORE cancelling the polling
         # task. This is NOT a delivery guarantee -- see _flush_all_albums: the
         # handler it spawns races SessionManager._closing and may be refused,

--- a/src/kiro_crew/telegram/gateway.py
+++ b/src/kiro_crew/telegram/gateway.py
@@ -18,6 +18,10 @@ import logging
 from typing import TYPE_CHECKING
 
 from kiro_crew.messaging.driver import APPROVAL_AUTO, APPROVAL_INTERACTIVE
+from kiro_crew.messaging.spawn_approval_delivery import (
+    register_channel_delivery,
+    unregister_channel_delivery,
+)
 from kiro_crew.telegram.client import TelegramAuthError, TelegramClient
 from kiro_crew.telegram.commands import bot_command_payload
 from kiro_crew.telegram.transport import TelegramTransport
@@ -101,6 +105,15 @@ async def maybe_start_telegram(orch: "GatewayOrchestrator") -> "TelegramClient |
         # set_message_handler avoids the client<->transport construction cycle.
         client.set_message_handler(transport.receive)
         dispatcher.client = client
+
+        # Channel-side spawn-approval delivery (issue #2381 item 1). Register this
+        # dispatcher's in-channel Approve/Deny/Trust prompt as the "telegram"
+        # surface the host spawn gate consults before its Slack-DM/dashboard
+        # fallback, and retire it when the client shuts down so the gate stops
+        # routing to a dispatcher that is going away. Idempotent: a restart
+        # replaces this channel's own hook.
+        register_channel_delivery("telegram", dispatcher.deliver_spawn_approval)
+        client.on_close = lambda: unregister_channel_delivery("telegram")
 
         # Prove the token with an authenticated call BEFORE reporting the
         # channel as connected — transport.connect() only schedules the

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -838,6 +838,17 @@ class TelegramApprovalDecider:
         """Record the nonce for the buttons the renderer is about to post."""
         cls._NONCES[key] = nonce
 
+    @classmethod
+    def retire(cls, key: str) -> None:
+        """Drop an armed nonce whose prompt never went out (idempotent).
+
+        ``__call__`` retires the nonce with the prompt it waited on, but a caller
+        that ARMS then fails to post (a spawn-approval prompt Telegram rejected)
+        has no wait to run that ``finally`` — without this the stale nonce would
+        outlive the prompt that never existed.
+        """
+        cls._NONCES.pop(key, None)
+
     async def __call__(self, event: Any) -> bool:
         k = self.key(self._session_key, getattr(event, "request_id", ""))
         fut: "asyncio.Future[bool]" = asyncio.get_running_loop().create_future()

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -2721,6 +2721,16 @@ class TelegramDispatcher:
         approval does, so Trust still runs ``add_trusted_session`` and a spawn id
         (``spawn:<agent_id>``) cannot collide with an opaque tool id in the
         registry keyed by ``session_key:request_id``.
+
+        The prompt is armed under ``parent_session_key`` VERBATIM (its ``:genN``
+        suffix included), but a press recomputes the key from the LIVE
+        conversation (``_callback_session_key``). A generation rotation between the
+        spawn and the press — ``/new``, an idle reset, a daily rotation — bumps the
+        generation, so the recomputed key no longer matches the armed one, the
+        press resolves nothing, and the prompt deny-by-defaults at the timeout
+        (the user sees "already expired"). This mirrors how a mid-run tool prompt
+        behaves across a rotation; it is not surfaced here as a decision, so the
+        gate simply falls through to Slack/dashboard when the wait elapses.
         """
         client = self.client
         if client is None:

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -31,6 +31,7 @@ import re
 import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
 from kiro_crew.acp.client import AcpError
@@ -68,6 +69,7 @@ from kiro_crew.messaging.link import (
     ChannelLink,
     bind_origin_mirror,
     build_dm_session_key,
+    parse_session_key,
     rebind_conversation_location,
     release_conversation_location,
     seed_generation,
@@ -75,6 +77,7 @@ from kiro_crew.messaging.link import (
 from kiro_crew.messaging.renderer import (
     SilentRenderer,
     display_safe,
+    new_approval_nonce,
     session_provenance_tag,
 )
 from kiro_crew.messaging.session_resume import (
@@ -2695,6 +2698,116 @@ class TelegramDispatcher:
                 interpret_commands=False,
                 origin_tag=origin_tag,
             )
+
+    # ── Spawn-approval channel delivery (issue #2381 item 1) ────────────────
+
+    async def deliver_spawn_approval(
+        self, request_id: str, description: str, parent_session_key: str
+    ) -> bool | None:
+        """Post a spawn-approval prompt to the ORIGINATING Telegram conversation.
+
+        Registered into the channel-neutral
+        :mod:`~kiro_crew.messaging.spawn_approval_delivery` seam so the single
+        host spawn gate can reach the same Approve/Deny/Trust keyboard the
+        main-agent tool ladder already uses here. Returns the user's decision
+        (``True``/``False``), or ``None`` to tell the gate "not surfaced here,
+        fall through to Slack/dashboard" — for a key this dispatcher cannot turn
+        back into a chat (``unified`` dm_scope drops the peer, a non-``telegram``
+        key, an unparseable one) or when the client is not up.
+
+        The wait is the SAME deny-by-default one a tool prompt uses
+        (:class:`TelegramApprovalDecider`, ``APPROVAL_TIMEOUT_S``): the press
+        resolves through the ``on_callback`` ``a:`` branch exactly as a tool
+        approval does, so Trust still runs ``add_trusted_session`` and a spawn id
+        (``spawn:<agent_id>``) cannot collide with an opaque tool id in the
+        registry keyed by ``session_key:request_id``.
+        """
+        client = self.client
+        if client is None:
+            return None
+        target = self._spawn_chat_target(parent_session_key)
+        if target is None:
+            # A key this channel does not own or cannot address (unified DM
+            # bucket, non-telegram key, malformed). Let the gate fall through.
+            return None
+        chat_id, thread_id, session_key = target
+
+        rid = str(request_id)
+        nonce = new_approval_nonce()
+        key = TelegramApprovalDecider.key(session_key, rid)
+        TelegramApprovalDecider.arm(key, nonce)
+        keyboard = {
+            "inline_keyboard": [
+                [
+                    {"text": "✅ Approve", "callback_data": f"a:{rid}:{nonce}:1"},
+                    {"text": "🚫 Deny", "callback_data": f"a:{rid}:{nonce}:0"},
+                ],
+                [
+                    {
+                        "text": "🤝 Trust this conversation",
+                        "callback_data": f"a:{rid}:{nonce}:t",
+                    }
+                ],
+            ]
+        }
+        # ``description`` is the gate's own ``spawn_run(<task-preview>)`` string,
+        # already credential/exfil-redacted in admission.py before it reaches
+        # here; escape it for the HTML body it lands in.
+        detail = " ".join((description or "spawn_run").split())
+        body = f"🔐 Approve sub-agent spawn?\n<pre>{html.escape(detail)}</pre>"
+        try:
+            await client.send_message(
+                chat_id,
+                body,
+                parse_mode="HTML",
+                reply_markup=keyboard,
+                message_thread_id=thread_id,
+            )
+        except Exception:
+            # Could not surface it: retire the armed nonce and fall through so the
+            # spawn can still be answered on Slack/dashboard rather than deny by a
+            # timeout nobody could see.
+            TelegramApprovalDecider.retire(key)
+            logger.warning(
+                "Telegram: failed to post spawn-approval prompt for %s", rid, exc_info=True
+            )
+            return None
+
+        decider = TelegramApprovalDecider(session_key=session_key)
+        event = SimpleNamespace(request_id=rid)
+        return bool(await decider(event))
+
+    def _spawn_chat_target(self, parent_session_key: str) -> tuple[int, int | None, str] | None:
+        """``(chat_id, thread_id, session_key)`` for a Telegram spawn parent, else None.
+
+        Reconstructs the conversation from the parent session key's grammar
+        (``telegram:{agent}:{chat_type}:{scope…}``): a direct DM's scope is the
+        peer's user id, and a Telegram private chat's id EQUALS that user id; a
+        forum route's scope is ``{chat_id}:{thread}``. A ``unified`` DM bucket
+        (``unified:{agent}``) parses as a non-telegram surface and returns None —
+        it names no single conversation to post into, which is the same reason the
+        origin mirror declines it. ``session_key`` is returned so the caller arms
+        the decider under the exact key ``on_callback`` recomputes for a press in
+        that chat.
+        """
+        parsed = parse_session_key(parent_session_key)
+        if parsed is None or parsed.surface != "telegram":
+            return None
+        try:
+            if parsed.chat_type == CHAT_TYPE_FORUM and len(parsed.scope) >= 2:
+                chat_id = int(parsed.scope[0])
+                thread_id: int | None = int(parsed.scope[1])
+            elif parsed.chat_type == CHAT_TYPE_DIRECT and len(parsed.scope) == 1:
+                chat_id = int(parsed.scope[0])
+                thread_id = None
+            else:
+                return None
+        except (TypeError, ValueError):
+            return None
+        # The key was minted with a generation suffix; the press recomputes the
+        # same key from the live conversation, so key the decider by the exact
+        # value the gate handed us.
+        return chat_id, thread_id, parent_session_key
 
     # ── Helpers ────────────────────────────────────────────────────────────
 

--- a/test/test_spawn_approval_channel_delivery_2381.py
+++ b/test/test_spawn_approval_channel_delivery_2381.py
@@ -1,0 +1,421 @@
+"""Channel-side delivery of the spawn-approval prompt — issue #2381 item 1.
+
+Post-#8914 a spawn parented on a Telegram conversation reached no surface and was
+refused fast (``no_approval_surface``): the host spawn gate raced only a Slack
+owner DM and the dashboard. This suite covers the fix — a channel-neutral
+delivery seam the host gate consults FIRST, and Telegram's implementation of it
+over the same Approve/Deny/Trust keyboard the main-agent tool ladder already
+uses.
+
+Four things are pinned:
+
+* the seam registry itself — register/lookup by session, per-channel isolation,
+  and the ``None`` fall-through contract;
+* the wrapped ``on_spawn_approval`` shape — the channel decision is returned when
+  a hook answers ``True``/``False``, and the pre-existing Slack-DM/dashboard gate
+  (still raising ``SpawnApprovalUnreachable`` with no surface attached) runs when
+  the hook answers ``None`` or none is registered;
+* the Telegram delivery hook — an Approve/Deny/Trust keyboard for a ``spawn:<id>``
+  request, resolving ``True`` on Approve, ``False`` on Deny, and granting session
+  trust on Trust, all through the existing ``on_callback`` ``a:`` path;
+* precedence — a trusted/auto parent never reaches the channel prompt, because
+  the host auto-approve rungs run before ``on_spawn_approval`` is ever invoked.
+
+All Telegram client I/O is faked; nothing touches the network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Reuse the channel fixtures the existing Telegram suite uses (fake client,
+# fake sessions, dispatcher factory) so this suite exercises the SAME doubles.
+from test_telegram import _dispatcher  # noqa: E402
+
+from kiro_crew.messaging import spawn_approval_delivery as seam
+from kiro_crew.messaging.session_trust import (
+    _trusted_sessions,
+    clear_trusted_sessions,
+    is_session_trusted,
+)
+from kiro_crew.subagent import SpawnApprovalUnreachable
+from kiro_crew.telegram.renderer import TelegramApprovalDecider
+
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
+
+@pytest.fixture(autouse=True)
+def _clean_seam():
+    """Every test starts and ends with an empty registry and no lingering trust."""
+    seam.clear_channel_delivery_hooks()
+    TelegramApprovalDecider._REGISTRY.clear()
+    TelegramApprovalDecider._NONCES.clear()
+    _trusted_sessions.clear()
+    yield
+    seam.clear_channel_delivery_hooks()
+    TelegramApprovalDecider._REGISTRY.clear()
+    TelegramApprovalDecider._NONCES.clear()
+    clear_trusted_sessions()
+
+
+# ── (a) the delivery seam registry ──────────────────────────────────────────
+
+
+class TestDeliverySeamRegistry:
+    """A process-global map from a channel to its live delivery hook."""
+
+    @pytest.mark.asyncio
+    async def test_registered_hook_is_resolved_for_its_channel_session(self) -> None:
+        async def _hook(_rid: str, _desc: str, _parent: str) -> bool:
+            return True
+
+        seam.register_channel_delivery("telegram", _hook)
+        resolved = seam.resolve_channel_delivery("telegram:kirocrew:direct:7")
+        assert resolved is _hook
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_the_hooks_decision(self) -> None:
+        async def _yes(_rid: str, _desc: str, _parent: str) -> bool:
+            return True
+
+        seam.register_channel_delivery("telegram", _yes)
+        assert await seam.deliver_spawn_approval("spawn:a", "spawn_run(x)", "telegram:k:direct:7")
+
+    @pytest.mark.asyncio
+    async def test_an_unregistered_channel_falls_through_with_none(self) -> None:
+        # Nothing registered for slack -> None (the gate falls through).
+        assert await seam.deliver_spawn_approval("spawn:a", "d", "slack:1700000000.0001") is None
+
+    @pytest.mark.asyncio
+    async def test_an_unowned_or_non_channel_key_falls_through_with_none(self) -> None:
+        async def _hook(_rid: str, _desc: str, _parent: str) -> bool:
+            return True
+
+        seam.register_channel_delivery("telegram", _hook)
+        # A dashboard/cron/subagent key is not a channel key -> no hook resolves.
+        assert seam.resolve_channel_delivery("dashboard:chat-1-2") is None
+        assert seam.resolve_channel_delivery("") is None
+        assert await seam.deliver_spawn_approval("spawn:a", "d", "cron:job7") is None
+
+    @pytest.mark.asyncio
+    async def test_hooks_are_per_channel_isolated(self) -> None:
+        async def _tg(_rid: str, _desc: str, _parent: str) -> bool:
+            return True
+
+        async def _slack(_rid: str, _desc: str, _parent: str) -> bool:
+            return False
+
+        seam.register_channel_delivery("telegram", _tg)
+        seam.register_channel_delivery("slack", _slack)
+        assert seam.resolve_channel_delivery("telegram:k:direct:7") is _tg
+        assert seam.resolve_channel_delivery("slack:1700000000.0001") is _slack
+
+    @pytest.mark.asyncio
+    async def test_unregister_stops_resolution(self) -> None:
+        async def _hook(_rid: str, _desc: str, _parent: str) -> bool:
+            return True
+
+        seam.register_channel_delivery("telegram", _hook)
+        seam.unregister_channel_delivery("telegram")
+        assert seam.resolve_channel_delivery("telegram:k:direct:7") is None
+        # Idempotent: a second unregister (or one that never registered) is safe.
+        seam.unregister_channel_delivery("telegram")
+        seam.unregister_channel_delivery("discord")
+
+    @pytest.mark.asyncio
+    async def test_a_raising_hook_is_contained_as_a_fall_through(self) -> None:
+        async def _boom(_rid: str, _desc: str, _parent: str) -> bool:
+            raise RuntimeError("delivery bug")
+
+        seam.register_channel_delivery("telegram", _boom)
+        # A channel-delivery bug degrades to the fallback (None), never a hard fail.
+        assert await seam.deliver_spawn_approval("spawn:a", "d", "telegram:k:direct:7") is None
+
+    @pytest.mark.asyncio
+    async def test_registering_replaces_the_channels_prior_hook(self) -> None:
+        async def _old(_rid: str, _desc: str, _parent: str) -> bool:
+            return True
+
+        async def _new(_rid: str, _desc: str, _parent: str) -> bool:
+            return False
+
+        seam.register_channel_delivery("telegram", _old)
+        seam.register_channel_delivery("telegram", _new)
+        assert seam.resolve_channel_delivery("telegram:k:direct:7") is _new
+
+
+# ── (b) the wrapped on_spawn_approval callback ──────────────────────────────
+
+
+def _spawn_callback():  # type: ignore[no-untyped-def]
+    """Reproduce the gateway's ``_spawn_approve`` wiring over the real seam.
+
+    Seam FIRST; on ``None`` fall through to a stand-in for the pre-existing
+    ``_approve_spawn_gate`` that raises ``SpawnApprovalUnreachable`` exactly as
+    the Slack-DM/dashboard gate does when no surface is attached. The source
+    ratchet below pins that the production callback keeps this shape.
+    """
+    from kiro_crew.messaging.spawn_approval_delivery import deliver_spawn_approval
+    from kiro_crew.providers.base import LLMEvent
+
+    async def _approve_spawn_gate(_event: LLMEvent, _parent: str) -> bool:
+        raise SpawnApprovalUnreachable("no interactive surface is attached")
+
+    async def _spawn_approve(
+        request_id: str, description: str, parent_session_key: str = ""
+    ) -> bool:
+        channel_decision = await deliver_spawn_approval(request_id, description, parent_session_key)
+        if channel_decision is not None:
+            return channel_decision
+        event = LLMEvent(kind="permission_request", request_id=request_id, title=description)
+        return await _approve_spawn_gate(event, parent_session_key)
+
+    return _spawn_approve
+
+
+class TestWrappedSpawnApproval:
+    """The host callback consults the channel FIRST, then the Slack/dashboard gate."""
+
+    @pytest.mark.asyncio
+    async def test_channel_true_is_the_decision(self) -> None:
+        async def _yes(_rid: str, _desc: str, _parent: str) -> bool:
+            return True
+
+        seam.register_channel_delivery("telegram", _yes)
+        cb = _spawn_callback()
+        assert await cb("spawn:a", "spawn_run(x)", "telegram:k:direct:7") is True
+
+    @pytest.mark.asyncio
+    async def test_channel_false_is_the_decision(self) -> None:
+        async def _no(_rid: str, _desc: str, _parent: str) -> bool:
+            return False
+
+        seam.register_channel_delivery("telegram", _no)
+        cb = _spawn_callback()
+        assert await cb("spawn:a", "spawn_run(x)", "telegram:k:direct:7") is False
+
+    @pytest.mark.asyncio
+    async def test_channel_none_falls_through_to_the_unreachable_gate(self) -> None:
+        async def _none(_rid: str, _desc: str, _parent: str) -> "bool | None":
+            return None
+
+        seam.register_channel_delivery("telegram", _none)
+        cb = _spawn_callback()
+        with pytest.raises(SpawnApprovalUnreachable):
+            await cb("spawn:a", "spawn_run(x)", "telegram:k:direct:7")
+
+    @pytest.mark.asyncio
+    async def test_no_hook_falls_through_to_the_unreachable_gate(self) -> None:
+        # No channel registered at all -> the pre-#8914 behaviour is byte-for-byte.
+        cb = _spawn_callback()
+        with pytest.raises(SpawnApprovalUnreachable):
+            await cb("spawn:a", "spawn_run(x)", "telegram:k:direct:7")
+
+    def test_source_still_consults_the_seam_before_the_gate(self) -> None:
+        """Source ratchet: the seam consult must precede the Slack/dashboard gate.
+
+        The behavioural tests above run over a stand-in gate; this pins that the
+        REAL ``_spawn_approve`` keeps the seam-first shape and that the exact
+        substring the #8914 ratchet also asserts is still present.
+        """
+        import kiro_crew.slack.gateway as gateway_mod
+
+        src = Path(gateway_mod.__file__).read_text(encoding="utf-8")
+        consult = src.index("deliver_spawn_approval(")
+        fallback = src.index("return await _approve_spawn_gate(event, parent_session_key)")
+        assert consult < fallback, "the channel seam must be consulted before the fallback gate"
+        assert "return await _approve_spawn_gate(event, parent_session_key)" in src
+
+
+# ── (c) the Telegram delivery hook ──────────────────────────────────────────
+
+
+async def _press(dispatcher, session_key: str, request_id: str, flag: str) -> None:  # type: ignore[no-untyped-def]
+    """Simulate the user pressing an Approve/Deny/Trust button in the DM.
+
+    Waits for the hook to post its prompt and register its awaiting future, then
+    recovers the nonce it armed and drives ``on_callback`` exactly as a real
+    inline-button press does — so the spawn prompt resolves through the SAME
+    ``a:`` path a tool approval uses.
+    """
+    key = TelegramApprovalDecider.key(session_key, request_id)
+    for _ in range(50):
+        if key in TelegramApprovalDecider._REGISTRY:
+            break
+        await asyncio.sleep(0.01)
+    nonce = TelegramApprovalDecider._NONCES[key]
+    cb = SimpleNamespace(
+        callback_query_id="q1",
+        user_id=7,
+        chat_id=7,
+        message_id=100,
+        data=f"a:{request_id}:{nonce}:{flag}",
+        label="",
+        chat_type="private",
+    )
+    await dispatcher.on_callback(cb)
+
+
+class TestTelegramDeliveryHook:
+    """The prompt lands in the originating conversation and the press resolves it."""
+
+    def test_approve_resolves_true(self) -> None:
+        d, cli, _sess = _dispatcher({7})
+        session_key = d._session_key(("direct", "7"))
+
+        async def _go() -> bool:
+            task = asyncio.ensure_future(
+                d.deliver_spawn_approval("spawn:abc", "spawn_run(build)", session_key)
+            )
+            await asyncio.sleep(0)  # let the prompt post and the future register
+            await _press(d, session_key, "spawn:abc", "1")
+            return await task
+
+        assert asyncio.run(_go()) is True
+
+    def test_deny_resolves_false(self) -> None:
+        d, cli, _sess = _dispatcher({7})
+        session_key = d._session_key(("direct", "7"))
+
+        async def _go() -> bool:
+            task = asyncio.ensure_future(
+                d.deliver_spawn_approval("spawn:abc", "spawn_run(build)", session_key)
+            )
+            await asyncio.sleep(0)
+            await _press(d, session_key, "spawn:abc", "0")
+            return await task
+
+        assert asyncio.run(_go()) is False
+
+    def test_trust_grants_session_trust_and_resolves_true(self) -> None:
+        d, cli, sess = _dispatcher({7})
+        session_key = d._session_key(("direct", "7"))
+
+        async def _go() -> bool:
+            task = asyncio.ensure_future(
+                d.deliver_spawn_approval("spawn:abc", "spawn_run(build)", session_key)
+            )
+            await asyncio.sleep(0)
+            await _press(d, session_key, "spawn:abc", "t")
+            return await task
+
+        assert asyncio.run(_go()) is True
+        # Trust granted for the parent session so subsequent spawns auto-approve.
+        assert is_session_trusted(session_key)
+
+    def test_the_prompt_is_an_approve_deny_trust_keyboard(self) -> None:
+        d, cli, _sess = _dispatcher({7})
+        session_key = d._session_key(("direct", "7"))
+
+        async def _go() -> None:
+            task = asyncio.ensure_future(
+                d.deliver_spawn_approval("spawn:abc", "spawn_run(build)", session_key)
+            )
+            for _ in range(50):
+                if cli.sent:
+                    break
+                await asyncio.sleep(0.01)
+            # One prompt posted, carrying the three-button keyboard for spawn:abc.
+            assert len(cli.sent) == 1
+            _text, markup = cli.sent[0]
+            rows = markup["inline_keyboard"]
+            datas = [btn["callback_data"] for row in rows for btn in row]
+            assert any(cd.startswith("a:spawn:abc:") and cd.endswith(":1") for cd in datas)
+            assert any(cd.startswith("a:spawn:abc:") and cd.endswith(":0") for cd in datas)
+            assert any(cd.startswith("a:spawn:abc:") and cd.endswith(":t") for cd in datas)
+            # Resolve so the awaiting task does not leak.
+            await _press(d, session_key, "spawn:abc", "0")
+            await task
+
+        asyncio.run(_go())
+
+    def test_a_non_telegram_parent_key_falls_through(self) -> None:
+        d, cli, _sess = _dispatcher({7})
+        # A Slack key handed to the Telegram hook cannot be turned into a chat.
+        result = asyncio.run(d.deliver_spawn_approval("spawn:abc", "d", "slack:1700000000.0001"))
+        assert result is None
+        assert cli.sent == []
+
+    def test_a_failed_post_falls_through_and_retires_the_nonce(self) -> None:
+        d, cli, _sess = _dispatcher({7})
+        session_key = d._session_key(("direct", "7"))
+
+        async def _boom(*_a, **_k):  # type: ignore[no-untyped-def]
+            raise RuntimeError("telegram is down")
+
+        d.client.send_message = _boom  # type: ignore[assignment]
+
+        result = asyncio.run(d.deliver_spawn_approval("spawn:abc", "spawn_run(build)", session_key))
+        assert result is None
+        # The armed nonce was retired so no stale prompt lingers.
+        key = TelegramApprovalDecider.key(session_key, "spawn:abc")
+        assert key not in TelegramApprovalDecider._NONCES
+
+    def test_a_missing_client_falls_through(self) -> None:
+        d, _cli, _sess = _dispatcher({7})
+        d.client = None  # type: ignore[assignment]
+        result = asyncio.run(
+            d.deliver_spawn_approval("spawn:abc", "d", d._session_key(("direct", "7")))
+        )
+        assert result is None
+
+
+# ── (d) precedence: a trusted/auto parent never reaches the channel prompt ──
+
+
+class TestAutoApprovedNeverReachesTheChannel:
+    """The host auto-approve rungs run BEFORE ``on_spawn_approval`` is invoked."""
+
+    @staticmethod
+    def _mock_sessions(*, policy: str) -> MagicMock:
+        sessions = MagicMock()
+        sessions.get_pid = MagicMock(return_value=None)
+        provider = AsyncMock()
+        provider.start = AsyncMock()
+        provider.shutdown = AsyncMock()
+        provider.context_usage_pct = lambda: 0.0
+
+        async def _empty_stream(*_a: object, **_k: object):  # type: ignore[no-untyped-def]
+            return
+            yield
+
+        provider.stream = MagicMock(side_effect=lambda *a, **kw: _empty_stream())
+        sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+        sessions.release = MagicMock()
+        sessions.reset = AsyncMock()
+        sessions.record_success = MagicMock()
+        sessions.get_agent = MagicMock(return_value="")
+        sessions.get_approval_policy = MagicMock(return_value=policy)
+        return sessions
+
+    @pytest.mark.asyncio
+    async def test_a_trusted_parent_never_calls_the_spawn_approval(self) -> None:
+        from kiro_crew.subagent import SubagentManager
+
+        ctx = MagicMock()
+        ctx.build_message = MagicMock(return_value=("built", None))
+        ctx.hooks.on_tool_call = MagicMock()
+        ctx.hooks.auto_approve_subagent_spawn = False
+
+        approval = AsyncMock(return_value=True)
+        mgr = SubagentManager(
+            sessions=self._mock_sessions(policy="auto"),  # parent trusted
+            ctx_builder=ctx,
+            on_spawn_approval=approval,
+            is_yolo=lambda: False,
+        )
+        info = mgr.spawn("do a thing", parent_session_key="telegram:k:direct:7")
+        assert info is not None
+        for _ in range(50):
+            await asyncio.sleep(0)
+        # The parent_trusted rung admitted the spawn — the approval callback (and
+        # thus the channel prompt behind it) was never consulted.
+        approval.assert_not_awaited()
+        for t in list(mgr._tasks.values()):
+            t.cancel()
+        await asyncio.sleep(0)

--- a/test/test_spawn_approval_channel_delivery_2381.py
+++ b/test/test_spawn_approval_channel_delivery_2381.py
@@ -38,6 +38,7 @@ import pytest
 from test_telegram import _dispatcher  # noqa: E402
 
 from kiro_crew.messaging import spawn_approval_delivery as seam
+from kiro_crew.messaging.link import CHAT_TYPE_FORUM, parse_session_key
 from kiro_crew.messaging.session_trust import (
     _trusted_sessions,
     clear_trusted_sessions,
@@ -333,6 +334,126 @@ class TestTelegramDeliveryHook:
             await task
 
         asyncio.run(_go())
+
+    def test_a_forum_parent_threads_the_prompt_into_the_originating_topic(self) -> None:
+        # A supergroup forum Topic parent: the only branch of _spawn_chat_target
+        # that derives a thread id. The prompt must be posted into that Topic
+        # (message_thread_id carried through) and the press through the same
+        # forum-shaped callback resolves it.
+        chat_id, thread = -1001234567890, 42
+        d, cli, _sess = _dispatcher({7}, allow_forum=True, allowed_forum_chat_ids=[chat_id])
+        route = (CHAT_TYPE_FORUM, f"{chat_id}:{thread}")
+        session_key = d._session_key(route)
+        # The parent key is a genuine forum shape: telegram:{agent}:forum:{chat}:{thread}.
+        parsed = parse_session_key(session_key)
+        assert parsed is not None and parsed.chat_type == CHAT_TYPE_FORUM
+        assert parsed.scope == (str(chat_id), str(thread))
+
+        async def _go() -> bool:
+            task = asyncio.ensure_future(
+                d.deliver_spawn_approval("spawn:abc", "spawn_run(build)", session_key)
+            )
+            for _ in range(50):
+                if cli.sent:
+                    break
+                await asyncio.sleep(0.01)
+            # The prompt was threaded into the originating Topic, not the group root.
+            assert cli.send_threads == [thread]
+            key = TelegramApprovalDecider.key(session_key, "spawn:abc")
+            for _ in range(50):
+                if key in TelegramApprovalDecider._REGISTRY:
+                    break
+                await asyncio.sleep(0.01)
+            nonce = TelegramApprovalDecider._NONCES[key]
+            cb = SimpleNamespace(
+                callback_query_id="q1",
+                user_id=7,
+                chat_id=chat_id,
+                message_id=100,
+                data=f"a:spawn:abc:{nonce}:1",
+                label="",
+                chat_type="supergroup",
+                message_thread_id=thread,
+            )
+            await d.on_callback(cb)
+            return await task
+
+        assert asyncio.run(_go()) is True
+
+    def test_a_generation_rotation_between_spawn_and_press_expires_the_prompt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The prompt is armed under parent_session_key VERBATIM, but a press
+        # recomputes the key from the LIVE conversation. A /new (or idle/daily)
+        # rotation between spawn and press bumps the generation, so the recomputed
+        # key no longer matches the armed one: the press resolves nothing and the
+        # prompt deny-by-defaults at the timeout. Pin that coupling here.
+        import kiro_crew.telegram.renderer as renderer_mod
+
+        monkeypatch.setattr(renderer_mod, "_APPROVAL_TIMEOUT_S", 0.2)
+        d, cli, _sess = _dispatcher({7})
+        route = ("direct", "7")
+        session_key = d._session_key(route)  # gen0
+
+        async def _go() -> bool:
+            task = asyncio.ensure_future(
+                d.deliver_spawn_approval("spawn:abc", "spawn_run(build)", session_key)
+            )
+            key = TelegramApprovalDecider.key(session_key, "spawn:abc")
+            for _ in range(50):
+                if key in TelegramApprovalDecider._REGISTRY:
+                    break
+                await asyncio.sleep(0.01)
+            nonce = TelegramApprovalDecider._NONCES[key]
+            # Rotate the parent conversation's generation AFTER arming.
+            d._conv.bump_gen(route)
+            # The press recomputes the (now rotated) key, which diverges from the
+            # armed one, so the approve press cannot resolve the gen0 prompt.
+            assert d._session_key(route) != session_key
+            cb = SimpleNamespace(
+                callback_query_id="q1",
+                user_id=7,
+                chat_id=7,
+                message_id=100,
+                data=f"a:spawn:abc:{nonce}:1",
+                label="",
+                chat_type="private",
+            )
+            await d.on_callback(cb)
+            # The armed prompt is still pending — the press landed on a different
+            # key — so it deny-by-defaults when the (shortened) timeout elapses.
+            return await task
+
+        assert asyncio.run(_go()) is False
+
+    def test_a_cancelled_awaiting_decider_leaks_no_registry_or_nonce_entry(self) -> None:
+        # The prompt posts and the hook awaits the press, but the awaiting task is
+        # cancelled mid-prompt (e.g. gateway teardown) before a press arrives. The
+        # decider's finally must still pop BOTH the registry future and the armed
+        # nonce so a later request-id reuse cannot match a stale entry.
+        d, cli, _sess = _dispatcher({7})
+        session_key = d._session_key(("direct", "7"))
+        key = TelegramApprovalDecider.key(session_key, "spawn:abc")
+
+        async def _go() -> None:
+            task = asyncio.ensure_future(
+                d.deliver_spawn_approval("spawn:abc", "spawn_run(build)", session_key)
+            )
+            for _ in range(50):
+                if key in TelegramApprovalDecider._REGISTRY:
+                    break
+                await asyncio.sleep(0.01)
+            # Prompt is live and awaiting: both entries armed.
+            assert key in TelegramApprovalDecider._REGISTRY
+            assert key in TelegramApprovalDecider._NONCES
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        asyncio.run(_go())
+        # No leak: the finally ran on cancellation and cleared both maps.
+        assert key not in TelegramApprovalDecider._REGISTRY
+        assert key not in TelegramApprovalDecider._NONCES
 
     def test_a_non_telegram_parent_key_falls_through(self) -> None:
         d, cli, _sess = _dispatcher({7})


### PR DESCRIPTION
## Problem / Motivation

Follow-up to merged PR #8914 on issue #2381. #8914 fixed the 1800s hang: a subagent spawn whose approval prompt reaches no surface now fast-fails instead of stalling until the reaper. But issue #2381 item 1 stayed open: a spawn approval still could not be answered from its originating Telegram channel. The single host-wide spawn gate raced only a Slack owner DM and the dashboard, so a spawn parented on a Telegram conversation had no in-channel way to be approved. A Telegram user either watched the dashboard or the spawn fast-failed.

## Why it matters

Subagent orchestration is effectively unusable from Telegram: every `spawn_run` from a Telegram-originated turn cannot be approved where the user actually is. Post-#8914 it fails fast rather than hanging, which is better than a 30-minute silent stall, but the user still cannot say "yes, run it" from the channel that started the turn. Delivering the prompt in-channel (with an optional Trust action) restores spawn orchestration for chat-channel users and realizes the issue's suggested fixes (a) deliver the prompt to the originating channel and (b) let a trusted session auto-approve future spawns.

## What changed (motivation → approach → change)

Goal: let a Telegram user answer a spawn approval in the originating channel, without weakening the #8914 fast-fail backstop and without adding the per-agent auto-approve rung (issue item 2, deferred by the commenter to #4751/#4693).

Approach: rather than teaching the host spawn gate about every channel (the coupling the gate exists to avoid), introduce a channel-neutral delivery seam modelled on `messaging/session_trust.py`. The host callback consults the seam first; a channel that owns the parent session registers a hook and answers in-channel; anything else falls through to the unchanged Slack-DM/dashboard path, and then to the #8914 fast-fail backstop. Fall-through is fail-open toward the existing gate: no hook, an unowned/non-channel key, a hook returning `None`, or a hook that raises all collapse to the same "fall through", so a channel-delivery bug can never turn an answerable spawn into a hard failure and can never bypass the backstop.

What was built:
- **New seam** `src/kiro_crew/messaging/spawn_approval_delivery.py`: an in-memory, process-global registry mapping a channel namespace (`telegram`, `slack`, …) to an async delivery hook `(request_id, description, parent_session_key) -> bool | None`. Register/unregister/resolve/deliver, keyed by `channel_namespace_of(parent_session_key)`, raise-contained to `None`.
- **Host spawn gate** (`src/kiro_crew/slack/gateway.py` `_spawn_approve`) now consults the seam first; `True`/`False` is the in-channel decision, `None` falls through to the unchanged `_approve_spawn_gate` (Slack DM + dashboard, still raising `SpawnApprovalUnreachable` when nothing is attached — the #8914 backstop, unchanged).
- **Telegram delivery hook** (`src/kiro_crew/telegram/transport_dispatch.py` `deliver_spawn_approval` + `_spawn_chat_target`): reconstructs the originating chat from the parent session key grammar, posts an Approve/Deny/Trust inline keyboard for `spawn:<id>`, and awaits the press via the existing `TelegramApprovalDecider`/`on_callback` `a:` path. Trust routes through `add_trusted_session` so future spawns from that session auto-approve, scoped to exactly the parent session key the prompt was armed under.
- **Lifecycle** (`src/kiro_crew/telegram/gateway.py`, `src/kiro_crew/telegram/client.py`, `src/kiro_crew/telegram/renderer.py`): the hook is registered on gateway startup and unregistered on client close (new `on_close`); `TelegramApprovalDecider.retire()` drops an armed nonce whose prompt never posted.
- **Docs updated in the same change**: `docs/system-specs/modules/subagent.md` and `docs/system-specs/modules/messaging.md` document the delivery order (channel hook → Slack-DM/dashboard fallback → #8914 fast-fail backstop) and the seam.

## Tests

- `test/test_spawn_approval_channel_delivery_2381.py` (new): the seam's register/resolve/unregister/isolation/replace, raise-containment to `None`, and the `None` fall-through; the wrapped host callback's True/False/None/no-hook behavior; a source ratchet that `_spawn_approve` consults the seam before the gate; the Telegram hook's Approve→True, Deny→False, Trust→True-plus-`add_trusted_session` (with `is_session_trusted` asserted), the three-button keyboard shape, non-telegram fall-through, failed-post retiring the nonce, generation-rotation expiry, forum-Topic threading, and cancellation-leak; and a precedence test that a trusted/auto parent never reaches the channel prompt.
- `test/test_spawn_approval_no_surface_2381.py` (the #8914 regression tests): unchanged and still green, confirming the fast-fail backstop and the separate tool-vs-spawn callbacks are intact.
- `test/test_messaging_driver.py`: unchanged, still green.

## Manual verification

N/A — unit coverage is sufficient. The delivery seam, the wrapped host callback, the real `TelegramApprovalDecider.deliver_spawn_approval`, and the `on_callback` press path (including Trust → `add_trusted_session`) are all driven directly by the new tests rather than mocked away; the commenter on #2381 also offered to test the follow-up against their headless Telegram setup.

## Related Issues

Refs #2381
Follows #8914 (fast-fail backstop, preserved unchanged)
Defers the per-agent auto-approve rung (issue item 2) to #4751 / #4693