### PR TITLE
revert: put the AI review lanes back on Opus 4.8 and Fable 5

### DIFF
--- a/.github/workflows/ai-review-human-override.yml
+++ b/.github/workflows/ai-review-human-override.yml
@@ -291,7 +291,7 @@ jobs:
 
           #                workflow             label      fork check-run name / external-id lane / fork workflow
           if [ "$TARGET" = "fable" ] || [ "$TARGET" = "all" ]; then
-            rerun_reviewer "claude-review.yml" "Opus 4.8" "Opus 4.8 Review" "opus" "fork-opus-review.yml"
+            rerun_reviewer "claude-review.yml" "Fable 5" "Opus 4.8 Review" "opus" "fork-opus-review.yml"
           fi
           if [ "$TARGET" = "gpt" ] || [ "$TARGET" = "all" ]; then
             rerun_reviewer "codex-review.yml" "GPT 5.6" "GPT 5.6 Review" "gpt" "fork-gpt-review.yml"

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -71,7 +71,7 @@ jobs:
     # pass timeout, is what kills pass 2, and the job is cancelled with no
     # verdict and no diagnostic. 2 x 55m + ~20m of setup/posting = 130, plus a
     # 30m allowance for the adjudication pass below, which runs ONLY when pass 2
-    # emitted [BLOCK-MERGE] and drives Fable through `claude-code-action` -- that
+    # emitted [BLOCK-MERGE] and drives Opus through `claude-code-action` -- that
     # action cannot be wrapped in `timeout`, so it has no pass wall of its own
     # and this is the only thing bounding it. Still well under GitHub's 360-min
     # job default.
@@ -268,7 +268,7 @@ jobs:
             fi
           done
 
-          # gpt-block-adjudication.md is the contract for the Fable adjudication
+          # gpt-block-adjudication.md is the contract for the Opus adjudication
           # pass at the end of this job, NOT part of GPT's own instruction set,
           # so it is deliberately NOT concatenated here. It is also the ONE block
           # loaded from the base with NO checkout fallback: unlike the review
@@ -729,14 +729,14 @@ jobs:
       # [BLOCK-MERGE]. Every GPT blocking finding here already passed a
       # three-part reachability bar twice (discovery, then falsification), so
       # this stage does NOT re-review the code or re-litigate reachability --
-      # Fable reviews GPT'S JUDGEMENT and asks one question per finding: is
+      # Opus reviews GPT'S JUDGEMENT and asks one question per finding: is
       # blocking the merge on it PROPORTIONATE to what the fix would cost,
       # including the maintenance load the new machinery leaves behind forever.
       # That question was previously asked NOWHERE: the FIX BAR is a shape test
       # (does the fix touch untouched code?), never a cost/harm weighing.
       #
       # Three properties keep this from becoming a bypass surface:
-      #   - it can only ever WIDEN the gate. Fable may UPHOLD or DOWNGRADE; it
+      #   - it can only ever WIDEN the gate. Opus may UPHOLD or DOWNGRADE; it
       #     cannot add a finding, raise an advisory, or alter a claim. A stage
       #     that can only turn red into amber cannot invent a new red.
       #   - security-class findings carry no downgrade eligibility. The
@@ -748,7 +748,7 @@ jobs:
       #     pre-draft the human override rationale, and nothing it writes can
       #     change the gate (#8693). The prompt ALSO treats unbounded harm as
       #     unweighable; these are two independent layers on purpose.
-      #   - the gate reads ARITHMETIC over markers, never Fable's prose. Any
+      #   - the gate reads ARITHMETIC over markers, never Opus's prose. Any
       #     missing marker, malformed footer, or count that fails to reconcile
       #     leaves GPT's verdict exactly as it was. There is no path where a
       #     degraded adjudication turns a red gate green.
@@ -766,7 +766,7 @@ jobs:
           # these is withheld from DOWNGRADE adjudication and keeps blocking, no
           # matter what would have been ruled: for this class the harm has no
           # ceiling for a remedy cost to be weighed against, so there is nothing
-          # to weigh. It still enters Fable's input, in a separate ANNOTATE-ONLY
+          # to weigh. It still enters Opus's input, in a separate ANNOTATE-ONLY
           # section that cannot affect the gate (#8693).
           # It covers BOTH unbounded rungs the contract names -- the security
           # vocabulary AND silent data corruption / irreversible data loss -- so
@@ -796,7 +796,7 @@ jobs:
           # "Write review prompt" step). If it is absent there -- the bootstrap
           # PR that introduces it, or any run where base lacks it -- there is no
           # trusted judge, so nothing is adjudicable and GPT's verdict stands.
-          # Emitting adjudicable=0 skips the Fable call and routes the gate to its
+          # Emitting adjudicable=0 skips the Opus call and routes the gate to its
           # "no blocking finding was adjudicable" branch. Fail closed; never read
           # a PR-supplied contract.
           if [ ! -s .review-prompts-gpt/gpt-block-adjudication.md ]; then
@@ -831,7 +831,7 @@ jobs:
           # F<n> ids are assigned HERE, by script, in emission order. They are
           # what lets the gate pair a per-finding verdict back to the finding it
           # ruled on; a footer that only says "3 of 4" cannot be reconciled.
-          # Fenced findings still consume their id, so the ids Fable sees can have
+          # Fenced findings still consume their id, so the ids Opus sees can have
           # gaps -- it is told to echo them unchanged, and the gate compares the
           # exact set.
           nonce="$(openssl rand -hex 16)"
@@ -944,7 +944,7 @@ jobs:
             } >> .review-adjudication/findings.md
           fi
 
