### PR TITLE
fix(instances): pane journal faked a remount storm; add pane boot-stage journal

### DIFF
--- a/website/src/components/EmbeddedHostBridge.tsx
+++ b/website/src/components/EmbeddedHostBridge.tsx
@@ -109,6 +109,17 @@ export default function EmbeddedHostBridge() {
     let acked = false
     const retryTimers: number[] = []
 
+    // The App tree reached this bridge: the last `boot` stage before `ready`.
+    // A parent journal showing `boot stage=render` but not `stage=bridge` means
+    // something between main.tsx and this effect (the prerequisite gate, a
+    // provider, an error boundary) swallowed the tree.
+    try {
+      // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+      window.parent?.postMessage({ type: 'mc-embedded-boot', v: 1, stage: 'bridge' }, '*')
+    } catch {
+      /* covered by announceReady's retries */
+    }
+
     const announceReady = () => {
       try {
         // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -36,7 +36,7 @@ import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { Trans } from 'react-i18next'
 import { api } from '../api/client'
 import { SettingsLink } from './SettingsLink'
-import { useAppDispatch, useAppSelector } from '../store'
+import { useAppDispatch, useAppSelector, useAppStore } from '../store'
 import { clearPaneReady, removeWarm, setActiveId, setPaneReady, setUnread, setWarm } from '../store/instancesSlice'
 import InstanceTabBar, { visibleInstanceTabs, useCrewPins, toggleCrewPin, useCrewSwitcherStableOrder, setStableOrder } from './InstanceTabBar'
 import { parseLoopbackOriginPort, resolveTunnelOrigin } from '../lib/tunnelOrigin'
@@ -168,8 +168,19 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // Live iframe elements by id, so the parent can postMessage the switcher model
   // into each embedded pane. Set/cleared by the iframe ref cb.
   const iframeRefs = useRef<Map<string, HTMLIFrameElement>>(new Map())
+  // One STABLE ref callback per pane id. An inline `ref={el => ...}` gets a new
+  // function identity on every render, and React 18 then calls the OLD callback
+  // with null and the NEW one with the same, never-detached element on each
+  // re-render. With the journal lines inside that callback, every 10s poll and
+  // every host-model broadcast printed an `iframe-unmounted` + `iframe-mounted`
+  // pair for every warm pane (600+ per pane per hour in one capture) and read
+  // as a remount storm that never happened, burying the one real question --
+  // did THIS pane's document ever load -- under fake churn. Caching the callback
+  // per id means React only calls it when the element genuinely attaches or
+  // detaches, which is what the two journal lines claim to mean.
+  const iframeRefCallbacks = useRef<Map<string, (el: HTMLIFrameElement | null) => void>>(new Map())
   // Read-only mirrors for the long-lived message listener, kept current without
-  // re-subscribing (mirrors the warmRef / portToIdRef pattern already used here).
+  // re-subscribing (mirrors the warmRef pattern already used here).
   const postModelToRef = useRef<(id: string) => void>(() => {})
   // Distinct readiness ack, sent ONLY from the mc-embedded-ready handler (never
   // from the input-driven broadcast). It is the pane's proof that THIS parent
@@ -239,13 +250,17 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     [dispatch],
   )
 
-  // Origin→id map for the relay listener, kept current without re-subscribing.
-  const portToIdRef = useRef<Map<number, string>>(new Map())
-  useEffect(() => {
+  // Origin→id map for the relay listener, read from the store at message time.
+  // The store is current the instant `setWarm` dispatches; a render and its
+  // passive effects come later. A fast loopback iframe can post its first
+  // `mc-embedded-boot` inside that gap, so a map refreshed by an effect on
+  // `warm` would still lack the new port and drop the boot as unattributed.
+  const store = useAppStore()
+  const currentPortToId = useCallback((): Map<number, string> => {
     const m = new Map<number, string>()
-    for (const [id, w] of Object.entries(warm)) m.set(w.port, id)
-    portToIdRef.current = m
-  }, [warm])
+    for (const [id, w] of Object.entries(store.getState().instances.warm)) m.set(w.port, id)
+    return m
+  }, [store])
 
   // Drop relayed drag gaps for panes that are no longer warm, so the map cannot
   // grow without bound and a re-warmed pane starts from its own fresh report.
@@ -259,26 +274,38 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
       }
       return changed ? next : prev
     })
