### PR TITLE
fix(dashboard): serialize reload teardown under the switch locks (#9019)

### DIFF
--- a/comment-history-baseline.json
+++ b/comment-history-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Comments and docstrings that narrate change history, per file, as a match COUNT. The rule they break is in docs/system-specs/common/code-style.md (\"Comments explain the WHY\"); it predates any enforcement, so the tree is recorded here rather than rewritten in one pass. The gate requires every OTHER file to be clean and none of these counts to grow, so this list can only shrink. Do NOT add or raise an entry to make a red gate green: a new offender means the comment should state CURRENT behavior in present tense. Lower and prune with `python3 scripts/check_comment_history.py --write-baseline`, which never adds or raises one.",
-  "_total": 7600,
+  "_total": 7592,
   "files": {
     "src/kiro_crew/__main__.py": 1,
     "src/kiro_crew/acp/_dispatch.py": 8,
@@ -1535,7 +1535,6 @@
     "test/test_slot_close_recreation_race.py": 6,
     "test/test_slot_create_default_agent.py": 2,
     "test/test_slot_detail_disk_window_authority_7526.py": 3,
-    "test/test_slot_reset_interleaving_seam.py": 8,
     "test/test_slot_sync_on_create.py": 1,
     "test/test_snapshot.py": 16,
     "test/test_snapshot_archive_name_escaping.py": 1,

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -7376,55 +7376,121 @@ async def api_chat_slot_reload(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
-    # The session the reload will tear down. ``effective_session_key``, never
-    # ``_history_key_for``: a channel- or cron-born slot runs its turns under
-    # its linked key, and the dashboard-prefixed spelling names a session that
-    # never existed -- the reset would "succeed" against nothing while the
-    # live process kept its stale config.
-    session_key = effective_session_key(slot)
-    # App isolation, same policy as the cancel routes: reload is a teardown,
-    # so an app token must own both the slot and the session the teardown
-    # lands on, and a denial is indistinguishable from a missing slot.
-    denied = _app_cancel_denied(request, slot, "chat.slot_reload", session_key)
-    if denied is not None:
-        return denied
-    provider = state.sessions.get_provider(session_key)
-    if provider is not None and provider.has_active_turn():
-        return web.json_response(
-            {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
-        )
-    # Children guard, shared with api_chat_slot_continue: RUNNING children die
-    # with the parent runtime, and _subagents_attached_response documents why
-    # queued children and in-flight deliveries count too.
-    denied_409 = _subagents_attached_response(state, slot, session_key, "reload")
-    if denied_409 is not None:
-        return denied_409
-    if _test_interleave is not None:
-        # Reload's teardown takes neither slot._lock nor the session-keyed switch
-        # lock, so nothing orders it against a switch's commit-then-reset span.
-        # Suspending here is the only way to hold the unguarded teardown open
-        # across another actor's whole transaction and observe what that produces.
-        await _test_interleave("reload:pre_reset")
-    reloaded = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
-    if not reloaded:
+    # Two locks, in the order documented at _slot_switch_session_lock:
+    # slot._lock, then the session lock. The four commit-before-reset switch
+    # handlers hold both across their commit-then-reset span, and reload joins
+    # them so its probe-then-teardown is serialized against that span:
+    # reload holds no setting to commit, but it tears the session down
+    # the same way, and holding neither lock let a reload land inside a
+    # switch's span -- the switch could report success on a session reload had
+    # already replaced, or vice versa. An ExitStack because the session lock's
+    # KEY is only known after the in-lock read below, and locking on any
+    # earlier read could leave this holding the wrong session lock.
+    async with contextlib.AsyncExitStack() as _stack:
+        await _stack.enter_async_context(slot._lock)
+        # Re-authorize after the await above: ``name`` can be recreated for a
+        # DIFFERENT app while this request queued on the lock (slot removal +
+        # re-registration under the same name is how a client reconnects), and
+        # the stale ``slot`` object's app-isolation check below would then
+        # authorize this teardown against the NEW slot's session -- the same
+        # cross-slot-identity gap the tags/folders/regenerate handlers close
+        # with this exact re-check (e.g. chat_tags.py's ``is not slot`` guard).
+        # A mismatch here is indistinguishable from a missing slot.
+        if state._slots.get(name) is not slot:
+            return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
+        # The session the reload will tear down. ``effective_session_key``,
+        # never ``_history_key_for``: a channel- or cron-born slot runs its
+        # turns under its linked key, and the dashboard-prefixed spelling
+        # names a session that never existed -- the reset would "succeed"
+        # against nothing while the live process kept its stale config.
+        # Resolved INSIDE slot._lock, not before it: a channel/cron rebind can
+        # land while this request queues on the lock, so keying the session
+        # lock on an earlier read would guard the wrong session (see
+        # _slot_switch_session_lock).
+        session_key = effective_session_key(slot)
+        # Now serialize against every OTHER alias slot's switch on this same
+        # session, keyed on the value resolved just above -- the same one the
+        # probe and reset below use.
+        await _stack.enter_async_context(_slot_switch_session_lock(session_key))
+        # Re-authorize again: the session-lock wait above is a SECOND await
+        # point (real contention when a switch on the same session holds it),
+        # and a slot removal + re-registration under this name can land while
+        # this request queued on THAT lock just as easily as on slot._lock
+        # above. Without this, the 7396 check would guard only the first
+        # await and leave the exact gap it exists to close open on the
+        # second.
+        if state._slots.get(name) is not slot:
+            return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
+        # Re-derive rather than trust the captured session_key: it names a
+        # MUTABLE attribute (slot.linked_session_key), so a cron/channel
+        # rebind landing on the SAME slot object during the session-lock wait
+        # changes what effective_session_key(slot) resolves to without
+        # tripping the identity check above. Mirrors the switch handlers'
+        # own post-lock ``effective_session_key(slot) != session_key`` guard.
+        if effective_session_key(slot) != session_key:
+            return web.json_response(
+                {"error": "slot session was rebound during the switch", "code": "session_rebound"},
+                status=409,
+            )
+        # App isolation, same policy as the cancel routes: reload is a
+        # teardown, so an app token must own both the slot and the session the
+        # teardown lands on, and a denial is indistinguishable from a missing
+        # slot.
+        denied = _app_cancel_denied(request, slot, "chat.slot_reload", session_key)
+        if denied is not None:
+            return denied
         provider = state.sessions.get_provider(session_key)
         if provider is not None and provider.has_active_turn():
             return web.json_response(
                 {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
             )
-        if provider is not None:
-            # A turn slipped into the guard window and already FINISHED: the
-            # declined reset left a live idle session untouched, and falling
-            # through would report success while the stale process survives --
-            # the silent failure this endpoint exists to prevent. Retry once;
-            # a second decline means another turn is genuinely racing, which
-            # is the turn-in-flight case.
-            reloaded = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
-            if not reloaded:
+        # Children guard, shared with api_chat_slot_continue: RUNNING children
+        # die with the parent runtime, and _subagents_attached_response
+        # documents why queued children and in-flight deliveries count too.
+        denied_409 = _subagents_attached_response(state, slot, session_key, "reload")
+        if denied_409 is not None:
+            return denied_409
+        if _test_interleave is not None:
+            # Reload now holds slot._lock and _slot_switch_session_lock across
+            # its probe-then-teardown, so its teardown is serialized against a
+            # switch's commit-then-reset span. Suspending here holds that
+            # span open across another actor's transaction so a test
+            # can observe that the other actor now blocks on the session lock
+            # instead of interleaving.
+            await _test_interleave("reload:pre_reset")
+        reloaded = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
+        if not reloaded:
+            provider = state.sessions.get_provider(session_key)
+            if provider is not None and provider.has_active_turn():
                 return web.json_response(
-                    {"error": "a turn is in flight", "code": "turn_in_flight"},
-                    status=409,
+                    {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
                 )
+            if provider is not None:
+                # A turn slipped into the guard window and already FINISHED:
+                # the declined reset left a live idle session untouched, and
+                # falling through would report success while the stale process
+                # survives -- the silent failure this endpoint exists to
+                # prevent. Retry once; a second decline means another turn is
+                # genuinely racing, which is the turn-in-flight case.
+                reloaded = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
+                if not reloaded:
+                    return web.json_response(
+                        {"error": "a turn is in flight", "code": "turn_in_flight"},
+                        status=409,
+                    )
+        # Re-check once more, still inside both locks: _reset_slot_session
+        # (and its one retry above) is itself an await, and _bind_cron_slot
+        # writes slot.linked_session_key with NO lock of its own, so a rebind
+        # can land during that specific await just as it can during the
+        # earlier lock-acquisition waits. Skipping this would report success
+        # while the now-current session was never touched -- the exact silent
+        # stale-session failure the two earlier checks exist to prevent, just
+        # moved one await later.
+        if effective_session_key(slot) != session_key:
+            return web.json_response(
+                {"error": "slot session was rebound during the switch", "code": "session_rebound"},
+                status=409,
+            )
     logger.info("Slot %s session reloaded (had_live_session=%s)", name, reloaded)
     # Feed notice: the visible confirmation (and the durable record) that the
     # relaunch happened. Tagged so the last-real-message scans skip it on both

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -7486,6 +7486,20 @@ async def api_chat_slot_reload(request: web.Request) -> web.Response:
         # while the now-current session was never touched -- the exact silent
         # stale-session failure the two earlier checks exist to prevent, just
         # moved one await later.
+        #
+        # Identity first, same as the 7399/7422 checks above: registry
+        # mutation (slot removal + same-name re-registration for a DIFFERENT
+        # app) takes no lock of its own, so it can land during this same
+        # await exactly as it can during the two earlier lock-acquisition
+        # waits those checks guard. A key-only re-check would still pass for
+        # a stale ``slot`` object recreated under app B's name whenever B's
+        # session happens to resolve to the same key, and the notice/
+        # broadcast below would then fire under B's identity -- the same
+        # cross-slot-identity gap the two earlier checks close, just moved to
+        # this last await. Same response as those checks: a mismatch here is
+        # indistinguishable from a missing slot.
+        if state._slots.get(name) is not slot:
+            return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
         if effective_session_key(slot) != session_key:
             return web.json_response(
                 {"error": "slot session was rebound during the switch", "code": "session_rebound"},

--- a/test/test_slot_reset_interleaving_seam.py
+++ b/test/test_slot_reset_interleaving_seam.py
@@ -6,8 +6,10 @@ with the point names in the order the code reaches them -- and then use it for t
 thing it exists for: driving a reload's teardown into the middle of a switch
 handler's commit-then-reset span, deterministically, with no sleep.
 
-That interleaving is the one described in issue #9019, and the test named for it
-below asserts TODAY's outcome, not the desired one. See its docstring.
+That interleaving is what reload joining the same two locks the switch
+handlers hold now closes: the tests named for it below assert the serialized
+outcome -- the second racer blocks on the session lock while the first holds
+it. See their docstrings.
 """
 
 from __future__ import annotations
@@ -177,32 +179,33 @@ class TestInterleaveSeamContract:
 
 
 class TestReloadRacesSwitchCommitResetSpan:
-    """The race in issue #9019, driven through the seam.
+    """The reload-vs-switch race, driven through the seam, serialized.
 
-    ``api_chat_slot_reload`` tears down the slot's effective session while
-    holding neither ``slot._lock`` nor the session-keyed switch lock. The four
-    commit-before-reset switch handlers hold both across their commit-then-reset
-    span. Nothing orders the two, so a reload's teardown can land inside that
-    span -- which is what these tests make happen, deterministically, by
-    suspending one racer at a named point and driving the other from there.
+    Without a shared lock, ``api_chat_slot_reload`` tears down the slot's
+    effective session while holding neither ``slot._lock`` nor the
+    session-keyed switch lock, while the four commit-before-reset switch
+    handlers hold both across their commit-then-reset span -- nothing orders
+    the two. Reload joins the SAME two locks in the SAME order, so its
+    probe-then-teardown is serialized against a switch's span on the same
+    session. These tests drive the interleaving from both directions and
+    prove that the second racer BLOCKS on the session lock while the first
+    holds it, then completes only in the serialized order once the first
+    releases.
     """
 
     @pytest.mark.asyncio
-    async def test_switch_transaction_completes_inside_reloads_unguarded_teardown(
+    async def test_switch_blocks_until_reloads_serialized_teardown_completes(
         self, state, slot, monkeypatch
     ):
-        """A whole model switch runs while reload sits on its pre-teardown point.
+        """A model switch launched while reload holds the locks must wait its turn.
 
-        DEFECT PIN for issue #9019: this asserts the CURRENT outcome, which is
-        the wrong one. Reload holds no lock here, so the switch takes both of
-        its own locks unopposed, commits the new model, and tears the session
-        down -- all inside reload's window -- and reload's own teardown then
-        lands on the session that switch just prepared.
-
-        Serializing reload onto the session-keyed lock flips this test: the
-        switch would block on that lock instead, so ``switch.done()`` stays
-        False and the two assertions marked below fail. That is the intended
-        signal to the fix -- invert them and drop the "unguarded" wording.
+        Reload is suspended at ``reload:pre_reset`` holding both ``slot._lock``
+        and the session-keyed switch lock. A model switch on the same session
+        is launched from there: it BLOCKS on the session
+        lock, so ``switch.done()`` stays False for as long as reload is
+        suspended. Once reload resumes, finishes its teardown and releases the
+        locks, the switch proceeds -- its whole transaction lands strictly
+        AFTER reload's teardown pair.
         """
         order: list[str] = []
         switch: asyncio.Task[object] | None = None
@@ -213,24 +216,31 @@ class TestReloadRacesSwitchCommitResetSpan:
                 order.append(point)
                 if point != "reload:pre_reset":
                     return
-                # Suspended inside reload's teardown. Start the switch here:
-                # whether it can proceed while reload is mid-teardown IS the
-                # question, so run it to completion and record what happened.
+                # Suspended inside reload's teardown while it holds both locks.
+                # Start the switch here and hand the loop back a bounded number
+                # of turns: a serialized switch cannot make progress, so this
+                # proves it blocks rather than interleaves.
                 nonlocal switch
                 switch = asyncio.create_task(
                     client.post(f"/api/chat/slots/{_SLOT}/model", json={"model": _MODEL_NEW})
                 )
-                await _yield_until(lambda: switch is not None and switch.done())
+                blocked = not await _yield_until(lambda: switch is not None and switch.done())
+                # The switch is blocked on the session lock reload holds: it has
+                # made no progress past the lock, so none of its seam points
+                # have fired yet.
+                assert blocked, "switch completed while reload held the session lock"
+                assert "switch:post_commit" not in order
 
             monkeypatch.setattr(chat_handlers, "_test_interleave", _interleave)
             reload_resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
 
             assert switch is not None
             try:
-                # DEFECT (#9019): the switch got all the way through while
-                # reload's teardown was open. A serialized reload leaves this
-                # False.
-                assert switch.done(), "switch never completed inside reload's window"
+                # Reload has released its locks by now, so the switch that was
+                # blocked runs to completion in the serialized order.
+                assert await _yield_until(
+                    lambda: switch.done()
+                ), "switch never completed after reload released the locks"
                 switch_resp = switch.result()
             finally:
                 switch.cancel()
@@ -239,38 +249,225 @@ class TestReloadRacesSwitchCommitResetSpan:
             assert switch_resp.status == 200
             assert reload_resp.status == 200
 
-        # DEFECT (#9019): the switch's committed value and its teardown both land
-        # between reload's own two points, so reload's pop -- the last entry --
-        # destroys the session the switch reported success for. A serialized
-        # reload orders every switch entry AFTER reload's pair.
+        # Reload's own teardown pair completes BEFORE any switch point: the
+        # switch was blocked on the session lock until reload released it, so
+        # its commit and teardown land strictly after reload's pair.
         assert order == [
             "reload:pre_reset",
-            "switch:post_commit",
             "reset:pre_pop",
             "reset:post_pop",
+            "switch:post_commit",
             "reset:pre_pop",
             "reset:post_pop",
         ]
         assert slot.model == _MODEL_NEW
-        # Two teardowns of ONE session key, unserialized.
+        # Reload's single teardown, then the switch's -- serialized on the one
+        # session key, serialized rather than two unserialized teardowns racing.
         assert state.sessions.reset.await_count == 2
         assert {c.args[0] for c in state.sessions.reset.await_args_list} == {_SESSION_KEY}
 
     @pytest.mark.asyncio
-    async def test_reload_teardown_lands_inside_a_suspended_switch_span(
+    async def test_reload_refuses_a_slot_recreated_under_the_same_name_while_it_queued(
         self, state, slot, monkeypatch
     ):
-        """The same race driven from the other side: switch first, reload second.
+        """A stale slot reference must not authorize tearing down its replacement.
 
-        DEFECT PIN for issue #9019, and the direction that shows the harm the
-        issue names. The switch is suspended after committing its new model and
-        before tearing the old session down, holding both of its locks. Reload
-        then runs its ENTIRE teardown from inside that span, because it joins
-        neither lock -- so the switch resumes and tears down a session that has
-        already been replaced.
+        Reload reads ``state._slots.get(name)`` before ever awaiting, then
+        queues on ``slot._lock``. If the name is deleted and recreated (a
+        different app's slot, or the same app reconnecting) while that request
+        sits on the lock, the locks it eventually acquires belong to the OLD
+        object -- but ``session_key`` and the app-isolation check downstream
+        would resolve against the NEW slot if nothing re-checked identity. This
+        drives that exact window: hold ``slot._lock`` itself (so reload queues
+        on it, never reaching any interleave seam), swap in a same-named
+        replacement, then release. Reload must see the mismatch and refuse
+        with 404 -- not tear down the replacement's session.
+        """
+        replacement = _ChatSlot(_SLOT)
+        replacement.model = _MODEL_OLD
 
-        A serialized reload leaves ``reload.done()`` False while the switch is
-        suspended, failing the assertion marked below.
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with slot._lock:
+                reload_task = asyncio.create_task(client.post(f"/api/chat/slots/{_SLOT}/reload"))
+                # Give the request a chance to read the (still-current) slot and
+                # queue on the lock this block already holds.
+                stuck = not await _yield_until(lambda: reload_task.done())
+                assert stuck, "reload completed without ever contending for slot._lock"
+
+                # The name is now a different slot object -- same shape a
+                # delete-then-recreate under the same key produces.
+                state._slots[_SLOT] = replacement
+
+            try:
+                resp = await _yield_until(lambda: reload_task.done())
+                assert resp, "reload never completed after slot._lock was released"
+                reload_resp = reload_task.result()
+                reload_status = reload_resp.status
+                reload_body = await reload_resp.json()
+            finally:
+                reload_task.cancel()
+                await asyncio.gather(reload_task, return_exceptions=True)
+
+        assert reload_status == 404
+        assert reload_body["code"] == "slot_not_found"
+        # The replacement's session was never touched by the stale request.
+        state.sessions.reset.assert_not_awaited()
+        assert state._slots[_SLOT] is replacement
+
+    @pytest.mark.asyncio
+    async def test_reload_refuses_a_slot_recreated_while_queued_on_the_session_lock(
+        self, state, slot, monkeypatch
+    ):
+        """The same stale-authorization window, reopened by the SECOND await.
+
+        Reload re-checks slot identity right after ``slot._lock`` -- the test
+        above pins that. But ``_slot_switch_session_lock(session_key)`` is a
+        SECOND suspension point (a concurrent switch on the same session holds
+        it), and nothing re-checks identity between resuming from it and the
+        app-isolation call that follows. This drives that exact window: hold
+        the session lock externally (via the same registry function reload
+        uses) so reload passes ``slot._lock`` and its first re-check, then
+        queues on the session lock; swap in a same-named replacement; release.
+        Reload must refuse with 404 rather than authorize against the
+        replacement.
+        """
+        replacement = _ChatSlot(_SLOT)
+        replacement.model = _MODEL_OLD
+        session_lock = chat_handlers._slot_switch_session_lock(_SESSION_KEY)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with session_lock:
+                reload_task = asyncio.create_task(client.post(f"/api/chat/slots/{_SLOT}/reload"))
+                # Give the request a chance to pass slot._lock, pass its first
+                # identity re-check (the slot is still current at this point),
+                # resolve session_key, and queue on the session lock this
+                # block already holds.
+                stuck = not await _yield_until(lambda: reload_task.done())
+                assert stuck, "reload completed without ever contending for the session lock"
+
+                # The name is now a different slot object -- reload is queued
+                # past its first re-check with the OLD slot captured, so only
+                # a second re-check after the session lock catches this.
+                state._slots[_SLOT] = replacement
+
+            try:
+                resp = await _yield_until(lambda: reload_task.done())
+                assert resp, "reload never completed after the session lock was released"
+                reload_resp = reload_task.result()
+                reload_status = reload_resp.status
+                reload_body = await reload_resp.json()
+            finally:
+                reload_task.cancel()
+                await asyncio.gather(reload_task, return_exceptions=True)
+
+        assert reload_status == 404
+        assert reload_body["code"] == "slot_not_found"
+        # The replacement's session was never touched by the stale request.
+        state.sessions.reset.assert_not_awaited()
+        assert state._slots[_SLOT] is replacement
+
+    @pytest.mark.asyncio
+    async def test_reload_refuses_a_rebind_that_lands_while_queued_on_the_session_lock(
+        self, state, slot, monkeypatch
+    ):
+        """A same-slot rebind must not let a stale session_key authorize a teardown.
+
+        Unlike the two tests above, the slot object here is NEVER swapped --
+        ``state._slots[_SLOT] is slot`` holds throughout, so both identity
+        re-checks pass. What changes is ``slot.linked_session_key`` itself: a
+        cron/channel rebind mutates that attribute on the SAME slot object
+        while reload is queued on the session lock it already resolved
+        ``session_key`` from. ``effective_session_key(slot)`` now names a
+        DIFFERENT session than the one the lock guards, so reload must refuse
+        with 409/session_rebound rather than tear the new session down under
+        an authorization computed for the old one.
+        """
+        NEW_SESSION_KEY = "slack:1234.5678"
+        new_lock = chat_handlers._slot_switch_session_lock(NEW_SESSION_KEY)
+        session_lock = chat_handlers._slot_switch_session_lock(_SESSION_KEY)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with session_lock:
+                reload_task = asyncio.create_task(client.post(f"/api/chat/slots/{_SLOT}/reload"))
+                # Give the request a chance to pass slot._lock, its first
+                # identity re-check, resolve session_key = _SESSION_KEY, and
+                # queue on the session lock this block already holds.
+                stuck = not await _yield_until(lambda: reload_task.done())
+                assert stuck, "reload completed without ever contending for the session lock"
+
+                # The rebind: same slot object, new linked session. Reload's
+                # captured session_key (_SESSION_KEY) is now stale.
+                slot.linked_session_key = NEW_SESSION_KEY
+
+            try:
+                resp = await _yield_until(lambda: reload_task.done())
+                assert resp, "reload never completed after the session lock was released"
+                reload_resp = reload_task.result()
+                reload_status = reload_resp.status
+                reload_body = await reload_resp.json()
+            finally:
+                reload_task.cancel()
+                await asyncio.gather(reload_task, return_exceptions=True)
+
+        assert reload_status == 409
+        assert reload_body["code"] == "session_rebound"
+        # Neither the stale session nor the new one was torn down by this
+        # request: the guard fires before any teardown call.
+        state.sessions.reset.assert_not_awaited()
+        assert state._slots[_SLOT] is slot
+        assert not new_lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_reload_refuses_a_rebind_that_lands_during_the_reset_await(
+        self, state, slot, monkeypatch
+    ):
+        """The same rebind race, one await later: during the teardown itself.
+
+        The two earlier guards re-check identity/binding before
+        ``_reset_slot_session`` is awaited. ``_bind_cron_slot`` takes NO lock
+        of its own, so a rebind is just as free to land WHILE that await is
+        in flight -- one await later than the second guard's window, and past
+        it. This drives that exact placement: hook ``reset:pre_pop`` (a seam
+        point INSIDE ``_reset_slot_session``, reached only after both earlier
+        guards already passed) to mutate ``slot.linked_session_key`` there,
+        then let the reset and the rest of reload's flow proceed. Reload must
+        still refuse with 409/session_rebound rather than report success for
+        a session that was never touched.
+        """
+        NEW_SESSION_KEY = "slack:9999.1111"
+
+        async def _interleave(point: str) -> None:
+            if point == "reset:pre_pop":
+                slot.linked_session_key = NEW_SESSION_KEY
+
+        monkeypatch.setattr(chat_handlers, "_test_interleave", _interleave)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+            status = resp.status
+            body = await resp.json()
+
+        assert status == 409
+        assert body["code"] == "session_rebound"
+        # The reset itself still ran against the ORIGINAL session_key (the
+        # rebind lands mid-reset, not before it) -- this guard's job is to
+        # stop the response, not to have prevented the one reset already in
+        # flight when the rebind arrived.
+        state.sessions.reset.assert_awaited_once_with(_SESSION_KEY, skip_if_busy=True)
+        assert slot.linked_session_key == NEW_SESSION_KEY
+
+    @pytest.mark.asyncio
+    async def test_reload_blocks_until_a_suspended_switch_releases_its_locks(
+        self, state, slot, monkeypatch
+    ):
+        """The same race from the other side: switch holds the locks, reload waits.
+
+        The switch is suspended at ``switch:post_commit`` after committing its
+        new model and before tearing the old session down, holding both of its
+        locks. A reload on the same session is launched from there: it BLOCKS on the session lock, so ``reload_task.done()`` stays
+        False for as long as the switch is suspended. Only after the switch
+        resumes, finishes its teardown and releases the locks does reload run
+        its own teardown -- strictly AFTER the switch's pair.
         """
         order: list[str] = []
         reload_task: asyncio.Task[object] | None = None
@@ -284,9 +481,19 @@ class TestReloadRacesSwitchCommitResetSpan:
                 order.append(point)
                 if point != "switch:post_commit":
                     return
+                # Suspended inside the switch's span while it holds both locks.
+                # Launch reload and hand the loop back a bounded number of
+                # turns: a serialized reload cannot make progress, so this
+                # proves it blocks rather than interleaves.
                 nonlocal reload_task
                 reload_task = asyncio.create_task(client.post(f"/api/chat/slots/{_SLOT}/reload"))
-                await _yield_until(lambda: reload_task is not None and reload_task.done())
+                blocked = not await _yield_until(
+                    lambda: reload_task is not None and reload_task.done()
+                )
+                # Reload is blocked on the session lock the switch holds: it has
+                # not reached its own pre-reset seam point.
+                assert blocked, "reload completed while the switch held the session lock"
+                assert "reload:pre_reset" not in order
                 hook_completed.set()
 
             monkeypatch.setattr(chat_handlers, "_test_interleave", _interleave)
@@ -296,9 +503,11 @@ class TestReloadRacesSwitchCommitResetSpan:
 
             assert reload_task is not None
             try:
-                # DEFECT (#9019): reload completed a full teardown while the
-                # switch held both locks with its commit already applied.
-                assert reload_task.done(), "reload never completed inside the switch span"
+                # The switch has released its locks by now, so the reload that
+                # was blocked runs to completion in the serialized order.
+                assert await _yield_until(
+                    lambda: reload_task.done()
+                ), "reload never completed after the switch released the locks"
                 reload_resp = reload_task.result()
             finally:
                 reload_task.cancel()
@@ -308,14 +517,14 @@ class TestReloadRacesSwitchCommitResetSpan:
             assert switch_resp.status == 200
 
         assert hook_completed.is_set()
-        # DEFECT (#9019): reload's whole teardown pair sits between the switch's
-        # commit and the switch's own pop, so the switch reports success for a
-        # session reload had already torn down and re-armed.
+        # The switch's whole commit-then-reset pair completes BEFORE reload's
+        # pre-reset point: reload was blocked on the session lock until the
+        # switch released it, so its teardown lands strictly after.
         assert order == [
             "switch:post_commit",
-            "reload:pre_reset",
             "reset:pre_pop",
             "reset:post_pop",
+            "reload:pre_reset",
             "reset:pre_pop",
             "reset:post_pop",
         ]

--- a/test/test_slot_reset_interleaving_seam.py
+++ b/test/test_slot_reset_interleaving_seam.py
@@ -457,6 +457,57 @@ class TestReloadRacesSwitchCommitResetSpan:
         assert slot.linked_session_key == NEW_SESSION_KEY
 
     @pytest.mark.asyncio
+    async def test_reload_refuses_a_slot_recreated_during_the_reset_await(
+        self, state, slot, monkeypatch
+    ):
+        """The recreation race, one await later: during the teardown itself.
+
+        The two earlier guards re-check ``state._slots.get(name) is slot``
+        before ``_reset_slot_session`` is awaited. Registry mutation (slot
+        removal + same-name re-registration for a DIFFERENT app) takes no
+        lock of its own, so it is just as free to land WHILE that await is
+        in flight -- one await later than the second guard's window, and
+        past it. Unlike the rebind test above, this swaps the OBJECT itself
+        (not just ``linked_session_key`` on the same object), and the
+        replacement's session happens to resolve to the SAME key: a key-only
+        re-check would pass, since ``effective_session_key(replacement) ==
+        session_key`` holds. This drives that exact placement: hook
+        ``reset:pre_pop`` to swap in a same-named replacement there, then let
+        the reset and the rest of reload's flow proceed. Reload must still
+        refuse with 404/slot_not_found rather than broadcast a reload notice
+        under the replacement's identity.
+        """
+        replacement = _ChatSlot(_SLOT)
+        replacement.model = _MODEL_OLD
+        # Same key as the original: this is what makes a key-only re-check
+        # insufficient to catch the swap, unlike the rebind test above.
+        assert replacement.key == slot.key
+
+        async def _interleave(point: str) -> None:
+            if point == "reset:pre_pop":
+                state._slots[_SLOT] = replacement
+
+        monkeypatch.setattr(chat_handlers, "_test_interleave", _interleave)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(f"/api/chat/slots/{_SLOT}/reload")
+            status = resp.status
+            body = await resp.json()
+
+        assert status == 404
+        assert body["code"] == "slot_not_found"
+        # The reset itself still ran against the ORIGINAL slot's session (the
+        # swap lands mid-reset, not before it) -- this guard's job is to stop
+        # the response, not to have prevented the one reset already in
+        # flight when the swap arrived.
+        state.sessions.reset.assert_awaited_once_with(_SESSION_KEY, skip_if_busy=True)
+        # Neither slot's message history gained the reload notice: the guard
+        # fires before the notice append, on either identity.
+        assert slot.messages == []
+        assert replacement.messages == []
+        assert state._slots[_SLOT] is replacement
+
+    @pytest.mark.asyncio
     async def test_reload_blocks_until_a_suspended_switch_releases_its_locks(
         self, state, slot, monkeypatch
     ):


### PR DESCRIPTION
## Summary

Fixes #9019. `api_chat_slot_reload` tore down the slot's **effective** session while holding no lock, so a reload could interleave with a switch handler's commit-then-reset span on the same session. Nothing ordered the two: a switch could report success on a session that reload had already replaced, or vice versa.

### The contract decision

The issue left an open premise: is `skip_if_busy=True` alone sufficient, or must reload join the switch's session-keyed lock? The answer is **(b)** — reload must be serialized. `skip_if_busy=True` declines atomically, but **only while the session is BUSY**, and a switch handler's commit-then-reset span is exactly the *idle* window in which that decline never fires. So the atomic decline cannot cover the span; reload has to take the lock.

## Changes

**`src/kiro_crew/dashboard/chat_handlers.py`**
- `api_chat_slot_reload` now wraps its probe-then-teardown in a `contextlib.AsyncExitStack` acquiring the same two locks the four commit-before-reset switch handlers hold, in the same order: `slot._lock`, then `_slot_switch_session_lock(session_key)` with `session_key = effective_session_key(slot)` resolved **inside** `slot._lock` (resolving it earlier would guard the wrong session if a channel/cron rebind lands while the request queues).
- Both lock-acquisition awaits are each a suspension point where the slot's `name` can be recreated for a *different* app, so each is immediately followed by `state._slots.get(name) is slot` and a 404 on mismatch — the same re-authorization the tags/folders/regenerate handlers already do after their own await points (e.g. `chat_tags.py`). Without the first check, a stale request queued on `slot._lock` could authorize a teardown against a same-named replacement slot; without the second, the same gap reopens across the session-lock wait (real contention exists there too, when a switch on the same session holds it).
- Also after the session-lock wait: `effective_session_key(slot) != session_key` is re-checked and answers 409/`session_rebound`. The slot-identity check alone is insufficient here — `effective_session_key` reads the MUTABLE `slot.linked_session_key`, so a cron/channel rebind on the very same slot object (no swap, no recreation) can change what session the captured `session_key` names while this request sits on the lock. Mirrors the switch handlers' own post-lock `effective_session_key(slot) != session_key` guard (e.g. the model/agent/effort switch handlers).
- The same `effective_session_key(slot) != session_key` check runs a THIRD time, after the teardown call (`_reset_slot_session`, including its one retry) completes, still inside both locks. `_bind_cron_slot` writes `slot.linked_session_key` with no lock of its own, so a rebind is just as free to land during that specific await — one await later than the second guard's window — and reporting success there would be the same silent stale-session failure, just later.
- The `has_active_turn()` 409 fast path, the children 409 (`_subagents_attached_response`), the app-isolation denial, the `reload:pre_reset` seam point, and both `_reset_slot_session(..., skip_if_busy=True)` calls plus the retry-once 409 ladder now run under both locks.
- The slot-not-found 404 stays before the lock (no slot to lock). Success-only work (feed notice, eager respawn, `push_slots_update`) runs after the locks release, unchanged from before.
- Reload's external 409/200 contract and `skip_if_busy=True` semantics are unchanged apart from the new 409/`session_rebound` case above. The only other behavioral change is ordering: a concurrent switch on the same session now serializes behind reload (and vice versa) instead of interleaving.

**`test/test_slot_reset_interleaving_seam.py`**
- The two defect-pinning tests in `TestReloadRacesSwitchCommitResetSpan` were flipped and renamed to assert the serialized (correct) behavior. Each suspends one racer at a seam point while it holds the session lock, launches the other, and asserts (via a bounded `_yield_until` plus a "has not reached its own seam point" clause) that the second racer is blocked, then releases the first and asserts both finish in serialized order.
- Four more tests in the same class pin the identity/rebind re-checks independently: one holds `slot._lock` itself (reload queues on it before reaching its first re-check) and swaps in a same-named replacement slot, one holds the session lock directly via `chat_handlers._slot_switch_session_lock` and does the same swap after reload passes the first re-check, a third holds the session lock and instead mutates `slot.linked_session_key` on the SAME slot object (no swap) to pin the rebind guard, and a fourth hooks the `reset:pre_pop` seam INSIDE `_reset_slot_session` itself to mutate the link mid-teardown, pinning the third guard. Each asserts reload refuses (404 for the two identity cases, 409/`session_rebound` for the two rebind cases) rather than tearing down the wrong session.

**`comment-history-baseline.json`**
- `test/test_slot_reset_interleaving_seam.py`'s entry drops from the pre-existing 8 to 0 (pruned) as a direct consequence of rewriting this PR's own added comments/docstrings to present tense, per the repo's shrink-only comment-history ratchet (`scripts/check_comment_history.py --write-baseline`, which only lowers or prunes, never raises).

## Testing

All green:
- `test/test_slot_reset_interleaving_seam.py` — 11 passed (including the two flipped tests and the four new identity/rebind tests)
- `test/test_chat_slot_switch_atomicity.py` — 88 passed (no regression to the switch handlers)
- `test/test_dashboard_chat.py::TestSessionReload` — 13 passed (reload's external contract unchanged)
- `flake8`, `black --check` (py310), `mypy`, `isort` — clean on both changed files
- `scripts/check_comment_history.py`, `scripts/check_sync_io_in_async.py`, `scripts/check_loop_bound_locks.py` — clean

**Test quality:** reverting only the handler fix while keeping the flipped tests makes both tests fail, confirming they exercise the new lock serialization rather than static values. The reload span went from 0 `async with` (the bug) to 1 guarding both resets. All four identity/rebind tests were mutation-verified: removing any one of the four guards makes exactly its own test fail without affecting the other three.

Refs #8442

## Pattern harvest

Not generalizable: reload was the one teardown path outside `_slot_switch_session_lock` (grepped `_slot_switch_session_lock` — 5 pre-existing sites already used the ExitStack two-lock template; grepped `_reset_slot_session(` — all other callers already ran under those locks). The fix joins the existing lock mechanism verbatim rather than introducing a new one. The four additions beyond the original diff — the two `state._slots.get(name) is slot` re-checks and the two `effective_session_key(slot) != session_key` rebind guards (one after the session lock, one after the teardown call itself) — are also not a new pattern: all four mirror guards the tags/folders/regenerate and switch handlers already carry elsewhere in this file; reload was simply the one handler in this family that had not been given the full set yet. The 5 pre-existing switch handlers share the identity-check gap (not the rebind gaps, which they already guard) and are not touched by this PR — tracked as #9383 rather than folded in here, since fixing them is a wider, separable change from what #9019 asked for.
