### PR TITLE
fix(aws-control): open lock files non-truncating before the acquire

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
@@ -50,7 +50,7 @@ from kiro_crew.apps.manager import app_data_dir
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import data_home, kiro_sessions_dir
 from kiro_crew.history import SESSIONS_DIR_NAME
-from kiro_crew.platform_compat import file_lock, is_link_or_junction
+from kiro_crew.platform_compat import file_lock, is_link_or_junction, open_lock_file
 from kiro_crew.sel import sel
 from kiro_crew.snapshot import snapshot_main
 
@@ -174,8 +174,8 @@ def _locked_state_update(mutate) -> Any:
     """
     lock_path = _state_path().with_suffix(".lock")
     _state_path().parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as fd:
-        with file_lock(fd.fileno(), exclusive=True, required=True):
+    with open_lock_file(lock_path) as fd:
+        with file_lock(fd, exclusive=True, required=True):
             state = _read_state_for_update()
             result = mutate(state)
             write_state(state)

--- a/src/kiro_crew/apps/builtins/aws_control/backend/library.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/library.py
@@ -38,7 +38,7 @@ from kiro_crew.apps.manager import app_data_dir
 from kiro_crew.artifacts import ArtifactValidationError, _validate_slug, get_default_store
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.deploy.engine import AWSError
-from kiro_crew.platform_compat import file_lock
+from kiro_crew.platform_compat import file_lock, open_lock_file
 
 logger = logging.getLogger(__name__)
 
@@ -193,8 +193,8 @@ def _update_ledger(account: str, mutate: Callable[[dict[str, Any]], bool]) -> bo
     """
     lock_path = _ledger_path().with_suffix(".lock")
     _ledger_path().parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as fd:
-        with file_lock(fd.fileno(), exclusive=True, required=True):
+    with open_lock_file(lock_path) as fd:
+        with file_lock(fd, exclusive=True, required=True):
             ledger = _read_ledger_for_update()
             slugs = ledger.get(account)
             if not isinstance(slugs, dict):

--- a/src/kiro_crew/apps/builtins/aws_control/backend/shares.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/shares.py
@@ -39,7 +39,7 @@ from typing import Any, Collection, Optional
 from kiro_crew.apps.builtins.aws_control.backend import storage
 from kiro_crew.apps.manager import app_data_dir
 from kiro_crew.atomic_write import atomic_write
-from kiro_crew.platform_compat import file_lock
+from kiro_crew.platform_compat import file_lock, open_lock_file
 
 logger = logging.getLogger(__name__)
 
@@ -199,8 +199,8 @@ def record_share(
     }
     lock_path = _store_path().with_suffix(".lock")
     _store_path().parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as fd:
-        with file_lock(fd.fileno(), exclusive=True, required=True):
+    with open_lock_file(lock_path) as fd:
+        with file_lock(fd, exclusive=True, required=True):
             entries = _prune(_load_for_update())
             entries.append(entry)
             _save(entries[-_MAX_SHARES:])
@@ -219,8 +219,8 @@ def forget_share(share_id: str) -> Optional[dict[str, Any]]:
     """Remove one record from the ledger (the link itself lives to expiry)."""
     lock_path = _store_path().with_suffix(".lock")
     _store_path().parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as fd:
-        with file_lock(fd.fileno(), exclusive=True, required=True):
+    with open_lock_file(lock_path) as fd:
+        with file_lock(fd, exclusive=True, required=True):
             entries = _prune(_load_for_update())
             kept = [e for e in entries if e.get("id") != share_id]
             removed = next((e for e in entries if e.get("id") == share_id), None)

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -682,6 +682,29 @@ def flock_exclusive(fd: int) -> Iterator[None]:
         yield
 
 
