### PR TITLE
fix(apps): read the answer to the stop the Job SDK already performs

### DIFF
--- a/src/kiro_crew/apps/job_sdk.py
+++ b/src/kiro_crew/apps/job_sdk.py
@@ -38,9 +38,13 @@ nothing. A runner cooperates in one of two ways: it may poll ``handle.cancelled`
 directly, or it may call ``handle.checkpoint``, which RAISES at a pending cancel
 so the runner unwinds AT that point. The second is the stronger form -- the
 ``cancelled`` record then names an observed stop rather than a set flag -- but
-neither can stop work the runner spawned onto a thread the SDK does not own; that
-remaining gap is #7814's execution-ownership half, out of scope here and disclosed
-on the unsettled-future reason string.
+neither reaches work the runner spawned onto a thread the SDK does not own. For
+that work there is exactly one instant where a stop is possible: if the runner
+hands the work back -- the reported #7814 case returns an unwaited
+``concurrent.futures.Future`` -- then ``_stop_returned_work`` asks it not to run,
+and the record states which of the two things happened. If nothing comes back,
+nothing can be asked; that residue is #7814's execution-ownership half, which needs
+the spawn to register itself and is out of scope here.
 
 **One writer per run file.** There is no lock helper beside ``atomic_write`` and
 concurrent read-modify-write of one document is last-writer-wins, so each run is
@@ -95,6 +99,7 @@ later pass revisits.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import inspect
 import json
 import logging
@@ -349,6 +354,103 @@ _SUSPENDABLE_KINDS: tuple[tuple[str, Any], ...] = (
 )
 
 
+#: The wording for an unsettled future this SDK could NOT stop. Kept verbatim from
+#: the string #7737 shipped, because for this branch every clause of it is still
+#: true and a consumer matching the old text must still find it.
+_UNSETTLED_NOT_STOPPED = (
+    "a future that is not settled, so the runner returned before its work "
+    "finished; that work may still be running somewhere this SDK does not "
+    "own and cannot stop, so a retry of this run can overlap it"
+)
+
+#: The wording for one this SDK DID stop, with the guarantee named. Only reachable
+#: when :func:`_stop_returned_work` answered ``True``, which is the one answer that
+#: means the work will never run.
+_UNSETTLED_STOPPED = (
+    "a future that is not settled, so the runner returned before its work "
+    "finished; that work had not started and this SDK stopped it before it "
+    "could, so a retry of this run cannot overlap it"
+)
+
+
+def _stop_returned_work(result: Any) -> bool:
+    """Ask work a runner handed back to not run. ``True`` ONLY when it is stopped.
+
+    This is the reachability half of #7814. The SDK cannot stop work a runner
+    spawned onto a thread it does not own -- unless the runner hands the work back,
+    which the reported case does: it submits to a pool and returns the unwaited
+    ``concurrent.futures.Future``. At that instant this process holds the only
+    reference to that work, so this is the one moment a stop is even possible.
+
+    The stop itself was ALREADY happening before this function existed, as
+    hygiene: :func:`_close_quietly` reaches for ``cancel`` on a future to stop it
+    warning about an unretrieved exception, and discarded the answer. So the
+    record said the work "may still be running ... and cannot stop" about work the
+    next line had just guaranteed would never run. This function makes that stop
+    deliberate, moves it BEFORE the verdict is worded, and reads what it returned.
+
+    **One answer, and it is one-sided on purpose.** ``True`` means the work is
+    stopped and will never run. Everything else is ``False``, which the caller
+    words as the unchanged disclosure -- the work may still be running and this SDK
+    cannot stop it. An earlier revision returned a third value to separate "already
+    executing" from "no guarantee available"; the two collapse to the same wording
+    and nothing read the difference, so by this module's own doctrine -- a
+    distinction stays out until the consumer that reads it exists -- there are two
+    answers, not three.
+
+    **Why the answer is keyed on the TYPE and not on having a ``cancel`` method.**
+    A truthy ``cancel()`` does not mean stopped in general. Measured identically on
+    3.10, 3.11 and 3.12: an ``asyncio.Task`` whose coroutine suppresses
+    ``CancelledError`` answers ``cancel()`` with ``True`` and then runs to
+    completion and returns a value. Treating that as a stop would report success
+    for work that is still going -- the exact defect this module exists to remove,
+    and worse than reporting failure, because the owner then believes the work is
+    over and proceeds.
+
+    ``concurrent.futures.Future`` is different, and its difference is documented
+    rather than inferred: ``cancel()`` returns ``False`` if the call is executing
+    or finished, and otherwise the call "will be cancelled" -- the executor's
+    ``_WorkItem.run`` asks ``set_running_or_notify_cancel()`` first and returns
+    without invoking the function when it is cancelled. So ``True`` from THAT type
+    means the work never ran. ``isinstance`` is the right test because the
+    guarantee belongs to the class's contract, and ``asyncio.Future`` is not a
+    subclass of it, so the two never blur.
+
+    **The stop runs app code on this thread, so it is fenced from BaseException.**
+    ``Future.cancel`` invokes the future's done callbacks inline, and
+    ``_invoke_callbacks`` catches only ``Exception`` -- measured on 3.10, 3.11 and
+    3.12, a callback raising ``SystemExit`` escapes ``cancel()`` while an ordinary
+    ``ValueError`` is swallowed and ``cancel()`` still answers ``True``. An escape
+    here is not a caller's problem to handle: it would pass ``_execute``'s
+    ``except JobCancelled`` and ``except Exception`` untouched, leave ``run.status``
+    at ``RUNNING``, and let the ``finally`` persist a ``running`` record while
+    dropping the live entry and the dedupe key -- a run reported active that nothing
+    owns, which no pass revisits until a restart makes its origin foreign. So the
+    stop is attempted inside a fence: a run must never be corrupted by app code
+    misbehaving inside this SDK's own hygiene.
+
+    The fence answers ``False``, which UNDER-claims -- the state transition happens
+    before the callbacks fire, so the work is in fact cancelled. Claiming it anyway
+    would rest on a control flow that was just violently interrupted, and the
+    hedged wording is true either way.
+    """
+    if not isinstance(result, concurrent.futures.Future):
+        return False
+    try:
+        if result.done():
+            return False
+        # ``is True`` rather than truthiness: only the documented answer counts, so
+        # a subclass returning some other truthy value cannot buy a guarantee.
+        return result.cancel() is True
+    except BaseException:  # noqa: BLE001 - see the fence paragraph above
+        logger.warning(
+            "a returned future raised while being asked to stop; recording that its "
+            "work was not stopped rather than losing the run's record",
+            exc_info=True,
+        )
+        return False
+
+
 def _undriven_result(result: Any) -> str:
     """Name why a runner's return value is not a completed unit of work, else ``""``.
 
@@ -404,15 +506,22 @@ def _undriven_result(result: Any) -> str:
     handing back something unfinished violates it -- ``failed`` is what this SDK
     observed about the RUN, not a guess about the work.
 
-    What this SDK cannot do is STOP that work. An unsettled
-    ``concurrent.futures.Future`` stands for a thread it does not own, and
-    terminalizing the run releases the dedupe key -- so an owner who retries gets a
-    second run overlapping work that never stopped. Relabelling the status would not
-    change that: the overlap is a consequence of the contract violation, not
-    something the record misstates. So the reason string SAYS the work may still be
-    running, because the owner reading that record is the only party who can judge
-    whether a retry is safe. The missing capability -- no way to stop work a runner
-    spawned outside this thread -- is filed rather than pretended away.
+    **Whether it can STOP that work is now asked rather than assumed.** An
+    unsettled ``concurrent.futures.Future`` stands for work in a pool this SDK does
+    not own -- but the runner handed the future back, so the reference is in hand
+    at this one instant, and :func:`_stop_returned_work` uses it. A ``True`` there
+    is a documented guarantee that the work never began and never will, so the
+    reason says the stop happened and a retry cannot overlap. Anything else keeps
+    the earlier disclosure verbatim: the work may still be running, this SDK cannot
+    stop it, and a retry can overlap it. Terminalizing still releases the dedupe
+    key either way; what changed is that the owner reading the record -- the only
+    party who can judge whether a retry is safe -- is told which of the two
+    situations they are in instead of always being told the worse one.
+
+    What remains missing is a stop for work whose handle never comes back at all: a
+    runner that spawns a thread and returns ``None`` leaves nothing to act on, and
+    no stopping logic can reach it. That half needs the spawn to register itself,
+    which changes the runner contract, and is filed rather than pretended away.
 
     **Why this is complete, which after nine review rounds is a fair thing to ask.**
     Not because cases stopped being found, but because the two carriers are now
@@ -436,11 +545,11 @@ def _undriven_result(result: Any) -> str:
     done = getattr(result, "done", None)
     if callable(done):
         if not done():
-            return (
-                "a future that is not settled, so the runner returned before its work "
-                "finished; that work may still be running somewhere this SDK does not "
-                "own and cannot stop, so a retry of this run can overlap it"
-            )
+            # The ONE side effect in this function, and it is here because the
+            # verdict depends on it: this is the only instant the SDK holds a
+            # reference to the spawned work, so the stop has to be attempted
+            # before the record can say what became of that work.
+            return _UNSETTLED_STOPPED if _stop_returned_work(result) else _UNSETTLED_NOT_STOPPED
         cancelled = getattr(result, "cancelled", None)
         if callable(cancelled) and cancelled():
             return "a cancelled future, so the work it stood for never completed"
@@ -481,6 +590,26 @@ def _close_quietly(result: Any) -> None:
     which is what stops it warning that its exception was never retrieved. An
     async generator's ``aclose`` is itself a coroutine needing a loop, so it is
     left to the interpreter rather than driven from this thread.
+
+    This ``cancel`` is HYGIENE, and it used to be the only one. Stopping the work a
+    future stands for is now :func:`_stop_returned_work`'s job, which runs earlier
+    and reads what the stop returned. The two are not duplicates: that one answers
+    a question the record needs, this one silences a warning, and by the time this
+    runs on a future the earlier call has usually already settled it -- a second
+    ``cancel`` on a cancelled or running future returns ``False`` and invokes no
+    callbacks, since those fire once, at the state transition. Anything that call
+    declined to touch still arrives here and is retired exactly as before.
+
+    ``except Exception`` here is narrower than the fence
+    :func:`_stop_returned_work` uses, and deliberately so rather than by oversight.
+    Both calls can run app code -- a done callback, a coroutine's ``finally`` -- and
+    a ``BaseException`` from either escapes ``_execute``'s handlers. The
+    consequences differ: this call site is reached only AFTER ``run.status`` and
+    ``run.error`` are set, so the ``finally`` still persists a correct terminal
+    record and the cost of an escape is one lost log line. The earlier call runs
+    while the status is still ``RUNNING``, where the same escape persists a
+    ``running`` record nothing owns. Widening this one would change pre-existing
+    behaviour to no end.
     """
     for method in ("close", "cancel"):
         handler = getattr(result, method, None)

--- a/test/test_job_sdk.py
+++ b/test/test_job_sdk.py
@@ -3304,25 +3304,44 @@ class TestAnUndrivenResultIsFailedNotDone:
         suspended.close()
 
     def test_an_unsettled_future_discloses_that_the_work_may_still_run(self) -> None:
-        """The record must warn the owner, because the SDK cannot stop the work.
+        """The record must warn the owner about work the SDK could NOT stop.
 
-        An unsettled future stands for a thread this SDK does not own. Marking the run
-        terminal releases the dedupe key, so an owner who retries can start a second
-        run overlapping work that never stopped. `failed` is the true verdict about the
-        RUN -- the runner returned before finishing, violating its contract -- but the
-        reason has to name what the SDK cannot control, since the owner reading it is
-        the only party who can judge whether retrying is safe.
+        An unsettled future can stand for work already executing in a pool this SDK
+        does not own. Marking the run terminal releases the dedupe key, so an owner
+        who retries can start a second run overlapping work that never stopped.
+        `failed` is the true verdict about the RUN -- the runner returned before
+        finishing, violating its contract -- but the reason has to name what the SDK
+        cannot control, since the owner reading it is the only party who can judge
+        whether retrying is safe.
+
+        The FIXTURE changed with #7814 and the change is the point. This test used to
+        pass a bare `concurrent.futures.Future()`, which is PENDING and therefore
+        stoppable -- so it asserted "may still be running" about work that provably
+        had not started, and passed only because the SDK never looked. The un-stoppable
+        case is work that is genuinely RUNNING, which is what this now builds.
         """
-        pool_future: concurrent.futures.Future = concurrent.futures.Future()
+        entered = threading.Event()
+        release = threading.Event()
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+        def slow() -> str:
+            entered.set()
+            release.wait(5)
+            return "done"
+
         try:
+            pool_future = pool.submit(slow)
+            assert entered.wait(5), "premise: the work must be executing, not queued"
             verdict = job_sdk._undriven_result(pool_future)
             assert "not settled" in verdict
             # The disclosure, pinned on the FACTS it must convey rather than wording.
             assert "may still be running" in verdict
             assert "cannot stop" in verdict
             assert "overlap" in verdict
+            assert "cannot overlap" not in verdict, "must not claim a stop it did not make"
         finally:
-            pool_future.cancel()
+            release.set()
+            pool.shutdown(wait=True)
 
     def test_the_states_are_reachable_and_deliberately_not_distinguished(self) -> None:
         """The states are real; the verdict ignores them ON PURPOSE.
@@ -3694,6 +3713,258 @@ class TestAnUndrivenResultIsFailedNotDone:
         sdk.register("probe", lambda h: Probe())
         assert _wait_terminal(sdk, sdk.start("probe")).status == FAILED
         assert closed == [True]
+
+
+# ── 8. stopping work the runner spawned outside the worker thread (#7814) ──
+
+
+class TestStoppingWorkTheRunnerHandedBack:
+    """The reachability half of #7814, and the reason it is reachable at all.
+
+    The SDK cannot stop work a runner spawned onto a thread it does not own -- unless
+    the runner hands that work back, and the reported case does exactly that: it
+    submits to a pool and returns the unwaited `concurrent.futures.Future`. For one
+    instant `_execute` holds the only reference to that work.
+
+    It already ASKED that reference to stop before this change, as hygiene, and threw
+    the answer away -- so the record warned about work the next line had guaranteed
+    would never run. These tests pin both directions: the record must say a stop
+    happened when it did, and must never say one happened when it did not.
+    """
+
+    def test_work_the_runner_spawned_is_stopped_and_the_record_says_so(self, sdk: JobSDK) -> None:
+        """The losing branch, end to end: spawned outside the thread, then stopped.
+
+        A one-worker pool is occupied, so the runner's own submission sits PENDING and
+        the runner returns it unwaited. Two things must hold together: the spawned work
+        never runs, and the record does not warn the owner about work that cannot
+        overlap a retry.
+        """
+        entered = threading.Event()
+        release = threading.Event()
+        ran: list[str] = []
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+        def occupy() -> None:
+            entered.set()
+            release.wait(5)
+
+        def spawned() -> str:
+            ran.append("spawned")
+            return "spawned"
+
+        def wrapper(handle: JobHandle):
+            pool.submit(occupy)
+            assert entered.wait(5), "premise: the single worker must be busy"
+            # Queued behind `occupy`, so PENDING, and handed back undriven.
+            return pool.submit(spawned)
+
+        try:
+            sdk.register("poolspawn", wrapper)
+            run = _wait_terminal(sdk, sdk.start("poolspawn"))
+            assert run.status == FAILED, run.error
+            assert "not settled" in run.error
+            assert ran == [], f"the spawned work ran despite the stop: {ran}"
+            assert "may still be running" not in run.error, (
+                "the record warns the owner about work this SDK stopped, so work that "
+                "provably never started reads as work a retry could overlap"
+            )
+            assert (
+                "cannot stop" not in run.error
+            ), "the record claims it cannot stop work it did stop"
+            assert "stopped it" in run.error, "the record does not say the stop happened"
+            assert (
+                "cannot overlap" in run.error
+            ), "the record does not tell the owner a retry is safe"
+        finally:
+            release.set()
+            pool.shutdown(wait=True)
+        assert ran == [], "the cancelled work ran once the pool drained"
+
+    def test_work_already_executing_is_never_claimed_stopped(self, sdk: JobSDK) -> None:
+        """The direction that matters more: a stop must not be reported when it failed.
+
+        Work already running in a pool cannot be stopped from here. Reporting success
+        would be worse than reporting failure -- the owner would believe the work is
+        over and proceed -- so this run keeps the disclosure #7737 shipped, verbatim.
+        """
+        entered = threading.Event()
+        release = threading.Event()
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+        def slow() -> str:
+            entered.set()
+            release.wait(5)
+            return "done"
+
+        def wrapper(handle: JobHandle):
+            future = pool.submit(slow)
+            assert entered.wait(5), "premise: the work must be executing, not queued"
+            return future
+
+        try:
+            sdk.register("poolrunning", wrapper)
+            run = _wait_terminal(sdk, sdk.start("poolrunning"))
+            assert run.status == FAILED, run.error
+            assert "may still be running" in run.error
+            assert "cannot stop" in run.error
+            assert (
+                "cannot overlap" not in run.error
+            ), "a stop was claimed for work that is still executing"
+            assert (
+                "stopped it" not in run.error
+            ), "a stop was claimed for work that is still executing"
+        finally:
+            release.set()
+            pool.shutdown(wait=True)
+
+    def test_the_stop_answers_two_ways_one_case_per_answer(self) -> None:
+        """One control per branch, so True is not inferred from the others.
+
+        True is the only answer that licenses the record to claim a stop, so each
+        way of reaching False needs its own case.
+        """
+        entered = threading.Event()
+        release = threading.Event()
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+        def occupy() -> None:
+            entered.set()
+            release.wait(5)
+
+        try:
+            pool.submit(occupy)
+            assert entered.wait(5), "premise: the single worker must be busy"
+            pending = pool.submit(lambda: 1)
+            assert job_sdk._stop_returned_work(pending) is True
+            assert pending.cancelled(), "True was returned without cancelling"
+
+            release.set()
+            running_entered = threading.Event()
+            running_release = threading.Event()
+
+            def slow() -> int:
+                running_entered.set()
+                running_release.wait(5)
+                return 1
+
+            running = pool.submit(slow)
+            assert running_entered.wait(5), "premise: the work must be executing"
+            assert job_sdk._stop_returned_work(running) is False
+            running_release.set()
+
+            settled: concurrent.futures.Future = concurrent.futures.Future()
+            settled.set_result(1)
+            assert job_sdk._stop_returned_work(settled) is False
+        finally:
+            release.set()
+            pool.shutdown(wait=True)
+
+    def test_a_callback_raising_baseexception_cannot_corrupt_the_record(self, sdk: JobSDK) -> None:
+        """The stop runs app code on this thread, so it must not lose the record.
+
+        `Future.cancel` invokes done callbacks inline and `_invoke_callbacks` catches
+        only `Exception`, so a callback raising `SystemExit` escapes `cancel()` --
+        measured on 3.10, 3.11 and 3.12. Unfenced, that escape passes `_execute`'s
+        `except JobCancelled` and `except Exception`, leaves the status at RUNNING,
+        and the `finally` persists a `running` record while dropping the live entry
+        and the dedupe key. The run then reads as active with nothing owning it, and
+        nothing revisits it until a restart makes its origin foreign.
+        """
+        entered = threading.Event()
+        release = threading.Event()
+        ran: list[str] = []
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+        def occupy() -> None:
+            entered.set()
+            release.wait(5)
+
+        def hostile(_future: concurrent.futures.Future) -> None:
+            raise SystemExit("a done callback that does not play nicely")
+
+        def wrapper(handle: JobHandle):
+            pool.submit(occupy)
+            assert entered.wait(5), "premise: the single worker must be busy"
+            future = pool.submit(lambda: ran.append("spawned"))
+            future.add_done_callback(hostile)
+            return future
+
+        try:
+            sdk.register("hostilecb", wrapper)
+            run_id = sdk.start("hostilecb")
+            deadline = time.monotonic() + 5.0
+            run = None
+            while time.monotonic() < deadline:
+                run = sdk.get(run_id)
+                if run is not None and run.is_terminal:
+                    break
+                time.sleep(0.01)
+            assert run is not None, "the record vanished"
+            assert run.status == FAILED, (
+                f"a done callback raising BaseException left the record at "
+                f"{run.status!r} with no worker owning it, so the run reads as "
+                f"active forever and only a restart resolves it"
+            )
+            # The fence under-claims rather than guessing, so the owner gets the
+            # hedged disclosure even though the state did transition.
+            assert "may still be running" in run.error
+            assert "cannot overlap" not in run.error
+        finally:
+            release.set()
+            pool.shutdown(wait=True)
+        assert ran == [], "the cancelled work ran once the pool drained"
+
+    def test_a_truthy_cancel_is_not_accepted_as_a_stop(self) -> None:
+        """Why the answer is keyed on the TYPE and not on having a `cancel` method.
+
+        Measured identically on 3.10, 3.11 and 3.12: an `asyncio.Task` whose coroutine
+        suppresses `CancelledError` answers `cancel()` with True and then finishes and
+        returns a value. A duck-typed check would read that True as a stop and record
+        success for work that is still going. So both asyncio carriers, and anything
+        merely shaped like a future, answer False and keep the honest disclosure.
+        """
+        kept_going: list[str] = []
+
+        async def main() -> object:
+            async def suppress() -> str:
+                try:
+                    await asyncio.sleep(3)
+                except asyncio.CancelledError:
+                    kept_going.append("ran on past the cancel")
+                    await asyncio.sleep(0)
+                    return "finished anyway"
+                return "not cancelled"
+
+            task = asyncio.ensure_future(suppress())
+            await asyncio.sleep(0.05)
+            assert task.cancel() is True, "premise: asyncio reports the cancel taken"
+            return await task
+
+        assert asyncio.run(main()) == "finished anyway"
+        assert kept_going == ["ran on past the cancel"]
+
+        loop = asyncio.new_event_loop()
+        try:
+            unsettled = loop.create_future()
+            assert job_sdk._stop_returned_work(unsettled) is False
+            assert not unsettled.cancelled(), "an asyncio future was touched off-loop"
+            verdict = job_sdk._undriven_result(unsettled)
+            assert "may still be running" in verdict
+            assert "cannot overlap" not in verdict
+            unsettled.cancel()
+        finally:
+            loop.close()
+
+        class Lookalike:
+            def done(self) -> bool:
+                return False
+
+            def cancel(self) -> bool:
+                return True
+
+        assert job_sdk._stop_returned_work(Lookalike()) is False
+        assert "may still be running" in job_sdk._undriven_result(Lookalike())
 
 
 class TestForeignRecordFieldsAreCoerced:


### PR DESCRIPTION
## Problem / Motivation

A Job SDK runner can hand its work to a thread pool and return the `concurrent.futures.Future` without waiting. The SDK records that run `failed`, which is true  --  the runner's contract is to finish its work before returning. The record then tells the owner:

> that work may still be running somewhere this SDK does not own and cannot stop, so a retry of this run can overlap it

For work still executing in the pool, that is correct. For work still sitting in the pool's queue, it is false. The SDK had already stopped that work, one line later, and never looked at the answer.

`_close_quietly` retires an undriven result. A future has no `close`, so it reaches for `cancel`. On a queued `concurrent.futures.Future` that call removes the work item, and the work never runs. The bool it returns was thrown away, and `_undriven_result` had already written the record before that call happened.

So an owner reading `failed` on work that provably never started was told to treat a retry as unsafe.

## Why it matters

The owner of a run is the only party who can decide whether to retry it. This record gave them the worse of the two answers every time, including when the safe answer was available and the SDK already knew it.

The reverse mistake is the dangerous one: a record claiming work stopped while it keeps running makes the owner believe the work is over and proceed. This change adds a claim of a stop, so it has to earn that claim. It does, on the one type whose contract supplies it.

## What changed (motivation → approach → change)

The record was written before the stop was attempted, and the stop's answer was discarded. So the fix is not a stronger stop. It is reading an answer already there.

`_stop_returned_work` asks work the runner handed back not to run, and answers one thing: was it stopped. `True` means it will never run. Everything else is `False`. `_undriven_result` calls it before it words the verdict, and says the stop happened only on `True`. Every other answer keeps the old string, word for word.

The stop runs app code on the SDK's own worker thread, so it is fenced. `Future.cancel` invokes the future's done callbacks inline and `_invoke_callbacks` catches only `Exception` -- measured on 3.10, 3.11 and 3.12, a callback raising `SystemExit` escapes `cancel()` while an ordinary `ValueError` is swallowed and `cancel()` still answers `True`. Unfenced, that escape passes `_execute`'s `except JobCancelled` and `except Exception`, leaves the status at `RUNNING`, and lets the `finally` persist a `running` record while dropping the live entry and the dedupe key -- a run reported active that nothing owns. So the stop sits inside `try/except BaseException`, which logs and answers `False`. That under-claims, because the state transition happens before the callbacks fire, and a guarantee resting on control flow that was just interrupted is not worth publishing.

`_close_quietly`'s sibling `except Exception` is deliberately NOT widened, and its docstring now says why: that call runs only after `run.status` and `run.error` are set, so an escape there costs one log line and still persists a correct terminal record.

`True` comes only from a `concurrent.futures.Future`. That class documents `cancel()` as returning `False` when the call is running or finished, and cancelling it otherwise; the executor's `_WorkItem.run` asks `set_running_or_notify_cancel()` first and skips the function when it is cancelled. A truthy `cancel()` in general means nothing of the kind. Measured the same on Python 3.10, 3.11 and 3.12: an `asyncio.Task` whose coroutine swallows `CancelledError` answers `cancel()` with `True`, runs on, and returns a value. So the answer is keyed on the type that guarantees it, not on a method being present.

```mermaid
flowchart LR
  subgraph Before
    A1[runner returns<br/>unwaited future]:::ctx --> B1[word the record:<br/>cannot stop it]:::removed --> C1[_close_quietly<br/>cancel, answer dropped]:::removed
  end
  subgraph After
    A2[runner returns<br/>unwaited future]:::ctx --> B2[_stop_returned_work<br/>cancel, read the answer]:::added --> C2[word the record:<br/>stopped, or cannot stop]:::changed
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
```

green = added, amber = changed, red = removed, blue = unchanged

*The stop now happens before the record is written, and the record says which of the two things happened.*

No runner API changes. No new runner obligation. Nothing is killed that this process does not hold a reference to. The dedupe key is still released on the terminal write, either way  --  what changed is only what the record says about the work.

**What this does not fix, deliberately.** A runner that spawns a thread or a subprocess and returns `None` hands back nothing. No stopping logic can reach that work, and none is added here. That half needs the spawn to register itself with the SDK, which changes the runner contract, and it stays open on #7814. Two other spawn shapes have the same exposure and are also left alone: a runner that returns an `asyncio.Task` or `asyncio.Future`, where a handle does come back but no stop guarantee exists (the measurement above is why), and `cancel()` on a live run, which runs before the runner has returned anything and so has nothing in hand. All three keep today's honest disclosure.

Today's only in-tree runner, `aws_control`'s backup job, submits to no pool and returns no future, so its behaviour is unchanged.

## Tests

`test/test_job_sdk.py`, one new class plus one re-fixtured test.

- `test_work_the_runner_spawned_is_stopped_and_the_record_says_so`  --  end to end on the reported case. A one-worker pool is occupied, so the runner's own submission is queued, and the runner returns it unwaited. Locks in both halves: the spawned work never runs, and the record no longer warns about work a retry cannot overlap. This is the test that reddens when the fix is reverted.
- `test_work_already_executing_is_never_claimed_stopped`  --  the direction that matters more. Work genuinely running in the pool keeps the old disclosure, and the record must not say a stop happened.
- `test_the_stop_answers_two_ways_one_case_per_answer`  --  one control per way of reaching each answer, so `True` is not inferred from the others.
- `test_a_callback_raising_baseexception_cannot_corrupt_the_record`  --  a queued future whose done callback raises `SystemExit`. Locks in that the run's record still reaches `failed` rather than being left at `running` with no worker owning it, and that the fence under-claims rather than guessing. Mutation-verified: with the fence removed it reddens on its own message.
- `test_a_truthy_cancel_is_not_accepted_as_a_stop`  --  pins the language behaviour the type check exists for: an `asyncio.Task` reports its cancel taken and returns `"finished anyway"`. Also covers an `asyncio.Future` and a plain object with `done()`/`cancel()`, both of which answer `False`.
- `test_an_unsettled_future_discloses_that_the_work_may_still_run`  --  re-fixtured. It used to pass a bare `concurrent.futures.Future()`, which is queued and therefore stoppable, and asserted "may still be running" about work that provably had not started. It passed only because the SDK never looked. It now builds work that is genuinely running, which is the case that disclosure is about, and keeps every original assertion.

### How these were run

Scoped to the one changed test file, never a directory and never bare:

```
timeout 900 python3 -m pytest -n0 test/test_job_sdk.py -x -q </dev/null
# 173 passed
python3 -m black --target-version py310 src/kiro_crew/apps/job_sdk.py test/test_job_sdk.py
python3 -m isort src/kiro_crew/apps/job_sdk.py test/test_job_sdk.py
python3 -m flake8 src/kiro_crew/apps/job_sdk.py test/test_job_sdk.py
python3 -m mypy src/kiro_crew/apps/job_sdk.py
```

`mypy` reports 2 errors, both in `src/kiro_crew/transcribe.py`, which this diff does not
touch -- `git diff --quiet origin/main -- src/kiro_crew/transcribe.py` confirms that file is
identical to main. Zero errors are attributed to `job_sdk.py`.

Broader coverage is CI's, not this host's. No global suite was run.

## Manual verification

N/A  --  unit coverage sufficient. The behaviour is a record string and a bool, both asserted end to end through a real `ThreadPoolExecutor` rather than a stub.

The `cancel()` semantics the design rests on were measured directly, and are identical on Python 3.10, 3.11 and 3.12: a queued `concurrent.futures.Future` answers `cancel()` `True` and its function never runs; a running one answers `False` and completes; an `asyncio.Task` suppressing `CancelledError` answers `True` and returns a value. `asyncio.Future` is not a subclass of `concurrent.futures.Future` on any of the three.

## Related Issues

Closes #7814

## Pattern harvest

A call was made for one purpose (hygiene: stop a future warning about an unretrieved exception), had a second and larger effect (the queued work never runs), and its return value  --  the only place that effect was reported  --  was discarded. A sibling function then published a claim about the same subject, before the call, that the call's answer contradicted.

Rule candidate: review-prompt
Pattern: a discarded return value from a call with a side effect, where a nearby record or log states something that value could have contradicted. Ask what the call decided, and whether anything the code says out loud depends on it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
