### PR TITLE
fix(instances): stalled pane module graph: journal it, rebuild the tunnel on Retry, stagger auto-warm

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -173,7 +173,14 @@ simultaneously-connected instance use a distinct remote port. The shipped
 defaults contradicted it — a stock gateway binds the same default port on both
 ends, so a stock hub already held the port a stock remote reported and two stock
 installs could never connect (#1972). Reconnects reuse the instance's own
-previous port so the iframe origin and its cookie stay stable.
+previous port so the iframe origin and its cookie stay stable — with one
+deliberate exception: a **rebuild** (`connect?rebuild=1`, §4 step 1) excludes the
+port it just freed from the allocation, so the rebuilt forwarder lands on a
+different port. Rebuild exists to escape a tunnel that passes every probe yet
+never finishes serving one stream, and the field evidence for that stall is
+port-correlated (every case so far sat on the first allocated port), so a new
+origin is the point rather than a cost; the pane's Retry reloads at the new
+origin and mints its own port-scoped cookie.
 
 **Platform note.** The hub side of this feature assumes a POSIX host with an
 OpenSSH `ssh` client on `PATH`, and run-marker port discovery refuses outright on
@@ -189,7 +196,33 @@ non-POSIX (§12). Treat a Windows hub as unverified.
    dashboard token on the remote over SSH, and returns the live status plus the
    token. Connect is **idempotent**: an already-connected instance returns its
    current status, and the handler then *probes* the stored token before handing
-   it over (see below). The browser loads
+   it over (see below). Two opt-in query flags bend that in opposite directions,
+   and they are mutually exclusive (`400` together):
+   - `?rebuild=1` — the pane's Retry after a load watchdog fired on a document
+     that DID navigate. Every probe says the tunnel is healthy, so the idempotent
+     connect would hand back the same forwarder and the pane would reload into
+     the same stalled stream. Rebuild tears the CONNECTED tunnel down under the
+     manager lock with `keep_intent=True`, then runs the normal connect with the
+     freed port excluded from allocation (§3). A teardown whose stop raises is
+     returned as an ERROR status / `502`, the old tunnel left intact and tracked.
+     Audited as `connect/rebuild`. One consumer: `InstancesViewport`'s Retry.
+     **Provisional.** The recovery rests on a hypothesis — that a fresh
+     forwarder on a new port clears the stalled stream — which the
+     `[pane-assets]` journal exists to confirm or refute. Until a field
+     `STALLED → retry rebuild=true → ready` trace is on record the flag is not a
+     stability commitment: if the trace shows the stall recur on the new port,
+     the flag, the §3 port exclusion and the mutual-exclusion `400` are removed
+     together rather than kept as API.
+   - `?only_if_connected=1` — the viewport's auto-warm. Answers a CONNECTED
+     tunnel exactly like a plain connect but, for a tunnel that is not up, spawns
+     nothing, mints nothing and leaves `was_connected` untouched: `200` with
+     `state=disconnected`, `code=instance_not_connected`, audited
+     `connect/declined`. Decided under the same lock `disconnect` holds, so an
+     auto-warm racing an explicit disconnect can never re-open the tunnel the
+     user just closed. Auto-warm pre-mounts panes for tunnels that are already
+     up; bringing one up is the fan-out's and the click's job.
+
+   The browser loads
    `http://<dashboard-hostname>:<local>/?token=...` in an iframe, deliberately
    reusing the parent's own hostname so the pane is same-site with the parent and
    `SameSite=Lax` auth cookies are not withheld.
@@ -395,7 +428,7 @@ request with no `request["user"]` with `401`, and rejects a disabled feature wit
 | `POST /api/instances` | Add an instance. A rejection carries a machine-readable `code` beside its human message, so a client can branch without parsing prose: `invalid_json` / `invalid_body` (unreadable request), `invalid_field` (a named field failed validation), `instance_duplicate` (the name is taken), `instance_invalid` (the record as a whole is not addressable) and `instances_manager_unavailable`. The dashboard forwards the code into its error → agent hand-off, which is why it has to be on the wire rather than derived from the message. |
 | `PATCH /api/instances/{id}` | Edit `name`/`ssh_host`/`remote_port`/`ttl`/`remote_bin`/`connection_method`/`ssm_target`/`ssm_run_as`/`aws_profile`/`aws_region` (`id` and internal hints are not editable). Editing a field the tunnel is BUILT from (everything except `name` and `ttl`) disconnects a live tunnel first, because it would otherwise keep forwarding the old port to the old host under the new label; the teardown passes `keep_intent=True` so it does not touch `was_connected` — that flag records a USER disconnect, so a reconfiguration leaves it alone and a real disconnect arriving mid-edit still wins. The crew therefore keeps its switcher entry and reconnects in one click. The teardown and the coordinate rewrite happen as ONE operation, `SshTunnelManager.reconfigure()`, which holds the manager lock across both. Done as two steps a `connect` can read the OLD record in between, and whether its tunnel is already CONNECTED or still CONNECTING when the write lands decides whether any after-the-fact sweep would notice it — so the window is removed rather than narrowed: a racing `connect` either completes before (and is torn down inside the section) or starts after (and reads the new coordinates). It also cancels and AWAITS that instance's in-flight self-heal first: recovery reads the record before it takes the lock, so a recovery already running carries the pre-edit coordinates and would reinstall a tunnel to the old machine. Because that cancellation itself awaits, a reconfiguration additionally raises a per-instance BARRIER before its first await; while the barrier is up the scheduling seams refuse to start work — `_on_tunnel_exit` will not begin a self-heal, a backed-off one returns without acting, and `_schedule_token_refresh` will not restart a mint loop — so nothing can slip into the window. Self-heal is cancelled AND awaited before the coordinates move, because it rebuilds from the record it read. The token-refresh loop is unwound by the teardown instead — after the stop succeeds — so a REJECTED edit leaves the live tunnel holding both its credential and its refresh; in both cases the cancellation is awaited, since a mint already in flight would otherwise store a token for a tunnel that is being replaced. A teardown that raises ABORTS the edit with `503` / `code: tunnel_teardown_failed` and persists nothing: a stop that failed leaves the old forward live, so advancing the record would describe one machine while the still-open tunnel serves another — and that tunnel is the one the user reaches. Nothing is discarded unless the stop succeeded — the tunnel keeps its place in `_tunnels` along with its token and refresh task — so a failed stop can neither leave an untracked process holding the port nor a live forward without a credential. The registry write is also shielded from cancellation: a client hanging up mid-write must not unwind the `async with` and free the lock while the write is still in flight. An edit sends only the fields that DIFFER from an IMMUTABLE snapshot of the record taken when its form opened (not the live polled record, which a concurrent CLI edit would move under the user), so the later of two concurrent saves cannot revert the earlier one's corrections; optional fields travel as explicit empty values, so emptying one clears it instead of being read as "leave as-is". The dashboard does NOT reconnect afterwards: any automatic reconnect races an explicit Disconnect arriving mid-save, so the row offers **Connect** instead. A crew CORRELATED to a cloud stack has its `connection_method`/`ssm_target`/`aws_profile`/`aws_region` frozen in the edit form and omitted from the request — Stop/Start/Delete resolve the machine through those, so editing them would strand a billing instance. That freeze is now enforced **server-side too**: this endpoint rejects the four addressing fields for a correlated cloud instance with `400` / `code: cloud_instance_addressing_locked`, so a non-dashboard caller (CLI, script, the agent driving this owner-only API) can no longer rewrite the coordinates and strand a billing instance. Correlation is resolved against the cloud launch store via `_is_correlated_cloud_instance()`, checked against the record already fetched for the edit. An SSM crew that cannot be correlated is offered no lifecycle action, so its fields stay editable — that identity is how the dashboard finds the machine to stop or delete, and editing it away would strand a billing instance. |
 | `DELETE /api/instances/{id}` | Disconnect then remove. |
-| `POST /api/instances/{id}/connect` | Open tunnel + mint token. Returns the token. A failure carries a machine-readable `code`, and that code is the failure-diagnosis ladder's OWN verdict (`ssh_unreachable`, `remote_down`, `tunnel_down`, …) promoted to the top level, so a client reads which link broke without walking into `diagnosis`. Only a verdict that is present AND **negative** is promoted: the stored diagnosis is the last ladder RUN, so a stale `ok` from before the failure would otherwise be published as this call's reason. With no usable verdict the stage that failed names itself — `instance_connect_failed`, or `instance_token_unconfirmed` when the tunnel came up but its credential did not confirm. The frontend applies the same present-AND-negative rule before quoting a verdict or its probe chain into the agent hand-off, for the same staleness reason. |
+| `POST /api/instances/{id}/connect` | Open tunnel + mint token. Returns the token. Idempotent by default; `?rebuild=1` (Retry after a load-watchdog verdict: tear down and re-spawn on a different local port) and `?only_if_connected=1` (auto-warm: answer an up tunnel, never bring one up — a down tunnel is a `200` with `code: instance_not_connected`) are the two opt-in exceptions, mutually exclusive (`400`), described in §4 step 1. A failure carries a machine-readable `code`, and that code is the failure-diagnosis ladder's OWN verdict (`ssh_unreachable`, `remote_down`, `tunnel_down`, …) promoted to the top level, so a client reads which link broke without walking into `diagnosis`. Only a verdict that is present AND **negative** is promoted: the stored diagnosis is the last ladder RUN, so a stale `ok` from before the failure would otherwise be published as this call's reason. With no usable verdict the stage that failed names itself — `instance_connect_failed`, or `instance_token_unconfirmed` when the tunnel came up but its credential did not confirm. The frontend applies the same present-AND-negative rule before quoting a verdict or its probe chain into the agent hand-off, for the same staleness reason. |
 | `POST /api/instances/{id}/refresh-token` | Force a fresh mint and return the new token. See below. |
 | `POST /api/instances/{id}/disconnect` | Tear down one tunnel. |
 | `GET /api/instances/{id}/status[?diagnose=1]` | Live status; `?diagnose=1` runs the failure ladder and merges the result. |

--- a/src/kiro_crew/dashboard/handlers_instances.py
+++ b/src/kiro_crew/dashboard/handlers_instances.py
@@ -609,12 +609,59 @@ async def api_instances_connect(request: web.Request) -> web.Response:
             {"error": "instances manager not running", "code": "instances_manager_unavailable"},
             status=503,
         )
