### PR TITLE
fix(browser-cli): fence the browse install prefix against agent writes

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -319,6 +319,39 @@ _CREW_READONLY_LEAVES: tuple[str, ...] = (
     # fence how a command SPELLS this path, and the kernel denial is what still
     # holds when a spelling is built at runtime (``$(printf ...)``).
     "settings_seeds.json",
+    # The browse CLI's install prefix (``browser_cli/install.py``'s
+    # ``managed_prefix``; ``playwright-cli.sh`` defaults to the same directory).
+    # Whatever resolves out of it is EXECUTED by the gateway -- ``detect()`` spawns
+    # ``[path, "--version"]`` through ``cli_env()`` on every browser-status read --
+    # so a sandboxed process that can write here chooses a program the gateway
+    # runs with its own environment.
+    #
+    # READONLY rather than hidden, and this one is not a close call: the agent's
+    # own shell has to EXECUTE the launcher for browsing to work at all, so a mask
+    # would break the very feature this protects. Read + execute with a
+    # kernel-denied write is the asymmetry every legitimate consumer already lives
+    # within -- ``install()`` writes the tree from the GATEWAY and never from a
+    # sandboxed turn, ``cli_path``/``detect``/``available`` only resolve and spawn,
+    # and the revision probe only reads. Precedent in this same list:
+    # ``aws-control-staging``, gateway-owned and fenced so a same-UID agent cannot
+    # swap the contents between the gateway's write and its read.
+    #
+    # Paired with the same leaf on ``security``'s write floors -- the deny rules
+    # fence how a command SPELLS this path, and the kernel denial is what still
+    # holds when a spelling is built at runtime.
+    #
+    # Two shapes escape this seal, and both are answered by REFUSING TO TRUST them
+    # rather than by refusing to launch. A SYMLINK here seals the target inode while
+    # the link name stays writable (``_warn_if_alias_backed`` reports it), and an
+    # operator's ``KIROCREW_PLAYWRIGHT_CLI_HOME`` may name a directory outside the
+    # data home entirely, which no ``$HOME``-relative rule can cover. In both cases
+    # ``browser_cli.install`` does not resolve the launcher from the prefix at all,
+    # so nothing is executed out of an unfenced directory. Refusing the SPAWN
+    # instead would turn a relocated install tree -- a reasonable thing to do with
+    # a 500 MB directory -- into a host where no agent turn starts, which is a far
+    # wider blast radius than the exposure. That is the same trade
+    # ``_warn_if_alias_backed`` argues for the config ceilings.
+    "playwright-cli",
 )
 
 #: Crew-home leaves that MUST stay read-write for a sandboxed process. Every entry is
@@ -528,6 +561,11 @@ def carveout_shadowed_by_foreign_mask(path: str, mode: str = "standard") -> bool
 #: 1. An EMPTY document must mean what an ABSENT file means to the reader:
 #:
 #:    * ``profiles`` — an empty dir yields no profile, same as no dir;
+#:    * ``playwright-cli`` — the browse CLI's install prefix. An empty dir resolves
+#:      no launcher (``cli_path``'s last tier finds nothing in it) and holds no
+#:      ``@playwright/cli`` tree for the revision probe, which is precisely what an
+#:      absent prefix means: the CLI is not installed. Like ``profiles`` it is a
+#:      DIRECTORY, so criterion 2 does not arise — see the note there;
 #:    * ``computer_use.json`` — ``computer_use.enable_state.load_state`` reads ``{}``
 #:      as DISABLED, which is what an absent keystone means;
 #:    * ``oauth_endpoints.json`` — ``security._validate_operator_oauth_entries``
@@ -550,7 +588,10 @@ def carveout_shadowed_by_foreign_mask(path: str, mode: str = "standard") -> bool
 #:    for ``settings_seeds.json`` at "Crew owns no settings file", so the writer takes
 #:    its leave-it-alone branch: the seed is not refreshed, and nothing is overwritten
 #:    or unlinked. The empty ``profiles`` dir is exempt from the concern entirely: a
