### PR TITLE
test: read setup.cfg as utf-8 in the ci-surface testpaths guard

### DIFF
--- a/test/test_ci_surface_tests.py
+++ b/test/test_ci_surface_tests.py
@@ -132,7 +132,14 @@ def test_backend_roots_cover_every_configured_testpath() -> None:
     import configparser
 
     parser = configparser.ConfigParser()
-    parser.read(_REPO_ROOT / "setup.cfg")
+    # `encoding` is not optional here. `ConfigParser.read` opens with no encoding,
+    # which decodes using `locale.getpreferredencoding()` -- UTF-8 on POSIX, but
+    # the legacy ANSI code page on Windows. `setup.cfg` contains non-ASCII (em
+    # dashes in its comments), so on a CJK Windows host this raises
+    # `UnicodeDecodeError` and the contract below is never checked at all. Same
+    # failure class `scripts/check_subprocess_encoding.py` exists for, reached
+    # through a file read rather than a subprocess pipe.
+    parser.read(_REPO_ROOT / "setup.cfg", encoding="utf-8")
     configured = parser.get("tool:pytest", "testpaths").split()
     assert configured, "setup.cfg declares no testpaths -- selector cannot be verified"
     missing = [p for p in configured if p not in _load_selector()._BACKEND_ROOTS]
@@ -141,6 +148,40 @@ def test_backend_roots_cover_every_configured_testpath() -> None:
         "_BACKEND_ROOTS, so every test under them would be SKIPPED (never run) "
         "on a frontend-only diff. Add them to _BACKEND_ROOTS."
     )
+
+
+def test_setup_cfg_carries_non_ascii_so_its_read_must_pin_utf8() -> None:
+    """Pins WHY the read above names an encoding, on hosts that cannot show it.
+
+    The defect is host-conditioned: an unpinned `ConfigParser.read` only
+    misbehaves where `locale.getpreferredencoding()` is not UTF-8, so a UTF-8 CI
+    runner passes either way and cannot exercise it. The two facts that make the
+    encoding load-bearing DO hold everywhere, and this asserts both -- so the
+    guard cannot rot silently on the runners that never feel it.
+
+    Deliberately not a repo-wide "missing encoding=" rule. `cross-platform.yml`
+    documents why it ships none (a line regex breaks on nested and multi-line
+    calls), and an AST version means editing `.github/workflows/**`. This stays
+    the size of the defect.
+    """
+    import configparser
+
+    raw = (_REPO_ROOT / "setup.cfg").read_bytes()
+    assert any(b > 0x7F for b in raw), (
+        "premise gone: setup.cfg is now pure ASCII, so the host code page can no "
+        "longer break this read and the pinned encoding may be retired"
+    )
+
+    # Guard the guard: those bytes are genuinely undecodable under a legacy code
+    # page, so an unpinned read really does RAISE rather than merely differ. cp950
+    # is the code page this was first reproduced on.
+    with pytest.raises(UnicodeDecodeError):
+        (_REPO_ROOT / "setup.cfg").read_text(encoding="cp950")
+
+    # And the pinned read is the one that works, on every host.
+    parser = configparser.ConfigParser()
+    assert parser.read(_REPO_ROOT / "setup.cfg", encoding="utf-8")
+    assert parser.get("tool:pytest", "testpaths").split()
 
 
 def test_frontend_spec_roots_cover_vitest_include(selector) -> None:


### PR DESCRIPTION
## Problem / Motivation

`test/test_ci_surface_tests.py` reads `setup.cfg` through `configparser` without
naming an encoding:

```python
parser = configparser.ConfigParser()
parser.read(_REPO_ROOT / "setup.cfg")
```

`ConfigParser.read` opens with no encoding, so the file is decoded with
`locale.getpreferredencoding()` — UTF-8 on POSIX, but the legacy **ANSI code page**
on Windows. `setup.cfg` contains non-ASCII: 48 bytes of UTF-8 em dashes in its
comments. On a Windows host whose code page is not UTF-8 — any CJK install — that
decode raises.

Measured on `origin/main` `6598107cb`, unmodified, on a `cp950` host:

```
FAILED test/test_ci_surface_tests.py::test_backend_roots_cover_every_configured_testpath
  UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 514:
  illegal multibyte sequence
```

Two consequences, and the second is the one that matters:

1. The suite cannot run clean on such a host, so a contributor there cannot use
   `python -m pytest` as `AGENTS.md` prescribes.
2. **The contract this test exists to enforce is never checked.** It is the guard
   that every `setup.cfg` `testpaths` entry is a scanned selector root — a test
   under an unenumerated root is not "unclassified but still running", it never
   runs at all. The test dies at the read, before it reaches its own assertion, so
   on that host it protects nothing while still reporting as a failure for an
   unrelated-looking reason.

