### PR TITLE
fix(acp): classify prose-spelled dispatch failure as transient

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1810,9 +1810,12 @@ _RE_AUTH = re.compile(
     r"\b(AccessDenied(?:Exception)?|UnauthorizedException|ExpiredToken(?:Exception)?"
     r"|InvalidSignatureException|UnrecognizedClientException)\b"
 )
+_5XX_SEP = r"[ \t_-]?"
 _RE_5XX_NAMED = re.compile(
-    r"\b(InternalServerError|InternalFailure|ServiceUnavailable(?:Exception)?"
-    r"|DispatchFailure|ConnectionReset(?:Error)?)\b"
+    rf"\b(internal{_5XX_SEP}server{_5XX_SEP}error|internal{_5XX_SEP}failure"
+    rf"|service{_5XX_SEP}unavailable(?:{_5XX_SEP}exception)?"
+    rf"|dispatch{_5XX_SEP}failure|connection{_5XX_SEP}reset(?:{_5XX_SEP}error)?)\b",
+    re.IGNORECASE,
 )
 _RE_5XX_STATUS = re.compile(r"(?:HTTP|status)\s*(?:code\s*)?(?:50[0234]|529)\b", re.IGNORECASE)
 # Genuine retry hint only. "response stream" is deliberately NOT matched here,

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -9172,6 +9172,88 @@ class TestIsTransientRawError:
             is False
         )
 
+    def test_prose_spelled_dispatch_failure_is_transient(self):
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        # The AWS Rust SDK spells ONE connector fault two ways: the Debug repr
+        # is CamelCase (DispatchFailure) and the Display impl is prose
+        # ("dispatch failure"). kiro-cli surfaces whichever the failing layer
+        # produced. While the pattern was CamelCase-only and case-SENSITIVE the
+        # prose form read as an unknown shape and was classified TERMINAL, so
+        # every affected turn surfaced a bare error on the FIRST attempt and no
+        # retry ladder ever ran.
+        err = {
+            "code": -32603,
+            "message": "Internal error",
+            "data": (
+                "Encountered an error in the response stream: "
+                "An unknown error occurred: dispatch failure"
+            ),
+        }
+        assert _is_transient_raw_error(err) is True
+        # The CamelCase spelling keeps classifying identically.
+        assert _is_transient_raw_error({"data": "DispatchFailure ConnectionReset"}) is True
+        # Same two-spelling split for the sibling connector fault.
+        assert _is_transient_raw_error({"data": "connection reset by peer"}) is True
+
+    def test_bare_internal_error_stays_terminal(self):
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        # -32603's canonical message is literally "Internal error". The
+        # separator tolerance loosens only the gaps BETWEEN words, never the
+        # tokens, so this still matches nothing (no "server", no "failure") and
+        # keeps falling through to the unknown-shape branch instead of being
+        # mis-told to retry a condition that will never succeed.
+        assert (
+            _is_transient_raw_error(
+                {"code": -32603, "message": "Internal error", "data": "Input is too long"}
+            )
+            is False
+        )
+
+    def test_terminal_branches_outrank_a_co_occurring_dispatch_failure(self):
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        # Every terminal branch is checked BEFORE the 5xx family, so widening
+        # the 5xx pattern must not let a connector token rescue an error that
+        # can only be reproduced by retrying it.
+        for data in (
+            "You've reached your monthly usage limit. dispatch failure",
+            "dispatch failure: session expired",
+            "AccessDeniedException dispatch failure",
+            "Improperly formed request dispatch failure",
+        ):
+            assert _is_transient_raw_error({"data": data, "message": ""}) is False
+
+    def test_prose_dispatch_failure_reaches_the_retry_decider(self):
+        import pytest
+
+        from kiro_crew.acp.client import AcpError, _raise_acp_error
+        from kiro_crew.llm_helpers import acp_error_is_transient
+
+        # The classifier and the retry decider are two different layers, and
+        # the gap between them is what broke: acp_error_is_transient prefers the
+        # structured AcpError.transient flag and consults its string markers
+        # ONLY when no flag is present. _TRANSIENT_MARKERS already listed the
+        # prose spellings, so a transient=False flag made that list unreachable
+        # dead code on this path. Assert the end-to-end verdict, not just the
+        # classifier, or the next regex edit silently reintroduces this.
+        err = {
+            "code": -32603,
+            "message": "Internal error",
+            "data": (
+                "Encountered an error in the response stream: "
+                "An unknown error occurred: dispatch failure"
+            ),
+        }
+        with pytest.raises(AcpError) as ei:
+            _raise_acp_error(err)
+        exc = ei.value
+        assert exc.transient is True
+        assert acp_error_is_transient(exc) is True
+        # The raw provider text is replaced by the actionable 5xx wording.
+        assert "transient error (HTTP 5xx)" in str(exc)
+
     def test_raise_acp_error_carries_transient_flag_and_formatted_message(self):
         import pytest
 


