### PR TITLE
fix(session): pool health sweep heals an under-filled warm pool

### DIFF
--- a/src/kiro_crew/session_pool.py
+++ b/src/kiro_crew/session_pool.py
@@ -495,14 +495,13 @@ class WarmSessionPool:
         if not self._pool_size:
             return
         qsize = self._warm_pool.qsize()
-        if not qsize:
-            return
-        self._deps.logger.debug(
-            "Pool health: sweeping %d providers (target=%d, ttl=%ds)",
-            qsize,
-            self._pool_size,
-            self._pool_ttl_secs,
-        )
+        if qsize:
+            self._deps.logger.debug(
+                "Pool health: sweeping %d providers (target=%d, ttl=%ds)",
+                qsize,
+                self._pool_size,
+                self._pool_ttl_secs,
+            )
         healthy: list[tuple[LLMProvider, float]] = []
         to_shutdown: list[LLMProvider] = []
         now = time.monotonic()
@@ -558,15 +557,23 @@ class WarmSessionPool:
                 self._pool_sweep_pids.clear()
 
         removed = qsize - len(healthy)
+        deficit = self._pool_size - len(healthy)
         if removed:
             self._deps.logger.info(
                 "Pool health: removed %d dead/expired, %d healthy remain",
                 removed,
                 len(healthy),
             )
-            self._owner._schedule_replenish()
+        elif deficit > 0:
+            self._deps.logger.debug(
+                "Pool health: pool under target (%d healthy, target=%d), replenishing",
+                len(healthy),
+                self._pool_size,
+            )
         else:
             self._deps.logger.debug("Pool health: all %d providers healthy", len(healthy))
+        if removed or deficit > 0:
+            self._owner._schedule_replenish()
 
     async def drain_warm_pool(self) -> list[LLMProvider]:
         """Remove and return all queued providers without shutting them down."""

--- a/test/test_session_pool.py
+++ b/test/test_session_pool.py
@@ -886,8 +886,8 @@ class TestPoolHealthLoop:
 
     @pytest.mark.asyncio
     async def test_keeps_healthy_provider(self):
-        """Healthy provider survives health sweep."""
-        mgr, _ = _make_manager(pool_agent="kirocrew")
+        """Healthy provider at target survives health sweep with no churn."""
+        mgr, _ = _make_manager(pool_size=1, pool_agent="kirocrew")
         healthy = _make_provider()
         mgr._warm_pool.put_nowait((healthy, time.monotonic()))
         mgr._schedule_replenish = MagicMock()
@@ -909,8 +909,8 @@ class TestPoolHealthLoop:
         mgr._schedule_replenish.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_skips_when_pool_empty(self):
-        """No crash when pool is empty during sweep."""
+    async def test_empty_pool_schedules_replenish(self):
+        """Empty pool self-heals: sweep schedules a refill instead of skipping."""
         mgr, _ = _make_manager(pool_agent="kirocrew")
         mgr._schedule_replenish = MagicMock()
 
@@ -925,6 +925,43 @@ class TestPoolHealthLoop:
         with patch("asyncio.sleep", side_effect=_sleep_once):
             with pytest.raises(asyncio.CancelledError):
                 await mgr._pool_health_loop()
+
+        mgr._schedule_replenish.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_under_target_pool_schedules_replenish(self):
+        """A short-but-healthy pool is a deficit: sweep schedules a refill."""
+        mgr, _ = _make_manager(pool_size=3, pool_agent="kirocrew")
+        healthy = _make_provider()
+        mgr._warm_pool.put_nowait((healthy, time.monotonic()))
+        mgr._schedule_replenish = MagicMock()
+
+        await mgr._sweep_warm_pool_once()
+
+        assert mgr._warm_pool.qsize() == 1
+        healthy.shutdown.assert_not_awaited()
+        mgr._schedule_replenish.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_at_target_pool_does_not_replenish(self):
+        """A full healthy pool has no deficit: sweep schedules nothing."""
+        mgr, _ = _make_manager(pool_size=2, pool_agent="kirocrew")
+        for _ in range(2):
+            mgr._warm_pool.put_nowait((_make_provider(), time.monotonic()))
+        mgr._schedule_replenish = MagicMock()
+
+        await mgr._sweep_warm_pool_once()
+
+        assert mgr._warm_pool.qsize() == 2
+        mgr._schedule_replenish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disabled_pool_sweep_is_noop(self):
+        """pool_size=0 keeps the sweep a no-op: no refill for a disabled pool."""
+        mgr, _ = _make_manager(pool_size=0)
+        mgr._schedule_replenish = MagicMock()
+
+        await mgr._sweep_warm_pool_once()
 
         mgr._schedule_replenish.assert_not_called()
 


### PR DESCRIPTION
# fix(session): pool health sweep heals an under-filled warm pool

## Problem / Motivation

`_pool_health_loop` (`src/kiro_crew/session_pool.py`) documents its job as
"Periodically discard dead/expired providers and refill the pool." The refill
half of that contract only executed when the sweep itself removed an in-queue
entry, so population lost *outside* the sweep's own accounting was never
healed:

- **An empty pool was an absorbing state.** `_sweep_warm_pool_once`
  early-returned at `if not qsize: return` before any accounting ran, so a
  pool at zero was never swept and never refilled. A pool can reach zero with
  no compensating replenish signal: the fill loop `break`s on a spawn failure
  (provider binary briefly unavailable, auth hiccup), and the claim path's
  exception arm hard-kills a claimed provider and re-raises *before* the
  success-path `_schedule_replenish()` is reached. Once at zero, every
  subsequent session cold-starts — the warm-pool feature silently turns off
  until gateway restart. The `miss_empty` decision path records the miss but
  never schedules a refill.

