### PR TITLE
fix(knowledge): require a direct local request for the native folder picker

### DIFF
--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -25,6 +25,7 @@ from kiro_crew.dashboard.handlers.files import (
     _ZIP_CONTAINER_EXTS,
     _content_matches_ext,
 )
+from kiro_crew.dashboard.origin import is_direct_local_request
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.knowledge.agent_fetch import fetch_url_content
 from kiro_crew.knowledge.agent_source import add_agent_document
@@ -828,7 +829,19 @@ def _folder_picker_available(request: web.Request) -> bool:
     """The native folder picker is offered only on macOS (via osascript) and
     only when the dashboard is local -- a dialog on a remote gateway would open
     on the wrong screen."""
-    return sys.platform == "darwin" and bool(request.app.get("local_only", False))
+    if sys.platform != "darwin" or not bool(request.app.get("local_only", False)):
+        return False
+    # `local_only` is necessary but not sufficient: it describes how the GATEWAY
+    # was started, not where THIS request came from. The gateway binds loopback
+    # and remote access is delivered by a same-host tunnel or reverse proxy, so a
+    # remote user's request arrives from a loopback peer with `local_only` still
+    # True. A host-side native dialog must never open for such a request -- it
+    # would appear on the gateway operator's screen, not the requester's, and
+    # block there for up to `_FOLDER_DIALOG_TIMEOUT`. Require a DIRECT local
+    # request too, so a proxied one fails the gate and falls back to the
+    # typed-path route. The sibling project picker in `handlers/files.py`
+    # gates on the same helper for the same reason.
+    return is_direct_local_request(request)
 
 
 def _run_folder_dialog() -> str | None:

--- a/test/test_knowledge_add_source.py
+++ b/test/test_knowledge_add_source.py
@@ -256,8 +256,18 @@ def _make_pick_app(store, local_only=True):
     return app
 
 
-def _fake_request(local_only=True):
-    return SimpleNamespace(app={"local_only": local_only})
+def _fake_request(local_only=True, remote="127.0.0.1", headers=None):
+    """A request the REAL ``is_direct_local_request`` can judge.
+
+    It reads ``request.remote`` and ``request.headers``, so the stand-in has to
+    carry both rather than only ``app``. Patching the helper out instead would
+    leave the gate asserted against a mock of itself; supplying a genuine
+    loopback peer with no forwarding headers exercises the real predicate, and
+    the proxied cases below only have to add one header to flip it.
+    """
+    return SimpleNamespace(
+        app={"local_only": local_only}, remote=remote, headers=headers or {}
+    )
 
 
 class TestFolderPickerAvailable:
