### PR TITLE
feat: security-conductor evaluator scripts (scope_check, finding_entry, verify_finding)

### DIFF
--- a/docs/request-for-change/rfc-security-conductor.md
+++ b/docs/request-for-change/rfc-security-conductor.md
@@ -32,7 +32,7 @@ reports upward. It never touches a target itself.
 Three child roles:
 
 - **Auditor** — one per attack surface. Static review plus a unit-test-level proof of concept in a
-  local sandbox. Emits one structured finding file per candidate. Runs the installed
+  disposable local checkout. Emits one structured finding file per candidate. Runs the installed
   `security-assistance` (ARCC) skill before starting, so governance search happens before any probe.
 - **Verifier** — one per finding, independently re-runs the PoC. It exists specifically to reject
   false positives. Hallucinated vulnerabilities are the dominant noise source in agentic security
@@ -109,6 +109,55 @@ Registered alongside `kirocrew-pipeline-conductor` in `UNADVERTISED_AGENTS`
 (`src/kiro_crew/subagent.py`), with its own filename constant in `src/kiro_crew/agent_files.py` and
 its own installer in `src/kiro_crew/agent.py`, mirroring the existing installer tests.
 
+## The trust boundary
+
+Every containment claim below is bounded by one fact: the verifier runs as the operator, on the
+operator's machine, against a checkout the operator chose. There is no privilege drop between the
+two. A checkout that can execute code already has everything the verifier has, so a defense against
+a hostile checkout defends a boundary that does not exist. This RFC therefore draws the boundary in
+one place and states plainly what falls outside it.
+
+**Trusted, for host integrity: the target checkout.** Its code runs as the operator, and this
+design does not defend the operator's machine from code the operator chose to check out — a
+symlink out of the tree, a detached process, a report the checkout's own code rewrote. Those are
+the operator attacking themselves, and no privilege drop exists to stop it.
+
+**Defended regardless: verdict integrity.** Trusting the checkout with the host is not trusting
+its exit status or its stdout with the verdict. A test suite that exits 1 because collection failed,
+a `conftest.py` that prints `1 failed`, a command that dies on a missing import — none of these is a
+reproduction, and the verifier reads its verdict from a structured report keyed to the requested
+test, or from a deliberate exit status, precisely so that ordinary breakage cannot confirm a
+finding. That discipline is about false positives, not about adversaries, and it stays.
+
+**Untrusted: the auditor's finding.** The proof of concept is model-authored text, and the
+conductor ingests it on unattended cycles. Screening it against the `forbidden` rules of engagement
+before execution is the mechanism that makes "not too aggressive" checkable, and it stays. It is a
+named-shape screen, and this RFC says plainly what that does and does not bound: it catches the
+sloppy PoC -- an auditor that reaches for `curl`, names a credential path, or writes outside the
+worktree -- and it does not catch an adversarially crafted one, because a `cmd::` proof is an
+arbitrary program and `python -c` with `urllib` names none of the screened words. What bounds that
+case is not this script. It is the two layers the RFC already places around it: the auditor is a
+Kiro Crew session and its PoC is written under the session's own tool gate and, where the host
+provides one, its sandbox; and the verifier runs as the operator's session, inheriting the same
+containment the operator granted that session. A `cmd::` proof therefore executes with exactly the
+privileges the operator gave the crew, no more. For the dogfood pilot -- the operator auditing the
+operator's own repository -- that is the accepted bound. An operator who wants a stricter one has
+two levers without any change here: disallow `cmd::` in the rules of engagement so only `pytest::`
+proofs file, or run the crew under the host sandbox. A future RFC may add attended confirmation for
+first-run `cmd::` proofs; this one does not.
+
+**Containment is a disposable worktree plus a deadline, not an OS sandbox.** The verifier refuses a
+`--worktree` that is not a git checkout, refuses the checkout it is itself running from, bounds the
+proof's wall time, and reaps the process it started. It does not attempt kernel-level isolation.
+Kiro Crew's own namespace sandbox is Linux-only and package-internal, and these scripts are
+standard-library files with no package import, so reaching for it would trade a cross-platform
+verifier for a Linux one. Where those two conflict, cross-platform wins.
+
+**Out of scope, explicitly.** A verifier pointed at a checkout the operator did not author —
+auditing a third party's repository, or a branch from an untrusted pull request — is not a supported
+use. Nothing in this design contains such a tree, and a finding that assumes one is out of scope
+rather than unfixed.
+
 ## The harness
 
 Deliverables, following the four-piece shape the pipeline conductor ships:
@@ -121,8 +170,9 @@ Deliverables, following the four-piece shape the pipeline conductor ships:
    `UNKNOWN`, never permission. The conductor decides scope with this script, not by judgment.
 3. **`scripts/finding_entry.py`** — dedupe and format. One finding per real defect, so a surface
    re-audited later does not re-file what is already recorded.
-4. **`scripts/verify_finding.py`** — re-run one finding's PoC in the sandbox and emit the verdict.
-   The conductor reads the verdict; it never reads a verifier's prose and decides for itself.
+4. **`scripts/verify_finding.py`** — re-run one finding's PoC in a disposable worktree under a
+   deadline (see the trust boundary above) and emit the verdict. The conductor reads the verdict;
+   it never reads a verifier's prose and decides for itself.
 5. **`scripts/ledger.py`** — the ledger CLI: init schema, add finding, record verdict, propose a
    lesson, approve a lesson, export the rules-of-engagement JSON, list. This is also the human's
    editing surface (see the learning section).

