### PR TITLE
fix(session-pid): stop the PID lock opens from truncating the lock file

### DIFF
--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -145,7 +145,17 @@ def _session_pid_file_lock():  # type: ignore[no-untyped-def]
     """Exclusive file lock for session PID file operations."""
     lock_path = _session_pid_file_path().with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as lock_fd:
+    # ``touch`` + ``"r+"``: WRITABLE, and crucially WITHOUT truncation.
+    # ``msvcrt.locking`` needs a writable handle, so ``"r"`` is not an option;
+    # but ``"w"`` TRUNCATES on open, and on Windows a truncating open of a lock
+    # file whose first byte another holder already locked raises a sharing
+    # violation rather than waiting, so the contending acquirer crashes BEFORE
+    # it reaches ``file_lock`` and the serialisation this lock exists to provide
+    # never happens. POSIX ``flock`` tolerates the truncate, which is why the
+    # defect is Windows-only. Same shape as ``dashboard/handlers/mcp.py``'s
+    # ``_McpFileLock`` and ``work_ledger._open_lock``.
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as lock_fd:
         with platform_compat.file_lock(lock_fd.fileno(), exclusive=True):
             yield
 
@@ -181,7 +191,17 @@ def _pid_file_lock():  # type: ignore[no-untyped-def]
     """Exclusive file lock for all PID file read-modify-write operations."""
     lock_path = _pid_file_path().with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as lock_fd:
+    # ``touch`` + ``"r+"``: WRITABLE, and crucially WITHOUT truncation.
+    # ``msvcrt.locking`` needs a writable handle, so ``"r"`` is not an option;
+    # but ``"w"`` TRUNCATES on open, and on Windows a truncating open of a lock
+    # file whose first byte another holder already locked raises a sharing
+    # violation rather than waiting, so the contending acquirer crashes BEFORE
+    # it reaches ``file_lock`` and the serialisation this lock exists to provide
+    # never happens. POSIX ``flock`` tolerates the truncate, which is why the
+    # defect is Windows-only. Same shape as ``dashboard/handlers/mcp.py``'s
+    # ``_McpFileLock`` and ``work_ledger._open_lock``.
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as lock_fd:
         with platform_compat.file_lock(lock_fd.fileno(), exclusive=True):
             yield
 
