### PR TITLE
fix(issue-radar): open lock sidecars non-truncating before the acquire

### DIFF
--- a/src/kiro_crew/apps/builtins/issue_radar/backend/crew_store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/crew_store.py
@@ -406,7 +406,9 @@ def _skip_lock_path(owner: str, repo: str, number: int, root: Path | None = None
 def _skip_lock(owner: str, repo: str, number: int, root: Path | None = None):
     """Hold :func:`_skip_lock_path` for *number*. See it for why, and the module
     docstring for where this sits in the lock order."""
-    with open(_skip_lock_path(owner, repo, number, root), "w") as fd:
+    lock_path = _skip_lock_path(owner, repo, number, root)
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             yield
 
@@ -515,7 +517,8 @@ def write_settings(
 ) -> dict[str, Any]:
     """Merge *patch* into the repo's protocol settings. Returns the stored doc."""
     lock_path = crews_dir(owner, repo, root) / "settings.lock"
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             record = read_settings(owner, repo, root)
             if "claim_ttl_hours" in patch:
@@ -658,7 +661,8 @@ def create_crew(
         raise CrewStoreError("a crew needs a name")
 
     lock_path = _records_lock_path(owner, repo, root)
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             if name in taken_names(owner, repo, root):
                 raise CrewStoreError(f"crew name {name!r} is already taken in this repo")
@@ -719,7 +723,8 @@ def update_crew(
     those crews. See ``_records_lock_path``.
     """
     lock_path = _records_lock_path(owner, repo, root)
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             record = read_crew(owner, repo, crew_id, root)
             if record is None:
@@ -767,7 +772,8 @@ def retire_crew(
     its work log all survive."""
     record = update_crew(owner, repo, crew_id, {"enabled": False}, root)
     lock_path = _records_lock_path(owner, repo, root)
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             record = read_crew(owner, repo, crew_id, root) or record
             record["retired_at"] = store._now_iso()
@@ -855,7 +861,8 @@ def upsert_work_item(
     same thread blocks on itself forever rather than nesting.
     """
     lock_path = _crew_lock_path(owner, repo, crew_id, root)
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             return _upsert_work_item_locked(owner, repo, crew_id, number, patch, root)
 
@@ -1120,7 +1127,8 @@ def append_event(
     logged reason, and folding one in twice must still merge.
     """
     lock_path = crews_dir(owner, repo, root) / "events.lock"
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             entry = _event_entry(crew_id, number, kind, text, phase=phase)
             _write_event_line(owner, repo, entry, root)
@@ -1230,7 +1238,8 @@ def record_crew_checkpoint(
     # an idle crew appends once per stretch, not once per wake -- but a compaction
     # story is still owed if the file becomes large enough to matter here.
     lock_path = crews_dir(owner, repo, root) / "events.lock"
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             latest = _latest_crew_event(owner, repo, crew_id, root)
             if latest is not None and latest.get("kind") == CREW_LEVEL_EVENT_KIND:
@@ -1415,7 +1424,8 @@ def record_skip(
         "decided_at": store._now_iso(),
     }
     lock_path = _records_lock_path(owner, repo, root)
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             index = read_skips(owner, repo, root)
             existing = index.get(key)
@@ -1453,7 +1463,8 @@ def unrecord_skip(
     """
     key = str(int(number))
     lock_path = _records_lock_path(owner, repo, root)
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             index = read_skips(owner, repo, root)
             if index.get(key) != entry:
@@ -1571,7 +1582,8 @@ def commit_work_progress(
     """
     number = int(number)
     lock_path = _crew_lock_path(owner, repo, crew_id, root)
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             # Under the lock that also guards the write, so no writer can land
             # between the two and leave this holding a value that is already stale.

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
@@ -68,7 +68,8 @@ def _config_lock(root: Path | None = None):
     that race, so every config RMW below holds this exclusive lock across the
     whole read→mutate→atomic-write."""
     lock_path = data_dir(root) / "config.json.lock"
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             yield
 
@@ -174,7 +175,9 @@ def issues_cache_lock(owner: str, repo: str, root: Path | None = None, state: st
     """
     path = issues_cache_path(owner, repo, root, state)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path.with_suffix(".json.lock"), "w") as fd:
+    lock_path = path.with_suffix(".json.lock")
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             yield
 
@@ -193,7 +196,8 @@ def issue_write_lock(owner: str, repo: str, number: int, root: Path | None = Non
     the network call, which is the point: ordering the writes is what matters."""
     path = repo_data_dir(owner, repo, root) / f"issue-{int(number)}.write.lock"
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as fd:
+    path.touch(exist_ok=True)
+    with open(path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             yield
 
@@ -365,7 +369,9 @@ def labels_cache_lock(owner: str, repo: str, root: Path | None = None):
     could be dropped and stay invisible until a manual refresh."""
     path = labels_cache_path(owner, repo, root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path.with_suffix(".json.lock"), "w") as fd:
+    lock_path = path.with_suffix(".json.lock")
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             yield
 
@@ -1344,7 +1350,9 @@ def _tagging_cache_lock(owner: str, repo: str, root: Path | None = None):
     with its own stale copy. Same reasoning as :func:`_config_lock`."""
     path = tagging_cache_path(owner, repo, root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path.with_suffix(".json.lock"), "w") as fd:
+    lock_path = path.with_suffix(".json.lock")
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             yield
 
@@ -2050,7 +2058,8 @@ def write_investigation(
     now = _now_iso()
     lock_path = investigation_path(owner, repo, number, root, kind=kind).with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as fd:
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             existing = read_investigation(owner, repo, number, root, kind=kind) or {}
             # Read the findings' owning session from the PRE-patch record: the
@@ -2172,7 +2181,9 @@ def _pulls_cache_lock(owner: str, repo: str, root: Path | None, state: str):
     """
     path = pulls_cache_path(owner, repo, root, state)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path.with_suffix(".json.lock"), "w") as fd:
+    lock_path = path.with_suffix(".json.lock")
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             yield
 

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_lock_no_truncate.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_lock_no_truncate.py
@@ -1,0 +1,105 @@
+"""issue_radar lock sidecars must be opened WRITABLE but WITHOUT truncation.
+
+Regression for #9263 (part of the #9248 sweep). Every lock context manager in
+``store.py`` and ``crew_store.py`` used ``open(lock_path, "w")`` and then handed
+the descriptor to ``platform_compat.file_lock(..., exclusive=True)``. ``"w"``
+truncates at open, BEFORE the lock is held. ``msvcrt.locking`` needs a writable
+handle, so ``"r"`` is not an option either; but on Windows a truncating open of a
+lock file whose first byte another holder already locked raises a sharing
+violation instead of waiting, so the second contending acquirer crashes before it
+ever reaches ``file_lock`` and the critical section is never mutually excluded.
+POSIX ``flock`` tolerates the truncate, which is why the defect is Windows-only.
+
+Truncation is the direct, platform-independent observable, exactly as the
+work_ledger regression (#9237) pins it: seed the lock file with bytes, acquire
+and release the lock, and assert the bytes survived. Under the old
+``open(path, "w")`` these fail on every platform (the file is emptied); under the
+``touch`` + ``"r+"`` open they pass, and the same non-truncating open is what
+stops the Windows sharing violation.
+
+The cases below cover both modules and all three path expressions the sweep
+touched: a bound ``lock_path`` variable, a ``.with_suffix(".json.lock")`` cache
+sidecar, and a per-item ``.lock`` name.
+"""
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from kiro_crew.apps.builtins.issue_radar.backend import crew_store, store
+
+SENTINEL = b"held by a prior acquirer\n"
+
+OWNER = "o"
+REPO = "r"
+
+
+class TestLockOpenDoesNotTruncate(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def _assert_survives(self, lock_path: Path, run):
+        """Seed *lock_path* with bytes, run the critical section, assert survival."""
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_bytes(SENTINEL)
+        run()
+        self.assertEqual(
+            lock_path.read_bytes(),
+            SENTINEL,
+            f"acquiring the lock truncated {lock_path.name}",
+        )
+
+    # ── store.py ──────────────────────────────────────────────────────────
+
+    def test_config_lock_does_not_truncate(self):
+        lock_path = store.data_dir(self.tmp) / "config.json.lock"
+
+        def run():
+            with store._config_lock(self.tmp):
+                pass
+
+        self._assert_survives(lock_path, run)
+
+    def test_issues_cache_lock_does_not_truncate(self):
+        path = store.issues_cache_path(OWNER, REPO, self.tmp, "open")
+        lock_path = path.with_suffix(".json.lock")
+
+        def run():
+            with store.issues_cache_lock(OWNER, REPO, self.tmp, state="open"):
+                pass
+
+        self._assert_survives(lock_path, run)
+
+    def test_issue_write_lock_does_not_truncate(self):
+        lock_path = store.repo_data_dir(OWNER, REPO, self.tmp) / "issue-7.write.lock"
+
+        def run():
+            with store.issue_write_lock(OWNER, REPO, 7, self.tmp):
+                pass
+
+        self._assert_survives(lock_path, run)
+
+    # ── crew_store.py ─────────────────────────────────────────────────────
+
+    def test_skip_lock_does_not_truncate(self):
+        lock_path = crew_store._skip_lock_path(OWNER, REPO, 7, self.tmp)
+
+        def run():
+            with crew_store._skip_lock(OWNER, REPO, 7, self.tmp):
+                pass
+
+        self._assert_survives(lock_path, run)
+
+    def test_write_settings_lock_does_not_truncate(self):
+        lock_path = crew_store.crews_dir(OWNER, REPO, self.tmp) / "settings.lock"
+
+        def run():
+            crew_store.write_settings(OWNER, REPO, {}, self.tmp)
+
+        self._assert_survives(lock_path, run)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem / Motivation

Eighteen lock context managers in issue_radar's backend open their lock sidecar
with `open(lock_path, "w")` and only then hand the descriptor to
`platform_compat.file_lock(..., exclusive=True)`. `"w"` truncates the file at
open -- before the lock is held.

## Why it matters

On Windows the acquire routes to `msvcrt.locking`. A truncating open of a lock
file whose first byte another holder already locked raises a sharing violation
instead of waiting. The contending acquirer crashes before it reaches the lock,
so the critical section it was serialising runs unserialised -- a silent loss of
mutual exclusion, not a visible error. POSIX `flock` tolerates the truncate,
which is why the class is invisible on Linux and shows up only as intermittently
red Windows shards. The same class fixed one-write-short concurrency assertions
elsewhere in the sweep (`test_work_ledger` `assert 2 == 3`, `test_sel`
`assert 39 == 40`). issue_radar's store carries connect/settings/label/tag caches
and the whole crew ledger behind these locks, so a lost acquire can drop a config
write or a crew-record update on Windows.

## What changed (motivation -> approach -> change)

Symptom: on Windows a second process contending for one of these locks fails
instead of waiting, and the guarded read-modify-write is not serialised.

Root cause: the lock file is opened truncating (`"w"`). The truncate lands before
the lock, and on Windows a truncating open of an already-locked file is itself
what raises the sharing violation.

Change: each of the 18 sites now ensures the parent dir exists,
`lock_path.touch(exist_ok=True)`, then `open(lock_path, "r+")` -- writable
(`msvcrt.locking` needs a writable handle, so `"r"` is not an option) but NOT
truncating -- acquiring on that handle exactly as before. This is the same shape
and rationale as `work_ledger._open_lock` (#9237) and `session_pid.py` (#9250).
No shared helper is introduced: consolidating this preamble into one public
opener is #9267's job, which the reporter deliberately kept separate. `store.py`
takes 7 sites, `crew_store.py` 11. The lock directories are already ensured by
`data_dir` / `repo_data_dir` / `crews_dir`; the added `touch` makes each site
self-sufficient and matches the reference fix.

`eval/bench/safepath.open_write_nofollow` is not the tool here: its load-bearing
flag is `O_EXCL` (atomic exclusive CREATE, refuse an existing name) for
write-once/temp files, so it cannot open a persistent lock sidecar that is reused
across acquires.

## Tests

`src/kiro_crew/apps/builtins/issue_radar/tests/test_lock_no_truncate.py` -- pins
the property the sweep uses (#9237/#9250): seed the lock file with bytes, acquire
and release the lock, assert the bytes survive. Five cases cover both modules and
all three path expressions the sweep touched -- a bound `lock_path` variable
(`_config_lock`), a `.with_suffix(".json.lock")` cache sidecar
(`issues_cache_lock`), a per-item `.lock` name (`issue_write_lock`), the
inline-expression `_skip_lock`, and a real read-modify-write consumer
(`write_settings`). Each fails on every platform under the old truncating open
and passes under `touch` + `"r+"`.

Proven non-vacuous: reverting `_config_lock` alone back to `open(lock_path, "w")`
reddens its case with `b'' != b'held by a prior acquirer\n'`; the skill's
`prove.py` reports PROVEN with the production hunks reverted.

## Manual verification

N/A -- unit coverage sufficient. The change is a mechanical open-mode fix on
Linux (dev host); the Windows sharing-violation path is what the truncation
property stands in for, and it is the same property the two merged sibling PRs
pinned.

## Related Issues

Closes #9263
Refs #9248

Coordination note for the reviewer: on #9248, @jeeshofone claimed these exact
issue_radar sites (2026-09-07 13:57Z) with a shared-helper plan and a "PR to
follow shortly"; that PR has not appeared, and open PR #9269 covers a different
file set (deploy/mcp/pod), not issue_radar. This PR takes the per-subsystem local
route the #9263 body prescribes and leaves the shared-opener consolidation to
#9267. If #9267 lands first and consolidates these 18 sites, this PR should
defer to it.

## Pattern harvest

Defect class: a lock file opened truncating (`open(path, "w")`) before the
descriptor is handed to a lock acquire. Truncation happens before the lock is
held; on Windows a truncating open of an already-locked file raises a sharing
violation instead of waiting, silently losing mutual exclusion, while POSIX
`flock` hides it.

Rule candidate: review-prompt / semgrep -- flag `open(<x>, "w")` (or
`os.open(..., O_TRUNC)`) whose descriptor is passed to a `file_lock` /
`flock_exclusive` / `msvcrt.locking` acquire on the same handle. The fix is
always `touch(exist_ok=True)` + `open(..., "r+")`.
