### PR TITLE
fix(conductor): reject a non-boolean exists in a file acceptance

### DIFF
--- a/src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py
+++ b/src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py
@@ -156,7 +156,13 @@ def _evaluate(item):
         path = accept.get("path")
         if not isinstance(path, str) or not path:
             return ("error", "file spec needs a path")
-        want = bool(accept.get("exists", True))
+        # bool() would coerce, and a truthy `{"exists": "false"}` must not
+        # invert an absence check into a presence check; reject non-booleans
+        # (including 1/0 — the pr guard already refuses bool as an int).
+        exists = accept.get("exists", True)
+        if not isinstance(exists, bool):
+            return ("error", "file spec needs a boolean exists")
+        want = exists
         have = Path(path).exists()
         verdict = "pass" if have == want else "fail"
         return (verdict, f"{path} {'exists' if have else 'does not exist'}")

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -788,6 +788,55 @@ class TestAcceptEvaluator:
         assert out["junk"]["verdict"] == "error"
         assert out["nopath"]["verdict"] == "error"
 
+    def test_file_rejects_a_non_boolean_exists(self, tmp_path):
+        """``bool()`` coercion would read ``{"exists": "false"}`` as ``True``.
+
+        The reported shape: an acceptance assembled from text carries string
+        booleans, and a truthy ``"false"`` silently inverts an absence check
+        into a presence check — the evaluator reports ``pass`` for exactly the
+        state the spec asked to reject. ``1``/``0`` are rejected too, on
+        purpose: the ``pr`` guard already refuses ``bool`` as an ``int``, so
+        accepting ``int`` as a ``bool`` here would contradict the sibling
+        field. A malformed spec gets a loud ``error``, never a coerced verdict.
+        """
+        mod = _load_evaluator()
+        present = tmp_path / "made"
+        present.write_text("x", encoding="utf-8")
+        for bad in ("false", "true", 1, 0, None):
+            verdict, evidence = mod._evaluate(
+                {"accept": {"kind": "file", "path": str(present), "exists": bad}}
+            )
+            assert verdict == "error", bad
+            assert "boolean exists" in evidence
+
+    def test_file_absent_exists_key_still_defaults_to_presence_check(self, tmp_path):
+        """The default is unchanged: no ``exists`` key means ``exists: true``."""
+        mod = _load_evaluator()
+        present = tmp_path / "made"
+        present.write_text("x", encoding="utf-8")
+        verdict, _ = mod._evaluate({"accept": {"kind": "file", "path": str(present)}})
+        assert verdict == "pass"
+        verdict, _ = mod._evaluate({"accept": {"kind": "file", "path": str(tmp_path / "no")}})
+        assert verdict == "fail"
+
+    def test_file_real_booleans_still_work(self, tmp_path):
+        """Regression floor: genuine ``True``/``False`` keep their semantics."""
+        mod = _load_evaluator()
+        present = tmp_path / "made"
+        present.write_text("x", encoding="utf-8")
+        missing = tmp_path / "no"
+        cases = [
+            (present, True, "pass"),
+            (present, False, "fail"),
+            (missing, True, "fail"),
+            (missing, False, "pass"),
+        ]
+        for path, want, expected in cases:
+            verdict, _ = mod._evaluate(
+                {"accept": {"kind": "file", "path": str(path), "exists": want}}
+            )
+            assert verdict == expected, (path.name, want)
+
     def test_the_cmd_kind_is_refused_and_says_what_to_use(self):
         """A conductor carrying an older skill gets guidance, not 'unknown kind'.
 


### PR DESCRIPTION
Fixes #9293

## Symptom

The goal-conductor acceptance evaluator decides a `file` acceptance by comparing the file's real presence against a wanted state read as `bool(accept.get("exists", True))`. `bool()` coerces instead of validating: any non-empty string is truthy, so an acceptance spelled `{"exists": "false"}` — the shape produced whenever the acceptance was assembled from text rather than from real JSON booleans — is read as `True`. A "this file must be gone" check silently becomes "this file must be present", and the evaluator reports `pass` for exactly the state the spec asked to reject.

## Root cause

`src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py`, `_evaluate`'s `file` branch: the one field in the branch that was coerced rather than validated. Its two neighbours already return an `error` verdict for a malformed field — the `pr` guard (which goes out of its way to reject `bool` as an `int` subclass) and the `path` guard in the same branch.

## Fix

Validate before use, in the same shape and idiom as the two neighbouring guards: a non-boolean `exists` now returns `("error", "file spec needs a boolean exists")`. Points that are deliberate, not incidental:

- The absent-key default of `True` is preserved (read through `accept.get("exists", True)`; the default is itself a `bool` so it passes the guard) and pinned by test.
- `isinstance(exists, bool)` is strict on purpose: `1`/`0` and `"true"`/`"false"` are all rejected. The sibling `pr` guard already reasons in exactly this direction (it rejects `bool` as an `int`), so accepting `int` as a `bool` here would contradict it. A rejected spec gets a loud `error` a human reads; a coerced one silently inverts a check.
- The verdict is `error` ("this spec is malformed"), not `fail` ("the world is not in the wanted state") — matching both existing guards, so a conductor fixes the spec instead of re-working the item.

## Which copies existed at branch time

The issue names a second copy at `src/kiro_crew/builtin_skills/goal-ledger-conductor/scripts/accept_eval.py` and its byte-identical pin in `test/test_ledger_conductor_agent.py`. Neither exists on main at branch time — both arrive with open PR #9277 (`feat/ledger-conductor-agent`). This PR therefore fixes the one existing copy under `goal-conductor/`; when #9277 rebases, its byte-identical pin test will correctly go red until it carries this guard into its new copy — CI-caught, not silent, and the expected cost of fixing a live defect rather than waiting on merge order.

## Verification

- Red before green: `test_file_rejects_a_non_boolean_exists` was written first and run against unmodified main — it fails with the exact reported inversion (`assert 'pass' == 'error'` for a present file with `{"exists": "false"}`), not an incidental error.
- Coverage: `"false"`, `"true"`, `1`, `0`, `None` all rejected; absent key still defaults to a presence check; real `True`/`False` semantics pinned across all four presence/wanted combinations (the regression floor).
- Mutation checks, both directions recorded:
  - Reverting the guard to the original `bool()` coercion → `test_file_rejects_a_non_boolean_exists` goes red (`AssertionError: false`); restore → green.
  - Widening `isinstance(exists, bool)` to `isinstance(exists, (bool, int))` → the `1`/`0` cases go red (`AssertionError: 1`); restore → green. This pins the strictness decision rather than leaving it incidental.
- `scripts/local-gate.py --base origin/main`: backend-only diff, full backend suite run on this branch AND, with the identical bare invocation (`pytest -q -n auto --dist loadgroup`, no path args), on a `git worktree` at `origin/main`. Sorted FAILED/ERROR id sets (ANSI-stripped) diffed both directions: byte-identical except one branch-only entry in `test/test_pod_seed_scenarios.py` (unrelated file, passes standalone on the branch — a parallel-run flake, not a regression). This repo has a known environmental failure baseline; set identity is the proof.
- Frontend cross-surface guard specs (the gate's 219-file vitest selection) run green.
- Docs: no spec module or SKILL.md documents the `exists` field's type contract (grepped `docs/system-specs/modules/` and `goal-conductor/SKILL.md`), so no same-commit doc update is owed.

No frontend change; no visual delta.

<!-- no-visual-delta --> Backend-only skill-script validation fix; there is no UI surface to screenshot.

## Pattern harvest

Rule candidate: in a spec-parsing branch that already returns `error` verdicts for malformed fields, every field read must validate its type before use — a `bool()`/`str()`/`int()` coercion beside `isinstance` guards is the defect shape, because coercion silently inverts semantics instead of surfacing the malformed spec. Knowingly out-of-scope sibling: the second `accept_eval.py` copy arriving with PR #9277 (will need this same guard carried into it on rebase).
