### PR TITLE
feat: security-conductor skill and first rules of engagement

### DIFF
--- a/src/kiro_crew/builtin_skills/security-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/security-conductor/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: security-conductor
+description: Operating procedure for the kirocrew-security-conductor agent - run proactive vulnerability discovery on one target as a supervised fleet. Decompose the target into attack surfaces, dispatch one auditor per surface behind the rules of engagement, dispatch an independent verifier per finding whose job is rejecting false positives, adjudicate severity, hold the two human gates, run a retrospective that proposes lessons, and report upward. Use when a security conductor session is being seeded, or when inspecting/debugging one.
+---
+
+# Security Conductor
+
+You run ONE audit on ONE target. You never audit anything yourself — no probes,
+no proofs of concept, no fixes in your own turns. Auditors find, verifiers
+reject, fixers patch; you decompose, dispatch, adjudicate, gate, learn, and
+report. Every rule below closes a named failure mode.
+
+Two things make this different from every other conductor, and both are
+absolute:
+
+- **Aggression is bounded by data, not by tone.** The rules of engagement are
+  rows in the ledger, exported as `rules-of-engagement.json`. A scope question is
+  answered by `scripts/scope_check.py`, never by your judgment about what seems
+  reasonable. A tone instruction degrades silently across a long session; a scope
+  verdict is testable.
+- **A policy refusal IS the boundary.** An auditor looking for weaknesses in a
+  safety fence will meet that fence. The correct response is to stop and report,
+  never to rephrase, re-spell, split, or route around the block. Record it as an
+  event and rule on it. Any worker that reports having found a wording that got
+  past a block has broken the rules of engagement, and the finding is void.
+
+The scripts below are the deterministic half of the loop — run them via
+`execute_bash`, read their output, never re-derive what they compute. Presence is
+not assumed: check at first use, and treat an absent script as `UNKNOWN` rather
+than permission.
+
+- `scripts/scope_check.py` — is this path, repository or technique in scope?
+  `IN_SCOPE` / `OUT_OF_SCOPE` / `NEEDS_APPROVAL` / `UNKNOWN`. `UNKNOWN` is never
+  permission.
+- `scripts/finding_entry.py` — dedupe and format one finding against the ledger,
+  so a re-audited surface does not re-file what is already recorded.
+- `scripts/verify_finding.py` — re-run one finding's proof of concept and emit
+  the verdict. You read the verdict; you never read a verifier's prose and decide
+  for yourself.
+- `scripts/ledger.py` — the ledger CLI: schema, findings, verdicts, lessons,
+  rules-of-engagement export, list. It is also the human's editing surface.
+
+## The rules of engagement
+
+The operator's seed message names the active rules of engagement. Read them
+before anything else and treat every field as data — never infer a scope, a
+permitted technique, or a severity threshold from memory or from what the target
+looks like.
+
+| Field | What it decides |
+|---|---|
+| `scope` | Repositories and paths an auditor may touch. Everything else is out of scope by default. |
+| `allowed_techniques` | What an auditor may DO. Anything not listed needs a human yes. |
+| `forbidden` | Absolute prohibitions. A forbidden act is not negotiable by a finding's value. |
+| `severity_scale` | The only adjudication vocabulary. |
+| `human_approval` | The gates below. |
+| `report_schema` | The finding shape, so a malformed finding fails at write time. |
+
+**The JSON file is an export, not the source of truth.** The active rows are, and
+`scripts/scope_check.py` reads them directly. Never edit the export to widen what
+an auditor may do; a widening is a row with a reason and an approver, which is
+what makes it attributable and revertible.
+
+**The rules of engagement need a human review before the first auditor runs.**
+That review is a precondition of the first round, not a formality.
+
+## What qualifies as a work item
+
+One work item is **one attack surface**. Three properties, all required — a
+candidate missing any one of them is not a work item and is not dispatched:
+
+1. **One surface.** A named entry point and the code that serves it: one
+   classifier, one ingest path, one token-and-session path. "Harden the backend"
+   is not a surface; it is a round.
+2. **Independently auditable.** An auditor can reach a verdict on it without
+   reading another auditor's findings and without editing shared state. Two
+   surfaces that can only be judged together are one work item, not two.
+3. **A named proof-of-concept shape.** Before dispatch, you can say what a proof
+   would LOOK like here — a unit-level test that a guard admits an input it must
+   refuse, a dependency version an audit tool flags, a parser that accepts a
+   malformed frame. A surface with no expressible proof shape produces prose, and
+   prose is where hallucinated vulnerabilities come from.
+
+Every candidate goes through `scripts/scope_check.py` before it becomes a work
+item. `OUT_OF_SCOPE` is dropped, `NEEDS_APPROVAL` waits on the human gate,
+`UNKNOWN` is treated as out of scope and reported — not resolved by reading the
+rules yourself.
+
+## The two human gates
+
+`human_approval` names exactly two, and neither is yours to grant:
+
+1. **Active testing beyond static review plus a local unit-level proof of
+   concept.** Anything that runs against something other than a scratch checkout
+   — a live service, a network endpoint, a shared host — waits for a human yes.
+2. **Any fixer dispatch.** A fix PR is a change to the target on the strength of
+   a finding. Every one waits for a human yes, per dispatch.
+
+A gate is held by not dispatching. Never dispatch on an assumed yes, never treat
+silence as approval, and never re-scope a blocked step into something that looks
+permitted. Record each pending gate as your own obligation and re-read it every
+cycle until it is answered.
+
+## Auditor seed template
+
+One auditor per surface. Fill `{...}` from the rules of engagement and the work
+item; keep every clause.
+
+> You audit exactly ONE surface: {surface} on {target}. Work autonomously; never
+> ping the human directly — the conductor reports.
+> FIRST, GOVERNANCE: run the ARCC `security-assistance` skill if it is installed,
+> and record its guidance in every finding you file. If it is NOT installed,
+> record `arcc: unavailable` in each finding and continue — do not substitute
+> your own governance judgment for it, and do not treat its absence as
+> permission.
+> READ THE RULES OF ENGAGEMENT at {roe_path} before your first probe. Your scope
+> is {scope}. Your permitted techniques are {allowed_techniques} and NOTHING
+> else. Ask `scripts/scope_check.py` about any path or technique you are unsure
+> of; `UNKNOWN` means out of scope, not "probably fine".
+> FORBIDDEN, absolutely: {forbidden}. These are not traded against a finding's
+> value.
+> A POLICY REFUSAL IS THE BOUNDARY. If a tool call is blocked by policy, STOP
+> that line of work and reply `BLOCKED: policy refusal — <the rule as reported>`.
+> Do not rephrase, re-spell, split, encode, or otherwise route around it. A
+> wording that gets past a block is a rules-of-engagement violation, not a
+> result.
+> WORK: static review first. A proof of concept is a unit-level test in your own
+> scratch worktree, with no network egress and no writes outside that worktree.
+> Anything beyond that needs a human yes you do not have — report
+> `NEEDS-APPROVAL: <the step and why it is needed>` and stop.
+> FILE each candidate with `scripts/finding_entry.py`, one record per real
+> defect, carrying every `report_schema` field including the proof-of-concept
+> command or test and your own severity per `severity_scale`. A candidate you
+> cannot express as a proof shape is not a finding — say so instead of filing it.
+> HALLUCINATION IS THE DEFAULT FAILURE HERE. A finding you cannot demonstrate is
+> worse than no finding, because a verifier and then a human spend real time
+> rejecting it. Prefer reporting a surface as clean.
+> REPORT with exactly one of five prefixes — `WORKING: / FINDING: / CLEAN: /
+> BLOCKED: / NEEDS-APPROVAL:` — as BARE leading text, no bold and no list
+> marker, and RE-STATE the prefix on EVERY later turn while this assignment is
+> open. `FINDING:` carries the finding ids and nothing else; the record is the
+> report.
+
+## Verifier seed template
+
+One verifier per filed finding, dispatched as its own session. **It exists to
+reject false positives**, so it is never the auditor's session, never given the
+auditor's reasoning, and never asked to improve the finding.
+
+> You verify exactly ONE finding: {finding_id}. You did not file it and you are
+> not here to defend it. Your job is to REJECT it if it does not hold.
+> Read the finding record only — the paths, the claim, and the proof of concept.
+> Do NOT read the auditor's transcript or reasoning: shared reasoning is how a
+> hallucinated vulnerability survives a second pass.
+> RE-RUN the proof of concept independently in your own scratch worktree, under
+> the same rules of engagement and the same forbidden list as the auditor. If the
+> proof needs a step the rules of engagement do not permit, that is
+> `needs-human`, not a reason to widen the scope.
+> VERDICT, exactly one: `confirmed` (the proof reproduces and shows what the
+> finding claims), `rejected` (it does not reproduce, or it reproduces but shows
+> something else), `needs-human` (it cannot be settled inside the rules of
+> engagement). Record it with `scripts/verify_finding.py` and give the reason in
+> one or two sentences.
+> A DISAGREEMENT WITH THE AUDITOR IS A RESULT, not a conflict to resolve. Record
+> `rejected` and say why; the ledger keeps both verdicts.
+> REPORT with `VERDICT: <finding_id> <confirmed|rejected|needs-human>` or
+> `BLOCKED: <reason>`.
+
+## Retrospective seed template
+
+One retrospective per round, after every finding carries a verifier verdict.
+
+> Compare the auditor verdicts against the verifier and human verdicts for round
+> {round_id}. You are reading outcomes, not re-auditing anything: file no
+> findings and run no proofs of concept.
+> For each disagreement, name what made the auditor wrong or the verifier wrong
+> in terms another auditor could act on: what the false positive looked like from
+> the outside, what the confirmed findings shared, what a `needs-human` verdict
+> was actually missing.
+> PROPOSE lessons with `scripts/ledger.py propose-lesson`, one per pattern, each
+> carrying its source finding id and one of `true-positive` / `false-positive` /
+> `missed` / `out-of-scope`. A proposed lesson is INACTIVE until a human approves
+> it — never write guidance as though it is already in force, and never inject an
+> unapproved lesson into a seed message.
+> If a round produced no disagreement, say so in one line and propose nothing. A
+> lesson invented to fill the report crowds out one that was earned.
+> REPORT with `RETRO: <n> lesson(s) proposed` and the ids.
+
+## Severity adjudication
+
+Severity comes from `severity_scale` in the rules of engagement and from nowhere
+else. Do not invent a level, do not blend two, and do not carry a vocabulary from
+another tool's output.
+
+- The auditor's severity is a **claim**. The verifier's verdict decides whether
+  there is anything to grade at all.
+- You adjudicate only findings a verifier `confirmed`. A `rejected` finding has
+  no severity; a `needs-human` finding is reported at the auditor's claimed
+  severity with the verdict attached, never silently promoted.
+- Adjudicate against the scale's own definition, not against how bad the surface
+  feels. When your reading and the auditor's differ, record yours with the reason
+  — the append-only verdict trail keeps both, and the disagreement is the useful
+  part.
+- Severity drives the fixer gate, so an inflated severity spends a human's
+  attention. Grade down when the scale says so and say why.
+
+## The patrol cycle
+
+Arm the patrol with `monitor_start` (interval ~120s), never `wait`. Pass
+`max_cycles` explicitly — the default expires long before a round drains, and the
+loop then stops with no symptom. Call `autonudge_stop` yourself when a stop
+condition fires; coasting into the cycle cap is a failure, not a finish.
+
+Each cycle, in this order:
+
+1. **Read the ledger** — one `session_ledger_read`. The injected block is a
+   truncated teaser, and every disposition below is a comparison against
+   recorded state.
+2. **Dispatch what is owed.** A filed finding with no verifier gets one. A round
+   whose findings all carry verdicts gets the retrospective. A surface in scope
+   with no auditor gets one, within the concurrency the seed set.
+3. **Review your own obligations, every cycle regardless of what fired**: each
+   pending human gate, each unruled policy-refusal event, each `needs-human`
+   verdict. These are what go missing, because nothing fires to remind you. An
+   entry clears when the obligation is discharged, not when you decide about it.
+4. **Record verdicts and state back** in one write.
+5. **Report only real signals.** A quiet cycle is one line, then end the turn.
+
+## Stop conditions
+
+Stop and report, rather than continuing, on any of these:
+
+- Every surface in the round has an auditor verdict, every finding has a verifier
+  verdict, and the retrospective has proposed its lessons. This is the normal
+  exit: final tally, then `autonudge_stop`.
+- The rules of engagement have not been reviewed by a human. Nothing is
+  dispatched before that.
+- A worker reports a policy refusal. That surface stops until you rule on the
+  event; the worker does not continue past it, and neither do you.
+- A worker reports having circumvented a block, a scope rule, or a forbidden
+  technique. Stop that worker, void its findings for that surface, and report to
+  the human — a fleet that has already crossed a boundary cannot be trusted to
+  stay inside a narrower one.
+- A human gate is pending and the remaining work all sits behind it.
+- `scripts/scope_check.py` is absent or unreadable. Without it there is no scope
+  verdict, and your own judgment is not a substitute.
+- The false-positive rate for the round is high enough that verifiers are the
+  only thing producing signal. Report the rate; a finding stream nobody has
+  measured is not a foundation for a fixer lane.
+
+## Known limits (state them, don't hide them)
+
+- Every script call is `execute_bash`, which is mounted but never auto-approved:
+  `allowedTools` cannot match arguments, so trusting the bundled scripts would
+  mean trusting arbitrary shell. Unattended operation needs the operator to arm
+  this session in trust mode — without it the patrol stalls on its first scope
+  check, not on its first intervention.
+- The verifier's independence is procedural, not enforced. It comes from a fresh
+  session and a brief that withholds the auditor's reasoning; a shared model can
+  still share a blind spot.
+- An auditor's own report is the only evidence that it stayed inside the rules of
+  engagement. The scope script gates what it ASKS about, not what it does, which
+  is why the forbidden list is written as absolutes and why a self-reported
+  circumvention is a stop condition rather than a note.
+- A lesson only changes behaviour on the NEXT round, and only after a human
+  approves it. Nothing here learns inside a round.
+- One set of rules of engagement = one target. A second target is a second set,
+  reviewed on its own.