+    for (const id of iframeRefCallbacks.current.keys()) {
+      if (!warm[id]) iframeRefCallbacks.current.delete(id)
+    }
   }, [warm])
 
   useEffect(() => {
     const onMessage = (e: MessageEvent) => {
       const data = e.data
       if (!data || typeof data !== 'object') return
-      const id = resolveTunnelOrigin(e.origin, portToIdRef.current)
+      const portToId = currentPortToId()
+      const id = resolveTunnelOrigin(e.origin, portToId)
       if (!id) {
-        // A readiness announce from a loopback origin this parent does not
-        // currently map to a warm pane is the handshake being dropped on the
-        // floor: the pane loaded and said so, and the parent could not tell
-        // whose voice it was (the warm entry moved to another port, was
-        // evicted, or the origin map has not caught up). Only THIS type is
-        // journaled, and the child sends it at most six times per load, so the
-        // line cannot flood; every other unattributed message stays silent.
-        if (data.type === 'mc-embedded-ready' && parseLoopbackOriginPort(e.origin) !== null) {
-          paneLog('ready-unattributed', {
-            origin: e.origin,
-            knownPorts: [...portToIdRef.current.keys()].join(','),
-          })
+        // A readiness or boot announce from a loopback origin this parent does
+        // not currently map to a warm pane is the handshake being dropped on
+        // the floor: the pane's bundle ran and said so, and the parent could
+        // not tell whose voice it was (the warm entry moved to another port or
+        // was evicted). Only these two types are journaled -- the child sends
+        // ready at most six times and boot exactly three times per load, so
+        // the lines cannot flood; every other unattributed message stays
+        // silent. Journaling the boot here is what keeps "no `boot` line" a
+        // trustworthy reading of "no JavaScript of ours ran in that frame".
+        if (parseLoopbackOriginPort(e.origin) !== null) {
+          const knownPorts = [...portToId.keys()].join(',')
+          if (data.type === 'mc-embedded-ready') {
+            paneLog('ready-unattributed', { origin: e.origin, knownPorts })
+          } else if (data.type === 'mc-embedded-boot') {
+            paneLog('boot-unattributed', {
+              origin: e.origin,
+              stage: typeof data.stage === 'string' ? data.stage : 'unknown',
+              knownPorts,
+            })
+          }
         }
         return
       }
@@ -376,6 +403,14 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
           paneChromeRef.current[id] = on
           if (id === activeIdRef.current) setFocusChromeVisible(on)
         }
+      } else if (data.type === 'mc-embedded-boot') {
+        // The pane's bundle EXECUTED (posted from main.tsx before React renders,
+        // see EmbeddedHostBridge for the ready half). This line splits the one
+        // failure the journal could not: a pane whose shell loaded (200,
+        // cross-origin) but never announced readiness was either a bundle that
+        // never ran (no `boot`) or an App that mounted and got stuck before the
+        // bridge (a `boot` with no `ready`). Journal only, no state change.
+        paneLog('boot', { id, stage: typeof data.stage === 'string' ? data.stage : 'unknown' })
       } else if (data.type === 'mc-embedded-ready') {
         // The pane just (re)mounted and asked for the current model — send it now
         // rather than waiting for the next input-driven broadcast. Also record
@@ -413,7 +448,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     }
     window.addEventListener('message', onMessage)
     return () => window.removeEventListener('message', onMessage)
-  }, [dispatch, refreshToken, canRefreshNow])
+  }, [dispatch, refreshToken, canRefreshNow, currentPortToId])
 
   // Proactive refresh: when an embedded token passes REFRESH_AT_ELAPSED_FRAC of
   // its TTL, re-mint and reload that iframe ahead of the cap. Skips the active
@@ -521,6 +556,39 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     }, PANE_LOAD_TIMEOUT_MS)
     return () => window.clearTimeout(t)
   }, [activeId, activeWarmPort, activeSeq, activeReady])