-#:    directory bind shows live contents, so a profile added later is visible.
+#:    directory bind shows live contents, so a profile added later is visible — and
+#:    the same holds for ``playwright-cli``, which is what makes sealing it
+#:    compatible with installing into it afterwards: the gateway writes the real
+#:    tree and a sandboxed process sees it, read-only.
 #:
 #: DELIBERATELY EXCLUDED, and each for a different one of those two reasons:
 #:
@@ -573,7 +614,7 @@ def carveout_shadowed_by_foreign_mask(path: str, mode: str = "standard") -> bool
 #: this list closes: a mask needs the opposite treatment (an empty bind OVER the
 #: name), and ``_CREW_HIDDEN_LEAVES`` has no reader to prove an empty document is
 #: absent-equivalent, so each leaf needs its own argument.
-_CREW_PRECREATE_READONLY_DIR_LEAVES: tuple[str, ...] = ("profiles",)
+_CREW_PRECREATE_READONLY_DIR_LEAVES: tuple[str, ...] = ("profiles", "playwright-cli")
 _CREW_PRECREATE_READONLY_FILE_LEAVES: tuple[str, ...] = (
     "computer_use.json",
     "oauth_endpoints.json",

--- a/src/kiro_crew/security/paths.py
+++ b/src/kiro_crew/security/paths.py
@@ -911,6 +911,26 @@ _WRITE_PROTECTED_HOME_PATHS += [
 _KIRO_AGENTS_DIR = ".kiro/agents"
 _WRITE_PROTECTED_HOME_PATHS += [_KIRO_AGENTS_DIR]
 
+# The browse CLI's install PREFIX (``browser_cli/install.py``; the same directory
+# ``playwright-cli.sh`` installs into). Same shape as ``playwright-cli-config.json``
+# above, one step further along: that file is an input to a security decision, this
+# directory holds the EXECUTABLE the decision runs. ``detect()`` spawns
+# ``[cli_path(), "--version"]`` through ``cli_env()`` on every browser-status read,
+# so an agent able to write here is choosing a program the gateway executes with
+# its own environment.
+#
+# WRITE-protected rather than read+write sensitive: every legitimate consumer reads
+# or EXECUTES -- ``cli_path``, ``detect``, ``available``, the revision probe, and
+# the agent's own shell running the CLI -- and only the gateway writes. Hiding it
+# would break browsing while doing nothing about the write, which is the whole
+# risk. ``_path_in_home_dirs`` resolves paths UNDER each entry, so one directory
+# entry covers the launcher and the package tree alike.
+#
+# Paired with the same leaf in ``sandbox._CREW_READONLY_LEAVES``: this gate fences
+# the agent's file-edit tool, and the kernel denial is what still holds for a path
+# spelled at runtime. Protected on one path only is not protected.
+_WRITE_PROTECTED_HOME_PATHS += [f"{prefix}/playwright-cli" for prefix in _CREW_HOME_PREFIXES]
+
 #: Longest command ``is_sensitive_bash_command`` will scan. Longer input is
 #: REFUSED, not skipped and not scanned: both detectors the gate runs are linear
 #: in the subject, so this bound is what turns "linear" into a hard wall-clock

--- a/test/test_browser_cli_launch.py
+++ b/test/test_browser_cli_launch.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import pytest
 
+from kiro_crew import platform_compat
 from kiro_crew.browser_cli import launch as mod
+from kiro_crew.config.paths import config_dir
 
 
 def test_launch_config_path_is_under_the_data_home(
@@ -585,3 +587,82 @@ def test_browser_socket_env_refuses_relative_configured_roots(
     }
 
     assert mod.browser_socket_env(env) == {}
+
+
+class TestTheInstallPrefixIsFenced:
+    """The prefix the CLI installs into must not be agent-WRITABLE.
+
+    Whatever resolves out of it is executed by the gateway — `detect()` spawns
+    `[cli_path(), "--version"]` through `cli_env()` on every browser-status read —
+    so an agent able to write there chooses a program the gateway runs with its own
+    environment. Fenced on both paths, because protected on one is not protected:
+    the tool gate refuses the agent's file-edit tool, and the sandbox's kernel
+    denial holds for a path spelled at runtime.
+
+    Read and EXECUTE stay open on purpose. Browsing requires the agent's own shell
+    to run the launcher, so hiding the prefix would break the feature the fence
+    exists to protect.
+    """
+
+    @staticmethod
+    def _prefix_paths() -> list[str]:
+        """The prefix, named the way THIS branch's code already names it.
+
+        `_STANDALONE_PREFIX_ENV` / `_STANDALONE_PREFIX_DIR` are what
+        `_standalone_node_modules()` already probes, and the same directory
+        `playwright-cli.sh` installs into by default — so this fence protects the
+        shipped unprivileged install shape as it exists today, independently of any
+        change to where the one-click install puts things.
+        """
+        import os
+
+        from kiro_crew.browser_cli import install as install_mod
+
+        override = os.environ.get(install_mod._STANDALONE_PREFIX_ENV, "").strip()
+        prefix = Path(override) if override else config_dir() / install_mod._STANDALONE_PREFIX_DIR
+        bin_dir = prefix if platform_compat.IS_WINDOWS else prefix / "bin"
+        return [
+            str(prefix),
+            str(bin_dir / install_mod.CLI_BIN),
+            str(prefix / "lib" / "node_modules" / "@playwright" / "cli" / "package.json"),
+        ]
+
+    def test_the_edit_gate_refuses_every_path_under_the_prefix(self) -> None:
+        from kiro_crew import security
+
+        for path in self._prefix_paths():
+            assert security.is_sensitive_write_path(path) is True, path
+
+    def test_the_prefix_stays_readable(self) -> None:
+        """Hiding it would stop the agent executing the launcher at all."""
+        from kiro_crew import security
+
+        for path in self._prefix_paths():
+            assert security.is_sensitive_path(path) is False, path
+
+    def test_the_sandbox_seals_the_prefix_read_only(self) -> None:
+        from kiro_crew import sandbox
+
+        assert "playwright-cli" in sandbox._CREW_READONLY_LEAVES
+        # Hidden and read-only are different tiers, and this leaf must be the
+        # second: a mask would deny the exec browsing depends on.
+        assert "playwright-cli" not in sandbox._CREW_HIDDEN_LEAVES
+
+    def test_the_seal_is_not_skipped_on_a_host_that_never_installed(self) -> None:
+        """`mount(2)` cannot target an absent path, so the launcher creates it.
+
+        Without this the data home stays writable at that name on exactly the
+        installs that have never run the browser install — the population the fence
+        matters most for.
+        """
+        from kiro_crew import sandbox
+
+        assert "playwright-cli" in sandbox._CREW_PRECREATE_READONLY_DIR_LEAVES
+
+    def test_an_unrelated_data_home_path_is_untouched(self) -> None:
+        """The fence is one subtree, not a broad write-lock on the data home."""
+        from kiro_crew import security
+
+        assert (
+            security.is_sensitive_write_path(str(config_dir() / "workspace" / "notes.md")) is False
+        )


### PR DESCRIPTION
## Problem / Motivation

`detect()` spawns `[cli_path(), "--version"]` through `cli_env()` on every browser-status read, so whatever resolves out of the browse CLI's install prefix is **executed in the gateway's process, with the gateway's environment**. That prefix — `<data-home>/playwright-cli`, which `playwright-cli.sh` installs into and `_standalone_node_modules()` already probes — is writable by a sandboxed agent turn. A launcher planted there is a program the gateway runs.

## Why it matters

It is the supported install shape, not a misconfiguration. The shipped unprivileged installer exists precisely to install without touching a privileged prefix, and its target sits inside the data home.

What makes this one fixable is that the path is **fixed and product-owned**. The other agent-writable directories in the same resolution chain (`~/.local/bin`, `~/.npm-packages/bin`, `~/.volta/bin`, the mise shims, all in `env._EXTRA_PATH_DIRS`) are the user's own and cannot be sealed without breaking them — that is #4438's open territory, which this PR does not claim to close.

## What changed (motivation → approach → change)

**Symptom** — an agent-writable directory supplies an executable the gateway spawns.
**Root cause** — the write, and only the write: every legitimate consumer reads or executes.
**Change** — fence the write on both paths, because protected on one path is not protected.

- **`security/paths.py`** — the prefix joins `_WRITE_PROTECTED_HOME_PATHS`, so the agent's file-edit tool refuses. `_path_in_home_dirs` resolves paths *under* each entry, so one directory entry covers the launcher and the package tree alike. Added as its own `+=` statement, leaving the existing comprehension untouched.
- **`sandbox.py`** — the leaf joins `_CREW_READONLY_LEAVES`: read + execute, kernel-denied write. That is what still holds when a path is spelled at runtime (`$(printf ...)`), which no deny rule can match.
- **`sandbox.py`** — and `_CREW_PRECREATE_READONLY_DIR_LEAVES`, because `mount(2)` cannot target an absent path: without it the seal is skipped and the data home stays writable at that name on exactly the installs that have never run the browser install.

### Why READONLY and not hidden

Browsing requires the agent's own shell to EXECUTE the launcher, so a mask would break the feature the fence protects. The read/execute-vs-write asymmetry is what every legitimate consumer already lives within:

| consumer | needs |
|---|---|
| `install()` | writes — but from the **gateway**, never from a sandboxed turn |
| `cli_path` / `detect` / `available` | resolve + spawn |
| `_standalone_node_modules()` (revision probe) | read |
| the agent's shell running the CLI | execute |
| `playwright-cli.sh` | writes — run by the operator from their own shell |

`aws-control-staging` is the precedent in the same list: gateway-owned staging, fenced so a same-UID agent cannot swap the contents between the gateway's write and its read.

### Why the precreate entry is sound

The leaf clears both documented criteria. (1) An empty `playwright-cli/` resolves no launcher and holds no `@playwright/cli` tree, which is exactly what an absent prefix means: the CLI is not installed. (2) It is a DIRECTORY, so the stale-read concern does not arise — a directory bind shows live contents, which is also what makes sealing it compatible with installing into it afterwards: the gateway writes the real tree and a sandboxed process sees it, read-only.

## Tests

`TestTheInstallPrefixIsFenced` in `test/test_browser_cli_launch.py`, 5 cases:

- the edit gate refuses the prefix, the launcher inside it, and the package tree
- **the prefix stays readable** — hiding it would stop the agent executing the launcher
- the sandbox seals it read-only, and it is **not** in `_CREW_HIDDEN_LEAVES` (the tiers are different and this leaf must be the second)
- the seal is not skipped on a host that never installed (the precreate entry)
- an unrelated data-home path is untouched — this is one subtree, not a broad write-lock

The test names the prefix through `_STANDALONE_PREFIX_ENV` / `_STANDALONE_PREFIX_DIR`, which is how this branch's own code already names it, so the fence is pinned against the install shape as it exists today.

## Manual verification

```
write refused: True | still readable: True
```

Gates on this branch: `pytest` on `test_browser_cli_launch.py`, `test_browser_cli_journeys.py`, every `test_sandbox*.py`, `test_app_sources_write_protection.py` (1349 passed), plus `black --check --target-version py310`, `flake8`, `isort --check-only`, `mypy` on both changed modules — all clean.

Eight failures in `test_sandbox_first_party_exec.py` reproduce identically on a **pristine `origin/main` worktree with this commit absent** (`assert 'foreign_sandbox' == 'no_backend'` — the host running the suite is itself sandboxed), so they are environmental to my machine rather than caused by this change.

## Related Issues

Fixes #9252

Unblocks #9208, whose blocking review finding names this remedy directly: *"Make the managed prefix agent-read-only at both the tool gate and OS sandbox before resolving executables from it."* The two are deliberately separate diffs — that one is a resolution fix for #9203, this one is a trust-boundary change — so a revert of either does not take the other with it.

Does **not** close #4438.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a directory that supplies an executable to a privileged process must be fenced at every path that can write it — the tool gate catches the spelling, the kernel catches the spelling built at runtime. Fencing one and not the other reads as protected while being bypassable, which is why the entries in these lists carry explicit "paired with" notes.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, the rationale lives beside both lists as those lists' convention requires
- [x] No secrets, credentials, or internal references in the diff
