### PR TITLE
fix(usage): add refused_transcripts to the empty-stats expected dict

### DIFF
--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -59,6 +59,10 @@ class TestParseSessions:
             "this_month": {"sessions": 0, "messages": 0, "tool_calls": 0},
             "avg_msgs_per_session": 0,
             "avg_tools_per_session": 0,
+            # Present-and-zero in every payload since #9254; this expected
+            # dict predated that merge (#9317 — the two PRs were each green
+            # in isolation and red together).
+            "refused_transcripts": 0,
         }
         assert sessions_dir.exists() == directory_exists
 


### PR DESCRIPTION
## Problem / Motivation

#9317: `test_usage.py::TestParseSessions::test_empty_session_stats` fails on every head built after 2026-09-07 22:03:57Z, across all authors' PRs. Cross-PR semantic conflict: **#9254** (merged 20:49Z) made `_parse_sessions` include `refused_transcripts` in every payload; **#9305** (merged 22:03:57Z — the exact boundary) added this test with an expected dict written before #9254 landed. Each PR was green in isolation; together, every head fails with one extra left-side key — `refused_transcripts: 0`.

## Why it matters

Base-red on shard 4 for the whole repository: every PR built on current main carries this failure regardless of its content, which both blocks unrelated merges and trains people to ignore a red shard.

## What changed

Motivation → approach → change: the empty-directory zero-statistics payload genuinely carries `refused_transcripts: 0` (the #9254 contract), so the test's expected dict gains that key with a comment explaining the semantic-conflict history. One-line-plus-comment test fix; no source change — the source behavior of both merged PRs is correct and mutually consistent.

## Tests

- `test/test_usage.py` full suite: 95 passed locally on main + this fix (was 2 failed).
- Reproduced the failure on unpatched main (`678fc3266`) first; verified both parametrizations (`[True]`/`[False]`) flip to green with the fix.
- black gate, flake8, isort on the touched file: clean.

## Manual verification

Confirmed via `git log -S refused_transcripts` that #9254 introduced the key into every payload path, and via the pytest `-vv` dict diff that the only mismatch is the single missing key — no value differences.

## Screenshots / video

N/A — test-only change.

## Related Issues

Fixes #9317. Context: #9254, #9305.

## Pattern harvest

Two PRs touching the same payload contract can be individually green and jointly red; when a whole-dict equality assertion starts failing repo-wide at an exact merge timestamp, diff the dict keys against `git log -S` for the extra key before suspecting the platform or the shard.

## Checklist

- [x] Tests added/updated and passing locally
- [x] Lint gates clean on touched files
- [x] No unrelated changes

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
