### PR TITLE
fix(protocol): keep a label closer only where it is matched or continues the list

### DIFF
--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -107,15 +107,19 @@ SUBAGENT_TIMEOUT_MAX = 86400
 # one-character slip that flips the flag semantics or reintroduces the ReDoS
 # class below on a single surface.
 #
-# Body: a TEMPERED greedy repetition that allows every bracket EXCEPT a ``[``
-# that begins a fresh ``[OPTIONS:``. This matters for ReDoS (py/polynomial-redos):
-# a plain greedy ``.*`` body can itself consume a ``[`` that also starts the outer
-# ``[OPTIONS:`` literal, so over untrusted text with many ``[OPTIONS:`` prefixes
-# ``search()``/``findall()`` re-explore the body from each position — polynomial
-# backtracking. The tempered body is unambiguous (linear) while still capturing a
-# literal ``]`` and any other inner ``[`` inside an option ("Fix [x] logging",
-# "a[1]"). This parser runs over untrusted LLM/relayed text before Slack, the
-# dashboard, Discord, Telegram, and WeCom render it.
+# Body: a TEMPERED greedy repetition. No alternative in it may consume a ``[``
+# that begins a fresh ``[OPTIONS:`` — both bracket forms carry that guard. This
+# matters for ReDoS (py/polynomial-redos): a plain greedy ``.*`` body can itself
+# consume a ``[`` that also starts the outer ``[OPTIONS:`` literal, so over
+# untrusted text with many ``[OPTIONS:`` prefixes ``search()``/``findall()``
+# re-explore the body from each position — polynomial backtracking. The tempered
+# body is unambiguous (linear) while still capturing an inner ``[`` inside an
+# option ("Fix [x] logging", "a[1]"). A CLOSER is admitted CONDITIONALLY, not
+# freely: only where an earlier ``[`` in the same label matches it or the label
+# list continues after it (#9284 — see :data:`_MARKER_LABEL_CONTINUES` for why
+# an unconditional ``]`` made the body run past the marker and delete prose).
+# This parser runs over untrusted LLM/relayed text before Slack, the dashboard,
+# Discord, Telegram, and WeCom render it.
 #
 # LINE (``re.MULTILINE``, ``$`` anchor) — for Slack/dashboard, where the marker
 # ends a LINE (not necessarily the whole message). The negated class EXCLUDES
@@ -155,9 +159,14 @@ SUBAGENT_TIMEOUT_MAX = 86400
 #: character happens to appear in the tail.
 #:
 #: ReDoS profile is unchanged from the previous literal ``\]``. The class shares
-#: no character with the trailing ``[ \t]*`` / ``\s*``, and the tempered body
-#: already admitted ``]`` via ``[^[\n]``, so adding these three codepoints
-#: introduces no new ambiguity.
+#: no character with the trailing ``[ \t]*`` / ``\s*``, and the body excludes it
+#: from its negated class and readmits it in exactly TWO places, both of which a
+#: widening of this constant has to be re-audited against: as the final atom of
+#: :data:`_MARKER_LABEL_PAIR`, and via :data:`_MARKER_LABEL_CONTINUES`. Those two
+#: are what the disjointness argument is about (see :data:`_MARKER_BODY_LINE`),
+#: so the pair form -- which is where the deciding lookahead lives -- is the one
+#: NOT to skip. Both readmit all four codepoints at once, which is why adding
+#: these three introduces no ambiguity that ASCII ``]`` did not already have.
 MARKER_CLOSERS = "]\u3011\uff3d\u3015"
 _MARKER_CLOSE_CLASS = "[" + re.escape(MARKER_CLOSERS) + "]"
 
@@ -191,21 +200,139 @@ _MARKER_CLOSE_CLASS = "[" + re.escape(MARKER_CLOSERS) + "]"
 MARKER_WRAPPERS = "`*_"
 _MARKER_WRAP_CLASS = "[" + re.escape(MARKER_WRAPPERS) + "]"
 
+#: A closer may stay INSIDE a label only where it CONTINUES the label list
+#: (#9284). A label may legitimately carry a closer -- ``[OPTIONS: Alpha ] |
+#: Bravo ]]`` is a supported shape -- so the body has to admit one. Admitting it
+#: UNCONDITIONALLY (the old ``[^[\n]``, which includes ``]``) made the body run to
+#: the LAST closer in range instead of the first plausible one, so an ordinary
+#: final line that mentions a bracket after the marker matched across BOTH:
+#:
+#:     Use [OPTIONS: A | B] then check arr[0]
+#:
+#: matched whole, and since every consumer removes the whole match -- ``slack.
+#: format`` and ``messaging.renderer`` cut the visible text at ``match.start()``,
+#: and ``whatsapp.turn_renderer`` PERSISTS the cut turn -- the sentence vanished
+#: from the message and came back as a pill label. Under TRAILER (``DOTALL``) the
+#: body crossed blank lines too, so the whole final paragraph went with it.
+#:
+#: This is the SAME discriminator the streaming probe already applies
+#: (``CONTINUES_LABELS_RE`` in ``website/src/app-sdk/protocol/optionMarker.ts``)
+#: to decide whether an arriving closer ended the marker, so the regex and the
+#: probe now answer that question the same way instead of two different ways.
+#:
+#: Continuation ALONE is too strict, though: ``[OPTIONS: Fix [x] logging |
+#: Skip]`` is a first-class supported shape (pinned by
+#: ``test_options_buttons.py`` and ``test_parse_options.py``, whose comments say
+#: so outright), and there the closer is followed by an ordinary word. So the
+#: body admits a closer under EITHER of two conditions -- it is MATCHED by a
+#: ``[`` earlier in the same label (:data:`_MARKER_LABEL_PAIR`), or the list
+#: CONTINUES after it (:data:`_MARKER_LABEL_CONTINUES`). Neither test alone
+#: separates the three shapes; the union does:
+#:
+#:     [OPTIONS: Fix [x] logging | Skip]   matched pair      -> parses
+#:     [OPTIONS: Alpha ] | Bravo ]]        list continues    -> parses
+#:     Use [OPTIONS: A | B] then check arr[0]   neither      -> declined
+#:
+#: The two alternatives are made disjoint by what FOLLOWS the closer -- the pair
+#: form requires that its closer NOT be followed by a separator or another
+#: closer, which is exactly when the continuation form applies. So no span of
+#: input ever has two parses, which is what keeps the body linear despite two
+#: bracket alternatives (see :data:`_MARKER_BODY_LINE`).
+#:
+#: RESIDUAL COST. Every shape the union gives up is a closer that satisfies
+#: NEITHER half and has ordinary words after it, so at that closer the input is
+#: genuinely indistinguishable from "marker ended, prose followed on the same
+#: line". There is more than one way to be that closer, and all of them parsed
+#: on the old body:
+#:
+#:     [OPTIONS: Fix ]x logging | Skip]            unmatched -- no ``[`` at all
+#:     [OPTIONS: Fix list[dict[str, Any]] now | S] nesting deeper than one level
+#:     [OPTIONS: 【重要】修复 | 跳过】               a lookalike PAIR: ``【`` is not
+#:                                                 an opener, only ``[`` is
+#:     [OPTIONS: Fix [multi\nline] now | Skip]     TRAILER only -- the pair
+#:                                                 interior excludes ``\n`` even
+#:                                                 under DOTALL
+#:
+#: All four fail toward a VISIBLE marker, not toward deleted prose, and that
+#: asymmetry is what makes them affordable: the user sees the marker they were
+#: already seeing for the broken shapes, and nothing is removed from the
+#: message. Making them parse means matching brackets to arbitrary depth and
+#: over an opener set this grammar does not have, which a regex is the wrong
+#: tool for; the cost is bounded instead by the direction it fails in.
+#:
+#: A declined marker leaves the text intact only because every partial-cut gate
+#: downstream tests for a closer over :data:`MARKER_CLOSERS` rather than ASCII
+#: ``]`` -- see the gate in ``messaging.renderer.split_options_trailer``, which
+#: this rule is what made load-bearing.
+#:
+#: NOT reachable by this rule, and deliberately unchanged: the separator-tail
+#: form (``Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]``). ``], ``
+#: DOES continue the list, by the very rule that makes ``[OPTIONS: Alpha ],
+#: Bravo]`` legal, so no guard applied at the internal closer can tell them
+#: apart. Resolving it means deciding which shape loses -- a separate call.
+_MARKER_LABEL_CONTINUES = rf"(?=[ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
+
+#: A closer MATCHED by a ``[`` earlier in the same label. One level deep, and its
+#: interior excludes ``[`` and EVERY closer (not just ASCII ``]``, so a lookalike
+#: cannot be swallowed into the interior and escape the rule), which makes its
+#: match from any given ``[`` unique. The trailing negative lookahead is what
+#: makes this disjoint from :data:`_MARKER_LABEL_CONTINUES` rather than an
+#: alternative spelling of it.
+#:
+#: The opening ``\[`` carries the SAME ``(?!OPTIONS:)`` guard as the bare-``[``
+#: alternative, and for the same reason: without it this form is the one place
+#: the union rule is LOOSER than the body it replaced, because it can open on a
+#: nested head and pair it with that head's own closer. ``Note [OPTIONS: see
+#: [OPTIONS: x] below | Skip]`` then matches from the OUTER head -- where the
+#: old body matched nothing at all -- and renders a pill whose label is a raw
+#: protocol marker, echoed back as the user's reply when tapped. The guard
+#: restores "no bracket form may consume a ``[`` that begins a fresh
+#: ``[OPTIONS:``" as an absolute property of the body rather than one that holds
+#: only for sibling heads.
+_MARKER_LABEL_PAIR = (
+    rf"\[(?!OPTIONS:)[^[{re.escape(MARKER_CLOSERS)}\n]*{_MARKER_CLOSE_CLASS}"
+    rf"(?![ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
+)
+
+#: Label body, spelled once per regex so LINE and TRAILER cannot drift. LINE
+#: stops at a newline; TRAILER spans them (``DOTALL``, as the old ``.*`` did).
+#: The one body-shaped pattern NOT derived from these is
+#: :data:`_OPTIONS_TAIL_PREFIX_RE`, which is a prefix closure and has to stay
+#: looser -- see the reason there before "fixing" it to match.
+#:
+#: ReDoS: the four alternatives are mutually exclusive at every position. The
+#: two bracket forms both begin at ``[`` (and both refuse a fresh ``[OPTIONS:``)
+#: but cannot consume the same span -- the pair form's lookahead and the
+#: continuation form's are each other's negation -- an unmatched ``[`` is left to
+#: the bare-``[`` form, and the negated class excludes both ``[`` and every
+#: closer. So there is never more than one way to consume a character, and each
+#: lookahead is entered only at a bracket and bounded by the run it scans.
+_MARKER_BODY_LINE = (
+    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:)"
+    rf"|{_MARKER_CLOSE_CLASS}{_MARKER_LABEL_CONTINUES}"
+    rf"|[^[{re.escape(MARKER_CLOSERS)}\n])*"
+)
+_MARKER_BODY_TRAILER = (
+    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:)"
+    rf"|{_MARKER_CLOSE_CLASS}{_MARKER_LABEL_CONTINUES}"
+    rf"|[^[{re.escape(MARKER_CLOSERS)}])*"
+)
+
 # The ``labels`` group is NAMED because the ``lwrap`` conditional group
 # necessarily precedes it, shifting positional numbering: consumers read
 # ``group("labels")`` (and iterate with ``finditer``, since ``findall`` on a
 # multi-group pattern yields tuples).
 OPTIONS_RE_LINE = re.compile(
     rf"(?:^[ \t]*(?P<lwrap>{_MARKER_WRAP_CLASS}{{1,3}}))?"
-    rf"\[OPTIONS:(?P<labels>(?:[^[\n]|\[(?!OPTIONS:))*){_MARKER_CLOSE_CLASS}"
+    rf"\[OPTIONS:(?P<labels>{_MARKER_BODY_LINE}){_MARKER_CLOSE_CLASS}"
     rf"(?:\([^\s()]*\))?(?(lwrap){_MARKER_WRAP_CLASS}{{0,3}})[ \t]*$",
     re.MULTILINE,
 )
 
 # TRAILER (``re.DOTALL``, ``\Z`` anchor) — for the Discord/Telegram/WeCom
 # renderers, which match the marker only at the very END of the message and
