### PR TITLE
feat(meetings): auto-split over-cap recordings on import instead of 413

### DIFF
--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/audio_import.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/audio_import.py
@@ -535,7 +535,9 @@ async def handle_import_audio(request: web.Request) -> web.Response:
             audio_exceeds_secs,
             batch_duration_cap_secs,
             load_stt_config,
+            provider_splits_oversized,
             transcribe_audio,
+            transcribe_oversized_in_segments,
         )
 
         # ONE configuration snapshot for the whole request. The readiness check, the
@@ -594,19 +596,26 @@ async def handle_import_audio(request: web.Request) -> web.Response:
 
             # BEFORE transcription, because the local recogniser's decode paths stop
             # reading at their ceiling WITHOUT saying so: a recording over the cap
-            # would transcribe its first hour, dispatch it, and return 200 — silent
-            # data loss, the exact failure the TranscriptTooLong branch below refuses.
-            # Provider-aware: the local decoder and the Apple lane (whose
-            # to-native remux is ``-t``-bounded the same way) share the
-            # ceiling, while AWS refuses an oversized payload loudly and so is
-            # not wrongly refused here.
+            # would otherwise transcribe its first hour, dispatch it, and return 200 —
+            # silent data loss. So an over-cap recording is not decoded whole: the
+            # probe detects it and the audio is split into cap-sized segments that are
+            # transcribed and stitched (see the ``exceeds`` branch below).
+            # Provider-aware: BOTH the local decoder and the Apple lane share the
+            # ceiling (both ``-t``-bound their decode), so both are PROBED here; but
+            # only the LOCAL decoder truncates SILENTLY, so only it splits. Apple
+            # fails loudly at the ceiling and its sandboxed helper cannot read the
+            # segment dir, so an over-cap Apple recording is REFUSED (413), not split
+            # (see ``provider_splits_oversized`` and the branch below). AWS refuses an
+            # oversized payload loudly and has no silent ceiling, so it is not probed.
             # A probe that cannot answer (None) is REFUSED, loudly and retryably
             # (GPT review r14): the aligned budget (``stt_config.timeout_secs``)
             # guarantees a PERSISTENT cause also defeats the transcode, but a
             # TRANSIENT one — a load spike that clears between probe and
             # transcode — would let the decoder truncate an over-cap recording
             # and answer 200. The error names the retry and the cap, so the
-            # refusal is actionable rather than a dead end.
+            # refusal is actionable rather than a dead end. (A None here refuses
+            # rather than splits, because the split needs the same decode the probe
+            # could not complete.)
             cap_secs = await asyncio.to_thread(batch_duration_cap_secs, stt_config)
             if cap_secs is not None:
                 exceeds = await audio_exceeds_secs(
@@ -621,13 +630,52 @@ async def handle_import_audio(request: web.Request) -> web.Response:
                         status=503,
                         code="duration_unverified",
                     )
-                if exceeds:
+                if exceeds and not provider_splits_oversized(stt_config):
+                    # Over the cap on a provider that FAILS LOUDLY at the ceiling
+                    # (Apple raises rather than truncating), so there is no silent
+                    # loss to prevent and splitting is wrong here: the Apple Swift
+                    # helper runs in a strict sandbox that masks the voice-runtime
+                    # root the segments are staged under, so a split would 502 every
+                    # time (GPT review). Refuse whole, as before this feature.
                     _reject("recording_too_long")
                     raise BadRequest(
-                        "recording is too long to import", status=413, code="recording_too_long"
+                        "recording is too long to import",
+                        status=413,
+                        code="recording_too_long",
                     )
-
-            transcript = await transcribe_audio(pinned, stt_config)
+                if exceeds:
+                    # OVER the cap on a provider that truncates SILENTLY (local):
+                    # split rather than refuse. The local decoder would otherwise
+                    # transcribe only its first hour and return 200 (the exact
+                    # silent-partial failure the probe exists to catch), so instead
+                    # the audio is cut into cap-sized segments at the pauses between
+                    # utterances, each segment transcribed through ``transcribe_audio``,
+                    # and the per-segment transcripts stitched into one. The stitched
+                    # result feeds ``split_transcript`` below exactly as a whole
+                    # transcript does, so it is ONE transcript sentence-split into
+                    # utterances -- and it still passes through the MAX_IMPORT_LINES /
+                    # MAX_TRANSCRIPT_CHARS ceiling there, so splitting is never a way
+                    # around the total-size refusal.
+                    # Segments are staged in this request's own snapshot dir (under
+                    # the agent-denied voice-runtime root), which ``transcribe_audio``'s
+                    # sensitive-path guard exempts, and removed with it in the finally.
+                    # Audited as ALLOWED, not rejected: this path succeeds (a 200), so
+                    # the split is a permission decision the incident trail wants to
+                    # see, the same way the owner-check ALLOW above is recorded. It
+                    # must NOT emit a ``rejected`` record (Opus review): a single
+                    # over-cap import would then write two contradictory SEL records.
+                    audit(
+                        "meetings.import_audio",
+                        f"{meeting_id} split:over-{cap_secs // 60}min",
+                        outcome="allowed",
+                    )
+                    transcript = await transcribe_oversized_in_segments(
+                        pinned, cap_secs, snapshot_dir, stt_config
+                    )
+                else:
+                    transcript = await transcribe_audio(pinned, stt_config)
+            else:
+                transcript = await transcribe_audio(pinned, stt_config)
         finally:
             # Join-then-close-then-remove, as its own task (see
             # ``_remove_snapshot_dir``): scheduled before it is awaited so a

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -1822,6 +1822,30 @@ def batch_duration_cap_secs(stt_config=None) -> int | None:  # type: ignore[no-u
     return _MAX_AUDIO_SECS
 
 
