### PR TITLE
fix(pipeline-conductor): put the process age on the banned probe line

### DIFF
--- a/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
@@ -483,7 +483,7 @@ carry **metadata only** — the probe never emits transcript text:
 
 ```
 🔔 <key>  <age>s <TAG> i=<index> d=<digest12>
-BANNED pid=<pid> rule=<regex> cwd=fleet|unknown
+BANNED pid=<pid> rule=<regex> cwd=fleet|unknown age=<secs|?>s
 OK <n> watched, <m> fired | load/cpu <x> (ok|hot) | mem <n>G | banned <n> | foreign <n> | deliver init-timeout <a>, watchdog <b>
 ```
 
@@ -550,7 +550,7 @@ digest keying, not a defect, and it does not recur.
 | `IDLE` | Intervention ladder (below). |
 | `NOPROGRESS` | The session has produced nothing — no message, no tool row — since you last acted on it, and that mark is at least one `idle_alert_secs` old. Check the **EFFECT, never liveness**: did the artifact appear, did the remote head move, is there a new commit. Effect present → healthy-slow; extend and name the expected completion signal. Effect absent → **route on the line's own age**, because two paths reach this tag and they do not mean the same thing. Within `idle_alert_secs` the transcript is WARM — held alive by inbound traffic the session never answers — and the first move is **not a nudge**, since a nudge is more of the input that produced the reading: enter the intervention ladder at its **Inspect** step. Past `idle_alert_secs` the session is cold as well as unproductive, so `IDLE`'s ladder applies from the top: the classifier ranks this tag below the clock, but the suppression fallback substitutes it for an already-dispositioned report with no age test, so a cold line can carry it. |
 | `GONE` | Transcript missing — treat as reclaim: re-queue the item with evidence. |
-| `BANNED pid=…` | Banned-ops response (below), keyed by the line's OWNERSHIP CLASS: every class is recorded, and a stop is reserved for `cwd=fleet`. Never read this as a single actionable-or-not decision. |
+| `BANNED pid=…` | Banned-ops response (below), keyed by the line's OWNERSHIP CLASS: every class is recorded, and a stop is reserved for `cwd=fleet`. Never read this as a single actionable-or-not decision. Read `age=` to tell the SAME line apart across cycles: an age that GROWS between cycles is one process you have not managed to stop, while a small age under a re-appearing pid is a fresh violation on a recycled number — a bare pid cannot separate those. `age=?s` means the age is unavailable: the process already exited (the expected reading for a short-lived runner), the pid was recycled between the probe's reads (in which case the whole record is stale and `cwd` also drops to `unknown`), or the platform has no `/proc`/`sysconf` to read it from. It never means the process is new. |
 
 The `OK` line's `deliver init-timeout <a>, watchdog <b>` counters are the
 admission instrument, not fleet trivia — see governance.
@@ -725,7 +725,7 @@ a silent drop. Key it on the class instead:
 | Class | Response |
 | --- | --- |
 | `cwd=fleet` | The heavy response: `session_stop` that worker, a ~5min cooldown, then restart it with the targeted-tests directive re-injected in the seed. |
