### PR TITLE
refactor: move event and stop-reason constants into agent_sdk

### DIFF
--- a/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
+++ b/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
@@ -899,11 +899,57 @@ Exit criteria, as verified on the merged tree:
 - Verified: `./scripts/docs-lint.sh` passes and the host-contract spec is
   reachable from `docs/system-specs/modules/README.md`.
 
-### PR 2 — the SDK owns the types
+### PR 2 — the SDK owns the types — **constants half LANDED (PR 2a)**
 
 `AgentEvent`, `ApprovalToken`, `ToolStatus`, `CompactionResult`,
 `SessionCapabilities`, the error taxonomy including `AgentRuntimeMissing`, and the
 driver translation. `providers/base.py` stops aliasing `AcpEvent`.
+
+**PR 2a — the event and stop-reason vocabulary — LANDED.** The strings came
+first because they are the one part of PR 2 that needs no shim mechanism at all:
+a constant has no fields to deprecate, so the move is a re-export and nothing
+above the boundary changes. `kiro_crew.agent_sdk.events` now declares the 19
+`EVENT_*` kinds, a frozenset `ALL_EVENT_KINDS` over them, and the six
+provider-neutral `STOP_REASON_*` reasons; `kiro_crew.acp.types` re-exports every
+name, so each existing `from kiro_crew.acp.types import EVENT_TOOL_CALL` call
+site is untouched. `agent_sdk/__init__` exports them too, and its two
+`TURN_STOP_REASON_*` names became aliases of the moved reasons rather than a
+second spelling of the same literals.
+
+Three things this slice settled that the rest of PR 2 inherits:
+
+- **One reason stayed behind.** `STOP_REASON_CONTENT_FILTERED_WIRE` is a harness's
+  own spelling, normalised to `STOP_REASON_REFUSAL` before any consumer sees it.
+  It is a wire literal the parser and its tests share, not vocabulary application
+  code compares against, so promoting it would export a name nothing above the
+  boundary reads. `test_agent_sdk_events.py` pins it in `acp/types.py` and out of
+  the SDK, in both directions.
+- **Identity alone cannot prove the move.** CPython interns short
+  identifier-like constants, so `acp/types.py` re-declaring `"cancelled"` would
+  satisfy an `is` assertion against the SDK's copy. The anti-drift gate is
+  therefore structural: an AST pass asserts `acp/types.py` assigns no `EVENT_*`
+  or `STOP_REASON_*` name of its own, with the wire literal as the single
+  recorded exception.
+- **The direction is checked twice.** The import gate exempts `agent_sdk/`
+  wholly, so a re-export pointing the wrong way is invisible to it — which is the
+  `LLMEvent = AcpEvent` channel that made two forbidden roots necessary. The new
+  tests read the module's own imports AND import it first in a fresh interpreter,
+  asserting no `kiro_crew.acp` module loads. The second half is what catches an
+  edge added lazily inside a function. Both match on the dotted root, never a
+  string prefix, so the `acp_backends` neighbour is not miscounted.
+
+Exit criteria, as verified on the merged tree:
+
+- Verified: no file outside `acp/`, `agent_sdk/`, `test/` and `docs/` changed, so
+  the re-export set is complete.
+- Verified: every replay snapshot under `test/fixtures/acp_frames/` is
+  byte-identical, and every `kind` they emit is a kind the SDK now defines.
+- Verified: `test/test_agent_lifecycle_cycle.py` still passes — the ACP layer
+  importing the SDK's leaf closes no cycle, because every `kiro_crew.acp` import
+  in `agent_sdk/drivers/acp.py` is function-local.
+- Verified: the boundary baseline did not grow. It did not shrink either: the
+  `EVENT_*` re-export in `providers/base.py` is still an ACP edge, and it is
+  PR 5's wave that pays it off.
 
 **PR 2 is additive only if `AgentEvent` carries deprecation shims, and it must.**
 An earlier draft claimed consumers "keep working through the deprecated shim"

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -39,29 +39,40 @@ from kiro_crew.acp_backends import (  # noqa: F401 - re-exported for existing im
     selectable_backends,
 )
 
