### PR TITLE
fix(ssl): stop shadowing the Windows trust store for child processes

### DIFF
--- a/src/kiro_crew/_ssl_compat.py
+++ b/src/kiro_crew/_ssl_compat.py
@@ -92,6 +92,9 @@ def _ensure_ssl_certs() -> None:
     if os.environ.get("SSL_CERT_FILE"):
         return
 
+    if sys.platform == "win32":
+        return
+
     if sys.platform == "darwin":
         _inject_macos_system_trust()
 

--- a/test/test_ssl_certs.py
+++ b/test/test_ssl_certs.py
@@ -144,6 +144,70 @@ class TestEnsureSslCerts:
         assert os.environ["SSL_CERT_FILE"] == str(fake_certifi_bundle)
         assert os.environ["REQUESTS_CA_BUNDLE"] == str(fake_certifi_bundle)
 
+    def test_win32_exports_nothing_even_when_a_bundle_is_discoverable(self, monkeypatch, tmp_path):
+        """win32 must export NEITHER variable, however findable a bundle is.
+
+        The mirror of ``test_falls_back_to_certifi_when_no_system_path_exists``:
+        identical setup, only the platform differs, opposite outcome.  Every
+        bundle discovery below the guard is made to succeed -- a candidate path
+        exists AND certifi resolves -- so this pins that the return sits ABOVE
+        the discovery block rather than merely that certifi is not reached.  A
+        future edit that moves the guard down, or adds a Windows-shaped path to
+        ``_CA_CANDIDATES``, fails here.
+
+        Why nothing may be exported: for ``rustls-native-certs``, which the
+        kiro-cli child uses, ``SSL_CERT_FILE`` REPLACES the platform store
+        rather than adding to it, and anything discovered here is a
+        public-roots-only bundle.  Exporting one therefore SUBTRACTS every
+        private CA the Windows ROOT store holds, breaking the child on any host
+        behind TLS inspection while this process -- CPython reads the variable
+        additively -- keeps working and hides it.
+        """
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+
+        mock_paths = type("P", (), {"cafile": None, "capath": None})()
+
+        existing_candidate = tmp_path / "ca-bundle.crt"
+        existing_candidate.write_text("fake cert bundle")
+
+        fake_certifi_bundle = tmp_path / "certifi-cacert.pem"
+        fake_certifi_bundle.write_text("fake certifi bundle")
+        mock_certifi = type("M", (), {"where": staticmethod(lambda: str(fake_certifi_bundle))})()
+
+        with (
+            patch("ssl.get_default_verify_paths", return_value=mock_paths),
+            patch("kiro_crew._ssl_compat._CA_CANDIDATES", (str(existing_candidate),)),
+            patch.dict("sys.modules", {"certifi": mock_certifi}),
+        ):
+            _ensure_ssl_certs()
+
+        import os
+
+        assert os.environ.get("SSL_CERT_FILE") is None
+        assert os.environ.get("REQUESTS_CA_BUNDLE") is None
+
+    def test_win32_still_honours_an_explicit_ssl_cert_file(self, monkeypatch):
+        """An operator's own bundle outranks the win32 guard and survives it.
+
+        The guard is placed BELOW the explicit-override check on purpose:
+        exporting a public-roots bundle is what breaks the child, but an
+        operator naming their own bundle is the supported way to add a private
+        CA on a host whose store this process cannot read.  That escape hatch is
+        the current workaround for affected users, so it must not regress.
+        """
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("SSL_CERT_FILE", r"C:\corp\ca-bundle.pem")
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+
+        _ensure_ssl_certs()
+
+        import os
+
+        assert os.environ["SSL_CERT_FILE"] == r"C:\corp\ca-bundle.pem"
+        assert os.environ.get("REQUESTS_CA_BUNDLE") is None
+
     def test_cafile_missing_on_disk_falls_through(self, monkeypatch, tmp_path):
         """If cafile is set but the file doesn't exist, should fall through to candidates."""
         monkeypatch.delenv("SSL_CERT_FILE", raising=False)


### PR DESCRIPTION
_ensure_ssl_certs() has no Windows-aware branch, so on win32 the Unix CA candidates never exist, get_default_verify_paths().cafile is None, and the certifi fallback always exports SSL_CERT_FILE + REQUESTS_CA_BUNDLE.

