### PR TITLE
fix(auto-research): write campaign text as utf-8, not the host code page

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -578,6 +578,47 @@ def _campaign_dir(campaign_id: str) -> Path:
     return d
 
 
+def _read_campaign_text(path: Path) -> str:
+    """Read campaign prose as UTF-8, without inferring what wrote anything else.
+
+    UTF-8 is the contract: every writer in this module pins it, and in agent
+    mode `FINDINGS.md` is written by the research agent, whose encoding this
+    code has never controlled. A campaign created BEFORE the pin was written
+    with ``locale.getpreferredencoding()``, so on a CJK Windows host its
+    findings may be sitting there in the legacy code page. A strict UTF-8 read
+    would raise ``UnicodeDecodeError`` on it and turn an upgrade into a
+    permanent HTTP 500 on report, fork, export and the knowledge route, so the
+    read must not raise.
+
+    It must also not GUESS. Decoding UTF-8 and retrying with the host code page
+    treats a successful decode as provenance, and it is not one: cp950 ``癒`` is
+    the bytes ``c2 a1``, which are equally valid UTF-8 for ``¡`` -- 899 cp950
+    multi-byte characters have that property -- so a legacy report could be
+    served, and copied into a fork, as Latin mojibake with nothing raised. It
+    would also read provenance out of ambient state, applying the READING host's
+    code page to a file some other host wrote.
+
+    Nothing on disk can break that tie: a campaign directory carries no format
+    or version marker, `status.json` has no schema version, and the campaign row
+    records no writer generation. So the codec is not chosen by trial.
+    ``latin-1`` is total (never raises) and lossless, so a pre-pin file still
+    renders and its characters stay recoverable from the string -- byte-exact up
+    to the universal-newline translation both reads apply, which folds ``\r\n``
+    to ``\n`` and changes nothing else. That is the contract this repository
+    already uses for text of unknown provenance; see
+    ``kiro_crew.knowledge.readers._decode_text_bytes``.
+
+    Nothing here writes. A read path that repairs its own input is how the
+    original bytes stop existing, and on a directory the research agent owns it
+    is also how viewing a report becomes a write primitive. The cost is one
+    extra open on a legacy file, on a route a human triggers.
+    """
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="latin-1")
+
+
 def _read_text_or_missing(path: Path) -> str | None:
     """Read *path*, or return ``None`` when it does not exist.
 
@@ -588,7 +629,7 @@ def _read_text_or_missing(path: Path) -> str | None:
     downgraded to "no findings yet".
     """
     try:
-        return path.read_text()
+        return _read_campaign_text(path)
     except FileNotFoundError:
         return None
 
@@ -613,7 +654,7 @@ def _write_text(path: Path, text: str) -> None:
     campaign deletion must keep winning (recreating the directory here would
     resurrect a deleted campaign's data).
     """
-    path.write_text(text)
+    path.write_text(text, encoding="utf-8")
 
 
 def _write_new_cycle_files(pending: list[tuple[Path, str]]) -> bool:
@@ -628,7 +669,7 @@ def _write_new_cycle_files(pending: list[tuple[Path, str]]) -> bool:
         if fpath.exists():
             continue
         fpath.parent.mkdir(parents=True, exist_ok=True)
-        fpath.write_text(text)
+        fpath.write_text(text, encoding="utf-8")
         wrote = True
     return wrote
 
@@ -637,10 +678,10 @@ def _copy_parent_findings(src: Path, dst: Path) -> None:
     """Seed a forked campaign with its parent's findings. Blocking; call off-loop."""
     dst.parent.mkdir(parents=True, exist_ok=True)
     try:
-        content = src.read_text()
+        content = _read_campaign_text(src)
     except FileNotFoundError:
         return
-    dst.write_text(content)
+    dst.write_text(content, encoding="utf-8")
 
 
 def _unlink_if_present(path: Path) -> bool:
@@ -685,7 +726,7 @@ def write_guidance(campaign_id: str, text: str) -> None:
     if not _validate_campaign_id(campaign_id):
         return
     d = _campaign_dir(campaign_id)
-    (d / "guidance.txt").write_text(text)
+    (d / "guidance.txt").write_text(text, encoding="utf-8")
 
 
 def get_findings(campaign_id: str) -> list[dict]:
@@ -1973,7 +2014,7 @@ def _write_brief(cid: str, row: Any) -> None:
             "Wait for all completion events, then synthesize results into your cycle finding. "
             f"If fewer than {pw} sub-questions remain open, spawn only as many as needed.",
         ]
