### PR TITLE
fix(aws-control): claim the nightly backup through the Job SDK

### DIFF
--- a/docs/system-specs/modules/aws-control.md
+++ b/docs/system-specs/modules/aws-control.md
@@ -407,10 +407,27 @@ locally; it does not restore it into live gateway state.
 pins the staged restore safety boundary.
 
 The nightly toggle records whether an account is eligible for a scheduled
-snapshot. `aws_control.hooks._run_once` resolves an account and drive, checks
-S3 consent, runs only due backups, and SEL-audits invocation, success, and
-failure. It skips unavailable accounts or absent drives rather than creating
-resources itself.
+snapshot. `aws_control.hooks._run_once` resolves an account, checks that the account
+has a working connection, then checks S3 consent, then that its drive exists, runs
+only due backups, and claims the work as a Job SDK run of the same kind and
+`dedupe_key=account` the HTTP route uses, so a nightly run and a manual one cannot
+both upload for one account and a nightly run appears in the account's `jobs` block
+like any other. That order is deliberate: the connection check warms the account
+snapshot the run's worker thread reads, since that worker cannot await, and it runs
+BEFORE consent is confirmed so no suspension point sits between the confirmation and
+`find_drive`, the first call it authorizes. Its own AWS work is an STS identity probe
+plus local CLI config reads, the same class as the identity probe the loop already
+performs before the consent check. A claim while a run is already in flight adopts it
+rather than starting a second upload. The loop follows the run and SEL-audits
+invocation, success, and failure under its own caller, which is what names a run as
+the scheduler's, and every exit after consent is confirmed writes one of those
+records -- a drive-discovery failure, a job-store read error, an absent or
+unreadable run record and a cancel all audit rather than reaching the loop
+supervisor's log-only catch; the upload gate names `backup.CALLER_JOB` itself rather than taking
+a caller argument, since there is one path to it. The drive check keeps an account
+that is not configured yet from accruing a failed run record on every wake. It skips
+unavailable accounts and absent drives rather than creating resources itself, and the
+drive is re-discovered inside the run.
 
 ## Dashboard surface
 

--- a/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
@@ -58,16 +58,27 @@ logger = logging.getLogger(__name__)
 
 APP_NAME = "aws-control"
 
-#: Who triggered an upload, as the SEL record names them.
+#: Who the upload gate records as having performed an upload. There is exactly
+#: ONE path to that gate -- a Job SDK worker -- so there is one value, and it
+#: names the app's job worker rather than any trigger.
 #:
-#: An attribution field only earns its place if it DISTINGUISHES, so neither of
-#: these is a default: ``caller`` is a required keyword all the way down to
-#: ``_authorize_upload``. A new call site has to say which it is rather than
-#: inheriting whichever guess happened to be written first -- and the guess that
-#: was written first here was the interactive one, which attributed unattended
-#: nightly work to a human who was not present.
-CALLER_OWNER = "dashboard-owner"
-CALLER_SCHEDULED = f"app:{APP_NAME}"
+#: It used to be two, ``dashboard-owner`` and ``app:aws-control``, chosen by the
+#: entry point: the runner served owner-gated surfaces only, and the nightly loop
+#: uploaded inline and named itself. Now that the nightly loop claims a run
+#: through the same kind and key, both triggers reach the one registered runner --
+#: and P1 of the Job SDK has no parameter channel (``JobFn`` is
+#: ``Callable[[JobHandle], Any]``), so the runner cannot be told which one it is.
+#: An out-of-band channel keyed on the dedupe identity was tried and is not
+#: sound: only ``start``'s own critical section knows atomically whether a claim
+#: was fresh or adopted, so a manual click landing beside a nightly claim could
+#: hand one worker the other's trigger.
+#:
+#: WHO ASKED is therefore recorded by the starter, which knows it without a race:
+#: the nightly loop's own ``aws_control.backup_nightly`` records name
+#: ``aws-control-nightly`` and carry the run id and its terminal status, and the
+#: dashboard layer audits an owner-driven start. A refusal at the gate is still
+#: never attributed to the dashboard owner, which is the property that matters.
+CALLER_JOB = f"app:{APP_NAME}:job"
 KIND_SNAPSHOT = "snapshot"
 KIND_SESSIONS = "sessions"
 
@@ -420,7 +431,7 @@ def clear_stop() -> None:
     _STOP.clear()
 
 