rustls-native-certs checks SSL_CERT_FILE first on every platform and loads that file INSTEAD of the platform store, so the export silently removed the Windows ROOT store from kiro-cli's trust while leaving the gateway's own HTTPS intact -- CPython reads the Windows store directly and treats the variable as an addition. Behind a TLS-inspecting proxy whose root is installed in Windows ROOT, every turn failed with "dispatch failure" on the intercepted q.<region>.amazonaws.com endpoint while sign-in and the usage API, which are not intercepted, kept working.

Return before discovery on win32. Nothing there needs the export: CPython and requests are already covered, and Node children read NODE_EXTRA_CA_CERTS. An explicit SSL_CERT_FILE is still honoured above.

<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

On Windows, Kiro Crew chat fails on **every** turn with `An unknown error occurred:
dispatch failure`, while sign-in and the usage/credit pill keep working. The natural
diagnostic — run `kiro-cli` in a terminal — *passes*, because a plain shell has no
`SSL_CERT_FILE` set.

The split is explained by which endpoints a TLS-inspecting proxy intercepts:

| Endpoint | Purpose | Issuer as presented | Intercepted |
|---|---|---|---|
| `q.us-east-1.amazonaws.com` | model / streaming | `Zscaler Intermediate Root CA (zscalertwo.net)` | **yes** |
| `oidc.us-east-1.amazonaws.com` | sign-in | `Amazon RSA 2048 M04` | no |
| `codewhisperer.us-east-1.amazonaws.com` | usage API | `Amazon RSA 2048 M04` | no |

Only the model endpoint is inspected, so only chat dies.

The Zscaler root is installed in both `Cert:\LocalMachine\Root` and
`Cert:\CurrentUser\Root`, so every ordinary Windows application is fine. The shipped
desktop backend's certifi bundle holds 121 public roots and contains no Zscaler entry.

`_ensure_ssl_certs()` runs at import of `cli.py` / `__main__.py` (and from
`mcp_gateway/gatewayd.py`), so it is in the gateway process before any kiro-cli spawn.
On Windows `ssl.get_default_verify_paths().cafile` is `None` and all three
`_CA_CANDIDATES` are Linux paths, so control always reaches the certifi fallback and
exports `SSL_CERT_FILE` + `REQUESTS_CA_BUNDLE`. kiro-cli inherits it.

## Why it matters

Kiro Crew is unusable for chat on any Windows host behind TLS inspection -- most
corporate Windows fleets. The failure is silent and misattributed: it presents as a
network fault or a Kiro CLI bug, and the obvious check (`kiro-cli` in a terminal)
passes, so the gateway is the last place anyone looks.

## What changed (motivation → approach → change)

The asymmetry is what makes this invisible. `SSL_CERT_FILE` means different things to
the two consumers:

- **CPython** — `create_default_context()` on Windows loads the Windows ROOT store
  *and* honours `SSL_CERT_FILE`. A **union**. The gateway's own HTTPS keeps working,
  which hides the problem.
- **rustls-native-certs**, which builds kiro-cli's trust store — checks
  `SSL_CERT_FILE` **first, on every platform**, and when set loads that file
  **instead of** the platform store. A **replacement**.

So exporting a public-roots-only bundle *subtracts* every private CA the machine
trusts from the child, while leaving the parent working.

The Windows branch was never intentional. The module docstring scopes the file-based
bootstrap to "Linux distributions whose Python default points at the wrong CA
location"; Windows falls into it only because the Unix candidate paths don't exist.

Fix: return before discovery on `win32`. Nothing there needs the export —

- CPython reads the Windows ROOT store directly, so this process and any Python child
  are already covered.
- `requests` never reads the Windows store, but its default *is* certifi, so pointing
  `REQUESTS_CA_BUNDLE` at certifi changes nothing.
- Node children read `NODE_EXTRA_CA_CERTS`, never this variable.

Placement is deliberate: **below** the explicit-override check, so an operator's own
`SSL_CERT_FILE` still wins (the current workaround for affected users, and the
supported way to add a private CA); **above** the discovery block, so no future edit
can reintroduce an export on that path.

Linux behaviour is unchanged. That branch is the module's stated purpose, the paths it
finds are real system bundles rather than public-roots-only files, and
rustls-native-certs reads `/etc/ssl/...` there anyway.

## Tests

Two cases added to `test/test_ssl_certs.py::TestEnsureSslCerts`:

