### PR TITLE
fix: allow reads of kiro-cli agent-spec directory in bash gate

### DIFF
--- a/src/kiro_crew/security/paths.py
+++ b/src/kiro_crew/security/paths.py
@@ -1804,10 +1804,35 @@ def is_sensitive_path(path_str: str, base_dir: str | None = None) -> bool:
     the leaf holds the leaf's full payload, so READ is blocked alongside write -- a
     write-only fence there would still disclose ``.env`` or ``token_signing.key`` to a
     reader that wins the race.
+
+    The kiro-cli agent-spec directory (~/.kiro/agents) is write-protected but
+    MUST remain readable for kiro-cli's own --agent resolution and the MCP
+    rewriter. Explicitly allow reads here to prevent the bash gate from
+    refusing legitimate read operations (fixes #9198).
     """
+    # Explicitly allow reads of the kiro-cli agent-spec directory
+    # It is write-protected (_WRITE_PROTECTED_HOME_PATHS) but must remain readable
+    if _is_kiro_agents_dir(path_str, base_dir):
+        return False
     return _path_in_home_dirs(
         path_str, _SENSITIVE_HOME_DIRS, base_dir
     ) or _is_keystone_publish_artifact(path_str, base_dir)
+
+
+def _is_kiro_agents_dir(path_str: str, base_dir: str | None = None) -> bool:
+    """Check if path is under the kiro-cli agent-spec directory (~/.kiro/agents).
+
+    This directory is write-protected (_WRITE_PROTECTED_HOME_PATHS) but must
+    remain readable for kiro-cli's --agent resolution and MCP rewriter.
+    """
+    candidates = _candidate_forms(path_str, base_dir)
+    kiro_agents = _home_dir_targets_uncached([_KIRO_AGENTS_DIR])
+    for cand in candidates:
+        cand_cf = cand.casefold()
+        for target in kiro_agents:
+            if cand_cf == target or cand_cf.startswith(target + os.sep):
+                return True
+    return False
 
 
 def path_contains_sensitive(dir_str: str, base_dir: str | None = None) -> bool:


### PR DESCRIPTION
## Problem / Motivation

The bash gate (and file-edit tool gate) was refusing READ operations on the kiro-cli agent-spec directory (`~/.kiro/agents`). This directory is correctly write-protected (in `_WRITE_PROTECTED_HOME_PATHS`) but MUST remain readable for:
- kiro-cli's `--agent <name>` resolution
- The MCP rewriter that materializes `mcpServers.<name>.command` into env vars

The bash gate was incorrectly blocking reads because the path matching logic could flag this directory.

## Why it matters

Agents and users could not read their own agent specifications, breaking:
- `kirocrew --agent <name>` workflows
- MCP server command resolution from agent specs
- Dashboard agent configuration UI

## What changed (motivation → approach → change)

Added an explicit exception in `is_sensitive_path()` to allow reads of the kiro-cli agent-spec directory (`~/.kiro/agents`). The directory remains write-protected via `_WRITE_PROTECTED_HOME_PATHS`, but reads are now explicitly allowed.

Added helper `_is_kiro_agents_dir()` that checks if a path is under the agent-spec directory using the same candidate-form/symlink-resolution logic as the main gate.

## Tests

- Verified reads of `~/.kiro/agents/spec.json` are allowed
- Verified writes to `~/.kiro/agents/` are still blocked
- Existing security tests pass

## Related Issues

Fixes #9198

## Checklist

- [x] Single commit with Conventional Commits title
- [x] Existing tests pass
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->