+
+  // See iframeRefCallbacks: the callback is created once per id and reused
+  // across renders, so React invokes it only on a real attach/detach. It reads
+  // the reload seq through a ref because a closure over `reloadSeq` state would
+  // force a new identity per change -- exactly the churn this avoids; Retry
+  // remounts via the element KEY, which detaches and re-attaches for real, so
+  // the seq journaled at attach time is already the new one.
+  const reloadSeqRef = useRef(reloadSeq)
+  reloadSeqRef.current = reloadSeq
+  const iframeRefFor = useCallback((id: string) => {
+    let cb = iframeRefCallbacks.current.get(id)
+    if (!cb) {
+      cb = (el: HTMLIFrameElement | null) => {
+        if (el) {
+          iframeRefs.current.set(id, el)
+          // The mount is the moment the src is committed to a live frame.
+          // An empty `src` here means srcFor found no warm entry, which is
+          // the one way the pane can end up parked on about:blank forever.
+          paneLog('iframe-mounted', {
+            id,
+            port: warmRef.current[id]?.port,
+            seq: reloadSeqRef.current[id] || 0,
+            src: safePaneUrl(el.getAttribute('src')),
+          })
+        } else {
+          iframeRefs.current.delete(id)
+          paneLog('iframe-unmounted', { id })
+        }
+      }
+      iframeRefCallbacks.current.set(id, cb)
+    }
+    return cb
+  }, [])
 
   const retry = useCallback(
     (id: string) => {
@@ -794,23 +862,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
           // reloadSeq in the key forces a remount (= reload) on Retry even when
           // the re-minted src is byte-identical to the dead frame's.
           key={`${id}:${reloadSeq[id] || 0}`}
-          ref={el => {
-            if (el) {
-              iframeRefs.current.set(id, el)
-              // The mount is the moment the src is committed to a live frame.
-              // An empty `src` here means srcFor found no warm entry, which is
-              // the one way the pane can end up parked on about:blank forever.
-              paneLog('iframe-mounted', {
-                id,
-                port: warmRef.current[id]?.port,
-                seq: reloadSeq[id] || 0,
-                src: safePaneUrl(el.getAttribute('src')),
-              })
-            } else {
-              iframeRefs.current.delete(id)
-              paneLog('iframe-unmounted', { id })
-            }
-          }}
+          ref={iframeRefFor(id)}
           title={nameFor(id)}
           src={srcFor(id)}
           // The embedded pane is the SAME SPA on the tunnel's loopback port, so

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -215,7 +215,29 @@ const appTree = (
 // localStorage read, so the usual launch renders on the same tick as before. The
 // first-time path is bounded by hydrateUiPrefs' own timeout, and a gateway that
 // never answers renders defaults rather than hanging the boot. See lib/uiPrefs.ts.
+
+// Embedded panes only: tell the parent this bundle EXECUTED, before React renders
+// anything. The parent's pane journal records `boot` for it. Without this line a
+// pane that loads its shell (a 200 the parent can see) and then never announces
+// `mc-embedded-ready` is indistinguishable from one whose bundle never ran; with
+// it the parent can tell "the entry ran but App/its bridge never mounted" from
+// "no JavaScript of ours ever executed in that frame". `stage` names how far
+// this file got. Wildcard target is safe: the payload carries no data and the
+// parent validates the origin. See EmbeddedHostBridge for the ready half.
+function announceBoot(stage: string): void {
+  if (!isEmbeddedPane()) return
+  try {
+    // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+    window.parent?.postMessage({ type: 'mc-embedded-boot', v: 1, stage }, '*')
+  } catch {
+    /* no parent reachable — the ready announce carries its own retries */
+  }
+}
+announceBoot('entry')
+
+// (See the block above announceBoot for why the first-time boot may reload.)
 function boot(startSync: boolean): void {
+  announceBoot('render')
   createRoot(document.getElementById('root')!).render(appTree)
   if (startSync) startUiPrefsSync()
 }

--- a/website/src/test/InstancesViewport.test.tsx
+++ b/website/src/test/InstancesViewport.test.tsx
@@ -1115,4 +1115,130 @@ describe('InstancesViewport', () => {
       vi.useRealTimers()
     }
   })
+
+  it('journals iframe-mounted once per real attach, not once per re-render (stable ref callback)', async () => {
+    mockConnectedCd1()
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+      const paneLines = () => info.mock.calls.map(c => String(c[0])).filter(l => l.startsWith('[pane]'))
+      const mounts = () => paneLines().filter(l => l.includes('iframe-mounted id=cd-1')).length
+      const unmounts = () => paneLines().filter(l => l.includes('iframe-unmounted id=cd-1')).length
+      expect(mounts()).toBe(1)
+      expect(unmounts()).toBe(0)
+
+      // Force several re-renders of the viewport WITHOUT touching the iframe:
+      // a host-model input (unread count) and a same-port/token warm write are
+      // both things the 10s poll and the broadcast effect do in production. An
+      // inline `ref={el => ...}` would journal an unmount+mount pair for each.
+      for (let i = 1; i <= 5; i++) {
+        act(() => {
+          window.dispatchEvent(new MessageEvent('message', {
+            data: { type: 'mc-unread-slots', count: i },
+            origin: 'http://127.0.0.1:7778',
+          }))
+        })
+        act(() => { store.dispatch(setWarm({ id: 'cd-1', conn: { port: 7778, token: 'tok' } })) })
+      }
+      await waitFor(() => expect(store.getState().instances.unread['cd-1']).toBe(5))
+      expect(mounts()).toBe(1)
+      expect(unmounts()).toBe(0)
+
+      // A real detach (the pane leaves the warm set) still journals exactly once.
+      act(() => { store.dispatch(removeWarm('cd-1')) })
+      await waitFor(() => expect(unmounts()).toBe(1))
+      expect(mounts()).toBe(1)
+    } finally {
+      info.mockRestore()
+    }
+  })
+
+  it('journals the pane bundle\'s mc-embedded-boot stages from its tunnel origin, and only from a mapped origin', async () => {
+    mockConnectedCd1()
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+      const bootLines = () => info.mock.calls.map(c => String(c[0])).filter(l => l.startsWith('[pane] boot '))
+
+      for (const stage of ['entry', 'render', 'bridge']) {
+        act(() => {
+          window.dispatchEvent(new MessageEvent('message', {
+            data: { type: 'mc-embedded-boot', v: 1, stage },
+            origin: 'http://127.0.0.1:7778',
+          }))
+        })
+      }
+      expect(bootLines()).toEqual([
+        '[pane] boot id=cd-1 stage=entry',
+        '[pane] boot id=cd-1 stage=render',
+        '[pane] boot id=cd-1 stage=bridge',
+      ])
+      // Boot is a journal line, never readiness: the overlay stays up.
+      expect(store.getState().instances.ready['cd-1']).toBeUndefined()
+      expect(screen.getByText(/Loading pane/i)).toBeInTheDocument()
+
+      // A loopback origin the parent does not map is journaled as unattributed
+      // (mirrors ready-unattributed) rather than dropped: "no boot line" must
+      // keep meaning "no JavaScript of ours ran", not "the parent lost it".
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'mc-embedded-boot', v: 1, stage: 'entry' },
+          origin: 'http://127.0.0.1:9999',
+        }))
+      })
+      expect(bootLines().length).toBe(3)
+      const unattributed = info.mock.calls.map(c => String(c[0])).filter(l => l.startsWith('[pane] boot-unattributed '))
+      expect(unattributed).toEqual(['[pane] boot-unattributed origin=http://127.0.0.1:9999 stage=entry knownPorts=7778'])
+
+      // A non-loopback origin stays silent.
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'mc-embedded-boot', v: 1, stage: 'entry' },
+          origin: 'https://example.com',
+        }))
+      })
+      expect(info.mock.calls.filter(c => String(c[0]).startsWith('[pane] boot')).length).toBe(4)
+    } finally {
+      info.mockRestore()
+    }
+  })
+
+  it('attributes a boot from a pane warmed in the same tick, before the warm effect has flushed', async () => {
+    mockConnectedCd1()
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+
+      // Warm a second pane and let its bundle announce boot inside the SAME
+      // React flush. The render has already seen the new warm entry (warmRef
+      // is assigned during render) but no passive effect keyed on `warm` has
+      // run yet -- the exact window in which an effect-populated origin map
+      // still lacks port 7790 and would drop this boot as unattributed.
+      act(() => {
+        store.dispatch(setWarm({ id: 'cd-2', conn: { port: 7790, token: 'tok2' } }))
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'mc-embedded-boot', v: 1, stage: 'entry' },
+          origin: 'http://127.0.0.1:7790',
+        }))
+      })
+      const lines = info.mock.calls.map(c => String(c[0])).filter(l => l.startsWith('[pane] boot'))
+      expect(lines).toContain('[pane] boot id=cd-2 stage=entry')
+      expect(lines.some(l => l.startsWith('[pane] boot-unattributed'))).toBe(false)
+    } finally {
+      info.mockRestore()
+    }
+  })
+
 })