This is the same failure class the repository already guards elsewhere:
`scripts/check_subprocess_encoding.py` exists precisely because
`locale.getpreferredencoding` decoding produced mojibake and `UnicodeDecodeError`
for users (issue #3219, sites fixed in #3669, gate added in #5249). That gate
covers subprocess pipes. This is the same decode reached through a **file read**,
which it does not cover.

## Why it matters

The testing contract in `AGENTS.md` is `python -m pytest`, unqualified. A
contributor on a CJK Windows box currently gets a red suite out of the box, from a
`UnicodeDecodeError` that names neither the real cause nor anything they changed —
the kind of failure that reads as "the repo is broken here" rather than "one read
is missing an argument".

The silent half is worse than the noisy half. `test_backend_roots_cover_every_configured_testpath`
is a guard against tests silently never running. On the affected hosts it is
itself silently not running, so the guard and the thing it guards fail together.

## What changed (motivation → approach → change)

Root cause: a decode that inherits the host code page for a file that is
committed as UTF-8.

Approach: pin the encoding at the read, and pin the two facts that make it
load-bearing so the guard cannot rot on the machines that never feel it.

* **`parser.read(_REPO_ROOT / "setup.cfg", encoding="utf-8")`** — the file is
  UTF-8 in the repository, so it is read as UTF-8 everywhere. One argument, with
  a comment recording the failure class and pointing at the existing subprocess
  gate so the next reader does not have to rediscover why it is there.
* **`test_setup_cfg_carries_non_ascii_so_its_read_must_pin_utf8`** — asserts the
  file really does carry non-ASCII, that those bytes really are undecodable under
  a legacy code page, and that the pinned read works. All three hold on every
  host, including the UTF-8 runners that cannot exercise the bug itself.

**Deliberately NOT a repo-wide "missing `encoding=`" rule.**
`.github/workflows/cross-platform.yml` ships no such rule and documents why: a
line regex breaks on nested calls (`write_text(json.dumps(x), encoding=...)`) and
on multi-line calls under `--unified=0`. An AST version would not have those
limits, but it means editing `.github/workflows/**`, which turns a one-argument
portability fix into a workflow-security change. This stays the size of the
defect; the broader gate is a separate decision for a maintainer.

**Scope boundary, stated because the file makes it look tempting.** Lines 280–282
of this module contain the string `'PARSER.read(ROOT / "setup.cfg")\n'`. That is a
**fixture written to a temp file** so the surface selector can pattern-match it —
it is never executed, and editing it would change what
`test_own_surface_config_references_stay_single_surface` asserts. It is
intentionally left byte-identical.

## Tests

**Red-before, on unmodified `origin/main` `6598107cb`:**

```
FAILED test/test_ci_surface_tests.py::test_backend_roots_cover_every_configured_testpath
  UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 514
```

**Green-after, same host, same command:** 2 passed (the repaired test plus the new
guard). Whole module: 45 passed, 1 failed — and that one failure,
`test_explicit_cli_target_bypasses_collect_ignore`
(`AssertionError: recursive collection should honour collect_ignore`), **reproduces
identically on pristine `origin/main` with this branch's changes reverted**, so it
is inherited by this environment and not attributable to this diff.

**The honest limit of the red-before:** the defect is host-conditioned. On a UTF-8
runner the repaired test passes before and after, because
`locale.getpreferredencoding()` already returns UTF-8 there. CI therefore cannot
show this one going red. That is exactly why the second test exists: its three
assertions — non-ASCII present, undecodable under `cp950`, decodable as UTF-8 —
hold on every host, so if `setup.cfg` ever becomes pure ASCII the guard fails
loudly and can be retired deliberately rather than quietly becoming decoration.

The `cp950` decode is asserted with `pytest.raises(UnicodeDecodeError)` rather
than assumed, so the guard cannot pass vacuously on a build where those bytes
turned out to be decodable.

**Gates:** `flake8` and `isort --check-only` clean on the changed file.
`scripts/check_black_formatting.py` passes — the file is in the repository's black
baseline (its base revision is already unformatted), so it is deliberately not
reformatted; running `black` on it would bury a 42-line diff under an unrelated
rewrite.

## Manual verification

N/A — unit coverage sufficient: the defect reproduces and is fixed under
`python -m pytest` on the affected host, which is the same command a contributor
would run by hand.

## Related Issues

None. Found while auditing `locale.getpreferredencoding` decode sites for the
failure class `scripts/check_subprocess_encoding.py` guards (#3219 / #3669 /
#5249), for the case where that decode is reached through a file read rather than
a subprocess pipe.

**File-level overlap, disclosed:** open PR #9223 (`feat(aws-control): the crew
container image and its runtime`) also edits this file. The hunks are disjoint —
#9223 touches the imports, a reformat around line 318, and
`test_explicit_cli_target_bypasses_collect_ignore` around line 438; this PR
touches the `setup.cfg` read around line 134 and adds a test beside it. Whichever
lands second should need only a line-offset rebase. Worth noting that #9223's own
hunk at line 318 already reads with `read_text(encoding="utf-8")`, which is the
same discipline this PR applies to the one site in the module that still lacked
it.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **a missing `encoding=` is only latent until you can name a writer that
emits non-ASCII.** Most of this repository's unpinned reads are genuinely harmless
because `json.dumps` defaults to `ensure_ascii=True`, so the bytes on disk are
ASCII whatever the code page. The way to tell a real one from a theoretical one is
not to count call sites — it is to open the target file and look for a byte above
`0x7F`. Here there were 48 of them, committed, in `setup.cfg`.

Second lesson, about where these hide: **a test that dies before its assertion is
a guard that is not running.** The visible symptom was a red suite; the invisible
one was that a contract test against "tests that silently never run" was itself
silently not running. When triaging a decode error inside a test, ask what that
test was supposed to be checking before deciding the failure is cosmetic.

Third, for review prompts: **an existing gate marks a class the project has
already agreed is real, and its scope boundary is where the next bug lives.** The
subprocess encoding gate exists because this exact decode reached users. Its
edge — file reads — is where this one was.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