-    _campaign_dir(cid).joinpath("brief.md").write_text("\n".join(lines))
+    _campaign_dir(cid).joinpath("brief.md").write_text("\n".join(lines), encoding="utf-8")
 
 
 # --- RL v2: recursive exploration (emergent sub-questions) ---
@@ -2818,7 +2859,7 @@ def _read_report(campaign_id: str) -> str:
         return ""
     p = d / "FINDINGS.md"
     try:
-        return p.read_text() if p.exists() else ""
+        return _read_campaign_text(p) if p.exists() else ""
     except OSError:
         return ""
 
@@ -2831,7 +2872,7 @@ async def _handle_report(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     _audit("campaign_report", cid)
     # FINDINGS.md is agent-authored — redact before serving to the dashboard.
-    report = _redact_finding({"v": _read_report(cid)})["v"]
+    report = _redact_finding({"v": await asyncio.to_thread(_read_report, cid)})["v"]
     return web.json_response({"report": report})
 
 

--- a/test/test_auto_research_onloop_fs.py
+++ b/test/test_auto_research_onloop_fs.py
@@ -396,3 +396,173 @@ class TestCancellationSettlesWorker:
         )
         assert result == 42
         assert observed == [], "on_settled must not fire on the uncancelled path"
+
+
+class TestCampaignTextIsUtf8NotTheHostCodePage:
+    """Research prose is written and read as UTF-8, whatever the host code page.
+
+    The same reasoning this module opens with: ``FINDINGS.md`` is the report an
+    LLM research loop produces, so its content is bounded by the model's output
+    and not by anything this code controls. A model routinely emits characters
+    the host's legacy ANSI code page cannot represent -- an emoji is the common
+    one. ``Path.write_text`` with no ``encoding`` encodes with
+    ``locale.getpreferredencoding()``, which is UTF-8 on POSIX but the ANSI code
+    page on Windows, so on a CJK Windows host that write raises
+    ``UnicodeEncodeError`` and the cycle's finding is lost rather than saved.
+
+    Measured on a `cp950` host before the fix, calling these very helpers:
+
+        _write_text             UnicodeEncodeError: 'cp950' codec can't encode
+                                character '\\U0001f600'
+        _write_new_cycle_files  UnicodeEncodeError: ... same
+
+    The bug is host-conditioned, so a UTF-8 CI runner cannot make it fail. What
+    IS checkable everywhere is the property that fixes it: the bytes on disk are
+    UTF-8, chosen by this code, rather than whatever the host would have picked.
+    That is what these assert, so the guard holds on the runners too.
+
+    The JSON paths in this module are deliberately NOT covered here:
+    ``json.dumps`` defaults to ``ensure_ascii=True``, so those files are pure
+    ASCII and decode identically under every code page. Pinning them would be
+    noise.
+    """
+
+    #: A finding shaped like real model output: an emoji (outside every legacy
+    #: ANSI code page), an em dash and CJK (inside some, outside others).
+    FINDING = "Cycle 1 \U0001f600 adoption — up 12% 已完成"
+
+    def _campaign(self, tmp_path: Path, name: str = "aaaa0100") -> Path:
+        d = tmp_path / name
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_write_text_encodes_utf8(self, tmp_path: Path) -> None:
+        target = self._campaign(tmp_path) / "FINDINGS.md"
+        h._write_text(target, self.FINDING)
+        assert target.read_bytes() == self.FINDING.encode("utf-8")
+
+    def test_new_cycle_files_encode_utf8(self, tmp_path: Path) -> None:
+        target = self._campaign(tmp_path) / "cycle-1.md"
+        assert h._write_new_cycle_files([(target, self.FINDING)]) is True
+        assert target.read_bytes() == self.FINDING.encode("utf-8")
+
+    def test_findings_survive_a_fork_round_trip(self, tmp_path: Path) -> None:
+        """The fork path reads a parent's findings and writes them straight back.
+
+        Read and write must agree; a decode-then-encode through two different
+        code pages is how a forked campaign silently inherits mojibake.
+        """
+        src = self._campaign(tmp_path, "aaaa0101") / "FINDINGS.md"
+        src.write_bytes(self.FINDING.encode("utf-8"))
+        dst = self._campaign(tmp_path, "aaaa0102") / "FINDINGS.md"
+
+        h._copy_parent_findings(src, dst)
+
+        assert dst.read_bytes() == self.FINDING.encode("utf-8")
+        assert h._read_text_or_missing(dst) == self.FINDING
+
+    def test_the_guard_can_actually_fail(self) -> None:
+        """Guard the guard: the fixture really does defeat a legacy code page.
+
+        Without this, every assertion above would pass just as happily on a
+        payload that was ASCII all along, and would be pinning nothing.
+        """
+        with pytest.raises(UnicodeEncodeError):
+            self.FINDING.encode("cp950")
+        assert self.FINDING.encode("utf-8").decode("utf-8") == self.FINDING
+
+    def test_a_legacy_code_page_campaign_reads_back_recoverable(self, tmp_path: Path) -> None:
+        """A campaign written BEFORE the encoding was pinned must not 500.
+
+        Its `FINDINGS.md` is sitting on disk in the host code page, so a strict
+        UTF-8 read would raise and make every report/fork/export route fail for
+        good. Nothing on disk records which code page that was, so the read does
+        not pick one: it decodes ``latin-1``, which never raises and maps every
+        byte to the code point of the same value. The report therefore renders,
+        the file is untouched, and the original bytes are recoverable from the
+        string -- byte-exact up to the universal-newline translation text mode
+        applies, which is stated rather than glossed, and is why the fixture
+        carries a ``\r\n``.
+        """
+        raw = "Old finding - 已完成\r\nsecond line".encode("cp950")
+        target = self._campaign(tmp_path) / "FINDINGS.md"
+        target.write_bytes(raw)
+        with pytest.raises(UnicodeDecodeError):
+            raw.decode("utf-8")  # guard the guard: the non-UTF-8 branch is reached
+        assert b"\r\n" in raw  # ... and the newline fold is genuinely exercised
+
+        out = h._read_text_or_missing(target)
+
+        assert out is not None
+        assert out.encode("latin-1") == raw.replace(b"\r\n", b"\n")
+        assert target.read_bytes() == raw, "reading a report must not rewrite it"
+
+    def test_bytes_valid_under_both_decodings_resolve_to_the_declared_contract(
+        self, tmp_path: Path
+    ) -> None:
+        """The ambiguous case: bytes that decode successfully under BOTH candidates.
+
+        cp950 ``癒`` is the two bytes ``c2 a1``, and those same bytes are valid
+        UTF-8 for ``¡``; 899 cp950 multi-byte characters have that property. A
+        read that chose its codec by trying the host code page could not tell
+        the two apart, because a decode succeeding is not evidence of what wrote
+        the file -- and no marker, version or writer generation is stored
+        anywhere in a campaign directory to break the tie.
+
+        So the tie is not broken by inspection. UTF-8 is the declared contract
+        for campaign prose, these bytes are read as UTF-8, and that answer is
+        the same on every host whatever its code page happens to be.
+        """
+        raw = "癒".encode("cp950")
+        assert raw == b"\xc2\xa1"
+        assert raw.decode("utf-8") == "\u00a1"  # guard the guard: genuinely ambiguous
+        target = self._campaign(tmp_path) / "FINDINGS.md"
+        target.write_bytes(raw)
+
+        assert h._read_text_or_missing(target) == "\u00a1"
+        assert target.read_bytes() == raw, "reading a report must not rewrite it"
+
+    def test_the_read_never_consults_the_host_code_page(self) -> None:
+        """Ratchet: a code-page probe must not come back into this read path.
+
+        Picking the host codec assumes the READING host wrote the file. It need
+        not have: a campaign directory can be copied or restored between
+        machines, and a host's code page can change under a campaign that never
+        moved. That assumption makes one directory decode differently in two
+        places, which is a worse contract than a render that is uniformly
+        latin-1 and uniformly reversible.
+        """
+        assert not hasattr(h, "locale"), "handlers imports a host-code-page probe again"
+        source = inspect.getsource(h._read_campaign_text)
+        assert "getpreferredencoding" not in source.split('"""')[-1]
+
+    def test_an_undecodable_file_degrades_without_destroying_it(self, tmp_path: Path) -> None:
+        """Bytes no candidate decoding claims must not become an HTTP 500.
+
+        They must also survive: ``errors="replace"`` throws away exactly the
+        bytes a later correct migration would need, so a decode that dropped
+        them would make the damage permanent on the one file that still had the
+        original.
+        """
+        raw = b"\xff\xfe\x00 broken \xf0\x28\x8c\x28"
+        target = self._campaign(tmp_path) / "FINDINGS.md"
+        target.write_bytes(raw)
+
+        out = h._read_text_or_missing(target)
+
+        assert out is not None and "broken" in out
+        assert out.encode("latin-1") == raw
+        assert target.read_bytes() == raw, "a lossy decode must not be persisted"
+
+    def test_a_crlf_findings_file_still_comes_back_with_newlines(self, tmp_path: Path) -> None:
+        """Text mode's universal-newline translation is load-bearing here.
+
+        Two tests in this tree compare a findings file's contents after a fork,
+        so a read that returned ``\r\n`` would shift them. Both the UTF-8 read
+        and the legacy fallback stay in text mode, which is what keeps this
+        free.
+        """
+        target = self._campaign(tmp_path) / "FINDINGS.md"
+        target.write_bytes(b"line one\r\nline two\r\n")
+
+        assert h._read_text_or_missing(target) == "line one\nline two\n"