-| `cwd=unknown` | The probe classified, but this one pid's cwd was unreadable. NON-stopping: re-inject the directive to the owning session WITHOUT stopping it, and record the line. Never a stop, never a silent drop. |
+| `cwd=unknown` | The probe could not attribute this line to the fleet: either the pid's cwd was unreadable, or the process incarnation changed between the probe's reads (a recycled pid), so the record's fields cannot be trusted as one process. NON-stopping: re-inject the directive to the owning session WITHOUT stopping it, and record the line. Never a stop, never a silent drop — a stale record can never trigger a stop against an innocent worker. |
 | no `cwd=` field at all | The probe predates classification, so the line carries no ownership. Attempt attribution ONCE at action time (read that pid's cwd): resolved inside a fleet worktree → treat it as `cwd=fleet` and take the stop response above; not resolved → record the count and re-inject the directive fleet-wide as a reminder, stopping nobody. See the legacy-line fallback below. |
 | `cwd=foreign` | Count only. Not the fleet's process to police, and never grounds for stopping a session. |
 

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py
@@ -66,7 +66,7 @@ Metadata only, by design: transcript-derived text never appears in the output,
 so no private session content crosses into the caller's context whatever keys
 the config watches. Content, when a ruling needs it, is read through the
 workspace-authorized session tools.
-    BANNED pid=<pid> rule=<regex> cwd=fleet|unknown
+    BANNED pid=<pid> rule=<regex> cwd=fleet|unknown age=<secs|?>s
     OK <n> watched, <m> fired | load/cpu <x> (<posture>) | mem <G>G
        | banned <k> | foreign <k> | deliver init-timeout <a>, watchdog <b>
 
@@ -1082,6 +1082,108 @@ def _owner_class(proc_entry: Path, fleet: list[str], cmd: str = "") -> str:
     return "foreign"
 
 
+def _proc_starttime_ticks(proc_root: Path, pid: str) -> int | None:
+    """The ``starttime`` of the process at *pid* in clock ticks since boot, or None.
+
+    This is the process INCARNATION token: a pid is reused, but boot-relative
+    starttime distinguishes one incarnation of that pid from the next. The banned
+    scan reads ``cmdline`` at one instant and the age at another, so it captures
+    this token beside the cmdline and checks it again before emitting; a mismatch
+    means the pid was recycled between the reads and the two facts describe two
+    processes, so the age is not printed. The signed pid supervisor reads the same
+    field to bind a mapping to a process incarnation; here it is read only to
+    compare, never to grant anything.
+
+    ``/proc/<pid>/stat`` field 22 is ``starttime``. The ``comm`` field (field 2)
+    can hold spaces and parentheses, so the parse resumes after the LAST ``)``; a
+    comm like ``(sh )nasty)`` keeps its own parentheses out of the field split.
+    None on any unreadable or malformed input -- the caller treats an unreadable
+    token exactly like a mismatch and emits ``age=?s``.
+    """
+    try:
+        stat = (proc_root / pid / "stat").read_text(encoding="ascii", errors="replace")
+        rparen = stat.rindex(")")
+        return int(stat[rparen + 2 :].split()[19])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _proc_age_secs(proc_root: Path, pid: str, expected_start: int | None) -> int | None:
+    """How many seconds the process at *pid* has been alive, or None.
+
+    The reader problem the age solves: a bare ``BANNED pid=`` line is the same
+    every cycle whether the process the conductor stopped is still running or a
+    new offender holds its recycled number -- pids are recycled, so the number
+    alone cannot tell those apart, and a re-emitted line reads as either
+    "handled, ignore" or "still burning the host" with no way to choose. The
+    process's own age settles it: an age that grows across cycles marks one
+    process still alive; a small age under a recycled number marks a fresh
+    violation. The age is a fact about the running process, so it costs no state
+    file and no second writer -- the probe stays read-only outside
+    ``--mark-handled``.
+
+    ``expected_start`` is the incarnation token captured before the per-pid reads
+    and is REQUIRED. The banned scan reads ``cmdline``/``cwd`` and the age at
+    DIFFERENT instants, so a pid recycled between them would splice one process's
+    identity onto another process's age -- the fidelity fix's own fidelity defect.
+    This re-reads ``starttime`` and returns None (rendered ``age=?s``) unless it
+    still matches, so the age is emitted only when it provably describes the same
+    process the reads did. A None token refuses as well: an age with no
+    incarnation to anchor it cannot be trusted.
+
+    Both reads are world-readable like ``/proc/<pid>/cmdline`` (the field this
+    scan trusts), so a process owned by another user answers here even though its
+    ``cwd``/``exe`` links do not. ``proc_root`` is threaded through rather than
+    ``/proc`` hardcoded, so the test harness's ``KIROCREW_PROBE_PROC_ROOT``
+    supplies both files, under the same containment rule as every other path here.
+
+    ``/proc/<pid>/stat`` field 22 is ``starttime`` in clock ticks since boot.
+    Any unreadable or malformed input returns None, which the caller renders as
+    ``age=?s`` -- the same handling as an unreadable cwd, and never crashes the
+    scan.
+
+    The source is ``/proc`` plus ``os.sysconf`` for the clock tick rate, both
+    POSIX-only. On a platform without them the age is genuinely uncomputable, so
+    this returns None and the caller emits ``age=?s`` there too. The field is
+    never omitted: a missing field would read as "no age" and let a reader assume
+    the process is new, while ``age=?s`` says the age is unavailable. There is no
+    stdlib-only process create-time source on Windows, so ``age=?s`` is the honest
+    answer rather than a number from a guessed tick rate.
+    """
+    starttime_ticks = _proc_starttime_ticks(proc_root, pid)
+    if starttime_ticks is None:
+        return None
+    # Bind the age to the incarnation the caller saw: the token is REQUIRED, so a
+    # None token (starttime unreadable when the caller captured it) refuses too --
+    # an age with no incarnation to anchor it cannot be trusted. If the pid was
+    # recycled between the caller's capture and now, ``starttime`` differs from
+    # the token and the age would belong to a different process. Refuse it -- the
+    # caller renders ``age=?s``, the same unknown the Windows path already emits,
+    # so this needs no new output shape.
+    if expected_start is None or starttime_ticks != expected_start:
+        return None
+    try:
+        uptime = float((proc_root / "uptime").read_text(encoding="ascii").split()[0])
+    except (OSError, ValueError, IndexError):
+        return None
+    # The tick rate converts starttime into seconds and comes from ``os.sysconf``,
+    # which is POSIX-only. Where it is absent there is no reliable rate, so the
+    # age is genuinely uncomputable: return None (rendered ``age=?s``) rather than
+    # guess a rate and print a wrong number. A wrong age reads as a real age, so a
+    # reader trusts it; ``age=?s`` tells them the answer is unavailable.
+    try:
+        hz = os.sysconf("SC_CLK_TCK")
+    except (AttributeError, ValueError, OSError):
+        return None
+    if hz <= 0:
+        return None
+    age = uptime - starttime_ticks / hz
+    # A negative age means the two reads disagreed (clock skew, or a pid that
+    # exited and its number was reused between the two opens); clamp to 0 rather
+    # than print a value that reads as nonsense.
+    return int(age) if age >= 0 else 0
+
+
 def _host_lines(cfg: dict[str, Any]) -> tuple[list[str], str]:
     """Banned-process lines plus the host summary fragment."""
     banned_res = [
@@ -1099,6 +1201,13 @@ def _host_lines(cfg: dict[str, Any]) -> tuple[list[str], str]:
             if not entry.name.isdigit():
                 continue
             try:
+                # The process incarnation, captured BEFORE any other per-pid read.
+                # cmdline, cwd and exe are separate /proc reads at different
+                # instants; if the pid is recycled partway through, they describe
+                # two processes. Capturing starttime first and re-reading it before
+                # emit brackets the whole record: a change means the reads cannot
+                # be trusted as one process, so the derived fields are withheld.
+                start_tok = _proc_starttime_ticks(proc_root, entry.name)
                 # argv is kept as a LIST, not just the space-joined string. The
                 # banned-operation rules are arg-shaped and must still see the
                 # joined form, but deciding whether this pid is a shell wrapper is
@@ -1158,12 +1267,57 @@ def _host_lines(cfg: dict[str, Any]) -> tuple[list[str], str]:
                     foreign += 1
                     continue
                 banned += 1
+                # Re-read the incarnation token now that every per-pid read is
+                # done. If it is unreadable or differs from the one captured
+                # before the reads, the pid was recycled partway through and the
+                # cmdline, cwd and age describe more than one process -- so the
+                # WHOLE record is stale, not just the age. Withhold both derived
+                # fields: cwd drops to ``unknown`` (the non-stopping class, so a
+                # spliced record can never trigger a stop against an innocent
+                # worker) and age to ``?s``. pid and rule still print, so the
+                # violation is not silently dropped and the next cycle re-observes.
+                #
+                # EVERY per-pid read in the emission path is bracketed by this one
+                # token, so there is no third unguarded read:
+                #   * ``/proc/<pid>/stat``  -> start_tok (captured first, above)
+                #   * ``/proc/<pid>/cmdline`` (rule + argv)   -- inside the bracket
+                #   * ``/proc/<pid>/exe``  (_trusted_program_base) -- inside
+                #   * ``/proc/<pid>/cwd``  (_owner_class)          -- inside
+                #   * ``/proc/<pid>/stat`` -> end_tok (this line): start==end proves
+                #     the four reads above saw ONE incarnation, else cwd->unknown.
+                #   * ``/proc/<pid>/stat``+``/proc/uptime`` (age) -- independently
+                #     re-bound to start_tok inside ``_proc_age_secs`` (mismatch or
+                #     None -> ``age=?s``).
+                # starttime is monotonic per boot, so a recycle anywhere in the
+                # window necessarily changes it and is caught; a recycle back to
+                # the same starttime is impossible.
+                end_tok = _proc_starttime_ticks(proc_root, entry.name)
+                incarnation_stable = start_tok is not None and end_tok == start_tok
+                if not incarnation_stable:
+                    cwd_class = "unknown"
                 # pid + WHICH RULE fired + the cwd class is everything the
                 # conductor needs (stop the owner, re-seed with the directive).
                 # The argv is deliberately not echoed: a command line can carry
                 # credentials or presigned URLs, and this line lands in the
                 # conductor's model context.
-                lines.append(f"BANNED pid={entry.name} rule={matched} cwd={cwd_class}")
+                #
+                # ``age=`` is what makes a re-emitted line readable across
+                # cycles: a bare pid cannot say whether the process the conductor
+                # stopped is still running or a new offender holds its recycled
+                # number, so the same line reads as either handled-ignore or
+                # still-burning with no way to choose. A process age that grows
+                # across cycles marks one process still alive; a small age marks a
+                # fresh violation. The age comes from the running process, so it
+                # costs no state and keeps the probe read-only outside
+                # ``--mark-handled``. An unreadable or stale age prints ``age=?s``,
+                # like an unknown cwd, and never blocks the line.
+                age = (
+                    _proc_age_secs(proc_root, entry.name, start_tok) if incarnation_stable else None
+                )
+                age_field = "?" if age is None else str(age)
+                lines.append(
+                    f"BANNED pid={entry.name} rule={matched} cwd={cwd_class} age={age_field}s"
+                )
     per_cpu = None
     if hasattr(os, "getloadavg"):
         try:

--- a/test/test_pipeline_conductor_agent.py
+++ b/test/test_pipeline_conductor_agent.py
@@ -1701,10 +1701,22 @@ class TestFleetProbe:
 
     def _proc(self, tmp_path: Path, pid: str, argv: bytes, cwd: Path | None) -> Path:
         """One fake ``/proc/<pid>``. ``cwd`` is written as a SYMLINK because that
-        is what the kernel exposes and what the probe reads."""
+        is what the kernel exposes and what the probe reads.
+
+        A ``stat`` file is always written: every live process on a real system
+        has one, and the probe reads its ``starttime`` (field 22) as the process
+        incarnation token that brackets the per-pid reads. A stable ``stat`` here
+        means one incarnation across the scan, so cwd classification is exercised
+        as it is in production; omitting it would model a process that exited
+        mid-scan, which is a different case with its own tests.
+        """
         proc = tmp_path / "proc"
         (proc / pid).mkdir(parents=True, exist_ok=True)
         (proc / pid / "cmdline").write_bytes(argv)
+        # field 1 pid, field 2 comm, field 3 state, then starttime is field 22 --
+        # index 19 in the split after ') ', where index 0 is the state field.
+        stat_tail = ["0"] * 18 + ["1000"] + ["0"] * 30
+        (proc / pid / "stat").write_text(f"{pid} (proc) R " + " ".join(stat_tail) + "\n", "ascii")
         if cwd is not None:
             cwd.mkdir(parents=True, exist_ok=True)
             os.symlink(str(cwd), str(proc / pid / "cwd"))

--- a/test/test_pipeline_conductor_probe_banned_age.py
+++ b/test/test_pipeline_conductor_probe_banned_age.py
@@ -1,0 +1,221 @@
+"""The banned-process line carries the running process's age.
+
+The ``BANNED`` line the fleet probe emits carries ``age=<secs>s`` (or ``age=?s``
+when the age is unavailable), derived at scan time from ``/proc/<pid>/stat`` field
+22 plus ``os.sysconf`` for the clock tick rate. An age that grows across cycles
+marks one process still alive; a small age under a re-appearing pid marks a fresh
+violation on a recycled pid number. The age is a fact about the running process,
+so it costs no state file and no second writer, and the probe stays read-only
+outside ``--mark-handled``.
+
+The field is never omitted. Where ``/proc``/``os.sysconf`` are absent (Windows)
+the helper returns None and the caller emits ``age=?s``, so a reader sees an
+explicit unknown instead of assuming the process is new. These tests drive the
+probe over a fake ``/proc`` (the ``KIROCREW_PROBE_PROC_ROOT`` seam the script
+exposes) and also pin the no-tick-rate path directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from skill_script_helpers import load_skill_script
+
+#: The two banned-line tests build a fake ``/proc`` and a ``cwd`` symlink and let
+#: the probe follow it. Both are POSIX process semantics: ``os.symlink`` needs a
+#: privilege Windows CI does not grant, and the probe reads ``/proc/<pid>/cwd`` as
+#: a symlink. The age-helper unit test below is pure file reads and runs anywhere.
+_POSIX_PROC_ONLY = pytest.mark.skipif(
+    sys.platform == "win32", reason="fake /proc + cwd symlink are POSIX process semantics"
+)
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "pipeline-conductor"
+)
+
+
+def _fake_proc_with_banned_pytest(
+    proc_root: Path, fleet_root: Path, pid: str, *, starttime_ticks: int, uptime_secs: float
+) -> None:
+    """A ``/proc`` holding one pid whose cmdline is a bare (unbounded) pytest run
+    inside *fleet_root*, plus the ``stat``/``uptime`` the age helper reads.
+
+    The cmdline is a real NUL-separated argv with ``argv[0]`` a pytest path, so it
+    is neither a shell wrapper (no ``exe`` link -> no exemption) nor bounded (no
+    ``-n``), and the ``cwd`` symlink into the fleet worktree makes it ``cwd=fleet``.
+    """
+    proc_root.mkdir(parents=True, exist_ok=True)
+    fleet_root.mkdir(parents=True, exist_ok=True)
+    (proc_root / "uptime").write_text(f"{uptime_secs} 0.0\n", encoding="ascii")
+    pdir = proc_root / pid
+    pdir.mkdir()
+    argv = [str(fleet_root / ".venv" / "bin" / "pytest"), "test/test_x.py", "-q"]
+    (pdir / "cmdline").write_bytes(b"\0".join(a.encode() for a in argv) + b"\0")
+    # field 1 pid, field 2 comm in parens (can hold spaces), field 3 state, then
+    # starttime is field 22 -- index 19 in the split AFTER the ') ', where index 0
+    # is the state field. So 18 padding fields sit between state and starttime.
+    tail_fields = ["0"] * 18 + [str(starttime_ticks)] + ["0"] * 30
+    (pdir / "stat").write_text(
+        f"{pid} (pytest) R " + " ".join(tail_fields) + "\n", encoding="ascii"
+    )
+    os.symlink(str(fleet_root), str(pdir / "cwd"))
+
+
+def _run(tmp_path, monkeypatch, fleet_root: Path) -> str:
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "crew"))
+    monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(tmp_path / "proc"))
+    mod = load_skill_script("fleet_probe", SKILL_DIR / "scripts" / "fleet_probe.py")
+    cfg_path = tmp_path / "probe-config.json"
+    cfg_path.write_text(
+        json.dumps({"sessions": [], "fleet_worktrees": [str(fleet_root)]}), encoding="utf-8"
+    )
+    assert mod.main(["--config", str(cfg_path)]) == 0
+    return cfg_path, mod
+
+
+class TestBannedLineCarriesAge:
+    @_POSIX_PROC_ONLY
+    def test_banned_line_reports_the_process_age(self, tmp_path, capsys, monkeypatch):
+        """A fleet-owned unbounded pytest alive for ~600s prints ``age=600s`` on its
+        BANNED line, so a re-emitted line whose age keeps growing is readable as one
+        unkilled process rather than a fresh offender on a recycled pid."""
+        fleet_root = tmp_path / "wt-worker"
+        # Build starttime from the REAL clock tick rate so the expected age is 600s
+        # whatever the host's rate is -- the helper reads the same os.sysconf, so
+        # this needs no monkeypatch (patching os.sysconf is what broke on Windows,
+        # where the attribute does not exist to replace).
+        hz = os.sysconf("SC_CLK_TCK")
+        _fake_proc_with_banned_pytest(
+            tmp_path / "proc", fleet_root, "4242", starttime_ticks=400 * hz, uptime_secs=1000.0
+        )
+        _run(tmp_path, monkeypatch, fleet_root)
+        out = capsys.readouterr().out
+        assert "BANNED pid=4242" in out, out
+        assert "cwd=fleet" in out, out
+        assert "age=600s" in out, out
+
+    @_POSIX_PROC_ONLY
+    def test_unreadable_age_prints_question_mark(self, tmp_path, capsys, monkeypatch):
+        """A pid whose ``stat`` is missing (the process exited between the cmdline
+        read and the age read -- the common short-lived case) prints ``age=?s`` and
+        still emits the line; the age never blocks the signal or crashes the scan."""
+        fleet_root = tmp_path / "wt-worker"
+        hz = os.sysconf("SC_CLK_TCK")
+        _fake_proc_with_banned_pytest(
+            tmp_path / "proc", fleet_root, "4243", starttime_ticks=400 * hz, uptime_secs=1000.0
+        )
+        (tmp_path / "proc" / "4243" / "stat").unlink()
+        _run(tmp_path, monkeypatch, fleet_root)
+        out = capsys.readouterr().out
+        assert "BANNED pid=4243" in out, out
+        assert "age=?s" in out, out
+
+    def test_age_helper_reads_starttime_after_a_paren_heavy_comm(self, tmp_path):
+        """``_proc_age_secs`` resumes the field parse after the LAST ``)``, so a
+        comm containing spaces and parentheses -- ``(sh )evil)`` -- does not shift
+        the starttime field and mis-read the age. Cross-platform: pure file reads,
+        skipped only where ``os.sysconf`` (the tick rate) is unavailable, which is
+        the same platform on which the helper returns None."""
+        if not hasattr(os, "sysconf"):
+            pytest.skip("os.sysconf is POSIX-only; the helper returns None without it")
+        proc_root = tmp_path / "proc"
+        (proc_root / "9").mkdir(parents=True)
+        (proc_root / "uptime").write_text("1000.0 0.0\n", encoding="ascii")
+        hz = os.sysconf("SC_CLK_TCK")
+        starttime_ticks = 400 * hz  # 400s into boot, whatever the tick rate is
+        tail = ["0"] * 18 + [str(starttime_ticks)] + ["0"] * 5
+        (proc_root / "9" / "stat").write_text("9 (sh )evil) R " + " ".join(tail) + "\n", "ascii")
+        mod = load_skill_script("fleet_probe", SKILL_DIR / "scripts" / "fleet_probe.py")
+        # starttime 400s in, uptime 1000s -> age 600s, independent of clk_tck.
+        # The token is required; pass the matching incarnation.
+        assert mod._proc_age_secs(proc_root, "9", starttime_ticks) == 600
+
+    def test_age_is_none_without_a_clock_tick_rate(self, tmp_path, monkeypatch):
+        """Cross-platform contract: where ``os.sysconf`` is unavailable (Windows)
+        the tick rate is unknown, so the age is uncomputable and the helper returns
+        None rather than guessing a rate -- which the caller renders as ``age=?s``.
+        The field is present as an explicit unknown, never a wrong number and never
+        absent. Simulated by removing ``os.sysconf`` so the test runs everywhere."""
+        proc_root = tmp_path / "proc"
+        (proc_root / "9").mkdir(parents=True)
+        (proc_root / "uptime").write_text("1000.0 0.0\n", encoding="ascii")
+        tail = ["0"] * 18 + ["40000"] + ["0"] * 5
+        (proc_root / "9" / "stat").write_text("9 (pytest) R " + " ".join(tail) + "\n", "ascii")
+        mod = load_skill_script("fleet_probe", SKILL_DIR / "scripts" / "fleet_probe.py")
+        monkeypatch.delattr(os, "sysconf", raising=False)
+        # Token matches (40000), so None comes from the missing tick rate, not a
+        # mismatch -- the property under test.
+        assert mod._proc_age_secs(proc_root, "9", 40000) is None
+
+    def test_age_refused_when_the_incarnation_token_moved(self, tmp_path):
+        """cmdline and age are separate /proc reads; a pid recycled between them
+        would splice one process's identity onto another's age. When the
+        starttime read at emit does not match the token captured at scan, the
+        helper returns None (the caller renders ``age=?s``) rather than a spliced
+        age. The matching token still yields the age, so the guard only fires on a
+        genuine mismatch."""
+        if not hasattr(os, "sysconf"):
+            pytest.skip("os.sysconf is POSIX-only; the helper returns None without it")
+        proc_root = tmp_path / "proc"
+        (proc_root / "9").mkdir(parents=True)
+        (proc_root / "uptime").write_text("1000.0 0.0\n", encoding="ascii")
+        hz = os.sysconf("SC_CLK_TCK")
+        starttime_ticks = 400 * hz
+        tail = ["0"] * 18 + [str(starttime_ticks)] + ["0"] * 5
+        (proc_root / "9" / "stat").write_text("9 (pytest) R " + " ".join(tail) + "\n", "ascii")
+        mod = load_skill_script("fleet_probe", SKILL_DIR / "scripts" / "fleet_probe.py")
+        # Token captured at scan matches the live starttime -> age is trusted.
+        assert mod._proc_age_secs(proc_root, "9", starttime_ticks) == 600
+        # A different token means the pid was recycled between the reads -> refuse.
+        assert mod._proc_age_secs(proc_root, "9", starttime_ticks + 1) is None
+        # The token is required: a None token (starttime unreadable at capture)
+        # also refuses, since an age with no incarnation to anchor it is untrusted.
+        assert mod._proc_age_secs(proc_root, "9", None) is None
+
+    @_POSIX_PROC_ONLY
+    def test_banned_line_prints_unknown_age_when_pid_recycled_mid_scan(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """End to end: the probe captures the incarnation token before its per-pid
+        reads and re-checks it at emit. When the process's ``stat`` reports a
+        different starttime at emit than at scan (a recycled pid), the WHOLE record
+        is stale, so the line still fires but carries `cwd=unknown` (never a
+        spliced `cwd=fleet` that would stop an innocent worker) and `age=?s`."""
+        fleet_root = tmp_path / "wt-worker"
+        hz = os.sysconf("SC_CLK_TCK")
+        _fake_proc_with_banned_pytest(
+            tmp_path / "proc", fleet_root, "4244", starttime_ticks=400 * hz, uptime_secs=1000.0
+        )
+        mod = load_skill_script("fleet_probe", SKILL_DIR / "scripts" / "fleet_probe.py")
+        # Make the emit-time starttime read differ from the scan-time one: the
+        # scan captures start_tok first, then re-reads it before emit, so flipping
+        # the value after the first call models the pid being recycled between the
+        # bracketing reads without racing a real process.
+        real = mod._proc_starttime_ticks
+        calls = {"n": 0}
+
+        def flipping(proc_root, pid):
+            calls["n"] += 1
+            base = real(proc_root, pid)
+            return base if calls["n"] == 1 else (None if base is None else base + 1)
+
+        monkeypatch.setattr(mod, "_proc_starttime_ticks", flipping)
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "crew"))
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(tmp_path / "proc"))
+        cfg = tmp_path / "probe-config.json"
+        cfg.write_text(
+            json.dumps({"sessions": [], "fleet_worktrees": [str(fleet_root)]}), encoding="utf-8"
+        )
+        assert mod.main(["--config", str(cfg)]) == 0
+        out = capsys.readouterr().out
+        assert "BANNED pid=4244" in out, out
+        assert "cwd=unknown" in out, out
+        assert "age=?s" in out, out