-def _refuse_upload(account: str, reason: str, *, caller: str, outcome: str = "denied") -> NoReturn:
+def _refuse_upload(account: str, reason: str, *, outcome: str = "denied") -> NoReturn:
     """Record why an upload was refused in the SEL, then refuse.
 
     A refusal is the outcome an auditor most wants evidence of, and it was the
@@ -438,12 +449,15 @@ def _refuse_upload(account: str, reason: str, *, caller: str, outcome: str = "de
     reached from the nightly loop in ``hooks.py``, and a runner-level catch would
     leave that path unaudited.
 
-    ``caller`` is passed in rather than assumed, because covering the nightly path
-    is exactly what makes a hardcoded interactive caller a lie: an unattended run
-    refused at 03:00 must not be recorded against the dashboard owner. Each entry
-    point states its own (``CALLER_OWNER`` / ``CALLER_SCHEDULED``), so attribution
-    stays true on both instead of being flattened to a neutral string that is
-    honest for one path and lossy for the other.
+    The audited caller is :data:`CALLER_JOB`, named here rather than taken as an
+    argument. It used to be a required keyword so each entry point could state its
+    own, which mattered while the nightly loop uploaded inline and the runner served
+    owner-gated surfaces only. There is now one path to this gate, so the parameter
+    carried one value from one call site and could not distinguish anything -- and
+    an attribution field that cannot distinguish is not earning its place. The
+    property it existed to protect is unchanged and is pinned by name: a refusal is
+    never attributed to the dashboard owner. WHO ASKED is recorded by the starter,
+    which knows it without a race.
 
     ``outcome`` is ``denied`` for the access decisions and ``failed`` for
     teardown. Every refusal leaves a record -- one covered path among several
@@ -457,7 +471,7 @@ def _refuse_upload(account: str, reason: str, *, caller: str, outcome: str = "de
     """
     try:
         sel().log_api_access(
-            caller=caller,
+            caller=CALLER_JOB,
             operation="aws_control.backup_upload",
             outcome=outcome,
             source="aws-control",
@@ -469,7 +483,7 @@ def _refuse_upload(account: str, reason: str, *, caller: str, outcome: str = "de
     raise RuntimeError(reason)
 
 
-def _authorize_upload(account: str, profile: str, region: str, *, caller: str) -> None:
+def _authorize_upload(account: str, profile: str, region: str) -> None:
     """Re-check the authorization decisions at the moment of upload.
 
     An archive build can run for minutes inside a worker thread; consent
@@ -503,19 +517,15 @@ def _authorize_upload(account: str, profile: str, region: str, *, caller: str) -
         _refuse_upload(
             account,
             "this connection no longer points at the requested account; upload refused",
-            caller=caller,
         )
     if not is_app_enabled("aws-control"):
         _refuse_upload(
             account,
             "aws-control was disabled during the backup build; upload refused",
-            caller=caller,
         )
     granted, reason = aws_consent.is_granted(aws_consent.SERVICE_S3, profile=profile, region=region)
     if not granted:
-        _refuse_upload(
-            account, f"S3 consent no longer holds; upload refused: {reason}", caller=caller
-        )
+        _refuse_upload(account, f"S3 consent no longer holds; upload refused: {reason}")
     # `is_granted` is only the LOCAL half of the gate and its own docstring says
     # so: it matches profile+region and deliberately does not look at the
     # account. Checking the live account (above) against our target is therefore
@@ -532,26 +542,20 @@ def _authorize_upload(account: str, profile: str, region: str, *, caller: str) -
         _refuse_upload(
             account,
             "S3 consent was withdrawn during the backup build; upload refused",
-            caller=caller,
         )
     if not grant.account or grant.account != account:
         _refuse_upload(
             account,
             "the recorded S3 consent does not name this account; upload refused",
-            caller=caller,
         )
     # Last, and deliberately after every other check: app teardown. A worker
     # thread cannot be killed, so cancelling the loop's await leaves the archive
     # build running; this is what makes that build stop short of uploading.
     if _STOP.is_set():
-        _refuse_upload(
-            account, "aws-control is shutting down; upload refused", caller=caller, outcome="failed"
-        )
+        _refuse_upload(account, "aws-control is shutting down; upload refused", outcome="failed")
 
 
-def run_snapshot_backup(
-    account: str, profile: str, region: str, bucket: str, *, caller: str
-) -> dict[str, Any]:
+def run_snapshot_backup(account: str, profile: str, region: str, bucket: str) -> dict[str, Any]:
     """Build a snapshot archive and push it. Returns the run record."""
     with tempfile.TemporaryDirectory(prefix="kc-backup-") as tmp:
         rc = snapshot_main([tmp, "--keep", "1"])
@@ -579,7 +583,7 @@ def run_snapshot_backup(
         # would collide on the key, so the pushed key carries its own
         # entropy (the _stamp shape) rather than trusting the file name.
         key = f"snapshots/kirocrew-snapshot-{_stamp()}.tar.gz"
-        _authorize_upload(account, profile, region, caller=caller)
+        _authorize_upload(account, profile, region)
         storage.put_file(
             profile,
             region,
@@ -747,9 +751,7 @@ def _add_tree(tar: tarfile.TarFile, root: Path, arc_prefix: str) -> int:
         os.close(root_fd)
 
 
-def run_sessions_backup(
-    account: str, profile: str, region: str, bucket: str, *, caller: str
-) -> dict[str, Any]:
+def run_sessions_backup(account: str, profile: str, region: str, bucket: str) -> dict[str, Any]:
     """Tar both session halves and push. Returns the run record.
 
     Refuses outright on a platform that cannot pin the traversal to descriptors.
@@ -770,7 +772,7 @@ def run_sessions_backup(
         if count == 0:
             raise RuntimeError("no session files to archive")
         key = f"sessions/{archive.name}"
-        _authorize_upload(account, profile, region, caller=caller)
+        _authorize_upload(account, profile, region)
         storage.put_file(
             profile,
             region,
@@ -813,6 +815,11 @@ def make_job_runner(sdk: Any, kind: str) -> Any:
     * profile/region/bucket are RE-RESOLVED here rather than carried, which is
       the rule this app already documents for the nightly loop: the drive is
       tag-discovered per run rather than trusted from memory.
+    * WHO ASKED is deliberately NOT resolved here. Two triggers reach this one
+      runner now that the nightly loop claims its run through the same kind and
+      key, and only ``start``'s own critical section knows atomically which claim
+      was fresh, so the runner names the app's job worker
+      (:data:`CALLER_JOB`) and the starter records the trigger.
 
     Every resolution step is therefore sync. ``accounts.resolve_account_profile``
     and ``aws_consent.authorize`` are coroutines and are NOT reachable from a
@@ -865,17 +872,14 @@ def make_job_runner(sdk: Any, kind: str) -> Any:
         # build takes minutes, and consent can be withdrawn during it. This one
         # decides whether we may touch AWS at all; that one decides whether the
         # bytes may leave. Both are needed, and both audit through the same helper.
-        _authorize_upload(account, profile, region, caller=CALLER_OWNER)
+        _authorize_upload(account, profile, region)
         bucket = storage.find_drive(profile, region, account=account)
         if not bucket:
             raise RuntimeError("this account has no drive yet; nothing was sent to AWS")
         # Resolved by NAME at call time, not captured at registration: the module
         # attribute stays the single definition of what a snapshot backup is.
         work = run_snapshot_backup if kind == KIND_SNAPSHOT else run_sessions_backup
-        # A job exists because an owner asked for one through the app's route or
-        # the `_jobs` surface, both owner-gated. The nightly loop does not come
-        # through here and states `CALLER_SCHEDULED` for itself.
-        work(account, profile, region, bucket, caller=CALLER_OWNER)
+        work(account, profile, region, bucket)
 
     return _run
 

--- a/src/kiro_crew/apps/builtins/aws_control/hooks.py
+++ b/src/kiro_crew/apps/builtins/aws_control/hooks.py
@@ -1,11 +1,13 @@
 """Lifecycle hooks — the nightly backup loop.
 
-One background task, started on enable, that wakes every half hour and runs
-the snapshot backup when it is due (nightly toggle on AND >23 h since the
-last run — see ``backup.due_for_nightly``). Every AWS-reaching step keeps
-the same guards the HTTP path has: consent fails closed (a silent skip plus
-a log line, never an unconfirmed charge), and the drive is tag-discovered
-per run rather than trusted from memory.
+One background task, started on enable, that wakes every half hour and claims a
+snapshot backup when it is due (nightly toggle on AND >23 h since the last run —
+see ``backup.due_for_nightly``). The backup itself runs as a Job SDK run of the
+same kind and ``dedupe_key`` the HTTP route uses, so one account cannot pay for
+two concurrent uploads and a nightly run is visible on the Backup row like any
+other. Every AWS-reaching step keeps the same guards the HTTP path has: consent
+fails closed (a silent skip plus a log line, never an unconfirmed charge), and
+the drive is tag-discovered per run rather than trusted from memory.
 
 The loop runs against the REGISTRY DEFAULT account only — the same account
 the consent card confirms. Multi-account nightly schedules arrive with the
@@ -15,19 +17,26 @@ per-account grant store (spec §9).
 from __future__ import annotations
 
 import asyncio
-import functools
 import logging
 from typing import Any
 
 from kiro_crew import aws_consent
+from kiro_crew.apps import job_sdk
+from kiro_crew.apps.builtins.aws_control.backend import accounts as accounts_mod
 from kiro_crew.apps.builtins.aws_control.backend import backup as backup_mod
 from kiro_crew.apps.builtins.aws_control.backend import storage as storage_mod
+from kiro_crew.apps.job_sdk import get_sdk as get_job_sdk
 from kiro_crew.deploy import profiles as deploy_profiles
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
 
 _CHECK_INTERVAL_SECS = 30 * 60
+
+#: How often the loop re-reads its own claimed run's record while it is in
+#: flight. Short enough that the terminal audit lands near the event, long enough
+#: that a multi-minute archive build costs a handful of reads.
+_RUN_POLL_SECS = 15
 
 _task: asyncio.Task[None] | None = None
 
@@ -37,8 +46,11 @@ def _audit(operation: str, resources: str, outcome: str, *, error: str = "") -> 
 
     The HTTP handlers get their audit from the dashboard layer; this loop has no
     request, so without this the only unattended S3 mutation in the app would be
-    the one operation with no trail. Best-effort by the same rule the handlers
-    use: an audit failure must never abort the backup.
+    the one operation with no trail. The Job SDK audits a run's own lifecycle
+    (``jobs.job_start``, ``jobs.job_done``) but attributes every run to the app,
+    so these records remain the only ones that name the NIGHTLY trigger — they
+    carry the run id, which is what joins the two trails. Best-effort by the same
+    rule the handlers use: an audit failure must never abort the backup.
     """
     try:
         sel().log_api_access(
@@ -54,7 +66,26 @@ def _audit(operation: str, resources: str, outcome: str, *, error: str = "") -> 
 
 
 async def _run_once() -> None:
-    """One due-check + backup attempt. Every failure is a log line, not a crash."""
+    """One due-check, then hand the backup to a Job SDK run. Failures log.
+
+    The backup itself is NOT performed here. It is claimed through
+    ``sdk.start_async(kind, dedupe_key=account)`` — the same kind and the same key
+    the HTTP route uses — because the SDK's ``(kind, dedupe_key)`` index is what
+    stops one account paying for two concurrent uploads, and an index cannot see a
+    caller that does not enter it. Claiming here also makes a nightly run visible
+    on ``GET /backup/{account}``, whose ``jobs`` block is read from the SDK's own
+    records: before this, the Backup row read idle while a nightly backup was in
+    flight.
+
+    What is still decided HERE, before the claim, is unchanged: which account the
+    default profile points at, whether that account is due (``due_for_nightly`` --
+    nightly toggle on AND >23 h since the last run), and whether S3 consent still
+    holds. Those keep the loop from claiming a run it knows will refuse, and keep
+    a nightly-disabled account from being asked to spend money. One check is NEW
+    and the migration needs it: the run's worker cannot await, so it reads the
+    account's profile from a snapshot only the async resolver builds, and nothing
+    on this path warmed it.
+    """
     resolved = await asyncio.to_thread(deploy_profiles.resolve_profile, "")
     if resolved is None:
         logger.info("aws-control nightly: no registered profile; skipping")
@@ -69,43 +100,161 @@ async def _run_once() -> None:
     account = identity.account
     if not await asyncio.to_thread(backup_mod.due_for_nightly, account):
         return
+    # WARM THE SNAPSHOT BEFORE CONSENT IS CONFIRMED, deliberately, so that nothing
+    # suspends between the confirmation and the calls it authorizes.
+    #
+    # The run's worker is a thread and cannot await, so it resolves its profile
+    # through `accounts.resolve_account_profile_cached`, which serves the WARM
+    # snapshot only and returns None past its 300 s TTL. Nothing else on this path
+    # warms it -- neither `resolve_profile` nor `probe_identity` does -- and at
+    # 03:00 there is no dashboard traffic to have warmed it either, so without this
+    # await the worker would resolve None and every unattended run would be
+    # recorded `failed` with no upload. `resolve_account_profile_cached` names this
+    # pre-flight as the reason it may return None; the HTTP route does it too.
+    #
+    # ORDER, not the call, is what makes it safe. Awaiting it AFTER `refuse_and_log`
+    # left a suspension point between consent being confirmed and `find_drive`
+    # acting on it, so consent could be withdrawn while the probe sweep ran. Its own
+    # AWS work is an STS `GetCallerIdentity` per profile plus local `aws configure
+    # get` reads, the same class as the `probe_identity` above, which this loop
+    # already performs before the consent check -- so moving it here adds no
+    # pre-consent surface. It also fails the loop closed on an account with no
+    # working connection, rather than claiming a run that can only refuse.
+    if await accounts_mod.resolve_account_profile(account) is None:
+        logger.info("aws-control nightly: no working connection for the account; skipping")
+        return
     allowed = await aws_consent.refuse_and_log(
         aws_consent.SERVICE_S3, profile=profile, region=region
     )
     if not allowed:
         return  # refuse_and_log already logged + audited
+    sdk = get_job_sdk(backup_mod.APP_NAME)
+    if sdk is None:
+        # Same gap `_register_job_runners` reports at startup, reached from the
+        # other side: without the `jobs` permission there is no run to claim, and
+        # doing the upload anyway would put back the untracked path this replaced.
+        logger.warning(
+            "aws-control nightly: no job runtime; skipping (is the 'jobs' permission declared?)"
+        )
+        return
+    # A due account whose drive does not exist yet is a SILENT skip, as it was
+    # before this loop claimed runs. The runner refuses a driveless account by
+    # raising, which the SDK records as `failed`, and a failed run never reaches
+    # `_record_run` -- so `due_for_nightly` stays True and the account would accrue
+    # one more failed record every half hour, forever, for a state that is simply
+    # not configured yet.
+    #
+    # Discovery runs under the profile CONSENT WAS CHECKED FOR just above, not under
+    # whichever same-account profile the resolver picked. `find_drive` reaches AWS
+    # (tag:GetResources), consent is keyed per (service, profile, region), and
+    # `_pick_profile` may return a healthy non-default profile of the same account
+    # -- so using its answer here would make an unconsented call in the course of
+    # deciding whether to claim. The drive is still re-discovered inside the run,
+    # under the run's own authorized profile: this check decides whether to claim at
+    # all. It is the first call after consent, with no suspension point between.
+    # Discovery is the first call after consent and it can FAIL, not just come back
+    # empty: `find_drive` raises on an ordinary AWS error or an ambiguous match.
+    # Before this loop claimed runs that raise was caught here and audited `failed`;
+    # the migration moved the upload out and took the handler with it, so a
+    # discovery failure reached `_loop`'s log-only catch and the one unattended S3
+    # path in this app recorded nothing. The handler is back, in the shape it had.
     try:
         bucket = await asyncio.to_thread(storage_mod.find_drive, profile, region, account=account)
-        if not bucket:
-            logger.info("aws-control nightly: no drive bucket yet; skipping")
-            return
-        # The nightly path never touches an HTTP handler, so the audit the
-        # dashboard layer adds to every owner-driven mutation is simply absent
-        # here -- an unattended export would leave no SEL trace of having run,
-        # succeeded or failed. Emit the same three-part record the handlers do,
-        # around the call, so the trail does not depend on who triggered it.
-        _audit("backup_nightly", "backup/snapshots", "invoked")
-        record = await asyncio.to_thread(
-            functools.partial(
-                backup_mod.run_snapshot_backup,
-                account,
-                profile,
-                region,
-                bucket,
-                # Nobody is at the keyboard at 03:00. An upload refused here must
-                # not be recorded against the dashboard owner, which is what a
-                # hardcoded interactive caller inside the gate would have done.
-                caller=backup_mod.CALLER_SCHEDULED,
-            )
-        )
-        _audit("backup_nightly", str(record.get("key", "")), "succeeded")
-        logger.info("aws-control nightly backup pushed: %s", record.get("key", ""))
     except asyncio.CancelledError:
         _audit("backup_nightly", "backup/snapshots", "cancelled")
         raise
     except Exception as exc:
         _audit("backup_nightly", "backup/snapshots", "failed", error=str(exc))
-        logger.warning("aws-control nightly backup failed", exc_info=True)
+        logger.warning("aws-control nightly: drive discovery failed", exc_info=True)
+        return
+    if not bucket:
+        logger.info("aws-control nightly: no drive bucket yet; skipping")
+        return
+    await _claim_and_watch(sdk, backup_mod.KIND_SNAPSHOT, account)
+
+
+async def _claim_and_watch(sdk: Any, kind: str, account: str) -> None:
+    """Claim the run, then follow it to a terminal state.
+
+    The claim is ``start_async``, so if a run of this kind and key is already in
+    flight the SDK ADOPTS it and returns its id rather than beginning a second
+    paid upload. The loop does NOT try to tell adoption from a fresh claim: only
+    ``start``'s own critical section knows that atomically, and nothing here needs
+    to know it -- either way the id names the run that is doing this account's
+    backup, which is the run to follow and to report.
+
+    Following it to terminal is what keeps the SEL trail this loop has always
+    produced: the SDK records the run's own lifecycle but attributes every run to
+    the app, so these records stay the only ones naming the nightly trigger, and a
+    success with no record would leave the app's one unattended S3 mutation
+    reported as invoked and never resolved. It also keeps the loop from re-entering
+    while the backup is still uploading, which the direct call gave for free.
+    """
+    _audit("backup_nightly", "backup/snapshots", "invoked")
+    try:
+        run_id = await sdk.start_async(kind, dedupe_key=account)
+    except asyncio.CancelledError:
+        _audit("backup_nightly", "backup/snapshots", "cancelled")
+        raise
+    except Exception as exc:
+        _audit("backup_nightly", "backup/snapshots", "failed", error=str(exc))
+        logger.warning("aws-control nightly backup could not be claimed", exc_info=True)
+        return
+    logger.info("aws-control nightly backup is running as job %s", run_id)
+    await _watch_run(sdk, run_id)
+
+
+def _terminal_outcome(sdk: Any, run_id: str) -> tuple[str, str] | None:
+    """Terminal ``(status, error)`` for the run, or None while it is still going.
+
+    Reading the record and classifying it live together so ONE handler covers
+    both: a job-store I/O error, an absent record and a record whose shape cannot
+    be read are the same thing to the loop -- it cannot say how the run ended.
+    Absence raises rather than returning a sentinel, because "no record" is a
+    failure to report and a sentinel invites a caller to treat it as "not yet".
+    """
+    run = sdk.get(run_id)
+    if run is None:
+        raise RuntimeError("the run record could not be read")
+    if not run.is_terminal:
+        return None
+    return run.status, run.error
+
+
+async def _watch_run(sdk: Any, run_id: str) -> None:
+    """Audit how the claimed run ended. One record, from the run's own status.
+
+    Every exit from here writes a record. A read that raises used to propagate to
+    ``_loop``'s log-only catch, which left a claimed nightly run audited ``invoked``
+    and never resolved -- an audit that is present exactly when nothing went wrong.
+    """
+    while True:
+        try:
+            outcome = await asyncio.to_thread(_terminal_outcome, sdk, run_id)
+        except asyncio.CancelledError:
+            _audit("backup_nightly", f"run={run_id}", "cancelled")
+            raise
+        except Exception as exc:
+            _audit("backup_nightly", f"run={run_id}", "failed", error=str(exc))
+            logger.warning("aws-control nightly: run %s could not be read", run_id, exc_info=True)
+            return
+        if outcome is not None:
+            status, error = outcome
+            if status == job_sdk.DONE:
+                _audit("backup_nightly", f"run={run_id}", "succeeded")
+                logger.info("aws-control nightly backup finished: run %s", run_id)
+            else:
+                _audit("backup_nightly", f"run={run_id}", status, error=error)
+                logger.warning("aws-control nightly backup ended %s: run %s", status, run_id)
+            return
+        try:
+            await asyncio.sleep(_RUN_POLL_SECS)
+        except asyncio.CancelledError:
+            # Teardown cancels the loop task mid-backup. The worker thread is not
+            # killable, so this records that the LOOP stopped watching, which is
+            # the same thing the direct call recorded when it was cancelled.
+            _audit("backup_nightly", f"run={run_id}", "cancelled")
+            raise
 
 
 async def _loop() -> None:
@@ -186,10 +335,10 @@ async def on_startup(ctx: Any) -> None:
 async def on_shutdown(ctx: Any) -> None:  # noqa: ARG001 — kept for the hook ABI
     """Stop the loop, and stop a worker that has not begun uploading yet.
 
-    ``_task.cancel()`` alone only unblocks the ``await``: a
-    ``asyncio.to_thread`` worker is a real thread and Python cannot kill one, so
-    a snapshot already streaming to S3 runs to completion regardless of what the
-    hook does. The stop EVENT closes the part that is closeable -- the worker
+    ``_task.cancel()`` alone only unblocks the ``await``: the upload now runs on a
+    Job SDK worker thread, and Python cannot kill a thread, so a snapshot already
+    streaming to S3 runs to completion regardless of what the hook does. The stop
+    EVENT closes the part that is closeable -- the worker
     re-checks authorization immediately before ``put_file``, and that check now
     also refuses once teardown has been signalled, so a backup still building its
     archive when the owner disables the app never starts its upload.

--- a/test/test_aws_control_app.py
+++ b/test/test_aws_control_app.py
@@ -1933,12 +1933,14 @@ class TestRound22Hardening:
         ):
             backup.clear_stop()
             backup._authorize_upload(
-                ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER
+                ACCOUNT,
+                "p",
+                "us-west-2",
             )  # no raise
             backup.signal_stop()
             try:
                 with pytest.raises(RuntimeError, match="shutting down"):
-                    backup._authorize_upload(ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER)
+                    backup._authorize_upload(ACCOUNT, "p", "us-west-2")
             finally:
                 backup.clear_stop()
 
@@ -1953,6 +1955,16 @@ class TestRound22Hardening:
     def test_nightly_backup_emits_sel_records(self):
         from kiro_crew.apps.builtins.aws_control import hooks
 
+        # The loop now CLAIMS a Job SDK run rather than uploading inline, so the
+        # trail it owns is "invoked" at the claim and the run's own terminal
+        # status once the record settles. A stub SDK stands in for the runtime:
+        # this test is about the SEL records, not about the worker.
+        done = SimpleNamespace(status="done", error="", is_terminal=True)
+        sdk = SimpleNamespace(
+            list_active=lambda kind: [],
+            start_async=AsyncMock(return_value="run-1"),
+            get=lambda run_id: done,
+        )
         with (
             mock.patch.object(
                 hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
@@ -1965,13 +1977,12 @@ class TestRound22Hardening:
             mock.patch.object(hooks.backup_mod, "due_for_nightly", return_value=True),
             mock.patch.object(hooks.aws_consent, "refuse_and_log", AsyncMock(return_value=True)),
             mock.patch.object(
-                hooks.storage_mod, "find_drive", return_value="kirocrew-drive-abc123def456"
+                hooks.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
-            mock.patch.object(
-                hooks.backup_mod,
-                "run_snapshot_backup",
-                return_value={"key": "snapshots/x.tar.gz"},
-            ),
+            mock.patch.object(hooks.storage_mod, "find_drive", return_value="kirocrew-drive-abc"),
+            mock.patch.object(hooks, "get_job_sdk", return_value=sdk),
             mock.patch.object(hooks, "_audit") as audit,
         ):
             asyncio.run(hooks._run_once())
@@ -1982,6 +1993,15 @@ class TestRound22Hardening:
     def test_nightly_backup_failure_is_audited(self):
         from kiro_crew.apps.builtins.aws_control import hooks
 
+        # A run that ends "failed" is reported by the loop too, not left as an
+        # "invoked" with no resolution: the run record is where the outcome lives
+        # now, so the loop reads it rather than catching an exception.
+        failed = SimpleNamespace(status="failed", error="boom", is_terminal=True)
+        sdk = SimpleNamespace(
+            list_active=lambda kind: [],
+            start_async=AsyncMock(return_value="run-1"),
+            get=lambda run_id: failed,
+        )
         with (
             mock.patch.object(
                 hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
@@ -1994,11 +2014,12 @@ class TestRound22Hardening:
             mock.patch.object(hooks.backup_mod, "due_for_nightly", return_value=True),
             mock.patch.object(hooks.aws_consent, "refuse_and_log", AsyncMock(return_value=True)),
             mock.patch.object(
-                hooks.storage_mod, "find_drive", return_value="kirocrew-drive-abc123def456"
+                hooks.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
-            mock.patch.object(
-                hooks.backup_mod, "run_snapshot_backup", side_effect=RuntimeError("boom")
-            ),
+            mock.patch.object(hooks.storage_mod, "find_drive", return_value="kirocrew-drive-abc"),
+            mock.patch.object(hooks, "get_job_sdk", return_value=sdk),
             mock.patch.object(hooks, "_audit") as audit,
         ):
             asyncio.run(hooks._run_once())  # swallowed, not raised
@@ -2206,7 +2227,7 @@ class TestRound26Hardening:
         with p1, p2, p3, p4:
             backup.clear_stop()
             with pytest.raises(RuntimeError, match="does not name this account"):
-                backup._authorize_upload(ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER)
+                backup._authorize_upload(ACCOUNT, "p", "us-west-2")
 
     def test_grant_naming_no_account_refuses_the_upload(self):
         from kiro_crew.apps.builtins.aws_control.backend import backup
@@ -2215,7 +2236,7 @@ class TestRound26Hardening:
         with p1, p2, p3, p4:
             backup.clear_stop()
             with pytest.raises(RuntimeError, match="does not name this account"):
-                backup._authorize_upload(ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER)
+                backup._authorize_upload(ACCOUNT, "p", "us-west-2")
 
     def test_matching_grant_account_allows_the_upload(self):
         from kiro_crew.apps.builtins.aws_control.backend import backup
@@ -2224,7 +2245,9 @@ class TestRound26Hardening:
         with p1, p2, p3, p4:
             backup.clear_stop()
             backup._authorize_upload(
-                ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER
+                ACCOUNT,
+                "p",
+                "us-west-2",
             )  # no raise
 
     def test_grant_withdrawn_mid_build_refuses_the_upload(self):
@@ -2241,7 +2264,7 @@ class TestRound26Hardening:
         ):
             backup.clear_stop()
             with pytest.raises(RuntimeError, match="withdrawn"):
-                backup._authorize_upload(ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER)
+                backup._authorize_upload(ACCOUNT, "p", "us-west-2")
 
 
 class TestProfileDiscovery:

--- a/test/test_aws_control_backup.py
+++ b/test/test_aws_control_backup.py
@@ -56,7 +56,7 @@ class TestAuthorizeUpload:
             return_value=json.dumps({"Account": "999988887777"}),
         ):
             with pytest.raises(RuntimeError, match="no longer points at"):
-                backup._authorize_upload(ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER)
+                backup._authorize_upload(ACCOUNT, "p", "us-west-2")
 
     def test_unparseable_sts_output_reads_as_no_account_and_refuses(self):
         # A garbled STS response must not be trusted as a match: it decodes to
@@ -64,7 +64,7 @@ class TestAuthorizeUpload:
         # upload is refused rather than proceeding on unknown identity.
         with mock.patch("kiro_crew.deploy.engine._checked", return_value="not json"):
             with pytest.raises(RuntimeError, match="no longer points at"):
-                backup._authorize_upload(ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER)
+                backup._authorize_upload(ACCOUNT, "p", "us-west-2")
 
     def test_upload_refused_when_app_disabled_during_build(self):
         # STS agrees, but the app was disabled while the archive built: the
@@ -77,7 +77,7 @@ class TestAuthorizeUpload:
             mock.patch("kiro_crew.apps.manager.is_app_enabled", return_value=False),
         ):
             with pytest.raises(RuntimeError, match="was disabled"):
-                backup._authorize_upload(ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER)
+                backup._authorize_upload(ACCOUNT, "p", "us-west-2")
 
     def test_upload_refused_when_s3_consent_no_longer_holds(self):
         # STS agrees and the app is on, but S3 consent was withdrawn: the
@@ -91,7 +91,7 @@ class TestAuthorizeUpload:
             mock.patch("kiro_crew.aws_consent.is_granted", return_value=(False, "expired")),
         ):
             with pytest.raises(RuntimeError, match="consent no longer holds.*expired"):
-                backup._authorize_upload(ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER)
+                backup._authorize_upload(ACCOUNT, "p", "us-west-2")
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +115,10 @@ class TestRunSnapshotBackup:
         ):
             with pytest.raises(RuntimeError, match="snapshot build failed"):
                 backup.run_snapshot_backup(
-                    ACCOUNT, "p", "us-west-2", "bkt", caller=backup.CALLER_OWNER
+                    ACCOUNT,
+                    "p",
+                    "us-west-2",
+                    "bkt",
                 )
         authz.assert_not_called()
         put_file.assert_not_called()
@@ -129,7 +132,10 @@ class TestRunSnapshotBackup:
         ):
             with pytest.raises(RuntimeError, match="produced no archive"):
                 backup.run_snapshot_backup(
-                    ACCOUNT, "p", "us-west-2", "bkt", caller=backup.CALLER_OWNER
+                    ACCOUNT,
+                    "p",
+                    "us-west-2",
+                    "bkt",
                 )
         put_file.assert_not_called()
 
@@ -150,10 +156,13 @@ class TestRunSnapshotBackup:
             mock.patch.object(backup.storage, "put_file") as put_file,
         ):
             record = backup.run_snapshot_backup(
-                ACCOUNT, "p", "us-west-2", "bkt", caller=backup.CALLER_OWNER
+                ACCOUNT,
+                "p",
+                "us-west-2",
+                "bkt",
             )
 
-        authz.assert_called_once_with(ACCOUNT, "p", "us-west-2", caller=backup.CALLER_OWNER)
+        authz.assert_called_once_with(ACCOUNT, "p", "us-west-2")
         put_file.assert_called_once()
         # Same long-timeout contract as the sessions push: the declared
         # `_PUSH_TIMEOUT_SECS` has to REACH the uploader, not sit unread.
@@ -189,7 +198,10 @@ class TestRunSessionsBackup:
         ):
             with pytest.raises(RuntimeError, match="no session files to archive"):
                 backup.run_sessions_backup(
-                    ACCOUNT, "p", "us-west-2", "bkt", caller=backup.CALLER_OWNER
+                    ACCOUNT,
+                    "p",
+                    "us-west-2",
+                    "bkt",
                 )
         authz.assert_not_called()
         put_file.assert_not_called()
@@ -229,7 +241,10 @@ class TestRunSessionsBackup:
             mock.patch.object(backup.storage, "put_file", side_effect=fake_put),
         ):
             record = backup.run_sessions_backup(
-                ACCOUNT, "p", "us-west-2", "bkt", caller=backup.CALLER_OWNER
+                ACCOUNT,
+                "p",
+                "us-west-2",
+                "bkt",
             )
 
         assert pushed["key"].startswith("sessions/sessions-")
@@ -354,7 +369,10 @@ class TestRefusalWithoutPinnedTraversal:
         ):
             with pytest.raises(RuntimeError) as exc:
                 backup.run_sessions_backup(
-                    "123456789012", "p", "us-west-2", "b", caller=backup.CALLER_OWNER
+                    "123456789012",
+                    "p",
+                    "us-west-2",
+                    "b",
                 )
         assert "refused" in str(exc.value)
         put.assert_not_called()

--- a/test/test_aws_control_backup_job.py
+++ b/test/test_aws_control_backup_job.py
@@ -62,7 +62,7 @@ class TestNoAwsCallBeforeTheGate:
     def test_discovery_never_runs_when_the_gate_refuses(self):
         order: list[str] = []
 
-        def _gate(account, profile, region, *, caller):
+        def _gate(account, profile, region):
             order.append("gate")
             raise PermissionError("consent withdrawn; upload refused")
 
@@ -144,7 +144,7 @@ class TestEveryUploadRefusalIsAudited:
         with ExitStack() as stack:
             sel_factory = self._arrange(stack, **over)
             with pytest.raises(RuntimeError, match="upload refused"):
-                backup._authorize_upload(ACCOUNT, PROFILE, REGION, caller=backup.CALLER_OWNER)
+                backup._authorize_upload(ACCOUNT, PROFILE, REGION)
 
             sel_factory.return_value.log_api_access.assert_called_once()
             kwargs = sel_factory.return_value.log_api_access.call_args.kwargs
@@ -159,45 +159,43 @@ class TestEveryUploadRefusalIsAudited:
             # HTTP view, so this audit names the account deliberately.
             assert ACCOUNT in kwargs["resources"], label
 
-    @pytest.mark.parametrize(
-        "caller,expected",
-        [("interactive", "dashboard-owner"), ("scheduled", "app:aws-control")],
-    )
-    def test_a_refusal_is_attributed_to_whoever_triggered_it(
-        self, caller: str, expected: str
-    ) -> None:
-        """Attribution has to DISTINGUISH, so both paths are asserted.
+    def test_a_refusal_names_the_worker_that_refused(self) -> None:
+        """The audited caller must be a value the call site can vouch for.
 
-        Covering the nightly path is what made a hardcoded interactive caller a
-        lie: an unattended run refused at 03:00 was recorded against the dashboard
-        owner, a person who was not there. That is the same defect as everywhere
-        else in this change -- a record asserting something nobody observed --
-        committed at the audit layer instead of the record layer.
+        This used to be two values chosen by entry point, because the nightly loop
+        uploaded inline and the runner served owner-gated surfaces only -- a
+        hardcoded interactive caller was then a lie, recording an unattended 03:00
+        refusal against a person who was not there.
 
-        A neutral string for both paths would fix the lie by discarding the truth
-        on the interactive path, where the owner really did trigger the work. So
-        each entry point states its own, and a test that checked only one value
-        would not be testing attribution at all.
+        Both triggers now reach the one registered runner, and P1 of the Job SDK
+        has no parameter channel, so the runner cannot know which one it is: only
+        ``start``'s critical section knows atomically whether a claim was fresh or
+        adopted. So the gate names the actor it can observe -- the app's job
+        worker -- and WHO ASKED is recorded by the starter, which knows it without
+        a race. The property the old pair protected is kept below: a refusal is
+        never attributed to the dashboard owner.
         """
-        chosen = backup.CALLER_OWNER if caller == "interactive" else backup.CALLER_SCHEDULED
         with ExitStack() as stack:
             sel_factory = self._arrange(stack, granted=(False, "revoked_by_owner"))
             with pytest.raises(RuntimeError, match="upload refused"):
-                backup._authorize_upload(ACCOUNT, PROFILE, REGION, caller=chosen)
+                backup._authorize_upload(ACCOUNT, PROFILE, REGION)
 
             kwargs = sel_factory.return_value.log_api_access.call_args.kwargs
-            assert kwargs["caller"] == expected
+            assert kwargs["caller"] == "app:aws-control:job"
 
-    def test_the_two_entry_points_pass_different_callers(self) -> None:
-        """The constants only matter if the call sites actually differ.
+    def test_no_upload_is_ever_attributed_to_the_dashboard_owner(self) -> None:
+        """Pinned by reading the sources, which is where the lie would live.
 
-        Pinned by reading the sources: the Job SDK runner exists because an owner
-        asked through an owner-gated route, and the nightly loop has no owner at
-        all. If both ever named the same constant, the field would be decoration.
+        The runner is the only path to the upload gate, so if it ever named an
+        interactive caller again, every unattended nightly refusal would be filed
+        against the owner. And the nightly loop must keep auditing under its own
+        name, because that record is the only one that says a run was the
+        scheduler's.
         """
-        assert backup.CALLER_OWNER != backup.CALLER_SCHEDULED
-        assert "CALLER_OWNER" in inspect.getsource(backup.make_job_runner)
-        assert "CALLER_SCHEDULED" in inspect.getsource(hooks._run_once)
+        assert "dashboard-owner" not in backup.CALLER_JOB
+        assert "CALLER_JOB" in inspect.getsource(backup.make_job_runner)
+        assert "dashboard-owner" not in inspect.getsource(backup.make_job_runner)
+        assert "aws-control-nightly" in inspect.getsource(hooks._audit)
 
     def test_teardown_is_recorded_but_not_as_an_access_denial(self) -> None:
         """Every refusal leaves a record; only access decisions are denials.
@@ -210,7 +208,7 @@ class TestEveryUploadRefusalIsAudited:
         with ExitStack() as stack:
             sel_factory = self._arrange(stack, stopping=True)
             with pytest.raises(RuntimeError, match="shutting down"):
-                backup._authorize_upload(ACCOUNT, PROFILE, REGION, caller=backup.CALLER_OWNER)
+                backup._authorize_upload(ACCOUNT, PROFILE, REGION)
 
             sel_factory.return_value.log_api_access.assert_called_once()
             kwargs = sel_factory.return_value.log_api_access.call_args.kwargs
@@ -617,7 +615,7 @@ class TestRunnerShape:
             mock.patch.object(backup, "run_snapshot_backup") as work,
         ):
             runner(SimpleNamespace(run_id="r"))
-        work.assert_called_once_with(ACCOUNT, PROFILE, REGION, BUCKET, caller=backup.CALLER_OWNER)
+        work.assert_called_once_with(ACCOUNT, PROFILE, REGION, BUCKET)
 
 
 class _FakeRun:
@@ -637,7 +635,7 @@ class TestRunnerResolvesItsTarget:
             run = _await_terminal(sdk, run_id)
         assert run.status == job_sdk.DONE
         assert run.error == ""
-        work.assert_called_once_with(ACCOUNT, PROFILE, REGION, BUCKET, caller=backup.CALLER_OWNER)
+        work.assert_called_once_with(ACCOUNT, PROFILE, REGION, BUCKET)
 
     def test_runner_rediscovers_the_drive_rather_than_trusting_a_carried_name(self, sdk):
         # The app's own rule for the nightly loop: the drive is tag-discovered
@@ -736,7 +734,7 @@ class TestRunnerResolvesItsTarget:
             run_id = sdk.start(backup.KIND_SESSIONS, dedupe_key=ACCOUNT)
             run = _await_terminal(sdk, run_id)
         assert run.status == job_sdk.DONE
-        work.assert_called_once_with(ACCOUNT, PROFILE, REGION, BUCKET, caller=backup.CALLER_OWNER)
+        work.assert_called_once_with(ACCOUNT, PROFILE, REGION, BUCKET)
         other.assert_not_called()
 
 

--- a/test/test_aws_control_hooks.py
+++ b/test/test_aws_control_hooks.py
@@ -13,6 +13,7 @@ exactly those, and never leaves a real background task running past a test.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -134,10 +135,12 @@ class TestRunOnceEarlyReturns:
             _run(hooks._run_once())
         refuse.assert_not_called()
 
-    def test_consent_refused_skips_before_drive_lookup(self):
+    def test_consent_refused_skips_before_claiming_a_run(self):
         # Consent fails closed: if refuse_and_log returns False the run stops
-        # (it already logged + audited), before find_drive is called, so a
-        # revoked grant produces no S3 read and no upload.
+        # (it already logged + audited) before the loop even looks for the job
+        # runtime, so a revoked grant produces no run record and no upload. The
+        # drive lookup this used to name now happens inside the run, which is
+        # never claimed here.
         with (
             mock.patch.object(
                 hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
@@ -148,16 +151,22 @@ class TestRunOnceEarlyReturns:
                 AsyncMock(return_value=aws_consent.Identity(ok=True, account=ACCOUNT)),
             ),
             mock.patch.object(hooks.backup_mod, "due_for_nightly", return_value=True),
+            mock.patch.object(
+                hooks.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
+            ),
             mock.patch.object(hooks.aws_consent, "refuse_and_log", AsyncMock(return_value=False)),
-            mock.patch.object(hooks.storage_mod, "find_drive") as find,
+            mock.patch.object(hooks, "get_job_sdk") as get_sdk,
         ):
             _run(hooks._run_once())
-        find.assert_not_called()
+        get_sdk.assert_not_called()
 
-    def test_no_drive_bucket_skips_before_backup(self):
-        # The drive is tag-discovered per run, not trusted from memory. Until one
-        # exists there is nowhere to push, so the run returns before invoking the
-        # snapshot backup (and before the "invoked" audit).
+    def test_no_job_runtime_skips_before_any_audit(self):
+        # Without the `jobs` permission the app context carries no SDK, so there
+        # is no run to claim. The loop must NOT fall back to uploading inline --
+        # that is the untracked path this change removed -- and it must not audit
+        # an "invoked" it never performed.
         with (
             mock.patch.object(
                 hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
@@ -169,7 +178,7 @@ class TestRunOnceEarlyReturns:
             ),
             mock.patch.object(hooks.backup_mod, "due_for_nightly", return_value=True),
             mock.patch.object(hooks.aws_consent, "refuse_and_log", AsyncMock(return_value=True)),
-            mock.patch.object(hooks.storage_mod, "find_drive", return_value=""),
+            mock.patch.object(hooks, "get_job_sdk", return_value=None),
             mock.patch.object(hooks.backup_mod, "run_snapshot_backup") as backup,
             mock.patch.object(hooks, "_audit") as audit,
         ):
@@ -179,10 +188,10 @@ class TestRunOnceEarlyReturns:
 
 
 class TestRunOnceCancellation:
-    """A cancel during the backup is audited as ``cancelled`` and re-raised, so
+    """A cancel during the claim is audited as ``cancelled`` and re-raised, so
     teardown stops the loop cleanly AND leaves a trail that it was interrupted."""
 
-    def test_cancelled_backup_is_audited_and_reraised(self):
+    def test_cancelled_claim_is_audited_and_reraised(self):
         with (
             mock.patch.object(
                 hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
@@ -194,11 +203,18 @@ class TestRunOnceCancellation:
             ),
             mock.patch.object(hooks.backup_mod, "due_for_nightly", return_value=True),
             mock.patch.object(hooks.aws_consent, "refuse_and_log", AsyncMock(return_value=True)),
+            mock.patch.object(
+                hooks.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
+            ),
             mock.patch.object(hooks.storage_mod, "find_drive", return_value="kirocrew-drive-abc"),
             mock.patch.object(
-                hooks.backup_mod,
-                "run_snapshot_backup",
-                side_effect=asyncio.CancelledError(),
+                hooks,
+                "get_job_sdk",
+                return_value=SimpleNamespace(
+                    start_async=AsyncMock(side_effect=asyncio.CancelledError()),
+                ),
             ),
             mock.patch.object(hooks, "_audit") as audit,
         ):
@@ -208,6 +224,39 @@ class TestRunOnceCancellation:
         # "invoked" fired before the cancel, then "cancelled" -- never "failed",
         # because a cancel is not an error to swallow.
         assert outcomes == ["invoked", "cancelled"]
+
+    def test_a_claim_that_raises_is_audited_failed_and_swallowed(self):
+        # A bad night must not kill the loop: a claim that cannot be made is a
+        # record and a log line, and the next wake tries again.
+        with (
+            mock.patch.object(
+                hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
+            ),
+            mock.patch.object(
+                hooks.aws_consent,
+                "probe_identity",
+                AsyncMock(return_value=aws_consent.Identity(ok=True, account=ACCOUNT)),
+            ),
+            mock.patch.object(hooks.backup_mod, "due_for_nightly", return_value=True),
+            mock.patch.object(hooks.aws_consent, "refuse_and_log", AsyncMock(return_value=True)),
+            mock.patch.object(
+                hooks.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
+            ),
+            mock.patch.object(hooks.storage_mod, "find_drive", return_value="kirocrew-drive-abc"),
+            mock.patch.object(
+                hooks,
+                "get_job_sdk",
+                return_value=SimpleNamespace(
+                    start_async=AsyncMock(side_effect=RuntimeError("no runner")),
+                ),
+            ),
+            mock.patch.object(hooks, "_audit") as audit,
+        ):
+            _run(hooks._run_once())  # swallowed
+        outcomes = [c.args[2] for c in audit.call_args_list]
+        assert outcomes == ["invoked", "failed"]
 
 
 class TestLoopSupervisor:

--- a/test/test_aws_control_nightly_job.py
+++ b/test/test_aws_control_nightly_job.py
@@ -1,0 +1,451 @@
+"""The nightly backup loop as a Job SDK run.
+
+The loop used to call ``backup.run_snapshot_backup`` directly. Two consequences
+followed, and both are pinned here:
+
+* the SDK's ``(kind, dedupe_key)`` index cannot see a caller that never enters
+  it, so a nightly run and a manual click could each pay for an upload of the
+  same account;
+* the Backup row reads its busy state from the account-scoped ``jobs`` block,
+  which is built from SDK records, so a nightly run showed the row idle.
+
+Two more cases cover what the migration itself could break. The run's worker is a
+thread and cannot await, so it reads its profile from a snapshot only the async
+resolver builds -- an unattended run would be recorded ``failed`` with no upload if
+the loop did not warm it. And the gate must never attribute an upload to the
+dashboard owner, now that a trigger nobody is watching reaches the same runner.
+
+Every worker started here is driven to a terminal record before its test returns:
+a Job SDK worker is a real thread, and one still running at teardown would write
+its record into a directory pytest has already removed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kiro_crew import aws_consent
+from kiro_crew.apps import job_sdk
+from kiro_crew.apps.builtins.aws_control import hooks
+from kiro_crew.apps.builtins.aws_control.backend import accounts as accounts_mod
+from kiro_crew.apps.builtins.aws_control.backend import backup
+
+ACCOUNT = "111122223333"
+PROFILE = "prof"
+REGION = "us-west-2"
+BUCKET = "kirocrew-drive-abc"
+KIND = backup.KIND_SNAPSHOT
+
+
+def _drain(sdk: job_sdk.JobSDK, release: threading.Event, run_id: str) -> None:
+    """Release a blocked worker and wait for its record to settle.
+
+    A `JobStore.write` landing after pytest removed the test's directory would
+    recreate it -- a side effect outside the test's own sandbox. Waiting for the
+    terminal record is what makes that impossible, rather than merely unlikely.
+    """
+    release.set()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        run = sdk.get(run_id)
+        if run is not None and run.is_terminal:
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"worker for run {run_id} never reached a terminal record")
+
+
+def _nightly_preconditions(stack: ExitStack, sdk, *, warm_profile: bool = True) -> None:
+    """Every pre-claim check passing, so a case exercises only the claim.
+
+    ``warm_profile=False`` leaves the loop's own profile pre-flight REAL, for the
+    case that is about that pre-flight.
+    """
+    stack.enter_context(
+        mock.patch.object(hooks.deploy_profiles, "resolve_profile", return_value=(PROFILE, REGION))
+    )
+    stack.enter_context(
+        mock.patch.object(
+            hooks.aws_consent,
+            "probe_identity",
+            AsyncMock(return_value=aws_consent.Identity(ok=True, account=ACCOUNT)),
+        )
+    )
+    stack.enter_context(mock.patch.object(hooks.backup_mod, "due_for_nightly", return_value=True))
+    stack.enter_context(
+        mock.patch.object(hooks.aws_consent, "refuse_and_log", AsyncMock(return_value=True))
+    )
+    if warm_profile:
+        stack.enter_context(
+            mock.patch.object(
+                hooks.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=(PROFILE, REGION)),
+            )
+        )
+    stack.enter_context(mock.patch.object(hooks, "get_job_sdk", return_value=sdk))
+    stack.enter_context(mock.patch.object(hooks.storage_mod, "find_drive", return_value=BUCKET))
+    # The watch poll is a real sleep; a test must not wait 15 s for a record that
+    # is already terminal on the second read.
+    stack.enter_context(mock.patch.object(hooks, "_RUN_POLL_SECS", 0.01))
+
+
+class TestOneUploadPerAccount:
+    """A nightly claim and a manual run must not both do the paid work."""
+
+    def test_a_nightly_claim_adopts_a_manual_run_in_flight(self, tmp_path):
+        sdk = job_sdk.JobSDK(backup.APP_NAME, tmp_path)
+        entered = threading.Event()
+        release = threading.Event()
+        ran: list[str] = []
+
+        def _runner(handle) -> None:
+            ran.append(handle.run_id)
+            entered.set()
+            release.wait(10)
+
+        sdk.register(KIND, _runner)
+        manual = sdk.start(KIND, dedupe_key=ACCOUNT)
+        try:
+            assert entered.wait(10), "the manual run's worker never started"
+
+            with ExitStack() as stack:
+                _nightly_preconditions(stack, sdk)
+                # If the loop ever uploads inline again this is the call that
+                # proves it: the registered runner above is a stub, so nothing
+                # else in this test can reach the real snapshot backup.
+                inline = stack.enter_context(
+                    mock.patch.object(backup, "run_snapshot_backup", return_value={"key": "k"})
+                )
+                stack.enter_context(
+                    mock.patch(
+                        "kiro_crew.apps.builtins.aws_control.backend.storage.find_drive",
+                        return_value=BUCKET,
+                    )
+                )
+                stack.enter_context(mock.patch.object(hooks, "_audit"))
+                # The watch is covered by the row-visibility case below. Here it
+                # would block on the deliberately-stuck manual worker, so this
+                # case is scoped to the claim, which is what it pins.
+                stack.enter_context(mock.patch.object(hooks, "_watch_run", AsyncMock()))
+                asyncio.run(hooks._run_once())
+        finally:
+            _drain(sdk, release, manual)
+
+        inline.assert_not_called()
+        assert ran == [manual], "a second worker ran for the same account"
+
+
+class TestTheRowSeesANightlyRun:
+    """The Backup row is honest about every run the SDK knows about."""
+
+    def test_a_nightly_claim_leaves_an_account_scoped_run_record(self, tmp_path):
+        sdk = job_sdk.JobSDK(backup.APP_NAME, tmp_path)
+        done: list[str] = []
+        sdk.register(KIND, lambda handle: done.append(handle.run_id))
+
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk)
+            stack.enter_context(mock.patch.object(hooks, "_audit"))
+            asyncio.run(hooks._run_once())
+
+        mine = [r for r in sdk.list_recent(KIND, limit=20) if r.dedupe_key == ACCOUNT]
+        assert len(mine) == 1, "the nightly run left no record for this account"
+        assert mine[0].kind == KIND
+        assert mine[0].is_terminal, "the loop returned before its own run settled"
+
+
+class TestTheWorkerCanResolveItsProfile:
+    """The migration moved the upload onto a thread that cannot await."""
+
+    def test_the_loop_warms_the_snapshot_before_claiming(self, tmp_path):
+        # `resolve_account_profile_cached` serves the WARM snapshot only and
+        # returns None past its 300 s TTL, which the runner turns into "no working
+        # connection". At 03:00 no dashboard traffic has warmed it, so without the
+        # loop's own pre-flight every unattended run would be recorded failed with
+        # no upload -- where the pre-PR loop used the probed profile and succeeded.
+        sdk = job_sdk.JobSDK(backup.APP_NAME, tmp_path)
+        sdk.register(KIND, backup.make_job_runner(sdk, KIND))
+        snapshot = {
+            "accounts": [
+                {
+                    "account": ACCOUNT,
+                    "profiles": [
+                        {
+                            "name": PROFILE,
+                            "region": REGION,
+                            "identityOk": True,
+                            "default": True,
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with ExitStack() as stack:
+            # The async resolver is left REAL here -- it is the call under test --
+            # and only the probe sweep underneath `list_accounts` is faked, so the
+            # snapshot the worker later reads is warmed by the real code path.
+            _nightly_preconditions(stack, sdk, warm_profile=False)
+            stack.enter_context(mock.patch.object(hooks, "_audit"))
+            stack.enter_context(
+                mock.patch.object(accounts_mod, "_build_snapshot", AsyncMock(return_value=snapshot))
+            )
+            stack.enter_context(mock.patch.object(backup, "_authorize_upload"))
+            stack.enter_context(
+                mock.patch(
+                    "kiro_crew.apps.builtins.aws_control.backend.storage.find_drive",
+                    return_value=BUCKET,
+                )
+            )
+            work = stack.enter_context(mock.patch.object(backup, "run_snapshot_backup"))
+            asyncio.run(hooks._run_once())
+
+        assert work.called, "the unattended run never reached the upload"
+        assert work.call_args.args[0] == ACCOUNT
+
+    def test_an_account_with_no_working_connection_claims_nothing(self, tmp_path):
+        # Fail closed: a run that can only refuse is worse than no run, because it
+        # leaves a `failed` record the owner has to interpret.
+        sdk = SimpleNamespace(start_async=AsyncMock(return_value="run-1"))
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk)
+            stack.enter_context(
+                mock.patch.object(
+                    hooks.accounts_mod, "resolve_account_profile", AsyncMock(return_value=None)
+                )
+            )
+            audit = stack.enter_context(mock.patch.object(hooks, "_audit"))
+            asyncio.run(hooks._run_once())
+        sdk.start_async.assert_not_called()
+        audit.assert_not_called()
+
+
+class TestAnUnconfiguredAccountIsASilentSkip:
+    """A due account with no drive yet must not accrue a record every wake."""
+
+    def test_a_due_account_with_no_drive_claims_nothing(self, tmp_path):
+        # The runner refuses a driveless account by raising, which the SDK records
+        # as `failed`, and a failed run never reaches `_record_run` -- so
+        # `due_for_nightly` stays True and one more failed record would land every
+        # half hour, forever, for a state that is simply not configured yet. The
+        # pre-PR loop skipped silently and so must this one.
+        sdk = SimpleNamespace(start_async=AsyncMock(return_value="run-1"))
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk)
+            stack.enter_context(mock.patch.object(hooks.storage_mod, "find_drive", return_value=""))
+            audit = stack.enter_context(mock.patch.object(hooks, "_audit"))
+            asyncio.run(hooks._run_once())
+        sdk.start_async.assert_not_called()
+        audit.assert_not_called()
+
+    def test_the_drive_is_looked_up_with_the_consented_profile(self, tmp_path):
+        # `find_drive` reaches AWS (tag:GetResources) and consent is keyed per
+        # (service, profile, region). The loop checked S3 consent for the registry
+        # default, so discovery must run under THAT profile: `_pick_profile` can
+        # return a healthy non-default profile of the same account, and using its
+        # answer here would make an unconsented call while deciding whether to
+        # claim. The run re-discovers the drive under its own authorized profile.
+        sdk = SimpleNamespace(start_async=AsyncMock(return_value="run-1"))
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk)
+            stack.enter_context(
+                mock.patch.object(
+                    hooks.accounts_mod,
+                    "resolve_account_profile",
+                    AsyncMock(return_value=("other-profile", "eu-1")),
+                )
+            )
+            find = stack.enter_context(
+                mock.patch.object(hooks.storage_mod, "find_drive", return_value=BUCKET)
+            )
+            stack.enter_context(mock.patch.object(hooks, "_audit"))
+            stack.enter_context(mock.patch.object(hooks, "_watch_run", AsyncMock()))
+            asyncio.run(hooks._run_once())
+        assert find.call_args.args[:2] == (PROFILE, REGION)
+        assert "other-profile" not in find.call_args.args
+        assert find.call_args.kwargs["account"] == ACCOUNT
+
+
+class TestNothingSuspendsBetweenConsentAndUse:
+    """Consent is an approval control, so the gap after confirming it matters."""
+
+    def test_the_snapshot_is_warmed_before_consent_is_confirmed(self, tmp_path):
+        # The warming runs a probe sweep, which suspends. Awaiting it AFTER
+        # `refuse_and_log` put that suspension between consent being confirmed and
+        # `find_drive` acting on it, so consent could be withdrawn while the sweep
+        # ran. Moving it above the check closes the window by subtraction rather
+        # than by re-checking consent afterwards. Its own AWS work is an STS
+        # identity probe plus local `aws configure get` reads -- the same class as
+        # the `probe_identity` this loop already performs before the consent check
+        # -- so nothing consent-gated moves ahead of consent.
+        order: list[str] = []
+        sdk = SimpleNamespace(start_async=AsyncMock(return_value="run-1"))
+
+        async def _warm(account):
+            order.append("warm")
+            return (PROFILE, REGION)
+
+        async def _consent(*a, **k):
+            order.append("consent")
+            return True
+
+        def _find(*a, **k):
+            order.append("find_drive")
+            return BUCKET
+
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk, warm_profile=False)
+            stack.enter_context(
+                mock.patch.object(hooks.accounts_mod, "resolve_account_profile", _warm)
+            )
+            stack.enter_context(mock.patch.object(hooks.aws_consent, "refuse_and_log", _consent))
+            stack.enter_context(mock.patch.object(hooks.storage_mod, "find_drive", _find))
+            stack.enter_context(mock.patch.object(hooks, "_audit"))
+            stack.enter_context(mock.patch.object(hooks, "_watch_run", AsyncMock()))
+            asyncio.run(hooks._run_once())
+
+        assert order == ["warm", "consent", "find_drive"]
+        # And the confirmation is the LAST await before the call it authorizes:
+        # anything inserted between them reopens the window.
+        assert order.index("consent") + 1 == order.index("find_drive")
+
+
+class TestNoPostConsentFailureIsSilent:
+    """Once consent is confirmed, every exit writes a nightly record.
+
+    An audit an error path can skip is present exactly when nothing went wrong,
+    which is the opposite of the case it exists for. Before this loop claimed runs,
+    a drive-discovery failure was caught in `_run_once` and audited `failed`; the
+    migration moved the upload out and took the handler with it, so the raise
+    reached `_loop`'s log-only catch. One case per raising exit.
+    """
+
+    def test_a_drive_discovery_failure_is_audited(self, tmp_path):
+        # `find_drive` raises on an ordinary AWS error or an ambiguous match, so
+        # this is a common path rather than an extreme one.
+        sdk = SimpleNamespace(start_async=AsyncMock(return_value="run-1"))
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk)
+            stack.enter_context(
+                mock.patch.object(
+                    hooks.storage_mod, "find_drive", side_effect=RuntimeError("tag:GetResources")
+                )
+            )
+            audit = stack.enter_context(mock.patch.object(hooks, "_audit"))
+            asyncio.run(hooks._run_once())
+        outcomes = [c.args[2] for c in audit.call_args_list]
+        assert outcomes == ["failed"]
+        assert "tag:GetResources" in audit.call_args.kwargs["error"]
+        sdk.start_async.assert_not_called()
+
+    def test_a_cancel_during_discovery_is_audited_and_reraised(self, tmp_path):
+        sdk = SimpleNamespace(start_async=AsyncMock(return_value="run-1"))
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk)
+            stack.enter_context(
+                mock.patch.object(
+                    hooks.storage_mod, "find_drive", side_effect=asyncio.CancelledError()
+                )
+            )
+            audit = stack.enter_context(mock.patch.object(hooks, "_audit"))
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(hooks._run_once())
+        assert [c.args[2] for c in audit.call_args_list] == ["cancelled"]
+
+    def test_a_run_store_read_error_is_audited(self, tmp_path):
+        # A claimed run whose record cannot be read left `invoked` with no
+        # resolution -- the loop reported starting work and never reported its end.
+        sdk = SimpleNamespace(
+            start_async=AsyncMock(return_value="run-1"),
+            get=mock.Mock(side_effect=OSError("job store unreadable")),
+        )
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk)
+            audit = stack.enter_context(mock.patch.object(hooks, "_audit"))
+            asyncio.run(hooks._run_once())
+        outcomes = [c.args[2] for c in audit.call_args_list]
+        assert outcomes == ["invoked", "failed"]
+        assert "job store unreadable" in audit.call_args.kwargs["error"]
+
+    def test_an_absent_run_record_is_audited_as_failed(self, tmp_path):
+        # Absence and an unreadable store are the same thing to the loop: it cannot
+        # say how the run ended, so both take the one failure exit.
+        sdk = SimpleNamespace(
+            start_async=AsyncMock(return_value="run-1"), get=mock.Mock(return_value=None)
+        )
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk)
+            audit = stack.enter_context(mock.patch.object(hooks, "_audit"))
+            asyncio.run(hooks._run_once())
+        outcomes = [c.args[2] for c in audit.call_args_list]
+        assert outcomes == ["invoked", "failed"]
+        assert "could not be read" in audit.call_args.kwargs["error"]
+
+    def test_a_malformed_run_record_is_audited_rather_than_raising(self, tmp_path):
+        # The record's shape is read inside the same handler as the store read, so a
+        # record missing `is_terminal` cannot escape unaudited either.
+        sdk = SimpleNamespace(
+            start_async=AsyncMock(return_value="run-1"),
+            get=mock.Mock(return_value=SimpleNamespace()),
+        )
+        with ExitStack() as stack:
+            _nightly_preconditions(stack, sdk)
+            audit = stack.enter_context(mock.patch.object(hooks, "_audit"))
+            asyncio.run(hooks._run_once())
+        assert [c.args[2] for c in audit.call_args_list] == ["invoked", "failed"]
+
+
+class TestAttribution:
+    """One runner, two triggers, and no upload attributed to a person."""
+
+    def test_the_gate_names_the_job_worker_not_the_owner(self):
+        # The property the old owner/scheduler pair protected: an unattended
+        # refusal is not recorded against the dashboard owner. The runner cannot
+        # know which trigger it serves, so the gate names the actor it can observe
+        # -- and names it itself, rather than taking it as an argument no caller
+        # varies. Pinned here as the CALL SHAPE: nothing threads a caller through.
+        sdk = SimpleNamespace(get=lambda run_id: SimpleNamespace(dedupe_key=ACCOUNT))
+        runner = backup.make_job_runner(sdk, KIND)
+        with (
+            mock.patch.object(
+                accounts_mod, "resolve_account_profile_cached", return_value=(PROFILE, REGION)
+            ),
+            mock.patch.object(backup, "_authorize_upload") as authorize,
+            mock.patch(
+                "kiro_crew.apps.builtins.aws_control.backend.storage.find_drive",
+                return_value=BUCKET,
+            ),
+            mock.patch.object(backup, "run_snapshot_backup") as work,
+        ):
+            runner(SimpleNamespace(run_id="run-1"))
+        assert authorize.call_args.args == (ACCOUNT, PROFILE, REGION)
+        assert "caller" not in authorize.call_args.kwargs
+        assert "caller" not in work.call_args.kwargs
+        assert "dashboard-owner" not in backup.CALLER_JOB
+
+    def test_the_nightly_record_is_what_names_the_scheduler(self):
+        # WHO ASKED moved to the starter, which knows it without a race. If this
+        # record stopped naming the scheduler, nothing in SEL would say a run was
+        # unattended.
+        with mock.patch.object(hooks, "sel") as sel_factory:
+            hooks._audit("backup_nightly", "run=abc", "succeeded")
+        kwargs = sel_factory.return_value.log_api_access.call_args.kwargs
+        assert kwargs["caller"] == "aws-control-nightly"
+        assert "abc" in kwargs["resources"]
+        assert kwargs["caller"] != backup.CALLER_JOB
+
+
+@pytest.fixture(autouse=True)
+def _reset_account_cache():
+    """The account snapshot is module state; no test may inherit a warm one."""
+    accounts_mod.invalidate_cache()
+    yield
+    accounts_mod.invalidate_cache()


