### PR TITLE
fix(slack): stop a refused progress card from splitting the reply

### DIFF
--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -204,6 +204,13 @@ _THINKING_PLACEHOLDER = "💭 _Thinking…_"
 _CURSOR = " ▍"
 _NO_RESPONSE = "_No response._"
 _STATUS_WORKING = "is working on your request"
+#: First chunk of a REPLACEMENT stream opened by ``_rotate_stream``. A rotation
+#: abandons the message the reader is already watching and continues the same
+#: answer in a new one, so without this the thread reads as a stalled reply
+#: followed by an unexplained second reply. Slack appends stream chunks and
+#: never replaces them, so the text already shown stays in the abandoned
+#: message — this line is what tells the reader the two belong together.
+_STREAM_CONTINUED = "_(continued)_\n\n"
 
 # Max chars of reasoning to surface inline in Slack before truncating. Keeps
 # the 💭 Thinking block from becoming a wall of text; the full
@@ -3014,7 +3021,11 @@ async def handle_message(
         if stream_ts:
             await slack.stop_stream(channel, stream_ts)
         new_ts = await slack.start_stream(
-            channel, reply_ts, team_id=team_id or None, user_id=user_id or None
+            channel,
+            reply_ts,
+            initial_text=_STREAM_CONTINUED,
+            team_id=team_id or None,
+            user_id=user_id or None,
         )
         if new_ts:
             stream_ts = new_ts
@@ -3052,19 +3063,26 @@ async def handle_message(
         return ok
 
     async def _append_task(task_id: str, title: str, status: str, details: str = "") -> bool:
-        """Append task card to stream, rotating on failure."""
+        """Append task card to stream. Never rotates — see below.
+
+        A task card is progress decoration: the tool's name, its state, and the
+        elapsed-time refresh ``_tool_elapsed_updater`` fires every 30s for as
+        long as a tool runs. During a several-minute tool phase it is the ONLY
+        thing appending to the stream, which makes it by far the likeliest call
+        to meet a rate limit or a stream Slack has already closed.
+
+        Rotating on that failure costs the reader their in-progress message and
+        moves the rest of the answer into a new one, so a transient refusal on a
+        decorative refresh renders as a failed reply plus a second reply minutes
+        later. Skipping the card costs nothing: no answer text is withheld, and
+        ``_append_stream`` still rotates when there is real text to deliver and
+        the stream refuses it, which is the moment a rotation is worth its price.
+        """
         if not stream_ts:
             return False
         if channel_activation == ACTIVATION_REVIEW:
             return True  # Suppress task cards in review mode
-        ok = await slack.append_task(channel, stream_ts, task_id, title, status, details=details)
-        if not ok and use_slack_stream:
-            if await _rotate_stream():
-                assert stream_ts is not None
-                return await slack.append_task(
-                    channel, stream_ts, task_id, title, status, details=details
-                )
-        return ok
+        return await slack.append_task(channel, stream_ts, task_id, title, status, details=details)
 
     async def _tool_elapsed_updater() -> None:
         """Periodically update the active task card with elapsed time (every 30s)."""

--- a/src/kiro_crew/slack/renderer.py
+++ b/src/kiro_crew/slack/renderer.py
@@ -62,6 +62,7 @@ from kiro_crew.slack.handler import (
     _APPROVAL_TIMEOUT,
     _CURSOR,
     _EDIT_INTERVAL,
+    _STREAM_CONTINUED,
     _THINKING,
     StatusReactionController,
     _append_footer_actions,
@@ -434,7 +435,10 @@ class SlackRenderer(Renderer):
         if self._stream_ts:
             await self.slack.stop_stream(self.channel, self._stream_ts)
         new_ts = await self.slack.start_stream(
-            self.channel, self.thread_ts or "", user_id=self._user_id or None
+            self.channel,
+            self.thread_ts or "",
+            initial_text=_STREAM_CONTINUED,
+            user_id=self._user_id or None,
         )
         if new_ts:
             self._stream_ts = new_ts
@@ -689,19 +693,19 @@ class SlackRenderer(Renderer):
                 logger.debug("slack: posting a continuation chunk failed", exc_info=True)
 
     async def _append_task(self, task_id: str, title: str, status: str, details: str = "") -> bool:
-        """Append a task card, rotating once on failure (native ``_append_task``)."""
+        """Append a task card. Never rotates (native ``_append_task``).
+
+        The card is progress decoration and ``_tool_elapsed_updater`` re-sends it
+        every 30s for as long as a tool runs, so on a long tool phase it is the
+        only caller touching the stream — and rotating on its failure would cost
+        the reader the message they are watching and split the answer in two.
+        ``_append_stream`` still rotates for real text.
+        """
         if not self._stream_ts:
             return False
-        ok = await self.slack.append_task(
+        return await self.slack.append_task(
             self.channel, self._stream_ts, task_id, title, status, details=details
         )
-        if not ok and self._use_slack_stream:
-            if await self._rotate_stream():
-                assert self._stream_ts is not None
-                return await self.slack.append_task(
-                    self.channel, self._stream_ts, task_id, title, status, details=details
-                )
-        return ok
 
     def _tool_elapsed_str(self) -> str:
         """Formatted elapsed time for the active tool, or '' (native helper)."""

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -3512,6 +3512,86 @@ class TestToolElapsedTimer:
         assert all("⏱" not in d for d in details_list), f"⏱ leaked into details: {details_list}"
 
 
+class _TaskCardRefusedSlack(MockSlackClient):
+    """append_task is refused; every other call is healthy.
+
+    The shape of a long tool phase meeting a Slack rate limit: the elapsed-time
+    refresh is the only thing touching the stream and Slack turns it down.
+    """
+
+    async def append_task(self, channel, ts, task_id, title, status, details="", output=""):
+        await super().append_task(
+            channel, ts, task_id, title, status, details=details, output=output
+        )
+        return False
+
+
+class _StreamAppendRefusedOnceSlack(MockSlackClient):
+    """The first append_stream is refused, so real text forces one rotation."""
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self._n_append = 0
+
+    async def append_stream(self, channel, ts, text):
+        self._n_append += 1
+        await super().append_stream(channel, ts, text)
+        return self._n_append > 1
+
+
+class TestTaskCardNeverAbandonsTheStream:
+    """A refused task card must not cost the reader their in-progress message.
+
+    Rotating on a task-card failure stops the stream the reader is watching and
+    continues the same answer in a NEW message, so the thread reads as a reply
+    that failed followed minutes later by an unexplained second reply
+    (issue 8511). A task card is decoration, so skipping it withholds no answer
+    text; ``_append_stream`` still rotates when real text is refused.
+    """
+
+    @pytest.mark.asyncio
+    async def test_refused_task_card_does_not_open_a_second_stream(self):
+        slack = _TaskCardRefusedSlack()
+        slack._stream_enabled = True
+        provider = FakeProvider(
+            [
+                LLMEvent(kind="text_chunk", text="looking"),
+                LLMEvent(kind="tool_call", title="Run Shell", tool_kind="execute"),
+                LLMEvent(kind="text_chunk", text=" done"),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "do it", None, "msg1", "U1")
+
+        starts = [a for a in slack.actions if a[0] == "start_stream"]
+        assert len(starts) == 1, slack.actions
+        assert [a for a in slack.actions if a[0] == "append_task"], slack.actions
+        # One stream opened, one stopped: the answer stayed in a single message.
+        stops = [a for a in slack.actions if a[0] == "stop_stream"]
+        assert len(stops) == 1, slack.actions
+        assert stops[0][1]["ts"] == starts[0][1]["ts"], slack.actions
+
+    @pytest.mark.asyncio
+    async def test_refused_real_text_still_rotates_and_says_it_continues(self):
+        """The branch that protects answer delivery is untouched, and the
+        replacement stream opens with the continuation marker so the two
+        messages read as one answer."""
+        slack = _StreamAppendRefusedOnceSlack()
+        slack._stream_enabled = True
+        # Trailing space: StreamRedactor withholds a trailing credential-class
+        # run, so a chunk with no separator never reaches append_stream at all.
+        provider = FakeProvider([LLMEvent(kind="text_chunk", text="hello ")])
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "hi", None, "msg1", "U1")
+
+        starts = [a for a in slack.actions if a[0] == "start_stream"]
+        assert len(starts) == 2, slack.actions
+        assert starts[0][1]["text"] is None, starts
+        # The literal, not the constant: a test that imports the constant still
+        # passes when the marker is emptied out.
+        assert "continued" in (starts[1][1]["text"] or ""), starts
+
+
 class TestCondenseThinking:
     """Unit tests for the _condense_thinking blockquote/truncation helper."""
 

--- a/test/test_slack_renderer.py
+++ b/test/test_slack_renderer.py
@@ -45,7 +45,12 @@ class _RecSlack:
     async def start_stream(self, channel, thread_ts, **kw):
         self.calls.append((
             "start_stream",
-            {"channel": channel, "thread_ts": thread_ts, "user_id": kw.get("user_id")},
+            {
+                "channel": channel,
+                "thread_ts": thread_ts,
+                "user_id": kw.get("user_id"),
+                "initial_text": kw.get("initial_text"),
+            },
         ))
         return self._ts()
 
@@ -597,6 +602,78 @@ class _FlakyAppendSlack(_RecSlack):
         ok = self._n_append > 1  # first append fails -> rotation, retry succeeds
         self.calls.append(("append_stream", {"text": text, "ok": ok}))
         return ok
+
+
+class _FlakyTaskSlack(_RecSlack):
+    """append_task refuses; append_stream is healthy.
+
+    The shape of a long tool phase meeting a rate limit: the 30s elapsed-time
+    refresh is the only thing touching the stream, and Slack turns it down.
+    """
+
+    async def append_task(self, channel, ts, task_id, title, status, details="", output=""):
+        self.calls.append(("append_task", {"title": title, "status": status, "ok": False}))
+        return False
+
+
+class TestTaskCardNeverAbandonsTheStream:
+    """A refused task card must not cost the reader their in-progress message.
+
+    Rotating on a task-card failure stops the stream the reader is watching and
+    continues the answer in a NEW message, so the thread reads as a reply that
+    failed followed minutes later by an unexplained second reply (issue 8511).
+    The card is decoration; skipping it withholds no answer text, and
+    ``_append_stream`` still rotates when real text is refused.
+    """
+
+    def test_refused_task_card_does_not_rotate(self):
+        rec = _FlakyTaskSlack()
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
+
+        async def scenario():
+            ts = await renderer._ensure_stream()
+            assert await renderer._append_task("t-1", "Bash", "in_progress") is False
+            return ts
+
+        opened = asyncio.run(scenario())
+        opens = [kw for m, kw in rec.calls if m == "start_stream"]
+        assert len(opens) == 1, rec.calls
+        assert renderer._stream_ts == opened, rec.calls
+        assert not [m for m, _ in rec.calls if m == "stop_stream"], rec.calls
+
+    def test_elapsed_refresh_failure_leaves_the_answer_in_one_message(self):
+        """Whole-turn shape: tool runs, its card is refused, the answer still
+        lands in the message that was already open."""
+        rec = _FlakyTaskSlack()
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
+        provider = _Provider([
+            AcpEvent(kind=EVENT_TEXT_CHUNK, text="looking "),
+            AcpEvent(kind=EVENT_TOOL_CALL, title="Bash", tool_name="Bash"),
+            AcpEvent(kind=EVENT_TEXT_CHUNK, text="done "),
+            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+        ])
+        asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
+        opens = [kw for m, kw in rec.calls if m == "start_stream"]
+        assert len(opens) == 1, rec.calls
+        assert [kw for m, kw in rec.calls if m == "append_task"], rec.calls
+
+    def test_real_text_refused_still_rotates_and_says_it_continues(self):
+        """The branch that protects delivery is untouched, and the replacement
+        stream opens with the continuation marker so the two messages read as
+        one answer rather than as a failure plus a mystery reply."""
+        rec = _FlakyAppendSlack()  # first append_stream fails => one rotation
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
+        provider = _Provider([
+            AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi "),
+            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+        ])
+        asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
+        opens = [kw for m, kw in rec.calls if m == "start_stream"]
+        assert len(opens) == 2, rec.calls
+        assert opens[0]["initial_text"] is None, opens
+        # The literal, not the constant: a test that imports the constant still
+        # passes when the marker is emptied out.
+        assert "continued" in (opens[1]["initial_text"] or ""), opens
 
 
 class _NoStreamSlack(_RecSlack):


### PR DESCRIPTION
## Problem / Motivation

On Slack, a long agent turn showed the reply going wrong and then going right. The
in-progress bot message stopped and started reading as a failure, and minutes later
the real answer arrived as a second message in the thread. The agent never failed.
Only the reporting of it did.

## Why it matters

A false failure followed by a correct answer is worse than either a clean failure or
a slow success. The reader stops waiting, retries, or asks again, and the retry costs
a whole second agent run. It teaches people not to trust the channel for exactly the
long, tool-heavy work the agent is most useful for.

## What changed (motivation -> approach -> change)

The symptom is a split reply, so the question is what splits it. Two Slack pipelines
open a stream and then append to it: `handler.py` (native) and `SlackRenderer`
(transport). Both had the same rule  -  if Slack refuses an append, stop that stream and
start a new one. That rule protects the answer. It also moves the rest of the answer
into a different message and leaves the old one stopped part-way through.

The root cause is which append triggers it. A task card is decoration: the tool's name,
its state, and an elapsed-time refresh that `_tool_elapsed_updater` re-sends every 30
seconds for as long as a tool runs. During a several-minute tool phase there is no
answer text to send, so that card is the only thing touching the stream  -  which makes
it the likeliest call to meet a rate limit or a stream Slack has already closed. Both
pipelines then paid for a "1m 30s" title with the reader's message. That is why the
break tracked how long the turn ran, and why the answer landed elsewhere afterwards.

So `_append_task` now returns the refusal and keeps the stream. Nothing is withheld:
the card is decoration, and `_append_stream` still rotates when Slack refuses real
text, which is the moment a rotation is worth its price. When that rotation does
happen, the replacement stream opens with a `_(continued)_` marker, so the two
messages read as one answer instead of a stalled reply plus an unexplained second one.

```mermaid
flowchart LR
  subgraph Before
    A1["30s elapsed refresh"]:::ctx --> B1["Slack refuses the card"]:::ctx
    B1 --> C1["stop the stream, open a new one"]:::removed
    C1 --> D1["answer continues in message 2"]:::removed
  end
  subgraph After
    A2["30s elapsed refresh"]:::ctx --> B2["Slack refuses the card"]:::ctx
    B2 --> C2["skip the card, keep the stream"]:::added
    C2 --> D2["answer stays in message 1"]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 1,2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 4,5 stroke:#16A34A,stroke-width:2px
```

green = added, yellow = changed, red = removed, blue = unchanged

*A refused progress card no longer takes the reader's message with it, so the answer
stays where they are already looking.*

One thing this does not change. If Slack has genuinely closed the stream, the first
real text still forces a rotation, and whatever terminal state Slack painted on the
closed message stays there  -  repainting it needs a `chat.update`, which downgrades the
rich stream render. What the fix guarantees is that a live stream is never abandoned
for a decorative update, and that a forced rotation says it continues.

## Tests

Both pipelines get the same pair, because both carried the same rule.

- `TestTaskCardNeverAbandonsTheStream` in `test/test_slack_handler.py` and in
  `test/test_slack_renderer.py`. A fake whose `append_task` is refused and whose
  `append_stream` is healthy. Each asserts one `start_stream` for the turn, no
  `stop_stream` of the first stream, and the card still attempted  -  so a refusal
  costs the reader nothing.
- The delivery branch is pinned too: a fake that refuses the first `append_stream`
  must still produce two `start_stream` calls, the first with no initial text and the
  second carrying the continuation marker. These assert the literal `continued`, not
  the constant, so emptying the constant reddens them.

Proved with `prepare-pr/scripts/prove.py --base main`: **PROVEN**  -  reverting the
production hunks while keeping the tests makes an assertion fail, so the tests observe
the defect rather than merely passing beside it.

Scoped runs on the changed files and on every consumer test that asserts on
`append_task` / `start_stream` call shape: `test_slack_handler.py` 188 passed,
`test_slack_renderer.py` 45 passed, `test_review_mode.py` 73, `test_slack_backports.py`
36, `test_slack_handler_more_coverage.py` 56, `test_slack_transport_integration.py` 3.
`black --target-version py310`, `isort`, `flake8` clean on the changed files, and
`scripts/check_black_formatting.py` passes in real scope.

## Manual verification

N/A  -  Slack cannot be driven from a pod (the channel's credentials are scrubbed from
the pod environment and there is no injectable Slack transport), so the streaming call
sequence is pinned by the fakes above, which assert the outgoing call shape rather than
the rendered text.

## Related Issues

Closes #8511

## Pattern harvest

The defect class: **a shared retry path serving two callers of very different value,
where the recovery costs more than the thing it recovers.** Rotating the stream is
correct for an answer chunk, whose loss is unrecoverable, and wrong for a decorative
progress card, whose loss is nothing. One helper carried the rule for both, and the
cheap caller  -  the one that fires every 30 seconds, so the one most likely to fail  - 
paid the expensive price.

Rule candidate: review-prompt  -  when a failure handler is reached from more than one
call site, ask what each caller loses if the operation is simply skipped, and do not
let the caller with the least to lose trigger the most destructive recovery.
