### PR TITLE
feat(chat): double-press paste shortcut to expand a collapsed paste

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -57,6 +57,7 @@ import {
   makePasteId,
   formatToken,
   tokenRangeAt,
+  expandTokenAt,
   pruneBlocks,
   nextSeq,
   findTokenRanges,
@@ -2495,6 +2496,43 @@ function ChatInput({
           const el = inputRef.current
           if (el) el.setSelectionRange(r.start, r.start)
         })
+      }
+
+      // Cmd/Ctrl+V a SECOND time, with the caret resting on a collapsed paste
+      // token, expands that one paste inline so it can be reviewed, trimmed or
+      // edited in place. The FIRST Cmd/Ctrl+V pasted the block and collapsed it
+      // to `[ Paste #N ]`, leaving the caret on the token; pressing it again is
+      // the "show me what I pasted" gesture (issue #8513, matching Claude Code).
+      //
+      // Positional, not timed: the trigger is "caret is on a token", the same
+      // model the Backspace/Delete/Arrow branches above use. There is no
+      // double-tap timeout, so a single Cmd/Ctrl+V anywhere else keeps its
+      // instant native paste and never feels slower.
+      //
+      // Plain Cmd/Ctrl+V only. Shift+V (rawPasteRef, inline-paste next) and any
+      // selection that spans the token (a copy/cut/replace intent) fall through
+      // to native handling.
+      if (
+        (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey &&
+        e.key.toLowerCase() === 'v' && isCollapsed
+      ) {
+        const expanded = expandTokenAt(v, pasteBlocks, ss)
+        if (expanded) {
+          // preventDefault stops the clipboard from being re-pasted on top of
+          // the token; the gesture replaces the token with its own content.
+          e.preventDefault()
+          onChange(expanded.text)
+          // Drop the expanded block: it is now plain editable text and must not
+          // be re-sent as a separate paste (send maps remaining tokens via
+          // pruneBlocks). The pruneBlocks effect would drop it anyway once its
+          // token is gone; doing it here keeps the two in sync in one tick.
+          onPasteBlocksChange?.(pasteBlocks.filter(b => b.id !== expanded.block.id))
+          requestAnimationFrame(() => {
+            const el = inputRef.current
+            if (el) el.setSelectionRange(expanded.selStart, expanded.selEnd)
+          })
+          return
+        }
       }
 
       // Backspace with caret just past a token → delete whole token

--- a/website/src/test/ChatInput.paste.test.tsx
+++ b/website/src/test/ChatInput.paste.test.tsx
@@ -417,3 +417,93 @@ describe('ChatInput paste: strip trailing blank lines', () => {
     expect(onChange).toHaveBeenCalledWith('just one line')
   })
 })
