### PR TITLE
feat: SQLite findings ledger for security conductor

### DIFF
--- a/src/kiro_crew/builtin_skills/security-conductor/scripts/ledger.py
+++ b/src/kiro_crew/builtin_skills/security-conductor/scripts/ledger.py
@@ -1,0 +1,771 @@
+#!/usr/bin/env python3
+"""The security conductor's findings ledger — one SQLite database, four tables.
+
+A round that does not remember the last one repeats its false positives. This
+script is the harness's only programmatic writer for four kinds of row: findings,
+the verdicts folded into them, the lessons a retrospective proposes, and the
+rules of engagement ``scope_check.py`` reads.
+
+Usage. ``--db PATH`` goes BEFORE the subcommand and defaults to
+``<data home>/security-conductor/findings.db``:
+
+    python3 ledger.py [--db PATH] init
+    python3 ledger.py [--db PATH] add-finding --surface S --title T --severity SEV
+                                  [--path P ...] [--poc CMD] [--round-id R]
+    python3 ledger.py record-verdict --finding ID --role ROLE --verdict V
+                                     [--reason WHY]
+    python3 ledger.py propose-lesson --kind K --surface S --pattern P
+                                     --guidance G --source-finding ID
+    python3 ledger.py approve-lesson --id ID --approved-by WHO
+    python3 ledger.py add-rule --field F --value V --reason WHY --approved-by WHO
+    python3 ledger.py export-roe
+    python3 ledger.py list {findings|lessons|rules|verdicts}
+    python3 ledger.py seed-lessons --surface S --budget-bytes N
+
+The data home is ``$KIROCREW_HOME``, else ``~/.kiro/crew``.
+
+**This CLI is not an authentication boundary, and does not try to be.**
+``--role human`` and ``--approved-by`` are UNVERIFIED caller assertions: nothing
+here can tell a human at a terminal from an agent invoking the same command, and
+a forged ``human`` verdict wins the fold exactly as a real one would. The boundary
+is instead **filesystem ownership of the database**. Anything that can run this
+script can run ``sqlite3`` against the same file and write any row directly, so
+authenticating this CLI would move no boundary -- it would only make the weakest
+path less obvious. A deployment that needs an enforced human gate has to own
+``findings.db`` under a different uid than the agent, or put the approval step
+behind something that is not a local CLI; that is a deployment property this
+script cannot assert, and the RFC does not yet decide it.
+
+What the four properties below therefore mean: given whatever writes reach this
+script, it will not itself lose, reorder, or silently overwrite them. They are
+storage guarantees, not authorization ones.
+
+Four properties this script exists to hold, none of which a prompt can:
+
+1. **``verdicts`` is append-only.** There is no UPDATE and no DELETE path to it
+   anywhere in this CLI, so the disagreement between an auditor and a verifier
+   stays readable instead of being overwritten by whoever wrote last.
+   ``findings.final_verdict`` is therefore a FOLD over those rows —
+   ``human > verifier > auditor`` — recomputed on every append, never assigned.
+2. **A proposed lesson is inert, and its approval is recorded once.**
+   ``propose-lesson`` writes ``active=0`` and takes no flag that could write
+   anything else; only ``approve-lesson``, which requires a named approver, flips
+   it. ``seed-lessons`` reads ``active=1`` only, so an unapproved lesson cannot
+   reach an auditor's seed message. Approval is write-once: ``approve-lesson``
+   updates only a row that is still ``active=0``, so a second approval is a named
+   refusal rather than a silent replacement of who approved it.
+3. **The seed is bounded.** ``seed-lessons`` emits at most ``--budget-bytes``
+   bytes, because an unbounded lesson list becomes the seed and crowds out the
+   brief.
+4. **Every lesson is attributable, in both directions.**
+   ``source_finding_id`` is NOT NULL and a real foreign key, enforced with
+   ``PRAGMA foreign_keys=ON``, so guidance traces back to the finding that earned
+   it; and ``approved_by`` cannot be overwritten once set -- not by a second
+   approval, and not by deactivating the lesson and approving it again, since the
+   write requires ``approved_by IS NULL`` and not merely ``active = 0``. Every
+   required text
+   argument is rejected when blank -- ``required=True`` only asserts a flag is
+   PRESENT, so an empty approver would otherwise satisfy the parser and store no
+   attribution at all.
+
+Deactivating a rule or a lesson is deliberately NOT a command here: the RFC
+makes that the human's row edit (``UPDATE roe_rules SET active=0``), so that
+reverting a rule is a flip with an audit trail rather than a code change. The
+append-only ban above covers ``verdicts`` specifically, not the whole database.
+
+Exit codes: 0 on success; 2 on malformed arguments or a referenced row that does
+not exist. Reads and writes one SQLite file; no network, no subprocess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+try:
+    # Preferred: the same shim every other store in this tree imports SQLite
+    # through (memory, vector memory, knowledge). It resolves ``pysqlite3``
+    # when present, which is the build guaranteed to carry FTS5.
+    from kiro_crew._sqlite_compat import sqlite3  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover - exercised when the package is not importable
+    # A skill's scripts are synced OUT of the package tree (into the skills
+    # directory) and run as bare files, so ``kiro_crew`` is usually not on the
+    # path. Falling back is safe here specifically because this ledger uses no
+    # FTS5 — it is four ordinary tables — which is the only capability the shim
+    # exists to secure. Nothing else about the shim's behaviour is relied on.
+    import sqlite3  # type: ignore[no-redef]
+
+SCHEMA_VERSION = 1
+
+ROLES = ("auditor", "verifier", "human")
+# Fold precedence, weakest first: a human overrules a verifier, who overrules an
+# auditor. Derived from ROLES' order nowhere — spelled out, because the fold is
+# the contract and reordering ROLES for any other reason must not change it.
+FOLD_ORDER = ("auditor", "verifier", "human")
+LESSON_KINDS = ("true-positive", "false-positive", "missed", "out-of-scope")
+
+LIST_QUERIES = {
+    "findings": "SELECT * FROM findings ORDER BY id ASC",
+    "lessons": "SELECT * FROM lessons ORDER BY id ASC",
+    "rules": "SELECT * FROM roe_rules ORDER BY id ASC",
+    # verdicts has no surrogate key (the RFC's schema does not give it one), so
+    # its append order is the implicit rowid -- surfaced under that name so a
+    # reader can see which column the ordering came from.
+    "verdicts": "SELECT rowid AS rowid, * FROM verdicts ORDER BY rowid ASC",
+}
+LIST_TABLES = tuple(LIST_QUERIES)
+
+DDL = (
+    "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)",
+    # The version row is a SINGLETON, and this index is what makes that a
+    # property of the table rather than of the code that writes it: two
+    # concurrent `init` runs (or any two commands, since every command calls
+    # init_schema first) would otherwise both find the table empty and both
+    # insert, leaving a migration ladder with two rows to branch on.
+    "CREATE UNIQUE INDEX IF NOT EXISTS schema_version_single ON schema_version (version)",
+    """CREATE TABLE IF NOT EXISTS findings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        surface TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        title TEXT NOT NULL,
+        paths TEXT NOT NULL,
+        poc TEXT,
+        auditor_verdict TEXT,
+        verifier_verdict TEXT,
+        final_verdict TEXT,
+        status TEXT NOT NULL,
+        created TEXT NOT NULL,
+        round_id TEXT
+    )""",
+    """CREATE TABLE IF NOT EXISTS verdicts (
+        finding_id INTEGER NOT NULL REFERENCES findings(id),
+        role TEXT NOT NULL CHECK (role IN ('auditor', 'verifier', 'human')),
+        verdict TEXT NOT NULL,
+        reason TEXT,
+        ts TEXT NOT NULL
+    )""",
+    """CREATE TABLE IF NOT EXISTS lessons (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        kind TEXT NOT NULL CHECK (
+            kind IN ('true-positive', 'false-positive', 'missed', 'out-of-scope')
+        ),
+        surface TEXT NOT NULL,
+        pattern TEXT NOT NULL,
+        guidance TEXT NOT NULL,
+        source_finding_id INTEGER NOT NULL REFERENCES findings(id),
+        approved_by TEXT,
+        ts TEXT NOT NULL,
+        active INTEGER NOT NULL DEFAULT 0
+    )""",
+    """CREATE TABLE IF NOT EXISTS roe_rules (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        field TEXT NOT NULL,
+        value TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        approved_by TEXT NOT NULL,
+        ts TEXT NOT NULL,
+        active INTEGER NOT NULL DEFAULT 1
+    )""",
+    # The dedupe identity of a finding, enforced by the storage layer rather than
+    # only by the read-then-write in add_finding: two auditors racing the same
+    # surface would otherwise both miss and both insert.
+    "CREATE UNIQUE INDEX IF NOT EXISTS findings_identity " "ON findings (surface, title, paths)",
+    "CREATE INDEX IF NOT EXISTS verdicts_by_finding ON verdicts (finding_id)",
+    "CREATE INDEX IF NOT EXISTS lessons_active ON lessons (active, surface)",
+)
+
+
+def data_home() -> Path:
+    """Where Kiro Crew keeps its data, resolved without importing the package.
+
+    Mirrors ``pipeline-conductor/scripts/credit_spend.py``: a skill script cannot
+    call ``kiro_crew.config.paths.data_home`` because it runs as a bare file
+    outside the package.
+    """
+    env = os.environ.get("KIROCREW_HOME")
+    return Path(env) if env else Path.home() / ".kiro" / "crew"
+
+
+def default_db_path() -> Path:
+    return data_home() / "security-conductor" / "findings.db"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def canonical_paths(paths: Iterable[str]) -> str:
+    """The stored, comparable form of a finding's affected paths.
+
+    Sorted and de-duplicated, so ``paths`` is itself the dedupe key: the
+    identity is (surface, title, sorted paths), and normalising at write time
+    turns that into one exact-match lookup (and one UNIQUE index) instead of a
+    scan that re-normalises every candidate row.
+    """
+    cleaned = sorted({item.strip() for item in paths if item and item.strip()})
+    return json.dumps(cleaned, sort_keys=True)
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    # NOT NULL + REFERENCES on lessons.source_finding_id is only a real
+    # constraint with this pragma on; SQLite defaults it OFF per connection.
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+    except sqlite3.Error:  # pragma: no cover - filesystem without WAL support
+        # A network filesystem can refuse WAL. The ledger is correct without it
+        # (one writer at a time), so degrade rather than refuse to open.
+        pass
+    return conn
+
+
+def init_schema(conn: sqlite3.Connection) -> int:
+    """Create every table and index if absent; return the schema version.
+
+    Idempotent and versioned: the version row is written once, so a future
+    migration ladder has a value to branch on.
+
+    The insert carries its own precondition (``WHERE NOT EXISTS``) instead of
+    being gated by a Python read. A read-then-write here was racy on the ORDINARY
+    path, because every command calls this first -- two parallel auditors running
+    ``add-finding`` both saw an empty table and both inserted. One statement
+    cannot interleave with itself, and the unique index in :data:`DDL` is the
+    backstop for a row written any other way.
+    """
+    with conn:
+        for statement in DDL:
+            conn.execute(statement)
+        conn.execute(
+            "INSERT INTO schema_version (version)"
+            " SELECT ? WHERE NOT EXISTS (SELECT 1 FROM schema_version)",
+            (SCHEMA_VERSION,),
+        )
+        row = conn.execute("SELECT version FROM schema_version").fetchone()
+    return int(row["version"])
+
+
+def add_finding(
+    conn: sqlite3.Connection,
+    *,
+    surface: str,
+    title: str,
+    severity: str,
+    paths: Sequence[str],
+    poc: str | None,
+    round_id: str | None,
+) -> tuple[int, bool]:
+    """Insert a finding, or return the existing one. Returns ``(id, created)``.
+
+    Dedupe identity is (surface, title, sorted paths): one finding per real
+    defect, so a surface re-audited in a later round does not re-file what is
+    already recorded. A hit returns the original id untouched — the earlier
+    row's severity, PoC and verdict history are the record, and a re-report is
+    not evidence to overwrite them with.
+    """
+    key = canonical_paths(paths)
+    found = _find_by_identity(conn, surface, title, key)
+    if found is not None:
+        return found, False
+    try:
+        with conn:
+            # `status` is written 'open' rather than taken from a flag. The column
+            # is part of the RFC's schema, but M1 ships no command that reads it
+            # and none that transitions it, so a creation-time knob would be a
+            # setting nothing can act on. The milestone that adds the reader adds
+            # the transition, and the flag with it.
+            cursor = conn.execute(
+                "INSERT INTO findings (surface, severity, title, paths, poc, status, created,"
+                " round_id) VALUES (?, ?, ?, ?, ?, 'open', ?, ?)",
+                (surface, severity, title, key, poc, now_iso(), round_id),
+            )
+    except sqlite3.IntegrityError:
+        # The identity index fired, so another writer inserted between the read
+        # above and this insert. That is the race the index exists to catch, and
+        # catching it is what makes dedupe hold under it: without this branch a
+        # second auditor on the same surface gets a traceback where the contract
+        # promises the existing id. Re-read rather than trusting the lost value.
+        found = _find_by_identity(conn, surface, title, key)
+        if found is None:  # pragma: no cover - a violation of some OTHER constraint
+            raise
+        return found, False
+    return int(cursor.lastrowid or 0), True
+
+
+def _find_by_identity(conn: sqlite3.Connection, surface: str, title: str, key: str) -> int | None:
+    row = conn.execute(
+        "SELECT id FROM findings WHERE surface = ? AND title = ? AND paths = ?",
+        (surface, title, key),
+    ).fetchone()
+    return None if row is None else int(row["id"])
+
+
+def fold_verdicts(conn: sqlite3.Connection, finding_id: int) -> dict[str, str | None]:
+    """Recompute a finding's verdict columns from its append-only verdict rows.
+
+    Per role the latest APPENDED row wins, and ``final_verdict`` takes the
+    strongest role present per :data:`FOLD_ORDER`.
+
+    Ordering is ``rowid`` alone -- deliberately NOT ``ts``. The table is
+    append-only, so rowid already records the true sequence, while ``ts`` records
+    only what the wall clock claimed at the time. Sorting by ``ts`` first made a
+    clock rollback (an NTP correction, a restored VM snapshot, a container with a
+    bad clock) reorder the fold: a superseded verdict carries the LATER timestamp,
+    so it sorted last and won, silently reinstating a call a human had already
+    overruled. rowid cannot roll back.
+
+    rowid is reusable only after a DELETE, and there is no delete path to this
+    table -- that is the append-only guarantee, and
+    ``test_the_cli_carries_no_update_or_delete_path_to_verdicts`` asserts its
+    absence rather than describing it.
+    """
+    latest: dict[str, str] = {}
+    rows = conn.execute(
+        "SELECT role, verdict FROM verdicts WHERE finding_id = ? ORDER BY rowid ASC",
+        (finding_id,),
+    ).fetchall()
+    for row in rows:
+        latest[str(row["role"])] = str(row["verdict"])
+    final: str | None = None
+    for role in FOLD_ORDER:
+        if role in latest:
+            final = latest[role]
+    return {
+        "auditor_verdict": latest.get("auditor"),
+        "verifier_verdict": latest.get("verifier"),
+        "final_verdict": final,
+    }
+
+
+def record_verdict(
+    conn: sqlite3.Connection,
+    *,
+    finding_id: int,
+    role: str,
+    verdict: str,
+    reason: str | None,
+) -> dict[str, str | None]:
+    """Append one verdict and refresh the finding's folded columns.
+
+    INSERT only. The three columns on ``findings`` are a materialised view of
+    the fold, never an independent assignment, so they cannot disagree with the
+    rows they summarise.
+    """
+    with conn:
+        conn.execute(
+            "INSERT INTO verdicts (finding_id, role, verdict, reason, ts) VALUES (?, ?, ?, ?, ?)",
+            (finding_id, role, verdict, reason, now_iso()),
+        )
+        folded = fold_verdicts(conn, finding_id)
+        conn.execute(
+            "UPDATE findings SET auditor_verdict = ?, verifier_verdict = ?, final_verdict = ?"
+            " WHERE id = ?",
+            (
+                folded["auditor_verdict"],
+                folded["verifier_verdict"],
+                folded["final_verdict"],
+                finding_id,
+            ),
+        )
+    return folded
+
+
+def _read_lesson_state(conn: sqlite3.Connection, lesson_id: int) -> tuple[bool, str | None] | None:
+    """``(is_active, approved_by)`` for one lesson, or None when it does not exist."""
+    row = conn.execute(
+        "SELECT active, approved_by FROM lessons WHERE id = ?", (lesson_id,)
+    ).fetchone()
+    if row is None:
+        return None
+    return bool(int(row["active"])), row["approved_by"]
+
+
+def approve_lesson(
+    conn: sqlite3.Connection, *, lesson_id: int, approved_by: str
+) -> tuple[str, str | None]:
+    """Activate a proposed lesson. Returns ``(outcome, approver_on_record)``.
+
+    Outcomes: ``approved`` (this call did it), ``missing`` (no such lesson),
+    ``already`` (it is approved and active), ``deactivated`` (it was approved
+    before and later switched off by hand), ``raced`` (it was approved between
+    this call's read and its write).
+
+    Approval is WRITE-ONCE. ``approved_by`` names the approval that let a lesson
+    into an auditor's seed, so replacing it destroys the audit trail the human
+    gate exists to leave -- and an unconditional UPDATE did exactly that on any
+    re-run of the command.
+
+    The UPDATE's WHERE clause is the guarantee -- ``active = 0`` AND
+    ``approved_by IS NULL`` -- and the read above it only buys a better message.
+    Both conditions are load-bearing. ``active = 0`` alone is satisfied by a
+    lesson that was approved and then switched off by hand, which is the RFC's own
+    revert path: that row still names its original approver, so re-approving it
+    overwrote the very attribution this function exists to keep. Requiring
+    ``approved_by IS NULL`` narrows the write to a lesson that has never been
+    approved at all.
+
+    Reactivating a deactivated lesson is therefore NOT this command's job -- it
+    reports ``deactivated`` and names the holder, because the revert was a row
+    edit and so is undoing it. That keeps one approver per lesson for its whole
+    life instead of one per activation.
+
+    A concurrent approval landing between the read and the write makes the UPDATE
+    match no row, so the loser reports ``raced`` rather than printing a success
+    line for a write that did not happen. Same shape as :func:`add_finding`'s
+    dedupe race.
+
+    ``ts`` is deliberately untouched -- it is when the lesson was PROPOSED, which
+    is the recency :func:`seed_lessons` ranks by.
+    """
+    state = _read_lesson_state(conn, lesson_id)
+    if state is None:
+        return "missing", None
+    was_active, holder = state
+    if was_active:
+        return "already", holder
+    if holder is not None:
+        # Inactive but already attributed: approved once, then switched off by
+        # hand. Undoing that is a row edit too, not a second approval.
+        return "deactivated", holder
+    with conn:
+        cursor = conn.execute(
+            "UPDATE lessons SET active = 1, approved_by = ?"
+            " WHERE id = ? AND active = 0 AND approved_by IS NULL",
+            (approved_by, lesson_id),
+        )
+    if cursor.rowcount != 1:
+        raced = _read_lesson_state(conn, lesson_id)
+        return "raced", None if raced is None else raced[1]
+    return "approved", approved_by
+
+
+def seed_lessons(
+    conn: sqlite3.Connection, *, surface: str, budget_bytes: int
+) -> tuple[list[sqlite3.Row], int]:
+    """The approved lessons to inject, in priority order, within the budget.
+
+    Priority is surface match first, then recency. Truncation takes the longest
+    fitting PREFIX rather than packing best-fit: skipping a lesson that does not
+    fit to admit a lower-priority one silently reorders the ranking the caller
+    asked for, and "top-N" would stop meaning top.
+
+    "Recency" is measured by ``id`` -- the proposal order -- not by ``ts``, for the
+    same reason :func:`fold_verdicts` orders by rowid: a lesson's id is assigned
+    when it is proposed and cannot move, while ``ts`` is only what the clock said.
+    The two agree on a healthy host and disagree exactly when the clock has rolled
+    back, and there the id is the one that is still right. A lesson therefore
+    cannot be re-prioritised by editing its timestamp; if a human-settable
+    priority is ever wanted, it belongs in a column that says so rather than in a
+    field every reader also interprets as "when".
+    """
+    rows = conn.execute(
+        "SELECT * FROM lessons WHERE active = 1 ORDER BY (surface = ?) DESC, id DESC",
+        (surface,),
+    ).fetchall()
+    chosen: list[sqlite3.Row] = []
+    used = 0
+    for row in rows:
+        cost = len(format_lesson(row).encode("utf-8")) + 1  # + the newline it is printed with
+        if used + cost > budget_bytes:
+            break
+        chosen.append(row)
+        used += cost
+    return chosen, used
+
+
+def format_lesson(row: sqlite3.Row) -> str:
+    """One lesson as one seed line, carrying the finding that earned it."""
+    return (
+        f"- [{row['kind']}] {row['surface']}: {row['pattern']} -> {row['guidance']}"
+        f" (finding #{row['source_finding_id']})"
+    )
+
+
+def export_roe(conn: sqlite3.Connection) -> dict[str, list[dict[str, Any]]]:
+    """The active rules of engagement, grouped by field.
+
+    An export, never the source of truth: ``scope_check.py`` reads the rows.
+    Inactive rules are absent rather than present-and-flagged, so a consumer
+    cannot mistake a reverted rule for a live one by ignoring a field.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    rows = conn.execute(
+        "SELECT id, field, value, reason, approved_by, ts FROM roe_rules"
+        " WHERE active = 1 ORDER BY field ASC, id ASC"
+    ).fetchall()
+    for row in rows:
+        grouped.setdefault(str(row["field"]), []).append(
+            {
+                "id": int(row["id"]),
+                "value": row["value"],
+                "reason": row["reason"],
+                "approved_by": row["approved_by"],
+                "ts": row["ts"],
+            }
+        )
+    return grouped
+
+
+def row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    return {key: row[key] for key in row.keys()}
+
+
+def _require_finding(conn: sqlite3.Connection, finding_id: int) -> bool:
+    return conn.execute("SELECT 1 FROM findings WHERE id = ?", (finding_id,)).fetchone() is not None
+
+
+def _emit(payload: Any) -> None:
+    print(json.dumps(payload, sort_keys=True))
+
+
+def nonblank(value: str) -> str:
+    """An argparse ``type`` for a required text argument: strip, refuse empty.
+
+    ``required=True`` only asserts the FLAG is present, so ``--approved-by ""``
+    satisfied it and wrote an active lesson (or an active rule) with no
+    attribution at all -- defeating the guarantee that every approval names its
+    approver, while still passing the argument parser.
+
+    Applied at the declaration rather than at each write, because the next
+    required argument someone adds would otherwise have to remember this. It
+    strips too: a trailing space in an approver name is noise, not identity.
+    """
+    stripped = value.strip()
+    if not stripped:
+        raise argparse.ArgumentTypeError("must not be blank or whitespace-only")
+    return stripped
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Security conductor findings ledger")
+    # ONE position, before the subcommand, and the usage block says so. Accepting
+    # it on both sides was tried and removed: it needs a second declaration whose
+    # default must be argparse.SUPPRESS (with `None` the subparser silently
+    # overwrites a value given before the subcommand every time it is omitted
+    # after it), which is a subtlety every later reader has to re-derive for a
+    # flag whose normal case is to be omitted entirely.
+    parser.add_argument("--db", default=None, help="ledger path (default: data home)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def command(name: str, help_text: str) -> argparse.ArgumentParser:
+        return sub.add_parser(name, help=help_text)
+
+    command("init", "create or upgrade the schema")
+
+    add = command("add-finding", "record a candidate finding (deduped)")
+    add.add_argument("--surface", required=True, type=nonblank)
+    add.add_argument("--title", required=True, type=nonblank)
+    add.add_argument("--severity", required=True, type=nonblank)
+    add.add_argument("--path", action="append", default=[], dest="paths")
+    add.add_argument("--poc", default=None)
+    add.add_argument("--round-id", default=None)
+
+    verdict = command("record-verdict", "append one verdict (never overwrites)")
+    verdict.add_argument("--finding", required=True, type=int)
+    verdict.add_argument("--role", required=True, type=nonblank)
+    verdict.add_argument("--verdict", required=True, type=nonblank)
+    verdict.add_argument("--reason", default=None)
+
+    propose = command("propose-lesson", "propose a lesson (inert until approved)")
+    propose.add_argument("--kind", required=True, type=nonblank)
+    propose.add_argument("--surface", required=True, type=nonblank)
+    propose.add_argument("--pattern", required=True, type=nonblank)
+    propose.add_argument("--guidance", required=True, type=nonblank)
+    propose.add_argument("--source-finding", required=True, type=int)
+
+    approve = command("approve-lesson", "activate a proposed lesson")
+    approve.add_argument("--id", required=True, type=int)
+    approve.add_argument("--approved-by", required=True, type=nonblank)
+
+    rule = command("add-rule", "add a rules-of-engagement row")
+    rule.add_argument("--field", required=True, type=nonblank)
+    rule.add_argument("--value", required=True, type=nonblank)
+    # Both required AND non-blank: the RFC makes every widening of what an auditor
+    # may do attributable, so a rule with no reason or no approver is not a rule --
+    # and `required=True` alone would accept an empty string for either.
+    rule.add_argument("--reason", required=True, type=nonblank)
+    rule.add_argument("--approved-by", required=True, type=nonblank)
+
+    command("export-roe", "emit the active rules as JSON, grouped by field")
+
+    listing = command("list", "dump a table as JSON")
+    listing.add_argument("table", choices=LIST_TABLES)
+
+    seed = command("seed-lessons", "approved lessons for a seed message")
+    seed.add_argument("--surface", required=True, type=nonblank)
+    seed.add_argument("--budget-bytes", required=True, type=int)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    db_path = Path(args.db) if args.db else default_db_path()
+    conn = connect(db_path)
+    try:
+        version = init_schema(conn)
+        return _dispatch(conn, args, db_path, version)
+    finally:
+        conn.close()
+
+
+def _dispatch(
+    conn: sqlite3.Connection, args: argparse.Namespace, db_path: Path, version: int
+) -> int:
+    if args.command == "init":
+        _emit({"db": str(db_path), "schema_version": version})
+        return 0
+
+    if args.command == "add-finding":
+        finding_id, created = add_finding(
+            conn,
+            surface=args.surface,
+            title=args.title,
+            severity=args.severity,
+            paths=args.paths,
+            poc=args.poc,
+            round_id=args.round_id,
+        )
+        _emit({"id": finding_id, "created": created})
+        return 0
+
+    if args.command == "record-verdict":
+        if args.role not in ROLES:
+            print(
+                f"unknown role {args.role!r}; expected one of {', '.join(ROLES)}",
+                file=sys.stderr,
+            )
+            return 2
+        if not _require_finding(conn, args.finding):
+            print(f"no finding with id {args.finding}", file=sys.stderr)
+            return 2
+        folded = record_verdict(
+            conn,
+            finding_id=args.finding,
+            role=args.role,
+            verdict=args.verdict,
+            reason=args.reason,
+        )
+        _emit({"finding_id": args.finding, **folded})
+        return 0
+
+    if args.command == "propose-lesson":
+        if args.kind not in LESSON_KINDS:
+            print(
+                f"unknown kind {args.kind!r}; expected one of {', '.join(LESSON_KINDS)}",
+                file=sys.stderr,
+            )
+            return 2
+        if not _require_finding(conn, args.source_finding):
+            # Checked here as well as by the foreign key so the operator gets a
+            # sentence instead of an IntegrityError traceback.
+            print(
+                f"no finding with id {args.source_finding}; every lesson must cite one",
+                file=sys.stderr,
+            )
+            return 2
+        with conn:
+            cursor = conn.execute(
+                "INSERT INTO lessons (kind, surface, pattern, guidance, source_finding_id, ts,"
+                " active) VALUES (?, ?, ?, ?, ?, ?, 0)",
+                (
+                    args.kind,
+                    args.surface,
+                    args.pattern,
+                    args.guidance,
+                    args.source_finding,
+                    now_iso(),
+                ),
+            )
+        _emit({"id": int(cursor.lastrowid or 0), "active": 0})
+        return 0
+
+    if args.command == "approve-lesson":
+        outcome, holder = approve_lesson(conn, lesson_id=args.id, approved_by=args.approved_by)
+        if outcome == "missing":
+            print(f"no lesson with id {args.id}", file=sys.stderr)
+            return 2
+        if outcome == "already":
+            # Reporting the holder rather than a bare refusal is the point: the
+            # operator asked who may approve this, and someone already did.
+            print(
+                f"lesson {args.id} was already approved by {holder!r};"
+                " approval is recorded once and is never replaced",
+                file=sys.stderr,
+            )
+            return 2
+        if outcome == "deactivated":
+            print(
+                f"lesson {args.id} was approved by {holder!r} and later deactivated;"
+                " approval is recorded once, so re-enable it with"
+                f" 'UPDATE lessons SET active = 1 WHERE id = {args.id}'"
+                " rather than approving it again",
+                file=sys.stderr,
+            )
+            return 2
+        if outcome == "raced":
+            print(
+                f"lesson {args.id} was approved concurrently by {holder!r};"
+                " approval is recorded once",
+                file=sys.stderr,
+            )
+            return 2
+        _emit({"id": args.id, "active": 1, "approved_by": args.approved_by})
+        return 0
+
+    if args.command == "add-rule":
+        with conn:
+            cursor = conn.execute(
+                "INSERT INTO roe_rules (field, value, reason, approved_by, ts, active)"
+                " VALUES (?, ?, ?, ?, ?, 1)",
+                (args.field, args.value, args.reason, args.approved_by, now_iso()),
+            )
+        _emit({"id": int(cursor.lastrowid or 0), "field": args.field, "active": 1})
+        return 0
+
+    if args.command == "export-roe":
+        _emit(export_roe(conn))
+        return 0
+
+    if args.command == "list":
+        # A literal query per choice rather than an interpolated table name: the
+        # argparse `choices` already bounds the value, but the safety of the SQL
+        # should be readable AT the query, not inferred from an argument
+        # declaration two hundred lines away.
+        rows = conn.execute(LIST_QUERIES[args.table]).fetchall()
+        _emit([row_to_dict(row) for row in rows])
+        return 0
+
+    if args.command == "seed-lessons":
+        if args.budget_bytes < 0:
+            print("--budget-bytes must not be negative", file=sys.stderr)
+            return 2
+        chosen, used = seed_lessons(conn, surface=args.surface, budget_bytes=args.budget_bytes)
+        for row in chosen:
+            print(format_lesson(row))
+        if not chosen:
+            # Report the shortfall on stderr so stdout stays exactly the seed
+            # text a caller splices into a message, empty when nothing fits.
+            # An empty ledger and a budget too small for the top lesson are
+            # different operator problems, so they do not share a message.
+            approved = conn.execute("SELECT COUNT(*) FROM lessons WHERE active = 1").fetchone()
+            if int(approved[0]) == 0:
+                print("no approved lesson to seed", file=sys.stderr)
+            else:
+                print(f"no approved lesson fits {args.budget_bytes} bytes", file=sys.stderr)
+        print(f"{len(chosen)} lesson(s), {used} bytes", file=sys.stderr)
+        return 0
+
+    print(f"unknown command {args.command!r}", file=sys.stderr)  # pragma: no cover
+    return 2  # pragma: no cover
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_security_conductor_ledger.py
+++ b/test/test_security_conductor_ledger.py
@@ -1,0 +1,1662 @@
+"""The security conductor's findings ledger — the properties, not the plumbing.
+
+Each test here pins one guarantee the RFC asks the ledger to hold instead of
+asking an agent to hold it: an append-only verdict log whose fold is
+``human > verifier > auditor``, a proposed lesson that cannot reach a seed
+message before a human approves it, a bounded seed, an export that shows only
+live rules, one finding per real defect, and a lesson that always cites one.
+
+The CLI is driven through ``main`` with argv, the way the skill invokes it, so a
+property that holds only in a helper called directly does not count.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from skill_script_helpers import load_skill_script
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "security-conductor"
+    / "scripts"
+    / "ledger.py"
+)
+
+
+def script_source_with_joined_literals() -> str:
+    """The script's source with implicit string concatenation collapsed.
+
+    Python joins adjacent literals into one string, so a scan matching a single
+    quoted run sees only the FIRST fragment of every multi-line SQL statement in
+    this file -- a WHERE clause on the next line is invisible to it, which makes
+    the assertion pass by inspecting nothing. Collapsing `" "` joins is what lets
+    the structural assertions reason about whole statements. Only true
+    concatenation is affected: `"a", "b"` has a comma between the quotes.
+    """
+    return re.sub(r'"\s*"', "", SCRIPT.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def mod():
+    return load_skill_script("security_conductor_ledger", SCRIPT)
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    return tmp_path / "findings.db"
+
+
+def run(mod, db: Path, *argv: str) -> int:
+    return mod.main(["--db", str(db), *argv])
+
+
+def out_json(capsys):
+    return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+
+
+def a_finding(mod, db: Path, capsys, *, surface="security.is_denied", title="fence bypass") -> int:
+    run(
+        mod,
+        db,
+        "add-finding",
+        "--surface",
+        surface,
+        "--title",
+        title,
+        "--severity",
+        "High",
+        "--path",
+        "src/kiro_crew/security.py",
+    )
+    return int(out_json(capsys)["id"])
+
+
+def a_lesson(
+    mod,
+    db: Path,
+    capsys,
+    finding_id: int,
+    *,
+    surface="security.is_denied",
+    pattern="regex matched echo text",
+    guidance="read argv, not the command string",
+    kind="false-positive",
+    approve=True,
+) -> int:
+    run(
+        mod,
+        db,
+        "propose-lesson",
+        "--kind",
+        kind,
+        "--surface",
+        surface,
+        "--pattern",
+        pattern,
+        "--guidance",
+        guidance,
+        "--source-finding",
+        str(finding_id),
+    )
+    lesson_id = int(out_json(capsys)["id"])
+    if approve:
+        run(mod, db, "approve-lesson", "--id", str(lesson_id), "--approved-by", "zejiangg")
+        capsys.readouterr()
+    return lesson_id
+
+
+class TestInit:
+    def test_init_is_idempotent_and_versioned(self, mod, db, capsys):
+        assert run(mod, db, "init") == 0
+        first = out_json(capsys)
+        assert first["schema_version"] == mod.SCHEMA_VERSION
+        assert run(mod, db, "init") == 0
+        # A second init must not stack a second version row, or the ladder a
+        # future migration branches on reads an arbitrary one of them.
+        assert out_json(capsys)["schema_version"] == mod.SCHEMA_VERSION
+        conn = mod.connect(db)
+        try:
+            rows = conn.execute("SELECT version FROM schema_version").fetchall()
+        finally:
+            conn.close()
+        assert [row["version"] for row in rows] == [mod.SCHEMA_VERSION]
+
+    def test_every_command_creates_the_schema_first(self, mod, db, capsys):
+        """No command may require a prior ``init``: a skill step that forgets it
+        would otherwise fail on a fresh host with a ``no such table`` error."""
+        assert run(mod, db, "list", "findings") == 0
+        assert out_json(capsys) == []
+
+
+class TestDedupeIdentity:
+    def test_same_surface_title_and_paths_returns_the_existing_id(self, mod, db, capsys):
+        first = a_finding(mod, db, capsys)
+        run(
+            mod,
+            db,
+            "add-finding",
+            "--surface",
+            "security.is_denied",
+            "--title",
+            "fence bypass",
+            "--severity",
+            "Critical",  # a re-report is not evidence to overwrite the record
+            "--path",
+            "src/kiro_crew/security.py",
+        )
+        again = out_json(capsys)
+        assert again["id"] == first
+        assert again["created"] is False
+        run(mod, db, "list", "findings")
+        rows = out_json(capsys)
+        assert len(rows) == 1
+        assert rows[0]["severity"] == "High"
+
+    def test_path_order_and_duplicates_do_not_create_a_second_finding(self, mod, db, capsys):
+        """Identity is *sorted* paths, so the same defect reported with its paths
+        in another order is the same finding, not a second one."""
+        run(
+            mod,
+            db,
+            "add-finding",
+            "--surface",
+            "webhooks",
+            "--title",
+            "unvalidated payload",
+            "--severity",
+            "Medium",
+            "--path",
+            "src/kiro_crew/webhooks.py",
+            "--path",
+            "src/kiro_crew/hooks.py",
+        )
+        first = out_json(capsys)["id"]
+        run(
+            mod,
+            db,
+            "add-finding",
+            "--surface",
+            "webhooks",
+            "--title",
+            "unvalidated payload",
+            "--severity",
+            "Medium",
+            "--path",
+            "src/kiro_crew/hooks.py",
+            "--path",
+            "src/kiro_crew/webhooks.py",
+            "--path",
+            "src/kiro_crew/hooks.py",
+        )
+        assert out_json(capsys)["id"] == first
+
+    def test_a_different_path_set_is_a_different_finding(self, mod, db, capsys):
+        first = a_finding(mod, db, capsys)
+        run(
+            mod,
+            db,
+            "add-finding",
+            "--surface",
+            "security.is_denied",
+            "--title",
+            "fence bypass",
+            "--severity",
+            "High",
+            "--path",
+            "src/kiro_crew/platform/security_authority.py",
+        )
+        second = out_json(capsys)
+        assert second["id"] != first
+        assert second["created"] is True
+
+
+class TestSchemaMatchesTheRfc:
+    """The RFC's four tables, column for column.
+
+    A column added for convenience is a design change made in an
+    implementation PR, so the shape is asserted rather than described.
+    """
+
+    @pytest.mark.parametrize(
+        "table,columns",
+        [
+            (
+                "findings",
+                [
+                    "id",
+                    "surface",
+                    "severity",
+                    "title",
+                    "paths",
+                    "poc",
+                    "auditor_verdict",
+                    "verifier_verdict",
+                    "final_verdict",
+                    "status",
+                    "created",
+                    "round_id",
+                ],
+            ),
+            ("verdicts", ["finding_id", "role", "verdict", "reason", "ts"]),
+            (
+                "lessons",
+                [
+                    "id",
+                    "kind",
+                    "surface",
+                    "pattern",
+                    "guidance",
+                    "source_finding_id",
+                    "approved_by",
+                    "ts",
+                    "active",
+                ],
+            ),
+            ("roe_rules", ["id", "field", "value", "reason", "approved_by", "ts", "active"]),
+            ("schema_version", ["version"]),
+        ],
+    )
+    def test_table_has_exactly_the_specified_columns(self, mod, db, capsys, table, columns):
+        run(mod, db, "init")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        finally:
+            conn.close()
+        assert [row["name"] for row in rows] == columns
+
+    def test_the_append_order_of_verdicts_is_the_implicit_rowid(self, mod, db, capsys):
+        """``verdicts`` gets no surrogate key, so the fold's tiebreak has to come
+        from SQLite's own rowid — this asserts the ordering column exists and is
+        what ``list verdicts`` reports."""
+        finding = a_finding(mod, db, capsys)
+        for verdict in ("confirmed", "rejected"):
+            run(
+                mod,
+                db,
+                "record-verdict",
+                "--finding",
+                str(finding),
+                "--role",
+                "auditor",
+                "--verdict",
+                verdict,
+            )
+        capsys.readouterr()
+        run(mod, db, "list", "verdicts")
+        rows = out_json(capsys)
+        assert [row["rowid"] for row in rows] == [1, 2]
+        assert [row["verdict"] for row in rows] == ["confirmed", "rejected"]
+
+
+class TestSchemaVersionIsASingleton:
+    """The version row is what a migration ladder branches on, so two of them is
+    two answers to one question.
+
+    `init_schema` read the table and inserted when empty. That is racy on the
+    ORDINARY path, not just between two `init` calls: every command calls
+    `init_schema` first, so two parallel auditors running `add-finding` both saw an
+    empty table and both inserted.
+    """
+
+    def test_a_concurrent_initialisation_writes_one_row(self, mod, db, capsys):
+        """Two connections initialise the same fresh database. The insert carries
+        `WHERE NOT EXISTS`, so the second finds the first's row and writes
+        nothing."""
+        first = mod.connect(db)
+        second = mod.connect(db)
+        try:
+            assert mod.init_schema(first) == mod.SCHEMA_VERSION
+            assert mod.init_schema(second) == mod.SCHEMA_VERSION
+            rows = first.execute("SELECT version FROM schema_version").fetchall()
+        finally:
+            first.close()
+            second.close()
+        assert [row["version"] for row in rows] == [mod.SCHEMA_VERSION]
+
+    def test_many_initialisations_still_write_one_row(self, mod, db, capsys):
+        """Every command initialises, so the idempotence has to survive repetition,
+        not just a second call."""
+        for _ in range(6):
+            assert run(mod, db, "list", "findings") == 0
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            rows = conn.execute("SELECT version FROM schema_version").fetchall()
+        finally:
+            conn.close()
+        assert len(rows) == 1
+
+    def test_the_index_refuses_a_duplicate_written_any_other_way(self, mod, db, capsys):
+        """The conditional insert fixes this code's path; the unique index is what
+        makes the singleton a property of the TABLE, so a row written by hand
+        cannot duplicate it either."""
+        run(mod, db, "init")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            with pytest.raises(Exception):
+                conn.execute(
+                    "INSERT INTO schema_version (version) VALUES (?)", (mod.SCHEMA_VERSION,)
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+    def test_init_still_reports_the_version(self, mod, db, capsys):
+        assert run(mod, db, "init") == 0
+        assert out_json(capsys)["schema_version"] == mod.SCHEMA_VERSION
+
+
+class TestApprovalSurvivesADeactivation:
+    """`active = 0` alone was the wrong precondition.
+
+    A lesson approved and then switched off by hand -- the RFC's own revert path --
+    still carries its original approver, so it satisfied `AND active = 0` and a
+    second approval overwrote the attribution. The write now also requires
+    `approved_by IS NULL`, which is true only of a lesson never approved at all.
+    """
+
+    def _approved_then_deactivated(self, mod, db, capsys) -> int:
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "first")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            with conn:
+                conn.execute("UPDATE lessons SET active = 0 WHERE id = ?", (lesson,))
+        finally:
+            conn.close()
+        return lesson
+
+    def test_reapproval_after_a_hand_deactivation_is_refused(self, mod, db, capsys):
+        lesson = self._approved_then_deactivated(mod, db, capsys)
+        assert run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "second") == 2
+        err = capsys.readouterr().err
+        assert "approved by 'first' and later deactivated" in err
+        assert "rather than approving it again" in err
+
+    def test_the_original_approver_survives_that_refusal(self, mod, db, capsys):
+        lesson = self._approved_then_deactivated(mod, db, capsys)
+        run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "second")
+        capsys.readouterr()
+        run(mod, db, "list", "lessons")
+        row = out_json(capsys)[0]
+        assert row["approved_by"] == "first"
+        assert row["active"] == 0
+
+    def test_the_refusal_names_the_documented_way_back(self, mod, db, capsys):
+        """The revert was a row edit, so undoing it is one too. An operator told
+        only "refused" would reasonably re-run the command that just failed."""
+        lesson = self._approved_then_deactivated(mod, db, capsys)
+        run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "second")
+        assert "UPDATE lessons SET active = 1" in capsys.readouterr().err
+
+    def test_the_update_itself_carries_both_conditions(self, mod, db, capsys):
+        """Driven at the SQL layer: the guard must be in the WHERE clause, not only
+        in the Python branch that produces the message."""
+        lesson = self._approved_then_deactivated(mod, db, capsys)
+        conn = mod.connect(db)
+        try:
+            cursor = conn.execute(
+                "UPDATE lessons SET active = 1, approved_by = ?"
+                " WHERE id = ? AND active = 0 AND approved_by IS NULL",
+                ("second", lesson),
+            )
+            conn.commit()
+            assert cursor.rowcount == 0
+            row = conn.execute("SELECT approved_by FROM lessons WHERE id = ?", (lesson,)).fetchone()
+        finally:
+            conn.close()
+        assert row["approved_by"] == "first"
+
+    def test_a_never_approved_lesson_still_approves(self, mod, db, capsys):
+        """The narrower precondition must not break the path it protects."""
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        assert run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "x") == 0
+        assert out_json(capsys)["approved_by"] == "x"
+
+
+class TestNoWriteIsGatedOnlyByAPythonRead:
+    """The invariant the retrospective produced, as a scan.
+
+    Four rounds produced four findings in one span, and every one was the same
+    mechanism: a Python read-then-write deciding whether a write was safe, where
+    the database should have been the authority. Rounds 0, 2 and 4 were
+    check-then-act (dedupe, approval, schema version); round 1 was the read-path
+    variant (trusting a wall clock over the append order the table records).
+
+    These assertions cover the write that does not exist yet, which is the only
+    way to stop a fifth instance.
+    """
+
+    def test_the_schema_version_insert_carries_its_own_precondition(self, mod):
+        source = script_source_with_joined_literals()
+        inserts = re.findall(r'"INSERT INTO schema_version[^"]*"', source)
+        assert inserts, "expected the schema_version insert to be present"
+        for statement in inserts:
+            assert "WHERE NOT EXISTS" in statement or "OR IGNORE" in statement, statement
+
+    def test_every_approval_update_requires_an_unset_approver(self, mod):
+        source = script_source_with_joined_literals()
+        updates = [
+            statement
+            for statement in re.findall(r'"UPDATE lessons[^"]*"', source)
+            if "active = 1" in statement
+        ]
+        assert updates, "expected the approval UPDATE to be present"
+        for statement in updates:
+            assert "active = 0" in statement, statement
+            assert "approved_by IS NULL" in statement, statement
+
+    def test_the_literal_join_is_what_makes_these_scans_see_whole_statements(self):
+        """The scans above are only as good as this collapse.
+
+        Matching one quoted run at a time saw a multi-line statement's first
+        fragment only, so a WHERE clause on the second line was invisible -- an
+        assertion that passes because it inspects nothing. Pinned so the helper
+        cannot regress into that quietly.
+        """
+        collapsed = re.sub(r'"\s*"', "", 'x = "UPDATE t SET a = 1" " WHERE b = 0"')
+        assert collapsed == 'x = "UPDATE t SET a = 1 WHERE b = 0"'
+        # A comma between the quotes is not concatenation and must survive.
+        assert re.sub(r'"\s*"', "", '("a", "b")') == '("a", "b")'
+
+    def test_the_singleton_index_exists(self, mod):
+        source = script_source_with_joined_literals()
+        assert "UNIQUE INDEX IF NOT EXISTS schema_version_single" in source
+
+
+class TestDedupeSurvivesTheRace:
+    def test_a_concurrent_insert_returns_the_existing_id_not_a_traceback(self, mod, db, capsys):
+        """The identity index is what makes dedupe hold when two auditors hit the
+        same surface at once — but only if the losing writer RECOVERS. Without the
+        IntegrityError branch the loser gets a traceback where the contract
+        promises the existing id.
+
+        The race is simulated by inserting the twin between the read and the
+        write: patching the read to miss is what a real concurrent writer causes.
+        """
+        first = a_finding(mod, db, capsys)
+        conn = mod.connect(db)
+        try:
+            original = mod._find_by_identity
+            calls = []
+
+            def racing_find(connection, surface, title, key):
+                calls.append(key)
+                # Miss on the FIRST lookup only — the pre-insert read — so the
+                # insert proceeds into a row that already exists, and the
+                # post-IntegrityError re-read behaves like the real one.
+                if len(calls) == 1:
+                    return None
+                return original(connection, surface, title, key)
+
+            mod._find_by_identity = racing_find
+            try:
+                found, created = mod.add_finding(
+                    conn,
+                    surface="security.is_denied",
+                    title="fence bypass",
+                    severity="High",
+                    paths=["src/kiro_crew/security.py"],
+                    poc=None,
+                    round_id=None,
+                )
+            finally:
+                mod._find_by_identity = original
+        finally:
+            conn.close()
+        assert found == first
+        assert created is False
+        assert len(calls) == 2, "the losing writer must re-read after the IntegrityError"
+
+    def test_the_identity_index_exists_so_the_race_is_detectable_at_all(self, mod, db, capsys):
+        a_finding(mod, db, capsys)
+        conn = mod.connect(db)
+        try:
+            with pytest.raises(Exception):
+                conn.execute(
+                    "INSERT INTO findings (surface, severity, title, paths, status, created)"
+                    " VALUES ('security.is_denied', 'Low', 'fence bypass',"
+                    " '[\"src/kiro_crew/security.py\"]', 'open',"
+                    " '2026-09-07T00:00:00+00:00')"
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+
+class TestApprovalDoesNotRestampTheProposal:
+    def test_ts_still_means_when_the_lesson_was_proposed(self, mod, db, capsys):
+        """``ts`` is the only timestamp the RFC gives a lesson, and
+        ``seed-lessons`` ranks recency by it. Restamping on approval would make
+        the column mean proposal-time or approval-time depending on ``active``,
+        and would let a batch of old approvals outrank a genuinely fresh lesson.
+        """
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        run(mod, db, "list", "lessons")
+        proposed_at = out_json(capsys)[0]["ts"]
+        run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "zejiangg")
+        capsys.readouterr()
+        run(mod, db, "list", "lessons")
+        row = out_json(capsys)[0]
+        assert row["ts"] == proposed_at
+        assert row["active"] == 1
+
+
+class TestSeedShortfallIsHonest:
+    def test_an_empty_ledger_and_a_tight_budget_report_differently(self, mod, db, capsys):
+        """Two different operator problems: nothing approved yet, versus a budget
+        too small for the top lesson. One message for both sends the reader to
+        the wrong place."""
+        assert run(mod, db, "seed-lessons", "--surface", "s", "--budget-bytes", "4000") == 0
+        assert "no approved lesson to seed" in capsys.readouterr().err
+
+        finding = a_finding(mod, db, capsys)
+        a_lesson(mod, db, capsys, finding)
+        assert run(mod, db, "seed-lessons", "--surface", "s", "--budget-bytes", "5") == 0
+        assert "fits 5 bytes" in capsys.readouterr().err
+
+
+class TestListQueriesAreLiteral:
+    def test_no_table_name_is_interpolated_into_sql(self, mod):
+        """The argparse ``choices`` bounds the value, but the query site should be
+        readable as safe on its own — a later flag that widens ``choices`` must
+        not silently widen the SQL too."""
+        assert set(mod.LIST_TABLES) == set(mod.LIST_QUERIES)
+        source = script_source_with_joined_literals()
+        assert 'f"SELECT * FROM {' not in source
+        assert 'f"SELECT * FROM {' not in source
+
+
+class TestVerdictsAreAppendOnly:
+    def test_a_second_verdict_from_one_role_does_not_replace_the_first(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        run(
+            mod,
+            db,
+            "record-verdict",
+            "--finding",
+            str(finding),
+            "--verdict",
+            "confirmed",
+            "--role",
+            "auditor",
+            "--reason",
+            "poc reproduces",
+        )
+        run(
+            mod,
+            db,
+            "record-verdict",
+            "--finding",
+            str(finding),
+            "--verdict",
+            "rejected",
+            "--role",
+            "auditor",
+            "--reason",
+            "poc was wrong",
+        )
+        capsys.readouterr()
+        run(mod, db, "list", "verdicts")
+        rows = out_json(capsys)
+        assert [row["verdict"] for row in rows] == ["confirmed", "rejected"]
+        assert [row["reason"] for row in rows] == ["poc reproduces", "poc was wrong"]
+
+    def test_the_cli_carries_no_update_or_delete_path_to_verdicts(self, mod):
+        """A structural check, because the guarantee is the ABSENCE of a writer.
+
+        A behavioural test can only show that the commands which exist append;
+        it cannot show that no command mutates. Reading the SQL is what catches
+        a later ``amend-verdict`` being added.
+        """
+        sql = [
+            line.strip().lower()
+            for line in SCRIPT.read_text(encoding="utf-8").splitlines()
+            if "verdicts" in line.lower()
+        ]
+        assert sql, "expected the script to mention the verdicts table"
+        for line in sql:
+            assert "delete from verdicts" not in line
+            assert "update verdicts" not in line
+
+
+class TestFinalVerdictIsAFold:
+    def test_human_outranks_verifier_which_outranks_auditor(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        run(
+            mod,
+            db,
+            "record-verdict",
+            "--finding",
+            str(finding),
+            "--role",
+            "auditor",
+            "--verdict",
+            "confirmed",
+        )
+        assert out_json(capsys)["final_verdict"] == "confirmed"
+
+        run(
+            mod,
+            db,
+            "record-verdict",
+            "--finding",
+            str(finding),
+            "--role",
+            "verifier",
+            "--verdict",
+            "rejected",
+        )
+        folded = out_json(capsys)
+        assert folded["final_verdict"] == "rejected"
+        # The disagreement stays readable: the auditor's call is not erased by
+        # the verifier winning the fold.
+        assert folded["auditor_verdict"] == "confirmed"
+        assert folded["verifier_verdict"] == "rejected"
+
+        run(
+            mod,
+            db,
+            "record-verdict",
+            "--finding",
+            str(finding),
+            "--role",
+            "human",
+            "--verdict",
+            "needs-human",
+        )
+        folded = out_json(capsys)
+        assert folded["final_verdict"] == "needs-human"
+        assert folded["auditor_verdict"] == "confirmed"
+        assert folded["verifier_verdict"] == "rejected"
+
+    def test_a_weaker_role_arriving_later_does_not_win(self, mod, db, capsys):
+        """Precedence is by ROLE, not by arrival: an auditor re-filing after the
+        verifier rejected must not flip the finding back to confirmed."""
+        finding = a_finding(mod, db, capsys)
+        run(
+            mod,
+            db,
+            "record-verdict",
+            "--finding",
+            str(finding),
+            "--role",
+            "verifier",
+            "--verdict",
+            "rejected",
+        )
+        run(
+            mod,
+            db,
+            "record-verdict",
+            "--finding",
+            str(finding),
+            "--role",
+            "auditor",
+            "--verdict",
+            "confirmed",
+        )
+        assert out_json(capsys)["final_verdict"] == "rejected"
+
+    def test_the_findings_row_matches_the_fold(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        run(
+            mod,
+            db,
+            "record-verdict",
+            "--finding",
+            str(finding),
+            "--role",
+            "auditor",
+            "--verdict",
+            "confirmed",
+        )
+        run(
+            mod,
+            db,
+            "record-verdict",
+            "--finding",
+            str(finding),
+            "--role",
+            "human",
+            "--verdict",
+            "confirmed-critical",
+        )
+        capsys.readouterr()
+        run(mod, db, "list", "findings")
+        row = out_json(capsys)[0]
+        assert row["final_verdict"] == "confirmed-critical"
+        assert row["verifier_verdict"] is None
+
+    def test_latest_within_a_role_wins_even_on_an_identical_timestamp(self, mod, db, capsys):
+        """Two rows written inside one clock tick still fold deterministically —
+        insertion order breaks the tie, so the fold is not left to ``ts``
+        resolution."""
+        finding = a_finding(mod, db, capsys)
+        conn = mod.connect(db)
+        try:
+            for verdict in ("confirmed", "rejected"):
+                conn.execute(
+                    "INSERT INTO verdicts (finding_id, role, verdict, reason, ts)"
+                    " VALUES (?, 'verifier', ?, NULL, '2026-09-07T00:00:00+00:00')",
+                    (finding, verdict),
+                )
+            conn.commit()
+            assert mod.fold_verdicts(conn, finding)["final_verdict"] == "rejected"
+        finally:
+            conn.close()
+
+
+class TestOrderingSurvivesAClockRollback:
+    """Append order, not the wall clock, decides both orderings.
+
+    `verdicts` and `lessons` each record their own sequence structurally (rowid,
+    id). Sorting by `ts` first handed that sequence to the system clock, so a
+    rollback -- an NTP correction, a restored VM snapshot, a container with a bad
+    clock -- reordered it. These tests write a rolled-back timestamp directly,
+    which is what the clock does to a row that is appended later.
+    """
+
+    def test_a_rolled_back_clock_does_not_reinstate_a_superseded_verdict(self, mod, db, capsys):
+        """The damaging case: a human overrules a verdict, the clock then rolls
+        back, and the fold hands the finding back to the call that was overruled.
+
+        The superseded row carries the LATER timestamp, so under `ts` ordering it
+        sorted last and won.
+        """
+        finding = a_finding(mod, db, capsys)
+        conn = mod.connect(db)
+        try:
+            # Appended first, but stamped in the future -- the pre-rollback clock.
+            conn.execute(
+                "INSERT INTO verdicts (finding_id, role, verdict, reason, ts)"
+                " VALUES (?, 'human', 'confirmed', 'before the rollback',"
+                " '2026-09-07T12:00:00+00:00')",
+                (finding,),
+            )
+            # Appended second, stamped EARLIER because the clock went backwards.
+            conn.execute(
+                "INSERT INTO verdicts (finding_id, role, verdict, reason, ts)"
+                " VALUES (?, 'human', 'rejected', 'after the rollback',"
+                " '2026-09-07T09:00:00+00:00')",
+                (finding,),
+            )
+            conn.commit()
+            folded = mod.fold_verdicts(conn, finding)
+        finally:
+            conn.close()
+        assert folded["final_verdict"] == "rejected"
+        assert folded["auditor_verdict"] is None
+
+    def test_the_fold_ignores_ts_entirely(self, mod, db, capsys):
+        """Not merely tie-broken by rowid -- `ts` must carry no weight at all, so
+        the guarantee does not depend on how far the clock moved."""
+        finding = a_finding(mod, db, capsys)
+        conn = mod.connect(db)
+        try:
+            for verdict, ts in (
+                ("first", "2099-01-01T00:00:00+00:00"),
+                ("second", "1999-01-01T00:00:00+00:00"),
+                ("third", "2050-01-01T00:00:00+00:00"),
+            ):
+                conn.execute(
+                    "INSERT INTO verdicts (finding_id, role, verdict, reason, ts)"
+                    " VALUES (?, 'verifier', ?, NULL, ?)",
+                    (finding, verdict, ts),
+                )
+            conn.commit()
+            folded = mod.fold_verdicts(conn, finding)
+        finally:
+            conn.close()
+        assert folded["final_verdict"] == "third"
+        assert folded["verifier_verdict"] == "third"
+
+    def test_a_rolled_back_clock_does_not_reorder_lesson_recency(self, mod, db, capsys):
+        """The sibling site, fixed in the same round: a lesson proposed later must
+        still rank as newer after a rollback, or the seed silently promotes stale
+        guidance the moment a host's clock is corrected."""
+        finding = a_finding(mod, db, capsys)
+        older = a_lesson(mod, db, capsys, finding, pattern="proposed-first")
+        newer = a_lesson(mod, db, capsys, finding, pattern="proposed-second")
+        conn = mod.connect(db)
+        try:
+            conn.execute(
+                "UPDATE lessons SET ts = '2026-09-07T12:00:00+00:00' WHERE id = ?", (older,)
+            )
+            conn.execute(
+                "UPDATE lessons SET ts = '2026-09-07T09:00:00+00:00' WHERE id = ?", (newer,)
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "4000")
+        lines = capsys.readouterr().out.strip().splitlines()
+        assert "proposed-second" in lines[0]
+        assert "proposed-first" in lines[1]
+
+    def test_surface_match_still_outranks_recency_after_a_rollback(self, mod, db, capsys):
+        """Dropping `ts` must not disturb the primary key of the ranking."""
+        finding = a_finding(mod, db, capsys)
+        on_surface = a_lesson(
+            mod, db, capsys, finding, surface="security.is_denied", pattern="on-surface"
+        )
+        a_lesson(mod, db, capsys, finding, surface="webhooks", pattern="off-surface")
+        conn = mod.connect(db)
+        try:
+            # Make the on-surface lesson look oldest by the clock as well.
+            conn.execute(
+                "UPDATE lessons SET ts = '1999-01-01T00:00:00+00:00' WHERE id = ?", (on_surface,)
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "4000")
+        lines = capsys.readouterr().out.strip().splitlines()
+        assert "on-surface" in lines[0]
+        assert "off-surface" in lines[1]
+
+    def test_no_ordering_query_in_the_cli_sorts_by_ts(self, mod):
+        """A structural check on the class, not on the two instances.
+
+        The next ordering someone adds is the one that would reintroduce this, and
+        a behavioural test only covers the sites that already exist.
+        """
+        source = script_source_with_joined_literals()
+        offenders = []
+        for clause in re.findall(r"ORDER BY ([^\"']+)", source):
+            for term in clause.split(","):
+                # First token of each sort term, so `ts` is caught but `verdicts`
+                # (which merely CONTAINS it) is not -- the bug this assertion had
+                # on its first draft.
+                head = term.strip().split()[:1]
+                if head and head[0] == "ts":
+                    offenders.append(clause.strip())
+        assert offenders == [], offenders
+
+    def test_that_check_would_catch_a_ts_ordering(self):
+        """The guard above is a regex over source text, so it needs its own proof
+        that it fires -- an assertion that can only pass is not a check."""
+        sample = 'x = "SELECT a FROM t ORDER BY ts DESC, id DESC"'
+        found = []
+        for clause in re.findall(r"ORDER BY ([^\"']+)", sample):
+            for term in clause.split(","):
+                head = term.strip().split()[:1]
+                if head and head[0] == "ts":
+                    found.append(clause.strip())
+        assert found, "the ts-ordering detector must fire on a ts ORDER BY"
+
+
+class TestRecordVerdictRejectsUnknownRoles:
+    @pytest.mark.parametrize("role", ["fixer", "AUDITOR", "auditor2", "human-approver"])
+    def test_unknown_role_is_exit_2_and_writes_nothing(self, mod, db, capsys, role):
+        finding = a_finding(mod, db, capsys)
+        assert (
+            run(
+                mod,
+                db,
+                "record-verdict",
+                "--finding",
+                str(finding),
+                "--role",
+                role,
+                "--verdict",
+                "confirmed",
+            )
+            == 2
+        )
+        assert "unknown role" in capsys.readouterr().err
+        run(mod, db, "list", "verdicts")
+        assert out_json(capsys) == []
+
+    def test_a_blank_role_is_refused_by_the_argument_parser(self, mod, db, capsys):
+        """Exit 2 either way, but via `nonblank` rather than the role check, so it
+        raises instead of returning -- the blank-argument class owns it."""
+        finding = a_finding(mod, db, capsys)
+        with pytest.raises(SystemExit) as excinfo:
+            run(
+                mod,
+                db,
+                "record-verdict",
+                "--finding",
+                str(finding),
+                "--role",
+                "",
+                "--verdict",
+                "confirmed",
+            )
+        assert excinfo.value.code == 2
+        run(mod, db, "list", "verdicts")
+        assert out_json(capsys) == []
+
+    def test_surrounding_whitespace_on_a_role_is_stripped_not_rejected(self, mod, db, capsys):
+        """`--role "human "` IS `human`. Whitespace is a shell-quoting artifact,
+        not a different role, and refusing it was never a control -- someone
+        forging a human verdict types the word correctly. Case is still
+        significant, so `AUDITOR` remains unknown.
+        """
+        finding = a_finding(mod, db, capsys)
+        assert (
+            run(
+                mod,
+                db,
+                "record-verdict",
+                "--finding",
+                str(finding),
+                "--role",
+                " human ",
+                "--verdict",
+                "confirmed",
+            )
+            == 0
+        )
+        assert out_json(capsys)["final_verdict"] == "confirmed"
+        run(mod, db, "list", "verdicts")
+        assert [row["role"] for row in out_json(capsys)] == ["human"]
+
+    def test_the_schema_refuses_an_unknown_role_too(self, mod, db, capsys):
+        """Belt and braces: the CLI check is a good error message, the CHECK
+        constraint is the guarantee — a human writing SQL by hand hits it."""
+        finding = a_finding(mod, db, capsys)
+        conn = mod.connect(db)
+        try:
+            with pytest.raises(Exception):
+                conn.execute(
+                    "INSERT INTO verdicts (finding_id, role, verdict, ts)"
+                    " VALUES (?, 'fixer', 'confirmed', '2026-09-07T00:00:00+00:00')",
+                    (finding,),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+    def test_a_verdict_for_a_missing_finding_is_exit_2(self, mod, db, capsys):
+        assert (
+            run(
+                mod,
+                db,
+                "record-verdict",
+                "--finding",
+                "999",
+                "--role",
+                "auditor",
+                "--verdict",
+                "confirmed",
+            )
+            == 2
+        )
+        assert "no finding" in capsys.readouterr().err
+
+
+class TestLessonsCiteAFinding:
+    def test_an_unknown_source_finding_is_refused(self, mod, db, capsys):
+        assert (
+            run(
+                mod,
+                db,
+                "propose-lesson",
+                "--kind",
+                "false-positive",
+                "--surface",
+                "s",
+                "--pattern",
+                "p",
+                "--guidance",
+                "g",
+                "--source-finding",
+                "404",
+            )
+            == 2
+        )
+        assert "every lesson must cite one" in capsys.readouterr().err
+        run(mod, db, "list", "lessons")
+        assert out_json(capsys) == []
+
+    def test_the_foreign_key_is_enforced_on_direct_sql(self, mod, db, capsys):
+        """``PRAGMA foreign_keys`` is OFF by default per connection, so the
+        NOT NULL REFERENCES is only a constraint because ``connect`` turns it
+        on. A human editing rows by hand must not be able to orphan a lesson."""
+        a_finding(mod, db, capsys)
+        conn = mod.connect(db)
+        try:
+            with pytest.raises(Exception):
+                conn.execute(
+                    "INSERT INTO lessons (kind, surface, pattern, guidance,"
+                    " source_finding_id, ts, active) VALUES"
+                    " ('missed', 's', 'p', 'g', 4242, '2026-09-07T00:00:00+00:00', 1)"
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+    def test_an_unknown_kind_is_refused(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        assert (
+            run(
+                mod,
+                db,
+                "propose-lesson",
+                "--kind",
+                "hunch",
+                "--surface",
+                "s",
+                "--pattern",
+                "p",
+                "--guidance",
+                "g",
+                "--source-finding",
+                str(finding),
+            )
+            == 2
+        )
+        assert "unknown kind" in capsys.readouterr().err
+
+
+class TestUnapprovedLessonsNeverSeed:
+    def test_a_proposed_lesson_is_inactive_and_absent_from_the_seed(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        run(mod, db, "list", "lessons")
+        row = out_json(capsys)[0]
+        assert row["active"] == 0
+        assert row["approved_by"] is None
+
+        assert (
+            run(
+                mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "4000"
+            )
+            == 0
+        )
+        assert capsys.readouterr().out == ""
+
+        run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "zejiangg")
+        capsys.readouterr()
+        run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "4000")
+        assert "read argv, not the command string" in capsys.readouterr().out
+
+    def test_approving_a_missing_lesson_is_exit_2(self, mod, db, capsys):
+        assert run(mod, db, "approve-lesson", "--id", "7", "--approved-by", "zejiangg") == 2
+        assert "no lesson" in capsys.readouterr().err
+
+    def test_approval_records_who_approved(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        a_lesson(mod, db, capsys, finding)
+        run(mod, db, "list", "lessons")
+        row = out_json(capsys)[0]
+        assert row["active"] == 1
+        assert row["approved_by"] == "zejiangg"
+
+
+class TestApprovalIsWriteOnce:
+    """`approved_by` names the approval that let a lesson into a seed, so losing
+    it loses the audit trail the human gate exists to leave.
+
+    The module docstring claimed "every lesson is attributable" and that approval
+    "demands a named approver" while the UPDATE was unconditional -- a claimed
+    guarantee with no test, which is the pattern this PR's retrospective found
+    behind all three of its rounds.
+    """
+
+    def test_reapproval_is_refused_and_the_original_approver_survives(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        assert run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "first") == 0
+        capsys.readouterr()
+
+        assert run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "second") == 2
+        err = capsys.readouterr().err
+        assert "already approved by 'first'" in err
+        assert "never replaced" in err
+
+        run(mod, db, "list", "lessons")
+        row = out_json(capsys)[0]
+        assert row["approved_by"] == "first"
+        assert row["active"] == 1
+
+    def test_a_refused_reapproval_is_distinguishable_from_a_missing_lesson(self, mod, db, capsys):
+        """Both exit 2, so the message is the only thing that tells an operator
+        whether to go find the id or go find the approver."""
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding)
+        assert run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "x") == 2
+        assert "already approved" in capsys.readouterr().err
+        assert run(mod, db, "approve-lesson", "--id", "4242", "--approved-by", "x") == 2
+        assert "no lesson with id" in capsys.readouterr().err
+
+    def test_the_update_itself_refuses_not_just_the_read(self, mod, db, capsys):
+        """The read is a good error message; `AND active = 0` is the guarantee.
+
+        Called at the SQL layer the way a concurrent approver reaches it, so this
+        fails if the guard lives only in the Python branch above.
+        """
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "first")
+        capsys.readouterr()
+        conn = mod.connect(db)
+        try:
+            cursor = conn.execute(
+                "UPDATE lessons SET active = 1, approved_by = ? WHERE id = ? AND active = 0",
+                ("second", lesson),
+            )
+            conn.commit()
+            assert cursor.rowcount == 0
+            row = conn.execute("SELECT approved_by FROM lessons WHERE id = ?", (lesson,)).fetchone()
+        finally:
+            conn.close()
+        assert row["approved_by"] == "first"
+
+    def test_a_concurrent_approval_reports_raced_instead_of_a_false_success(self, mod, db, capsys):
+        """The read and the UPDATE are separate, so a second approver can land
+        between them. Without the rowcount check the loser prints a success line
+        naming ITSELF as the approver for a write that changed no row.
+
+        The race is driven by making the first read report the lesson as still
+        unapproved, which is exactly what a concurrent approver causes.
+        """
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        conn = mod.connect(db)
+        try:
+            original = mod._read_lesson_state
+            calls = []
+
+            def stale_then_real(connection, lesson_id):
+                calls.append(lesson_id)
+                if len(calls) == 1:
+                    # The pre-UPDATE read, taken before the rival committed.
+                    return False, None
+                return original(connection, lesson_id)
+
+            # The rival's approval, already committed by the time the UPDATE runs.
+            with conn:
+                conn.execute(
+                    "UPDATE lessons SET active = 1, approved_by = 'rival' WHERE id = ?",
+                    (lesson,),
+                )
+            mod._read_lesson_state = stale_then_real
+            try:
+                outcome, holder = mod.approve_lesson(conn, lesson_id=lesson, approved_by="loser")
+            finally:
+                mod._read_lesson_state = original
+            row = conn.execute("SELECT approved_by FROM lessons WHERE id = ?", (lesson,)).fetchone()
+        finally:
+            conn.close()
+        assert outcome == "raced"
+        assert holder == "rival"
+        assert row["approved_by"] == "rival"
+        assert len(calls) == 2, "the loser must re-read to name the winner"
+
+    def test_the_cli_surfaces_a_raced_approval_as_exit_2(self, mod, db, capsys, monkeypatch):
+        """The outcome has to reach the operator, not just the helper's caller."""
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        monkeypatch.setattr(mod, "approve_lesson", lambda *a, **k: ("raced", "rival"))
+        assert run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "x") == 2
+        err = capsys.readouterr().err
+        assert "approved concurrently by 'rival'" in err
+
+    def test_no_unguarded_approval_update_remains_in_the_cli(self, mod):
+        """Structural: every `UPDATE lessons ... active = 1` must carry the guard.
+
+        A behavioural test covers the one call site that exists; this covers the
+        next one someone adds.
+        """
+        source = script_source_with_joined_literals()
+        updates = [
+            statement
+            for statement in re.findall(r'"UPDATE lessons[^"]*"', source)
+            if "active = 1" in statement
+        ]
+        assert updates, "expected the approval UPDATE to be present"
+        for statement in updates:
+            assert "active = 0" in statement, statement
+
+    def test_approval_still_works_the_first_time(self, mod, db, capsys):
+        """The guard must not break the ordinary path it protects."""
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        assert run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "zejiangg") == 0
+        assert out_json(capsys)["approved_by"] == "zejiangg"
+        run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "4000")
+        assert "read argv, not the command string" in capsys.readouterr().out
+
+
+class TestRequiredArgumentsMustCarryText:
+    """`required=True` asserts a flag is PRESENT, not that it has a value.
+
+    `--approved-by ""` satisfied the parser and wrote an ACTIVE lesson (and an
+    active rule) with no attribution at all, which is the attribution guarantee
+    failing while every gate stayed green.
+    """
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n "])
+    def test_a_blank_approver_cannot_approve_a_lesson(self, mod, db, capsys, blank):
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        with pytest.raises(SystemExit) as excinfo:
+            run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", blank)
+        assert excinfo.value.code == 2
+        run(mod, db, "list", "lessons")
+        row = out_json(capsys)[0]
+        assert row["active"] == 0, "a refused approval must not activate the lesson"
+        assert row["approved_by"] is None
+
+    @pytest.mark.parametrize(
+        "field,value,reason,approver",
+        [
+            ("scope", "v", "r", ""),
+            ("scope", "v", "", "zejiangg"),
+            ("scope", "", "r", "zejiangg"),
+            ("", "v", "r", "zejiangg"),
+        ],
+    )
+    def test_a_rule_needs_text_in_every_attribution_field(
+        self, mod, db, capsys, field, value, reason, approver
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            run(
+                mod,
+                db,
+                "add-rule",
+                "--field",
+                field,
+                "--value",
+                value,
+                "--reason",
+                reason,
+                "--approved-by",
+                approver,
+            )
+        assert excinfo.value.code == 2
+        run(mod, db, "list", "rules")
+        assert out_json(capsys) == [], "a refused rule must not be written"
+
+    def test_a_blank_finding_field_is_refused(self, mod, db, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            run(mod, db, "add-finding", "--surface", "  ", "--title", "t", "--severity", "Low")
+        assert excinfo.value.code == 2
+        run(mod, db, "list", "findings")
+        assert out_json(capsys) == []
+
+    def test_a_blank_verdict_is_refused(self, mod, db, capsys):
+        """A blank verdict folds into `final_verdict = ""`, which reads as
+        "no verdict" while a row exists -- indistinguishable from an unjudged
+        finding."""
+        finding = a_finding(mod, db, capsys)
+        with pytest.raises(SystemExit) as excinfo:
+            run(
+                mod,
+                db,
+                "record-verdict",
+                "--finding",
+                str(finding),
+                "--role",
+                "auditor",
+                "--verdict",
+                "",
+            )
+        assert excinfo.value.code == 2
+        run(mod, db, "list", "verdicts")
+        assert out_json(capsys) == []
+
+    def test_a_blank_lesson_field_is_refused(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        with pytest.raises(SystemExit) as excinfo:
+            run(
+                mod,
+                db,
+                "propose-lesson",
+                "--kind",
+                "missed",
+                "--surface",
+                "s",
+                "--pattern",
+                "",
+                "--guidance",
+                "g",
+                "--source-finding",
+                str(finding),
+            )
+        assert excinfo.value.code == 2
+        run(mod, db, "list", "lessons")
+        assert out_json(capsys) == []
+
+    def test_surrounding_whitespace_is_stripped_not_stored(self, mod, db, capsys):
+        """A trailing space in an approver name is noise, not identity -- storing
+        it would make two spellings of one person look like two approvers."""
+        finding = a_finding(mod, db, capsys)
+        lesson = a_lesson(mod, db, capsys, finding, approve=False)
+        assert (
+            run(mod, db, "approve-lesson", "--id", str(lesson), "--approved-by", "  zejiangg  ")
+            == 0
+        )
+        capsys.readouterr()
+        run(mod, db, "list", "lessons")
+        assert out_json(capsys)[0]["approved_by"] == "zejiangg"
+
+    def test_the_validator_guards_every_required_text_argument(self, mod):
+        """Applied at the declaration, so the NEXT required argument added here is
+        covered without anyone remembering. Every `required=True` must either be
+        numeric or carry the validator.
+        """
+        source = script_source_with_joined_literals()
+        offenders = [
+            line.strip()
+            for line in source.splitlines()
+            if "add_argument(" in line
+            and "required=True" in line
+            and "type=nonblank" not in line
+            and "type=int" not in line
+        ]
+        assert offenders == [], offenders
+
+    def test_the_validator_itself_accepts_and_rejects(self, mod):
+        assert mod.nonblank(" value ") == "value"
+        for blank in ("", " ", "\t\n"):
+            with pytest.raises(Exception):
+                mod.nonblank(blank)
+
+
+class TestTheCliDoesNotClaimToAuthenticate:
+    """GPT round-2 F1, answered as prose rather than as a guard.
+
+    The CLI cannot tell a human from an agent, and adding a check that pretends to
+    would be the same overclaim in code. What it CAN do is not assert a boundary it
+    has not got, so the docstring now names filesystem ownership as the real one.
+    """
+
+    def test_the_docstring_names_the_trust_boundary(self, mod):
+        doc = mod.__doc__ or ""
+        assert "not an authentication boundary" in doc
+        assert "UNVERIFIED caller assertions" in doc
+        assert "filesystem ownership" in doc
+
+    def test_human_is_still_a_writable_role(self, mod, db, capsys):
+        """Deliberately NOT refused. The RFC's fold needs human rows, and refusing
+        them here would only push the same write to `sqlite3` while reading as a
+        control -- the boundary is the file, not this argument parser.
+        """
+        finding = a_finding(mod, db, capsys)
+        assert (
+            run(
+                mod,
+                db,
+                "record-verdict",
+                "--finding",
+                str(finding),
+                "--role",
+                "human",
+                "--verdict",
+                "confirmed",
+            )
+            == 0
+        )
+        assert out_json(capsys)["final_verdict"] == "confirmed"
+
+
+class TestSeedLessonsBudgetAndOrder:
+    def test_output_never_exceeds_the_byte_budget(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        for index in range(12):
+            a_lesson(mod, db, capsys, finding, pattern=f"pattern-{index}", guidance="g" * 40)
+        budget = 300
+        assert (
+            run(
+                mod,
+                db,
+                "seed-lessons",
+                "--surface",
+                "security.is_denied",
+                "--budget-bytes",
+                str(budget),
+            )
+            == 0
+        )
+        text = capsys.readouterr().out
+        assert len(text.encode("utf-8")) <= budget
+        # and the budget is doing real work, not trivially satisfied
+        assert 0 < len(text.strip().splitlines()) < 12
+
+    def test_a_zero_budget_emits_nothing(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        a_lesson(mod, db, capsys, finding)
+        assert (
+            run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "0")
+            == 0
+        )
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "no approved lesson fits" in captured.err
+
+    def test_a_negative_budget_is_exit_2(self, mod, db, capsys):
+        assert run(mod, db, "seed-lessons", "--surface", "s", "--budget-bytes", "-1") == 2
+        assert "must not be negative" in capsys.readouterr().err
+
+    def test_surface_match_outranks_recency(self, mod, db, capsys):
+        """A newer lesson about another surface must not displace an older one
+        about the surface being audited — otherwise the seed drifts off-topic
+        exactly as the budget tightens."""
+        finding = a_finding(mod, db, capsys)
+        a_lesson(mod, db, capsys, finding, surface="security.is_denied", pattern="on-surface")
+        a_lesson(mod, db, capsys, finding, surface="webhooks", pattern="off-surface")
+        run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "4000")
+        lines = capsys.readouterr().out.strip().splitlines()
+        assert "on-surface" in lines[0]
+        assert "off-surface" in lines[1]
+
+    def test_within_one_surface_the_newest_comes_first(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        a_lesson(mod, db, capsys, finding, pattern="older")
+        a_lesson(mod, db, capsys, finding, pattern="newer")
+        run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "4000")
+        lines = capsys.readouterr().out.strip().splitlines()
+        assert "newer" in lines[0]
+        assert "older" in lines[1]
+
+    def test_truncation_takes_the_priority_prefix_not_a_best_fit_pack(self, mod, db, capsys):
+        """A long top-priority lesson ENDS the list rather than being skipped so
+        a shorter, lower-priority one can slip in — skipping would silently
+        reorder the ranking the caller asked for."""
+        finding = a_finding(mod, db, capsys)
+        a_lesson(mod, db, capsys, finding, pattern="short-and-old")
+        a_lesson(mod, db, capsys, finding, pattern="long-and-new", guidance="g" * 400)
+        run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "200")
+        assert capsys.readouterr().out == ""
+
+    def test_every_seed_line_carries_its_source_finding(self, mod, db, capsys):
+        finding = a_finding(mod, db, capsys)
+        a_lesson(mod, db, capsys, finding)
+        run(mod, db, "seed-lessons", "--surface", "security.is_denied", "--budget-bytes", "4000")
+        assert f"(finding #{finding})" in capsys.readouterr().out
+
+
+class TestExportRoe:
+    def test_only_active_rules_are_exported_and_they_group_by_field(self, mod, db, capsys):
+        run(
+            mod,
+            db,
+            "add-rule",
+            "--field",
+            "scope",
+            "--value",
+            "kirodotdev/KiroCrew",
+            "--reason",
+            "pilot target",
+            "--approved-by",
+            "zejiangg",
+        )
+        live_scope = out_json(capsys)["id"]
+        run(
+            mod,
+            db,
+            "add-rule",
+            "--field",
+            "scope",
+            "--value",
+            "src/kiro_crew/security.py",
+            "--reason",
+            "surface 1",
+            "--approved-by",
+            "zejiangg",
+        )
+        run(
+            mod,
+            db,
+            "add-rule",
+            "--field",
+            "forbidden",
+            "--value",
+            "no production systems",
+            "--reason",
+            "blast radius",
+            "--approved-by",
+            "zejiangg",
+        )
+        reverted = out_json(capsys)["id"]
+
+        conn = mod.connect(db)
+        try:
+            conn.execute("UPDATE roe_rules SET active = 0 WHERE id = ?", (reverted,))
+            conn.commit()
+        finally:
+            conn.close()
+
+        run(mod, db, "export-roe")
+        exported = out_json(capsys)
+        assert sorted(exported) == ["scope"]
+        assert len(exported["scope"]) == 2
+        assert live_scope in [entry["id"] for entry in exported["scope"]]
+        # A reverted rule is ABSENT, not present-and-flagged: a consumer that
+        # ignores an `active` field must not be able to read it as live.
+        assert "forbidden" not in exported
+        assert all("active" not in entry for entry in exported["scope"])
+
+    def test_every_exported_rule_is_attributable(self, mod, db, capsys):
+        run(
+            mod,
+            db,
+            "add-rule",
+            "--field",
+            "allowed_techniques",
+            "--value",
+            "code review",
+            "--reason",
+            "static only by default",
+            "--approved-by",
+            "zejiangg",
+        )
+        run(mod, db, "export-roe")
+        entry = out_json(capsys)["allowed_techniques"][0]
+        assert entry["reason"] == "static only by default"
+        assert entry["approved_by"] == "zejiangg"
+        assert entry["ts"]
+
+    def test_a_rule_without_a_reason_or_approver_cannot_be_added(self, mod, db):
+        with pytest.raises(SystemExit) as excinfo:
+            run(mod, db, "add-rule", "--field", "scope", "--value", "everything")
+        assert excinfo.value.code == 2
+
+    def test_an_empty_ledger_exports_an_empty_object(self, mod, db, capsys):
+        run(mod, db, "export-roe")
+        assert out_json(capsys) == {}
+
+
+class TestListing:
+    def test_rules_lists_the_roe_rules_table(self, mod, db, capsys):
+        run(
+            mod,
+            db,
+            "add-rule",
+            "--field",
+            "scope",
+            "--value",
+            "v",
+            "--reason",
+            "r",
+            "--approved-by",
+            "zejiangg",
+        )
+        capsys.readouterr()
+        run(mod, db, "list", "rules")
+        rows = out_json(capsys)
+        assert [row["field"] for row in rows] == ["scope"]
+        assert rows[0]["active"] == 1
+
+    def test_findings_paths_round_trip_as_a_sorted_json_list(self, mod, db, capsys):
+        """Enough paths that set-iteration order is not sorted order by accident:
+        two elements can round-trip correctly under a mutation that drops the sort
+        entirely, which is exactly what the red-before harness caught."""
+        given = ["z.py", "b.py", "m.py", "a.py", "q.py", "c.py", "y.py"]
+        argv = ["add-finding", "--surface", "s", "--title", "t", "--severity", "Low"]
+        for path in given:
+            argv += ["--path", path]
+        run(mod, db, *argv)
+        capsys.readouterr()
+        run(mod, db, "list", "findings")
+        stored = json.loads(out_json(capsys)[0]["paths"])
+        assert stored == sorted(given)
+        assert stored != given, "the input order must not already be sorted"
+
+    def test_an_unknown_table_is_refused(self, mod, db):
+        with pytest.raises(SystemExit) as excinfo:
+            run(mod, db, "list", "secrets")
+        assert excinfo.value.code == 2
+
+
+class TestDbFlagPosition:
+    """``--db`` has exactly ONE position: before the subcommand, as documented.
+
+    Accepting it on both sides was tried and removed. It needed a second
+    declaration defaulting to ``argparse.SUPPRESS`` -- with ``None`` the subparser
+    silently overwrote a value given before the subcommand whenever it was
+    omitted after it -- and that trap is not worth carrying for a flag whose
+    normal case is to be omitted. The usage block now states the one position, so
+    argparse refusing the other is the contract rather than the defect a reviewer
+    first reported.
+    """
+
+    def test_before_the_subcommand_is_the_documented_position(self, mod, tmp_path, capsys):
+        target = tmp_path / "before.db"
+        assert mod.main(["--db", str(target), "init"]) == 0
+        assert json.loads(capsys.readouterr().out)["db"] == str(target)
+        assert target.exists()
+
+    def test_after_the_subcommand_is_refused(self, mod, tmp_path):
+        """Pinned deliberately: the previous defect was the USAGE BLOCK promising
+        this spelling, not argparse declining it."""
+        with pytest.raises(SystemExit) as excinfo:
+            mod.main(["init", "--db", str(tmp_path / "after.db")])
+        assert excinfo.value.code == 2
+
+    def test_the_usage_block_documents_the_position_it_accepts(self, mod):
+        """The doc and the parser must not drift apart again -- that drift IS the
+        finding this replaced."""
+        doc = mod.__doc__ or ""
+        assert "``--db PATH`` goes BEFORE the subcommand" in doc
+        assert "python3 ledger.py [--db PATH] init" in doc
+
+
+class TestDefaultDbPath:
+    def test_the_default_path_follows_the_data_home(self, mod, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "crew"))
+        assert mod.default_db_path() == tmp_path / "crew" / "security-conductor" / "findings.db"
+
+    def test_the_parent_directory_is_created_on_demand(self, mod, tmp_path, capsys):
+        target = tmp_path / "nested" / "deeper" / "findings.db"
+        assert mod.main(["--db", str(target), "init"]) == 0
+        capsys.readouterr()
+        assert target.exists()


### PR DESCRIPTION
## Problem / Motivation

The security conductor has no memory. Its RFC ([#9195](https://github.com/kirodotdev/KiroCrew/pull/9195)) describes a fleet of auditors whose dominant noise source is hallucinated vulnerabilities, and whose rules of engagement must be machine-checked rather than requested in a prompt. Neither is possible today: there is nowhere to record a finding, nowhere to keep the auditor-versus-verifier disagreement that turns a claim into evidence, nowhere to hold a lesson learned from a false positive, and nothing for `scope_check.py` to read when it answers "is this in scope?". `security-conductor` and `roe_rules` return zero hits in the tree.

## Why it matters

A round that does not remember the last one repeats its false positives, and that is the cost that decides whether the whole use case is affordable: the verification pass is the product, so re-litigating the same rejected finding every round is the failure mode, not an inefficiency. Two properties in particular cannot live in a prompt and survive an unattended cycle:

- **A verdict that can be overwritten is not evidence.** If the last writer wins, an auditor re-filing after a verifier rejected silently flips the finding back to confirmed, and the disagreement a human needs to read is gone.
- **An unapproved lesson reaching a seed message is an unreviewed instruction to an auditor.** The retrospective lane proposes guidance from its own reading of a round; a human ruling on it is the gate, and a gate implemented as prompt tone degrades across a long session.

## What changed (motivation → approach → change)

**Goal:** M1 of the RFC — the schema plus `scripts/ledger.py`, with behaviour pinned by tests.

**Approach.** SQLite, following what this tree already does for durable agent knowledge (`memory.py`, `vector_memory.py`, `knowledge/store.py`): one database at `<data_home>/security-conductor/findings.db`, `CREATE TABLE IF NOT EXISTS` DDL behind a `schema_version` row, and SQLite imported through `src/kiro_crew/_sqlite_compat.py`. The alternative — JSON or YAML files per finding — was rejected by the RFC and is worse here for a specific reason: the guarantees below are storage-layer constraints (`CHECK`, `NOT NULL REFERENCES`, `UNIQUE`), and in a file store each becomes a convention that the next writer has to remember.

A skill's scripts are synced *out* of the package tree (into the skills directory) and run as bare files, so the shim import is a `try` with a plain `sqlite3` fallback. That fallback is safe here specifically because this ledger uses no FTS5 — it is four ordinary tables — which is the only capability the shim exists to secure; the comment at the import says so.

**This CLI is not an authentication boundary, and the docstring now says so.** `--role human` and `--approved-by` are unverified caller assertions; nothing here can tell a human at a terminal from an agent running the same command. The boundary is filesystem ownership of `findings.db`: anything that can run this script can run `sqlite3` against the same file, so authenticating the CLI would move no boundary — it would only make the weakest path less obvious. A deployment that needs an enforced human gate has to own the file under a different uid than the agent, which is a deployment property this script cannot assert and one the RFC does not yet decide. What the guarantees below mean is narrower and honest: given whatever writes reach this script, it will not itself lose, reorder, or silently overwrite them. They are storage guarantees, not authorization ones.

**What was built.** `scripts/ledger.py`, a stdlib-only CLI (`init`, `add-finding`, `record-verdict`, `propose-lesson`, `approve-lesson`, `add-rule`, `export-roe`, `list`, `seed-lessons`), structured like the shipped `pipeline-conductor/scripts/*.py`: module docstring as the usage contract, JSON on stdout, exit 2 for malformed input or a missing referenced row, and a `data_home()` that resolves `$KIROCREW_HOME` without importing the package. Four tables exactly as the RFC states — `findings`, `verdicts`, `lessons`, `roe_rules` — plus `schema_version`. `verdicts` deliberately gets **no** surrogate key, because the RFC's schema gives it none and SQLite's implicit `rowid` already supplies the append order the fold needs; `TestSchemaMatchesTheRfc` asserts every table's columns rather than describing them, so a column added for convenience reds a test.

Four guarantees are held by the store rather than by an agent:

- **`verdicts` is append-only.** No `UPDATE` and no `DELETE` path to it anywhere in the CLI, so `findings.final_verdict` is a *fold* — `human > verifier > auditor`, recomputed on every append and never assigned — and `findings.auditor_verdict` / `verifier_verdict` are a materialised view of the same rows, so they cannot disagree with what they summarise. Precedence is by role, not by arrival.
- **A proposed lesson is inert, and its approval is write-once.** `propose-lesson` writes `active=0` and takes no flag that could write anything else; only `approve-lesson`, which requires a named approver, flips it; `seed-lessons` reads `active=1` only. Approval updates only a row still at `active=0`, so a second approval is a named refusal rather than a silent replacement of who approved it — `approved_by` names the approval that let a lesson into a seed, so overwriting it destroys the audit trail the human gate exists to leave. Approval does **not** restamp `ts`, so the column keeps one meaning (proposal time) and a batch of old approvals cannot outrank a genuinely fresh lesson.
- **The seed is bounded.** `seed-lessons --budget-bytes N` emits at most N bytes. Truncation takes the longest fitting *prefix* of the priority order (surface match, then recency) rather than packing best-fit, because skipping a lesson that does not fit to admit a lower-priority one silently reorders the ranking and "top-N" stops meaning top.
- **Every lesson is attributable in both directions.** `source_finding_id` is `NOT NULL REFERENCES findings(id)`, and `connect()` sets `PRAGMA foreign_keys=ON` — without which that declaration is decoration — so a human editing rows by hand cannot orphan a lesson either; and `approved_by` cannot be overwritten once set, nor written blank, nor replaced by deactivating the lesson and approving it again. `required=True` only asserts a flag is *present*, so `--approved-by ""` satisfied the parser and stored an active lesson with no attribution at all. Every required text argument now goes through one `nonblank` validator at its declaration, which also strips — a trailing space in an approver name is noise, not a second approver.

**No ordering in this store follows the wall clock.** `verdicts` and `lessons` each record their own sequence structurally — `rowid` and `id` — so the fold orders by `rowid` alone and lesson recency by `id` alone. Sorting by `ts` first handed that sequence to the system clock: after a rollback (an NTP correction, a restored VM snapshot, a bad container clock) a superseded verdict carries the *later* timestamp, so it sorted last and won, silently reinstating a call a human had already overruled. `rowid` cannot roll back. One consequence, stated plainly: a lesson can no longer be re-prioritised by editing its timestamp — `active` is the RFC's lever, and a human-settable priority belongs in a column that says so rather than in a field every reader also reads as "when".

Dedupe identity for a finding is `(surface, title, sorted paths)`, normalised at write time so the identity *is* the stored `paths` value: one exact-match lookup plus a `UNIQUE` index, rather than a scan that re-normalises every candidate row. A hit returns the original id untouched — the earlier row's severity, PoC and verdict history are the record, and a re-report is not evidence to overwrite them with.

**Every conditional write carries its precondition in the SQL, and the read above it only buys a better message.** That is one rule rather than three coincidences, and it is what four review rounds converged on. A concurrent double-insert trips the `UNIQUE` index; a concurrent approval fails `AND active = 0 AND approved_by IS NULL`; a concurrent `init` fails `WHERE NOT EXISTS`. In each the loser re-reads and reports the winner instead of printing a success line for a write that changed no row. `approve_lesson` is a module-level function like every other command's logic, which is what gives its race a seam a test can drive.

Two of those came from round 4. `init_schema` read `schema_version` and inserted when empty, which races on the *ordinary* path rather than only between two `init` calls — every command initialises first, so two parallel auditors both saw an empty table and both inserted, leaving a migration ladder two rows to branch on. And `AND active = 0` alone was the wrong precondition for approval: a lesson approved and then switched off by hand — the RFC's own revert path — still names its original approver, so re-approving overwrote the attribution the guard exists to protect. Requiring `approved_by IS NULL` narrows the write to a lesson never approved at all, and reactivating a deactivated one is a row edit, which the refusal says in as many words.

`--db` has one position, before the subcommand, and the usage block says so. Accepting it on both sides was tried and removed at a design lane's request: the second declaration had to default to `argparse.SUPPRESS`, because with `None` the subparser silently overwrote a value given *before* the subcommand every time it was omitted after it, and that trap is not worth carrying for a flag whose normal case is to be omitted entirely. Removing it also lands where the original reviewer finding pointed — its own proposed fix was the doc change.

`--status` is gone from `add-finding` for the same reason. The column stays, because the RFC's schema specifies it, but M1 ships no command that reads a finding's status and none that transitions it, so a creation-time knob would have been a setting nothing could act on. The milestone that adds the reader adds the transition and the flag with it.

Two deliberate omissions. `add-rule` requires `--reason` and `--approved-by`, because the RFC makes every widening of what an auditor may do attributable, so a rule with neither is not a rule. And there is no `deactivate-rule` command: the RFC makes reverting a rule a human row edit (`UPDATE roe_rules SET active=0`) with an audit trail, and the append-only ban covers `verdicts` specifically, not the whole database.

## Tests

97 tests in `test/test_security_conductor_ledger.py`, each driving the CLI through `main` with argv the way the skill invokes it, so a property that holds only in a directly-called helper does not count. What each group locks in:

- `TestSchemaMatchesTheRfc` — every table's exact column list, and that `verdicts`' append order is the implicit `rowid`.
- `TestVerdictsAreAppendOnly` — a second verdict from one role does not replace the first; plus a structural check that no line mentioning `verdicts` carries an `UPDATE` or `DELETE`, because the guarantee is the *absence* of a writer and only reading the SQL catches a later `amend-verdict` being added.
- `TestFinalVerdictIsAFold` — `human > verifier > auditor`; a weaker role arriving later does not win; the `findings` row matches the fold; two rows sharing one timestamp still fold deterministically.
- `TestSchemaVersionIsASingleton` — two connections initialising one fresh database write one row; six sequential commands still write one; the unique index refuses a duplicate written by hand; `init` still reports the version.
- `TestApprovalSurvivesADeactivation` — re-approval after a hand deactivation is refused, the original approver survives it, the refusal names the documented way back, the `WHERE` clause carries both conditions when driven at the SQL layer, and a never-approved lesson still approves.
- `TestNoWriteIsGatedOnlyByAPythonRead` — the retrospective's invariant as a scan: the `schema_version` insert carries its own precondition, every approval `UPDATE` requires an unset approver, the singleton index exists, and the literal-join helper the scans depend on actually collapses.
- `TestApprovalIsWriteOnce` — re-approval is refused and the first approver survives; a refused re-approval is distinguishable from a missing lesson (both exit 2, so the message is the only signal); the `AND active = 0` guard holds when driven at the SQL layer, not just in the Python branch; a concurrent approval reports `raced` instead of a false success, and that outcome reaches the operator as exit 2; approval still works the first time. Plus a structural check that every `UPDATE lessons ... active = 1` carries the guard.
- `TestRequiredArgumentsMustCarryText` — a blank or whitespace-only approver cannot approve a lesson and leaves it inactive; a rule needs text in every attribution field and a refused rule is not written; blank surface, verdict and pattern are refused; surrounding whitespace is stripped rather than stored. Plus a structural check that every `required=True` argument is either numeric or carries the validator, so the next one added is covered without anyone remembering.
- `TestTheCliDoesNotClaimToAuthenticate` — the docstring names the real trust boundary, and `--role human` is deliberately still writable, because refusing it here would push the same write to `sqlite3` while reading as a control.
- `TestOrderingSurvivesAClockRollback` — a rolled-back clock does not reinstate a superseded verdict; `ts` carries no weight at all (not merely tie-broken); the lesson-recency sibling holds; surface match still outranks recency. Plus a structural scan of every `ORDER BY` in the file for a bare `ts` term, so the *next* query added here cannot reintroduce it — and that detector carries its own test proving it fires.
- `TestDedupeIdentity` / `TestDedupeSurvivesTheRace` — re-adding returns the existing id and does not overwrite severity; path order and duplicate paths do not create a second finding; a different path set does; and a concurrent insert returns the existing id rather than raising, with the identity index proven to fire on direct SQL.
- `TestUnapprovedLessonsNeverSeed` / `TestSeedLessonsBudgetAndOrder` / `TestApprovalDoesNotRestampTheProposal` — an `active=0` lesson is absent from the seed and appears after approval; output never exceeds the budget; zero budget emits nothing; surface match outranks recency; newest first within a surface; truncation takes the prefix rather than best-fit packing; approval leaves `ts` alone.
- `TestExportRoe` — only `active=1` rules are exported, grouped by field; a reverted rule is *absent* rather than present-and-flagged, so a consumer ignoring an `active` field cannot read it as live; every entry carries its reason and approver.
- `TestRecordVerdictRejectsUnknownRoles` / `TestLessonsCiteAFinding` — unknown role is exit 2 and writes nothing (five spellings, including case and trailing space), and the `CHECK` constraint refuses it on direct SQL too; an unknown source finding and an unknown lesson kind are refused; the foreign key holds against hand-written SQL.
- `TestDbFlagPosition` / `TestDefaultDbPath` / `TestInit` / `TestListQueriesAreLiteral` / `TestSeedShortfallIsHonest` — `--db` before the subcommand works, after it is refused, and the usage block documents the position it accepts, so the doc and the parser cannot drift apart again (that drift was the finding, not argparse declining); the default path follows `$KIROCREW_HOME`; `init` is idempotent and does not stack version rows; every command creates the schema first, so a skill step that forgets `init` does not fail with `no such table`; no table name is interpolated into SQL; an empty ledger and a too-small budget report differently.

**Red-before proven on 32 mutations**, each reverted after: the `schema_version` insert stripped of its precondition, its singleton index downgraded to non-unique, approval accepting a deactivated lesson again, the dual-position `--db` re-added, the usage block no longer naming the position it accepts, the `nonblank` validator accepting an empty value, the validator no longer stripping, the validator dropped from the approver, the rule reason and the verdict, the approval `UPDATE` stripped of its `active = 0` guard, the already-approved branch removed, the rowcount check removed, each approval outcome left unreported by the CLI, the trust-boundary paragraph dropped from the docstring, `ts` restored as the fold's primary key, `ts` as its only key, the lesson site's `ts` ordering restored, the fold reversed to oldest-wins, reversed fold precedence, a seed query that ignores `active`, dropped path sorting, inverted path sorting, a budget that never stops, surface match dropped from the ranking, the role check removed, the dedupe lookup removed, its race recovery removed, the identity index downgraded to non-unique, a restamped approval, a surrogate key added to `verdicts`, `--db` accepted before the subcommand only, `--db` clobbering when omitted after it, the empty-ledger message merged with the tight-budget one, and `PRAGMA foreign_keys` left off. Every one reds this file.

The harness earns its keep by catching branches that are present but unreachable: the rowcount check for a raced approval passed every test with the check deleted, because the read above it caught every case the tests could produce. That is what prompted extracting `approve_lesson` into a module-level function — the seam a race test needs.

Round 4 caught a worse one, in the tests themselves. The structural scans matched one quoted string at a time, so a statement split across adjacent literals was only scanned up to its first fragment. Round 2's approval scan passed because that SQL sat on one line; adding a `WHERE` clause on a second line made it cover nothing. It failed loudly rather than approving silently, which is the only reason it surfaced. All the scans now collapse implicit concatenation first, the way Python does, and a test pins that the collapse works and that `"a", "b"` is left alone.

Two more proofs are worth naming, because both caught a test that only looked adequate. The `paths`-sorting assertion first used two paths, and a mutation dropping the sort entirely still passed it by set-iteration accident; it now uses seven whose set order is not their sorted order. And the `ts`-ordering scan first matched the substring `ts ` inside `verdicts `, so it failed on a correct file; it now inspects each `ORDER BY` term's leading token.

## Manual verification

N/A — this is a stdlib CLI over a local SQLite file with no external service, and the tests exercise it through its real entry point rather than through helpers.

## Related Issues

No linked issue: this implements M1 of the design of record, [PR #9195](https://github.com/kirodotdev/KiroCrew/pull/9195) (`docs/request-for-change/rfc-security-conductor.md`) — sections "Learning from past audits — the findings ledger is SQLite", "Finding schema and `finding-status/v1`", "The harness" item 5, and M1 under "Phases". The RFC tracks its own milestones, so there is no separate issue for this one to close.

Out of scope by design, owned by sibling work items: `SKILL.md`, `scope_check.py`, `finding_entry.py`, `verify_finding.py`, and the agent installer (`agent.py` / `subagent.py` / `agent_files.py`) are untouched here. A builtin-skill directory carrying only `scripts/` is inert — `skills.py`'s discovery walk skips a directory with no `SKILL.md`.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a docstring or comment states a guarantee that no test asserts, and the code does not implement it.

All four review rounds on this PR found exactly one instance each, and a retrospective in round 2 found the shared mechanism rather than treating each as unrelated. Round 0: a DDL comment claimed the `UNIQUE` index won a race the code lost. Round 1: a docstring claimed insertion order broke fold ties while a wall clock decided them. Round 2: a docstring claimed lessons are attributable and that approval "demands a named approver" while the approval `UPDATE` overwrote the approver, and it described the CLI as the human's editing surface, which reads as a claim that it authenticates its caller.

Round 3 is the pattern's fourth and cheapest instance, found by the reviewer as an advisory rather than a blocker: `required=True` on `--approved-by` read as "attribution is guaranteed" while an empty string satisfied it.

The fix is not four point patches. Every guarantee sentence in the module docstring now names a test, and the one claim that could not be implemented — an authenticated human gate in a local CLI over an owner-writable file — was removed rather than tested. Three narrower invariants are enforced mechanically for the next writer: `test_no_ordering_query_in_the_cli_sorts_by_ts` scans every `ORDER BY` for a bare `ts` term, `test_no_unguarded_approval_update_remains_in_the_cli` requires every `UPDATE lessons ... active = 1` to carry the `active = 0` guard, and `test_the_validator_guards_every_required_text_argument` requires every `required=True` argument to be numeric or non-blank-validated. Each is a scan over the file rather than a check on one call site, so it covers the site that does not exist yet.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the script's module docstring is its usage contract, matching the `pipeline-conductor` scripts; the RFC carries the design
- [x] No secrets, credentials, or internal references in the diff