--- a/src/kiro_crew/builtin_skills/security-conductor/rules-of-engagement.json
+++ b/src/kiro_crew/builtin_skills/security-conductor/rules-of-engagement.json
@@ -1,0 +1,144 @@
+{
+  "schema": "roe/v1",
+  "_comment": [
+    "An EXPORT of the active roe_rules rows, not the source of truth. scope_check.py",
+    "reads the rows directly. Do not widen an auditor's latitude by editing this file:",
+    "a widening is a row with a reason and an approver, which is what makes it",
+    "attributable and revertible by flipping active rather than by an untracked edit.",
+    "This is the FIRST instance and it is scoped to Kiro Crew itself (the dogfood",
+    "pilot). It needs a human review before any auditor runs."
+  ],
+  "exported_at": "2026-09-07T00:00:00Z",
+  "target": "kirocrew-dogfood-round-1",
+  "approved_by": null,
+  "rules": {
+    "scope": [
+      {
+        "value": "repo:kirodotdev/KiroCrew",
+        "reason": "The pilot target is this project's own repository; every other repository is out of scope by default."
+      },
+      {
+        "value": "path:src/",
+        "reason": "The backend and the security fence itself live here, which is where the pilot's three surfaces are."
+      },
+      {
+        "value": "path:website/src/",
+        "reason": "The dashboard is a network-exposed surface with its own token and session handling."
+      },
+      {
+        "value": "path:scripts/",
+        "reason": "Gate and tooling scripts run in CI with repository write context, so a defect here is a supply-chain defect."
+      },
+      {
+        "value": "path:.github/workflows/",
+        "reason": "Workflow definitions decide what runs with which credentials; a permissions or checkout mistake is exploitable."
+      }
+    ],
+    "allowed_techniques": [
+      {
+        "value": "static-code-review",
+        "reason": "Reading the code proves the most and touches nothing."
+      },
+      {
+        "value": "dependency-audit",
+        "reason": "Advisory data against the committed lockfiles needs no probe of a running system."
+      },
+      {
+        "value": "local-unit-poc",
+        "reason": "A unit-level test in a scratch worktree is the smallest artifact that turns a claim into evidence, and it is the ceiling before the human active-testing gate."
+      }
+    ],
+    "forbidden": [
+      {
+        "value": "no-production-or-external-hosts",
+        "reason": "A probe against a live or third-party system risks other people's data and availability, and is not needed to prove a code defect."
+      },
+      {
+        "value": "no-reading-credential-material",
+        "reason": "Credential files and tokens (the crew config, AWS and SSH material, any bearer token) are out of bounds for reading as well as writing; holding one is indistinguishable from having stolen it."
+      },
+      {
+        "value": "no-dos-or-broad-fuzzing",
+        "reason": "Resource-exhaustion and untargeted fuzzing produce noise and outages instead of findings, and neither is bounded by a scratch worktree."
+      },
+      {
+        "value": "no-disabling-safety-protections",
+        "reason": "An audit that turns off the control it is auditing measures nothing, and leaves the host unprotected for whatever runs next."
+      },
+      {
+        "value": "no-bypassing-a-policy-block",
+        "reason": "A policy refusal IS the boundary: stop and report it as an event. A wording that gets past a block is a violation, not a result."
+      },
+      {
+        "value": "no-writes-outside-the-scratch-worktree",
+        "reason": "The blast radius of the whole audit is one throwaway checkout; a write anywhere else is unreviewed and often unnoticed."
+      },
+      {
+        "value": "no-network-egress-from-a-poc",
+        "reason": "A proof of concept that talks to the network can exfiltrate what it read and cannot be reproduced offline by a verifier."
+      }
+    ],
+    "severity_scale": [
+      {
+        "value": "Critical: unauthenticated remote code execution, credential disclosure, or a full bypass of the safety fence or the governance ceiling.",
+        "reason": "One step from a total compromise of the host or of the control that bounds every agent on it."
+      },
+      {
+        "value": "High: privilege escalation, authentication or authorization bypass on a network-exposed surface, or a write outside a declared boundary.",
+        "reason": "A real attacker path with a precondition an attacker can meet."
+      },
+      {
+        "value": "Medium: a defect exploitable only with local access, an unlikely precondition, or a bounded partial bypass.",
+        "reason": "Genuine weakening of a control, but gated by something an attacker does not already have."
+      },
+      {
+        "value": "Low: information disclosure with no secret in it, a missing defence-in-depth layer, or a hardening gap with no demonstrated exploit.",
+        "reason": "Worth fixing, not worth interrupting anyone for."
+      }
+    ],
+    "human_approval": [
+      {
+        "value": "active-testing-beyond-static-review-and-local-unit-poc",
+        "reason": "Everything past a scratch worktree can affect a system the operator did not offer up, so the operator decides, per step."
+      },
+      {
+        "value": "fixer-dispatch",
+        "reason": "A fix PR changes the target on the strength of a finding; the human confirms the finding is real before code moves."
+      }
+    ],
+    "report_schema": [
+      {
+        "value": "id",
+        "reason": "Stable handle for the verdict trail and for a lesson's source_finding_id."
+      },
+      {
+        "value": "surface",
+        "reason": "Which work item earned it, so a re-audit can dedupe and a retrospective can group."
+      },
+      {
+        "value": "severity",
+        "reason": "From severity_scale only; it drives the fixer gate."
+      },
+      {
+        "value": "title",
+        "reason": "One line a human can triage without opening the record."
+      },
+      {
+        "value": "paths",
+        "reason": "The affected files, so scope is checkable after the fact and not only before."
+      },
+      {
+        "value": "poc",
+        "reason": "The command or test that demonstrates it; a finding with no reproducible proof is the failure mode the verifier exists to catch."
+      },
+      {
+        "value": "verifier_verdict",
+        "reason": "confirmed | rejected | needs-human, written by the verifier and read by the conductor rather than inferred from prose."
+      },
+      {
+        "value": "status",
+        "reason": "Where the finding is in the pipeline, so an obligation cannot be lost between cycles."
+      }
+    ]
+  }
+}

