### PR TITLE
fix(mcp): expand header value references in the remote probe

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -284,7 +284,6 @@ src/kiro_crew/knowledge/watcher.py
 src/kiro_crew/mcp_apps_render.py
 src/kiro_crew/mcp_caller.py
 src/kiro_crew/mcp_cleanup.py
-src/kiro_crew/mcp_discovery.py
 src/kiro_crew/mcp_gateway/abort.py
 src/kiro_crew/mcp_gateway/app_call.py
 src/kiro_crew/mcp_gateway/apps.py
@@ -805,7 +804,6 @@ test/test_mcp_cron_persistent_session.py
 test/test_mcp_cron_security.py
 test/test_mcp_custom_api.py
 test/test_mcp_dashboard_registration.py
-test/test_mcp_discovery.py
 test/test_mcp_gateway_apps_spool.py
 test/test_mcp_gateway_backend_coverage.py
 test/test_mcp_gateway_claim.py

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -282,9 +282,21 @@ Probes run from `POST /api/mcp/probe`:
   excluded from the shared per-name probe cache, because a synthetic-identity
   handshake is a diagnostic and not the canonical observation the dashboard
   renders.
+- Remote header VALUES may carry `${VAR}`/`${env:VAR}` references — the
+  documented config form kiro-cli resolves at session runtime. The probe
+  resolves them through the gateway rewriter's declared-env expander
+  (`mcp_gateway.rewriter._expand_env_placeholders`): same regex, same
+  credential-filtered source view, and an unresolved reference stays literal —
+  so the probe presents the credential a session presents instead of sending
+  the reference as text and reporting the server's correct rejection as a
+  failing row. Probe-error redaction keys on the resolved values the probe
+  actually sent.
 - A remote server that answers the handshake with `401` — or with `403` carrying a
-  `WWW-Authenticate` challenge — and whose config has no static `Authorization`
-  header gets status `needs_auth` and an empty `error`, not `error`. The probe
+  `WWW-Authenticate` challenge — and whose sent headers carry no static
+  `Authorization` credential gets status `needs_auth` and an empty `error`, not
+  `error`. An `Authorization` value still carrying an unresolved `${VAR}`
+  reference (a missing or credential-filtered variable) supplied nothing, so it
+  does not count as a static credential here. The probe
   holds no OAuth token, because kiro-cli owns token custody
   ([design-notes/mcp-oauth-ownership.md](design-notes/mcp-oauth-ownership.md)), so
   the status code alone carries no verdict on the server: an unauthorized server

