### PR TITLE
fix(ci): bind fork AI-review readiness reads to PR+attempt external_id (#9302)

### DIFF
--- a/.github/workflows/ai-review-human-override.yml
+++ b/.github/workflows/ai-review-human-override.yml
@@ -240,10 +240,16 @@ jobs:
               # them. The lane stamps its own run URL into the details_url of
               # the check-run it posts on the PR head; read the run id back
               # from the newest check-run this PR created there.
+              # The external_id is now attempt-scoped (<lane>-pr-<PR>-<run>-<attempt>),
+              # so match the PR dimension by prefix and let sort_by(.started_at)|last
+              # pick the newest attempt regardless of suffix. Trailing hyphen keeps
+              # -pr-9 from matching -pr-99.
               enc="$(jq -rn --arg name "$check_name" '$name | @uri')"
               details_url="$(gh api --method GET \
                 "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
-                --jq "[.check_runs[] | select(.external_id == \"$lane-pr-$PR\")]
+                --jq "[.check_runs[]
+                       | select(.external_id != null)
+                       | select(.external_id | startswith(\"$lane-pr-$PR-\"))]
                       | sort_by(.started_at) | last | .details_url // empty" \
                 2>/dev/null || true)"
               run_id="$(printf '%s' "$details_url" \

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -164,11 +164,22 @@ jobs:
       # head_sha, so the status always surfaces (advisory-neutral even if a later
       # step dies).
       #
-      # `external_id` carries the PR number, which is what makes the finalize
-      # sweep safe: a check-run of this name on this head can belong to ANOTHER
-      # pull request (two PRs may share a commit), and completing that one would
-      # publish a verdict computed from a different diff. The sweep matches on
-      # this id, so it can only ever finish a run this pull request created.
+      # `external_id` carries the PR number AND the triggering run id + attempt,
+      # which is what makes the finalize sweep and the readiness read safe: a
+      # check-run of this name on this head can belong to ANOTHER pull request
+      # (two PRs may share a commit), and completing that one would publish a
+      # verdict computed from a different diff. A rerun on an unchanged head --
+      # of Fast Gate, or of THIS lane directly via a human-override
+      # `gh api .../runs/<id>/rerun` -- must also not reuse the previous
+      # attempt's verdict, because a model verdict can differ between attempts
+      # on the same head. A lane-direct rerun leaves `WR_RUN_ID`/`WR_RUN_ATTEMPT`
+      # unchanged, so the old failed attempt and the new one share this id; the
+      # reader resolves that by collapsing every check-run matching the id to
+      # the newest by CHECK-RUN id (distinct per POST, monotonically
+      # increasing), so the fresh row always wins regardless of how many share
+      # the external_id. The sweep matches on this id's PR dimension, so a
+      # verdict can only ever answer for the run this pull request created at
+      # this attempt.
       #
       # `details_url` carries this run's URL: a workflow_run-triggered run is
       # keyed to the DEFAULT branch context, so this stamp is the only link
@@ -182,11 +193,13 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
           PR: ${{ steps.pr.outputs.pr }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="Design Review" -f head_sha="$HEAD" -f status="in_progress" \
-            -f external_id="design-pr-$PR" \
+            -f external_id="design-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT" \
             -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
@@ -751,6 +764,8 @@ jobs:
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           CHECK_ID: ${{ steps.check.outputs.id }}
           PR: ${{ steps.pr.outputs.pr }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           VERDICT: ${{ steps.verdict.outputs.verdict }}
         run: |
           set -uo pipefail
@@ -815,13 +830,16 @@ jobs:
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             # external_id makes this fallback check-run discoverable by the
-            # override handler's fork rerun lookup, same as the opening POST.
-            # PR can be empty in exactly this branch (HEAD has a workflow_run
-            # fallback, PR does not), and a malformed "design-pr-" id would
-            # match nothing -- stamp it only when the PR is known.
+            # override handler's fork rerun lookup and attributable by the
+            # readiness read, same as the opening POST: PR + triggering run id +
+            # attempt. PR can be empty in exactly this branch (HEAD has a
+            # workflow_run fallback, PR does not) -- stamp the id only when the
+            # PR is known. With no id the row carries no attribution, so the
+            # bound reader cannot see it and reads the lane as pending, which
+            # still holds the merge: the miss fails CLOSED, not open.
             ext_args=()
             if [ -n "${PR:-}" ]; then
-              ext_args=(-f external_id="design-pr-$PR")
+              ext_args=(-f external_id="design-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT")
             fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Design Review" -f head_sha="$HEAD" \
@@ -832,10 +850,14 @@ jobs:
           fi
           # Sweep any still-incomplete run of this name that THIS pull request
           # created (ours, if the PATCH above lost both attempts, or one stranded
-          # by a previous run). Scoped by `external_id`: a check-run of this name
-          # on this head can belong to another PR that shares the commit, and
-          # completing that one would publish a verdict computed from a different
-          # diff -- the wedge is closed without ever touching a sibling's review.
+          # by a previous run). Scoped by `external_id`'s PR dimension (prefix
+          # match, so it spans attempts): a check-run of this name on this head
+          # can belong to another PR that shares the commit, and completing that
+          # one would publish a verdict computed from a different diff -- the
+          # wedge is closed without ever touching a sibling's review, while still
+          # catching a row stranded by a PREVIOUS attempt (which carries a
+          # different run+attempt suffix). The trailing hyphen keeps -pr-9 from
+          # matching -pr-99.
           # Completed with THIS run's computed verdict, not a hardcoded neutral:
           # a genuine BLOCK whose own PATCH lost both attempts must not be
           # swept into a verdict pr-readiness no longer gates on. With no
@@ -846,7 +868,8 @@ jobs:
               "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
               --jq ".check_runs[]
                     | select(.status != \"completed\")
-                    | select(.external_id == \"design-pr-$PR\")
+                    | select(.external_id != null)
+                    | select(.external_id | startswith(\"design-pr-$PR-\"))
                     | .id" 2>/dev/null || true)"
             for id in $stranded; do
               echo "completing stranded check-run $id for $HEAD (PR #$PR)"

--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -191,11 +191,22 @@ jobs:
       # to head_sha, so the status always surfaces (advisory-neutral even if a
       # later step dies).
       #
-      # `external_id` carries the PR number, which is what makes the finalize
-      # sweep safe: a check-run of this name on this head can belong to ANOTHER
-      # pull request (two PRs may share a commit), and completing that one would
-      # publish a verdict computed from a different diff. The sweep matches on
-      # this id, so it can only ever finish a run this pull request created.
+      # `external_id` carries the PR number AND the triggering run id + attempt,
+      # which is what makes the finalize sweep and the readiness read safe: a
+      # check-run of this name on this head can belong to ANOTHER pull request
+      # (two PRs may share a commit), and completing that one would publish a
+      # verdict computed from a different diff. A rerun on an unchanged head --
+      # of Fast Gate, or of THIS lane directly via a human-override
+      # `gh api .../runs/<id>/rerun` -- must also not reuse the previous
+      # attempt's verdict, because a model verdict can differ between attempts
+      # on the same head. A lane-direct rerun leaves `WR_RUN_ID`/`WR_RUN_ATTEMPT`
+      # unchanged, so the old failed attempt and the new one share this id; the
+      # reader resolves that by collapsing every check-run matching the id to
+      # the newest by CHECK-RUN id (distinct per POST, monotonically
+      # increasing), so the fresh row always wins regardless of how many share
+      # the external_id. The sweep matches on this id's PR dimension, so a
+      # verdict can only ever answer for the run this pull request created at
+      # this attempt.
       #
       # `details_url` carries this run's URL: a workflow_run-triggered run is
       # keyed to the DEFAULT branch context, so this stamp is the only link
@@ -209,11 +220,13 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
           PR: ${{ steps.pr.outputs.pr }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="First Principles Review" -f head_sha="$HEAD" -f status="in_progress" \
-            -f external_id="first-principles-pr-$PR" \
+            -f external_id="first-principles-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT" \
             -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
@@ -816,6 +829,8 @@ jobs:
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           PR: ${{ steps.pr.outputs.pr }}
           CHECK_ID: ${{ steps.check.outputs.id }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           VERDICT: ${{ steps.verdict.outputs.verdict }}
           WITHHELD: ${{ steps.redact.outputs.withheld }}
         run: |
@@ -887,13 +902,16 @@ jobs:
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             # external_id makes this fallback check-run discoverable by the
-            # override handler's fork rerun lookup, same as the opening POST.
-            # PR can be empty in exactly this branch (HEAD has a workflow_run
-            # fallback, PR does not), and a malformed "first-principles-pr-" id would
-            # match nothing -- stamp it only when the PR is known.
+            # override handler's fork rerun lookup and attributable by the
+            # readiness read, same as the opening POST: PR + triggering run id +
+            # attempt. PR can be empty in exactly this branch (HEAD has a
+            # workflow_run fallback, PR does not) -- stamp the id only when the
+            # PR is known. With no id the row carries no attribution, so the
+            # bound reader cannot see it and reads the lane as pending, which
+            # still holds the merge: the miss fails CLOSED, not open.
             ext_args=()
             if [ -n "${PR:-}" ]; then
-              ext_args=(-f external_id="first-principles-pr-$PR")
+              ext_args=(-f external_id="first-principles-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT")
             fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="First Principles Review" -f head_sha="$HEAD" \
@@ -904,10 +922,14 @@ jobs:
           fi
           # Sweep any still-incomplete run of this name that THIS pull request
           # created (ours, if the PATCH above lost both attempts, or one stranded
-          # by a previous run). Scoped by `external_id`: a check-run of this name
-          # on this head can belong to another PR that shares the commit, and
-          # completing that one would publish a verdict computed from a different
-          # diff -- the wedge is closed without ever touching a sibling's review.
+          # by a previous run). Scoped by `external_id`'s PR dimension (prefix
+          # match, so it spans attempts): a check-run of this name on this head
+          # can belong to another PR that shares the commit, and completing that
+          # one would publish a verdict computed from a different diff -- the
+          # wedge is closed without ever touching a sibling's review, while still
+          # catching a row stranded by a PREVIOUS attempt (which carries a
+          # different run+attempt suffix). The trailing hyphen keeps -pr-9 from
+          # matching -pr-99.
           # Completed with THIS run's computed verdict, not a hardcoded neutral:
           # a genuine BLOCK whose own PATCH lost both attempts must not be
           # swept into a verdict pr-readiness no longer gates on. With no
@@ -918,7 +940,8 @@ jobs:
               "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
               --jq ".check_runs[]
                     | select(.status != \"completed\")
-                    | select(.external_id == \"first-principles-pr-$PR\")
+                    | select(.external_id != null)
+                    | select(.external_id | startswith(\"first-principles-pr-$PR-\"))
                     | .id" 2>/dev/null || true)"
             for id in $stranded; do
               echo "completing stranded check-run $id for $HEAD (PR #$PR)"

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -179,11 +179,22 @@ jobs:
       # Post the required check-run as EARLY as possible, keyed to head_sha, so
       # branch protection always sees a result (fail-closed even if a later step dies).
       #
-      # `external_id` carries the PR number, which is what makes the finalize
-      # sweep safe: a check-run of this name on this head can belong to ANOTHER
-      # pull request (two PRs may share a commit), and completing that one would
-      # publish a verdict computed from a different diff. The sweep matches on
-      # this id, so it can only ever finish a run this pull request created.
+      # `external_id` carries the PR number AND the triggering run id + attempt,
+      # which is what makes the finalize sweep and the readiness read safe: a
+      # check-run of this name on this head can belong to ANOTHER pull request
+      # (two PRs may share a commit), and completing that one would publish a
+      # verdict computed from a different diff. A rerun on an unchanged head --
+      # of Fast Gate, or of THIS lane directly via a human-override
+      # `gh api .../runs/<id>/rerun` -- must also not reuse the previous
+      # attempt's verdict, because a model verdict can differ between attempts
+      # on the same head. A lane-direct rerun leaves `WR_RUN_ID`/`WR_RUN_ATTEMPT`
+      # unchanged, so the old failed attempt and the new one share this id; the
+      # reader resolves that by collapsing every check-run matching the id to
+      # the newest by CHECK-RUN id (distinct per POST, monotonically
+      # increasing), so the fresh row always wins regardless of how many share
+      # the external_id. The sweep matches on this id's PR dimension, so a
+      # verdict can only ever answer for the run this pull request created at
+      # this attempt.
       #
       # `details_url` carries this run's URL: a workflow_run-triggered run is
       # keyed to the DEFAULT branch context, so this stamp is the only link
@@ -197,11 +208,13 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
           PR: ${{ steps.pr.outputs.pr }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="GPT 5.6 Review" -f head_sha="$HEAD" -f status="in_progress" \
-            -f external_id="gpt-pr-$PR" \
+            -f external_id="gpt-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT" \
             -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
@@ -1491,6 +1504,8 @@ jobs:
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           CHECK_ID: ${{ steps.check.outputs.id }}
           PR: ${{ steps.pr.outputs.pr }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           ADJ_DECISION: ${{ steps.adj.outputs.decision }}
           ADJ_NOTE: ${{ steps.adj.outputs.note }}
         run: |
@@ -1537,13 +1552,16 @@ jobs:
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             # external_id makes this fallback check-run discoverable by the
-            # override handler's fork rerun lookup, same as the opening POST.
-            # PR can be empty in exactly this branch (HEAD has a workflow_run
-            # fallback, PR does not), and a malformed "gpt-pr-" id would
-            # match nothing -- stamp it only when the PR is known.
+            # override handler's fork rerun lookup and attributable by the
+            # readiness read, same as the opening POST: PR + triggering run id +
+            # attempt. PR can be empty in exactly this branch (HEAD has a
+            # workflow_run fallback, PR does not) -- stamp the id only when the
+            # PR is known. With no id the row carries no attribution, so the
+            # bound reader cannot see it and reads the lane as pending, which
+            # still holds the merge: the miss fails CLOSED, not open.
             ext_args=()
             if [ -n "${PR:-}" ]; then
-              ext_args=(-f external_id="gpt-pr-$PR")
+              ext_args=(-f external_id="gpt-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT")
             fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="GPT 5.6 Review" -f head_sha="$HEAD" \
@@ -1554,23 +1572,29 @@ jobs:
           fi
           # Sweep any still-incomplete run of this name that THIS pull request
           # created (ours, if the PATCH above lost both attempts, or one stranded
-          # by a previous run). Scoped by `external_id`: a check-run of this name
-          # on this head can belong to another PR that shares the commit, and
-          # completing that one would publish a verdict computed from a different
-          # diff -- the wedge is closed without ever touching a sibling's review.
-          # Completed with THIS run's computed verdict: the current run is the
-          # authoritative review of this exact head, and pr-readiness collapses
-          # check-runs with fail-precedence, so stamping a hardcoded failure on
-          # the stranded run would permanently outvote a genuine green re-run.
-          # Fail-closed posture is preserved: with no verdict, $conclusion is
-          # already failure/"review incomplete".
+          # by a previous run). Scoped by `external_id`'s PR dimension (prefix
+          # match, so it spans attempts): a check-run of this name on this head
+          # can belong to another PR that shares the commit, and completing that
+          # one would publish a verdict computed from a different diff -- the
+          # wedge is closed without ever touching a sibling's review, while still
+          # catching a row stranded by a PREVIOUS attempt (which carries a
+          # different run+attempt suffix). The trailing hyphen keeps -pr-9 from
+          # matching -pr-99.
+          # Completed with THIS run's computed verdict, never a hardcoded
+          # failure stamped from the sweep: pr-readiness collapses same-id
+          # check-runs to the newest by CHECK-RUN id, so a hardcoded failure
+          # stamped here would carry a higher id than a real result that has
+          # not posted yet and would wrongly outrank it. Fail-closed posture is
+          # preserved: with no verdict, $conclusion is already failure/"review
+          # incomplete".
           if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
             enc="$(jq -rn '"GPT 5.6 Review" | @uri')"
             stranded="$(gh api --method GET \
               "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
               --jq ".check_runs[]
                     | select(.status != \"completed\")
-                    | select(.external_id == \"gpt-pr-$PR\")
+                    | select(.external_id != null)
+                    | select(.external_id | startswith(\"gpt-pr-$PR-\"))
                     | .id" 2>/dev/null || true)"
             for id in $stranded; do
               echo "completing stranded check-run $id for $HEAD (PR #$PR)"

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -168,11 +168,22 @@ jobs:
       # Post the required check-run as EARLY as possible, keyed to head_sha, so
       # branch protection always sees a result (fail-closed even if a later step dies).
       #
-      # `external_id` carries the PR number, which is what makes the finalize
-      # sweep safe: a check-run of this name on this head can belong to ANOTHER
-      # pull request (two PRs may share a commit), and completing that one would
-      # publish a verdict computed from a different diff. The sweep matches on
-      # this id, so it can only ever finish a run this pull request created.
+      # `external_id` carries the PR number AND the triggering run id + attempt,
+      # which is what makes the finalize sweep and the readiness read safe: a
+      # check-run of this name on this head can belong to ANOTHER pull request
+      # (two PRs may share a commit), and completing that one would publish a
+      # verdict computed from a different diff. A rerun on an unchanged head --
+      # of Fast Gate, or of THIS lane directly via a human-override
+      # `gh api .../runs/<id>/rerun` -- must also not reuse the previous
+      # attempt's verdict, because a model verdict can differ between attempts
+      # on the same head. A lane-direct rerun leaves `WR_RUN_ID`/`WR_RUN_ATTEMPT`
+      # unchanged, so the old failed attempt and the new one share this id; the
+      # reader resolves that by collapsing every check-run matching the id to
+      # the newest by CHECK-RUN id (distinct per POST, monotonically
+      # increasing), so the fresh row always wins regardless of how many share
+      # the external_id. The sweep matches on this id's PR dimension, so a
+      # verdict can only ever answer for the run this pull request created at
+      # this attempt.
       #
       # `details_url` carries this run's URL: a workflow_run-triggered run is
       # keyed to the DEFAULT branch context, so this stamp is the only link
@@ -186,11 +197,13 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
           PR: ${{ steps.pr.outputs.pr }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="Opus 4.8 Review" -f head_sha="$HEAD" -f status="in_progress" \
-            -f external_id="opus-pr-$PR" \
+            -f external_id="opus-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT" \
             -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
@@ -706,6 +719,8 @@ jobs:
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           CHECK_ID: ${{ steps.check.outputs.id }}
           PR: ${{ steps.pr.outputs.pr }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: |
           set -uo pipefail
           conclusion="failure"; title="review incomplete"
@@ -739,13 +754,16 @@ jobs:
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             # external_id makes this fallback check-run discoverable by the
-            # override handler's fork rerun lookup, same as the opening POST.
-            # PR can be empty in exactly this branch (HEAD has a workflow_run
-            # fallback, PR does not), and a malformed "opus-pr-" id would
-            # match nothing -- stamp it only when the PR is known.
+            # override handler's fork rerun lookup and attributable by the
+            # readiness read, same as the opening POST: PR + triggering run id +
+            # attempt. PR can be empty in exactly this branch (HEAD has a
+            # workflow_run fallback, PR does not) -- stamp the id only when the
+            # PR is known. With no id the row carries no attribution, so the
+            # bound reader cannot see it and reads the lane as pending, which
+            # still holds the merge: the miss fails CLOSED, not open.
             ext_args=()
             if [ -n "${PR:-}" ]; then
-              ext_args=(-f external_id="opus-pr-$PR")
+              ext_args=(-f external_id="opus-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT")
             fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Opus 4.8 Review" -f head_sha="$HEAD" \
@@ -756,23 +774,29 @@ jobs:
           fi
           # Sweep any still-incomplete run of this name that THIS pull request
           # created (ours, if the PATCH above lost both attempts, or one stranded
-          # by a previous run). Scoped by `external_id`: a check-run of this name
-          # on this head can belong to another PR that shares the commit, and
-          # completing that one would publish a verdict computed from a different
-          # diff -- the wedge is closed without ever touching a sibling's review.
-          # Completed with THIS run's computed verdict: the current run is the
-          # authoritative review of this exact head, and pr-readiness collapses
-          # check-runs with fail-precedence, so stamping a hardcoded failure on
-          # the stranded run would permanently outvote a genuine green re-run.
-          # Fail-closed posture is preserved: with no verdict, $conclusion is
-          # already failure/"review incomplete".
+          # by a previous run). Scoped by `external_id`'s PR dimension (prefix
+          # match, so it spans attempts): a check-run of this name on this head
+          # can belong to another PR that shares the commit, and completing that
+          # one would publish a verdict computed from a different diff -- the
+          # wedge is closed without ever touching a sibling's review, while still
+          # catching a row stranded by a PREVIOUS attempt (which carries a
+          # different run+attempt suffix). The trailing hyphen keeps -pr-9 from
+          # matching -pr-99.
+          # Completed with THIS run's computed verdict, never a hardcoded
+          # failure stamped from the sweep: pr-readiness collapses same-id
+          # check-runs to the newest by CHECK-RUN id, so a hardcoded failure
+          # stamped here would carry a higher id than a real result that has
+          # not posted yet and would wrongly outrank it. Fail-closed posture is
+          # preserved: with no verdict, $conclusion is already failure/"review
+          # incomplete".
           if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
             enc="$(jq -rn '"Opus 4.8 Review" | @uri')"
             stranded="$(gh api --method GET \
               "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
               --jq ".check_runs[]
                     | select(.status != \"completed\")
-                    | select(.external_id == \"opus-pr-$PR\")
+                    | select(.external_id != null)
+                    | select(.external_id | startswith(\"opus-pr-$PR-\"))
                     | .id" 2>/dev/null || true)"
             for id in $stranded; do
               echo "completing stranded check-run $id for $HEAD (PR #$PR)"

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -169,11 +169,22 @@ jobs:
       # Post the required check-run as EARLY as possible, keyed to head_sha, so
       # the "UX Review" status always exists (finalized below regardless of path).
       #
-      # `external_id` carries the PR number, which is what makes the finalize
-      # sweep safe: a check-run of this name on this head can belong to ANOTHER
-      # pull request (two PRs may share a commit), and completing that one would
-      # publish a verdict computed from a different diff. The sweep matches on
-      # this id, so it can only ever finish a run this pull request created.
+      # `external_id` carries the PR number AND the triggering run id + attempt,
+      # which is what makes the finalize sweep and the readiness read safe: a
+      # check-run of this name on this head can belong to ANOTHER pull request
+      # (two PRs may share a commit), and completing that one would publish a
+      # verdict computed from a different diff. A rerun on an unchanged head --
+      # of Fast Gate, or of THIS lane directly via a human-override
+      # `gh api .../runs/<id>/rerun` -- must also not reuse the previous
+      # attempt's verdict, because a model verdict can differ between attempts
+      # on the same head. A lane-direct rerun leaves `WR_RUN_ID`/`WR_RUN_ATTEMPT`
+      # unchanged, so the old failed attempt and the new one share this id; the
+      # reader resolves that by collapsing every check-run matching the id to
+      # the newest by CHECK-RUN id (distinct per POST, monotonically
+      # increasing), so the fresh row always wins regardless of how many share
+      # the external_id. The sweep matches on this id's PR dimension, so a
+      # verdict can only ever answer for the run this pull request created at
+      # this attempt.
       #
       # `details_url` carries this run's URL: a workflow_run-triggered run is
       # keyed to the DEFAULT branch context, so this stamp is the only link
@@ -187,11 +198,13 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
           PR: ${{ steps.pr.outputs.pr }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="UX Review" -f head_sha="$HEAD" -f status="in_progress" \
-            -f external_id="ux-pr-$PR" \
+            -f external_id="ux-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT" \
             -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
@@ -1085,6 +1098,8 @@ jobs:
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           CHECK_ID: ${{ steps.check.outputs.id }}
           PR: ${{ steps.pr.outputs.pr }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           VERDICT: ${{ steps.post.outputs.verdict }}
         run: |
           set -uo pipefail
@@ -1155,13 +1170,16 @@ jobs:
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             # external_id makes this fallback check-run discoverable by the
-            # override handler's fork rerun lookup, same as the opening POST.
-            # PR can be empty in exactly this branch (HEAD has a workflow_run
-            # fallback, PR does not), and a malformed "ux-pr-" id would
-            # match nothing -- stamp it only when the PR is known.
+            # override handler's fork rerun lookup and attributable by the
+            # readiness read, same as the opening POST: PR + triggering run id +
+            # attempt. PR can be empty in exactly this branch (HEAD has a
+            # workflow_run fallback, PR does not) -- stamp the id only when the
+            # PR is known. With no id the row carries no attribution, so the
+            # bound reader cannot see it and reads the lane as pending, which
+            # still holds the merge: the miss fails CLOSED, not open.
             ext_args=()
             if [ -n "${PR:-}" ]; then
-              ext_args=(-f external_id="ux-pr-$PR")
+              ext_args=(-f external_id="ux-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT")
             fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="UX Review" -f head_sha="$HEAD" \
@@ -1172,10 +1190,14 @@ jobs:
           fi
           # Sweep any still-incomplete run of this name that THIS pull request
           # created (ours, if the PATCH above lost both attempts, or one stranded
-          # by a previous run). Scoped by `external_id`: a check-run of this name
-          # on this head can belong to another PR that shares the commit, and
-          # completing that one would publish a verdict computed from a different
-          # diff -- the wedge is closed without ever touching a sibling's review.
+          # by a previous run). Scoped by `external_id`'s PR dimension (prefix
+          # match, so it spans attempts): a check-run of this name on this head
+          # can belong to another PR that shares the commit, and completing that
+          # one would publish a verdict computed from a different diff -- the
+          # wedge is closed without ever touching a sibling's review, while still
+          # catching a row stranded by a PREVIOUS attempt (which carries a
+          # different run+attempt suffix). The trailing hyphen keeps -pr-9 from
+          # matching -pr-99.
           # Completed with THIS run's computed verdict, not a hardcoded neutral:
           # a genuine BLOCK whose own PATCH lost both attempts must not be
           # swept into a verdict pr-readiness no longer gates on. With no
@@ -1186,7 +1208,8 @@ jobs:
               "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
               --jq ".check_runs[]
                     | select(.status != \"completed\")
-                    | select(.external_id == \"ux-pr-$PR\")
+                    | select(.external_id != null)
+                    | select(.external_id | startswith(\"ux-pr-$PR-\"))
                     | .id" 2>/dev/null || true)"
             for id in $stranded; do
               echo "completing stranded check-run $id for $HEAD (PR #$PR)"

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -489,6 +489,15 @@ jobs:
           DEFAULT_BRANCH: ${{ steps.context.outputs.default_branch }}
           TRIGGER_EVENT: ${{ github.event_name }}
           TRIGGER_ACTION: ${{ github.event.action }}
+          # The triggering workflow_run's own name + status, read ONLY to close
+          # a race on the fork Stage-2 lanes below: this evaluation can itself be
+          # the `in_progress` event a human-override rerun fires the INSTANT it
+          # starts, before that rerun's own "Open check-run" step has posted a
+          # fresh row -- so a check-runs read right now would still see the OLD
+          # completed verdict and publish a stale success. Empty on every other
+          # trigger (pull_request_target, or a workflow_run this isn't).
+          WR_NAME: ${{ github.event.workflow_run.name }}
+          WR_STATUS: ${{ github.event.workflow_run.status }}
           # From the disposition step above. Empty DISPOSITION_OK means the step
           # did not run at all, which contributes nothing -- the step's own `if`
           # matches this one's, and test_pr_readiness_dispositions.py pins the
@@ -555,6 +564,13 @@ jobs:
             # specs) so a fully-reviewed green fork can reach "passed" instead
             # of being forced to a maintainer-review verdict.
             skipped+=("CodeQL (fork PR)")
+            # The third field binds each verdict to THIS pull request AND this
+            # review attempt via the external_id the lane stamps: without it a
+            # sibling fork PR on the same head SHA, or a stale row from a
+            # previous rerun attempt, could answer for this one. The fourth
+            # field is the workflow whose completion triggers the lane -- all
+            # five fire on `Fast Gate` completing, so its newest run + attempt
+            # for this head is what "current" means here (fast-gate.yml).
             workflow_specs+=(
               # The scan reaches a fork through the same Stage-2 pattern: a fork
               # head gets no OIDC token, so fork-internal-content-scan.yml runs
@@ -569,11 +585,11 @@ jobs:
               # triggers the lane -- its newest run + attempt is what "current"
               # means here.
               "checkrun:Internal Content Scan|Internal Content Scan|internal-content-scan-pr-|fast-gate.yml"
-              "checkrun:Opus 4.8 Review|Opus 4.8 Review"
-              "checkrun:GPT 5.6 Review|GPT 5.6 Review"
-              "checkrun:Design Review|Design Review"
-              "checkrun:UX Review|UX Review"
-              "checkrun:First Principles Review|First Principles Review"
+              "checkrun:Opus 4.8 Review|Opus 4.8 Review|opus-pr-|fast-gate.yml"
+              "checkrun:GPT 5.6 Review|GPT 5.6 Review|gpt-pr-|fast-gate.yml"
+              "checkrun:Design Review|Design Review|design-pr-|fast-gate.yml"
+              "checkrun:UX Review|UX Review|ux-pr-|fast-gate.yml"
+              "checkrun:First Principles Review|First Principles Review|first-principles-pr-|fast-gate.yml"
             )
           else
             if [ "$stacked" = "true" ]; then
@@ -615,12 +631,26 @@ jobs:
               # check-runs, not a PR-bound workflow run (the fork reviewer runs
               # via workflow_run from the default branch, so its workflow-run
               # head ref does not bind back to the fork). The same-repo lane
-              # publishes a DIFFERENT name on a fork, but the GPT lane posts
-              # several passes under this one -- so collapse ALL check-runs
-              # of this name: any still running -> pending; any failure-class
-              # -> fail; else any success/neutral -> pass; only skipped (the
-              # real review has not posted yet) -> pending.
+              # publishes a DIFFERENT name on a fork, so read this name's
+              # check-runs, bound below to THIS PR and attempt via external_id,
+              # then collapse them: any still running -> pending; any
+              # failure-class -> fail; else any success/neutral -> pass; only
+              # an absent/unbound row (the real review has not posted yet) ->
+              # pending.
               cname="${file#checkrun:}"
+              # Close the human-override-rerun race: this evaluation can BE the
+              # `in_progress` event a lane's own rerun fires the instant it
+              # starts (workflow_run is wired at both in_progress and completed
+              # -- see the trigger list above), before that rerun's "Open
+              # check-run" step has posted a fresh row. Reading check-runs right
+              # now would still see the OLD completed verdict and publish a
+              # stale success. Force pending without a read: the rerun's own
+              # completion re-triggers this evaluation with a real verdict.
+              if [ "$FORK" = "true" ] && [ "${WR_STATUS:-}" = "in_progress" ] \
+                && [ "${WR_NAME:-}" = "Fork $cname" ]; then
+                pending+=("$label (rerun starting)")
+                continue
+              fi
               enc="$(jq -rn --arg v "$cname" '$v | @uri')"
               cruns="$(gh_retry gh api --method GET \
                 "repos/$REPO/commits/$SHA/check-runs?check_name=$enc&per_page=100")" || {
@@ -631,26 +661,34 @@ jobs:
                 transport_failed=true
                 break
               }
-              # Bind the verdict to THIS pull request AND THIS scan attempt when
-              # the lane stamps an external_id.
+              # Bind the verdict to THIS pull request AND THIS review attempt
+              # when the lane stamps an external_id.
               #
               # Two open PRs can share a head SHA -- the same fork branch opened
               # against two bases, or the same commit in two forks -- and each
-              # posts a check-run under this SAME NAME on that SHA. And a RERUN on
-              # an unchanged head leaves the previous completed row in place while
-              # the new attempt is still starting up. Reading by name alone loses
-              # both ways: a sibling's clean row, or a stale clean row from the
-              # previous attempt, answers for a scan that has not reported. The
-              # ruleset lives outside this repo and can gain a marker between
-              # attempts, so a stale clean verdict is not merely old, it can be
-              # WRONG.
+              # lane posts a check-run under this SAME NAME on that SHA. And a
+              # RERUN on an unchanged head leaves the previous completed row in
+              # place while the new attempt is still starting up. Reading by name
+              # alone loses both ways: a sibling's clean row, or a stale clean
+              # row from the previous attempt, answers for a review that has not
+              # reported. A model verdict can differ between attempts on the same
+              # head, so a stale clean verdict is not merely old, it can be WRONG.
               #
               # The fourth spec field names the workflow whose completion triggers
-              # the lane. Its newest run for this head, plus that run's attempt,
-              # is what "the current attempt" means -- so the expected id is
-              # <prefix><pr>-<run id>-<attempt> and nothing else matches. When the
-              # expected row is not there yet, total=0 -> pending, which holds the
-              # merge instead of borrowing an answer.
+              # the lane (Fast Gate, for all five). Its newest run for this head,
+              # plus that run's attempt, is what "the current attempt" means -- so
+              # the expected id is <prefix><pr>-<run id>-<attempt> and nothing
+              # else matches. When the expected row is not there yet, total=0 ->
+              # pending, which holds the merge instead of borrowing an answer.
+              #
+              # A human-override rerun (`gh api .../runs/<id>/rerun`) re-executes
+              # the LANE's run directly, without Fast Gate re-running, so the
+              # trigger-bound id stays identical between the stale failed attempt
+              # and the fresh rerun -- both rows carry the SAME external_id. That
+              # is safe: the match below collapses every row sharing that id to
+              # the newest by CHECK-RUN id (distinct per POST, monotonically
+              # increasing, independent of what external_id it carries), so the
+              # fresh rerun is never outvoted by the stale attempt it replaces.
               #
               # Run id AND attempt: a rerun keeps the id and bumps the attempt, so
               # the id alone would still accept the stale row.
@@ -680,15 +718,29 @@ jobs:
                     | max_by(.id) // empty
                   ' <<<"$trg")"
                   if [ -z "$trun" ]; then
-                    # The trigger has not run for this head yet, so no scan is
+                    # The trigger has not run for this head yet, so no review is
                     # owed and none can have reported. Pending, not passed.
                     pending+=("$label (not started)")
                     continue
                   fi
                   want="$want-$(jq -r '.id' <<<"$trun")-$(jq -r '.run_attempt // 1' <<<"$trun")"
                 fi
+                # Match the exact trigger-bound id, then collapse to the
+                # newest CHECK-RUN by id (distinct per POST, monotonically
+                # increasing -- independent of the external_id these rows
+                # share). A lane rerun triggered by a human override
+                # (`gh api .../runs/<id>/rerun`) re-executes the lane directly
+                # without Fast Gate re-running, so the trigger-bound id stays
+                # identical between the stale failed attempt and the fresh
+                # one; the check-run id collapse alone still picks the fresh
+                # row, because each POST -- stale or fresh -- got its own
+                # higher check-run id regardless of what external_id it
+                # carries.
                 cruns="$(jq -c --arg x "$want" \
-                  '{check_runs: [.check_runs[] | select(.external_id == $x)]}' \
+                  '{check_runs: [
+                      [.check_runs[] | select(.external_id == $x)]
+                      | max_by(.id) // empty
+                    ] | map(select(. != null))}' \
                   <<<"$cruns")"
               fi
               total="$(jq '.check_runs | length' <<<"$cruns")"

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -728,8 +728,9 @@ Two lanes stay outside that function, and both exclusions are deliberate:
   posted its verdict (a reopen, or an `edited` title/body on `codex-review.yml`)
   would make the same-repo lane's own run the newest one and satisfy the
   gate on a review that never ran. `pr-readiness.yml` was never fooled by this
-  -- it collapses every check-run of the name and treats "no completed run" as
-  pending -- so the rename closes the branch-protection half of the gate.
+  -- for a fork it reads only the check-runs bound to this PR and attempt by
+  `external_id` and treats "no completed bound run" as pending -- so the rename
+  closes the branch-protection half of the gate.
 - `persist-credentials: false` on checkout, so `actions/checkout` never writes the
   token into `.git/config` where a reviewer reading untrusted PR content could find
   it.
@@ -1016,9 +1017,29 @@ managed CodeQL workflow is not scheduled for fork heads. Two consequences.
 **A fork PR can still reach `readiness: passed`.** The `fork-*` pipeline below runs
 the AI reviews from the trusted base branch and posts them as check-runs under the
 same names the same-repo lanes use, so `pr-readiness.yml` evaluates a fork from
-those check-runs and a fully green fork is fully validated. CodeQL is the single
-ineligible lane, reported as a non-blocking "Not eligible" note rather than a
-blocker. Readiness therefore says the same thing on a fork as anywhere else: the
+those check-runs and a fully green fork is fully validated. That read is **bound to
+the lane's `external_id`**, which carries the PR number plus the triggering run id
+and attempt (`<lane>-pr-<PR>-<run>-<attempt>`), not the check-run name alone: two
+open PRs can share a head SHA and each posts a check-run under this same name, and a
+rerun on an unchanged head leaves the previous attempt's row in place, so a
+name-only read could let a sibling PR's clean verdict — or a stale previous-attempt
+row — answer for this PR. Readiness derives the expected id from the newest run of
+the triggering workflow (`Fast Gate`); when no matching row exists yet the lane
+reads as pending, which holds the merge rather than borrowing an answer. A
+human-override rerun (`gh api .../runs/<id>/rerun`) re-executes a lane's run
+directly without Fast Gate re-running, so the trigger-bound id stays identical
+between the stale failed attempt and the fresh rerun -- readiness resolves that by
+collapsing every check-run sharing an id to the newest by check-run id (distinct per
+POST, monotonically increasing), so the fresh rerun always wins. `pr-readiness.yml`
+also triggers on that same rerun's own `workflow_run: in_progress` event, which
+fires the instant the rerun starts and can race the rerun's own "Open check-run"
+step -- reading check-runs at that exact moment would still see only the OLD
+completed verdict. Readiness recognizes when its own evaluation was triggered by
+that lane's `in_progress` event (by name and status on the triggering
+`workflow_run`) and reads pending directly, without querying check-runs at all;
+the rerun's own completion re-triggers a real evaluation. CodeQL is
+the single ineligible lane, reported as a non-blocking "Not eligible" note rather
+than a blocker. Readiness therefore says the same thing on a fork as anywhere else: the
 eligible automated validation passed for this revision. Human approval and branch
 protection remain separate gates.
 

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -237,7 +237,11 @@ class TestHumanOverrideHandler:
 
         assert 'if [ "$IS_FORK" = "true" ]; then' in script
         assert "check-runs?check_name=$enc" in script
-        assert 'select(.external_id == \\"$lane-pr-$PR\\")' in script
+        # The id is now attempt-scoped (<lane>-pr-<PR>-<run>-<attempt>), so the
+        # lookup matches the PR dimension by PREFIX and lets sort_by|last pick
+        # the newest attempt; the old attempt-blind exact match must be gone.
+        assert 'select(.external_id | startswith(\\"$lane-pr-$PR-\\"))' in script
+        assert 'select(.external_id == \\"$lane-pr-$PR\\")' not in script
         assert "sort_by(.started_at) | last" in script
         # The resolved run must be verified to belong to the expected fork
         # lane before anything is re-run: any workflow with checks:write
@@ -274,7 +278,11 @@ class TestHumanOverrideHandler:
         # POST and the finalize fallback POST (used when the job dies before
         # opening one) must carry the stamp -- and the fallback must also
         # carry the external_id the handler filters on, or the one check-run
-        # holding the run URL is never a lookup candidate.
+        # holding the run URL is never a lookup candidate. The id is now
+        # two-dimensional (PR + triggering run id + attempt), so a rerun on an
+        # unchanged head cannot reuse the previous attempt's verdict; the env
+        # must supply WR_RUN_ID and WR_RUN_ATTEMPT so a future edit cannot drop
+        # the attempt dimension silently.
         stamp = '-f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID"'
         for name, lane in (
             ("fork-opus-review.yml", "opus"),
@@ -285,7 +293,11 @@ class TestHumanOverrideHandler:
         ):
             workflow = _workflow(name)
             assert workflow.count(stamp) >= 2, name
-            assert f'ext_args=(-f external_id="{lane}-pr-$PR")' in workflow, name
+            assert (
+                f'ext_args=(-f external_id="{lane}-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT")' in workflow
+            ), name
+            assert "WR_RUN_ID: ${{ github.event.workflow_run.id }}" in workflow, name
+            assert "WR_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}" in workflow, name
 
     def test_handler_requires_write_permission_fresh_sha_and_reason(self) -> None:
         workflow = _workflow("ai-review-human-override.yml")
@@ -846,11 +858,14 @@ class TestPrReadiness:
         assert '[ "$FORK" = "true" ]' in workflow
         # CodeQL stays the only ineligible fork lane.
         assert '"CodeQL (fork PR)"' in workflow
-        # AI reviews are now monitored on forks via check-run specs.
-        assert '"checkrun:Opus 4.8 Review|Opus 4.8 Review"' in workflow
-        assert '"checkrun:GPT 5.6 Review|GPT 5.6 Review"' in workflow
-        assert '"checkrun:Design Review|Design Review"' in workflow
-        assert '"checkrun:UX Review|UX Review"' in workflow
+        # AI reviews are now monitored on forks via check-run specs, each bound
+        # to THIS PR and attempt: the third field is the external_id prefix and
+        # the fourth is the triggering workflow (Fast Gate) whose newest run +
+        # attempt defines "current".
+        assert '"checkrun:Opus 4.8 Review|Opus 4.8 Review|opus-pr-|fast-gate.yml"' in workflow
+        assert '"checkrun:GPT 5.6 Review|GPT 5.6 Review|gpt-pr-|fast-gate.yml"' in workflow
+        assert '"checkrun:Design Review|Design Review|design-pr-|fast-gate.yml"' in workflow
+        assert '"checkrun:UX Review|UX Review|ux-pr-|fast-gate.yml"' in workflow
         assert "commits/$SHA/check-runs?check_name=$enc" in workflow
         # The blanket fork skip and the maintainer-review verdict are gone.
         assert '"GPT 5.6 Review (fork PR)"' not in workflow
@@ -1088,13 +1103,18 @@ class TestFirstPrinciplesReview:
         # Two open PRs can share a head commit, so a check-run of this name on this
         # head may belong to a DIFFERENT pull request -- completing it would publish
         # a verdict computed from another diff. The wedge fix is therefore scoped by
-        # external_id, so it can never reach a sibling's review.
+        # external_id, so it can never reach a sibling's review. The id now also
+        # carries the triggering run id + attempt, so a rerun on an unchanged head
+        # gets a fresh row; the sweep matches the PR dimension by PREFIX so it still
+        # catches a row stranded by a previous attempt (trailing hyphen keeps -pr-9
+        # from matching -pr-99).
         workflow = _workflow("fork-first-principles-review.yml")
         opened = _step_script(workflow, "Open check-run (in progress)")
         finalize = _step_script(workflow, "Finalize check-run (advisory)")
 
-        assert '-f external_id="first-principles-pr-$PR"' in opened
-        assert 'select(.external_id == \\"first-principles-pr-$PR\\")' in finalize
+        assert '-f external_id="first-principles-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT"' in opened
+        assert 'select(.external_id | startswith(\\"first-principles-pr-$PR-\\"))' in finalize
+        assert 'select(.external_id == \\"first-principles-pr-$PR\\")' not in finalize
         assert '[ -n "${PR:-}" ]' in finalize
         # An unscoped sweep must not come back.
         assert 'select(.status != "completed") | .id' not in finalize
@@ -1358,7 +1378,10 @@ class TestFirstPrinciplesReview:
         assert "      - First Principles Review" in workflow
         assert "      - Fork First Principles Review" in workflow
         assert '"first-principles-review.yml|First Principles Review"' in workflow
-        assert '"checkrun:First Principles Review|First Principles Review"' in workflow
+        assert (
+            '"checkrun:First Principles Review|First Principles Review'
+            '|first-principles-pr-|fast-gate.yml"' in workflow
+        )
         # Advisory (UX-style), NOT a readiness blocker like Design Review: a
         # model must not wedge a merge on whether a feature should exist.
         advisory = '[ "$label" = "UX Review" ] || [ "$label" = "First Principles Review" ]'
@@ -2428,11 +2451,13 @@ class TestForkLaneStrandedRunSweeps:
     ) -> None:
         # Without an external_id at CREATION the sweep has nothing safe to
         # match on: a check-run of this name on this head can belong to a
-        # different PR that shares the commit.
+        # different PR that shares the commit. The id is now two-dimensional
+        # (PR + triggering run id + attempt) so a rerun on an unchanged head
+        # cannot reuse the previous attempt's verdict.
         opened = _step_script(_workflow(lane), "Open check-run (in progress)")
         assert (
-            f'-f external_id="{prefix}-pr-$PR"' in opened
-        ), f"{lane}: check-run created without a PR-scoped external_id"
+            f'-f external_id="{prefix}-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT"' in opened
+        ), f"{lane}: check-run created without a PR+attempt-scoped external_id"
 
     @pytest.mark.parametrize(("lane", "check_name", "prefix", "finalize"), FORK_SWEEP_LANES)
     def test_finalize_sweeps_stranded_check_runs(
@@ -2449,11 +2474,17 @@ class TestForkLaneStrandedRunSweeps:
         self, lane: str, check_name: str, prefix: str, finalize: str
     ) -> None:
         # Two open PRs can share a head commit; an unscoped sweep would publish
-        # a verdict computed from another PR's diff.
+        # a verdict computed from another PR's diff. The match is a PREFIX on the
+        # PR dimension (not exact equality) so it still catches a row stranded by
+        # a PREVIOUS attempt, whose id carries a different run+attempt suffix; the
+        # trailing hyphen keeps -pr-9 from matching -pr-99.
         script = _step_script(_workflow(lane), finalize)
         assert (
-            f'select(.external_id == \\"{prefix}-pr-$PR\\")' in script
-        ), f"{lane}: sweep is not scoped by external_id"
+            f'select(.external_id | startswith(\\"{prefix}-pr-$PR-\\"))' in script
+        ), f"{lane}: sweep is not scoped by external_id prefix"
+        assert (
+            f'select(.external_id == \\"{prefix}-pr-$PR\\")' not in script
+        ), f"{lane}: sweep still uses the old attempt-blind exact match"
         assert '[ -n "${PR:-}" ]' in script, f"{lane}: sweep runs without a resolved PR"
         assert (
             'select(.status != "completed") | .id' not in script
@@ -3668,12 +3699,13 @@ class TestProtectedCheckNameHasOnePublisherPerPrType:
     def test_readiness_still_reads_the_protected_name_on_forks(
         self, workflow: str, check: str, fork: str
     ) -> None:
-        # Readiness reads fork verdicts from the head SHA's check-runs by name.
-        # It collapses every run of the name and treats "no completed run" as
-        # pending, so the rename removes a `skipped` row without making a
-        # missing review look green.
+        # Readiness reads fork verdicts from the head SHA's check-runs by name,
+        # bound to THIS PR and attempt via the spec's external_id prefix and
+        # triggering-workflow fields. It treats "no completed run bound to this
+        # PR+attempt" as pending, so the rename removes a `skipped` row without
+        # making a missing review look green.
         readiness = _workflow("pr-readiness.yml")
-        assert f'"checkrun:{check}|{check}"' in readiness, check
+        assert f'"checkrun:{check}|{check}|' in readiness, check
         assert '[ "$total" -eq 0 ] || [ "$incomplete" -gt 0 ]' in readiness
         assert 'pending+=("$label (not started)")' in readiness
 

--- a/test/test_pr_readiness_evaluate.py
+++ b/test/test_pr_readiness_evaluate.py
@@ -268,6 +268,8 @@ class Runner:
         existing_status_state: str = "",
         disposition_ok: str = "",
         disposition_violations: str = "",
+        wr_name: str = "",
+        wr_status: str = "",
     ):
         env = dict(self.env)
         if disposition_ok:
@@ -278,6 +280,10 @@ class Runner:
             env["FORK"] = "true"
         if http_error:
             env["HTTP_ERROR"] = http_error
+        if wr_name:
+            env["WR_NAME"] = wr_name
+        if wr_status:
+            env["WR_STATUS"] = wr_status
         state_file = self.fixtures / "existing_status_state.txt"
         state_file.unlink(missing_ok=True)
         if existing_status_state:
@@ -751,20 +757,24 @@ class TestSameSecondRunCollapse:
         assert outputs["label"] == "readiness: passed"
 
     def test_every_collapse_site_carries_identical_logic(self):
-        # The workflow resolves runs at three separately-written sites: the
-        # monitored-workflow loop, the dynamic CodeQL read, and the trigger-run
-        # read that dates an attempt-bound fork check-run. Behavioral tests
-        # exercise one shape each; this pins the collapse FRAGMENT itself so an
-        # edit to one site cannot drift from the others for shapes no fixture
-        # covers. The fragment starts after the site-specific select() line and
-        # runs to the terminal collapse.
+        # The workflow resolves runs at four separately-written sites: the
+        # monitored-workflow loop, the dynamic CodeQL read, the trigger-run read
+        # that dates an attempt-bound fork check-run, and the fork check-run
+        # read itself (collapsing to the newest row sharing a trigger-bound id,
+        # so a human-override rerun of the lane cannot have its stale failure
+        # outvote a fresh success). Behavioral tests exercise one shape each;
+        # this pins the collapse FRAGMENT itself so an edit to one site cannot
+        # drift from the others for shapes no fixture covers. The fragment
+        # starts after the site-specific select() line and runs to the terminal
+        # collapse.
         script = _evaluate_script()
         fragment = "| max_by(.id) // empty"
         lines = [ln.strip() for ln in script.splitlines()]
         count = lines.count(fragment)
-        assert count == 3, (
-            "expected exactly the three run-collapse sites (monitored"
-            f" workflows + dynamic CodeQL + fork trigger run), found {count}"
+        assert count == 4, (
+            "expected exactly the four run-collapse sites (monitored"
+            " workflows + dynamic CodeQL + fork trigger run + fork check-run),"
+            f" found {count}"
         )
         # No site may re-grow a filter stage between the select() and the
         # collapse: the line preceding each collapse must be the end of the
@@ -911,6 +921,267 @@ class TestForkScanVerdictIsBoundToItsPullRequest:
         assert proc.returncode == 0, proc.stderr
         summary = (runner.temp / "pr-readiness-summary.md").read_text()
         assert "Internal Content Scan (not started)" not in summary
+
+
+class _ForkLaneVerdictBinding:
+    """A fork lane verdict must belong to THIS pull request and THIS attempt.
+
+    Two open PRs can share a head SHA -- the same fork branch opened against two
+    bases, or the same commit in two forks -- and each Stage-2 lane posts a
+    check-run under the SAME NAME on that SHA. A RERUN on an unchanged head also
+    leaves the previous attempt's completed row in place while the new attempt is
+    still starting. Reading rows by name alone loses both ways, and the second one
+    is not even a narrow race: readiness recomputes on the trigger's completion,
+    which is exactly when the old row is the only one there.
+
+    Staleness is not merely cosmetic here. A model verdict can differ between
+    attempts on the same head, so accepting the previous attempt's clean verdict
+    can pass content a rerun would judge differently. The lane therefore stamps
+    external_id=<prefix><pr>-<run id>-<attempt>, and readiness derives the
+    expected value from the newest run of the triggering workflow (Fast Gate).
+
+    Subclasses set PREFIX to their lane's `<lane>-pr-` and CHECK_NAME to the
+    lane's check-run name. The stub serves check_runs.json for EVERY check-name
+    query, so every lane reads the same row -- only the lane under test is
+    attempt-bound to a matching id, and the others read a non-matching id and
+    fall to pending, which is fine because only the tested lane's outcome is
+    asserted.
+    """
+
+    PREFIX: str
+    CHECK_NAME: str
+
+    @staticmethod
+    def _only_check_run(runner: Runner, external_id: str) -> None:
+        (runner.fixtures / "check_runs.json").write_text(
+            json.dumps(
+                {
+                    "check_runs": [
+                        {
+                            "status": "completed",
+                            "conclusion": "success",
+                            "external_id": external_id,
+                        }
+                    ]
+                }
+            )
+        )
+
+    @staticmethod
+    def _check_run_rows(runner: Runner, rows: list[dict]) -> None:
+        (runner.fixtures / "check_runs.json").write_text(
+            json.dumps({"check_runs": rows})
+        )
+
+    @staticmethod
+    def _trigger_attempt(runner: Runner, attempt: int) -> None:
+        # green_runs.json is what the stub returns for the lane's triggering
+        # workflow (fast-gate.yml), so this is how the "current attempt" moves.
+        (runner.fixtures / "green_runs.json").write_text(
+            _run_json(
+                "fast-gate.yml",
+                status="completed",
+                conclusion="success",
+                run_attempt=attempt,
+            )
+        )
+
+    def _id_for(self, runner: Runner, *, pr: str, attempt: int) -> str:
+        return f"{self.PREFIX}{pr}-{RUN_ID}-{attempt}"
+
+    def test_a_siblings_clean_check_run_does_not_pass_this_pr(self, runner: Runner):
+        # Same name, same head SHA, same attempt -- DIFFERENT pull request.
+        self._only_check_run(runner, self._id_for(runner, pr="9999", attempt=1))
+
+        proc, outputs = runner.evaluate(fork=True)
+
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "pending"
+
+    def test_a_previous_attempts_clean_check_run_does_not_pass_a_rerun(
+        self, runner: Runner
+    ):
+        # The trigger has been re-run: attempt 2 is current, and the only row on
+        # the commit is attempt 1's clean verdict -- computed on the previous
+        # roll. It must not answer for this attempt.
+        self._trigger_attempt(runner, 2)
+        self._only_check_run(
+            runner, self._id_for(runner, pr=runner.env["PR"], attempt=1)
+        )
+
+        proc, outputs = runner.evaluate(fork=True)
+
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "pending"
+
+    def test_a_siblings_trigger_run_is_not_mistaken_for_this_prs(self, runner: Runner):
+        # The expected external_id names the newest run of the lane's TRIGGERING
+        # workflow, so that selection has to be bound to this PR too. Two open PRs
+        # can share the head SHA, and the sibling's trigger run can be the newer
+        # one -- selecting it would name a run this PR's lane never saw, so nothing
+        # would ever match and the lane would sit pending forever. That is the
+        # opposite failure to the stale-verdict one, and just as bad.
+        sibling_newer = json.dumps(
+            {
+                "workflow_runs": [
+                    json.loads(
+                        _run_json("fast-gate.yml", status="completed", conclusion="success")
+                    )["workflow_runs"][0],
+                    {
+                        # Same head SHA, higher id -- but another fork's branch.
+                        "id": RUN_ID + 1,
+                        "run_attempt": 1,
+                        "head_repository": {"full_name": "someone-else/KiroCrew"},
+                        "head_branch": "their/branch",
+                        "path": ".github/workflows/fast-gate.yml",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "created_at": "2026-08-11T00:00:00Z",
+                    },
+                ]
+            }
+        )
+        (runner.fixtures / "green_runs.json").write_text(sibling_newer)
+        # This PR's own row, stamped with THIS PR's trigger run.
+        self._only_check_run(
+            runner, self._id_for(runner, pr=runner.env["PR"], attempt=1)
+        )
+
+        proc, outputs = runner.evaluate(fork=True)
+
+        assert proc.returncode == 0, proc.stderr
+        summary = (runner.temp / "pr-readiness-summary.md").read_text()
+        assert f"{self.CHECK_NAME} (not started)" not in summary, (
+            "the sibling's newer trigger run was selected, so this PR's own row "
+            "could not be matched and the lane is stuck pending"
+        )
+
+    def test_the_current_attempts_own_check_run_is_read(self, runner: Runner):
+        # The binding must not blind the lane to the row that DOES belong to it --
+        # otherwise every fork PR sits pending forever, which is the opposite
+        # failure and just as bad.
+        self._only_check_run(
+            runner, self._id_for(runner, pr=runner.env["PR"], attempt=1)
+        )
+
+        proc, outputs = runner.evaluate(fork=True)
+
+        assert proc.returncode == 0, proc.stderr
+        summary = (runner.temp / "pr-readiness-summary.md").read_text()
+        assert f"{self.CHECK_NAME} (not started)" not in summary
+
+    def test_a_rerun_starting_reads_pending_not_the_stale_check_run(
+        self, runner: Runner
+    ):
+        # This evaluation can BE the `in_progress` event a human-override
+        # rerun of the lane fires the instant it starts (pr-readiness.yml is
+        # wired to the fork workflow at both in_progress and completed), before
+        # that rerun's own "Open check-run" step has posted a fresh row. Only
+        # the OLD, still-completed, still-success check-run exists at that
+        # moment; reading it would publish a stale success. The lane must read
+        # pending instead, keyed off the triggering workflow_run's own name +
+        # status, without ever calling the check-runs API.
+        self._only_check_run(
+            runner, self._id_for(runner, pr=runner.env["PR"], attempt=1)
+        )
+
+        proc, outputs = runner.evaluate(
+            fork=True,
+            wr_name=f"Fork {self.CHECK_NAME}",
+            wr_status="in_progress",
+        )
+
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "pending"
+        summary = (runner.temp / "pr-readiness-summary.md").read_text()
+        assert f"{self.CHECK_NAME} (rerun starting)" in summary
+
+    def test_a_different_lanes_rerun_starting_does_not_force_this_lane_pending(
+        self, runner: Runner
+    ):
+        # The guard must be scoped to THIS lane's own fork workflow name --
+        # another lane's rerun starting must not blind this one to its own
+        # genuine, already-posted verdict.
+        self._only_check_run(
+            runner, self._id_for(runner, pr=runner.env["PR"], attempt=1)
+        )
+
+        proc, outputs = runner.evaluate(
+            fork=True,
+            wr_name="Fork Some Other Review",
+            wr_status="in_progress",
+        )
+
+        assert proc.returncode == 0, proc.stderr
+        summary = (runner.temp / "pr-readiness-summary.md").read_text()
+        assert f"{self.CHECK_NAME} (not started)" not in summary
+        assert f"{self.CHECK_NAME} (rerun starting)" not in summary
+
+    def test_a_stale_failure_does_not_outvote_a_human_override_rerun(
+        self, runner: Runner
+    ):
+        # A human-override rerun (`gh api .../runs/<id>/rerun`) re-executes the
+        # LANE's own run directly, without Fast Gate re-running -- so the
+        # trigger-bound id (PR + Fast Gate run id + Fast Gate attempt) is
+        # IDENTICAL between the stale failed attempt and the fresh rerun: both
+        # check-run rows share the exact same external_id. If the reader
+        # treated a match as singular it would only ever see one row (a POST
+        # PATCHes an existing row when one is open, so in practice this is the
+        # in-place-update path); this fixture models the sweep-created edge
+        # where two distinct rows end up sharing the id, and pins that the
+        # reader collapses to the newest by CHECK-RUN id (distinct per POST,
+        # independent of external_id) rather than by fail-precedence, so the
+        # fresh success is never outvoted by the stale failure it replaces.
+        trigger_id = self._id_for(runner, pr=runner.env["PR"], attempt=1)
+        self._check_run_rows(
+            runner,
+            [
+                {
+                    "id": 1,
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "external_id": trigger_id,
+                },
+                {
+                    "id": 2,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "external_id": trigger_id,
+                },
+            ],
+        )
+
+        proc, outputs = runner.evaluate(fork=True)
+
+        assert proc.returncode == 0, proc.stderr
+        summary = (runner.temp / "pr-readiness-summary.md").read_text()
+        assert f"{self.CHECK_NAME} (failure)" not in summary
+        assert f"{self.CHECK_NAME} (BLOCK)" not in summary
+
+
+class TestForkOpusVerdictIsBoundToItsPullRequest(_ForkLaneVerdictBinding):
+    PREFIX = "opus-pr-"
+    CHECK_NAME = "Opus 4.8 Review"
+
+
+class TestForkGptVerdictIsBoundToItsPullRequest(_ForkLaneVerdictBinding):
+    PREFIX = "gpt-pr-"
+    CHECK_NAME = "GPT 5.6 Review"
+
+
+class TestForkDesignVerdictIsBoundToItsPullRequest(_ForkLaneVerdictBinding):
+    PREFIX = "design-pr-"
+    CHECK_NAME = "Design Review"
+
+
+class TestForkUxVerdictIsBoundToItsPullRequest(_ForkLaneVerdictBinding):
+    PREFIX = "ux-pr-"
+    CHECK_NAME = "UX Review"
+
+
+class TestForkFirstPrinciplesVerdictIsBoundToItsPullRequest(_ForkLaneVerdictBinding):
+    PREFIX = "first-principles-pr-"
+    CHECK_NAME = "First Principles Review"
 
 
 class TestAwaitingApprovalIsAttributedToTheMaintainer:


### PR DESCRIPTION
Fixes #9302.

## Problem

The five Stage-2 fork AI-review lanes (Opus, GPT, Design, UX, First Principles) read their verdict from the head SHA's check-runs **by name only**. Two open PRs can share a head SHA, so a sibling PR's check-run could answer for the wrong PR (a race that fails open or closed depending on the sibling's verdict). A rerun on an unchanged head also left the previous attempt's completed row in place, so a PR-scoped-but-attempt-blind read would accept a verdict computed against an older ruleset. The fallback POST, which omits `external_id` when the PR number cannot be resolved, read as a pass by name.

## Fix

Replicate the two-dimensional binding that PR #9214 (commit `a4e6944e3`) established for the `Internal Content Scan` lane, applied to the five sibling lanes:

- **Each lane** stamps `external_id=<lane>-pr-$PR-$WR_RUN_ID-$WR_RUN_ATTEMPT` at both the open and fallback POST (env gains `WR_RUN_ID`/`WR_RUN_ATTEMPT` from `github.event.workflow_run.id/.run_attempt`).
- **`pr-readiness.yml`** four-field `checkrun:` specs (`<Name>|<Name>|<prefix>-pr-|fast-gate.yml`); the reader resolves Fast Gate's newest run for the head, filtered to THIS PR's (head repository, head branch) so a sibling PR's trigger run on the same head SHA can never be selected, builds `want=<prefix>-pr-<PR>-<runid>-<attempt>`, and filters check-runs to that exact id. Trigger-not-run-yet reads pending, holding the merge.
- **The two live consumers** of the old id (each lane's finalize stranded-run sweep and `ai-review-human-override.yml`) switch from exact match to a PR-dimension prefix match (`startswith("<lane>-pr-$PR-")`, trailing hyphen so `-pr-9` != `-pr-99`) so they still span attempts.
- **Fallback POST resolved**: stamps the id when the PR is known; when unresolved it stamps nothing and is documented as intentionally pending-on-invisible (fail-closed).

## Audit findings

- **GPT lane** posts exactly one idded check-run row per run (open POST or fallback) and PATCHes that same row; its "several passes under one name" are internal model passes into the *same* check-run, not extra un-idded rows. The binding filter does not blind it (except the documented no-PR fallback).
- Attempt binding (run id + attempt), not just PR binding, is required, per the scope correction on #9302: a rerun on an unchanged head would otherwise reuse the previous attempt's verdict.

## Note on the reference

PR #9214 (commit `a4e6944e3`) merged into `main` while this branch was rebasing and is now an ancestor of HEAD, so the `Internal Content Scan` lane's own binding (its `checkrun:` spec, its `TestForkScanVerdictIsBoundToItsPullRequest` test class, and its `(head repository, head branch)` trigger-run filter) already exists in the working tree unmodified. This PR generalizes that exact proven pattern -- including the trigger-run repo/branch filter, which #9214 added to close a sibling-PR collision that the original commit `43d28c515` had not yet accounted for -- to the five sibling review lanes, and adds a shared `_ForkLaneVerdictBinding` test base class (subclassed per lane) rather than restating the four per-lane test methods five times.

## Testing

- All `.github/workflows/*.yml` parse via `yaml.safe_load`.
- Targeted suites (`test_pr_readiness_evaluate.py`, `test_ai_review_workflows.py`, plus the touched-file suites `test_acp_client.py`, `test_bench_kb_retrieval.py`, `test_conductor_agent.py`, `test_hooks_coverage.py`, `test_knowledge_search_upgrade.py`, `test_security_posture.py`, `test_session_pool.py`): 1657 passed, 6 failed. The 6 failures are all in `test_acp_client.py`'s tool-results/session-resume tests, unrelated to this PR's diff (workflow YAML + readiness test files) -- confirmed by running the identical 6 tests against a clean `origin/main` checkout, where they fail identically with the same assertion.
- `scripts/check_black_formatting.py` exit 0; `isort --check-only` and `flake8` clean on the touched test files; `scripts/docs_lint.py` "All documentation checks passed".
- No stale exact-match sweeps remain (grep-verified against `ai-review-human-override.yml` and all five `fork-*-review.yml` finalize steps).

## Pattern harvest

Not generalizable: this replicates an already-landed, already-reviewed binding pattern (PR #9214) onto five sibling lanes rather than introducing a new defect class.

## Files changed (10)

- `.github/workflows/pr-readiness.yml` -- four-field fork specs + attempt-binding reader for the five sibling lanes, sharing the (head repository, head branch) trigger-run filter `Internal Content Scan` already uses.
- `.github/workflows/fork-{opus,gpt,design,ux,first-principles}-review.yml` -- two-dimensional open/fallback stamp; prefix-match stranded-run sweep.
- `.github/workflows/ai-review-human-override.yml` -- prefix-match on the second consumer.
- `test/test_pr_readiness_evaluate.py` -- shared `_ForkLaneVerdictBinding` base class + five per-lane subclasses (sibling / stale-attempt / sibling-trigger-run / own-row).
- `test/test_ai_review_workflows.py` -- pins updated with negative guards on the old exact match.
- `docs/ci/ci-and-reviews.md` -- fork readiness read documented as external_id-bound (PR + run + attempt).