### PR DESCRIPTION
## Problem / Motivation

`aws_control`'s nightly backup loop called `backup.run_snapshot_backup` directly.
The Job SDK's `(kind, dedupe_key)` index cannot see a caller that never enters it,
so two things were true at once for one account:

- A nightly run and a manual click could each pay for an upload. The manual path
  claims a run with `start_async(kind, dedupe_key=account)`, so a second click
  adopts the first. The nightly loop took no run, so it was invisible to that key
  and did its own upload alongside.
- A nightly run was invisible in the UI. The Backup row reads its busy state from
  the account-scoped `jobs` block on `GET /backup/{account}`, which is built from
  SDK records. A nightly run had no record, so the row read idle while a backup
  was genuinely in flight.

## Why it matters

Two backups of one account writing at the same time is not a cosmetic race. They
can interleave, tear an archive, or leave one overwriting the other's partial
output -- and you find out when you need the backup, which is the worst moment to
find out. The invisible row makes it worse: the owner cannot see that anything is
running, so the natural move is to click Back up now, which is exactly the second
upload.

## What changed (motivation -> approach -> change)

The issue named the cause and the remedy, so the first thing to check was whether
the SDK's guarantee really covers this case. It does, and here is its own wording
from `job_sdk.py` `start`:

> With a `dedupe_key`, a second start while a run of the same kind and key is
> still in flight ADOPTS that run instead of beginning another -- which is what
> stops a double click, or two tabs, from doing the paid work twice.