-# ── ACP Event Kinds ──
-
-EVENT_TEXT_CHUNK = "text_chunk"
-EVENT_THINKING_CHUNK = "thinking_chunk"
-EVENT_TOOL_CALL = "tool_call"
-EVENT_TOOL_CALL_UPDATE = "tool_call_update"
-EVENT_TOOL_RESULT = "tool_result"
-EVENT_PERMISSION_REQUEST = "permission_request"
-EVENT_COMPLETE = "complete"
-EVENT_COMPACTION_STATUS = "compaction_status"
-EVENT_CLEAR_STATUS = "clear_status"
-EVENT_AGENT_SWITCHED = "agent_switched"
-EVENT_MCP_OAUTH_REQUEST = "mcp_oauth_request"
-# Agent's own task/TODO list snapshot, recovered from the `todo_list` tool's
-# rawOutput. Not an ACP-native update kind — see KIRO_TOOL_TODO_LIST.
-EVENT_TODO_UPDATE = "todo_update"
-EVENT_MCP_SERVER_INITIALIZED = "mcp_server_initialized"
-EVENT_MCP_SERVER_INIT_FAILURE = "mcp_server_init_failure"
-EVENT_SUBAGENT_LIST = "subagent_list"
-EVENT_SUBAGENT_ACTIVITY = "subagent_activity"
-EVENT_STEER_QUEUED = "steer_queued"
-EVENT_STEER_CONSUMED = "steer_consumed"
-EVENT_STEER_CLEARED = "steer_cleared"
+# The event-kind and stop-reason vocabulary is SDK-owned and lives in the leaf
+# module ``kiro_crew.agent_sdk.events`` (it imports nothing from this package,
+# which is what lets consumers read the vocabulary without reaching the ACP
+# layer). Re-exported here so every existing ``from kiro_crew.acp.types import
+# EVENT_*`` and ``STOP_REASON_*`` call site is unchanged — see the "Stop Reasons"
+# section below for the one reason that stays.
+from kiro_crew.agent_sdk.events import (  # noqa: F401 - re-exported for existing importers
+    ALL_EVENT_KINDS,
+    EVENT_AGENT_SWITCHED,
+    EVENT_CLEAR_STATUS,
+    EVENT_COMPACTION_STATUS,
+    EVENT_COMPLETE,
+    EVENT_MCP_OAUTH_REQUEST,
+    EVENT_MCP_SERVER_INIT_FAILURE,
+    EVENT_MCP_SERVER_INITIALIZED,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_STEER_CLEARED,
+    EVENT_STEER_CONSUMED,
+    EVENT_STEER_QUEUED,
+    EVENT_SUBAGENT_ACTIVITY,
+    EVENT_SUBAGENT_LIST,
+    EVENT_TEXT_CHUNK,
+    EVENT_THINKING_CHUNK,
+    EVENT_TODO_UPDATE,
+    EVENT_TOOL_CALL,
+    EVENT_TOOL_CALL_UPDATE,
+    EVENT_TOOL_RESULT,
+    STOP_REASON_CANCELLED,
+    STOP_REASON_COMPACTION_FAILED,
+    STOP_REASON_END_TURN,
+    STOP_REASON_REFUSAL,
+    STOP_REASON_STALE_RECOVER,
+    STOP_REASON_TOOL_STALL,
+)
 
 # ── ACP Protocol Methods ──
 
@@ -258,36 +269,16 @@ OPTION_ALLOW_ALWAYS = "allow_always"
 
 # ── Stop Reasons ──
 
-STOP_REASON_CANCELLED = "cancelled"
-STOP_REASON_END_TURN = "end_turn"
-# Model-side content refusal ("response declined by the model"). Non-retryable:
-# retrying the same prompt hits the same refusal, so chat_runner surfaces an
-# actionable message instead of churning the retry ladder.
-STOP_REASON_REFUSAL = "refusal"
+# The provider-neutral reasons are re-exported from
+# ``kiro_crew.agent_sdk.events`` at the top of this module. Only the wire literal
+# below stays here: it never reaches a consumer.
+
 # The Kiro service's own spelling of a content-filter refusal, as it appears in
 # the ``stopReason`` field of a ``_kiro.dev/metadata`` notification. It is
 # NORMALISED to ``STOP_REASON_REFUSAL`` on the ``EVENT_COMPLETE`` that follows
 # (see ``RefusalInfo``), so no consumer outside ``acp/`` ever compares against
 # it; named here so the parser and its tests share one literal.
 STOP_REASON_CONTENT_FILTERED_WIRE = "CONTENT_FILTERED"
-# Signalled by the ACP layer when a genuinely-wedged (stale) turn was probed via
-# session/cancel and got no ack within the grace window — a confirmed wedge, not
-# a done-but-missing-frame turn (which acks and completes normally). The
-# dashboard routes this to reset+resume+continue-nudge auto-recovery.
-STOP_REASON_STALE_RECOVER = "stale_recover"
-# Signalled by the per-session watchdog when an in-flight tool was judged dead
-# / stuck / UNKNOWN-past-budget and the session was cancelled. Kept in the
-# "error:" family so callers without a dedicated branch fall back to the
-# generic error handling; chat_runner routes it to a dedicated recovery
-# (continue-nudge, NOT a verbatim re-run of the original message).
-STOP_REASON_TOOL_STALL = "error: tool stall"
-# Signalled by the ACP layer when automatic compaction reported `failed`
-# and the backend then abandoned the turn (no prompt response, no
-# end_turn) past the post-failure budget. Kept in the "error:" family so
-# callers without a dedicated branch fall back to generic error handling;
-# it deliberately triggers NO retry — the user-visible compaction notice
-# already explains what happened, and this only releases the slot.
-STOP_REASON_COMPACTION_FAILED = "error: compaction failed"
 
 # ── Approval Modes ──
 

