### PR TITLE
fix(messaging): refuse over-limit audio attachments

### DIFF
--- a/src/kiro_crew/messaging/attachments.py
+++ b/src/kiro_crew/messaging/attachments.py
@@ -594,7 +594,19 @@ async def transcribe_audio_attachments(result: IngestResult, source: str) -> Ing
 
     for path in result.audio_paths:
         try:
-            transcript = await transcribe.transcribe_audio(path)
+            stt_config = await asyncio.to_thread(transcribe.load_stt_config)
+            duration_cap = transcribe.batch_duration_cap_secs(stt_config)
+            if duration_cap is not None:
+                exceeds = await transcribe.audio_exceeds_secs(
+                    path, duration_cap, timeout_secs=stt_config.timeout_secs
+                )
+                if exceeds is not False:
+                    reason = "duration could not be verified"
+                    if exceeds:
+                        reason = f"exceeds the {duration_cap // 60}-minute transcription limit"
+                    result.rejections.append(f"[Audio attachment — {reason}]")
+                    continue
+            transcript = await transcribe.transcribe_audio(path, stt_config)
         except Exception:
             logger.exception("%s: audio transcription raised", source)
             transcript = None

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -1441,12 +1441,13 @@ class TestDiscordAttachmentAdapter:
         client.attachment_bodies[url] = b"OggS" + b"\x00" * 32
         transcribed: list[str] = []
 
-        async def _transcribe(path: str) -> str:
+        async def _transcribe(path: str, _cfg: object) -> str:
             assert os.path.exists(path)
             transcribed.append(path)
             return "spoken words"
 
         monkeypatch.setattr("kiro_crew.transcribe.is_available", lambda: True)
+        monkeypatch.setattr("kiro_crew.transcribe.batch_duration_cap_secs", lambda _cfg: None)
         monkeypatch.setattr("kiro_crew.transcribe.transcribe_audio", _transcribe)
 
         result = await process_discord_attachments(

--- a/test/test_slack_backports.py
+++ b/test/test_slack_backports.py
@@ -23,6 +23,7 @@ import os
 import stat
 import threading
 from dataclasses import replace
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -701,15 +702,69 @@ class TestVoiceMemoRejections:
         )
         assert unavailable.rejections == [VOICE_MEMO_UNAVAILABLE]
 
-        async def _no_words(path: str) -> str:
+        async def _no_words(path: str, _cfg) -> str:
             return ""
 
         monkeypatch.setattr(transcribe, "is_available", lambda *a, **k: True)
+        monkeypatch.setattr(transcribe, "load_stt_config", lambda: object())
+        monkeypatch.setattr(transcribe, "batch_duration_cap_secs", lambda _cfg: None)
         monkeypatch.setattr(transcribe, "transcribe_audio", _no_words)
         failed = await transcribe_audio_attachments(
             IngestResult(audio_paths=["/tmp/memo.webm"]), "Slack"
         )
         assert failed.rejections == [VOICE_MEMO_FAILED]
+
+    @pytest.mark.asyncio
+    async def test_over_duration_attachment_is_refused_before_transcription(
+        self, monkeypatch
+    ) -> None:
+        from kiro_crew import transcribe
+        from kiro_crew.messaging.attachments import IngestResult, transcribe_audio_attachments
+
+        monkeypatch.setattr(transcribe, "is_available", lambda: True)
+        cfg = SimpleNamespace(timeout_secs=900)
+        monkeypatch.setattr(transcribe, "load_stt_config", lambda: cfg)
+        monkeypatch.setattr(transcribe, "batch_duration_cap_secs", lambda _cfg: 3600)
+
+        async def _too_long(path: str, max_secs: int, *, timeout_secs: int) -> bool:
+            assert path == "/tmp/memo.webm"
+            assert max_secs == 3600
+            assert timeout_secs == 900
+            return True
+
+        transcribe_call = AsyncMock()
+        monkeypatch.setattr(transcribe, "audio_exceeds_secs", _too_long)
+        monkeypatch.setattr(transcribe, "transcribe_audio", transcribe_call)
+
+        result = await transcribe_audio_attachments(
+            IngestResult(audio_paths=["/tmp/memo.webm"]), "Slack"
+        )
+
+        assert result.rejections == [
+            "[Audio attachment — exceeds the 60-minute transcription limit]"
+        ]
+        transcribe_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unverified_attachment_duration_is_refused(self, monkeypatch) -> None:
+        from kiro_crew import transcribe
+        from kiro_crew.messaging.attachments import IngestResult, transcribe_audio_attachments
+
+        monkeypatch.setattr(transcribe, "is_available", lambda: True)
+        monkeypatch.setattr(
+            transcribe, "load_stt_config", lambda: SimpleNamespace(timeout_secs=900)
+        )
+        monkeypatch.setattr(transcribe, "batch_duration_cap_secs", lambda _cfg: 3600)
+        monkeypatch.setattr(transcribe, "audio_exceeds_secs", AsyncMock(return_value=None))
+        transcribe_call = AsyncMock()
+        monkeypatch.setattr(transcribe, "transcribe_audio", transcribe_call)
+
+        result = await transcribe_audio_attachments(
+            IngestResult(audio_paths=["/tmp/memo.webm"]), "Slack"
+        )
+
+        assert result.rejections == ["[Audio attachment — duration could not be verified]"]
+        transcribe_call.assert_not_awaited()
 
 
 class TestReleasedTailIsRedacted:

