### PR TITLE
chore(config): default feature videos off until real clips ship

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5911,7 +5911,7 @@
         "user_role_other": "",
         "user_technical_level": "",
         "tips_enabled": true,
-        "feature_videos_enabled": true,
+        "feature_videos_enabled": false,
         "folder_suggestions_enabled": true,
         "tips_cadence_hours": 6.0,
         "tips_snooze_hours": 48.0,
@@ -6686,7 +6686,7 @@
       "help": "Show short feature-intro clips for features this install has not used yet. Instance-wide kill switch.",
       "hasChildren": false,
       "enumValues": null,
-      "defaultValue": true
+      "defaultValue": false
     },
     {
       "path": "dashboard.folder_suggestions_enabled",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3455,7 +3455,7 @@ class KiroCrewConfig:
                 user_technical_level=str(dashboard_data.get("user_technical_level", "")),
                 tips_enabled=bool(dashboard_data.get("tips_enabled", True)),
                 feature_videos_enabled=_safe_bool(
-                    dashboard_data.get("feature_videos_enabled"), True
+                    dashboard_data.get("feature_videos_enabled"), False
                 ),
                 folder_suggestions_enabled=bool(
                     dashboard_data.get("folder_suggestions_enabled", True)

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -2870,7 +2870,7 @@ class DashboardConfig:
         ),
     )
     feature_videos_enabled: bool = field(
-        default=True,
+        default=False,
         metadata=_meta(
             "Feature Videos Enabled",
             "Show short feature-intro clips for features this install has not used "

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -254,7 +254,7 @@ Set via `kirocrew config set agent.acp_backend kas`.
 | `dashboard.merge_queued_messages` | Concatenate follow-up messages while the agent is busy | `false` |
 | `dashboard.mcp_probe_timeout_secs` | Seconds to wait for an MCP server handshake during a probe (5-120) | `15` |
 | `dashboard.link_previews` | Fetch and render HTTP(S) link metadata in assistant messages. Off by default because each linked site receives a request from this machine | `false` |
-| `dashboard.feature_videos_enabled` | Play a short intro clip for a feature this install has not used yet. Instance-wide kill switch; see [Feature Videos](feature-videos.md) | `true` |
+| `dashboard.feature_videos_enabled` | Play a short intro clip for a feature this install has not used yet. Instance-wide kill switch; see [Feature Videos](feature-videos.md). Off until real clips ship | `false` |
 
 ### Slack
 

--- a/src/kiro_crew/docs/feature-videos.md
+++ b/src/kiro_crew/docs/feature-videos.md
@@ -5,7 +5,8 @@ Kiro Crew plays a short intro clip for a feature this install has not used yet. 
 ## How It Works
 
 - The catalog is a static list in `feature_videos.py`. There is no generation step and no model call.
-- Selection walks the catalog in order and returns the first entry that is enabled, not yet recorded as seen or dismissed, satisfied by the running version, and not withdrawn by a "you already use this" signal.
+- Selection walks the catalog in order and returns the first entry that is enabled, has both its clip and poster shipped on disk, is not yet recorded as seen or dismissed, is satisfied by the running version, and is not withdrawn by a "you already use this" signal.
+- An entry whose media is not shipped is withheld, not shown. The dialog opens on the JSON answer alone and fetches nothing until the user presses play, so it cannot detect a missing clip itself -- it would open around a blank player, and the verdict a user then records is permanent. Withholding keeps the entry on offer for the launch after its clip lands.
 - Clips and posters are same-origin paths under `/app-assets/feature-videos/`. A path carrying a scheme, `//`, `..`, a percent sign, or a backslash is refused, so a catalog entry can never point the browser off this origin. Remote clip downloads are a separate future change.
 - Seen and dismissed are both permanent. There is no snooze: a feature intro that comes back is noise.
 - Temporary and incognito sessions get no video, because the state a video records is permanent and instance-wide.
@@ -17,7 +18,7 @@ Kiro Crew plays a short intro clip for a feature this install has not used yet. 
 |--------|--------|
 | Watch a clip to the end | Records `seen`; that video is never offered again. |
 | Close the modal | Records `dismissed`; same permanence. |
-| `dashboard.feature_videos_enabled: false` in config | Instance-wide kill switch. |
+| `dashboard.feature_videos_enabled: true` in config | Turns the feature ON. It is OFF by default until real clips ship. |
 
 ## Adding a Catalog Entry
 
@@ -66,7 +67,7 @@ To add one, register a function in `_PROBES` (no argument) or `_PARAM_PROBES` (t
 
 ```yaml
 dashboard:
-  feature_videos_enabled: true   # instance-wide switch
+  feature_videos_enabled: true   # instance-wide switch; DEFAULT false
 ```
 
 Display state lives in `feature_videos_state.json` beside `tips_state.json`, written with owner-only permissions.

--- a/src/kiro_crew/feature_videos.py
+++ b/src/kiro_crew/feature_videos.py
@@ -242,8 +242,58 @@ CATALOG: tuple[VideoEntry, ...] = (
 
 
 def catalog() -> tuple[VideoEntry, ...]:
-    """The catalog with unsafe entries filtered out."""
+    """The catalog with unsafe entries filtered out.
+
+    This is STRUCTURAL validity only -- a well-formed entry whose media has not
+    shipped yet is still in here. That is deliberate: the feedback route checks
+    membership against this set, and a user who has already been shown a clip
+    must be able to record a verdict on it even if its asset later goes missing.
+    :func:`offerable` is the set that may actually be shown.
+    """
     return tuple(e for e in CATALOG if _entry_is_valid(e))
+
+
+def _asset_root() -> Path:
+    """Where ``ASSET_PREFIX`` is served from on disk.
+
+    ``server.py`` mounts ``static/dist/app-assets`` at ``/app-assets``, so a
+    catalog ``src`` of ``/app-assets/feature-videos/x.mp4`` is the file
+    ``<static>/dist/app-assets/feature-videos/x.mp4``. Resolved through a
+    function, not a constant, so a test can point it at a temp directory.
+    """
+    return Path(__file__).resolve().parent / "static" / "dist" / "app-assets"
+
+
+def _asset_exists(url_path: str) -> bool:
+    """Whether the file behind a validated ``/app-assets/...`` path is on disk."""
+    prefix = "/app-assets/"
+    if not url_path.startswith(prefix):
+        return False
+    return (_asset_root() / url_path[len(prefix) :]).is_file()
+
+
+def offerable() -> tuple[VideoEntry, ...]:
+    """The entries that may be SHOWN: valid, and with both media files on disk.
+
+    "Asset shipped" is a precondition of "on offer", enforced here rather than
+    trusted to the client. The dialog opens on the JSON answer alone and its
+    ``<video>`` is ``preload="none"``, so nothing is fetched -- and no media error
+    can fire -- until the user presses play. An entry whose clip is not shipped
+    would therefore open a dialog around a blank player, and the natural "Got it"
+    writes a PERMANENT verdict, retiring the real intro before anyone saw it.
+    Dropping such an entry here keeps it on offer for the launch after its clip
+    lands, which is the recoverable outcome.
+    """
+    kept: list[VideoEntry] = []
+    for entry in catalog():
+        missing = [p for p in (entry.src, entry.poster) if not _asset_exists(p)]
+        if missing:
+            logger.info(
+                "feature video %r withheld: asset(s) not shipped: %s", entry.id, ", ".join(missing)
+            )
+            continue
+        kept.append(entry)
+    return tuple(kept)
 
 
 # ── "Already used this feature" probes ──
@@ -537,7 +587,7 @@ def select_next(running_version: str) -> VideoEntry | None:
     an entry already ruled out by state or version must not pay for them.
     """
     st = load_state()
-    for entry in catalog():
+    for entry in offerable():
         if st.status_of(entry.id):
             continue
         if not _version_ok(entry.min_version, running_version):

--- a/test/test_feature_videos.py
+++ b/test/test_feature_videos.py
@@ -51,6 +51,19 @@ def _entry(video_id: str, **kwargs: object) -> fv.VideoEntry:
     return fv.VideoEntry(id=video_id, **defaults)  # type: ignore[arg-type]
 
 
+@pytest.fixture(autouse=True)
+def _assets_shipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Treat every catalog asset as present on disk.
+
+    ``offerable()`` withholds an entry whose media is not shipped, and the test
+    tree has no ``static/dist``. Without this default every selection and route
+    test would exercise the withholding branch instead of what it is about. The
+    gate itself is tested in :class:`TestAssetExistenceGate`, which replaces this
+    default with a real temp directory.
+    """
+    monkeypatch.setattr(fv, "_asset_exists", lambda _p: True)
+
+
 class TestAssetPathValidation:
     """A clip src is fetched by the browser with the dashboard's credentials."""
 
@@ -148,6 +161,87 @@ class TestShippedCatalog:
         payload = fv.CATALOG[0].payload()
         assert "used_when" not in payload
         assert payload["id"] == "feature-tips"
+
+
+class TestAssetExistenceGate:
+    """ "Asset shipped" is a precondition of "on offer"."""
+
+    @pytest.fixture
+    def asset_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        # Undo the module-wide default so the real check runs against tmp_path.
+        monkeypatch.undo()
+        root = tmp_path / "app-assets"
+        (root / "feature-videos").mkdir(parents=True)
+        monkeypatch.setattr(fv, "_asset_root", lambda: root)
+        return root
+
+    @staticmethod
+    def _ship(root: Path, video_id: str, *, clip: bool = True, poster: bool = True) -> None:
+        d = root / "feature-videos"
+        if clip:
+            (d / f"{video_id}.mp4").write_bytes(b"\x00")
+        if poster:
+            (d / f"{video_id}.jpg").write_bytes(b"\x00")
+
+    def test_maps_the_url_prefix_onto_the_dist_directory(self, asset_root: Path) -> None:
+        self._ship(asset_root, "x")
+        assert fv._asset_exists(f"{fv.ASSET_PREFIX}x.mp4") is True
+        assert fv._asset_exists(f"{fv.ASSET_PREFIX}missing.mp4") is False
+        # A path outside the served prefix is never "present", whatever is on disk.
+        assert fv._asset_exists("/static/x.mp4") is False
+
+    def test_entry_with_no_shipped_media_is_withheld_not_offered(
+        self, asset_root: Path, tmp_path: Path
+    ) -> None:
+        # The frontend cannot catch this: its <video> is preload="none", so no
+        # fetch -- and no error -- happens before the user presses play, and the
+        # dialog opens on the JSON alone. An unshipped entry must not reach it.
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            with patch.object(fv, "CATALOG", (_entry("unshipped"),)):
+                assert fv.offerable() == ()
+                assert fv.select_next("9.9.9") is None
+
+    def test_a_missing_poster_alone_withholds_the_entry(self, asset_root: Path) -> None:
+        self._ship(asset_root, "half", poster=False)
+        with patch.object(fv, "CATALOG", (_entry("half"),)):
+            assert fv.offerable() == ()
+
+    def test_shipped_entry_is_offered(self, asset_root: Path, tmp_path: Path) -> None:
+        self._ship(asset_root, "ready")
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            with patch.object(fv, "CATALOG", (_entry("ready"),)):
+                picked = fv.select_next("9.9.9")
+        assert picked is not None and picked.id == "ready"
+
+    def test_selection_skips_past_an_unshipped_entry_to_a_shipped_one(
+        self, asset_root: Path, tmp_path: Path
+    ) -> None:
+        self._ship(asset_root, "second")
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            with patch.object(fv, "CATALOG", (_entry("first"), _entry("second"))):
+                picked = fv.select_next("9.9.9")
+        assert picked is not None and picked.id == "second"
+
+    def test_withholding_is_recoverable_once_the_clip_lands(
+        self, asset_root: Path, tmp_path: Path
+    ) -> None:
+        # The whole point: nothing is written, so the entry comes back by itself.
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            with patch.object(fv, "CATALOG", (_entry("late"),)):
+                assert fv.select_next("9.9.9") is None
+                self._ship(asset_root, "late")
+                picked = fv.select_next("9.9.9")
+        assert picked is not None and picked.id == "late"
+
+    def test_catalog_membership_ignores_shipping_so_a_verdict_can_still_land(
+        self, asset_root: Path
+    ) -> None:
+        # A user shown a clip whose asset later vanished must still be able to
+        # record a verdict on it: the feedback route checks catalog(), not
+        # offerable(), and this pins that the two sets genuinely differ.
+        with patch.object(fv, "CATALOG", (_entry("gone"),)):
+            assert [e.id for e in fv.catalog()] == ["gone"]
+            assert fv.offerable() == ()
 
 
 class TestProbes:
@@ -827,10 +921,10 @@ class TestRouteRegistration:
 
 
 class TestConfigFlag:
-    def test_default_is_on(self) -> None:
+    def test_default_is_off(self) -> None:
         from kiro_crew.config.sections import DashboardConfig
 
-        assert DashboardConfig().feature_videos_enabled is True
+        assert DashboardConfig().feature_videos_enabled is False
 
     def test_loader_reads_the_key(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from kiro_crew.config.loader import KiroCrewConfig
@@ -850,12 +944,16 @@ class TestConfigFlag:
         cfg_file = tmp_path / "config.json"
         cfg_file.write_text(json.dumps({"dashboard": {}}), encoding="utf-8")
         monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg_file)
-        assert KiroCrewConfig.load().dashboard.feature_videos_enabled is True
+        assert KiroCrewConfig.load().dashboard.feature_videos_enabled is False
 
     def test_a_non_bool_value_keeps_the_default(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A configured string must not read as "on" -- bool("false") is True."""
+        """A configured string must not read as "on" -- bool("false") is True.
+
+        Still load-bearing with the default OFF: a naive ``bool(...)`` would read the
+        STRING "false" as True and turn the feature on against the operator's config.
+        """
         from kiro_crew.config.loader import KiroCrewConfig
 
         cfg_file = tmp_path / "config.json"
@@ -863,4 +961,4 @@ class TestConfigFlag:
             json.dumps({"dashboard": {"feature_videos_enabled": "false"}}), encoding="utf-8"
         )
         monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg_file)
-        assert KiroCrewConfig.load().dashboard.feature_videos_enabled is True
+        assert KiroCrewConfig.load().dashboard.feature_videos_enabled is False


### PR DESCRIPTION
## Problem / Motivation

Two ways the feature-video dialog can show a user something nobody should see yet.

**It ships on.** The backend landed in #9168 with `dashboard.feature_videos_enabled`
defaulting to `true`. Nothing shows yet only because no frontend mounts the dialog.
The moment #9169 merges, every install starts playing a clip at startup — a feature
nobody has used end to end, with placeholder media rather than real recordings.

**It offers clips that are not on disk.** `_entry_is_valid` checks the *shape* of an
entry's `src` and `poster` but never whether the file exists. The catalog already
names `feature-tips.mp4` and `monitor-loops.mp4`, and neither has been recorded.

## Why it matters

A startup dialog is the most intrusive surface this app has, and its verdict is
**permanent**: watch or close a clip and that clip never comes back.

The second problem is the sharper one, because the frontend cannot defend against
it. The dialog opens on the JSON answer alone, and its `<video>` is `preload="none"`
— nothing is fetched, and no media error can fire, until the user presses play. So an
entry whose clip is not shipped opens a real dialog titled "Feature tips above the
composer" around a blank player. The natural "Got it" writes a permanent `seen`, and
the real intro is retired before anyone could see it. Design Review on #9169 found
this and named the backend check as the smaller, more general fix; it is.

## What changed (motivation → approach → change)

Both changes sit in the same gate and change nothing about selection order, the
probes, or what a verdict means.

**The default flips to `false`** in the two places that decide it: the dataclass
field (`config/sections.py`) and the loader's fallback for a config that does not
mention the key (`config/loader.py`). `config-baseline.json` is regenerated from the
dataclass registry — it records the default in two spots, so a hand-edit would have
missed one. To turn it on: `{ "dashboard": { "feature_videos_enabled": true } }` in
`~/.kiro/crew/config.json`.

**"Asset shipped" becomes a precondition of "on offer".** A new `offerable()` is
`catalog()` filtered to entries whose clip AND poster exist on disk under
`static/dist/app-assets` — the directory `server.py` mounts at `/app-assets`.
`select_next` walks `offerable()`. An entry it withholds is logged and left alone:
nothing is written, so it comes back on its own the launch after its clip lands.

`catalog()` deliberately keeps its structural-only meaning. The feedback route checks
membership against it, and a user who was shown a clip must still be able to record a
verdict on it even if its asset later goes missing. The two sets differing is pinned
by a test.

```mermaid
flowchart LR
  subgraph Before
    A1[CATALOG]:::ctx --> B1[_entry_is_valid<br/>shape only]:::ctx --> C1[select_next]:::ctx --> D1[dialog opens<br/>blank player]:::removed
  end
  subgraph After
    A2[CATALOG]:::ctx --> B2[_entry_is_valid<br/>shape only]:::ctx --> E2[offerable<br/>clip + poster on disk?]:::added --> C2[select_next]:::ctx
    E2 -. withheld, nothing written .-> F2[offered again<br/>once clip lands]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 4,5,6 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*A clip with no file on disk is now withheld by the backend, so the dialog never
opens around a blank player.*

Both docs pages say `false` is the default, and the feature-videos page's selection
rule now names the shipped-asset precondition.

This is a pause, not a retreat: land this, turn it on locally, record real clips,
then flip the default back to `true` in its own change. The existence gate stays.

## Tests

`test/test_feature_videos.py::TestConfigFlag` pinned the old default in three places;
all three now pin the new one. `test_a_non_bool_value_keeps_the_default` is **more**
load-bearing now: `bool("false")` is `True`, so without `_safe_bool` that config would
turn the feature ON against the operator's wishes.

An autouse fixture treats every asset as shipped, so the 100+ existing selection,
probe and route tests keep testing what they were written for instead of all
exercising the withholding branch. `TestAssetExistenceGate` (7 cases) replaces that
default with a real temp directory and covers: the `/app-assets/...` → disk mapping
(and that an off-prefix path is never "present"); withholding on a missing clip;
withholding on a missing poster alone; a shipped entry being offered; selection
skipping past an unshipped entry to a shipped one; the entry coming back once its
clip lands; and `catalog()` still containing what `offerable()` withholds.

Mutation-verified: routing `select_next` back through `catalog()` fails 3 of the 7.
123 tests pass across this file and `test_config_baseline.py`.

## Manual verification

N/A — unit coverage is sufficient. The default is read through the real loader from
a real config file, and the existence gate is exercised against a real directory.

Blast radius, checked: `_enabled()` (`feature_videos.py:555`) is the flag's only
consumer in `src/`; `select_next` is the only caller that moved to `offerable()`, and
the feedback route's membership check stays on `catalog()` by design.

## Related Issues

no linked issue: pre-launch gating, not a tracked defect.

Sequencing note: this should land **before or with** #9169. Merging #9169 first opens
a window where an unvalidated feature is on for everyone, offering clips that do not
exist.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