+    # `?rebuild=1` is the pane's Retry after a load watchdog fired on a document
+    # that DID navigate: every probe says the tunnel is fine, yet one stream in it
+    # stalled and the pane will wait on it forever. Only a fresh forwarder on a
+    # different local port clears that; the
+    # idempotent connect would hand
+    # the same stalled tunnel straight back. Opt-in and explicit so the
+    # auto-connect fan-out and plain tab clicks keep their no-op-when-up cost.
+    rebuild = request.query.get("rebuild") in ("1", "true")
+    # `?only_if_connected=1` is the viewport's auto-warm: pre-mount a pane for a
+    # tunnel that is ALREADY up, never bring one up. Evaluated atomically under
+    # the manager lock, so an auto-warm racing an explicit disconnect can never
+    # re-open the tunnel (or re-persist the intent) the user just closed.
+    only_if_connected = request.query.get("only_if_connected") in ("1", "true")
+    if rebuild and only_if_connected:
+        # A refusal, so it leaves the same `denied` SEL line as every other
+        # early exit here: the audit trail must see an owner hand-crafting a
+        # pair the frontend never sends, not just the connects that went through.
+        _audit(
+            "connect",
+            "denied",
+            request_id=instance_id,
+            error="rebuild and only_if_connected are mutually exclusive",
+        )
+        return web.json_response(
+            {
+                "error": "rebuild and only_if_connected are mutually exclusive",
+                "code": "bad_request",
+            },
+            status=400,
+        )
     try:
-        status = await mgr.connect(instance_id)
+        # Keyword only when asked: the default call keeps the manager's existing
+        # positional contract (and every fake that implements it).
+        if rebuild:
+            status = await mgr.connect(instance_id, rebuild=True)
+        elif only_if_connected:
+            status = await mgr.connect(instance_id, only_if_connected=True)
+        else:
+            status = await mgr.connect(instance_id)
     except KeyError:
         _audit("connect", "denied", request_id=instance_id, error="not found")
         return web.json_response({"error": "not found", "code": "instance_not_found"}, status=404)
+    if rebuild:
+        _audit("connect", "rebuild", request_id=instance_id)
     body = status.to_dict()
+    if only_if_connected and status.state.value != "connected":
+        # Declined, not failed: the tunnel is simply not up, which is the one
+        # answer a connected-only caller asked to be given without side effects.
+        # 200 with a non-connected state is what the shared connect step reads
+        # as `warm-declined`.
+        _audit("connect", "declined", request_id=instance_id, error="not connected")
+        body["code"] = "instance_not_connected"
+        return web.json_response(body)
     if status.state.value == "connected":
         token = mgr.get_token(instance_id)
         # Validate the stored token before handing it to the browser. connect()

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -1403,7 +1403,9 @@ class SshTunnelManager:
             timeout_secs=self._mint_timeout_for(params.method),
         )
 
-    async def connect(self, instance_id: str) -> TunnelStatus:
+    async def connect(
+        self, instance_id: str, *, rebuild: bool = False, only_if_connected: bool = False
+    ) -> TunnelStatus:
         """Open a tunnel + mint a token for *instance_id*; return its status.
 
         Idempotent: connecting an already-connected instance returns its current
@@ -1411,13 +1413,96 @@ class SshTunnelManager:
         validation / mint / spawn error via the returned status (state ERROR).
         Works for either ``connection_method`` — the transport is resolved by
         :meth:`_resolve_transport`.
+
+        ``rebuild=True`` breaks the idempotence on purpose: a CONNECTED tunnel is
+        torn down first (``keep_intent`` — the user is asking for the crew, not
+        turning it off) and a fresh forwarder is spawned on a DIFFERENT local
+        port: the port just freed is excluded from the allocation, so both a
+        stalled stream on the old forwarder and a cause bound to the old port
+        itself are escaped by one Retry. This is the pane's Retry after a load watchdog
+        fired on a document that DID navigate: the transport is up by every
+        probe the manager runs (``/api/health`` answers, the credential
+        validates), yet one stream inside it stalled and the pane's module
+        graph will wait on it forever. Nothing short of a new TCP path clears
+        that, and the plain connect — which sees CONNECTED and returns — would
+        hand the same stalled tunnel back.
+
+        A teardown that fails (the stop raises) is reported as an ERROR status,
+        the same way every other connect failure is: the live tunnel is left
+        exactly as :meth:`_teardown_locked` leaves it (intact — nothing is
+        removed unless the stop succeeded), the reason is retained for
+        :meth:`last_error`, and the caller gets a 502 with a message instead of
+        a propagated exception turned into an unexplained 500.
+
+        ``only_if_connected=True`` is the opposite restriction: answer a
+        CONNECTED tunnel exactly like the plain connect (its status, its cached
+        token) but, when the tunnel is not up, spawn nothing and touch nothing
+        -- return a DISCONNECTED status and leave ``was_connected`` as the user
+        last set it. This is the viewport's auto-warm, whose job is to pre-mount
+        panes for tunnels that are ALREADY up, never to bring one up. The check
+        runs under the manager lock, the same lock :meth:`disconnect` holds
+        while it stops a tunnel, so an auto-warm racing a disconnect either sees
+        the tunnel still CONNECTED (and warms a pane the disconnect's
+        ``removeWarm`` then drops) or sees it gone and stands down; it can never
+        re-open a tunnel the user just closed, which a probe-then-connect from
+        the browser could.
         """
+        if rebuild and only_if_connected:
+            raise ValueError("rebuild and only_if_connected are mutually exclusive")
         async with self._lock:
             inst = await asyncio.to_thread(self._registry.get, instance_id)
             if inst is None:
                 raise KeyError(f"no instance with id {instance_id!r}")
 
             existing = self._tunnels.get(instance_id)
+            # The port a rebuild tears down. Kept out of the allocation below so
+            # the new forwarder lands on a DIFFERENT local port: the field
+            # evidence has every stall on the first allocated port, so a cause
+            # bound to the port itself (a stale listener, a local firewall or
+            # proxy rule) is a live hypothesis alongside the stalled stream. A
+            # first-free allocator would hand the just-freed port straight back
+            # and Retry could loop on it forever with no in-product escape.
+            rebuild_freed_port: int | None = None
+            if only_if_connected and (
+                existing is None or existing.status.state != TunnelState.CONNECTED
+            ):
+                logger.info(
+                    "Connected-only connect for %s declined: tunnel is %s",
+                    instance_id,
+                    existing.status.state.value if existing is not None else "absent",
+                )
+                return TunnelStatus(
+                    instance_id=inst.id,
+                    state=TunnelState.DISCONNECTED,
+                    local_port=inst.local_port,
+                    remote_port=inst.remote_port,
+                )
+            if rebuild and existing is not None:
+                logger.info(
+                    "Rebuilding tunnel for %s on request (was %s on 127.0.0.1:%s)",
+                    instance_id,
+                    existing.status.state.value,
+                    existing.status.local_port,
+                )
+                try:
+                    await self._teardown_locked(instance_id, keep_intent=True)
+                except Exception as e:  # noqa: BLE001 - reported, not swallowed
+                    logger.warning(
+                        "Rebuild of %s could not stop the old tunnel: %s", instance_id, e
+                    )
+                    return self._error_status(
+                        inst,
+                        f"could not stop the existing tunnel to rebuild it: {e}. "
+                        f"Disconnect and connect again, or retry.",
+                    )
+                if existing.status.local_port:
+                    rebuild_freed_port = existing.status.local_port
+                existing = None
+                # The registry row was just rewritten (local_port reset); re-read
+                # so the allocation below skips nothing stale and records fresh.
+                inst = await asyncio.to_thread(self._registry.get, instance_id)
+                if inst is None:
+                    raise KeyError(f"no instance with id {instance_id!r}")
             if existing is not None and existing.status.state == TunnelState.CONNECTED:
                 return existing.status
             if existing is not None:
@@ -1519,6 +1604,8 @@ class SshTunnelManager:
             # stall unrelated requests and heartbeats. This matches how the rest
             # of the module already reaches the registry (``asyncio.to_thread``).
             reserved = await asyncio.to_thread(self._reserved_ports)
+            if rebuild_freed_port is not None:
+                reserved = set(reserved) | {rebuild_freed_port}
             try:
                 local_port = await asyncio.to_thread(self._allocator.allocate, exclude=reserved)
             except RuntimeError as e:

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -1662,6 +1662,131 @@ class TestSshTunnelManager:
         assert (await mgr.connect("cd-1")).state == TunnelState.CONNECTED
 
     @pytest.mark.asyncio