+
+describe('ChatInput: Cmd/Ctrl+V on a collapsed paste token expands it inline (#8513)', () => {
+  const TOKEN = '[ Paste #1 · 3 lines ]'
+  const CONTENT = 'line1\nline2\nline3'
+
+  // Controlled host so onChange writes flow back into `value`, and the caret
+  // can be parked inside the token before the gesture fires.
+  const renderHost = (onPasteBlocksChange = vi.fn()) => {
+    const seen = { blocks: [{ id: 'p1', seq: 1, lines: 3, content: CONTENT }] as { id: string; seq: number; lines: number; content: string }[] }
+    const Host = () => {
+      const [v, setV] = useState(`before ${TOKEN} after`)
+      return (
+        <ChatInput
+          value={v}
+          onChange={setV}
+          onSend={vi.fn()}
+          pasteBlocks={seen.blocks}
+          onPasteBlocksChange={onPasteBlocksChange}
+        />
+      )
+    }
+    renderWithProviders(<Host />)
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    return ta
+  }
+
+  const caretInsideToken = (ta: HTMLTextAreaElement) => {
+    const at = ta.value.indexOf('[') + 4
+    ta.focus()
+    ta.setSelectionRange(at, at)
+    return at
+  }
+
+  it('replaces the token with its full content when Cmd+V is pressed on it', () => {
+    const ta = renderHost()
+    caretInsideToken(ta)
+    fireEvent.keyDown(ta, { key: 'v', metaKey: true })
+    expect(ta.value).toBe(`before ${CONTENT} after`)
+  })
+
+  it('drops the expanded block so it is not also re-sent as a paste', () => {
+    const onPasteBlocksChange = vi.fn()
+    const ta = renderHost(onPasteBlocksChange)
+    caretInsideToken(ta)
+    fireEvent.keyDown(ta, { key: 'v', ctrlKey: true })
+    expect(onPasteBlocksChange).toHaveBeenCalledWith([])
+  })
+
+  it('leaves the token collapsed when the caret is NOT on it', () => {
+    const ta = renderHost()
+    ta.focus()
+    ta.setSelectionRange(0, 0) // caret at the very start, before the token
+    fireEvent.keyDown(ta, { key: 'v', metaKey: true })
+    // Token untouched — the gesture fell through to native paste handling.
+    expect(ta.value).toContain(TOKEN)
+  })
+
+  it('does not fire for Cmd+Shift+V (raw-inline-paste), leaving the token collapsed', () => {
+    const ta = renderHost()
+    caretInsideToken(ta)
+    fireEvent.keyDown(ta, { key: 'v', metaKey: true, shiftKey: true })
+    expect(ta.value).toContain(TOKEN)
+  })
+
+  it('expands when the caret is one trailing newline past the token (paste before existing text)', () => {
+    // Collapse-on-paste at the start of the box inserts `token + "\n"` and parks
+    // the caret AFTER the newline, so a plain caret-on-token test would miss and
+    // the second Cmd/Ctrl+V would re-paste the clipboard instead of expanding.
+    const seen = { blocks: [{ id: 'p1', seq: 1, lines: 3, content: CONTENT }] }
+    const Host = () => {
+      const [v, setV] = useState(`${TOKEN}\nrest of the message`)
+      return (
+        <ChatInput
+          value={v}
+          onChange={setV}
+          onSend={vi.fn()}
+          pasteBlocks={seen.blocks}
+          onPasteBlocksChange={vi.fn()}
+        />
+      )
+    }
+    renderWithProviders(<Host />)
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    ta.focus()
+    const pastNewline = TOKEN.length + 1 // just past the "\n" the collapse added
+    ta.setSelectionRange(pastNewline, pastNewline)
+    fireEvent.keyDown(ta, { key: 'v', metaKey: true })
+    expect(ta.value).toBe(`${CONTENT}\nrest of the message`)
+  })
+})

