### PR TITLE
fix(pptx-maker): decode the engine and uv spawns as utf-8, not the host code page

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -27,8 +27,6 @@
 3 src/kiro_crew/apps/builtins/file_explorer/server.py
 1 src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
 3 src/kiro_crew/apps/builtins/md_notebook/server.py
-1 src/kiro_crew/apps/builtins/pptx_maker/backend/engine.py
-1 src/kiro_crew/apps/builtins/pptx_maker/backend/provision.py
 1 src/kiro_crew/browser_cli/install.py
 1 src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
 2 src/kiro_crew/builtin_skills/ios-simulator-preview/scripts/sim_mirror.py

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/engine.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/engine.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 from kiro_crew.apps.builtins.pptx_maker.backend import engine_source, paths
 from kiro_crew.sandbox import cgroup_scope_argv, run_limited, sandboxed_spawn_argv
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 logger = logging.getLogger("kirocrew.app.pptx-maker")
 
@@ -212,7 +213,7 @@ def _spawn(argv: list[str], *, cwd: str, timeout: int) -> EngineResult:
             cwd=cwd,
             env=env,
             capture_output=True,
-            text=True,
+            **UTF8_TEXT,
             timeout=timeout,
             check=False,
         )

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/provision.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/provision.py
@@ -43,6 +43,7 @@ from kiro_crew.apps.builtins.pptx_maker.backend import engine_source, paths
 from kiro_crew.apps.manager import app_dir
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.sandbox import cgroup_scope_argv, run_limited, sandboxed_spawn_argv
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 logger = logging.getLogger("kirocrew.app.pptx-maker")
 
@@ -224,7 +225,7 @@ def _run(argv: list[str], *, cwd: str, timeout: int) -> tuple[int, str]:
             cwd=cwd,
             env=env,
             capture_output=True,
-            text=True,
+            **UTF8_TEXT,
             timeout=timeout,
             check=False,
         )

--- a/test/test_pptx_maker_engine.py
+++ b/test/test_pptx_maker_engine.py
@@ -19,16 +19,22 @@ happy path, and each is pinned below:
 * **The engine's shape is normalized.** ``load_lists`` and ``scan_new_templates``
   coerce whatever comes back over the subprocess boundary.
 