### PR DESCRIPTION
## Problem / Motivation

`auto_research` writes the prose an LLM research loop produces — `FINDINGS.md`,
the per-cycle files, `guidance.txt`, `brief.md` — with `Path.write_text` and no
`encoding`:

```python
def _write_text(path: Path, text: str) -> None:
    path.write_text(text)
```

`write_text` with no encoding encodes with `locale.getpreferredencoding()`: UTF-8
on POSIX, but the legacy **ANSI code page** on Windows. The content of these files
is bounded by the model's output and by nothing this code controls — the module's
own test file already says exactly that about `FINDINGS.md`.

A model routinely emits characters that code page cannot represent. **An emoji
does not degrade to a placeholder; it raises.** Measured on a `cp950` host by
calling these helpers directly with a realistic finding:

```
_write_text             UnicodeEncodeError: 'cp950' codec can't encode
                        character '\U0001f600' in position 8
_write_new_cycle_files  UnicodeEncodeError: ... same
```

Not everything non-ASCII trips it, which is what makes it look fine until it
isn't — on `cp950` an em dash, curly quotes and Greek all encode successfully
(Big5 covers them) and an emoji does not.

The write is not retried and not caught, so the cycle's finding is lost and the
caller surfaces a 500 for a campaign that otherwise ran correctly.