-          # Fable gets the extracted blocks and nothing else -- not GPT's
+          # Opus gets the extracted blocks and nothing else -- not GPT's
           # narrative, not its preamble, not the PR body. GPT's vocabulary in
           # surrounding prose has historically pulled a downstream lane toward
           # agreeing with it, and this stage exists to judge that lane, not to
@@ -982,7 +982,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Fable 5.1 adjudication (blocking findings only)
+      - name: Opus 4.8 adjudication (blocking findings only)
         id: adjudicate
         if: >-
           github.event.pull_request.head.repo.full_name == github.repository
@@ -999,7 +999,7 @@ jobs:
           # enter an agentic reviewer's context, and this stage in particular
           # must not be able to post its own verdict anywhere.
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-opus-4-8
             --max-turns 60
             --allowedTools "Read,Grep,Glob"
           prompt: |
@@ -1224,7 +1224,7 @@ jobs:
               if [ "${ADJ_DECISION:-}" = "cleared" ]; then
                 kind="clear"
                 verdict="✅ no blocking findings (all downgraded on adjudication)"
-                sentence="GPT 5.6 flagged blocking issues on \`$HEAD\`; Fable 5.1 adjudication downgraded every one of them to advisory. ${ADJ_NOTE:-} Read them as advice, not as merge conditions."
+                sentence="GPT 5.6 flagged blocking issues on \`$HEAD\`; Opus 4.8 adjudication downgraded every one of them to advisory. ${ADJ_NOTE:-} Read them as advice, not as merge conditions."
               else
                 kind="blocked"
                 verdict="🔴 changes requested (blocking)"
@@ -1269,7 +1269,7 @@ jobs:
             if [ -s codex-adjudication.md ]; then
               echo
               echo "<details>"
-              echo "<summary>Adjudication (Fable 5.1) — is blocking on each finding proportionate?</summary>"
+              echo "<summary>Adjudication (Opus 4.8) — is blocking on each finding proportionate?</summary>"
               echo
               cat codex-adjudication.md
               echo
@@ -1446,7 +1446,7 @@ jobs:
           # finding, any upheld finding) leaves it at "uphold" and this gate red.
           if grep -Fq "$blocked" codex-review-output.md; then
             if [ "${ADJ_DECISION:-}" = "cleared" ]; then
-              echo "::warning::GPT 5.6 flagged blocking findings on $HEAD; Fable 5.1 adjudication downgraded all of them to advisory. ${ADJ_NOTE:-} They remain in the PR comment as advice."
+              echo "::warning::GPT 5.6 flagged blocking findings on $HEAD; Opus 4.8 adjudication downgraded all of them to advisory. ${ADJ_NOTE:-} They remain in the PR comment as advice."
             else
               echo "::error::GPT 5.6 review flagged a blocking issue on $HEAD — see PR comment. ${ADJ_NOTE:-}"
               exit 1

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -1,6 +1,6 @@
 name: Design Review
 
-# ADVISORY design-level AI review using the "Fable 5.1" model via Amazon Bedrock.
+# ADVISORY design-level AI review using the "Fable 5" model via Amazon Bedrock.
 # Complements the two line-level reviewers (claude-review.yml, codex-review.yml)
 # with a Sage-Phase-1-style DESIGN gate: does the change actually solve the PR's
 # stated problem, is the underlying approach/logic sound, and does the solution
@@ -8,7 +8,7 @@ name: Design Review
 # (the other two own that). It is ADVISORY — it upserts a verdict comment and is
 # NON-BLOCKING because it is not a required status check (the check MAY go red
 # if the review errors, but that red is override-able by a human). Same auth path
-# as claude-review.yml: OIDC → Amazon Bedrock; Fable 5.1 runs through
+# as claude-review.yml: OIDC → Amazon Bedrock; Fable 5 runs through
 # anthropics/claude-code-action with use_bedrock.
 
 on:
@@ -132,7 +132,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Design review (Fable 5.1)
+      - name: Design review (Fable 5)
         id: review
         # We deliberately do NOT set continue-on-error: if the model call fails
         # (Bedrock throttling / 403 / action error) this step fails and the
@@ -152,7 +152,7 @@ jobs:
           # Inference via Amazon Bedrock (region from the AWS creds step above).
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Fable 5.1's BARE, REGIONAL (`us.`) Bedrock inference-profile id.
+          # Fable 5's BARE, REGIONAL (`us.`) Bedrock inference-profile id.
           # Two reasons it must be this exact form:
           #  - No `[1m]` tag: that suffix is the Anthropic-API/claude_code
           #    provider-id form in model_registry.json; the Bedrock path
@@ -177,12 +177,12 @@ jobs:
           #
           # --fallback-model pins the overload fallback to Opus 4.8 (regional
           # `us.` profile, as in claude-review.yml). Without it, Claude Code
-          # falls back to its own smaller/older default (e.g. 4.6) when Fable 5.1
+          # falls back to its own smaller/older default (e.g. 4.6) when Fable 5
           # is overloaded; pinning keeps the reviewer on a top-tier model.
           # us.anthropic.* is already IAM-granted and honors the account
           # provider_data_share retention mode.
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 60
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
@@ -413,7 +413,7 @@ jobs:
             OV_MARKER="<!-- design-review -->"
             {
               echo "$OV_MARKER"
-              echo "## Design Review (Fable 5.1) — ✅ human override accepted"
+              echo "## Design Review (Fable 5) — ✅ human override accepted"
               echo
               echo "_@$OVERRIDE_ACTOR overrode this lane for \`$HEAD\` via \`/ai-review override\` (this commit only)._"
             } > /tmp/ai-override-note.md