@@ -276,6 +286,44 @@ class TestFolderPickerAvailable:
     def test_fail_closed_when_local_only_unset(self, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
         assert _folder_picker_available(SimpleNamespace(app={})) is False
+
+    def test_unavailable_when_a_proxy_forwarded_the_request(self, monkeypatch):
+        """`local_only` describes the GATEWAY, not the requester.
+
+        The gateway binds loopback and remote access is delivered by a same-host
+        tunnel or reverse proxy, so a remote user's request arrives from
+        127.0.0.1 with ``local_only`` still True. Opening a native dialog for it
+        would put a modal on the gateway operator's screen -- not the
+        requester's -- and hold it there for up to ``_FOLDER_DIALOG_TIMEOUT``,
+        driven by someone else entirely.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+        proxied = _fake_request(local_only=True, headers={"X-Forwarded-For": "203.0.113.7"})
+
+        assert _folder_picker_available(proxied) is False
+
+    def test_unavailable_when_the_peer_is_not_loopback(self, monkeypatch):
+        """A directly-bound non-loopback peer is remote however `local_only` reads."""
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+
+        assert _folder_picker_available(_fake_request(remote="203.0.113.7")) is False
+
+    def test_the_forwarding_header_is_what_flips_it(self, monkeypatch):
+        """Guard the guard: the two requests differ ONLY by that one header.
+
+        Without this, `test_unavailable_when_a_proxy_forwarded_the_request`
+        could be passing because the fixture is malformed rather than because
+        the gate noticed the proxy.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.knowledge.sys.platform", "darwin")
+
+        assert _folder_picker_available(_fake_request(local_only=True)) is True
+        assert (
+            _folder_picker_available(
+                _fake_request(local_only=True, headers={"X-Forwarded-For": "203.0.113.7"})
+            )
+            is False
+        )
 
 
 class TestRunFolderDialog:


### PR DESCRIPTION
## Problem / Motivation

`POST /api/knowledge/pick-folder` opens a **native macOS folder dialog on the
gateway host**. Its gate is:

```python
def _folder_picker_available(request: web.Request) -> bool:
    return sys.platform == "darwin" and bool(request.app.get("local_only", False))
```

`local_only` describes **how the gateway was started**, not **where this request
came from** — and those come apart in exactly the deployment this project ships.
`dashboard/origin.py`'s own helper states why:

> A loopback TCP peer alone is NOT sufficient: the gateway binds loopback and
> remote access is delivered via a same-host tunnel or reverse proxy, so a
> forwarded remote request also arrives from 127.0.0.1.

So on a `local_only` gateway published through `tailscale serve`, an AEA tunnel,
nginx or Caddy, a **remote** user's request satisfies this gate. The consequences
are all on the operator's machine, not the requester's:

* a **native modal opens on the gateway operator's physical screen**, put there
  by someone else;
* it **blocks there for up to `_FOLDER_DIALOG_TIMEOUT` (180 s)**, and the handler
  holds an executor thread for the duration;
* whatever the operator picks — or is socially engineered into picking — is
  **returned to the remote caller as an absolute host path**, which is a small
  filesystem-layout disclosure even though `add_source` re-validates the path
  before using it.

The same gate also drives `GET /api/knowledge/config`'s `folder_picker` flag, so
a remote dashboard currently advertises the button as available.

## Why it matters

This is the **unfixed sibling the review of #9233 counted.** That PR added
exactly this predicate to the project picker in `handlers/files.py`, and its
review recorded:

> Proxy-remote hardening via `is_direct_local_request` — justified; sibling
> `knowledge._folder_picker_available` (checks only `local_only`) lacks it

Two host-side native dialogs, one hardened and one not, is the state that helper
exists to prevent. Fixing only the first left the same capability reachable one
route over.

The scope is deliberately not overstated: reaching the endpoint still requires a
valid dashboard token. This closes the gap between "a token holder on the far
end of the tunnel" and "someone sitting at the machine", which is the same
boundary the `is_direct_local_request` docstring says it exists to hold — it is
not, and does not claim to be, protection against a host-level actor.

## What changed (motivation → approach → change)

Root cause: a per-deployment flag was standing in for a per-request property.

* **`_folder_picker_available` gains `is_direct_local_request(request)`** as a
  third conjunct — loopback peer **and** no forwarding headers. One import, one
  early return, one call.
* **`local_only` is kept, not replaced.** It is still the right switch for
  "this deployment offers host-side dialogs at all", and dropping it would
  *widen* the gate on a gateway deliberately started without it. The check order
  also preserves the existing fail-closed behaviour when `local_only` is unset.
* **The comment points back at #9233**, so the pair stays visible to whoever
  touches either next.

Behaviour is unchanged for a genuine local browser, which is loopback with no
forwarding headers — pinned by a test that flips only that one header.

**Deliberately not widened.** No other `local_only` reader is touched. Most are
correct as they stand (they gate *deployment* capability, not a host-side side
effect), and auditing all of them is a different change from fixing the sibling a
reviewer already counted.

## Tests

Extended `TestFolderPickerAvailable` in `test/test_knowledge_add_source.py`.

The existing `_fake_request` helper carried only `app`, which is no longer enough
— the real predicate reads `request.remote` and `request.headers`. Rather than
patch `is_direct_local_request` out (which would assert the gate against a mock
of itself), the fixture now supplies **a genuine loopback peer and real headers**,
so the production predicate actually runs and the new cases flip it by changing
one field.

**Red-before** (production file reverted to `origin/main`, tests kept):

```
FAILED ...::TestFolderPickerAvailable::test_unavailable_when_a_proxy_forwarded_the_request
  AssertionError: assert True is False
FAILED ...::TestFolderPickerAvailable::test_unavailable_when_the_peer_is_not_loopback
  AssertionError: assert True is False
FAILED ...::TestFolderPickerAvailable::test_the_forwarding_header_is_what_flips_it
  AssertionError: assert True is False
```

`assert True is False` is the defect stated plainly: the gate reports the host
dialog as available to a proxied remote request.

* `test_unavailable_when_a_proxy_forwarded_the_request` — the reported case: a
  loopback peer carrying `X-Forwarded-For`.
* `test_unavailable_when_the_peer_is_not_loopback` — a directly-bound remote
  peer, which `local_only` alone also failed to exclude.
* `test_the_forwarding_header_is_what_flips_it` — guard the guard: asserts the
  allowed and denied requests differ **only** by that one header, so the denial
  cannot be passing because the fixture is malformed.

All four pre-existing tests in the class are unchanged and still pass, including
`test_fail_closed_when_local_only_unset`, which passes a bare `SimpleNamespace`
with no peer at all — the check order keeps that reaching `False` before the new
predicate is consulted.

**Green-after:** **417 passed / 2 skipped** across
`test_knowledge_add_source.py`, `test_dashboard_origin.py`, `test_knowledge.py`
and `test_knowledge_budget.py`.

**Gates:** `flake8`, `isort --check-only`, `mypy --platform linux` and
`scripts/check_black_formatting.py` all pass. The one black finding in
`test_knowledge_add_source.py` is a pre-existing baseline entry in a region this
PR does not touch, so the file was not reformatted.

## Manual verification

N/A — unit coverage sufficient: the gate is a pure predicate over
`request.remote` and `request.headers`, and the tests drive the real predicate
with the exact peer/header combinations a tunnel and a direct browser produce.
Reproducing it by hand would need a macOS host behind a reverse proxy, and would
assert nothing these do not.

## Related Issues

None filed. Found by mining merged-PR review threads for counted-but-unfixed
siblings; this one is named explicitly in the review of #9233.

Contention checked immediately before opening: `handlers/knowledge.py` is touched
by 5 open PRs (#2937, #8345, #8985, #9222, #9333), and **none of them has a hunk
in the `_folder_picker_available` / `pick_folder` region** — the nearest are at
lines ~519–661 and ~919+.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **a deployment flag is not a request property.** `local_only` answers
"how was this gateway started", and it was being used to answer "is the person
making this request at the keyboard". Those diverge the moment a tunnel or
reverse proxy is in front — which is not an edge case here, it is the shipped
remote-access design, and it is why `is_direct_local_request` exists. Any gate
protecting a **host-side side effect** (a native dialog, a local file write, a
desktop notification, a shell) needs the per-request check; the deployment flag
can only decide whether the capability is offered at all.

Second lesson: **when a shared predicate is introduced to fix one call site,
the other call sites of the old weaker check are the change's real scope.**
#9233's review counted this sibling correctly, and it stayed open because
counting is not fixing. A helper added to close a class leaves the class open
until every member is migrated — which argues for landing the sibling in the
same cycle, or filing it, rather than only naming it in a review thread.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