So the guarantee is about a run of the same **kind and key still in flight** in
this process, which is precisely the nightly-versus-manual case: one gateway, one
account, two triggers. Using it is the fix. Adding a second lock beside it would
have created a second source of truth that can disagree with the first.

`hooks._run_once` therefore no longer performs the backup. It still decides
everything it decided before -- which account the default profile points at,
whether that account is due, whether S3 consent holds -- and then claims
`sdk.start_async(KIND_SNAPSHOT, dedupe_key=account)`, the same kind and the same
key the route uses. The dedupe now covers both callers, and the row sees a nightly
run like any other.

**What a genuine second attempt does: it is coalesced.** Not refused, not queued.
The second caller receives the first run's id and follows that run; the row shows
the one run it always showed, and the loop reports that run's outcome, which for
this account is the outcome that matters whoever triggered it. The loop does not
try to distinguish adoption from a fresh claim: only `start`'s own critical
section knows that atomically, and nothing here needs to know it.

```mermaid
flowchart LR
  subgraph Before
    N1[nightly loop]:::removed --> U1[run_snapshot_backup]:::ctx
    R1[POST /backup start]:::ctx --> K1[SDK claim<br/>kind + account]:::ctx --> U1
  end
  subgraph After
    N2[nightly loop]:::added --> K2[SDK claim<br/>kind + account]:::changed
    R2[POST /backup start]:::ctx --> K2 --> U2[run_snapshot_backup]:::ctx
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 3 stroke:#16A34A,stroke-width:2px
```

