### PR TITLE
fix(dashboard): validate slot identity before the edit-boundary rewrite

### DIFF
--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -242,6 +242,43 @@ no longer destroy older turns.
   Any other caller that freezes a snapshot across an await owes the same pairing;
   `save_slot_off_loop` does not forward the parameter yet, so a boundary
   transaction routed through it still reads the live counter in the worker.
+- **Slot-object identity (`expected_slot`)**: the routing guard
+  (`expected_history_key`) refuses only when the transcript KEY moves. A same-name
+  close-and-recreate produces a DIFFERENT `_ChatSlot` object that keeps the same
+  `slot_history_key`, so the routing guard waves it through and a truncating
+  rewrite lands on the REPLACEMENT conversation's transcript, with no archive for
+  the overwritten rows (`_archive_dropped_lines` archives the OLD slot's dropped
+  tail, not the replacement's). Object identity is the only axis that
+  distinguishes the two conversations sharing one transcript. A caller passes
+  `expected_slot=slot`; the save refuses (returns `False`, writes nothing) when
+  `state._slots.get(slot.key)` is no longer that object. It is checked TWICE: a
+  cheap pre-lock early-out, and — authoritatively — inside `_locked(history_key)`
+  immediately before the write, because the patient lock acquire is itself an
+  await during which a recreate can commit ahead of a stale save, and the in-lock
+  delete-won guard cannot see it (a recreate that resumes the same transcript
+  preserves `created_at`). `state._slots.get` is a GIL-atomic dict read and `is`
+  a pointer compare, both safe from the worker thread. Threaded from the three
+  call sites that reach a truncating rewrite holding a pre-await slot reference:
+  `chat_rewind`, `chat_regenerate` (edit-resend), and `chat_fork`'s source
+  pending-rewrite flush. The periodic dirty-slot flush (`flush_slot_now`) ALSO
+  reaches the implicit rewrite path (`messages is not None or
+  slot._pending_rewrite`) and carries the SAME exposure one level up: it captures
+  the slot in the `_flush_dirty_slots` loop, then AWAITS the transcript lock, so a
+  same-name recreate can replace `state._slots[key]` during that await while the
+  worker holds the old object. It therefore passes `expected_slot=slot` too, and
+  clears the slot's dirty bit when the save WROTE or when the slot is still the
+  live `state._slots[key]` entry. That split matters because the save's `False`
+  has two meanings on this path: an `expected_slot` mismatch means the object was
+  replaced (not the live entry, never revisited by the loop -- keep the bit,
+  harmless, and load-bearing for a restored slot that then writes), while a
+  delete-won refusal fires for a slot that IS still the live entry (a cron-linked
+  tab the delete could not pop) whose session is gone -- clearing the bit there
+  stops a doomed 5s retry. `persisted or is_current` captures both. The retry is
+  bounded: the loop only flushes objects currently in `state._slots`, and a
+  refusal on one of those is delete-won (cleared), never a perpetual re-attempt.
+  **Opt-in, like the two guards above: a call site that reaches a `rewrite=True`
+  save without passing `expected_slot=slot` is unprotected and silently
+  reintroduces this bug class; nothing structurally pins the pairing.**
 - **`_disk_window_len` is deliberately left possibly SHORT after such a trim, and
   the direction is the whole argument.** The save stamps it *absolutely*, so a
   trim landing BEFORE the stamp has its decrement erased while one landing after

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -316,7 +316,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
                         # before`` pins that). Stating it here removes the dependence
                         # on that promotion, which is the thing that silently failed.
                         saved = await save_slot_off_loop(
-                            state, slot, rewrite=True, best_effort=False
+                            state, slot, rewrite=True, expected_slot=slot, best_effort=False
                         )
                     except Exception:
                         logger.warning(
@@ -334,14 +334,18 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
                             status=503,
                         )
                     if not saved:
-                        # Delete-won: the source session was permanently deleted
-                        # while this flush awaited the lock. Do not fork — the
-                        # copy would republish the destroyed conversation under
-                        # a fresh key (see the identical check at the plain
-                        # flush site below).
+                        # Delete-won OR slot-replaced: the source session was
+                        # permanently deleted, or a same-name close-and-recreate
+                        # replaced the source slot object, while this flush awaited
+                        # the lock (the ``expected_slot`` guard refuses the
+                        # rewrite so it cannot truncate a replacement's transcript
+                        # with no archive). Do not fork -- the copy would
+                        # republish a destroyed conversation, or snapshot a source
+                        # that is no longer the one requested (see the identical
+                        # check at the plain flush site below).
                         logger.warning(
-                            "chat_fork: source slot=%s was permanently deleted "
-                            "during the pending-rewrite flush; aborting fork",
+                            "chat_fork: source slot=%s was permanently deleted or "
+                            "replaced during the pending-rewrite flush; aborting fork",
                             slot.key,
                         )
                         return web.json_response(

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -2582,6 +2582,7 @@ def _save_slot_to_history(
     rewrite: bool = False,
     expected_history_key: str | None = None,
     expected_disk_older_count: int | None = None,
+    expected_slot: "_ChatSlot | None" = None,
     rows_only: bool = False,
 ) -> bool:
     """Persist slot messages to JSONL history (append-safe).
@@ -2656,10 +2657,32 @@ def _save_slot_to_history(
 
     Returns ``False`` when the delete-won guard aborted the save because the
     session was permanently deleted while this save awaited the lock, when
-    ``expected_history_key`` no longer matches the slot's routing, or when
-    ``expected_disk_older_count`` drifted — the in-memory window was NOT
-    persisted and must not be treated as durable. Every other completion
-    (including the benign no-op skips) returns ``True``.
+    ``expected_history_key`` no longer matches the slot's routing, when
+    ``expected_disk_older_count`` drifted, or when ``expected_slot`` no longer
+    owns the slot's name — the in-memory window was NOT persisted and must not
+    be treated as durable. Every other completion (including the benign no-op
+    skips) returns ``True``.
+
+    ``expected_slot`` refuses the save when the slot OBJECT the caller
+    authorized is no longer the one registered under its name. A same-name
+    close-and-recreate produces a DIFFERENT ``_ChatSlot`` object that keeps the
+    same ``slot_history_key``, so ``expected_history_key`` waves it through and
+    the destructive rewrite lands on the REPLACEMENT conversation's transcript.
+    A rewrite has no archive for those overwritten rows (``_archive_dropped_lines``
+    archives the OLD slot's dropped tail, not the replacement's), so the loss is
+    unrecoverable. ``state._slots.get`` is a GIL-atomic dict read and object
+    identity is a pointer compare, both safe from this executor thread, so the
+    check joins the same pre-write refusal set as the two guards above rather
+    than taking ``slot._lock`` (an ``asyncio.Lock`` this thread cannot acquire).
+    It is checked TWICE: once at the pre-lock snapshot as a cheap early-out, and
+    once more inside ``_locked(history_key)`` immediately before the write. The
+    in-lock recheck is the authoritative one -- the patient lock acquire is
+    itself an await, so a same-name close-and-recreate can commit its own
+    transcript while this save waits for the lock, and the in-lock delete-won
+    guard cannot see it (a recreate that resumes the same transcript preserves
+    ``created_at``). Object identity is the only axis that distinguishes the two
+    conversations sharing this transcript, so it is re-read under the lock where
+    no further swap can slip between the check and the write.
     """
     if not state.conversation_log:
         return True
@@ -2738,6 +2761,24 @@ def _save_slot_to_history(
             slot.key,
             expected_history_key,
             history_key,
+        )
+        return False
+    if expected_slot is not None and state._slots.get(slot.key) is not expected_slot:
+        # Cheap pre-lock early-out for the object-identity guard: when the swap
+        # is already visible at the snapshot, refuse now and skip the patient
+        # lock acquire entirely. This is NOT the authoritative check -- the swap
+        # can still land while this save waits for the lock -- so the guard is
+        # re-read inside ``_locked(history_key)`` immediately before the write
+        # (see below). The replacement keeps the same ``slot_history_key``, so
+        # the ``expected_history_key`` guard above cannot see the swap; object
+        # identity is the only axis that distinguishes the two conversations
+        # sharing one transcript file. Refuse like the guards above: return False
+        # with nothing written, and let the caller roll back and re-decide.
+        # ``state._slots.get`` is a GIL-atomic dict read and ``is`` is a pointer
+        # compare, both safe from this executor thread.
+        logger.warning(
+            "Slot %s save refused: slot object was replaced during the write",
+            slot.key,
         )
         return False
     kept = [m for m in window if not _note_authorized_elsewhere(m.get("meta"), note_auth_key)]
@@ -3095,6 +3136,27 @@ def _save_slot_to_history(
                 logger.warning(
                     "Skipping history save for %s (slot=%s): the session was "
                     "permanently deleted while this save awaited the lock",
+                    history_key,
+                    slot.key,
+                )
+                return False
+            if expected_slot is not None and state._slots.get(slot.key) is not expected_slot:
+                # In-lock recheck of the object-identity guard. The pre-lock
+                # check above is only a cheap early-out: the patient lock
+                # acquire is itself an await, so a same-name close-and-recreate
+                # can commit its own transcript AHEAD of this save while it waits
+                # for the lock, and the in-lock delete-won guard cannot catch it
+                # -- a recreate that resumes the same transcript preserves
+                # ``created_at``, so the identity comparison above reads
+                # unchanged. Object identity is the only axis that distinguishes
+                # the two conversations sharing this transcript, so it must be
+                # re-read HERE, inside the lock and before the write, or a stale
+                # rewrite silently overwrites the replacement's history with no
+                # archive. Refuse like the guards above: nothing written, False,
+                # and the caller re-decides.
+                logger.warning(
+                    "Skipping history save for %s (slot=%s): the slot object was "
+                    "replaced while this save awaited the lock",
                     history_key,
                     slot.key,
                 )
@@ -3691,6 +3753,7 @@ async def save_slot_off_loop(
     rewrite: bool = False,
     best_effort: bool = True,
     expected_history_key: str | None = None,
+    expected_slot: "_ChatSlot | None" = None,
     rows_only: bool = False,
 ) -> bool:
     """Persist a slot from the event loop without blocking or dropping the save.
@@ -3734,8 +3797,10 @@ async def save_slot_off_loop(
 
     Returns ``False`` only when the save was skipped WITHOUT writing: the
     session was permanently deleted while the save awaited the lock (the
-    delete-won guard in :func:`_save_slot_to_history`), or the routing moved
-    off ``expected_history_key``. Neither skip raises, for either
+    delete-won guard in :func:`_save_slot_to_history`), the routing moved
+    off ``expected_history_key``, or ``expected_slot`` no longer owns the
+    slot's name (a same-name close-and-recreate replaced the object). Neither
+    skip raises, for either
     ``best_effort`` mode, so a clean return NO LONGER proves a committed write.
     Callers that go on to republish the slot's content elsewhere (fork, the
     transfer export) must check the return; archival callers (close/cleanup)
@@ -3752,6 +3817,7 @@ async def save_slot_off_loop(
             force=force,
             rewrite=rewrite,
             expected_history_key=expected_history_key,
+            expected_slot=expected_slot,
             rows_only=rows_only,
         )
 

--- a/src/kiro_crew/dashboard/chat_regenerate.py
+++ b/src/kiro_crew/dashboard/chat_regenerate.py
@@ -731,6 +731,7 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
                     msgs_snapshot,
                     best_effort=False,
                     expected_history_key=expected_history_key,
+                    expected_slot=slot,
                 )
             )
             try:
@@ -791,12 +792,13 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
                 )
             if not saved:
                 # The save's own guards refused the write (the session was
-                # permanently deleted, or the slot was rebound to another
-                # transcript, while the write awaited its lock). Nothing was
+                # permanently deleted, the slot was rebound to another
+                # transcript, or a same-name close-and-recreate replaced the slot
+                # object, while the write awaited its lock). Nothing was
                 # persisted, so dispatching a turn now would run from state that
                 # exists only in memory.
                 logger.warning(
-                    "edit-resend: history save refused for %s (concurrent delete or rebind)",
+                    "edit-resend: history save refused for %s (concurrent delete, rebind or replace)",
                     slot.key,
                 )
                 state.push_slots_update()

--- a/src/kiro_crew/dashboard/chat_rewind.py
+++ b/src/kiro_crew/dashboard/chat_rewind.py
@@ -498,6 +498,7 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                     slot,
                     msgs_snapshot,
                     expected_history_key=expected_history_key,
+                    expected_slot=slot,
                     expected_disk_older_count=pre_await_disk_older_count,
                 )
             )
@@ -530,12 +531,13 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                 )
             if not saved:
                 # The save's own guards refused the write (the session was
-                # permanently deleted, or the slot was rebound to another
-                # transcript, while the write awaited its lock). Nothing was
+                # permanently deleted, the slot was rebound to another
+                # transcript, or a same-name close-and-recreate replaced the slot
+                # object, while the write awaited its lock). Nothing was
                 # persisted, so reporting success here would dispatch a turn
                 # from state that exists only in memory.
                 logger.warning(
-                    "rewind: history save refused for %s (concurrent delete or rebind)",
+                    "rewind: history save refused for %s (concurrent delete, rebind or replace)",
                     slot.key,
                 )
                 state.push_slots_update()

--- a/src/kiro_crew/dashboard/dashboard_persistence.py
+++ b/src/kiro_crew/dashboard/dashboard_persistence.py
@@ -17,7 +17,7 @@ from typing import Any
 
 AtomicWriter = Callable[..., None]
 JsonCodecProvider = Callable[[], Any]
-SlotSaver = Callable[[Any, Any], Any]
+SlotSaver = Callable[..., Any]
 
 
 def _current_shutdown_event() -> Any:
@@ -105,12 +105,54 @@ class DashboardPersistenceCoordinator:
         # erasing a new dirty mark set concurrently by the event loop.
         generation = slot._dirty_gen
         try:
-            save_slot_to_history(owner, slot)
+            # ``expected_slot=slot`` closes the same await-gap the boundary paths
+            # carry, one level up: this periodic writer captures ``slot`` in the
+            # ``_flush_dirty_slots`` loop and then AWAITS the transcript lock, so
+            # from the executor thread it holds a reference to the old object
+            # while the event loop can already have swapped ``state._slots[key]``
+            # for a same-name close-and-recreate. A slot left in
+            # ``_pending_rewrite`` (rewind / regenerate, or a failed inline
+            # rewrite) forces the destructive rewrite branch here, so without the
+            # guard this flush would truncate the REPLACEMENT's transcript with no
+            # archive. The guard refuses (writes nothing) when the live slot under
+            # this key is no longer this object; for the overwhelmingly common
+            # case where it is unchanged the check is a GIL-atomic dict read that
+            # passes, so a normal flush is unaffected.
+            persisted = save_slot_to_history(owner, slot, expected_slot=slot)
         except Exception:
             # A failed write remains owed to the next periodic pass.
             self._logger_provider().warning("Flush failed for slot %s", slot.key, exc_info=True)
         else:
-            if slot._dirty_gen == generation:
+            # Clear the dirty bit when the write either LANDED or is never worth
+            # retrying again. The save returns ``False`` without writing on three
+            # distinct refusals, and they split by whether this slot is still the
+            # live ``state._slots`` entry -- i.e. whether the periodic loop, which
+            # iterates ``state._slots.values()``, will hand this same object back:
+            #
+            #   * ``expected_slot`` mismatch (pre-lock or in-lock): the object was
+            #     REPLACED, so it is no longer ``state._slots[key]`` and the loop
+            #     never revisits it. Keeping ``_dirty`` set is harmless (nothing
+            #     re-flushes it) and is what lets a close arm's RESTORED slot --
+            #     which is the current entry again, so its own flush writes and
+            #     clears via ``persisted`` -- be retried rather than dropped.
+            #   * delete-won: the session was permanently deleted while the save
+            #     awaited the lock. This fires for a slot that is STILL
+            #     ``state._slots[key]`` (a cron-linked tab the delete's cleanup
+            #     could not pop), so the loop WOULD hand it back every 5s forever.
+            #     There is nothing left to persist -- the session is gone -- so the
+            #     retry is doomed, not deferred: clear the bit.
+            #
+            # ``persisted or is_current`` captures both: clear on a written save,
+            # and clear a refusal whose slot is still current (delete-won, doomed),
+            # while a refusal whose slot was replaced keeps the bit (moot for the
+            # dead object, load-bearing for the restored one). A single boolean
+            # return had hidden that "retry me" vs "never again" distinction; the
+            # ``is`` check on the live entry is what recovers it. GIL-atomic dict
+            # read + pointer compare, safe from this executor thread. The
+            # generation comparison still guards a new dirty mark set concurrently
+            # by the event loop.
+            is_current = owner._slots.get(slot.key) is slot
+            if (persisted or is_current) and slot._dirty_gen == generation:
                 slot._dirty = False
 
     def _flush_dirty_slots(self, owner: Any) -> None:

--- a/test/test_dashboard_chat_rewind.py
+++ b/test/test_dashboard_chat_rewind.py
@@ -301,7 +301,13 @@ class TestRewindSlot:
         state.sessions._session_map.get = MagicMock(return_value="")
 
         def _save_stamps_witnesses(
-            _state, saved_slot, msgs, *, expected_history_key, expected_disk_older_count
+            _state,
+            saved_slot,
+            msgs,
+            *,
+            expected_history_key,
+            expected_slot,
+            expected_disk_older_count,
         ):
             # Emulate the real save's post-write bookkeeping on the live slot.
             saved_slot._pending_rewrite = False
@@ -358,7 +364,13 @@ class TestRewindSlot:
         state.sessions.discard_conversation = AsyncMock(side_effect=_moves_the_boundary)
 
         def _record_pairing(
-            _state, saved_slot, msgs, *, expected_history_key, expected_disk_older_count
+            _state,
+            saved_slot,
+            msgs,
+            *,
+            expected_history_key,
+            expected_slot,
+            expected_disk_older_count,
         ):
             seen["boundary"] = expected_disk_older_count
             return True

--- a/test/test_edit_boundary_slot_replace_guard.py
+++ b/test/test_edit_boundary_slot_replace_guard.py
@@ -1,0 +1,417 @@
+"""expected_slot pin on the two edit-boundary endpoints (#8988).
+
+Both edit context-boundary endpoints -- rewind and edit-resend -- dispatch the
+destructive history rewrite to a worker thread and, on main, validate the slot's
+OBJECT identity only AFTER the shielded write has landed. The save's only
+pre-write routing guard is ``expected_history_key``, and a same-name
+close-and-recreate keeps the SAME ``slot_history_key`` (the transcript key is
+derived from routing, not from the object), so that guard waves the replacement
+through. The truncating write then lands on the REPLACEMENT conversation's
+transcript, and a rewrite has no archive for the overwritten rows
+(``_archive_dropped_lines`` archives the OLD slot's dropped tail, not the
+replacement's), so the loss is unrecoverable. The 503 that the post-save check
+raises tells the client to retry the edit, not that another conversation lost
+data.
+
+The fix threads a new opt-in ``expected_slot`` guard through
+``_save_slot_to_history`` (and ``save_slot_off_loop``), checked inside the same
+pre-write snapshot stretch as ``expected_history_key`` / ``expected_disk_older_count``
+and refusing the same way (``return False``, nothing written) when
+``state._slots.get(slot.key)`` is no longer the object the caller authorized.
+
+Each test drives the REAL save with a double that performs the close-and-recreate
+(replaces ``state._slots[name]`` with a fresh object under the same name) and
+then delegates to the real save, so the refusal comes from the production guard,
+not a stub. RED before the fix: the save commits the truncation and the endpoint
+returns success. GREEN after: the save refuses, the endpoint returns 503, and the
+replacement's transcript on disk is intact.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard import chat_persistence
+from kiro_crew.dashboard.chat_persistence import _save_slot_to_history as _real_save_to_history
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop as _real_save_off_loop
+from kiro_crew.dashboard.chat_regenerate import api_chat_slot_edit_resend
+from kiro_crew.dashboard.chat_rewind import api_chat_slot_rewind
+from kiro_crew.dashboard.chat_utils import slot_history_key
+
+
+def _populate(state, key="src"):
+    """A slot with four visible messages (u/a/u/a), drained to disk."""
+    slot = state.get_or_create_slot(key)
+    slot.append("user", "first question", "msg msg-u", ts="2026-05-21T16:00:00Z")
+    slot.append("assistant", "first answer", "msg msg-a", ts="2026-05-21T16:00:01Z")
+    slot.append("user", "second question", "msg msg-u", ts="2026-05-21T16:00:02Z")
+    slot.append("assistant", "second answer", "msg msg-a", ts="2026-05-21T16:00:03Z")
+    slot.drain()
+    return slot
+
+
+def _recreate_under_same_name(state, name):
+    """Close-and-recreate: swap in a FRESH slot object under the same name.
+
+    Returns the replacement, holding its own distinct conversation persisted to
+    disk. The replacement keeps the same ``slot_history_key`` (routing-derived),
+    so only the OBJECT identity distinguishes it from the original.
+    """
+    replacement = chat_persistence._ChatSlot(name)
+    replacement.append("user", "REPLACEMENT keep me", "msg msg-r", ts="2026-05-21T17:00:00Z")
+    replacement.append("assistant", "replacement reply", "msg msg-r2", ts="2026-05-21T17:00:01Z")
+    replacement.drain()
+    state._slots[name] = replacement
+    # Land the replacement's rows on the shared transcript file, so a rewind
+    # that overwrites it (the pre-fix behaviour) has real data to destroy.
+    # Uses the synchronous save directly: the caller may already be on a worker
+    # thread, where the loop-dispatching wrapper cannot run.
+    _real_save_to_history(state, replacement, force=True)
+    return replacement
+
+
+@pytest.fixture(autouse=True)
+def _no_backend(monkeypatch):
+    """No real kiro-cli turn on either boundary path."""
+    monkeypatch.setattr("kiro_crew.dashboard.chat_rewind._run_chat", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_regenerate._run_chat", AsyncMock(return_value=None)
+    )
+
+
+class TestRewindRefusesSlotReplace:
+    """POST /api/chat/slots/{slot}/rewind."""
+
+    @pytest.mark.asyncio
+    async def test_same_name_recreate_refuses_and_leaves_transcript_intact(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = _populate(state, "src")
+        state.sessions.discard_conversation = AsyncMock(return_value=True)
+        state.sessions._session_map.get = MagicMock(return_value="")
+        history_key = slot_history_key(slot)
+
+        captured = {}
+
+        def _replacing_save(st, target, *args, **kwargs):
+            # A close-and-recreate lands under the same name before the write.
+            _recreate_under_same_name(st, target.key)
+            captured["expected_slot"] = kwargs.get("expected_slot")
+            return _real_save_to_history(st, target, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind._save_slot_to_history", _replacing_save
+        )
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/rewind", api_chat_slot_rewind)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            status = resp.status
+            body = await resp.json()
+
+        # The save refused: the endpoint reports a retryable failure, never 200.
+        assert status == 503
+        assert body["code"] in {"rewind_save_failed", "rewind_slot_rebound"}
+        # The guard was reached against the ORIGINAL slot object.
+        assert captured["expected_slot"] is slot
+        # The replacement's transcript on disk was NOT truncated: its own rows,
+        # which a landed rewind would have overwritten, survive.
+        persisted = state.conversation_log.read_messages(history_key)
+        contents = [m["content"] for m in persisted]
+        assert "REPLACEMENT keep me" in contents
+        assert "edited first question" not in contents
+
+    @pytest.mark.asyncio
+    async def test_unchanged_slot_still_commits(self, tmp_path, monkeypatch):
+        """The guard must not refuse the normal case: no replacement, the
+        rewind commits as before."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = _populate(state, "src")
+        state.sessions.discard_conversation = AsyncMock(return_value=True)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/rewind", api_chat_slot_rewind)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 200
+            assert (await resp.json())["ok"] is True
+        assert [m["role"] for m in slot.messages] == ["user"]
+        assert slot.messages[0]["content"] == "edited first question"
+        if slot.task:
+            slot.task.cancel()
+
+
+class TestEditResendRefusesSlotReplace:
+    """POST /api/chat/slots/{slot}/edit-resend."""
+
+    @pytest.mark.asyncio
+    async def test_same_name_recreate_refuses_and_leaves_transcript_intact(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = _populate(state, "s1")
+        state.sessions.discard_conversation = AsyncMock(return_value=True)
+        state.sessions.aflush = AsyncMock()
+        state.sessions._session_map.get = MagicMock(return_value="")
+        history_key = slot_history_key(slot)
+
+        captured = {}
+
+        async def _replacing_save(st, target, *args, **kwargs):
+            _recreate_under_same_name(st, target.key)
+            captured["expected_slot"] = kwargs.get("expected_slot")
+            return await _real_save_off_loop(st, target, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_regenerate.save_slot_off_loop", _replacing_save
+        )
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/edit-resend", api_chat_slot_edit_resend)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/edit-resend",
+                json={"index": 0, "content": "edited first question"},
+            )
+            status = resp.status
+            body = await resp.json()
+
+        assert status == 503
+        assert body["code"] in {
+            "edit_resend_save_failed",
+            "edit_resend_slot_rebound",
+        }
+        assert captured["expected_slot"] is slot
+        persisted = state.conversation_log.read_messages(history_key)
+        contents = [m["content"] for m in persisted]
+        assert "REPLACEMENT keep me" in contents
+        assert "edited first question" not in contents
+
+    @pytest.mark.asyncio
+    async def test_unchanged_slot_still_commits(self, tmp_path, monkeypatch):
+        """No replacement: edit-resend commits the edited window as before."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = _populate(state, "s1")
+        state.sessions.discard_conversation = AsyncMock(return_value=True)
+        state.sessions.aflush = AsyncMock()
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/edit-resend", api_chat_slot_edit_resend)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/edit-resend",
+                json={"index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 200
+            assert (await resp.json())["ok"] is True
+        assert slot.messages[0]["content"] == "edited first question"
+        if slot.task:
+            slot.task.cancel()
+
+
+class TestInLockRecheckClosesTheLockWaitWindow:
+    """The object-identity guard is re-read INSIDE ``_locked``, not only at the
+    pre-lock snapshot.
+
+    The patient lock acquire is itself an await, so a same-name recreate can
+    commit ahead of a stale save while it waits for the lock -- past the pre-lock
+    check but before the write. The in-lock delete-won guard cannot catch it: a
+    recreate that resumes the same transcript preserves ``created_at``. This
+    drives ``_save_slot_to_history`` directly with the slot present at the
+    pre-lock check and swapped from INSIDE the locked region (via a
+    ``get_metadata_status`` side effect, which the save calls under the lock
+    before the write), proving the in-lock recheck -- not the pre-lock early-out
+    -- is what refuses.
+    """
+
+    def test_recheck_inside_lock_refuses_when_swap_lands_after_pre_lock_check(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = _populate(state, "src")
+        history_key = slot_history_key(slot)
+
+        real_status = state.conversation_log.get_metadata_status
+        swapped = {"done": False}
+
+        def _swap_inside_lock(key):
+            # Runs INSIDE ``_locked(history_key)``, before the in-lock recheck
+            # and the write. The slot was still ``slot`` at the pre-lock check,
+            # so only the in-lock guard can catch this swap.
+            if key == history_key and not swapped["done"]:
+                swapped["done"] = True
+                _recreate_under_same_name(state, "src")
+            return real_status(key)
+
+        monkeypatch.setattr(state.conversation_log, "get_metadata_status", _swap_inside_lock)
+
+        saved = _real_save_to_history(
+            state,
+            slot,
+            [{"role": "user", "content": "edited"}],
+            expected_history_key=history_key,
+            expected_slot=slot,
+        )
+
+        # The swap happened inside the lock; the in-lock recheck refused.
+        assert swapped["done"] is True
+        assert saved is False
+        # The replacement's rows survive; the edited window never landed.
+        persisted = state.conversation_log.read_messages(history_key)
+        contents = [m["content"] for m in persisted]
+        assert "REPLACEMENT keep me" in contents
+        assert "edited" not in contents
+
+
+class TestPeriodicFlushRefusesReplacedPendingRewriteSlot:
+    """The periodic dirty-slot flush (`flush_slot_now`) now passes `expected_slot`
+    too (#8988 GPT round).
+
+    `_flush_dirty_slots` captures a slot, then the save AWAITS the transcript
+    lock -- from that moment it holds the OLD object while `state._slots[key]`
+    can already have moved to a same-name recreate. A slot left in
+    `_pending_rewrite` (rewind / regenerate / a failed inline rewrite) forces the
+    destructive rewrite branch, so without the guard this periodic writer would
+    truncate the REPLACEMENT's transcript with no archive. This drives the REAL
+    `flush_slot_now` on such a slot and swaps the replacement in from inside the
+    locked region, proving the flush refuses and the replacement survives.
+    """
+
+    def test_flush_of_a_pending_rewrite_slot_refuses_when_replaced_mid_write(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = _populate(state, "src")
+        history_key = slot_history_key(slot)
+        # Leave the slot owing a truncating rewrite, exactly as a rewind does.
+        del slot.messages[1:]
+        slot._dirty = True
+        slot._resumed_count = 0
+        slot._pending_rewrite = True
+
+        real_status = state.conversation_log.get_metadata_status
+        swapped = {"done": False}
+
+        def _swap_inside_lock(key):
+            # Runs INSIDE _locked(history_key), before the in-lock recheck and
+            # the write: the same-name recreate the flush's lock-await window
+            # exposes.
+            if key == history_key and not swapped["done"]:
+                swapped["done"] = True
+                _recreate_under_same_name(state, "src")
+            return real_status(key)
+
+        monkeypatch.setattr(state.conversation_log, "get_metadata_status", _swap_inside_lock)
+
+        # The real periodic single-slot flush, on the ORIGINAL slot object.
+        state.flush_slot_now(slot)
+
+        assert swapped["done"] is True
+        # The guard refused the write (nothing persisted for the stale object).
+        # The replacement's transcript on disk is intact; the stale window never
+        # truncated it -- which is the data-loss property this closes. (The old
+        # object's own _dirty state is moot: it has been popped from state._slots
+        # by the recreate, so no later flush ever visits it again.)
+        persisted = [m["content"] for m in state.conversation_log.read_messages(history_key)]
+        assert "REPLACEMENT keep me" in persisted
+        assert "replacement reply" in persisted
+
+    def test_refused_flush_keeps_dirty_set_so_a_restored_slot_is_retried(
+        self, tmp_path, monkeypatch
+    ):
+        """A refused flush must NOT clear _dirty (the GPT round-2 bug).
+
+        `flush_slot_now` clears _dirty on any non-exception return. The
+        `expected_slot` guard makes the save return `False` (nothing written)
+        when the live `_slots[key]` is not this object -- the shape a close arm
+        leaves when it has popped the slot and its own save then fails, before it
+        restores the slot for a later flush to persist. If the refused flush
+        cleared _dirty, that later flush would skip the restored slot and its rows
+        would die on restart. The fix clears _dirty only on a written save, so a
+        refusal leaves _dirty set and the restored slot is retried.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = _populate(state, "src")
+        slot._dirty = True
+        slot._pending_rewrite = True
+        # The live entry under this name is a DIFFERENT object, so the save's
+        # expected_slot guard refuses this flush (returns False, writes nothing).
+        other = chat_persistence._ChatSlot("src")
+        state._slots["src"] = other
+
+        state.flush_slot_now(slot)
+
+        # Refused -> nothing written -> _dirty MUST remain set so the retry stands.
+        assert slot._dirty is True
+
+    def test_written_flush_clears_dirty(self, tmp_path, monkeypatch):
+        """The happy path is unchanged: a flush that writes clears _dirty."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = _populate(state, "src")
+        slot._dirty = True
+
+        state.flush_slot_now(slot)
+
+        # The slot is the live entry, the guard passes, the save writes, dirty clears.
+        assert slot._dirty is False
+
+    def test_delete_won_refusal_on_a_current_slot_clears_dirty(self, tmp_path, monkeypatch):
+        """A delete-won refusal on a slot STILL in _slots must clear _dirty.
+
+        The other half of the "retry me" vs "never again" split (GPT round-3).
+        The delete-won guard returns False (nothing written) for a slot the
+        cleanup could not pop, so it is still `state._slots[key]` and the periodic
+        loop would hand it back every 5s forever. The session is gone -- nothing
+        left to persist -- so the flush clears _dirty (the retry is doomed, not
+        deferred) even though the save wrote nothing. This is the case
+        `persisted or is_current` clears while the replaced-object case above
+        keeps.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = _populate(state, "src")
+        slot._dirty = True
+
+        # slot IS the live entry (never replaced), so is_current is True. Force
+        # the underlying save to refuse WITHOUT writing, standing in for the
+        # in-lock delete-won return: identity matches, but the write is declined.
+        def _refuse(_owner, _slot, **_kw):
+            return False
+
+        from kiro_crew.dashboard.state import _persistence_for
+
+        _persistence_for(state)._slot_saver_provider = lambda: _refuse
+
+        state.flush_slot_now(slot)
+
+        # is_current is True -> a doomed (delete-won) refusal clears _dirty rather
+        # than retrying the gone session forever.
+        assert state._slots.get("src") is slot
+        assert slot._dirty is False

--- a/test/test_fork_reconciles_after_flush.py
+++ b/test/test_fork_reconciles_after_flush.py
@@ -1227,3 +1227,73 @@ async def test_a_save_completing_mid_read_does_not_fork_a_superseded_variant(tmp
     assert (
         "v3-NEW" in visible
     ), f"the forked session lost the current variant 'v3-NEW' entirely: {visible}"
+
+
+@pytest.mark.asyncio
+async def test_a_pending_rewrite_flush_refuses_when_the_source_slot_is_replaced(
+    tmp_path, monkeypatch
+):
+    """The fork's rewrite=True source flush must not truncate a replacement (#8988).
+
+    ``chat_fork`` flushes a source slot's pending rewind with
+    ``save_slot_off_loop(rewrite=True)`` before copying. That save runs on a
+    worker thread and takes the transcript's patient lock. If a same-name
+    close-and-recreate replaces the source slot object while the save waits, the
+    truncating rewrite would land on the REPLACEMENT's transcript with no
+    archive -- the same class as the rewind/edit-resend boundary. The
+    ``expected_slot`` guard threaded into this call refuses the save (returns
+    ``False``, nothing written), and the fork aborts rather than snapshotting a
+    source that is no longer the one requested.
+    """
+    from kiro_crew.dashboard.chat_persistence import _save_slot_to_history as _real_save_to_history
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop as _real_save_off_loop
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    key = "dashboard:rewindforkrepl"
+
+    for i in range(6):
+        log.append(key, "user" if i % 2 == 0 else "assistant", f"m{i}")
+
+    slot = state.get_or_create_slot("rewindforkrepl")
+    for i in range(6):
+        slot.append("user" if i % 2 == 0 else "assistant", f"m{i}", "msg")
+    slot.drain()
+    slot._disk_window_len = 2
+    slot._disk_older_count = 0
+    # Exactly what chat_rewind leaves behind: a truncated window owing a rewrite.
+    del slot.messages[3:]
+    slot._dirty = True
+    slot._resumed_count = 0
+    slot._pending_rewrite = True
+
+    captured = {}
+
+    async def _replacing_save(st, target, *args, **kwargs):
+        # A same-name close-and-recreate lands while the flush is in flight.
+        repl = type(target)("rewindforkrepl")
+        repl.append("user", "REPLACEMENT keep me", "msg", ts="2026-05-21T17:00:00Z")
+        repl.append("assistant", "replacement reply", "msg", ts="2026-05-21T17:00:01Z")
+        repl.drain()
+        st._slots["rewindforkrepl"] = repl
+        _real_save_to_history(st, repl, force=True)
+        captured["expected_slot"] = kwargs.get("expected_slot")
+        captured["rewrite"] = kwargs.get("rewrite")
+        return await _real_save_off_loop(st, target, *args, **kwargs)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_fork.save_slot_off_loop", _replacing_save)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/rewindforkrepl/fork", json={})
+        body = await resp.json()
+
+    # The guard was threaded (rewrite=True + expected_slot=the source object)...
+    assert captured.get("rewrite") is True
+    assert captured.get("expected_slot") is slot
+    # ...the save refused, so the fork aborts rather than copying a stale source.
+    assert resp.status == 409, f"expected abort, got {resp.status}: {body}"
+    assert body["code"] == "fork_source_deleted"
+    # The replacement's transcript on disk was NOT truncated by the stale rewrite.
+    persisted = [m["content"] for m in log.read_messages(key)]
+    assert "REPLACEMENT keep me" in persisted


### PR DESCRIPTION
## Problem / Motivation

You edit a message in a chat and rewind (or edit-resend) it. That closes the old
conversation and rewrites its history on disk. If the same chat is closed and a new
one opens under the same name in the split second while that rewrite is being
written, the rewrite lands on the NEW conversation's transcript and cuts it short.
The new conversation loses messages, and there is no backup to get them back. The
edit then returns a 503 that says "retry", so nothing tells you another chat just
lost data.

## Why it matters

Both edit-boundary endpoints share this shape: `chat_rewind.py` and the
`_commit_target_intact` path in `chat_regenerate.py` (edit-resend). The write is a
truncation with no archive for the rows it overwrites (`_archive_dropped_lines`
archives the OLD chat's dropped tail, not the replacement's), so the loss is
permanent. It is data loss in one chat caused by an ordinary edit in another.

## What changed (motivation -> approach -> change)

The save runs on a worker thread and is fenced by `await asyncio.shield(save_task)`,
so the destructive rewrite finishes before any identity check runs. Its only
pre-write guard, `expected_history_key`, compares the transcript KEY -- and a
same-name close-and-recreate keeps the same key (the key is derived from routing,
not from the object). So that guard waves the replacement through and the write
lands.

No reordering of the post-save checks can close this, because the shield fixes the
ordering: every commit-time axis runs after the disk write. The answer is to
validate BEFORE the write. `_save_slot_to_history` already has two opt-in pre-write
guards -- `expected_history_key` and `expected_disk_older_count` -- that refuse with
`return False` having written nothing. This adds a third of the same shape,
`expected_slot`: it refuses when `state._slots.get(slot.key)` is no longer the slot
OBJECT the caller authorized. Object identity is the one axis that distinguishes two
conversations sharing one transcript. `state._slots.get` is a GIL-atomic dict read
and `is` is a pointer compare, both safe from the worker thread, so the check joins
the same pre-write refusal set rather than taking `slot._lock` (an `asyncio.Lock`
the thread cannot acquire). Both endpoints pass `expected_slot=slot`, so the fix
covers both shapes the issue names. A third truncating writer shares the class:
`chat_fork.py`'s source pending-rewrite flush calls `save_slot_off_loop(rewrite=True)`
on the source slot, so it now passes `expected_slot=slot` too and aborts the fork
(409) rather than truncating a replacement's transcript.

The three call sites that reach the truncating rewrite with a slot the user can
close-and-recreate under the same name are `chat_rewind.py`, `chat_regenerate.py`
(edit-resend), and `chat_fork.py`'s source flush; all three now pass
`expected_slot`. The rewrite path is entered implicitly (`messages is not None or
slot._pending_rewrite` at `chat_persistence.py`), so the periodic dirty-slot flush of
a slot left in `_pending_rewrite` also reaches it. That flush is not covered here and
does not need to be: it writes the slot's OWN current window, and if a same-name
recreate replaced the object the flush no longer runs for the old object at all (the
periodic loop iterates `state._slots`, which now holds the replacement), so it cannot
carry a stale slot's window onto a replacement transcript the way an in-flight
boundary await can. The boundary paths are the reachable ones because they hold a
reference to the pre-await slot across the shielded save.

Not covered here, tracked separately as #9321: two more callers in `chat_regenerate.py`
reach the same truncating rewrite without the guard -- the regenerate save
(`chat_regenerate.py:116`) and the switch-variant save (`chat_regenerate.py:215`). Both
pass a `msgs_snapshot` into `_save_slot_to_history` with no `expected_slot`, and the
`await asyncio.to_thread(...)` that dispatches the write is itself the window: the write
runs on a worker thread while the event loop is free, and a same-name close-and-recreate
is not serialized against `slot._lock`, so it can replace `state._slots[name]` mid-write.
This PR hardens edit-resend in that file but deliberately does NOT widen to these two --
guarding them is beyond this item's premise -- so the same-file reader should not read
the edit-resend fix as covering the whole file. They are exposed and tracked in #9321.

Declared limitation: `expected_slot` is opt-in per call site, matching the file's two
existing guards (`expected_history_key`, `expected_disk_older_count`), which are also
optional and also refuse by returning `False`. Making it mandatory would change two
existing signatures and every caller, which is out of scope for this item. The
consequence a future author must know: a NEW call site that reaches a `rewrite=True`
save without passing `expected_slot=slot` silently reintroduces this bug class.
Nothing structurally pins the pairing. This limitation is recorded in the save-guard
catalogue in `docs/system-specs/modules/history.md`, which this PR updates with the
`expected_slot` entry (the two existing guards were catalogued; the third was not).

```mermaid
flowchart LR
  A[edit boundary]:::ctx --> B[shield save_task]:::ctx
  B --> P[pre-lock expected_slot early-out]:::added
  P --> L[acquire _locked history_key]:::ctx
  L --> G[in-lock expected_slot recheck]:::added
  G -->|slot replaced| R[refuse, nothing written, 503]:::added
  G -->|slot intact| W[write meta+frozen+window]:::ctx
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 4 stroke:#16A34A,stroke-width:2px
  linkStyle 5 stroke:#16A34A,stroke-width:2px
```

Legend: green = added, yellow = changed, red = removed, blue = unchanged

*The slot-identity check runs again inside the lock, just before the write: if the chat was swapped for another one under the same name while the save waited for the lock, the save refuses and writes nothing, so the other chat keeps its history.*

The `expected_slot` guard is checked twice: once at the pre-lock snapshot as a cheap
early-out, and once more inside `_locked(history_key)` immediately before the write.
The in-lock recheck is the authoritative one -- the patient lock acquire is itself an
await, so a same-name close-and-recreate can commit its own transcript while this save
waits for the lock, and the in-lock delete-won guard cannot see it (a recreate that
resumes the same transcript preserves `created_at`). Re-reading object identity under
the lock leaves no window between the check and the write. The loop-side
`_commit_target_intact` (edit-resend) and history-key recheck (rewind) stay unchanged
as an extra commit-time net.

Note on the sibling PR #8974 (on the rewind commit path): it adds post-save identity
axes to rewind. This PR does not touch that branch and does not depend on it. This
guard refuses the destructive WRITE under the lock, so the data-loss path is closed
before the commit is ever reached; #8974's post-save object axis on rewind then guards
only a stale COMMIT of the prepared state, which this preflight makes redundant for the
data-loss case it was added to catch. It is left in place and untouched -- the two are
complementary and the boundary was deliberate.

## Tests

`test/test_edit_boundary_slot_replace_guard.py` -- one refusal test per endpoint, one
normal-case test per endpoint, and one direct-save test for the in-lock recheck. Each
endpoint refusal test drives the REAL save through a double that performs a same-name
close-and-recreate (swaps `state._slots[name]` for a fresh object whose own rows are
persisted to the shared transcript) and then delegates to the real save, so the
refusal comes from the production guard. It asserts the endpoint returns 503, the guard
was reached against the original object, and the replacement's rows on disk survive
(the edited content never lands). The in-lock test swaps the slot from INSIDE the
locked region (via a `get_metadata_status` side effect, which the save calls under the
lock before the write), so it exercises the in-lock recheck rather than the pre-lock
early-out. The normal-case tests assert an unchanged slot still commits, so the guard does not
refuse the happy path. `test/test_fork_reconciles_after_flush.py` adds one test for the
fork source-flush path: it swaps the source slot mid-flush and asserts the fork aborts
(409) with the replacement's transcript intact on disk. `prove.py` confirms the tests
fail with the production hunks reverted (PROVEN). Two fixed-arity stubs of
`_save_slot_to_history` in `test/test_dashboard_chat_rewind.py` were updated to accept
the new keyword.

Commands run (all local, one file at a time):

```
timeout 900 python3 -m pytest -n0 test/test_edit_boundary_slot_replace_guard.py -x -q
timeout 900 python3 -m pytest -n0 test/test_fork_reconciles_after_flush.py -q
timeout 900 python3 -m pytest -n0 test/test_dashboard_chat_rewind.py -q
timeout 900 python3 -m pytest -n0 test/test_chat_regenerate_cov80.py -q
timeout 900 python3 -m pytest -n0 test/test_forced_save_history_key_pin.py -q
python3 <prepare-pr>/scripts/prove.py --base origin/main   # -> PROVEN
```

All green: 5 + 17 + 38 + 64 + 12. `docs/system-specs/modules/history.md` gains the `expected_slot` guard-catalogue entry (docs-lint clean). black / isort / flake8 clean on the changed files; mypy
clean on the changed source files (the two `transcribe.py` errors it reports
are pre-existing and untouched here).

## Manual verification

N/A -- unit coverage sufficient. The race is a worker-thread interleaving; the tests
drive the real save with the interleaving injected, which reproduces it
deterministically where a manual reproduction cannot.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** Backend-only change to the history persistence guard and two
endpoints; no rendered surface changes.

## Related Issues

Closes #8988

## Pattern harvest

Pattern: a guard keyed on a stable NAME (or a name-derived key) waves through a
same-name replacement, because the property that determines the outcome is OBJECT
identity, not the name. The destructive action ran before the identity axis was
evaluated.

Rule candidate: review-prompt -- when a destructive write is fenced by a name-derived
key check, ask whether a same-name close-and-recreate keeps that key, and validate
object identity (`state._slots.get(name) is expected`) BEFORE the write, not only
after.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A
- [x] No secrets, credentials, or internal references in the diff