### PR DESCRIPTION
kiro-cli surfaces the AWS SDK connector error in two spellings: the Rust Debug repr (DispatchFailure) and the Display prose ("dispatch failure"). _RE_5XX_NAMED matched only the CamelCase form, case-sensitively, so a frame carrying the prose form fell through to the terminal default and AcpError was raised with transient=False.

That flag outranks the llm_helpers string-marker fallback, which already listed the prose spellings but is only consulted when no structured verdict exists. The markers were therefore dead on this path and no retry ladder fired -- every affected turn surfaced a bare error on the first attempt.

Make the pattern separator- and case-tolerant so both spellings of one fault classify identically. The separator loosens only the gaps between words, so a bare -32603 ("Internal error") still matches nothing and keeps falling through to the unknown-shape branch.

<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Every chat turn fails immediately with `❌ An unknown error occurred: dispatch failure`.
The gateway log shows it repeatedly:

```
WARNING kiro_crew.dashboard.chat_runner: ACP error in slot chat-1-...:
[AcpError] An unknown error occurred: dispatch failure
```

The raw JSON-RPC frame is:

```python
{"code": -32603, "message": "Internal error",
 "data": "Encountered an error in the response stream: An unknown error occurred: dispatch failure"}
```

`dispatch failure` is the AWS Rust SDK's connector-level error inside `kiro-cli`
(DNS, TLS, proxy, or a dropped connection) — the request never reached the
backend. The trigger is environmental, but what turned a retryable blip into an
instant hard failure on every turn is a classifier bug that is present
regardless of the network.

## Why it matters

A momentary connector-level fault — the most retry-worthy class of failure there
is — is reported to the user as a hard failure on the first attempt, with no
retry. Because every surface routes through the same classifier, this affects the
dashboard, Slack, cron, subagents and tips alike. Users see an unactionable raw
provider string instead of a recovered turn.

## What changed (motivation → approach → change)

**Symptom:** the frame above is classified terminal, so no retry ladder fires.

**Root cause:** `_RE_5XX_NAMED` in `src/kiro_crew/acp/client.py` was CamelCase-only
and case-sensitive. The Rust SDK spells one fault two ways — the `Debug` repr is
`DispatchFailure`, the `Display` impl is the prose `dispatch failure` — and
kiro-cli surfaces whichever the failing layer produced. The prose form matched
nothing, so:

1. `_is_transient_raw_error` fell through to its terminal default → `False`.
2. `_raise_acp_error` constructed `AcpError(formatted, transient=False)`.
3. `llm_helpers.acp_error_is_transient` prefers the structured `.transient` flag
   and consults its string markers *only when the flag is absent*. A `False` flag
   is authoritative.
4. `llm_helpers._TRANSIENT_MARKERS` — which already lists both `"dispatch failure"`
   and `"dispatchfailure"` — was therefore unreachable dead code on this path.