+    async def test_connect_rebuild_replaces_a_connected_tunnel(self, tmp_path):
+        """``rebuild=True`` is the pane's Retry after a watchdog verdict on a
+        document that DID navigate: every probe says the tunnel is fine, so the
+        idempotent connect would hand the same (stalled) forwarder back. The
+        rebuild must stop the old child, spawn a new one, keep the user's
+        connect intent, and answer CONNECTED with a live token."""
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+
+        first = await mgr.connect("cd-1")
+        assert first.state == TunnelState.CONNECTED
+        old_tunnel = mgr._tunnels["cd-1"]
+
+        second = await mgr.connect("cd-1", rebuild=True)
+        assert second.state == TunnelState.CONNECTED
+        assert mgr._tunnels["cd-1"] is not old_tunnel, "a rebuild must spawn a new forwarder"
+        assert old_tunnel.stopped, "the stalled forwarder must be stopped, not orphaned"
+        assert mgr.get_token("cd-1") == "SECRET_TOK"
+        inst = reg.get("cd-1")
+        assert inst.was_connected is True, "rebuild keeps the connect intent (keep_intent)"
+        assert inst.local_port == second.local_port
+        assert inst.local_port >= mgr._allocator.base_port
+        # The freed port is excluded from the re-allocation: a cause bound to the
+        # old port (not just a stalled stream on the old forwarder) is escaped too.
+        assert second.local_port != first.local_port, "rebuild must not re-use the port it freed"
+        # A plain connect afterwards is idempotent on the NEW tunnel.
+        assert (await mgr.connect("cd-1")).state == TunnelState.CONNECTED
+        assert mgr._tunnels["cd-1"] is not old_tunnel
+
+    @pytest.mark.asyncio
+    async def test_connect_rebuild_teardown_failure_is_an_error_status(self, tmp_path):
+        """A stop that raises during rebuild must NOT propagate out of connect()
+        (the handler would turn it into an unexplained 500). It is reported like
+        every other connect failure: ERROR status with the reason, retained for
+        last_error, and the old tunnel is left tracked and intact — nothing is
+        removed unless the stop succeeded."""
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        first = await mgr.connect("cd-1")
+        assert first.state == TunnelState.CONNECTED
+        old_tunnel = mgr._tunnels["cd-1"]
+
+        async def boom():
+            raise RuntimeError("kill failed: EPERM")
+
+        old_tunnel.stop = boom
+
+        st = await mgr.connect("cd-1", rebuild=True)
+        assert st.state == TunnelState.ERROR
+        assert "EPERM" in (st.error or "")
+        assert "EPERM" in (mgr.last_error("cd-1") or "")
+        # The live tunnel is untouched: still tracked, credential still held.
+        assert mgr._tunnels["cd-1"] is old_tunnel
+        assert mgr.get_token("cd-1") == "SECRET_TOK"
+        assert reg.get("cd-1").was_connected is True
+
+    @pytest.mark.asyncio
+    async def test_connect_only_if_connected_declines_without_side_effects(self, tmp_path):
+        """The viewport's auto-warm must never bring a tunnel up or touch the
+        connect intent: for an absent tunnel it answers DISCONNECTED, spawns
+        nothing, mints nothing, and leaves was_connected exactly as the user
+        last set it (here: cleared by an explicit disconnect)."""
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+
+        # Never connected.
+        st = await mgr.connect("cd-1", only_if_connected=True)
+        assert st.state == TunnelState.DISCONNECTED
+        assert "cd-1" not in mgr._tunnels
+        assert not mgr.get_token("cd-1")
+        assert reg.get("cd-1").was_connected is False
+
+        # Connected, then explicitly disconnected: the race auto-warm loses.
+        assert (await mgr.connect("cd-1")).state == TunnelState.CONNECTED
+        await mgr.disconnect("cd-1")
+        assert reg.get("cd-1").was_connected is False
+        st = await mgr.connect("cd-1", only_if_connected=True)
+        assert st.state == TunnelState.DISCONNECTED
+        assert (
+            "cd-1" not in mgr._tunnels
+        ), "a connected-only connect must not re-open a closed tunnel"
+        assert (
+            reg.get("cd-1").was_connected is False
+        ), "a connected-only connect must not re-persist intent"
+
+    @pytest.mark.asyncio
+    async def test_connect_only_if_connected_answers_a_live_tunnel_like_plain_connect(
+        self, tmp_path
+    ):
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        first = await mgr.connect("cd-1")
+        tunnel = mgr._tunnels["cd-1"]
+        st = await mgr.connect("cd-1", only_if_connected=True)
+        assert st.state == TunnelState.CONNECTED
+        assert st.local_port == first.local_port
+        assert mgr._tunnels["cd-1"] is tunnel, "idempotent on the live tunnel"
+        assert mgr.get_token("cd-1") == "SECRET_TOK"
+
+    @pytest.mark.asyncio
+    async def test_connect_rebuild_and_only_if_connected_are_exclusive(self, tmp_path):
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        with pytest.raises(ValueError):
+            await mgr.connect("cd-1", rebuild=True, only_if_connected=True)
+
+    @pytest.mark.asyncio
+    async def test_connect_rebuild_with_no_tunnel_is_a_plain_connect(self, tmp_path):
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        st = await mgr.connect("cd-1", rebuild=True)
+        assert st.state == TunnelState.CONNECTED
+        assert mgr.get_token("cd-1") == "SECRET_TOK"
+
+    @pytest.mark.asyncio
     async def test_connect_resets_recover_attempts(self, tmp_path):
         reg, mgr = self._mgr(tmp_path)
         reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
@@ -2377,6 +2502,154 @@ class TestHandlers:
         # list must NOT leak the token
         r = asyncio.run(handlers.api_instances_list(_FakeReq(state)))
         assert "SECRET_TOK" not in r.body.decode()