**The read side has the matching half.** `_copy_parent_findings` seeds a forked
campaign by reading the parent's findings and writing them straight back, both
with the locale codec. A findings file that is UTF-8 on disk — because it was
written on a UTF-8 host, or restored from a backup — makes the fork raise
`UnicodeDecodeError` instead.

## Why it matters

The failure lands after the expensive part. A research cycle has already called
the model and produced its finding; the only thing left is to save it, and that is
the step that raises. There is no retry and no partial write, so the output is
gone and the operator sees a 500 with a codec error naming a character rather than
anything about their campaign.

It is silent in review because it is host-conditioned: on POSIX and on a
UTF-8-code-page Windows box, `locale.getpreferredencoding()` already returns UTF-8
and every one of these calls is correct. Only a CJK Windows host — a large share of
Windows installs — sees it, and the failing character is whatever the model
happened to emit that day.

## What changed (motivation → approach → change)

Root cause: the encoding of a file whose content this process does not control was
left to the host's locale instead of being chosen. The change is scoped to that
and nothing else — **59 changed lines in one production file**, most of them the
reader's docstring.

* **Five free-text writes pin `encoding="utf-8"`** — `_write_text`,
  `_write_new_cycle_files`, `_copy_parent_findings`'s destination,
  `write_guidance`, and the `brief.md` write. UTF-8 is the choice the rest of the
  repository already makes, and it is what these files already are wherever they
  were written on POSIX.
* **The reads that pair with them go through `_read_campaign_text`.** It exists
  for one reason: pinning the reads to UTF-8 would make a campaign created
  *before* the pin — whose findings are sitting on disk in the host code page —
  raise `UnicodeDecodeError` on every report, fork, export and knowledge route,
  turning an upgrade into a permanent HTTP 500. So the read must not raise.

  ```python
  try:
      return path.read_text(encoding="utf-8")
  except UnicodeDecodeError:
      return path.read_text(encoding="latin-1")
  ```

