### PR TITLE
test(work-ledger): pin the containment helper routing and prefix tolerance (#9343)

### DIFF
--- a/test/test_work_ledger.py
+++ b/test/test_work_ledger.py
@@ -1417,6 +1417,104 @@ def test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding():
         assert (item.worker_session_key == WORKER) == ((key, item_id) == binding)
 
 
+def test_the_guards_tolerate_a_prefixed_leaf_resolve(monkeypatch):
+    """A leaf resolve that comes back extended-length-prefixed must not refuse.
+
+    ``ntpath.realpath`` keeps Windows' ``\\\\?\\`` prefix when its prefix-strip
+    re-check races a concurrent swap of the same file -- exactly what a losing
+    ``bind`` sees while the winner replaces the binding record it is composing
+    the path of. A guard that compares that prefixed child against an
+    unprefixed parent reads the spelling as an escape and turns a clean
+    ``already_bound`` refusal into ``invalid_value``, which is Windows-only
+    because POSIX ``realpath`` has no prefix re-check. The guards therefore go
+    through ``resolved_within``, which strips the prefix from BOTH sides before
+    comparing. POSIX cannot produce the prefixed spelling natively, so this
+    simulates it where it arises: ``Path.resolve`` returning the
+    extended-length form of the correct answer.
+    """
+    import kiro_crew.session_ledger as sl
+
+    original_resolve = Path.resolve
+
+    def prefixing(self: Path, *args, **kwargs) -> Path:
+        real = original_resolve(self, *args, **kwargs)
+        text = str(real)
+        # Only a drive-absolute spelling can legally carry the prefix; POSIX
+        # paths get a synthetic one through _plain's own contract instead.
+        return Path(f"\\\\?\\{text}") if text[1:2] == ":" else real
+
+    # The pure half: _plain must strip both prefix spellings.
+    assert sl._plain(Path("\\\\?\\C:\\store\\bindings\\w.json")) == Path(
+        "C:\\store\\bindings\\w.json"
+    )
+    assert sl._plain(Path("\\\\?\\UNC\\host\\share\\x")) == Path("\\\\host\\share\\x")
+
+    # The integration half: both guards answer a real path, not a refusal,
+    # when every resolve is prefixed the way the Windows race spells it.
+    monkeypatch.setattr(Path, "resolve", prefixing)
+    assert wl.binding_path(WORKER).name == f"{wl._store_name(WORKER)}.json"
+    assert wl.conductor_dir(CONDUCTOR).name == wl._store_name(CONDUCTOR)
+    # And hostile keys are still refused with the guards' own code.
+    with pytest.raises(wl.WorkLedgerError) as excinfo:
+        wl.conductor_dir("evil/../key")
+    assert excinfo.value.code == wl.CODE_INVALID_VALUE
+    with pytest.raises(wl.WorkLedgerError) as excinfo:
+        wl.binding_path("has\0null")
+    assert excinfo.value.code == wl.CODE_INVALID_VALUE
+
+
+def test_a_planted_link_at_a_guarded_leaf_is_refused(tmp_path):
+    """A pre-planted symlink at either guard's composed leaf must be refused.
+
+    ``resolved_within`` resolves the composed leaf, so a link whose target sits
+    outside the base lands outside the resolved base and reads as an escape.
+    This pins that the shared-helper path keeps the containment the guards had
+    when each spelled the check inline. Skipped where symlinks cannot be
+    created (Windows without privilege), matching how the defense is exercised
+    there; the prefix-tolerance half has its own test above.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.json").write_text("{}", encoding="utf-8")
+
+    linked_dir = wl._work_ledger_root() / wl._store_name(CONDUCTOR)
+    linked_dir.parent.mkdir(parents=True, exist_ok=True)
+    linked_binding = wl.bindings_dir() / f"{wl._store_name(WORKER)}.json"
+    linked_binding.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        linked_dir.symlink_to(outside, target_is_directory=True)
+        linked_binding.symlink_to(outside / "victim.json")
+    except OSError:
+        pytest.skip("cannot create symlinks on this platform/account")
+    with pytest.raises(wl.WorkLedgerError) as excinfo:
+        wl.conductor_dir(CONDUCTOR)
+    assert excinfo.value.code == wl.CODE_INVALID_VALUE
+    with pytest.raises(wl.WorkLedgerError) as excinfo:
+        wl.binding_path(WORKER)
+    assert excinfo.value.code == wl.CODE_INVALID_VALUE
+
+
+def test_the_guards_share_one_containment_helper(monkeypatch):
+    """Both guards must route through ``session_ledger.resolved_within``.
+
+    The helper is where the prefix-stripped, single-base-resolve comparison
+    lives; a guard that re-inlines its own two-``resolve()`` comparison
+    silently reintroduces the Windows race the helper exists to close, with
+    every existing test still green on POSIX. Patching the helper to refuse
+    and watching both guards refuse is what makes the routing itself a tested
+    property rather than a convention.
+    """
+    import kiro_crew.work_ledger as wl_module
+
+    monkeypatch.setattr(wl_module, "resolved_within", lambda base, name: None)
+    with pytest.raises(wl.WorkLedgerError) as excinfo:
+        wl.binding_path(WORKER)
+    assert excinfo.value.code == wl.CODE_INVALID_VALUE
+    with pytest.raises(wl.WorkLedgerError) as excinfo:
+        wl.conductor_dir(CONDUCTOR)
+    assert excinfo.value.code == wl.CODE_INVALID_VALUE
+
+
 def test_acquiring_a_lock_does_not_truncate_the_lock_file():
     """The lock-file open must be WRITABLE but MUST NOT truncate.
 


### PR DESCRIPTION
# What is the problem?

The Windows-only bind race behind issue 9343 (a losing concurrent `bind` reported `invalid_value` where the test requires `already_bound`) was root-caused to the path guards' two-`resolve()` containment comparison: `ntpath.realpath` keeps the `\\?\` extended-length prefix when its prefix-strip re-check races a concurrent `os.replace` on the same binding record, and the prefixed-child-vs-unprefixed-parent comparison reads as a path escape. Main commit 07131cba8 fixed the mechanism with a shared `session_ledger.resolved_within` helper (single base resolve, both sides stripped of the prefix via `_plain`) now used by `conductor_dir`, `binding_path`, and `ledger_dir` -- but nothing in the test tree names `resolved_within`, `_plain`, or the routing: the fix has zero regression coverage, so any of its three properties can be silently unfixed with every suite green on POSIX.

# Why this issue matters to the user

The failure cost a red Windows shard and a red PR Readiness rollup on every PR landing work in shard 4, clearable only by rerunning. An uncovered fix for a race this subtle is one refactor away from coming back: re-inlining the comparison in one guard, or dropping the `_plain` strip, reproduces the flake and nothing red flags it until the Windows shard starts failing again.

# How our fix solves it

Three tests in `test/test_work_ledger.py` pin the three properties that make the fix hold:

- `test_the_guards_tolerate_a_prefixed_leaf_resolve`: `_plain` strips both extended-length spellings (drive and UNC), and with `Path.resolve` monkeypatched to return the prefixed form -- the exact spelling the Windows race produces -- both guards answer a real path instead of a spurious `invalid_value`, while hostile keys stay refused.
- `test_a_planted_link_at_a_guarded_leaf_is_refused`: the resolve-based containment still refuses a pre-planted symlink at either guard's leaf whose target sits outside the base (skips only where symlink creation is unprivileged).
- `test_the_guards_share_one_containment_helper`: both guards actually route through `resolved_within` -- patching the helper to refuse makes both guards refuse, so a guard that re-inlines its own comparison turns this red rather than passing by convention.

No source change: `src/kiro_crew/work_ledger.py` is byte-identical to main. The earlier revisions of this PR carried an independent fix for the same race; main's shared-helper fix supersedes it and this PR now contributes the coverage that fix lacks.

# What tests we did

- `timeout 900 python3 -m pytest -n0 test/test_work_ledger.py -x -q </dev/null` -- 126 passed (123 from main + 3 new).
- The routing pin is self-verifying: it passes only because the guards consult the patched module symbol.
- Gate floor: isort / flake8 / black on the touched file, `mypy src/kiro_crew/work_ledger.py`, comment-history gate (both files level with baseline: src 1/1, test 24/24), brand gate, black gate -- all exit 0.

# Any other suggestions on the work

`resolved_within` lives in `session_ledger` and also guards `ledger_dir`; a sibling pin there would cover the third consumer. Left out to keep this PR one file.

## Pattern harvest
Rule candidate: lint (extend an existing gate)
Pattern: a containment guard that compares two independent `Path.resolve()` calls (`X.resolve()` vs `base.resolve()` + `is_relative_to`); on Windows the two non-strict `realpath` probes can disagree about the `\\?\` prefix under concurrent filesystem activity, turning the guard into a spurious refusal. Grep-able as "two `.resolve()` calls compared in one containment check"; the sanctioned shape is `session_ledger.resolved_within`.

Refs #9343
