### PR TITLE
fix(deploy): stop the deploy lock opens from truncating the lock file

### DIFF
--- a/src/kiro_crew/deploy/pending.py
+++ b/src/kiro_crew/deploy/pending.py
@@ -106,7 +106,12 @@ def add_pending(params: dict[str, Any]) -> dict[str, Any]:
     # required=True: a deploy store that cannot obtain cross-process exclusion
     # must fail loudly rather than risk a double-deploy / lost write. flock_compat
     # is a Windows no-op, so this uses platform_compat's real msvcrt lock.
-    with open(lock_path, "w") as fd:
+    # touch + "r+": writable (msvcrt.locking needs it) but NON-TRUNCATING — a
+    # truncating "w" open of a lock file whose first byte another holder already
+    # locked raises a sharing violation on Windows instead of waiting. Full
+    # rationale: work_ledger._open_lock.
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
             entries = _prune_expired(_load_raw())
             entries.append(entry)
@@ -127,7 +132,10 @@ def remove_pending(entry_id: str) -> bool:
     """Remove an entry (confirm or dismiss). Returns True if found."""
     lock_path = _store_path().with_suffix(".lock")
     _store_path().parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as fd:
+    # touch + "r+": writable but non-truncating; see add_pending above and
+    # work_ledger._open_lock for the Windows sharing-violation rationale.
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
             entries = _prune_expired(_load_raw())
             before = len(entries)
@@ -145,7 +153,10 @@ def claim_pending(entry_id: str) -> dict[str, Any] | None:
     """
     lock_path = _store_path().with_suffix(".lock")
     _store_path().parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as fd:
+    # touch + "r+": writable but non-truncating; see add_pending above and
+    # work_ledger._open_lock for the Windows sharing-violation rationale.
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
             entries = _prune_expired(_load_raw())
             claimed = None

--- a/src/kiro_crew/deploy/profiles.py
+++ b/src/kiro_crew/deploy/profiles.py
@@ -123,7 +123,12 @@ def locked_registry() -> Generator[dict[str, Any], None, None]:
     # required=True: a lost profile write is silent data loss, so refuse to
     # proceed without cross-process exclusion. flock_compat is a Windows no-op,
     # so this uses platform_compat's real msvcrt lock.
-    with open(lock_path, "w") as fd:
+    # touch + "r+": writable (msvcrt.locking needs it) but NON-TRUNCATING — a
+    # truncating "w" open of a lock file whose first byte another holder already
+    # locked raises a sharing violation on Windows instead of waiting. Full
+    # rationale: work_ledger._open_lock.
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
             reg = load_registry()
             yield reg
@@ -217,7 +222,10 @@ def load_registry() -> dict[str, Any]:
 def save_registry(reg: dict[str, Any]) -> dict[str, Any]:
     _data_dir().mkdir(parents=True, exist_ok=True)
     lock_path = _registry_path().with_suffix(".lock")
-    with open(lock_path, "w") as fd:
+    # touch + "r+": writable but non-truncating; see locked_registry above and
+    # work_ledger._open_lock for the Windows sharing-violation rationale.
+    lock_path.touch(exist_ok=True)
+    with open(lock_path, "r+") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
             tmp_fd = tempfile.NamedTemporaryFile(
                 mode="w", dir=str(_data_dir()), suffix=".json.tmp",

--- a/test/test_deploy_lock_truncate.py
+++ b/test/test_deploy_lock_truncate.py
@@ -1,0 +1,74 @@
+"""The deploy lock sidecars must open WRITABLE but NON-TRUNCATING.
+
+``msvcrt.locking`` needs a writable handle, so the lock fd cannot be opened
+``"r"``; but ``"w"`` truncates on open, and on Windows a truncating open of a
+lock file whose first byte another holder already locked raises a sharing
+violation instead of waiting — the contending acquirer crashes before it ever
+reaches ``file_lock`` and mutual exclusion silently does not happen. POSIX
+``flock`` tolerates the truncate, which is why the defect is invisible on
+Linux. Same property the ``work_ledger._open_lock`` and ``session_pid`` fixes
+pinned.
+
+Truncation is the direct, platform-independent observable: seed each lock
+sidecar with bytes, drive the public function that takes the lock, and assert
+the bytes survive. Under ``open(lock_path, "w")`` every one of these fails on
+every platform (the file is emptied); under ``touch`` + ``"r+"`` they pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import kiro_crew.deploy.pending as pending
+import kiro_crew.deploy.profiles as profiles
+
+SENTINEL = b"held by a prior acquirer\n"
+
+
+@pytest.fixture
+def pending_lock(tmp_path, monkeypatch) -> Path:
+    store = tmp_path / "deploy" / "pending-deploys.json"
+    monkeypatch.setattr(pending, "_store_path", lambda: store)
+    lock = store.with_suffix(".lock")
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_bytes(SENTINEL)
+    return lock
+
+
+@pytest.fixture
+def registry_lock(tmp_path, monkeypatch) -> Path:
+    data_dir = tmp_path / "deploy"
+    monkeypatch.setattr(profiles, "_data_dir", lambda: data_dir)
+    monkeypatch.setattr(profiles, "_registry_path", lambda: data_dir / "profiles.json")
+    lock = data_dir / "profiles.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_bytes(SENTINEL)
+    return lock
+
+
+def test_add_pending_does_not_truncate_the_lock_file(pending_lock):
+    pending.add_pending({"site_id": "s1"})
+    assert pending_lock.read_bytes() == SENTINEL
+
+
+def test_remove_pending_does_not_truncate_the_lock_file(pending_lock):
+    pending.remove_pending("absent-id")
+    assert pending_lock.read_bytes() == SENTINEL
+
+
+def test_claim_pending_does_not_truncate_the_lock_file(pending_lock):
+    assert pending.claim_pending("absent-id") is None
+    assert pending_lock.read_bytes() == SENTINEL
+
+
+def test_locked_registry_does_not_truncate_the_lock_file(registry_lock):
+    with profiles.locked_registry():
+        pass
+    assert registry_lock.read_bytes() == SENTINEL
+
+
+def test_save_registry_does_not_truncate_the_lock_file(registry_lock):
+    profiles.save_registry({"version": 2, "profiles": [], "default": ""})
+    assert registry_lock.read_bytes() == SENTINEL