green = added | amber = changed | red = removed | blue = unchanged

*The nightly loop now goes through the same claim the button goes through, so one
account has one run.*

**Three things the migration itself had to answer.**

The run's worker is a thread, so it resolves its profile through
`accounts.resolve_account_profile_cached`, which serves the WARM snapshot only and
returns None past a 300 s TTL. Nothing on the nightly path warms that snapshot --
neither `resolve_profile` nor `probe_identity` does, only `list_accounts` -- and at
03:00 there is no dashboard traffic to have warmed it either, so the worker would
have raised "no working connection for this account" and every unattended run
would have been recorded `failed` with no upload. `_run_once` now awaits
`resolve_account_profile(account)`, the same pre-flight the HTTP route runs and the
one `resolve_account_profile_cached` names as the reason it may return None. It also
fails the loop closed on an account with no working connection rather than claiming a
run that can only refuse.

That await sits ABOVE the consent check, and the order is the point. Placed after it,
the probe sweep was a suspension point between consent being confirmed and
`find_drive` acting on it, so consent could be withdrawn while the sweep ran. Moving
it up closes that window by subtraction -- no re-check after the await, no new
approval control. It moves nothing consent-gated ahead of consent either: the
warming's own AWS work is an STS `GetCallerIdentity` per profile plus local `aws
configure get` reads whose values are discarded, the same class as the
`probe_identity` this loop already performs before the consent check on `main` today.
Consent is now the last await before `find_drive`, which is where `main` has it.

A due account whose drive does not exist yet has to stay a SILENT skip. The runner
refuses a driveless account by raising, which the SDK records as `failed`, and a
failed run never reaches `_record_run` -- so `due_for_nightly` stays True and the
account would accrue one more failed record every half hour, forever, for a state
that is simply not configured yet. `_run_once` keeps the pre-claim drive check the
old loop had, and runs it under the profile CONSENT WAS CHECKED FOR rather than
under whichever same-account profile the resolver picked: `find_drive` reaches AWS
(`tag:GetResources`), consent is keyed per `(service, profile, region)`, and
`_pick_profile` may return a healthy non-default profile of the same account, so
using its answer here would make an unconsented call while deciding whether to
claim. The resolved value is used for its None check and for warming the snapshot,
not as a credential choice. The check decides whether to claim a run at all; the
run re-discovers the drive under its own authorized profile.

And WHO ASKED can no longer be resolved inside the runner. `_refuse_upload` takes
its `caller` in so that an unattended upload refused at 03:00 is not audited
against the dashboard owner. Both triggers now reach the one registered runner, and
P1 of the Job SDK has no parameter channel -- the module states that a runner
"receives its handle and nothing else" -- so the runner cannot know which trigger
it serves. An out-of-band channel keyed on the dedupe identity was tried in the
first round of this PR and is not sound: only `start`'s own critical section knows
atomically whether a claim was fresh or adopted, so a manual click landing beside a
nightly claim could hand one worker the other's trigger. It is gone. There is one
path to the upload gate, so there is one caller value -- `CALLER_JOB` =
`app:aws-control:job`, naming the actor that can be observed -- and the trigger is
recorded by the starter, which knows it with no race: the loop's own
`aws_control.backup_nightly` records carry the run id and its terminal status under
caller `aws-control-nightly`, and the dashboard layer audits an owner-driven start.
The property the old two-constant vocabulary protected is kept and is now pinned by
name: no upload is ever attributed to the dashboard owner.

With one value left, the `caller` keyword itself stopped earning its place, so it is
gone from `run_snapshot_backup`, `run_sessions_backup`, `_authorize_upload` and
`_refuse_upload`; the gate names `CALLER_JOB` directly. The old comment said an
attribution field only earns its place if it DISTINGUISHES, and after the collapse it
distinguished nothing -- one origin threaded through four signatures.
`dashboard-owner` still exists where it is true, in the dashboard layer's own audit
of an owner-driven request (`routes.py:441`, untouched by this diff).

**Every exit after consent writes a nightly record.** Before this loop claimed runs,
a drive-discovery failure was caught in `_run_once` and audited `failed`; the
migration moved the upload out and took that handler with it, so a raise from
`find_drive` -- which fails loud on an ordinary AWS error or an ambiguous match --
reached `_loop`'s log-only catch and the app's one unattended S3 path recorded
nothing. The handler is back in the shape it had. The same gap existed one step
later: a job-store read error inside the watch propagated the same way, leaving a
claimed run audited `invoked` and never resolved. Reading the record and classifying
it now live in one helper behind one handler, so a store error, an absent record and
a record whose shape cannot be read all take the single audited failure exit instead
of three different ones.

The loop also follows its claimed run to a terminal status. That keeps the SEL
trail it has always produced: the SDK audits a run's lifecycle but attributes every
run to the app, so these records stay the only ones that name the nightly trigger.
It also keeps the loop from re-entering while the upload is still going, which the
direct call gave for free.

**A documented property: the pre-claim guards vet the consented profile, the run
resolves its own, and that split cannot act outside consent.** The loop confirms S3
consent for the registry default and runs its pre-claim drive check under that same
pair. The run's worker is a thread, so it re-resolves through
`resolve_account_profile_cached`, which can return a different healthy profile of the
same account. Three things make the gap safe, and none of them is inheritance of the
loop's decision:

- `_pick_profile` (`accounts.py`) only ever returns a profile from a snapshot row
  whose `account` equals the target account -- it `continue`s past every other row --
  so the run's profile is claimed to belong to the same account, never another one.
- That claim is re-verified LIVE rather than trusted. `_authorize_upload` runs
  `sts:GetCallerIdentity` under the run's own profile and refuses when the live
  account is not the target, so a stale snapshot cannot produce an action against a
  different account.
- Consent is re-checked FOR THE RUN'S OWN PAIR, not the loop's:
  `is_granted(SERVICE_S3, profile=profile, region=region)` with the profile the run
  resolved, plus `read_grant(SERVICE_S3)` refused unless the recorded grant names this
  account. So a sibling profile with no consent of its own is refused rather than
  used.

`_authorize_upload` runs BEFORE the run's own `find_drive`, and again inside each work
function immediately before `put_file`, so both the run's tagging call and its upload
sit behind a check keyed on the profile actually being used.

What that makes the pre-claim guards is worth stating plainly, because it is the part
the split looks like a weakness of: they are not the authorisation. Authorisation
happens once, in the runner's gate, under the profile that acts. The pre-claim checks
exist to stop the loop claiming a run that could only refuse, and to stop an
unconfigured account accruing a failed record every wake. A guard that vets a
different profile is therefore not a weaker authorisation -- it is not an
authorisation at all.

The residual, stated: when the run's resolved profile differs from the consented one
and has no consent of its own, the run refuses and the SDK records `failed`. A failed
run never reaches `_record_run`, so `due_for_nightly` stays true and that repeats each
wake -- record noise of the same shape as the driveless case, bounded to a
multi-account-profile setup whose healthy default is not the consented profile. It is
not an unauthorised action, and closing it would mean adding an authorisation check
where the design deliberately has one.

**What this PR does not decide.** The missed-window policy the issue puts first --
what a scheduled run should do when the gateway was down at its hour -- is
untouched. `due_for_nightly` still decides, unchanged: nightly toggle on and more
than 23 h since the last run, re-checked every half hour, so a missed hour still
runs late at the next wake. That is today's behaviour, and answering the policy
question would be a separate change with its own evidence.

**One unserialised pair remains, declared and out of scope.** Dedupe is per
process: `_keys` is documented as "(kind, dedupe_key) -> run_id for runs live in
THIS process". Two gateway processes over one account are still unserialised, and
this change neither improves nor worsens that. The nightly loop and the route are
the same process, which is the pair this issue reports.

## Tests

`test/test_aws_control_nightly_job.py` is new and pins the reported pair plus the
two properties the migration could break.

- `test_a_nightly_claim_adopts_a_manual_run_in_flight` -- a real `JobSDK` with a
  blocking runner, a manual run already in flight, then one nightly wake. Exactly
  one worker runs, and `run_snapshot_backup` is never called directly. This is the
  second-run test: it collides with a live run and is coalesced, not duplicated.
- `test_a_nightly_claim_leaves_an_account_scoped_run_record` -- after a nightly
  wake the SDK holds one terminal record whose `dedupe_key` is the account. This is
  what the row reads.
- `test_the_loop_warms_the_snapshot_before_claiming` -- a cold account cache, the
  real resolver and the real `list_accounts` left in place, only the probe sweep
  faked. The unattended run reaches the upload. Written first against the unfixed
  code, where it failed with the worker recording "no working connection".
- `test_an_account_with_no_working_connection_claims_nothing` -- fail closed: no
  claim and no audit, rather than a `failed` record the owner has to interpret.
- `test_a_due_account_with_no_drive_claims_nothing` and
  `test_the_drive_is_looked_up_with_the_consented_profile` -- an unconfigured account
  claims nothing and audits nothing, and the pre-claim lookup runs under the profile
  consent was checked for, never under another same-account profile.
- Five cases under `TestNoPostConsentFailureIsSilent` -- a drive-discovery failure, a
  cancel during discovery, a job-store read error, an absent run record and a
  malformed one. Each asserts the exact outcome sequence, so a silent exit reddens.
- `test_the_snapshot_is_warmed_before_consent_is_confirmed` -- the call order is
  warm, consent, `find_drive`, with the confirmation immediately before the call it
  authorizes.
- `test_the_gate_names_the_job_worker_not_the_owner` and
  `test_the_nightly_record_is_what_names_the_scheduler` -- the two halves of
  attribution after the trigger channel was removed.

Every worker started in that file is driven to a terminal record in a `finally`
before its test returns. A Job SDK worker is a real thread, and one still running at
teardown would write its record into a directory pytest has already removed.

Updated because the loop no longer resolves a drive, uploads inline, or resolves a
trigger: `test_aws_control_hooks.py` (consent fails closed before the job runtime
is looked up; a missing `jobs` permission claims nothing and audits nothing; a
cancelled claim audits `invoked` then `cancelled`; a claim that raises audits
`invoked` then `failed` and is swallowed), the two nightly SEL cases in
`test_aws_control_app.py`, and the attribution guards in
`test_aws_control_backup_job.py`, where the pair of caller constants became one.

`prove.py --base main` reports `PROVEN: an assertion failed with the bug
reintroduced`.

Run locally exactly as follows, one file per invocation, `-n0` spelled out, no bare
or directory-wide run:

```
timeout 900 python3 -m pytest -n0 test/test_aws_control_nightly_job.py -x -q </dev/null
timeout 900 python3 -m pytest -n0 test/test_aws_control_hooks.py -x -q </dev/null
timeout 900 python3 -m pytest -n0 test/test_aws_control_backup_job.py -x -q </dev/null
timeout 900 python3 -m pytest -n0 test/test_aws_control_app.py -x -q </dev/null
timeout 900 python3 -m pytest -n0 test/test_aws_control_backup.py -x -q </dev/null
timeout 900 python3 -m pytest -n0 test/test_aws_control_routes.py -x -q </dev/null