* **It must also not GUESS, and this is the part worth reading.** Retrying with
  `locale.getpreferredencoding()` treats a decode succeeding as evidence of what
  wrote the file. It is not: cp950 `癒` is the bytes `c2 a1`, which are equally
  valid UTF-8 for `¡`. Enumerating the code page gives **899** cp950 multi-byte
  characters with that property, so a legacy report could be served — and copied
  into a fork — as Latin mojibake with nothing raised. That branch would also take
  provenance from ambient state: it applies the **reading** host's code page to a
  file some other host wrote, so one campaign directory decodes differently on two
  machines, or after a locale change on one.

  **Nothing on disk can break that tie, so nothing pretends to.** A campaign
  directory carries no format or version marker, `status.json` has no schema
  version, the campaign row records no writer generation, and in agent mode
  `FINDINGS.md` is written by the research agent itself rather than by this
  process — so even "we pinned our own writer" does not establish the encoding of
  every file on this path. `latin-1` is **total** (never raises) and **lossless**,
  so a pre-pin file still renders, the file is never rewritten, and its characters
  stay recoverable from the string — byte-exact up to the universal-newline
  translation both reads already applied, which folds `\r\n` to `\n` and changes
  nothing else. That is the contract
  `kiro_crew.knowledge.readers._decode_text_bytes` already uses for text of
  unknown provenance.

  **The cost, stated rather than hidden:** a pre-pin campaign whose findings
  really were in the host code page renders as mojibake on that host instead of
  correct text. That population is narrow — pre-pin, the same write raised
  `UnicodeEncodeError` for any character outside the code page, which is the very
  defect this fixes, so the files that survived are the ones that were entirely
  code-page-encodable — and its characters stay recoverable, where a wrong guess
  is not detectable at all.

* **Both reads stay in text mode.** Universal-newline translation is therefore
  unchanged and a CRLF findings file still comes back with `\n`; two tests in the
  tree compare findings contents after a fork and would shift otherwise.
* **Nothing on the read path writes.** No migration, no re-encode of the source,
  no `errors="replace"` landing back on disk. A read path that repairs its own
  input is how the original bytes stop existing.
* **`_handle_report` reads through `asyncio.to_thread`**, matching the export and
  fork siblings that already offload this same unbounded file. This change is what
  can make that read two opens on a legacy campaign, so it is the change's own
  cost being paid off the loop rather than an unrelated tidy-up.

### The JSON boundary, narrowed

**The JSON paths in this module are deliberately NOT changed**, but the rule is
narrower than "JSON is ASCII" and an earlier revision of this description
overstated it. The correct statement is about the **writer**, not the format:

* **Process-written JSON is provably ASCII.** `status.json`, `grill_tree.json`,
  the queue file and the workflow-run file are all written by this process
  through `json.dumps`, which defaults to `ensure_ascii=True`, so their bytes are
  pure ASCII and decode identically under every code page. Pinning those reads
  would add call sites of noise to a diff whose whole claim is "this file can
  contain a character the host cannot encode" — which is not true of them.
  `flag.write_text(str(time.time()))` is left for the same reason.
* **Agent-written JSON is NOT**, and this PR does not fix it. The per-cycle
  finding files, `questions.json` and `emergent_questions.json` are written by the
  research agent, so they are UTF-8 with raw non-ASCII rather than ASCII. Their
  reads use a bare `read_text()` — the locale codec — so on the same CJK Windows
  host this PR targets, they carry the same root cause.

**Which of those reads is actually exposed, measured rather than counted.**
`UnicodeDecodeError` is a `ValueError`, *not* an `OSError`, so it escapes a guard
written as `except (json.JSONDecodeError, OSError)`:

| Site | Guard | `UnicodeDecodeError` |
|---|---|---|
| `check_stagnation` | `(json.JSONDecodeError, OSError)` | **escapes** |
| `_pending_question` | `(json.JSONDecodeError, OSError)` | **escapes** |
| `get_findings` | `(json.JSONDecodeError, OSError)` | **escapes** |
| `_ingest_emergent_questions` | `(json.JSONDecodeError, OSError)` | **escapes** |
| `_read_json_or_missing` | `(OSError, ValueError)` | already caught |
| `_read_finding_file` | names `UnicodeDecodeError` explicitly | already caught |

