### PR TITLE
fix(dashboard): a failing slots broadcast must not fail the write

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -333,7 +333,7 @@ def _slots_ws_frame(
 
     ONE builder for the two sites that send this frame — the generic fan-out in
     :meth:`DashboardState._broadcast` and the owner frame in
-    :meth:`DashboardState._do_slots_broadcast` — because they must carry the SAME
+    :meth:`DashboardState._send_slots_frames` — because they must carry the SAME
     keys and nothing else enforces that. ``_send_ws_all`` skips owner sockets for
     ``slots``, so the generic frame no longer backstops an owner: a key present in
     one envelope and not the other silently deprives every owner window, with no
@@ -445,6 +445,14 @@ def _delivery_key(content: str) -> str:
 # Slot-list broadcast coalescing window. The sub-agent slots debouncer in
 # slack/gateway.py hardcodes the same value independently; the two are not shared.
 _SLOTS_BROADCAST_INTERVAL_S: float = 0.2
+
+# How often a DROPPED slots broadcast may log its full traceback. The drop is
+# contained (see _do_slots_broadcast), and the fault that causes it is a property
+# of slot state, not of one push: it therefore recurs on EVERY later broadcast,
+# and a slot mutation fires several per turn. Logging each one buries the first
+# traceback under thousands of copies. First drop always logs; after that one
+# per window, carrying the running count so nothing is silently absorbed.
+_SLOTS_BROADCAST_DROP_LOG_INTERVAL_S: float = 60.0
 
 
 def native_subagent_output_tail(chunks: list[str], limit: int = NATIVE_SUBAGENT_OUTPUT_TAIL) -> str:
@@ -4862,6 +4870,13 @@ class DashboardState:
     _slots_broadcast_lock: "threading.Lock | None" = None
     _slots_broadcast_timer: "asyncio.TimerHandle | None" = None
     _slots_broadcast_last: float = 0.0
+    # Dropped-broadcast bookkeeping, on that same read path and for the same
+    # reason: _do_slots_broadcast reads both while HANDLING a failure, so an
+    # __init__-only attribute would raise AttributeError there and re-raise the
+    # very exception the containment exists to absorb. Counts drops for the whole
+    # process lifetime; the timestamp throttles the repeat log, not the count.
+    _slots_broadcast_drops: int = 0
+    _slots_broadcast_drop_logged: float = 0.0
     # The one loop this dashboard is served on. Every surface that hands work in
     # from a foreign thread -- the coalesced slots broadcast, an off-loop
     # websocket send, the log handler's fan-out -- resolves it through
@@ -7674,6 +7689,14 @@ class DashboardState:
         exception (`PEP 678`) so the buried original stays visible — the flush's
         exception otherwise replaces the body's in the caller's view, demoting
         the actual fault to ``__context__`` (how #6522 was first misread).
+
+        The EVIDENCED way to reach that annotation is gone: a failing broadcast
+        is now contained in ``_do_slots_broadcast`` and logged, so the flush no
+        longer raises over the body's exception and the body's fault propagates
+        as itself (#8745). What remains is the narrow rest of
+        ``push_slots_update`` — a lock or timer-scheduling fault — which is why
+        the annotation stays rather than being deleted with the case that
+        motivated it.
         """
         self._slots_push_suspend += 1
         try:
@@ -7814,7 +7837,74 @@ class DashboardState:
         self._do_slots_broadcast()
 
     def _do_slots_broadcast(self) -> None:
-        """Serialize and broadcast the slot list. Bypasses coalescing."""
+        """Announce the slot list. A failure here is logged, never raised.
+
+        This is the ONE funnel both coalescing branches reach — the leading-edge
+        call in ``push_slots_update`` and the trailing timer's
+        ``_trailing_slots_flush`` — so containing the failure here makes both
+        branches answer identically by construction. That convergence is the
+        point (#8745): before this, a broken slots projection surfaced as a 500
+        on the leading edge and as a log line inside the 0.2s window, so a timer
+        decided whether the caller was told, and the 500 landed on the idle
+        dashboard doing one deliberate new-chat.
+
+        WHY CONTAINING IT IS CORRECT. A broadcast is work that happens AFTER the
+        state change it announces has already committed. ``api_chat_slot_create``
+        is the evidenced caller: the slot is in ``_slots`` and its metadata is
+        persisted before ``suspend_slots_push.__exit__`` flushes the owed push,
+        so an exception escaping that flush turned a create that HAPPENED into a
+        500 the caller reads as "it did not". The user retries and gets a second
+        slot. A listener being absent, slow or broken says nothing about whether
+        the write landed, so it must not be able to fail the write.
+
+        The evidenced fault is a non-serializable value in slot state (#6522,
+        #8745), and this broadcast serializes EVERY slot: one poisoned slot
+        therefore failed an unrelated healthy create. That is a fault in the
+        messenger being charged to the write.
+
+        WHAT THIS DELIBERATELY DOES NOT COVER. The slots READ paths — ``GET
+        /api/chat/slots``, the WS connect snapshot, ``_slots_ws_frame`` — keep
+        failing loud, and that is not an oversight. A read path's answer IS the
+        projection, so a caller asking for it must be told it is unrenderable.
+        This path's answer is "something changed"; the change is already true
+        whether or not anyone hears it. Same fault, opposite obligation.
+
+        LOUD, NOT SILENT. Every drop increments ``_slots_broadcast_drops`` and
+        the first one logs the full traceback, which carries the offender note
+        naming the slot, field and type (see ``_slots_serialization_note``). Only
+        the REPEATS are throttled, and each surviving line carries the running
+        count. A client repairs a dropped frame on its next read; nothing repairs
+        a wrong 500.
+        """
+        try:
+            self._send_slots_frames()
+        except Exception:
+            # Both reads resolve through class-level defaults (see the block at
+            # the top of DashboardState), because this handler runs on a
+            # __new__-built state too. An __init__-only counter would raise
+            # AttributeError here and re-raise the 500 this exists to absorb.
+            drops = self._slots_broadcast_drops + 1
+            self._slots_broadcast_drops = drops
+            now = time.monotonic()
+            if (
+                drops == 1
+                or now - self._slots_broadcast_drop_logged >= _SLOTS_BROADCAST_DROP_LOG_INTERVAL_S
+            ):
+                self._slots_broadcast_drop_logged = now
+                logger.exception(
+                    "slots broadcast dropped; the state change it announces is "
+                    "already committed and every slots read path is equally "
+                    "broken (%d dropped since start)",
+                    drops,
+                )
+
+    def _send_slots_frames(self) -> None:
+        """Serialize and broadcast the slot list. Bypasses coalescing.
+
+        Called only by :meth:`_do_slots_broadcast`, which owns the contract that
+        a failure here never reaches the caller. Raising is how this reports a
+        fault: the guard logs it with the offender note attached.
+        """
         from kiro_crew.dashboard.handlers.source_providers import (
             gitlab_hosts_generation,
         )
@@ -7845,7 +7935,8 @@ class DashboardState:
         # the failure with the offender so one traceback is enough to find it.
         # Both coalescing branches (leading edge and trailing timer) funnel
         # through this method, so both report identically by construction.
-        # Diagnosis only: the exception still propagates unchanged.
+        # The note rides the exception up to ``_do_slots_broadcast``, which logs
+        # it instead of failing the committed write that asked for this push.
         try:
             slots_json = json.dumps(slots_data)
         except (TypeError, ValueError) as exc:
@@ -8044,7 +8135,7 @@ class DashboardState:
                     "channelTrusted": note.get("channelTrusted", False),
                 }
                 # Built by `_slots_ws_frame`, NOT inline: the owner frame in
-                # `_do_slots_broadcast` has to carry an identical key set, and it
+                # `_send_slots_frames` has to carry an identical key set, and it
                 # cannot if each site names its own keys. See that function.
                 ws_msg = _slots_ws_frame(
                     slots_list,

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -163,7 +163,10 @@ class TestSlotsBroadcastCarriesFolders:
         ws = self._DashboardWS()
         state.register_ws(ws)  # type: ignore[arg-type]
 
-        state._do_slots_broadcast()  # must not raise
+        # The frame assertion below is the pin: a broadcast failure is contained
+        # in _do_slots_broadcast (#8745), so send_str would simply never be
+        # called and call_args would be None.
+        state._do_slots_broadcast()
 
         frame = json.loads(ws.send_str.call_args[0][0])
         assert frame["folders"] == [{"id": "ok", "name": "Keep", "order": 0}]
@@ -178,7 +181,10 @@ class TestSlotsBroadcastCarriesFolders:
         ws = self._DashboardWS()
         state.register_ws(ws)  # type: ignore[arg-type]
 
-        state._do_slots_broadcast()  # must not raise
+        # The frame assertion below is the pin: a broadcast failure is contained
+        # in _do_slots_broadcast (#8745), so send_str would simply never be
+        # called and call_args would be None.
+        state._do_slots_broadcast()
 
         frame = json.loads(ws.send_str.call_args[0][0])
         assert frame["folders"] == []

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -960,18 +961,21 @@ def test_suspend_slots_push_no_push_means_no_broadcast(tmp_path, monkeypatch):
     assert seen.count("slots") == 0
 
 
-# ── #8745: a serialization failure in the slots flush must name its offender ──
+# ── #8745: a failing slots broadcast must not fail the write it announces ──
 #
 # The evidenced failure class behind a slots-broadcast 500 is a non-serializable
 # value in slot state: json.dumps raises deep in the flush, every slots read
 # path is equally broken, and the stock TypeError names neither the slot nor
-# the field. Worse, when the flush fails while a suspend block is unwinding
-# over the body's own exception, the flush's exception REPLACES the body's in
-# the caller's view (the original demoted to __context__) — exactly how #6522
-# was first misread as a broadcast bug. These pin the two diagnostics: the
-# offender note on BOTH coalescing branches, and the unwinding-over note.
-# Semantics stay untouched: same exception types, same propagation, same
-# chaining, no caught-and-swallowed anything.
+# the field. #8888 added the diagnostics (an offender note on every path, plus
+# an unwinding-over note) and deliberately left the SEMANTICS alone, because
+# what the caller should be told was an unowned decision.
+#
+# That decision is made here: the broadcast is contained. It runs AFTER the
+# state change it announces has committed, so it must not be able to fail it.
+# Both coalescing branches funnel through _do_slots_broadcast, so both now
+# answer the same way and no timer decides the outcome. The offender note is
+# not lost -- it rides the exception into the log line. The READ paths keep
+# failing loud on purpose: a read path's answer IS the projection.
 
 
 def _poison_slots_projection(state):
@@ -980,82 +984,148 @@ def _poison_slots_projection(state):
     state.serialize_slots = lambda **kw: [dict(entry)]  # type: ignore[method-assign]
 
 
-def test_leading_edge_serialization_failure_names_the_offender(tmp_path, monkeypatch):
-    """The immediate (leading-edge) broadcast annotates the raising TypeError."""
+def test_leading_edge_serialization_failure_is_contained_and_logged(tmp_path, monkeypatch, caplog):
+    """The immediate (leading-edge) broadcast logs the offender instead of raising."""
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
     _poison_slots_projection(state)
 
-    with pytest.raises(TypeError) as excinfo:
-        state.push_slots_update()
+    with caplog.at_level(logging.ERROR, logger="kiro_crew.dashboard.state"):
+        state.push_slots_update()  # must not raise: the write already committed
 
-    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
-    assert "'chat-poison'" in notes, f"note must name the slot key, got: {notes!r}"
+    assert state._slots_broadcast_drops == 1, "the drop must be counted, not absorbed"
+    record = next(r for r in caplog.records if "slots broadcast dropped" in r.getMessage())
+    assert record.exc_info is not None, "a dropped broadcast must log its traceback"
+    notes = "\n".join(getattr(record.exc_info[1], "__notes__", []))
+    assert "'chat-poison'" in notes, f"the offender note must survive containment, got: {notes!r}"
     assert "'title'" in notes, "note must name the offending field"
     assert "object" in notes, "note must name the value's type"
     assert "value withheld" in notes, "note must never carry the value itself"
 
 
-def test_trailing_flush_serialization_failure_names_the_offender(tmp_path, monkeypatch):
-    """The trailing-edge callback funnels through the same annotated dump.
+def test_trailing_flush_serialization_failure_is_contained(tmp_path, monkeypatch):
+    """The trailing-edge callback funnels through the same contained broadcast.
 
-    Both timing branches converge on _do_slots_broadcast, so the diagnostic
-    covers them by construction — this pins the trailing half of that claim.
+    Both timing branches converge on _do_slots_broadcast, so containment covers
+    them by construction -- this pins the trailing half of that claim. Before
+    this fix the leading edge 500ed the caller while the trailing edge only
+    logged, so a 0.2s timer decided what the caller was told.
     """
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
     _poison_slots_projection(state)
 
-    with pytest.raises(TypeError) as excinfo:
+    state._trailing_slots_flush()  # must not raise
+
+    assert state._slots_broadcast_drops == 1
+
+
+def test_repeated_drops_are_all_counted_and_the_log_is_throttled(tmp_path, monkeypatch, caplog):
+    """A recurring fault must not bury its own first traceback under copies.
+
+    The poison is a property of slot state, so it recurs on every push. Every
+    drop counts; only the repeats inside the window are quiet.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _poison_slots_projection(state)
+
+    with caplog.at_level(logging.ERROR, logger="kiro_crew.dashboard.state"):
+        for _ in range(5):
+            state._trailing_slots_flush()
+
+    assert state._slots_broadcast_drops == 5, "every drop must be counted"
+    logged = [r for r in caplog.records if "slots broadcast dropped" in r.getMessage()]
+    assert len(logged) == 1, f"repeats must be throttled, got {len(logged)} lines"
+    assert "1 dropped since start" in logged[0].getMessage()
+
+
+def test_drop_log_resumes_after_the_throttle_window(tmp_path, monkeypatch, caplog):
+    """Throttling is a window, not a mute: a later drop logs with the running count."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _poison_slots_projection(state)
+
+    with caplog.at_level(logging.ERROR, logger="kiro_crew.dashboard.state"):
+        state._trailing_slots_flush()
+        # Backdate well past any sane window rather than importing its value, so
+        # this test pins the resume behaviour and not the constant.
+        state._slots_broadcast_drop_logged = time.monotonic() - 100_000.0
         state._trailing_slots_flush()
 
-    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
-    assert "'chat-poison'" in notes
-    assert "'title'" in notes
+    logged = [r for r in caplog.records if "slots broadcast dropped" in r.getMessage()]
+    assert len(logged) == 2
+    assert "2 dropped since start" in logged[1].getMessage()
 
 
-def test_flush_failure_during_unwind_names_the_masked_exception(tmp_path, monkeypatch):
-    """A flush failing during exception unwind must say whose funeral it crashed.
+def test_broadcast_drop_survives_a_partially_constructed_state():
+    """The failure handler must work on a __new__-built state (no __init__).
 
-    The body's RuntimeError is the actual fault; the flush's TypeError merely
-    reports a broken projection. Today's chaining (body as __context__) is
-    preserved and now NAMED, so the top of the traceback stops eating the lede.
+    Several endpoint suites build their fixture that way. The drop counter is a
+    class-level default for exactly this reason: an AttributeError inside the
+    handler would re-raise the 500 the containment exists to prevent, and it
+    would do so only in those suites.
+    """
+    bare = DashboardState.__new__(DashboardState)
+    # The same minimal seeding test_push_slots_update_survives_a_partially_
+    # constructed_state uses, so the ONLY fault is the poisoned projection.
+    bare._slots = {}
+    bare._ws_clients = []
+    bare._sse_queues = []
+    bare._notify_event = MagicMock()
+    bare.channel_manager = None
+    assert bare._slots_broadcast_drops == 0, "counter must read at baseline without __init__"
+    _poison_slots_projection(bare)
+
+    bare.push_slots_update()  # must not raise
+
+    assert bare._slots_broadcast_drops == 1
+
+
+def test_flush_failure_no_longer_masks_the_body_exception(tmp_path, monkeypatch):
+    """The body's own fault is what the caller sees, not the messenger's.
+
+    This is the masking half of #8745. The body's RuntimeError is the actual
+    fault; the flush's TypeError merely reported a broken projection, and
+    @contextmanager propagated the flush's exception with the body's demoted to
+    __context__ -- which is how #6522 was misread as a broadcast bug. With the
+    broadcast contained the flush no longer raises, so the original propagates
+    as itself and there is nothing left to mask.
     """
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
     _poison_slots_projection(state)
 
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         with state.suspend_slots_push():
             state.push_slots_update()  # queue the owed push
             raise RuntimeError("boom")  # the body's actual fault
 
-    exc = excinfo.value
-    assert isinstance(exc.__context__, RuntimeError), "implicit chaining must survive"
-    notes = "\n".join(getattr(exc, "__notes__", []))
-    assert "unwinding over" in notes and "RuntimeError" in notes
-    assert "__context__" in notes, "note must point at where the original went"
-    assert "'chat-poison'" in notes, "offender note must also be present"
+    assert type(excinfo.value) is RuntimeError, "the body's fault must not be replaced"
     assert state._slots_push_suspend == 0, "depth must still unwind"
+    assert state._slots_broadcast_drops == 1, "the owed flush still ran, and still counted"
 
 
-def test_flush_failure_without_inflight_exception_has_no_unwind_note(tmp_path, monkeypatch):
-    """A plain flush failure (body exited normally) gets the offender note only."""
+def test_committed_write_is_not_failed_by_its_own_flush(tmp_path, monkeypatch):
+    """A suspend block whose owed flush fails must still exit normally.
+
+    This is the create path's shape in miniature: the write commits inside the
+    block, __exit__ flushes the owed push, and the flush is the only thing that
+    used to turn a committed write into an exception for its caller.
+    """
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
     _poison_slots_projection(state)
 
-    with pytest.raises(TypeError) as excinfo:
-        with state.suspend_slots_push():
-            state.push_slots_update()  # owed flush raises on a clean exit
+    with state.suspend_slots_push():
+        state.push_slots_update()  # owed flush will fail on a clean exit
 
-    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
-    assert "'chat-poison'" in notes
-    assert "unwinding over" not in notes, "no body exception, so no unwind note"
+    assert state._slots_push_suspend == 0
+    assert state._slots_broadcast_drops == 1
 
 
-def test_healthy_flush_is_unchanged_by_the_diagnostics(tmp_path, monkeypatch):
-    """Benign control: the hoisted dump changes nothing on the happy path."""
+def test_healthy_flush_is_unchanged_by_the_containment(tmp_path, monkeypatch):
+    """Benign control: a healthy broadcast still fires exactly once, and counts no drop."""
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
     seen: list[str] = []
@@ -1064,6 +1134,7 @@ def test_healthy_flush_is_unchanged_by_the_diagnostics(tmp_path, monkeypatch):
     state.push_slots_update()
 
     assert seen.count("slots") == 1
+    assert getattr(state, "_slots_broadcast_drops", 0) == 0
 
 
 # ── #8745 follow-up: the REMAINING slots read paths carry the same offender note ──

--- a/test/test_slot_create_broadcast_failure.py
+++ b/test/test_slot_create_broadcast_failure.py
@@ -1,0 +1,110 @@
+"""POST /api/chat/slots must not report a failure for a create that committed.
+
+The symptom (#8745): ``api_chat_slot_create`` finishes its body, the slot is in
+``state._slots`` and its metadata is persisted, and only THEN does
+``suspend_slots_push.__exit__`` flush the owed slots push. On the coalescing
+window's leading edge that flush broadcasts synchronously, so an exception in it
+escaped the handler and aiohttp rendered a 500 -- for a create that happened. The
+user retries and gets a second session.
+
+The broadcast serializes EVERY slot, so the evidenced fault (a non-serializable
+value in slot state) fails a healthy create because some OTHER slot is poisoned.
+These pin the handler-visible half of the containment: success, the slot present,
+and no second slot needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard import chat_handlers
+
+
+@pytest.fixture
+def dashboard_state(tmp_path: Any) -> Any:
+    return _make_state(tmp_path)
+
+
+async def _post_create(state: Any, payload: dict[str, Any]) -> tuple[int, str]:
+    """POST a create and return (status, body text).
+
+    The body is read INSIDE the client's context: the response object is dead
+    once the test server closes, so a caller reading it afterwards gets
+    ClientConnectionError rather than the payload.
+    """
+    app = web.Application()
+    app["state"] = state
+    app.router.add_post("/api/chat/slots", chat_handlers.api_chat_slot_create)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/api/chat/slots", json=payload)
+        return resp.status, await resp.text()
+
+
+def _break_the_broadcast(state: Any) -> None:
+    """Make the slots BROADCAST fail while every other path stays healthy.
+
+    Patched at ``_broadcast`` -- the fan-out the announcement ends in -- rather
+    than at ``serialize_slots``: the handler's own response serializes the
+    created slot through ``serialize_slot``, so poisoning the shared projection
+    would break that too and the test would pass for the wrong reason. This
+    isolates the announcement, which is the step under test. The exception type
+    mirrors the evidenced fault (a non-serializable value in slot state).
+    """
+
+    def _boom(note: Any) -> None:
+        raise TypeError("Object of type object is not JSON serializable")
+
+    state._broadcast = _boom  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_create_succeeds_when_the_slots_broadcast_fails(
+    dashboard_state: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A broadcast failure must not turn a committed create into a 500."""
+    _break_the_broadcast(dashboard_state)
+
+    with caplog.at_level(logging.ERROR, logger="kiro_crew.dashboard.state"):
+        status, text = await _post_create(dashboard_state, {"name": "committed"})
+
+    assert status < 300, (
+        "the slot create committed, so a failure announcing it must not be "
+        f"reported as a failed create; got {status}: {text}"
+    )
+    assert "committed" in dashboard_state._slots, "the create really did commit"
+    assert dashboard_state._slots_broadcast_drops >= 1, "the drop must be counted"
+    assert any(
+        "slots broadcast dropped" in r.getMessage() for r in caplog.records
+    ), "contained is not silent: the drop must be logged"
+
+
+@pytest.mark.asyncio
+async def test_create_response_still_describes_the_new_slot(dashboard_state: Any) -> None:
+    """The caller gets the slot it created, not an empty acknowledgement.
+
+    A 200 whose body did not describe the new slot would be its own defect: the
+    dashboard renders the created session from this payload.
+    """
+    _break_the_broadcast(dashboard_state)
+
+    status, text = await _post_create(dashboard_state, {"name": "described"})
+
+    assert status < 300
+    assert json.loads(text).get("key") == "described"
+
+
+@pytest.mark.asyncio
+async def test_healthy_create_is_unchanged(dashboard_state: Any) -> None:
+    """Benign control: nothing is dropped and nothing is logged on the happy path."""
+    status, text = await _post_create(dashboard_state, {"name": "healthy"})
+
+    assert status < 300, text
+    assert "healthy" in dashboard_state._slots
+    assert dashboard_state._slots_broadcast_drops == 0


### PR DESCRIPTION
## Problem / Motivation

You click New chat. The chat is created. You are told it failed.

`api_chat_slot_create` finishes its work, so the slot is in `state._slots` and its
metadata is on disk. Only then does `suspend_slots_push.__exit__` flush the owed
slots push. On the coalescing window's leading edge that flush broadcasts right
away, so an exception in it escaped the handler and aiohttp answered a text/plain
500. The write had already happened. You retry, and now you have two sessions, or
a name conflict on a session you cannot see.

Inside the 0.2s window (`_SLOTS_BROADCAST_INTERVAL_S`) the very same fault was
deferred through `loop.call_later(_trailing_slots_flush)`, the handler answered
200, and the exception turned up later as a log line. So a timer decided what the
caller was told. A busy dashboard got 200 and a log; an idle one -- someone doing
a single deliberate New chat -- got the 500. No client can be written against
that, and the failure landed on the most deliberate case.

Reachability, stated plainly: no production path is demonstrated. The evidenced
fault is a value in slot state that `json.dumps` cannot serialize, and a value
parsed from a request body is serializable by construction, so this needs a
server-constructed object to reach slot state. In #6522 that was a test fixture.
This is latent, not live.

## Why it matters

A caller cannot tell "it did not happen" from "it happened and I could not tell
you". Those need opposite responses. The first says retry. The second says do not.

The broadcast serializes EVERY slot. The response serializes one. So one bad
value on some unrelated old session failed a brand-new, perfectly healthy create.
The write was blamed for a fault in the thing announcing it.

And the 500 was not even the honest error. A broken slots projection breaks every
slots read path too -- `GET /api/chat/slots`, the websocket connect snapshot. The
dashboard is unrenderable whether or not anyone created a slot. The create was
just standing nearby when the projection broke.

## What changed (motivation -> approach -> change)

The symptom is a 500 on a create that committed. The root cause is that work
which runs AFTER a commit could fail that commit. A broadcast is that kind of
work. A listener being absent, slow or broken says nothing about whether the
write landed, so it must not be able to fail the write.

So the broadcast's failure is contained, and contained in one place:
`_do_slots_broadcast`. That is the single funnel both coalescing branches reach --
the leading-edge call in `push_slots_update` and the trailing timer's
`_trailing_slots_flush`. Containing it there makes both branches answer the same
way by construction, which is the convergence #8745 asks for. No timer decides
anything any more. The frame-building body moved unchanged into
`_send_slots_frames`; raising is still how it reports a fault, and the guard is
the only thing that reads that.

```mermaid
flowchart LR
  subgraph Before
    A1[create commits]:::ctx --> B1[flush broadcasts]:::ctx --> C1[dumps raises]:::removed --> D1[HTTP 500]:::removed
  end
  subgraph After
    A2[create commits]:::ctx --> B2[flush broadcasts]:::ctx --> C2[dumps raises]:::changed --> D2[log + count]:::added --> E2[HTTP 200]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 4,5 stroke:#16A34A,stroke-width:2px
```

Legend: green added, amber changed, red removed, blue unchanged.
*The failing broadcast now ends in a log line instead of in the caller's response.*

Contained is not silent. Every drop increments `_slots_broadcast_drops`. The
first one logs a full traceback, and that traceback carries the offender note
#8888 added, which names the slot, the field and the type. Only repeats are
throttled, to one line per `_SLOTS_BROADCAST_DROP_LOG_INTERVAL_S`, and each line
carries the running count. The throttle is there because the fault is a property
of slot state, not of one push: it recurs on every later broadcast, and a slot
mutation fires several per turn, so logging each one buries the first traceback
under thousands of copies.

The slots READ paths keep failing loud, and that is the point, not an oversight.
A read path's answer IS the projection, so a caller asking for it must be told it
is unrenderable. This path's answer is "something changed", and the change is
already true whether or not anyone hears it. Same fault, opposite obligation.

Both counters are class-level defaults, following the block at the top of
`DashboardState`. The failure handler runs on a `__new__`-built state too, and an
`__init__`-only attribute would raise `AttributeError` there -- re-raising the
very 500 this exists to absorb, and only in those test suites.

### Which side of the commit each step is on

Read this to check that everything made non-fatal is genuinely after the commit.

1. body read, folder/mode/memory validation, the three remote-binding gates -- before
2. `create_peer_slot` (remote binds only) -- before
3. `get_or_create_slot` -- THE COMMIT: the slot is in `state._slots`
4. title, artifact, folder filing, folder-tag inheritance, project defaults -- after
5. `save_slot_off_loop(force=True)` -- after, already contained: `best_effort=True` logs and marks the slot dirty, never raises
6. `suspend_slots_push.__exit__` -> the slots broadcast -- after, THIS is what 500'd, and what this PR contains
7. `schedule_eager_spawn` -- after, already self-contained: its config read is wrapped in `except Exception: return None`
8. `return web.json_response(state.serialize_slot(slot))` -- after, still exposed

### The other post-commit step, named rather than left for a reviewer to find

Step 8 still turns a raise into a 500 on a committed create, and this PR leaves it
alone on purpose.

It serializes only the created slot, where the broadcast serializes all of them.
For the evidenced fault -- a bad value on some OTHER slot -- step 6 fails and step
8 does not, which is exactly the case that made a healthy create 500. That case is
now closed. The remaining case is a bad value on the NEW slot itself, and there the
caller genuinely cannot be handed the payload it asked for. Deciding what to answer
instead is a different question from containment, and widening this PR to guess at
it would ship an unreviewed contract.

Step 7 is structurally the same shape and is already contained, so it is listed
above for completeness rather than as work.

One prose change comes with the behaviour change. `suspend_slots_push`'s PEP 678
annotation exists for a flush that fails while the body's own exception is
unwinding, and the evidenced way to reach it is now gone -- a contained broadcast
does not raise, so the body's fault propagates as itself instead of being demoted
to `__context__`. The annotation stays, because the rest of `push_slots_update`
(a lock or timer-scheduling fault) can still reach it. The docstring now says
which case it is left for.

## Tests

`test/test_slot_create_broadcast_failure.py`, new, is the handler-visible half.
It POSTs `/api/chat/slots` with the broadcast broken and pins that the response
is a success, that the slot really is in `state._slots`, that the drop was counted
and that it was logged. A second test pins that the response still describes the
new slot, because a 200 with an empty body would be its own defect -- the
dashboard renders the created session from that payload. The third is the benign
control: a healthy create drops nothing and logs nothing. It breaks `_broadcast`
rather than `serialize_slots`, because poisoning the shared projection would break
the response too and the test would pass for the wrong reason.

In `test/test_open_slots_persistence.py`, the four pins that #8888 wrote for the
old fail-loud semantics now pin containment instead. That file's #8745 section
said its diagnostics were "independent of whichever option above is chosen", and
this PR chooses one, so those propagation assertions are the part that moves.
What they protected is kept: the leading-edge test asserts the offender note
survives containment by reading it off the logged record's exception, so the note
cannot be lost. Added alongside: both timing branches contained, every drop
counted with repeats throttled to one line, the throttle resuming afterwards with
the running count, containment working on a `__new__`-built state, and the body's
own exception no longer being masked by its flush.

In `test/test_dashboard_state_ws.py`, two comments reading "must not raise" now
say what actually pins those tests -- the frame assertion, since `call_args` is
`None` when no frame is sent. Containment would otherwise have made that comment
describe something the guard now provides for free.

Scoped runs, all green: `test_open_slots_persistence.py` 77 passed,
`test_slot_create_broadcast_failure.py` 3 passed, `test_dashboard_state_ws.py` 80
passed (that last file is a consumer -- it drives `_do_slots_broadcast` directly
seven times). `black`, `isort`, `flake8` clean on the changed files; `mypy` reports
nothing in `state.py`. The two touched test files are in the black baseline and
were deliberately left unformatted so the shrinking baseline is not tripped; only
the new lines were shaped to black's output by hand.

Mutation-verified rather than asserted: reverting the production hunks while
keeping the test hunks reddens the new tests on their own assertion messages.

## Manual verification

N/A -- unit coverage sufficient. The fault has no demonstrated production trigger
(a live gateway journal over three days shows zero frames through this broadcast),
so reproducing it by hand means constructing the poisoned value the tests already
construct, at the same seam.

## Related Issues

Closes #8745

## Pattern harvest

The defect class is failure attribution across a commit boundary: a post-commit
notification whose exception propagates into the committing request, so the caller
is told the write failed when it succeeded. It has a recognisable shape --
announce/notify/broadcast/publish work reached from a context manager's `__exit__`
or from the tail of a handler, after the state change it describes. It also has a
recognisable tell: two code paths for one fault, one synchronous and one deferred,
which makes the caller-visible outcome depend on a timer rather than on the fault.

Rule candidate: review-prompt
Pattern: a broadcast or notification raising after its write has committed, so a
committed operation is reported to the caller as failed.