--- a/src/kiro_crew/agent_sdk/__init__.py
+++ b/src/kiro_crew/agent_sdk/__init__.py
@@ -59,10 +59,42 @@ from kiro_crew.agent_sdk.backend_install import (
     probe_backend,
     probe_backends,
 )
+from kiro_crew.agent_sdk.events import (
+    ALL_EVENT_KINDS,
+    EVENT_AGENT_SWITCHED,
+    EVENT_CLEAR_STATUS,
+    EVENT_COMPACTION_STATUS,
+    EVENT_COMPLETE,
+    EVENT_MCP_OAUTH_REQUEST,
+    EVENT_MCP_SERVER_INIT_FAILURE,
+    EVENT_MCP_SERVER_INITIALIZED,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_STEER_CLEARED,
+    EVENT_STEER_CONSUMED,
+    EVENT_STEER_QUEUED,
+    EVENT_SUBAGENT_ACTIVITY,
+    EVENT_SUBAGENT_LIST,
+    EVENT_TEXT_CHUNK,
+    EVENT_THINKING_CHUNK,
+    EVENT_TODO_UPDATE,
+    EVENT_TOOL_CALL,
+    EVENT_TOOL_CALL_UPDATE,
+    EVENT_TOOL_RESULT,
+    STOP_REASON_CANCELLED,
+    STOP_REASON_COMPACTION_FAILED,
+    STOP_REASON_END_TURN,
+    STOP_REASON_REFUSAL,
+    STOP_REASON_STALE_RECOVER,
+    STOP_REASON_TOOL_STALL,
+)
 from kiro_crew.agent_sdk.native_commands import NativeCommandBatch, run_kiro_native_commands
 
-TURN_STOP_REASON_CANCELLED = "cancelled"
-TURN_STOP_REASON_END_TURN = "end_turn"
+#: Historical spellings of the two terminal reasons, kept because
+#: ``monitoring/completion.py`` reads them. They are ALIASES, not a second
+#: definition: one literal per reason lives in
+#: :mod:`kiro_crew.agent_sdk.events`, so the two cannot drift apart.
+TURN_STOP_REASON_CANCELLED = STOP_REASON_CANCELLED
+TURN_STOP_REASON_END_TURN = STOP_REASON_END_TURN
 
 
 class AgentTurnUsage(Protocol):