--- a/website/src/test/pasteTokens.test.ts
+++ b/website/src/test/pasteTokens.test.ts
@@ -7,6 +7,7 @@ import {
   nextSeq,
   findTokenRanges,
   tokenRangeAt,
+  expandTokenAt,
   pruneBlocks,
   expandAll,
   recollapsePastes,
@@ -112,6 +113,67 @@ describe('pasteTokens', () => {
       const b = block({ seq: 1 })
       const input = [b]
       expect(pruneBlocks(formatToken(b), input)).toBe(input)
+    })
+  })
+
+  describe('expandTokenAt', () => {
+    it('replaces the token at the caret with its content and selects it', () => {
+      const b = block({ id: 'x', seq: 1, content: 'line1\nline2\nline3' })
+      const text = `before ${formatToken(b)} after`
+      const caret = text.indexOf('[') + 4 // inside the token
+      const r = expandTokenAt(text, [b], caret)
+      expect(r).not.toBeNull()
+      expect(r!.text).toBe('before line1\nline2\nline3 after')
+      expect(r!.block.id).toBe('x')
+      // Selection wraps exactly the inserted content.
+      expect(r!.text.slice(r!.selStart, r!.selEnd)).toBe('line1\nline2\nline3')
+    })
+
+    it('expands ONLY the token at the caret, leaving the others collapsed', () => {
+      const b1 = block({ id: 'a', seq: 1, content: 'AAA' })
+      const b2 = block({ id: 'b', seq: 2, content: 'BBB' })
+      const text = `${formatToken(b1)} mid ${formatToken(b2)}`
+      const onB2 = text.indexOf(formatToken(b2)) + 3 // caret inside b2's token
+      const r = expandTokenAt(text, [b1, b2], onB2)
+      expect(r).not.toBeNull()
+      expect(r!.block.id).toBe('b')
+      expect(r!.text).toBe(`${formatToken(b1)} mid BBB`)
+    })
+
+    it('returns null when the caret is not on a token', () => {
+      const b = block({ seq: 1, content: 'ZZZ' })
+      const text = `plain ${formatToken(b)} text`
+      expect(expandTokenAt(text, [b], 0)).toBeNull()
+    })
+
+    it('resolves a token the caret is one trailing newline past (paste before existing text)', () => {
+      // Collapse-on-paste wraps the token as `token + "\n"` and parks the caret
+      // AFTER the newline, so tokenRangeAt misses. expandTokenAt must still find
+      // it or the second shortcut re-pastes the clipboard.
+      const b = block({ id: 'p', seq: 1, content: 'AAA\nBBB\nCCC' })
+      const text = `${formatToken(b)}\nrest`
+      const caretPastNewline = formatToken(b).length + 1 // just past the "\n"
+      const r = expandTokenAt(text, [b], caretPastNewline)
+      expect(r).not.toBeNull()
+      expect(r!.block.id).toBe('p')
+      expect(r!.text).toBe('AAA\nBBB\nCCC\nrest')
+    })
+
+    it('does NOT bridge more than a single newline', () => {
+      // A caret out in ordinary text, two chars past a token, is not an expand.
+      const b = block({ seq: 1, content: 'ZZZ' })
+      const text = `${formatToken(b)}\nxy`
+      const caretDeep = formatToken(b).length + 3 // past "\nxy" — well clear
+      expect(expandTokenAt(text, [b], caretDeep)).toBeNull()
+    })
+
+    it('does NOT bridge a space (a caret one space past a token is normal typing)', () => {
+      // `[ Paste #1 ] and more`, caret before "and" -> the user means to paste
+      // new clipboard content, not re-expand. Only a newline is bridged.
+      const b = block({ seq: 1, content: 'ZZZ' })
+      const text = `${formatToken(b)} and more`
+      const caretPastSpace = formatToken(b).length + 1 // just past the space
+      expect(expandTokenAt(text, [b], caretPastSpace)).toBeNull()
     })
   })
 

--- a/website/src/utils/pasteTokens.ts
+++ b/website/src/utils/pasteTokens.ts
@@ -133,6 +133,58 @@ export function tokenRangeAt(
   return null
 }
 