This is exactly the formatter/verdict drift the module's own comments say the
shared-pattern design exists to prevent. Notably the repo already had a *passing*
test, `test_llm_helpers.py::test_dispatch_failure_is_transient`, asserting this
exact frame is transient — it exercises only the string layer, which production
never reaches.

**Change:** make `_RE_5XX_NAMED` separator- and case-tolerant so both spellings of
one fault classify identically. Fixed at the classifier, not the decider:
making `acp_error_is_transient` OR the two layers would resurrect retries for
terminal errors the marker list happens to match (monthly-limit, unentitled-model),
which is what the flag's precedence was introduced to stop.

The separator loosens only the gaps *between* words, never the tokens, so a bare
uncaught `-32603` (canonical message `Internal error` — no "server", no "failure")
still matches nothing and keeps falling through to the unknown-shape branch.

This makes the fault **recoverable, not absent**: if the network path is genuinely
broken the retries exhaust and the user still gets an error, after backoff and
with a clearer message.

## Tests

Four cases added to `TestIsTransientRawError` in `test/test_acp_client.py`:

- `test_prose_spelled_dispatch_failure_is_transient` — the exact reported frame
  classifies transient; the CamelCase spelling still does; prose
  `connection reset by peer` (also previously missed) does too.
- `test_bare_internal_error_stays_terminal` — a bare `-32603` carrying
  `Internal error` / `Input is too long` stays terminal, pinning that the
  separator tolerance did not loosen the tokens themselves.
- `test_terminal_branches_outrank_a_co_occurring_dispatch_failure` — usage limit,
  session expired, `AccessDeniedException` and `Improperly formed request` all stay
  terminal even with `dispatch failure` co-occurring in the same frame.
- `test_prose_dispatch_failure_reaches_the_retry_decider` — end-to-end through
  `_raise_acp_error` + `llm_helpers.acp_error_is_transient`. This is the assertion
  that actually pins the reported bug: the classifier and the decider are two
  different layers, and the gap between them is what broke.

Reverting only `client.py` fails exactly the two bug-pinning tests (prose spelling,
end-to-end decider) and leaves the two guard-rail tests green, which is the
intended split.

## Manual verification

On the reported frame, before the change:

```
_RE_5XX_NAMED match            : None
_is_transient_raw_error        : False
llm_helpers string classifier  : True    # markers list, unreachable
acp_error_is_transient (used)  : False
```

After:

```
_is_transient_raw_error        : True
acp_error_is_transient (used)  : True
_format_acp_error              : "The model backend hit a transient error (HTTP 5xx).
                                  This is usually momentary — retry in a moment. If it
                                  keeps happening, switch to a different model in the picker."
```

Test groups run locally:

- `test_acp_client.py` + `test_acp_client_more_coverage.py` — 719 passed
- `test_acp_error_surface.py` + `test_acp_true_provider_error.py` + `test_llm_helpers.py` — 193 passed
- `test_dashboard_chat.py` + `test_llm_helpers_tool_gate.py` + `test_session_health.py` — 789 passed
- a broader sweep of all 224 test files referencing the transient classifier — 21249 passed

`black`, `flake8` and `mypy` clean on the changed files.

## Related Issues

<!-- Add "Fixes #N" here if you opened an issue for this first. -->

## Pattern harvest

```
Rule candidate: review-prompt
Pattern: a structured verdict that takes precedence over a string-matching
fallback, where the fallback enumerates spellings the structured matcher
cannot match — making the fallback silently dead code and the verdict
authoritative-but-wrong.
```

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: `docs/system-specs/modules/providers.md`
      already documents DispatchFailure / ConnectionReset as transient under
      "Interactive transient-5xx retry". This change makes the code match what the
      doc already claimed, so there is no documented behavior to update.
- [x] No secrets, credentials, or internal references in the diff


## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
