### PR TITLE
fix(hooks): stop the hooks.json lock opens from truncating the lock file

### DIFF
--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -872,7 +872,12 @@ def register_hook(name: str, args: dict[str, Any]) -> str:
     hook_file = mcp_core.config_dir() / "hooks.json"
     hook_file.parent.mkdir(parents=True, exist_ok=True)
     lock_path = hook_file.parent / "hooks.json.lock"
-    with open(lock_path, "w") as lock_fd:
+    # touch + "r+", never "w": a truncating open of a lock file another holder
+    # already locked raises a sharing violation on Windows instead of waiting.
+    # Same file as webhooks.locked guards; full rationale at
+    # work_ledger._open_lock (issue #9248).
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as lock_fd:
         with platform_compat.flock_exclusive(lock_fd.fileno()):
             # Re-read under lock to avoid lost updates
             hooks = {}

--- a/src/kiro_crew/webhooks.py
+++ b/src/kiro_crew/webhooks.py
@@ -186,7 +186,11 @@ def locked(path: Path) -> Iterator[None]:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.parent / (path.name + ".lock")
-    with open(lock_path, "w") as lock_fd:
+    # touch + "r+", never "w": a truncating open of a lock file another holder
+    # already locked raises a sharing violation on Windows instead of waiting.
+    # Full rationale at work_ledger._open_lock (issue #9248).
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as lock_fd:
         with platform_compat.flock_exclusive(lock_fd.fileno()):
             yield
 

--- a/test/test_hooks_json_shared_file.py
+++ b/test/test_hooks_json_shared_file.py
@@ -361,3 +361,55 @@ class TestConcurrentMutationsAreSerialised:
         assert "review:pr-123" in after
         assert len(after["hooks"]) == 16
         assert len(store.list_all()) == 16
+
+
+class TestAcquiringTheSharedLockDoesNotTruncateTheLockFile:
+    """A lock file must be opened WRITABLE but never TRUNCATING.
+
+    ``msvcrt.locking`` needs a writable handle, so the fd cannot be opened
+    ``"r"``. But ``"w"`` truncates at open, and on Windows a truncating open of
+    a lock file whose first byte another holder already locked raises a sharing
+    violation instead of waiting — so the contending acquirer crashes with a
+    bare ``OSError`` *before* it reaches ``file_lock``, and the serialisation
+    the lock exists to provide never happens. POSIX ``flock`` tolerates the
+    truncate, which is why the defect is invisible on Linux and reddens only
+    the Windows shards.
+
+    Issue #9248; same defect and same fix as ``work_ledger._open_lock``
+    (PR #9237) and ``session_pid.py``'s three lock helpers (PR #9250).
+    ``webhooks.locked`` matters doubly: it guards ``hooks.json.lock``, the SAME
+    file ``register_hook`` (``mcp_tools/control.py``) locks from another
+    module, so cross-process contention on it is the store's normal state.
+
+    Truncation is the direct, PLATFORM-INDEPENDENT observable, and that is what
+    this asserts: seed the lock file with bytes, take and release the lock, and
+    require the bytes to have survived. Under the old ``open(lock_path, "w")``
+    this fails on every platform, so the guard does not depend on running the
+    suite on Windows to have teeth.
+    """
+
+    SEED = b"lock-file-content-that-must-survive"
+
+    def test_locked_preserves_the_lock_file(self, tmp_path):
+        from kiro_crew import webhooks
+
+        path = tmp_path / "hooks.json"
+        lock_path = tmp_path / "hooks.json.lock"
+        lock_path.write_bytes(self.SEED)
+
+        with webhooks.locked(path):
+            pass
+
+        assert lock_path.read_bytes() == self.SEED
+
+    def test_locked_works_when_the_lock_file_is_absent(self, tmp_path):
+        """First acquisition must create the lock file rather than raise."""
+        from kiro_crew import webhooks
+
+        path = tmp_path / "hooks.json"
+        assert not (tmp_path / "hooks.json.lock").exists()
+
+        with webhooks.locked(path):
+            pass
+
+        assert (tmp_path / "hooks.json.lock").exists()

