### PR TITLE
fix(usage): reconcile empty-session stats contract after #9305 collision

### DIFF
--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -59,6 +59,13 @@ class TestParseSessions:
             "this_month": {"sessions": 0, "messages": 0, "tool_calls": 0},
             "avg_msgs_per_session": 0,
             "avg_tools_per_session": 0,
+            # An empty history is COMPLETE data, not incomplete: nothing was
+            # dropped, so the did-not-load total is a present zero rather than
+            # an absent key (#6733). Omitting it would make "complete" and
+            # "unknown" indistinguishable on the wire -- the adapter's
+            # ``s.refused_transcripts ?? 0`` would synthesise the promise of
+            # completeness the payload never made.
+            "refused_transcripts": 0,
         }
         assert sessions_dir.exists() == directory_exists
 


### PR DESCRIPTION
## Heals broken main

`main` at 678fc3266 is red on `test/test_usage.py::TestParseSessions::test_empty_session_stats[False]` and `[True]`, both on the same assertion: the dict `_parse_sessions()` actually returns carries one key the expectation does not.

```
E         Left contains 1 more item:
E         {'refused_transcripts': 0}
```

## Root cause: a semantic mid-air collision, 74 minutes apart

Two commits, no textual overlap, each green on its own merge ref:

| commit | PR | merged | what it did |
|---|---|---|---|
| `f654ad072` | #9254 | 13:49 PDT | made `refused_transcripts` an **unconditional** field of the `_parse_sessions()` return dict, so the usage page can say the totals are incomplete instead of rendering a silent under-count on a Windows UNC home |
| `5780471f3` | #9305 | 15:04 PDT | removed the `{"error": "No sessions directory"}` early return so a missing transcript directory yields **complete zero** period counts, and rewrote `test_no_directory` into an exact-equality `test_empty_session_stats` |

#9305's exact-equality dict was authored against the **pre-#9254 shape**. Neither CI run ever saw both changes:

- #9254 changed `test_usage.py` but never touched `test_no_directory`, which at that point asserted only the error dict — so no conflict and nothing to fail.
- #9305's source hunk applied cleanly over #9254's source hunk (`index 48f660ca6..381411ac1` in the landed commit is post-#9254), so git had no conflict to report either.

Classic both-green-in-isolation, red-together.

## Which side is right

**The source is right; the test expectation is the stale side.**

A present zero is the contract #9254 deliberately established (`"refused_transcripts": refused_transcripts` is emitted on every return), and it is exactly what #9305 wants for an empty history: nothing was dropped, so the zeros are a *fact* rather than an under-count. Omitting the key would make "complete" and "unknown" indistinguishable on the wire — the dashboard adapter's `refusedTranscripts: s.refused_transcripts ?? 0` (`website/src/providers/adapters/acp.ts`) would synthesise a completeness promise the payload never made, which is the precise failure #9254 exists to prevent.

So this adds the key to the expectation. It does **not** relax the assertion to a subset match, and it does **not** make the field conditional — either of those would re-open the silent-zero hole. The added comment records why the zero is present rather than absent, so the next author of this expectation does not read it as incidental.

Adjacent `TestParseSessions` cases already assert `r["refused_transcripts"] == 0` on non-empty-but-nothing-refused paths, which independently confirms the field is expected present-and-zero rather than absent.

## Tests

| suite | result |
|---|---|
| `test/test_usage.py` | 95 passed (was 2 failed / 17 passed in `TestParseSessions` alone) |
| `test_kiro_usage_api.py` + `test_acp_usage_cost.py` + `test_hooks_coverage.py` | 389 passed |
| `test_security_posture.py` + `test_spawn_audit.py` | 65 passed |
| `flake8 test/test_usage.py` | clean |
| `scripts/check_black_formatting.py` | passed (file is in the 1,146-file black baseline; the explicit `black --diff` complaints are pre-existing file-wide `with`-statement restyle drift present on pristine `origin/main`, and none fall inside this diff's hunk) |

No frontend file is touched, so the usage adapter and `UsageTab.refusedTranscripts.test.tsx` are unaffected by this diff.

<!-- no-visual-delta -->
Test-expectation change only: one key added to an assertion dict. No rendered surface changes — `_parse_sessions()` source, the `/api/usage/kiro` payload, and the usage page are all byte-identical to `main`.

## Pattern harvest

This failure was invisible to both PRs' CI by construction: the mechanism that normally catches a collision (a textual conflict) had nothing to catch, because one PR changed a data shape's *producer* and the other changed that shape's *pinning assertion*, in disjoint hunks.

Rule candidate: a PR changing a data shape and its pinning test must be re-run against main tip immediately before merge when neighbors touch the same shape — semantic collisions pass both PRs' own CI.

Two corollaries worth keeping with it:

- An exact-equality assertion on a payload dict is a *shape lock*, and any PR that adds a field to that payload is a modifier of every such lock in the repo — even the ones it does not textually touch. `grep` for the shape's other assertions when adding a field.
- `gh run rerun` cannot substitute for this: it re-executes the run's original pinned merge ref, so it would have reproduced the same green. Only a fresh run (push, or close/reopen) sees main tip.

