### PR TITLE
fix: unbreak the security-conductor script contract on main

### DIFF
--- a/test/test_security_conductor_skill_contract.py
+++ b/test/test_security_conductor_skill_contract.py
@@ -118,11 +118,33 @@ class TestSkillIsInstallable:
         # loading the body, so it has to name the agent it is the procedure for.
         assert "kirocrew-security-conductor" in meta["description"]
 
-    def test_no_bundled_scripts_are_shipped_here(self) -> None:
-        """Sibling changes own the scripts. This one must not have created a stub:
-        a present-but-empty script is worse than an absent one, because the
-        absent-script rule below stops reading as the live path."""
-        assert not (SKILL_DIR / "scripts").exists()
+    def test_every_shipped_script_is_named_and_substantive(self) -> None:
+        """No stubs, and no script the prose does not cite.
+
+        The scripts land across sibling changes, so this directory is populated a
+        file at a time and `BUNDLED_SCRIPTS` above is the whole set the procedure
+        delegates to. Two ways that goes wrong, and neither goes red anywhere
+        else: a script appears that the body never names, which is a capability
+        with no procedure governing it; or a placeholder is committed to reserve
+        the name, which is worse than an absent file because
+        `test_an_absent_script_is_unknown_and_not_permission` below stops reading
+        as the live path the moment the file exists.
+        """
+        scripts_dir = SKILL_DIR / "scripts"
+        if not scripts_dir.is_dir():
+            return
+        shipped = sorted(p for p in scripts_dir.iterdir() if p.is_file())
+        for path in shipped:
+            assert path.name in BUNDLED_SCRIPTS, f"uncited script shipped: {path.name}"
+            # A stub is a file whose body is imports and a docstring. Judged by
+            # executable content rather than byte count so a long banner comment
+            # cannot pass for an implementation.
+            body = [
+                line
+                for line in path.read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.lstrip().startswith("#")
+            ]
+            assert len(body) > 20, f"placeholder script committed: {path.name}"
 
 
 class TestTheProcedureDelegatesToItsScripts:


### PR DESCRIPTION
## What

`test/test_security_conductor_skill_contract.py::TestSkillIsInstallable::test_no_bundled_scripts_are_shipped_here` asserted that the security-conductor skill directory contains no `scripts/` subdirectory at all. [#9270](https://github.com/kirodotdev/KiroCrew/pull/9270) then shipped `src/kiro_crew/builtin_skills/security-conductor/scripts/ledger.py` (771 lines) without retiring the assertion.

**main is currently red for every pull request.** The failure lands on `Backend Tests (3.12, 3)` and `Backend Tests (Windows) (3)`, and because `Coverage Gate` fails closed on `backend-test=failure` it takes `Coverage Gate` and therefore `PR Readiness` down as well. Four failing checks, one cause, none of them anything to do with the PR under test.

```
E       AssertionError: assert not True
E        +  where True = exists()
E        +    where exists = (PosixPath('.../builtin_skills/security-conductor') / 'scripts').exists
test/test_security_conductor_skill_contract.py:125: AssertionError
```

## Why this shape of fix

The assertion's own docstring says what it was for: *"Sibling changes own the scripts. This one must not have created a stub: a present-but-empty script is worse than an absent one, because the absent-script rule below stops reading as the live path."* It guarded the skill's introducing change against reserving a filename with a placeholder. It was never a rule that the scripts may not arrive — and one has now arrived for real.

So the premise is dropped and the property kept. The replacement, `test_every_shipped_script_is_named_and_substantive`, holds while the directory is populated a file at a time:

- every file under `scripts/` must be named in `BUNDLED_SCRIPTS`, the set the skill body cites — a script the prose never names is a capability with no procedure governing it;
- every shipped script must carry a real body, judged by non-blank non-comment lines rather than byte count so a long banner comment cannot pass for an implementation.

The second half is the original guard, restated so it survives the file existing. Deleting the test outright would have dropped it, and `test_an_absent_script_is_unknown_and_not_permission` — which asserts the prose clause that makes a missing script read as UNKNOWN rather than as permission — depends on a placeholder never being committed.

## Verification

- `pytest test/test_security_conductor_skill_contract.py` — 42 passed (was 1 failed).
- Negative control, stub: wrote a two-line `scope_check.py` → `AssertionError: placeholder script committed: scope_check.py`.
- Negative control, uncited script: wrote `rogue.py` → `AssertionError: uncited script shipped: rogue.py`.
- isort, black gate, flake8, `mypy --platform linux`, `docs-lint.sh` all clean.
- Both negative controls were run against a throwaway file in the skill's `scripts/` directory and removed again; `git status` clean apart from the test file.

## Pattern harvest

A contract test that encodes "the sibling change has not landed yet" is a **dated** assertion, and nothing marks it as dated. It passes for exactly as long as the thing it is waiting for is missing, then fails on a change that is doing precisely what the comment says will happen — and it fails in a shard of someone else's pull request, so the cost lands on whoever pushes next rather than on the change that invalidated it.

Rule candidate: semgrep — flag an `assert not (<path>).exists()` in `test/**` whose asserted path lies inside the package tree, and require the assertion to name the condition under which it is expected to stop holding. The honest form of "not yet" is an assertion about what IS true of the files that exist, not about the directory being absent.

Two prior instances of the same shape were fixed in this repo the same way: `_dir_holds_sensitive_leaf`'s base-state assertion, and this one.