--- a/src/kiro_crew/builtin_skills/security-conductor/scripts/finding_entry.py
+++ b/src/kiro_crew/builtin_skills/security-conductor/scripts/finding_entry.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""File one finding against the ledger: validate its shape, then dedupe it.
+
+One record per real defect. A surface re-audited in a later round must not
+re-file what is already recorded, so this script never inserts blindly: it hands
+the candidate to ``ledger.add_finding``, whose identity is
+``(surface, title, sorted paths)`` and which returns the EXISTING id on a hit.
+
+Usage::
+
+    python3 finding_entry.py [--db PATH] [--roe-json PATH] --json-file FINDING.json
+
+One input shape. The RFC has the auditor "emit one structured finding file per
+candidate", and that file is what this reads. An inline-flag spelling shipped
+beside it for a while with no consumer -- SKILL.md never invoked it -- and the
+two modes' mutual exclusion produced its own defect (a `--round-id` that was
+neither honoured nor refused), so the second spelling is gone.
+
+
+Exit codes::
+
+    0  filed -- a new finding, and ``created`` is true
+    3  duplicate -- nothing written, and the EXISTING id is still printed
+    2  invalid input -- nothing written
+
+stdout is one JSON object, ``{"finding_id": N, "created": true|false}``, on the
+success and the duplicate path alike. A duplicate prints the id because the
+caller's next step (dispatch a verifier, cite it in a report) needs the handle,
+and making it parse stderr for it would be the same information behind a worse
+contract.
+
+**Why a malformed finding fails HERE and not later.** ``report_schema`` in the
+rules of engagement names the fields a finding must carry, and the verifier pass
+is the whole product -- so every requirement below exists because the record is
+useless to a verifier without it:
+
+- ``severity`` must be a level ``severity_scale`` names. A grade invented
+  outside the scale cannot be adjudicated, and severity is what drives the fixer
+  gate. When no ``severity_scale`` rule can be read, that is a REFUSAL (exit 2),
+  not a pass: an unvalidatable grade is exactly what the scale exists to stop.
+- ``poc`` must be present and must be a shape ``verify_finding.py`` can run.
+  The check is that script's OWN parser, loaded as a sibling rather than a second
+  list of prefixes here -- write-time validation and the verifier then cannot
+  drift apart, so adding a third proof shape cannot leave this script rejecting
+  what the verifier runs.
+- At least one entry in ``paths``, because the paths are part of the dedupe identity and
+  of after-the-fact scope checking.
+
+Reads and writes one SQLite file through ``ledger.py``. No network, no
+subprocess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+from collections.abc import Buffer
+from pathlib import Path
+from typing import Any, Sequence
+
+EXIT_OK = 0
+EXIT_INVALID = 2
+EXIT_DUPLICATE = 3
+
+JSON_FIELDS = ("surface", "severity", "title", "paths", "poc", "round_id")
+JSON_REQUIRED = ("surface", "severity", "title", "paths", "poc")
+
+SEVERITY_FIELD = "severity_scale"
+
+
+class _NoBytecodeSourceLoader(importlib.machinery.SourceFileLoader):
+    """Load shipped source normally while suppressing cache writes."""
+
+    def get_code(self, fullname: str) -> Any:
+        path = self.get_filename(fullname)
+        source = self.get_data(path)
+        return self.source_to_code(source, path)
+
+    def set_data(self, path: str, data: Buffer, *, _mode: int = 0o666) -> None:
+        return None
+
+
+def load_sibling(filename: str, module_name: str) -> Any:
+    """Load a script beside this one without cwd, sys.path or bytecode effects.
+
+    Mirrors ``prepare-pr/scripts/pr_status.py``: a skill's scripts are synced out
+    of the package tree and run as bare files, so a sibling is a file next to
+    this one rather than an importable module, and importing it the ordinary way
+    would drop a ``__pycache__`` entry into the checked-out tree.
+    """
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
+    loader = _NoBytecodeSourceLoader(module_name, path)
+    spec = importlib.util.spec_from_loader(module_name, loader)
+    if spec is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"cannot import {filename}: {path}")
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+# scope_check is the reader of record for the rules of engagement -- rows first,
+# export only when there are no rows. Reusing it means the severity scale is
+# resolved by exactly the same precedence as a scope verdict, instead of by a
+# second implementation that could disagree with it.
+_scope_check = load_sibling("scope_check.py", "_security_conductor_scope_check")
+# verify_finding owns the proof shapes, because it is what runs them.
+_verify_finding = load_sibling("verify_finding.py", "_security_conductor_verify_finding")
+# Both siblings load the ledger lazily, so this shares ONE instance with them
+# rather than executing ledger.py again in the same invocation.
+_ledger = _scope_check.ledger()
+
+
+def severity_label(rule_value: str) -> str:
+    """The level named by a ``severity_scale`` value.
+
+    A scale row reads ``"High: privilege escalation, ..."`` -- a level and its
+    definition in one string, because the definition is what an adjudicator
+    grades against. The comparable part is the label before the first colon.
+    """
+    head = rule_value.split(":", 1)[0]
+    return head.strip().lower()
+
+
+def known_severities(rules: Sequence[Any]) -> list[str]:
+    """Every level the scale names, in the order the rules gave them."""
+    labels: list[str] = []
+    for rule in rules:
+        if rule.field != SEVERITY_FIELD:
+            continue
+        label = severity_label(rule.value)
+        if label and label not in labels:
+            labels.append(label)
+    return labels
+
+
+def has_auditor_verdict(conn: Any, finding_id: int) -> bool:
+    """Whether this finding already carries the auditor's own claim.
+
+    Asked of the ``verdicts`` rows rather than of ``findings.auditor_verdict``,
+    because that column is a fold of these rows and this is the thing being
+    folded -- reading the summary to decide whether to write the detail would
+    invert the direction the ledger maintains it in.
+    """
+    row = conn.execute(
+        "SELECT 1 FROM verdicts WHERE finding_id = ? AND role = 'auditor' LIMIT 1",
+        (finding_id,),
+    ).fetchone()
+    return row is not None
+
+
+def validate_poc(poc: str) -> str | None:
+    """``None`` when the verifier can run this PoC, else why it cannot."""
+    if not poc.strip():
+        return "poc must not be blank; a finding with no proof cannot be verified"
+    if _verify_finding.poc_argv(poc) is None:
+        shapes = ", ".join(_verify_finding.POC_PREFIXES)
+        return f"poc must be a shape verify_finding.py can run ({shapes}<...>); got {poc!r}"
+    return None
+
+
+class Candidate:
+    """A finding as asked for, before the ledger has seen it."""
+
+    def __init__(
+        self,
+        *,
+        surface: str,
+        severity: str,
+        title: str,
+        paths: Sequence[str],
+        poc: str,
+        round_id: str | None,
+    ) -> None:
+        self.surface = surface.strip()
+        self.severity = severity.strip()
+        self.title = title.strip()
+        self.paths = [item for item in (p.strip() for p in paths) if item]
+        self.poc = poc.strip()
+        self.round_id = (round_id or "").strip() or None
+
+    def problems(self, severities: Sequence[str]) -> list[str]:
+        """Every reason this candidate is not a filable finding."""
+        found: list[str] = []
+        for name, value in (
+            ("surface", self.surface),
+            ("title", self.title),
+            ("severity", self.severity),
+        ):
+            if not value:
+                found.append(f"{name} must not be blank")
+        if not self.paths:
+            found.append("at least one path is required; paths are part of a finding's identity")
+        poc_problem = validate_poc(self.poc)
+        if poc_problem is not None:
+            found.append(poc_problem)
+        if self.severity:
+            if not severities:
+                found.append(
+                    "the rules of engagement name no severity_scale, so a severity cannot be"
+                    " validated; add the scale as a rule before filing findings"
+                )
+            elif self.severity.lower() not in severities:
+                found.append(
+                    f"severity {self.severity!r} is not in the severity_scale"
+                    f" ({', '.join(severities)})"
+                )
+        return found
+
+
+def candidate_from_json(path: Path) -> Candidate:
+    """Read a candidate from a JSON file. Raises ``ValueError`` when malformed."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    unknown = sorted(set(payload) - set(JSON_FIELDS))
+    if unknown:
+        # Refused rather than ignored: a typo'd key is silently dropped data,
+        # and the field it meant to set is one report_schema asked for.
+        raise ValueError(f"{path}: unknown field(s) {', '.join(unknown)}")
+    missing = [name for name in JSON_REQUIRED if payload.get(name) in (None, "", [])]
+    if missing:
+        raise ValueError(f"{path}: missing required field(s) {', '.join(missing)}")
+    paths = payload["paths"]
+    if isinstance(paths, str):
+        paths = [paths]
+    if not isinstance(paths, list) or not all(isinstance(item, str) for item in paths):
+        raise ValueError(f"{path}: 'paths' must be a string or a list of strings")
+    for name in ("surface", "severity", "title", "poc"):
+        if not isinstance(payload[name], str):
+            raise ValueError(f"{path}: {name!r} must be a string")
+    round_id = payload.get("round_id")
+    if round_id is not None and not isinstance(round_id, str):
+        raise ValueError(f"{path}: 'round_id' must be a string")
+    return Candidate(
+        surface=payload["surface"],
+        severity=payload["severity"],
+        title=payload["title"],
+        paths=paths,
+        poc=payload["poc"],
+        round_id=round_id,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="File one finding against the ledger (deduped)")
+    parser.add_argument("--db", default=None, help="ledger path (default: data home)")
+    parser.add_argument(
+        "--roe-json",
+        default=None,
+        help="rules-of-engagement export to fall back to (default: beside the skill)",
+    )
+    parser.add_argument("--json-file", required=True, help="the finding to file, as a JSON file")
+    return parser
+
+
+def _refuse(reasons: Sequence[str]) -> int:
+    for reason in reasons:
+        print(reason, file=sys.stderr)
+    return EXIT_INVALID
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        candidate = candidate_from_json(Path(args.json_file))
+    except ValueError as exc:
+        return _refuse([str(exc)])
+
+    db_path = Path(args.db) if args.db else _ledger.default_db_path()
+    roe_json = Path(args.roe_json) if args.roe_json else _scope_check.default_roe_json()
+    rules, failure = _scope_check.load_rules(db_path, roe_json, _ledger)
+    if failure is not None:
+        # No readable rules means no readable scale, and an unvalidatable
+        # severity is the one thing the scale exists to prevent.
+        return _refuse(failure.reasons)
+
+    problems = candidate.problems(known_severities(rules))
+    if problems:
+        return _refuse(problems)
+
+    conn = _ledger.connect(db_path)
+    try:
+        _ledger.init_schema(conn)
+        finding_id, created = _ledger.add_finding(
+            conn,
+            surface=candidate.surface,
+            title=candidate.title,
+            severity=candidate.severity,
+            paths=candidate.paths,
+            poc=candidate.poc,
+            round_id=candidate.round_id,
+        )
+        # Filing IS the auditor's claim that the defect is real, and
+        # ``findings.auditor_verdict`` is a materialised view of the verdict rows,
+        # so a finding with no row leaves that column NULL and makes an auditor's
+        # claim indistinguishable from an absent one. The retrospective reads the
+        # disagreement between this row and the verifier's as the round's
+        # false-positive signal, which the procedure obliges the conductor to
+        # report.
+        #
+        # Written on the ABSENCE of the row rather than on `created`, which makes
+        # filing idempotent and self-repairing. `add_finding` commits on its own,
+        # so a crash between the insert and this write is possible and would
+        # otherwise be permanent: the retry returns the existing id as a duplicate
+        # and, keyed on `created`, would skip the repair forever. Keyed on the
+        # row, the retry completes the record. A finding that already carries an
+        # auditor verdict is left exactly as it is, so a re-report never stacks a
+        # second claim or overwrites a human's.
+        # The absence check and the insert run under ONE write lock. Two
+        # parallel filings of the same defect both saw "no auditor row" and both
+        # appended one; BEGIN IMMEDIATE makes the second wait for the first's
+        # commit and then observe the row. record_verdict's own `with conn:`
+        # commits this transaction.
+        conn.execute("BEGIN IMMEDIATE")
+        if has_auditor_verdict(conn, finding_id):
+            conn.execute("COMMIT")
+        else:
+            _ledger.record_verdict(
+                conn,
+                finding_id=finding_id,
+                role="auditor",
+                verdict="confirmed",
+                reason="filed by the auditor as a real defect",
+            )
+    finally:
+        conn.close()
+
+    print(json.dumps({"finding_id": finding_id, "created": created}, sort_keys=True))
+    if not created:
+        print(
+            f"finding {finding_id} already records this defect"
+            f" ({candidate.surface} / {candidate.title}); nothing was written",
+            file=sys.stderr,
+        )
+        return EXIT_DUPLICATE
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kiro_crew/builtin_skills/security-conductor/scripts/scope_check.py
+++ b/src/kiro_crew/builtin_skills/security-conductor/scripts/scope_check.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""Is this repository, path or technique inside the rules of engagement?
+
+The conductor decides scope with this script, never by its own judgment about
+what seems reasonable: a tone instruction degrades silently across a long
+session, and a scope verdict is testable. **Exit codes are the interface** --
+stdout carries the reasons, the exit code carries the answer:
+
+===  ==================  ================================================
+  0  ``IN_SCOPE``        every asked-about item is covered by an active rule
+ 10  ``OUT_OF_SCOPE``    a ``forbidden`` rule matched, or an item is covered
+                         by no ``scope`` / ``allowed_techniques`` rule
+ 20  ``UNKNOWN``         no rules, an unreadable database, a rule this script
+                         cannot interpret, or nothing asked
+ 30  ``NEEDS_APPROVAL``  a technique the ``human_approval`` gate names
+===  ==================  ================================================
+
+``UNKNOWN`` IS NEVER PERMISSION. It is a distinct nonzero code rather than a
+flavour of zero precisely so a caller that only checks ``rc == 0`` cannot read
+"I could not tell" as "go ahead". ``NEEDS_APPROVAL`` is nonzero for the same
+reason: the gate is held by not proceeding, and only a human lifts it.
+
+Usage::
+
+    python3 scope_check.py [--db PATH] [--roe-json PATH] \\
+        [--repo NAME] [--path P ...] [--technique T ...]
+
+Where the rules come from. The ACTIVE ``roe_rules`` rows are the source of
+truth, read straight out of the ledger (``ledger.py``, ``--db`` overriding
+``ledger.default_db_path()``). ``rules-of-engagement.json`` beside the skill is
+an EXPORT, so it is consulted ONLY when the database holds zero rule ROWS, and
+that substitution is announced on stderr -- a scope answer that came from a file
+somebody could edit without leaving a row behind should say so out loud.
+
+Two things are NOT fallback triggers, because neither says the ledger is empty:
+
+- **An unreadable database.** It told us nothing, so the answer is ``UNKNOWN``.
+- **Rows that exist with none active.** That is the RFC's revert path -- a bad
+  rule is undone by flipping ``active``, not by deleting it -- so reading it as
+  "no rules" and consulting the export restored the very scope the revert
+  removed. Every rule revoked means there is no scope to check against:
+  ``UNKNOWN``.
+
+The value grammar this script can interpret, and nothing else:
+
+``repo:<name>``
+    Matches ``--repo`` exactly, case-insensitively.
+``path:<prefix>``
+    Matches a ``--path`` that IS the prefix or sits under it, compared by whole
+    path segment so ``path:src`` never covers ``srcfoo``. The query is
+    normalised first, so ``src/../../etc/passwd`` cannot borrow ``src/``'s
+    coverage.
+``technique:<slug>`` or a bare slug
+    A technique. In ``allowed_techniques`` and ``human_approval`` -- the two
+    fields that GRANT -- those two forms are the ONLY interpretable ones: a
+    ``repo:`` or ``path:`` value there is malformed, and since the matcher
+    compares the value with its prefix stripped, reading one anyway let
+    ``path:network-egress`` authorise the technique ``network-egress``.
+
+**A rule that PERMITS is matched exactly; only a rule that REFUSES is matched by
+containment.** ``allowed_techniques`` and ``human_approval`` need whole-value
+equality, because containment there let a fragment stand in for the whole:
+``--technique unit`` matched the allowed ``local-unit-poc`` and came back
+``IN_SCOPE`` for a technique no rule authorises. ``forbidden`` keeps containment,
+since its values are negative phrases -- ``no-network-egress-from-a-poc`` -- and
+matching ``--technique network-egress`` against it is the point. The asymmetry is
+the invariant: widening only ever widens what is refused.
+
+``severity_scale`` and ``report_schema`` rows are not scope inputs; they are
+skipped, and their presence never makes a verdict ``UNKNOWN``. Any OTHER field
+name, and any value whose form is not above, is a rule this script cannot
+interpret -- recorded and reported, never guessed at.
+
+Precedence, in evaluation order:
+
+1. a ``forbidden`` match, which no other rule trades against;
+2. no interpretable rules at all -- there is nothing to check against;
+3. an item no rule covers;
+4. a ``human_approval`` technique -- the gate holds even when an
+   ``allowed_techniques`` row also names it, because a gate any allow row can
+   neutralise is not a gate;
+5. a rule that could not be interpreted;
+6. otherwise in scope.
+
+Reads one SQLite file (SELECT only) or one JSON file. No network, no subprocess,
+and no write anywhere -- including no creation of an absent database, so asking
+a scope question never leaves a ledger behind.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import json
+import os
+import posixpath
+import re
+import sys
+from collections.abc import Buffer
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+IN_SCOPE = "IN_SCOPE"
+OUT_OF_SCOPE = "OUT_OF_SCOPE"
+UNKNOWN = "UNKNOWN"
+NEEDS_APPROVAL = "NEEDS_APPROVAL"
+
+EXIT_CODES = {
+    IN_SCOPE: 0,
+    OUT_OF_SCOPE: 10,
+    UNKNOWN: 20,
+    NEEDS_APPROVAL: 30,
+}
+
+SCOPE_FIELD = "scope"
+ALLOWED_FIELD = "allowed_techniques"
+FORBIDDEN_FIELD = "forbidden"
+APPROVAL_FIELD = "human_approval"
+SCOPE_FIELDS = (SCOPE_FIELD, ALLOWED_FIELD, FORBIDDEN_FIELD, APPROVAL_FIELD)
+# The two fields that GRANT latitude. `forbidden` is excluded on purpose: a
+# `path:` or `repo:` value there is meaningful and is matched as one, because
+# widening what is REFUSED is safe in a way that widening what is permitted is
+# not.
+PERMITTING_FIELDS = (ALLOWED_FIELD, APPROVAL_FIELD)
+# Present in the rules of engagement, but not scope inputs: they describe how a
+# finding is graded and shaped, not what an auditor may touch. Named so their
+# presence is a deliberate skip rather than an uninterpretable field.
+NON_SCOPE_FIELDS = ("severity_scale", "report_schema")
+
+ROE_EXPORT_FILENAME = "rules-of-engagement.json"
+
+# ANY drive-prefixed Windows path, separator or not. `C:/x` and `C:\x` are
+# drive-ABSOLUTE; `C:x` is drive-RELATIVE -- relative to that drive's own current
+# directory, which is still not this repository. Requiring the separator let the
+# drive-relative form read as an ordinary relative path, so a bare-dot scope
+# prefix covered `C:Windows\System32`. Neither form is inside the repo, so the
+# separator is not part of what makes it out of scope.
+_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+
+class _NoBytecodeSourceLoader(importlib.machinery.SourceFileLoader):
+    """Load shipped source normally while suppressing cache writes."""
+
+    def get_code(self, fullname: str) -> Any:
+        path = self.get_filename(fullname)
+        source = self.get_data(path)
+        return self.source_to_code(source, path)
+
+    def set_data(self, path: str, data: Buffer, *, _mode: int = 0o666) -> None:
+        return None
+
+
+def load_ledger() -> Any:
+    """Load the sibling ledger without cwd, sys.path, or bytecode side effects.
+
+    Mirrors ``prepare-pr/scripts/pr_status.py``: a skill's scripts are synced out
+    of the package tree and run as bare files, so ``ledger`` is a file beside
+    this one rather than an importable module, and importing it the ordinary way
+    would drop a ``__pycache__`` entry into the checked-out tree.
+    """
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ledger.py")
+    name = "_security_conductor_ledger"
+    loader = _NoBytecodeSourceLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    if spec is None:  # pragma: no cover - defensive
+        raise RuntimeError("cannot import security conductor ledger: " + path)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+_LEDGER: Any = None
+
+
+def ledger() -> Any:
+    """The ledger module, loaded once on first use.
+
+    LAZY, and public, so ``finding_entry.py`` can share this one instance rather
+    than executing ``ledger.py`` a second time in the same invocation.
+    """
+    global _LEDGER
+    if _LEDGER is None:
+        _LEDGER = load_ledger()
+    return _LEDGER
+
+
+def normalize_technique(value: str) -> tuple[str, ...]:
+    """A technique as comparable whole words: lowercase, punctuation as breaks.
+
+    Returned as a tuple of words rather than a string so containment can be
+    checked word-wise. ``no-network-egress``, ``no_network_egress`` and
+    ``No Network Egress`` are one technique written three ways, and a rule
+    author should not have to guess which spelling the script compares.
+    """
+    return tuple(part for part in re.split(r"[^0-9a-z]+", value.strip().lower()) if part)
+
+
+def technique_equals(rule_value: str, asked: str) -> bool:
+    """Whole-value equality, for a rule that PERMITS.
+
+    Used by ``allowed_techniques`` and ``human_approval``. Anything looser lets
+    a fragment authorise a technique nobody approved.
+    """
+    rule_words = normalize_technique(rule_value)
+    asked_words = normalize_technique(asked)
+    return bool(rule_words) and rule_words == asked_words
+
+
+def forbidden_technique_matches(rule_value: str, asked: str) -> bool:
+    """Containment, for a rule that REFUSES.
+
+    A ``forbidden`` value is a negative phrase, so the asked-about technique is
+    looked for as a run of consecutive whole words inside it once a leading
+    ``no`` is dropped. Word runs, not substrings: ``dos`` must not match
+    ``no-windows-paths``, and ``poc`` must not match ``no-pocket``.
+    """
+    rule_words = normalize_technique(rule_value)
+    if rule_words and rule_words[0] == "no":
+        rule_words = rule_words[1:]
+    asked_words = normalize_technique(asked)
+    if not asked_words or not rule_words:
+        return False
+    if rule_words == asked_words:
+        return True
+    span = len(asked_words)
+    return any(
+        rule_words[index : index + span] == asked_words
+        for index in range(len(rule_words) - span + 1)
+    )
+
+
+def is_absolute_path(value: str) -> bool:
+    """Outside relative repository scope on ANY host.
+
+    A leading separator, or ANY drive prefix. Not ``os.path.isabs``, which answers
+    for the host running this script -- a Windows path checked on Linux would read
+    as relative, and the rules of engagement are the same document on both. Nor is
+    it only the drive-ABSOLUTE form: `C:x` is relative to that drive's current
+    directory, which is not this repository either.
+    """
+    text = value.strip().replace("\\", "/")
+    return text.startswith("/") or bool(_DRIVE_RE.match(value.strip()))
+
+
+def normalize_path(value: str) -> str:
+    """A path as compared: posix separators, normalised, no trailing slash.
+
+    ``normpath`` runs BEFORE any prefix comparison so a traversal cannot borrow
+    an in-scope prefix's coverage: ``src/../../etc/passwd`` normalises to
+    ``../etc/passwd``, which no ``path:src/`` rule covers.
+    """
+    text = value.strip().replace("\\", "/")
+    if not text:
+        return ""
+    normalized = posixpath.normpath(text)
+    if normalized in (".", "/"):
+        return normalized
+    return normalized.rstrip("/")
+
+
+def path_covered_by(prefix: str, asked: str, *, fold_case: bool = False) -> bool:
+    """Is ``asked`` the path ``prefix`` or something under it, segment-wise.
+
+    ``fold_case`` is for rules that REFUSE. On a case-insensitive filesystem
+    ``SRC/private/key.py`` and ``src/private/key.py`` are one file, so a
+    forbidden prefix compared byte-for-byte missed the file it names. Granting
+    rules keep the exact comparison: folding case there would widen what is
+    permitted, and the permit/refuse asymmetry says only refusal may widen.
+    """
+    base = normalize_path(prefix)
+    target = normalize_path(asked)
+    if fold_case:
+        base = base.lower()
+        target = target.lower()
+    if not base or not target:
+        return False
+    if target == ".." or target.startswith("../"):
+        # Escapes whatever it was measured against, so no rule can cover it.
+        return False
+    if base == ".":
+        # "Everything under the repository root" is the only sensible reading of
+        # a bare-dot prefix, and only for a RELATIVE query. An absolute path is
+        # somewhere else on the host entirely -- including a drive-qualified
+        # Windows one, which has no leading slash and so read as relative.
+        return not is_absolute_path(asked)
+    return target == base or target.startswith(base + "/")
+
+
+class Rule:
+    """One active ``roe_rules`` row, or one entry of the JSON export."""
+
+    def __init__(self, *, rule_id: int | None, field: str, value: str) -> None:
+        self.id = rule_id
+        self.field = field
+        self.value = value
+
+    def as_match(self) -> dict[str, Any]:
+        return {"id": self.id, "field": self.field, "value": self.value}
+
+
+KNOWN_KINDS = ("repo", "path", "technique")
+# A value whose text before the first colon LOOKS like a kind prefix: a run of
+# word characters with no whitespace, hyphen or path separator. `pth:src/private`
+# and the one-character `p:src/private` are both kind-shaped typos. The ONE thing
+# that is not a kind is a Windows drive: a single letter followed by `:` and then
+# a separator (`C:/x`, `C:\\x`) or nothing at all (`C:`), which `is_absolute_path`
+# already refuses as out of repo. `no-dos:ever` and `a b:c` are bare values.
+_KIND_PREFIX_RE = re.compile(r"^([A-Za-z_]\w*):")
+_DRIVE_ONLY_RE = re.compile(r"^[A-Za-z]:(?:[\\/]|$)")
+
+
+def split_value(value: str) -> tuple[str | None, str]:
+    """``("repo", "x")`` for ``repo:x``; ``(None, value)`` for a bare value.
+
+    An UNKNOWN kind prefix is returned as itself -- ``("pth", "src/private")`` --
+    so ``uninterpretable`` can refuse it. Stripping it to a bare value read a
+    typo'd ``forbidden=pth:src/private`` as a technique phrase, and the path
+    ceiling it was meant to be silently vanished.
+    """
+    match = _KIND_PREFIX_RE.match(value)
+    if match is None or _DRIVE_ONLY_RE.match(value):
+        return None, value.strip()
+    kind = match.group(1)
+    return kind, value[match.end() :].strip()
+
+
+def unknown_kind(kind: str | None) -> bool:
+    return kind is not None and kind not in KNOWN_KINDS
+
+
+def rules_from_db(db_path: Path, module: Any) -> tuple[list[Rule], int]:
+    """``(active rules, total rule rows)``. Raises on an unreadable database.
+
+    The TOTAL count is returned because the two zero cases are opposite
+    instructions. Zero rows means nobody has written the rules of engagement yet.
+    Zero ACTIVE rows out of many means somebody deliberately switched them off --
+    which is the RFC's revert path (``UPDATE roe_rules SET active = 0``) -- so
+    reading that as "no rules" and consulting the export restored exactly the
+    scope the revert removed.
+    """
+    conn = module.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, field, value FROM roe_rules WHERE active = 1 ORDER BY field ASC, id ASC"
+        ).fetchall()
+        total = int(conn.execute("SELECT COUNT(*) FROM roe_rules").fetchone()[0])
+    finally:
+        conn.close()
+    return [
+        Rule(rule_id=int(row["id"]), field=str(row["field"]), value=str(row["value"]))
+        for row in rows
+    ], total
+
+
+def rules_from_json(path: Path) -> list[Rule]:
+    """Rules from the export file. Raises on unreadable or malformed JSON.
+
+    Export entries carry no row id, so ``id`` is ``null`` in the verdict -- the
+    visible difference between an answer backed by an attributable row and one
+    backed by a file.
+    """
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    grouped = payload.get("rules", payload) if isinstance(payload, dict) else payload
+    if not isinstance(grouped, dict):
+        raise ValueError(f"{path}: expected an object of rule fields")
+    rules: list[Rule] = []
+    for field, entries in grouped.items():
+        if not isinstance(entries, list):
+            raise ValueError(f"{path}: field {field!r} is not a list")
+        for entry in entries:
+            value = entry.get("value") if isinstance(entry, dict) else entry
+            if not isinstance(value, str):
+                raise ValueError(f"{path}: field {field!r} has a non-string value")
+            rules.append(Rule(rule_id=None, field=str(field), value=value))
+    return rules
+
+
+def default_roe_json() -> Path:
+    """The export beside the skill, one directory up from ``scripts/``."""
+    return Path(os.path.dirname(os.path.abspath(__file__))).parent / ROE_EXPORT_FILENAME
+
+
+class Question:
+    """What the caller asked about."""
+
+    def __init__(
+        self, *, repo: str | None, paths: Sequence[str], techniques: Sequence[str]
+    ) -> None:
+        self.repo = (repo or "").strip() or None
+        self.paths = [item for item in (p.strip() for p in paths) if item]
+        self.techniques = [item for item in (t.strip() for t in techniques) if item]
+
+    def is_empty(self) -> bool:
+        return self.repo is None and not self.paths and not self.techniques
+
+
+class Verdict:
+    def __init__(self, verdict: str, matched: list[dict[str, Any]], reasons: list[str]) -> None:
+        self.verdict = verdict
+        self.matched = matched
+        self.reasons = reasons
+
+    def payload(self) -> dict[str, Any]:
+        return {"verdict": self.verdict, "matched_rules": self.matched, "reasons": self.reasons}
+
+    def exit_code(self) -> int:
+        return EXIT_CODES[self.verdict]
+
+
+def forbidden_hits(rules: Iterable[Rule], question: Question) -> list[tuple[Rule, str]]:
+    """Every ``forbidden`` rule the question runs into, with its reason."""
+    hits: list[tuple[Rule, str]] = []
+    for rule in rules:
+        if rule.field != FORBIDDEN_FIELD:
+            continue
+        kind, body = split_value(rule.value)
+        if unknown_kind(kind):
+            # Not a technique phrase; `uninterpretable` reports it.
+            continue
+        if kind == "repo":
+            if question.repo and body.lower() == question.repo.lower():
+                hits.append((rule, f"repository {question.repo!r} is forbidden by {rule.value!r}"))
+            continue
+        if kind == "path":
+            for asked in question.paths:
+                if path_covered_by(body, asked, fold_case=True):
+                    hits.append((rule, f"path {asked!r} is forbidden by {rule.value!r}"))
+            continue
+        # A bare or `technique:`-prefixed forbidden value is a technique phrase.
+        for asked in question.techniques:
+            if forbidden_technique_matches(body, asked):
+                hits.append((rule, f"technique {asked!r} is forbidden by {rule.value!r}"))
+    return hits
+
+
+def uninterpretable(rules: Iterable[Rule]) -> list[tuple[Rule, str]]:
+    """Rules whose field or value form this script cannot read."""
+    problems: list[tuple[Rule, str]] = []
+    for rule in rules:
+        if rule.field in NON_SCOPE_FIELDS:
+            continue
+        if rule.field not in SCOPE_FIELDS:
+            problems.append((rule, f"rule field {rule.field!r} is not one this script interprets"))
+            continue
+        kind, body = split_value(rule.value)
+        if not body:
+            problems.append((rule, f"rule {rule.field}={rule.value!r} has an empty value"))
+            continue
+        if unknown_kind(kind):
+            # Applies to `forbidden` too, the one field the permit/refuse
+            # asymmetry otherwise leaves alone: a refusing rule nobody can read
+            # is a ceiling that is not being enforced, and that fails OPEN.
+            problems.append(
+                (
+                    rule,
+                    f"rule {rule.field}={rule.value!r} names {kind!r}, not a kind this script reads",
+                )
+            )
+            continue
+        if rule.field == SCOPE_FIELD and kind not in ("repo", "path"):
+            # A bare `scope` value cannot be read: a repository and a path are
+            # matched by different rules, and guessing which was meant is
+            # exactly the judgment this script exists to remove.
+            problems.append((rule, f"scope rule {rule.value!r} names neither repo: nor path:"))
+            continue
+        if rule.field in PERMITTING_FIELDS and kind in ("repo", "path"):
+            # A PERMITTING field grants a technique, so a `repo:` or `path:`
+            # value in one is malformed, and reading it fails OPEN: the matcher
+            # strips the prefix before comparing, so `path:network-egress`
+            # authorises the technique `network-egress`. A malformed rule in the
+            # field that GRANTS is the one place a wrong reading hands out
+            # latitude, so it withholds permission instead.
+            problems.append(
+                (
+                    rule,
+                    f"{rule.field} rule {rule.value!r} names a"
+                    f" {kind}, but that field grants a technique",
+                )
+            )
+    return problems
+
+
+def _first_permitting(rules: Sequence[Rule], asked: str) -> Rule | None:
+    return next(
+        (rule for rule in rules if technique_equals(split_value(rule.value)[1], asked)), None
+    )
+
+
+def evaluate(rules: Sequence[Rule], question: Question) -> Verdict:
+    """Apply the precedence order in the module docstring."""
+    if question.is_empty():
+        return Verdict(UNKNOWN, [], ["nothing was asked about; UNKNOWN is never permission"])
+
+    hits = forbidden_hits(rules, question)
+    if hits:
+        return Verdict(
+            OUT_OF_SCOPE,
+            [rule.as_match() for rule, _ in hits],
+            [reason for _, reason in hits],
+        )
+
+    problems = uninterpretable(rules)
+    broken = {id(rule) for rule, _ in problems}
+    interpretable = [
+        rule for rule in rules if rule.field not in NON_SCOPE_FIELDS and id(rule) not in broken
+    ]
+    if not interpretable:
+        return Verdict(
+            UNKNOWN,
+            [rule.as_match() for rule, _ in problems],
+            ["no interpretable rule of engagement to check against"]
+            + [reason for _, reason in problems],
+        )
+
+    allowed = [rule for rule in interpretable if rule.field == ALLOWED_FIELD]
+    gates = [rule for rule in interpretable if rule.field == APPROVAL_FIELD]
+    scope_rules = [rule for rule in interpretable if rule.field == SCOPE_FIELD]
+    repo_rules = [rule for rule in scope_rules if split_value(rule.value)[0] == "repo"]
+    path_rules = [rule for rule in scope_rules if split_value(rule.value)[0] == "path"]
+
+    matched: list[dict[str, Any]] = []
+    reasons: list[str] = []
+    approvals: list[tuple[Rule, str]] = []
+    uncovered: list[str] = []
+
+    for asked in question.techniques:
+        # The gate is checked FIRST. A technique in both `human_approval` and
+        # `allowed_techniques` is the ordinary "in scope, but a human says go"
+        # configuration, and letting the allow row win made the approval
+        # ceiling vanish whenever someone also listed the technique as allowed.
+        gate = _first_permitting(gates, asked)
+        if gate is not None:
+            approvals.append((gate, f"technique {asked!r} needs a human yes per {gate.value!r}"))
+            continue
+        hit = _first_permitting(allowed, asked)
+        if hit is not None:
+            matched.append(hit.as_match())
+            reasons.append(f"technique {asked!r} is allowed by {hit.value!r}")
+            continue
+        uncovered.append(f"technique {asked!r} is in no allowed_techniques rule")
+
+    if question.repo is not None:
+        hit = next(
+            (
+                rule
+                for rule in repo_rules
+                if split_value(rule.value)[1].lower() == question.repo.lower()
+            ),
+            None,
+        )
+        if hit is None:
+            uncovered.append(f"repository {question.repo!r} is in no scope rule")
+        else:
+            matched.append(hit.as_match())
+            reasons.append(f"repository {question.repo!r} is in scope by {hit.value!r}")
+
+    for asked in question.paths:
+        hit = next(
+            (rule for rule in path_rules if path_covered_by(split_value(rule.value)[1], asked)),
+            None,
+        )
+        if hit is None:
+            uncovered.append(f"path {asked!r} is in no scope rule")
+        else:
+            matched.append(hit.as_match())
+            reasons.append(f"path {asked!r} is in scope by {hit.value!r}")
+
+    if uncovered:
+        return Verdict(OUT_OF_SCOPE, matched, uncovered)
+    if approvals:
+        return Verdict(
+            NEEDS_APPROVAL,
+            matched + [rule.as_match() for rule, _ in approvals],
+            reasons + [reason for _, reason in approvals],
+        )
+    if problems:
+        # Everything asked about is covered, but a rule in the set could not be
+        # read -- so "in scope" would be a claim about rules nobody parsed.
+        return Verdict(
+            UNKNOWN,
+            matched + [rule.as_match() for rule, _ in problems],
+            reasons + [reason for _, reason in problems],
+        )
+    return Verdict(IN_SCOPE, matched, reasons)
+
+
+def load_rules(db_path: Path, roe_json: Path, module: Any) -> tuple[list[Rule], Verdict | None]:
+    """Rules to evaluate, or the ``UNKNOWN`` verdict that replaces them."""
+    if db_path.exists():
+        try:
+            rules, total = rules_from_db(db_path, module)
+        except Exception as exc:  # sqlite3.Error, OSError, a missing table
+            return [], Verdict(UNKNOWN, [], [f"cannot read rules from {db_path}: {exc}"])
+        if rules:
+            return rules, None
+        if total:
+            # Rules exist and every one is switched off. That is a REVOCATION,
+            # not an empty ledger, and the export still carries what was revoked.
+            return [], Verdict(
+                UNKNOWN,
+                [],
+                [
+                    f"{db_path} holds {total} rule(s) and none is active;"
+                    " every rule of engagement has been revoked, so there is no scope to"
+                    " check against and the export is not a substitute for it"
+                ],
+            )
+        print(
+            f"{db_path} holds no rules of engagement; falling back to the export at {roe_json}",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"{db_path} does not exist; falling back to the export at {roe_json}",
+            file=sys.stderr,
+        )
+    if not roe_json.exists():
+        return [], Verdict(UNKNOWN, [], [f"no rules in {db_path} and no export at {roe_json}"])
+    try:
+        return rules_from_json(roe_json), None
+    except Exception as exc:
+        return [], Verdict(UNKNOWN, [], [f"cannot read rules from {roe_json}: {exc}"])
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Is this repository, path or technique inside the rules of engagement?"
+    )
+    parser.add_argument("--db", default=None, help="ledger path (default: data home)")
+    parser.add_argument(
+        "--roe-json",
+        default=None,
+        help="rules-of-engagement export to fall back to (default: beside the skill)",
+    )
+    parser.add_argument("--repo", default=None, help="repository to ask about")
+    parser.add_argument("--path", action="append", default=[], dest="paths")
+    parser.add_argument("--technique", action="append", default=[], dest="techniques")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    module = ledger()
+    db_path = Path(args.db) if args.db else module.default_db_path()
+    roe_json = Path(args.roe_json) if args.roe_json else default_roe_json()
+
+    rules, failure = load_rules(db_path, roe_json, module)
+    if failure is not None:
+        verdict = failure
+    else:
+        question = Question(repo=args.repo, paths=args.paths, techniques=args.techniques)
+        verdict = evaluate(rules, question)
+    print(json.dumps(verdict.payload(), sort_keys=True))
+    return verdict.exit_code()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kiro_crew/builtin_skills/security-conductor/scripts/verify_finding.py
+++ b/src/kiro_crew/builtin_skills/security-conductor/scripts/verify_finding.py
@@ -1,0 +1,779 @@
+#!/usr/bin/env python3
+"""Re-run one finding's proof of concept and record the verdict.
+
+Hallucinated vulnerabilities are the dominant noise source in agentic security
+review, so every finding gets an independent second pass whose job is REJECTING
+it. This script is that pass's only writer: the conductor reads the verdict it
+records and never reads a verifier's prose and decides for itself.
+
+Usage::
+
+    python3 verify_finding.py [--db PATH] --finding-id N --worktree DIR \\
+        [--timeout SECONDS]
+
+Exit codes, which are the interface::
+
+    0   confirmed    -- the proof reproduces
+    10  rejected     -- it does not reproduce
+    20  needs-human  -- it cannot be settled here: refused, timed out, or the
+                        proof did not actually run
+    2   invalid input -- no such finding, a bad timeout, an unrunnable PoC
+                        shape; NOTHING is recorded, because a verdict about a
+                        finding that is not there has nothing to attach to
+
+stdout is one JSON object: ``{"finding_id": N, "verdict": V, "reason": R}``.
+Every verdict this script reaches is appended through
+``ledger.record_verdict(role="verifier", ...)``, so the disagreement with the
+auditor stays readable instead of being overwritten by whoever wrote last.
+
+The two proof shapes::
+
+    pytest::<nodeid>     a unit-level test that FAILS while the defect is present
+    cmd::<argv ...>      a command that exits NONZERO while the defect is present
+
+``cmd::`` is split with ``shlex`` and run WITHOUT a shell, so a pipe, a
+redirection or a substitution in a PoC is an argument rather than an operator.
+
+**Neither lane may read its verdict off an exit status alone**, and both for the
+same reason: a nonzero exit means "this did not succeed", which covers "the
+defect reproduced" AND "the proof never ran". Confirming a finding on a proof
+that never ran is the exact false positive this pass exists to catch.
+
+- ``pytest::`` takes its verdict from a **JUnit XML report written outside the
+  worktree**, keyed to the requested nodeid, never from the run's stdout or exit
+  status. A run that exits 1 because collection failed, or because a DIFFERENT
+  test failed, is not a reproduction; the report says which test ran and what it
+  did. A missing, unparseable or unrelated report is ``needs-human``, so the
+  failure direction is toward a human rather than toward a confirmation.
+- ``cmd::`` treats **launch-failure shapes as ``needs-human``**: a spawn error,
+  a death by signal, and exit 126/127 all mean the command did not run. So is
+  exit 1, the uncaught-crash status of every common interpreter, which cannot
+  be told from a reproduction. Only a command that ran and exited a deliberate
+  status in 2..125 confirms.
+
+**The refusal screen.** A PoC is refused, unrun, as ``needs-human`` when it
+carries a shape the rules of engagement forbid outright, or when ``--worktree``
+is not a git checkout -- "in a scratch checkout" is the entire blast-radius
+bound, and an unverified directory is not one. The screened shapes:
+
+- network egress (``curl``, ``wget``, ``nc``, ``ssh``) and ``token``, applied to
+  a ``cmd::`` PoC's argv only. A ``pytest::`` nodeid is a test SELECTOR, not a
+  program: it cannot itself reach the network, so word-screening it buys nothing
+  -- what the selected test DOES was never visible to a string screen -- while
+  refusing real nodeids from this codebase's dominant finding class, wherever a
+  screened word stands alone: a parametrised id (``test_token[query]``), a module
+  (``token.py``), a directory (``ssh/``).
+- credential paths (``~/.aws``, ``~/.ssh``, the crew config), applied to both
+  shapes, since no legitimate nodeid names one.
+- a ``cmd::`` argument that is an absolute path or contains a ``..`` segment --
+  the write-outside-the-worktree shape.
+
+This screen is a NAMED-SHAPE CHECK on the AUDITOR'S text, not a sandbox. The
+RFC's trust boundary is explicit: the auditor's finding is model-authored and
+untrusted, so its PoC is screened before it runs; the target checkout is the
+operator's own and is trusted. Containment is the disposable worktree plus the
+deadline. This script does not attempt to defend the operator from code they
+chose to check out and run as themselves -- there is no privilege drop to
+defend, and Kiro Crew's namespace sandbox is Linux-only, which a cross-platform
+verifier cannot take on.
+
+What the child process gets: the PoC's argv, ``cwd`` set to the worktree, a
+minimal environment, and a deadline. ``HOME`` points AT the worktree, so a
+``~``-relative credential path resolves inside the throwaway checkout instead of
+into the operator's real home.
+
+Reads and writes one SQLite file through ``ledger.py``, and runs exactly one
+subprocess. No network of its own.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Buffer
+from pathlib import Path
+from typing import Any
+
+CONFIRMED = "confirmed"
+REJECTED = "rejected"
+NEEDS_HUMAN = "needs-human"
+
+EXIT_CODES = {CONFIRMED: 0, REJECTED: 10, NEEDS_HUMAN: 20}
+EXIT_INVALID = 2
+
+DEFAULT_TIMEOUT = 120
+# How long to wait for a killed proof to be reaped. Short and bounded: the verdict
+# is already decided by the time this runs, so the only thing at stake is whether
+# the verifier leaves a zombie behind, and blocking on an unkillable child forever
+# would be worse than the zombie.
+REAP_SECONDS = 5
+
+PYTEST_PREFIX = "pytest::"
+CMD_PREFIX = "cmd::"
+POC_PREFIXES = (PYTEST_PREFIX, CMD_PREFIX)
+
+# Programs whose presence in a cmd:: PoC means network egress. Matched as whole
+# words over the whole argv rather than only as the leading program, so a proof
+# that hides one inside `sh -c "..."` is refused too.
+EGRESS_PROGRAMS = ("curl", "wget", "nc", "ssh")
+# Credential shapes, matched as substrings: these are paths, not program names.
+CREDENTIAL_SUBSTRINGS = ("~/.aws", "~/.ssh", ".kiro/crew/config.json")
+_EGRESS_RE = re.compile(r"\b(" + "|".join(EGRESS_PROGRAMS) + r")\b", re.IGNORECASE)
+# `token` as a whole word, so it does not fire on `tokenize`.
+_TOKEN_RE = re.compile(r"\btoken\b", re.IGNORECASE)
+# A parent-directory reference ANYWHERE inside an argument, in either spelling of
+# a separator. Deliberately not anchored to the argument's start: the shapes that
+# matter are quoted (`-c "open('../sibling','w')"`) and flag-attached
+# (`--config=../outside.cfg`), and a boundary-anchored pattern missed both while
+# looking correct. `...` in prose is still not a parent reference.
+_PARENT_SEGMENT_RE = re.compile(r"\.\.[\\/]|[\\/]\.\.(?=[\\/]|$)|^\.\.$")
+# An absolute path reference anywhere inside an argument: a `/` that begins a
+# path (so `1/2` and `a / b` are arithmetic, not paths), a drive qualifier, or a
+# UNC prefix. The screen errs toward refusal, which routes to a human rather
+# than to a verdict.
+_ABSOLUTE_REF_RE = re.compile(r"""(?:^|['"=,(\s])(?:/[\w.]|[A-Za-z]:[\\/]|\\\\[\w.])""")
+
+# Exit statuses that mean the command never ran. 126 is "found but not
+# executable", 127 is "not found" (what a shell inside a PoC reports where a
+# direct spawn would have raised OSError instead).
+LAUNCH_FAILURE_CODES = (126, 127)
+# The uncaught-exception status of every common interpreter and shell.
+AMBIGUOUS_CRASH_CODE = 1
+# The largest status a proof exits ON PURPOSE. 128+N is a shell reporting signal N.
+MAX_DELIBERATE_CODE = 125
+
+
+class _NoBytecodeSourceLoader(importlib.machinery.SourceFileLoader):
+    """Load shipped source normally while suppressing cache writes."""
+
+    def get_code(self, fullname: str) -> Any:
+        path = self.get_filename(fullname)
+        source = self.get_data(path)
+        return self.source_to_code(source, path)
+
+    def set_data(self, path: str, data: Buffer, *, _mode: int = 0o666) -> None:
+        return None
+
+
+def load_ledger() -> Any:
+    """Load the sibling ledger without cwd, sys.path, or bytecode side effects.
+
+    Mirrors ``prepare-pr/scripts/pr_status.py``: a skill's scripts are synced out
+    of the package tree and run as bare files, so ``ledger`` is a file beside
+    this one rather than an importable module, and importing it the ordinary way
+    would drop a ``__pycache__`` entry into the checked-out tree.
+    """
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ledger.py")
+    name = "_security_conductor_ledger"
+    loader = _NoBytecodeSourceLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    if spec is None:  # pragma: no cover - defensive
+        raise RuntimeError("cannot import security conductor ledger: " + path)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+_LEDGER: Any = None
+
+
+def ledger() -> Any:
+    """The ledger module, loaded once on first use.
+
+    LAZY on purpose. ``finding_entry.py`` loads this script for the two PoC
+    shapes it validates against, and a module-level load would execute the
+    ledger a second time for a caller that only wanted two constants.
+    """
+    global _LEDGER
+    if _LEDGER is None:
+        _LEDGER = load_ledger()
+    return _LEDGER
+
+
+def poc_body(poc: str) -> tuple[str, str] | None:
+    """``(kind, payload)`` for a known PoC shape, else ``None``."""
+    if poc.startswith(PYTEST_PREFIX):
+        return "pytest", poc[len(PYTEST_PREFIX) :].strip()
+    if poc.startswith(CMD_PREFIX):
+        return "cmd", poc[len(CMD_PREFIX) :].strip()
+    return None
+
+
+def nodeid_file_part(nodeid: str) -> str:
+    """The file a nodeid selects -- everything before the first ``::``."""
+    return nodeid.split("::", 1)[0].strip()
+
+
+def refusal_reason(poc: str) -> str | None:
+    """Why this PoC must not be run at all, or ``None`` when it may be."""
+    for needle in CREDENTIAL_SUBSTRINGS:
+        if needle in poc:
+            return (
+                f"the proof of concept names {needle!r}, credential material the rules of"
+                " engagement forbid reading; a human decides how to settle this finding"
+            )
+    parsed = poc_body(poc)
+    if parsed is None:
+        return None
+    if parsed[0] != "cmd":
+        # The WORD screens below do not apply to a pytest nodeid: it is a selector,
+        # not a program, and they would refuse any nodeid where a screened word
+        # stands alone -- a parametrised `test_token[query]`, a `token.py`, an
+        # `ssh/` directory -- which in this codebase is the dominant real finding
+        # class.
+        #
+        # The PATH screen does apply, and only to the FILE part. A nodeid's file
+        # part IS a path that pytest resolves against the worktree, so `..` or a
+        # root/drive prefix there selects code the scratch checkout does not
+        # contain -- the same escape the cmd lane is screened for, spelled as a
+        # selector instead of as an argument. The test-name part is excluded
+        # because a parametrised id legitimately carries arbitrary text.
+        selector = nodeid_file_part(parsed[1])
+        if _PARENT_SEGMENT_RE.search(selector) or _ABSOLUTE_REF_RE.search(selector):
+            return (
+                f"the proof of concept selects {selector!r}, which is outside the scratch"
+                " worktree; a proof may only run code the audited checkout contains"
+            )
+        return None
+    body = parsed[1]
+    egress = _EGRESS_RE.search(body)
+    if egress is not None:
+        return (
+            f"the proof of concept names {egress.group(1)!r}, a network-egress shape the rules"
+            " of engagement forbid; a human decides how to settle this finding"
+        )
+    if _TOKEN_RE.search(body) is not None:
+        return (
+            "the proof of concept names a token, which the rules of engagement forbid"
+            " handling; a human decides how to settle this finding"
+        )
+    escape = _escaping_argument(body)
+    if escape is not None:
+        return (
+            f"the proof-of-concept command names {escape!r}, which points outside the scratch"
+            " worktree; the rules of engagement bound every write to that checkout, so a"
+            " human decides how to settle this finding"
+        )
+    return None
+
+
+def _escaping_argument(body: str) -> str | None:
+    """The first ``cmd::`` argument that points outside the worktree, if any.
+
+    An absolute path or a ``..`` reference is the write-outside-the-worktree
+    shape. Screened per argument, and per argument INTERIOR rather than only at
+    its start: the shapes that matter are quoted (``-c "open('../x','w')"``) and
+    flag-attached (``--config=../x``), and a boundary-anchored check missed both
+    while reading as correct.
+    """
+    try:
+        arguments = shlex.split(body)
+    except ValueError:
+        # Unbalanced quoting: poc_argv refuses it as an unreadable shape, so
+        # there is nothing here to screen.
+        return None
+    for argument in arguments:
+        if _PARENT_SEGMENT_RE.search(argument) or _ABSOLUTE_REF_RE.search(argument):
+            return argument
+    return None
+
+
+def is_git_worktree(directory: Path) -> bool:
+    """Is this a git checkout -- a clone (``.git/`` directory) or a worktree?
+
+    A linked worktree carries a ``.git`` FILE holding a gitdir pointer, not a
+    directory, so an ``is_dir()`` check would reject exactly the layout the
+    verifier brief asks for.
+    """
+    if not directory.is_dir():
+        return False
+    marker = directory / ".git"
+    return marker.is_dir() or marker.is_file()
+
+
+def is_own_checkout(worktree: Path) -> bool:
+    """Is this the very tree these scripts are running from?
+
+    The narrow, checkable half of "the worktree must be disposable". Provenance in
+    general is NOT checkable here -- the caller chooses the path and therefore
+    controls anything inside it, so no marker the verifier reads is unforgeable by
+    the one party that could forge it -- but this case is decidable without trusting
+    the caller at all, and it is the one an operator reaches by accident: pointing
+    the verifier at the repository it lives in, where a relative write in a PoC
+    lands on real source instead of on a throwaway copy.
+    """
+    try:
+        here = Path(__file__).resolve()
+        root = worktree.resolve()
+    except OSError:  # pragma: no cover - unresolvable path, caller's own check reports it
+        return False
+    return root == here or root in here.parents
+
+
+def child_env(worktree: Path) -> dict[str, str]:
+    """The minimal environment a PoC runs in.
+
+    Inherits nothing but ``PATH`` (a PoC needs an interpreter), the locale, and
+    the three names a Windows process needs in order to start at all.
+    ``HOME`` is the worktree itself, so a ``~``-relative path in a PoC resolves
+    inside the throwaway checkout rather than into the operator's real home, and
+    a tool that wants a cache directory writes it where the blast radius already
+    is. ``TMPDIR`` follows for the same reason.
+
+    The ``PATH`` fallback is ``os.defpath`` rather than a POSIX literal: a
+    hardcoded ``/usr/bin:/bin`` names nothing on Windows, where the same
+    fallback has to be a Windows search path.
+    """
+    env = {
+        "PATH": os.environ.get("PATH", os.defpath),
+        "HOME": str(worktree),
+        "TMPDIR": str(worktree),
+        # Windows spells the scratch directory ``TEMP``/``TMP``, and that is what
+        # ``tempfile`` reads there, so pinning ``TMPDIR`` alone put a PoC's scratch
+        # files outside the throwaway checkout on that platform -- the one place the
+        # blast radius is bounded.
+        "TEMP": str(worktree),
+        "TMP": str(worktree),
+        "PYTHONDONTWRITEBYTECODE": "1",
+        # Deterministic text decoding of whatever the child prints.
+        "PYTHONIOENCODING": "utf-8",
+        "LC_ALL": os.environ.get("LC_ALL", "C.UTF-8"),
+    }
+    # Windows needs three more names to start a process at all, and withholding
+    # them hardens nothing: ``SYSTEMROOT`` is where CPython finds the crypto
+    # provider it seeds ``os.urandom`` from, so a child without it dies during
+    # interpreter startup and never runs the proof; ``PATHEXT`` and ``COMSPEC`` are
+    # how a bare program name resolves to an executable there. Each is forwarded
+    # only when the host defines it, so on POSIX this loop adds nothing rather than
+    # branching on the platform.
+    for name in ("SYSTEMROOT", "PATHEXT", "COMSPEC"):
+        value = os.environ.get(name)
+        if value is not None:
+            env[name] = value
+    return env
+
+
+def poc_argv(poc: str, report_path: Path | None = None) -> tuple[list[str], str] | None:
+    """``(argv, kind)`` for a runnable PoC, or ``None`` when the shape is unknown."""
+    parsed = poc_body(poc)
+    if parsed is None:
+        return None
+    kind, body = parsed
+    if not body:
+        return None
+    if kind == "pytest":
+        # A selector that names only a file is unverifiable: the report it produces
+        # is keyed to no single test, so ANY failure in that file would read as the
+        # claimed defect reproducing. Refusing the SHAPE is what keeps that out of
+        # the ledger entirely -- `finding_entry.validate_poc` runs this same parser,
+        # so an unkeyed selector is refused at filing time and not only at run time.
+        if nodeid_test_name(body) is None:
+            return None
+        argv = [
+            sys.executable,
+            "-m",
+            "pytest",
+            # No cache and no header: the run must depend on the worktree's own
+            # test, not on state beside it.
+            "-p",
+            "no:cacheprovider",
+            "--no-header",
+            "-q",
+            "--tb=no",
+        ]
+        if report_path is not None:
+            argv.append(f"--junitxml={report_path}")
+        argv.append(body)
+        return argv, kind
+    try:
+        argv = shlex.split(body)
+    except ValueError:
+        return None
+    return (argv, kind) if argv else None
+
+
+def nodeid_test_name(nodeid: str) -> str | None:
+    """The test name a nodeid selects, or ``None`` when it names only a file."""
+    if "::" not in nodeid:
+        return None
+    return nodeid.rsplit("::", 1)[1].strip() or None
+
+
+def read_report(report_path: Path) -> str | None:
+    """The report's text, or ``None`` when there is no readable file there.
+
+    Read as text rather than parsed as XML only because the three questions asked
+    of it -- which cases ran, what each was named, which outcome child it carries
+    -- are answered by flat start tags, and a tree buys nothing for that.
+    """
+    try:
+        return report_path.read_bytes().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def report_cases(text: str) -> list[str]:
+    """One chunk of report text per ``<testcase``, in document order.
+
+    ``testcase`` elements are flat inside ``testsuite``, so splitting on the
+    start tag gives each case its own text -- enough to see which outcome child
+    it carries without building a tree.
+    """
+    return text.split("<testcase")[1:]
+
+
+def _has_element(chunk: str, tag: str) -> bool:
+    """Is ``<tag`` present as MARKUP in this chunk?
+
+    Requires the tag name to be followed by whitespace, ``>`` or ``/``, so
+    ``<failures>`` does not count as ``<failure``. A raw ``<`` can only be
+    markup: XML escapes one inside an attribute value or text as ``&lt;``, so a
+    test NAMED ``test_<failure/>`` cannot forge an outcome element here.
+    """
+    return bool(re.search(r"<" + tag + r"(?=[\s/>])", chunk))
+
+
+def case_name(chunk: str) -> str | None:
+    """The ``name`` attribute of the testcase this chunk starts.
+
+    Two bounds, both load-bearing. The attribute name is anchored, because
+    ``name="`` is a SUBSTRING of ``classname="`` and an unanchored search
+    returned the module name for every case. And only the START TAG is searched
+    -- text up to the first ``>`` -- so a nested ``<failure message="...">``
+    cannot supply a name either.
+    """
+    start_tag = chunk.split(">", 1)[0]
+    match = re.search(r'(?<![\w-])name="([^"]*)"', start_tag)
+    return None if match is None else match.group(1)
+
+
+def judge_report(report_path: Path, nodeid: str) -> tuple[str, str]:
+    """Map pytest's JUnit report onto a verdict. Fails closed to ``needs-human``.
+
+    The report is the channel: written to a path outside the worktree and keyed
+    to the nodeid that was asked for, so an exit status that means "collection
+    failed" or "a different test failed" cannot read as a reproduction.
+    """
+    if not report_path.exists():
+        return (
+            NEEDS_HUMAN,
+            "pytest wrote no result report, so the proof did not run to completion;"
+            " it neither reproduces nor refutes the finding",
+        )
+    text = read_report(report_path)
+    if text is None:
+        return (
+            NEEDS_HUMAN,
+            "pytest's result report could not be read; a report the verifier cannot read"
+            " is not evidence either way",
+        )
+    cases = report_cases(text)
+    if not cases:
+        return (
+            NEEDS_HUMAN,
+            "pytest's result report names no test, so the proof of concept selected nothing",
+        )
+    wanted = nodeid_test_name(nodeid)
+    if wanted is None:
+        return (
+            NEEDS_HUMAN,
+            "the proof of concept names a file rather than one test, so no result in the"
+            " report can be attributed to the defect this finding claims",
+        )
+    # ONLY the requested case decides. A run can report tests beside the one the
+    # finding cites -- a module-level fixture, a parametrised sibling, whatever else
+    # the selector's file collected -- and folding those in let an UNRELATED failure
+    # confirm this finding. Naming the test was never enough on its own: the verdict
+    # has to be read off that test's own result.
+    requested = [chunk for chunk in cases if case_name(chunk) == wanted]
+    if not requested:
+        return (
+            NEEDS_HUMAN,
+            f"pytest's result report does not name {wanted!r}, so the test this finding"
+            " cites did not run",
+        )
+    failed = [chunk for chunk in requested if _has_element(chunk, "failure")]
+    errored = [chunk for chunk in requested if _has_element(chunk, "error")]
+    skipped = [chunk for chunk in requested if _has_element(chunk, "skipped")]
+    if failed:
+        return (
+            CONFIRMED,
+            f"the proof of concept failed as the finding claims"
+            f" ({len(failed)} of {len(requested)} run(s) of {wanted!r})",
+        )
+    if errored:
+        return (
+            NEEDS_HUMAN,
+            f"the proof of concept errored rather than failing ({len(errored)});"
+            " it did not run, so it neither reproduces nor refutes the finding",
+        )
+    if skipped and len(skipped) == len(requested):
+        return NEEDS_HUMAN, "the proof of concept was skipped, so nothing was demonstrated"
+    return (
+        REJECTED,
+        f"the proof of concept passed ({len(requested)} run(s) of {wanted!r}), so the"
+        " defect it claims does not reproduce",
+    )
+
+
+def judge_cmd(returncode: int) -> tuple[str, str]:
+    """Map a command PoC onto a verdict.
+
+    Nonzero means the defect is present -- EXCEPT for the three statuses that say
+    the command never ran: a death by signal, exit 126 (found, not executable)
+    and exit 127 (not found). Those are not evidence about the finding.
+
+    Exit 1 is the fourth. It is the uncaught-exception status of every common
+    interpreter -- a Python PoC that dies on a hallucinated import exits 1, and so
+    does a shell script whose first command is mistyped -- so it cannot be told
+    apart from a PoC that ran and demonstrated the defect. A model-authored PoC
+    crashing is the ORDINARY input here, not the rare one, and confirming on it
+    persisted a false verdict into the ledger. A ``cmd::`` proof that wants to be
+    confirmable exits a deliberate status in 2..125; exit 1 is handed to a human
+    with the reason. A spawn failure is caught earlier, in :func:`run_poc`, as
+    ``LaunchFailed``.
+    """
+    if returncode == 0:
+        return (
+            REJECTED,
+            "the proof-of-concept command exited 0, so the defect it claims does not reproduce",
+        )
+    if returncode < 0:
+        return (
+            NEEDS_HUMAN,
+            f"the proof-of-concept command was killed by signal {-returncode}, so it did not"
+            " run to a verdict",
+        )
+    if returncode in LAUNCH_FAILURE_CODES:
+        return (
+            NEEDS_HUMAN,
+            f"the proof-of-concept command exited {returncode}, which means it was not found"
+            " or not executable rather than that the defect reproduced",
+        )
+    if returncode == AMBIGUOUS_CRASH_CODE:
+        return (
+            NEEDS_HUMAN,
+            "the proof-of-concept command exited 1, which is also what an uncaught crash"
+            " exits, so it cannot be told apart from a proof that never ran; a confirmable"
+            " command proof exits a deliberate status in 2..125",
+        )
+    if returncode > MAX_DELIBERATE_CODE:
+        # 128+N is a shell wrapper reporting its child's death by signal N, and a
+        # Windows crash is a large positive status: neither is a status the proof
+        # CHOSE, so neither is a claim about the defect.
+        return (
+            NEEDS_HUMAN,
+            f"the proof-of-concept command exited {returncode}, which is above the range a"
+            " proof exits on purpose and is the shape of a signal death or a crash",
+        )
+    return (
+        CONFIRMED,
+        f"the proof-of-concept command exited {returncode} as the finding claims",
+    )
+
+
+class Timeout:
+    """The deadline was hit."""
+
+
+class LaunchFailed:
+    """The child could not be started at all."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+
+def reap(process: subprocess.Popen[bytes]) -> None:
+    """Kill the proof if it is still running, then wait for it. Safe to call twice.
+
+    The direct child only. A proof that detaches a grandchild is the operator's
+    own checkout leaving a process on the operator's own machine, which the RFC's
+    trust boundary places outside this script: there is no privilege drop to
+    defend, and a portable process-tree kill does not exist in the standard
+    library. The verdict is already decided when this runs, so a bounded wait
+    beats blocking the conductor on an unreapable child.
+    """
+    process.kill()
+    try:
+        process.wait(timeout=REAP_SECONDS)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def run_poc(argv: list[str], worktree: Path, timeout: int) -> int | Timeout | LaunchFailed:
+    """The child's return code, or why there is no return code.
+
+    The child's OUTPUT is discarded, not captured. No verdict reads it -- the
+    pytest lane reads the report file and the command lane reads the status --
+    and capturing it through a pipe buffered the whole stream in this process,
+    so a PoC that prints without stopping exhausted the verifier's memory before
+    any verdict was written. ``timeout`` bounds wall time, never bytes.
+
+    """
+    try:
+        process = subprocess.Popen(
+            argv,
+            cwd=str(worktree),
+            env=child_env(worktree),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            # No shell, no inherited stdin: a PoC that waits on input must hit
+            # the deadline rather than hang on a terminal nobody is watching.
+            stdin=subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        # A mistyped or hallucinated program name is the verifier's ordinary
+        # adversarial input, and it raises here rather than returning a status.
+        # Letting it propagate killed the process outside the documented exit
+        # contract with no verdict recorded at all.
+        return LaunchFailed(str(exc))
+    # No pipes are open, so waiting cannot deadlock on an unread buffer.
+    try:
+        returncode = process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        reap(process)
+        return Timeout()
+    return returncode
+
+
+def read_finding(conn: Any, finding_id: int) -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT id, surface, title, poc FROM findings WHERE id = ?", (finding_id,)
+    ).fetchone()
+    return None if row is None else {key: row[key] for key in row.keys()}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Re-run one finding's proof of concept and record the verdict"
+    )
+    parser.add_argument("--db", default=None, help="ledger path (default: data home)")
+    parser.add_argument("--finding-id", required=True, type=int)
+    parser.add_argument("--worktree", required=True, help="the scratch checkout to run in")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    return parser
+
+
+def decide(finding: dict[str, Any], worktree: Path, timeout: int) -> tuple[str, str]:
+    """The verdict and its reason, having run the proof of concept if allowed."""
+    poc = str(finding.get("poc") or "")
+    refusal = refusal_reason(poc)
+    if refusal is not None:
+        return NEEDS_HUMAN, refusal
+    if not is_git_worktree(worktree):
+        return (
+            NEEDS_HUMAN,
+            f"{worktree} is not a git worktree, and a scratch checkout is the whole"
+            " blast-radius bound a proof of concept runs inside",
+        )
+    if is_own_checkout(worktree):
+        return (
+            NEEDS_HUMAN,
+            f"{worktree} is the checkout these scripts are running from, so a proof of"
+            " concept would run against real source rather than a throwaway copy",
+        )
+    parsed = poc_body(poc)
+    if parsed is None:  # pragma: no cover - guarded by the caller's shape check
+        raise ValueError(f"unrunnable proof-of-concept shape: {poc!r}")
+    kind, body = parsed
+    # The report lands OUTSIDE the worktree, so the audited checkout is not
+    # writing into the directory the verdict is read from by accident.
+    report_dir = Path(tempfile.mkdtemp(prefix="secc-verify-"))
+    try:
+        report_path = report_dir / "result.xml" if kind == "pytest" else None
+        argv_and_kind = poc_argv(poc, report_path)
+        if argv_and_kind is None:  # pragma: no cover - guarded by the caller
+            raise ValueError(f"unrunnable proof-of-concept shape: {poc!r}")
+        argv, _ = argv_and_kind
+        outcome = run_poc(argv, worktree, timeout)
+        if isinstance(outcome, Timeout):
+            return (
+                NEEDS_HUMAN,
+                f"the proof of concept did not finish within {timeout}s; a proof that cannot be"
+                " re-run inside the deadline is not evidence either way",
+            )
+        if isinstance(outcome, LaunchFailed):
+            return (
+                NEEDS_HUMAN,
+                f"the proof of concept could not be started ({outcome.message}), so it says"
+                " nothing about the finding",
+            )
+        if kind == "pytest":
+            assert report_path is not None
+            return judge_report(report_path, body)
+        return judge_cmd(outcome)
+    finally:
+        shutil.rmtree(report_dir, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.timeout <= 0:
+        print("--timeout must be a positive number of seconds", file=sys.stderr)
+        return EXIT_INVALID
+
+    module = ledger()
+    db_path = Path(args.db) if args.db else module.default_db_path()
+    worktree = Path(args.worktree).expanduser()
+
+    if not db_path.exists():
+        # Verifying never CREATES a ledger. A finding has to have been filed to
+        # be verified, and filing is what creates the database -- so a missing
+        # one means a mistyped --db, and creating it there left an empty ledger
+        # behind that later reads as "zero rules" to scope_check.
+        print(
+            f"no ledger at {db_path}; a finding must be filed before it can be verified",
+            file=sys.stderr,
+        )
+        return EXIT_INVALID
+
+    conn = module.connect(db_path)
+    try:
+        try:
+            finding = read_finding(conn, args.finding_id)
+        except Exception as exc:  # sqlite3.Error: not a ledger, or no findings table
+            print(f"cannot read findings from {db_path}: {exc}", file=sys.stderr)
+            return EXIT_INVALID
+        if finding is None:
+            print(f"no finding with id {args.finding_id}", file=sys.stderr)
+            return EXIT_INVALID
+        poc = str(finding.get("poc") or "")
+        if refusal_reason(poc) is None and poc_argv(poc) is None:
+            # An unreadable proof shape is an input defect in the RECORD, not a
+            # verdict about the defect it claims, so nothing is recorded here.
+            print(
+                f"finding {args.finding_id} carries no runnable proof of concept"
+                f" ({poc!r}); expected {PYTEST_PREFIX}<nodeid> or {CMD_PREFIX}<argv>",
+                file=sys.stderr,
+            )
+            return EXIT_INVALID
+        verdict, reason = decide(finding, worktree, args.timeout)
+        module.record_verdict(
+            conn,
+            finding_id=args.finding_id,
+            role="verifier",
+            verdict=verdict,
+            reason=reason,
+        )
+    finally:
+        conn.close()
+
+    print(
+        json.dumps(
+            {"finding_id": args.finding_id, "verdict": verdict, "reason": reason}, sort_keys=True
+        )
+    )
+    return EXIT_CODES[verdict]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_security_conductor_scripts.py
+++ b/test/test_security_conductor_scripts.py
@@ -1,0 +1,2118 @@
+"""The security conductor's three evaluator scripts -- the properties, not the plumbing.
+
+Each test pins one guarantee the RFC asks a SCRIPT to hold rather than asking an
+agent to hold it: a scope verdict whose precedence is fixed, an ``UNKNOWN`` that
+is never permission, one finding per real defect, and a verifier that refuses a
+proof of concept the rules of engagement forbid instead of running it.
+
+Every script is driven through ``main`` with argv, the way the skill invokes it,
+because the exit code IS the interface -- a property that holds only in a helper
+called directly would not be the one the conductor reads.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from skill_script_helpers import load_skill_script
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "security-conductor"
+    / "scripts"
+)
+
+
+@pytest.fixture
+def ledger():
+    return load_skill_script("security_conductor_ledger_for_scripts", SCRIPTS / "ledger.py")
+
+
+@pytest.fixture
+def scope_check():
+    return load_skill_script("security_conductor_scope_check", SCRIPTS / "scope_check.py")
+
+
+@pytest.fixture
+def finding_entry():
+    return load_skill_script("security_conductor_finding_entry", SCRIPTS / "finding_entry.py")
+
+
+@pytest.fixture
+def verify_finding():
+    return load_skill_script("security_conductor_verify_finding", SCRIPTS / "verify_finding.py")
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    return tmp_path / "findings.db"
+
+
+@pytest.fixture
+def missing_json(tmp_path: Path) -> Path:
+    """An export path that does not exist, so no test silently reads the shipped one."""
+    return tmp_path / "no-such-rules-of-engagement.json"
+
+
+def out_json(capsys) -> dict:
+    return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+
+
+def add_rule(ledger, db: Path, field: str, value: str) -> int:
+    code = ledger.main(
+        [
+            "--db",
+            str(db),
+            "add-rule",
+            "--field",
+            field,
+            "--value",
+            value,
+            "--reason",
+            "pinned by a test",
+            "--approved-by",
+            "test-human",
+        ]
+    )
+    assert code == 0
+    return code
+
+
+SEVERITY_ROWS = (
+    "Critical: a full bypass of the safety fence.",
+    "High: an authorization bypass on a network-exposed surface.",
+    "Low: a hardening gap with no demonstrated exploit.",
+)
+
+
+def seed_roe(ledger, db: Path) -> None:
+    """A minimal, realistic rules-of-engagement set, in the shipped value grammar."""
+    add_rule(ledger, db, "scope", "repo:kirodotdev/KiroCrew")
+    add_rule(ledger, db, "scope", "path:src/")
+    add_rule(ledger, db, "allowed_techniques", "static-code-review")
+    add_rule(ledger, db, "allowed_techniques", "local-unit-poc")
+    add_rule(ledger, db, "forbidden", "no-network-egress-from-a-poc")
+    add_rule(ledger, db, "forbidden", "no-dos-or-broad-fuzzing")
+    add_rule(ledger, db, "human_approval", "active-testing-beyond-static-review")
+    for row in SEVERITY_ROWS:
+        add_rule(ledger, db, "severity_scale", row)
+
+
+def run_scope(scope_check, db: Path, roe_json: Path, *argv: str) -> int:
+    return scope_check.main(["--db", str(db), "--roe-json", str(roe_json), *argv])
+
+
+# --------------------------------------------------------------------------- #
+# scope_check
+# --------------------------------------------------------------------------- #
+
+
+def test_a_technique_both_allowed_and_forbidden_is_out_of_scope(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """Forbidden beats allowed. Precedence is the whole point of the script.
+
+    A rules-of-engagement set can contain both an ``allowed_techniques`` row and
+    a ``forbidden`` row that speak about the same technique -- that is what a
+    narrowing edit LOOKS like, since reverting is flipping ``active`` rather than
+    deleting the older row. If the allowed row could win, every narrowing would
+    be silently undone by the row it was meant to narrow.
+    """
+    seed_roe(ledger, db)
+    add_rule(ledger, db, "allowed_techniques", "network-egress")
+
+    code = run_scope(scope_check, db, missing_json, "--technique", "network-egress")
+
+    payload = out_json(capsys)
+    assert code == 10
+    assert payload["verdict"] == "OUT_OF_SCOPE"
+    assert [rule["field"] for rule in payload["matched_rules"]] == ["forbidden"]
+    assert "forbidden" in payload["reasons"][0]
+
+
+def test_a_forbidden_path_beats_the_scope_row_that_covers_it(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """Same precedence, on the path axis rather than the technique axis."""
+    seed_roe(ledger, db)
+    add_rule(ledger, db, "forbidden", "path:src/kiro_crew/secrets/")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/secrets/keys.py")
+
+    payload = out_json(capsys)
+    assert code == 10
+    assert payload["verdict"] == "OUT_OF_SCOPE"
+    assert payload["matched_rules"][0]["value"] == "path:src/kiro_crew/secrets/"
+
+
+def test_an_empty_ledger_with_no_export_is_unknown_not_permission(
+    scope_check, db, missing_json, capsys
+):
+    """No rules means no answer, and no answer is a nonzero exit."""
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/security.py")
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "UNKNOWN"
+    assert payload["matched_rules"] == []
+
+
+def test_a_rule_field_the_script_cannot_interpret_is_unknown(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """An unreadable rule withholds permission even when the query is covered.
+
+    The query below is covered by ``path:src/``, so without this the verdict
+    would be ``IN_SCOPE`` -- an answer computed while ignoring a rule somebody
+    approved and nobody parsed.
+    """
+    seed_roe(ledger, db)
+    add_rule(ledger, db, "aggression_budget", "3")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/security.py")
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "UNKNOWN"
+    assert any("aggression_budget" in reason for reason in payload["reasons"])
+
+
+def test_a_bare_scope_value_is_unknown_because_repo_and_path_differ(
+    ledger, scope_check, db, missing_json, capsys
+):
+    seed_roe(ledger, db)
+    add_rule(ledger, db, "scope", "everything-really")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/security.py")
+
+    assert code == 20
+    assert any("neither repo: nor path:" in reason for reason in out_json(capsys)["reasons"])
+
+
+def test_severity_scale_and_report_schema_rows_are_skipped_not_unknown(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """The two non-scope fields must not poison every verdict.
+
+    They ship in the real rules of engagement, so treating them as
+    uninterpretable would make ``UNKNOWN`` the only reachable verdict.
+    """
+    seed_roe(ledger, db)
+    add_rule(ledger, db, "report_schema", "poc")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/security.py")
+
+    assert code == 0
+    assert out_json(capsys)["verdict"] == "IN_SCOPE"
+
+
+def test_nothing_asked_is_unknown(scope_check, db, missing_json, capsys):
+    code = run_scope(scope_check, db, missing_json)
+
+    assert code == 20
+    assert out_json(capsys)["verdict"] == "UNKNOWN"
+
+
+def test_a_repo_and_path_and_technique_all_covered_is_in_scope(
+    ledger, scope_check, db, missing_json, capsys
+):
+    seed_roe(ledger, db)
+
+    code = run_scope(
+        scope_check,
+        db,
+        missing_json,
+        "--repo",
+        "kirodotdev/KiroCrew",
+        "--path",
+        "src/kiro_crew/security.py",
+        "--technique",
+        "static-code-review",
+    )
+
+    payload = out_json(capsys)
+    assert code == 0
+    assert payload["verdict"] == "IN_SCOPE"
+    assert {rule["field"] for rule in payload["matched_rules"]} == {"scope", "allowed_techniques"}
+
+
+def test_an_uncovered_repo_is_out_of_scope(ledger, scope_check, db, missing_json, capsys):
+    seed_roe(ledger, db)
+
+    code = run_scope(scope_check, db, missing_json, "--repo", "someone-else/their-repo")
+
+    assert code == 10
+    assert out_json(capsys)["verdict"] == "OUT_OF_SCOPE"
+
+
+def test_a_human_approval_technique_is_needs_approval_not_in_scope(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """The gate is held by a nonzero exit; only a human lifts it."""
+    seed_roe(ledger, db)
+
+    code = run_scope(
+        scope_check, db, missing_json, "--technique", "active-testing-beyond-static-review"
+    )
+
+    payload = out_json(capsys)
+    assert code == 30
+    assert payload["verdict"] == "NEEDS_APPROVAL"
+    assert payload["matched_rules"][0]["field"] == "human_approval"
+
+
+def test_a_traversal_cannot_borrow_an_in_scope_prefix(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """``src/../../etc/passwd`` starts with ``src/`` as text and is not under it."""
+    seed_roe(ledger, db)
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/../../etc/passwd")
+
+    assert code == 10
+    assert out_json(capsys)["verdict"] == "OUT_OF_SCOPE"
+
+
+def test_a_root_scope_prefix_still_does_not_cover_a_path_above_the_root(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """``path:.`` means everything under the repository root, and ``..`` is not.
+
+    This is the case the traversal guard exists for: the escape survives
+    normalisation as a leading ``..``, and a relative path is exactly what a
+    bare-dot prefix otherwise admits, so without the guard the widest legitimate
+    scope rule would also be the one that leaks the whole host.
+    """
+    add_rule(ledger, db, "scope", "path:.")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "../etc/passwd")
+
+    assert code == 10
+    assert out_json(capsys)["verdict"] == "OUT_OF_SCOPE"
+
+
+def test_a_path_prefix_matches_whole_segments_only(ledger, scope_check, db, missing_json, capsys):
+    """``path:src`` must not cover ``srcfoo/``."""
+    add_rule(ledger, db, "scope", "path:src")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "srcfoo/thing.py")
+
+    assert code == 10
+    assert out_json(capsys)["verdict"] == "OUT_OF_SCOPE"
+
+
+def test_a_partial_technique_word_does_not_authorise_the_whole_technique(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """A rule that PERMITS is matched whole; only a rule that REFUSES contains.
+
+    Containment on ``allowed_techniques`` let a fragment stand in for the whole:
+    ``unit`` sat inside the allowed ``local-unit-poc`` and came back IN_SCOPE for
+    a technique no rule authorises. Widening must only ever widen what is
+    refused.
+    """
+    seed_roe(ledger, db)
+
+    code = run_scope(scope_check, db, missing_json, "--technique", "unit")
+
+    payload = out_json(capsys)
+    assert code == 10
+    assert payload["verdict"] == "OUT_OF_SCOPE"
+    assert payload["matched_rules"] == []
+
+
+def test_a_partial_technique_word_still_meets_a_forbidden_phrase(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """The other half of the asymmetry: containment stays on ``forbidden``.
+
+    ``no-network-egress-from-a-poc`` has to refuse ``--technique network-egress``,
+    which is the whole reason the containment scan exists.
+    """
+    seed_roe(ledger, db)
+
+    code = run_scope(scope_check, db, missing_json, "--technique", "network-egress")
+
+    assert code == 10
+    assert out_json(capsys)["matched_rules"][0]["field"] == "forbidden"
+
+
+@pytest.mark.parametrize(
+    "outside",
+    [
+        "C:\\outside\\file",
+        "C:/outside/file",
+        "//host/share/file",
+        "\\\\host\\share\\file",
+        # Drive-RELATIVE: no separator after the colon. Relative to that
+        # drive's own current directory, which is still not this repository --
+        # and the form a separator-requiring pattern let through.
+        "C:Windows\\System32\\drivers\\etc\\hosts",
+        "C:outside",
+    ],
+)
+def test_a_root_scope_prefix_does_not_cover_an_absolute_path_on_any_host(
+    ledger, scope_check, db, missing_json, capsys, outside
+):
+    """``path:.`` means "under the repository root" -- and a drive path is not.
+
+    A drive-qualified Windows path has no leading slash, so a leading-slash test
+    read it as relative and the widest legitimate scope rule covered the whole
+    host. Absoluteness is judged for BOTH conventions, not for whichever host
+    happens to run the script -- the rules of engagement are one document on
+    Linux and Windows alike.
+    """
+    add_rule(ledger, db, "scope", "path:.")
+
+    code = run_scope(scope_check, db, missing_json, "--path", outside)
+
+    assert code == 10
+    assert out_json(capsys)["verdict"] == "OUT_OF_SCOPE"
+
+
+def test_a_permitting_rule_naming_a_path_is_unknown_not_permission(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """A malformed rule in the field that GRANTS must fail closed.
+
+    The matcher compares a technique with its prefix stripped, so
+    ``allowed_techniques=path:network-egress`` authorised the technique
+    ``network-egress`` -- a rule nobody wrote as a technique grant, handing out
+    latitude. Only ``scope`` was checked for a sensible prefix, so this was the
+    one field where a malformed rule failed OPEN.
+    """
+    add_rule(ledger, db, "scope", "path:src/")
+    add_rule(ledger, db, "allowed_techniques", "path:network-egress")
+
+    code = run_scope(scope_check, db, missing_json, "--technique", "network-egress")
+
+    payload = out_json(capsys)
+    # OUT_OF_SCOPE, not UNKNOWN: the documented precedence puts "an item no rule
+    # covers" ahead of "a rule that could not be interpreted", and the malformed
+    # grant covers nothing. Both codes are nonzero, so what matters is
+    # that the rule did not authorise the technique -- which is what the empty
+    # matched_rules asserts.
+    assert code == 10
+    assert payload["verdict"] == "OUT_OF_SCOPE"
+    assert payload["matched_rules"] == []
+
+
+def test_a_permitting_rule_naming_a_path_is_recorded_as_uninterpretable(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """The other half: the malformed grant is REPORTED, not silently skipped.
+
+    Dropping it from the grant list closes the fail-open, but a rule somebody
+    approved and nobody could read must also withhold permission from the rest of
+    the query rather than being quietly ignored -- so with everything asked about
+    covered, the verdict is still UNKNOWN and names the rule.
+    """
+    add_rule(ledger, db, "scope", "path:src/")
+    add_rule(ledger, db, "allowed_techniques", "path:network-egress")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/security.py")
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "UNKNOWN"
+    assert any("grants a technique" in reason for reason in payload["reasons"])
+
+
+def test_a_human_approval_rule_naming_a_repo_is_unknown(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """Both granting fields, not just the one the finding cited."""
+    add_rule(ledger, db, "scope", "path:src/")
+    add_rule(ledger, db, "human_approval", "repo:active-testing")
+
+    code = run_scope(scope_check, db, missing_json, "--technique", "active-testing")
+
+    payload = out_json(capsys)
+    assert code == 10
+    assert payload["matched_rules"] == []
+
+
+def test_a_forbidden_rule_may_still_name_a_path_or_repo(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """`forbidden` keeps the path and repo forms -- refusing is not granting.
+
+    The asymmetry is the invariant: widening what is REFUSED is safe in a way
+    that widening what is PERMITTED is not, so narrowing the granting fields must
+    not narrow this one.
+    """
+    add_rule(ledger, db, "scope", "path:src/")
+    add_rule(ledger, db, "forbidden", "path:src/kiro_crew/secrets/")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/secrets/k.py")
+
+    payload = out_json(capsys)
+    assert code == 10
+    assert payload["verdict"] == "OUT_OF_SCOPE"
+    assert payload["matched_rules"][0]["field"] == "forbidden"
+
+
+def test_a_forbidden_path_rule_does_not_poison_an_unrelated_verdict(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """A forbidden `path:` rule that is NOT hit must stay interpretable.
+
+    This is the half that catches over-narrowing. The sibling test cannot: the
+    forbidden check runs BEFORE the interpretability check, so a forbidden rule
+    that MATCHES returns OUT_OF_SCOPE either way. Only an unrelated query
+    separates "interpretable" from "uninterpretable" here -- and the shipped rules
+    of engagement carry seven forbidden entries, so getting this wrong would
+    answer UNKNOWN for every question ever asked.
+    """
+    add_rule(ledger, db, "scope", "path:src/")
+    add_rule(ledger, db, "forbidden", "path:src/kiro_crew/secrets/")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/security.py")
+
+    payload = out_json(capsys)
+    assert code == 0
+    assert payload["verdict"] == "IN_SCOPE"
+
+
+def test_a_forbidden_rule_with_a_mistyped_kind_withholds_permission(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """A typo in a REFUSING rule must not fail open.
+
+    `forbidden=pth:src/private` is the operator meaning `path:`. Read as a bare
+    technique phrase it matched no path, so the ceiling it was written to be
+    silently vanished and `path:.` answered IN_SCOPE for `src/private/key.py`.
+    An unknown kind is uninterpretable in every scope field, `forbidden`
+    included: the permit/refuse asymmetry lets a forbidden rule name a path, it
+    does not let one nobody can read count as enforced.
+    """
+    add_rule(ledger, db, "scope", "path:.")
+    add_rule(ledger, db, "forbidden", "pth:src/private")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/private/key.py")
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "UNKNOWN"
+    assert any("'pth'" in reason for reason in payload["reasons"])
+    assert payload["matched_rules"][-1]["field"] == "forbidden"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "no-dos-or-broad-fuzzing",
+        "no bypassing a policy block: refusal is the boundary",
+        "C:/Windows",
+        "C:\\Windows",
+        "D:",
+    ],
+)
+def test_a_bare_forbidden_value_with_a_colon_is_still_a_technique_phrase(
+    ledger, scope_check, db, missing_json, capsys, value
+):
+    """Only a word-shaped prefix is a kind. A colon inside prose, or a drive
+    letter, is part of the value, and refusing those would answer UNKNOWN to
+    every question the shipped rules of engagement are asked."""
+    add_rule(ledger, db, "scope", "path:src/")
+    add_rule(ledger, db, "forbidden", value)
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/security.py")
+
+    assert code == 0
+    assert out_json(capsys)["verdict"] == "IN_SCOPE"
+
+
+def test_a_human_approval_gate_holds_even_when_the_technique_is_also_allowed(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """A gate any allow row can neutralise is not a gate.
+
+    "In scope, but a human says go" is the ordinary configuration for a gated
+    technique: the allow row puts it in scope, the approval row gates it. Checking
+    the allow row first made the approval ceiling vanish exactly when both were
+    present, which is the case the gate exists for.
+    """
+    add_rule(ledger, db, "allowed_techniques", "active-testing")
+    add_rule(ledger, db, "human_approval", "active-testing")
+
+    code = run_scope(scope_check, db, missing_json, "--technique", "active-testing")
+
+    payload = out_json(capsys)
+    assert code == 30
+    assert payload["verdict"] == "NEEDS_APPROVAL"
+
+
+@pytest.mark.parametrize("asked", ["SRC/private/key.py", "src/Private/KEY.py"])
+def test_a_forbidden_path_refuses_regardless_of_case(
+    ledger, scope_check, db, missing_json, capsys, asked
+):
+    """On a case-insensitive filesystem these are one file, so a forbidden prefix
+    compared byte-for-byte missed the file it names. Only the REFUSING side folds
+    case; the granting side stays exact, per the permit/refuse asymmetry."""
+    add_rule(ledger, db, "scope", "path:.")
+    add_rule(ledger, db, "forbidden", "path:src/private")
+
+    code = run_scope(scope_check, db, missing_json, "--path", asked)
+
+    payload = out_json(capsys)
+    assert code == 10
+    assert payload["verdict"] == "OUT_OF_SCOPE"
+
+
+def test_a_granting_path_rule_does_not_fold_case(ledger, scope_check, db, missing_json, capsys):
+    """Folding case on a GRANT would widen what is permitted."""
+    add_rule(ledger, db, "scope", "path:src/")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "SRC/kiro_crew/security.py")
+
+    assert code == 10
+    assert out_json(capsys)["verdict"] == "OUT_OF_SCOPE"
+
+
+def test_a_one_character_mistyped_kind_withholds_permission(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """`p:` for `path:` is a one-key typo and must not read as a technique phrase.
+    A drive letter is the only single-letter colon prefix that is NOT a kind, and
+    it is told apart by what follows the colon: a separator or nothing."""
+    add_rule(ledger, db, "scope", "path:.")
+    add_rule(ledger, db, "forbidden", "p:src/private")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/private/key.py")
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "UNKNOWN"
+    assert any("'p'" in reason for reason in payload["reasons"])
+
+
+def test_a_technique_prefixed_grant_is_still_interpretable(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """Narrowing the granting fields must not refuse their legitimate forms."""
+    add_rule(ledger, db, "allowed_techniques", "technique:static-code-review")
+
+    code = run_scope(scope_check, db, missing_json, "--technique", "static-code-review")
+
+    assert code == 0
+    assert out_json(capsys)["verdict"] == "IN_SCOPE"
+
+
+def test_a_root_scope_prefix_still_covers_a_path_inside_the_repository(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """The absoluteness check must not refuse what ``path:.`` is FOR."""
+    add_rule(ledger, db, "scope", "path:.")
+
+    code = run_scope(scope_check, db, missing_json, "--path", "src/kiro_crew/security.py")
+
+    assert code == 0
+    assert out_json(capsys)["verdict"] == "IN_SCOPE"
+
+
+def test_revoking_every_rule_is_unknown_and_does_not_reach_the_export(
+    ledger, scope_check, db, tmp_path, capsys
+):
+    """Deactivating every rule is the RFC's REVERT path, not an empty ledger.
+
+    A bad rule is undone by flipping ``active``, so the rows stay. Falling back on
+    "zero ACTIVE rows" therefore consulted the export and handed back exactly the
+    scope the revert removed -- with the export still listing it, because an
+    export is a snapshot nobody re-runs on a revert.
+    """
+    seed_roe(ledger, db)
+    export = tmp_path / "rules-of-engagement.json"
+    export.write_text(
+        json.dumps({"rules": {"scope": [{"value": "path:src/", "reason": "the revoked scope"}]}}),
+        encoding="utf-8",
+    )
+    conn = ledger.connect(db)
+    try:
+        with conn:
+            conn.execute("UPDATE roe_rules SET active = 0")
+    finally:
+        conn.close()
+
+    code = scope_check.main(
+        ["--db", str(db), "--roe-json", str(export), "--path", "src/kiro_crew/security.py"]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip().splitlines()[-1])
+    assert code == 20
+    assert payload["verdict"] == "UNKNOWN"
+    assert "none is active" in payload["reasons"][0]
+    assert "falling back" not in captured.err
+
+
+def test_a_truly_empty_ledger_still_reaches_the_export(scope_check, db, tmp_path, capsys):
+    """The other side of the same condition: zero ROWS is the fallback trigger.
+
+    Narrowing the trigger must not disable the fallback the RFC asks for.
+    """
+    conn_module = None  # the ledger is created by the export-less path below
+    assert conn_module is None
+    export = tmp_path / "rules-of-engagement.json"
+    export.write_text(
+        json.dumps({"rules": {"scope": [{"value": "path:src/", "reason": "seed"}]}}),
+        encoding="utf-8",
+    )
+
+    code = scope_check.main(
+        ["--db", str(db), "--roe-json", str(export), "--path", "src/kiro_crew/security.py"]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "falling back to the export" in captured.err
+
+
+def test_a_ledger_whose_rules_were_all_revoked_reports_the_count(
+    ledger, scope_check, db, missing_json, capsys
+):
+    """The reason names how many rules were revoked, so an operator can tell a
+    revocation from a ledger nobody has written yet."""
+    add_rule(ledger, db, "scope", "path:src/")
+    add_rule(ledger, db, "allowed_techniques", "static-code-review")
+    conn = ledger.connect(db)
+    try:
+        with conn:
+            conn.execute("UPDATE roe_rules SET active = 0")
+    finally:
+        conn.close()
+
+    code = run_scope(scope_check, db, missing_json, "--technique", "static-code-review")
+
+    assert code == 20
+    assert "2 rule(s)" in out_json(capsys)["reasons"][0]
+
+
+def test_the_export_is_read_only_when_the_ledger_holds_no_rules(scope_check, db, tmp_path, capsys):
+    """The fallback path, and the stderr notice that it was taken.
+
+    The export is a file somebody can edit without leaving an attributable row,
+    so an answer that came from it says so, and carries ``id: null`` where a row
+    would have carried its id.
+    """
+    export = tmp_path / "rules-of-engagement.json"
+    export.write_text(
+        json.dumps(
+            {
+                "schema": "roe/v1",
+                "rules": {
+                    "scope": [{"value": "path:src/", "reason": "the export's own copy"}],
+                    "allowed_techniques": [{"value": "static-code-review", "reason": "reading"}],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    code = scope_check.main(
+        [
+            "--db",
+            str(db),
+            "--roe-json",
+            str(export),
+            "--path",
+            "src/kiro_crew/security.py",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip().splitlines()[-1])
+    assert code == 0
+    assert payload["verdict"] == "IN_SCOPE"
+    assert payload["matched_rules"] == [{"id": None, "field": "scope", "value": "path:src/"}]
+    assert "falling back to the export" in captured.err
+
+
+def test_a_seeded_ledger_is_never_overridden_by_the_export(
+    ledger, scope_check, db, tmp_path, capsys
+):
+    """Rows are the source of truth: an export that widens scope is not consulted."""
+    seed_roe(ledger, db)
+    export = tmp_path / "rules-of-engagement.json"
+    export.write_text(
+        json.dumps({"rules": {"scope": [{"value": "path:", "reason": "everything"}]}}),
+        encoding="utf-8",
+    )
+
+    code = scope_check.main(
+        ["--db", str(db), "--roe-json", str(export), "--path", "website/src/main.tsx"]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 10
+    assert "falling back" not in captured.err
+
+
+def test_an_unreadable_database_is_unknown_and_does_not_fall_back(
+    scope_check, db, tmp_path, capsys
+):
+    """Falling back needs the ledger to have SAID it holds no rules.
+
+    A database that cannot be read said nothing, so reaching for the export
+    would answer a scope question from a file while the source of truth was
+    unavailable -- an answer nobody could attribute.
+    """
+    db.write_bytes(b"this is not a sqlite database at all")
+    export = tmp_path / "rules-of-engagement.json"
+    export.write_text(
+        json.dumps({"rules": {"scope": [{"value": "path:src/", "reason": "wide open"}]}}),
+        encoding="utf-8",
+    )
+
+    code = scope_check.main(
+        ["--db", str(db), "--roe-json", str(export), "--path", "src/kiro_crew/security.py"]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip().splitlines()[-1])
+    assert code == 20
+    assert payload["verdict"] == "UNKNOWN"
+    assert "falling back" not in captured.err
+
+
+def test_asking_a_scope_question_never_creates_a_ledger(scope_check, db, missing_json, capsys):
+    """A read must not leave a database behind for a later write to inherit."""
+    run_scope(scope_check, db, missing_json, "--path", "src/x.py")
+    capsys.readouterr()
+
+    assert not db.exists()
+
+
+# --------------------------------------------------------------------------- #
+# finding_entry
+# --------------------------------------------------------------------------- #
+
+
+FINDING_ARGS = (
+    "--surface",
+    "security.is_denied",
+    "--severity",
+    "High",
+    "--title",
+    "echo text is classified as an executed program",
+    "--path",
+    "src/kiro_crew/security.py",
+    "--poc",
+    "pytest::test/test_security.py::test_echo_is_not_a_program",
+)
+
+
+def finding_json(*flags: str) -> dict:
+    """Turn a flag-style spelling into the finding file's dict.
+
+    The flag spelling is kept in the tests only because it reads well beside the
+    field it varies; the script itself accepts one input, `--json-file`.
+    """
+    body: dict = {"paths": []}
+    it = iter(flags)
+    for flag in it:
+        value = next(it)
+        key = flag.lstrip("-").replace("-", "_")
+        if key == "path":
+            body["paths"].append(value)
+        else:
+            body[key] = value
+    return body
+
+
+def file_finding(finding_entry, db: Path, missing_json: Path, *extra: str) -> int:
+    payload = db.parent / f"finding-{abs(hash(extra)) % 10**8}.json"
+    payload.write_text(json.dumps(finding_json(*(extra or FINDING_ARGS))), encoding="utf-8")
+    return finding_entry.main(
+        ["--db", str(db), "--roe-json", str(missing_json), "--json-file", str(payload)]
+    )
+
+
+def test_a_second_file_of_the_same_defect_is_a_duplicate_with_the_same_id(
+    ledger, finding_entry, db, missing_json, capsys
+):
+    """One record per real defect: a re-audit must not re-file what is recorded.
+
+    The duplicate exit is nonzero AND still prints the id, because the caller's
+    next step needs the handle and making it parse stderr for it would be the
+    same information behind a worse contract.
+    """
+    seed_roe(ledger, db)
+
+    first_code = file_finding(finding_entry, db, missing_json)
+    first = out_json(capsys)
+    second_code = file_finding(finding_entry, db, missing_json)
+    second = out_json(capsys)
+
+    assert (first_code, first["created"]) == (0, True)
+    assert (second_code, second["created"]) == (3, False)
+    assert second["finding_id"] == first["finding_id"]
+
+
+def test_the_same_paths_in_a_different_order_are_the_same_defect(
+    ledger, finding_entry, db, missing_json, capsys
+):
+    """Identity is the SORTED paths, so argument order cannot fork a finding."""
+    seed_roe(ledger, db)
+    base = [
+        "--surface",
+        "webhooks.ingest",
+        "--severity",
+        "High",
+        "--title",
+        "unbounded frame accepted",
+        "--poc",
+        "cmd::python3 -c pass",
+    ]
+
+    file_finding(finding_entry, db, missing_json, *base, "--path", "a.py", "--path", "b.py")
+    first = out_json(capsys)
+    code = file_finding(finding_entry, db, missing_json, *base, "--path", "b.py", "--path", "a.py")
+    second = out_json(capsys)
+
+    assert code == 3
+    assert second["finding_id"] == first["finding_id"]
+
+
+def test_a_severity_outside_the_scale_is_refused(ledger, finding_entry, db, missing_json, capsys):
+    """The scale is the only adjudication vocabulary, so a level it does not name
+    cannot be graded and must not reach the ledger."""
+    seed_roe(ledger, db)
+    capsys.readouterr()  # the seeding rules printed their own ids
+
+    code = file_finding(
+        finding_entry,
+        db,
+        missing_json,
+        "--surface",
+        "security.is_denied",
+        "--severity",
+        "Catastrophic",
+        "--title",
+        "invented grade",
+        "--path",
+        "src/kiro_crew/security.py",
+        "--poc",
+        "cmd::python3 -c pass",
+    )
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "severity_scale" in captured.err
+    assert captured.out.strip() == ""
+
+
+def test_no_severity_scale_at_all_is_a_refusal_not_a_pass(
+    ledger, finding_entry, db, missing_json, capsys
+):
+    """An unvalidatable grade is exactly what the scale exists to stop."""
+    add_rule(ledger, db, "scope", "path:src/")
+
+    code = file_finding(finding_entry, db, missing_json)
+
+    assert code == 2
+    assert "severity_scale" in capsys.readouterr().err
+
+
+def test_a_finding_with_no_runnable_proof_is_refused(
+    ledger, finding_entry, db, missing_json, capsys
+):
+    """A proof the verifier cannot re-run is prose, and prose is where
+    hallucinated vulnerabilities come from."""
+    seed_roe(ledger, db)
+
+    code = file_finding(
+        finding_entry,
+        db,
+        missing_json,
+        "--surface",
+        "security.is_denied",
+        "--severity",
+        "High",
+        "--title",
+        "described but not demonstrated",
+        "--path",
+        "src/kiro_crew/security.py",
+        "--poc",
+        "read the function and it is obvious",
+    )
+
+    assert code == 2
+    assert "pytest::" in capsys.readouterr().err
+
+
+def test_a_finding_with_no_path_is_refused(ledger, finding_entry, db, missing_json, capsys):
+    seed_roe(ledger, db)
+
+    code = file_finding(
+        finding_entry,
+        db,
+        missing_json,
+        "--surface",
+        "security.is_denied",
+        "--severity",
+        "High",
+        "--title",
+        "nowhere in particular",
+        "--poc",
+        "cmd::python3 -c pass",
+    )
+
+    assert code == 2
+    assert "paths" in capsys.readouterr().err
+
+
+def test_a_json_finding_is_filed_and_an_unknown_key_is_refused(
+    ledger, finding_entry, db, missing_json, tmp_path, capsys
+):
+    """A typo'd key is silently dropped data, so it is refused rather than ignored."""
+    seed_roe(ledger, db)
+    good = tmp_path / "finding.json"
+    good.write_text(
+        json.dumps(
+            {
+                "surface": "dashboard.token_auth",
+                "severity": "Critical",
+                "title": "session token accepted from a query string",
+                "paths": ["src/kiro_crew/dashboard/token_auth.py"],
+                "poc": "cmd::python3 -c pass",
+                "round_id": "kirocrew-dogfood-round-1",
+            }
+        ),
+        encoding="utf-8",
+    )
+    bad = tmp_path / "typo.json"
+    bad.write_text(
+        json.dumps(
+            {
+                "surface": "s",
+                "severity": "Low",
+                "title": "t",
+                "paths": ["p"],
+                "poc": "cmd::true",
+                "sevrity": "Low",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    good_code = finding_entry.main(
+        ["--db", str(db), "--roe-json", str(missing_json), "--json-file", str(good)]
+    )
+    filed = out_json(capsys)
+    bad_code = finding_entry.main(
+        ["--db", str(db), "--roe-json", str(missing_json), "--json-file", str(bad)]
+    )
+
+    assert (good_code, filed["created"]) == (0, True)
+    assert bad_code == 2
+    assert "sevrity" in capsys.readouterr().err
+
+
+def test_parallel_filings_of_one_defect_record_one_auditor_verdict(
+    ledger, finding_entry, db, missing_json, tmp_path
+):
+    """The absence check and the auditor-row insert run under one write lock.
+
+    Two auditors filing the same defect at once both saw "no auditor row" and
+    both appended one -- into a verdict history that is INSERT-only by design, so
+    the duplicate was permanent. Driven through real subprocesses against one
+    SQLite file, with a barrier so both are past argument parsing before either
+    touches the ledger.
+    """
+    seed_roe(ledger, db)
+    payload = tmp_path / "finding.json"
+    payload.write_text(json.dumps(finding_json(*FINDING_ARGS)), encoding="utf-8")
+    script = Path(finding_entry.__file__ or "")
+    argv = [
+        sys.executable,
+        str(script),
+        "--db",
+        str(db),
+        "--roe-json",
+        str(missing_json),
+        "--json-file",
+        str(payload),
+    ]
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KIROCREW_")}
+    procs = [subprocess.Popen(argv, env=env, stdout=subprocess.DEVNULL) for _ in range(6)]
+    codes = [p.wait(timeout=120) for p in procs]
+
+    assert sorted(codes) == [0, 3, 3, 3, 3, 3] or codes.count(3) == 5
+    conn = ledger.connect(db)
+    try:
+        rows = conn.execute("SELECT COUNT(*) FROM verdicts WHERE role = 'auditor'").fetchone()[0]
+        findings = conn.execute("SELECT COUNT(*) FROM findings").fetchone()[0]
+    finally:
+        conn.close()
+    assert findings == 1
+    assert rows == 1
+
+
+# --------------------------------------------------------------------------- #
+# verify_finding
+# --------------------------------------------------------------------------- #
+
+
+FAILING_TEST = "def test_the_guard_admits_what_it_must_refuse():\n    assert False\n"
+PASSING_TEST = "def test_the_guard_refuses_it():\n    assert True\n"
+BROKEN_TEST = "import no_such_module_anywhere\n\n\ndef test_x():\n    assert False\n"
+
+
+@pytest.fixture
+def worktree(tmp_path: Path) -> Path:
+    """A real git checkout, because that is what the verifier brief asks for."""
+    root = tmp_path / "scratch-checkout"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=str(root), check=True)
+    return root
+
+
+def a_finding(ledger, db: Path, *, poc: str, title: str = "the guard admits a bad input") -> int:
+    conn = ledger.connect(db)
+    try:
+        ledger.init_schema(conn)
+        finding_id, _ = ledger.add_finding(
+            conn,
+            surface="security.is_denied",
+            title=title,
+            severity="High",
+            paths=["src/kiro_crew/security.py"],
+            poc=poc,
+            round_id="r1",
+        )
+    finally:
+        conn.close()
+    return finding_id
+
+
+def verdict_rows(ledger, db: Path, finding_id: int) -> list[tuple[str, str]]:
+    conn = ledger.connect(db)
+    try:
+        rows = conn.execute(
+            "SELECT role, verdict FROM verdicts WHERE finding_id = ? ORDER BY rowid ASC",
+            (finding_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [(str(row["role"]), str(row["verdict"])) for row in rows]
+
+
+def test_a_failing_pytest_proof_confirms_the_finding(ledger, verify_finding, db, worktree, capsys):
+    (worktree / "test_poc.py").write_text(FAILING_TEST, encoding="utf-8")
+    finding_id = a_finding(
+        ledger, db, poc="pytest::test_poc.py::test_the_guard_admits_what_it_must_refuse"
+    )
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 0
+    assert payload["verdict"] == "confirmed"
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "confirmed")]
+
+
+def test_a_passing_pytest_proof_rejects_the_finding(ledger, verify_finding, db, worktree, capsys):
+    (worktree / "test_poc.py").write_text(PASSING_TEST, encoding="utf-8")
+    finding_id = a_finding(ledger, db, poc="pytest::test_poc.py::test_the_guard_refuses_it")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 10
+    assert payload["verdict"] == "rejected"
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "rejected")]
+
+
+def test_a_proof_that_errors_rather_than_fails_is_needs_human(
+    ledger, verify_finding, db, worktree, capsys
+):
+    """pytest exits nonzero for a collection error too.
+
+    Reading the exit status alone would confirm a finding whose proof never
+    executed -- the exact false positive this pass exists to catch.
+    """
+    (worktree / "test_poc.py").write_text(BROKEN_TEST, encoding="utf-8")
+    finding_id = a_finding(ledger, db, poc="pytest::test_poc.py::test_x")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "needs-human"
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "needs-human")]
+
+
+def test_a_nonzero_command_proof_confirms_and_a_zero_one_rejects(
+    ledger, verify_finding, db, worktree, capsys
+):
+    reproduces = a_finding(
+        ledger, db, poc='cmd::python3 -c "raise SystemExit(3)"', title="exits nonzero"
+    )
+    does_not = a_finding(ledger, db, poc="cmd::python3 -c pass", title="exits zero")
+
+    confirmed = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(reproduces), "--worktree", str(worktree)]
+    )
+    capsys.readouterr()
+    rejected = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(does_not), "--worktree", str(worktree)]
+    )
+    capsys.readouterr()
+
+    assert (confirmed, rejected) == (0, 10)
+
+
+def test_an_egress_proof_is_refused_unrun(ledger, verify_finding, db, worktree, capsys):
+    """A forbidden shape is REFUSED, not run and then judged.
+
+    The proof of concept below would create ``was-run`` in the worktree if it
+    ever executed, so its absence is what proves the screen fired before the
+    subprocess rather than after it.
+    """
+    finding_id = a_finding(ledger, db, poc="cmd::touch was-run curl")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "needs-human"
+    assert "curl" in payload["reason"]
+    assert not (worktree / "was-run").exists()
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "needs-human")]
+
+
+@pytest.mark.parametrize(
+    "poc",
+    [
+        "cmd::cat ~/.aws/credentials",
+        "cmd::cat ~/.ssh/id_rsa",
+        "cmd::cat .kiro/crew/config.json",
+        "cmd::python3 -c print(token)",
+        "cmd::wget http://example.invalid/x",
+        "cmd::ssh host true",
+        "cmd::nc host 80",
+    ],
+)
+def test_every_named_forbidden_shape_is_refused(ledger, verify_finding, db, worktree, capsys, poc):
+    finding_id = a_finding(ledger, db, poc=poc, title=f"forbidden shape {poc}")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    assert code == 20
+    assert out_json(capsys)["verdict"] == "needs-human"
+
+
+def test_a_word_inside_another_word_is_not_an_egress_shape(verify_finding):
+    """``nc`` must not fire on ``since``, and ``token`` must not fire on ``tokenize``.
+
+    A screen that refused every innocent PoC would route the whole round to a
+    human, which is the same outcome as having no verifier at all.
+    """
+    assert verify_finding.refusal_reason("cmd::python3 -m tokenize since.py") is None
+    assert verify_finding.refusal_reason("pytest::test/test_concurrency.py::test_since") is None
+
+
+def test_a_directory_that_is_not_a_git_worktree_is_refused(
+    ledger, verify_finding, db, tmp_path, capsys
+):
+    """A scratch checkout is the whole blast-radius bound."""
+    plain = tmp_path / "just-a-directory"
+    plain.mkdir()
+    finding_id = a_finding(ledger, db, poc="cmd::python3 -c pass")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(plain)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "needs-human"
+    assert "git worktree" in payload["reason"]
+
+
+def test_a_proof_that_outlives_the_deadline_is_needs_human(
+    ledger, verify_finding, db, worktree, capsys
+):
+    finding_id = a_finding(ledger, db, poc='cmd::python3 -c "import time; time.sleep(30)"')
+
+    code = verify_finding.main(
+        [
+            "--db",
+            str(db),
+            "--finding-id",
+            str(finding_id),
+            "--worktree",
+            str(worktree),
+            "--timeout",
+            "1",
+        ]
+    )
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "needs-human"
+    assert "did not finish" in payload["reason"]
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "needs-human")]
+
+
+def test_an_unknown_finding_records_nothing(ledger, verify_finding, db, worktree, capsys):
+    """A verdict about a finding that is not there has nothing to attach to."""
+    a_finding(ledger, db, poc="cmd::python3 -c pass")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", "9999", "--worktree", str(worktree)]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert captured.out.strip() == ""
+    assert verdict_rows(ledger, db, 9999) == []
+
+
+def test_a_recorded_finding_with_an_unreadable_proof_shape_records_nothing(
+    ledger, verify_finding, db, worktree, capsys
+):
+    finding_id = a_finding(ledger, db, poc="just some prose")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    assert code == 2
+    assert verdict_rows(ledger, db, finding_id) == []
+
+
+def test_a_nonpositive_timeout_is_refused(ledger, verify_finding, db, worktree, capsys):
+    finding_id = a_finding(ledger, db, poc="cmd::python3 -c pass")
+
+    code = verify_finding.main(
+        [
+            "--db",
+            str(db),
+            "--finding-id",
+            str(finding_id),
+            "--worktree",
+            str(worktree),
+            "--timeout",
+            "0",
+        ]
+    )
+
+    assert code == 2
+    assert verdict_rows(ledger, db, finding_id) == []
+
+
+def test_the_child_environment_does_not_inherit_the_operators_home(verify_finding, tmp_path):
+    """``HOME`` points at the worktree, so ``~/.aws`` resolves inside the sandbox.
+
+    The key set is asserted CLOSED, because that is what keeps the operator's
+    credentials out of a child the audited checkout controls: a name arrives in
+    this environment by being listed, never by being inherited.
+    """
+    env = verify_finding.child_env(tmp_path)
+
+    assert env["HOME"] == str(tmp_path)
+    expected = {
+        "PATH",
+        "HOME",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "PYTHONDONTWRITEBYTECODE",
+        "PYTHONIOENCODING",
+        "LC_ALL",
+    }
+    # The three Windows names are forwarded only where the host defines them, so
+    # the closed set varies by platform in exactly this one way.
+    expected |= {name for name in ("SYSTEMROOT", "PATHEXT", "COMSPEC") if name in os.environ}
+    assert set(env) == expected
+
+
+def test_the_verifier_verdict_is_appended_not_overwritten(
+    ledger, verify_finding, db, worktree, capsys
+):
+    """The ledger keeps the disagreement; two runs leave two rows."""
+    (worktree / "test_poc.py").write_text(PASSING_TEST, encoding="utf-8")
+    finding_id = a_finding(ledger, db, poc="pytest::test_poc.py::test_the_guard_refuses_it")
+    conn = ledger.connect(db)
+    try:
+        ledger.record_verdict(
+            conn, finding_id=finding_id, role="auditor", verdict="confirmed", reason="I saw it"
+        )
+    finally:
+        conn.close()
+
+    verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+    capsys.readouterr()
+
+    assert verdict_rows(ledger, db, finding_id) == [
+        ("auditor", "confirmed"),
+        ("verifier", "rejected"),
+    ]
+
+
+def test_the_scripts_shell_out_to_nothing_but_the_proof_of_concept(scope_check, finding_entry):
+    """Only ``verify_finding`` runs a subprocess; the other two are pure readers.
+
+    Asserted on the source rather than described in a comment, because "this
+    script runs nothing" is a property a later edit can quietly take away.
+    """
+    for module in (scope_check, finding_entry):
+        source = Path(module.__file__ or "").read_text(encoding="utf-8")
+        # The import, not the word: both files DISCUSS running nothing in their
+        # docstrings, and a scan that matched the prose would pass for the wrong
+        # reason and fail the moment someone rewrote a sentence.
+        assert "import subprocess" not in source
+        assert "os.system" not in source
+        assert "os.popen" not in source
+
+
+def test_every_script_carries_a_shebang_and_is_stdlib_only():
+    for name in ("scope_check.py", "finding_entry.py", "verify_finding.py"):
+        source = (SCRIPTS / name).read_text(encoding="utf-8")
+        assert source.startswith("#!/usr/bin/env python3\n")
+        imports = [
+            line.split()[1].split(".")[0]
+            for line in source.splitlines()
+            if line.startswith("import ")
+        ] + [
+            line.split()[1].split(".")[0]
+            for line in source.splitlines()
+            if line.startswith("from ") and " import " in line
+        ]
+        assert set(imports) <= set(sys.stdlib_module_names), sorted(
+            set(imports) - set(sys.stdlib_module_names)
+        )
+
+
+def test_a_proof_that_writes_outside_the_worktree_is_refused_unrun(
+    ledger, verify_finding, db, worktree, capsys
+):
+    """The write-escape shape is refused, not run and then judged.
+
+    The command below would create ``escaped`` in the worktree's PARENT if it
+    ran, so that file's absence is what proves the screen fired before the
+    subprocess. This is a named-shape screen, not containment: it refuses a
+    ``..`` segment and an absolute path, and the module docstring says plainly
+    that a program reaching outside by another spelling is bounded by the rules
+    of engagement and the host's policy gate rather than by this check.
+    """
+    finding_id = a_finding(ledger, db, poc="cmd::touch ../escaped")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "needs-human"
+    assert not (worktree.parent / "escaped").exists()
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "needs-human")]
+
+
+@pytest.mark.parametrize(
+    "poc",
+    [
+        "cmd::python3 -c \"open('../sibling', 'w').write('x')\"",
+        "cmd::cp secrets /etc/passwd",
+        "cmd::python3 --config=../outside.cfg",
+    ],
+)
+def test_every_escape_shape_is_refused(ledger, verify_finding, db, worktree, capsys, poc):
+    finding_id = a_finding(ledger, db, poc=poc, title=f"escape shape {poc}")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    assert code == 20
+    assert out_json(capsys)["verdict"] == "needs-human"
+
+
+def test_an_ordinary_relative_proof_is_not_read_as_an_escape(verify_finding):
+    """The escape screen must not refuse the proofs the verifier exists to run."""
+    assert verify_finding.refusal_reason("cmd::python3 -m pytest test/test_x.py") is None
+    assert verify_finding.refusal_reason("cmd::python3 poc.py --mode=strict") is None
+
+
+@pytest.mark.parametrize(
+    "nodeid",
+    [
+        # A parametrised id: `token` then `[`, which IS a word boundary.
+        "pytest::test/test_dashboard_auth.py::test_token[query-string]",
+        # A module named for the thing under test.
+        "pytest::test/token.py::test_rejects_a_query_string",
+        # A directory named for it.
+        "pytest::test/ssh/test_transport.py::test_refuses_an_unknown_host",
+    ],
+)
+def test_a_pytest_nodeid_naming_a_screened_word_is_not_refused(verify_finding, nodeid):
+    """A nodeid is a SELECTOR, not a program.
+
+    Each id here really does contain a screened word as a WHOLE word -- which is
+    what the word screen matches -- so word-screening nodeids refused exactly the
+    tests this codebase's dominant finding class is written as, and bought
+    nothing: what the selected test DOES was never visible to a string screen.
+    The credential-PATH screen still applies to both shapes.
+    """
+    assert verify_finding.refusal_reason(nodeid) is None
+
+
+def test_the_word_screen_still_applies_to_a_command_proof(verify_finding):
+    """Narrowing the screen to ``cmd::`` must not disarm it there."""
+    assert verify_finding.refusal_reason('cmd::python3 -c "print(token)"') is not None
+    assert verify_finding.refusal_reason("cmd::ssh host true") is not None
+
+
+def test_the_credential_path_screen_applies_to_a_nodeid_too(verify_finding):
+    """No legitimate nodeid names a credential path, so both shapes keep it."""
+    assert verify_finding.refusal_reason("pytest::test_x.py::test_reads_from_~/.aws")
+
+
+def test_a_hostile_checkout_cannot_print_its_way_to_a_confirmation(
+    ledger, verify_finding, db, worktree, capsys
+):
+    """The audited checkout is untrusted, so its STDOUT cannot be the verdict.
+
+    A ``conftest.py`` in the target that prints pytest's own summary text and
+    exits nonzero forged ``confirmed`` while the named test never ran. The
+    verdict now comes from a JUnit report written outside the worktree and keyed
+    to the requested nodeid, so this reaches a human instead.
+    """
+    (worktree / "conftest.py").write_text(
+        "import sys\n\n\ndef pytest_sessionfinish(session, exitstatus):\n"
+        "    print('1 failed, 0 passed in 0.01s')\n"
+        "    sys.stdout.flush()\n"
+        "    import os\n"
+        "    os._exit(1)\n",
+        encoding="utf-8",
+    )
+    (worktree / "test_poc.py").write_text(PASSING_TEST, encoding="utf-8")
+    finding_id = a_finding(ledger, db, poc="pytest::test_poc.py::test_the_guard_refuses_it")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code != 0
+    assert payload["verdict"] != "confirmed"
+
+
+def test_a_report_that_names_another_test_is_needs_human(verify_finding, tmp_path):
+    """The report is keyed to the nodeid that was asked for."""
+    report = tmp_path / "result.xml"
+    report.write_text(
+        '<testsuites><testsuite name="pytest" tests="1">'
+        '<testcase classname="test_other" name="test_something_else">'
+        "<failure>boom</failure></testcase></testsuite></testsuites>",
+        encoding="utf-8",
+    )
+
+    verdict, reason = verify_finding.judge_report(report, "test_poc.py::test_the_real_one")
+
+    assert verdict == "needs-human"
+    assert "test_the_real_one" in reason
+
+
+def test_a_missing_report_is_needs_human(verify_finding, tmp_path):
+    """Fail closed: no report means the proof did not run to completion."""
+    verdict, _ = verify_finding.judge_report(tmp_path / "absent.xml", "test_poc.py::test_x")
+
+    assert verdict == "needs-human"
+
+
+def test_a_pytest_selector_may_not_escape_the_worktree(verify_finding):
+    """The path screen was wired to the cmd lane only, so a nodeid carried the same
+    escape past it -- spelled as a selector instead of as an argument.
+
+    pytest resolves a nodeid's file part against its working directory, which is the
+    scratch checkout, so `..` there runs code the audited checkout does not contain.
+    """
+    for nodeid in (
+        "pytest::../outside/test_poc.py::test_x",
+        "pytest::../../etc/test_poc.py::test_x",
+        "pytest::/abs/test_poc.py::test_x",
+        "pytest::..\\outside\\test_poc.py::test_x",
+    ):
+        reason = verify_finding.refusal_reason(nodeid)
+        assert reason is not None, nodeid
+        assert "outside the scratch worktree" in reason, nodeid
+
+
+def test_an_ordinary_nodeid_is_not_caught_by_the_escape_screen(verify_finding):
+    """The screen must not cost the dominant real finding shape.
+
+    Only the FILE part is screened, so a parametrised id carrying arbitrary text --
+    including a screened word or a dotted value -- still runs.
+    """
+    for nodeid in (
+        "pytest::test/test_security.py::test_echo_is_not_a_program",
+        "pytest::test/test_security.py::test_token_auth[query]",
+        "pytest::test/sub/dir/test_poc.py::test_x[a..b]",
+        "pytest::test/test_poc.py::test_x[/abs/path]",
+    ):
+        assert verify_finding.refusal_reason(nodeid) is None, nodeid
+
+
+def test_a_pytest_selector_that_names_only_a_file_is_not_runnable(verify_finding):
+    """An unkeyed selector is refused as a SHAPE, before anything runs.
+
+    A file-wide run produces a report keyed to no single test, so ANY failure in
+    that file satisfies the finding. Refusing the shape is what makes that verdict
+    unreachable rather than merely unlikely.
+    """
+    assert verify_finding.poc_argv("pytest::test_poc.py") is None
+    assert verify_finding.poc_argv("pytest::test_poc.py::") is None
+    assert verify_finding.poc_argv("pytest::test_poc.py::test_x") is not None
+
+
+def test_a_finding_whose_proof_names_only_a_file_is_refused_at_filing(
+    ledger, finding_entry, db, missing_json, capsys
+):
+    """Write-time validation runs the verifier's own parser, so an unkeyed
+    selector never reaches the ledger at all."""
+    seed_roe(ledger, db)
+
+    code = file_finding(
+        finding_entry,
+        db,
+        missing_json,
+        "--surface",
+        "security.is_denied",
+        "--severity",
+        "High",
+        "--title",
+        "a whole file stands in for one test",
+        "--path",
+        "src/kiro_crew/security.py",
+        "--poc",
+        "pytest::test/test_security.py",
+    )
+
+    assert code == 2
+    assert "pytest::" in capsys.readouterr().err
+
+
+def test_an_unkeyed_selector_is_never_confirmed_by_a_report(verify_finding, tmp_path):
+    """The reader refuses too: a failure belonging to some other test in the same
+    file is not evidence for this finding."""
+    report = tmp_path / "result.xml"
+    report.write_text(
+        '<testsuites><testsuite name="pytest" tests="1">'
+        '<testcase classname="test_poc" name="test_something_unrelated">'
+        "<failure>boom</failure></testcase></testsuite></testsuites>",
+        encoding="utf-8",
+    )
+
+    verdict, reason = verify_finding.judge_report(report, "test_poc.py")
+
+    assert verdict == "needs-human"
+    assert "one test" in reason
+
+
+def test_the_child_env_carries_what_a_windows_process_needs_to_start(
+    verify_finding, tmp_path, monkeypatch
+):
+    """Withholding these does not harden the child, it stops it existing.
+
+    Without ``SYSTEMROOT`` a Windows CPython dies seeding ``os.urandom`` during
+    interpreter startup, so the proof never runs and every pytest finding reads
+    ``needs-human``. ``PATHEXT`` and ``COMSPEC`` are how a bare program name
+    resolves to an executable there.
+    """
+    monkeypatch.setenv("SYSTEMROOT", r"C:\Windows")
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT")
+    monkeypatch.setenv("COMSPEC", r"C:\Windows\system32\cmd.exe")
+
+    env = verify_finding.child_env(tmp_path)
+
+    assert env["SYSTEMROOT"] == r"C:\Windows"
+    assert env["PATHEXT"] == ".COM;.EXE;.BAT"
+    assert env["COMSPEC"] == r"C:\Windows\system32\cmd.exe"
+
+
+def test_a_name_the_host_does_not_define_is_not_invented(verify_finding, tmp_path, monkeypatch):
+    """The passthrough is a filter, not a set of required keys, so a minimal host
+    is unaffected rather than handed empty strings."""
+    for name in ("SYSTEMROOT", "PATHEXT", "COMSPEC"):
+        monkeypatch.delenv(name, raising=False)
+
+    env = verify_finding.child_env(tmp_path)
+
+    assert "SYSTEMROOT" not in env
+    assert "PATHEXT" not in env
+    assert "COMSPEC" not in env
+
+
+def test_the_child_scratch_directory_is_the_worktree_in_every_spelling(verify_finding, tmp_path):
+    """``tempfile`` reads ``TMPDIR`` on POSIX and ``TEMP``/``TMP`` on Windows, so
+    pinning one spelling left a PoC's scratch files outside the throwaway
+    checkout on the other platform."""
+    env = verify_finding.child_env(tmp_path)
+
+    assert env["TMPDIR"] == str(tmp_path)
+    assert env["TEMP"] == str(tmp_path)
+    assert env["TMP"] == str(tmp_path)
+
+
+def test_filing_records_the_auditor_verdict(ledger, finding_entry, db, missing_json, capsys):
+    """Filing IS the auditor's claim, and the retrospective reads it.
+
+    ``findings.auditor_verdict`` is a materialised view of the verdict rows, so
+    with no row written the column stays NULL and an auditor claim is
+    indistinguishable from an absent one -- which is the false-positive signal the
+    procedure obliges the conductor to report.
+    """
+    seed_roe(ledger, db)
+
+    code = file_finding(finding_entry, db, missing_json)
+
+    finding_id = out_json(capsys)["finding_id"]
+    assert code == 0
+    assert verdict_rows(ledger, db, finding_id) == [("auditor", "confirmed")]
+    conn = ledger.connect(db)
+    try:
+        row = conn.execute(
+            "SELECT auditor_verdict FROM findings WHERE id = ?", (finding_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["auditor_verdict"] == "confirmed"
+
+
+def test_a_duplicate_filing_does_not_append_a_second_auditor_verdict(
+    ledger, finding_entry, db, missing_json, capsys
+):
+    """A re-report returns the original id, and the earlier row's verdict history
+    is the record rather than something a second filing appends to."""
+    seed_roe(ledger, db)
+    assert file_finding(finding_entry, db, missing_json) == 0
+    finding_id = out_json(capsys)["finding_id"]
+
+    assert file_finding(finding_entry, db, missing_json) == 3
+
+    assert verdict_rows(ledger, db, finding_id) == [("auditor", "confirmed")]
+
+
+def test_a_filing_repairs_a_finding_that_carries_no_auditor_claim(
+    ledger, finding_entry, db, missing_json, capsys
+):
+    """``add_finding`` commits on its own, so a crash before the verdict write is
+    possible -- and keyed on ``created`` the retry would skip the repair forever.
+
+    This drives that state directly: a finding inserted through the ledger, with no
+    verdict row, is what the process would leave behind. Re-filing it must complete
+    the record rather than report a duplicate and walk away.
+    """
+    seed_roe(ledger, db)
+    finding_id = a_finding(
+        ledger,
+        db,
+        poc="pytest::test/test_security.py::test_echo_is_not_a_program",
+        title="echo text is classified as an executed program",
+    )
+    assert verdict_rows(ledger, db, finding_id) == []
+
+    code = file_finding(finding_entry, db, missing_json)
+
+    assert code == 3
+    assert out_json(capsys)["finding_id"] == finding_id
+    assert verdict_rows(ledger, db, finding_id) == [("auditor", "confirmed")]
+
+
+def test_a_filing_does_not_overwrite_a_verdict_someone_else_recorded(
+    ledger, finding_entry, db, missing_json, capsys
+):
+    """A human ruling outranks a re-report, so the repair is keyed on the auditor
+    row's absence and never on the folded column."""
+    seed_roe(ledger, db)
+    assert file_finding(finding_entry, db, missing_json) == 0
+    finding_id = out_json(capsys)["finding_id"]
+    conn = ledger.connect(db)
+    try:
+        ledger.record_verdict(
+            conn, finding_id=finding_id, role="human", verdict="rejected", reason="not a defect"
+        )
+    finally:
+        conn.close()
+
+    assert file_finding(finding_entry, db, missing_json) == 3
+
+    assert verdict_rows(ledger, db, finding_id) == [
+        ("auditor", "confirmed"),
+        ("human", "rejected"),
+    ]
+
+
+def test_an_unrelated_failure_beside_the_requested_test_does_not_confirm(verify_finding, tmp_path):
+    """Naming the test is not enough -- the verdict is that test's OWN result.
+
+    A run reports tests beside the cited one (a parametrised sibling, whatever else
+    the selector's file collected), and folding those in let an unrelated failure
+    confirm this finding.
+    """
+    report = tmp_path / "result.xml"
+    report.write_text(
+        '<testsuites><testsuite name="pytest" tests="2">'
+        '<testcase classname="test_poc" name="test_the_real_one"/>'
+        '<testcase classname="test_poc" name="test_a_sibling">'
+        "<failure>boom</failure></testcase></testsuite></testsuites>",
+        encoding="utf-8",
+    )
+
+    verdict, reason = verify_finding.judge_report(report, "test_poc.py::test_the_real_one")
+
+    assert verdict == "rejected"
+    assert "test_the_real_one" in reason
+
+
+def test_the_requested_test_failing_still_confirms(verify_finding, tmp_path):
+    """The narrowing must not cost the verdict it exists to produce."""
+    report = tmp_path / "result.xml"
+    report.write_text(
+        '<testsuites><testsuite name="pytest" tests="2">'
+        '<testcase classname="test_poc" name="test_a_sibling"/>'
+        '<testcase classname="test_poc" name="test_the_real_one">'
+        "<failure>boom</failure></testcase></testsuite></testsuites>",
+        encoding="utf-8",
+    )
+
+    verdict, _ = verify_finding.judge_report(report, "test_poc.py::test_the_real_one")
+
+    assert verdict == "confirmed"
+
+
+def test_the_verifier_refuses_the_checkout_it_is_running_from(verify_finding, tmp_path):
+    """The checkable half of "the sandbox must be disposable".
+
+    Provenance in general is not checkable from here -- the caller picks the path and
+    so controls what is inside it -- but "you pointed me at my own source tree" is
+    decidable without trusting the caller, and it is the case an operator reaches by
+    accident.
+    """
+    repo_root = Path(verify_finding.__file__ or "").resolve().parents[5]
+
+    assert verify_finding.is_own_checkout(repo_root)
+    assert not verify_finding.is_own_checkout(tmp_path)
+
+
+def test_a_proof_is_refused_when_the_sandbox_is_the_verifiers_own_repository(verify_finding):
+    """Wired into the verdict path, not just available as a helper."""
+    repo_root = Path(verify_finding.__file__ or "").resolve().parents[5]
+
+    verdict, reason = verify_finding.decide(
+        {"poc": "pytest::test/test_security.py::test_echo_is_not_a_program"}, repo_root, 5
+    )
+
+    assert verdict == "needs-human"
+    assert "running from" in reason
+
+
+def test_a_missing_command_records_needs_human_instead_of_crashing(
+    ledger, verify_finding, db, worktree, capsys
+):
+    """A mistyped or hallucinated program name is the verifier's ordinary input.
+
+    ``subprocess.run`` raises ``FileNotFoundError`` for it rather than returning
+    a status, and letting that propagate killed the process outside the
+    documented ``{0,10,20,2}`` contract with no verdict recorded at all.
+    """
+    finding_id = a_finding(ledger, db, poc="cmd::definitely-no-such-command-anywhere --flag")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "needs-human"
+    assert "could not be started" in payload["reason"]
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "needs-human")]
+
+
+@pytest.mark.parametrize(
+    "returncode,verdict",
+    [
+        (0, "rejected"),
+        (1, "needs-human"),
+        (2, "confirmed"),
+        (3, "confirmed"),
+        (125, "confirmed"),
+        (126, "needs-human"),
+        (127, "needs-human"),
+        (137, "needs-human"),
+        (139, "needs-human"),
+        (255, "needs-human"),
+        (3221225477, "needs-human"),
+        (-9, "needs-human"),
+    ],
+)
+def test_a_command_that_never_ran_does_not_confirm(verify_finding, returncode, verdict):
+    """``cmd::`` may not read its verdict off "nonzero" alone.
+
+    Nonzero covers "the defect reproduced" AND "the command never ran" -- a
+    missing interpreter, a wrong cwd, a death by signal. Confirming on the second
+    is the errored-proof false positive the pytest lane already rejects, so the
+    two lanes now hold the same bar. Exit 1 is in the second set: it is what a
+    model-authored PoC exits when it dies on a hallucinated import, and nothing
+    in the status separates that from a reproduction.
+    """
+    assert verify_finding.judge_cmd(returncode)[0] == verdict
+
+
+def test_a_command_proof_that_crashes_is_not_confirmed(
+    ledger, verify_finding, db, worktree, capsys
+):
+    """End to end: a PoC dying on a missing import must not persist `confirmed`."""
+    finding_id = a_finding(ledger, db, poc='cmd::python3 -c "import no_such_module_anywhere_xyz"')
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "needs-human"
+    assert "exited 1" in payload["reason"]
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "needs-human")]
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="SIGKILL is POSIX-only. Windows reports no negative returncode, so the"
+    " signal-death shape this drives end to end cannot arise there; judge_cmd's"
+    " mapping for it is covered directly by the unit test above.",
+)
+def test_a_signal_killed_command_records_needs_human(ledger, verify_finding, db, worktree, capsys):
+    """The launch-failure mapping, driven end to end rather than unit-only."""
+    finding_id = a_finding(
+        ledger, db, poc='cmd::python3 -c "import os, signal; os.kill(os.getpid(), signal.SIGKILL)"'
+    )
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 20
+    assert payload["verdict"] == "needs-human"
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "needs-human")]
+
+
+def test_the_child_path_fallback_names_no_posix_only_directory(
+    verify_finding, tmp_path, monkeypatch
+):
+    """A hardcoded ``/usr/bin:/bin`` fallback names nothing on Windows."""
+    monkeypatch.delenv("PATH", raising=False)
+
+    assert verify_finding.child_env(tmp_path)["PATH"] == os.defpath
+
+
+def test_the_ledger_is_loaded_once_per_invocation(finding_entry, scope_check, verify_finding):
+    """Three scripts, one ledger module -- not one load per sibling.
+
+    ``finding_entry`` loads both siblings, and a module-level ledger load in each
+    executed ``ledger.py`` three times for one filing. The siblings load it
+    lazily and ``finding_entry`` takes ``scope_check``'s instance.
+    """
+    assert finding_entry._ledger is finding_entry._scope_check.ledger()
+    assert scope_check.ledger() is scope_check.ledger()
+    assert verify_finding.ledger() is verify_finding.ledger()
+
+
+def test_the_proof_shapes_are_declared_once(finding_entry, verify_finding):
+    """Write-time validation and the verifier cannot drift apart.
+
+    ``finding_entry`` validates a PoC with ``verify_finding``'s own parser, so a
+    third proof shape cannot leave filing rejecting what the verifier runs.
+    """
+    source = Path(finding_entry.__file__ or "").read_text(encoding="utf-8")
+    assert "POC_PREFIXES = (" not in source
+    assert finding_entry.validate_poc("pytest::test_x.py::test_y") is None
+    assert finding_entry.validate_poc("cmd::python3 -c pass") is None
+    assert finding_entry.validate_poc("prose about the bug") is not None
+    assert verify_finding.POC_PREFIXES == ("pytest::", "cmd::")
+
+
+def test_an_output_flood_does_not_buffer_into_the_verifier(
+    ledger, verify_finding, db, worktree, capsys
+):
+    """The PoC's output is discarded, so a printing PoC cannot exhaust memory.
+
+    No verdict reads the child's output -- the pytest lane reads the report file
+    and the command lane reads the status -- but capturing it through a pipe
+    buffered the whole stream in this process, and ``--timeout`` bounds wall time,
+    never bytes. This PoC prints ~64MB and must still reach a verdict.
+    """
+    program = (
+        "import sys\n"
+        "block = 'x' * 65536\n"
+        "for _ in range(1000):\n"
+        "    sys.stdout.write(block)\n"
+        "raise SystemExit(7)\n"
+    )
+    (worktree / "flood.py").write_text(program, encoding="utf-8")
+    finding_id = a_finding(ledger, db, poc="cmd::python3 flood.py")
+
+    code = verify_finding.main(
+        ["--db", str(db), "--finding-id", str(finding_id), "--worktree", str(worktree)]
+    )
+
+    payload = out_json(capsys)
+    assert code == 0
+    assert payload["verdict"] == "confirmed"
+    assert verdict_rows(ledger, db, finding_id) == [("verifier", "confirmed")]
+
+
+def test_run_poc_returns_a_bare_status_and_captures_nothing(verify_finding):
+    """Asserted on the source: a pipe re-added is the whole defect coming back."""
+    source = Path(verify_finding.__file__ or "").read_text(encoding="utf-8")
+    assert "stdout=subprocess.DEVNULL" in source
+    assert "stderr=subprocess.DEVNULL" in source
+    assert "subprocess.PIPE" not in source
+
+
+def test_a_test_named_like_an_outcome_element_cannot_forge_one(verify_finding, tmp_path):
+    """The test file is in the untrusted checkout, so a test NAME is attacker text.
+
+    XML escapes a ``<`` inside an attribute as ``&lt;``, so a raw ``<failure`` can
+    only be markup -- which is why the reader matches the tag and not the word.
+    """
+    report = tmp_path / "result.xml"
+    report.write_text(
+        '<testsuites><testsuite><testcase classname="c" name="test_x&lt;failure/&gt;"'
+        ' time="0.0"></testcase></testsuite></testsuites>',
+        encoding="utf-8",
+    )
+
+    verdict, _ = verify_finding.judge_report(report, "test_poc.py::test_x&lt;failure/&gt;")
+
+    assert verdict == "rejected"
+
+
+def test_the_case_name_is_not_read_off_classname(verify_finding, tmp_path):
+    """``name="`` is a SUBSTRING of ``classname="``.
+
+    An unanchored search returned the module name for every case, so the
+    nodeid check compared the wrong string and every real run came back
+    ``needs-human``. Caught by the suite before it shipped.
+    """
+    chunk = ' classname="test_poc" name="test_boom" time="0.001"><failure>E</failure></testcase>'
+
+    assert verify_finding.case_name(chunk) == "test_boom"
+
+
+def test_a_name_inside_a_nested_element_is_not_the_case_name(verify_finding):
+    """Only the start tag is searched, so a nested attribute cannot supply one."""
+    chunk = ' classname="c" time="0.0"><failure name="not-the-test">E</failure></testcase>'
+
+    assert verify_finding.case_name(chunk) == "c" or verify_finding.case_name(chunk) is None
+
+
+def test_an_element_name_must_be_a_whole_tag(verify_finding, tmp_path):
+    """``<failures>`` is not ``<failure``."""
+    report = tmp_path / "result.xml"
+    report.write_text(
+        '<testsuites><testsuite><testcase classname="c" name="test_x">'
+        "<failures>0</failures></testcase></testsuite></testsuites>",
+        encoding="utf-8",
+    )
+
+    verdict, _ = verify_finding.judge_report(report, "test_poc.py::test_x")
+
+    assert verdict == "rejected"
+
+
+def test_verifying_against_a_missing_ledger_creates_nothing(
+    verify_finding, tmp_path, worktree, capsys
+):
+    """Verifying never CREATES a ledger.
+
+    A finding must be filed to be verified, and filing is what creates the
+    database -- so a missing one is a mistyped ``--db``. Creating it there left an
+    empty ledger behind, which ``scope_check`` then reads as a ledger with zero
+    rules rather than as no ledger at all.
+    """
+    absent = tmp_path / "nested" / "findings.db"
+
+    code = verify_finding.main(
+        ["--db", str(absent), "--finding-id", "1", "--worktree", str(worktree)]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert not absent.exists()
+    assert not absent.parent.exists()
+    assert "no ledger at" in captured.err
+
+
+def test_a_ledger_that_is_not_a_database_exits_two(verify_finding, tmp_path, worktree, capsys):
+    """A file that is not a ledger is an input error, not a verdict."""
+    bogus = tmp_path / "findings.db"
+    bogus.write_bytes(b"not a sqlite database")
+
+    code = verify_finding.main(
+        ["--db", str(bogus), "--finding-id", "1", "--worktree", str(worktree)]
+    )
+
+    assert code == 2
+    assert "cannot read findings" in capsys.readouterr().err
+
+
+def test_a_json_file_alone_still_carries_its_own_round_id(
+    ledger, finding_entry, db, missing_json, tmp_path, capsys
+):
+    """Refusing the COMBINATION must not refuse the file's own round id."""
+    seed_roe(ledger, db)
+    payload = tmp_path / "finding.json"
+    payload.write_text(
+        json.dumps(
+            {
+                "surface": "webhooks.ingest",
+                "severity": "High",
+                "title": "unbounded frame accepted",
+                "paths": ["src/kiro_crew/webhooks.py"],
+                "poc": "cmd::python3 -c pass",
+                "round_id": "kirocrew-dogfood-round-1",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    code = finding_entry.main(
+        ["--db", str(db), "--roe-json", str(missing_json), "--json-file", str(payload)]
+    )
+    filed = out_json(capsys)
+
+    conn = ledger.connect(db)
+    try:
+        row = conn.execute(
+            "SELECT round_id FROM findings WHERE id = ?", (filed["finding_id"],)
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert code == 0
+    assert row["round_id"] == "kirocrew-dogfood-round-1"


### PR DESCRIPTION
> **#9270 has merged** (squash `5134dcea4`), so this PR is now retargeted to
> `main` and rebased onto it — the diff is only its own commit, and `ledger.py`
> comes from main. Note for anyone reading the timeline: deleting the merged base
> branch auto-CLOSED this PR, so it was reopened and retargeted; its full review
> history (dispositions, rounds, intent) is intact. `ledger.py` is imported, never
> touched.

## Problem / Motivation

The security-conductor RFC (#9195) makes three judgments the conductor is
explicitly NOT allowed to make from its own reading: whether a candidate surface
is inside the rules of engagement, whether a defect is already recorded, and
whether a finding's proof of concept actually reproduces. The SKILL.md in #9271
already calls three scripts for exactly those three answers — `scope_check.py`,
`finding_entry.py`, `verify_finding.py` — and none of them exist. Today the skill
names tools that are not there, and the conductor's only fallback is the judgment
the RFC removed on purpose.

## Why it matters

Two of the RFC's load-bearing claims are claims about these scripts, not about
prompt wording:

- **"Aggression is bounded by data, not by tone."** A tone instruction degrades
  silently across a long session. A scope verdict is testable — but only if
  something computes it. Without `scope_check.py` the bound is back to being a
  sentence in a brief.
- **"The verification pass is the product."** Hallucinated vulnerabilities are the
  dominant noise source in agentic security review, and the whole point of the
  verifier lane is a second, independent pass whose job is *rejecting* them. A
  verifier that reports in prose is a verifier the conductor has to interpret,
  which is where a shared blind spot survives.

`finding_entry.py` carries the third: one record per real defect, so a surface
re-audited in a later round does not re-file what a human already ruled on.

## What changed (motivation → approach → change)

**Goal:** move those three judgments into exit codes, with the ledger as the
source of truth.

**The RFC gains a "The trust boundary" section**, and the two "in the sandbox"
phrases in it are reworded. Seven review rounds argued the boundary in
dispositions; this writes it down once. The verifier runs as the operator, on the
operator's machine, against a checkout the operator chose, so there is no
privilege drop between them. The **target checkout is trusted** — source, test
suite, reports. The **auditor's finding is untrusted** — model-authored text
ingested on unattended cycles — and its PoC is screened before it runs.
The section separates **host integrity** (out of scope: the checkout runs as
the operator, and a symlink, a detached process or a self-rewritten report is the
operator attacking themselves) from **verdict integrity** (defended: an exit
status or stdout is never the verdict, because ordinary breakage must not confirm
a finding — that discipline is about false positives, not adversaries).
The **"Untrusted: the auditor's finding"** paragraph states what the named-shape
screen does and does not bound: it catches a sloppy PoC, not an adversarial one,
and what bounds the latter is the crew session's own tool gate and host sandbox
— a `cmd::` proof runs with exactly the privileges the operator gave the crew.
Two operator levers are named (disallow `cmd::` in the rules; run under the host
sandbox); attended confirmation for first-run `cmd::` proofs is left to a future
RFC. **Containment is a disposable worktree plus a deadline, not an OS sandbox**:
Kiro Crew's namespace sandbox is Linux-only and package-internal, these are stdlib
bare files, and where "sandboxed" and "cross-platform" conflict, cross-platform
wins. Auditing a checkout the operator did not author is named out of scope.
**This is a decision this PR makes, not one #9195 made** — the merged RFC said
"in the sandbox" without a mechanism these scripts could reach; approving this
diff is approving the section.

**Approach.** Exit codes are the interface, not stdout — the conductor reads a
number, so a script cannot be misread the way prose can. Each script is stdlib
only and imports `ledger.py` as a sibling through the same no-bytecode loader
`prepare-pr/scripts/pr_status.py` uses, because a skill's scripts are synced out
of the package tree and run as bare files. The ledger loads lazily and is shared,
so one invocation parses it once however many siblings are involved.

**`scope_check.py`** reads the ACTIVE `roe_rules` rows and answers
`IN_SCOPE` (0) / `OUT_OF_SCOPE` (10) / `UNKNOWN` (20) / `NEEDS_APPROVAL` (30),
with the matched rules and the reasons as JSON on stdout.

- `UNKNOWN` and `NEEDS_APPROVAL` are **distinct nonzero codes rather than
  flavours of zero**, so a caller that checks only `rc == 0` cannot read "I could
  not tell" or "a human must decide" as permission.
- **A rule that PERMITS is matched whole; only a rule that REFUSES is matched by
  containment.** `allowed_techniques` and `human_approval` need whole-value
  equality — containment there let a fragment stand in for the whole, so
  `--technique unit` matched the allowed `local-unit-poc`. `forbidden` keeps
  containment, since its values are negative phrases and matching
  `--technique network-egress` against `no-network-egress-from-a-poc` is the
  point. The asymmetry is the invariant: loosening a matcher can only ever widen
  what is refused.
- **Precedence is fixed**: a `forbidden` match beats an `allowed_techniques` row
  about the same technique, and a `human_approval` gate is checked **before** the
  allow list — a technique in both is "in scope, but a human says go", and
  letting the allow row win made the gate vanish exactly when it applied. That collision is what a *narrowing* edit looks like —
  reverting is flipping `active`, not deleting the older row — so if the allowed
  row could win, every narrowing would be undone by the row it narrowed.
- An **uninterpretable rule withholds permission** instead of being skipped.
  `severity_scale` and `report_schema` are named as non-scope fields, so the two
  rows that ship in the real rules of engagement do not poison every verdict.
- The JSON export is consulted **only when the ledger holds zero rule ROWS**,
  and the substitution is announced on stderr with `id: null` in the verdict.
  Two states are *not* fallback triggers, because neither says the ledger is
  empty: an **unreadable** database (it told us nothing), and **rows that exist
  with none active** — that is the RFC's revert path, so reading it as "no rules"
  restored exactly the scope the revert removed. Both are `UNKNOWN`.
- Paths are compared by **whole segment after normalisation**, and a path is
  judged outside relative repository scope for **both conventions and both drive
  forms** — a leading separator, a UNC prefix, and ANY drive prefix. So
  `path:src` never covers `srcfoo/`, `src/../../etc/passwd` cannot borrow
  `src/`'s coverage, and neither `C:\outside\file` nor the drive-RELATIVE
  `C:Windows\System32` is read as relative by the widest legitimate rule,
  `path:.`. The separator was never what put the path outside the repo.
- **A malformed rule in a granting field withholds permission.** The technique
  matcher compares a value with its prefix stripped, so
  `allowed_techniques=path:network-egress` authorised the technique
  `network-egress`. `allowed_techniques` and `human_approval` now accept only a
  bare slug or `technique:`; anything else there is uninterpretable. `forbidden`
  keeps the path and repo forms, because widening what is refused is safe in a way
  that widening what is permitted is not.
- **An unknown kind prefix is uninterpretable in every scope field, `forbidden`
  included.** `forbidden=pth:src/private` or `p:src/private` (the operator
  meaning `path:`) was stripped to a bare technique phrase, matched no path, and
  the ceiling it was written to be silently vanished — `path:.` answered
  `IN_SCOPE` for `src/private/key.py`. Any word-shaped prefix is a kind; the one
  exception is a Windows drive, told apart by a separator or nothing after the
  colon (`C:/x`, `C:\x`, `D:`).
- **Forbidden path rules fold case; granting rules do not.** On the filesystems
  most operators run, `SRC/private/key.py` is `src/private/key.py`, and a
  byte-for-byte forbidden prefix missed the file it names. Only the refusing side
  folds, per the permit/refuse asymmetry.
- Asking a scope question never creates a database.

**`finding_entry.py`** reads one input, `--json-file` — the RFC has the auditor
"emit one structured finding file per candidate", and the inline-flag spelling
that shipped beside it had no consumer and had already produced its own defect,
so it is gone. It validates the file against `report_schema` and
`severity_scale`, then hands the candidate to `ledger.add_finding` — identity
`(surface, title, sorted paths)` — and prints `{finding_id, created}`. Exit 0 new,
**3 duplicate (still printing the existing id**, because the caller's next step
needs the handle), 2 invalid. A malformed finding fails *here* rather than a
dispatch later: a severity outside the scale is refused, **a scale that cannot be
read at all is also a refusal**, and the PoC is validated by **`verify_finding`'s
own parser** rather than a second list of prefixes, so write-time validation
cannot drift from what the verifier runs. The severity scale is resolved by
reusing `scope_check.load_rules`, so it follows the same rows-then-export
precedence as a scope verdict. **Filing also records the auditor's `confirmed`
verdict row**, because `findings.auditor_verdict` is a fold of the verdict rows
and a finding with none makes an auditor's claim indistinguishable from an
absent one; it is written on the ABSENCE of the row (so a crash between insert
and verdict is repaired by the retry) under one `BEGIN IMMEDIATE` lock (so two
parallel filings append one row, not two).

**`verify_finding.py`** re-runs one PoC (`pytest::<nodeid>` or `cmd::<argv>`, the
latter `shlex`-split and run **without a shell**) in a scratch worktree and
appends the verdict via `ledger.record_verdict(role="verifier", ...)`. Exit 0
confirmed / 10 rejected / 20 needs-human.

- **Neither lane reads its verdict off an exit status alone**, and for one
  reason: a nonzero exit covers "the defect reproduced" AND "the proof never
  ran". Confirming on the second is the false positive this pass exists to catch.
  - `pytest::` takes its verdict from pytest's **JUnit report, written outside
    the worktree** and keyed to the requested nodeid — never from the run's
    stdout or exit status, which cannot separate "the cited test failed" from
    "collection failed" or "a different test failed". The verdict is read off
    the **requested test's own result**: a passing cited test beside a failing
    parametrised sibling is not a reproduction. A selector must name ONE test;
    a file-wide selector is refused at filing time.
  - That report is read as text rather than parsed as XML only because the three
    questions asked of it — which cases ran, what each is named, which outcome
    child it carries — are answered by flat start tags. An outcome is recognised
    as a whole **tag**, so `<failures>` is not `<failure`, and a test *named*
    `test_<failure/>` cannot forge one because XML escapes a `<` in an
    attribute. A missing, unreadable, empty or unrelated report is `needs-human`.
  - `cmd::` treats **launch-failure shapes as `needs-human`**: a spawn `OSError`,
    a death by signal, exit 126, exit 127 — **and exit 1, and anything above
    125**. Exit 1 is the uncaught-exception status of every common interpreter
    and shell; 128+N is a shell wrapper reporting signal N; a Windows crash is a
    large positive code. None is a status the proof chose, so a model-authored
    PoC dying on a hallucinated import was indistinguishable from a reproduction
    and persisted a false `confirmed`. A confirmable command proof exits a
    deliberate status in 2..125. No schema change was needed.
  - The child's **output is discarded, not piped**. No verdict reads it, and
    buffering it into this process exhausted the verifier's memory on a PoC that
    printed without stopping, because a timeout bounds wall time and never
    bytes.
- A PoC is **refused unrun** as `needs-human` when it names network egress or
  `token` (a `cmd::` argv only — a `pytest::` nodeid is a test SELECTOR, and
  word-screening it refused real findings while buying nothing), a credential
  path (both shapes), or a **write outside the worktree** — a `cmd::` argument, or
  a `pytest::` selector's FILE part, that is absolute or carries a `..`
  reference, checked in the interior so a quoted `open('../x','w')` and a
  `--config=../x` both trip it. `--worktree` must be a git checkout and must not
  be the checkout these scripts are themselves running from — the one
  disposability mistake an operator reaches by accident.
- This screen reads the **auditor's text**, per the RFC's trust boundary. It is
  a named-shape check, not a sandbox, and the docstring says so.
- The child gets a **closed allowlist environment**: `HOME`, `TMPDIR`, `TEMP` and
  `TMP` point at the worktree so `~`-relative paths and scratch files land inside
  the throwaway checkout; `PATH` falls back to `os.defpath`; `SYSTEMROOT`,
  `PATHEXT` and `COMSPEC` are forwarded on Windows when the host defines them,
  because without them CPython dies at startup and a bare program name never
  resolves.
- A **timed-out proof is killed and reaped** with a bounded wait — the direct
  child only. **Removed on this head, under the trust boundary:** the
  process-group / `taskkill` tree teardown (a detached grandchild is the
  operator's own checkout leaving a process on the operator's own machine) and
  the report reader's DOCTYPE refusal and byte cap (the report is written by a
  pytest run the verifier itself launched against a trusted tree). Fewer lines,
  no platform branch.
- **Verifying never creates a ledger.** A finding must be filed to be verified,
  and filing is what creates the database — so a missing one is a mistyped
  `--db`, and creating it there left an empty ledger that `scope_check` then reads
  as a ledger with zero rules rather than as no ledger at all.

## Tests

`test/test_security_conductor_scripts.py`, 138 tests, each driven through `main()`
with argv the way the skill invokes it, because the exit code is the interface.

- **scope_check**: forbidden beats allowed on the technique and the path axis; a
  partial technique word does not authorise the whole technique, while the
  forbidden phrase still matches one; `UNKNOWN` on an empty ledger, an unknown
  rule field and a bare `scope` value; `severity_scale`/`report_schema` skipped;
  `NEEDS_APPROVAL` for a gated technique; the export read only when the ledger is
  empty and never overriding rows; an unreadable database `UNKNOWN` **without**
  falling back; revoking every rule `UNKNOWN` and never reaching the export while
  a truly empty ledger still does; traversal, whole-segment prefixes, and six
  spellings of an out-of-repo path (including both drive-relative forms) rejected
  under `path:.` while a real in-repo path still passes; a `path:`/`repo:` value in
  a granting field granting nothing and being reported, while a forbidden `path:`
  rule still refuses and does not poison an unrelated verdict; a mistyped
  `forbidden=pth:` or `p:` kind withholding permission (red-before: `0 == 20`)
  while `C:/x`, `C:\x`, `D:` and a colon inside prose stay technique phrases; a
  gate holding when the technique is also allowed (red-before: `0 == 30`); a
  forbidden path refusing in either case while a grant stays case-exact; no
  database created by a read.
- **finding_entry**: duplicate exits 3 with the same id; path order does not fork
  a finding; a severity outside the scale, a missing scale, a non-runnable PoC and
  missing paths each exit 2; an unknown key is refused; the proof shapes are
  declared once and the ledger is loaded once; six parallel filings of one defect
  through real subprocesses leave one finding and one auditor row.
- **verify_finding**: confirmed / rejected / needs-human over a real `git init`
  worktree, including the errored-not-failed case; a `conftest.py` that prints
  `1 failed` and exits 1 does not confirm; a report naming another test or a
  missing one is `needs-human`; an unrelated failure beside the requested test
  does not confirm while the requested test failing still does; a test *named*
  like an outcome element cannot forge one, and `<failures>` is not `<failure`;
  the full `judge_cmd` mapping (0, 1, 2, 3, 125, 126, 127, 137, 139, 255,
  3221225477, -9) plus a real `SIGKILL` end to end, and a `cmd::` PoC dying on a missing import recording
  `needs-human` rather than `confirmed` (red-before: it confirmed); a PoC printing ~64MB still reaches a verdict; a missing command records
  `needs-human` instead of crashing; every named forbidden and escape shape
  refused — as a `cmd::` argument and as a `pytest::` selector — the egress one
  proven **unrun** by a PoC that would have created a file; nodeids naming a
  screened word not refused while a `cmd::` argv still is; the verifier refusing
  its own checkout; the child environment closed and worktree-rooted in every
  spelling; a missing ledger creates neither the database nor its parent
  directory; the verifier verdict **appended** beside the auditor's, and filing
  records the auditor's.

**Red-before proven on forty-three mutations** across ten rounds, each restored
afterwards: forbidden losing precedence, an uninterpretable field becoming
permission, the traversal guard deleted, the refusal screen removed, a pytest exit
status trusted without its report, allowed techniques matched by containment,
absoluteness judged by a leading slash, the escape screen removed, `OSError`
uncaught at spawn, `cmd::` confirming on any nonzero, the word screen applied to a
nodeid, the POSIX-literal `PATH` fallback, the export reached on zero *active*
rows, the child's output piped again, the document-type refusal and the size cap
removed, an outcome matched as a word instead of a tag, `case_name` unanchored,
the read path creating the ledger, `--round-id` outside the exclusion set, the
drive pattern requiring a separator, the malformed-grant guard removed, that guard
over-applied to `forbidden`, the selector path screen removed, the own-checkout
refusal removed, the outcome lists unscoped from the requested case, the auditor
verdict not written on filing, the unknown-kind guard removed, and exit 1
confirming a `cmd::` proof, the allow row checked before the gate, forbidden
paths compared case-exact, a one-character kind read as a phrase, and exit 137
confirming. (Mutations
against the DOCTYPE refusal, the size cap and the process-group teardown were
proven in earlier rounds; that code is removed on this head.)

**Three mutations came back GREEN, and each was a finding about a test rather than
a pass.** The traversal guard was unreachable from the suite — `normpath` handles
the common case, and the guard is load-bearing only under a bare-dot `path:.`
prefix — so the test that drives that case was added. The nodeid word-screen test
used `token_auth`, which `\btoken\b` never matches (`_` is a word character), so
it passed for the wrong reason and survived deleting the fix; it now uses ids
where a screened word really does stand alone (`test_token[query]`, `token.py`,
`ssh/`). The forbidden-path test passed because `forbidden_hits` runs BEFORE the
interpretability check, so a MATCHING forbidden rule returns `OUT_OF_SCOPE` either
way and over-narrowing was invisible; only an unrelated query separates the two.
And the suite caught `case_name` reading `classname="..."` — `name="` is a
substring of it — which had made every real pytest run come back `needs-human`.

## Manual verification

N/A — unit coverage sufficient. Every path is a script invocation with an exit
code, and the tests drive `main()` with argv exactly as the skill does, including
real subprocess PoC runs in a real `git init` worktree.

## Related Issues

- Design of record: #9195 (RFC, merged — "Rules of engagement are machine-checked",
  "The harness" items 2–4, "Finding schema and `finding-status/v1`", "Learning
  from past audits")
- Was stacked on: #9270 (the findings ledger these scripts read) — merged, so this
  PR is now based on `main`
- Consumer: #9271 (the SKILL.md that calls all three)

**The hostile-checkout class of finding is out of scope by the RFC section this
PR adds, not open.** Earlier rounds carried it as a residual and — wrongly —
described it as "an RFC #9195 decision"; #9195 said "sandbox" with no mechanism,
and the decision is made here, in `rfc-security-conductor.md` ("The trust
boundary"). Approving this diff is approving that section. Findings that
assume the target checkout is adversarial — a forged report, a symlink out of the
tree, a detached grandchild, a PoC reaching the host by a spelling the screen
does not carry — are rebutted as not-a-defect against that section, and each
disposition carries a pre-drafted `/ai-review override` sentence should the GPT
lane not converge on its own.

no linked issue: this is RFC #9195's M1 script half, tracked by the RFC and by
#9271, neither of which this PR closes on its own.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the RFC gains "The trust
      boundary"; the operating procedure lives in #9271; each script's docstring
      is its own reference
- [x] No secrets, credentials, or internal references in the diff