- **A short-but-healthy pool never replenished from the sweep.** The sweep
  computed `removed = qsize - len(healthy)` and only scheduled a replenish
  inside `if removed:`. A deficit created by out-of-queue kills is invisible
  to that arithmetic (`removed == 0`), so an idle pool sat under target
  indefinitely — the component whose docstring owns the healing job could not
  perform it.

Under ongoing claim traffic a deficit heals as a side effect of the next
successful claim (`_schedule_replenish()` on the success path, and
`_fill_warm_pool` loops `while qsize < pool_size`, healing the full deficit).
The genuinely stuck cases are exactly the ones the health loop exists for:
a deterministic claim-path exception draining the pool to empty (no claim
ever succeeds again to fire the success-path heal), an idle pool with no
further claims, and `pool_size=1` where a single exception empties the pool
immediately.

## Why it matters

The warm pool exists to hide provider spawn latency. When it silently decays
to empty, the degradation is invisible — nothing errors, sessions just get
slower — and it is sticky until a restart. A health loop that cannot heal the
empty state inverts its purpose: the worst decay state is the one state it
refuses to touch.

## What changed (motivation → approach → change)

Replace removal-triggered refill with target-triggered refill in
`_sweep_warm_pool_once`:

- Drop the `if not qsize: return` fast path (the `if not self._pool_size:
  return` guard stays — a disabled pool remains a no-op; the sweep-loop body
  is skipped naturally when the queue is empty).
- After the sweep, compute the deficit against the target
  (`self._pool_size - len(healthy)`) and call `_schedule_replenish()`
  whenever the pool is under target — covering `removed > 0`, pre-existing
  shortfall with zero removals, and the empty pool.
- Logging: the removal info line is unchanged; a shortfall with no removals
  gets a debug line; the all-healthy-at-target case keeps its debug line.

`_fill_warm_pool` is already idempotent, lock-guarded, and target-capped
(`while ... qsize < pool_size`), so redundant replenish signals are safe by
construction; the fix adds a trigger, not a new fill mechanism. The deny
direction is preserved: `pool_size=0` schedules nothing.

## Tests

All in `test/test_session_pool.py` (`TestPoolHealthLoop`):

| Test | Shape | Before fix | After |
| --- | --- | --- | --- |
| `test_empty_pool_schedules_replenish` | pool_size set, queue empty → sweep | **FAILS** (early return, replenish never called) | passes |
| `test_under_target_pool_schedules_replenish` | pool_size=3, 1 healthy in queue → sweep | **FAILS** (`removed == 0` arm skipped replenish) | passes |
| `test_at_target_pool_does_not_replenish` | pool_size=2, 2 healthy → sweep | passes (regression pin: no deficit → no churn) | passes |
| `test_disabled_pool_sweep_is_noop` | pool_size=0 → sweep | passes (regression pin: disabled pool stays no-op) | passes |
| `test_keeps_healthy_provider` (updated) | healthy provider at target survives sweep | passes | passes (now also pins no-replenish at target) |

The dead-provider removal path (`removed > 0` → replenish) keeps its existing
coverage in the suite. Full file: 82 passed, 0 failed.

## Manual verification

Reproduced the absorbing state deterministically via the failing tests
against the unchanged tree: with the fix stashed, the empty-pool and
under-target sweeps complete without ever calling `_schedule_replenish`
(2 failed, 3 passed); with the fix restored, the full module suite is green
(82 passed). Gates run locally: targeted + neighboring pytest (effort/pool
suites, 310 passed), `mypy` on the changed source file (clean), `flake8`,
`isort --check-only`, the repo black gate (`scripts/check_black_formatting.py`,
passes — the test file is baseline-listed, no unrelated reformat churn
included), and `scripts/docs_lint.py` (all checks passed).

## Related Issues

No open issue tracks this decay; filing as a direct fix. Related population
accounting: #8835 capped unbounded pool *growth* on the eager-spawn path —
this PR is the complementary direction, healing unreplenished *shrinkage*.
(#2264 asks for per-agent standby counts — a feature on a different seam,
not covered or affected here.)

## Pattern harvest

The pattern is a maintenance loop that triggers its remediation off its own
bookkeeping instead of the invariant it owns. The sweep measured "how much
did *I* remove this pass" when the docstring's promise is "the pool is at
target" — so every decay path that bypassed the loop's ledger (fill-time
spawn failure, claim-path exception kill) produced drift the loop could not
see, and the deepest decay state (empty) was excluded by a fast path before
measurement even began. Harvested across this seam: the claim path already
heals opportunistically on success, which *masks* the loop's gap under
traffic and makes the defect present only in idle/poisoned/size-1 regimes —
the regimes where a background loop is the only actor left.

Rule candidate: a self-heal loop must compute its trigger from the owned
invariant (target minus observed state), never solely from its own
removal/mutation count — and fast-path exits must be proven not to skip the
states the loop exists to repair (an early return on "nothing to sweep" must
not also mean "nothing to refill").

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable — no doc file documents the sweep's refill trigger; the corrected behavior now matches the existing `_pool_health_loop` docstring)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Per the template placeholder (CLA text pending): offered under the same terms as my prior merged contributions to this repository (#8835).

<!-- no-visual-delta -->
**Why no screenshot:** no visual delta — backend-only change to the session
pool's health sweep; no UI surface is touched.