+def provider_splits_oversized(stt_config) -> bool:  # type: ignore[no-untyped-def]
+    """Whether an over-cap recording should be SPLIT rather than refused.
+
+    Only the local recogniser both HAS a ceiling and TRUNCATES SILENTLY past it
+    (both decode paths stop at ``_MAX_AUDIO_SECS`` and say nothing), so it is the
+    one provider where auto-splitting turns silent data loss into a transparent
+    success. The Apple lane also has the ceiling but FAILS LOUDLY at it
+    (``_to_native_audio`` raises ``RecordingTooLongError``), so it needs no split
+    and must not get one: its Swift helper runs in the ``mode="strict"`` sandbox,
+    which masks the ``run/voice-runtime`` leaf the import stages its segments
+    under (``sandbox.py``), so a segment WAV handed to the helper by name is
+    unreadable and every over-cap Apple import would 502. AWS Transcribe has no
+    silent ceiling at all (``batch_duration_cap_secs`` is None for it). So the
+    split is local-only, which is also what issue #8272 intends: "segmentation
+    only ever triggers where the ceiling exists (AWS/Apple providers fail loudly
+    and need no split)". Takes the caller's config snapshot as a REQUIRED
+    argument (the one production caller always has it in hand, from the same
+    snapshot the readiness/cap/transcribe calls share); it never reads config
+    itself, so there is no window for the three answers to describe different
+    providers.
+    """
+    return stt_config.provider not in ("transcribe", "apple")
+
+
 def _wav_duration_secs(audio_path: str) -> float | None:
     """Exact duration from a WAV header, or None when it is not a readable WAV.
 
@@ -1937,6 +1961,493 @@ async def audio_exceeds_secs(
             ffmpeg_bin,
             preserve_active_exception=sys.exc_info()[1] is not None,
         )
+
+
+# ---------------------------------------------------------------------------
+# Splitting an over-cap recording into transcribable segments
+# ---------------------------------------------------------------------------
+
+#: How far back from a target cut a silence is allowed to sit and still be
+#: used. A recording is cut at the last silence BEFORE each cap multiple, but
+#: only if that silence is within this window — otherwise the segment would be
+#: far shorter than the cap and the split would need many more passes than the
+#: recording's length warrants. 30s at a 3600s cap means a segment is at worst
+#: 0.8% shorter than the cap; a recording whose only silence sits further back
+#: than this is cut hard at the cap instead (see ``_choose_segment_cuts``).
+_SILENCE_SEARCH_WINDOW_SECS = 30
+
+#: ``silencedetect`` threshold. -30 dBFS for at least 0.3s is quiet enough to be
+#: a real pause between utterances rather than a breath, and short enough to
+#: catch the gaps a meeting recording actually has. These are the boundary rule,
+#: not a tuning knob a caller passes, so they live here as constants.
+_SILENCE_NOISE_DBFS = "-30dB"
+_SILENCE_MIN_SECS = 0.3
+
+_SILENCE_END_RE = re.compile(rb"silence_end:\s*([0-9]+(?:\.[0-9]+)?)")
+
+#: Hard ceiling on how many silence points the scan retains. A cut is chosen per
+#: cap-sized window, so even a many-hour recording needs only a handful; a few
+#: thousand covers any recording a human would import with margin to spare. The
+#: ceiling exists to bound MEMORY, not to shape the split: ffmpeg's stderr is read
+#: incrementally (not buffered whole by ``communicate``) and only the parsed
+#: ``silence_end`` floats are kept, so a pathological low-bitrate, pause-dense file
+#: -- ~149h at ~8 kbps would emit ~1.5M events -- cannot buffer hundreds of MiB and
+#: OOM/hard-exit the gateway (GPT review, security-class). Crossing the ceiling
+#: means the input is pathological, so the scan refuses (returns None) and the
+#: import is refused rather than risking the crash.
+_MAX_SILENCE_POINTS = 100_000
+
+#: Hard ceiling on how many segments one recording may be split into. A real
+#: recording under the import size cap cannot exceed a knowable duration, so a
+#: decoded duration implying more than this many cap-sized segments is not a real
+#: recording -- it is a crafted container whose terminal PTS (ffmpeg
+#: ``out_time_us``) was authored far into the future. ``_choose_segment_cuts``
+#: appends one cut per cap-sized window in a single synchronous loop, so an
+#: unbounded duration would allocate billions of cuts and freeze/OOM the gateway
+#: before any caller check runs (GPT review, security-class). The caller refuses
+#: (returns None) rather than build the cuts when the duration crosses this
+#: ceiling. 512 covers ~21 days at the 1-hour cap -- far past any real meeting,
+#: and far past what the 512 MiB import size cap can hold at any real bitrate.
+_MAX_SEGMENTS = 512
+
+
+async def _drain_progress_and_silence(
+    proc: Any, *, timeout_secs: int
+) -> "tuple[list[float], float] | None":
+    """Read ffmpeg's stdout (-progress) and stderr (silencedetect) INCREMENTALLY.
+
+    ``communicate()`` buffers both whole streams in memory; a pathological
+    pause-dense recording could make stderr hundreds of MiB and OOM the gateway
+    (GPT review, security-class). This reads both streams line by line and keeps
+    only the parsed data -- the latest ``out_time_us`` and up to
+    :data:`_MAX_SILENCE_POINTS` ``silence_end`` floats -- so memory is bounded by
+    the ceiling, not by the input. Returns ``(silence_ends, duration)``, or None
+    when the duration is unreadable or the silence ceiling is crossed (a
+    pathological input the caller must refuse rather than risk crashing on).
+    Reaps nothing itself: the caller owns kill/close on timeout and cancellation.
+    """
+    silence_ends: list[float] = []
+    last_out_time: int | None = None
+    overflowed = False
+
+    #: Bytes kept across chunk reads so a token split by a chunk boundary is not
+    #: missed. Longer than any ``out_time_us=<digits>`` or ``silence_end: <float>``
+    #: token ffmpeg emits. Reading with ``read(n)`` instead of ``readline()`` is the
+    #: point: ``StreamReader.readline`` raises ``ValueError`` on a line past its
+    #: 64 KiB limit (GPT review, security-class -- a >64 KiB no-newline stderr line
+    #: would otherwise escape as an unhandled 500), while ``read`` has no
+    #: line-length limit. A partial trailing fragment longer than this carry cannot
+    #: contain a whole token that also straddles the boundary, so trimming to it is
+    #: safe and keeps memory bounded against a pathological no-newline line.
+    _CARRY = 256
+
+    async def _read_stream(reader: Any, on_match: Any, pattern: Any) -> None:
+        if reader is None:
+            return
+        pending = b""  # the trailing partial line carried to the next chunk
+        while True:
+            chunk = await reader.read(65536)
+            if not chunk:
+                break
+            data = pending + chunk
+            # Scan complete lines; keep only the trailing partial for next time so a
+            # token split across a chunk boundary is still matched whole. Each line
+            # is scanned exactly once, so an appending consumer never double-counts.
+            newline = data.rfind(b"\n")
+            if newline == -1:
+                # No line terminator yet: keep only a bounded tail. A fragment
+                # longer than the carry cannot hold a token that will still be
+                # completed by later bytes, so discarding its head is lossless and
+                # caps memory against a giant no-newline line.
+                pending = data[-_CARRY:] if len(data) > _CARRY else data
+                continue
+            for m in pattern.finditer(data[: newline + 1]):
+                on_match(m)
+            pending = data[newline + 1 :]
+            if len(pending) > _CARRY:
+                pending = pending[-_CARRY:]
+        if pending:
+            for m in pattern.finditer(pending):
+                on_match(m)
+
+    def _on_silence(m: Any) -> None:
+        nonlocal overflowed
+        if len(silence_ends) >= _MAX_SILENCE_POINTS:
+            overflowed = True
+            return
+        silence_ends.append(float(m.group(1)))
+
+    def _on_progress(m: Any) -> None:
+        nonlocal last_out_time
+        last_out_time = int(m.group(1))
+
+    await asyncio.wait_for(
+        asyncio.gather(
+            _read_stream(proc.stdout, _on_progress, _PROGRESS_OUT_TIME_RE),
+            _read_stream(proc.stderr, _on_silence, _SILENCE_END_RE),
+        ),
+        timeout=timeout_secs,
+    )
+    await proc.wait()
+    if proc.returncode != 0:
+        return None
+    if last_out_time is None:
+        return None
+    if overflowed:
+        logger.error(
+            "ffmpeg silence scan produced more than %d points; refusing", _MAX_SILENCE_POINTS
+        )
+        return None
+    return silence_ends, last_out_time / 1_000_000
+
+
+#: Bytes of ffmpeg stderr retained for an error message. Only a short tail is
+#: logged, so the reader keeps at most this much and discards the rest -- ffmpeg
+#: can emit a per-frame warning line, so reading the whole stream with
+#: ``communicate()`` would buffer unbounded memory on a long/pathological input
+#: (GPT review, security-class: same class as the silence scan).
+_STDERR_TAIL_BYTES = 8192
+
+
+async def _drain_stderr_tail(proc: Any, *, timeout_secs: int) -> bytes:
+    """Drain ffmpeg's stderr INCREMENTALLY, retaining only the last
+    :data:`_STDERR_TAIL_BYTES`, then reap the child.
+
+    ``communicate()`` buffers all of stderr; a segment extract of a long input
+    could make that hundreds of MiB and OOM the gateway. This keeps a bounded
+    tail (all the error log needs) and discards the rest as it arrives, so the
+    pipe never blocks the child and memory stays bounded. Returns the tail;
+    the caller reads ``proc.returncode`` after this returns.
+    """
+    tail = bytearray()
+    if proc.stderr is not None:
+
+        async def _read() -> None:
+            while True:
+                chunk = await proc.stderr.read(65536)
+                if not chunk:
+                    break
+                tail.extend(chunk)
+                if len(tail) > _STDERR_TAIL_BYTES:
+                    del tail[: len(tail) - _STDERR_TAIL_BYTES]
+
+        await asyncio.wait_for(_read(), timeout=timeout_secs)
+    await proc.wait()
+    return bytes(tail)
+
+
+def _choose_segment_cuts(
+    duration_secs: float, cap_secs: int, silence_ends: "list[float]"
+) -> "list[float]":
+    """Where to cut a *duration_secs* recording into segments each <= *cap_secs*.
+
+    Returns the INTERIOR cut points in seconds, ascending — the segment
+    boundaries between 0 and *duration_secs*, excluding both ends. A recording
+    already within the cap returns ``[]`` (one segment, no split).
+
+    Each cut is placed at the last ``silence_end`` at or before the running
+    target (``previous_cut + cap_secs``) and no earlier than the target minus
+    :data:`_SILENCE_SEARCH_WINDOW_SECS`, so a word straddling the target is not
+    split — the cut lands in the pause after the previous utterance. When the
+    window holds no silence (continuous speech across the whole window), the cut
+    falls HARD on the target: a rare, documented seam that may split one word,
+    which is still strictly better than refusing the whole import. The target
+    always advances by a real amount, so the loop always terminates and every
+    segment is <= *cap_secs*.
+
+    Pure function, no IO: the boundary rules are the interesting part and are
+    unit-tested directly, the way ``audio.split_transcript`` is.
+    """
+    cuts: list[float] = []
+    ordered = sorted(silence_ends)
+    start = 0.0
+    while duration_secs - start > cap_secs:
+        target = start + cap_secs
+        floor = target - _SILENCE_SEARCH_WINDOW_SECS
+        # The last silence in ``(floor, target]``. A silence exactly at the
+        # target counts; one at or before ``start`` never does (it would make a
+        # zero-length or backwards segment).
+        candidates = [s for s in ordered if floor < s <= target and s > start]
+        cut = candidates[-1] if candidates else target
+        cuts.append(cut)
+        start = cut
+    return cuts
+
+
+async def _detect_silence_ends(
+    audio_path: str, *, timeout_secs: int
+) -> "tuple[list[float], float] | None":
+    """Silence-end timestamps and the decoded duration, or None when unknown.
+
+    One decode pass through ffmpeg's ``silencedetect`` filter, reading
+    ``silence_end`` events from stderr and the final decoded timestamp from the
+    ``-progress`` stream. Both streams are drained INCREMENTALLY
+    (:func:`_drain_progress_and_silence`), never buffered whole, so a
+    pause-dense recording cannot make stderr hundreds of MiB and OOM the gateway
+    (GPT review, security-class); only the parsed floats are kept, capped at
+    :data:`_MAX_SILENCE_POINTS`. None on any failure the caller must treat as
+    "cannot split safely" -- an undecodable file, a decoder that is unavailable,
+    a timeout, a nonzero exit, or a pathological input past the silence ceiling
+    -- so the caller refuses the import rather than proceeding to a truncating
+    decode. Mirrors the spawn shape of :func:`audio_exceeds_secs`: forced
+    demuxer, local-protocol pin (inherited from :func:`_create_ffmpeg_subprocess`),
+    authenticated-handle lifetime, kill-and-reap on timeout and cancellation.
+    """
+    try:
+        demux_args = _forced_demuxer_args(audio_path)
+    except OSError:
+        logger.exception("Could not resolve a demuxer to scan %s for silence", audio_path)
+        return None
+    ffmpeg_bin = await _resolve_ffmpeg_for_execution()
+    if not ffmpeg_bin:
+        return None
+    try:
+        try:
+            proc = await _create_ffmpeg_subprocess(
+                ffmpeg_bin,
+                "-nostdin",
+                # -hide_banner drops ffmpeg's input-metadata dump from stderr, so a
+                # crafted container's oversized tag value cannot appear there;
+                # silencedetect logs at info level, which is kept. Defence in depth
+                # for the bounded reader below, not the primary guard.
+                "-hide_banner",
+                "-progress",
+                "pipe:1",
+                *demux_args,
+                "-i",
+                audio_path,
+                "-vn",
+                "-af",
+                f"silencedetect=noise={_SILENCE_NOISE_DBFS}:d={_SILENCE_MIN_SECS}",
+                "-f",
+                "null",
+                "-",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except OSError:
+            logger.exception("Could not run ffmpeg (%s) to scan %s", ffmpeg_bin, audio_path)
+            return None
+        try:
+            result = await _drain_progress_and_silence(proc, timeout_secs=timeout_secs)
+        except asyncio.TimeoutError:
+            await _kill_and_reap(proc)
+            logger.error("ffmpeg silence scan of %s timed out after %ds", audio_path, timeout_secs)
+            return None
+        except BaseException:
+            await _kill_and_reap(proc)
+            raise
+        return result
+    finally:
+        await _close_ffmpeg_for_execution(
+            ffmpeg_bin,
+            preserve_active_exception=sys.exc_info()[1] is not None,
+        )
+
+
+async def _extract_segment(
+    audio_path: str,
+    start_secs: float,
+    end_secs: "float | None",
+    out_path: str,
+    *,
+    timeout_secs: int,
+) -> bool:
+    """Decode ``[start_secs, end_secs)`` of *audio_path* to a 16 kHz mono WAV.
+
+    ``end_secs`` of None means "to the end of the recording" (the last segment).
+    Returns True on a clean extraction, False on any failure — the caller turns
+    a False into a whole-import refusal, never a partial transcript.
+
+    ``-ss`` before ``-i`` is an INPUT seek (ffmpeg skips to the start without
+    decoding the skipped span), so extracting the k-th segment costs one
+    segment's worth of decode, not k. The output targets the recogniser's own
+    format (16 kHz mono ``pcm_s16le``) exactly as :func:`_pcm_via_ffmpeg` does,
+    so each segment file is a plain WAV the transcriber's fast path reads with no
+    second transcode.
+    """
+    try:
+        demux_args = _forced_demuxer_args(audio_path)
+    except OSError:
+        logger.exception("Could not resolve a demuxer to extract a segment of %s", audio_path)
+        return False
+    ffmpeg_bin = await _resolve_ffmpeg_for_execution()
+    if not ffmpeg_bin:
+        return False
+    # ``-ss`` is an INPUT option (before ``-i``) so the skip is not decoded;
+    # ``-t`` bounds the segment length. A None end means the final segment,
+    # which runs to end-of-file with no ``-t``.
+    seek_args = ("-ss", f"{start_secs:.3f}")
+    length_args = () if end_secs is None else ("-t", f"{end_secs - start_secs:.3f}")
+    try:
+        try:
+            proc = await _create_ffmpeg_subprocess(
+                ffmpeg_bin,
+                "-y",
+                "-nostdin",
+                *seek_args,
+                *demux_args,
+                "-i",
+                audio_path,
+                *length_args,
+                "-ar",
+                str(stt.SAMPLE_RATE_HZ),
+                "-ac",
+                "1",
+                "-c:a",
+                "pcm_s16le",
+                out_path,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except OSError:
+            logger.exception(
+                "Could not run ffmpeg (%s) to extract a segment of %s", ffmpeg_bin, audio_path
+            )
+            return False
+        try:
+            stderr_tail = await _drain_stderr_tail(proc, timeout_secs=timeout_secs)
+        except asyncio.TimeoutError:
+            await _kill_and_reap(proc)
+            logger.error(
+                "ffmpeg segment extract of %s timed out after %ds", audio_path, timeout_secs
+            )
+            return False
+        except BaseException:
+            await _kill_and_reap(proc)
+            raise
+        if proc.returncode != 0:
+            tail = stderr_tail.decode(errors="replace").strip()[-500:] if stderr_tail else ""
+            logger.error(
+                "ffmpeg %s extracting a segment of %s",
+                _describe_ffmpeg_exit(proc.returncode, tail),
+                audio_path,
+            )
+            return False
+        return True
+    finally:
+        await _close_ffmpeg_for_execution(
+            ffmpeg_bin,
+            preserve_active_exception=sys.exc_info()[1] is not None,
+        )
+
+
+async def transcribe_oversized_in_segments(
+    audio_path: str,
+    cap_secs: int,
+    segment_dir: str,
+    stt_config,  # type: ignore[no-untyped-def]
+) -> "str | None":
+    """Transcribe a recording longer than *cap_secs* by splitting it first.
+
+    Returns the stitched transcript, or None when the recording cannot be split
+    or any segment fails to decode or transcribe — the same None-means-failure
+    contract as :func:`transcribe_audio`, so the caller reports one clean failure
+    rather than a partial import.
+
+    The split is on the AUDIO, not the transcript: one ffmpeg pass locates the
+    pauses (:func:`_detect_silence_ends`), a pure function picks a cut at the
+    last pause before each cap multiple (:func:`_choose_segment_cuts`), and each
+    segment is decoded to its own WAV (:func:`_extract_segment`) and transcribed
+    through the ordinary :func:`transcribe_audio` — so every segment gets the same
+    provider dispatch, sensitive-path guard and redaction a whole recording does.
+    Segments are NON-OVERLAPPING (cut in the silence between utterances), so the
+    stitch is a plain space join with nothing to de-duplicate; the joined text is
+    one paragraph, so the meetings import route's ``split_transcript`` sentence-
+    splits it into utterances exactly as it does for a whole recording, and the
+    seams are invisible.
+
+    *segment_dir* is a caller-owned directory the segment WAVs are written into;
+    the caller removes it. It must be a trusted directory the transcriber is
+    allowed to read (the meetings route stages it under the voice-runtime root,
+    which ``transcribe_audio``'s sensitive-path guard exempts).
+
+    This does NOT re-check the stitched result against any total-size ceiling:
+    that stays the caller's job (the import route's ``split_transcript`` still
+    enforces ``MAX_IMPORT_LINES``/``MAX_TRANSCRIPT_CHARS``), so splitting is never
+    a way around the total-size refusal.
+    """
+    scanned = await _detect_silence_ends(audio_path, timeout_secs=stt_config.timeout_secs)
+    if scanned is None:
+        logger.error("Could not scan %s for split boundaries", audio_path)
+        return None
+    silence_ends, duration = scanned
+    # Bound the segment count BEFORE building cuts. ``duration`` is ffmpeg's
+    # decoded terminal PTS, which a crafted container can author far into the
+    # future; ``_choose_segment_cuts`` appends one cut per cap-sized window in a
+    # single synchronous loop, so an unbounded duration would allocate billions of
+    # cuts and freeze/OOM the gateway before any later check runs (GPT review,
+    # security-class). A real recording under the import size cap cannot span more
+    # than ``_MAX_SEGMENTS`` cap-sized windows, so a duration past that ceiling is
+    # not a real recording -- refuse rather than build the cuts.
+    if duration <= 0 or duration > _MAX_SEGMENTS * cap_secs:
+        logger.error(
+            "%s reports an implausible duration (%.1fs > %d segments x %ds); refusing",
+            audio_path,
+            duration,
+            _MAX_SEGMENTS,
+            cap_secs,
+        )
+        return None
+    cuts = _choose_segment_cuts(duration, cap_secs, silence_ends)
+    # Boundaries as [start, end) pairs, end=None on the last (runs to EOF).
+    bounds: list[tuple[float, float | None]] = []
+    prev = 0.0
+    for cut in cuts:
+        bounds.append((prev, cut))
+        prev = cut
+    bounds.append((prev, None))
+
+    transcripts: list[str] = []
+    for index, (seg_start, seg_end) in enumerate(bounds):
+        seg_path = os.path.join(segment_dir, f"segment-{index:03d}.wav")
+        ok = await _extract_segment(
+            audio_path, seg_start, seg_end, seg_path, timeout_secs=stt_config.timeout_secs
+        )
+        if not ok:
+            logger.error(
+                "Could not extract segment %d of %s; refusing the whole import", index, audio_path
+            )
+            return None
+        try:
+            text = await transcribe_audio(seg_path, stt_config)
+        finally:
+            await asyncio.to_thread(_unlink_if_exists, seg_path)
+        if not text:
+            # A falsy result refuses the WHOLE import (GPT + Opus review, both
+            # BLOCKING). transcribe_audio returns None for a genuine recogniser
+            # failure -- a per-segment decode error, a timeout, the shared
+            # recogniser singleton being swapped mid-import -- as well as for a
+            # legitimately silent segment, and the two are INDISTINGUISHABLE here
+            # (``return text or None``). _extract_segment returning True only
+            # proves ffmpeg carved the WAV, not that the recogniser succeeded on
+            # it. So skipping a falsy segment would silently drop a real spoken
+            # span and still answer 200 -- the exact silent-partial data loss this
+            # feature exists to prevent, one level down. Refusing the whole import
+            # is the safe answer: distinguishing decoded-empty from
+            # recogniser-failure would require a new failure flag on
+            # transcribe_audio's contract (8 callers), which is out of scope for
+            # this route-level change. A recording with a genuinely silent
+            # cap-sized stretch is refused loudly rather than imported with a gap.
+            logger.error(
+                "Segment %d of %s produced no transcript; refusing the whole import",
+                index,
+                audio_path,
+            )
+            return None
+        transcripts.append(text)
+    # Join with a SPACE, not a newline (GPT review): a segment transcript from the
+    # local/Apple recognisers is one whitespace-joined paragraph with no internal
+    # newlines (``stt/engine.py`` joins whisper segments with " "). A newline join
+    # would hand ``split_transcript`` N>1 lines, which makes it treat each whole
+    # segment as ONE line (tier 1) and only hard-wrap it at ``max_chars`` -- so a
+    # segment would dispatch as 4000-char chunks instead of utterances, worse line
+    # structure than the un-split path produces. A space join keeps the stitched
+    # text as one paragraph, so ``split_transcript`` sentence-splits it into
+    # utterances (tier 2) exactly as it does for a whole recording; any internal
+    # newline a segment DOES carry (a future recogniser with its own line
+    # structure) is preserved across the join and still read as tier-1 structure.
+    return " ".join(transcripts)
 
 
 def _whisper_language(language_code: str) -> str:

--- a/test/test_meetings_audio_import.py
+++ b/test/test_meetings_audio_import.py
@@ -88,6 +88,7 @@ def _patch(monkeypatch: pytest.MonkeyPatch, **over: Any) -> dict[str, list]:
         "snapshot_files": [],
         "ready_config": [],
         "cap_config": [],
+        "split_calls": [],
     }
 
     def _vet(raw: str) -> "tuple[str, tuple[int, int] | None, str]":
@@ -119,9 +120,22 @@ def _patch(monkeypatch: pytest.MonkeyPatch, **over: Any) -> dict[str, list]:
         log["transcribed"].append((os.path.realpath(path), a[0] if a else kw.get("stt_config")))
         return over.get("transcript", "we decided to ship on Friday")
 
+    async def _split(path: str, cap_secs: int, segment_dir: str, cfg: Any) -> str | None:
+        # The route hands the pinned descriptor path; realpath it so the assertion
+        # matches the snapshot the same way ``_transcribe`` does.
+        log["split_calls"].append((os.path.realpath(path), cap_secs, segment_dir))
+        if "split_transcript" in over:
+            return over["split_transcript"]
+        return over.get("transcript", "we decided to ship on Friday")
+
     def _cap(cfg: Any = None) -> int | None:
         log["cap_config"].append(cfg)
         return over.get("cap", 3600)
+
+    def _splits(cfg: Any = None) -> bool:
+        # Default: the active provider splits (local). The Apple/AWS case overrides
+        # to False, which makes an over-cap import refuse with 413 instead.
+        return over.get("splits", True)
 
     async def _exceeds(path: str, max_secs: int, **kw: Any) -> bool | None:
         log["probed"].append((os.path.realpath(path), max_secs))
@@ -138,7 +152,9 @@ def _patch(monkeypatch: pytest.MonkeyPatch, **over: Any) -> dict[str, list]:
     monkeypatch.setattr(ai, "supports_pinned_walk", lambda: True)
     monkeypatch.setattr(transcribe_mod, "load_stt_config", _load_config)
     monkeypatch.setattr(transcribe_mod, "transcribe_audio", _transcribe)
+    monkeypatch.setattr(transcribe_mod, "transcribe_oversized_in_segments", _split)
     monkeypatch.setattr(transcribe_mod, "batch_duration_cap_secs", _cap)
+    monkeypatch.setattr(transcribe_mod, "provider_splits_oversized", _splits)
     monkeypatch.setattr(transcribe_mod, "audio_exceeds_secs", _exceeds)
     return log
 
@@ -555,13 +571,117 @@ class TestRefusals:
         assert log["transcribed"] == []
 
     @pytest.mark.asyncio
-    async def test_a_recording_over_the_decoder_cap_is_413_not_a_truncated_200(
+    async def test_a_recording_over_the_decoder_cap_is_split_not_refused(
         self, app, fake_sessions, monkeypatch
     ):
-        """GPT review: the local decoder stops reading at its ceiling WITHOUT
-        saying so, so a recording over the cap must be refused whole before
-        transcription — never transcribed-truncated and dispatched as a 200."""
-        log = _patch(monkeypatch, exceeds=True)
+        """The local decoder stops reading at its ceiling WITHOUT saying so, so an
+        over-cap recording is not decoded whole. Instead of the old 413 refusal it
+        is split into cap-sized segments, transcribed, and stitched — a transparent
+        200, the same way an oversized pasted image is auto-resized."""
+        log = _patch(
+            monkeypatch,
+            exceeds=True,
+            split_transcript="segment one text\nsegment two text",
+        )
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/marathon.webm"}
+            )
+            assert resp.status == 200
+            body = await resp.json()
+            # Two stitched lines dispatched, seams are ordinary line breaks.
+            assert body["lines"] == 2
+        # The probe and the split BOTH consumed the PINNED snapshot, never the
+        # user-writable original name; the whole-file transcriber was NOT called.
+        assert log["probed"] == [(os.path.realpath(log["snapshot_files"][0]), 3600)]
+        assert len(log["split_calls"]) == 1
+        split_path, split_cap, _seg_dir = log["split_calls"][0]
+        assert split_path == os.path.realpath(log["snapshot_files"][0])
+        assert split_cap == 3600
+        assert log["transcribed"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_successful_split_audits_allowed_not_rejected(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """Opus review: the split path succeeds (a 200), so it records the split as
+        an ALLOWED permission decision the incident trail wants to see. It must NOT
+        also emit a ``rejected`` record — a single over-cap import would otherwise
+        write two contradictory SEL records for one outcome."""
+        _patch(monkeypatch, exceeds=True, split_transcript="one\ntwo")
+        records: list[tuple[str, str, str]] = []
+        monkeypatch.setattr(
+            ai,
+            "audit",
+            lambda op, res, *, outcome, error="": records.append((op, res, outcome)),
+        )
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/marathon.webm"}
+            )
+            assert resp.status == 200
+        split_records = [(r, o) for _op, r, o in records if "split:" in r]
+        assert split_records == [("standup split:over-60min", "allowed")]
+        # No rejection was recorded for this successful import.
+        assert all(o != "rejected" for _op, _r, o in records)
+
+    @pytest.mark.asyncio
+    async def test_an_over_cap_recording_on_a_loud_fail_provider_is_413_not_split(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """Apple has the ceiling but FAILS LOUDLY at it, and its Swift helper's
+        strict sandbox masks the voice-runtime root the segments stage under, so a
+        split would 502 every time. An over-cap recording on such a provider is
+        refused whole with 413 (as before this feature) and never split (GPT
+        review)."""
+        log = _patch(monkeypatch, exceeds=True, splits=False)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/long.m4a"}
+            )
+            assert resp.status == 413
+            assert (await resp.json())["code"] == "recording_too_long"
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            assert all(len(q.queue) == 0 for q in session.agents.values())
+        # Neither the split nor the whole-file transcriber ran.
+        assert log["split_calls"] == []
+        assert log["transcribed"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_failed_split_refuses_the_whole_import(self, app, fake_sessions, monkeypatch):
+        """A segment that cannot be decoded or transcribed means the stitched
+        transcript would be missing a span. The split returns None and the route
+        answers 502 — one clean failure, never a partial import that returns 200
+        with the middle of the recording silently absent."""
+        _patch(monkeypatch, exceeds=True, split_transcript=None)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/marathon.webm"}
+            )
+            assert resp.status == 502
+            assert (await resp.json())["code"] == "transcription_failed"
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            assert all(len(q.queue) == 0 for q in session.agents.values())
+
+    @pytest.mark.asyncio
+    async def test_a_split_result_over_the_line_budget_is_still_413(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """Splitting must not become a way around the total-size ceiling. The
+        stitched transcript still passes through ``split_transcript``, so a result
+        past ``MAX_IMPORT_LINES`` is refused whole with 413 — nothing dispatched."""
+        _patch(
+            monkeypatch,
+            exceeds=True,
+            split_transcript="\n".join(f"line {i}" for i in range(10)),
+        )
+        monkeypatch.setattr(k, "MAX_IMPORT_LINES", 5)
         async with client_for(app) as client:
             await _start(client)
             resp = await client.post(
@@ -569,10 +689,27 @@ class TestRefusals:
             )
             assert resp.status == 413
             assert (await resp.json())["code"] == "recording_too_long"
-        # The probe consumed the PINNED snapshot (call-time realpath), not the
-        # user-writable original name.
-        assert log["probed"] == [(os.path.realpath(log["snapshot_files"][0]), 3600)]
-        assert log["transcribed"] == []
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            assert all(len(q.queue) == 0 for q in session.agents.values())
+
+    @pytest.mark.asyncio
+    async def test_the_split_segments_are_staged_under_the_snapshot_dir(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """The split writes its segment WAVs into the request's own snapshot dir —
+        the 0700 directory under the agent-denied voice-runtime root that the
+        sensitive-path guard exempts — so they are removed with it on every exit."""
+        log = _patch(monkeypatch, exceeds=True, split_transcript="ok")
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/marathon.webm"}
+            )
+            assert resp.status == 200
+        _split_path, _cap, seg_dir = log["split_calls"][0]
+        # The segment dir is exactly the dir the snapshot lives in.
+        assert seg_dir == os.path.dirname(log["snapshot_files"][0])
 
     @pytest.mark.asyncio
     async def test_the_probe_gets_the_transcodes_own_time_budget(

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -1331,6 +1331,20 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # snapshot-copied via `pinned_fs` into its own 0700 directory.)
         "transcribe.py::_pcm_via_ffmpeg",
         "transcribe.py::audio_exceeds_secs",
+        # The two spawns that split an over-cap recording for the meetings import
+        # route, both ffmpeg-only through `_create_ffmpeg_subprocess` above, so
+        # `_SPAWN_NAMES` propagates the same audit and both are classified here.
+        # `_detect_silence_ends` is a null decode (`-f null -`) with the fixed
+        # `silencedetect` filter and no output file; `_extract_segment` decodes one
+        # `-ss`/`-t` span to a 16 kHz mono WAV in the route's own 0700 snapshot dir.
+        # In both the only variable argv element is the positional input, which the
+        # route hands in as the process-private pinned descriptor path
+        # (`/dev/fd/N`) of the snapshot it already validated and copied — a hostile
+        # value can only name a bad input, never a second command, and the output
+        # path (`_extract_segment`) is a gateway-chosen name under the snapshot dir,
+        # not agent input.
+        "transcribe.py::_detect_silence_ends",
+        "transcribe.py::_extract_segment",
         "transcribe.py::_transcribe_aws",
         # The build probe executes the same authenticated image with the single
         # fixed `-version` argument; it accepts no external input at all. Both

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -3308,3 +3308,580 @@ class TestAudioExceedsSecsProbe:
             transcribe, "_load_stt_config", lambda: SimpleNamespace(provider="transcribe")
         )
         assert transcribe.batch_duration_cap_secs() is None
+
+    def test_only_the_local_provider_splits(self):
+        # Local truncates silently -> split. Apple fails loudly + its helper's
+        # sandbox masks the segment dir -> no split. AWS has no ceiling -> no split.
+        assert transcribe.provider_splits_oversized(SimpleNamespace(provider="local")) is True
+        assert transcribe.provider_splits_oversized(SimpleNamespace(provider="apple")) is False
+        assert transcribe.provider_splits_oversized(SimpleNamespace(provider="transcribe")) is False
+        # An unrecognised provider degrades to local (the config loader does this),
+        # so it splits like local rather than silently refusing.
+        assert transcribe.provider_splits_oversized(SimpleNamespace(provider="whatever")) is True
+
+    def test_it_takes_a_required_config_and_never_reads_config_itself(self, monkeypatch):
+        # First Principles subtraction: the one caller always passes the shared
+        # snapshot, so the function takes a REQUIRED arg and never self-loads config
+        # (which would open a window for the three answers to describe different
+        # providers). A bare call is a TypeError, not a silent config read.
+        called = {"n": 0}
+        monkeypatch.setattr(
+            transcribe, "_load_stt_config", lambda: called.__setitem__("n", called["n"] + 1)
+        )
+        transcribe.provider_splits_oversized(SimpleNamespace(provider="local"))
+        assert called["n"] == 0
+        with pytest.raises(TypeError):
+            transcribe.provider_splits_oversized()
+
+
+class TestChooseSegmentCuts:
+    """The boundary rules for splitting an over-cap recording — a pure function,
+    tested directly the way ``audio.split_transcript`` is, because the interesting
+    part is where the cuts land, not the ffmpeg plumbing around them."""
+
+    def _cuts(self, duration, cap, silences):
+        return transcribe._choose_segment_cuts(duration, cap, silences)
+
+    def test_a_recording_within_the_cap_is_not_split(self):
+        assert self._cuts(50.0, 60, [10.0, 20.0]) == []
+
+    def test_a_recording_exactly_at_the_cap_is_not_split(self):
+        # duration - start == cap is NOT "> cap", so no cut.
+        assert self._cuts(60.0, 60, []) == []
+
+    def test_it_cuts_at_the_last_silence_before_the_cap(self):
+        # Cap 60, window 30: silences at 35 and 58 are both in (30, 60]; the last
+        # one (58) is chosen so the segment is as full as the pause allows.
+        assert self._cuts(90.0, 60, [35.0, 58.0]) == [58.0]
+
+    def test_a_silence_past_the_cap_is_not_used(self):
+        # 61 is past the cap; only 40 qualifies.
+        assert self._cuts(90.0, 60, [40.0, 61.0]) == [40.0]
+
+    def test_no_silence_in_the_window_cuts_hard_at_the_cap(self):
+        # The only silence (5) is outside the (30, 60] window, so the cut is the
+        # hard cap boundary — the documented rare seam.
+        assert self._cuts(90.0, 60, [5.0]) == [60.0]
+
+    def test_no_silence_at_all_cuts_hard_at_every_cap_multiple(self):
+        assert self._cuts(200.0, 60, []) == [60.0, 120.0, 180.0]
+
+    def test_each_cut_advances_from_the_previous_one(self):
+        # Second window is (start+30, start+60] measured from the FIRST cut, not
+        # from zero — a silence reused would stall the loop.
+        cuts = self._cuts(150.0, 60, [55.0, 110.0])
+        assert cuts == [55.0, 110.0]
+        # Every resulting segment is within the cap.
+        bounds = [0.0, *cuts, 150.0]
+        assert all(bounds[i + 1] - bounds[i] <= 60 for i in range(len(bounds) - 1))
+
+    def test_a_silence_at_or_before_the_running_start_is_ignored(self):
+        # After the first cut at 60, a silence at 60 (== start) must not be reused
+        # as the next cut; the loop falls to the hard target 120.
+        assert self._cuts(150.0, 60, [60.0]) == [60.0, 120.0]
+
+    def test_the_last_segment_may_be_shorter_than_the_cap(self):
+        # 130s at cap 60 with a silence at 58: cuts at 58 and 118, leaving a 12s
+        # tail — a short final segment is fine, it is not padded.
+        assert self._cuts(130.0, 60, [58.0, 118.0]) == [58.0, 118.0]
+
+    def test_unsorted_silence_input_is_handled(self):
+        assert self._cuts(90.0, 60, [58.0, 35.0]) == [58.0]
+
+
+class TestTranscribeOversizedInSegments:
+    """The orchestration that splits, transcribes and stitches an over-cap
+    recording. The ffmpeg seam (silence scan + segment extract) is stubbed — the
+    point here is the control flow: how many segments are cut, that each is
+    transcribed through the ordinary ``transcribe_audio``, that the results are
+    joined with spaces, and that ANY failure refuses the whole import."""
+
+    def _cfg(self, timeout_secs=300):
+        return SimpleNamespace(timeout_secs=timeout_secs)
+
+    @pytest.mark.asyncio
+    async def test_it_cuts_transcribes_and_stitches_into_one_paragraph(self, tmp_path, monkeypatch):
+        # 130s at cap 60, one silence at 58 -> cuts [58, 118] -> 3 segments.
+        async def _scan(path, *, timeout_secs):
+            return [58.0, 118.0], 130.0
+
+        extracted: list[tuple[float, float | None, str]] = []
+
+        async def _extract(path, start, end, out, *, timeout_secs):
+            extracted.append((start, end, out))
+            return True
+
+        transcribed: list[str] = []
+
+        async def _transcribe(path, cfg):
+            transcribed.append(path)
+            # Segment index encoded in the filename; return distinct text.
+            return f"text of {os.path.basename(path)}"
+
+        monkeypatch.setattr(transcribe, "_detect_silence_ends", _scan)
+        monkeypatch.setattr(transcribe, "_extract_segment", _extract)
+        monkeypatch.setattr(transcribe, "transcribe_audio", _transcribe)
+
+        result = await transcribe.transcribe_oversized_in_segments(
+            "/dev/fd/9", 60, str(tmp_path), self._cfg()
+        )
+        # Three segments, joined by a SPACE in order (one paragraph, so the route's
+        # split_transcript sentence-splits it into utterances instead of treating
+        # each whole segment as one hard-wrapped line).
+        assert result == ("text of segment-000.wav text of segment-001.wav text of segment-002.wav")
+        assert "\n" not in result
+        # Boundaries: [0,58), [58,118), [118,None) — last runs to EOF.
+        assert [(s, e) for s, e, _ in extracted] == [(0.0, 58.0), (58.0, 118.0), (118.0, None)]
+        assert len(transcribed) == 3
+
+    @pytest.mark.asyncio
+    async def test_an_unscannable_recording_refuses_the_whole_import(self, tmp_path, monkeypatch):
+        async def _scan(path, *, timeout_secs):
+            return None
+
+        monkeypatch.setattr(transcribe, "_detect_silence_ends", _scan)
+        result = await transcribe.transcribe_oversized_in_segments(
+            "/dev/fd/9", 60, str(tmp_path), self._cfg()
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_a_segment_that_fails_to_extract_refuses_the_whole_import(
+        self, tmp_path, monkeypatch
+    ):
+        async def _scan(path, *, timeout_secs):
+            return [], 200.0  # no silence -> hard cuts at 60, 120, 180
+
+        async def _extract(path, start, end, out, *, timeout_secs):
+            return start == 0.0  # only the first segment extracts
+
+        async def _transcribe(path, cfg):
+            return "ok"
+
+        monkeypatch.setattr(transcribe, "_detect_silence_ends", _scan)
+        monkeypatch.setattr(transcribe, "_extract_segment", _extract)
+        monkeypatch.setattr(transcribe, "transcribe_audio", _transcribe)
+
+        result = await transcribe.transcribe_oversized_in_segments(
+            "/dev/fd/9", 60, str(tmp_path), self._cfg()
+        )
+        assert result is None, "a segment that cannot be extracted refuses the whole import"
+
+    @pytest.mark.asyncio
+    async def test_a_falsy_segment_transcript_refuses_the_whole_import(self, tmp_path, monkeypatch):
+        # GPT + Opus review (both BLOCKING): transcribe_audio returns None for a
+        # genuine recogniser failure (decode error, timeout, singleton swapped
+        # mid-import) as well as for a silent segment, indistinguishable here. A
+        # clean _extract_segment only proves ffmpeg carved the WAV, not that the
+        # recogniser succeeded. So a falsy segment must refuse the WHOLE import,
+        # never be skipped -- skipping would silently drop a real spoken span and
+        # answer 200, the exact silent-partial loss the feature prevents.
+        async def _scan(path, *, timeout_secs):
+            return [], 130.0  # hard cuts -> 3 segments
+
+        async def _extract(path, start, end, out, *, timeout_secs):
+            return True
+
+        calls = {"n": 0}
+
+        async def _transcribe(path, cfg):
+            calls["n"] += 1
+            return "" if calls["n"] == 2 else "ok"  # the middle segment is falsy
+
+        monkeypatch.setattr(transcribe, "_detect_silence_ends", _scan)
+        monkeypatch.setattr(transcribe, "_extract_segment", _extract)
+        monkeypatch.setattr(transcribe, "transcribe_audio", _transcribe)
+
+        result = await transcribe.transcribe_oversized_in_segments(
+            "/dev/fd/9", 60, str(tmp_path), self._cfg()
+        )
+        assert result is None, "a falsy segment transcript refuses the whole import"
+
+    @pytest.mark.asyncio
+    async def test_an_implausible_duration_is_refused_before_building_cuts(
+        self, tmp_path, monkeypatch
+    ):
+        # GPT security-class review: a crafted container can report a far-future
+        # terminal PTS. The cut loop appends one float per cap-sized window, so an
+        # unbounded duration would allocate billions of cuts and freeze/OOM. The
+        # duration is refused against _MAX_SEGMENTS * cap BEFORE any cut is built,
+        # and no segment is ever extracted.
+        extracted = {"n": 0}
+
+        async def _scan(path, *, timeout_secs):
+            # cap=60, _MAX_SEGMENTS=512 -> ceiling 30720s; report far past it.
+            return [], 60.0 * 512 * 1000
+
+        async def _extract(path, start, end, out, *, timeout_secs):
+            extracted["n"] += 1
+            return True
+
+        monkeypatch.setattr(transcribe, "_detect_silence_ends", _scan)
+        monkeypatch.setattr(transcribe, "_extract_segment", _extract)
+
+        result = await transcribe.transcribe_oversized_in_segments(
+            "/dev/fd/9", 60, str(tmp_path), self._cfg()
+        )
+        assert result is None
+        assert extracted["n"] == 0, "no cut is built and no segment is extracted"
+
+    @pytest.mark.asyncio
+    async def test_a_nonpositive_duration_is_refused(self, tmp_path, monkeypatch):
+        async def _scan(path, *, timeout_secs):
+            return [], 0.0
+
+        monkeypatch.setattr(transcribe, "_detect_silence_ends", _scan)
+        result = await transcribe.transcribe_oversized_in_segments(
+            "/dev/fd/9", 60, str(tmp_path), self._cfg()
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_each_segment_file_is_removed_after_transcription(self, tmp_path, monkeypatch):
+        async def _scan(path, *, timeout_secs):
+            return [], 130.0  # 3 segments
+
+        async def _extract(path, start, end, out, *, timeout_secs):
+            # Actually create the file, so the unlink is observable.
+            with open(out, "wb") as fh:
+                fh.write(b"RIFFfake")
+            return True
+
+        async def _transcribe(path, cfg):
+            assert os.path.exists(path), "the segment must exist while it is transcribed"
+            return "ok"
+
+        monkeypatch.setattr(transcribe, "_detect_silence_ends", _scan)
+        monkeypatch.setattr(transcribe, "_extract_segment", _extract)
+        monkeypatch.setattr(transcribe, "transcribe_audio", _transcribe)
+
+        result = await transcribe.transcribe_oversized_in_segments(
+            "/dev/fd/9", 60, str(tmp_path), self._cfg()
+        )
+        assert result == "ok ok ok"
+        # No segment WAV is left behind in the caller's dir.
+        assert list(tmp_path.glob("segment-*.wav")) == []
+
+
+class _FakeLineReader:
+    """A StreamReader stand-in: hands back scripted bytes one line at a time,
+    then b"" at EOF. In hang mode it blocks until released (kill)."""
+
+    def __init__(self, data: bytes, released: "asyncio.Event | None" = None, hang: bool = False):
+        self._lines = data.splitlines(keepends=True) if data else []
+        self._i = 0
+        self._released = released
+        self._hang = hang
+
+    async def readline(self) -> bytes:
+        if self._i < len(self._lines):
+            line = self._lines[self._i]
+            self._i += 1
+            return line
+        if self._hang and self._released is not None and not self._released.is_set():
+            await self._released.wait()
+        return b""
+
+    async def read(self, _n: int = -1) -> bytes:
+        # Hand back all remaining bytes at once (bounded reader in the code keeps
+        # only a tail), then EOF.
+        if self._i < len(self._lines):
+            rest = b"".join(self._lines[self._i :])
+            self._i = len(self._lines)
+            return rest
+        if self._hang and self._released is not None and not self._released.is_set():
+            await self._released.wait()
+        return b""
+
+
+class _FakeFfmpegProcWithStderr:
+    """Like ``_FakeFfmpegProc`` but carries stderr too. Serves BOTH read shapes:
+    ``communicate()`` (the segment extract) AND ``stdout``/``stderr`` line
+    readers + ``wait()`` (the silence scan's incremental drain)."""
+
+    def __init__(
+        self, stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0, hang: bool = False
+    ) -> None:
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self._hang = hang
+        self._released = asyncio.Event()
+        self.killed = False
+        self.stdout = _FakeLineReader(stdout, self._released, hang)
+        self.stderr = _FakeLineReader(stderr, self._released, hang)
+
+    async def communicate(self):
+        if self._hang and not self.killed:
+            await self._released.wait()
+        return self._stdout, self._stderr
+
+    async def wait(self):
+        return self.returncode
+
+    def kill(self) -> None:
+        self.killed = True
+        self._released.set()
+
+
+class _CancellingLineReader:
+    async def readline(self):
+        raise asyncio.CancelledError()
+
+    async def read(self, _n: int = -1):
+        raise asyncio.CancelledError()
+
+
+class _CancellingFfmpegProc:
+    """A child whose reads/communicate raise CancelledError, to exercise the
+    reap-and-reraise cancellation arm of the spawn sites."""
+
+    def __init__(self) -> None:
+        self.returncode = None
+        self.killed = False
+        self.stdout = _CancellingLineReader()
+        self.stderr = _CancellingLineReader()
+
+    async def communicate(self):
+        if not self.killed:
+            raise asyncio.CancelledError()
+        return b"", b""
+
+    async def wait(self):
+        return self.returncode
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def _arm_ffmpeg(monkeypatch, proc):
+    """Point the resolver + spawn seam at a scripted child (or an exception)."""
+
+    async def _resolve():
+        return "/opt/fake/ffmpeg"
+
+    async def _spawn(_executable, *_argv, **_kw):
+        if isinstance(proc, BaseException):
+            raise proc
+        return proc
+
+    async def _close(_executable, **_kw):
+        return None
+
+    monkeypatch.setattr(transcribe, "_resolve_ffmpeg_for_execution", _resolve)
+    monkeypatch.setattr(transcribe, "_create_ffmpeg_subprocess", _spawn)
+    monkeypatch.setattr(transcribe, "_close_ffmpeg_for_execution", _close)
+
+
+class TestDetectSilenceEnds:
+    """The one silence-scan ffmpeg pass, driven through a scripted child."""
+
+    @pytest.mark.asyncio
+    async def test_it_reads_silence_ends_and_the_duration(self, tmp_path, monkeypatch):
+        p = tmp_path / "meeting.webm"
+        p.write_bytes(b"x")
+        # stdout carries the -progress out_time; stderr carries silencedetect events.
+        stdout = b"out_time_us=1000000\nprogress=continue\nout_time_us=130000000\nprogress=end\n"
+        stderr = (
+            b"[silencedetect @ 0x1] silence_start: 57.5\n"
+            b"[silencedetect @ 0x1] silence_end: 58.2 | silence_duration: 0.7\n"
+            b"[silencedetect @ 0x1] silence_end: 118.9 | silence_duration: 0.4\n"
+        )
+        _arm_ffmpeg(monkeypatch, _FakeFfmpegProcWithStderr(stdout=stdout, stderr=stderr))
+        result = await transcribe._detect_silence_ends(str(p), timeout_secs=300)
+        assert result is not None
+        silence_ends, duration = result
+        assert silence_ends == [58.2, 118.9]
+        assert duration == 130.0
+
+    @pytest.mark.asyncio
+    async def test_no_silence_events_is_an_empty_list_not_none(self, tmp_path, monkeypatch):
+        p = tmp_path / "talky.webm"
+        p.write_bytes(b"x")
+        stdout = b"out_time_us=90000000\nprogress=end\n"
+        _arm_ffmpeg(monkeypatch, _FakeFfmpegProcWithStderr(stdout=stdout, stderr=b""))
+        result = await transcribe._detect_silence_ends(str(p), timeout_secs=300)
+        assert result == ([], 90.0)
+
+    @pytest.mark.asyncio
+    async def test_no_progress_output_is_unanswerable(self, tmp_path, monkeypatch):
+        p = tmp_path / "bad.webm"
+        p.write_bytes(b"x")
+        _arm_ffmpeg(monkeypatch, _FakeFfmpegProcWithStderr(stdout=b"", stderr=b""))
+        assert await transcribe._detect_silence_ends(str(p), timeout_secs=300) is None
+
+    @pytest.mark.asyncio
+    async def test_a_nonzero_exit_is_unanswerable(self, tmp_path, monkeypatch):
+        p = tmp_path / "corrupt.webm"
+        p.write_bytes(b"x")
+        stdout = b"out_time_us=5000000\nprogress=end\n"
+        _arm_ffmpeg(
+            monkeypatch, _FakeFfmpegProcWithStderr(stdout=stdout, stderr=b"boom", returncode=1)
+        )
+        assert await transcribe._detect_silence_ends(str(p), timeout_secs=300) is None
+
+    @pytest.mark.asyncio
+    async def test_a_missing_decoder_is_unanswerable(self, tmp_path, monkeypatch):
+        p = tmp_path / "x.webm"
+        p.write_bytes(b"x")
+
+        async def _no_decoder():
+            return None
+
+        monkeypatch.setattr(transcribe, "_resolve_ffmpeg_for_execution", _no_decoder)
+        assert await transcribe._detect_silence_ends(str(p), timeout_secs=300) is None
+
+    @pytest.mark.asyncio
+    async def test_a_timeout_kills_the_child_and_is_unanswerable(self, tmp_path, monkeypatch):
+        p = tmp_path / "slow.webm"
+        p.write_bytes(b"x")
+        proc = _FakeFfmpegProcWithStderr(hang=True)
+        _arm_ffmpeg(monkeypatch, proc)
+        assert await transcribe._detect_silence_ends(str(p), timeout_secs=0) is None
+        assert proc.killed, "the timed-out child must be killed, not leaked"
+
+    @pytest.mark.asyncio
+    async def test_an_unresolvable_demuxer_is_unanswerable(self, monkeypatch):
+        # _forced_demuxer_args raises OSError for a descriptor path whose suffix
+        # cannot be read; the scan must answer None rather than sniff content.
+        assert await transcribe._detect_silence_ends("/dev/fd/999", timeout_secs=300) is None
+
+    @pytest.mark.asyncio
+    async def test_an_unspawnable_ffmpeg_is_unanswerable(self, tmp_path, monkeypatch):
+        p = tmp_path / "x.webm"
+        p.write_bytes(b"x")
+        _arm_ffmpeg(monkeypatch, OSError("exec format error"))
+        assert await transcribe._detect_silence_ends(str(p), timeout_secs=300) is None
+
+    @pytest.mark.asyncio
+    async def test_a_cancellation_kills_the_child_and_propagates(self, tmp_path, monkeypatch):
+        # A CancelledError landing on communicate() must reap the child (so no
+        # decoder leaks) and re-raise, not be swallowed as a None answer.
+        p = tmp_path / "x.webm"
+        p.write_bytes(b"x")
+        proc = _CancellingFfmpegProc()
+        _arm_ffmpeg(monkeypatch, proc)
+        with pytest.raises(asyncio.CancelledError):
+            await transcribe._detect_silence_ends(str(p), timeout_secs=300)
+        assert proc.killed
+
+    @pytest.mark.asyncio
+    async def test_a_pathological_flood_of_silence_events_is_refused(self, tmp_path, monkeypatch):
+        # GPT security-class review: a pause-dense recording could emit millions of
+        # silence_end lines. The scan keeps only parsed floats, capped at
+        # _MAX_SILENCE_POINTS, and refuses (None) past the cap rather than buffering
+        # unbounded memory and OOM-crashing the gateway.
+        p = tmp_path / "flood.webm"
+        p.write_bytes(b"x")
+        monkeypatch.setattr(transcribe, "_MAX_SILENCE_POINTS", 3)
+        stdout = b"out_time_us=90000000\nprogress=end\n"
+        stderr = b"".join(
+            b"[silencedetect] silence_end: %d.0 | silence_duration: 0.3\n" % i for i in range(10)
+        )
+        _arm_ffmpeg(monkeypatch, _FakeFfmpegProcWithStderr(stdout=stdout, stderr=stderr))
+        assert await transcribe._detect_silence_ends(str(p), timeout_secs=300) is None
+
+    @pytest.mark.asyncio
+    async def test_an_over_64kib_stderr_line_with_no_newline_does_not_raise(
+        self, tmp_path, monkeypatch
+    ):
+        # GPT security-class review: StreamReader.readline() raises ValueError on a
+        # line past its 64 KiB limit, which a crafted container's metadata tag can
+        # produce -> unhandled 500. The reader now uses read(n) (no line limit) and
+        # a bounded rolling buffer, so a >64 KiB stderr line with NO newline is
+        # handled cleanly and the scan still returns its duration from stdout.
+        p = tmp_path / "bigline.webm"
+        p.write_bytes(b"x")
+        stdout = b"out_time_us=90000000\nprogress=end\n"
+        stderr = b"[metadata] title: " + (b"A" * (200 * 1024))  # >64 KiB, no newline
+        _arm_ffmpeg(monkeypatch, _FakeFfmpegProcWithStderr(stdout=stdout, stderr=stderr))
+        result = await transcribe._detect_silence_ends(str(p), timeout_secs=300)
+        assert result == ([], 90.0), "no ValueError; duration still parsed, no silence found"
+
+
+class TestExtractSegment:
+    """The per-segment ffmpeg extract, driven through a scripted child."""
+
+    @pytest.mark.asyncio
+    async def test_a_clean_extract_returns_true(self, tmp_path, monkeypatch):
+        inp = tmp_path / "in.webm"
+        inp.write_bytes(b"x")
+        out = tmp_path / "segment-000.wav"
+        _arm_ffmpeg(monkeypatch, _FakeFfmpegProcWithStderr(returncode=0))
+        ok = await transcribe._extract_segment(str(inp), 0.0, 58.0, str(out), timeout_secs=300)
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_the_last_segment_has_no_end(self, tmp_path, monkeypatch):
+        # end=None must not raise (it means "run to EOF", no -t arg).
+        inp = tmp_path / "in.webm"
+        inp.write_bytes(b"x")
+        out = tmp_path / "segment-001.wav"
+        _arm_ffmpeg(monkeypatch, _FakeFfmpegProcWithStderr(returncode=0))
+        ok = await transcribe._extract_segment(str(inp), 58.0, None, str(out), timeout_secs=300)
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_a_nonzero_exit_returns_false(self, tmp_path, monkeypatch):
+        inp = tmp_path / "in.webm"
+        inp.write_bytes(b"x")
+        out = tmp_path / "segment-000.wav"
+        _arm_ffmpeg(
+            monkeypatch,
+            _FakeFfmpegProcWithStderr(stderr=b"decode error", returncode=1),
+        )
+        ok = await transcribe._extract_segment(str(inp), 0.0, 58.0, str(out), timeout_secs=300)
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_a_missing_decoder_returns_false(self, tmp_path, monkeypatch):
+        inp = tmp_path / "in.webm"
+        inp.write_bytes(b"x")
+        out = tmp_path / "segment-000.wav"
+
+        async def _no_decoder():
+            return None
+
+        monkeypatch.setattr(transcribe, "_resolve_ffmpeg_for_execution", _no_decoder)
+        ok = await transcribe._extract_segment(str(inp), 0.0, 58.0, str(out), timeout_secs=300)
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_a_timeout_kills_the_child_and_returns_false(self, tmp_path, monkeypatch):
+        inp = tmp_path / "in.webm"
+        inp.write_bytes(b"x")
+        out = tmp_path / "segment-000.wav"
+        proc = _FakeFfmpegProcWithStderr(hang=True)
+        _arm_ffmpeg(monkeypatch, proc)
+        ok = await transcribe._extract_segment(str(inp), 0.0, 58.0, str(out), timeout_secs=0)
+        assert ok is False
+        assert proc.killed, "the timed-out child must be killed, not leaked"
+
+    @pytest.mark.asyncio
+    async def test_an_unspawnable_ffmpeg_returns_false(self, tmp_path, monkeypatch):
+        inp = tmp_path / "in.webm"
+        inp.write_bytes(b"x")
+        out = tmp_path / "segment-000.wav"
+        _arm_ffmpeg(monkeypatch, OSError("exec format error"))
+        ok = await transcribe._extract_segment(str(inp), 0.0, 58.0, str(out), timeout_secs=300)
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_an_unresolvable_demuxer_returns_false(self, tmp_path, monkeypatch):
+        # _forced_demuxer_args raises OSError for a descriptor path whose suffix
+        # cannot be read; the extract must refuse rather than sniff content.
+        out = tmp_path / "segment-000.wav"
+        ok = await transcribe._extract_segment("/dev/fd/999", 0.0, 58.0, str(out), timeout_secs=300)
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_a_cancellation_kills_the_child_and_propagates(self, tmp_path, monkeypatch):
+        # A CancelledError on communicate() must reap the child and re-raise.
+        inp = tmp_path / "in.webm"
+        inp.write_bytes(b"x")
+        out = tmp_path / "segment-000.wav"
+        proc = _CancellingFfmpegProc()
+        _arm_ffmpeg(monkeypatch, proc)
+        with pytest.raises(asyncio.CancelledError):
+            await transcribe._extract_segment(str(inp), 0.0, 58.0, str(out), timeout_secs=300)
+        assert proc.killed


### PR DESCRIPTION
## Problem / Motivation

Import a recording longer than one hour into a meeting and the request is refused
with `413 recording_too_long`. The user then has to find an audio editor, cut the
file into pieces by hand, and import each piece one at a time. A multi-hour
all-hands or workshop recording  -  the input the import feature is most valuable
for  -  is exactly the input it turns away.

## Why it matters

The one-hour ceiling is not a product decision the user should have to work
around. It is an implementation detail of the local speech-to-text decoder: both
of its decode paths stop reading at `_MAX_AUDIO_SECS` (3600s) and neither says it
did. Before the guard that returns the 413 (PR #5741), an over-cap recording was
transcribed to only its first hour and returned `200`  -  a transcript that ends
early with no sign it is incomplete, which then gets trusted as the whole meeting.
That silent partial import is the worst case, and the 413 exists to prevent it.
This change removes the manual work without reopening that hole: long audio gets
the same transparent treatment an oversized pasted image already gets when it is
auto-resized to fit.

## What changed (motivation -> approach -> change)

The decoder truncates silently at the cap, so the recording must not be handed to
it whole. The import route already probes the duration before transcribing (to
catch exactly this); that probe's `exceeds` branch used to raise the 413. It now
splits instead.

The split is on the **audio**, not the transcript. One ffmpeg pass locates the
pauses with `silencedetect`. A pure function then picks each cut at the last pause
before the running cap boundary, within a 30-second window, so a word straddling
the boundary is never cut  -  the cut lands in the silence between utterances. When
a window holds no pause (continuous speech across the whole window), the cut falls
hard on the cap: a rare, documented seam that may split one word, still strictly
better than refusing the whole recording. Because the segments are
**non-overlapping** (cut in the silence between utterances), the stitch is a plain
space join with nothing to de-duplicate. Each segment is decoded to its own WAV
and transcribed through the ordinary `transcribe_audio`, so every segment gets the
same provider dispatch, sensitive-path guard and redaction a whole recording does.

The user gets **one** transcript, not several. The joined text feeds the route's
existing `split_transcript` exactly as a whole transcript does, so each segment's
lines become ordinary transcript lines and the seams are invisible. That same
`split_transcript` still enforces `MAX_IMPORT_LINES` and `MAX_TRANSCRIPT_CHARS`, so
splitting is never a way around the total-size ceiling  -  a stitched result past the
line budget is still refused whole with 413.

If any segment fails to decode or transcribes empty, the whole import is refused
(`502`) and nothing is dispatched: a partial import that reported success would be
the same silent-data-loss defect this fixes, one level up. The split is
local-only. Apple has the same one-hour ceiling but fails loudly at it, and its
speech helper runs in a sandbox that cannot read the segment files, so an over-cap
Apple recording keeps its prior `413` refusal rather than being split. AWS
Transcribe has no silent ceiling (it refuses an oversized payload loudly), so it
is not probed and not split. An indeterminate duration probe still refuses
retryably (`503`), because the split needs the same decode the probe could not
complete.

An empty or failed segment refuses the whole import. A segment can fail at two
steps: the ffmpeg extract (a decode error) or the recogniser (a per-segment
timeout, or the shared recogniser being swapped mid-import). `transcribe_audio`
reports both a genuine recogniser failure and a legitimately silent segment as the
same empty result, so the two cannot be told apart here. Rather than risk skipping
a segment whose recogniser actually failed and silently dropping a real spoken
span, any empty segment refuses the whole import (502) with nothing dispatched.
That is the same silent-partial defect this fixes, one level down, so it is refused
loudly instead. A recording under the size cap can span at most a fixed number of
cap-sized segments, so a crafted file reporting a far-future duration is refused
before any cut is built. Each split records one `allowed` SEL audit line
(`split:over-Nmin`, via the route's existing `audit()` sink) so the incident trail
carries an over-cap import as a durable record.

Cost, measured. The split runs one silence scan of the whole recording, then per
segment one ffmpeg extract and one recogniser decode, all sequential inside the
import request under the STT `timeout_secs` (default 300s) per operation. The scan
is a null decode with an RMS filter and no model, so it is ~1000x real time: a
2-hour recording scans in ~7s and a 4-hour in ~15s (measured with the host ffmpeg).
The local recogniser runs at a 0.007-0.011 real-time factor, so a full 1-hour
segment decodes in ~25-40s; the extract is a few seconds. Every operation clears
the 300s budget with wide margin, and a 2-4 hour meeting -- the input this feature
is named for -- completes in one to three minutes. The bound: a 512 MiB file at a
low bitrate (~12 kbps) is ~95 hours of audio, capped at 512 one-hour segments, so
the worst case is ~512 x ~34s ~= 4.9 hours holding one HTTP request. A recording of
tens of hours therefore holds the request for a long time; past 512 cap-sized
segments it is refused before any cut is built. This is a synchronous split, not a
background job queue -- that would be a different change and is out of scope.

Scope this PR does NOT cover, deferred: the same silent-truncation cause (the local
decoder stops at `_MAX_AUDIO_SECS` without saying so) still reaches the three other
`transcribe_audio` callers that do not probe duration -- `slack/events.py:1644`,
`dashboard/handlers/core.py:1334`, and `messaging/attachments.py:575`. Those admit
smaller uploads (25 MiB, still hours at voice-memo bitrates) so a long memo there
transcribes only its first hour and reports success. A general fix inside
`transcribe_audio` is larger (its segment staging must sit under the guard-exempt
voice-runtime root) and is left to a follow-up; this PR cures the cause only on the
meetings import route, which is the one that probes.

```mermaid
flowchart LR
  A[import over-cap recording]:::ctx --> B{probe: exceeds cap?}:::ctx
  B -->|before| C[413 recording_too_long]:::removed
  B -->|now| D[cut at pauses into<br/>cap-sized segments]:::added
  D --> E[transcribe each<br/>segment]:::added
  E --> F[join with spaces =<br/>one transcript]:::added
  F --> G[dispatch into meeting]:::ctx
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3,4,5 stroke:#16A34A,stroke-width:2px
```

added / changed / removed / unchanged: green / amber / red / blue

*A recording over the cap used to be refused; now it is cut at its pauses, each piece transcribed, and the pieces joined into one transcript the meeting receives.*

## Tests

Ran with (Python, single file, no parallelism):

```
timeout 900 python3 -m pytest -n0 test/test_transcribe.py -x -q
timeout 900 python3 -m pytest -n0 test/test_meetings_audio_import.py -x -q
timeout 900 python3 -m pytest -n0 test/test_spawn_audit.py -x -q
```

- `test_transcribe.py::TestChooseSegmentCuts`  -  the boundary rules as a pure
  function: cuts at the last pause before the cap, hard-cuts at the cap when a
  window has no pause, advances from each cut so the loop terminates, and every
  segment stays within the cap.
- `test_transcribe.py::TestTranscribeOversizedInSegments`  -  cut/transcribe/stitch
  control flow, space join in order, that a segment which fails to EXTRACT or
  produces a falsy transcript (decode-empty or a recogniser failure, which cannot
  be told apart) refuses the whole import (never a silent skip), and that an
  implausible/far-future duration is refused before any cut is built (the
  segment-count ceiling); each segment WAV is removed after transcription.
- `test_meetings_audio_import.py`  -  the route now splits an over-cap recording and
  answers `200` (was 413); a failed split answers `502` with nothing dispatched; a
  stitched result over `MAX_IMPORT_LINES` is still `413`; segments are staged under
  the request's own snapshot dir.
- `test_spawn_audit.py`  -  the two new ffmpeg spawns are classified in the audit.

`prove.py` reports `PROVEN`: reverting the production hunks while keeping the test
hunks makes an assertion fail, so the tests catch the change.

## Manual verification

N/A  -  unit coverage sufficient. The ffmpeg seam (silence scan, segment extract) is
the same spawn shape as the existing duration probe and decode, tested at the
function boundary; the boundary rules are a pure function tested directly.

## Related Issues

Closes #8272
