### PR TITLE
fix(stt): reject over-limit dashboard audio

### DIFF
--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1337,18 +1337,28 @@ async def api_stt_transcribe(request: web.Request) -> web.Response:
             )
 
         duration_cap = batch_duration_cap_secs(cfg.stt)
-        if duration_cap is not None and await audio_exceeds_secs(
-            tmp, duration_cap, timeout_secs=cfg.stt.timeout_secs
-        ):
-            return web.json_response(
-                {
-                    "error": (f"audio exceeds the {duration_cap // 60}-minute transcription limit"),
-                    "code": "stt_audio_too_long",
-                },
-                status=422,
-            )
+        if duration_cap is not None:
+            exceeds = await audio_exceeds_secs(tmp, duration_cap, timeout_secs=cfg.stt.timeout_secs)
+            if exceeds is None:
+                return web.json_response(
+                    {
+                        "error": "could not verify audio duration; retry the upload",
+                        "code": "stt_audio_duration_unverified",
+                    },
+                    status=503,
+                )
+            if exceeds:
+                return web.json_response(
+                    {
+                        "error": (
+                            f"audio exceeds the {duration_cap // 60}-minute transcription limit"
+                        ),
+                        "code": "stt_audio_too_long",
+                    },
+                    status=422,
+                )
 
-        text = await transcribe_audio(tmp)
+        text = await transcribe_audio(tmp, cfg.stt)
         if text:
             from kiro_crew.security import (  # noqa: F811
                 redact_credentials,

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -81,7 +81,9 @@ from kiro_crew.stt.limits import (
 from kiro_crew.transcribe import (
     _find_ffmpeg,
     _whisper_language,
+    audio_exceeds_secs,
     availability_detail,
+    batch_duration_cap_secs,
     ensure_ffmpeg_in_path,
     ffmpeg_source,
     is_available,
@@ -1332,6 +1334,18 @@ async def api_stt_transcribe(request: web.Request) -> web.Response:
         except part_stream.PartTooLarge:
             return web.json_response(
                 {"error": "audio too large", "code": _CODE_STT_AUDIO_TOO_LARGE}, status=413
+            )
+
+        duration_cap = batch_duration_cap_secs(cfg.stt)
+        if duration_cap is not None and await audio_exceeds_secs(
+            tmp, duration_cap, timeout_secs=cfg.stt.timeout_secs
+        ):
+            return web.json_response(
+                {
+                    "error": (f"audio exceeds the {duration_cap // 60}-minute transcription limit"),
+                    "code": "stt_audio_too_long",
+                },
+                status=422,
             )
 
         text = await transcribe_audio(tmp)

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -1432,6 +1432,7 @@ class TestSttTranscribe:
         with the ``voice`` extra installed than on one without.
         """
         monkeypatch.setattr(core_mod, "availability_detail", lambda _cfg: _availability(True))
+        monkeypatch.setattr(core_mod, "audio_exceeds_secs", AsyncMock(return_value=False))
 
     @pytest.mark.asyncio
     async def test_unavailable_backend_is_503_naming_the_reason(self, monkeypatch) -> None:
@@ -1489,6 +1490,27 @@ class TestSttTranscribe:
         body = json.loads(resp.body)
         assert body["error"] == "audio too large"
         assert body["code"] == "stt_audio_too_large"
+
+    @pytest.mark.asyncio
+    async def test_over_duration_upload_is_refused_before_transcription(self, monkeypatch) -> None:
+        monkeypatch.setattr(core_mod, "batch_duration_cap_secs", lambda _cfg: 3600)
+        probe = AsyncMock(return_value=True)
+        monkeypatch.setattr(core_mod, "audio_exceeds_secs", probe)
+        transcribe = AsyncMock()
+        monkeypatch.setattr("kiro_crew.transcribe.transcribe_audio", transcribe)
+        field = SimpleNamespace(
+            name="audio",
+            filename="recording.webm",
+            read_chunk=AsyncMock(side_effect=[b"audio-bytes", b""]),
+        )
+
+        resp = await core_mod.api_stt_transcribe(_multipart_req(field))
+
+        assert resp.status == 422
+        body = json.loads(resp.body)
+        assert body["code"] == "stt_audio_too_long"
+        assert "60-minute" in body["error"]
+        transcribe.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_transcript_is_returned_and_redacted(self, monkeypatch) -> None:

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -1513,6 +1513,24 @@ class TestSttTranscribe:
         transcribe.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_unverified_duration_is_retryable_and_not_transcribed(self, monkeypatch) -> None:
+        monkeypatch.setattr(core_mod, "batch_duration_cap_secs", lambda _cfg: 3600)
+        monkeypatch.setattr(core_mod, "audio_exceeds_secs", AsyncMock(return_value=None))
+        transcribe = AsyncMock()
+        monkeypatch.setattr("kiro_crew.transcribe.transcribe_audio", transcribe)
+        field = SimpleNamespace(
+            name="audio",
+            filename="recording.webm",
+            read_chunk=AsyncMock(side_effect=[b"audio-bytes", b""]),
+        )
+
+        resp = await core_mod.api_stt_transcribe(_multipart_req(field))
+
+        assert resp.status == 503
+        assert json.loads(resp.body)["code"] == "stt_audio_duration_unverified"
+        transcribe.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_transcript_is_returned_and_redacted(self, monkeypatch) -> None:
         """A dictated credential must not come back in the response body: speech
         reaches this endpoint from a microphone, so nothing upstream of it has had


### PR DESCRIPTION
## Problem / Motivation

The dashboard dictation endpoint can pass recordings longer than the active recognizer's one-hour batch limit to `transcribe_audio`, which silently returns only the prefix.

## Why it matters

A successful-looking partial transcript gives users no indication that the end of a long recording was lost.

## What changed (motivation → approach → change)

The endpoint now uses one STT configuration snapshot for availability, the provider cap, the duration probe, and transcription. It gives the probe the configured transcription timeout, rejects proven over-limit audio with `422 stt_audio_too_long`, and returns retryable `503 stt_audio_duration_unverified` when duration cannot be established. Providers without a silent cap retain their existing behavior.

## Tests

- Added endpoint coverage for both over-limit and indeterminate-duration refusals before transcription.
- `test/test_dashboard_handlers_core_coverage.py -k TestSttTranscribe`: 9 passed.
- `flake8`, `isort --check-only`, and `mypy` pass for the touched files.

## Manual verification

N/A — the endpoint behavior and pre-transcription refusals are covered directly without requiring an installed speech model.

## Related Issues

Part of #9331.

## Pattern harvest

Rule candidate: review-prompt
Pattern: A caller of a deliberately truncating media API must use one configuration snapshot and fail closed when its aligned duration probe cannot verify the input.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — awaiting the repository's OSPO-provided CLA wording.
