### PR TITLE
fix(tailnet): decode the tailscale CLI as utf-8, not the host code page

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -41,8 +41,6 @@
 1 src/kiro_crew/dashboard/handlers/terminal.py
 1 src/kiro_crew/dashboard/handlers_system.py
 1 src/kiro_crew/dashboard/port_reclaim.py
-1 src/kiro_crew/dashboard/tailnet.py
-1 src/kiro_crew/dashboard/tailnet_serve.py
 1 src/kiro_crew/deploy/engine.py
 1 src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
 1 src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py

--- a/src/kiro_crew/dashboard/tailnet.py
+++ b/src/kiro_crew/dashboard/tailnet.py
@@ -48,6 +48,7 @@ from kiro_crew.platform.governance_profiles import (
 )
 from kiro_crew.platform_compat import IS_POSIX
 from kiro_crew.sandbox import scrub_env
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 if TYPE_CHECKING:
     from aiohttp import web
@@ -200,7 +201,7 @@ def _run_json_detail(args: list[str]) -> tuple[Any | None, bool]:
         proc = subprocess.run(  # noqa: S603 - vetted absolute binary, fixed argv, no shell
             [cli, *args],
             capture_output=True,
-            text=True,
+            **UTF8_TEXT,
             timeout=_CLI_TIMEOUT_SECS,
             check=False,
             # Defence in depth behind the pinned binary above: even a legitimate

--- a/src/kiro_crew/dashboard/tailnet_serve.py
+++ b/src/kiro_crew/dashboard/tailnet_serve.py
@@ -53,6 +53,7 @@ from typing import Any, Literal
 
 from kiro_crew.dashboard.tailnet import _cli_path, is_governance_pinned_off
 from kiro_crew.sandbox import scrub_env
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -227,7 +228,7 @@ def _run(args: list[str], timeout: float) -> tuple[int, str, str]:
         proc = subprocess.run(  # noqa: S603 - vetted absolute binary, fixed argv, no shell
             [cli, *args],
             capture_output=True,
-            text=True,
+            **UTF8_TEXT,
             timeout=timeout,
             check=False,
             env=scrub_env(),

--- a/test/test_tailnet_e2e.py
+++ b/test/test_tailnet_e2e.py
@@ -346,3 +346,131 @@ class TestAgainstARealDaemon:
         state = tailnet_serve.serve_state(_DASH_PORT)
         assert state.published in (True, False, None)
         assert state.detail
+
+
+# A device name a real tailnet routinely carries. Its UTF-8 encoding is
+# ``e6 b8 ac e8 a9 a6``, and every one of those bytes is ALSO a legal Big5 lead
+# or trail byte, so a cp950 host decodes it into different characters rather
+# than raising -- the mojibake half of this class, which no exception handler
+# can notice.
+_CJK_HOST = "測試-desk"
+
+#: Bytes that are not valid UTF-8 at all (``0xff`` can never begin a UTF-8
+#: sequence), wrapped in otherwise well-formed JSON. This is the half that is
+#: deterministic on EVERY host: it does not depend on what the host code page
+#: happens to be, only on the decode being strict.
+_UNDECODABLE_JSON = (
+    b'{"BackendState":"Running","Self":{"DNSName":"' + bytes([0xFF, 0xFE]) + b'.ts.net"}}'
+)
+
+
+def _raw_cli(tmp_path, monkeypatch, payload: bytes) -> None:
+    """Stage a fake ``tailscale`` that writes *payload* to stdout as RAW BYTES.
+
+    The suite's main fake answers through ``print(json.dumps(...))``, which is
+    ASCII by construction (``ensure_ascii`` defaults on) and re-encodes through
+    the CHILD's stdout encoding — so it can never place a non-ASCII byte on the
+    pipe and cannot exercise the parent's decode at all. Writing to
+    ``sys.stdout.buffer`` puts exactly these bytes on the pipe, which is what a
+    Go binary such as ``tailscale`` does.
+
+    Reuses the two seams the module docstring already justifies: the candidate
+    path is patched because ``_CLI_CANDIDATE_PATHS`` holds only root-owned
+    locations, and the POSIX provenance check is relaxed because an unprivileged
+    test cannot satisfy it.
+    """
+    body = tmp_path / "raw_tailscale.py"
+    body.write_text(
+        "import sys\n"
+        f"sys.stdout.buffer.write({payload!r})\n"
+        "sys.stdout.buffer.flush()\n",
+        encoding="utf-8",
+    )
+    if sys.platform == "win32":
+        cli = tmp_path / "tailscale.bat"
+        cli.write_text(f'@echo off\r\n"{sys.executable}" "{body}" %*\r\n')
+    else:
+        cli = tmp_path / "tailscale"
+        cli.write_text(f"#!{sys.executable}\n" + body.read_text(encoding="utf-8"))
+        cli.chmod(cli.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (str(cli),))
+    if tailnet.IS_POSIX:
+        monkeypatch.setattr(tailnet, "_posix_candidate_trusted", lambda _c: True)
+    else:
+        monkeypatch.setattr(
+            tailnet.github_runner, "validate_provider_executable", lambda candidate: candidate
+        )
+
+
+class TestTheCliIsDecodedAsUtf8NotTheHostCodePage:
+    """``tailscale`` is a Go binary and ``--json`` output is JSON: both are UTF-8.
+
+    ``subprocess.run(..., text=True)`` with no ``encoding=`` decodes the child
+    with ``locale.getpreferredencoding()`` — UTF-8 on POSIX, but the legacy ANSI
+    code page on Windows. Tailnet device names are operator-chosen free text, so
+    non-ASCII here is ordinary rather than exotic, and JSON is defined as UTF-8
+    (RFC 8259 §8.1), so pinning the decode is reading the spec, not guessing.
+
+    The class has two halves, and only the second is reproducible on a UTF-8 CI
+    runner:
+
+    * bytes that ARE valid in the host code page decode to the wrong characters,
+      silently — ``_CJK_HOST``;
+    * bytes that decode under neither take a platform-specific path. POSIX raises
+      ``UnicodeDecodeError`` out of ``subprocess.run``; that is a ``ValueError``,
+      so it passes straight through the ``except (OSError,
+      subprocess.SubprocessError)`` guard. On Windows ``capture_output`` reads on
+      a helper thread, so the same error kills that thread, prints a traceback to
+      the gateway's stderr, and leaves ``proc.stdout`` as ``None`` — measured,
+      not assumed. Either way ``_run_json_detail`` breaks its documented promise
+      to return "a name or nothing" and degrade every failure to ``None``.
+    """
+
+    def test_undecodable_bytes_degrade_to_a_name_rather_than_escaping(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The cross-platform half — red on POSIX and Windows alike.
+
+        With the decode pinned, ``errors="replace"`` turns the bad bytes into
+        U+FFFD *inside the string*, so the surrounding JSON still parses and the
+        caller gets its answer. That is the degradation policy this repository
+        applies to decoded child output: one malformed byte costs one
+        character, not the whole payload.
+        """
+        _raw_cli(tmp_path, monkeypatch, _UNDECODABLE_JSON)
+        with pytest.raises(UnicodeDecodeError):
+            _UNDECODABLE_JSON.decode("utf-8")  # guard the guard
+
+        parsed, transient = tailnet._run_json_detail(["status", "--json"])
+
+        assert parsed is not None, "a malformed byte must not cost the whole payload"
+        assert transient is False
+        assert parsed["Self"]["DNSName"].endswith(".ts.net")
+
+    def test_a_non_ascii_device_name_round_trips(self, tmp_path, monkeypatch) -> None:
+        """The real-world half: an operator-named device must survive the read.
+
+        Host-conditioned by construction — a UTF-8 runner decodes it correctly
+        either way — so it is paired with the deterministic test above rather
+        than relied on alone. It is nonetheless the thing that actually breaks
+        for the user, so it is asserted rather than only described.
+        """
+        name = f"{_CJK_HOST}.{_SUFFIX}"
+        payload = json.dumps(
+            {"BackendState": "Running", "Self": {"DNSName": name}}, ensure_ascii=False
+        ).encode("utf-8")
+        _raw_cli(tmp_path, monkeypatch, payload)
+
+        parsed, _ = tailnet._run_json_detail(["status", "--json"])
+
+        assert parsed is not None
+        assert parsed["Self"]["DNSName"] == name
+
+    def test_the_fixture_really_defeats_a_legacy_code_page(self) -> None:
+        """Guard the guard: ``_CJK_HOST`` must be a name cp950 reads DIFFERENTLY.
+
+        Without this, the round-trip test above would pass just as happily on a
+        name that was ASCII all along, and would be pinning nothing.
+        """
+        raw = _CJK_HOST.encode("utf-8")
+        assert raw.decode("cp950", errors="replace") != _CJK_HOST


### PR DESCRIPTION
## Problem / Motivation

Both spawns of the `tailscale` CLI run in text mode with no `encoding=`:

```python
proc = subprocess.run(
    [cli, *args],
    capture_output=True,
    text=True,          # <- decodes with locale.getpreferredencoding()
    ...
)
```

`text=True` without an encoding decodes the child with
`locale.getpreferredencoding()`: UTF-8 on POSIX, but the legacy **ANSI code
page** on Windows. What the child actually writes is not in doubt here —
`tailscale` is a Go binary, and `tailscale ... --json` emits JSON, which **is
defined as UTF-8** (RFC 8259 §8.1). So this is a known encoding being decoded
with the wrong one, not a guess about an unknowable child.

The payload is operator-chosen free text: a tailnet **device name**. Non-ASCII
there is ordinary, not exotic.

**Two distinct failures, both measured on a `cp950` host, not inferred.**

**1 — bytes that are also legal in the host code page decode to different
characters, silently.** `測試-desk` encodes to `e6 b8 ac e8 a9 a6`, and each of
those is a legal Big5 lead or trail byte, so nothing raises — the name simply
comes back as other characters. `_valid_magicdns_name` then rejects a name that
was valid, and the tailnet origin is never derived. The red-before below shows
this as a plain inequality of two rendered names.

**2 — bytes that decode under neither take a platform-specific path, and
neither is caught.** Both sites guard with
`except (OSError, subprocess.SubprocessError)`:

* **POSIX** — `subprocess.run` raises `UnicodeDecodeError`. That is a
  `ValueError`, so it is caught by **neither** arm and propagates out of the
  function.
* **Windows** — `capture_output` reads on a helper thread, so the same error
  kills that thread, prints an unhandled-thread traceback to the gateway's
  stderr, and leaves `proc.stdout` as `None`. Measured:

  ```
  Exception in thread Thread-1 (_readerthread):
    File ".../subprocess.py", line 1497, in _readerthread
      buffer.append(fh.read())
  UnicodeDecodeError: 'cp950' codec can't decode byte 0xff in position 20
  ...
  no exception; stdout = None
  ```

## Why it matters

`_run_json_detail` states its contract in its own docstring, and both failures
break it:

> Run the CLI and parse stdout as JSON. ``None`` on ANY failure.
> Deliberately broad: the caller's contract is "a name or nothing", and every
> failure mode here (no binary, daemon down, timeout, non-zero exit, non-JSON
> output) means the same thing to it.

Failure 1 returns **a wrong name** rather than "a name or nothing". Failure 2
either **escapes** the function entirely (POSIX) or drops the whole payload and
leaves a stray traceback in the gateway's log (Windows). The listed failure
modes were all meant to converge on `None`; a decode failure is the one that
does not.

It is invisible where most development happens: on POSIX
`locale.getpreferredencoding()` already returns UTF-8, so every one of these
calls is correct there. Only a non-UTF-8 Windows host sees it, and only for an
operator who named a device in their own script.

## What changed (motivation → approach → change)

Root cause: a child whose output encoding **is** knowable was decoded with the
host's locale instead.

* **Both spawns now splat `UTF8_TEXT`** — `src/kiro_crew/subprocess_utf8.py`,
  the repository's existing mapping for exactly this, whose own docstring names
  `gh` ("a Go binary; always writes UTF-8") as the same case. Three lines of
  production change plus two imports.
* **`errors="replace"` comes with it**, and it is what restores the documented
  contract on the undecodable path: a malformed byte costs one character inside
  the string, the surrounding JSON still parses, and the caller gets its answer.
  That is the policy #3669 established rather than a new one.
* **`tailnet_serve.py` is fixed in the same commit**, not left as a follow-up.
  Its own docstring gives the reason:

  > Binary resolution and environment scrubbing are **shared with the read
  > path** rather than re-implemented ... A second, subtly different copy of
  > either is how one spawn comes to be hardened and its sibling not.

  Its `_run` has the identical spawn and the identical `except (OSError,
  subprocess.SubprocessError)` guard, and its stdout/stderr are shown to the
  operator verbatim.
* **`.github/subprocess-encoding-baseline.txt` loses both entries.** The repo's
  ratchet requires a file whose count shrinks to be pruned, so this is the
  gate's own bookkeeping, not an unrelated edit.

**Deliberately NOT widened.** The other 112 baselined files stay as they are.
Several of them genuinely should keep locale decoding — `subprocess_utf8`'s
docstring names `systeminfo` and user shells, where pinning UTF-8 trades one
mojibake for another — so a sweep would need a per-child judgement each time and
would not be this defect.

## Tests

Added `TestTheCliIsDecodedAsUtf8NotTheHostCodePage` to `test/test_tailnet_e2e.py`
— the suite that already spawns a **real** fake `tailscale` through the
production `_cli_path` and the production `subprocess.run`, so the decode under
test is the real process boundary rather than a mock.

The existing fake could not exercise this at all: it answers via
`print(json.dumps(...))`, which is ASCII by construction (`ensure_ascii` defaults
on) and re-encodes through the *child's* stdout encoding, so it can never place a
non-ASCII byte on the pipe. The new helper writes to `sys.stdout.buffer`, which
puts exactly the intended bytes there — what a Go binary does.

**Red-before** (product code reverted to `origin/main`, tests kept):

```
FAILED ...::test_undecodable_bytes_degrade_to_a_name_rather_than_escaping
  AssertionError: a malformed byte must not cost the whole payload
FAILED ...::test_a_non_ascii_device_name_round_trips
  AssertionError: assert '測試-desk.tail1a2b3c.ts.net' == '����-desk.tail1a2b3c.ts.net'
2 failed, 1 passed
```

The second failure is the mojibake itself, printed side by side.

The two halves are deliberately different in strength, and the difference is
stated rather than papered over:

* `test_undecodable_bytes_degrade_to_a_name_rather_than_escaping` is
  **deterministic on every host, CI included**. It does not depend on what the
  host code page is, only on the decode being strict, so it goes red on a UTF-8
  Linux runner (where it raises) and on Windows (where the reader thread dies)
  alike.
* `test_a_non_ascii_device_name_round_trips` is **host-conditioned** — a UTF-8
  runner decodes it correctly either way — so it is paired with the above rather
  than relied on alone. It is kept because it is the thing that actually breaks
  for the user.
* `test_the_fixture_really_defeats_a_legacy_code_page` passes on both builds by
  design: it asserts `測試-desk` is a name cp950 reads *differently*, so the
  round-trip test cannot pass vacuously on a payload that was ASCII all along.

**Green-after:** **450 passed / 3 skipped** across `test_tailnet_e2e.py`,
`test_tailnet_serve.py`, `test_tailnet_cli.py`, `test_tailnet_origin.py`,
`test_tailnet_mobile.py`, `test_tailnet_peer.py`, `test_tailnet_governance.py`
and `test_spawn_audit.py` — the last of which audits
`dashboard/tailnet.py::_run_json_detail` by name as a spawn primitive.

**Gates:** `flake8`, `isort --check-only`, `mypy --platform linux` and
`scripts/check_subprocess_encoding.py` all pass;
`scripts/check_black_formatting.py` passes (the two pre-existing black findings
in `test_tailnet_e2e.py` are baseline entries in untouched regions, so the file
was not reformatted).

## Manual verification

N/A — unit coverage sufficient: the defect is a decode at a real process
boundary, and these tests exercise that exact boundary with a real child process
emitting real bytes, which is precisely what a manual run against a daemon would
do. The suite's own `TestAgainstARealDaemon` still covers a genuine `tailscale`
where one is installed.

## Related Issues

None. Found by auditing `.github/subprocess-encoding-baseline.txt` — the repo's
own record of pre-existing sites in the failure class `#3219` / `#3669` / `#5249`
established — for entries whose child has a *knowable* encoding.

Contention checked immediately before opening: across all 357 open PRs, the only
other PR touching these files is #9333, a comments-only "strip history narration"
sweep with no overlap with these lines.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **`UnicodeDecodeError` is a `ValueError`, so
`except (OSError, subprocess.SubprocessError)` does not catch it** — the guard
around almost every spawn in this repository looks total and is not. Any function
that documents "None on ANY failure" while decoding a child in text mode is
making a promise its own except clause cannot keep. When reviewing a spawn, check
the exception *type lattice* against the decode, not just against the spawn.

Second lesson, and the one that cost the most to find here: **the same decode
failure has two different shapes by platform.** POSIX `communicate()` decodes on
the calling thread and raises into the caller; Windows `capture_output` decodes
on a reader thread, so the exception is swallowed by the threading machinery and
the caller silently receives `stdout is None`. A test asserting "it raises" would
have passed on Linux and proved nothing on Windows. Assert the **post-condition**
the caller depends on (a parsed payload came back) rather than the mechanism, and
one test covers both.

Third: **an `ensure_ascii` fake cannot test a decode.** The existing e2e fake
looked like a real process boundary and was structurally incapable of putting a
non-ASCII byte on the pipe. When the property under test is an encoding, the
fixture has to write bytes, not call `print`.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