-# allow it to span newlines (the body keeps ``[^[]`` because the old ``.*``
-# already spanned newlines under DOTALL). Trailing ``\s*`` before ``\Z``. Carries
+# allow it to span newlines (the body omits ``\n`` from its negated class, as the
+# old ``.*`` spanned newlines under DOTALL). Trailing ``\s*`` before ``\Z``. Carries
 # the same optional markdown-link close as LINE (same ``[^\s()]`` inner class, so it
 # shares no character with the trailing ``\s*`` — ReDoS-safe) so the grammar stays
 # identical.
@@ -214,7 +341,7 @@ OPTIONS_RE_LINE = re.compile(
 # ``\Z`` is unaffected by the flag, so nothing else changes.
 OPTIONS_RE_TRAILER = re.compile(
     rf"(?:^[ \t]*(?P<lwrap>{_MARKER_WRAP_CLASS}{{1,3}}))?"
-    rf"\[OPTIONS:(?P<labels>(?:[^[]|\[(?!OPTIONS:))*){_MARKER_CLOSE_CLASS}"
+    rf"\[OPTIONS:(?P<labels>{_MARKER_BODY_TRAILER}){_MARKER_CLOSE_CLASS}"
     rf"(?:\([^\s()]*\))?(?(lwrap){_MARKER_WRAP_CLASS}{{0,3}})\s*\Z",
     re.DOTALL | re.MULTILINE,
 )
@@ -349,9 +476,18 @@ def strip_control_comments(text: str) -> str:
 #: Prefix closures of the marker grammars, for
 #: :func:`split_trailing_protocol_suffix`'s unfinished-marker probe: a tail is
 #: a STILL-STREAMING marker only when every byte it holds so far could extend
-#: into a complete marker. ``[OPTIONS`` must be followed by ``:`` and then
-#: :data:`OPTIONS_RE_TRAILER`'s body (DOTALL; ``[`` admitted only when not
-#: opening a nested ``[OPTIONS:``). ``[STEERING`` follows the steer-ack
+#: into a complete marker. ``[OPTIONS`` must be followed by ``:`` and then a
+#: PREFIX CLOSURE of :data:`OPTIONS_RE_TRAILER`'s body (DOTALL; ``[`` admitted
+#: only when not opening a nested ``[OPTIONS:``) -- deliberately LOOSER than
+#: that body, and the one place the "spelled once" rule in
+#: :data:`_MARKER_BODY_LINE` does not apply. It has to be: a prefix of a legal
+#: body need not itself be a legal body. ``[OPTIONS: A ]`` mid-stream holds a
+#: closer that satisfies neither half of the #9284 rule YET, and becomes legal
+#: the moment ``| B]`` arrives, so a probe spelled as the real body would call
+#: that tail dead and publish the marker as raw text. Widening this to the
+#: grammar is what ``test_options_marker_closers.py``'s
+#: ``test_closer_inside_an_unfinished_label_is_still_unfinished`` forbids.
+#: ``[STEERING`` follows the steer-ack
 #: grammar (``messaging/driver.py``): whitespace gap, literal ``steer-``, a
 #: nonempty hex/dash id, then an optional ``:`` summary -- spelled as nested
 #: optionals so every cut point of the literal run is admitted, while a tail

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from kiro_crew.constants import (
+    MARKER_CLOSERS,
     OPTIONS_RE_TRAILER,
     _leading_wrapper_start,
     strip_control_comments,
@@ -469,7 +470,25 @@ def split_options_trailer(text: str, *, hide_partial: bool = False) -> tuple[str
         return text[: match.start()].rstrip(), choices
     if hide_partial:
         idx = text.rfind("[OPTIONS")
-        if idx != -1 and "]" not in text[idx:]:
+        # "Holds no CLOSER at all", over the whole ``MARKER_CLOSERS`` set rather
+        # than ASCII ``]`` alone. A tail that already holds a closer is not in
+        # flight: either it reads as a marker, in which case the search above
+        # took it, or the grammar declined it and it is PROSE -- which is the
+        # rule ``test_hide_partial_does_not_touch_a_closed_bracket_elsewhere``
+        # already pins for ASCII. Spelling it ASCII-only made that rule miss a
+        # marker whose only closers are lookalikes (``[OPTIONS: 【重要】修复 |
+        # 跳过】``), and the cut there is the permanent kind described below:
+        # WeCom's sealed frame and its persisted history entry, and the Discord
+        # and Telegram ``self._buf = [body]`` reseat, would show the leading
+        # prose with the entire option list deleted and no pills to recover it
+        # from. Widening here can only ever KEEP more text, never cut more.
+        #
+        # Not the same question as ``split_trailing_protocol_suffix``'s probe,
+        # which asks "is this tail COMPLETE?" and must stay ASCII-only (see the
+        # comment there): presence of a closer is not completeness, but it is
+        # conclusive evidence of not-in-flight, and only the latter is asked
+        # here. The two checks differ because the questions differ.
+        if idx != -1 and not any(c in text[idx:] for c in MARKER_CLOSERS):
             # Judge the fragment against the grammar it would have to satisfy,
             # not by substring presence alone. :data:`OPTIONS_RE_TRAILER` opens
             # ``[OPTIONS:`` -- once any byte other than ``:`` follows the

--- a/test/test_options_marker_closers.py
+++ b/test/test_options_marker_closers.py
@@ -70,8 +70,13 @@ class TestClosersNotOverlyBroad:
         assert OPTIONS_RE_LINE.search("[OPTIONS: A | B\u3011 and then more") is None
 
     def test_label_may_contain_a_closer_block_ends_at_the_last_one(self):
-        # Tempered-body property: the block ends at the LAST closer that ends the
-        # line, not the first, so a label may itself contain one.
+        # Tempered-body property: a label may itself contain a closer, so the block
+        # does not necessarily end at the FIRST one. It ends at the last closer
+        # reachable through closers that are MATCHED by an earlier ``[`` or that
+        # CONTINUE the label list -- here the ``]`` after ``a`` is followed by ``|``,
+        # so it stays inside the label. An UNMATCHED closer followed by ordinary
+        # words ends the block instead (#9284); see
+        # ``test_options_marker_label_closers.py``.
         match = OPTIONS_RE_LINE.search("[OPTIONS: a] | b\u3011")
         assert match is not None
         assert [s.strip() for s in match.group("labels").split("|")] == ["a]", "b"]

--- a/test/test_options_marker_label_closers.py
+++ b/test/test_options_marker_label_closers.py
@@ -1,0 +1,348 @@
+"""Tests for #9284: a closer stays in an ``[OPTIONS:]`` label only where it is
+MATCHED by an earlier ``[``, or where it CONTINUES the label list.
+
+A label may legitimately carry a closer -- ``[OPTIONS: Alpha ] | Bravo ]]`` is a
+supported, tested shape -- so the body has to admit one. Admitting it
+UNCONDITIONALLY (the old ``[^[\\n]``, which includes ``]``) made the body run to
+the LAST closer in range instead of the first plausible one, so an ordinary final
+line that mentions a bracket after the marker matched across BOTH::
+
+    Use [OPTIONS: A | B] then check arr[0]
+
+matched whole. Every consumer removes the whole match -- ``slack.format`` and
+``messaging.renderer`` cut the visible text at ``match.start()``, and
+``whatsapp.turn_renderer`` PERSISTS the cut turn -- so the sentence vanished from
+the message and came back as a pill label. Under TRAILER (``DOTALL``) the body
+crossed blank lines too, so the whole final paragraph went with it.
+
+NEITHER condition alone is enough, which is why the rule is a union of two:
+
+===================================== ================== ==========
+input                                 admitted by        outcome
+===================================== ================== ==========
+``[OPTIONS: Fix [x] logging | Skip]``  matched pair       parses
+``[OPTIONS: Alpha ] | Bravo ]]``       list continues     parses
+``Use [OPTIONS: A | B] ... arr[0]``    neither            declined
+===================================== ================== ==========
+
+The first row is pinned independently by ``test_parse_options.py`` and
+``test_options_buttons.py``, whose comments call it out as supported: continuation
+alone would have broken it, so this suite asserts it here too, as the guard it is.
+
+Two claims are asserted separately throughout, because they are different and only
+the second is what the user experiences: that the grammar does not MATCH, and that
+``sub`` leaves the text UNCHANGED. ``TestAcceptedCosts`` extends the second claim
+one step further down, to ``split_options_trailer``, because narrowing the grammar
+is what made that function's partial-cut gate load-bearing: a marker the grammar
+declines must not be silently deleted by the consumer instead.
+
+Measured against ``origin/main`` at 56f67aa43 (post-#9174): every case in
+``OVERREACH`` and ``TRAILER_OVERREACH`` matches there and deletes the prose shown.
+"""
+
+from __future__ import annotations
+
+import time
+
+from kiro_crew.constants import (
+    MARKER_CLOSERS,
+    OPTIONS_RE_LINE,
+    OPTIONS_RE_TRAILER,
+)
+from kiro_crew.messaging.renderer import split_options_trailer
+
+#: Same-line shapes that must NOT match: the swallowed closer has no ``[`` to
+#: match it AND is followed by an ordinary word rather than a separator, so
+#: neither half of the rule admits it.
+OVERREACH = [
+    "Use [OPTIONS: A | B] then check arr[0]",
+    "Pick [OPTIONS: A | B] and the type is dict[str, Any]",
+    "All set [OPTIONS: Ship | Hold] before you diff src/app[0]",
+    "Ready [OPTIONS: Yes | No] see the note in docs[2]",
+    # The wrapped forms of the same shape, on #9174's leading-wrapper path.
+    "`[OPTIONS: A | B] then check arr[0]`",
+    "**[OPTIONS: Merge | Wait] then read CHANGELOG[1]**",
+]
+
+#: End-of-buffer shapes for the DOTALL grammar, where the body used to cross blank
+#: lines and take the whole closing paragraph.
+TRAILER_OVERREACH = [
+    "[OPTIONS: A | B]\n\nAnd then a whole closing paragraph about arr[0]",
+    "Here are your choices.\n\n[OPTIONS: A | B]\n\nRemember to read docs[1]",
+]
+
+
+class TestACloserMustBeMatchedOrContinueTheList:
+    def test_a_closer_followed_by_words_ends_the_block(self):
+        for text in OVERREACH:
+            assert OPTIONS_RE_LINE.search(text) is None, text
+
+    def test_and_therefore_no_prose_is_deleted(self):
+        # The claim that actually matters. "Does not match" and "the message is
+        # intact" are different assertions; every consumer removes the whole match,
+        # so only this one describes what the user sees.
+        for text in OVERREACH:
+            assert OPTIONS_RE_LINE.sub("", text) == text, text
+
+    def test_the_trailer_grammar_no_longer_eats_the_final_paragraph(self):
+        for text in TRAILER_OVERREACH:
+            assert OPTIONS_RE_TRAILER.search(text) is None, text
+            assert OPTIONS_RE_TRAILER.sub("", text) == text, text
+
+    def test_the_rule_stated_positively(self):
+        # An UNMATCHED closer stays inside the label when a separator or another
+        # closer follows it -- that is the second half of the rule on its own,
+        # with no ``[`` anywhere to satisfy the first.
+        match = OPTIONS_RE_LINE.search("[OPTIONS: Alpha ] | Bravo ]]")
+        assert match is not None
+        assert [s.strip() for s in match.group("labels").split("|")] == ["Alpha ]", "Bravo ]"]
+
+    def test_a_comma_continues_the_list_just_as_well_as_a_pipe(self):
+        match = OPTIONS_RE_LINE.search("[OPTIONS: Alpha ], Bravo]")
+        assert match is not None
+        assert match.group("labels") == " Alpha ], Bravo"
+
+    def test_every_lookalike_closer_continues_the_list_too(self):
+        # The rule is spelled over MARKER_CLOSERS, not over ASCII ``]``, so a
+        # model that substitutes one codepoint mid-label is treated identically.
+        for close in MARKER_CLOSERS:
+            text = f"[OPTIONS: Alpha {close} | Bravo]"
+            match = OPTIONS_RE_LINE.search(text)
+            assert match is not None, text
+            assert match.group("labels") == f" Alpha {close} | Bravo", text
+
+    def test_a_bracket_that_ends_a_label_is_unaffected(self):
+        # Admitted by the CONTINUATION half only. The pair half is excluded here by
+        # its own trailing lookahead, precisely because a ``|`` follows -- which is
+        # what keeps the two disjoint, and is why neither alternative is redundant:
+        # delete the continuation half and this pinned shape regresses.
+        match = OPTIONS_RE_LINE.search("[OPTIONS: Fix arr[0] | Skip]")
+        assert match is not None
+        assert [s.strip() for s in match.group("labels").split("|")] == ["Fix arr[0]", "Skip"]
+
+    def test_a_matched_pair_mid_label_with_words_after_it_parses(self):
+        # The rows continuation ALONE would have broken, and the reason the rule
+        # is a union: ``test_parse_options.py`` and ``test_options_buttons.py`` pin
+        # ``Fix [x] logging`` as a supported shape, and there the closer is
+        # followed by an ordinary word rather than a separator. It parses because
+        # the ``[`` before it matches.
+        for text in (
+            "[OPTIONS: Fix [x] logging | Skip]",
+            "[OPTIONS: Fix arr[0] now | Skip]",
+            "Pick one.\n[OPTIONS: Fix [x] logging | Skip]",
+        ):
+            match = OPTIONS_RE_LINE.search(text)
+            assert match is not None, text
+            assert match.group("labels").startswith(" Fix "), text
+
+    def test_an_unmatched_opener_in_a_label_still_parses(self):
+        # The pair alternative must not become a REQUIREMENT: a stray ``[`` with no
+        # closer of its own is still just a character in the label, as it was
+        # before this rule.
+        match = OPTIONS_RE_LINE.search("[OPTIONS: Fix [x logging | Skip]")
+        assert match is not None
+        assert match.group("labels") == " Fix [x logging | Skip"
+
+
+class TestAcceptedCosts:
+    """Every shape the union rule gives up, enumerated rather than summarised.
+
+    They share one form -- a closer that satisfies NEITHER half, with ordinary
+    words after it -- but there is more than one way to be that closer, and all of
+    them parsed on the old body. Each fails toward a VISIBLE marker, not toward
+    deleted prose, and ``test_a_declined_marker_never_loses_the_option_list``
+    below is what holds that asymmetry up.
+    """
+
+    def test_an_unmatched_closer_with_words_after_it_is_the_cost(self):
+        # The base shape: no ``[`` to match it, no separator after it. There the
+        # input is genuinely indistinguishable from "marker ended, prose followed
+        # on the same line", which the grammar declines by design.
+        assert OPTIONS_RE_LINE.search("[OPTIONS: Fix ]x logging | Skip]") is None
+
+    def test_nesting_deeper_than_one_level_is_also_a_cost(self):
+        # The pair form is ONE level deep, so a closer whose nearest preceding
+        # ``[`` is separated from it by another bracket has no pair parse either.
+        # Depth-general matching is not something a regex can do; the boundary is
+        # named here rather than left for a reader to discover.
+        for text in (
+            "[OPTIONS: Fix list[dict[str, Any]] now | Skip]",
+            "[OPTIONS: Update arr[i[0]] then rerun | Skip]",
+        ):
+            assert OPTIONS_RE_LINE.search(text) is None, text
+        # ...and the same nesting with a SEPARATOR after it still parses, because
+        # then the continuation half admits it. The cost is the tail, not the depth.
+        match = OPTIONS_RE_LINE.search("[OPTIONS: Fix list[dict[str, Any]] | Skip]")
+        assert match is not None
+        assert match.group("labels") == " Fix list[dict[str, Any]] | Skip"
+
+    def test_a_lookalike_PAIR_is_a_cost_because_only_ascii_opens(self):
+        # ``MARKER_CLOSERS`` widened the CLOSER set; there is no matching OPENER
+        # set, so ``【`` is an ordinary character and the ``】`` after it reads as
+        # unmatched. Common in Chinese output, hence stated explicitly.
+        assert OPTIONS_RE_LINE.search("[OPTIONS: 【重要】修复 | 跳过】") is None
+
+    def test_a_pair_spanning_a_newline_is_a_trailer_only_cost(self):
+        # The pair interior excludes ``\n`` on BOTH grammars, so under TRAILER
+        # (``DOTALL``) a matched pair that spans a line break inside a label has no
+        # pair parse even though the body may otherwise cross newlines.
+        assert OPTIONS_RE_TRAILER.search("Pick:\n[OPTIONS: Fix [multi\nline] now | Skip]") is None
+
+    def test_a_declined_marker_never_loses_the_option_list(self):
+        """The cost is only affordable because declining is NON-DESTRUCTIVE.
+
+        A declined marker falls through to
+        ``messaging.renderer.split_options_trailer``, whose ``hide_partial`` gate
+        cuts a tail that could still be a marker mid-flight. That gate tested for
+        ASCII ``]`` alone, so a marker whose only closers are lookalikes read as
+        in-flight and was CUT -- and on WeCom the sealed frame and its persisted
+        history entry, and on Discord/Telegram the ``self._buf = [body]`` reseat,
+        would then show the leading prose with the whole option list deleted and no
+        pills to recover it from. Narrowing the grammar is what made that gate
+        load-bearing, so the two are pinned together.
+        """
+        for text in (
+            "请选择：\n[OPTIONS: 【重要】修复 | 跳过】",
+            "Pick one:\n[OPTIONS: Fix ]x logging | Skip]",
+            "Pick one:\n[OPTIONS: Fix list[dict[str, Any]] now | Skip]",
+        ):
+            assert OPTIONS_RE_TRAILER.search(text) is None, text
+            assert split_options_trailer(text, hide_partial=True) == (text, []), text
+
+    def test_a_genuinely_unfinished_lookalike_tail_is_still_hidden(self):
+        # The other direction, so the widening above is not mistaken for "never
+        # cut": a tail holding NO closer at all really may be a marker in flight,
+        # and the streaming surfaces still hide it.
+        body, choices = split_options_trailer(
+            "Working on it. [OPTIONS: 修复 | 跳", hide_partial=True
+        )
+        assert body == "Working on it."
+        assert choices == []
+
+    def test_a_nested_head_is_not_swallowed_into_a_label(self):
+        # The one place this rule could have been LOOSER than the body it replaced:
+        # without ``(?!OPTIONS:)`` on the pair form's opener, the pair alternative
+        # opens on a nested head and pairs it with that head's own closer, so the
+        # OUTER head matches and the pill's label is a raw protocol marker --
+        # echoed back as the user's reply when tapped. The old body matched nothing
+        # here, and neither does this one.
+        assert OPTIONS_RE_LINE.search("Note [OPTIONS: see [OPTIONS: x] below | Skip]") is None
+
+    def test_the_separator_tail_form_is_out_of_scope_and_unchanged(self):
+        # NOT reachable by this rule, and pinned so it is not read as a regression
+        # introduced here: ``], `` DOES continue the label list, by the very rule
+        # that makes ``[OPTIONS: Alpha ], Bravo]`` legal, so no guard applied at the
+        # internal closer can tell the two apart. Resolving it means deciding which
+        # shape loses -- a separate call with its own cost. Behaviour here is
+        # byte-for-byte what origin/main does.
+        text = "Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]"
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None
+        assert OPTIONS_RE_LINE.sub("", text) == "Done. "
+
+
+class TestTheWideningIsNotOverlyNarrow:
+    """Everything #9174 and the closer widening added must still parse."""
+
+    def test_the_plain_marker_still_parses_on_both_grammars(self):
+        for text in ("Done.\n\n[OPTIONS: Merge | Wait]", "Done. [OPTIONS: Merge | Wait]"):
+            match = OPTIONS_RE_LINE.search(text)
+            assert match is not None, text
+            assert match.group("labels") == " Merge | Wait", text
+        trailer = OPTIONS_RE_TRAILER.search("Done.\n\n[OPTIONS: Merge | Wait]")
+        assert trailer is not None
+        assert trailer.group("labels") == " Merge | Wait"
+
+    def test_every_wrapper_still_parses(self):
+        for wrap in ("`", "``", "```", "*", "**", "_", "__"):
+            text = f"Done.\n\n{wrap}[OPTIONS: Merge | Wait]{wrap}"
+            match = OPTIONS_RE_LINE.search(text)
+            assert match is not None, text
+            assert match.group("labels") == " Merge | Wait", text
+            assert match.group("lwrap") == wrap, text
+
+    def test_a_wrapped_marker_with_a_continuing_closer_still_parses(self):
+        # The two rules compose: the wrapper is #9174's, the mid-label closer is
+        # this one's, and a marker carrying both is still a marker.
+        match = OPTIONS_RE_LINE.search("`[OPTIONS: Alpha ] | Bravo]`")
+        assert match is not None
+        assert match.group("lwrap") == "`"
+        assert [s.strip() for s in match.group("labels").split("|")] == ["Alpha ]", "Bravo"]
+
+    def test_prose_emphasis_before_the_marker_is_still_never_eaten(self):
+        text = "**Choose:** [OPTIONS: Merge | Wait]"
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None
+        assert match.group("lwrap") is None
+        assert OPTIONS_RE_LINE.sub("", text) == "**Choose:** "
+
+    def test_a_marker_spanning_newlines_still_closes_the_trailer(self):
+        # TRAILER's body omits ``\n`` from its negated class on purpose (DOTALL),
+        # so the temper must not have re-introduced a line boundary.
+        match = OPTIONS_RE_TRAILER.search("Done.\n\n[OPTIONS: Alpha |\nBravo]")
+        assert match is not None
+        assert match.group("labels") == " Alpha |\nBravo"
+
+    def test_the_markdown_link_close_tic_still_composes(self):
+        match = OPTIONS_RE_LINE.search("[OPTIONS: A | B](OPTIONS)")
+        assert match is not None
+        assert match.group("labels") == " A | B"
+
+    def test_a_marker_with_same_line_prose_after_it_still_fails_the_anchor(self):
+        # Unchanged, and the reason the cost above is bounded: this was already
+        # declined before the temper.
+        assert OPTIONS_RE_LINE.search("[OPTIONS: A | B] see the note") is None
+
+
+class TestLinearity:
+    """The temper adds a lookahead inside a quantified body. These drive it
+    directly -- a quadratic implementation wedges rather than failing an
+    assertion, so the bound is generous and the shapes are the adversarial ones."""
+
+    def test_a_long_trailing_whitespace_run_is_linear(self):
+        # The marker's OWN closer followed by a 100k-tab run: a legitimate match
+        # (the tabs are the trailing ``[ \t]*``), and the scan is single-pass.
+        text = "[OPTIONS: A ]" + "\t" * 100_000
+        start = time.monotonic()
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None
+        assert match.group("labels") == " A "
+        assert time.monotonic() - start < 5.0
+
+    def test_a_long_FAILING_continuation_scan_is_linear(self):
+        # The adversarial direction: the closer is INSIDE the body, so it enters the
+        # lookahead, whose whitespace scan runs to the end of a 100k-tab run and then
+        # FAILS on ``x``. The body cannot cross the closer either, so the whole match
+        # fails -- after the longest scan the lookahead can be made to do.
+        text = "[OPTIONS: A ]" + "\t" * 100_000 + "x]"
+        start = time.monotonic()
+        assert OPTIONS_RE_LINE.search(text) is None
+        assert time.monotonic() - start < 5.0
+
+    def test_many_failing_closers_are_linear(self):
+        # 5,000 closers, each entering the lookahead and each failing it.
+        text = "[OPTIONS: " + "] x " * 5_000
+        start = time.monotonic()
+        OPTIONS_RE_LINE.search(text)
+        assert time.monotonic() - start < 5.0
+
+    def test_many_continuing_closers_then_a_long_tail_are_linear(self):
+        # The other direction: 30,000 closers that all SUCCEED in the lookahead,
+        # followed by a 30,000-tab tail that fails the end anchor.
+        text = "[OPTIONS: " + "] | " * 30_000 + "\t" * 30_000
+        start = time.monotonic()
+        OPTIONS_RE_LINE.search(text)
+        assert time.monotonic() - start < 5.0
+
+    def test_the_two_bracket_alternatives_cannot_blow_up_together(self):
+        # THE shape that would be exponential if the matched-pair and
+        # continuation alternatives could consume the same span: N blocks that
+        # each look like both, followed by a tail that fails the whole match, so
+        # the engine is forced to exhaust every combination it believes exists.
+        # They are disjoint by what follows the closer, so there is only one.
+        for block in ("[x] ", "[x] | ", "[a[b] ", "[a] ]a ", "[x", "[] "):
+            text = "[OPTIONS: " + block * 20_000 + "z"
+            start = time.monotonic()
+            OPTIONS_RE_LINE.search(text)
+            OPTIONS_RE_TRAILER.search(text)
+            assert time.monotonic() - start < 5.0, block

--- a/website/src/app-sdk/protocol/optionMarker.ts
+++ b/website/src/app-sdk/protocol/optionMarker.ts
@@ -3,11 +3,15 @@
 // (src/kiro_crew/constants.py). Import this instead of hand-rolling a copy so the
 // grammar can't drift between the dashboard's several parsers.
 //
-// The tempered body `(?:[^[\n]|\[(?!OPTIONS?:))*` matches any run of characters that
-// does NOT begin a fresh `[OPTION(S):` marker, which gives three properties:
-//   1. a label may itself contain `]` — the block ends at the LAST `]` that ends the
-//      line, not the first `]` (so "[OPTIONS: a] | b]]" → ["a]", "b]"]);
-//   2. two same-line markers can't merge into one garbage label;
+// The tempered body matches any run of characters in which no alternative begins a
+// fresh `[OPTION(S):` marker — both bracket forms carry that guard — which gives
+// three properties:
+//   1. a label may itself contain a closer, so the block does not end at the FIRST
+//      one (so "[OPTIONS: a] | b]]" → ["a]", "b]"]) — but it is admitted
+//      CONDITIONALLY, not freely: see #9284 below for the rule and why an
+//      unconditional `]` ran the body past the marker and deleted prose;
+//   2. two same-line markers can't merge into one garbage label — including a
+//      NESTED head, which the pair form's own `(?!OPTIONS?:)` is what preserves;
 //   3. it fails in O(1) per `[OPTIONS:` prefix instead of rescanning the line, so
 //      untrusted model output with thousands of `[OPTIONS:` prefixes can't drive
 //      quadratic (ReDoS-class) backtracking in the synchronous render path.
@@ -33,8 +37,53 @@
 // breaks the end anchor — the marker then leaks into the message as literal text
 // and the turn silently loses its pills. Labels are unaffected, so accepting the
 // lookalike costs nothing. ReDoS profile is unchanged from the previous literal
-// `\]`: the class shares no character with the trailing `[ \t]*`, and the
-// tempered body already admitted `]` via `[^[\n]`.
+// `\]`: the class shares no character with the trailing `[ \t]*`, and the body
+// excludes it from its negated class and readmits all four codepoints in exactly
+// TWO tempered places (below) — as the matched-pair form's final atom, and via the
+// continuation lookahead. A widening of this class has to be re-audited against
+// both; the pair form is the one holding the deciding lookahead, so it is the one
+// not to skip.
+//
+// A CLOSER MUST BE MATCHED, OR CONTINUE THE LABEL LIST (#9284). A label may
+// legitimately carry a closer (`[OPTIONS: Alpha ] | Bravo ]]` is a supported,
+// tested shape), so the body has to admit one — but admitting it UNCONDITIONALLY
+// (the old `[^[\n]`, which includes `]`) made the body run to the LAST closer in
+// range instead of the first plausible one. An ordinary final line that mentions
+// a bracket after the marker then matched across BOTH — `Use [OPTIONS: A | B]
+// then check arr[0]` matched whole — and since the marker is removed by
+// `replace`, the sentence vanished from the message and came back as a pill
+// label. So the body now admits a closer under either of two conditions, because
+// neither alone separates the three shapes that matter:
+//
+//   [OPTIONS: Fix [x] logging | Skip]        MATCHED by an earlier `[` -> parses
+//   [OPTIONS: Alpha ] | Bravo ]]            list CONTINUES after it   -> parses
+//   Use [OPTIONS: A | B] then check arr[0]  neither                   -> declined
+//
+// The second is exactly the rule `CONTINUES_LABELS_RE` below already applies to
+// the STREAMING probe, now applied by the grammar too, so the two stop answering
+// the same question differently. The first is required by `Fix [x] logging`,
+// which the backend's `test_parse_options.py` pins as a supported shape outright.
+// The two are kept DISJOINT by what follows the closer — the matched form
+// requires that its closer NOT be followed by a separator or another closer,
+// which is precisely when the continuation form applies — so no span has two
+// parses and the body stays linear despite two bracket alternatives.
+//
+// RESIDUAL COST: every shape given up is a closer that satisfies NEITHER half and
+// has ordinary words after it, where the input is genuinely indistinguishable from
+// "marker ended, prose followed". There is more than one way to be that closer,
+// and all of them parsed on the old body:
+//
+//   [OPTIONS: Fix ]x logging | Skip]             unmatched — no `[` at all
+//   [OPTIONS: Fix list[dict[str, Any]] now | S]  nesting deeper than one level
+//   [OPTIONS: 【重要】修复 | 跳过】                 a lookalike PAIR — `【` is not an
+//                                                opener, only `[` is
+//
+// All fail toward a VISIBLE marker, not toward deleted prose, and that asymmetry
+// is what makes them affordable. Making them parse means matching brackets to
+// arbitrary depth and over an opener set this grammar does not have. The
+// separator-tail form (`…| Wait], details in CHANGELOG[1]`) is NOT reachable by
+// this rule and is unchanged: `], ` does continue the list, by the same rule that
+// makes `[OPTIONS: Alpha ], Bravo]` legal.
 //
 // MARKDOWN WRAPPERS (#9110): a model sometimes wraps the whole marker line in
 // inline code or emphasis — `` `[OPTIONS: A | B]` `` or `**[OPTIONS: A | B]**`.
@@ -70,7 +119,7 @@
 // `new RegExp(OPTION_MARKER_RE)` there. Never call `.exec`/`.test` on it: both leave the index
 // advanced, and the next reader silently scans from the wrong offset.
 export const OPTION_MARKER_RE =
-  /(?:^[ \t]*[`*_]{1,3}\[OPTION(S)?:((?:[^[\n]|\[(?!OPTIONS?:))*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}|\[OPTION(S)?:((?:[^[\n]|\[(?!OPTIONS?:))*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?)[ \t]*$/gim
+  /(?:^[ \t]*[`*_]{1,3}\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}|\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?)[ \t]*$/gim
 
 /** The closing brackets OPTION_MARKER_RE accepts — ASCII plus the CJK lookalikes.
  *  Module-private and used with matchAll only (to take the LAST closer in the
@@ -210,8 +259,12 @@ export function stripPartialOptionMarker(text: string): string {
     let closer = -1
     for (const m of body.matchAll(CLOSER_RE)) closer = m.index
     // No closer yet, or the label list resumes after it → still being written.
-    // A closer with only trailing blanks after it cannot actually reach here
-    // (parseOptions would have stripped that marker), so it falls in with "cut".
+    // A closer with only trailing blanks after it DOES reach here since #9284:
+    // parseOptions now declines a marker whose interior closer is neither matched
+    // nor continuing (`[OPTIONS: Fix ]x logging | Skip]`), so its final closer
+    // arrives with nothing after it. Cutting is still the right branch — this is
+    // reached only under the isStreaming gate (AssistantMessage.tsx), so the frame
+    // is transient and the sealed render shows the marker as written.
     const rest = closer < 0 ? '' : body.slice(closer + 1)
     const forming = closer < 0 || rest.trim() === '' || CONTINUES_LABELS_RE.test(rest)
     return forming ? cutAt(text, start + wrapperStart(tail, head)) : text

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -790,8 +790,20 @@ describe('parseOptions', () => {
   // adversarial input still parses to no options — is asserted directly below.
   it('does not catastrophically backtrack on adversarial `[OPTIONS:` input', () => {
     const src = OPTION_MARKER_RE.source
-    // The label body: tempered alternation, NOT a nested quantifier.
-    expect(src).toContain('(?:[^[\\n]|\\[(?!OPTIONS?:))*')
+    // The label body: tempered alternation, NOT a nested quantifier. Spelled with
+    // `\uXXXX` escapes because that is how the SOURCE spells the closer class —
+    // `.source` is the literal pattern text, so a literal `】` here would not match.
+    const C = '\\]\\u3011\\uFF3D\\u3015'
+    const CONT = `[ \\t]*[|,]|[${C}]`
+    // Four alternatives, mutually exclusive at every position. The two bracket
+    // forms both begin at `[` but are each other's negation on what FOLLOWS the
+    // closer, so no span of input ever has two parses — that disjointness is what
+    // the linearity rests on, so it is pinned here character for character. BOTH
+    // bracket forms carry `(?!OPTIONS?:)`: that is what keeps a nested head out of
+    // a label, and dropping it from the pair form is a widening, not a tidy-up.
+    expect(src).toContain(
+      `(?:\\[(?!OPTIONS?:)[^[${C}\\n]*[${C}](?!${CONT})|\\[(?!OPTIONS?:)|[${C}](?=${CONT})|[^[${C}\\n])*`,
+    )
     // No `(x+)+` / `(x*)*` anywhere: that is the shape that backtracks
     // exponentially, and it is what the tempered body above replaced.
     expect(src).not.toMatch(/\([^)]*[+*]\)[+*]/)

--- a/website/src/test/optionsMarkerLabelClosers.test.ts
+++ b/website/src/test/optionsMarkerLabelClosers.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest'
+import { parseOptions } from '../app-sdk/protocol'
+// The pattern is in-tree only — the barrel deliberately withholds it from the app surface.
+import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+
+// #9284: a label may legitimately carry a closer (`[OPTIONS: Alpha ] | Bravo ]]` is
+// a supported, tested shape), so the body has to admit one — but admitting it
+// UNCONDITIONALLY made the body run to the LAST closer in range instead of the first
+// plausible one. An ordinary final line mentioning a bracket after the marker then
+// matched across BOTH, and since the marker is removed by `replace`, the sentence
+// vanished from the message and came back as a pill label.
+//
+// So a closer stays inside a label only where it is MATCHED by an earlier `[`, or
+// where a separator or another closer follows it. Neither condition alone separates
+// the three shapes that matter — continuation alone breaks `Fix [x] logging`, which
+// the backend pins as supported; matching alone breaks `Alpha ] | Bravo ]]`. The
+// second half is the rule `CONTINUES_LABELS_RE` already applied to the STREAMING
+// probe.
+//
+// Every row in `overreach` matches on origin/main at 56f67aa43 (post-#9174) and
+// deletes the prose shown. Two claims are asserted separately throughout, because
+// they are different and only the second is what the user experiences: that the
+// grammar does not MATCH, and that the visible text is UNCHANGED.
+describe('OPTION_MARKER_RE label closers must be matched or continue the list (#9284)', () => {
+  const overreach = [
+    'Use [OPTIONS: A | B] then check arr[0]',
+    'Pick [OPTIONS: A | B] and the type is dict[str, Any]',
+    'All set [OPTIONS: Ship | Hold] before you diff src/app[0]',
+    'Ready [OPTIONS: Yes | No] see the note in docs[2]',
+    // The wrapped forms of the same shape, on #9174's leading-wrapper path.
+    '`[OPTIONS: A | B] then check arr[0]`',
+    '**[OPTIONS: Merge | Wait] then read CHANGELOG[1]**',
+  ]
+
+  it('declines a closer followed by ordinary words', () => {
+    for (const text of overreach) {
+      expect(parseOptions(text).options, text).toEqual([])
+    }
+  })
+
+  it('and therefore deletes no prose', () => {
+    for (const text of overreach) {
+      expect(text.replace(OPTION_MARKER_RE, ''), text).toBe(text)
+    }
+  })
+
+  it('states the rule positively — a separator or another closer keeps it in', () => {
+    expect(parseOptions('[OPTIONS: Alpha ] | Bravo ]]').options).toEqual(['Alpha ]', 'Bravo ]'])
+    expect(parseOptions('[OPTIONS: Alpha ], Bravo]').options).toEqual(['Alpha ]', 'Bravo'])
+  })
+
+  it('applies the rule to every lookalike closer, not just ASCII', () => {
+    for (const close of [']', '】', '］', '〕']) {
+      const text = `[OPTIONS: Alpha ${close} | Bravo]`
+      expect(parseOptions(text).options, text).toEqual([`Alpha ${close}`, 'Bravo'])
+    }
+  })
+
+  it('leaves a bracket that ENDS a label alone — via the continuation half', () => {
+    // The pair half is excluded here by its own trailing lookahead, precisely
+    // because a `|` follows — which is what keeps the two disjoint, and is why
+    // neither alternative is redundant: delete the continuation half and this
+    // pinned shape regresses.
+    expect(parseOptions('[OPTIONS: Fix arr[0] | Skip]').options).toEqual(['Fix arr[0]', 'Skip'])
+  })
+
+  it('keeps a MATCHED pair mid-label with words after it', () => {
+    // Continuation alone would have broken these, and they are why the rule is a
+    // union: the backend pins `Fix [x] logging` as a supported shape, and there
+    // the closer is followed by an ordinary word rather than a separator.
+    expect(parseOptions('[OPTIONS: Fix [x] logging | Skip]').options).toEqual([
+      'Fix [x] logging',
+      'Skip',
+    ])
+    expect(parseOptions('[OPTIONS: Fix arr[0] now | Skip]').options).toEqual([
+      'Fix arr[0] now',
+      'Skip',
+    ])
+  })
+
+  it('does not make the pair a REQUIREMENT — a stray opener still parses', () => {
+    expect(parseOptions('[OPTIONS: Fix [x logging | Skip]').options).toEqual([
+      'Fix [x logging',
+      'Skip',
+    ])
+  })
+
+  // Every shape the union rule gives up, enumerated rather than summarised. They
+  // share one form — a closer that satisfies NEITHER half, with ordinary words
+  // after it — but there is more than one way to be that closer, and all of them
+  // parsed on the old body. Each fails toward a VISIBLE marker, and the assertion
+  // on `.text` is what says so: nothing is deleted.
+  it('accepts an UNMATCHED closer with words after it as the cost', () => {
+    const text = '[OPTIONS: Fix ]x logging | Skip]'
+    expect(parseOptions(text).options).toEqual([])
+    expect(parseOptions(text).text).toBe(text)
+  })
+
+  it('accepts nesting deeper than one level as a cost too', () => {
+    // The pair form is ONE level deep, so a closer whose nearest preceding `[` is
+    // separated from it by another bracket has no pair parse either. Depth-general
+    // matching is not something a regex can do; the boundary is named here rather
+    // than left for a reader to discover.
+    for (const text of [
+      '[OPTIONS: Fix list[dict[str, Any]] now | Skip]',
+      '[OPTIONS: Update arr[i[0]] then rerun | Skip]',
+    ]) {
+      expect(parseOptions(text).options, text).toEqual([])
+      expect(parseOptions(text).text, text).toBe(text)
+    }
+    // ...and the same nesting with a SEPARATOR after it still parses, because then
+    // the continuation half admits it. The cost is the tail, not the depth.
+    expect(parseOptions('[OPTIONS: Fix list[dict[str, Any]] | Skip]').options).toEqual([
+      'Fix list[dict[str, Any]]',
+      'Skip',
+    ])
+  })
+
+  it('accepts a lookalike PAIR as a cost, because only ASCII `[` opens', () => {
+    // The closer set was widened to the CJK lookalikes; there is no matching
+    // OPENER set, so `【` is an ordinary character and the `】` after it reads as
+    // unmatched. Common in Chinese output, hence stated explicitly.
+    const text = '[OPTIONS: 【重要】修复 | 跳过】'
+    expect(parseOptions(text).options).toEqual([])
+    expect(parseOptions(text).text).toBe(text)
+  })
+
+  it('never swallows a NESTED head into a label', () => {
+    // The one place this rule could have been LOOSER than the body it replaced:
+    // without `(?!OPTIONS?:)` on the pair form's opener, the pair alternative opens
+    // on a nested head and pairs it with that head's own closer, so the OUTER head
+    // matches and the pill's label is a raw protocol marker — echoed back as the
+    // user's reply when tapped. The old body matched nothing here, nor does this one.
+    const text = 'Note [OPTIONS: see [OPTIONS: x] below | Skip]'
+    expect(parseOptions(text).options).toEqual([])
+    expect(parseOptions(text).text).toBe(text)
+  })
+
+  it('leaves the separator-tail form out of scope and unchanged', () => {
+    // NOT reachable by this rule, pinned so it is not read as a regression here:
+    // `], ` DOES continue the label list, by the very rule that makes
+    // `[OPTIONS: Alpha ], Bravo]` legal, so no guard applied at the internal closer
+    // can tell them apart. Byte-for-byte what origin/main does.
+    expect(parseOptions('Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]').text).toBe(
+      'Done.',
+    )
+  })
+})
+
+describe('the #9284 temper leaves the rest of the grammar where it was', () => {
+  it('still parses the plain marker', () => {
+    expect(parseOptions('Done.\n\n[OPTIONS: Merge | Wait]').options).toEqual(['Merge', 'Wait'])
+    expect(parseOptions('Done. [OPTIONS: Merge | Wait]').options).toEqual(['Merge', 'Wait'])
+  })
+
+  it('still parses every wrapper #9174 added', () => {
+    for (const wrap of ['`', '``', '```', '*', '**', '_', '__', '***']) {
+      const text = `Done.\n${wrap}[OPTIONS: Merge | Wait]${wrap}`
+      expect(parseOptions(text).options, text).toEqual(['Merge', 'Wait'])
+      expect(parseOptions(text).text, text).toBe('Done.')
+    }
+  })
+
+  it('composes the two rules — a wrapped marker with a continuing closer parses', () => {
+    expect(parseOptions('`[OPTIONS: Alpha ] | Bravo]`').options).toEqual(['Alpha ]', 'Bravo'])
+  })
+
+  it('still keeps [OPTION:] single-select', () => {
+    expect(parseOptions('[OPTION: Ship | Hold]').multi).toBe(false)
+    expect(parseOptions('`[OPTION: Ship | Hold]`').multi).toBe(false)
+  })
+
+  it('still never eats prose emphasis before the marker', () => {
+    const text = '**Choose:** [OPTIONS: Merge | Wait]'
+    expect(parseOptions(text).options).toEqual(['Merge', 'Wait'])
+    expect(parseOptions(text).text).toBe('**Choose:**')
+  })
+
+  it('still composes with the markdown-link close tic', () => {
+    expect(parseOptions('[OPTIONS: A | B](OPTIONS)').options).toEqual(['A', 'B'])
+  })
+
+  it('still declines a marker with same-line prose after it', () => {
+    expect(parseOptions('[OPTIONS: A | B] see the note').options).toEqual([])
+  })
+
+  it('still cannot let a label span a line break', () => {
+    expect(parseOptions('[OPTIONS: Alpha |\nBravo]').options).toEqual([])
+  })
+})
+
+describe('the #9284 temper stays linear', () => {
+  // The temper adds a lookahead inside a quantified body. A quadratic
+  // implementation wedges rather than failing an assertion, so the bound is
+  // generous and the shapes are the adversarial ones.
+  it('is linear over a long trailing whitespace run', () => {
+    const text = `[OPTIONS: A ]${'\t'.repeat(100_000)}`
+    const start = Date.now()
+    expect(parseOptions(text).options).toEqual(['A'])
+    expect(Date.now() - start).toBeLessThan(2000)
+  })
+
+  it('is linear over a long FAILING continuation scan', () => {
+    // The closer is INSIDE the body, so it enters the lookahead, whose whitespace
+    // scan runs to the end of a 100k-tab run and then fails on `x`.
+    const text = `[OPTIONS: A ]${'\t'.repeat(100_000)}x]`
+    const start = Date.now()
+    expect(parseOptions(text).options).toEqual([])
+    expect(Date.now() - start).toBeLessThan(2000)
+  })
+
+  it('is linear over many failing closers', () => {
+    const text = `[OPTIONS: ${'] x '.repeat(5_000)}`
+    const start = Date.now()
+    parseOptions(text)
+    expect(Date.now() - start).toBeLessThan(2000)
+  })
+
+  it('is linear over many CONTINUING closers then a long tail', () => {
+    const text = `[OPTIONS: ${'] | '.repeat(30_000)}${'\t'.repeat(30_000)}`
+    const start = Date.now()
+    parseOptions(text)
+    expect(Date.now() - start).toBeLessThan(2000)
+  })
+
+  it('cannot blow up where the two bracket alternatives meet', () => {
+    // THE shape that would be exponential if the matched-pair and continuation
+    // alternatives could consume the same span: N blocks that look like both,
+    // then a tail that fails the whole match, forcing the engine to exhaust
+    // every combination it believes exists. They are disjoint by what follows
+    // the closer, so there is only one.
+    for (const block of ['[x] ', '[x] | ', '[a[b] ', '[a] ]a ', '[x', '[] ']) {
+      const text = `[OPTIONS: ${block.repeat(20_000)}z`
+      const start = Date.now()
+      parseOptions(text)
+      expect(Date.now() - start, block).toBeLessThan(2000)
+    }
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The `[OPTIONS:]` label body admits `]` unconditionally, so it runs to the **last** closer in range rather than the first plausible one. A turn whose final line mentions a bracket after the marker matches across **both**:

```
Use [OPTIONS: A | B] then check arr[0]
```

| | |
|---|---|
| visible text after strip | `Use ` |
| `labels` | `' A | B] then check arr[0'` |

The trailing sentence is gone from the message and is offered to the user as a button. Under `OPTIONS_RE_TRAILER` (`DOTALL`, `\Z`-anchored, serving the Discord/Telegram/WeCom renderers) the body crosses blank lines too, so the whole closing paragraph goes with it — and with no leading prose the visible text becomes the **empty string**:

```
Here are your choices.

[OPTIONS: A | B]

Remember to read docs[1]
```
→ visible text `Here are your choices.\n\n`, `labels` = `' A | B]\n\nRemember to read docs[1'`.

Filed as #9284, with both classes measured against `origin/main` at `56f67aa43`.

## Why it matters

Every consumer treats a match as removable: `parseOptions` replaces it, `slack/format.py` and `messaging/renderer.py` cut the visible text at `match.start()`, and `whatsapp/turn_renderer.py` **persists** the cut turn. So this is silent data loss in the user-facing message, not a rendering glitch — and the swallowed prose is simultaneously surfaced as a clickable option, which is its own confusion.

It fires on ordinary agent output. A turn ending in a file path, an array index, a type annotation, or a footnote marker is common, and the marker rule puts `[OPTIONS:]` on that same final line by design. It is also backend- and channel-independent, because this is the shared grammar.

## What changed (motivation → approach → change)

**Symptom** → a sentence (or a whole final paragraph) disappears from the message and reappears as a pill label.
**Root cause** → the label body `(?:[^[\n]|\[(?!OPTIONS:))*`. `[^[\n]` includes `]`, so a closer inside the body is free, and the greedy body therefore extends to the last closer that still satisfies the end anchor.

### The obvious rule is wrong, and the tests say so

A label *may* legitimately carry a closer, so the body cannot simply exclude `]`. The natural fix is to admit one only where the label list **continues** — where a separator or another closer follows. That is also the rule the streaming probe already applies (`CONTINUES_LABELS_RE`), so it looked like the grammar and the probe merely disagreeing.

Applying it broke two existing tests:

```
test/test_options_buttons.py::TestExtractOptions::test_bracket_inside_option_text_survives
test/test_parse_options.py::test_bracket_inside_option_text
    AssertionError: assert [] == ['Fix [x] logging', 'Skip']
```

`[OPTIONS: Fix [x] logging | Skip]` is a **first-class supported shape**, and both tests say so in their comments ("a literal `]` inside an option must not truncate the pill"). There the closer is followed by an ordinary word, so continuation alone rejects it. Matching alone is equally wrong in the other direction: `[OPTIONS: Alpha ] | Bravo ]]` carries closers with no opener at all, and is also tested.

So the rule is the **union** of the two, and each of the three shapes is now pinned:

| input | admitted by | outcome |
|---|---|---|
| `[OPTIONS: Fix [x] logging \| Skip]` | matched pair | parses |
| `[OPTIONS: Alpha ] \| Bravo ]]` | list continues | parses |
| `Use [OPTIONS: A \| B] then check arr[0]` | neither | declined |

```python
_MARKER_LABEL_CONTINUES = rf"(?=[ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
_MARKER_LABEL_PAIR = (
    rf"\[[^[{re.escape(MARKER_CLOSERS)}\n]*{_MARKER_CLOSE_CLASS}"
    rf"(?![ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
)
```

The pair form is one level deep and its interior excludes `[` **and every closer** (not just ASCII `]`), so a lookalike codepoint cannot be swallowed into the interior and escape the rule.

### Disjointness is the linearity argument, not a side note

Two alternatives that both begin at `[` would be a genuine ReDoS shape if they could consume the same span — N blocks with two parses each is 2ⁿ on failure. They cannot: the pair form requires that its closer **not** be followed by a separator or another closer, which is exactly when the continuation form applies. The two lookaheads are each other's negation, so the four body alternatives are mutually exclusive at every position, an unmatched `[` is left to the bare-`[` form, and the negated class excludes both `[` and every closer. There is never more than one way to consume a character.

That is asserted rather than argued: six block shapes that each *look* like both alternatives (`[x] `, `[x] | `, `[a[b] `, `[a] ]a `, `[x`, `[] `), repeated 20,000 times and followed by a tail that fails the whole match, so the engine must exhaust every combination it believes exists. Worst single search across the battery is 20 ms. Each lookahead is also entered only at a bracket and bounded by the run it scans.

### Declining must not delete — the part that made a latent hole load-bearing

Narrowing a grammar whose consumers cut at `match.start()` moves the risk downstream: a shape that no longer parses has to survive the *partial-marker* path instead. It did not.

`messaging/renderer.py`'s `hide_partial` gate asks "could this tail still be a marker in flight?" and answered by looking for ASCII `]` alone. A marker whose only closers are lookalikes is now declined, falls through to that gate, holds no ASCII `]` — and so read as in-flight and was **cut**:

```
请选择：
[OPTIONS: 【重要】修复 | 跳过】     →  ('请选择：', [])
```

Reached via `WeComRenderer.text()` → `_render_options_as_text`, and via `_extract_options` in the Discord and Telegram renderers, which then do `self._buf = [body]`. That is WeCom's **sealed frame and its persisted history entry**, plus the sealed Discord/Telegram messages, showing the leading prose with the entire option list deleted and no pills to recover it from. Unrecoverable, and on exactly the channels that cannot render buttons.

The gate now tests the whole `MARKER_CLOSERS` set — which is the rule `test_hide_partial_does_not_touch_a_closed_bracket_elsewhere` **already pinned for ASCII** ("`[OPTIONS: …]` that failed the end anchor is prose, not a live marker"), just spelled over one codepoint. Widening it can only ever *keep* more text, never cut more. It is a different question from `split_trailing_protocol_suffix`'s probe, which asks whether a tail is **complete** and must stay ASCII-only (revision `7115a04a` widened *that* one and was blocked): presence of a closer is not completeness, but it is conclusive evidence of not-in-flight, and only the latter is asked here.

### One place the rule was looser than what it replaced

The pair form needs the same `(?!OPTIONS:)` guard the bare-`[` form carries. Without it, it opens on a **nested head** and pairs it with that head's own closer:

```
Note [OPTIONS: see [OPTIONS: x] below | Skip]
```

matched from the **outer** head — where the old body matched nothing at all — and rendered a pill labelled `see [OPTIONS: x] below | Skip`, a raw protocol marker as button text, echoed back as the user's reply when tapped. The guard restores "no bracket form may consume a `[` that begins a fresh `[OPTIONS:`" as an absolute property of the body rather than one that holds only for sibling heads.

### Accepted cost, enumerated rather than summarised

Every shape the union gives up is a closer that satisfies **neither** half with ordinary words after it, where the input is genuinely indistinguishable from "marker ended, prose followed on the same line". There is more than one way to be that closer, and all of them parsed before:

| shape | why neither half admits it |
|---|---|
| `[OPTIONS: Fix ]x logging \| Skip]` | unmatched — no `[` at all |
| `[OPTIONS: Fix list[dict[str, Any]] now \| S]` | nesting deeper than one level |
| `[OPTIONS: 【重要】修复 \| 跳过】` | a lookalike **pair** — `【` is not an opener, only `[` is |
| `[OPTIONS: Fix [multi\nline] now \| Skip]` | TRAILER only; the pair interior excludes `\n` even under `DOTALL` |

All four fail toward a **visible marker**, not toward deleted prose — which is the whole reason they are affordable, and why the gate fix above is what holds the cost up rather than a separate tidy-up. The two are pinned together in one test. Making them parse means matching brackets to arbitrary depth and over an opener set this grammar does not have, which a regex is the wrong tool for; the cost is bounded by the direction it fails in instead.

**Row 3 is tracked for a follow-up rather than left as a bare cost: #9375.** It is the one of the four that does *not* need arbitrary-depth matching — only an opener set paired positionally to `MARKER_CLOSERS`, so a closer counts as matched by the bracket it actually closes. Measured on a transcription of this body with that added: the two lookalike-pair shapes parse, a *mismatched* `【…]` still declines, and this PR's own trailing-prose fix still holds. Deliberately not folded in here — it widens the grammar in the opposite direction from the narrowing this PR is about, and it wants its own tests and its own review. The other three rows stay costs.

Note what the union *saves* relative to the continuation-only rule: `Fix [x] logging`, `Fix arr[0] now`, `dict[str, Any]`-style labels, and a stray unmatched `[` all keep working.

### Out of scope, pinned so it is not read as a regression introduced here

```
Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]     → visible 'Done. '
```

still cuts to `Done.`, **byte-for-byte as it does on `main`**. `], ` *does* continue the label list — by the very rule that makes `[OPTIONS: Alpha ], Bravo]` legal — so no guard applied at the internal closer can tell the two apart. Resolving it means deciding which of the two shapes loses, which is a separate call with its own cost, not a free extension of this one. A test asserts the current output exactly, so the boundary is legible rather than arguable.

### Relationship to #9174

#9174 (merged 2026-09-07) fixed the **wrapper anchor** on these same two regexes — a different root cause on the same lines. Its rules are untouched here and compose with this one: a wrapped marker carrying a continuing closer (`` `[OPTIONS: Alpha ] | Bravo]` ``) still parses, and all seven of its wrapper shapes are re-asserted in this PR's tests as guards. Two of the six same-line over-reach rows in the new tables are the *wrapped* forms of the bug, which #9174's leading-wrapper path inherited unchanged.

### The rest of the change

* **`src/kiro_crew/constants.py`** — the rule applies to `OPTIONS_RE_LINE` **and** `OPTIONS_RE_TRAILER`, with the body spelled once per regex (`_MARKER_BODY_LINE` / `_MARKER_BODY_TRAILER`) so the two cannot drift from each other. The one body-shaped pattern deliberately *not* derived from them is `_OPTIONS_TAIL_PREFIX_RE`, a **prefix closure** that has to stay looser: a prefix of a legal body need not be a legal body, and `[OPTIONS: A ]` mid-stream becomes legal only once `| B]` arrives, so a probe spelled as the real body would call that tail dead and publish the marker as raw text. Its docstring now says that, instead of claiming to hold the grammar's body.
* **`src/kiro_crew/messaging/renderer.py`** — the `hide_partial` viability gate, widened from ASCII `]` to `MARKER_CLOSERS` (see above).
* **`website/src/app-sdk/protocol/optionMarker.ts`** — the same rule in both branches of `OPTION_MARKER_RE`, in one commit with the backend so the grammars cannot drift.
* **Comments corrected rather than left to mislead** — the module header on both surfaces, which described the pre-change unconditional body; the ReDoS note claiming a closer is readmitted "in exactly one place" (it is **two** — the pair form's final atom and the continuation lookahead, and the pair form is where the deciding lookahead lives, so it is the one a future `MARKER_CLOSERS` widening must not skip); `stripPartialOptionMarker`'s "cannot actually reach here", which this change makes reachable (harmless — that branch is behind the `isStreaming` gate, so the frame is transient); and `test_options_marker_closers.py`'s "ends at the LAST closer that ends the line". Two test comments claimed `[OPTIONS: Fix arr[0] | Skip]` is "admitted by both halves at once"; it is admitted by the continuation half only, since the pair half's own lookahead fires precisely because a `|` follows — which is the disjointness, and means neither alternative is redundant.

## Tests

**`test/test_options_marker_label_closers.py`** (new, 29 cases) and **`website/src/test/optionsMarkerLabelClosers.test.ts`** (new, 25 cases), as a sibling to #9174's `optionsMarkerWrapper.test.ts`.

Both assert the two claims **separately** throughout, because they are different and only the second is what the user experiences: that the grammar does not **match**, and that the visible text is **unchanged**.

Verified as real discriminators rather than restatements, by running every case table against a verbatim transcription of `origin/main`'s two regexes: of **49** distinct case/grammar pairs, **18 disagree with `main`** (the eight bug rows — six same-line, two TRAILER paragraph; the eight accepted-cost rows, which parsed before and now do not; the nested head; and one linearity shape that was itself an over-reach) and **31 agree** — the guards, i.e. the behaviour the rule had to leave alone. A table where every row disagreed would only be proving that the code changed. The disjointness battery is excluded from that tally on purpose: it asserts elapsed time, not a parse, so "does `main` agree?" is not defined for it.

Covered:

* the six same-line over-reach rows and the two TRAILER paragraph rows, each asserted as both "does not match" and "no prose is deleted";
* both halves of the rule stated **positively** — a matched pair mid-label (including the two upstream-pinned `Fix [x] logging` spellings), and a separator or another closer keeping an unmatched closer inside the label, with both `|` and `,`;
* the continuation half applied to **every** closer in `MARKER_CLOSERS`, not just ASCII, so a model that substitutes one codepoint mid-label is treated identically;
* the pair form is not a *requirement* — a stray unmatched `[` in a label still parses;
* **all four accepted-cost shapes**, each asserted as both "does not match" and "the text is unchanged", plus one test that carries the second claim down into `split_options_trailer` — the declined marker must not be silently deleted by the consumer either, which is the assertion that fails without the gate fix;
* the nested-head guard, and the out-of-scope separator-tail form, each stated as a decision with its reasoning;
* **not overly narrow**: the plain marker on both grammars, all seven of #9174's wrappers (plus `***`), the two rules composing, `[OPTION:]` staying single-select, prose emphasis before the marker still never eaten, the `](OPTIONS)` tic still composing, same-line prose after the marker still declined, a label still unable to span a line break on LINE, and a marker that *does* span newlines still closing TRAILER (the rule must not have re-introduced a line boundary into the `DOTALL` body);
* five linearity guards per surface, including the disjointness battery described above.

The ReDoS **shape** assertion in `AssistantMessage.test.tsx` is updated to pin the new four-alternative body character for character, since the disjointness is the property the linearity rests on.

All existing marker suites pass otherwise: **226 backend cases** across the seven `test/` files that exercise the marker grammar directly (`test_options_cap_contract`, `test_options_marker_closers`, `test_options_marker_label_closers`, `test_options_marker_wrapper`, `test_parse_options`, `test_options_buttons`, `test_weixin`), and **621 frontend cases** across the seventeen `website/src/test` files that reference the marker or `parseOptions`.

## Manual verification

N/A — unit coverage is sufficient and manual reproduction is not deterministic: the trigger is what the model happens to put on the marker's line, not an input a user can type. Both classes are exercised at the parser level on both surfaces, which is the only code the marker passes through.

## Related Issues

Fixes #9284

Related: #9110 / #9174 — the wrapper anchor on these same two regexes, different root cause, landed first. This PR is additive to it.

Follow-up: #9375 — the lookalike-pair row of the accepted-cost table above, deferred deliberately.

**Overlaps #6823 heavily — please tell me if this should live there instead.** #6823 (`feat(chat): zero-turn option actions + visible-only note mode`) restructures this same block: it introduces `_MARKER_BODY_LINE` / `_MARKER_BODY_TRAILER` under the **same two names** and recomposes `OPTIONS_RE_LINE` / `OPTIONS_RE_TRAILER` from them. Its body is `(?P<labels>(?:[^[\n]|{_TEMPER})*)` — `[^[\n]` still admits `]`, so **#6823 carries this bug forward** into `[OPTION-ACTIONS:]` as well as `[OPTIONS:]`.

That is now **confirmed by execution**, not read off the diff. Running all three bodies side by side on the two PRs' respective shapes:

```
input: 'Use [OPTIONS: Keep it | Drop it] then check arr[0]'
  base    labels=' Keep it | Drop it] then check arr[0'   surviving text='Use '
  #6823   labels=' Keep it | Drop it] then check arr[0'   surviving text='Use '
  #9341   NO MATCH

input: '[OPTIONS: A | B] [OPTION-ACTIONS: close=Close this tab]'
  base    labels=' A | B] [OPTION-ACTIONS: close=Close this tab'
  #6823   labels=' A | B'    surviving='[OPTION-ACTIONS: close=Close this tab]'
  #9341   NO MATCH
```

The two fix **different halves** of one defect and neither subsumes the other: #6823 fixes what may *follow or be crossed* (a shared multi-head temper, plus `_MARKER_LINE_END` letting a sibling marker terminate the line form), and this PR fixes *where the body ends*. #6823's own description scopes the remainder out explicitly — "Trailing PROSE still does not terminate a marker -- only a sibling marker does" — so the gap is deliberate there rather than missed. They compose: this body with its `(?!OPTIONS:)` widened to #6823's `_MARKER_HEAD_ALT`, plus that terminator, passes every shape from both PRs. Raised on the #6823 thread with the measurements, so the sequencing decision has the evidence attached.

The overlap is a rewrite, not a brush: measured as churn against current file size, #6823 is **88%** on `src/kiro_crew/constants.py` (+680/-24 over 796 lines) and **139%** on `website/src/app-sdk/protocol/optionMarker.ts` (+363/-43 over 291 lines), and it also touches `messaging/renderer.py` and `AssistantMessage.test.tsx`. #7157 (`render the (recommended) option marker as a badge`) adds +125 to `constants.py` and +14/-7 to `renderer.py`. Both are open, non-draft and active.

Whichever lands second has to re-apply the union rule inside the other's composition. This PR is the smaller of the two by more than an order of magnitude (7 files / +846 vs 121 files / +16206), so it is the cheaper one to rebase, and #6823 has to carry the rule regardless because it reintroduces the same body. That is the reason it is proposed standalone — but the call is the maintainer's, and closing this in favour of folding the rule into #6823 is a reasonable answer.

## Pattern harvest

Rule candidate: review-prompt
Pattern: when a regex both **parses** a marker and **defines what gets deleted**, a greedy body that admits its own terminator does not merely mis-parse — it silently removes the prose between the real terminator and the last one in range. The tell is a body spelled as a negated class that forgets to exclude the closer (`[^[\n]` includes `]`), combined with consumers that treat `match.start()`/`replace` as "safe to cut". General rules: for any parse-and-strip grammar, ask what the **longest** possible match is, not whether the intended one matches, and assert the negative cases as "the text is unchanged" rather than only as "no match" — the two are different claims and only the first is what the user sees. Where a marker's terminator may legitimately appear inside its payload, expect the discriminator to be a **union** and let the existing test suite tell you so: the single obvious rule here (reuse the streaming probe's `CONTINUES_LABELS_RE`) was clean, well-motivated, and broke two tests that pinned the opposite shape — run the whole suite before believing a one-line grammar rule, not just the new tests. When a fix does end up with two alternatives that can begin at the same character, make them each other's negation on some lookahead so no span has two parses; that turns the ReDoS question into a property you can pin in a test instead of an argument in a comment. Finally, check whether the greedy variant is under a `DOTALL` anchor too, where the blast radius grows from a line to a paragraph.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A; the rationale lives in the comment block the rule is defined in
- [x] No secrets, credentials, or internal references in the diff