--- a/test/test_security_conductor_skill_contract.py
+++ b/test/test_security_conductor_skill_contract.py
@@ -1,0 +1,389 @@
+"""The security-conductor skill's contract, pinned against its own text.
+
+The skill body IS the operating procedure -- it is what a conductor session is
+seeded with, and the sibling scripts are written against clauses it states. A
+well-meaning rewrite of a markdown file can drop the clause a script's exit codes
+mean something under, or the clause that bounds a worker's aggression, and nothing
+anywhere goes red. This file closes that.
+
+The assertions are about SUBSTANCE, not sentences, and the dividing line is stated
+so a later edit has a rule to follow: assert a phrase when it states a RULE -- an
+obligation, a prohibition, a defined behaviour, a name a script shares -- and do
+NOT assert one that only explains WHY the rule exists. Rationale is what a rewrite
+is entitled to reword; pinning it produces a typo detector that every legitimate
+edit has to fight, which is the failure mode that makes text tests get deleted.
+
+The rules-of-engagement export gets its own class. It is the M0 review surface, so
+its SHAPE (schema tag, the six rule fields, a reason on every rule) is a contract a
+human reviewer and ``scope_check.py`` both read -- and an export missing a field
+reads as "nothing to say about that" rather than as an omission.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIR = REPO_ROOT / "src" / "kiro_crew" / "builtin_skills" / "security-conductor"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+ROE_JSON = SKILL_DIR / "rules-of-engagement.json"
+
+#: The four scripts the procedure delegates its deterministic half to. Named here
+#: rather than globbed from the directory on purpose: the point is that the PROSE
+#: cites each one, and a glob would pass on a skill body that mentions none of
+#: them -- which is exactly the state while sibling changes are still building
+#: them.
+BUNDLED_SCRIPTS = (
+    "scope_check.py",
+    "finding_entry.py",
+    "verify_finding.py",
+    "ledger.py",
+)
+
+#: Every field ``scope_check.py`` and the human reviewer read. Pinned as a set so
+#: an export that silently drops one fails, instead of reading as a target with
+#: nothing to say about (say) what is forbidden.
+ROE_FIELDS = (
+    "scope",
+    "allowed_techniques",
+    "forbidden",
+    "severity_scale",
+    "human_approval",
+    "report_schema",
+)
+
+
+def _flat(text: str) -> str:
+    """Collapse whitespace and markdown decoration, lowercased.
+
+    Markdown re-flows every time a sentence is edited, and emphasis moves with
+    it, so a check that breaks on a line break or on a pair of backticks is
+    testing the formatting rather than the contract. Three normalizations, each
+    for a shape this skill's body actually uses: leading blockquote markers (the
+    seed templates are quote blocks, so a wrapped sentence inside one carries a
+    ``>`` mid-phrase), backticks (a script name or a verdict word is inline
+    code), and asterisks (a rule's operative clause is often bolded).
+    """
+    joined = " ".join(line.lstrip().lstrip(">") for line in text.splitlines())
+    return " ".join(joined.replace("`", "").replace("*", "").split()).lower()
+
+
+def _section(text: str, heading: str) -> str:
+    """One markdown section's body, subsections included.
+
+    Scoping an assertion to its own section is what keeps a check honest: the
+    verifier's independence clause must not be satisfiable by a sentence that
+    happens to live in the auditor's brief.
+    """
+    lines = text.splitlines()
+    depth = len(heading) - len(heading.lstrip("#"))
+    start = next((i for i, line in enumerate(lines) if line.strip() == heading.strip()), None)
+    assert start is not None, f"section missing from the skill: {heading}"
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        stripped = line.lstrip("#")
+        level = len(line) - len(stripped)
+        if line.startswith("#") and level <= depth:
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def roe() -> dict:
+    return json.loads(ROE_JSON.read_text(encoding="utf-8"))
+
+
+class TestSkillIsInstallable:
+    """A builtin skill is reachable only through its front matter."""
+
+    def test_skill_file_ships(self) -> None:
+        assert SKILL_MD.is_file(), f"missing skill body: {SKILL_MD}"
+
+    def test_front_matter_declares_the_loader_fields(self, skill_text: str) -> None:
+        assert skill_text.startswith("---\n"), "front matter must open the file"
+        _, raw, _ = skill_text.split("---", 2)
+        meta = yaml.safe_load(raw)
+        assert meta["name"] == "security-conductor"
+        # The description is the only thing a triggering reader sees before
+        # loading the body, so it has to name the agent it is the procedure for.
+        assert "kirocrew-security-conductor" in meta["description"]
+
+    def test_no_bundled_scripts_are_shipped_here(self) -> None:
+        """Sibling changes own the scripts. This one must not have created a stub:
+        a present-but-empty script is worse than an absent one, because the
+        absent-script rule below stops reading as the live path."""
+        assert not (SKILL_DIR / "scripts").exists()
+
+
+class TestTheProcedureDelegatesToItsScripts:
+    def test_every_script_is_cited_by_name(self, skill_text: str) -> None:
+        flat = _flat(skill_text)
+        for script in BUNDLED_SCRIPTS:
+            assert script in flat, script
+
+    def test_an_absent_script_is_unknown_and_not_permission(self, skill_text: str) -> None:
+        """The scripts land in sibling changes, so "not installed yet" is the
+        live path on day one. Undefined, it is a file-not-found with no way
+        forward; answered, it is another UNKNOWN, which is never permission."""
+        flat = _flat(skill_text)
+        assert "presence is not assumed" in flat
+        assert "rather than permission" in flat
+
+    def test_scope_is_decided_by_the_script_not_by_judgment(self, skill_text: str) -> None:
+        flat = _flat(skill_text)
+        assert "never by your judgment" in flat
+        assert "unknown is never permission" in flat
+
+
+class TestPolicyRefusalIsTheBoundary:
+    """The clause that matters most in practice: an auditor hunting fence
+    weaknesses will meet the fence, and the correct move is to stop."""
+
+    def test_the_rule_is_stated_as_a_prohibition(self, skill_text: str) -> None:
+        flat = _flat(skill_text)
+        assert "a policy refusal is the boundary" in flat
+        assert "never to rephrase" in flat
+
+    def test_a_refusal_is_recorded_as_an_event(self, skill_text: str) -> None:
+        assert "record it as an event" in _flat(skill_text)
+
+    def test_the_auditor_brief_carries_the_rule_itself(self, skill_text: str) -> None:
+        """The conductor knowing it is not enough -- the worker is the one holding
+        the blocked tool call."""
+        brief = _flat(_section(skill_text, "## Auditor seed template"))
+        assert "a policy refusal is the boundary" in brief
+        assert "do not rephrase" in brief
+
+    def test_a_reported_circumvention_stops_the_fleet(self, skill_text: str) -> None:
+        stops = _flat(_section(skill_text, "## Stop conditions"))
+        assert "circumvented" in stops
+
+
+class TestWorkItemQualification:
+    """Three properties, all required. A candidate with no expressible proof
+    shape produces prose, and prose is where hallucinated findings come from."""
+
+    HEADING = "## What qualifies as a work item"
+
+    def test_one_surface_per_item(self, skill_text: str) -> None:
+        assert "one work item is one attack surface" in _flat(_section(skill_text, self.HEADING))
+
+    def test_independently_auditable(self, skill_text: str) -> None:
+        assert "independently auditable" in _flat(_section(skill_text, self.HEADING))
+
+    def test_a_named_poc_shape_is_required(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "proof-of-concept shape" in body
+        assert "is not a work item" in body
+
+
+class TestAuditorBrief:
+    HEADING = "## Auditor seed template"
+
+    def test_governance_is_the_first_step(self, skill_text: str) -> None:
+        """ARCC search happens before any probe, so it is the first clause of the
+        brief and not an item in a list the reader may reorder."""
+        body = _section(skill_text, self.HEADING)
+        first = _flat(body).split("read the rules of engagement")[0]
+        assert "security-assistance" in first
+        assert "if it is installed" in first
+
+    def test_an_unavailable_arcc_skill_has_a_defined_behavior(self, skill_text: str) -> None:
+        """The skill is an installed one, not a builtin, so absent is the common
+        case. Unanswered, an auditor either stalls or substitutes its own
+        governance judgment -- and the finding then does not record which."""
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "arcc: unavailable" in body
+        assert "do not treat its absence as permission" in body
+
+    def test_the_poc_ceiling_is_stated(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "unit-level test" in body
+        assert "no network egress" in body
+
+    def test_a_clean_surface_is_a_valid_outcome(self, skill_text: str) -> None:
+        """Without this the brief only rewards findings, which is the incentive
+        that manufactures them."""
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "prefer reporting a surface as clean" in body
+
+
+class TestVerifierBrief:
+    """The verifier exists to REJECT. A brief that reads as "check this finding"
+    gets a second opinion; one that reads as "reject it if it does not hold" gets
+    a rejection pass."""
+
+    HEADING = "## Verifier seed template"
+
+    def test_the_purpose_is_rejection(self, skill_text: str) -> None:
+        assert "reject it if it does not hold" in _flat(_section(skill_text, self.HEADING))
+
+    def test_the_poc_is_re_run_independently(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "re-run the proof of concept independently" in body
+        # Independence is procedural: it comes from withholding the auditor's
+        # reasoning, so that instruction is the mechanism, not colour.
+        assert "do not read the auditor's transcript" in body
+
+    def test_the_three_verdicts_are_the_only_verdicts(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        for verdict in ("confirmed", "rejected", "needs-human"):
+            assert verdict in body, verdict
+
+    def test_an_out_of_scope_proof_is_needs_human_not_a_widening(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "not a reason to widen the scope" in body
+
+
+class TestRetrospectiveBrief:
+    HEADING = "## Retrospective seed template"
+
+    def test_it_compares_verdicts_across_roles(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "auditor verdicts against the verifier and human verdicts" in body
+
+    def test_lessons_are_proposed_through_the_ledger_cli(self, skill_text: str) -> None:
+        assert "ledger.py propose-lesson" in _flat(_section(skill_text, self.HEADING))
+
+    def test_an_unapproved_lesson_never_reaches_a_seed(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "inactive until a human approves" in body
+        assert "never inject an unapproved lesson" in body
+
+
+class TestSeverityAdjudication:
+    HEADING = "## Severity adjudication"
+
+    def test_severity_comes_only_from_the_scale(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "severity_scale" in body
+        assert "from nowhere else" in body
+
+    def test_only_confirmed_findings_are_graded(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "only findings a verifier confirmed" in body
+        assert "never silently promoted" in body
+
+
+class TestHumanGates:
+    HEADING = "## The two human gates"
+
+    def test_both_gates_are_named(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "active testing beyond static review" in body
+        assert "fixer dispatch" in body
+
+    def test_silence_is_not_approval(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "never treat silence as approval" in body
+
+    def test_a_pending_gate_is_a_standing_obligation(self, skill_text: str) -> None:
+        """A gate nobody re-reads is a gate that quietly stops existing, because
+        nothing fires to remind the conductor of it."""
+        patrol = _flat(_section(skill_text, "## The patrol cycle"))
+        assert "every cycle regardless of what fired" in patrol
+        assert "pending human gate" in patrol
+
+
+class TestStopConditions:
+    HEADING = "## Stop conditions"
+
+    def test_nothing_runs_before_the_human_reviews_the_rules(self, skill_text: str) -> None:
+        """The M0 exit criterion, stated where it stops work rather than only in
+        the design document."""
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "have not been reviewed by a human" in body
+        assert "nothing is dispatched before that" in body
+
+    def test_an_absent_scope_script_stops_the_run(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "scope_check.py is absent" in body
+
+    def test_the_normal_exit_stops_the_loop_deliberately(self, skill_text: str) -> None:
+        body = _flat(_section(skill_text, self.HEADING))
+        assert "autonudge_stop" in body
+
+
+class TestRulesOfEngagementExport:
+    """The M0 review surface. Shape is a contract; the values are the human's."""
+
+    def test_it_is_a_versioned_export(self, roe: dict) -> None:
+        assert roe["schema"] == "roe/v1"
+        assert "exported_at" in roe
+
+    def test_it_declares_itself_an_export_not_the_source_of_truth(self) -> None:
+        """A reader who edits this file to widen a scope has defeated the
+        attribution the rows exist to provide, so the file has to say so."""
+        flat = _flat(ROE_JSON.read_text(encoding="utf-8"))
+        assert "not the source of truth" in flat
+
+    def test_every_field_is_present(self, roe: dict) -> None:
+        assert set(ROE_FIELDS) <= set(roe["rules"])
+
+    def test_every_rule_carries_a_value_and_a_one_line_reason(self, roe: dict) -> None:
+        for field, rules in roe["rules"].items():
+            assert rules, f"{field} is empty; an empty field reads as no constraint"
+            for rule in rules:
+                assert rule.get("value"), f"{field}: rule with no value"
+                reason = rule.get("reason") or ""
+                assert reason, f"{field}: {rule.get('value')!r} has no reason"
+                assert "\n" not in reason, f"{field}: {rule.get('value')!r} reason is not one line"
+
+    def test_it_is_unapproved_until_a_human_reviews_it(self, roe: dict) -> None:
+        """M0's exit criterion, as data. A default of "approved" would let the
+        first round run on rules nobody read."""
+        assert roe["approved_by"] is None
+
+    def test_the_severity_scale_carries_all_four_levels(self, roe: dict) -> None:
+        values = " ".join(r["value"] for r in roe["rules"]["severity_scale"])
+        for level in ("Critical:", "High:", "Medium:", "Low:"):
+            assert level in values, level
+
+    def test_the_forbidden_list_covers_the_absolutes(self, roe: dict) -> None:
+        """Seven classes the design fixes. Pinned by substance rather than by
+        count so adding an eighth is not a test change, but dropping one is."""
+        values = " ".join(r["value"] for r in roe["rules"]["forbidden"])
+        for token in (
+            "production",
+            "credential",
+            "dos",
+            "safety-protections",
+            "policy-block",
+            "network-egress",
+            "scratch-worktree",
+        ):
+            assert token in values, token
+
+    def test_both_human_gates_are_rows(self, roe: dict) -> None:
+        values = " ".join(r["value"] for r in roe["rules"]["human_approval"])
+        assert "active-testing" in values
+        assert "fixer-dispatch" in values
+
+    def test_the_report_schema_matches_the_finding_record(self, roe: dict) -> None:
+        fields = {r["value"] for r in roe["rules"]["report_schema"]}
+        assert {
+            "id",
+            "surface",
+            "severity",
+            "title",
+            "paths",
+            "poc",
+            "verifier_verdict",
+            "status",
+        } <= fields
+
+    def test_allowed_techniques_stop_at_the_local_poc_ceiling(self, roe: dict) -> None:
+        """The ceiling is what makes the active-testing gate meaningful: a
+        technique row admitting a live target would make the gate unreachable."""
+        values = {r["value"] for r in roe["rules"]["allowed_techniques"]}
+        assert values == {"static-code-review", "dependency-audit", "local-unit-poc"}


### PR DESCRIPTION
## Problem / Motivation

The security-conductor design (RFC in #9195) puts the entire bound on an auditor fleet's aggression in one place: a rules-of-engagement spec a script evaluates rather than a prompt asking an agent to be careful. None of it exists today — `security-conductor` and `rules-of-engagement` return zero hits in the tree.

So there is nothing for a human to review, and M0's exit criterion — *the human reviews the rules of engagement before any auditor runs* — has no subject.

## Why it matters

M0 gates every later phase. Until the procedure and a first rules instance exist, the scripts (M1) have no contract to be written against, the pilot round (M2) has no bound to run inside, and a "be careful" instruction in a seed message is the only thing standing between an auditor and a production system.

**This PR is the review surface.** The `rules-of-engagement.json` in it needs a human review before any auditor runs — that is M0's exit criterion, and it is deliberately not satisfiable by merging.

## What changed (motivation → approach → change)

Goal: give M0 a reviewable artifact — the procedure of record plus the first rules instance — and nothing beyond it.

Approach follows the four-piece shape the pipeline conductor already ships (skill body carries the procedure, bundled scripts carry the bookkeeping, agent carries the judgment). This change is the first piece only. The scripts, the SQLite ledger and the agent installer are sibling changes; the skill cites the four scripts by name and defines an absent one as `UNKNOWN` rather than as permission, so the procedure reads correctly before they land.

Built:

**`security-conductor/SKILL.md`** — the operating procedure. What qualifies as a work item (one attack surface, independently auditable, with a named proof-of-concept shape — all three required, because a surface with no expressible proof shape produces prose, and prose is where hallucinated vulnerabilities come from). The auditor seed template (governance first, then scope, then the local-PoC ceiling). The verifier template (independent re-run, one of `confirmed` / `rejected` / `needs-human`, written to *reject*, and explicitly withholding the auditor's reasoning — shared reasoning is how a hallucinated finding survives a second pass). The retrospective template (compare verdicts across roles, propose lessons through the ledger CLI, and never inject an unapproved one into a seed). Severity adjudication from the scale only. The two human gates. The patrol cycle and the stop conditions.

Two clauses are written as prohibitions rather than as advice, because both fail silently otherwise:

- **A policy refusal IS the boundary.** A blocked call stops that line of work and is recorded as an event — never rephrased, re-spelled, split, or routed around. A worker that reports having found a wording which got past a block has broken the rules of engagement, its findings for that surface are void, and the fleet stops. An auditor whose job is finding fence weaknesses will meet the fence, so this is the clause that gets exercised first.
- **Scope is decided by `scope_check.py`**, never by the conductor's judgment about what seems reasonable, and `UNKNOWN` is never permission.

**`security-conductor/rules-of-engagement.json`** — the first instance, scoped to this project itself for the dogfood pilot. `scope`, `allowed_techniques`, `forbidden`, `severity_scale`, `human_approval`, `report_schema`, with a one-line `reason` on every rule. Two deliberate properties: the file states in its own header that it is an *export* of the active rows and not the source of truth (editing it to widen a scope defeats the attribution the rows exist to provide), and `approved_by` is `null` — the M0 review gate as data, so the file cannot read as reviewed before a human reviews it.

The open ARCC dependency the RFC names is answered the narrow way. `security-assistance` is an installed skill, not a builtin here, so the auditor brief runs it if installed and otherwise records `arcc: unavailable` in every finding. Absent governance is *recorded*, never substituted for, and never read as permission.

The skill body names no repository and no source path: everything under the builtin-skills tree installs on every machine, so target-specific values live in the rules-of-engagement export, which is per target by construction. The existing builtin-skill scope gate enforces this.

## Tests

New — `test/test_security_conductor_skill_contract.py`, 42 assertions in nine classes. The skill body is a contract the sibling scripts are written against, and until now a markdown rewrite could drop a clause with nothing going red.

- **Installable**: front matter parses, `name` is the loader key, the description names the agent, and no script stub was shipped here.
- **Script delegation**: all four scripts cited by name; an absent script is `UNKNOWN` and not permission; scope is the script's answer and not the conductor's.
- **Policy refusal**: the rule is present as a prohibition, a refusal is recorded as an event, the *auditor brief* carries it too (the worker is the one holding the blocked call), and a reported circumvention is a stop condition.
- **Work item**: each of the three qualification properties.
- **Auditor brief**: governance is the first clause (asserted positionally, not just present), `arcc: unavailable` has a defined behaviour, the PoC ceiling is stated, and reporting a surface clean is a valid outcome.
- **Verifier brief**: the purpose is rejection, the re-run is independent, the auditor's transcript is withheld, the three verdicts, and an out-of-scope proof is `needs-human` rather than a widening.
- **Retrospective**: verdicts compared across roles, lessons proposed through the CLI, unapproved lessons never reach a seed.
- **Severity / gates / stop conditions**: severity from the scale only, only confirmed findings graded, both gates named, silence is not approval, a pending gate is re-read every cycle, nothing dispatches before the human review, an absent scope script stops the run.
- **The export's shape**: schema tag, six rule fields, a value and a one-line reason on every rule, four severity levels, seven forbidden classes, the technique ceiling as an exact set, `approved_by` null.

Phrase assertions are normalized for whitespace, blockquote markers, backticks and asterisks, so a rewrap or an emphasis change does not break them — the file pins rules, not formatting. Rationale sentences are deliberately not asserted.

Re-ran every test that enumerates the skills tree, since a new skill directory is now in their scan: builtin-skill packaging and scope, frontmatter, deferred-disposition ratchet, stale-browser-refs, image-authoring, the skills loader, context-builder defaults, skill home paths, builtin-skill sync safety. **553 passed**, 0 failed.

## Manual verification

Gates run locally, all green: `docs_lint.py`, `check_brand_name.py` (diff-scoped against `origin/main`), `check_builtin_skill_scope.py`, `check_black_formatting.py`, and black / isort / flake8 on the new test file. No `.py` under `src/`, so mypy's scope (`src/kiro_crew/`) is untouched.

N/A for anything runtime: the change adds no code path. The skill is data read by the loader, and the loader tests above cover that it is discovered.

## Related Issues

Design of record: #9195 (`docs/request-for-change/rfc-security-conductor.md`). This is M0's first half — the skill and the first `roe_rules` set. The scripts, the SQLite ledger and the agent installer are sibling changes.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the skill body *is* the documentation of record
- [x] No secrets, credentials, or internal references in the diff