So four sites are exposed and two are already guarded — and the fact that
`_read_finding_file` names the exception by hand is evidence this class was
already known here.

**All six are pre-existing on `origin/main` and unchanged by this PR**, which
touches no JSON read or write. They are a separate sibling class and are left
unfixed here deliberately: this change is the prose encoding fix, and the point of
its scope reduction was to stop it accumulating adjacent work. `_ingest_emergent_questions`
is the one worth flagging to whoever takes it — it unlinks the file only after a
successful parse, so a raise there re-fires every cycle rather than once.

### Link-following on campaign paths is unchanged, and deliberately so

Everything under a campaign directory is agent-authored, so a planted link at
`FINDINGS.md` or `findings_for_knowledge.md` is a real threat — for both the read
and the write. **This change does not alter that in either direction:** every read
and write here follows links exactly as it does on `origin/main`, and the only
difference in the diff is an `encoding=` keyword.

Earlier revisions of this branch did harden the reads (a no-follow descriptor
read bounded to the research root). That is removed, because it was not free: the
no-follow primitive's 50 MB cap is opt-in truncation, and routing prose reads
through it introduced a *new* silent-corruption surface — a truncated prefix
feeding the fork seed and the knowledge export, and a cap landing inside a UTF-8
character sending the whole retained prefix through the fallback codec. Reviewers
found both, correctly. An encoding fix should not have to carry a preview/security
contract to land, and the riders were generating findings of their own.

**The write side is a real defect on `origin/main` and it should be fixed — in its
own PR.** For whoever takes it, the primitive already exists:
`pinned_fs.write_file_pinned`, which describes itself as *"THE single no-follow
file-publish path"* and keeps its `lstat` refusal of a planted symlink on Windows
too. It is not a drop-in here, and the reason is measured rather than assumed:

```
supports_pinned_walk()                     : False   (Windows)
planted hardlink -> victim file            : SECRET  (refused; the mechanism IS closed)
write into a deleted campaign directory    : parent recreated
```

That last line collides with an existing, test-pinned contract on `main` —
`TestWriteHelperDeletionRace::test_write_text_does_not_resurrect_a_deleted_campaign_dir`,
which names `findings_for_knowledge.md` specifically and requires that a
concurrent campaign deletion win rather than have its directory silently
recreated. Reconciling "never follow a planted link" with "never recreate a
deleted campaign" is a design decision about the write path, not a call-site swap,
and it is not something an encoding fix should decide in passing.

## Tests

Added to `test/test_auto_research_onloop_fs.py` — the module that already guards
this file's filesystem discipline, and which already documents `FINDINGS.md` as
model-sized output.

**Red-before**, production reverted to `origin/main` with the new tests kept, on a
**cp950 host**:

```
FAILED ...::test_write_text_encodes_utf8
  UnicodeEncodeError: 'cp950' codec can't encode character '\U0001f600'
FAILED ...::test_new_cycle_files_encode_utf8
  UnicodeEncodeError: ... same
FAILED ...::test_findings_survive_a_fork_round_trip
  UnicodeDecodeError: 'cp950' codec can't decode byte 0xf0 in position 8
FAILED ...::test_a_legacy_code_page_campaign_reads_back_recoverable
  UnicodeEncodeError: 'latin-1' codec can't encode characters in position 14-16
FAILED ...::test_an_undecodable_file_degrades_without_destroying_it
  UnicodeDecodeError: 'cp950' codec can't decode byte 0xff in position 0
FAILED ...::test_bytes_valid_under_both_decodings_resolve_to_the_declared_contract
FAILED ...::test_the_read_never_consults_the_host_code_page
7 failed, 2 passed
```

**Which of those go red on a UTF-8 CI runner, said plainly.** The original bug is
host-conditioned, so four of them (`write_text_encodes_utf8`,
`new_cycle_files_encode_utf8`, `findings_survive_a_fork_round_trip`,
`bytes_valid_under_both_decodings`) cannot fail where
`locale.getpreferredencoding()` already returns UTF-8. Their assertions are
therefore written as **"the bytes on disk are UTF-8"**, not "the write did not
raise", so they still pin the property everywhere. Three fail on **every** host:
`a_legacy_code_page_campaign_reads_back_recoverable` and
`an_undecodable_file_degrades_without_destroying_it` (a strict UTF-8 read raises
on those bytes wherever it runs), and `the_read_never_consults_the_host_code_page`,
which is a structural ratchet.

