### PR TITLE
fix(acp): derive fallback spellings when the model config-option push is rejected

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -3849,7 +3849,7 @@ class AcpClient:
                 model_id, self._model_registry_namespace
             )
         if self.backend in ACP_BACKENDS_MODEL_VIA_CONFIG_OPTION:
-            await self.set_config_option("model", model_id)
+            model_id = await self._push_model_config_option(model_id, strict=True)
         else:
             await self._send_request(
                 METHOD_SET_MODEL,
@@ -4008,6 +4008,79 @@ class AcpClient:
         """
         return model_is_unusable(model_id, self._advertised_model_ids())
 
+    @staticmethod
+    def _model_config_candidates(model_id: str) -> list[str]:
+        """Ordered fallback spellings for a config-option model push.
+
+        The cold-cache companion to :func:`resolve_wire_model_id`'s fold: with
+        an empty advertised cache there is nothing to fold against, so a
+        prefixed ``[1m]`` id would otherwise reach the wire verbatim. Candidates
+        are derived from the id itself — verbatim, then prefix-stripped, then
+        prefix- and window-stripped — and the adapter judges each; it knows
+        what it accepts.
+        """
+        out = [model_id]
+        stripped = model_registry.strip_provider_id_prefix(model_id)
+        if stripped != model_id:
+            out.append(stripped)
+        bare = stripped.replace("[1m]", "")
+        if bare != stripped:
+            out.append(bare)
+        return out
+
+    async def _push_model_config_option(self, model_id: str, *, strict: bool) -> str:
+        """Push ``model`` over ``session/set_config_option`` with cold-cache fallback.
+
+        The value-rejection twin of ``_set_effort_config_option``'s ladder in
+        ``providers.acp``: a model the adapter refuses must not bubble up as a
+        generic ``AcpError`` — that failure path resets the session and drops
+        the user onto the adapter default with no explanation. Each candidate
+        spelling is tried in turn; the first accepted one wins and is returned
+        so the caller records the spelling that actually went on the wire.
+
+        ``strict=True`` (an explicit user pick, ``set_model``) raises
+        ``AcpModelUnavailable`` when every candidate is refused — a silent
+        downgrade would report success while running something else.
+        ``strict=False`` (startup application of an inherited value) returns
+        ``""`` so the caller stays on the backend default, mirroring the
+        withhold contract in :meth:`_apply_startup_model`.
+        """
+        last_exc: AcpError | None = None
+        for cand in self._model_config_candidates(model_id):
+            try:
+                await self.set_config_option("model", cand)
+            except AcpError as exc:
+                msg = str(exc)
+                lowered = msg.lower()
+                if "unknown config option" in lowered:
+                    # No 'model' config option at all (other adapter build):
+                    # retrying spellings cannot help.
+                    if strict:
+                        raise
+                    logger.debug("adapter exposes no 'model' config option; skipping model push")
+                    return ""
+                if "config option model" not in lowered:
+                    raise  # transport/protocol failure — not a value rejection
+                last_exc = exc
+                continue
+            if cand != model_id:
+                logger.info(
+                    "ACP model %r rejected by the adapter; applied fallback spelling %r",
+                    model_id,
+                    cand,
+                )
+            return cand
+        _rejected_log, _ = redact_exfiltration_urls(str(model_id))
+        _rejected_log, _ = redact_credentials(_rejected_log)
+        if strict:
+            raise AcpModelUnavailable(_rejected_log, self._advertised_model_ids()) from last_exc
+        logger.warning(
+            "ACP model %s rejected by the adapter; staying on the backend default %s",
+            _rejected_log,
+            self._resolved_model_id or DEFAULT_MODEL,
+        )
+        return ""
+
     async def _apply_startup_model(self) -> None:
         """Apply the configured model to a freshly initialized session.
 
@@ -4077,7 +4150,15 @@ class AcpClient:
                 self._model = DEFAULT_MODEL
                 return
         if self.backend in ACP_BACKENDS_MODEL_VIA_CONFIG_OPTION:
-            await self.set_config_option("model", self._model)
+            sent = await self._push_model_config_option(self._model, strict=False)
+            if not sent:
+                # Every spelling refused: record the session as running the
+                # default (the warm-pool re-apply path reads this field, so
+                # leaving the refused id here would re-offer it every claim)
+                # and let session/new's own model stand.
+                self._model = DEFAULT_MODEL
+                return
+            self._model = sent
         else:
             await self._send_request(
                 METHOD_SET_MODEL,

--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -399,6 +399,23 @@ def _normalize_advertised_key(provider_id: str) -> str:
     return s.strip("-")
 
 
+def strip_provider_id_prefix(provider_id: str) -> str:
+    """Peel ONE leading inference-profile prefix, returned in WIRE form.
+
+    The wire-spelling counterpart of the prefix strip inside
+    :func:`_normalize_advertised_key`: when a prefixed id
+    (``global.anthropic.claude-opus-4-8[1m]``) is rejected by an adapter whose
+    accepted set carries the bare spelling, the retry candidate is this
+    function's output (``claude-opus-4-8[1m]``). Unchanged when no known
+    prefix matches.
+    """
+    s = provider_id.strip()
+    for pfx in _PROVIDER_ID_PREFIXES:
+        if s.lower().startswith(pfx):
+            return s[len(pfx) :]
+    return s
+
+
 def _is_1m_id(model_id: str) -> bool:
     """True if ``model_id`` names a 1M-window variant (``[1m]`` suffix or a
     standalone ``1m`` token)."""

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -11520,6 +11520,162 @@ def _record(sink):
     return _send_request
 
 
+class TestColdCacheModelFallback:
+    """The cold-cache push twin of TestModelEntitlementPreflight.
+
+    ``resolve_wire_model_id`` folds onto the advertised spelling only when the
+    advertised cache is warm. On the first-ever session that cache is empty,
+    so a prefixed ``[1m]`` id reached the wire verbatim and the adapter
+    rejected it — resetting the session and dropping the user onto the default
+    with no explanation (the ``Invalid value for config option model:
+    global.anthropic.claude-sonnet-4-6[1m]`` report). The push helper derives
+    fallback spellings from the id itself and lets the adapter judge each.
+    """
+
+    @staticmethod
+    def _claude_client(model):
+        from kiro_crew.acp.client import ACP_BACKEND_CLAUDE, AcpClient
+
+        client = AcpClient()
+        client._session_id = "sess-1"
+        client._model = model
+        client._resolved_model_id = model
+        client._acp_backend = ACP_BACKEND_CLAUDE
+        return client
+
+    @staticmethod
+    def _rejecting_set_config_option(applied, accepted):
+        from kiro_crew.acp.client import AcpError
+
+        async def _set_config_option(config_id, value):
+            applied.append((config_id, value))
+            if value not in accepted:
+                raise AcpError(f"Invalid value for config option model: {value}")
+
+        return _set_config_option
+
+    @pytest.mark.asyncio
+    async def test_startup_falls_back_to_bare_spelling(self):
+        """The reported failure: prefixed [1m] id refused, bare spelling served."""
+        from kiro_crew.acp.client import DEFAULT_MODEL
+
+        client = self._claude_client("global.anthropic.claude-sonnet-4-6[1m]")
+        applied = []
+        client.set_config_option = self._rejecting_set_config_option(
+            applied, {"claude-sonnet-4-6[1m]"}
+        )
+
+        await client._apply_startup_model()
+
+        assert applied == [
+            ("model", "global.anthropic.claude-sonnet-4-6[1m]"),
+            ("model", "claude-sonnet-4-6[1m]"),
+        ]
+        # Records the spelling that actually went on the wire, not the refused
+        # one (the warm-pool re-apply path reads this field).
+        assert client._model == "claude-sonnet-4-6[1m]"
+        assert client._model != DEFAULT_MODEL
+
+    @pytest.mark.asyncio
+    async def test_startup_prefers_verbatim_when_accepted(self):
+        """A warm cache folds before the wire: the original id is accepted as-is."""
+        client = self._claude_client("claude-sonnet-4-6[1m]")
+        applied = []
+        client.set_config_option = self._rejecting_set_config_option(
+            applied, {"claude-sonnet-4-6[1m]"}
+        )
+
+        await client._apply_startup_model()
+
+        assert applied == [("model", "claude-sonnet-4-6[1m]")]
+        assert client._model == "claude-sonnet-4-6[1m]"
+
+    @pytest.mark.asyncio
+    async def test_startup_all_refused_stays_on_default(self):
+        """Every spelling refused = the withhold contract, not a crash."""
+        from kiro_crew.acp.client import DEFAULT_MODEL
+
+        client = self._claude_client("global.anthropic.claude-sonnet-4-6[1m]")
+        applied = []
+        client.set_config_option = self._rejecting_set_config_option(applied, set())
+
+        await client._apply_startup_model()
+
+        assert len(applied) == 3  # verbatim, prefix-stripped, fully bare
+        assert client._model == DEFAULT_MODEL
+
+    @pytest.mark.asyncio
+    async def test_explicit_switch_refused_raises_unavailable(self):
+        """set_model is an explicit pick: refusal is typed, never a silent lie."""
+        from kiro_crew.acp.client import AcpModelUnavailable
+
+        client = self._claude_client("claude-sonnet-4-6[1m]")
+        client.set_config_option = self._rejecting_set_config_option([], set())
+
+        with pytest.raises(AcpModelUnavailable):
+            await client.set_model("global.anthropic.claude-sonnet-4-6[1m]")
+
+    @pytest.mark.asyncio
+    async def test_explicit_switch_sends_accepted_fallback(self):
+        """An explicit pick that SOME spelling serves still lands on the model."""
+        client = self._claude_client("global.anthropic.claude-sonnet-4-6[1m]")
+        applied = []
+        client.set_config_option = self._rejecting_set_config_option(
+            applied, {"claude-sonnet-4-6[1m]"}
+        )
+
+        await client.set_model("global.anthropic.claude-sonnet-4-6[1m]")
+
+        assert applied[-1] == ("model", "claude-sonnet-4-6[1m]")
+        assert client._model == "claude-sonnet-4-6[1m]"
+        assert client._resolved_model_id == "claude-sonnet-4-6[1m]"
+
+    @pytest.mark.asyncio
+    async def test_unknown_config_option_skips_push(self):
+        """No 'model' option at all (other adapter build): no spelling retry."""
+        from kiro_crew.acp.client import DEFAULT_MODEL, AcpError
+
+        client = self._claude_client("global.anthropic.claude-sonnet-4-6[1m]")
+        applied = []
+
+        async def _unknown(config_id, value):
+            applied.append((config_id, value))
+            raise AcpError("Unknown config option: model")
+
+        client.set_config_option = _unknown
+
+        await client._apply_startup_model()
+
+        assert applied == [("model", "global.anthropic.claude-sonnet-4-6[1m]")]
+        assert client._model == DEFAULT_MODEL
+
+    @pytest.mark.asyncio
+    async def test_transport_error_propagates(self):
+        """A non-value-rejection failure is not ours to swallow."""
+        from kiro_crew.acp.client import AcpError
+
+        client = self._claude_client("claude-sonnet-4-6[1m]")
+
+        async def _transport(config_id, value):
+            raise AcpError("transport closed")
+
+        client.set_config_option = _transport
+
+        with pytest.raises(AcpError, match="transport closed"):
+            await client._apply_startup_model()
+
+    def test_candidate_order_is_derived_from_the_id(self):
+        from kiro_crew.acp.client import AcpClient
+
+        assert AcpClient._model_config_candidates("global.anthropic.claude-sonnet-4-6[1m]") == [
+            "global.anthropic.claude-sonnet-4-6[1m]",
+            "claude-sonnet-4-6[1m]",
+            "claude-sonnet-4-6",
+        ]
+        # No prefix / no window marker: single candidate, nothing derived.
+        assert AcpClient._model_config_candidates("claude-sonnet-4-6") == ["claude-sonnet-4-6"]
+
+
 class TestMiseNodeInstallsDir:
     """ACP node resolution must honour mise's real data root (#1605).
 

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -247,7 +247,8 @@ def _gate_side_baseline_log_sites(
 #: nets to zero (both edits land in one reviewed diff), and the scan is
 #: single-scope (see :func:`_gate_side_baseline_log_sites`).
 _BASELINE_LOG_SITE_CENSUS: dict[str, int] = {
-    "acp/client.py": 7,
+    # +1: model-unavailable warning log in the rejected-model path
+    "acp/client.py": 8,
     "apps/builtins/pptx_maker/backend/routes.py": 1,
     "dashboard/chat_nav.py": 1,
     "dashboard/chat_orchestrator.py": 1,


### PR DESCRIPTION
## Problem / Motivation

Picking a model on the claude backend can reset the whole session with an opaque JSON-RPC internal error:

```
JSON-RPC error: {'code': -32603, 'message': 'Internal error',
 'data': {'details': 'Invalid value for config option model: global.anthropic.claude-sonnet-4-6[1m]'}}
```

The claude adapter advertises model variants under spellings its `model` config option does not accept (a prefixed provider id with a `[1m]` window marker), and that generic `AcpError` path resets the session and silently drops the user onto the backend default with no explanation.

## Why it matters

Trivially user-reachable: choose a 1M variant in the dashboard model picker on a cold advertised-model cache and the turn dies. Live E2E against the real adapter confirmed its accepted set there is aliases (`default`, `opus`, `claude-fable-5[1m]`, `sonnet`, `haiku`) — so a prefixed id can never be accepted, and the crash path was the *only* outcome for that selection. Subagent spawns inherit the same push, so the failure hits member sessions too, not just the picker.

## What changed (motivation → approach → change)

- **Symptom → root cause:** `resolve_wire_model_id` folds a stored id onto the advertised spelling — but only against a warm advertised-model cache. On a cold cache (first-ever session for the provider) the fold is a no-op, the raw prefixed id reaches the wire verbatim, and the adapter's value rejection had no handler at either config-option wire site — unlike the effort push, which already steps down a ladder in `_set_effort_config_option`.
- **Change:** add the value-rejection twin of that ladder at both sites (`set_model`, `_apply_startup_model`) via `_push_model_config_option`: derive fallback candidates from the id itself (verbatim → prefix-stripped → window-stripped) and let the **adapter judge each**; the first accepted spelling is returned and recorded as the id that actually went on the wire.
- **Explicit vs inherited:** `set_model` (an explicit user pick) raises the typed `AcpModelUnavailable` when every spelling is refused — a silent downgrade would report success while running something else. `_apply_startup_model` (an inherited value) keeps the session on the backend default, mirroring the existing withhold contract.
- **Scope guard:** no behavior change for the kiro backend (its path already resolves spelling via `resolve_pin_spelling`).

## Tests

New `TestColdCacheModelFallback` in `test/test_acp_client.py` (8 cases), each locking one behavior: fallback lands on the prefix-stripped spelling the adapter serves; verbatim id accepted unchanged (warm-cache behavior preserved); every candidate refused → withhold to default without raising; explicit switch refused → typed `AcpModelUnavailable`; explicit switch with a served fallback lands on it; unknown-config-option skips without spelling retries; non-value-rejection (transport) errors propagate untouched; candidate ordering derived from the id.

Validation: `TestModelEntitlementPreflight` + `test_model_registry.py` + `test_model_selection_scenarios.py` + `test_harness_parity.py` green (141 passed); `black --target-version py310`, `flake8`, `mypy` clean on touched files.

## Manual verification

End-to-end probe against the real claude adapter (claude CLI 2.1.251) with an isolated `KIROCREW_HOME` = genuinely cold advertised cache, pushing `global.anthropic.claude-sonnet-4-6[1m]`:

- **Before (upstream main):** `ACP init failed (… -32603 'Invalid value for config option model: global.anthropic.claude-sonnet-4-6[1m]' …)` — startup raised, session dead.
- **After (this change):** `E2E OK: session live` — warning logged, session stays on the backend default; explicit `set_model('default')` then lands exactly on the advertised id; advertised ids surfaced as `['default', 'opus', 'claude-fable-5[1m]', 'sonnet', 'haiku']`.

## Related Issues

N/A — reported via a live reproduction session; no existing issue number to reference.

## Pattern harvest

Rule candidate: review-prompt — "every `session/set_config_option` value push needs a value-rejection fallback; a raw rejected value resets the session." The effort option already had its ladder (`_set_effort_config_option`); the model option was the second instance of the same class, and any future config-option push (third instance) should inherit the pattern rather than rediscover the crash.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-facing docs cover adapter model spelling
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
