### PR TITLE
fix(test): security-conductor scripts guard checks for stubs, not absence

### DIFF
--- a/test/test_security_conductor_skill_contract.py
+++ b/test/test_security_conductor_skill_contract.py
@@ -118,11 +118,20 @@ class TestSkillIsInstallable:
         # loading the body, so it has to name the agent it is the procedure for.
         assert "kirocrew-security-conductor" in meta["description"]
 
-    def test_no_bundled_scripts_are_shipped_here(self) -> None:
-        """Sibling changes own the scripts. This one must not have created a stub:
-        a present-but-empty script is worse than an absent one, because the
-        absent-script rule below stops reading as the live path."""
-        assert not (SKILL_DIR / "scripts").exists()
+    def test_no_stub_scripts_are_shipped(self) -> None:
+        """The scripts land in sibling changes, one at a time. Whatever has
+        landed must be a real script, never a placeholder: a present-but-empty
+        script is worse than an absent one, because the absent-script rule below
+        stops reading as the live path. An absent script is fine here (the
+        sibling has not landed yet); an empty one is the defect."""
+        scripts_dir = SKILL_DIR / "scripts"
+        if not scripts_dir.exists():
+            return
+        for path in scripts_dir.iterdir():
+            if path.suffix != ".py":
+                continue
+            assert path.name in BUNDLED_SCRIPTS, f"unlisted script shipped: {path.name}"
+            assert path.stat().st_size > 0, f"stub script shipped: {path.name}"
 
 
 class TestTheProcedureDelegatesToItsScripts:


### PR DESCRIPTION
## Problem / Motivation

`main` is red. `test_security_conductor_skill_contract.py::test_no_bundled_scripts_are_shipped_here` fails on every CI run since #9270 merged (Backend Tests shard 3, Linux and Windows).

## Why it matters

Every open PR now inherits one red required shard. Nothing can reach `readiness: passed` until this test is fixed.

## What changed (motivation → approach → change)

#9271 added the skill and a guard test. The guard said `security-conductor/scripts/` must not exist yet, because sibling PRs would add the scripts later. #9270 then landed `scripts/ledger.py`. The guard's premise is now false, so it fails on every run.

The intent of the guard was "no stub scripts". That intent still holds. The check now says it directly.

`test_no_stub_scripts_are_shipped` passes when `scripts/` is absent. When it is present, every `.py` in it must be one of `BUNDLED_SCRIPTS` and must be non-empty. A placeholder file fails; a real script passes.

## Tests

- `test/test_security_conductor_skill_contract.py` 42/42 pass locally.
- The renamed test passes with `ledger.py` present and would fail on an empty or unlisted script.

## Manual verification

N/A — unit coverage sufficient; the change is one test in one file.

## Related Issues

no linked issue: unbreaks main after #9270 and #9271 merged in the wrong order.

## Pattern harvest

Not generalizable: a placeholder guard written to be removed by a sibling PR, where the sibling landed without removing it. One-off ordering slip.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