The two that pass on both builds do so **by design** and are reported as guards,
not as evidence: `test_the_guard_can_actually_fail` asserts the payload really is
undecodable under `cp950` and clean under UTF-8, so it tests the oracle rather
than the fix; `test_a_crlf_findings_file_still_comes_back_with_newlines` is a
no-regression guard for text mode.

`test_bytes_valid_under_both_decodings_resolve_to_the_declared_contract` is the
ambiguous case itself — `c2 a1`, valid under both candidate decodings — and it
carries its own guard-the-guard (`raw == b"\xc2\xa1"` and
`raw.decode("utf-8") == "¡"`) so it cannot pass on bytes that were never
ambiguous.

`test_the_read_never_consults_the_host_code_page` is a ratchet
(`not hasattr(h, "locale")` plus a source check on the reader), because the only
way to pick the host codec is to assume the reading host wrote the file, and that
assumption cannot come back by accident.

**Green-after:** 21 passed in that module; **254 passed / 9 skipped** across
`test_auto_research.py`, `test_auto_research_onloop_fs.py` and
`test_auto_research_onloop_db.py`.

**Gates:** `flake8` and `isort --check-only` clean; `mypy --platform linux` **0
errors in `handlers.py`**; `scripts/check_black_formatting.py` and
`scripts/check_comment_history.py` both passed, each re-run *after* the commit
because both scope `origin/main...HEAD` and pass vacuously before it exists.

## Manual verification

N/A — unit coverage sufficient: the failure is a codec raise inside two helper
functions, and the tests drive those helpers directly with a payload measured to
defeat the host code page, which is exactly what a manual run would do.

## Related Issues

None. Found while auditing `locale.getpreferredencoding` sites for the failure
class `scripts/check_subprocess_encoding.py` was added for — the same
decode/encode reached through a file read or write rather than a subprocess pipe,
which that gate does not cover.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **an unpinned `encoding=` is only a real defect once you can name a writer
that emits non-ASCII — but "the model wrote it" is always such a writer.** Most
unpinned reads in this repository are genuinely harmless because `json.dumps`
defaults to `ensure_ascii=True`, so the bytes are ASCII whatever the code page.
That is exactly why counting call sites is the wrong triage: the same call is
noise on a JSON file and a data-loss bug on a file an LLM filled. Ask what writes
the file, not how many places read it.

Second: **a partial code page is worse than a missing one.** On `cp950` an em dash
and CJK both encode fine and an emoji does not, so this class survives casual
testing with "some non-ASCII" and fails on the one character nobody tried. Pick
the payload from the *complement* of the host code page, and assert that choice in
the test so it cannot silently become a character the code page happens to cover.

Third, for tests of host-conditioned bugs: **assert the property the fix chooses,
not the symptom the host produces.** "The write did not raise" is untestable on a
runner that never raises. "The bytes on disk are UTF-8" is the same guarantee,
stated so that it holds — and fails — everywhere.

Fourth: **a successful decode is not provenance.** A
`try: decode(A) / except UnicodeDecodeError: decode(B)` chain reads like a
fallback and behaves like a classifier, and it is a *silent* one — the wrong
branch produces plausible text, not an error. Before writing one, ask what on disk
records the encoding. If the answer is "nothing", the honest move is one decoder
plus a total, lossless degradation, so the characters survive for whoever can
decide later. Where the two candidates' domains overlap by hundreds of characters,
as UTF-8 and a DBCS code page do, trial decoding should be a review smell.

Fifth, and the one this PR learned the hard way: **a security rider is not free
just because it is correct.** Hardening the reads here pulled in a no-follow
primitive whose opt-in size cap silently truncated the fork seed and the knowledge
export, and whose cut could land inside a UTF-8 character and mojibake the whole
retained prefix. Both were real findings, and neither existed before the rider
did. When a fix in one dimension needs a contract in another to stay correct, that
is the signal to split the PR, not to keep widening it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — n/a, no user-facing docs cover campaign file encoding
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

