### PR TITLE
test(work-ledger): name the cause when the binding race test shortfalls

### DIFF
--- a/test/test_work_ledger.py
+++ b/test/test_work_ledger.py
@@ -1349,22 +1349,53 @@ def test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding():
                 wl.apply_conductor_action(key, "create", title="t", acceptance={})["item"].item_id,
             )
         )
-    outcomes: list[str] = []
+    # One record per thread, keyed by the conductor that thread bound with, so a
+    # thread that dies silently or never finishes still leaves a named entry. The
+    # old helper caught only ``wl.WorkLedgerError`` and appended nothing on anything
+    # else, so a Windows sharing violation (a bare ``OSError`` per #9250's own
+    # docstring) killed the thread without a trace and shortened the count — the
+    # test then reported ``assert 2 == 3`` and threw away the one fact that names
+    # the cause. Each thread starts as ``"never-started"`` and is overwritten only
+    # when its body actually runs, so a thread that never scheduled is
+    # distinguishable from one that ran and died.
+    records: dict[str, str] = {key: "never-started" for key, _ in items}
 
     def bind(key: str, item_id: str) -> None:
         try:
             wl.apply_conductor_action(key, "bind", item_id=item_id, worker_session_key=WORKER)
-            outcomes.append("bound")
+            records[key] = "bound"
         except wl.WorkLedgerError as exc:
-            outcomes.append(exc.code)
+            records[key] = exc.code
+        except BaseException as exc:  # noqa: BLE001 — diagnostic: never swallow, always name
+            records[key] = f"{type(exc).__name__}: {exc}"
 
-    threads = [threading.Thread(target=bind, args=pair) for pair in items]
-    for thread in threads:
+    threads = {key: threading.Thread(target=bind, args=(key, item_id)) for key, item_id in items}
+    for thread in threads.values():
         thread.start()
-    for thread in threads:
+    for thread in threads.values():
         thread.join(timeout=120)
-    assert outcomes.count("bound") == 1
-    assert outcomes.count(wl.CODE_ALREADY_BOUND) == 3
+
+    # A ``join`` that timed out returns with the thread still alive, which is
+    # indistinguishable from a silent death by the records alone — mark those
+    # explicitly so a hung thread names itself instead of masquerading as one that
+    # appended nothing.
+    for key, thread in threads.items():
+        if thread.is_alive():
+            records[key] = f"still-running-after-120s (last record: {records[key]})"
+
+    outcomes = list(records.values())
+    _detail = "; ".join(f"{key}={records[key]}" for key, _ in items)
+    assert outcomes.count("bound") == 1, (
+        f"expected exactly one thread to bind the worker, got "
+        f"{outcomes.count('bound')} — per-thread outcomes: {_detail}"
+    )
+    assert outcomes.count(wl.CODE_ALREADY_BOUND) == 3, (
+        f"expected 3 threads to report {wl.CODE_ALREADY_BOUND!r}, got "
+        f"{outcomes.count(wl.CODE_ALREADY_BOUND)} — a shortfall means a thread hit "
+        f"something other than a clean already-bound refusal (a bare OSError from a "
+        f"Windows sharing violation, or a thread that never finished); per-thread "
+        f"outcomes: {_detail}"
+    )
     binding = wl.read_binding(WORKER)
     assert binding is not None
     bound = [pair for pair in items if pair == binding]


### PR DESCRIPTION
## Problem / Motivation

`test/test_work_ledger.py::test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding`
fails on `Backend Tests (Windows) (4)`, and only there, intermittently. It has
tripped several unrelated pull requests. When it fails it prints one line:
`assert 2 == 3`. That number tells you a thread went missing. It does not tell
you why, so nobody can aim a fix at it.

## Why it matters

A merged fix already failed to clear this. PR #9250 (commit `2b379bad9`) stopped
the lock-file open from truncating the file, which removed one Windows sharing
violation. The failure survived it: a run that started 41 minutes after that
merge, on a merge ref that contains `2b379bad9`, failed the same way. So a second
cause exists, and the test is built so that it cannot be identified. It spawns
four threads, each binding a different item to the same worker, and its `bind`
helper caught only `wl.WorkLedgerError`:

```python
except wl.WorkLedgerError as exc:
    outcomes.append(exc.code)
```

A Windows sharing violation surfaces as a bare `OSError`, which is exactly what
#9250's own docstring describes. That is not a `WorkLedgerError`, so it killed the
thread silently, appended nothing, and shortened the count. The test threw away
the one fact that names the cause and reported a bare number mismatch. Every
Windows failure so far has cost an investigation that starts from zero.

## What changed (motivation -> approach -> change)

The symptom is a count that is short by one. The root cause of the *blindness* is
a narrow `except` that drops any non-`WorkLedgerError` on the floor, plus a
`join(timeout=120)` that can return with the thread still running -- a hang and a
silent death look identical today.

So this records one outcome per thread, keyed by the conductor that thread bound
with. The helper now catches `BaseException`, keeping the exception type and its
message; a thread that never scheduled stays marked `never-started`; and after the
joins, any thread still alive is marked `still-running-after-120s`. Both count
assertions now carry the full per-thread map in their failure message, so the next
Windows failure reads, for example, `chat-3-c=OSError: [Errno 13] ...` instead of
`assert 2 == 3`.

The `== 1` and `== 3` assertions are byte-for-byte unchanged. This adds diagnosis,
not tolerance. A green board bought by relaxing the counts would be worse than the
intermittent red, which at least tells the truth.

This deliberately does not fix the underlying race. The point of the change is that
the next Windows failure identifies its own cause so the fix can be aimed rather
than guessed -- guessing already produced a partial fix once.

## Tests

`test/test_work_ledger.py` only; no production file changed. The edited test still
passes on Linux (123 passed in the file with `pytest -n0`), confirming the
instrumentation does not change the passing behaviour. The Windows-only failure
cannot be reproduced on the Linux CI or on this host; the value of the change is
observable only on the next Windows red, which will now name its exception.

## Manual verification

N/A -- test-only change, verified by running the file on Linux. The Windows path
is exactly what this change exists to instrument; it cannot be exercised here.

## Related Issues

Base maintenance for an intermittent Windows failure blocking unrelated PRs. No
closing keyword: this diagnostic does not by itself resolve the race, so closing
an issue on merge would be wrong.