@@ -74,6 +106,32 @@ class AgentTurnUsage(Protocol):
 
 __all__ = [
     "AgentTurnUsage",
+    "ALL_EVENT_KINDS",
+    "EVENT_AGENT_SWITCHED",
+    "EVENT_CLEAR_STATUS",
+    "EVENT_COMPACTION_STATUS",
+    "EVENT_COMPLETE",
+    "EVENT_MCP_OAUTH_REQUEST",
+    "EVENT_MCP_SERVER_INITIALIZED",
+    "EVENT_MCP_SERVER_INIT_FAILURE",
+    "EVENT_PERMISSION_REQUEST",
+    "EVENT_STEER_CLEARED",
+    "EVENT_STEER_CONSUMED",
+    "EVENT_STEER_QUEUED",
+    "EVENT_SUBAGENT_ACTIVITY",
+    "EVENT_SUBAGENT_LIST",
+    "EVENT_TEXT_CHUNK",
+    "EVENT_THINKING_CHUNK",
+    "EVENT_TODO_UPDATE",
+    "EVENT_TOOL_CALL",
+    "EVENT_TOOL_CALL_UPDATE",
+    "EVENT_TOOL_RESULT",
+    "STOP_REASON_CANCELLED",
+    "STOP_REASON_COMPACTION_FAILED",
+    "STOP_REASON_END_TURN",
+    "STOP_REASON_REFUSAL",
+    "STOP_REASON_STALE_RECOVER",
+    "STOP_REASON_TOOL_STALL",
     "CACHE_TTL_SECONDS",
     "COMPONENT_CLAUDE_ACP_ADAPTER",
     "COMPONENT_CLAUDE_CODE_CLI",

--- a/src/kiro_crew/agent_sdk/events.py
+++ b/src/kiro_crew/agent_sdk/events.py
@@ -1,0 +1,133 @@
+"""The event-kind and stop-reason vocabulary every backend is described in.
+
+These strings are what application code branches on: an event's ``kind`` and a
+turn's ``stop_reason``. They are provider-neutral by construction -- no backend
+puts them on the wire, the driver assigns them while translating a harness's own
+frames -- so the SDK owns them and the ACP layer reads them from here.
+
+``kiro_crew.acp.types`` re-exports every name below, so
+``from kiro_crew.acp.types import EVENT_TOOL_CALL`` keeps working unchanged. The
+re-export is the same *object*, not a copy of the literal: a test asserts
+identity in both directions, because two modules each spelling ``"tool_call"``
+would drift silently.
+
+One stop reason deliberately stays behind in ``kiro_crew.acp.types``:
+``STOP_REASON_CONTENT_FILTERED_WIRE`` is a harness's own spelling of a refusal,
+normalised to :data:`STOP_REASON_REFUSAL` before it reaches any consumer. It is
+a wire literal shared by the parser and its tests, not vocabulary application
+code compares against.
+
+This module imports nothing from ``kiro_crew.acp`` or ``kiro_crew.providers``,
+and must not: it is the leaf the boundary points at. See
+``docs/request-for-change/rfc-crew-agent-sdk-boundary.md`` §PR 2.
+"""
+
+from __future__ import annotations
+
+# ── Event Kinds ──
+
+EVENT_TEXT_CHUNK = "text_chunk"
+EVENT_THINKING_CHUNK = "thinking_chunk"
+EVENT_TOOL_CALL = "tool_call"
+EVENT_TOOL_CALL_UPDATE = "tool_call_update"
+EVENT_TOOL_RESULT = "tool_result"
+EVENT_PERMISSION_REQUEST = "permission_request"
+EVENT_COMPLETE = "complete"
+EVENT_COMPACTION_STATUS = "compaction_status"
+EVENT_CLEAR_STATUS = "clear_status"
+EVENT_AGENT_SWITCHED = "agent_switched"
+EVENT_MCP_OAUTH_REQUEST = "mcp_oauth_request"
+# Agent's own task/TODO list snapshot, recovered from the `todo_list` tool's
+# rawOutput. Not an ACP-native update kind — see KIRO_TOOL_TODO_LIST in
+# `kiro_crew.acp.types`, which names that tool's wire spelling.
+EVENT_TODO_UPDATE = "todo_update"
+EVENT_MCP_SERVER_INITIALIZED = "mcp_server_initialized"
+EVENT_MCP_SERVER_INIT_FAILURE = "mcp_server_init_failure"
+EVENT_SUBAGENT_LIST = "subagent_list"
+EVENT_SUBAGENT_ACTIVITY = "subagent_activity"
+EVENT_STEER_QUEUED = "steer_queued"
+EVENT_STEER_CONSUMED = "steer_consumed"
+EVENT_STEER_CLEARED = "steer_cleared"
+
+#: Every event kind the SDK defines. A dispatcher can assert an unknown kind
+#: against this instead of hand-listing the constants it happens to know, which
+#: is how a kind added here reaches an exhaustiveness check for free.
+ALL_EVENT_KINDS = frozenset(
+    {
+        EVENT_TEXT_CHUNK,
+        EVENT_THINKING_CHUNK,
+        EVENT_TOOL_CALL,
+        EVENT_TOOL_CALL_UPDATE,
+        EVENT_TOOL_RESULT,
+        EVENT_PERMISSION_REQUEST,
+        EVENT_COMPLETE,
+        EVENT_COMPACTION_STATUS,
+        EVENT_CLEAR_STATUS,
+        EVENT_AGENT_SWITCHED,
+        EVENT_MCP_OAUTH_REQUEST,
+        EVENT_TODO_UPDATE,
+        EVENT_MCP_SERVER_INITIALIZED,
+        EVENT_MCP_SERVER_INIT_FAILURE,
+        EVENT_SUBAGENT_LIST,
+        EVENT_SUBAGENT_ACTIVITY,
+        EVENT_STEER_QUEUED,
+        EVENT_STEER_CONSUMED,
+        EVENT_STEER_CLEARED,
+    }
+)
+
+# ── Stop Reasons ──
+
+STOP_REASON_CANCELLED = "cancelled"
+STOP_REASON_END_TURN = "end_turn"
+# Model-side content refusal ("response declined by the model"). Non-retryable:
+# retrying the same prompt hits the same refusal, so chat_runner surfaces an
+# actionable message instead of churning the retry ladder.
+STOP_REASON_REFUSAL = "refusal"
+# Signalled by the ACP layer when a genuinely-wedged (stale) turn was probed via
+# session/cancel and got no ack within the grace window — a confirmed wedge, not
+# a done-but-missing-frame turn (which acks and completes normally). The
+# dashboard routes this to reset+resume+continue-nudge auto-recovery.
+STOP_REASON_STALE_RECOVER = "stale_recover"
+# Signalled by the per-session watchdog when an in-flight tool was judged dead
+# / stuck / UNKNOWN-past-budget and the session was cancelled. Kept in the
+# "error:" family so callers without a dedicated branch fall back to the
+# generic error handling; chat_runner routes it to a dedicated recovery
+# (continue-nudge, NOT a verbatim re-run of the original message).
+STOP_REASON_TOOL_STALL = "error: tool stall"
+# Signalled by the ACP layer when automatic compaction reported `failed`
+# and the backend then abandoned the turn (no prompt response, no
+# end_turn) past the post-failure budget. Kept in the "error:" family so
+# callers without a dedicated branch fall back to generic error handling;
+# it deliberately triggers NO retry — the user-visible compaction notice
+# already explains what happened, and this only releases the slot.
+STOP_REASON_COMPACTION_FAILED = "error: compaction failed"
+
+__all__ = [
+    "ALL_EVENT_KINDS",
+    "EVENT_AGENT_SWITCHED",
+    "EVENT_CLEAR_STATUS",
+    "EVENT_COMPACTION_STATUS",
+    "EVENT_COMPLETE",
+    "EVENT_MCP_OAUTH_REQUEST",
+    "EVENT_MCP_SERVER_INITIALIZED",
+    "EVENT_MCP_SERVER_INIT_FAILURE",
+    "EVENT_PERMISSION_REQUEST",
+    "EVENT_STEER_CLEARED",
+    "EVENT_STEER_CONSUMED",
+    "EVENT_STEER_QUEUED",
+    "EVENT_SUBAGENT_ACTIVITY",
+    "EVENT_SUBAGENT_LIST",
+    "EVENT_TEXT_CHUNK",
+    "EVENT_THINKING_CHUNK",
+    "EVENT_TODO_UPDATE",
+    "EVENT_TOOL_CALL",
+    "EVENT_TOOL_CALL_UPDATE",
+    "EVENT_TOOL_RESULT",
+    "STOP_REASON_CANCELLED",
+    "STOP_REASON_COMPACTION_FAILED",
+    "STOP_REASON_END_TURN",
+    "STOP_REASON_REFUSAL",
+    "STOP_REASON_STALE_RECOVER",
+    "STOP_REASON_TOOL_STALL",
+]

--- a/test/test_agent_sdk_events.py
+++ b/test/test_agent_sdk_events.py
@@ -1,0 +1,301 @@
+"""GATE -- the event-kind and stop-reason vocabulary is SDK-owned, and only once.
+
+``kiro_crew.agent_sdk.events`` now defines every ``EVENT_*`` kind and the
+provider-neutral ``STOP_REASON_*`` reasons; ``kiro_crew.acp.types`` re-exports
+them so no consumer changed. Three properties make that a move rather than a
+copy, and each is a separate failure mode:
+
+1. **The shim is the same object.** Every name reachable as
+   ``kiro_crew.acp.types.X`` IS ``kiro_crew.agent_sdk.events.X``. Value equality
+   is checked too, because CPython interns short identifier-like literals and an
+   ``is`` assertion alone would pass on a re-declared ``"cancelled"``.
+2. **There is one declaration.** ``acp/types.py`` must not assign an ``EVENT_*``
+   or ``STOP_REASON_*`` name itself -- the one exception is
+   ``STOP_REASON_CONTENT_FILTERED_WIRE``, a harness's own spelling that is
+   normalised before any consumer sees it. This is the assertion that actually
+   catches drift; interning hides it from ``is``.
+3. **The direction is ``acp -> agent_sdk``, never back.** The import gate exempts
+   ``agent_sdk/`` wholly, so the one channel it cannot see is a verbatim
+   re-export *inside* the SDK -- precisely the ``providers/base.py`` aliasing
+   (``LLMEvent = AcpEvent``) that made two forbidden roots necessary. Checked
+   structurally (the module's own imports) and dynamically (a fresh interpreter
+   importing it loads no ACP module).
+
+The corpus check closes the last gap: a vocabulary the SDK owns but the dispatch
+layer does not emit would satisfy everything above and still be wrong, so every
+``kind`` in the committed replay snapshots must be a kind this module defines.
+
+See ``docs/request-for-change/rfc-crew-agent-sdk-boundary.md`` §PR 2.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.acp import types as acp_types
+from kiro_crew.agent_sdk import events as sdk_events
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+EVENTS_MODULE = SRC / "kiro_crew" / "agent_sdk" / "events.py"
+ACP_TYPES_MODULE = SRC / "kiro_crew" / "acp" / "types.py"
+FRAME_FIXTURES = ROOT / "test" / "fixtures" / "acp_frames"
+
+#: The two package roots the SDK is not allowed to reach. ``kiro_crew.acp`` is
+#: matched EXACTLY or as a dotted parent, never as a string prefix: the sibling
+#: leaf ``kiro_crew.acp_backends`` imports no ACP at all, and a ``startswith``
+#: check is the bug that made an earlier RFC draft overcount the baseline.
+FORBIDDEN_ROOTS = ("kiro_crew.acp", "kiro_crew.providers")
+
+#: The one stop reason that stays in ``acp/types.py``. It is a wire literal.
+WIRE_ONLY_NAMES = frozenset({"STOP_REASON_CONTENT_FILTERED_WIRE"})
+
+
+def _reaches_forbidden_root(module: str) -> bool:
+    """Whether *module* names one of :data:`FORBIDDEN_ROOTS` or a child of one."""
+    return any(module == root or module.startswith(root + ".") for root in FORBIDDEN_ROOTS)
+
+
+def _vocabulary_names() -> list[str]:
+    """Every ``EVENT_*`` / ``STOP_REASON_*`` name the SDK module exports."""
+    return sorted(
+        name
+        for name in sdk_events.__all__
+        if name.startswith("EVENT_") or name.startswith("STOP_REASON_")
+    )
+
+
+def _assigned_names(source: Path) -> set[str]:
+    """Module-scope names *source* assigns a value to."""
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    assigned: set[str] = set()
+    for node in tree.body:
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name):
+                assigned.add(target.id)
+    return assigned
+
+
+def _run_child(code: str) -> subprocess.CompletedProcess[str]:
+    """Run *code* in an isolated interpreter pinned to this repository's ``src/``.
+
+    ``-I`` isolates it from ``PYTHONPATH`` and user site so it measures this
+    tree rather than an editable install's; ``-B`` is separate and not implied,
+    and keeps a read-only assertion from writing ``__pycache__`` into ``src/``.
+    """
+    prelude = f"import sys; sys.path.insert(0, {str(SRC)!r})\n"
+    return subprocess.run(
+        [sys.executable, "-I", "-B", "-c", prelude + code],
+        cwd=str(ROOT),
+        capture_output=True,
+        timeout=120,
+        **UTF8_TEXT,
+    )
+
+
+# ── 1. the shim is the same object ──────────────────────────────────────────
+
+
+def test_the_vocabulary_is_not_empty() -> None:
+    """Guard every parametrised test below against an empty name list."""
+    names = _vocabulary_names()
+    kinds = [name for name in names if name.startswith("EVENT_")]
+    reasons = [name for name in names if name.startswith("STOP_REASON_")]
+    assert len(kinds) == 19, f"expected 19 event kinds, found {len(kinds)}: {kinds}"
+    assert len(reasons) >= 6, f"expected the provider-neutral stop reasons, found {reasons}"
+
+
+@pytest.mark.parametrize("name", _vocabulary_names())
+def test_the_acp_shim_re_exports_the_sdk_object(name: str) -> None:
+    """``from kiro_crew.acp.types import EVENT_*`` must still work, unchanged."""
+    assert hasattr(acp_types, name), (
+        f"kiro_crew.acp.types no longer exports {name}. Every existing importer "
+        "reads it from there; add it back to the re-export list rather than "
+        "editing the consumers."
+    )
+    sdk_value = getattr(sdk_events, name)
+    acp_value = getattr(acp_types, name)
+    assert acp_value == sdk_value, (
+        f"{name} drifted: kiro_crew.acp.types has {acp_value!r} but "
+        f"kiro_crew.agent_sdk.events has {sdk_value!r}. The ACP layer must read "
+        "the SDK's literal, not carry its own."
+    )
+    assert acp_value is sdk_value, (
+        f"{name} is a different object in kiro_crew.acp.types. It must be the "
+        "re-exported SDK constant, not a second declaration of the same string."
+    )
+
+
+def test_all_event_kinds_covers_every_event_constant() -> None:
+    """A kind added to the module but not the frozenset is invisible to callers."""
+    declared = {
+        getattr(sdk_events, name) for name in _vocabulary_names() if name.startswith("EVENT_")
+    }
+    assert sdk_events.ALL_EVENT_KINDS == declared, (
+        "ALL_EVENT_KINDS and the EVENT_* constants disagree. Symmetric difference: "
+        f"{sorted(sdk_events.ALL_EVENT_KINDS ^ declared)}"
+    )
+    assert isinstance(sdk_events.ALL_EVENT_KINDS, frozenset)
+
+
+def test_every_event_kind_string_is_distinct() -> None:
+    """Two kinds sharing a string would make a dispatcher branch unreachable."""
+    kinds = [getattr(sdk_events, name) for name in _vocabulary_names()]
+    events = [k for k in kinds if k in sdk_events.ALL_EVENT_KINDS]
+    assert len(set(events)) == len(events), f"duplicate event-kind string among {events}"
+
+
+# ── 2. there is one declaration ─────────────────────────────────────────────
+
+
+def test_the_acp_layer_declares_no_vocabulary_of_its_own() -> None:
+    """The real anti-drift assertion: interning hides a duplicate from ``is``.
+
+    ``"cancelled" is "cancelled"`` is True across modules because CPython
+    interns identifier-like constants, so a re-declared short literal in
+    ``acp/types.py`` would satisfy the identity test above. This one reads the
+    source instead.
+    """
+    redeclared = {
+        name
+        for name in _assigned_names(ACP_TYPES_MODULE)
+        if (name.startswith("EVENT_") or name.startswith("STOP_REASON_"))
+        and name not in WIRE_ONLY_NAMES
+    }
+    assert not redeclared, (
+        f"src/kiro_crew/acp/types.py assigns {sorted(redeclared)} itself. The "
+        "vocabulary lives in kiro_crew.agent_sdk.events and is re-exported here; "
+        "a second assignment is a copy that can drift."
+    )
+
+
+def test_the_wire_only_reason_stays_in_the_acp_layer() -> None:
+    """It is a harness spelling, not vocabulary a consumer compares against."""
+    for name in sorted(WIRE_ONLY_NAMES):
+        assert name in _assigned_names(ACP_TYPES_MODULE), (
+            f"{name} left src/kiro_crew/acp/types.py. It is normalised to "
+            "STOP_REASON_REFUSAL before any consumer sees it, so promoting it "
+            "into the SDK would export a literal nothing above the boundary reads."
+        )
+        assert not hasattr(sdk_events, name), (
+            f"{name} was added to kiro_crew.agent_sdk.events. See above -- it is a "
+            "wire detail owned by the parser."
+        )
+
+
+# ── 3. the direction is acp -> agent_sdk, never back ────────────────────────
+
+
+def test_the_sdk_vocabulary_module_imports_no_backend_package() -> None:
+    """Structural half of the identity guard: read what the module names."""
+    tree = ast.parse(EVENTS_MODULE.read_text(encoding="utf-8"), filename=str(EVENTS_MODULE))
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            offenders += [a.name for a in node.names if _reaches_forbidden_root(a.name)]
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            if _reaches_forbidden_root(node.module):
+                offenders.append(node.module)
+    assert not offenders, (
+        f"src/kiro_crew/agent_sdk/events.py imports {offenders}. This module is the "
+        "leaf the boundary points at: the ACP layer reads it, never the reverse. A "
+        "re-export the other way round would let a consumer look migrated while "
+        "holding the ACP object, and the import gate cannot see it because it "
+        "exempts agent_sdk/ wholly."
+    )
+
+
+def test_importing_the_sdk_vocabulary_loads_no_acp_module() -> None:
+    """Dynamic half: a lazily-added edge fails here even if the source looks clean."""
+    proc = _run_child(
+        "import kiro_crew.agent_sdk.events\n"
+        "leaked = sorted(m for m in sys.modules if "
+        f"any(m == r or m.startswith(r + '.') for r in {FORBIDDEN_ROOTS!r}))\n"
+        "print('ANSWER:' + ' '.join(leaked))\n"
+    )
+    assert proc.returncode == 0, (
+        "importing kiro_crew.agent_sdk.events as the first kiro_crew module failed. "
+        "kiro_crew.acp.types now imports it, so an edge back would close a cycle "
+        "and the ACP layer would only be importable after the SDK.\n"
+        f"stderr:\n{proc.stderr}"
+    )
+    answers = [
+        line[len("ANSWER:") :].strip()
+        for line in proc.stdout.splitlines()
+        if line.startswith("ANSWER:")
+    ]
+    assert len(answers) == 1, f"expected one sentinel line, got {answers!r}"
+    assert not answers[0], (
+        "importing kiro_crew.agent_sdk.events dragged in backend-layer modules: "
+        f"{answers[0].split()}. The SDK vocabulary is a leaf."
+    )
+
+
+def test_no_sdk_export_is_a_backend_object() -> None:
+    """No name the SDK package exports may be defined in the backend packages."""
+    import kiro_crew.agent_sdk as sdk
+
+    checked = 0
+    for name in sdk.__all__:
+        obj = getattr(sdk, name)
+        origin = getattr(obj, "__module__", None)
+        if not isinstance(origin, str):
+            continue
+        checked += 1
+        assert not _reaches_forbidden_root(origin), (
+            f"kiro_crew.agent_sdk exports {name}, which is defined in {origin}. A "
+            "verbatim re-export of a backend object makes a consumer read as "
+            "migrated while holding it, and shrinks the boundary baseline for free."
+        )
+    assert checked >= 3, (
+        f"only {checked} exported name carried a __module__, so this assertion is "
+        "close to vacuous. Point it at the classes and functions the SDK exports."
+    )
+
+
+# ── the replay corpus agrees with the vocabulary ─────────────────────────────
+
+
+def _snapshot_kinds() -> set[str]:
+    """Every ``kind`` value in the committed replay snapshots."""
+    kinds: set[str] = set()
+    for path in sorted(FRAME_FIXTURES.glob("*/*.expected.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        stack = [payload]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, dict):
+                kind = node.get("kind")
+                if isinstance(kind, str):
+                    kinds.add(kind)
+                stack.extend(node.values())
+            elif isinstance(node, list):
+                stack.extend(node)
+    return kinds
+
+
+def test_the_replay_corpus_emits_only_sdk_event_kinds() -> None:
+    """The dispatch layer's real output must be spelled in the SDK's vocabulary."""
+    kinds = _snapshot_kinds()
+    assert len(kinds) >= 5, (
+        f"only {len(kinds)} kind(s) found in {FRAME_FIXTURES}/*/*.expected.json, so "
+        "this assertion proves nothing. Check the fixture layout before relaxing it."
+    )
+    unknown = kinds - sdk_events.ALL_EVENT_KINDS
+    assert not unknown, (
+        f"the replay snapshots emit {sorted(unknown)}, which kiro_crew.agent_sdk."
+        "events does not define. Either the dispatch layer invented a kind or a "
+        "constant was renamed without the corpus being regenerated."
+    )


### PR DESCRIPTION
## Problem / Motivation

The event-kind and stop-reason strings live in `src/kiro_crew/acp/types.py`. Those strings are what application code branches on: an event's `kind`, a turn's `stop_reason`. A dashboard handler that wants to know "was this a tool call?" has to import from the ACP package to find out.

That is backwards. The ACP package is the backend layer the agent-SDK boundary exists to hide. Naming it is what the boundary gate counts as a violation, so the vocabulary sat on the wrong side of the line it is supposed to cross.

## Why it matters

The boundary baseline records 106 imports of the backend layer from application code, and each one has to be paid off before a second backend can be added without editing consumers. Some of those edges exist only to read a string. Every later slice of the RFC's PR 2 -- the event object, the approval token, the error taxonomy -- lands on top of this vocabulary, so it has to move first or each of them carries the same wrong-side import along.

## What changed (motivation → approach → change)

The strings were in the backend layer. The root cause is just where they were declared: nothing about a kind is backend-specific, because no backend puts these strings on the wire. The driver assigns them while translating a harness's own frames.

So a new leaf module `src/kiro_crew/agent_sdk/events.py` declares them: the 19 `EVENT_*` kinds, a frozenset `ALL_EVENT_KINDS` over them, and the six provider-neutral `STOP_REASON_*` reasons. `acp/types.py` imports the same objects back and re-exports every name. `from kiro_crew.acp.types import EVENT_TOOL_CALL` still works, so no consumer file changed. `agent_sdk/__init__.py` exports the names too, and its two `TURN_STOP_REASON_*` names became aliases of the moved reasons instead of a second spelling of the same literals.

One reason stayed behind. `STOP_REASON_CONTENT_FILTERED_WIRE` is a harness's own spelling of a refusal. The parser normalises it to `STOP_REASON_REFUSAL` before any consumer sees it, so it is a wire literal the parser and its tests share, not vocabulary anything above the boundary reads. Moving it would export a name nobody up there can use.

```mermaid
flowchart LR
  subgraph Before
    C1[consumer]:::ctx --> T1[acp/types.py<br/>declares EVENT_*]:::removed
  end
  subgraph After
    C2[consumer]:::ctx --> E2[agent_sdk/events.py<br/>declares EVENT_*]:::added
    T2[acp/types.py<br/>re-exports]:::changed --> E2
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 1,2 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*A consumer can now read a kind from the SDK; `acp/types.py` reads the same objects so existing importers do not change.*

## Tests

`test/test_agent_sdk_events.py` is new and locks in four things.

The shim is the same object. Every `EVENT_*` and `STOP_REASON_*` name reachable as `kiro_crew.acp.types.X` is asserted equal to and identical with `kiro_crew.agent_sdk.events.X`, name by name.

There is one declaration. An AST pass asserts `acp/types.py` assigns no `EVENT_*` or `STOP_REASON_*` name of its own, with `STOP_REASON_CONTENT_FILTERED_WIRE` as the single recorded exception. This is the assertion that actually catches drift: CPython interns short identifier-like constants, so a re-declared `"cancelled"` would satisfy the `is` check above.

The direction holds. One test reads the new module's own imports and asserts it names neither `kiro_crew.acp` nor `kiro_crew.providers`; another imports it first in a fresh interpreter and asserts no backend module loads, which catches an edge added lazily inside a function. A third asserts no name `agent_sdk` exports is defined in a backend package -- the `LLMEvent = AcpEvent` channel the import gate cannot see, because it exempts `agent_sdk/` wholly.

`ALL_EVENT_KINDS` matches the constants, no two kinds share a string, and every `kind` in the committed replay snapshots is a kind the SDK now defines.

All five gate assertions are mutation-verified: re-declaring a constant in `acp/types.py`, adding a backend import to the new module, dropping a kind from the frozenset, dropping a name from the re-export, and renaming the wire reason each turn their test red.

## Manual verification

N/A -- unit coverage sufficient. The change moves constants and adds no runtime path, and `test/test_acp_frame_replay.py` proves the observable output is unchanged: every snapshot under `test/fixtures/acp_frames/` is byte-identical, so the dispatch layer emits exactly the stream it did before.

## Related Issues

no linked issue: this is the first slice of the RFC's PR 2, tracked in `docs/request-for-change/rfc-crew-agent-sdk-boundary.md` rather than in an issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