### PR DESCRIPTION
## Problem / Motivation

The fleet probe prints `BANNED pid=<pid> rule=<regex> cwd=<class>` when it finds
a banned command, and prints the same line again every cycle that process is
still alive. A pid number alone cannot tell two very different things apart: the
process the conductor already stopped is still running, or that pid was freed and
a brand-new process took the recycled number. Measured tonight: a pid the probe
reported banned on three cycles in a row was still alive holding 404 worker
processes, load at 71, memory down to 15G -- and the line read the same as a
first sighting.

## Why it matters

The conductor reads this line to decide whether to act. When "already handled,
ignore" and "still burning the host" produce the same line, the reader picks one,
and the wrong pick either re-stops a healthy owner or leaves a runaway running.
Issue #8192 calls this out as item 2: the banned signal collapses no-answer and
answer into one output.

A conductor patrolling with a five-day-stale copy of this probe read a banned line for a process that was a shell wrapper and had already exited. One line misled four ways at once: the pid was meaningless because the process was gone; `cwd=unknown` said nothing; the match was wrong at the root because that stale copy predates the shell-wrapper fix (#8736); and a sibling reading printed `cwd=fleet`, which names a worktree a reader uses to decide WHICH worker to stop -- but a shell and a real test run in that worktree share the same cwd, so it accused an innocent session. The `age=` field this PR adds resolves the gone-or-alive axis on the current probe: `age=?s` says the process is gone, a growing `age=<secs>s` says it is still running. It does not touch the cwd attribution -- that is the matcher's job and #8736 fixed it upstream; the age is the orthogonal fact the reader still lacked. (Measured on the conductor's own five-day-stale install.)


## What changed (motivation -> approach -> change)

Symptom: a re-emitted `BANNED` line is unreadable across cycles. Root cause: the
line carries the detection but nothing about the process's own history, so a
recycled pid and a persisting pid look identical.

Approach: add the one fact that separates them -- the process's age. An age that
grows between cycles is one unkilled process; a small age under a re-appearing
pid is a fresh violation. Age is a fact about the running process, so it needs no
new state file and no second writer, which keeps the probe read-only outside
`--mark-handled` (a documented invariant).

Change: a `_proc_age_secs` helper reads `/proc/<pid>/stat` field 22 (`starttime`)
and `/proc/uptime` -- both world-readable, like the cmdline this scan already
trusts, so it survives the same access asymmetry that makes `cwd`/`exe` fail for
another user's process. The emit becomes
`BANNED pid=<pid> rule=<regex> cwd=<class> age=<secs>s`, or `age=?s` when the age
is unreadable (the process already exited -- the expected reading for a
short-lived runner). It is one appended field, not a new report format. `SKILL.md`
gains the field in the output block and a sentence in the `BANNED` action row on
how to read `age=` across cycles.

Deliberately out of scope: issue items 3-7. Item 1 (shell-wrapper mismatch)
already landed in #8736. The other item this dispatch flagged -- an unharvested
terminal report ageing into `IDLE` after it scrolls past `tail_bytes` -- is a
different mechanism (terminal-report stickiness) and is left for a separate change.

One more read makes the whole record trustworthy. The scan reads several `/proc` files for one pid at different instants, so a pid recycled partway through would splice one process's identity onto another's fields -- the fidelity fix's own fidelity defect. The probe captures the process `starttime` (a boot-relative incarnation token) BEFORE any other per-pid read and re-reads it before emitting. On a mismatch, unreadable token, or None token the WHOLE record is withheld: `cwd` drops to `unknown` (the non-stopping class, so a spliced record can never stop an innocent worker -- the field a stop is reserved for) and `age` to `?s`. pid and rule still print, so the violation is not dropped. No new output shape: `age=?s` and `cwd=unknown` already existed.

Every read in the emission path is bracketed by that one token -- enumerated so a reviewer can see there is no third unguarded read:

| read | file | bracket | on mismatch |
|---|---|---|---|
| start_tok | `/proc/<pid>/stat` | captured first | (the anchor) |
| rule + argv | `/proc/<pid>/cmdline` | inside start..end | record withheld |
| program base | `/proc/<pid>/exe` | inside start..end | record withheld |
| cwd class | `/proc/<pid>/cwd` | inside start..end | `cwd=unknown` |
| end_tok | `/proc/<pid>/stat` | start==end proves one incarnation | `cwd=unknown`, `age=?s` |
| age | `/proc/<pid>/stat` + `/proc/uptime` | re-bound to start_tok inside `_proc_age_secs` | `age=?s` |

`starttime` is monotonic per boot, so a recycle anywhere in the window changes it and is caught; a recycle back to the same `starttime` is impossible. The residual is therefore only the microseconds between capturing start_tok and the first read under it, and even that is bounded: the `/proc` walk runs every probe cycle and `age` is designed to be read as a SEQUENCE across cycles, so the worst case is one misleading line, once, in a field whose whole purpose is cross-cycle comparison -- it self-corrects on the next pass. A reader deciding whether to act on a single line should read `age` as a sequence, not a snapshot.

On the #8343 question -- why not bind a start token and refuse, as #8467 (Refs #8343) does for the signed pid mapping. The answer is that this PR does both, on different axes. #8467's consumer makes a kill decision on one identity, so a stale mapping must be refused. This probe's consumer is a reader who must still act and needs to know WHICH case they are in, so the age is reported, not refused. But the token is what makes that age trustworthy: `starttime` is read to VALIDATE that the age and the cmdline describe one process (mismatch -> `age=?s`), exactly #8467's technique, used to make the age meaningful rather than to replace it. The token is not an alternative to the age; it is its precondition.


## Tests

`test/test_pipeline_conductor_probe_banned_age.py`, six cases over a fake
`/proc` (the `KIROCREW_PROBE_PROC_ROOT` seam the script already exposes):

- a fleet-owned unbounded pytest alive ~600s prints `age=600s` on its line;
- a pid whose `stat` is gone (exited mid-scan) prints `age=?s` and still emits
  the line -- age never blocks the signal or crashes the scan;
- `_proc_age_secs` resumes the field parse after the LAST `)`, so a comm holding
  spaces and parentheses does not shift the starttime field;
- with `os.sysconf` unavailable (Windows), the helper returns None and the caller
  emits `age=?s` -- the field is an explicit unknown, never a guessed number and
  never absent.
- with the incarnation token mismatched (pid recycled between the cmdline and age
  reads), the helper returns None so the caller emits `age=?s` rather than a
  spliced age, and the matching token still yields the age;
- end to end, a scan whose second starttime read differs from the first prints
  the BANNED line with `age=?s`.

Commands run in the worktree, base `origin/main` `e7db5f5b8`:

```
timeout 900 python3 -m pytest -n0 test/test_pipeline_conductor_probe_banned_age.py -x -q
timeout 900 python3 -m pytest -n0 test/test_pipeline_conductor_probe_roundtrip.py test/test_pipeline_conductor_skill_contract.py -q
black --target-version py310 --check <both changed .py files>
isort --check-only <both>
flake8 <both>
mypy src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py
```

Results: 6 passed (new file), 93 passed (existing probe + skill-contract), black
/ isort / flake8 / mypy clean. Mutation-verified: reverting the emit to the old
bare line reds `test_banned_line_reports_the_process_age` while the existing
tests stay green; and reverting the no-`sysconf` guard to a guessed tick rate reds `test_age_is_none_without_a_clock_tick_rate`; and disabling the incarnation-token check reds `test_age_refused_when_the_incarnation_token_moved` and the recycled-mid-scan end-to-end test.

## Manual verification

N/A -- unit coverage over the fake-`/proc` seam exercises the emit and the age
helper directly, including the unreadable-age and paren-heavy-comm edge cases.

## Related Issues

Refs #8192

## Pattern harvest

Pattern: a signal built to resolve a pid-identity ambiguity was itself assembled from two unsynchronised `/proc` reads of that same ambiguous pid, so the fidelity fix carried a fidelity defect -- a recycled pid between the `cmdline` read and the age read splices one process's identity onto another's age. The general shape: when a fix reads a mutable identifier more than once to describe one entity, bind the reads to an immutable incarnation token (here process `starttime`) and refuse to combine them across a mismatch.

Rule candidate: review-prompt -- for any change that reads `/proc/<pid>` (or any reused OS handle) more than once to build one record, ask whether the reads are pinned to a single incarnation, since the pid can be recycled between them.




