### PR TITLE
fix: use persistent connection session for test to avoid 401

### DIFF
--- a/src/kiro_crew/connections/tool_test.py
+++ b/src/kiro_crew/connections/tool_test.py
@@ -127,7 +127,7 @@ async def test_connection_tools(provider: Provider) -> ConnectionTestResult:
     # dedicated test session if no persistent session exists.
     persistent_session_key = f"connections-{slug}"
     test_session_key = f"connections-test-{slug}"
-    
+
     try:
         work_root = await asyncio.to_thread(data_home)
         # Try persistent session first for credential reuse

--- a/src/kiro_crew/connections/tool_test.py
+++ b/src/kiro_crew/connections/tool_test.py
@@ -115,20 +115,42 @@ async def test_connection_tools(provider: Provider) -> ConnectionTestResult:
     provider tool. ``/mcp`` reads the MCP manager's post-``tools/list`` status;
     ``/tools`` reads the final agent-exposed set. Raw command output and tool
     descriptions never cross the API boundary.
+
+    For persistent connections, reuse the existing session to preserve stored
+    credentials. Fall back to a dedicated test session if no persistent session
+    exists.
     """
     slug = str(provider["slug"])
     alias = mcp_server_alias(slug)
+    # Try to use the connection's persistent session first (e.g. "connections-{slug}")
+    # which holds stored credentials for remote MCP servers. Fall back to a
+    # dedicated test session if no persistent session exists.
+    persistent_session_key = f"connections-{slug}"
+    test_session_key = f"connections-test-{slug}"
+    
     try:
         work_root = await asyncio.to_thread(data_home)
+        # Try persistent session first for credential reuse
         batch = await run_kiro_native_commands(
             ("/mcp", "/tools"),
-            work_dir=work_root / "connections" / "test",
+            work_dir=work_root / "connections" / slug,
             agent=_MAIN_AGENT,
-            session_key=f"connections-test-{slug}",
+            session_key=persistent_session_key,
             timeout_seconds=_TEST_TIMEOUT_SECONDS,
         )
     except Exception:
-        return _result(slug, "failed", "connection_test_failed")
+        # Fall back to isolated test session if persistent session unavailable
+        try:
+            work_root = await asyncio.to_thread(data_home)
+            batch = await run_kiro_native_commands(
+                ("/mcp", "/tools"),
+                work_dir=work_root / "connections" / "test",
+                agent=_MAIN_AGENT,
+                session_key=test_session_key,
+                timeout_seconds=_TEST_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            return _result(slug, "failed", "connection_test_failed")
     if not batch.ok:
         return _result(slug, "failed", batch.code)
     return _classify(batch.results, slug, alias)


### PR DESCRIPTION
## Problem / Motivation

The Connections page "Test Connection" button shows HTTP 401 / Failing for remote MCP servers that authenticate fine when used in regular chat sessions. The test was using a fresh isolated session (`connections-test-{slug}`) without the stored OAuth credentials, while the actual chat session (`connections-{slug}`) holds the credentials.

## Why it matters

Users cannot verify their remote MCP server connections from the Connections page, even though the servers work perfectly in chat. The test was creating an isolated session without the stored OAuth tokens.

## What changed (motivation → approach → change)

Modified `test_connection_tools()` in `tool_test.py` to:
1. First try the persistent connection session (`connections-{slug}`) which holds stored OAuth credentials
2. Uses the connection's actual working directory (`connections/{slug}/`) for proper MCP config access
3. Falls back to the isolated test session (`connections-test-{slug}`) only if the persistent session is unavailable

This ensures remote MCP servers that work in chat also pass the connection test.

## Tests

- Verified the test uses persistent session first (has credentials)
- Falls back to test session when persistent session unavailable
- Existing connection tests pass

## Related Issues

Fixes #9206

## Checklist

- [x] Single commit with Conventional Commits title
- [x] Existing tests pass
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->