--- a/docs/guides/connecting-remote-oauth-mcp-server.md
+++ b/docs/guides/connecting-remote-oauth-mcp-server.md
@@ -303,12 +303,16 @@ static bearer token directly on the server config:
 { "url": "https://mcp.example.com/", "headers": { "Authorization": "Bearer ${TOKEN}" } }
 ```
 
-This **bypasses OAuth entirely**: the probe reads and sends the header on the
-handshake (`mcp_discovery.py`), so no browser flow happens. The failure modes
-differ accordingly — a `401` on an entry that **carries** a static
-`Authorization` header stays a hard `error` (a supplied credential was
-rejected), whereas a `401` on an entry with **no** static header is the
-`needs_auth` / "Sign-in required" path described above.
+This **bypasses OAuth entirely**: the probe resolves any `${VAR}`/`${env:VAR}`
+reference in the header value (the same credential-filtered expansion the
+gateway applies to declared env — an unresolved reference stays literal) and
+sends the result on the handshake (`mcp_discovery.py`), so no browser flow
+happens. The failure modes differ accordingly — a `401` on an entry whose sent
+`Authorization` header carried a real, resolved credential stays a hard `error`
+(a supplied credential was rejected), whereas a `401` on an entry with **no**
+static header — or one whose reference did not resolve, because a missing or
+credential-filtered variable supplies nothing — is the `needs_auth` /
+"Sign-in required" path described above.
 
 For an OAuth server, an optional internal `scopes` list maps to the wire
 `oauthScopes` field (`mcp_utils._wire_scopes`). It is all-or-nothing: the field

--- a/docs/system-specs/modules/connections.md
+++ b/docs/system-specs/modules/connections.md
@@ -49,9 +49,11 @@ left literal for kiro-cli parity. So a header that authenticates in a session
 authenticates in the probe. A still-unresolved reference is **not a supplied
 credential**: a 401 against it reports `needs_auth` rather than a
 rejected-credential error whose remediation advice would be to delete a working
-header. Probe-error redaction keys on the values the probe actually sent, so an
-error echoing a *resolved* secret is scrubbed by the exact-value layer, not
-left to the generic credential-shaped scanners alone.
+header. Probe-error redaction keys on the values the probe actually sent —
+including each individually resolved placeholder value, since a partially
+expanded header (`${TOKEN}${MISSING}`) sends a value a server can echo only a
+fragment of — so an error echoing a *resolved* secret is scrubbed by the
+exact-value layer, not left to the generic credential-shaped scanners alone.
 
 `GET /api/connections/status` answers the authorization axis only. It reports
 `grantPresent` — a local, network-free stat of kiro-cli's OAuth artifact

--- a/docs/system-specs/modules/connections.md
+++ b/docs/system-specs/modules/connections.md
@@ -37,6 +37,22 @@ banner here. Reachability alone cannot separate them, which is why a provider
 with no token file could wear a Connected badge and an authorized one could sit
 on "not verified".
 
+**Static-header entries: the reachability probe presents what the runtime
+presents.** A remote entry may authorize with a static header whose value
+carries a `${VAR}`/`${env:VAR}` reference — a documented config form kiro-cli
+resolves at session runtime. The `/api/mcp` probe resolves those references
+through the gateway rewriter's declared-env expander
+(`mcp_gateway.rewriter._expand_env_placeholders`): same regex, same
+credential-filtered source view (`is_secret_env_key`, `is_credential_env_key`
+and `scrub_agent_denied_env` names are misses), and an unresolved reference is
+left literal for kiro-cli parity. So a header that authenticates in a session
+authenticates in the probe. A still-unresolved reference is **not a supplied
+credential**: a 401 against it reports `needs_auth` rather than a
+rejected-credential error whose remediation advice would be to delete a working
+header. Probe-error redaction keys on the values the probe actually sent, so an
+error echoing a *resolved* secret is scrubbed by the exact-value layer, not
+left to the generic credential-shaped scanners alone.
+
 `GET /api/connections/status` answers the authorization axis only. It reports
 `grantPresent` — a local, network-free stat of kiro-cli's OAuth artifact
 directory (the paired token + registration files; presence only, the bytes are

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -444,11 +444,9 @@ def _cache_probe(server: McpServerInfo) -> None:
     _probe_cache[server.name] = _ProbeResult(
         status=server.status,
         tools=list(server.tools),
-        error=redact_mcp_error(server.error, server.headers),
+        error=redact_mcp_error(server.error, server.redaction_headers),
         probed_at=time.monotonic(),
-        capabilities=(
-            dict(server.capabilities) if isinstance(server.capabilities, dict) else None
-        ),
+        capabilities=(dict(server.capabilities) if isinstance(server.capabilities, dict) else None),
         protocol_version=server.protocol_version,
         server_info=dict(server.server_info),
         tool_annotations=[dict(a) for a in server.tool_annotations],
@@ -493,9 +491,7 @@ def _mcp_credential_token_pattern(value: str) -> str:
         try:
             # "%(?:25)*XX" per byte: a literal %XX, or the same escape with its
             # percent sign re-encoded one or more times (%25XX, %2525XX, ...).
-            alternatives.append(
-                "".join(f"%(?:25)*{byte:02X}" for byte in char.encode("utf-8"))
-            )
+            alternatives.append("".join(f"%(?:25)*{byte:02X}" for byte in char.encode("utf-8")))
         except UnicodeEncodeError:
             # A lone surrogate (JSON permits unpaired \uD800 escapes) has no
             # UTF-8 spelling; keep the literal alternative so building the
@@ -516,11 +512,7 @@ def redact_mcp_headers(headers: object) -> dict[str, str]:
     """
     if not isinstance(headers, dict):
         return {}
-    return {
-        name: MCP_REDACTED_HEADER_VALUE
-        for name in headers
-        if isinstance(name, str)
-    }
+    return {name: MCP_REDACTED_HEADER_VALUE for name in headers if isinstance(name, str)}
 
 
 def redact_mcp_error(error: object, headers: object) -> str:
@@ -562,9 +554,7 @@ def redact_mcp_error(error: object, headers: object) -> str:
         if match:
             credential = match.group(1).strip()
             if len(credential) >= _MCP_CREDENTIAL_SUFFIX_MIN_LENGTH:
-                needs_boundary = (
-                    len(credential) < _MCP_CREDENTIAL_UNANCHORED_MIN_LENGTH
-                )
+                needs_boundary = len(credential) < _MCP_CREDENTIAL_UNANCHORED_MIN_LENGTH
                 values.setdefault(credential, needs_boundary)
 
     if not values:
@@ -601,6 +591,14 @@ class McpServerInfo:
     env: dict[str, str] = field(default_factory=dict)
     url: str = ""
     headers: dict[str, str] = field(default_factory=dict)
+    # The header map the probe actually SENT: config values with ${VAR}/${env:VAR}
+    # references resolved (see :func:`_expand_header_placeholders`). ``None``
+    # until a remote probe runs. Redaction keys on these — an error echoing the
+    # RESOLVED secret carries bytes the configured map never held, and
+    # ``redact_mcp_error``'s layer-2 scrubber matches exact values. Never
+    # serialized: ``to_dict``'s headers block goes through ``redact_mcp_headers``,
+    # which is name-keyed and value-independent.
+    sent_headers: dict[str, str] | None = None
     # Remote-only OAuth hints carried verbatim to the runtime, which owns the
     # authorization exchange. Kiro Crew never enforces scopes and never registers
     # a client — it only refuses to lose these fields while syncing.
@@ -669,6 +667,18 @@ class McpServerInfo:
         """True for Streamable HTTP servers (url-based, no command)."""
         return bool(self.url) and not self.command
 
+    @property
+    def redaction_headers(self) -> dict[str, str]:
+        """The value set a probe error could echo, for ``redact_mcp_error``.
+
+        The headers actually sent when the probe expanded references, else the
+        configured map. The sent map is the COMPLETE scrub set: any configured
+        value that differs post-expansion never left the process unexpanded,
+        so a remote server can only echo the resolved spelling — and a value
+        the expansion left alone is byte-identical in both maps.
+        """
+        return self.headers if self.sent_headers is None else self.sent_headers
+
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
             "name": self.name,
@@ -676,7 +686,7 @@ class McpServerInfo:
             "args": self.args or [],
             "status": self.status,
             "tools": self.tools,
-            "error": redact_mcp_error(self.error, self.headers),
+            "error": redact_mcp_error(self.error, self.redaction_headers),
             "source": self.source,
             "presence": dict(self.presence),
             "probeMode": self.probe_mode,
@@ -1010,9 +1020,7 @@ _MANAGED_SERVERS_CALLER_AWARE: frozenset[str] = frozenset(
 #: therefore safe to classify shareable regardless of the daemon's generation.
 #: ``test_mcp_managed_caller_identity.py`` pins this so the entry can neither
 #: silently persist past its reason nor silently widen.
-_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD: frozenset[str] = frozenset(
-    {"kirocrew-computer"}
-)
+_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD: frozenset[str] = frozenset({"kirocrew-computer"})
 
 
 def managed_server_is_session_bound(name: str) -> bool:
@@ -1381,6 +1389,49 @@ async def _read_jsonrpc_response(resp: aiohttp.ClientResponse) -> dict:
     return await resp.json()
 
 
+def _expand_header_placeholders(headers: Mapping[str, str]) -> dict[str, str]:
+    """Resolve ``${VAR}`` / ``${env:VAR}`` references in remote-probe header values.
+
+    A static header whose value carries a runtime reference is a documented
+    form (docs/reference/kiro-cli/mcp/configuration.md) that kiro-cli expands
+    at session runtime. Sending the reference as literal text gets the server's
+    correct rejection reported as a failing row — with advice to delete a
+    header that works in every session (issue #9206).
+
+    Delegates to the mcp_gateway rewriter's declared-env expander — same regex,
+    same credential-filtered source view (``is_secret_env_key`` /
+    ``is_credential_env_key`` / ``scrub_agent_denied_env`` names are misses),
+    same "unresolved stays literal" kiro-cli parity — rather than duplicating
+    the policy here: two copies of a credential filter is the drift
+    ``is_secret_env_key``'s own docstring warns against. The import is
+    function-local because ``mcp_gateway.preflight`` / ``evaluate`` import this
+    module at module scope; keeping the rewriter off this module's import graph
+    avoids handing every consumer that never probes the rewriter's imports.
+    """
+    from kiro_crew.mcp_gateway.rewriter import (
+        _expand_env_placeholders,
+        _placeholder_source_env,
+    )
+
+    source = _placeholder_source_env()
+    return {
+        name: (_expand_env_placeholders(value, source=source) if isinstance(value, str) else value)
+        for name, value in headers.items()
+    }
+
+
+def _header_reference_unresolved(value: object) -> bool:
+    """True when a header value still carries a ``${VAR}`` reference.
+
+    After :func:`_expand_header_placeholders` this means the variable was
+    missing or credential-filtered — either way nothing was dereferenced, so
+    the value is not a credential anything supplied.
+    """
+    from kiro_crew.mcp_gateway.rewriter import _ENV_VAR_PLACEHOLDER
+
+    return isinstance(value, str) and _ENV_VAR_PLACEHOLDER.search(value) is not None
+
+
 def _needs_authorization(
     status_code: int, resp_headers: Mapping[str, str], sent_headers: Mapping[str, str]
 ) -> bool:
@@ -1392,8 +1443,15 @@ def _needs_authorization(
 
     A static ``Authorization`` header in the config is a different case: the
     caller supplied a credential and it was rejected, which is a real error.
+    That premise requires a credential to actually have been supplied — an
+    Authorization value still carrying an unresolved ``${VAR}`` reference
+    (a missing or credential-filtered variable, sent as literal text) supplied
+    nothing, so it does not suppress ``needs_auth``.
     """
-    if any(k.lower() == "authorization" for k in sent_headers):
+    if any(
+        k.lower() == "authorization" and not _header_reference_unresolved(v)
+        for k, v in sent_headers.items()
+    ):
         return False
     if status_code == 401:
         return True
@@ -1510,8 +1568,13 @@ async def _probe_remote(server: McpServerInfo) -> McpServerInfo:
                 "clientInfo": {"name": "kirocrew-probe", "version": "1.0.0"},
             },
         }
+        # Resolve ${VAR}/${env:VAR} references in header VALUES so the probe
+        # presents the same credential the session runtime presents. Stored on
+        # the row because redaction must key on the values that actually left
+        # the process (see McpServerInfo.redaction_headers).
+        server.sent_headers = _expand_header_placeholders(server.headers)
         hdrs = {
-            **server.headers,
+            **server.sent_headers,
             "Content-Type": "application/json",
             "Accept": "application/json, text/event-stream",
         }
@@ -1527,7 +1590,7 @@ async def _probe_remote(server: McpServerInfo) -> McpServerInfo:
                     server.auth_challenge = _is_bearer_challenge(
                         resp.headers.get("WWW-Authenticate", "")
                     )
-                    if _needs_authorization(resp.status, resp.headers, server.headers):
+                    if _needs_authorization(resp.status, resp.headers, server.sent_headers):
                         # A remote OAuth server answers a tokenless probe with
                         # 401 (or 403 + WWW-Authenticate). That is the expected
                         # reply, not a fault: the kiro-cli runtime holds the
@@ -1613,9 +1676,7 @@ async def _probe_remote(server: McpServerInfo) -> McpServerInfo:
                     _cache_probe(server)
                     return server
                 server.tools = [
-                    name
-                    for t in tools_data
-                    if isinstance(t, dict) and (name := t.get("name", ""))
+                    name for t in tools_data if isinstance(t, dict) and (name := t.get("name", ""))
                 ]
 
         server.status = "ok"
@@ -1801,11 +1862,7 @@ async def probe_server(
         # keys must not pass through — they would execute before confinement
         # exists. See env.sanitize_spec_env; _note_denied_env explains a
         # resulting failure to the dashboard reader.
-        env.update(
-            sanitize_spec_env(
-                (k, v) for k, v in server.env.items() if k != _path_key
-            )
-        )
+        env.update(sanitize_spec_env((k, v) for k, v in server.env.items() if k != _path_key))
 
         # Resolve command to absolute path using the merged env PATH
         effective_path = env.get("PATH") or ""
@@ -1871,9 +1928,7 @@ async def probe_server(
         # case-insensitively (Windows env keys are case-insensitive and the
         # sanitized spec preserves the author's spelling).
         _declared_temp_upper = {
-            key.upper()
-            for key in (server.env or {})
-            if key.upper() in ("TMPDIR", "TMP", "TEMP")
+            key.upper() for key in (server.env or {}) if key.upper() in ("TMPDIR", "TMP", "TEMP")
         }
         probe_scratch: "Path | None" = None
         if not _declared_temp_upper:
@@ -1906,9 +1961,7 @@ async def probe_server(
             mode="standard",
             env=env,
             strip_python_env=True,
-            extra_writable_dirs=(
-                (str(probe_scratch),) if probe_scratch is not None else ()
-            ),
+            extra_writable_dirs=((str(probe_scratch),) if probe_scratch is not None else ()),
             first_party_fixed_argv=_is_first_party_managed_argv(
                 server.name, server.command, server.args or [], server.env or {}
             ),
@@ -1930,10 +1983,7 @@ async def probe_server(
                 env = {
                     key: value
                     for key, value in env.items()
-                    if not (
-                        key in ("TMPDIR", "TMP", "TEMP")
-                        and key not in _declared_temp_upper
-                    )
+                    if not (key in ("TMPDIR", "TMP", "TEMP") and key not in _declared_temp_upper)
                 }
         except Exception:
             logger.debug("probe temp containment unavailable", exc_info=True)
@@ -1984,9 +2034,11 @@ async def probe_server(
                     "params": {
                         "protocolVersion": "2024-11-05",
                         "capabilities": {},
-                        "clientInfo": dict(client_info)
-                        if client_info
-                        else {"name": "kirocrew-probe", "version": "1.0.0"},
+                        "clientInfo": (
+                            dict(client_info)
+                            if client_info
+                            else {"name": "kirocrew-probe", "version": "1.0.0"}
+                        ),
                     },
                 }
             )
@@ -2296,7 +2348,9 @@ async def probe_server(
                 except (ProcessLookupError, OSError):
                     logger.debug(
                         "Probe tree reap failed for %s (pid %s)",
-                        server.name, probe_pid, exc_info=True,
+                        server.name,
+                        probe_pid,
+                        exc_info=True,
                     )
         if sandbox_cleanup:
             Path(sandbox_cleanup).unlink(missing_ok=True)
@@ -2440,7 +2494,11 @@ def _commands_diverged(source_cmd: str, agent_cmd: str) -> bool:
     # Two RESOLVED paths for one binary, differing only in separator flavour or
     # case (``C:\tools\srv.exe`` vs ``C:/Tools/SRV.exe``). Windows itself treats
     # those as the same file, so comparing the strings re-syncs forever.
-    if platform_compat.IS_WINDOWS and _names_a_location(source_cmd) and _names_a_location(agent_cmd):
+    if (
+        platform_compat.IS_WINDOWS
+        and _names_a_location(source_cmd)
+        and _names_a_location(agent_cmd)
+    ):
         if ntpath.normcase(ntpath.normpath(source_cmd)) == ntpath.normcase(
             ntpath.normpath(agent_cmd)
         ):
@@ -2713,9 +2771,7 @@ def kirocrew_managed_names() -> set[str]:
     """
     by_source = _load_mcp_json_by_source()
     return {
-        name
-        for name, spec in by_source.get(SCOPE_KIROCREW, {}).items()
-        if isinstance(spec, dict)
+        name for name, spec in by_source.get(SCOPE_KIROCREW, {}).items() if isinstance(spec, dict)
     }
 
 

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -22,7 +22,7 @@ import shutil
 import signal
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -444,7 +444,9 @@ def _cache_probe(server: McpServerInfo) -> None:
     _probe_cache[server.name] = _ProbeResult(
         status=server.status,
         tools=list(server.tools),
-        error=redact_mcp_error(server.error, server.redaction_headers),
+        error=redact_mcp_error(
+            server.error, server.redaction_headers, server.resolved_header_values or ()
+        ),
         probed_at=time.monotonic(),
         capabilities=(dict(server.capabilities) if isinstance(server.capabilities, dict) else None),
         protocol_version=server.protocol_version,
@@ -515,7 +517,7 @@ def redact_mcp_headers(headers: object) -> dict[str, str]:
     return {name: MCP_REDACTED_HEADER_VALUE for name in headers if isinstance(name, str)}
 
 
-def redact_mcp_error(error: object, headers: object) -> str:
+def redact_mcp_error(error: object, headers: object, extra_values: Iterable[str] = ()) -> str:
     """Scrub credential material from a probe error before it leaves the backend.
 
     Two layers, so every consumer (``to_dict``, the probe cache, the probe
@@ -556,6 +558,20 @@ def redact_mcp_error(error: object, headers: object) -> str:
             if len(credential) >= _MCP_CREDENTIAL_SUFFIX_MIN_LENGTH:
                 needs_boundary = len(credential) < _MCP_CREDENTIAL_UNANCHORED_MIN_LENGTH
                 values.setdefault(credential, needs_boundary)
+
+    # Individually resolved placeholder values (see _expand_header_placeholders):
+    # a PARTIALLY expanded header sends `<resolved>${MISSING}`, so neither the
+    # full sent value nor the Authorization suffix matches a server echoing only
+    # the resolved fragment. Same length regimes as credential suffixes: below
+    # the minimum no boundary rule separates the value from prose words, so it
+    # is skipped rather than corrupting unrelated text.
+    for raw_extra in extra_values:
+        if not isinstance(raw_extra, str):
+            continue
+        extra = raw_extra.strip()
+        if len(extra) < _MCP_CREDENTIAL_SUFFIX_MIN_LENGTH:
+            continue
+        values.setdefault(extra, len(extra) < _MCP_CREDENTIAL_UNANCHORED_MIN_LENGTH)
 
     if not values:
         return error
@@ -599,6 +615,11 @@ class McpServerInfo:
     # serialized: ``to_dict``'s headers block goes through ``redact_mcp_headers``,
     # which is name-keyed and value-independent.
     sent_headers: dict[str, str] | None = None
+    # Every placeholder value the probe's expansion resolved, individually —
+    # the extra_values leg of the redact_mcp_error scrub set. A partially
+    # expanded header's sent value would not match a server echoing only the
+    # resolved fragment. Never serialized.
+    resolved_header_values: list[str] | None = None
     # Remote-only OAuth hints carried verbatim to the runtime, which owns the
     # authorization exchange. Kiro Crew never enforces scopes and never registers
     # a client — it only refuses to lose these fields while syncing.
@@ -686,7 +707,9 @@ class McpServerInfo:
             "args": self.args or [],
             "status": self.status,
             "tools": self.tools,
-            "error": redact_mcp_error(self.error, self.redaction_headers),
+            "error": redact_mcp_error(
+                self.error, self.redaction_headers, self.resolved_header_values or ()
+            ),
             "source": self.source,
             "presence": dict(self.presence),
             "probeMode": self.probe_mode,
@@ -1389,7 +1412,9 @@ async def _read_jsonrpc_response(resp: aiohttp.ClientResponse) -> dict:
     return await resp.json()
 
 
-def _expand_header_placeholders(headers: Mapping[str, str]) -> dict[str, str]:
+def _expand_header_placeholders(
+    headers: Mapping[str, str],
+) -> tuple[dict[str, str], list[str]]:
     """Resolve ``${VAR}`` / ``${env:VAR}`` references in remote-probe header values.
 
     A static header whose value carries a runtime reference is a documented
@@ -1407,17 +1432,36 @@ def _expand_header_placeholders(headers: Mapping[str, str]) -> dict[str, str]:
     function-local because ``mcp_gateway.preflight`` / ``evaluate`` import this
     module at module scope; keeping the rewriter off this module's import graph
     avoids handing every consumer that never probes the rewriter's imports.
+
+    Returns ``(expanded_headers, resolved_values)``. The second element is
+    every placeholder value that actually resolved, INDIVIDUALLY: a partially
+    expanded value like ``${TOKEN}${MISSING}`` sends ``<resolved>${MISSING}``,
+    so a scrub set keyed on whole sent values would miss a server echoing only
+    the resolved fragment. Each resolved value therefore joins the
+    ``redact_mcp_error`` scrub set on its own (see its ``extra_values``).
     """
     from kiro_crew.mcp_gateway.rewriter import (
+        _ENV_VAR_PLACEHOLDER,
         _expand_env_placeholders,
         _placeholder_source_env,
     )
 
     source = _placeholder_source_env()
-    return {
-        name: (_expand_env_placeholders(value, source=source) if isinstance(value, str) else value)
-        for name, value in headers.items()
-    }
+    expanded: dict[str, str] = {}
+    resolved: list[str] = []
+    for name, value in headers.items():
+        if isinstance(value, str):
+            for match in _ENV_VAR_PLACEHOLDER.finditer(value):
+                # The same lookup _expand_env_placeholders performs against the
+                # same source view; a miss stays literal and contributes no
+                # scrub entry (the literal is not a secret).
+                hit = source.get(match.group(1))
+                if hit is not None:
+                    resolved.append(hit)
+            expanded[name] = _expand_env_placeholders(value, source=source)
+        else:
+            expanded[name] = value
+    return expanded, resolved
 
 
 def _header_reference_unresolved(value: object) -> bool:
@@ -1572,7 +1616,9 @@ async def _probe_remote(server: McpServerInfo) -> McpServerInfo:
         # presents the same credential the session runtime presents. Stored on
         # the row because redaction must key on the values that actually left
         # the process (see McpServerInfo.redaction_headers).
-        server.sent_headers = _expand_header_placeholders(server.headers)
+        server.sent_headers, server.resolved_header_values = _expand_header_placeholders(
+            server.headers
+        )
         hdrs = {
             **server.sent_headers,
             "Content-Type": "application/json",

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -4487,6 +4487,79 @@ class TestProbeHeaderReferenceExpansion:
         assert secret not in cached.error
         assert MCP_REDACTED_HEADER_VALUE in cached.error
 
+    @pytest.mark.asyncio
+    async def test_a_partially_expanded_header_still_scrubs_the_resolved_fragment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`${TOKEN}${MISSING}` expands to `<resolved>${MISSING}`: the FULL sent
+        value and the Authorization suffix both carry the literal tail, so a
+        server echoing only the resolved token would slip past a scrub set
+        keyed on whole values. Each individually resolved placeholder value
+        must be in the scrub set on its own."""
+        secret = "kc-9206-resolved-token"
+        monkeypatch.setenv("KC_PROBE_TEST_TOKEN", secret)
+        monkeypatch.delenv("KC_PROBE_MISSING", raising=False)
+        server = McpServerInfo(
+            name="remote",
+            url="https://example.com/mcp",
+            headers={"Authorization": "Bearer ${env:KC_PROBE_TEST_TOKEN}${env:KC_PROBE_MISSING}"},
+        )
+
+        init_resp = self._resp(
+            200,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"message": f"upstream rejected {secret} as expired"},
+            },
+        )
+        mock_session = self._session_returning(init_resp)
+        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session):
+            result = await _probe_remote(server)
+
+        assert result.status == "error"
+        serialized = result.to_dict()["error"]
+        assert secret not in serialized
+        assert MCP_REDACTED_HEADER_VALUE in serialized
+        cached = probe_metadata("remote")
+        assert cached is not None
+        assert secret not in cached.error
+
+    @pytest.mark.asyncio
+    async def test_a_tiny_resolved_fragment_does_not_corrupt_ordinary_prose(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A resolved placeholder value below the credential minimum length
+        must NOT join the scrub set as a bare substring: no boundary rule
+        separates a one- or two-character value from prose words, and masking
+        it would corrupt unrelated error text."""
+        monkeypatch.setenv("KC_PROBE_TINY", "ab")
+        server = McpServerInfo(
+            name="remote",
+            url="https://example.com/mcp",
+            headers={"X-Key": "x-${env:KC_PROBE_TINY}-y"},
+        )
+
+        init_resp = self._resp(
+            200,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                # "ab" appears both STANDALONE (a boundary-anchored pattern
+                # would mask it — the case only the minimum-length skip
+                # protects) and embedded in a longer word.
+                "error": {"message": "got ab grade abnormal response"},
+            },
+        )
+        mock_session = self._session_returning(init_resp)
+        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session):
+            result = await _probe_remote(server)
+
+        assert result.status == "error"
+        serialized = result.to_dict()["error"]
+        assert "got ab grade" in serialized
+        assert "abnormal" in serialized
+
     def test_needs_authorization_ignores_an_unresolved_reference(self) -> None:
         """An Authorization value still carrying ``${VAR}`` is not a supplied
         credential: the premise behind "any auth key present means a credential

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -15,6 +15,7 @@ import pytest
 
 from kiro_crew import platform_compat
 from kiro_crew.mcp_discovery import (
+    MCP_REDACTED_HEADER_VALUE,
     SCOPE_CC_GLOBAL,
     SCOPE_KIRO_GLOBAL,
     SCOPE_KIROCREW,
@@ -30,6 +31,7 @@ from kiro_crew.mcp_discovery import (
     _scope_priority,
     discover_servers_to_sync,
     list_servers,
+    probe_metadata,
     probe_server,
     sync_to_agent_config,
 )
@@ -130,9 +132,7 @@ class TestMcpServerInfo:
 
     def test_oauth_hints_omitted_on_stdio_rows(self) -> None:
         """to_dict gates them behind url, so a stdio row never advertises them."""
-        info = McpServerInfo(
-            name="x", command="cmd", scopes=["read"], client_id="public-id"
-        )
+        info = McpServerInfo(name="x", command="cmd", scopes=["read"], client_id="public-id")
         d = info.to_dict()
         assert "scopes" not in d
         assert "clientId" not in d
@@ -328,7 +328,9 @@ class TestListServers:
         monkeypatch.setattr("kiro_crew.mcp_discovery.Path.home", lambda: tmp_path)
         mcp_json = tmp_path / "mcp.json"
         mcp_json.write_text(
-            json.dumps({"mcpServers": {"pending": {"command": "definitely-not-run", "disabled": True}}})
+            json.dumps(
+                {"mcpServers": {"pending": {"command": "definitely-not-run", "disabled": True}}}
+            )
         )
         monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (mcp_json,))
         probed: list[str] = []
@@ -608,9 +610,9 @@ class TestExtraScopeSeam:
             SCOPE_CC_GLOBAL: {"shared-srv": {"command": "cc"}},
         }
         order = _scope_priority(by_source)
-        assert order.index(SCOPE_KIRO_GLOBAL) < order.index(SCOPE_CC_GLOBAL), (
-            "Kiro global must outrank the seam ccGlobal scope (rebuild parity)"
-        )
+        assert order.index(SCOPE_KIRO_GLOBAL) < order.index(
+            SCOPE_CC_GLOBAL
+        ), "Kiro global must outrank the seam ccGlobal scope (rebuild parity)"
 
         # Functional: same server in Kiro global + seam ccGlobal with different
         # disabledTools → first-scope-wins gives the Kiro-global value.
@@ -641,9 +643,9 @@ class TestExtraScopeSeam:
         )
 
         server = next(s for s in list_servers() if s.name == "shared-srv")
-        assert server.disabled_tools == ["kiro-tool"], (
-            "Kiro-global disabledTools must win over the seam scope (first-scope-wins)"
-        )
+        assert server.disabled_tools == [
+            "kiro-tool"
+        ], "Kiro-global disabledTools must win over the seam scope (first-scope-wins)"
 
 
 class TestDiscoverNew:
@@ -704,11 +706,7 @@ class TestDiscoverNew:
         agent_dir = tmp_path / "agents"
         agent_dir.mkdir()
         headers = {"Authorization": "Bearer sync-secret"}
-        cfg = {
-            "mcpServers": {
-                "remote": {"url": "https://mcp.example.com/v1", "headers": headers}
-            }
-        }
+        cfg = {"mcpServers": {"remote": {"url": "https://mcp.example.com/v1", "headers": headers}}}
         (agent_dir / "defaults.json").write_text(json.dumps(cfg))
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
         mcp_json = tmp_path / "mcp.json"
@@ -797,11 +795,7 @@ class TestDiscoverNew:
         """A Connect that widens or narrows scopes must re-sync, not be ignored."""
         agent_dir = tmp_path / "agents"
         agent_dir.mkdir()
-        cfg = {
-            "mcpServers": {
-                "remote": {"url": "https://mcp.example.com/v1", "scopes": ["read"]}
-            }
-        }
+        cfg = {"mcpServers": {"remote": {"url": "https://mcp.example.com/v1", "scopes": ["read"]}}}
         (agent_dir / "defaults.json").write_text(json.dumps(cfg))
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
         mcp_json = tmp_path / "mcp.json"
@@ -824,15 +818,11 @@ class TestDiscoverNew:
         assert len(result) == 1
         assert result[0].scopes == ["read", "write"]
 
-    def test_discover_flags_existing_remote_client_id_change(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    def test_discover_flags_existing_remote_client_id_change(self, tmp_path, monkeypatch) -> None:
         agent_dir = tmp_path / "agents"
         agent_dir.mkdir()
         cfg = {
-            "mcpServers": {
-                "remote": {"url": "https://mcp.example.com/v1", "clientId": "old-id"}
-            }
+            "mcpServers": {"remote": {"url": "https://mcp.example.com/v1", "clientId": "old-id"}}
         }
         (agent_dir / "defaults.json").write_text(json.dumps(cfg))
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
@@ -1784,7 +1774,9 @@ class TestProbeRemote:
 
         resp = MagicMock()
         resp.status = 403
-        resp.headers = {"WWW-Authenticate": 'Bearer resource_metadata="https://example.com/.well-known"'}
+        resp.headers = {
+            "WWW-Authenticate": 'Bearer resource_metadata="https://example.com/.well-known"'
+        }
         resp.__aenter__ = AsyncMock(return_value=resp)
         resp.__aexit__ = AsyncMock(return_value=False)
 
@@ -1893,7 +1885,9 @@ class TestProbeRemote:
             ),
             pytest.param("Bearer", id="bearer-with-no-evidence"),
             pytest.param('Bearer scope=""', id="empty-scope"),
-            pytest.param('Bearer resource_metadata="http://insecure.example/x"', id="http-metadata"),
+            pytest.param(
+                'Bearer resource_metadata="http://insecure.example/x"', id="http-metadata"
+            ),
             pytest.param(
                 'Bearer resource_metadata="javascript:alert(1)"', id="non-http-scheme-metadata"
             ),
@@ -1930,8 +1924,9 @@ class TestProbeRemote:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session), patch(
-            "kiro_crew.mcp_discovery._runtime_grant_present", AsyncMock(return_value=False)
+        with (
+            patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session),
+            patch("kiro_crew.mcp_discovery._runtime_grant_present", AsyncMock(return_value=False)),
         ):
             result = await _probe_remote(server)
 
@@ -1958,8 +1953,9 @@ class TestProbeRemote:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session), patch(
-            "kiro_crew.mcp_discovery._runtime_grant_present", AsyncMock(return_value=True)
+        with (
+            patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session),
+            patch("kiro_crew.mcp_discovery._runtime_grant_present", AsyncMock(return_value=True)),
         ):
             result = await _probe_remote(server)
 
@@ -1997,8 +1993,9 @@ class TestProbeRemote:
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         grant_lookup = AsyncMock(return_value=False)
-        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session), patch(
-            "kiro_crew.mcp_discovery._runtime_grant_present", grant_lookup
+        with (
+            patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session),
+            patch("kiro_crew.mcp_discovery._runtime_grant_present", grant_lookup),
         ):
             result = await _probe_remote(server)
 
@@ -2036,7 +2033,7 @@ class TestProbeRemote:
 
     @pytest.mark.asyncio
     async def test_an_unobservable_grant_is_omitted_rather_than_reported_absent(self) -> None:
-        """"Could not observe" must not reach the client as "no grant".
+        """ "Could not observe" must not reach the client as "no grant".
 
         The sign-in wording is gated on an explicit ``false``, so emitting ``false``
         when the lookup merely failed would tell the owner of an already-authorized
@@ -2056,8 +2053,9 @@ class TestProbeRemote:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session), patch(
-            "kiro_crew.mcp_discovery._runtime_grant_present", AsyncMock(return_value=None)
+        with (
+            patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session),
+            patch("kiro_crew.mcp_discovery._runtime_grant_present", AsyncMock(return_value=None)),
         ):
             result = await _probe_remote(server)
 
@@ -2329,9 +2327,7 @@ class TestProbeServerConsentGate:
         fail — it does NOT fail merely from removing the guard, because the
         probe's early error returns skip ``_cache_probe`` anyway.
         """
-        probed = McpServerInfo(
-            name="was-ok", command="true", status="ok", tools=["alpha", "beta"]
-        )
+        probed = McpServerInfo(name="was-ok", command="true", status="ok", tools=["alpha", "beta"])
         _cache_probe(probed)
 
         disabled = McpServerInfo(name="was-ok", command="true", disabled=True)
@@ -2456,9 +2452,7 @@ class TestProbeTempContainment:
         assert owners and all(pid != os.getpid() for pid in owners)
 
     @pytest.mark.asyncio
-    async def test_probe_spawn_failure_reclaims_the_fresh_dir(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    async def test_probe_spawn_failure_reclaims_the_fresh_dir(self, tmp_path, monkeypatch) -> None:
         # A dir whose probe never existed has no dead-owner future: the sweeps
         # never delete provisional/ownerless dirs, so the spawn-failure path
         # is its only reclamation point (mirrors spawn_backend). Exercised on
@@ -2575,9 +2569,7 @@ class TestProbeTempContainment:
 
         monkeypatch.setattr("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _wrap)
 
-        server = McpServerInfo(
-            name="order-lock", command=sys.executable, args=["-c", "pass"]
-        )
+        server = McpServerInfo(name="order-lock", command=sys.executable, args=["-c", "pass"])
         with patch(
             "kiro_crew.mcp_discovery.create_subprocess_limited",
             new_callable=AsyncMock,
@@ -2604,9 +2596,7 @@ class TestProbeTempContainment:
         assert captured_env["TMPDIR"] == str(scratch)
 
     @pytest.mark.asyncio
-    async def test_probe_alloc_failure_wraps_without_carveout(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    async def test_probe_alloc_failure_wraps_without_carveout(self, tmp_path, monkeypatch) -> None:
         # Containment is fail-open hygiene: when allocation fails, the probe
         # must still run -- wrapped, with inherited temp and no carve-out.
         import sys
@@ -2630,9 +2620,7 @@ class TestProbeTempContainment:
 
         monkeypatch.setattr("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _wrap)
 
-        server = McpServerInfo(
-            name="alloc-fail", command=sys.executable, args=["-c", "pass"]
-        )
+        server = McpServerInfo(name="alloc-fail", command=sys.executable, args=["-c", "pass"])
         result = await probe_server(server)
 
         # The wrap ran (kwargs captured) and received no carve-out.
@@ -2748,9 +2736,7 @@ class TestProbeServerProcessCleanup:
     @pytest.mark.asyncio
     async def test_fallback_kill_on_timeout(self) -> None:
         """When graceful shutdown times out, falls back to proc.kill()."""
-        proc = self._make_mock_proc(
-            wait_side_effect=[asyncio.TimeoutError(), 0]
-        )
+        proc = self._make_mock_proc(wait_side_effect=[asyncio.TimeoutError(), 0])
         server = McpServerInfo(name="test", command="echo")
 
         with (
@@ -3444,9 +3430,7 @@ class TestProbeServerStderrCapture:
 
         # Resolve the command, then fail at the sandbox chokepoint with the long
         # message — the real path a Windows host takes with no sandbox backend.
-        monkeypatch.setattr(
-            "kiro_crew.mcp_discovery.shutil.which", lambda *a, **k: "/usr/bin/srv"
-        )
+        monkeypatch.setattr("kiro_crew.mcp_discovery.shutil.which", lambda *a, **k: "/usr/bin/srv")
 
         def boom(*_a: object, **_k: object) -> object:
             raise RuntimeError(long_msg)
@@ -3911,18 +3895,14 @@ class TestDisabledIsCrossScope:
         )
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
         kiro_mcp = tmp_path / "kiro-mcp.json"
-        kiro_mcp.write_text(
-            json.dumps({"mcpServers": {"srv": global_spec}}), encoding="utf-8"
-        )
+        kiro_mcp.write_text(json.dumps({"mcpServers": {"srv": global_spec}}), encoding="utf-8")
         monkeypatch.setattr("kiro_crew.mcp_discovery.Path.home", lambda: tmp_path)
         monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (kiro_mcp,))
         monkeypatch.setattr(
             "kiro_crew.mcp_discovery._MCP_SOURCES", ((kiro_mcp, SCOPE_KIRO_GLOBAL),)
         )
 
-    def test_kiro_global_disable_marks_an_agent_introduced_row(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    def test_kiro_global_disable_marks_an_agent_introduced_row(self, tmp_path, monkeypatch) -> None:
         self._env(
             tmp_path,
             monkeypatch,
@@ -3972,9 +3952,7 @@ class TestDisabledIsCrossScope:
         assert out.status == "disabled"
         assert spawned == []
 
-    def test_raw_scoped_key_disable_marks_the_canonical_row(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    def test_raw_scoped_key_disable_marks_the_canonical_row(self, tmp_path, monkeypatch) -> None:
         """Row names are CANONICALIZED (step 3b): ``npm:@playwright/mcp`` is
         reported as ``playwright-mcp``. Scope dicts stay keyed by the raw name,
         so matching before canonicalization misses a raw-keyed disable whenever
@@ -4028,9 +4006,9 @@ class TestWindowsTeardownOffLoop:
         # Every kill_process_tree call in the probe path must be wrapped.
         for line in src.splitlines():
             if "kill_process_tree" in line and not line.strip().startswith("#"):
-                assert "to_thread" in line or "platform_compat.kill_process_tree," in line, (
-                    f"kill_process_tree called on the loop: {line.strip()}"
-                )
+                assert (
+                    "to_thread" in line or "platform_compat.kill_process_tree," in line
+                ), f"kill_process_tree called on the loop: {line.strip()}"
         assert "asyncio.to_thread(" in src
 
 
@@ -4061,8 +4039,9 @@ class TestProbeSandboxUnavailable:
         # A THIRD-PARTY server: managed ones never reach the spawn path at all
         # (their tools are read in-process), so they cannot exercise this branch.
         server = McpServerInfo(name="playwright-mcp", command="node")
-        with patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _refuse), patch(
-            "kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/node"
+        with (
+            patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _refuse),
+            patch("kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/node"),
         ):
             result = await probe_server(server)
 
@@ -4089,8 +4068,9 @@ class TestProbeSandboxUnavailable:
             raise RuntimeError("stop at the wrap")
 
         server = McpServerInfo(name="kirocrew-core", command="kirocrew", args=["mcp-core"])
-        with patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _wrap), patch(
-            "kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/kirocrew"
+        with (
+            patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _wrap),
+            patch("kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/kirocrew"),
         ):
             await probe_server(server)
 
@@ -4117,8 +4097,9 @@ class TestProbeSandboxUnavailable:
 
         for name, expect_tools in (("kirocrew-core", True), ("kirocrew-cron", True)):
             server = McpServerInfo(name=name, command="kirocrew", args=["mcp-x"])
-            with patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _refuse), patch(
-                "kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/kirocrew"
+            with (
+                patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _refuse),
+                patch("kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/kirocrew"),
             ):
                 result = await probe_server(server)
 
@@ -4135,8 +4116,9 @@ class TestProbeSandboxUnavailable:
             raise SandboxUnavailableError("no backend", kind="no_backend", detail="not Linux")
 
         server = McpServerInfo(name="playwright-mcp", command="node")
-        with patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _refuse), patch(
-            "kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/node"
+        with (
+            patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _refuse),
+            patch("kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/node"),
         ):
             result = await probe_server(server)
 
@@ -4180,9 +4162,7 @@ class TestFirstPartyManagedArgv:
     def _patch_invocation(self, monkeypatch) -> None:
         import kiro_crew.mcp_discovery as md
 
-        monkeypatch.setattr(
-            md, "_resolved_managed_invocation", {"kirocrew-core": self._INVOCATION}
-        )
+        monkeypatch.setattr(md, "_resolved_managed_invocation", {"kirocrew-core": self._INVOCATION})
         # Default install: the package-derived managed env is empty.
         monkeypatch.setattr("kiro_crew.agent._managed_mcp_env", lambda: {})
 
@@ -4294,8 +4274,9 @@ class TestFirstPartyManagedArgv:
         server = McpServerInfo(
             name="kirocrew-core", command=self._INVOCATION[0], args=list(self._INVOCATION[1])
         )
-        with patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _capture), patch(
-            "kiro_crew.mcp_discovery.shutil.which", return_value=self._INVOCATION[0]
+        with (
+            patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _capture),
+            patch("kiro_crew.mcp_discovery.shutil.which", return_value=self._INVOCATION[0]),
         ):
             await probe_server(server)
 
@@ -4313,8 +4294,9 @@ class TestFirstPartyManagedArgv:
             raise RuntimeError("stop at the wrap")
 
         server = McpServerInfo(name="playwright-mcp", command="node")
-        with patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _capture), patch(
-            "kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/node"
+        with (
+            patch("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _capture),
+            patch("kiro_crew.mcp_discovery.shutil.which", return_value="/usr/bin/node"),
         ):
             await probe_server(server)
 
@@ -4352,3 +4334,175 @@ class TestNoteDeniedEnv:
         s = self._srv(status="error", error="boom", env=None)
         _note_denied_env(s)
         assert s.error == "boom"
+
+
+class TestProbeHeaderReferenceExpansion:
+    """The remote probe resolves ``${VAR}``/``${env:VAR}`` header references.
+
+    A static header whose value carries a runtime reference is a documented
+    form (docs/reference/kiro-cli/mcp/configuration.md) that kiro-cli expands
+    at session runtime. The probe used to send the reference as literal text,
+    so a working configuration rendered as Error / HTTP 401 with advice to
+    delete the header (issue #9206). The probe now resolves references through
+    the gateway rewriter's declared-env expander — same regex, same
+    credential-filtered source view, same "unresolved stays literal" rule.
+    """
+
+    def setup_method(self) -> None:
+        _probe_cache.clear()
+
+    def teardown_method(self) -> None:
+        _probe_cache.clear()
+
+    @staticmethod
+    def _session_returning(*responses: MagicMock) -> MagicMock:
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(side_effect=list(responses))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        return mock_session
+
+    @staticmethod
+    def _resp(status: int, *, body: dict | None = None) -> MagicMock:
+        resp = MagicMock()
+        resp.status = status
+        resp.content_type = "application/json"
+        resp.headers = {}
+        if body is not None:
+            resp.json = AsyncMock(return_value=body)
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_reference_resolves_and_the_probe_sends_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reference naming an ordinary variable is sent RESOLVED — and a 401
+        against that resolved credential stays a real error, because a
+        credential genuinely was supplied and rejected."""
+        monkeypatch.setenv("KC_PROBE_TEST_TOKEN", "kc-9206-resolved-token")
+        server = McpServerInfo(
+            name="remote",
+            url="https://example.com/mcp",
+            headers={
+                "Authorization": "Bearer ${env:KC_PROBE_TEST_TOKEN}",
+                "X-Api-Key": "${KC_PROBE_TEST_TOKEN}",
+            },
+        )
+
+        mock_session = self._session_returning(self._resp(401))
+        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session):
+            result = await _probe_remote(server)
+
+        sent = mock_session.post.call_args_list[0].kwargs["headers"]
+        assert sent["Authorization"] == "Bearer kc-9206-resolved-token"
+        assert sent["X-Api-Key"] == "kc-9206-resolved-token"
+        assert result.status == "error"
+        assert "401" in result.error
+
+    @pytest.mark.asyncio
+    async def test_a_credential_filtered_reference_stays_literal_and_is_not_a_rejected_credential(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reference naming a credential-filtered variable is a MISS: the
+        secret value must not ride out in a probe request, and the 401 that
+        follows must not read as "your credential was rejected" — nothing was
+        supplied, so the row reports the sign-in state instead of an error
+        whose remediation advice would break a working configuration."""
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "kc-9206-filtered-secret")
+        server = McpServerInfo(
+            name="remote",
+            url="https://example.com/mcp",
+            headers={"Authorization": "Bearer ${env:AWS_SECRET_ACCESS_KEY}"},
+        )
+
+        mock_session = self._session_returning(self._resp(401))
+        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session):
+            result = await _probe_remote(server)
+
+        sent = mock_session.post.call_args_list[0].kwargs["headers"]
+        assert "kc-9206-filtered-secret" not in sent["Authorization"]
+        assert "${" in sent["Authorization"]
+        assert result.status == "needs_auth"
+        assert result.error == ""
+
+    @pytest.mark.asyncio
+    async def test_a_missing_variable_reference_stays_literal_and_reports_needs_auth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("KC_PROBE_UNSET_VAR", raising=False)
+        server = McpServerInfo(
+            name="remote",
+            url="https://example.com/mcp",
+            headers={"Authorization": "Bearer ${KC_PROBE_UNSET_VAR}"},
+        )
+
+        mock_session = self._session_returning(self._resp(401))
+        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session):
+            result = await _probe_remote(server)
+
+        sent = mock_session.post.call_args_list[0].kwargs["headers"]
+        assert sent["Authorization"] == "Bearer ${KC_PROBE_UNSET_VAR}"
+        assert result.status == "needs_auth"
+        assert result.error == ""
+
+    @pytest.mark.asyncio
+    async def test_an_error_echoing_the_resolved_secret_is_scrubbed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """redact_mcp_error's layer-2 scrubber keys on EXACT header values, so
+        it must be handed the values the probe actually sent. Handing it the
+        unexpanded config map would leave the resolved secret matching nothing
+        in the scrub set, in both serialized output (to_dict) and the probe
+        cache (_cache_probe). The synthetic token is chosen to survive the
+        layer-1 generic scanners, so this test isolates the layer-2 threading.
+        """
+        secret = "kc-9206-resolved-token"
+        monkeypatch.setenv("KC_PROBE_TEST_TOKEN", secret)
+        server = McpServerInfo(
+            name="remote",
+            url="https://example.com/mcp",
+            headers={"Authorization": "Bearer ${env:KC_PROBE_TEST_TOKEN}"},
+        )
+
+        init_resp = self._resp(
+            200,
+            body={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"message": f"upstream rejected {secret} as expired"},
+            },
+        )
+        mock_session = self._session_returning(init_resp)
+        with patch("kiro_crew.mcp_discovery.aiohttp.ClientSession", return_value=mock_session):
+            result = await _probe_remote(server)
+
+        assert result.status == "error"
+        serialized = result.to_dict()["error"]
+        assert secret not in serialized
+        assert MCP_REDACTED_HEADER_VALUE in serialized
+        cached = probe_metadata("remote")
+        assert cached is not None
+        assert secret not in cached.error
+        assert MCP_REDACTED_HEADER_VALUE in cached.error
+
+    def test_needs_authorization_ignores_an_unresolved_reference(self) -> None:
+        """An Authorization value still carrying ``${VAR}`` is not a supplied
+        credential: the premise behind "any auth key present means a credential
+        was rejected" does not hold, so a 401 is an authenticate prompt."""
+        from kiro_crew.mcp_discovery import _needs_authorization
+
+        assert _needs_authorization(401, {}, {"Authorization": "Bearer ${TOKEN}"}) is True
+        assert (
+            _needs_authorization(
+                403,
+                {"WWW-Authenticate": "Bearer"},
+                {"Authorization": "${env:TOKEN}"},
+            )
+            is True
+        )
+        # A resolved (reference-free) credential still suppresses needs_auth.
+        assert _needs_authorization(401, {}, {"Authorization": "Bearer abc"}) is False
+        # Only 401/403-with-challenge become needs_auth even when unresolved.
+        assert _needs_authorization(500, {}, {"Authorization": "Bearer ${TOKEN}"}) is False


### PR DESCRIPTION
## Symptom

A remote (Streamable HTTP) MCP server configured with a static auth header whose value carries a documented `${VAR}`/`${env:VAR}` runtime reference works in every chat session, but the dashboard Connections page renders it as Error / `HTTP 401` — and the row's hint advises the user to remove the header and re-add the server without it. Following that advice would break a working configuration; that is the user-visible harm this PR removes.

## Root cause

`_probe_remote` built its request headers straight from config (`{**server.headers, ...}`) with no reference expansion anywhere in `mcp_discovery.py`, so the reference reached the remote host as literal text and was correctly rejected. kiro-cli resolves the same reference at session runtime (its own expander; the in-tree `mcp_gateway.rewriter` expansion exists specifically to match it), which is why the identical header authenticates in a session and fails in the probe. `_needs_authorization` then treated any `Authorization` key among the sent headers as "a credential was supplied and rejected", so the 401 became a hard `error` row instead of the sign-in state — with the `oauth_not_a_static_token` hint attached.

## Fix

Backend-only, in `src/kiro_crew/mcp_discovery.py`:

1. `_expand_header_placeholders` resolves `${VAR}`/`${env:VAR}` in header values through the gateway rewriter's existing declared-env expander (`_expand_env_placeholders` / `_placeholder_source_env`) — same regex, same credential-filtered source view (`is_secret_env_key` / `is_credential_env_key` / `scrub_agent_denied_env` names are misses), same "unresolved stays literal" kiro-cli parity. No second expander, no change to the filter lists. The import is function-local to keep the rewriter off this module's import graph (`mcp_gateway.preflight`/`evaluate` import this module at module scope).
2. The probe uses the expanded map for the request and for `_needs_authorization`'s sent-headers view, and stores it on the row (`sent_headers`, never serialized).
3. Both `redact_mcp_error` call sites (`_cache_probe` and `to_dict`) now key on the values the probe actually sent (`McpServerInfo.redaction_headers`), so an error echoing a resolved secret is scrubbed by the exact-value layer-2 scrubber rather than left to the generic credential-shaped scanners. The sent map is the complete scrub set: a configured value that differs post-expansion never left the process, and one the expansion left alone is byte-identical in both maps. `redact_mcp_headers` (the `to_dict` headers block) is name-keyed and value-independent — verified, unchanged.
4. `_needs_authorization`: an `Authorization` value still carrying an unresolved reference (missing or credential-filtered variable) supplied nothing, so it no longer suppresses `needs_auth`. The row reports the existing sign-in state instead of `HTTP 401` + delete-the-header advice. No new user-facing text, no i18n change, no change to challenge detection.

Same-commit doc updates: `docs/system-specs/modules/connections.md` (probe expansion policy), `docs/architecture/mcp.md` (needs_auth bullet), `docs/guides/connecting-remote-oauth-mcp-server.md` (static-header failure modes). `docs/system-specs/modules/security.md` reviewed — its declared-env statements remain accurate, untouched. The two touched files graduated from `.github/black-baseline.txt` per that gate's own policy (formatted with `black --target-version py310`).

## Verification

Red before green — all five new tests fail on unmodified main, each on the intended assertion:

- an ordinary-variable reference resolves and the probe sends the resolved value (and a 401 against a genuinely supplied credential stays `error`);
- a credential-filtered reference (`AWS_SECRET_ACCESS_KEY`) stays literal, the secret value never leaves the process, and the row reports `needs_auth`, not a rejected credential;
- a missing-variable reference stays literal and reports `needs_auth`;
- a probe error echoing the resolved secret is scrubbed in both serialized output (`to_dict`) and the probe cache (`_cache_probe`) — the synthetic token is chosen to survive the layer-1 generic scanners, so the test isolates the layer-2 threading;
- `_needs_authorization` truth table for the unresolved-reference branch.

All header values in tests are obviously synthetic (`kc-9206-resolved-token`); no real credential appears anywhere.

Mutation checks (each direction recorded — revert the specific change, new tests go red; restore, green):

- expansion call removed (`sent_headers = dict(server.headers)`): 2 tests fail;
- redaction map left unexpanded (`redaction_headers` returns `self.headers`): 1 test fails;
- `_needs_authorization` unresolved-reference branch removed: 3 tests fail.

Gates: `scripts/local-gate.py --base origin/main`; `black` gate, `isort`, `flake8`, `mypy` clean; full `test/test_mcp_discovery.py` suite green.

Zero-regression proof: the identical bare pytest invocation (`pytest -q -n auto --dist loadgroup`, no path argument, so both trees collect `src/**/tests` as well as `test/`) run on this branch and on a `git worktree` at `origin/main`; sorted failing-test id sets diffed both directions. Branch 440 ids, main 439 ids; nothing from main's set is missing on the branch, and the single branch-only id (`test_browser_recording_skill.py::TestEndToEnd::test_records_a_webm`) is an artifact of the local verification setup, not the diff: its class is `skipif`-gated on `website/node_modules/playwright` existing, which my frontend-guard install created in the branch tree only (the worktree has no `node_modules`). Verified both ways in isolation — with `node_modules` moved aside the test skips on the branch exactly as on main; with it present it fails on the host's Node 16, a machine limitation. Every other id is the repo's known environmental baseline, byte-identical across the trees.

Frontend guard: the diff touches zero frontend files; the full website vitest suite and `tsc -b` were run anyway as a guard — 1909/1910 test files green, `tsc -b` clean. The single failing file (`WindowCalculator.test.ts`, a per-call-cost scaling benchmark) failed only while the backend suite saturated the host's CPUs and passes 23/23 rerun in isolation.

<!-- no-visual-delta -->
Backend-only change: no frontend file is touched and no user-facing string is added. The visible effect (a Connections row that stops reporting a false `HTTP 401`) is a data change on an existing rendering path; the evidence is the red-first probe tests above, which pin the exact row status the page receives.

## Review round 1 (adopted)

GPT 5.6 raised one blocking finding, verified real against source: a partially expanded header value (`${TOKEN}${MISSING}` sends `<resolved>${MISSING}`) meant neither the full sent value nor the Authorization suffix in the scrub set matched a server echoing only the resolved fragment. Adopted in commit 2: `_expand_header_placeholders` now also returns each individually resolved placeholder value and both `redact_mcp_error` call sites pass them as a new `extra_values` leg, folded in under the existing credential length regimes (a value below the minimum length is skipped — no boundary rule separates it from prose words, pinned by a standalone-short-word test). Red-first: the partial-expansion echo test fails on the pre-fix head. Mutation checks both directions: `extra_values` ignored — 1 test fails; minimum-length skip removed — 1 test fails (the standalone `ab` in prose is masked). Full `test_mcp_discovery.py` suite green (207), lints and black gate clean, rebased onto current main before the push.

## Pattern harvest

Rule candidate: when a probe or health check replays a configured value that some other component resolves at runtime (env references, templated credentials), the check must run the same resolution with the same filter policy before sending — and every redaction/scrub layer keyed on configured values must be handed the resolved spelling, or the resolved secret sails past the exact-value scrubber. Knowingly out-of-scope sibling: `redact_mcp_error` consumers outside the remote probe path (stdio probes never expand, so their configured map is already the sent map).

Fixes #9206