### PR DESCRIPTION
## Problem / Motivation

A remote crew pane (`suneo`) sat on **Loading pane…** for 40+ minutes. Every signal the parent could see said the pane was healthy: the tunnel was up, the shell answered `frame navigated status=200`, the frame was a live `cross-origin` document, and the host-model broadcast was delivered. The one message that never arrived was `mc-embedded-ready`.

The pane journal could not say why. Two gaps caused that, and one of them sent the investigation the wrong way.

## Why it matters

A pane that never boots looks the same in the logs as a pane that boots fine. Anyone debugging a stuck remote crew today reads 600+ fake `iframe-unmounted` / `iframe-mounted` lines and chases a remount storm that does not exist. Meanwhile the real question (did the pane's own JavaScript ever run?) has no line in any log.

## What changed (motivation → approach → change)

The `iframe-mounted` / `iframe-unmounted` lines were wrong. They lived inside an inline `ref={el => …}`. React 18 calls the old callback with `null` and the new callback with the same, never-detached element on every re-render. So each 10-second poll and each host-model broadcast printed an unmount+mount pair for every warm pane, in lockstep across all four panes. `gateway-launch.log` then hit `PANE_REPEAT_LIMIT` and hid the repeats.

The fix caches the ref callback per pane id. React now calls it only on a real attach or detach. The reload sequence is read through a ref, so the callback identity never depends on it. Retry still remounts through the element `key`, which is a real detach.

The second change adds a boot journal. The pane posts `mc-embedded-boot` with a `stage` at three points: `entry` (main.tsx evaluated), `render` (about to `createRoot`), and `bridge` (App tree reached `EmbeddedHostBridge`). The parent journals `[pane] boot id=… stage=…` for a mapped tunnel origin. The origin-to-pane map is read from the Redux store at message time, not from an effect-refreshed copy. A fast iframe can post `entry` before the parent's effects have run, and the store is already current then. A loopback boot the parent still cannot map is journaled as `[pane] boot-unattributed origin=… stage=… knownPorts=…`, the same shape `ready-unattributed` already has. So "no `boot` line" keeps meaning "no JavaScript of ours ran". This is journal-only and changes no state. Reading it:

| journal shows | meaning |
|---|---|
| `iframe-load frame=cross-origin`, no `boot` | the shell's module script never ran in that frame |
| `boot stage=render`, no `stage=bridge` | the tree was swallowed between main.tsx and App (prerequisite gate / provider / error boundary) |
| `stage=bridge`, no `ready` | the handshake itself is being dropped |

## Tests

- A re-render burst (5× `mc-unread-slots` plus a same-token `setWarm`) journals **1** mount and **0** unmounts. The same test records **11** mounts against the old inline ref, so it reproduces the bug.
- A real `removeWarm` journals exactly one unmount.
- The three boot stages journal from a mapped origin. An unmapped loopback origin journals `boot-unattributed`; a non-loopback origin stays silent.
- A boot posted in the same tick as the `setWarm` that maps its port is attributed. The same test fails on the effect-refreshed map, so it pins the race.
- `InstancesViewport` 35/35, viewport/pane/embedded suites 159 files / 2600 tests, `tsc --noEmit` clean, eslint clean.

## Manual verification

Still required: deploy this build to a local dashboard that has a stuck remote pane and read `~/Library/Logs/Kiro Crew/chromium.log` for the `boot` line. The stage it stops at names the cause. This PR does not yet explain why `suneo` never announces readiness; it makes the next capture able to.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the diff changes only console journal lines and a ref-callback identity; every rendered pixel is identical before and after.

## Related Issues

no linked issue: found during a live incident investigation, no tracking issue was filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: journal/telemetry lines inside an inline React `ref={el => …}` callback fire on every re-render (null then same element), so they report lifecycle events that did not happen; cache the callback per key or journal from an effect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-facing doc describes the pane journal
- [x] No secrets, credentials, or internal references in the diff
