### PR TITLE
test(work-ledger): name the refusing validator in the bind race failure

### DIFF
--- a/src/kiro_crew/work_ledger.py
+++ b/src/kiro_crew/work_ledger.py
@@ -465,9 +465,20 @@ def _work_ledger_root() -> Path:
     return data_home() / "work-ledger"
 
 
+def _slot_key_is_shaped(slot_key: str) -> bool:
+    """Whether *slot_key* has the shape a store path may be built from.
+
+    A slot key names a directory, so a null byte or a path separator would let it
+    escape its own directory. This is the shape check :func:`conductor_dir` raises
+    on; it is a named predicate so a reader that must decide UNBOUND-vs-RAISE on a
+    stored key can ask the same question without provoking the raise.
+    """
+    return bool(slot_key) and "\0" not in slot_key and "/" not in slot_key and "\\" not in slot_key
+
+
 def conductor_dir(slot_key: str) -> Path:
     """The directory holding *slot_key*'s ledger. Does not create it."""
-    if not slot_key or "\0" in slot_key or "/" in slot_key or "\\" in slot_key:
+    if not _slot_key_is_shaped(slot_key):
         raise WorkLedgerError(
             f"invalid slot key for work ledger: {slot_key!r}", code=CODE_INVALID_VALUE
         )

--- a/test/test_work_ledger.py
+++ b/test/test_work_ledger.py
@@ -1360,12 +1360,21 @@ def test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding():
     # distinguishable from one that ran and died.
     records: dict[str, str] = {key: "never-started" for key, _ in items}
 
+    # ``records`` keeps the COUNTED outcome verbatim ("bound" or the error code) so
+    # the two assertions below count only that. ``details`` keeps, for the same
+    # thread, the field and message behind a WorkLedgerError -- an ``invalid_value``
+    # says nothing about WHICH validator refused or WHAT value it saw. Recording
+    # ``exc.field`` and the message names the choke point for a Windows-shard
+    # occurrence. This is diagnosis, not tolerance: the assertions are unaffected.
+    details: dict[str, str] = {key: "" for key, _ in items}
+
     def bind(key: str, item_id: str) -> None:
         try:
             wl.apply_conductor_action(key, "bind", item_id=item_id, worker_session_key=WORKER)
             records[key] = "bound"
         except wl.WorkLedgerError as exc:
             records[key] = exc.code
+            details[key] = f"field={exc.field!r} msg={exc}"
         except BaseException as exc:  # noqa: BLE001 — diagnostic: never swallow, always name
             records[key] = f"{type(exc).__name__}: {exc}"
 
@@ -1384,7 +1393,9 @@ def test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding():
             records[key] = f"still-running-after-120s (last record: {records[key]})"
 
     outcomes = list(records.values())
-    _detail = "; ".join(f"{key}={records[key]}" for key, _ in items)
+    _detail = "; ".join(
+        f"{key}={records[key]}" + (f" ({details[key]})" if details[key] else "") for key, _ in items
+    )
     assert outcomes.count("bound") == 1, (
         f"expected exactly one thread to bind the worker, got "
         f"{outcomes.count('bound')} — per-thread outcomes: {_detail}"


### PR DESCRIPTION
## Problem / Motivation

`test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding` fails
intermittently on the Windows shard, sometimes reporting `invalid_value`
(issue #9343). The test recorded only `exc.code` for a failing thread, so that
`invalid_value` did not say which validator refused or on what value -- the one
fact needed to attribute the failure from a shard you cannot reproduce on.

## Why it matters

A failure message that names only `invalid_value`, with no field and no value, sends
the next person to trace the whole bind path by hand. Naming the refusing validator's
field and the offending value turns a blind shard failure into a diagnosable one.

## What changed (motivation -> approach -> change)

Two behaviour-preserving changes.

The race test now records `exc.field` and the message alongside the counted
`exc.code`, and folds them into both assertion messages. The `== 1` and `== 3`
assertions are unchanged: this adds diagnosis, not tolerance.

`conductor_dir`'s inline slot-key shape check (`not key or "\0"/"/"/"\\" in key`) is
extracted into a shared `_slot_key_is_shaped` predicate. `conductor_dir` calls it and
raises exactly as before; behaviour is identical, the check just has a name.

## Scope -- what this does and does not do

This PR does NOT change any binding-read behaviour and does NOT diagnose the shard
failure. An earlier revision made `read_binding` treat a malformed stored conductor
key as unbound; GPT review showed that would let `_bootstrap` persist a depth-0 ledger
and bypass the nesting-depth ceiling, so that hunk was removed. A bind against a
binding with a malformed conductor key therefore raises today exactly as it does on
main -- unchanged. #9343's symptom is unchanged and only better reported.

## Tests

- The binding-race test's widened diagnostic (field + message on both assertions) is
  exercised by the existing test; the counted assertions are untouched.
- No behavioural test is added because no behaviour changed.

Commands run (Linux, one file at a time):

```
timeout 900 python3 -m pytest -n0 test/test_work_ledger.py -x -q
  -> 123 passed

black --target-version py310 --check + isort --check-only + flake8
  -> clean on both changed files
python3 scripts/check_comment_history.py  (baselined ratchet)
  -> clean
```

No `prove.py` mutation check applies: this change is a diagnostic plus a
behaviour-preserving refactor, so there is no production behaviour to revert.

## Manual verification

N/A -- the change is test-diagnostic and a refactor with identical behaviour. The
Windows-shard failure is not addressed here.

## Related Issues

Refs #9343 -- widens that test's diagnostic so a future Windows `invalid_value` names
its validator. Does not fix or diagnose it; the issue stays open.

Refs #9388 -- open question of whether the worker `binding_lock` serializes on Windows.

Refs #9389 -- open question of whether a malformed stored conductor key is reachable
and whether `_bootstrap` should refuse it regardless (the depth-ceiling question that
scoped this PR down).

no linked issue is closed by this PR.

## Pattern harvest

A single two-valued reader result was asked to answer two independent questions and
was wrong for opposite reasons on each. `read_binding` returning `None` means both
"not a usable report channel" (right for the worker / Phase 2) and "no parent for
depth" (a fail-open for `_bootstrap`'s nesting ceiling). Making an unreadable binding
REFUSE drew an objection that it removed self-healing; making it READ AS UNBOUND drew
an objection that it bypassed the depth ceiling. Both directions of the one boolean
were rejected, for unrelated reasons -- the signature of one value carrying two
questions that need not share an answer for a malformed file.

Rule candidate: review-prompt -- when a fix changes what a shared reader returns for a
malformed or unreadable input, enumerate every consumer of that return value and check
each for the OPPOSITE failure mode before shipping; when two consumers reject both
values of the result for unrelated reasons, split the result so each consumer asks its
own question rather than overloading one sentinel.