-No real subprocess: every test mocks at the ``_spawn`` / ``sandboxed_spawn_argv``
-boundary.
+No real subprocess, with ONE stated exception: every test mocks at the
+``_spawn`` / ``sandboxed_spawn_argv`` boundary, except
+``TestTheEngineStdoutIsDecodedAsUtf8``, which measures the decode that happens
+between the child's bytes and ``EngineResult.stdout`` and so cannot use a mock
+that hands back a ``str``.
 """
 
 from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from unittest import mock
+
+import pytest
 
 from kiro_crew.apps.builtins.pptx_maker.backend import engine, engine_source, paths
 
@@ -470,3 +476,92 @@ class TestProvisionState:
     def test_elapsed_counts_from_the_start(self):
         state = engine.ProvisionState(started=engine.time.time() - 5)
         assert state.elapsed() >= 5
+
+
+class TestTheEngineStdoutIsDecodedAsUtf8:
+    """The one class here that spawns a REAL child, because a mock cannot decode.
+
+    Every other test in this module mocks at the ``_spawn`` /
+    ``sandboxed_spawn_argv`` boundary, which is right for logic and structurally
+    useless here: the defect *is* the decode `subprocess` performs between the
+    child's bytes and `EngineResult.stdout`, so a mock that hands back a `str`
+    has already skipped the step under test. These therefore drive the real
+    ``run_limited`` with a real child, and mock only the sandbox wrapper (whose
+    argv rewriting is not what is being measured).
+
+    ``run_limited(..., text=True)`` with no ``encoding=`` decodes with
+    ``locale.getpreferredencoding()`` — UTF-8 on POSIX, the legacy ANSI code page
+    on Windows. The child here is the engine venv's own Python, driven with
+    model-authored deck content, so non-ASCII in its output is the normal case
+    rather than the exotic one.
+
+    What that costs is worse than a crash, and is measured rather than argued:
+    the child exits **0** and its entire stdout arrives as ``""``. On Windows
+    ``capture_output`` decodes on a helper thread, so `UnicodeDecodeError` kills
+    that thread instead of the call — `proc.stdout` is ``None``, which
+    ``_spawn`` folds to ``""``. `EngineResult.ok` is then ``False`` for a run
+    that succeeded, and the comment on ``test_a_zero_exit_with_empty_stdout_is_
+    not_ok`` above reads that state as "the snippet did not reach its `print`" —
+    a diagnosis this defect makes false. On POSIX the same decode raises
+    `UnicodeDecodeError`, which is a `ValueError` and so passes straight through
+    ``_spawn``'s ``except (OSError, subprocess.SubprocessError)``, breaking the
+    module's stated "degrades, never raises" contract instead.
+    """
+
+    #: Bytes that are not valid UTF-8 (``0xff`` can never begin a sequence),
+    #: wrapped in otherwise well-formed JSON. Chosen so the test does not depend
+    #: on what the host code page happens to be — only on the decode being
+    #: strict — which is what makes it red on a UTF-8 CI runner too.
+    PAYLOAD = b'{"added":["deck"],"note":"' + bytes([0xFF, 0xFE]) + b'"}'
+
+    def _argv(self) -> list[str]:
+        return [
+            sys.executable,
+            "-c",
+            f"import sys;sys.stdout.buffer.write({self.PAYLOAD!r});sys.stdout.buffer.flush()",
+        ]
+
+    def test_undecodable_engine_output_still_reaches_the_caller(self, tmp_path: Path):
+        """A malformed byte must cost one character, not the whole result."""
+        with pytest.raises(UnicodeDecodeError):
+            self.PAYLOAD.decode("utf-8")  # guard the guard
+
+        with (
+            mock.patch.object(
+                engine, "sandboxed_spawn_argv", return_value=(self._argv(), None, None)
+            ),
+            mock.patch.object(engine, "cgroup_scope_argv", side_effect=lambda a: a),
+        ):
+            result = engine._spawn(["ignored"], cwd=str(tmp_path), timeout=30)
+
+        assert result.returncode == 0
+        assert result.ok is True, "a run that exited 0 with output must not read as empty"
+        assert result.json() == {"added": ["deck"], "note": "��"}
+
+    def test_a_non_ascii_engine_payload_round_trips(self, tmp_path: Path):
+        """Deck content is model-authored, so CJK and emoji are ordinary here.
+
+        Host-conditioned — a UTF-8 runner decodes it correctly either way — so it
+        is paired with the deterministic test above rather than relied on alone.
+        """
+        payload = json.dumps({"added": ["提案 \U0001f600"]}, ensure_ascii=False).encode("utf-8")
+        argv = [
+            sys.executable,
+            "-c",
+            f"import sys;sys.stdout.buffer.write({payload!r});sys.stdout.buffer.flush()",
+        ]
+        with (
+            mock.patch.object(engine, "sandboxed_spawn_argv", return_value=(argv, None, None)),
+            mock.patch.object(engine, "cgroup_scope_argv", side_effect=lambda a: a),
+        ):
+            result = engine._spawn(["ignored"], cwd=str(tmp_path), timeout=30)
+
+        assert result.json() == {"added": ["提案 \U0001f600"]}
+
+    def test_the_fixture_really_defeats_a_legacy_code_page(self):
+        """Guard the guard: the round-trip payload must be one cp950 cannot carry.
+
+        Without this, that test would pass just as happily on an ASCII payload.
+        """
+        with pytest.raises(UnicodeEncodeError):
+            "提案 \U0001f600".encode("cp950")

--- a/test/test_pptx_maker_provision.py
+++ b/test/test_pptx_maker_provision.py
@@ -1076,3 +1076,57 @@ class TestShippedAgentsDoNotPreAuthorizeTools:
             "declares — kiro-cli will silently drop them at mount time:\n  "
             + "\n  ".join(offenders)
         )
+
+
+class TestTheProvisionLogIsDecodedAsUtf8:
+    """`_run`'s captured output is the provisioning log the operator reads.
+
+    ``ProvisionState`` serves it straight to the dashboard
+    (``{"ok": ..., "log": self.log[-LOG_TAIL_CHARS:], ...}``), so whatever this
+    decode gets wrong is what a human sees while trying to work out why an
+    install failed — the one moment the log has to be right.
+
+    The child is ``uv``, which this module's own docstring calls "a static Rust
+    binary": it writes UTF-8, not the console code page. But
+    ``run_limited(..., text=True)`` with no ``encoding=`` decodes with
+    ``locale.getpreferredencoding()``, which on Windows is the legacy ANSI code
+    page. uv's output carries package names and absolute paths under the user's
+    data home, so a non-ASCII account name is enough to reach this.
+
+    Measured, not argued: the child exits **0** and the whole log arrives as
+    ``""``. On Windows ``capture_output`` decodes on a helper thread, so the
+    error kills that thread rather than the call and ``proc.stdout`` is ``None``;
+    the operator gets a blank log for a run that printed plenty. On POSIX the
+    same decode raises `UnicodeDecodeError` — a `ValueError`, so neither
+    ``except subprocess.TimeoutExpired`` nor
+    ``except (OSError, subprocess.SubprocessError)`` catches it and it escapes
+    ``_run`` entirely.
+    """
+
+    #: Not valid UTF-8 (``0xff`` never begins a sequence), so this is red on
+    #: every host — it turns on the decode being strict, not on the host codec.
+    PAYLOAD = b"Resolved 41 packages\nerror: failed at " + bytes([0xFF, 0xFE]) + b"/pkg\n"
+
+    def _argv(self) -> list[str]:
+        return [
+            sys.executable,
+            "-c",
+            f"import sys;sys.stdout.buffer.write({self.PAYLOAD!r});sys.stdout.buffer.flush()",
+        ]
+
+    def test_undecodable_uv_output_still_reaches_the_log(self, tmp_path):
+        """A malformed byte must cost one character, not the entire log."""
+        with pytest.raises(UnicodeDecodeError):
+            self.PAYLOAD.decode("utf-8")  # guard the guard
+
+        with (
+            mock.patch.object(
+                provision, "sandboxed_spawn_argv", return_value=(self._argv(), None, None)
+            ),
+            mock.patch.object(provision, "cgroup_scope_argv", side_effect=lambda a: a),
+        ):
+            code, out = provision._run(self._argv(), cwd=str(tmp_path), timeout=30)
+
+        assert code == 0
+        assert "Resolved 41 packages" in out, "the log must survive one bad byte"
+        assert "error: failed at" in out


### PR DESCRIPTION
## Problem / Motivation

Both of PPTX Maker's backend spawns run in text mode with no `encoding=`:

```python
proc = run_limited(
    wrapped,
    cwd=cwd, env=env,
    capture_output=True,
    text=True,          # <- decodes with locale.getpreferredencoding()
    timeout=timeout, check=False,
)
```

`text=True` without an encoding decodes the child with
`locale.getpreferredencoding()`: UTF-8 on POSIX, the legacy **ANSI code page** on
Windows. Neither child writes in the console encoding:

* `provision._run` spawns **`uv`** — this module's own docstring calls it "a
  static Rust binary". Its output carries package names and absolute paths under
  the user's data home, so a non-ASCII account name reaches it.
* `engine._spawn` spawns **the engine venv's own Python**, driven with
  **model-authored deck content**. Non-ASCII there is the normal case, not the
  exotic one.

**The cost is worse than a crash, and it is measured rather than argued.** Driving
the real helpers with a real child that writes one invalid UTF-8 byte:

```
--- engine._spawn ---
  returncode: 0
  stdout repr: ''
  ok: False   json(): None
--- provision._run ---
  code: 0     out repr: ''
```

The child **exits 0** and its entire output is gone. On Windows `capture_output`
decodes on a helper thread, so `UnicodeDecodeError` kills that thread rather than
the call, `proc.stdout` comes back `None`, and both wrappers fold that to `""`.

Two consequences, one per site:

* **`EngineResult.ok` becomes `False` for a run that succeeded.** The existing
  test `test_a_zero_exit_with_empty_stdout_is_not_ok` comments that state as
  *"the engine exiting 0 while printing nothing means the snippet did not reach
  its `print`"* — a diagnosis this defect makes false, and the reading anyone
  debugging it would take.
* **The operator's provisioning log goes blank.** `ProvisionState` serves
  `_run`'s output straight to the dashboard
  (`{"ok": ..., "log": self.log[-LOG_TAIL_CHARS:], ...}`), so a failed install
  reports nothing at exactly the moment someone is trying to find out why.

On POSIX the same decode instead **raises**. `UnicodeDecodeError` is a
`ValueError`, so it passes straight through `except (OSError,
subprocess.SubprocessError)` — and through `provision._run`'s
`except subprocess.TimeoutExpired` — and escapes, breaking the contract
`engine.py`'s module docstring states:

> **A not-ready or misbehaving engine degrades, never raises.**

## Why it matters

The failure is silent and it lands after the expensive part: the deck has been
generated, or the third-party engine tree has been downloaded and built, and the
only thing left is to read what the child said. Both wrappers were written to
degrade — non-zero exit, non-JSON stdout and wrong-typed JSON all become a
documented empty/None result — and a decode failure is the one path that does not
converge there.

It is invisible where most development happens: on POSIX
`locale.getpreferredencoding()` already returns UTF-8, so both calls are correct
there. Only a non-UTF-8 Windows host sees it, and only once a deck or a path
carries a character that code page cannot represent.

## What changed (motivation → approach → change)

Root cause: two children whose output encoding **is** knowable were decoded with
the host's locale instead.

* **Both spawns now splat `UTF8_TEXT`** — `src/kiro_crew/subprocess_utf8.py`, the
  repository's existing mapping for exactly this case. Its docstring names the
  two categories in play here: Go/Rust binaries ("`gh` — a Go binary; always
  writes UTF-8") and "Python children we spawn ourselves whose output we
  control". Two lines of production change plus two imports.
* **`errors="replace"` comes with it**, and it is what restores the documented
  degrade-never-raise contract: a malformed byte becomes U+FFFD inside the
  string, the surrounding JSON still parses, and the caller gets its answer.
  That is the policy #3669 established, not a new one.
* **`.github/subprocess-encoding-baseline.txt` loses both entries**, as the
  repo's ratchet requires when a baselined file's count drops to zero.

**Deliberately NOT widened.** The other baselined files stay. Several genuinely
should keep locale decoding — `subprocess_utf8`'s docstring names `systeminfo`
and user shells, where pinning UTF-8 trades one mojibake for another — so a sweep
would need a per-child judgement each time and would not be this defect.

## Tests

Added one class per site, both driving a **real child process**.

`test_pptx_maker_engine.py`'s module docstring says "No real subprocess: every
test mocks at the `_spawn` / `sandboxed_spawn_argv` boundary". That is right for
logic and structurally useless here — the defect *is* the decode `subprocess`
performs between the child's bytes and `EngineResult.stdout`, so a mock handing
back a `str` has already skipped the step under test. The new class therefore
spawns for real and mocks only the sandbox wrapper, and **the module docstring is
updated to state that exception** rather than left silently false.

**Red-before** (product code reverted to `origin/main`, tests kept):

```
FAILED ...::TestTheEngineStdoutIsDecodedAsUtf8::test_undecodable_engine_output_still_reaches_the_caller
  AssertionError: a run that exited 0 with output must not read as empty
FAILED ...::TestTheEngineStdoutIsDecodedAsUtf8::test_a_non_ascii_engine_payload_round_trips
  AssertionError: assert None == {'added': ['提案 😀']}
FAILED ...::TestTheProvisionLogIsDecodedAsUtf8::test_undecodable_uv_output_still_reaches_the_log
  AssertionError: the log must survive one bad byte
3 failed, 109 passed
```

The three differ in strength, and the difference is stated rather than papered
over:

* The two `undecodable` tests are **deterministic on every host, CI included**.
  They use a byte (`0xff`) that can never begin a UTF-8 sequence, so they turn on
  the decode being *strict* rather than on what the host code page happens to be
  — red on a UTF-8 Linux runner (where it raises) and on Windows (where the
  reader thread dies) alike.
* `test_a_non_ascii_engine_payload_round_trips` is **host-conditioned** — a UTF-8
  runner decodes it correctly either way — so it is paired with the above rather
  than relied on alone. It is kept because it is the thing that actually breaks
  for the user.
* `test_the_fixture_really_defeats_a_legacy_code_page` passes on both builds by
  design: it asserts `提案 😀` is a payload cp950 genuinely cannot encode, so the
  round-trip test cannot pass vacuously on something ASCII all along.

**Green-after:** **112 passed** across `test_pptx_maker_engine.py` and
`test_pptx_maker_provision.py`.

**Gates:** `flake8`, `isort --check-only`, `mypy --platform linux`,
`scripts/check_subprocess_encoding.py` and `scripts/check_black_formatting.py`
all pass. The one black finding in `test_pptx_maker_provision.py` is a
pre-existing baseline entry in a region this PR does not touch, so the file was
not reformatted.

## Manual verification

N/A — unit coverage sufficient: the defect is a decode at a real process
boundary, and these tests exercise that exact boundary with a real child emitting
real bytes, which is what a manual run against the engine would do. Mocking is
what could not have caught it, which is why the tests do not.

## Related Issues

None. Found by auditing `.github/subprocess-encoding-baseline.txt` — the repo's
own record of pre-existing sites in the failure class `#3219` / `#3669` / `#5249`
established — for entries whose child has a *knowable* encoding.

Contention checked immediately before opening: across all 357 open PRs, **no
other PR touches either production file**.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **an unpinned text-mode decode fails as silent data loss on Windows, not
as an exception.** `capture_output` reads on a helper thread there, so
`UnicodeDecodeError` kills the thread and the caller sees `returncode == 0` with
`stdout is None`. Every `except` around the spawn is irrelevant — there is
nothing to catch. When reviewing a spawn, ask what the caller sees when the
*decode* fails, not only what it sees when the *spawn* fails; on POSIX the answer
is an escaping `ValueError`, on Windows it is a successful call with empty
output, and code written for one platform's answer is wrong on the other.

Second lesson: **`UnicodeDecodeError` is a `ValueError`, so
`except (OSError, subprocess.SubprocessError)` does not catch it.** That guard
wraps almost every spawn in this repository and looks total. Any wrapper
documenting "degrades, never raises" while decoding in text mode is promising
something its own except clause cannot deliver.

Third: **empty output is an ambiguous symptom that already had a wrong
explanation in the tree.** `EngineResult.ok`'s existing test comments exit-0-with-
empty-stdout as "the snippet did not reach its `print`". That was the only cause
when it was written, and this defect quietly added a second one. When a sentinel
state has a documented cause, adding a new way to reach it needs the comment
updated, or the next person debugs the wrong thing.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