@@ -476,7 +476,7 @@ jobs:
             # Valid verdict → post the review body (redacted below).
             {
               echo "$MARKER"
-              echo "## Design Review (Fable 5.1) — $badge"
+              echo "## Design Review (Fable 5) — $badge"
               echo
               echo "_Design-level review of \`$HEAD\` — updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
@@ -501,7 +501,7 @@ jobs:
             esac
             {
               echo "$MARKER"
-              echo "## Design Review (Fable 5.1) — ⚠️ could not complete"
+              echo "## Design Review (Fable 5) — ⚠️ could not complete"
               echo
               echo "_The design review did not produce a verdict for \`$HEAD\` ($why). See the Design Review job logs. Advisory — does not block merge._"
             } > "${RUNNER_TEMP:-/tmp}/design-comment.md"

--- a/.github/workflows/first-principles-review.yml
+++ b/.github/workflows/first-principles-review.yml
@@ -1,6 +1,6 @@
 name: First Principles Review
 
-# ADVISORY premise-level AI review using the "Fable 5.1" model via Amazon Bedrock.
+# ADVISORY premise-level AI review using the "Fable 5" model via Amazon Bedrock.
 # Fifth reviewer lane. The other four all accept the change's REASON FOR
 # EXISTING and argue about the change: the two line reviewers ask "is this code
 # correct", Design Review asks "given the stated problem, is this the right
@@ -28,7 +28,7 @@ name: First Principles Review
 # genuine BLOCK verdict, which fails this check and blocks PR readiness
 # (override-able by a human via `/ai-review override`). Same auth path as
 # design-review.yml: OIDC ->
-# Amazon Bedrock; Fable 5.1 runs through anthropics/claude-code-action with
+# Amazon Bedrock; Fable 5 runs through anthropics/claude-code-action with
 # use_bedrock.
 
 on:
@@ -309,7 +309,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: First-principles review (Fable 5.1)
+      - name: First-principles review (Fable 5)
         id: review
         # No continue-on-error: if the model call fails, this step fails and the
         # check goes RED -- an honest signal the review did not run. It stays
@@ -343,7 +343,7 @@ jobs:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 120
             --allowedTools "Read,Grep,Glob"
@@ -403,7 +403,7 @@ jobs:
             OV_MARKER="<!-- first-principles-review -->"
             {
               echo "$OV_MARKER"
-              echo "## First Principles Review (Fable 5.1) — ✅ human override accepted"
+              echo "## First Principles Review (Fable 5) — ✅ human override accepted"
               echo
               echo "_@$OVERRIDE_ACTOR overrode this lane for \`$HEAD\` via \`/ai-review override\` (this commit only)._"
             } > /tmp/ai-override-note.md
@@ -441,7 +441,7 @@ jobs:
             echo "verdict=NO_CONTRACT" >> "$GITHUB_OUTPUT"
             {
               echo "$MARKER"
-              echo "## First Principles Review (Fable 5.1) — ⏭️ no contract on the base commit"
+              echo "## First Principles Review (Fable 5) — ⏭️ no contract on the base commit"
               echo
               echo "_\`.github/review-prompts/first-principles.md\` does not exist on this PR's base commit, so there is no trusted contract to review \`$HEAD\` against. The contract is deliberately read from the base and never from the head, so a change cannot edit the reviewer that judges it — which also means this lane cannot review the pull request that introduces or moves the contract. Advisory — does not block merge._"
             } > "${RUNNER_TEMP:-/tmp}/fp-comment.md"
@@ -461,7 +461,7 @@ jobs:
             if [ -n "$existing" ] && [ "$existing" != "null" ]; then
               {
                 echo "$MARKER"
-                echo "## First Principles Review (Fable 5.1) — ⏭️ skipped"
+                echo "## First Principles Review (Fable 5) — ⏭️ skipped"
                 echo
                 echo "_Revision \`$HEAD\` ships no reviewable capability (docs, tests or generated files only), so there is nothing to inventory. Advisory — does not block merge._"
               } > "${RUNNER_TEMP:-/tmp}/fp-comment.md"
@@ -508,7 +508,7 @@ jobs:
             # Valid verdict → post the review body (redacted below).
             {
               echo "$MARKER"
-              echo "## First Principles Review (Fable 5.1) — $badge"
+              echo "## First Principles Review (Fable 5) — $badge"
               echo
               echo "_Premise-level review of \`$HEAD\` — why this exists and whether the shipped surface is the smallest honest version. Updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
@@ -533,7 +533,7 @@ jobs:
             esac
             {
               echo "$MARKER"
-              echo "## First Principles Review (Fable 5.1) — ⚠️ could not complete"
+              echo "## First Principles Review (Fable 5) — ⚠️ could not complete"
               echo
               echo "_The first-principles review did not produce a verdict for \`$HEAD\` ($why). See the First Principles Review job logs. Advisory — does not block merge._"
             } > "${RUNNER_TEMP:-/tmp}/fp-comment.md"
@@ -558,7 +558,7 @@ jobs:
             echo "verdict=UNKNOWN" >> "$GITHUB_OUTPUT"
             {
               echo "$MARKER"
-              echo "## First Principles Review (Fable 5.1) — ⚠️ output withheld"
+              echo "## First Principles Review (Fable 5) — ⚠️ output withheld"
               echo
               echo "_The review of \`$HEAD\` produced text that still matched a credential shape after redaction, so the body was withheld and no verdict is reported. See the job logs. Advisory — does not block merge._"
             } > "${RUNNER_TEMP:-/tmp}/fp-comment.md"

--- a/.github/workflows/fix-loop-analysis.yml
+++ b/.github/workflows/fix-loop-analysis.yml
@@ -5,7 +5,7 @@
 # (same contract as ship-report.yml). `.github/scripts/fix_loop_metrics.py`
 # computes volume, the SZZ culprit trace (git blame of each fix's removed
 # lines), deferred-finding discipline, and Pattern-harvest adoption. The model
-# (Fable 5.1 via Bedrock, same invocation shape as ux-review.yml) then reads the
+# (Fable 5 via Bedrock, same invocation shape as ux-review.yml) then reads the
 # window's fix-commit bodies in the checkout, classifies them against the
 # closed root-cause / detection-gap rubrics, compares against the 2026-08
 # full-coverage baseline, and narrates. The report is filed as a GitHub issue
@@ -90,7 +90,7 @@ jobs:
           role-to-assume: ${{ secrets.SHIP_REPORT_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Classify and narrate (Fable 5.1)
+      - name: Classify and narrate (Fable 5)
         id: narrate
         continue-on-error: true # the issue is still filed from the numbers
         uses: anthropics/claude-code-action@24dcd50c0568f0fc9e9211213a4fd2d9eb15c4e0 # v1
@@ -102,7 +102,7 @@ jobs:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 80
             --allowedTools "Read,Grep,Glob,Write"
@@ -251,7 +251,7 @@ jobs:
       - name: Re-raise a missing analysis
         if: always() && steps.file_issue.outputs.analysis_ok == '0'
         run: |
-          echo "::error::The Fable 5.1 analysis step produced no report; the weekly" \
+          echo "::error::The Fable 5 analysis step produced no report; the weekly" \
             "issue was filed with the deterministic metrics only. A failure that" \
             "assumes the Bedrock role successfully but reports num_turns 1 and zero" \
             "cost is an IAM action mismatch, not a model or credential problem:" \

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -1,7 +1,7 @@
 name: Fork Design Review
 
 # STAGE 2 (privileged) of the fork AI-review pipeline — the ADVISORY DESIGN
-# reviewer (Fable 5.1 via Amazon Bedrock). Triggered by the completion of "Fork AI
+# reviewer (Fable 5 via Amazon Bedrock). Triggered by the completion of "Fork AI
 # Review (collect)" (Stage 1). Runs from the DEFAULT branch with secrets + OIDC.
 # It NEVER checks out or executes the fork's code.
 #
@@ -19,7 +19,7 @@ name: Fork Design Review
 #   - harden-runner egress-block + OIDC short-lived Bedrock-only creds bound the
 #     blast radius of any prompt-injection.
 #
-# Mirrors design-review.yml's contract (Fable 5.1 model, Design-Verdict header,
+# Mirrors design-review.yml's contract (Fable 5 model, Design-Verdict header,
 # [DESIGN-REVIEWED] marker, advisory/non-blocking gate). design-review.yml is
 # UNCHANGED and owns same-repo PRs. The fork check-run is named exactly
 # "Design Review" so the same status surfaces on either path. Being ADVISORY, an
@@ -262,7 +262,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Design review (Fable 5.1)
+      - name: Design review (Fable 5)
         id: review
         # We deliberately do NOT set continue-on-error, but this reviewer is
         # ADVISORY: the finalize step below resolves an errored/incomplete run to
@@ -278,10 +278,10 @@ jobs:
           # auto-enables the action's subprocess secret-scrub + bubblewrap
           # isolation, which covers this lane's Bash(git diff/gh pr) grants.
           allowed_non_write_users: "*"
-          # Fable 5.1's BARE, REGIONAL (`us.`) Bedrock inference-profile id, with an
+          # Fable 5's BARE, REGIONAL (`us.`) Bedrock inference-profile id, with an
           # Opus 4.8 overload fallback — matches design-review.yml exactly.
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 60
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
@@ -566,7 +566,7 @@ jobs:
             # Valid verdict → post the (redacted) review body.
             {
               echo "$MARKER"
-              echo "## Design Review (Fable 5.1, fork) — $badge"
+              echo "## Design Review (Fable 5, fork) — $badge"
               echo
               echo "_Design-level review of \`$HEAD\` via the fork AI-review pipeline — updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
@@ -588,7 +588,7 @@ jobs:
             esac
             {
               echo "$MARKER"
-              echo "## Design Review (Fable 5.1, fork) — ⚠️ could not complete"
+              echo "## Design Review (Fable 5, fork) — ⚠️ could not complete"
               echo
               echo "_The design review did not produce a verdict for \`$HEAD\` ($why). See the Fork Design Review job logs. Advisory — does not block merge._"
             } > "$RUNNER_TEMP/design-comment.md"

--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -1,7 +1,7 @@
 name: Fork First Principles Review
 
 # STAGE 2 (privileged) of the fork AI-review pipeline — the ADVISORY
-# FIRST-PRINCIPLES reviewer (Fable 5.1 via Amazon Bedrock). Triggered by the
+# FIRST-PRINCIPLES reviewer (Fable 5 via Amazon Bedrock). Triggered by the
 # completion of "Fork AI Review (collect)" (Stage 1). Runs from the DEFAULT
 # branch with secrets + OIDC. It NEVER checks out or executes the fork's code.
 #
@@ -18,7 +18,7 @@ name: Fork First Principles Review
 #   - harden-runner egress-block + OIDC short-lived Bedrock-only creds bound the
 #     blast radius of any prompt-injection.
 #
-# Mirrors first-principles-review.yml's contract (Fable 5.1 model,
+# Mirrors first-principles-review.yml's contract (Fable 5 model,
 # First-Principles-Verdict header, [FIRST-PRINCIPLES-REVIEWED] marker, the
 # surface-scope gate, advisory/non-blocking except on BLOCK).
 # first-principles-review.yml is UNCHANGED and owns same-repo PRs. The fork
@@ -413,7 +413,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: First-principles review (Fable 5.1)
+      - name: First-principles review (Fable 5)
         id: review
         # We deliberately do NOT set continue-on-error, but this reviewer is
         # ADVISORY: the finalize step below resolves an errored/incomplete run to
@@ -446,7 +446,7 @@ jobs:
           # bubblewrap isolation. See issue #6116.
           allowed_non_write_users: "*"
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 120
             --allowedTools "Read,Grep,Glob"
@@ -718,7 +718,7 @@ jobs:
             # body was discarded upstream. Say that plainly and report no verdict.
             {
               echo "$MARKER"
-              echo "## First Principles Review (Fable 5.1, fork) — ⚠️ output withheld"
+              echo "## First Principles Review (Fable 5, fork) — ⚠️ output withheld"
               echo
               echo "_The review of \`$HEAD\` produced text that still matched a credential shape after redaction, so the body was withheld and no verdict is reported. See the Fork First Principles Review job logs. Advisory — does not block merge._"
             } > "$RUNNER_TEMP/fp-comment.md"
@@ -744,7 +744,7 @@ jobs:
             if [ -n "$existing" ] && [ "$existing" != "null" ]; then
               {
                 echo "$MARKER"
-                echo "## First Principles Review (Fable 5.1, fork) — $heading"
+                echo "## First Principles Review (Fable 5, fork) — $heading"
                 echo
                 echo "$body"
               } > "$RUNNER_TEMP/fp-comment.md"
@@ -764,7 +764,7 @@ jobs:
             # Valid verdict → post the (redacted) review body.
             {
               echo "$MARKER"
-              echo "## First Principles Review (Fable 5.1, fork) — $badge"
+              echo "## First Principles Review (Fable 5, fork) — $badge"
               echo
               echo "_Premise-level review of \`$HEAD\` via the fork AI-review pipeline — why this exists and whether the shipped surface is the smallest honest version. Updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
@@ -787,7 +787,7 @@ jobs:
             esac
             {
               echo "$MARKER"
-              echo "## First Principles Review (Fable 5.1, fork) — ⚠️ could not complete"
+              echo "## First Principles Review (Fable 5, fork) — ⚠️ could not complete"
               echo
               echo "_The first-principles review did not produce a verdict for \`$HEAD\` ($why). See the Fork First Principles Review job logs. Advisory — does not block merge._"
             } > "$RUNNER_TEMP/fp-comment.md"

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -75,7 +75,7 @@ jobs:
       # VERIFY before merge that this SHA resolves to the intended harden-runner
       # release (authoring host had no network to confirm it).
       #
-      # us-east-1 is GPT (both review passes); us-west-2 is the Fable ADJUDICATION
+      # us-east-1 is GPT (both review passes); us-west-2 is the Opus ADJUDICATION
       # pass at the end of the job -- a different role in a different region,
       # reached only when pass 2 emitted [BLOCK-MERGE]. Those three endpoints
       # mirror fork-opus-review.yml's allowlist. Comments cannot live inside the
@@ -893,7 +893,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Fable 5.1 adjudication (blocking findings only)
+      - name: Opus 4.8 adjudication (blocking findings only)
         id: adjudicate
         if: >-
           (steps.adj_input.outputs.adjudicable != '' && steps.adj_input.outputs.adjudicable != '0')
@@ -908,7 +908,7 @@ jobs:
           allowed_non_write_users: "*"
           # No Bash: everything this stage needs is already on disk as data.
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-opus-4-8
             --max-turns 60
             --allowedTools "Read,Grep,Glob"
           prompt: |
@@ -1083,7 +1083,7 @@ jobs:
               # never from the adjudication prose.
               if [ "${ADJ_DECISION:-}" = "cleared" ]; then
                 kind="clear"; verdict="✅ no blocking findings (all downgraded on adjudication)"
-                note="Fable 5.1 adjudication downgraded every blocking finding to advisory. ${ADJ_NOTE:-} Read them as advice, not as merge conditions."
+                note="Opus 4.8 adjudication downgraded every blocking finding to advisory. ${ADJ_NOTE:-} Read them as advice, not as merge conditions."
               else
                 kind="blocked"; verdict="🔴 changes requested (blocking)"
                 note="${ADJ_NOTE:-}"
@@ -1121,7 +1121,7 @@ jobs:
             if [ -s codex-adjudication.md ]; then
               echo
               echo "<details>"
-              echo "<summary>Adjudication (Fable 5.1) — is blocking on each finding proportionate?</summary>"
+              echo "<summary>Adjudication (Opus 4.8) — is blocking on each finding proportionate?</summary>"
               echo
               cat codex-adjudication.md
               echo

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -1,7 +1,7 @@
 name: Fork UX Review
 
 # STAGE 2 (privileged) of the fork AI-review pipeline — the ADVISORY UX
-# reviewer (Fable 5.1 via Amazon Bedrock). Triggered by the completion of
+# reviewer (Fable 5 via Amazon Bedrock). Triggered by the completion of
 # "Fork AI Review (collect)" (Stage 1). Runs from the DEFAULT branch with
 # OIDC. It NEVER checks out or executes the fork's code.
 #
@@ -20,7 +20,7 @@ name: Fork UX Review
 #   - harden-runner egress-block + OIDC short-lived Bedrock-only creds bound
 #     the blast radius of any prompt-injection.
 #
-# Mirrors ux-review.yml's contract (Fable 5.1 model, UX-Verdict/[UX-REVIEWED]
+# Mirrors ux-review.yml's contract (Fable 5 model, UX-Verdict/[UX-REVIEWED]
 # markers, UI-scope gate, ADVISORY: fail only on a genuine BLOCK) with ONE
 # deliberate difference: ux-review.yml runs a BLIND-READ first pass over the
 # screenshots the PR commits, and this lane does not, because those files are
@@ -304,7 +304,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: UX review (Fable 5.1)
+      - name: UX review (Fable 5)
         id: review
         # No continue-on-error: if the model call fails, this step fails and the
         # always()-run finalize below emits a NEUTRAL "UX Review" check (an
@@ -335,7 +335,7 @@ jobs:
           # isolation, which covers this lane's Bash(git diff/gh pr) grants.
           allowed_non_write_users: "*"
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 60
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
@@ -870,7 +870,7 @@ jobs:
             if [ -n "$existing" ] && [ "$existing" != "null" ]; then
               {
                 echo "$MARKER"
-                echo "## UX Review (Fable 5.1, fork) — ⏭️ skipped"
+                echo "## UX Review (Fable 5, fork) — ⏭️ skipped"
                 echo
                 echo "_Revision \`$HEAD\` touches no user-facing surface (no changes under \`website/\` or committed screenshots), so the UX review was skipped. Advisory — does not block merge._"
               } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"
@@ -924,7 +924,7 @@ jobs:
             # Valid verdict → post the review body (redacted below).
             {
               echo "$MARKER"
-              echo "## UX Review (Fable 5.1, fork) — $badge"
+              echo "## UX Review (Fable 5, fork) — $badge"
               echo
               echo "_UX-level review of \`$HEAD\` via the fork AI-review pipeline — updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
@@ -950,7 +950,7 @@ jobs:
             esac
             {
               echo "$MARKER"
-              echo "## UX Review (Fable 5.1, fork) — ⚠️ could not complete"
+              echo "## UX Review (Fable 5, fork) — ⚠️ could not complete"
               echo
               echo "_The UX review did not produce a verdict for \`$HEAD\` ($why). See the Fork UX Review job logs. Advisory — does not block merge._"
             } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -1,6 +1,6 @@
 name: UX Review
 
-# ADVISORY UX-level AI review using the "Fable 5.1" model via Amazon Bedrock.
+# ADVISORY UX-level AI review using the "Fable 5" model via Amazon Bedrock.
 # Fourth reviewer lane, complementing the two line-level reviewers
 # (claude-review.yml, codex-review.yml) and the design gate
 # (design-review.yml). Its lens is the USER-FACING SURFACE of the change:
@@ -12,7 +12,7 @@ name: UX Review
 # upserts a verdict comment and is NON-BLOCKING except on a genuine BLOCK
 # verdict (and even that red is override-able by a human, since it is not a
 # required status check). Same auth path as design-review.yml: OIDC →
-# Amazon Bedrock; Fable 5.1 runs through anthropics/claude-code-action with
+# Amazon Bedrock; Fable 5 runs through anthropics/claude-code-action with
 # use_bedrock.
 #
 # TWO PASSES, ONE WALL. The review is two model calls with a context wall
@@ -297,7 +297,7 @@ jobs:
       # deliberate: a failed blind read degrades to an evidence gap in pass 2
       # (the verdict is then capped below PASS), it must not turn the whole
       # lane red.
-      - name: Blind read of the committed screenshots (Fable 5.1)
+      - name: Blind read of the committed screenshots (Fable 5)
         id: blind
         continue-on-error: true
         if: >-
@@ -311,7 +311,7 @@ jobs:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 50
             --setting-sources user
@@ -429,7 +429,7 @@ jobs:
 
       # PASS 2 -- RECONCILE AND REVIEW. This is the pass whose verdict the
       # lane publishes (id: review is what the posting step reads).
-      - name: UX review (Fable 5.1)
+      - name: UX review (Fable 5)
         id: review
         # No continue-on-error: if the model call fails, this step fails and
         # the "UX Review" check goes RED — an honest signal the review did not
@@ -455,7 +455,7 @@ jobs:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-fable-5-1
+            --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 60
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
@@ -980,7 +980,7 @@ jobs:
             OV_MARKER="<!-- ux-review -->"
             {
               echo "$OV_MARKER"
-              echo "## UX Review (Fable 5.1) — ✅ human override accepted"
+              echo "## UX Review (Fable 5) — ✅ human override accepted"
               echo
               echo "_@$OVERRIDE_ACTOR overrode this lane for \`$HEAD\` via \`/ai-review override\` (this commit only)._"
             } > /tmp/ai-override-note.md
@@ -1011,7 +1011,7 @@ jobs:
             if [ -n "$existing" ] && [ "$existing" != "null" ]; then
               {
                 echo "$MARKER"
-                echo "## UX Review (Fable 5.1) — ⏭️ skipped"
+                echo "## UX Review (Fable 5) — ⏭️ skipped"
                 echo
                 echo "_Revision \`$HEAD\` touches no user-facing surface (no changes under \`website/\` or committed screenshots), so the UX review was skipped. Advisory — does not block merge._"
               } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"
@@ -1065,7 +1065,7 @@ jobs:
             # Valid verdict → post the review body (redacted below).
             {
               echo "$MARKER"
-              echo "## UX Review (Fable 5.1) — $badge"
+              echo "## UX Review (Fable 5) — $badge"
               echo
               echo "_UX-level review of \`$HEAD\` — updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
@@ -1091,7 +1091,7 @@ jobs:
             esac
             {
               echo "$MARKER"
-              echo "## UX Review (Fable 5.1) — ⚠️ could not complete"
+              echo "## UX Review (Fable 5) — ⚠️ could not complete"
               echo
               echo "_The UX review did not produce a verdict for \`$HEAD\` ($why). See the UX Review job logs. Advisory — does not block merge._"
             } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -461,9 +461,9 @@ design axis is **what each is allowed to read** (its prompt-injection surface) a
 |---|---|---|---|---|---|
 | Opus 4.8 | `Opus 4.8 Review` | Agentic, `--max-turns 120` per stage, **two real invocations** (discovery -> validation) | **Code only**: `Read`, `Grep`, `Glob`, `Bash(gh pr diff:*)` | Line-level correctness, security, AUTOSDE | Yes, fail-closed |
 | GPT 5.6 | `GPT 5.6 Review` | Non-agentic, **two** invocations (discovery, then authoritative falsification), `reasoning_effort: medium` | Code plus PR title and body as nonce-wrapped **UNTRUSTED** context | Line-level second perspective, plus description-versus-diff consistency (advisory) | Yes, fail-closed |
-| Design Review | `Design Review` | Agentic Fable 5.1, with an Opus fallback model | Code plus `gh pr view` (it must judge intent) | Should we build this, and is it the right *shape*? | Advisory; red only on a genuine `BLOCK` |
-| UX Review | `UX Review` | Agentic Fable 5.1, with the same fallback; **two real invocations** on same-repo PRs (blind read -> reconcile) | Pass 1: the committed screenshot PNGs **only**; pass 2: code, PR text, and pass 1's report | Can a first-time user who has read nothing tell what each new element is and does, and do state changes stay one continuous element? | Advisory; red only on a genuine `BLOCK` |
-| First Principles | `First Principles Review` | Agentic Fable 5.1, same fallback, `--max-turns 120` (inventorying and counting is grep-heavy) | Code, the whole repository, and `gh pr view` | What is the author trying to do, and does each thing this ships *deserve to exist*, already exist, or only patch a symptom? | Advisory; red only on a genuine `BLOCK` |
+| Design Review | `Design Review` | Agentic Fable 5, with an Opus fallback model | Code plus `gh pr view` (it must judge intent) | Should we build this, and is it the right *shape*? | Advisory; red only on a genuine `BLOCK` |
+| UX Review | `UX Review` | Agentic Fable 5, with the same fallback; **two real invocations** on same-repo PRs (blind read -> reconcile) | Pass 1: the committed screenshot PNGs **only**; pass 2: code, PR text, and pass 1's report | Can a first-time user who has read nothing tell what each new element is and does, and do state changes stay one continuous element? | Advisory; red only on a genuine `BLOCK` |
+| First Principles | `First Principles Review` | Agentic Fable 5, same fallback, `--max-turns 120` (inventorying and counting is grep-heavy) | Code, the whole repository, and `gh pr view` | What is the author trying to do, and does each thing this ships *deserve to exist*, already exist, or only patch a symptom? | Advisory; red only on a genuine `BLOCK` |
 
 ### Why a first-principles lane is not a second Design Review
 
@@ -535,7 +535,7 @@ Three constraints keep it honest:
 It runs whenever a diff touches product or CI surface — **including a plain bug
 fix**, which is where the root-cause lens earns the most. Only a change that ships
 no capability at all (docs, tests, screenshots, generated files) skips, so the
-2x-rate-card Fable 5.1 spend goes to diffs that can actually produce a finding.
+2x-rate-card Fable 5 spend goes to diffs that can actually produce a finding.
 
 It is advisory in `pr-readiness.yml` (UX-style, not Design-style): a `BLOCK` here is
 a judgment about whether a feature should exist, and a model does not get to wedge a
@@ -1182,7 +1182,7 @@ exact-match exception behavior without network access.
 
 The command grammar and the marker contract are in [Human override](#human-override); this section states the authorization and freshness rules the handler enforces.
 
-Human judgment is the final authority over the Opus 4.8 and GPT 5.6
+Human judgment is the final authority over the Fable 5 and GPT 5.6
 AI-review results. A repository member with `write`, `maintain`, or `admin`
 permission can record a false-positive, not-applicable, or accepted-risk
 decision with:
@@ -1215,7 +1215,7 @@ turn a gate green. The handler has only review-control permissions
 on a pull request; `issues:write` alone does not make that write reliable for a
 GitHub Actions installation token.
 
-For Opus 4.8 and GPT 5.6, the handler re-runs the existing PR workflow. The
+For Fable 5 and GPT 5.6, the handler re-runs the existing PR workflow. The
 re-run resolves the trusted marker before acquiring AWS credentials, skips the
 model invocation, updates the existing summary with a human-override banner,
 and exits its original gate successfully. Either event ordering — an override

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -198,7 +198,7 @@ def _step_env(workflow_name: str, step_name: str) -> dict[str, str]:
 
 # The three steps of the blocking-finding adjudication stage, in both GPT lanes.
 ADJ_EXTRACT = "Extract blocking findings for adjudication"
-ADJ_MODEL = "Fable 5.1 adjudication (blocking findings only)"
+ADJ_MODEL = "Opus 4.8 adjudication (blocking findings only)"
 ADJ_GATE = "Adjudicate the blocking verdict (script arithmetic, fail closed)"
 
 
@@ -897,9 +897,9 @@ class TestFirstPrinciplesReview:
             workflow = _workflow(name)
             # Each lane parses that header and pins the model.
             assert "grep -iE '^First-Principles-Verdict:'" in workflow
-            # Fable 5.1 with the same Opus overload fallback as the sibling
+            # Fable 5 with the same Opus overload fallback as the sibling
             # advisory lanes; a bare/`global.` profile id would be rejected.
-            assert "--model us.anthropic.claude-fable-5-1" in workflow
+            assert "--model us.anthropic.claude-fable-5" in workflow
             assert "--fallback-model us.anthropic.claude-opus-4-8" in workflow
 
     def test_intent_then_inventory_then_per_item_judgement(self) -> None:
@@ -1973,8 +1973,8 @@ class TestUxScopeGateSurvivesAWideDiff:
         assert "printf" not in gate, f"{lane}: writer is back in the pipeline"
 
 
-UX_BLIND_STEP = "Blind read of the committed screenshots (Fable 5.1)"
-UX_REVIEW_STEP = "UX review (Fable 5.1)"
+UX_BLIND_STEP = "Blind read of the committed screenshots (Fable 5)"
+UX_REVIEW_STEP = "UX review (Fable 5)"
 UX_EVIDENCE_STEP = "Collect blind-read evidence"
 UX_CAPTURE_STEP = "Capture the blind-read report"
 
@@ -4141,7 +4141,7 @@ class TestBlockAdjudicationContract:
             # Read-only tools, and no `gh`: this stage must not be able to post
             # its own verdict anywhere, only return text the script parses.
             assert '--allowedTools "Read,Grep,Glob"' in with_["claude_args"], lane
-            assert "us.anthropic.claude-fable-5-1" in with_["claude_args"], lane
+            assert "us.anthropic.claude-opus-4-8" in with_["claude_args"], lane
             assert "Bash" not in with_["claude_args"], lane
 
     def test_the_fork_lane_tells_the_adjudicator_the_head_is_not_on_disk(self) -> None:
@@ -4189,7 +4189,7 @@ class TestBlockAdjudicationContract:
             assert "all downgraded on adjudication" in comment, lane
             # Downgraded findings are still SHOWN. The signal was real; only its
             # authority to block the merge was removed.
-            assert "Adjudication (Fable 5.1)" in comment, lane
+            assert "Adjudication (Opus 4.8)" in comment, lane
             assert "codex-adjudication.md" in comment, lane
 
     def test_the_adjudication_step_never_fails_the_job_open(self) -> None:

--- a/test/test_prepare_pr_local_review.py
+++ b/test/test_prepare_pr_local_review.py
@@ -514,12 +514,12 @@ def test_model_pins_agree_with_the_bundled_profile():
 
 
 def test_the_gpt_pin_is_the_reviewers_not_its_adjudicators():
-    """The GPT lane embeds a claude-code-action for the Fable stage that
+    """The GPT lane embeds a claude-code-action for the Opus stage that
     adjudicates its blocking verdict. Reading THAT pin as the reviewer's would
-    make every local brief report drift and claim the GPT lane runs on Fable."""
+    make every local brief report drift and claim the GPT lane runs on Opus."""
     text = _gpt_text()
     scalars = local_review.block_scalars(text)
-    assert "us.anthropic.claude-fable-5-1" in text
+    assert "us.anthropic.claude-opus-4-8" in text
     assert local_review._extract_ci_model(text, scalars, prefer="cli") == "openai.gpt-5.6-sol"
 
 


### PR DESCRIPTION
Reverts #9158 (`ecf50cadd`) in full. **Urgent: that commit is turning the required `GPT 5.6 Review` check red on unrelated pull requests right now.**

## What broke

`us.anthropic.claude-fable-5-1` is not invokable from these lanes, even though the foundation model reports `modelLifecycle.status: ACTIVE` in this account and both the `us.` and `global.` inference profiles exist. Every first call is rejected before any tokens are billed.

The failure was invisible on three of the four lanes and fatal on the fourth:

- **Design / UX / First Principles** pass `--fallback-model us.anthropic.claude-opus-4-8`. They reported success, and their `modelUsage` names `us.anthropic.claude-opus-4-8`. The bump was a silent no-op there; the label said Fable 5.1 while Opus served every review.
- **The GPT lanes' adjudication pass** carries no fallback by design. It initializes on `us.anthropic.claude-fable-5-1`, then returns `is_error: true` after 863 ms with `num_turns: 1`, `total_cost_usd: 0` and `modelUsage: {}`. The step fails, and because it runs whenever GPT emits `[BLOCK-MERGE]`, the whole required check goes red.

Differential: the same adjudication step succeeded five consecutive times on Opus 4.8 in the window before the merge, and failed four consecutive times on Fable 5.1 after it (`fix/bash-gate-false-denials`, `feat/acp-frame-recorder`, `feat/appearance-library-api`, `fix/review-verdict-outlives-description-8925`), all inside sixteen minutes.

## Why it shipped

`ListFoundationModels` and `ListInferenceProfiles` were treated as evidence the reviewer role could invoke the model. They are not: availability and invoke entitlement are separate. Nothing in #9158's own CI could catch it either, since that PR's five review lanes all ran the fallback and reported green.

## Re-landing

A retry needs a real `InvokeModel` smoke test against the reviewer role first, not a listing. It should also drop or reconsider `--fallback-model` on the advisory lanes for the duration of the check, because a fallback that silently rescues a rejected primary is exactly what made this undetectable.

## Dropped by this revert

The two corrected labels for the Opus-4.8-running `claude-review.yml` lane (one log label in `ai-review-human-override.yml`, two lines in `docs/ci/ci-and-reviews.md`) go back to saying "Fable 5". That wording is pre-existing and wrong but harmless, and it comes back with the retry rather than holding up an urgent revert.

## Verification

`test_ai_review_workflows.py` + `test_prepare_pr_local_review.py`: 577 passed. All 30 workflow files parse as YAML. No `fable-5-1` or `Fable 5.1` remains under `.github/` or `docs/`.