--- a/test/test_mcp_core_coverage.py
+++ b/test/test_mcp_core_coverage.py
@@ -1012,6 +1012,44 @@ class TestRegisterHook:
         assert "hooks.json is corrupted" in out
         assert hook_file.read_text() == "{not json"
 
+    def test_acquiring_the_lock_does_not_truncate_the_lock_file(self):
+        """The lock-file open must be WRITABLE but MUST NOT truncate.
+
+        ``msvcrt.locking`` needs a writable handle, so the fd cannot be opened
+        ``"r"``; but ``"w"`` truncates at open, and on Windows a truncating
+        open of a lock file whose first byte another holder already locked
+        raises a sharing violation instead of waiting — the contending acquirer
+        crashes before it reaches ``flock_exclusive`` and the serialisation the
+        lock exists to provide never happens. POSIX ``flock`` tolerates the
+        truncate, which is why the defect is invisible on Linux.
+
+        Issue #9248; same fix as ``work_ledger._open_lock`` (PR #9237) and
+        ``session_pid.py`` (PR #9250). ``hooks.json.lock`` is the SAME file
+        ``webhooks.locked`` guards from another module, so cross-process
+        contention on it is the store's normal state — which is why truncation
+        (the platform-independent observable those PRs pinned) is asserted
+        here: seed the lock file, register a hook, require the bytes survived.
+        """
+        seed = b"lock-file-content-that-must-survive"
+        lock_path = mcp_core.config_dir() / "hooks.json.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_bytes(seed)
+
+        out = _call_tool("register_hook", {"hook_id": "review-bot", "context_summary": "c"})
+
+        assert "Hook registered: review-bot" in out
+        assert lock_path.read_bytes() == seed
+
+    def test_registration_works_when_the_lock_file_is_absent(self):
+        """First registration must create the lock file rather than raise."""
+        lock_path = mcp_core.config_dir() / "hooks.json.lock"
+        assert not lock_path.exists()
+
+        out = _call_tool("register_hook", {"hook_id": "first-run", "context_summary": "c"})
+
+        assert "Hook registered: first-run" in out
+        assert lock_path.exists()
+
 
 class TestReadSlackProfile:
     def test_profile_values_are_redacted_but_id_is_preserved(self):


### PR DESCRIPTION
Part of the #9248 sweep — the hooks.json subsystem. **Deliberately does not close #9248**: the issue is a per-subsystem umbrella and asks for one change per subsystem so each gets its own review. Predecessors already merged: `work_ledger._open_lock` (#9237) and all three `session_pid.py` sites (#9250, which also deferred `webhooks.py` by name to this PR). The remaining subsystems have their own follow-up issues, filed as part of this change: #9263 (issue_radar, 18 sites), #9264 (aws_control, 4 sites), #9265 (deploy, 5 sites), #9266 (cron store lock), and #9267 (shared-helper consolidation).

## Symptom

Intermittent Windows-shard failures wherever two processes contend for `hooks.json`: the second acquirer crashes with a bare `OSError` (sharing violation) instead of waiting for the lock — or, worse, the interleaving silently loses a write.

## Root cause

Both writers of `hooks.json` opened their shared lock sidecar with `open(lock_path, "w")` and only then acquired the lock. `"w"` truncates AT OPEN, so the mutation lands before the lock that is supposed to guard it is held. On Windows the acquire routes to `msvcrt.locking`, and a truncating open of a lock file whose first byte another holder already locked raises a sharing violation instead of waiting. POSIX `flock` tolerates the truncate, which is why the defect is invisible on Linux.

The two sites are ONE unit, not two: `webhooks.locked()` builds `path.parent / (path.name + ".lock")` and `register_hook` (`mcp_tools/control.py`) builds `hook_file.parent / "hooks.json.lock"` — verified to resolve to the SAME `<data-home>/hooks.json.lock` (both roots resolve through the same data home; `config_dir()` is resolve-plus-maintain over the home `data_home()` resolves). Cross-module, cross-process contention on one lock file is exactly what this defect needs, and is why `webhooks.locked` is documented public ("must use the same lock discipline"). Fixing one without the other would leave the pair half-locked and the Windows failure fully live.