@@ -497,7 +517,12 @@ def _periodic_pid_sweep(my_gw_pid: int, active_pids: set[int]) -> tuple[set[str]
     lock_path = path.with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        lock_fd = open(lock_path, "w")
+        # Non-truncating, for the reason spelled out in `_session_pid_file_lock`.
+        # This site is the likeliest of the three to feel it: the sweep runs on a
+        # timer while `_track_session_pid` is contending for the same lock, which
+        # is exactly the interleaving a truncating open turns into a crash.
+        lock_path.touch(exist_ok=True)
+        lock_fd = open(lock_path, "r+")
     except OSError:
         return set(), []
     try:

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -2993,3 +2993,93 @@ class TestBrowserSessionOwnerAlive:
         with patch.object(sp, "sys") as mock_sys:
             mock_sys.platform = "darwin"
             assert sp._browser_session_owner_alive(900, b"kc-1a2b3c4d") is True
+
+
+class TestAcquiringAPidLockDoesNotTruncateTheLockFile:
+    """A lock file must be opened WRITABLE but never TRUNCATING.
+
+    ``msvcrt.locking`` needs a writable handle, so the fd cannot be opened
+    ``"r"``. But ``"w"`` truncates at open, and on Windows a truncating open of a
+    lock file whose first byte another holder already locked raises a sharing
+    violation instead of waiting — so the contending acquirer crashes with a bare
+    ``OSError`` *before* it reaches ``file_lock``, and the serialisation the lock
+    exists to provide never happens. POSIX ``flock`` tolerates the truncate, which
+    is why the defect is invisible on Linux and reddened only the Windows shards.
+
+    Issue #9248; same defect and same fix as ``work_ledger._open_lock`` (PR #9237)
+    and ``dashboard/handlers/mcp.py``'s ``_McpFileLock``, which was already
+    written this way.
+
+    Truncation is the direct, PLATFORM-INDEPENDENT observable, and that is what
+    these assert: seed the lock file with bytes, take and release the lock, and
+    require the bytes to have survived. Under the old ``open(lock_path, "w")``
+    every one of these fails on every platform, so the guard does not depend on
+    running the suite on Windows to have teeth.
+    """
+
+    SEED = b"lock-file-content-that-must-survive"
+
+    def test_session_pid_file_lock_preserves_the_lock_file(self, session_pid_file: Path) -> None:
+        from kiro_crew.session_pid import _session_pid_file_lock, _session_pid_file_path
+
+        lock_path = _session_pid_file_path().with_suffix(".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_bytes(self.SEED)
+
+        with _session_pid_file_lock():
+            pass
+
+        assert lock_path.read_bytes() == self.SEED
+
+    def test_pid_file_lock_preserves_the_lock_file(self, pid_file: Path) -> None:
+        from kiro_crew.session_pid import _pid_file_lock, _pid_file_path
+
+        lock_path = _pid_file_path().with_suffix(".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_bytes(self.SEED)
+
+        with _pid_file_lock():
+            pass
+
+        assert lock_path.read_bytes() == self.SEED
+
+    def test_the_periodic_sweep_preserves_the_lock_file(self, session_pid_file: Path) -> None:
+        """The sweep is the site most likely to feel this in production.
+
+        It runs on a timer while ``_track_session_pid`` contends for the same
+        lock, which is exactly the interleaving a truncating open turns into a
+        crash rather than a wait.
+        """
+        from kiro_crew.session_pid import _periodic_pid_sweep, _session_pid_file_path
+
+        path = _session_pid_file_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # The sweep returns early unless the pid file exists, so it must exist
+        # for the lock to be reached at all.
+        path.write_text(f"{os.getpid()}:999999\n", encoding="utf-8")
+        lock_path = path.with_suffix(".lock")
+        lock_path.write_bytes(self.SEED)
+
+        _periodic_pid_sweep(os.getpid(), set())
+
+        assert lock_path.read_bytes() == self.SEED
+
+    def test_the_lock_is_still_actually_acquired(self, pid_file: Path) -> None:
+        """Guard the guard: a non-truncating open that never locks would pass above.
+
+        ``file_lock`` is asked for the lock through the same helper the production
+        path uses, so this fails if the fd stopped being writable — the failure
+        mode a naive ``"r"`` fix would introduce, and the reason ``"r+"`` rather
+        than ``"r"`` is the answer.
+        """
+        from kiro_crew.session_pid import _pid_file_path
+
+        lock_path = _pid_file_path().with_suffix(".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_bytes(self.SEED)
+
+        lock_path.touch(exist_ok=True)
+        with open(lock_path, "r+") as fd:
+            with platform_compat.file_lock(fd.fileno(), exclusive=True):
+                pass
+        assert lock_path.read_bytes() == self.SEED


### PR DESCRIPTION
## Problem / Motivation

`session_pid.py`'s lock helpers open the lock file **truncating** and only then
acquire the lock:

```python
with open(lock_path, "w") as lock_fd:
    with platform_compat.file_lock(lock_fd.fileno(), exclusive=True):
        yield
```

`"w"` truncates **at open**, so the truncation happens before the lock is held.
On Windows the acquire routes to `msvcrt.locking`, and a truncating open of a
lock file whose first byte another holder already locked raises a **sharing
violation instead of waiting** — the contending acquirer crashes with a bare
`OSError` before it ever reaches `file_lock`, and the mutual exclusion the lock
exists to provide never happens. POSIX `flock` tolerates the truncate, which is
why this is invisible on Linux and reddened only the Windows shards.

This is issue #9248, filed off the premise review of PR #9237, which fixed the
same defect in `work_ledger._open_lock`. That review recorded it reddening
`Backend Tests (Windows)` shard 4 across four separate pull requests,
intermittently rather than deterministically because the loss only lands on a
specific interleaving — it read as a flaky assertion and was not one.

**The issue named two sites here and explicitly asked whoever picked it up to
re-run the grep rather than treat the list as complete. Doing so found a third.**

| Site | Function | Lock |
|---|---|---|
| `session_pid.py:148` | `_session_pid_file_lock` | `file_lock(exclusive=True)` |
| `session_pid.py:184` | `_pid_file_lock` | `file_lock(exclusive=True)` |
| **`session_pid.py:520`** | **`_periodic_pid_sweep`** | **`try_acquire_lock(exclusive=False)`** |

The third is the worst of them, and it is the one that was not on the list: the
sweep runs **on a timer** while `_track_session_pid` contends for the same lock,
which is precisely the interleaving a truncating open converts from a wait into a
crash. The issue's own reasoning for prioritising this file — "PID files are read
by other processes precisely while they contend" — applies hardest here.

## Why it matters

A PID file is how the gateway finds the agent runtimes it must reap. When the
lock around it fails open on a sharing violation, two gateways can read and
rewrite that file with no mutual exclusion, and `_rewrite_pid_file`'s own
docstring already spells out what a lost entry costs: *"every dropped entry is an
agent runtime no reaper can find again."* The failure is a leaked process, not a
visible error.

It also costs review time repeatedly rather than once. The same defect has now
reddened Windows shards across four PRs — two of them belonging to other people —
each time looking like an unrelated flaky test.

## What changed (motivation → approach → change)

Root cause: the lock file is opened in a mode that mutates it, before the lock
that is supposed to guard that mutation is held.

All three sites now `touch(exist_ok=True)` and open `"r+"`:

* **writable**, which `msvcrt.locking` requires — `"r"` is not an option and would
  swap this bug for a silently-unlocked critical section;
* **not truncating**, which is the fix.

**Not a new mechanism.** `dashboard/handlers/mcp.py`'s `_McpFileLock` was already
written exactly this way, and `work_ledger._open_lock` was moved to it in #9237.
This applies the shape the repository had already settled on to the file that
still lacked it.

**Scope boundary.** `webhooks.py:189` carries the same pattern and is
**deliberately untouched**: issue #9248 asks for one change per subsystem, "so
they want their own review rather than riding along inside an unrelated unblock",
and the re-run grep shows the pattern also reaches `deploy/pending.py`,
`aws_control/backend/*` and `issue_radar/backend/*` — a sweep across those would
be exactly the omnibus the issue asks contributors not to file.

**No spec update owed.** `docs/system-specs/modules/session.md:1513` documents
*which* helper the PID-file locks use (`platform_compat.file_lock` /
`acquire_lock` / `try_acquire_lock`); this changes the mode the descriptor handed
to those helpers is opened in, not which helper is used, so what the spec asserts
is unchanged.

## Tests

`TestAcquiringAPidLockDoesNotTruncateTheLockFile` in `test/test_pid_lifecycle.py`,
one test per site plus a guard.

**The property is platform-independent on purpose.** Asserting "the acquire did
not raise" would be untestable on the POSIX runners, where it never raises.
Truncation is the direct observable of the same defect, so each test seeds the
lock file with bytes, takes and releases the lock through the production helper,
and requires the bytes to have survived. That fails on **every** platform if the
truncating open comes back — the guard does not depend on the suite running on
Windows to have teeth.

**Red-before**, with only `session_pid.py` reverted to `origin/main` and the new
tests kept:

```
FAILED ...::test_session_pid_file_lock_preserves_the_lock_file
FAILED ...::test_pid_file_lock_preserves_the_lock_file
FAILED ...::test_the_periodic_sweep_preserves_the_lock_file
  AssertionError: assert b'' == b'lock-file-content-that-must-survive'
3 failed, 1 passed
```

The one that passes is `test_the_lock_is_still_actually_acquired`, and it passes
on both builds **by design**: it takes the lock through `platform_compat.file_lock`
on an `"r+"` descriptor to pin that the replacement mode is still *writable*. That
is the failure mode a naive `"r"` fix would introduce — a lock that quietly never
locks — and it is why the answer is `"r+"` and not `"r"`.

**Green-after:** `test_pid_lifecycle.py` 6 failed / 139 passed / 27 skipped. The
6 failures are POSIX-only tests (`AttributeError: module 'os' has no attribute
'getuid'`) and are **inherited**: pristine `origin/main` on this Windows box gives
6 failed / 135 passed / 27 skipped, so the delta is exactly the 4 tests added
here. Sibling suites `test_pid_sweep_helpers.py` + `test_session_pid_sig.py` are
17 failed / 66 passed both before and after — byte-identical counts, zero delta.

**Gates:** `flake8`, `isort --check-only`, `mypy --platform linux` (0 errors in
`session_pid.py`) and `scripts/check_black_formatting.py` all clean.

## Manual verification

N/A — unit coverage sufficient: the defect is the mode a file is opened in, and
the tests exercise the real helpers and observe the real file, which is exactly
what a manual check would do.

## Related Issues

Fixes the `session_pid.py` portion of #9248. Follows PR #9237, which fixed the
same defect in `work_ledger.py` and whose review surfaced the remaining sites.

Not a duplicate: no open PR touches `session_pid.py` or `test_pid_lifecycle.py`
(checked across the 40 most recent open PRs immediately before opening this), and
the issue is unassigned with no competing PR.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **opening a lock file is itself a mutation, and it happens before the
lock.** The acquire is the line everyone reads; the `open` above it is treated as
plumbing. `"w"` is the natural way to say "make sure it exists", and it is the one
mode that empties the file in the window the lock does not cover. When reviewing a
file lock, read the `open` mode before the acquire, and ask what state the file is
in for a process that arrives between them.

Second lesson, about the platform: **`flock` forgives what `msvcrt` punishes.**
POSIX advisory locking tolerates a concurrent truncate, so the entire class is
invisible on Linux CI and surfaces on Windows as a *sharing violation raised from
the open* — which does not look like a locking bug at all. A guard for this class
must therefore assert something POSIX can also see; truncation is that something.

Third, and the one that paid here: **when an issue lists sites and says the list
was truncated, re-run the grep.** #9248 named two sites in this file and warned
its list was cut off in the source review. The third —
`_periodic_pid_sweep` — is the one that runs on a timer against a contending
writer, i.e. the likeliest of the three to actually fire. Trusting the list would
have shipped a fix that left the worst instance in place.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