### PR DESCRIPTION
## Problem / Motivation

Five deploy lock sidecars are opened with `open(lock_path, "w")`, which truncates the file at open time, BEFORE the `platform_compat.file_lock` acquire on the handle. Three sites are in `src/kiro_crew/deploy/pending.py` (`add_pending`, `remove_pending`, `claim_pending`) and two in `src/kiro_crew/deploy/profiles.py` (`locked_registry`, `save_registry`).

## Why it matters

On Windows the acquire routes to `msvcrt.locking`, and a truncating open of a lock file whose first byte another holder already locked raises a sharing violation instead of waiting: the contending acquirer crashes before it ever reaches `file_lock`, and the mutual exclusion these sidecars exist to provide silently does not happen. These locks guard the pending-deploy store (double-deploy protection) and the profile registry (lost-write protection), so the failure mode is exactly the data race they were added to prevent. POSIX `flock` tolerates the truncate, which is why this is invisible on Linux.

## What changed (motivation -> approach -> change)

Applied the exact fix shape the sibling subsystems landed in `work_ledger._open_lock` (#9237), `session_pid.py` (#9250), and the hooks.json pair (#9279): keep the existing parent-dir `mkdir`, add `lock_path.touch(exist_ok=True)`, and open `"r+"` instead of `"w"` -- writable (which `msvcrt.locking` requires; `"r"` would trade this bug for a silently-unlocked critical section) but non-truncating. The acquire on the handle is unchanged, including the deploy stores' `required=True`. None of the five sites reads the lock file's contents, so the substitution discards nothing. Nothing in the repo unlinks these sidecars (both pre-push review lanes verified), so the `touch` + `"r+"` pair introduces no new failure window.

## Tests

- New `test/test_deploy_lock_truncate.py`: the seed-bytes-survive property the sibling PRs pinned, once per public entry point (all five sites). Each test seeds the lock sidecar with bytes, drives the function that takes the lock, and asserts the bytes survive. Verified RED against the parent commit (all five fail: the file is emptied) and GREEN with the fix -- the truncation is the direct, platform-independent observable of the Windows defect.
- Existing deploy suites pass (`test_deploy_pending_replace_retry.py`, `test_deploy_profiles_cov80.py`, `test_deploy_web_profiles.py`: 57 passed, 1 skipped).
- Local gates: isort, flake8, mypy, black, and the repo scan scripts all pass.

## Manual verification

N/A -- unit coverage sufficient: the truncation property is directly observable in the tests on every platform, and the changed lines are exercised by every existing deploy-store test.

## Related Issues

Closes #9265
Refs #9248 (the umbrella issue stays open until the last subsystem lands)

Note: open PR #9269 touches these same files as part of a multi-subsystem change; this PR carries only the deploy subsystem, per the one-subsystem-per-PR structure the #9248 sweep asks for, and matches the merged siblings' fix shape.

## Pattern harvest

Rule candidate: semgrep
Pattern: truncating open(path, "w") whose handle flows into file_lock() before the acquire (Windows sharing violation); the #9248 sweep enumerates the instances by hand today.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