--- a/test/test_telegram_attachments.py
+++ b/test/test_telegram_attachments.py
@@ -342,8 +342,11 @@ class TestProcessTelegramAttachments:
                 "file_size": len(ogg_data),
             }
         ]
-        with patch("kiro_crew.transcribe.is_available", return_value=True), \
-             patch("kiro_crew.transcribe.transcribe_audio", return_value="hello from voice"):
+        with (
+            patch("kiro_crew.transcribe.is_available", return_value=True),
+            patch("kiro_crew.transcribe.batch_duration_cap_secs", return_value=None),
+            patch("kiro_crew.transcribe.transcribe_audio", return_value="hello from voice"),
+        ):
             result = await process_telegram_attachments(client, attachments)
 
         assert len(result.text_blocks) == 1

--- a/test/test_webex_attachments.py
+++ b/test/test_webex_attachments.py
@@ -168,12 +168,13 @@ class TestProcessWebexAttachments:
         )
         transcribed: list[str] = []
 
-        async def _transcribe(path: str) -> str:
+        async def _transcribe(path: str, _cfg: object) -> str:
             assert os.path.exists(path), "STT must run against the downloaded bytes"
             transcribed.append(path)
             return "spoken words"
 
         monkeypatch.setattr("kiro_crew.transcribe.is_available", lambda: True)
+        monkeypatch.setattr("kiro_crew.transcribe.batch_duration_cap_secs", lambda _cfg: None)
         monkeypatch.setattr("kiro_crew.transcribe.transcribe_audio", _transcribe)
         inbound = SimpleNamespace(file_urls=(url,))
 


### PR DESCRIPTION
## Problem / Motivation

The shared multi-channel audio-attachment path can accept recordings longer than the active recognizer's one-hour batch limit and present a silently truncated prefix as the complete memo. This path serves Discord, Telegram, WhatsApp, Teams, Webex, Weixin, and WeCom.

## Why it matters

Users on those channels can unknowingly act on incomplete transcripts with no indication that later audio was omitted.

## What changed (motivation → approach → change)

The shared attachment transcriber now loads one STT configuration snapshot and reuses it for the provider cap, aligned-timeout duration probe, and transcription. Both over-limit and indeterminate-duration recordings become visible rejections; uncapped providers retain the existing path. Existing Discord, Telegram, and Webex success-path tests now explicitly select the uncapped path so they continue testing transcription rather than duration probing.

## Tests

- Added shared attachment coverage for proven-over-limit and indeterminate-duration refusals, proving transcription is skipped.
- Affected Discord, Telegram, Webex, and shared attachment suites: 42 passed.
- `flake8`, `isort --check-only`, and diff whitespace checks pass for the touched files.

## Manual verification

N/A — the shared channel-neutral behavior is covered directly without an installed speech model.

## Related Issues

Part of #9331.

## Pattern harvest

Rule candidate: review-prompt
Pattern: A caller of a deliberately truncating media API must use one configuration snapshot and fail closed when its aligned duration probe cannot verify the input.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — awaiting the repository's OSPO-provided CLA wording.

