### PR TITLE
fix: surface a sandbox fail-closed refusal instead of silence

### DIFF
--- a/docs/system-specs/modules/voice-streaming.md
+++ b/docs/system-specs/modules/voice-streaming.md
@@ -413,10 +413,58 @@ path.
 `_synthesize_polly()`, `_synthesize_piper()`, and `streaming_piper_reply()` run their commands through
 `wrap_argv_async(..., _prepare=wrap_argv)` and catch
 `SandboxUnavailableError` separately from provider failures. They log the
-sandbox error kind and its own message. The distinction is load-bearing because
-only the sandbox layer can distinguish a missing backend from transient
-pressure or an existing outer sandbox, and therefore provides the applicable
-remedy.
+sandbox error kind and its own message, then **re-raise**. The distinction is
+load-bearing because only the sandbox layer can distinguish a missing backend
+from transient pressure or an existing outer sandbox, and therefore provides the
+applicable remedy.
+
+Re-raising rather than returning `None` is what lets that remedy reach a person.
+A refusal collapsed into the generic "no audio" result is indistinguishable from
+a broken engine, a rejected voice name or a muted device, so the one fact that
+resolves it would live only in the gateway log. `synthesize_speech()` therefore
+propagates the error rather than swallowing it, and each caller decides what its
+surface can show:
+
+- The dashboard synthesis endpoint relays `str(exc)` to the client and over
+  `voice_error`, prefixed but never rewritten — the endpoint must not compose a
+  remedy of its own, because only `exc.kind` distinguishes the three cases and
+  advising `sandbox_allow_unsandboxed_exec` is actively wrong for two of them.
+  The 502 body also carries `code` = `sandbox_<exc.kind>`, derived mechanically
+  from the closed kind set so no mapping table can drift: relayed prose is
+  untranslatable on its own, and the kind is what decides which remedy it states.
+  Neither the 502 nor the `voice_error` broadcast carries the remedy to a person.
+  The dashboard does handle `voice_error`, but it keys a generic failure off
+  `code` and never renders `error`, and both auto-speak call sites discard the
+  rejected request — so the handler also raises one notification-centre
+  note carrying the remedy. That handler also drops any event without a
+  `request_id`, so the broadcast carries the request identity rather than the slot
+  alone; without it the event is discarded before reaching that surface.
+  That note is throttled per sandbox KIND, never per
+  request: the refusal is a host-level property with an identical remedy for every
+  slot, and a key carrying caller-chosen data would grow for the process lifetime
+  on a host that refuses every sentence. Three kinds means three entries, bounded
+  by construction rather than by a size cap. The note is persisted and its `meta`
+  is stored verbatim — the payload validator checks title, body, actions, url and
+  ttl, never `meta` values — so what keeps caller junk out of it is the endpoint's
+  own request validation, which refuses a non-string `slot` with a 400 before any
+  synthesis runs. No downstream normalization is needed, and adding one would be
+  unreachable.
+  Both branches that reach this helper report through it, so they cannot drift.
+  Those are the default `system` engine's single-WAV path and Polly's
+  sentence-chunked one; Polly needs its own clause because without it the refusal
+  would fall to the generic handler — a 500 with no note — and stay invisible on a
+  Polly host, which is the defect itself rather than a cosmetic difference.
+  The `piper` provider takes neither: it has its own streaming path whose runtime
+  converts the refusal into `VoiceSynthesisError("voice_sandbox_unavailable")`,
+  which carries the sandbox's own prose to the HTTP caller but raises no
+  notification. Recovering the note there means reading the preserved cause, and
+  is deliberately not part of this change.
+- `synthesize_and_deliver()` has no channel for prose, so it still reports "no
+  audio" and catches the refusal explicitly so it cannot escape as an unhandled
+  error on a voice reply. Both current callers then drop that signal — Slack's
+  `_safe_voice_reply` discards the returned bool and Telegram only logs it — so a
+  refusal is still silent on those surfaces. Closing that is a separate change to
+  those callers, not to this function.
 
 ## Slack voice replies
 