+
+    def test_connect_rebuild_query_reaches_the_manager(self, tmp_path, monkeypatch):
+        """``?rebuild=1`` is the pane's Retry after a watchdog verdict; it must be
+        forwarded as ``rebuild=True`` and nothing else about the response changes.
+        Without the flag the manager is called with its plain positional
+        contract, so every existing caller (and fake) keeps working."""
+        from kiro_crew.dashboard import handlers_instances as handlers
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState, TunnelStatus
+
+        _enable(tmp_path, monkeypatch)
+        reg = self._reg(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+
+        calls = []
+
+        class FakeMgr:
+            async def connect(self, iid, *, rebuild=False, only_if_connected=False):
+                calls.append((rebuild, only_if_connected))
+                if only_if_connected and not reg.get(iid).was_connected:
+                    return TunnelStatus(
+                        iid, TunnelState.DISCONNECTED, local_port=0, remote_port=7777
+                    )
+                reg.update(iid, was_connected=True, local_port=7778)
+                return TunnelStatus(iid, TunnelState.CONNECTED, local_port=7778, remote_port=7777)
+
+            def get_token(self, iid):
+                return "SECRET_TOK"
+
+            async def token_validates(self, local_port, token):
+                return True
+
+        state = _State(reg, FakeMgr())
+        r = asyncio.run(handlers.api_instances_connect(_FakeReq(state, match={"id": "cd-1"})))
+        assert r.status == 200
+        r = asyncio.run(
+            handlers.api_instances_connect(
+                _FakeReq(state, match={"id": "cd-1"}, query={"rebuild": "1"})
+            )
+        )
+        assert r.status == 200 and _body(r)["token"] == "SECRET_TOK"
+        r = asyncio.run(
+            handlers.api_instances_connect(
+                _FakeReq(state, match={"id": "cd-1"}, query={"rebuild": "0"})
+            )
+        )
+        assert r.status == 200
+        assert calls == [(False, False), (True, False), (False, False)]
+
+    def test_connect_only_if_connected_query_declines_as_200_not_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """``?only_if_connected=1`` (auto-warm) reaches the manager as the keyword;
+        a declined (not-up) answer is a 200 with a non-connected state and
+        ``code=instance_not_connected`` — the shape the shared connect step reads
+        as `warm-declined` — never the 502 a real connect failure gets. A live
+        tunnel is answered exactly like a plain connect. Combining it with
+        ``rebuild`` is a 400."""
+        from kiro_crew.dashboard import handlers_instances as handlers
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState, TunnelStatus
+
+        _enable(tmp_path, monkeypatch)
+        reg = self._reg(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        calls = []
+
+        class FakeMgr:
+            async def connect(self, iid, *, rebuild=False, only_if_connected=False):
+                calls.append((rebuild, only_if_connected))
+                if only_if_connected and not reg.get(iid).was_connected:
+                    return TunnelStatus(
+                        iid, TunnelState.DISCONNECTED, local_port=0, remote_port=7777
+                    )
+                reg.update(iid, was_connected=True, local_port=7778)
+                return TunnelStatus(iid, TunnelState.CONNECTED, local_port=7778, remote_port=7777)
+
+            def get_token(self, iid):
+                return "SECRET_TOK"
+
+            async def token_validates(self, local_port, token):
+                return True
+
+        state = _State(reg, FakeMgr())
+        q = {"only_if_connected": "1"}
+        r = asyncio.run(
+            handlers.api_instances_connect(_FakeReq(state, match={"id": "cd-1"}, query=q))
+        )
+        assert r.status == 200
+        body = _body(r)
+        assert body["state"] == "disconnected" and body["code"] == "instance_not_connected"
+        assert "token" not in body
+        assert reg.get("cd-1").was_connected is False
+
+        # Bring it up the normal way, then the connected-only call is a plain answer.
+        r = asyncio.run(handlers.api_instances_connect(_FakeReq(state, match={"id": "cd-1"})))
+        assert r.status == 200
+        r = asyncio.run(
+            handlers.api_instances_connect(_FakeReq(state, match={"id": "cd-1"}, query=q))
+        )
+        assert r.status == 200 and _body(r)["token"] == "SECRET_TOK"
+        assert calls == [(False, True), (False, False), (False, True)]
+
+        r = asyncio.run(
+            handlers.api_instances_connect(
+                _FakeReq(
+                    state, match={"id": "cd-1"}, query={"rebuild": "1", "only_if_connected": "1"}
+                )
+            )
+        )
+        assert r.status == 400
+
+    def test_connect_exclusive_flags_rejection_is_audited(self, tmp_path, monkeypatch):
+        """The ``rebuild`` + ``only_if_connected`` 400 is a control-plane refusal
+        like every other early exit in connect (manager unavailable, not found),
+        so it must leave the same ``instances_connect`` / ``denied`` SEL line —
+        an owner hand-crafting the pair must not be the one connect outcome the
+        audit trail cannot see."""
+        from kiro_crew.dashboard import handlers_instances as handlers
+
+        _enable(tmp_path, monkeypatch)
+        reg = self._reg(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+
+        events = []
+
+        class FakeSel:
+            def log_tool_invocation(self, **kw):
+                events.append(kw)
+
+        monkeypatch.setattr(handlers, "sel", lambda: FakeSel())
+
+        class FakeMgr:
+            async def connect(self, iid, *, rebuild=False, only_if_connected=False):
+                raise AssertionError("manager must not be reached on a 400")
+
+        r = asyncio.run(
+            handlers.api_instances_connect(
+                _FakeReq(
+                    _State(reg, FakeMgr()),
+                    match={"id": "cd-1"},
+                    query={"rebuild": "1", "only_if_connected": "1"},
+                )
+            )
+        )
+        assert r.status == 400
+        assert [(e["tool_name"], e["outcome"], e["request_id"]) for e in events] == [
+            ("instances_connect", "denied", "cd-1")
+        ]
+        assert "mutually exclusive" in events[0]["error"]
 
     def test_connect_remints_when_stored_token_stale(self, tmp_path, monkeypatch):
         from kiro_crew.dashboard import handlers_instances as handlers

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -176,6 +176,7 @@
       "disable-gpu.js",
       "memory-watch-log.js",
       "frame-load-log.js",
+      "pane-asset-journal.js",
       "cage-trace.js",
       "pyspy-dump.js",
       "perf-metrics.js",

--- a/website/electron/pane-asset-journal.js
+++ b/website/electron/pane-asset-journal.js
@@ -1,0 +1,238 @@
+"use strict";
+
+/**
+ * Journal the module-graph fetches of the remote-crew panes, from the main process.
+ *
+ * The failure this closes: a pane's document loads (the parent sees
+ * `frame navigated status=200` and `iframe-load`), the inline scripts in its
+ * index.html run (its service worker registers), and then NOTHING — no console
+ * line, no `mc-embedded-boot`, no `mc-embedded-ready`, no API call ever reaches the
+ * remote gateway. Observed on four different crews across four days, always the one
+ * whose tunnel landed on the first allocated local port. Every renderer-side signal
+ * is silent there by construction: the entry bundle is an ES module with ~240
+ * statically preloaded chunks, and Chromium evaluates a module graph only once every
+ * edge has loaded. One `/assets/*` response that stalls mid-stream over a
+ * just-opened SSH tunnel leaves the graph waiting forever — no error event, no
+ * timeout, no JavaScript of ours runs, so nothing on the renderer side can report it.
+ *
+ * The main process CAN see it: `session.webRequest` observes every request the
+ * pane's frame issues. This module counts, per pane origin, the hashed-asset
+ * requests started / completed / failed, and journals:
+ *
+ *   `[pane-assets] origin=http://localhost:7778 started=242 done=241 failed=0
+ *    inflight=1 STALLED=/assets/App-abc.js after=20000ms`
+ *
+ * when a request has been in flight past `STALL_MS`, and a one-line summary when a
+ * pane's graph settles (`inflight` returns to 0 after having been non-zero). A pane
+ * that never settles and shows one STALLED line is this bug; a pane whose graph
+ * settled and still never announced readiness is a different one.
+ *
+ * Scope is deliberately narrow: loopback origins only, `/assets/` paths only (the
+ * content-hashed chunks the module graph is made of), and never the dashboard's own
+ * origin — its bundle is served by the local gateway and is not the surface that
+ * stalls. URLs are journaled without their query string, so a `?token=` can never
+ * reach the log through this path (hashed assets carry none, but the strip is
+ * unconditional).
+ *
+ * Bounded: one stall line per request, one settle line per settle, the request
+ * table is capped so a pane that issues requests forever cannot grow main-process
+ * memory without bound, and the journal as a whole writes at most `LOG_LINES_MAX`
+ * lines per attachment (one final `budget-exhausted` line, then silence). The
+ * remote pane is untrusted: without the aggregate cap a hostile one could loop
+ * single fetches and turn every settle into a log line, growing the unrotated
+ * launch log until the disk is full. The bug this exists to diagnose shows in the
+ * first handful of lines, so the cap costs nothing legitimate.
+ */
+
+/** In-flight time after which a hashed-asset request is journaled as stalled. */
+const STALL_MS = 20_000;
+/** Ceiling on tracked in-flight requests per origin. Past it, new requests count but are not timed. */
+const INFLIGHT_TRACK_MAX = 512;
+/** Ceiling on origins tracked; the instances feature caps warm panes far below this. */
+const ORIGINS_MAX = 64;
+/**
+ * Ceiling on journal lines written per attachment (per app launch), across all
+ * origins. Generous for the diagnostic (a stuck pane produces a few lines; a
+ * healthy one produces one settle line per navigation) and tiny for a disk.
+ */
+const LOG_LINES_MAX = 2_000;
+
+const PREFIX = "[pane-assets]";
+
+/** Origin + path of a request URL, or null when it is not a loopback hashed asset. */
+function classifyUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(String(url));
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  const host = parsed.hostname;
+  const loopback = host === "localhost" || host === "127.0.0.1" || host === "[::1]"
+    || host.endsWith(".localhost");
+  if (!loopback) return null;
+  if (!parsed.pathname.startsWith("/assets/")) return null;
+  return { origin: parsed.origin, path: parsed.pathname };
+}
+
+/**
+ * The tracker proper, with its clock and timers injected so the stall detection is
+ * testable without waiting 20 seconds. `log` receives complete lines.
+ */
+function createPaneAssetTracker({
+  log,
+  now = () => Date.now(),
+  setTimer = (fn, ms) => setTimeout(fn, ms),
+  clearTimer = (t) => clearTimeout(t),
+  stallMs = STALL_MS,
+  skipOrigin = "",
+  logLinesMax = LOG_LINES_MAX,
+} = {}) {
+  if (typeof log !== "function") throw new TypeError("log is required");
+  /** origin -> { started, done, failed, inflight: Map<requestId, {path, startedAt, timer}> , hadInflight } */
+  const origins = new Map();
+  // Aggregate line budget. Counters keep counting after it is spent (the snapshot
+  // hook still reports them); only the journal goes quiet.
+  let linesWritten = 0;
+  const emit = (line) => {
+    if (linesWritten >= logLinesMax) return;
+    linesWritten += 1;
+    if (linesWritten === logLinesMax) {
+      log(`${PREFIX} budget-exhausted lines=${logLinesMax}; further pane-asset lines suppressed for this session`);
+      return;
+    }
+    log(line);
+  };
+
+  const stats = (origin) => {
+    let s = origins.get(origin);
+    if (!s) {
+      if (origins.size >= ORIGINS_MAX) return null;
+      s = { started: 0, done: 0, failed: 0, stalled: 0, inflight: new Map(), untracked: 0, hadInflight: false };
+      origins.set(origin, s);
+    }
+    return s;
+  };
+
+  const summary = (origin, s) =>
+    `origin=${origin} started=${s.started} done=${s.done} failed=${s.failed} inflight=${s.inflight.size + s.untracked}`;
+
+  const onStart = (requestId, url) => {
+    const c = classifyUrl(url);
+    if (!c || c.origin === skipOrigin) return;
+    const s = stats(c.origin);
+    if (!s) return;
+    s.started += 1;
+    s.hadInflight = true;
+    if (s.inflight.size >= INFLIGHT_TRACK_MAX) {
+      s.untracked += 1;
+      return;
+    }
+    const startedAt = now();
+    const timer = setTimer(() => {
+      const entry = s.inflight.get(requestId);
+      if (!entry) return;
+      s.stalled += 1;
+      emit(`${PREFIX} ${summary(c.origin, s)} STALLED=${entry.path} after=${now() - entry.startedAt}ms`);
+    }, stallMs);
+    s.inflight.set(requestId, { path: c.path, startedAt, timer });
+  };
+
+  const finish = (requestId, url, outcome) => {
+    const c = classifyUrl(url);
+    if (!c || c.origin === skipOrigin) return;
+    const s = origins.get(c.origin);
+    if (!s) return;
+    const entry = s.inflight.get(requestId);
+    if (entry) {
+      clearTimer(entry.timer);
+      s.inflight.delete(requestId);
+    } else if (s.untracked > 0) {
+      s.untracked -= 1;
+    } else {
+      // A completion for a request we never saw start (attached mid-flight).
+      return;
+    }
+    if (outcome === "done") s.done += 1;
+    else s.failed += 1;
+    if (s.hadInflight && s.inflight.size === 0 && s.untracked === 0) {
+      s.hadInflight = false;
+      emit(`${PREFIX} ${summary(c.origin, s)} settled stalled=${s.stalled}`);
+    }
+  };
+
+  return {
+    onStart,
+    onCompleted: (requestId, url) => finish(requestId, url, "done"),
+    onError: (requestId, url) => finish(requestId, url, "failed"),
+    /** Test/inspection hook: a snapshot of one origin's counters. */
+    snapshot(origin) {
+      const s = origins.get(origin);
+      if (!s) return null;
+      return { started: s.started, done: s.done, failed: s.failed, stalled: s.stalled, inflight: s.inflight.size + s.untracked };
+    },
+  };
+}
+
+/**
+ * Wire the tracker to an Electron `session.webRequest`. Filtered at the source to
+ * loopback `/assets/*` URLs so the listeners never see the dashboard's API traffic.
+ * Tolerates a missing session so it can never break window creation.
+ *
+ * Observation only, on the non-blocking events: `onSendHeaders` (the request is
+ * on the wire), `onCompleted`, `onErrorOccurred`. None of them takes a callback,
+ * so the ~240 chunk fetches of a pane's module graph never wait on a
+ * main-process round-trip just to be counted — the path this journal watches is
+ * the one the stagger exists to decongest, and a blocking listener would add
+ * load to it. The trade: a request that fails BEFORE its headers go out
+ * (connection refused) reaches `onErrorOccurred` with no start on record and is
+ * ignored, so `failed=` undercounts pre-send failures. The stall this journal
+ * exists for is a request that DID go out and never finished; those are all
+ * tracked and timed.
+ *
+ * Listener ownership: Electron keeps ONE listener per `webRequest` event per
+ * session, so this module owns `onSendHeaders`, `onCompleted` and
+ * `onErrorOccurred` on the pane session it is attached to. A later registration
+ * elsewhere on the same session evicts these silently; register through here.
+ */
+function attachPaneAssetJournal(session, log, dashboardOrigin) {
+  const wr = session && session.webRequest;
+  if (!wr || typeof wr.onSendHeaders !== "function") return false;
+  if (typeof log !== "function") return false;
+  let skipOrigin = "";
+  try {
+    skipOrigin = new URL(String(dashboardOrigin)).origin;
+  } catch {
+    skipOrigin = "";
+  }
+  const tracker = createPaneAssetTracker({ log, skipOrigin });
+  const filter = {
+    urls: [
+      "http://localhost:*/assets/*",
+      "http://127.0.0.1:*/assets/*",
+      "http://*.localhost:*/assets/*",
+      "https://localhost:*/assets/*",
+      "https://127.0.0.1:*/assets/*",
+      "https://*.localhost:*/assets/*",
+    ],
+  };
+  wr.onSendHeaders(filter, (details) => {
+    tracker.onStart(details.id, details.url);
+  });
+  wr.onCompleted(filter, (details) => {
+    tracker.onCompleted(details.id, details.url);
+  });
+  wr.onErrorOccurred(filter, (details) => {
+    tracker.onError(details.id, details.url);
+  });
+  return true;
+}
+
+module.exports = {
+  INFLIGHT_TRACK_MAX,
+  PREFIX,
+  attachPaneAssetJournal,
+  classifyUrl,
+  createPaneAssetTracker,
+};

--- a/website/electron/test/pane-asset-journal.test.js
+++ b/website/electron/test/pane-asset-journal.test.js
@@ -1,0 +1,236 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  INFLIGHT_TRACK_MAX,
+  PREFIX,
+  attachPaneAssetJournal,
+  classifyUrl,
+  createPaneAssetTracker,
+} = require("../pane-asset-journal");
+
+/** A manual clock + timer queue so stall detection runs without real waiting. */
+function fakeTime() {
+  let t = 0;
+  const timers = new Map();
+  let seq = 0;
+  return {
+    now: () => t,
+    setTimer(fn, ms) {
+      const id = ++seq;
+      timers.set(id, { at: t + ms, fn });
+      return id;
+    },
+    clearTimer(id) {
+      timers.delete(id);
+    },
+    advance(ms) {
+      t += ms;
+      for (const [id, { at, fn }] of [...timers.entries()]) {
+        if (at <= t) {
+          timers.delete(id);
+          fn();
+        }
+      }
+    },
+    pending: () => timers.size,
+  };
+}
+
+function tracker(overrides = {}) {
+  const lines = [];
+  const time = fakeTime();
+  const tr = createPaneAssetTracker({
+    log: (l) => lines.push(l),
+    now: time.now,
+    setTimer: time.setTimer,
+    clearTimer: time.clearTimer,
+    stallMs: 1000,
+    ...overrides,
+  });
+  return { tr, lines, time };
+}
+
+const PANE = "http://localhost:7778";
+
+describe("classifyUrl", () => {
+  it("accepts loopback hashed assets and returns origin + path only", () => {
+    assert.deepEqual(classifyUrl("http://localhost:7778/assets/main-abc.js?x=1"), {
+      origin: "http://localhost:7778",
+      path: "/assets/main-abc.js",
+    });
+    assert.deepEqual(classifyUrl("http://127.0.0.1:7779/assets/a.css").origin, "http://127.0.0.1:7779");
+    assert.equal(classifyUrl("http://kirocrew.localhost:7780/assets/a.js").origin, "http://kirocrew.localhost:7780");
+  });
+
+  it("rejects non-asset paths, non-loopback hosts and non-http schemes", () => {
+    assert.equal(classifyUrl("http://localhost:7778/api/status"), null);
+    assert.equal(classifyUrl("http://localhost:7778/?token=abc"), null);
+    assert.equal(classifyUrl("http://example.com/assets/a.js"), null);
+    assert.equal(classifyUrl("chrome-error://chromewebdata/assets/a.js"), null);
+    assert.equal(classifyUrl("not a url"), null);
+  });
+});
+
+describe("createPaneAssetTracker", () => {
+  it("is silent while a graph loads and journals one settle line when it completes", () => {
+    const { tr, lines } = tracker();
+    for (let i = 0; i < 5; i++) tr.onStart(i, `${PANE}/assets/c${i}.js`);
+    assert.equal(lines.length, 0);
+    for (let i = 0; i < 4; i++) tr.onCompleted(i, `${PANE}/assets/c${i}.js`);
+    assert.equal(lines.length, 0, "not settled until the last request finishes");
+    tr.onCompleted(4, `${PANE}/assets/c4.js`);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /^\[pane-assets\] origin=http:\/\/localhost:7778 started=5 done=5 failed=0 inflight=0 settled stalled=0$/);
+  });
+
+  it("journals a STALLED line naming the request that sat in flight past stallMs", () => {
+    const { tr, lines, time } = tracker();
+    tr.onStart(1, `${PANE}/assets/main-abc.js`);
+    tr.onStart(2, `${PANE}/assets/App-def.js`);
+    tr.onCompleted(1, `${PANE}/assets/main-abc.js`);
+    time.advance(999);
+    assert.equal(lines.length, 0);
+    time.advance(1);
+    assert.equal(lines.length, 1);
+    assert.equal(
+      lines[0],
+      `${PREFIX} origin=${PANE} started=2 done=1 failed=0 inflight=1 STALLED=/assets/App-def.js after=1000ms`,
+    );
+    // The stall line is emitted once per request, never re-armed.
+    time.advance(5000);
+    assert.equal(lines.length, 1);
+    // A late completion still settles the origin and reports the stall count.
+    tr.onCompleted(2, `${PANE}/assets/App-def.js`);
+    assert.equal(lines.length, 2);
+    assert.match(lines[1], /settled stalled=1$/);
+  });
+
+  it("clears the stall timer when a request completes in time", () => {
+    const { tr, lines, time } = tracker();
+    tr.onStart(1, `${PANE}/assets/a.js`);
+    tr.onCompleted(1, `${PANE}/assets/a.js`);
+    assert.equal(time.pending(), 0);
+    time.advance(10_000);
+    assert.equal(lines.filter((l) => l.includes("STALLED")).length, 0);
+  });
+
+  it("counts network errors as failed, not done", () => {
+    const { tr, lines } = tracker();
+    tr.onStart(1, `${PANE}/assets/a.js`);
+    tr.onError(1, `${PANE}/assets/a.js`);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /started=1 done=0 failed=1 inflight=0 settled/);
+  });
+
+  it("keeps origins independent and never journals the dashboard's own origin", () => {
+    const { tr, lines } = tracker({ skipOrigin: "http://localhost:5476" });
+    tr.onStart(1, "http://localhost:5476/assets/main.js");
+    tr.onStart(2, `${PANE}/assets/a.js`);
+    tr.onStart(3, "http://localhost:7779/assets/a.js");
+    tr.onCompleted(2, `${PANE}/assets/a.js`);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /origin=http:\/\/localhost:7778 .* settled/);
+    assert.equal(tr.snapshot("http://localhost:5476"), null);
+    assert.deepEqual(tr.snapshot("http://localhost:7779"), { started: 1, done: 0, failed: 0, stalled: 0, inflight: 1 });
+  });
+
+  it("ignores completions for requests it never saw start", () => {
+    const { tr, lines } = tracker();
+    tr.onCompleted(99, `${PANE}/assets/a.js`);
+    tr.onStart(1, `${PANE}/assets/b.js`);
+    tr.onCompleted(99, `${PANE}/assets/a.js`);
+    assert.equal(lines.length, 0);
+    assert.deepEqual(tr.snapshot(PANE), { started: 1, done: 0, failed: 0, stalled: 0, inflight: 1 });
+  });
+
+  it("strips the query string from the journaled path", () => {
+    const { tr, lines, time } = tracker();
+    tr.onStart(1, `${PANE}/assets/a.js?token=secret`);
+    time.advance(1000);
+    assert.equal(lines.length, 1);
+    assert.doesNotMatch(lines[0], /secret|token/);
+    assert.match(lines[0], /STALLED=\/assets\/a\.js /);
+  });
+
+  it("stops timing (but keeps counting) past the in-flight tracking ceiling", () => {
+    const { tr, lines, time } = tracker();
+    for (let i = 0; i < INFLIGHT_TRACK_MAX + 10; i++) tr.onStart(i, `${PANE}/assets/c${i}.js`);
+    assert.equal(time.pending(), INFLIGHT_TRACK_MAX);
+    assert.equal(tr.snapshot(PANE).inflight, INFLIGHT_TRACK_MAX + 10);
+    for (let i = 0; i < INFLIGHT_TRACK_MAX + 10; i++) tr.onCompleted(i, `${PANE}/assets/c${i}.js`);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], new RegExp(`started=${INFLIGHT_TRACK_MAX + 10} done=${INFLIGHT_TRACK_MAX + 10} failed=0 inflight=0 settled`));
+  });
+});
+
+describe("attachPaneAssetJournal", () => {
+  function fakeSession() {
+    const listeners = {};
+    return {
+      listeners,
+      webRequest: {
+        onSendHeaders(filter, fn) { listeners.before = { filter, fn }; },
+        onCompleted(filter, fn) { listeners.completed = { filter, fn }; },
+        onErrorOccurred(filter, fn) { listeners.error = { filter, fn }; },
+      },
+    };
+  }
+
+  it("tolerates a missing session or log", () => {
+    assert.equal(attachPaneAssetJournal(null, () => {}, "http://localhost:5476"), false);
+    assert.equal(attachPaneAssetJournal({}, () => {}, "http://localhost:5476"), false);
+    assert.equal(attachPaneAssetJournal(fakeSession(), null, "http://localhost:5476"), false);
+  });
+
+  it("registers loopback-asset filtered non-blocking listeners", () => {
+    const s = fakeSession();
+    const lines = [];
+    assert.equal(attachPaneAssetJournal(s, (l) => lines.push(l), "http://localhost:5476/?token=abc"), true);
+    for (const key of ["before", "completed", "error"]) {
+      assert.ok(s.listeners[key], `${key} listener registered`);
+      assert.ok(s.listeners[key].filter.urls.every((u) => u.includes("/assets/*")), "filtered to hashed assets");
+    }
+    // Non-blocking: the fake exposes only `onSendHeaders` (no `onBeforeRequest`),
+    // so attaching at all proves the journal never takes the blocking slot.
+    s.listeners.before.fn({ id: 1, url: `${PANE}/assets/a.js` });
+    s.listeners.completed.fn({ id: 1, url: `${PANE}/assets/a.js` });
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /origin=http:\/\/localhost:7778 started=1 done=1/);
+  });
+
+  it("does not journal the dashboard's own bundle", () => {
+    const s = fakeSession();
+    const lines = [];
+    attachPaneAssetJournal(s, (l) => lines.push(l), "http://localhost:5476/?token=abc");
+    s.listeners.before.fn({ id: 1, url: "http://localhost:5476/assets/main.js" });
+    s.listeners.completed.fn({ id: 1, url: "http://localhost:5476/assets/main.js" });
+    assert.equal(lines.length, 0);
+  });
+});
+
+describe("aggregate log budget", () => {
+  it("a pane that settles forever writes at most logLinesMax lines, the last one naming the cap", () => {
+    const { tr, lines } = tracker({ logLinesMax: 5 });
+    // Each single fetch that completes is one settle -> one line. Loop well past the cap.
+    for (let i = 0; i < 50; i++) {
+      tr.onStart(i, `${PANE}/assets/c${i}.js`);
+      tr.onCompleted(i, `${PANE}/assets/c${i}.js`);
+    }
+    assert.equal(lines.length, 5);
+    assert.match(lines[4], /budget-exhausted lines=5/);
+    assert.equal(lines.filter((l) => /settled/.test(l)).length, 4);
+    // Counters still count; only the journal is quiet.
+    assert.equal(tr.snapshot(PANE).done, 50);
+  });
+
+  it("stall lines share the same budget", () => {
+    const { tr, lines, time } = tracker({ logLinesMax: 3 });
+    for (let i = 0; i < 10; i++) tr.onStart(i, `${PANE}/assets/c${i}.js`);
+    time.advance(1000);
+    assert.equal(lines.length, 3);
+    assert.match(lines[2], /budget-exhausted/);
+  });
+});