+/**
+ * Expand the single collapsed-paste token the caret is on (or immediately
+ * after), in place.
+ *
+ * Returns the rewritten text with that one token replaced by its block's
+ * verbatim content, the block whose token was expanded (so the caller can drop
+ * it from the tracked set — an expanded paste is plain editable text and must
+ * not also be re-sent as a separate paste), and the caret offsets that keep the
+ * selection wrapped around the freshly-inserted content. Returns `null` when
+ * the caret is not on a token, so the caller can fall through to native paste.
+ *
+ * Caret resolution has two cases, because collapsing a paste wraps the token in
+ * newlines and parks the caret AFTER the trailing one:
+ *   1. Caret inside/on the token (`tokenRangeAt`) — the end-of-line paste case,
+ *      where there is no trailing newline and the caret rests on the token.
+ *   2. Caret one newline past a token's end — the paste-before-existing-text
+ *      case: the insert is `token + "\n"` and the caret lands after the "\n",
+ *      so `tokenRangeAt` would miss and the second shortcut would re-paste the
+ *      clipboard. We resolve the token whose end is the single `\n` immediately
+ *      before the caret, mirroring the Backspace "caret just past a token"
+ *      branch in ChatInput. A space is NOT bridged: a caret one space past a
+ *      token is a normal mid-typing position where the user means to paste new
+ *      content, not re-expand.
+ *
+ * This is the composer counterpart to {@link expandAll}: `expandAll` inlines
+ * every token for send/optimize, while this inlines exactly the one the user
+ * asked to review, leaving any other tokens collapsed.
+ */
+export function expandTokenAt(
+  text: string,
+  blocks: PasteBlock[],
+  caret: number,
+): { text: string; block: PasteBlock; selStart: number; selEnd: number } | null {
+  let r = tokenRangeAt(text, blocks, caret)
+  if (!r && caret > 0 && text[caret - 1] === '\n') {
+    // Case 2: caret sits just past a token's trailing NEWLINE. Collapse-on-paste
+    // wraps the token as `token + "\n"` and parks the caret after the newline
+    // (the paste-before-existing-text case), so tokenRangeAt misses and a second
+    // shortcut would re-paste the clipboard. Only a newline is bridged, and only
+    // one: a caret one SPACE past a token's `]` is a normal typing position
+    // (`[ Paste #1 ] and more`, caret before "and"), where the user means to
+    // paste new clipboard content, not re-expand the paste -- so a space is left
+    // to native paste. A caret two or more chars past a token never matches.
+    r = findTokenRanges(text, blocks).find(x => x.end === caret - 1) ?? null
+  }
+  if (!r) return null
+  const out = text.slice(0, r.start) + r.block.content + text.slice(r.end)
+  // Select the inserted content so the user can immediately trim or replace it,
+  // and so a screen reader announces the newly-selected region.
+  return { text: out, block: r.block, selStart: r.start, selEnd: r.start + r.block.content.length }
+}
+
 export function pruneBlocks(text: string, blocks: PasteBlock[]): PasteBlock[] {
   if (!blocks.length) return blocks
   const survivors = new Set(findTokenRanges(text, blocks).map(r => r.block.id))


### PR DESCRIPTION
## Problem / Motivation

A large paste into the dashboard composer collapses to a `[ Paste #N | M lines ]`
token so the box stays readable. Today you cannot see what that token holds without
sending the message. The composer only offers a hover/caret PEEK tooltip
(`PasteHoverLayer`), which shows the first few lines and cannot be edited. The
click-to-expand chip in `PastedChip` exists only in the SENT bubble, not in the
composer while you are still writing. So you cannot verify you pasted the right
block, and you cannot trim or edit it in place.

## Why it matters

Pasting a log, a diff, or a transcript and being unable to check it before send is
easy to get wrong: the wrong block, an extra copy, a stray line. The user has no way
to open the paste back up and fix it without deleting the whole token and starting
over.

## What changed (motivation -> approach -> change)

Goal: let the user open a collapsed paste back into editable text, in place, with a
gesture that matches how Claude Code does it (issue #8513).

Approach and the design trap. The gesture is a SECOND Cmd/Ctrl+V while the caret is
resting on a collapsed token. The important choice is that it is POSITIONAL, not
timed. **There is no double-tap interval at all** -- the code does not wait, does not
buffer, and does not schedule anything. The first Cmd/Ctrl+V is the ordinary native
paste and fires immediately with zero added latency; it is never delayed and never
undone. The "second press" is simply "the caret is on a paste token and you pressed
Cmd/Ctrl+V again" -- the exact same "caret is on a token" model the composer already
uses for Backspace, Delete, and Arrow keys on these tokens. A timed double-tap would
have made every single paste feel slower while the code waited to see if a second
one was coming; because the trigger is the caret position and not a timer, the
ordinary paste keeps its full speed and the gesture adds nothing to it.

Existing convention. There was no repeated-keypress or double-tap handler in the
composer to match, so none was invented -- the gesture reuses the established
caret-on-token branch structure in `ChatInput` `handleKeyDown`. There is already an
expand affordance for a SENT paste (the `PastedChip` click toggle); this adds the
composer-side counterpart the issue asks for, beside the existing hover peek rather
than replacing it.

The change. `expandTokenAt(text, blocks, caret)` in `pasteTokens.ts` replaces the one
token under the caret with its block's verbatim content and returns the caret offsets
that select the inserted text. `ChatInput` calls it from a new keydown branch on
plain Cmd/Ctrl+V (not Shift+V, which is the existing raw-inline-paste shortcut), calls
`preventDefault` so the clipboard is not re-pasted on top of the token, and drops the
expanded block from the tracked set -- an expanded paste is now plain editable text
and must not also be re-sent as a separate paste (send maps the remaining tokens via
`pruneBlocks`).

```mermaid
flowchart LR
  subgraph Before
    A1[caret on paste token]:::ctx --> B1[Cmd/Ctrl+V]:::ctx --> C1[re-paste clipboard]:::removed
    A1 --> P1[hover/caret peek only]:::ctx
  end
  subgraph After
    A2[caret on paste token]:::ctx --> B2[Cmd/Ctrl+V]:::ctx --> C2[token becomes editable text, selected]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 4 stroke:#16A34A,stroke-width:2px
```

Legend: added, changed, removed, unchanged. Pressing the paste key on a collapsed
token now opens it into text you can trim, instead of pasting the clipboard again.

Scope notes for review:

- Shared file with a sibling. Issue #8309 (collapsed paste highlights detaching from
  composer text) is being worked in parallel and also touches `ChatInput.tsx`. My
  edit is one self-contained new branch inside the existing atomic-token block in
  `handleKeyDown`; it does not touch the highlight-layer wiring (`PasteHighlightLayer`,
  `PasteHoverLayer`) or the composer host files (`ChatPane`, `ChatPage`, `SideChat`)
  that #8309 is editing. If the two land close together this branch is an additive
  hunk and should rebase cleanly.
- Reversibility. The issue lists re-collapse-on-a-further-press as "ideally", i.e.
  not required for the ask. This PR ships the expand direction, which is the issue's
  stated need (see what a paste holds, trim/edit it in place) -- hence `Closes`. A
  reversible toggle needs an "expanded but still tracked" block state, and the composer's current model drops a block the moment its
  token leaves the text (the `pruneBlocks` effect, and `pruneBlocks` is also what the
  send path uses to decide which pastes to send). Keeping an expanded-yet-tracked
  block would change that send/prune contract and reach into the same composer wiring
  #8309 is editing. Re-collapse is left as a follow-up rather than widening this PR
  into that shared surface.
- Accessibility, and the non-gesture path. The gesture is fully keyboard-reachable:
  arrow keys land the caret inside a token (the existing `PasteHoverLayer` caret
  path), and Cmd/Ctrl+V there expands it, so it needs no pointer and no mouse. For
  READING a collapsed paste without the gesture, the existing hover/caret PEEK
  tooltip stays in place -- it opens on keyboard focus/caret as well as hover and is
  screen-reader announced via `aria-describedby`, so a user who cannot perform the
  double press can still see the content. Honest limit: there is no non-gesture
  affordance in the COMPOSER that performs the expand-into-editable-text itself
  (no click target, no menu item). The sent-bubble chip (`PastedChip`) has the full
  `title` + `aria-label` + click toggle, but the composer token is drawn in a
  non-interactive mirror layer on purpose -- `PasteHoverLayer` documents that the
  composer keeps no interactive layer above the textarea, because one would intercept
  clicks and selection. Adding a composer-side click/menu expand affordance would
  reach into that highlight/hover surface, which is #8309's territory, so it is
  deferred to the same follow-up as re-collapse rather than added here. If review
  wants a non-gesture expand path in this PR, that is a design call for the
  maintainer, since it changes the composer's no-interactive-overlay rule.

## Tests

- `website/src/test/pasteTokens.test.ts` -- `expandTokenAt`: replaces the token at the
  caret with its content and selects it; expands ONLY the token under the caret,
  leaving others collapsed; returns null when the caret is not on a token.
- `website/src/test/ChatInput.paste.test.tsx` -- the keydown wiring: Cmd+V on a token
  replaces it with the full content; the expanded block is dropped from
  `onPasteBlocksChange`; a caret NOT on a token leaves it collapsed; Cmd+Shift+V (raw
  inline paste) does not trigger the expand.

Commands run (one file at a time):

    npx vitest run src/test/pasteTokens.test.ts
    npx vitest run src/test/ChatInput.paste.test.tsx

Both green (46 and 27 tests). The two wiring assertions were mutation-verified:
disabling the new keydown branch reds exactly "replaces the token" and "drops the
block" and nothing else.

## Manual verification

Could not render a live frame in this environment: a fresh `vite build` fails to
resolve `@lexical/react` / `lexical` (both are `0.50.0` deps added by #8310 and are
not present in the available install), and `npm install` is disabled on this host.
The behaviour is pinned by the unit + wiring tests above, including the mutation
check. A rendered frame should come from CI or a maintainer's built environment.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the diff adds no new rendered element or style. The collapsed
`[ Paste #N ]` token and the expanded plain text are both produced by unchanged
rendering code; the change only moves existing content into the existing textarea via
`onChange`. A live frame also could not be produced here (see Manual verification: the
`lexical` deps are not installed and `npm install` is disabled).

## Related Issues

Closes #8513