- `test_win32_exports_nothing_even_when_a_bundle_is_discoverable` — the mirror of the
  existing `test_falls_back_to_certifi_when_no_system_path_exists`: identical setup,
  only the platform differs, opposite outcome. Both discovery paths are made to
  succeed (an existing candidate path **and** a resolvable certifi bundle), so it pins
  that the guard sits *above* discovery rather than merely that certifi goes
  unreached. Confirmed to fail without the guard, exporting the bundle.
- `test_win32_still_honours_an_explicit_ssl_cert_file` — pins that an operator's
  explicit bundle survives the guard. This passes without the fix too (the override
  check already existed); it guards the placement rather than catching the defect.

Both override the file's autouse `_reset_ssl_bootstrap` fixture, which forces
`sys.platform = "linux"`.

## Manual verification

Measured by the reporter on the affected Windows host:

TLS probe against the intercepted endpoint, trusting one bundle at a time:

```
certifi bundle only (what KiroCrew exports today):  FAIL -> SSLCertVerificationError:
    certificate verify failed: unable to get local issuer certificate
certifi + Zscaler root:                             OK  (tls=TLSv1.3)
```

End-to-end against the real `kiro-cli` binary, three runs in one shell:

```powershell
$env:SSL_CERT_FILE = $null                            # -> "Hi!"  (works)
$env:SSL_CERT_FILE = '<...>\certifi\cacert.pem'       # -> dispatch failure
$env:SSL_CERT_FILE = '<...>\bundle-with-zscaler.pem'  # -> "Hi!"  (works)
```

The failing run also lost the model name from its status bar (`kiro_default · ◔ 4%`
versus `kiro_default · claude-opus-5`), so model listing was failing on the same
handshake.

Prelude behaviour on that host, post-patch:

```
platform: win32
SSL_CERT_FILE after prelude: None
REQUESTS_CA_BUNDLE after prelude: None
this process default ctx CAs: {'x509': 69, 'crl': 0, 'x509_ca': 66}
```

On Linux (this PR's development host): `test_ssl_certs.py` passes 20/20; black,
isort, flake8 and mypy report nothing on the changed files; the repo black and
subprocess-encoding gates pass.

## Related Issues

Fixes #NNNN (filed alongside this PR — no existing issue covered the Windows case).

Related: #5602 — the macOS sibling of this class, same TLS-inspection context but
about this process's own trust rather than the child's. Still open after #5903
landed the Keychain work; see Open question 1.

## Open questions for maintainers

1. **macOS may carry the same defect, and #5602 is where it would land.** The
   `darwin` branch calls `_inject_macos_system_trust()` (added by #5903) and then
   *falls through* to discovery — there is no return. `inject_into_ssl()` is
   process-local, so the export exists deliberately to give children something they
   cannot inherit as a monkey-patch. But if discovery lands on certifi, a rustls child
   skips the Keychain for exactly the Windows reason — which would explain why #5602
   is still open after #5903. Whether it fires depends on whether
   `get_default_verify_paths().cafile` exists on a given macOS install, which was not
   testable from the affected host. Flagging rather than fixing: widening this diff
   onto an unverifiable platform is how a three-line fix stalls. Happy to take it as a
   follow-up against #5602 if you agree with the reading.

2. **Want a `windows-install.md` note?** No spec covers the SSL bootstrap (grepped
   `docs/**` and `src/kiro_crew/docs/**` for `_ssl_compat`, `_ensure_ssl_certs`,
   `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE` — no hits), so nothing goes stale. A short
   "corporate TLS inspection" section explaining that `SSL_CERT_FILE` is the supported
   way to add a private CA might help affected users find the workaround, but that is
   scope you did not ask for. Say the word and I'll add it here or as a follow-up.

3. **Interaction with #9330.** That PR classified the prose spelling of `dispatch
   failure` as transient, i.e. retry-eligible. A TLS trust failure is permanent, so on
   an affected host each turn now burns the retry ladder before surfacing. It does not
   change this fix, but the two share a symptom and it is worth knowing they interact.

## Pattern harvest

```
Rule candidate: review-prompt
Pattern: a process-wide env export intended to ADD capability to child
processes, where the variable is defined by at least one consumer as a
REPLACEMENT — so the export silently subtracts capability from the child
while the exporting process, which reads the variable additively, keeps
working and hides it.
```

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc covers this path (see Open questions)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