--- a/website/electron/window-lifecycle.js
+++ b/website/electron/window-lifecycle.js
@@ -46,6 +46,7 @@ const {
   OVERLAY_BACKGROUND: WINDOWS_TITLEBAR_BACKGROUND,
 } = require("./windows-titlebar");
 const { attachFrameLoadLogging } = require("./frame-load-log");
+const { attachPaneAssetJournal } = require("./pane-asset-journal");
 const { createMemoryWatchLog } = require("./memory-watch-log");
 const { createCageTrace } = require("./cage-trace");
 const { profilingEnabled } = require("./perf-metrics");
@@ -958,6 +959,11 @@ function createWindowLifecycle(options) {
     // enough on its own, because a pane can navigate the top-level window to a
     // remote document and inherit that position.
     attachFrameLoadLogging(mainWindow.webContents, glog, backendUrl);
+    // The pane's module graph is the one load stage no renderer-side line can
+    // report: a stalled hashed-chunk fetch leaves the entry module unevaluated,
+    // so nothing of ours runs in that frame to say so. The main process sees the
+    // request either way. See pane-asset-journal.js.
+    attachPaneAssetJournal(mainWindow.webContents.session, glog, backendUrl);
 
     const rendererRecovery = createRendererRecovery({
       isQuitting,

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -2412,10 +2412,13 @@ export const api = {
   removeInstance: (id: string) => del('/api/instances/' + encodeURIComponent(id)).then(j),
   instanceStatus: (id: string, diagnose = false) =>
     get('/api/instances/' + encodeURIComponent(id) + '/status' + (diagnose ? '?diagnose=1' : '')).then(j) as Promise<InstanceTunnelStatus>,
-  connectInstance: (id: string) =>
-    post('/api/instances/' + encodeURIComponent(id) + '/connect').then(j) as Promise<
-      InstanceTunnelStatus & { token?: string }
-    >,
+  connectInstance: (id: string, opts?: { rebuild?: boolean; onlyIfConnected?: boolean }) =>
+    post(
+      '/api/instances/' +
+        encodeURIComponent(id) +
+        '/connect' +
+        (opts?.rebuild ? '?rebuild=1' : opts?.onlyIfConnected ? '?only_if_connected=1' : ''),
+    ).then(j) as Promise<InstanceTunnelStatus & { token?: string }>,
   refreshInstanceToken: (id: string) =>
     post('/api/instances/' + encodeURIComponent(id) + '/refresh-token').then(j) as Promise<
       InstanceTunnelStatus & { token?: string }

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -73,6 +73,11 @@ const REFRESH_MIN_INTERVAL_MS = 10_000
 // deps below precisely so that a re-mint arriving inside the window cannot
 // postpone it.
 const PANE_LOAD_TIMEOUT_MS = 15_000
+// Gap between successive auto-warm iframe mounts on first load (see the
+// auto-warm effect). Long enough for a tunnel's shell + entry bundle to land
+// before the next pane starts pulling its own; short enough that four panes
+// are all warm within the time the user spends reading the Local tab.
+const AUTO_WARM_STAGGER_MS = 1_500
 // How many reactive re-mints one pane may ask for before the parent stops
 // answering. The child posts `mc-auth-expired` on EVERY 403 it sees
 // (api/client.ts hands recovery to the hub before it latches its own banner),
@@ -233,6 +238,13 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // backend already auto-reconnected the tunnel (connect() returns the cached
   // token without re-minting). Failures are swallowed: the sticky tab + in-pane
   // error/Retry panel handle an instance that can't be warmed.
+  //
+  // Connected-only, on purpose: auto-warm pre-mounts panes for tunnels that are
+  // ALREADY up; bringing one up is the fan-out's and the click's job. The
+  // gateway enforces that under its manager lock, so a warm that fires after
+  // the user disconnected the crew (the stagger below makes that window real)
+  // is declined server-side instead of re-opening the tunnel and re-persisting
+  // the intent the disconnect just cleared.
   const autoWarm = useCallback(
     async (id: string) => {
       try {
@@ -241,7 +253,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         // auto-warm is no longer untraceable: it used to leave any PREVIOUS warm
         // entry in place with nothing in the log, and the user saw only
         // "loading" forever.
-        await connectInstanceInto(dispatch, id, 'auto-warm')
+        await connectInstanceInto(dispatch, id, 'auto-warm', { onlyIfConnected: true })
       } catch {
         // Already journaled by connectInstanceInto; the sticky tab + in-pane
         // panel handle an instance that cannot be warmed.
@@ -477,7 +489,8 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     // (via=retry). Retry can "succeed" as a request while warming nothing, and
     // the pane then reloads into the same stuck state — that case is the
     // `warm-declined` line the step emits.
-    mutationFn: (id: string) => connectInstanceInto(dispatch, id, 'retry'),
+    mutationFn: ({ id, rebuild }: { id: string; rebuild: boolean }) =>
+      connectInstanceInto(dispatch, id, 'retry', { rebuild }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['instances'] })
     },
@@ -492,6 +505,10 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // src would otherwise not reload a dead frame).
   const [timedOut, setTimedOut] = useState<Record<string, boolean>>({})
   const [reloadSeq, setReloadSeq] = useState<Record<string, number>>({})
+  // Live mirror of `timedOut` for `retry`, which must read the verdict at press
+  // time without re-creating itself on every watchdog flip.
+  const timedOutRef = useRef(timedOut)
+  timedOutRef.current = timedOut
   const activeWarmConn = activeId ? warm[activeId] : undefined
   // Apply the INCOMING pane's chrome state at switch time. The store otherwise
   // keeps whatever the outgoing surface last reported — and a switch necessarily
@@ -592,19 +609,32 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
 
   const retry = useCallback(
     (id: string) => {
+      const frame = frameDocumentState(iframeRefs.current.get(id))
+      // A watchdog verdict on a document that DID navigate is the one case a
+      // plain reconnect cannot fix: the tunnel answers every probe, so the
+      // idempotent connect returns the same forwarder, and the pane reloads
+      // into the same stalled module graph (one hashed-chunk stream that never
+      // finishes over that TCP path). Ask the gateway to rebuild the tunnel —
+      // a new forwarder on a different local port (the freed one is excluded
+      // from the allocation) — so the reload rides neither the stalled stream
+      // nor whatever may be wrong with the old port. A pane
+      // that never navigated (`about:blank`) or whose connect itself failed
+      // keeps the cheap path: there is no stalled stream to escape.
+      const rebuild = !!timedOutRef.current[id] && frame === 'cross-origin'
       // Clear the stale verdict and force a reload even if the re-mint returns
       // an identical token (setWarm would be a no-op for the iframe src).
       paneLog('retry', {
         id,
         port: warmRef.current[id]?.port,
-        frame: frameDocumentState(iframeRefs.current.get(id)),
+        frame,
+        rebuild: rebuild || undefined,
       })
       setTimedOut(prev => ({ ...prev, [id]: false }))
       setReloadSeq(prev => ({ ...prev, [id]: (prev[id] || 0) + 1 }))
       // An explicit user press is a fresh start: re-open the reactive budget so
       // a pane that recovers on the next token can still self-heal afterwards.
       reactiveMintsRef.current.delete(id)
-      connectMutation.mutate(id)
+      connectMutation.mutate({ id, rebuild })
     },
     [connectMutation],
   )
@@ -659,6 +689,19 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // activeId: the dashboard always lands on the Local tab and the warmed iframes
   // sit hidden and ready. Down instances are skipped (they stay sticky error
   // tabs); this runs once per mount. warmRef avoids re-firing on warm changes.
+  //
+  // Staggered, not simultaneous. Each warm mounts an iframe that immediately
+  // pulls a ~4 MB module graph (~240 hashed chunks) over a just-opened SSH
+  // tunnel, and the tunnels themselves were raised seconds earlier by the
+  // auto-connect fan-out. Four panes cold-loading in the same second is the
+  // exact condition under which one stream stalled and its pane never
+  // finished loading (see pane-asset-journal in the desktop shell). One warm
+  // per AUTO_WARM_STAGGER_MS keeps the loads sequential enough that a single
+  // tunnel's first bytes are not competing with three others' bulk transfer.
+  // The user's active pane is never delayed by this: it is warmed by the
+  // select path, not here.
+  const autoWarmTimersRef = useRef<number[]>([])
+  useEffect(() => () => { for (const t of autoWarmTimersRef.current) window.clearTimeout(t) }, [])
   const didAutoWarmRef = useRef(false)
   useEffect(() => {
     const data = instancesQuery.data
@@ -669,7 +712,28 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     const candidates = data.instances
       .filter(i => i.status?.state === 'connected' && !warmRef.current[i.id])
       .slice(0, room)
-    for (const inst of candidates) void autoWarm(inst.id)
+    // Timers live in a ref and are cleared only on unmount: this effect re-runs
+    // on every instances poll (its deps include the query data), and a cleanup
+    // returned from it would cancel the pending warms after the first poll
+    // while the once-only guard above stops them from ever being re-armed.
+    //
+    // The delay opens a window the immediate fan-out never had: the user can
+    // disconnect a crew before its timer fires. That race is closed on the
+    // gateway, not here: autoWarm asks for a connected-only connect, which the
+    // manager evaluates under the same lock disconnect holds, so a late warm
+    // is declined (`warm-declined`) rather than re-opening the tunnel. The one
+    // thing worth checking client-side is whether something else (a click)
+    // already warmed the pane meanwhile — then the warm is simply redundant.
+    autoWarmTimersRef.current = candidates.map((inst, i) =>
+      window.setTimeout(() => {
+        if (warmRef.current[inst.id]) {
+          paneLog('auto-warm-skipped', { id: inst.id, index: i, alreadyWarm: true })
+          return
+        }
+        if (i > 0) paneLog('auto-warm-staggered', { id: inst.id, index: i, delayMs: i * AUTO_WARM_STAGGER_MS })
+        void autoWarm(inst.id)
+      }, i * AUTO_WARM_STAGGER_MS),
+    )
   }, [instancesQuery.data, warmCap, autoWarm])
 
   const warmIds = useMemo(() => Object.keys(warm), [warm])
@@ -840,13 +904,13 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
 
   const panelState = activeInst?.status?.state
   const panelConnecting =
-    (connectMutation.isPending && connectMutation.variables === activeId) ||
+    (connectMutation.isPending && connectMutation.variables?.id === activeId) ||
     panelState === 'connecting'
   // The Retry's own rejection used to reach only `paneLog`: the panel kept
   // showing the LIST's last status.error (or nothing) while the connect that
   // just failed said something newer. The mutation's error for THIS crew wins
   // while it is the latest thing that happened.
-  const connectFailure = connectMutation.isError && connectMutation.variables === activeId
+  const connectFailure = connectMutation.isError && connectMutation.variables?.id === activeId
     ? (errMessage(connectMutation.error) || i18nT('components.instancesViewport.connection_error'))
     : ''
   const panelError = connectFailure || activeInst?.status?.error || activeInst?.status?.diagnosis?.reason || ''

--- a/website/src/lib/connectInstance.test.ts
+++ b/website/src/lib/connectInstance.test.ts
@@ -37,6 +37,35 @@ describe('connectInstanceInto pane journal', () => {
     ])
   })
 
+  it('passes `rebuild` through to the API and stamps it on the warm line', async () => {
+    const lines = captureInfo()
+    const dispatch = vi.fn()
+    connectInstance.mockResolvedValue({ state: 'connected', local_port: 7783, token: 't' })
+    await connectInstanceInto(dispatch as never, 'shizuka', 'retry', { rebuild: true })
+    expect(connectInstance).toHaveBeenCalledWith('shizuka', { rebuild: true })
+    expect(lines).toEqual(['[pane] warm id=shizuka port=7783 via=retry rebuild=true'])
+  })
+
+  it('passes `onlyIfConnected` through to the API (auto-warm) and a declined answer is `warm-declined`', async () => {
+    const lines = captureInfo()
+    const dispatch = vi.fn()
+    connectInstance.mockResolvedValue({ state: 'disconnected', local_port: 0, remote_port: 7777 })
+    await connectInstanceInto(dispatch as never, 'shizuka', 'auto-warm', { onlyIfConnected: true })
+    expect(connectInstance).toHaveBeenCalledWith('shizuka', { onlyIfConnected: true })
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(lines).toEqual([
+      '[pane] warm-declined id=shizuka via=auto-warm state=disconnected hasPort=false hasToken=false',
+    ])
+  })
+
+  it('a plain connect asks for no rebuild and the warm line carries no flag', async () => {
+    const lines = captureInfo()
+    connectInstance.mockResolvedValue({ state: 'connected', local_port: 7781, token: 't' })
+    await connectInstanceInto(vi.fn() as never, 'shizuka', 'retry')
+    expect(connectInstance).toHaveBeenCalledWith('shizuka')
+    expect(lines).toEqual(['[pane] warm id=shizuka port=7781 via=retry'])
+  })
+
   it('journals a rejection as `warm-failed` and re-throws it unchanged', async () => {
     const lines = captureInfo()
     const err = new Error('502 tunnel down')

--- a/website/src/lib/connectInstance.ts
+++ b/website/src/lib/connectInstance.ts
@@ -42,18 +42,48 @@ import type { AppDispatch } from '../store'
  */
 export type ConnectVia = 'select' | 'auto-connect' | 'auto-warm' | 'retry'
 
-export async function connectInstanceInto(dispatch: AppDispatch, id: string, via: ConnectVia = 'select') {
+/**
+ * `rebuild` asks the gateway to tear the existing tunnel down and spawn a fresh
+ * forwarder on a different local port (the freed one is excluded from the
+ * allocation) before answering, instead of the idempotent
+ * "already connected, here is its status". Only Retry sets it, and only after a
+ * load watchdog fired on a document that DID navigate — the case where every
+ * probe says the tunnel is healthy yet the pane never finishes loading its
+ * module graph (one stalled stream). The journal carries the flag so a later
+ * `warm` line can be read as "new tunnel" rather than "same tunnel again".
+ *
+ * `onlyIfConnected` is the mirror image, for auto-warm: answer an already-up
+ * tunnel exactly like a plain connect, but never bring one up and never touch
+ * the connect intent. The gateway decides under its own manager lock, so an
+ * auto-warm racing an explicit disconnect cannot re-open the tunnel the user
+ * just closed; a tunnel that is not up comes back as a non-connected status,
+ * which this step journals as `warm-declined` and leaves the pane alone.
+ */
+export async function connectInstanceInto(
+  dispatch: AppDispatch,
+  id: string,
+  via: ConnectVia = 'select',
+  opts: { rebuild?: boolean; onlyIfConnected?: boolean } = {},
+) {
+  const rebuild = !!opts.rebuild
+  const onlyIfConnected = !!opts.onlyIfConnected
   let st
   try {
-    st = await api.connectInstance(id)
+    // The options object is passed only when set, so the plain call keeps the
+    // signature every existing caller and test spies on.
+    st = await (rebuild
+      ? api.connectInstance(id, { rebuild: true })
+      : onlyIfConnected
+        ? api.connectInstance(id, { onlyIfConnected: true })
+        : api.connectInstance(id))
   } catch (err) {
-    paneLog('warm-failed', { id, via, error: (err as Error)?.message || 'unknown' })
+    paneLog('warm-failed', { id, via, rebuild: rebuild || undefined, error: (err as Error)?.message || 'unknown' })
     throw err
   }
   if (st.state === 'connected' && st.local_port && st.token) {
     const conn: WarmConn = { port: st.local_port, token: st.token }
     dispatch(setWarm({ id, conn }))
-    paneLog('warm', { id, port: st.local_port, via })
+    paneLog('warm', { id, port: st.local_port, via, rebuild: rebuild || undefined })
   } else {
     // Same shape as the viewport's own `warm-declined`: the response says
     // something other than "connected with a port and a token", and whatever

--- a/website/src/test/InstancesViewport.test.tsx
+++ b/website/src/test/InstancesViewport.test.tsx
@@ -83,7 +83,9 @@ describe('InstancesViewport', () => {
     // Default mock has cd-1 connected. On load we pre-mount its iframe (hidden,
     // since we land on Local) so it's instantly usable without a click.
     const { store } = renderWithProviders(<InstancesViewport />)
-    await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-1'))
+    // Auto-warm is connected-only: it pre-mounts a tunnel that is already up
+    // and never asks the gateway to bring one up.
+    await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-1', { onlyIfConnected: true }))
     await waitFor(() => expect(store.getState().instances.warm['cd-1']).toBeDefined())
     // Landed on Local (activeId null) -> the warmed iframe is mounted but hidden.
     expect(store.getState().instances.activeId).toBeNull()
@@ -1239,6 +1241,112 @@ describe('InstancesViewport', () => {
     } finally {
       info.mockRestore()
     }
+  })
+
+  it('every auto-warm is connected-only, so one that fires after a disconnect is declined and warms nothing', async () => {
+    // Two connected crews: cd-1 warms at once, cd-2 is scheduled 1.5 s later.
+    const two = {
+      instances: [
+        { id: 'cd-1', name: 'One', ssh_host: 'a', remote_port: 7777, local_port: 7778, ttl: '20h', remote_bin: '',
+          status: { instance_id: 'cd-1', state: 'connected', local_port: 7778, remote_port: 7777 } },
+        { id: 'cd-2', name: 'Two', ssh_host: 'b', remote_port: 7777, local_port: 7779, ttl: '20h', remote_bin: '',
+          status: { instance_id: 'cd-2', state: 'connected', local_port: 7779, remote_port: 7777 } },
+      ],
+      warm_set_cap: 5,
+    }
+    vi.mocked(api.listInstances).mockResolvedValue(two as never)
+    // The gateway is the arbiter: cd-1 is up; cd-2 was disconnected before its
+    // warm arrived, so the connected-only connect declines it (200, state
+    // disconnected, no token) instead of re-opening the tunnel.
+    vi.mocked(api.connectInstance).mockImplementation(async (id: string, opts?: { onlyIfConnected?: boolean }) => {
+      expect(opts).toEqual({ onlyIfConnected: true })
+      return id === 'cd-1'
+        ? ({ state: 'connected', local_port: 7778, token: 'tok' } as never)
+        : ({ state: 'disconnected', local_port: 0, remote_port: 7777, code: 'instance_not_connected' } as never)
+    })
+    const { store } = renderWithProviders(<InstancesViewport />)
+    await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-1', { onlyIfConnected: true }))
+    expect(api.connectInstance).not.toHaveBeenCalledWith('cd-2', expect.anything())
+    // The stagger timer was armed under real timers at render; let it fire.
+    await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-2', { onlyIfConnected: true }), { timeout: 4_000 })
+    await new Promise(r => setTimeout(r, 20))
+    expect(store.getState().instances.warm['cd-1']).toBeDefined()
+    expect(store.getState().instances.warm['cd-2']).toBeUndefined()
+  })
+
+  it('a staggered auto-warm skips a crew something else already warmed in the meantime', async () => {
+    const two = {
+      instances: [
+        { id: 'cd-1', name: 'One', ssh_host: 'a', remote_port: 7777, local_port: 7778, ttl: '20h', remote_bin: '',
+          status: { instance_id: 'cd-1', state: 'connected', local_port: 7778, remote_port: 7777 } },
+        { id: 'cd-2', name: 'Two', ssh_host: 'b', remote_port: 7777, local_port: 7779, ttl: '20h', remote_bin: '',
+          status: { instance_id: 'cd-2', state: 'connected', local_port: 7779, remote_port: 7777 } },
+      ],
+      warm_set_cap: 5,
+    }
+    vi.mocked(api.listInstances).mockResolvedValue(two as never)
+    vi.mocked(api.connectInstance).mockImplementation(async (id: string) => ({
+      state: 'connected', local_port: id === 'cd-1' ? 7778 : 7779, token: 'tok',
+    }) as never)
+    const { store } = renderWithProviders(<InstancesViewport />)
+    await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-1', { onlyIfConnected: true }))
+    // A click (or the fan-out) warms cd-2 before its stagger slot.
+    act(() => { store.dispatch(setWarm({ id: 'cd-2', conn: { port: 7779, token: 'tok' } })) })
+    await new Promise(r => setTimeout(r, 1_800))
+    expect(api.connectInstance).not.toHaveBeenCalledWith('cd-2', expect.anything())
+  })
+
+  it('Retry after a watchdog verdict on a navigated frame asks the gateway to rebuild the tunnel', async () => {
+    mockConnectedCd1()
+    vi.mocked(api.connectInstance).mockResolvedValue({ state: 'connected', local_port: 7778, token: 'tok' })
+    vi.useFakeTimers()
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+    })
+    renderWithProviders(<InstancesViewport />, { store })
+    await act(async () => {
+      vi.advanceTimersByTime(15_000)
+    })
+    expect(screen.getByText(/Pane failed to load/i)).toBeInTheDocument()
+    vi.useRealTimers()
+    // happy-dom's disabled-iframe load leaves the frame a same-origin blank
+    // document; make it read as navigated (cross-origin), the one case rebuild
+    // is meant for.
+    const frame = document.querySelector('iframe') as HTMLIFrameElement
+    Object.defineProperty(frame, 'contentWindow', {
+      get: () => ({ get location() { throw new DOMException('blocked', 'SecurityError') } }),
+    })
+
+    const u = userEvent.setup()
+    await u.click(screen.getByRole('button', { name: /Retry/i }))
+    await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-1', { rebuild: true }))
+  })
+
+  it("Retry's own failure surfaces on the active pane's panel (variables keyed by id)", async () => {
+    // Stale warm: an iframe is mounted but the backend says the tunnel is down,
+    // so the panel is up and shows the LIST's error. Retry then fails with a
+    // NEWER reason; the mutation's error for THIS crew must win.
+    vi.mocked(api.listInstances).mockResolvedValue({
+      instances: [
+        {
+          id: 'cd-1', name: 'Cloud One', ssh_host: 'cd-1-alias', remote_port: 7777, local_port: 0, ttl: '20h', remote_bin: '',
+          was_connected: true,
+          status: { instance_id: 'cd-1', state: 'error', error: 'ssh unreachable', remote_port: 7777 },
+        },
+      ],
+      warm_set_cap: 5,
+    })
+    vi.mocked(api.connectInstance).mockRejectedValue(new Error('rebuild refused: EPERM'))
+    const store = createTestStore({
+      instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+    })
+    renderWithProviders(<InstancesViewport />, { store })
+    expect(await screen.findByText(/ssh unreachable/i)).toBeInTheDocument()
+    const u = userEvent.setup()
+    await u.click(screen.getByRole('button', { name: /Retry/i }))
+    await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-1'))
+    expect(await screen.findByText(/rebuild refused: EPERM/i)).toBeInTheDocument()
+    expect(screen.queryByText(/ssh unreachable/i)).toBeNull()
   })
 
 })


### PR DESCRIPTION
## Problem / Motivation

A remote-crew pane sits on "Loading pane…" forever, and every existing signal is silent for it. Across four days the `[pane]` journal (#9141) shows this on four different crews — gian, suneo, nobita, shizuka — and in every case the stuck one is whichever crew's tunnel landed on the first allocated local port (`tunnel_base_port`, 7778). The same crew on any other port loads in <1 s.

What the logs prove for the stuck pane, both locally and on the remote gateway's `security_events.jsonl`:
- parent: `frame navigated status=200`, `iframe-load frame=cross-origin`, `watchdog-armed`; never `ready`
- remote: the link-authenticated shell load OK → 2 s later the service worker's install pair (`/` + `/index.html`) → **then nothing, ever**. No `/api/*` from the App, and no `staleShellHeal` probe (a top-level statement in `main.tsx` that fires 3 s after the entry module evaluates)
- `chromium.log`: 0 console lines from that frame (healthy frames always emit the CSP/WASM burst)

So the inline `<script>`s in index.html ran, but the entry module `main-*.js` **never evaluated**. It is an ES module with ~240 statically preloaded chunks; Chromium evaluates a module graph only once every edge has loaded, and one `/assets/*` response that stalls mid-stream over a just-opened SSH tunnel leaves the graph waiting indefinitely — no error event, no timeout. None of our JavaScript runs in that frame, so nothing renderer-side (including #9325's `mc-embedded-boot stage=entry`) can ever report it. And Retry cannot escape it: `POST /connect` is idempotent, every probe says the tunnel is healthy, so the pane reloads over the same stalled TCP path.

## What changed

**This PR ships a diagnostic AND a remedy, deliberately on one branch** so a single local desktop build (the only environment that reproduces the bug) verifies both halves together. Every item below is intentional; none is diagnostics-only.

**1. Journal it (desktop main process)** — new `website/electron/pane-asset-journal.js`, attached next to `attachFrameLoadLogging`:
- `session.webRequest.onSendHeaders / onCompleted / onErrorOccurred` — all non-blocking, so the ~240 chunk fetches per pane never wait on a main-process callback just to be counted; filtered at the source to loopback `/assets/*`; the dashboard's own origin is skipped. The module owns those three listener slots on the pane session (Electron keeps one per event per session) and says so in its header. A request that fails before its headers go out is not counted as started; the stall this journals is one that did go out.
- `[pane-assets] origin=http://localhost:7778 started=242 done=241 failed=0 inflight=1 STALLED=/assets/App-abc.js after=20000ms` when a request sits in flight past 20 s (once per request); `… settled stalled=K` once when a pane's graph completes.
- Paths journaled without query strings; in-flight table capped at 512/origin, 64 origins; and an **aggregate budget of 2000 lines per attachment** (`logLinesMax`, internal default) across all origins — the remote pane is untrusted, and without the cap a hostile pane looping single fetches could turn every settle into a line and grow the unrotated launch log until the disk filled. The last line in budget says `budget-exhausted`; counters keep counting. Blocking listener calls back `{}` immediately. Listed in `build.files`. Exports only what has a consumer (`attachPaneAssetJournal`, `createPaneAssetTracker`, `classifyUrl`, `PREFIX`, `INFLIGHT_TRACK_MAX`).

**2. Retry rebuilds the tunnel (backend + viewport)** — behaviour change, not diagnostics.
- `SshTunnelManager.connect(id, rebuild=True)`: tears a CONNECTED tunnel down under the lock with `keep_intent=True`, then continues through the normal connect, spawning a **new forwarder on a different local port** — the port just freed is added to the allocator's `exclude` set. One Retry therefore escapes both hypotheses the evidence leaves open: a stalled stream on the old forwarder, and a cause bound to the old port itself (every field stall so far sat on the first allocated port, 7778). A teardown whose stop raises is returned as an ERROR status (502 with the reason, old tunnel left intact and tracked, reason retained for `last_error`) rather than propagating out of the handler as a 500.
- **New permanent API surface:** `POST /api/instances/{id}/connect?rebuild=1` maps onto it and is audited as `connect/rebuild`. One consumer today (the pane's Retry); without the flag the manager is called with its existing positional contract.
- The pane's Retry passes `rebuild` only when the load watchdog had fired **and** the frame is `cross-origin` (the document navigated). `about:blank` / connect-failed panes keep the cheap path. `paneLog('retry', …)` and the resulting `warm` line carry `rebuild=true`.
- Existing mechanisms do not cover this: `disconnect` drops the connect intent (the tab disappears) and the self-heal only fires on a *failed* probe, whereas here every probe passes.

**3. Stagger auto-warm (viewport)** — behaviour change, not diagnostics. First-load pre-mount raised every connected pane's iframe in the same tick, each pulling ~4 MB over a tunnel opened seconds earlier by the auto-connect fan-out. Now one mount per `AUTO_WARM_STAGGER_MS` (1.5 s), journaled `auto-warm-staggered id=… index=… delayMs=…`. Timers live in a ref cleared on unmount so the instances poll re-running the effect cannot cancel them. The active pane is unaffected (warmed by the select path).
- The delay opens a window the immediate fan-out never had: a crew disconnected before its timer fires must not be re-warmed (that would re-open the tunnel and re-persist `was_connected`). Closed on the gateway, atomically: **every auto-warm is a connected-only connect** — `SshTunnelManager.connect(id, only_if_connected=True)` / `POST …/connect?only_if_connected=1` — which, under the same manager lock `disconnect` holds, answers a CONNECTED tunnel exactly like a plain connect but, for a tunnel that is not up, spawns nothing, mints nothing, leaves `was_connected` untouched and returns a 200 with `state=disconnected`, `code=instance_not_connected` (the shared connect step journals that as `warm-declined`). A browser-side probe-then-connect could not close this (the disconnect can land between the probe and the connect); the lock can. Auto-warm's job is to pre-mount tunnels that are *already* up — bringing one up is the fan-out's and the click's job — so the mode is also the honest contract for that path. `rebuild` and `only_if_connected` together are a 400, audited as `connect/denied` like every other early exit of the handler. Client-side the timer only skips (journaled `auto-warm-skipped`) a pane something else already warmed meanwhile.
- The contention hypothesis behind the stagger ("four cold loads in the same second") is exactly what item 1 exists to confirm or refute in the field; the stagger is cheap (panes 2+ warm 1.5 s later, hidden); `?rebuild=1` is marked **provisional** in `instances.md` §4 step 1 — if the field trace shows the stall recur on the new port, the flag, the port exclusion and the mutual-exclusion 400 go together and the journal line makes its effect visible either way.

## How to read the log after a local build

`grep -E "pane-assets|\[pane\]" ~/Library/Logs/Kiro\ Crew/gateway-launch.log`
- `STALLED=…` with no `settled` for that origin → this bug, and the line names the chunk. Press Retry → expect `retry … rebuild=true`, then `warm … via=retry rebuild=true` on a **different port**, then `ready`. If it stalls again on the new port, the cause is neither the forwarder nor the port.
- `settled` but still no `ready` → a different problem; #9325's boot-stage journal is the next layer.
- `auto-warm-staggered` lines confirm the cold loads are sequenced; `warm-declined … via=auto-warm state=disconnected` means the gateway refused to re-open a tunnel that was no longer up (the disconnect race, closed); `auto-warm-skipped` means the pane was already warm when the timer fired.

## Tests

- `website/electron/test/pane-asset-journal.test.js` (new, 16): classification, silent-until-settled, STALLED at exactly `stallMs` once, timer cleared on completion, error→failed, origin isolation + dashboard skip, unseen completions ignored, query stripped, in-flight ceiling, aggregate line budget (settle loop and stall burst both capped, last line names the cap; fails with the guard removed), attach wiring. Full electron suite passes (incl. the packaging allowlist test).
- `test/test_instances.py`: `test_connect_rebuild_replaces_a_connected_tunnel` (old forwarder stopped, new one spawned on a different port — fails with the exclusion removed — intent kept, credential live, plain connect idempotent on the new tunnel), `test_connect_rebuild_with_no_tunnel_is_a_plain_connect`, `test_connect_rebuild_teardown_failure_is_an_error_status` (a raising stop → ERROR status with the reason, old tunnel untouched; fails with the guard removed), `test_connect_only_if_connected_declines_without_side_effects` (absent tunnel and connected-then-disconnected tunnel: DISCONNECTED, nothing spawned, no token, `was_connected` stays False; fails with the branch removed), `test_connect_only_if_connected_answers_a_live_tunnel_like_plain_connect`, `test_connect_rebuild_and_only_if_connected_are_exclusive`, `test_connect_rebuild_query_reaches_the_manager`, `test_connect_only_if_connected_query_declines_as_200_not_failure` (`?only_if_connected=1` → keyword; decline is 200 + `instance_not_connected`, no token, intent untouched; live tunnel answered like plain connect; combined with `rebuild` → 400), `test_connect_exclusive_flags_rejection_is_audited` (the 400 leaves one `instances_connect`/`denied` SEL event and never reaches the manager; fails with the audit line removed).
- `website/src/test/InstancesViewport.test.tsx` +4: every auto-warm asks `{ onlyIfConnected: true }` and a warm the gateway declines (crew disconnected inside the stagger window) warms nothing (fails with the flag removed from autoWarm); a staggered warm skips a pane something else already warmed; Retry on a navigated, timed-out frame calls `connectInstance(id, { rebuild: true })`; Retry's own rejection is shown on the active pane's panel (the `variables?.id` comparison).
- `connectInstance.test.ts` +3 (rebuild passthrough; `onlyIfConnected` passthrough with a declined answer journaled `warm-declined`; plain call keeps its one-arg signature). `tsc -b`, eslint clean.

## Manual verification

Pending — this PR exists so the author can build locally and reproduce with the journal on; see "How to read the log". The recovery half (a fresh forwarder unsticks the module graph) is a hypothesis until a field `STALLED → retry rebuild=true → ready` sequence is posted here; the journal half is what makes that sequence observable at all.

## Pattern harvest

Rule candidate: review-prompt. Pattern: a React Query `useMutation` whose variables type changes from a scalar to an object leaves every `mutation.variables === <scalar>` comparison silently `false` — `tsc` catches it only when the types have no overlap, and a `string | null` vs object comparison is exactly that case, so the local `tsc -b` gate must run before push. Also: a "fresh port" claim about a first-free allocator after its own teardown is an over-promise unless the freed port is explicitly excluded from the re-allocation; the comment must match what the allocator call actually does.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** log lines, a query flag and a mount timing change; no markup, layout, styling or user-visible string changes.

## Related

Follows #8274, #8813, #9141. Independent of #9325 (instruments the stage *after* the entry module evaluates; this covers the stage before it and the recovery).

no linked issue: the investigation lives in the `[pane]` journal threads of the PRs above, not in a tracked issue.

## Checklist

- [x] One squashed commit, Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated — `docs/system-specs/modules/instances.md` §3 (port re-use exception on rebuild) and §4 step 1 + §6 (`?rebuild=1`, `?only_if_connected=1`, mutual exclusion)
- [x] No secrets, credentials, or internal references in the diff