`register_hook` was NOT migrated onto `webhooks.locked`: the two lock scopes differ (`locked()` also mkdirs the store's parent and derives the sidecar name from the store path; `register_hook` builds both itself and holds different code under the lock), so forcing the merge is a refactor this PR deliberately avoids. The duplication is named in follow-up #9267.

## Fix

The settled in-tree shape, byte-for-byte the precedent's: `lock_path.touch(exist_ok=True)`, then `open(lock_path, "r+")`, acquiring on that handle exactly as before. `"r+"` rather than `"r"` because `msvcrt.locking` needs a writable handle — `"r"` would swap this bug for a silently-unlocked critical section. Precedent: `work_ledger._open_lock` (#9237, carries the full rationale docstring), `session_pid.py` (#9250), `dashboard/handlers/mcp.py::_McpFileLock` (written this way from the start). Each site carries a short comment pointing at `work_ledger._open_lock` rather than restating the rationale a fourth time.

Doc check: `docs/system-specs/modules/memory-skills-hooks.md` asserts WHICH helper guards the store, not the open mode of the descriptor handed to it — grep confirms no open-mode assertion anywhere in `docs/system-specs/modules/`, so no same-commit spec update is owed (same conclusion #9250 reached for `session.md`).

## Verification

- **Red first**: both new truncation tests written and run against unmodified main at `7dd090fb` — both FAILED (`assert b'' == b'lock-file-content-that-must-survive'`), proving the truncation is observable. Green after the fix.
- **Test property** (the platform-independent proxy #9237 and #9250 established): seed the lock file with bytes, take and release the lock, assert the bytes survive. One test per site, in each site's own suite: `test_hooks_json_shared_file.py` for `webhooks.locked`, `test_mcp_core_coverage.py::TestRegisterHook` for `register_hook`. Plus one absent-lock-file test per site (first-run coverage).
- **Mutation checks, all four killed, each by its own site's test**:
  - `webhooks.py` `"r+"` → `"w"`: only `test_locked_preserves_the_lock_file` red (1 failed / 6 passed across both new groups); restore → green.
  - `control.py` `"r+"` → `"w"`: only `TestRegisterHook::test_acquiring_the_lock_does_not_truncate_the_lock_file` red; restore → green.
  - `webhooks.py` drop `touch(exist_ok=True)`: `test_locked_works_when_the_lock_file_is_absent` red with `FileNotFoundError`; restore → green.
  - `control.py` drop `touch(exist_ok=True)`: `test_registration_works_when_the_lock_file_is_absent` red with `FileNotFoundError`; restore → green.
- **Gates**: `scripts/check_black_formatting.py` passed on the committed scope; `scripts/local-gate.py --base origin/main` plan = full backend + cross-surface frontend guard specs. Backend: 88,986 passed on this branch. Frontend guard: 221 spec files / 6,056 tests, all passed (run via vitest directly, same selector output as the gate).
- **Zero-regression proof**: full backend suite run with the IDENTICAL bare invocation (`pytest -q -n auto --dist loadgroup`, repo root, no path arg) on this branch and on a `git worktree` at `origin/main`; sorted FAILED/ERROR id sets compared both directions after ANSI strip. Branch⊄main direction: EMPTY (nothing fails on the branch that does not fail on main). Main-not-branch direction: exactly one id (`test_search_sessions_cost.py::TestAdmissionControlIsNotAOneWayRatchet::test_a_session_that_left_the_window_stops_holding_budget`), proven environmental — it fails identically in isolation on BOTH trees ("precondition: refusing"), i.e. an ordering flake in the known environmental baseline (438 vs 439 ids, otherwise byte-identical).
- **Screenshot evidence**: not applicable — backend-only diff, no visual surface. <!-- no-visual-delta --> Claiming the no-visual-delta waiver: the change is two lock-file open modes plus tests; there is no pixel anywhere that can change.

## Pattern harvest

Rule candidate: a lock file must be opened writable but never truncating — any `open(x, "w")` whose handle feeds a lock acquire (`file_lock` / `flock_exclusive` / `try_acquire_lock`) is the Windows sharing-violation defect regardless of subsystem. Knowingly out-of-scope sibling sites (28 across issue_radar, aws_control, deploy, cron) are inventoried with line numbers in follow-ups #9263 / #9264 / #9265 / #9266; the preamble consolidation that would make the class un-reintroducible is #9267.