+@contextlib.contextmanager
+def open_lock_file(path: "str | os.PathLike[str]") -> Iterator[int]:
+    """Open *path* for locking WITHOUT truncating it (GH-9248).
+
+    ``open(path, "w")`` truncates the file before any lock is held. On POSIX
+    that is survivable; on Windows the subsequent acquire routes to
+    ``msvcrt.locking`` on the already-truncated file, so a contending process
+    can observe or produce an empty lock file and crash out of the critical
+    section — the loss lands only on a specific interleaving, which is why it
+    read as shard flake rather than a deterministic failure.
+    ``O_RDWR | O_CREAT`` creates-or-opens in one syscall and never truncates.
+
+    Yields the raw integer fd, ready for :func:`file_lock` /
+    :func:`flock_exclusive`. The lock file's CONTENT is never meaningful to
+    the lock itself; this exists so contenders cannot watch it flicker empty.
+    """
+    fd = os.open(os.fspath(path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        yield fd
+    finally:
+        os.close(fd)
+
+
 def acquire_lock(fd: int, *, exclusive: bool = True) -> None:
     """Low-level lock acquire for the acquire-now / release-later fd-handoff
     pattern (where a context manager does not fit).

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -4491,3 +4491,77 @@ class TestPublishDirNoreplace:
             "permanently block retries"
         )
         assert (src / "f.txt").exists(), "the staged tree was consumed by a failed publish"
+
+
+class TestOpenLockFile:
+    """GH-9248: acquiring a lock must not truncate the file it locks."""
+
+    def test_preserves_existing_content(self, tmp_path):
+        # The defect shape: open(path, "w") truncates BEFORE the lock is
+        # held, so a contending process can observe an empty lock file
+        # mid-acquire. The helper must open the file without touching its
+        # bytes. Content is read while the fd is OPEN but not LOCKED, and
+        # again after release — on Windows msvcrt region locks are
+        # MANDATORY, so a read while the lock is held answers EACCES and
+        # would test the platform's locking semantics instead of the
+        # helper's non-truncation property.
+        lock = tmp_path / "x.lock"
+        lock.write_text("holder-pid 1234")
+        from kiro_crew.platform_compat import file_lock, open_lock_file
+
+        with open_lock_file(lock) as fd:
+            assert isinstance(fd, int)
+            assert lock.read_text() == "holder-pid 1234"  # open did not truncate
+            with file_lock(fd, exclusive=True):
+                pass  # lockable with content present
+        assert lock.read_text() == "holder-pid 1234"  # intact after release
+
+    def test_creates_missing_file_and_is_lockable(self, tmp_path):
+        lock = tmp_path / "sub" / "y.lock"
+        lock.parent.mkdir(parents=True)
+        from kiro_crew.platform_compat import flock_exclusive, open_lock_file
+
+        with open_lock_file(lock) as fd:
+            with flock_exclusive(fd):
+                pass
+        assert lock.exists()
+        assert lock.read_bytes() == b""
+
+    def test_no_lock_site_opens_truncating(self):
+        # CONTRACT (the work-ledger fix's test shape, applied fleet-wide): grep the source
+        # tree for a truncating open whose descriptor is handed to a
+        # file_lock-family acquire within the next two lines. Every site was
+        # converted to open_lock_file in this change; a new offender fails
+        # here with its file and line.
+        import kiro_crew
+
+        src_root = os.path.dirname(os.path.abspath(kiro_crew.__file__))
+        # deploy/pending.py and deploy/profiles.py are owned by an in-flight
+        # deploy-locks fix; drop the exemptions once it merges — the scan
+        # will then enforce those sites too.
+        exempt = {
+            os.path.join(src_root, "deploy", "pending.py"),
+            os.path.join(src_root, "deploy", "profiles.py"),
+        }
+        offenders = []
+        open_w = re.compile(r"""\bopen\([^)]*["']wb?["']\)""")
+        acquire = re.compile(r"\b(file_lock|flock_exclusive|acquire_lock)\(\s*\w+\.fileno\(\)")
+        for dirpath, _dirnames, filenames in os.walk(src_root):
+            for name in filenames:
+                if not name.endswith(".py"):
+                    continue
+                path = os.path.join(dirpath, name)
+                if path in exempt:
+                    continue
+                with open(path, encoding="utf-8", errors="replace") as fh:
+                    lines = fh.readlines()
+                for i, line in enumerate(lines):
+                    if not open_w.search(line):
+                        continue
+                    window = "".join(lines[i + 1 : i + 3])
+                    if acquire.search(window):
+                        offenders.append(f"{path}:{i + 1}")
+        assert not offenders, (
+            "lock files opened truncating before the acquire (GH-9248); "
+            "use platform_compat.open_lock_file: " + ", ".join(offenders)
+        )


### PR DESCRIPTION
## Problem / Motivation

#9248: a lock file opened with `open(path, "w")` is truncated **before** any lock is held. On Windows the acquire routes to `msvcrt.locking` on the already-truncated file, so a contending process can observe or produce an empty lock file and crash out of the critical section. The overnight sweep fixed most subsystems (#9250 session_pid, #9275 issue_radar, #9279 webhooks + mcp_tools/control, #9237 work_ledger), but the four **aws_control** sites were still live on main, and every merged fix re-derived its own local touch-then-`"r+"` preamble — nothing stops the class growing back.

This also covers the scope of #9264 (aws_control sites) and #9267 (consolidate a shared helper).

## Why it matters

Intermittent-by-interleaving Windows corruption: this exact class reddened Backend Tests (Windows) shards across four unrelated PRs before #9248 named it. The aws_control sites guard the backup/library/shares stores — user data writes serialized by locks that could flicker empty under contention.

## What changed

Motivation → approach → change:

- **`platform_compat.open_lock_file(path)`** (new, next to `file_lock`): create-or-open via `os.open(..., O_RDWR | O_CREAT)` — one syscall, never truncates — yielding a raw fd ready for `file_lock` / `flock_exclusive`. Future lock sites get the non-truncating shape by construction instead of by convention (#9267's ask).
- Converted the four aws_control lock sites (`backup.py`, `library.py`, `shares.py` ×2) to it (#9264's ask).
- **Fleet-wide contract test**: scans the source tree for a truncating `open(..., "w")` whose descriptor is handed to a `file_lock`-family acquire within the next two lines, and fails naming the file and line. `deploy/pending.py` / `deploy/profiles.py` are exempted while PR #9269 (which owns those sites) is in flight; the exemption comment says to drop them once it merges.

## Tests

- `TestOpenLockFile::test_preserves_existing_content` — the defect shape: pre-existing lock-file bytes survive open + exclusive lock.
- `TestOpenLockFile::test_creates_missing_file_and_is_lockable` — create-if-absent, lockable via `flock_exclusive`.
- `TestOpenLockFile::test_no_lock_site_opens_truncating` — the repo-wide contract scan. Detector verified against the pre-fix tree, where it named exactly the expected offenders and nothing else.
- aws_control suites (backup / library / storage): 202 passed.
- black gate, flake8 (CI scope), isort, mypy on the touched source files: clean.

## Manual verification

Ran the contract scanner standalone against current main: the only hits are the two exempted deploy sites (#9269's scope). No behavioral change on POSIX beyond the open mode; lock-file content is never meaningful to the lock itself.

## Screenshots / video

N/A — backend-only, no UI surface.

## Related Issues

- #9248 (umbrella; remaining sites)
- #9264 (aws_control sites — covered here)
- #9267 (shared helper consolidation — covered here)
- #9269 (deploy sites — deliberately NOT touched here; scan exemption documents the handoff)

## Pattern harvest

A lock-file open must never truncate: acquiring a lock cannot destroy the thing it serializes on. Codified as `open_lock_file` + a source-scanning contract test so the invariant is enforced, not remembered.

Rule candidate: any file descriptor handed to a `file_lock`-family acquire must come from a non-truncating open (`open_lock_file`, `"r+"`, `"a+"`, or `O_RDWR|O_CREAT`) — never `open(path, "w")`; enforced repo-wide by the contract scan in `test_platform_compat.py::TestOpenLockFile::test_no_lock_site_opens_truncating`.

## Checklist

- [x] Tests added/updated and passing locally
- [x] Lint/type gates clean (black, flake8, isort, mypy)
- [x] No unrelated changes

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.