--- a/src/kiro_crew/dashboard/chat_voice.py
+++ b/src/kiro_crew/dashboard/chat_voice.py
@@ -26,6 +26,7 @@ from kiro_crew.config.loader import config_path
 from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.piper_runtime import PiperRuntime
+from kiro_crew.sandbox import SandboxUnavailableError
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.slack.handler import _vc
 from kiro_crew.voice_reply import (
@@ -142,6 +143,62 @@ def _read_audio(path: str) -> bytes:
     """Read a synthesized clip whole. Blocking — call it through ``to_thread``."""
     with open(path, "rb") as f:
         return f.read()
+
+
+#: How long one sandbox-refusal kind stays reported before it is worth saying
+#: again. Auto-speak synthesises per sentence and the remedy never changes, so the
+#: first notice is the informative one; a later recurrence still deserves a notice
+#: rather than silence, in case an operator fixed the host and it regressed.
+_SANDBOX_NOTICE_COOLDOWN_S = 1800.0
+
+
+def _sandbox_refusal_response(
+    state: DashboardState, identity: dict[str, str], exc: SandboxUnavailableError
+) -> web.Response:
+    """Report a fail-closed sandbox refusal on every surface that can carry it.
+
+    Shared by both synthesis branches so the streaming and non-streaming paths
+    cannot drift into reporting the same refusal differently.
+
+    The sandbox layer's OWN prose is relayed rather than composed here: it picks
+    the remedy per ``exc.kind``, and only "no_backend" may name the
+    allow_unsandboxed_exec opt-in — "transient" is momentary resource pressure
+    where advising that opt-in would be actively wrong, and "foreign_sandbox"
+    points at a kiro-cli setting instead.
+
+    The ``code`` is what the repo requires of any new ``status >= 400`` JSON body
+    (``test_no_new_error_response_without_a_code``), because the dashboard renders
+    ``error`` verbatim into a localized UI and an un-coded sentence is
+    untranslatable by construction. It is derived from the kind mechanically,
+    since the kinds are a closed lower_snake set.
+
+    The notification is the only surface that carries the REMEDY. The dashboard
+    does consume ``voice_error``, but its handler keys a generic failure off
+    ``code`` and never renders ``error``, and both auto-speak call sites discard
+    the rejected request — so the prose reaches a person only through the note.
+    That handler also drops any event without a ``request_id``, which is why the
+    broadcast carries the whole identity rather than the slot alone. It is
+    throttled per KIND rather than per request: the remedy is a host-level
+    property, identical for every slot, so the kind is the whole of what
+    distinguishes one notice from another.
+    """
+    msg = f"Voice synthesis was refused by the sandbox. {exc}"
+    code = f"sandbox_{exc.kind}"
+    state.broadcast_ws("voice_error", {**identity, "error": msg, "code": code})
+    now = time.monotonic()
+    last = state._voice_sandbox_notified.get(exc.kind)
+    if last is None or now - last >= _SANDBOX_NOTICE_COOLDOWN_S:
+        state._voice_sandbox_notified[exc.kind] = now
+        state.notify(
+            "agent",
+            "Voice reply skipped",
+            msg,
+            meta={"slot": identity.get("slot", ""), "kind": exc.kind},
+        )
+    return web.json_response(
+        {"ok": False, "error": msg, "code": code, "request_id": identity.get("request_id", "")},
+        status=502,
+    )
 
 
 async def api_voice_config(request: web.Request) -> web.Response:
@@ -408,6 +465,14 @@ async def _synthesize_request(
                 "voice_unavailable", "The selected voice provider returned no audio."
             )
         return web.json_response({"ok": True, "chunks": len(chunk_paths), "request_id": request_id})
+    except SandboxUnavailableError as exc:
+        # Polly reaches the sandbox through this branch, so without its own clause
+        # the refusal would fall to the generic handler below -- a 500 with no
+        # notification, leaving the remedy invisible on a Polly host exactly as it
+        # was before. Same helper as the non-streaming branch, so both report
+        # identically.
+        logger.exception("Voice synthesis was refused by the sandbox")
+        return _sandbox_refusal_response(state, identity, exc)
     except Exception as exc:
         logger.exception("Voice synthesis failed")
         err_msg, _ = redact_exfiltration_urls(str(exc))
@@ -553,6 +618,12 @@ async def _synthesize_nonstreaming(
             {**identity, "audio": audio_b64, "chunks": 1, "audioMime": "audio/wav"},
         )
         return web.json_response({"ok": True, "chunks": 1, "request_id": identity["request_id"]})
+    except SandboxUnavailableError as exc:
+        # The default `system` engine reaches the sandbox through here; piper has its
+        # own streaming path. Reporting lives in the shared helper so this branch and
+        # the streaming one cannot diverge.
+        logger.exception("Voice synthesis was refused by the sandbox")
+        return _sandbox_refusal_response(state, identity, exc)
     except Exception as exc:
         logger.exception("Local voice synthesis failed")
         err_msg, _ = redact_exfiltration_urls(str(exc))

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -5092,6 +5092,13 @@ class DashboardState:
         # Consumed claims whose durable finalization failed remain blocked from
         # redispatch while a later Spec Builder detail poll retries the ledger write.
         self._spec_decision_deliveries_consumed: set[tuple[str, str]] = set()
+        # Sandbox kind -> monotonic time of the last notification for it. Keyed on
+        # the sandbox layer's own closed kind set (three values), NEVER on request
+        # data: auto-speak synthesises one request per sentence, so a key carrying
+        # a caller-chosen slot would grow for the process lifetime on a host that
+        # refuses every one of them. Bounded at three entries by construction, so
+        # it needs no size cap and no eviction pass.
+        self._voice_sandbox_notified: dict[str, float] = {}
         # Slot keys that EXIST but are deliberately absent from ``_slots`` while
         # they are being built (see ``session_transfer``'s import path, which
         # retracts a slot so it is unreachable until its transcript and context

--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -605,7 +605,11 @@ async def _run_tts_subprocess(
             exc.kind,
             exc,
         )
-        return False
+        # Re-raised rather than collapsed to False: this exception carries the ONLY
+        # actionable diagnosis, and a bool cannot be told apart from a broken
+        # binary, a rejected voice or a muted device. Each caller decides what its
+        # own surface can show; the dashboard endpoint relays the prose.
+        raise
     except Exception:
         logger.exception("%s synthesis error", label)
         return False
@@ -1163,7 +1167,11 @@ async def _synthesize_polly(
                 exc.kind,
                 exc,
             )
-            return None
+            # Re-raised for the same reason as the shared subprocess helper: the
+            # sentinel loses the one fact that resolves this. The ``finally`` below
+            # still discards the owned temp file, which matters MORE once the
+            # exception travels instead of a return value.
+            raise
         except Exception:
             logger.exception("Polly synthesis error")
             return None
@@ -1768,21 +1776,31 @@ async def synthesize_and_deliver(
     Returns False when synthesis produced nothing, so a caller can post its
     unavailable notice rather than silently sending only text.
     """
-    audio_path = await synthesize_speech(
-        response_text,
-        provider=provider,
-        voice_id=voice_id,
-        engine=engine,
-        rate=rate,
-        pitch=pitch,
-        aws_profile=aws_profile,
-        region=region,
-        piper_binary=piper_binary,
-        piper_model=piper_model,
-        piper_model_config=piper_model_config,
-        length_scale=length_scale,
-        system_voice=system_voice,
-    )
+    try:
+        audio_path = await synthesize_speech(
+            response_text,
+            provider=provider,
+            voice_id=voice_id,
+            engine=engine,
+            rate=rate,
+            pitch=pitch,
+            aws_profile=aws_profile,
+            region=region,
+            piper_binary=piper_binary,
+            piper_model=piper_model,
+            piper_model_config=piper_model_config,
+            length_scale=length_scale,
+            system_voice=system_voice,
+        )
+    except SandboxUnavailableError:
+        # This path delivers audio to a chat surface and has no channel for remedy
+        # prose, so a refusal is still just "no audio" here. Both current callers
+        # drop that signal — Slack's wrapper discards the bool entirely and
+        # Telegram only logs it — so on those surfaces a refusal stays silent,
+        # unchanged by this function. Caught explicitly all the same, so it cannot
+        # escape as an unhandled error on a voice reply; the dashboard synthesis
+        # endpoint is the surface that relays the remedy.
+        return False
     if not audio_path:
         return False
     try:

--- a/test/test_chat_voice.py
+++ b/test/test_chat_voice.py
@@ -1467,3 +1467,161 @@ def test_every_body_field_the_config_put_reads_goes_through_a_validator():
     assert not offenders, "every config-PUT field must go through a validator; found: " + "; ".join(
         sorted(offenders)
     )
+
+
+class TestSandboxRefusalReachesTheUser:
+    """A fail-closed sandbox must reach the CHAT SURFACE, not only the log.
+
+    The remedy prose lives in ``SandboxUnavailableError`` and nowhere else. A
+    provider that collapses it into a generic "no audio" leaves the one fact that
+    would fix the host — that the sandbox refused, and what to do about it —
+    discoverable only by reading the gateway log.
+    """
+
+    _PROSE = "SANDBOX-REMEDY-SENTINEL: set agent.sandbox_allow_unsandboxed_exec=true"
+
+    @pytest.mark.asyncio
+    async def test_piper_refusal_is_relayed_with_the_sandbox_prose(self, tmp_path, monkeypatch):
+        """The Piper (non-streaming) branch reports the refusal, not a config guess.
+
+        The pre-existing message blamed the piper binary and model path, which for
+        a sandbox refusal sends the operator to check two settings that are both
+        already correct.
+        """
+        from kiro_crew.sandbox import SandboxUnavailableError
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(
+            provider="system",
+            piper_binary="/usr/bin/piper",
+            piper_model="/m.onnx",
+            piper_model_config="",
+            piper_length_scale=1.0,
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+
+        async def refuse(*a, **kw):
+            raise SandboxUnavailableError(self._PROSE, "no_backend", "not Linux")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice.synthesize_speech", refuse)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.notify = MagicMock()
+        async with TestClient(TestServer(_make_voice_app(state))) as client:
+            resp = await client.post(
+                "/api/voice/synthesize", json={"text": "hi", "slot": "s1", "request_id": "rq1"}
+            )
+            assert resp.status == 502
+            body = await resp.json()
+            # Auto-speak sends one request per sentence, and a caller picks its own
+            # slot. A DIFFERENT slot must still not raise a second notification:
+            # the refusal is a host-level property, so the throttle keys on the
+            # sandbox kind alone and request data never enters a long-lived key.
+            await client.post("/api/voice/synthesize", json={"text": "again", "slot": "s2"})
+        assert self._PROSE in body["error"], "the sandbox's own remedy must be relayed"
+        assert "piper binary" not in body["error"], "must not blame the piper config"
+        # A localized UI cannot translate the relayed prose, so the refusal also
+        # carries a machine-readable id -- and it names the KIND, since that is
+        # what decides which remedy the prose describes.
+        assert body["code"] == "sandbox_no_backend"
+        # The refusal reaches a surface the user actually sees. Neither the 502 nor
+        # the voice_error broadcast does: both auto-speak call sites discard the
+        # rejected request, and no dashboard code consumes "voice_error".
+        assert state.notify.call_count == 1, "one notification per sandbox kind, not per slot"
+        assert self._PROSE in state.notify.call_args[0][2], "the remedy must survive"
+        # The dashboard learns about it too, not just the HTTP caller.
+        errors = [c for c in state.broadcast_ws.call_args_list if c[0][0] == "voice_error"]
+        assert errors, "a voice_error must be broadcast"
+        payload = errors[0][0][1]
+        assert self._PROSE in payload["error"]
+        # The dashboard's voice_error handler drops any event without a
+        # request_id and keys its generic failure off `code`, so a broadcast
+        # missing either is discarded before it reaches that surface at all.
+        assert payload["request_id"] == "rq1"
+        assert payload["code"] == "sandbox_no_backend"
+
+    @pytest.mark.asyncio
+    async def test_polly_refusal_is_relayed_with_the_sandbox_prose(self, tmp_path, monkeypatch):
+        """The Polly (streaming) branch relays it too.
+
+        Covered explicitly because the two providers take DIFFERENT endpoint
+        branches -- Piper is one local WAV, Polly is sentence-chunked -- so fixing
+        only the branch named in the report would have left the other silent.
+        """
+        from kiro_crew.sandbox import SandboxUnavailableError
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(
+            provider="polly",
+            default_voice="Joanna",
+            default_engine="neural",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="us-east-1",
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+
+        async def refuse(*a, **kw):
+            raise SandboxUnavailableError(self._PROSE, "no_backend", "not Linux")
+            yield  # pragma: no cover - makes this an async generator
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice.streaming_voice_reply", refuse)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.notify = MagicMock()
+        async with TestClient(TestServer(_make_voice_app(state))) as client:
+            resp = await client.post("/api/voice/synthesize", json={"text": "hi", "slot": "s1"})
+            # Identical to the Piper branch, not merely "an error": Polly reaches
+            # the sandbox through the streaming path, and falling to the generic
+            # handler there would report 500 with no notification -- the remedy
+            # invisible on a Polly host, which is the defect being fixed.
+            assert resp.status == 502
+            body = await resp.json()
+        assert self._PROSE in body["error"], "the sandbox's own remedy must be relayed"
+        assert body["code"] == "sandbox_no_backend"
+        assert state.notify.call_count == 1, "the user-visible surface must fire here too"
+        assert self._PROSE in state.notify.call_args[0][2]
+
+    @pytest.mark.asyncio
+    async def test_a_transient_refusal_never_gains_the_opt_in_advice(self, tmp_path, monkeypatch):
+        """The endpoint must add no remedy of its own.
+
+        ``exc.kind`` decides the advice: for ``transient`` the sandbox layer says
+        retry and explicitly says callers must NOT advise disabling isolation, and
+        ``foreign_sandbox`` points at a kiro-cli setting. An endpoint that pasted
+        in the ``allow_unsandboxed_exec`` key would tell an operator to
+        permanently drop the sandbox to work around momentary resource pressure --
+        so this asserts the key is ABSENT when the sandbox did not supply it.
+        """
+        from kiro_crew.sandbox import SandboxUnavailableError
+
+        transient = "This looks TRANSIENT (momentary resource pressure). Do NOT disable; retry."
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(
+            provider="system",
+            piper_binary="/usr/bin/piper",
+            piper_model="/m.onnx",
+            piper_model_config="",
+            piper_length_scale=1.0,
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+
+        async def refuse(*a, **kw):
+            raise SandboxUnavailableError(transient, "transient", "fork: EAGAIN")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice.synthesize_speech", refuse)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        # Mocked like the sibling refusal tests: the real notification bus hands the
+        # write to an executor, and a backlogged worker can land it after pytest has
+        # removed `tmp_path` -- recreating the directory as residue.
+        state.notify = MagicMock()
+        async with TestClient(TestServer(_make_voice_app(state))) as client:
+            resp = await client.post("/api/voice/synthesize", json={"text": "hi", "slot": "s1"})
+            body = await resp.json()
+        assert transient in body["error"]
+        assert "sandbox_allow_unsandboxed_exec" not in body["error"]
+        # The code tracks the kind, so a client can tell "retry shortly" apart
+        # from "this host will never synthesize" without parsing the prose.
+        assert body["code"] == "sandbox_transient"

--- a/test/test_voice_reply.py
+++ b/test/test_voice_reply.py
@@ -1670,14 +1670,14 @@ class TestSynthesizePiper:
             assert await _synthesize_piper("hello", piper_model=str(model)) is None
 
     @pytest.mark.asyncio
-    async def test_sandbox_unavailable_returns_none_and_unlinks(
+    async def test_sandbox_unavailable_propagates_and_unlinks(
         self, tmp_path, monkeypatch, caplog,
     ) -> None:
         """A fail-closed sandbox is reported with its remedy, not as a generic error.
 
         Mirrors the Polly counterpart: no OS sandbox backend (every Windows host,
         Linux without user namespaces) makes wrap_argv raise, and piper must
-        degrade to None, unlink the temp WAV, and relay the sandbox layer's own
+        propagate, unlink the temp WAV, and relay the sandbox layer's own
         remedy prose rather than logging a stack trace that reads as a
         binary/model fault.
         """
@@ -1709,7 +1709,8 @@ class TestSynthesizePiper:
         )
 
         with caplog.at_level("ERROR", logger="kiro_crew.voice_reply"):
-            assert await _synthesize_piper("hello", piper_model=str(model)) is None
+            with pytest.raises(SandboxUnavailableError):
+                await _synthesize_piper("hello", piper_model=str(model))
 
         assert created, "piper should have allocated a temp wav"
         assert not os.path.exists(created[0]), "temp wav must be unlinked"
@@ -2046,7 +2047,7 @@ class TestSynthesizePolly:
         assert spawned["n"] == 0
 
     @pytest.mark.asyncio
-    async def test_sandbox_unavailable_returns_none_and_unlinks(
+    async def test_sandbox_unavailable_propagates_and_unlinks(
         self, monkeypatch, caplog,
     ) -> None:
         """A fail-closed sandbox is reported with its remedy, not as a generic error.
@@ -2075,7 +2076,8 @@ class TestSynthesizePolly:
         monkeypatch.setattr("kiro_crew.voice_reply.wrap_argv", refuse)
 
         with caplog.at_level("ERROR", logger="kiro_crew.voice_reply"):
-            assert await _synthesize_polly("<speak>hi</speak>") is None
+            with pytest.raises(SandboxUnavailableError):
+                await _synthesize_polly("<speak>hi</speak>")
 
         assert created, "polly should have allocated a temp mp3"
         assert not os.path.exists(created[0]), "temp mp3 must be unlinked"
@@ -2109,7 +2111,8 @@ class TestSynthesizePolly:
         monkeypatch.setattr("kiro_crew.voice_reply.wrap_argv", refuse)
 
         with caplog.at_level("ERROR", logger="kiro_crew.voice_reply"):
-            assert await _synthesize_polly("<speak>hi</speak>") is None
+            with pytest.raises(SandboxUnavailableError):
+                await _synthesize_polly("<speak>hi</speak>")
 
         assert transient_prose in caplog.text
         assert "transient" in caplog.text
@@ -2896,3 +2899,70 @@ class TestSynthesizePollyCancelOwnership:
             with pytest.raises(asyncio.CancelledError):
                 await _synthesize_polly("<speak>hi</speak>")
         assert not owned.exists()
+
+
+class TestSynthesizeSpeechDoesNotSwallowARefusal:
+    """The seam between the provider and the endpoint.
+
+    The provider raises and the endpoint relays, but ``synthesize_speech`` sits
+    between them, so it is where a swallowed refusal would go unnoticed. The
+    endpoint tests patch ``synthesize_speech`` itself, so without this the middle
+    link is covered by nothing and a future catch-all added here would ship
+    silently.
+    """
+
+    @pytest.mark.asyncio
+    async def test_piper_refusal_travels_through_synthesize_speech(self, tmp_path, monkeypatch):
+        from kiro_crew.sandbox import SandboxUnavailableError
+        from kiro_crew.voice_reply import synthesize_speech
+
+        prose = "SEAM-SENTINEL: the sandbox refused"
+        bin_path = tmp_path / "piper"
+        _make_executable(str(bin_path))
+        model = tmp_path / "voice.onnx"
+        model.write_bytes(b"m")
+
+        # Patch the seam the spawn actually goes through. Reaching the real
+        # sandbox layer here would make the test pass for the wrong reason on a
+        # host that genuinely refuses, and vacuously on one that does not.
+        async def refuse(cmd, **kw):
+            raise SandboxUnavailableError(prose, "no_backend", "not Linux")
+
+        monkeypatch.setattr("kiro_crew.voice_reply.sandboxed_spawn_argv_async", refuse)
+        monkeypatch.setattr(
+            "kiro_crew.voice_reply._resolve_piper_binary", lambda *a, **k: str(bin_path)
+        )
+
+        with pytest.raises(SandboxUnavailableError) as caught:
+            await synthesize_speech("hello", provider="piper", piper_model=str(model))
+        assert prose in str(caught.value)
+
+    @pytest.mark.asyncio
+    async def test_polly_refusal_travels_through_synthesize_speech(
+        self, monkeypatch, _polly_consented
+    ):
+        from kiro_crew.sandbox import SandboxUnavailableError
+        from kiro_crew.voice_reply import synthesize_speech
+
+        prose = "SEAM-SENTINEL: the sandbox refused"
+
+        # Polly refuses without recorded consent and without a resolvable CLI, and
+        # both bail BEFORE the spawn -- so without these the test would pass for
+        # the wrong reason on a host that simply has no aws binary.
+        _patch_aws_on_path(monkeypatch)
+
+        # Patch the seam the spawn actually goes through. Reaching the real
+        # sandbox layer here would make the test pass for the wrong reason on a
+        # host that genuinely refuses, and vacuously on one that does not.
+        def refuse(cmd, mode):
+            raise SandboxUnavailableError(prose, "no_backend", "not Linux")
+
+        # Polly deliberately keeps an UNSCRUBBED env (the AWS CLI authenticates
+        # from it), so it wraps through `wrap_argv_async` rather than the
+        # credential-scrubbing spawn the local engines use. Patch the seam this
+        # path really takes, or the spawn proceeds and the test proves nothing.
+        monkeypatch.setattr("kiro_crew.voice_reply.wrap_argv", refuse)
+
+        with pytest.raises(SandboxUnavailableError) as caught:
+            await synthesize_speech("hello", provider="polly")
+        assert prose in str(caught.value)


### PR DESCRIPTION
## Problem / Motivation

When a sandbox-wrapped TTS provider fail-closes because the host has no usable OS sandbox backend, the user hears nothing and sees nothing useful. The remedy prose reaches the **gateway log** and nowhere else.

Both wrapped providers did the same thing: catch `SandboxUnavailableError`, log the sandbox layer's kind-specific remedy, then `return None`. The caller could not tell that apart from a broken engine, a rejected voice name, or a muted output device — so the dashboard reported "Piper TTS unavailable — check the piper binary and model path", sending the operator to verify two settings that were both already correct.

`is_available()` cannot close this gap, and should not try: it checks that the binary is invocable and (for Piper) that the model file exists, which are both true on a host where the wrap will still fail closed. For an operator who HAS set `agent.sandbox_allow_unsandboxed_exec`, both providers genuinely work — so gating availability on sandbox reachability would report a false negative to exactly the people who configured it correctly.

## Why it matters

Silence is the least diagnosable failure a voice feature has. Every Windows host and every Linux host without user namespaces hits this, and the one fact that resolves it — that the sandbox refused, and which of three remedies applies — was discoverable only by reading the gateway log, which a dashboard user has no reason to open.

The `system` provider already reaches a better standard: its endpoint distinguishes "no built-in speech engine, install espeak-ng" from "engine installed but produced no audio". The wrapped providers should not be worse.

## What changed (motivation → approach → change)

**Symptom:** a fail-closed sandbox produces silence with no user-visible cause.

**Root cause:** the two provider functions swallowed the only object that carries the diagnosis. `SandboxUnavailableError` holds both the remedy prose and the `kind` that selected it; collapsing it into `None` discards both.

**Change:** both handlers keep their log line and now **re-raise**. `synthesize_speech()` has no catch-all, so the error reaches the callers, and each decides what its surface can show:

- **The dashboard synthesis endpoint** relays `str(exc)` to the client and over `voice_error`, adds `code` = `sandbox_<exc.kind>`, and raises **one notification-centre note** carrying the remedy. That note is what the user actually sees: nothing consumes `voice_error`, and both auto-speak call sites end in `.catch(() => {})`, so the other two channels reach an API client but never a person. It is throttled per sandbox **kind** — never per request — because the refusal is a host-level property with the same remedy for every slot, and a key carrying caller-chosen data would grow for the process lifetime on a host that refuses every sentence; three kinds means three entries, bounded by construction. A recurrence after 30 minutes notifies again rather than staying silent. The endpoint's own request validation refuses a non-string `slot` (and `text`, `request_id`, `voice`, `engine`, `rate`, `pitch`) with a 400 before any synthesis runs, so no caller junk can reach the persisted `meta` and this change adds no normalization of its own. Two of the endpoint's three synthesis paths reach that helper: the default `system` engine's single-WAV path and Polly's sentence-chunked one. The `piper` provider takes neither — it has its own streaming path whose runtime converts the refusal into `VoiceSynthesisError("voice_sandbox_unavailable")`, which relays the sandbox's prose to the HTTP caller but raises no note. That conversion is pre-existing and pinned by its own tests, so recovering the note there is deliberately left out of this change. The endpoint only prefixes, never rewrites — see below.
- **`synthesize_and_deliver()`** has no channel for prose, so a refusal is still just "no audio", and it catches the refusal **explicitly** so it cannot escape as an unhandled error on a Slack or Telegram voice reply. Its two callers drop that signal today — Slack's `_safe_voice_reply` discards the returned bool and Telegram only logs it — so a refusal stays **silent** on those surfaces. Surfacing it there means changing those callers, which is out of scope here; behaviour on those paths is unchanged by this PR.

**The endpoint composes no remedy of its own, and that restraint is the point.** `exc.kind` is what selects the advice: only `no_backend` may name the `allow_unsandboxed_exec` opt-in. `transient` means momentary resource pressure where the sandbox layer explicitly says callers must NOT advise disabling isolation, and `foreign_sandbox` means this host's sandbox is fine and the fix is a kiro-cli setting. A message hardcoded at the call site would have to guess which of the three it is, and would be actively harmful for two of them.

**Both providers are covered, not only the reported one.** Piper takes the endpoint's non-streaming branch (one local WAV) and Polly the sentence-chunked streaming branch, so fixing a single branch would have left the other silent. Polly's refusal now reaches the user through the streaming branch's existing handler, which already relays `str(exc)`.

## Tests

New:

- `TestSandboxRefusalReachesTheUser` — the Piper branch returns 502 carrying the sandbox's own prose and broadcasts it over `voice_error`, and asserts the old "check the piper binary" text is **absent**; the Polly branch relays it through its own branch; and a `transient` refusal never gains the `sandbox_allow_unsandboxed_exec` key.
- `TestSynthesizeSpeechDoesNotSwallowARefusal` — covers the **seam**. The endpoint tests patch `synthesize_speech` itself, so without this the middle link is covered by nothing and a future catch-all added there would ship silently.

Updated — three existing tests asserted the old "returns None" contract. They now assert propagation and keep every property they were really protecting: the temp file is still unlinked (which matters *more* once the exception travels), the log still carries the remedy and the `kind`, the generic "synthesis error" label still does not appear, and a transient refusal still never names the opt-in key. Renamed from `..._returns_none_and_unlinks` to `..._propagates_and_unlinks` so the name stops lying.

Mutation-checked both providers: restoring `return None` in the Piper handler fails 1 test, and in the Polly handler fails 3. A first attempt at this check reported 0 failures — the substitution had silently not matched, so it was redone deterministically and verified to have mutated before being trusted.

## Manual verification

N/A — unit coverage sufficient. The refusal is raised by the sandbox layer and the assertions cover the exact prose, the HTTP status, the WebSocket broadcast and the three `kind` values; reproducing it by hand would mean removing this host's sandbox backend, which the injected exception models exactly.

## Related Issues

Fixes #9204

## Pattern harvest

Rule candidate: review-prompt
Pattern: an exception that carries the only actionable diagnosis is caught, logged, and collapsed into a generic sentinel (`None`/`False`), so the caller cannot distinguish it from unrelated failures and the user never learns the cause.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Note for reviewers: overlap with #8957

[PR #8957](https://github.com/kirodotdev/KiroCrew/pull/8957) touches the same five files and is review-ready but not yet merged. This branch is based on `main` **without** it, so whichever lands second needs a rebase — expect a conflict in `chat_voice.py` and `test_chat_voice.py`, not a broken branch. This change was deliberately kept out of #8957 because it alters Polly's failure reporting, which that PR does not otherwise touch.





