### PR TITLE
fix: stop recovery after question cards

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -180,6 +180,13 @@ send time.
   boundaries: steer cut, compaction, clear, agent switch) is load-bearing for the
   promise-only guard.
 
+  A successfully delivered non-blocking `ask_question` directive is different
+  from a generic productive tool-only turn: its card is the intended terminal
+  output, and the tool explicitly tells the model to end until the user's answer
+  arrives as a new message. The runner therefore records the successful card
+  outcome and skips the entire empty-response ladder. Delivery failures keep the
+  normal behavior so the model can fall back to a plain-text question.
+
   **Turn-end diagnostics.** The branch emits ONE privacy-safe WARNING per empty
   verdict, after the rung is chosen, naming a closed `cause` and `rung` plus
   booleans: `provider_empty`, `tool_only`, `thinking_only`, `visible_partial`,

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -127,7 +127,10 @@ from kiro_crew.dashboard.handlers.usage import (
     read_effective_agent,
     read_turn_model,
 )
-from kiro_crew.dashboard.session_directive_apply import apply_session_directive
+from kiro_crew.dashboard.session_directive_apply import (
+    QUESTION_CARD_SHOWN_PREFIX,
+    apply_session_directive,
+)
 from kiro_crew.dashboard.state import (
     CRON_NOTIFY_PREFIX,
     CRON_NOTIFY_RE,
@@ -6173,6 +6176,16 @@ async def _run_chat(
     # text and overwrite the applied outcome in the transcript. Replaying the
     # stored output keeps every frame consistent and marker-free.
     _dir_consumed_out: dict[str, str] = {}
+    # A successfully posted non-blocking question card is the intended terminal
+    # output of this turn. The tool tells the model to end without assistant
+    # text, so empty-response recovery must not inject a closing continuation.
+    _terminal_question_posted = False
+
+    def _record_terminal_question(kind: str, outcome: str) -> None:
+        nonlocal _terminal_question_posted
+        if kind == "ask_question" and outcome.startswith(QUESTION_CARD_SHOWN_PREFIX):
+            _terminal_question_posted = True
+
     # When this turn began, for bounding an out-of-band directive claim to it.
     # A directive belongs to the turn that asked for it: a record parked by a turn
     # that was cancelled before consuming it must not be claimable by a later one.
@@ -8147,14 +8160,16 @@ async def _run_chat(
                             else None
                         )
                     if _oob:
+                        _applied_kind = str(_oob.get("kind") or "")
                         _applied_one = await apply_session_directive(
                             state,
                             slot,
                             session_key,
-                            str(_oob.get("kind") or ""),
+                            _applied_kind,
                             dict(_oob.get("args") or {}),
                             producer_is_user_facing=_directive_user_origin,
                         )
+                        _record_terminal_question(_applied_kind, _applied_one)
                         logger.info(
                             "session-directive applied OUT OF BAND for %s "
                             "(tool_call_id=%s, kind=%s): this backend emits no "
@@ -8334,16 +8349,16 @@ async def _run_chat(
                             # arm two loops or render two cards, so retire the
                             # twin now that the marker path has taken it.
                             directive_queue.discard(session_key)
-                            _out = _redact_tool_field(
-                                await apply_session_directive(
-                                    state,
-                                    slot,
-                                    session_key,
-                                    _dir_tool,
-                                    _dir_args,
-                                    producer_is_user_facing=_directive_user_origin,
-                                )
+                            _applied_one = await apply_session_directive(
+                                state,
+                                slot,
+                                session_key,
+                                _dir_tool,
+                                _dir_args,
+                                producer_is_user_facing=_directive_user_origin,
                             )
+                            _record_terminal_question(_dir_tool, _applied_one)
+                            _out = _redact_tool_field(_applied_one)
                             _dir_consumed_out[event.tool_call_id] = _out
                         else:
                             # Recorded directive tool but no valid marker in the
@@ -10712,6 +10727,7 @@ async def _run_chat(
         elif (
             _stop_reason != STOP_REASON_CANCELLED
             and not _produced_visible_output
+            and not _terminal_question_posted
             and not _refusal_reasons
         ):
             # Model returned an empty response — retry once, then notify user.

--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -60,6 +60,8 @@ from kiro_crew.session_surface import has_dashboard_surface
 
 logger = logging.getLogger(__name__)
 
+QUESTION_CARD_SHOWN_PREFIX = "Question card shown in this session."
+
 # Card directives require a connected dashboard surface. ``set_project`` is
 # admitted by the user-surface provenance gate below, then separately requires
 # the current turn to own the slot it would mutate.
@@ -849,7 +851,7 @@ async def _ask_question(state: Any, slot: Any, args: dict[str, Any]) -> str:
             "ask in plain text and end your turn instead."
         )
     return (
-        "Question card shown in this session. End your turn now — the user's "
+        f"{QUESTION_CARD_SHOWN_PREFIX} End your turn now — the user's "
         "answer will arrive as your next message; do not re-ask or guess."
     )
 

--- a/test/test_acp_tool_identity.py
+++ b/test/test_acp_tool_identity.py
@@ -22,6 +22,7 @@ The ``_meta.kiro`` fixture shape mirrors ``test_todo_list_surface.py``.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -213,8 +214,9 @@ async def _drive(
     monkeypatch,
     *,
     directive_user_origin: bool = True,
+    applied_result: str | None = "[applied]",
 ):
-    """Stream *events* through _run_chat; return the apply_session_directive spy."""
+    """Stream *events* through _run_chat; optionally stub the directive applier."""
     from kiro_crew.dashboard import chat_runner
 
     async def _stream(_msg):
@@ -228,8 +230,10 @@ async def _drive(
     client.client = None
     state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
 
-    spy = AsyncMock(return_value="[applied]")
-    monkeypatch.setattr(chat_runner, "apply_session_directive", spy)
+    spy = None
+    if applied_result is not None:
+        spy = AsyncMock(return_value=applied_result)
+        monkeypatch.setattr(chat_runner, "apply_session_directive", spy)
 
     await chat_runner._run_chat(
         state,
@@ -337,6 +341,74 @@ class TestChatRunnerDirectiveSeam:
         assert call.args[3] == "monitor_start"  # kind
         assert call.args[4] == args  # decoded, validated args
         assert call.kwargs["producer_is_user_facing"] is True
+
+    @pytest.mark.asyncio
+    async def test_successful_question_card_ends_turn_without_recovery(
+        self, tmp_path, monkeypatch
+    ):
+        """A delivered non-blocking question card is the turn's terminal output.
+
+        The tool explicitly tells the model to end with no assistant text. Treating
+        that shape like a generic tool-only turn injects a continuation, which asks
+        the model to finish the same request and can post the same card repeatedly.
+        """
+        from kiro_crew.dashboard import chat_runner
+
+        state = _stub_state(tmp_path)
+        state.post_question_card = AsyncMock(return_value=1)
+        slot = state.get_or_create_slot("question-terminal")
+        slot._titled = True
+        questions = [
+            {
+                "question": "Choose one",
+                "options": [{"label": "Option A"}, {"label": "Option B"}],
+            }
+        ]
+        marker = session_directive.encode(
+            "ask_question", {"questions": questions}, "Question card requested."
+        )
+        events = [
+            AcpEvent(
+                kind=EVENT_TOOL_CALL,
+                tool_call_id="tc-question",
+                title="Ask the user",
+                tool_name="ask_question",
+                mcp_server_name="kirocrew-core",
+            ),
+            AcpEvent(
+                kind=EVENT_TOOL_RESULT,
+                tool_call_id="tc-question",
+                tool_output=marker,
+                tool_final=True,
+            ),
+            AcpEvent(kind=EVENT_COMPLETE),
+        ]
+        queue_calls = []
+        queue_insert = type(slot).queue_insert
+
+        def _record_queue(self_slot, *args, **kwargs):
+            queue_calls.append((args, kwargs))
+            return queue_insert(self_slot, *args, **kwargs)
+
+        monkeypatch.setattr(type(slot), "queue_insert", _record_queue)
+        monkeypatch.setattr(
+            chat_runner, "_start_next_queued_turn", AsyncMock(return_value=False)
+        )
+
+        try:
+            await _drive(state, slot, events, monkeypatch, applied_result=None)
+        finally:
+            tasks = list(state._background_tasks)
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        state.post_question_card.assert_awaited_once_with(slot.key, questions)
+        assert queue_calls == [], "a terminal question card queued a recovery turn"
+        assert slot._empty_response_retries == 0
+        notices = [m for m in slot.messages if m.get("role") == "notice"]
+        assert not any("continu" in m.get("content", "").lower() for m in notices)
 
     @pytest.mark.asyncio
     async def test_automation_provenance_reaches_directive_applier(


### PR DESCRIPTION
## Problem / Motivation

A successful non-blocking `ask_question` call posts a dashboard card and explicitly tells the model to end its turn without assistant text. The dashboard runner currently treats that intentional tool-only ending as an empty response and queues a synthetic continuation. The continuation can re-enter the same unresolved question intent and post the same card again.

## Why it matters

A user can become trapped behind a question card that reappears after they answer or dismiss it. Repeated recovery turns also waste model work and make the session appear to ignore the user's response.

## What changed (motivation → approach → change)

The card itself is the intended terminal output, so the fix records a turn-local terminal outcome only when `ask_question` was successfully delivered to an attached dashboard client. The marker and out-of-band directive paths both feed that outcome. The successful-card prefix is defined beside the directive applier and imported by the runner, so control flow cannot silently drift from outcome wording. The empty-response ladder is skipped for that one successful terminal case.

Delivery failures keep the existing behavior, allowing the model to fall back to asking in plain text. Other tool-only turns still receive the normal closing-continuation recovery.

## Tests

- Added an integration regression that drives the real dashboard runner and real directive applier.
- Asserts exactly one question-card delivery.
- Asserts no original-prompt replay or synthetic continuation is queued.
- Asserts the empty-response retry counter and recovery notices remain untouched.
- Existing directive-seam tests remain green.

## Manual verification

N/A — the integration test reproduces the exact tool-call/result/turn-complete shape and observes both card delivery and the runner queue.

## Related Issues

No linked issue: field-reported incident without a public issue.

## Pattern harvest

Rule candidate: review-prompt
Pattern: A successfully delivered non-blocking question card must terminate without generic missing-closing-reply recovery.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
