### PR TITLE
chore(test): drop unresolvable references from two security suites

### DIFF
--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -730,7 +730,7 @@ class TestProductNameAnywhereIsNotADenial:
         for allowed in (
             # The product name in a path, a search pattern, a filename, a
             # redirect target -- each once a match for a subcommand row.
-            "grep -rn kirocrew /Volumes/workplace/kc-wt/x/src",
+            "grep -rn kirocrew /Users/me/kirocrew-wt/x/src",
             "rg update /Users/me/kirocrew-wt/src",
             "ls /Users/me/kirocrew-wt/restart.log",
             "ls test/test_kirocrew_cron_schedule.py",

--- a/test/test_security_regex_linearity.py
+++ b/test/test_security_regex_linearity.py
@@ -8,12 +8,12 @@ direction fails.
 
 Covered:
 
-* Mesh-3654 -- ``redact_credentials`` pass 1 was ``for m in
+* ``redact_credentials`` pass 1 was ``for m in
   _CREDENTIAL_PATTERNS.finditer(result): result = result.replace(...)``, which
   rebuilt the whole string per match (O(n^2) on credential-dense text). It is now
   a single ``_CREDENTIAL_PATTERNS.sub(...)``. The redacted text AND the
   ``warnings`` list (content *and* order) must be unchanged.
-* Mesh-3693 -- the sensitive-path regex anchor rewrite. That regex is gone (the
+* The sensitive-path regex anchor rewrite. That regex is gone (the
   shell gate no longer matches paths in command text; the OS sandbox and
   ``is_sensitive_path`` hold the fence), so what remains of the differential is
   the ``is_sensitive_path`` half, which pins that the path gate's verdicts did
@@ -30,7 +30,7 @@ import pytest
 from kiro_crew.security import is_sensitive_path, redact_credentials
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Mesh-3654: redact_credentials pass 1 -- single sub() must be byte-identical
+# redact_credentials pass 1 -- single sub() must be byte-identical
 # ─────────────────────────────────────────────────────────────────────────────
 
 # (input, expected_redacted_text, expected_warnings) captured from the
@@ -125,7 +125,7 @@ def test_pass1_single_sub_is_byte_identical_to_pre_change_loop(
 ) -> None:
     """Pass 1 as one ``sub()`` reproduces the old loop's bytes and warnings.
 
-    Differential for Mesh-3654. ``expected_warnings`` is compared with ``==`` on
+    Differential for the pass-1 rewrite. ``expected_warnings`` is compared with ``==`` on
     the list, so both the CONTENT and the ORDER are pinned -- appending in the
     replacement callback has to keep the left-to-right match order the old
     ``finditer`` loop had.
@@ -161,7 +161,7 @@ def test_pass1_warnings_still_carry_no_secret_bytes() -> None:
 
 
 def test_pass1_is_linear_on_credential_dense_text() -> None:
-    """Complexity guard for Mesh-3654.
+    """Complexity guard for the pass-1 rewrite.
 
     The old shape rebuilt the whole string per match, so redacting N credentials
     in an N-credential string was O(N^2). 4000 credentials (~84 KB) is
@@ -178,7 +178,7 @@ def test_pass1_is_linear_on_credential_dense_text() -> None:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Mesh-3693: sensitive-path verdicts -- zero change (DENY surface)
+# sensitive-path verdicts -- zero change (DENY surface)
 # ─────────────────────────────────────────────────────────────────────────────
 
 SENSITIVE_PATH_GOLDEN: list[tuple[str, bool]] = [
@@ -194,7 +194,7 @@ SENSITIVE_PATH_GOLDEN: list[tuple[str, bool]] = [
 
 @pytest.mark.parametrize(("path", "expected"), SENSITIVE_PATH_GOLDEN)
 def test_sensitive_path_verdicts_unchanged_by_anchor_rewrite(path: str, expected: bool) -> None:
-    """Differential for Mesh-3693 on ``is_sensitive_path``."""
+    """Differential for the anchor rewrite on ``is_sensitive_path``."""
     assert bool(is_sensitive_path(path)) is expected
 
 


### PR DESCRIPTION
## Problem / Motivation

Two security test files carry references that mean nothing outside the repository they were written in: seven prose citations of origin-repo ticket ids in `test_security_regex_linearity.py` (docstrings and section banners), and one absolute path from a contributor's own machine inside a test input string in `test_denied_commands_security.py`.

They are residue. The scan gate added in #9157 and made blocking in #9214 would refuse each of them as a new added line today, but that gate is **diff-only by design** — it judges added lines, so lines that were already present when the gate landed are outside its reach and stay until someone removes them deliberately.

## Why it matters

An OSS reader cannot resolve any of these references, so each one is a dead end where the file otherwise explains itself well: every ticket citation here is immediately followed by prose that describes the regression in full, which is the part that actually carries the knowledge. The machine-specific path is worse than useless — it invites a reader to think the value matters, when the neighbouring case on the next line already expresses the same idea with a generic home path.

## What changed (motivation → approach → change)

The goal was to remove the references without removing information.

For the seven prose sites, a synthetic token (`TICKET-0000`) was the obvious move and the wrong one: it deletes the meaning and leaves a placeholder that reads like it should resolve to something. Instead each citation now names the regression it labels — "the pass-1 rewrite", "the anchor rewrite" — which is what a reader needed from the id in the first place. Note these were **two distinct** regressions (four sites on the `redact_credentials` pass-1 O(n²) rebuild, three on the sensitive-path anchor rewrite), so they get two different descriptions rather than one blanket substitution.

For the single test input string, the value is incidental to what the case pins — the product name appearing in a path must not trip a subcommand deny row — so it becomes a generic home path in the same shape as the case directly below it.

Nothing executable changed: seven of the eight added lines are comments or docstrings, and the eighth is a string literal whose meaning for its assertion is unchanged.

## Tests

No new tests. This diff cannot change behaviour, and the existing suites are the check that it did not: `test_security_regex_linearity.py` + `test_denied_commands_security.py` pass in full (729 tests), including the 100 cases around the modified literal.

## Manual verification

Ran the ruleset scanner against this change's own staged diff — clean over 8 added lines — which is the same engine the `Internal Content Scan` lane runs. This is the case worth verifying rather than assuming: a cleanup PR necessarily *shows* the removed values on its `-` lines, and the gate is clean precisely because it judges added lines only. The replacement values are synthetic, so had one still carried a marker the gate would have refused this PR too.

Full-file search, not the scanner's report, is what found all eight: the diff-only scan surfaced only the occurrences on lines it was already looking at, and three sites in the same file were never in its view.

## Related Issues

no linked issue: this is residue that predates the gate, tracked nowhere; #9173 (the gate's own tracking issue) closed with #9214.

## Pattern harvest

Rule candidate: agents-md
Pattern: a diff-only scanner cannot see pre-existing lines in a file it is scanning, so remediation driven by its findings systematically misses siblings — clean by full-file search, never by the scan report.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff — the point of the change; the removed values appear on `-` lines by necessity, and were already public in this file's history