python3 -m black --target-version py310 <changed files>
python3 -m isort <changed files>
python3 -m flake8 <changed files>
python3 -m mypy src/kiro_crew/apps/builtins/aws_control/hooks.py \
                src/kiro_crew/apps/builtins/aws_control/backend/backup.py
python3 scripts/check_black_formatting.py
python3 <skill>/scripts/prove.py          # against origin/main, not a local main
```

Those cover the files this diff touches and their consumers:
`test_aws_control_nightly_job.py`, `test_aws_control_hooks.py`,
`test_aws_control_backup_job.py`, `test_aws_control_app.py`,
`test_aws_control_backup.py` and `test_aws_control_routes.py` -- 413 passing.
`black --target-version py310`, `isort`, `flake8` and `mypy` clean on the changed
files (`mypy`'s two remaining errors are in `src/kiro_crew/transcribe.py`, which
this diff does not touch), and `scripts/check_black_formatting.py` passes on the
committed scope.

## Manual verification

N/A -- driving a real nightly wake needs a connected AWS account, a drive bucket and
a granted S3 consent, and the collision this fixes is a timing one. The adoption
case is exercised against a real `JobSDK` with a real worker thread instead, and the
cold-cache case against the real resolver, which are the parts that could not be
reasoned about safely.

## Related Issues

Closes #7783

## Pattern harvest

Two classes, both worth a rule.

The reported defect is a **concurrency guarantee that only covers the callers who
enter its index**. The index was right, the key was right, and one caller simply
did the guarded work beside it -- so every consumer that read the index (the
dedupe, and the UI's busy state) was correct about a subset and silent about the
rest. A count-of-guards review sees nothing wrong: the guard exists and is used.

The defect this PR's own first round introduced is an **out-of-band channel keyed
more coarsely than the thing it describes**. A trigger keyed on `(kind, account)`
is read by whichever worker for that account gets there first, and the only place
the answer is known atomically was inside the SDK's claim, where P1 offers no way
to put a value. Every variant fails the same way, which is why the answer was to
delete the channel rather than re-key it.

Rule candidate: review-prompt
Pattern: a dedupe / lock / registry gains a second call path that does the guarded
work without claiming the key, so the guarantee silently narrows to "the callers
who opted in". Ask, for every serialising index: enumerate the call sites that do
the guarded work, not the ones that take the key. And when a value must reach a
worker that cannot be passed one, ask whether the key you would file it under is
as specific as the run it describes -- if it is coarser, the wrong run will read
it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


