### PR TITLE
fix(chat): keep a still reader at the bottom on phones without anchoring

### DIFF
--- a/website/src/hooks/virtualizer/FollowController.ts
+++ b/website/src/hooks/virtualizer/FollowController.ts
@@ -363,14 +363,46 @@ export function evaluateAutoPin(args: {
    *  gives: skipping leaves follow armed, so the next growth yanks the reader
    *  from wherever the restore just put them. */
   restoreGate?: boolean
+  /** Has hardware input -- wheel / touch / pointer / a scrolling key -- reached
+   *  the scroller since we last placed the reader at the bottom?
+   *
+   *  False means the reader has done nothing, so a gap that opened while they
+   *  rest on our last write was opened by content -- a row settling from its
+   *  estimate, a code-block stand-in swapping for the highlighted block, the
+   *  top spacer repricing -- and is a gap WE owe them, not one they chose.
+   *
+   *  The idle rule below cannot tell those apart from distance alone, and it
+   *  errs toward release, which was invisible wherever the browser's native
+   *  scroll anchoring quietly carried the reader through the growth. WebKit has
+   *  no scroll anchoring at all, so on an iPhone every entry into an idle
+   *  session paid the whole post-pin reprice as a displacement and then had
+   *  follow released on top of it: the transcript opened a viewport or more
+   *  above the end with nothing streaming to bring it back.
+   *
+   *  Defaults to `true` = assume the reader may have moved, which is the
+   *  release-leaning legacy behaviour for a caller that has no input signal. */
+  readerMovedSinceWrite?: boolean
 }): AutoPinResult {
   const { stick, geom, lastWriteTop } = args
   const epsilon = args.epsilon ?? SELF_SCROLL_EPSILON
   const viewportShrink = Math.max(0, args.viewportShrink ?? 0)
   const runActive = args.runActive ?? true
+  const readerMovedSinceWrite = args.readerMovedSinceWrite ?? true
   const target = bottomTarget(geom)
   if (args.restoreGate) return { pin: false, stick: false, target }
   if (!stick) return { pin: false, stick: false, target }
+  // The reader is resting exactly where we last put them and has given no input
+  // since, so any gap is content settling under them -- carry them back, live
+  // turn or not. Both conditions are load-bearing. Position alone would read our
+  // own write as consent for a reader who wheeled up and happened to stop on it;
+  // input alone would drag back a programmatic reveal -- a search hit, a pinned
+  // prompt, find-in-page -- whose scroll event has not dispatched yet when a
+  // height commit lands, since none of those touch the scroller's input
+  // listeners. A reveal moves scrollTop off our write; a reprice does not.
+  const restingOnOurWrite = lastWriteTop >= 0 && Math.abs(geom.scrollTop - lastWriteTop) <= epsilon
+  if (!readerMovedSinceWrite && restingOnOurWrite) {
+    return { pin: distanceFromBottom(geom) > atBottomEpsilon(), stick: true, target }
+  }
   // Idle: release rather than merely skip the pin. Skipping would leave follow
   // armed, so the next turn to start would yank this reader to the bottom from
   // wherever they had settled — the same defect one event later.
@@ -379,14 +411,14 @@ export function evaluateAutoPin(args: {
   // opposite answers: a reader who scrolled up should be released, while a
   // reader the CONTENT moved away from should be carried back.
   if (!runActive && distanceFromBottom(geom) > atBottomEpsilon()) {
-    // Released, and deliberately WITHOUT an exception for "the reader is resting on
-    // our own last write". Reading our own write as consent is an automatic action
-    // authorizing itself: the tempting case -- a late tail image or a spacer reprice
-    // pushing the bottom away from a reader who never moved -- is indistinguishable
-    // from the case this rule exists for, and treating it as follow is what sprang a
-    // parked reader down to content they had not asked to see. With nothing running
-    // there is no output to follow, so the honest outcome is to leave them where they
-    // are and let a real downward gesture, or the next turn, re-arm this.
+    // Released. The question this branch cannot answer from geometry -- did the
+    // reader open this gap, or did the content -- is answered ABOVE by
+    // `readerMovedSinceWrite`: reaching here means input or an unexplained
+    // scroll has been seen since our last positioning, so a reader who is now
+    // above the bottom while nothing runs is one who left it. Reading our own
+    // last write as consent would be an automatic action authorizing itself;
+    // the only evidence that the reader never moved is the absence of input,
+    // and that is what the branch above requires.
     return { pin: false, stick: false, target }
   }
   // Release only on a genuine user scroll-UP: scrollTop dropped below our last

--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -733,6 +733,32 @@ export function useVirtualChat<T>(
   // hardware events and by the smooth-pin grab interrupts, never by scroll
   // events themselves.
   const lastHardInputAtRef = useRef<number>(Number.NEGATIVE_INFINITY)
+  // When WE last established the reader's bottom position: a pin write, or a
+  // re-baseline of `lastWriteTopRef` onto a layout clamp / an already-at-bottom
+  // observation. Compared against the hard-input stamp above it answers "has the
+  // reader touched the scroller since we placed them" -- the signal
+  // evaluateAutoPin's `readerMovedSinceWrite` needs to tell a reader who left
+  // the bottom from one the content left behind. Only our own positioning moves
+  // it forward, so a reprice that opens a gap with no gesture in between reads
+  // as ours to close, and a gesture -- however small -- reads as theirs.
+  const lastPinAtRef = useRef<number>(Number.NEGATIVE_INFINITY)
+  const readerMovedSinceWrite = useCallback(
+    (): boolean => lastHardInputAtRef.current > lastPinAtRef.current,
+    [],
+  )
+  // Follow was RELEASED by the reader: there is no write of ours they are
+  // resting on any more, so drop the self-scroll reference with it. Left in
+  // place, it kept pointing at the bottom we last pinned -- and a reader who
+  // scrolls back down lands on exactly that pixel, because it is still the
+  // maximum scrollTop. That arrival then read as our own scroll, the handler
+  // skipped its re-engagement branch, and follow never re-armed: the next turn
+  // streamed past a reader who had put themselves at the end to watch it. The
+  // coverage watchdog's per-tick forcePin used to paper over this by re-arming
+  // follow every 500ms; with that misfire gone the reference has to be honest.
+  const releaseFollowBaseline = useCallback(() => {
+    lastWriteTopRef.current = -1
+    lastWriteClientHRef.current = -1
+  }, [])
   // Scroller height as of the last SCROLL event. Deliberately not
   // `viewportHeightRef`, which the ResizeObserver updates: the resize and the
   // clamp it causes are two separate events, and if the observer ran first the
@@ -2063,6 +2089,7 @@ export function useVirtualChat<T>(
       else el.scrollTop = top
       lastWriteTopRef.current = accounting === 'pin' ? top : -1
       lastWriteClientHRef.current = accounting === 'pin' ? el.clientHeight : -1
+      if (accounting === 'pin') lastPinAtRef.current = performance.now()
       // The direction reference must move WITH our own writes, synchronously.
       // A programmatic scroll's event lands asynchronously (and a fake scroller
       // in tests dispatches none), so leaving the reference to the scroll
@@ -2157,13 +2184,16 @@ export function useVirtualChat<T>(
       // "assume live" so an unaware caller keeps its behaviour.
       runActive: runActiveRef.current,
       restoreGate: settleGateRef.current,
+      readerMovedSinceWrite: readerMovedSinceWrite(),
       // Chrome mounting below the transcript shrinks this box, often
       // spring-animated across many frames. Measure the scroll-up guard
       // against the box our reference was a bottom for, never the box the
       // animation just applied.
       viewportShrink,
     })
+    const wasStick = stickRef.current
     stickRef.current = result.stick
+    if (wasStick && !result.stick) releaseFollowBaseline()
     if (result.pin) {
       writeScrollTop(el, result.target, 'auto', 'pin', 'autopin')
     } else if (result.stick) {
@@ -2171,8 +2201,9 @@ export function useVirtualChat<T>(
       // self-scroll reference aligned with the current bottom.
       lastWriteTopRef.current = result.target
       lastWriteClientHRef.current = geom.clientHeight
+      lastPinAtRef.current = performance.now()
     }
-  }, [scrollerRef, writeScrollTop])
+  }, [scrollerRef, writeScrollTop, readerMovedSinceWrite, releaseFollowBaseline])
 
   // Forced pin: explicit jump-to-bottom (slot entry, scrollToBottom API,
   // jump-to-latest pill). Always lands at the bottom and (re-)arms follow.
@@ -2273,6 +2304,7 @@ export function useVirtualChat<T>(
         // real 3-100px scroll-up.
         const clampedAtBottom =
           geom.scrollHeight - (geom.scrollTop + geom.clientHeight) <= SELF_SCROLL_EPSILON
+        const wasStick = stickRef.current
         stickRef.current = resolveUserScrollStick({
           stick: stickRef.current,
           followOutput,
@@ -2289,6 +2321,7 @@ export function useVirtualChat<T>(
               ? geom.clientHeight - lastScrollClientHRef.current
               : 0,
         })
+        if (wasStick && !stickRef.current) releaseFollowBaseline()
         const layoutClamp = stickRef.current && clampedAtBottom
         // A clamp is OUR layout change, so it must not be stamped as input.
         // `lastUserScrollAtRef` arms the SCROLL_SETTLE_MS gate that holds
@@ -2319,6 +2352,7 @@ export function useVirtualChat<T>(
         if (layoutClamp) {
           lastWriteTopRef.current = el.scrollTop
           lastWriteClientHRef.current = geom.clientHeight
+          lastPinAtRef.current = performance.now()
         }
       }
       // Direction reference for the next event — updated for self-scrolls too,
@@ -2372,7 +2406,7 @@ export function useVirtualChat<T>(
       if (rafId) cancelAnimationFrame(rafId)
       scrollRafScheduledRef.current = false
     }
-  }, [scrollerEl, bottomThreshold, followOutput, recomputeWindow, detachSmoothAbort, pinAuto, scheduleAnchorSave])
+  }, [scrollerEl, bottomThreshold, followOutput, recomputeWindow, detachSmoothAbort, pinAuto, scheduleAnchorSave, releaseFollowBaseline])
 
   // ---- Viewport-coverage watchdog (see VIEWPORT_COVERAGE_TICK_MS) ----
   useEffect(() => {
@@ -2394,10 +2428,18 @@ export function useVirtualChat<T>(
       // has zero span and is uncovered by construction.
       const spanTop = idx.offsetOf(start)
       const spanBottom = end > start ? idx.offsetOf(end - 1) + idx.getHeight(end - 1) : spanTop
-      if (
-        top < spanTop - VIEWPORT_COVERAGE_SLACK_PX ||
-        bottom > spanBottom + VIEWPORT_COVERAGE_SLACK_PX
-      ) {
+      // A side the window has already reached the list's end on is covered by
+      // construction: there is no row left to mount there. Without this the
+      // chrome that shares the scroller with the rows -- the tail spacer and
+      // bottom sentinel below the last row, the paging bar above the first --
+      // sits inside the viewport whenever the reader is at an end, reads as
+      // uncovered pixels past the span, and made this fire forcePin every tick
+      // for a reader parked at the bottom: a same-value scrollTo each 500ms
+      // that re-armed follow the idle rule had just released and, on WebKit,
+      // cut every rubber-band and momentum tail short.
+      const uncoveredAbove = start > 0 && top < spanTop - VIEWPORT_COVERAGE_SLACK_PX
+      const uncoveredBelow = end < count && bottom > spanBottom + VIEWPORT_COVERAGE_SLACK_PX
+      if (uncoveredAbove || uncoveredBelow) {
         // Recovery is stick-aware. FOLLOWING: the window is tail-anchored, so
         // remounting rows at the displaced position would endorse a position
         // the reader never chose — force-pin back to the bottom (stick is the
@@ -3079,8 +3121,11 @@ export function useVirtualChat<T>(
         lastWriteTop: lastWriteTopRef.current,
         runActive: runActiveRef.current,
         restoreGate: settleGateRef.current,
+        readerMovedSinceWrite: readerMovedSinceWrite(),
       })
+      const wasStick = stickRef.current
       stickRef.current = decision.stick
+      if (wasStick && !decision.stick) releaseFollowBaseline()
       if (!decision.pin) return
       if (Math.abs(el.scrollTop - decision.target) > 0.5) writeScrollTop(el, decision.target, 'auto', 'pin', 'prepin')
       return
@@ -3129,7 +3174,37 @@ export function useVirtualChat<T>(
   }, [heightCommit, scrollerRef, writeScrollTop])
 
 
-  // ---- Follow-output: pin to bottom when items append ----
+  // ---- Leading chrome: content ABOVE the list inside the scroller ----
+  // The rows and the scroller's own box are observed; what sits between the
+  // scroll origin and the first row is not -- a paging bar that mounts once the
+  // server reports unloaded history, a header band the host renders above the
+  // rows. That chrome mounting or resizing moves every row by its height with
+  // no ResizeObserver seeing it and no scroll event: on Chromium native scroll
+  // anchoring silently carries a bottom-pinned reader through it, on WebKit
+  // (no anchoring) the reader is left the chrome's height short of the end.
+  // Measured on the phone rig: the earlier-messages bar mounting 46px after
+  // the entry pin, and nothing to bring the reader back.
+  //
+  // Re-evaluate the bottom pin whenever the leading offset changes between
+  // commits, while following. pinAuto's predicate decides: a reader resting on
+  // our last write with no input is carried to the live bottom (idempotent on
+  // Chromium, where anchoring already moved them there); anyone else is left
+  // alone. Measured only while following -- released readers own their position
+  // -- and reset on release so a stale value cannot fire on re-engagement.
+  const leadingChromeRef = useRef(-1)
+  useLayoutEffect(() => {
+    const el = scrollerRef.current
+    if (!el || !stickRef.current) { leadingChromeRef.current = -1; return }
+    const lead = leadingOffset(el)
+    const prev = leadingChromeRef.current
+    leadingChromeRef.current = lead
+    if (prev < 0 || Math.abs(lead - prev) <= 0.5) return
+    if (inspectorOn()) devLog('LEAD', `${Math.round(prev)}->${Math.round(lead)} y=${Math.round(el.scrollTop)}`)
+    // Same settle gate as the pre-paint pin: a gesture in flight outranks this
+    // correction, and the post-paint RO pin still covers a parked reader.
+    if (pinSuppressedNow(performance.now(), lastHardInputAtRef.current, pinCascadeUntilRef.current, SCROLL_SETTLE_MS)) return
+    pinAuto()
+  })
   const prevItemCountRef = useRef(itemCount)
   // Tail identity of the previous commit, session-scoped. What separates a
   // bulk PREPEND (idle history prefetch landing hundreds of rows ABOVE a

--- a/website/src/test/FollowController.test.ts
+++ b/website/src/test/FollowController.test.ts
@@ -233,6 +233,62 @@ describe('evaluateAutoPin — the race-proof core', () => {
     expect(r).toEqual({ pin: false, stick: false, target: 600 })
   })
 
+  describe('readerMovedSinceWrite — who opened the gap', () => {
+    // The idle rule above releases because a gap while idle USUALLY means the
+    // reader scrolled. When the caller can say that nothing but layout has
+    // happened since we last placed them (no hardware input, no unexplained
+    // scroll), the gap is content settling under a still reader, and the same
+    // geometry means the opposite: carry them back. WebKit has no native scroll
+    // anchoring, so this is the only thing standing between an entry pin and a
+    // transcript that opens a viewport above its end.
+    const up = { scrollTop: 480, scrollHeight: 1000, clientHeight: 400 }
+
+    it('IDLE + no reader movement: the gap is ours, so the reader is carried back', () => {
+      const r = evaluateAutoPin({ stick: true, geom: up, lastWriteTop: 480, runActive: false, readerMovedSinceWrite: false })
+      expect(r).toEqual({ pin: true, stick: true, target: 600 })
+    })
+
+    it('IDLE + reader moved: unchanged, released', () => {
+      const r = evaluateAutoPin({ stick: true, geom: up, lastWriteTop: 480, runActive: false, readerMovedSinceWrite: true })
+      expect(r).toEqual({ pin: false, stick: false, target: 600 })
+    })
+
+    it('no input but scrollTop has LEFT our last write: not ours to close (a reveal in flight)', () => {
+      // scrollTop below our last write AND away from the bottom is the
+      // user-scroll-up signature. With no hardware input it can still be a
+      // programmatic reveal -- a search hit, a pinned prompt, find-in-page --
+      // whose scroll event has not dispatched yet when a height commit lands.
+      // Position and input must BOTH say "the reader never moved"; here the
+      // position says otherwise, so the existing release stands.
+      const r = evaluateAutoPin({ stick: true, geom: up, lastWriteTop: 600, runActive: true, readerMovedSinceWrite: false })
+      expect(r).toEqual({ pin: false, stick: false, target: 600 })
+    })
+
+    it('resting on a clamp-rebaselined write counts as resting', () => {
+      // The clamp branch re-baselines lastWriteTop onto the clamped scrollTop;
+      // the regrowth then opens the gap with scrollTop unchanged. That is the
+      // entry shape on a phone, and it is carried.
+      const r = evaluateAutoPin({ stick: true, geom: up, lastWriteTop: 480, runActive: false, readerMovedSinceWrite: false })
+      expect(r).toEqual({ pin: true, stick: true, target: 600 })
+    })
+
+    it('at the bottom with no movement: still following, nothing to write', () => {
+      const r = evaluateAutoPin({ stick: true, geom: tall, lastWriteTop: 600, runActive: false, readerMovedSinceWrite: false })
+      expect(r).toEqual({ pin: false, stick: true, target: 600 })
+    })
+
+    it('never overrides a released stick or an owning restore', () => {
+      expect(evaluateAutoPin({ stick: false, geom: up, lastWriteTop: 480, readerMovedSinceWrite: false }).pin).toBe(false)
+      const r = evaluateAutoPin({ stick: true, geom: up, lastWriteTop: 480, restoreGate: true, readerMovedSinceWrite: false })
+      expect(r).toEqual({ pin: false, stick: false, target: 600 })
+    })
+
+    it('omitted = assume the reader may have moved (legacy, release-leaning)', () => {
+      const r = evaluateAutoPin({ stick: true, geom: up, lastWriteTop: 480, runActive: false })
+      expect(r.stick).toBe(false)
+    })
+  })
+
 
   it('IDLE: a reader ALREADY at the bottom keeps following', () => {
     // Rows settling under a reader parked at the very bottom must still keep them

--- a/website/src/test/useVirtualChat.coverageWatchdog.test.tsx
+++ b/website/src/test/useVirtualChat.coverageWatchdog.test.tsx
@@ -13,9 +13,12 @@ const getKey = (it: Item) => it.id
 const mkItems = (n: number, p = 'm'): Item[] =>
   Array.from({ length: n }, (_, i) => ({ id: `${p}-${i}`, text: `row ${i}` }))
 
-function Harness({ items, scrollerRef }: {
+function Harness({ items, scrollerRef, tailChrome = 0 }: {
   items: Item[]
   scrollerRef: RefObject<HTMLDivElement | null>
+  /** Height of page chrome sharing the scroller BELOW the rows (footer, tail
+   *  spacer) -- the shape the chat page mounts. */
+  tailChrome?: number
 }) {
   const v = useVirtualChat<Item>({
     items, sessionId: 'watchdog', getKey, overscan: 2, externalScrollerRef: scrollerRef,
@@ -29,6 +32,7 @@ function Harness({ items, scrollerRef }: {
       ))}
       <div data-spacer="after" style={{ height: v.offsetAfter }} />
       <div ref={v.bottomSentinelRef} data-sentinel="bottom" />
+      {tailChrome > 0 && <div data-chrome="tail" style={{ height: tailChrome }} />}
     </div>
   )
 }
@@ -229,5 +233,35 @@ describe('viewport-coverage watchdog', () => {
       })
     }
     expect(mountedSpan(el).join(',')).toBe(before)
+  })
+
+  it('a reader at the bottom with page chrome below the rows is covered: no write per tick', async () => {
+    // The chat page mounts a footer / tail spacer under the last row inside the
+    // same scroller, so a reader parked at the bottom always has more viewport
+    // below the last row than the slack allows. That is not uncovered list --
+    // there is no row left to mount -- yet it read as such and force-pinned
+    // every tick: a same-value write that re-armed follow the idle rule had
+    // released and, on WebKit, cut every momentum tail short.
+    const scrollerRef = { current: null as HTMLDivElement | null }
+    const items = mkItems(200)
+    render(<Harness items={items} scrollerRef={scrollerRef as RefObject<HTMLDivElement | null>} tailChrome={40} />)
+    const el = scrollerRef.current as HTMLDivElement
+    restore = installFakeLayout(el)
+    // Record every positioning write from here on. jsdom has no Element.scrollTo,
+    // so the hook writes scrollTop directly; route both through one recorder.
+    let top = 0
+    const writes: number[] = []
+    Object.defineProperty(el, 'scrollTop', { configurable: true, get: () => top, set: (v: number) => { top = v; writes.push(v) } })
+    await act(async () => {
+      el.scrollTop = el.scrollHeight - CLIENT
+      el.dispatchEvent(new Event('scroll'))
+      await vi.advanceTimersByTimeAsync(600)
+    })
+    expect(el.scrollHeight - el.scrollTop - CLIENT).toBe(0)
+    writes.length = 0
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1200 + 3 * 500) // outwait the yield, then three ticks
+    })
+    expect(writes).toEqual([])
   })
 })

--- a/website/src/test/useVirtualChat.idleCarryBack.test.tsx
+++ b/website/src/test/useVirtualChat.idleCarryBack.test.tsx
@@ -1,0 +1,216 @@
+import { renderHook, act } from '@testing-library/react'
+import type { RefObject } from 'react'
+import { useVirtualChat, type UseVirtualChatOptions } from '../hooks/virtualizer/useVirtualChat'
+
+/**
+ * REGRESSION GUARD — a still reader at the bottom is carried through content
+ * settling under them, even with nothing running.
+ *
+ * On entry the transcript is pinned to the bottom, and then its rows keep
+ * settling: a code-block stand-in swaps for the highlighted block, the top
+ * spacer reprices as rows above the window measure. When content ABOVE the
+ * viewport shrinks, the browser clamps scrollTop and the reader stays at the
+ * bottom; when it grows back, nothing moves scrollTop -- on Chromium native
+ * scroll anchoring quietly carries the reader, on WebKit nothing does. The idle
+ * rule then read the gap as the reader having scrolled up and RELEASED follow,
+ * so an iPhone opened every idle session a viewport or more above its end
+ * (measured 1007-1119px on the phone rig with anchoring disabled).
+ *
+ * The discriminator is not distance but INPUT plus position: a reader who left
+ * the bottom has touched the scroller since we last placed them, or is no
+ * longer resting where our last write put them. These cases pin the three ways
+ * that signal is fed.
+ */
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number, p = 'm'): Item[] => Array.from({ length: n }, (_, i) => ({ id: `${p}${i}` }))
+
+function mkRowNode(h: number): HTMLDivElement {
+  const node = document.createElement('div')
+  Object.defineProperty(node, 'offsetHeight', { configurable: true, get: () => h })
+  return node
+}
+
+interface Geom { scrollTop: number; scrollHeight: number; clientHeight: number }
+
+function makeScroller(initial: Geom) {
+  const el = document.createElement('div')
+  const state = { ...initial }
+  const writes: number[] = []
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => state.scrollTop,
+    set: (v: number) => { state.scrollTop = v; writes.push(v) },
+  })
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => state.scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => state.clientHeight })
+  ;(el as unknown as { scrollTo: (o: { top: number }) => void }).scrollTo = (o) => {
+    state.scrollTop = o.top
+    writes.push(o.top)
+  }
+  el.getBoundingClientRect = (() => ({ top: 0, bottom: state.clientHeight, height: state.clientHeight })) as unknown as typeof el.getBoundingClientRect
+  return { el, state, writes }
+}
+
+class FakeRO {
+  static instances: FakeRO[] = []
+  constructor(readonly cb: ResizeObserverCallback) { FakeRO.instances.push(this) }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const origRO = globalThis.ResizeObserver
+const origRaf = globalThis.requestAnimationFrame
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  FakeRO.instances = []
+  globalThis.ResizeObserver = FakeRO as unknown as typeof ResizeObserver
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  globalThis.ResizeObserver = origRO as typeof ResizeObserver
+  globalThis.requestAnimationFrame = origRaf
+})
+
+/** Mounts an IDLE session glued to the bottom of a settled transcript. */
+function mountIdleAtBottom(key: string) {
+  const { el, state, writes } = makeScroller({ scrollTop: 5000 - 700, scrollHeight: 5000, clientHeight: 700 })
+  const ref: RefObject<HTMLDivElement | null> = { current: el }
+  const view = renderHook(
+    (props: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(props),
+    {
+      initialProps: {
+        items: mkItems(60),
+        sessionId: `carry-${key}`,
+        getKey,
+        externalScrollerRef: ref,
+        followOutput: true,
+        runActive: false,
+      },
+    },
+  )
+  act(() => { vi.advanceTimersByTime(300) })
+  writes.length = 0
+  return { view, el, ref, state, writes, bottom: () => state.scrollHeight - state.clientHeight }
+}
+
+/** A height commit: rows measure, then the debounced sync announces it. */
+function landHeightCommit(view: ReturnType<typeof mountIdleAtBottom>['view'], rows = 60) {
+  act(() => {
+    for (let i = 0; i < rows; i++) view.result.current.measureRef(i)(mkRowNode(95))
+  })
+  act(() => { vi.advanceTimersByTime(400) })
+}
+
+/** Content above the viewport shrinks by `px`: the engine clamps scrollTop to
+ *  the new maximum and fires a scroll event nobody wrote. */
+function layoutClamp(t: ReturnType<typeof mountIdleAtBottom>, px: number) {
+  t.state.scrollHeight -= px
+  t.state.scrollTop = t.bottom()
+  act(() => { t.el.dispatchEvent(new Event('scroll')) })
+}
+
+describe('re-engaging follow by hand', () => {
+  it('scrolling back down onto the exact pixel of our last pin re-arms follow', () => {
+    // The bottom the reader returns to IS the bottom we last pinned -- maximum
+    // scrollTop has not moved -- so the arrival lands on our own last write to
+    // the pixel. It must still read as the reader's return, not as our scroll:
+    // follow re-arms, and the next turn is followed.
+    const t = mountIdleAtBottom('re-engage')
+    const bottom = t.bottom()
+    expect(t.view.result.current.getFollow()).toBe(true)
+    act(() => { t.el.dispatchEvent(new Event('wheel')) })
+    t.state.scrollTop = bottom - 500
+    act(() => { t.el.dispatchEvent(new Event('scroll')) })
+    expect(t.view.result.current.getFollow()).toBe(false)
+    act(() => { t.el.dispatchEvent(new Event('wheel')) })
+    t.state.scrollTop = bottom - 250
+    act(() => { t.el.dispatchEvent(new Event('scroll')) })
+    t.state.scrollTop = bottom
+    act(() => { t.el.dispatchEvent(new Event('scroll')) })
+    expect(t.view.result.current.getFollow()).toBe(true)
+  })
+})
+
+describe('idle carry-back: a still reader stays at the bottom through content settling', () => {
+  it('clamp then regrow with nobody touching the scroller: carried back to the bottom', () => {
+    // The entry shape measured on the phone rig: a row above the fold shrinks
+    // (clamp keeps us at the bottom), then grows back (nothing moves scrollTop,
+    // the reader is now the regrowth short of the end).
+    const t = mountIdleAtBottom('clamp-regrow')
+    layoutClamp(t, 300)
+    expect(t.state.scrollTop).toBe(t.bottom())
+    t.state.scrollHeight += 300
+    landHeightCommit(t.view)
+
+    expect(t.state.scrollTop).toBe(t.bottom())
+    expect(t.writes).toContain(t.bottom())
+  })
+
+  it('a wheel at the bottom BEFORE the clamp does not count: the clamp re-established the bottom', () => {
+    // The reader wheeled but never left the bottom (a wheel-down at the end moves
+    // nothing). The clamp that follows is our re-placement, later than that
+    // input, so the regrowth is still ours to close.
+    const t = mountIdleAtBottom('wheel-then-clamp')
+    act(() => { t.el.dispatchEvent(new Event('wheel')) })
+    layoutClamp(t, 300)
+    t.state.scrollHeight += 300
+    landHeightCommit(t.view)
+
+    expect(t.state.scrollTop).toBe(t.bottom())
+  })
+
+  it('a programmatic reveal whose scroll event is still pending is not dragged back', () => {
+    // A search hit / pinned-prompt jump writes the scroller through its own
+    // scrollTo, never through the virtualizer, and the click that asked for it
+    // landed outside the scroller -- so there is no hardware input on record.
+    // Its scroll event dispatches a frame later; a height commit landing in
+    // that window sees follow still armed, no input, and the reader away from
+    // the bottom. The position has LEFT our last write, and that is what keeps
+    // this from being read as content settling: the jump must stand.
+    const t = mountIdleAtBottom('reveal-race')
+    const revealed = t.bottom() - 500
+    t.state.scrollTop = revealed // no scroll event yet
+    landHeightCommit(t.view)
+
+    expect(t.state.scrollTop).toBe(revealed)
+    expect(t.writes.filter((w) => w > revealed)).toEqual([])
+  })
+
+  it('input in the OUTGOING session does not disown the incoming session\'s entry pin', () => {
+    // Scrolling around in session A, then switching to B: B's entry pin is our
+    // placement and comes after that input, so a reprice settling under B's
+    // bottom is still carried -- A's gesture must not outrank B's pin, or B
+    // would open short of its end, which is the "every session I enter" report.
+    const t = mountIdleAtBottom('switch')
+    act(() => { t.el.dispatchEvent(new Event('wheel')) })
+    t.state.scrollTop = t.bottom() - 800
+    act(() => { t.el.dispatchEvent(new Event('scroll')) })
+    // Switch sessions: the new transcript is shorter, the engine clamps, the
+    // entry pin lands at the bottom.
+    t.state.scrollHeight = 3000
+    t.state.scrollTop = t.bottom()
+    act(() => {
+      t.view.rerender({
+        items: mkItems(40, 'b'),
+        sessionId: 'carry-switch-B',
+        getKey,
+        externalScrollerRef: t.ref,
+        followOutput: true,
+        runActive: false,
+      })
+    })
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(t.state.scrollTop).toBe(t.bottom())
+    t.writes.length = 0
+    t.state.scrollHeight += 300
+    landHeightCommit(t.view, 40)
+
+    expect(t.state.scrollTop).toBe(t.bottom())
+  })
+})

--- a/website/src/test/useVirtualChat.idlePinGuard.test.tsx
+++ b/website/src/test/useVirtualChat.idlePinGuard.test.tsx
@@ -103,18 +103,42 @@ function mountGrownBelow(runActive: boolean, growPx: number) {
 }
 
 describe('automatic pin requires a live run', () => {
-  it('idle: content growing below the fold does not spring the reader down to it', () => {
+  it('idle: content growing below the fold does not spring a reader who has moved down to it', () => {
     const { view, el, state, writes, bottom } = mountGrownBelow(false, 120)
     const parked = state.scrollTop
+    // The reader touched the scroller since we last placed them (a wheel that
+    // moved nothing is enough): the gap is no longer provably ours, and with
+    // nothing running there is no output to follow.
+    act(() => { el.dispatchEvent(new Event('wheel')) })
+    // Step the hardware clock past the gesture-settle window, or the RO path
+    // declines to evaluate at all (a gesture in flight outranks any pin) and the
+    // idle rule is never reached. `performance.now` is not under the fake timers.
+    const afterGesture = performance.now() + 1000
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(afterGesture)
     const ro = FakeRO.instances[FakeRO.instances.length - 1]
     act(() => { ro.fire([{ target: el }]) })
     act(() => { vi.advanceTimersByTime(600) })
+    nowSpy.mockRestore()
 
     expect(state.scrollTop).toBe(parked)
     expect(writes.filter((w) => Math.abs(w - bottom()) < 2)).toEqual([])
     // Released, not merely skipped — leaving follow armed would hand the same
     // yank to whichever turn starts next.
     expect(view.result.current.getFollow()).toBe(false)
+  })
+
+  it('idle: the same growth under a reader who has NOT moved is carried back', () => {
+    // No input since the entry pin, resting on it to the pixel: every pixel of
+    // the gap is content settling, and the reader is kept at the end. This is
+    // what native scroll anchoring did silently on Chromium; WebKit has none,
+    // and releasing here is how a phone opened idle sessions above their end.
+    const { view, el, state, bottom } = mountGrownBelow(false, 120)
+    const ro = FakeRO.instances[FakeRO.instances.length - 1]
+    act(() => { ro.fire([{ target: el }]) })
+    act(() => { vi.advanceTimersByTime(600) })
+
+    expect(state.scrollTop).toBe(bottom())
+    expect(view.result.current.getFollow()).toBe(true)
   })
 
   it('running: the same growth IS followed', () => {

--- a/website/src/test/useVirtualChat.leadingChrome.test.tsx
+++ b/website/src/test/useVirtualChat.leadingChrome.test.tsx
@@ -1,0 +1,118 @@
+/** Chrome ABOVE the rows inside the scroller (the earlier-messages bar) mounting
+ *  under a bottom-pinned reader: nothing observes it -- not the row observer,
+ *  not the scroller's box, no scroll event -- so without native scroll
+ *  anchoring (WebKit) the reader was left the bar's height short of the end.
+ *  Measured 46px on the phone rig at every drawer entry into a long session. */
+import { act, render } from '@testing-library/react'
+import { type RefObject } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+
+type Item = { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m-${i}` }))
+
+function Harness({ items, scrollerRef, headChrome, runActive }: {
+  items: Item[]
+  scrollerRef: RefObject<HTMLDivElement | null>
+  /** Height of page chrome sharing the scroller ABOVE the rows. */
+  headChrome: number
+  runActive: boolean
+}) {
+  const v = useVirtualChat<Item>({
+    items, sessionId: 'lead', getKey, overscan: 2, externalScrollerRef: scrollerRef, runActive,
+  })
+  return (
+    <div ref={scrollerRef as RefObject<HTMLDivElement>} data-scroller>
+      {headChrome > 0 && <div data-chrome="head" style={{ height: headChrome }} />}
+      <div ref={v.topSentinelRef} data-sentinel="top" />
+      <div data-spacer="before" style={{ height: v.offsetBefore }} />
+      {v.virtualItems.map((it) => (
+        <div key={it.key} data-index={it.index} ref={v.measureRef(it.index)} />
+      ))}
+      <div data-spacer="after" style={{ height: v.offsetAfter }} />
+      <div ref={v.bottomSentinelRef} data-sentinel="bottom" />
+    </div>
+  )
+}
+
+const ROW = 100
+const CLIENT = 400
+
+function installFakeLayout(scroller: HTMLElement) {
+  const proto = HTMLElement.prototype
+  const origRect = proto.getBoundingClientRect
+  const childHeight = (child: Element): number => {
+    if ((child as HTMLElement).getAttribute('data-index') !== null) return ROW
+    const h = (child as HTMLElement).style?.height
+    return h ? parseFloat(h) : 0
+  }
+  proto.getBoundingClientRect = function (this: HTMLElement): DOMRect {
+    const rect = (y: number, h: number) =>
+      ({ top: y, bottom: y + h, height: h, left: 0, right: 390, width: 390, x: 0, y, toJSON: () => ({}) }) as DOMRect
+    if (this === scroller) return rect(0, CLIENT)
+    if (this.parentElement === scroller) {
+      let y = 0
+      for (const sib of Array.from(scroller.children)) {
+        if (sib === this) break
+        y += childHeight(sib)
+      }
+      return rect(y - scroller.scrollTop, childHeight(this))
+    }
+    return origRect.call(this)
+  }
+  Object.defineProperty(proto, 'offsetHeight', {
+    configurable: true,
+    get(this: HTMLElement) { return this.getAttribute('data-index') !== null ? ROW : 0 },
+  })
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => CLIENT })
+  Object.defineProperty(scroller, 'scrollHeight', {
+    configurable: true,
+    get: () => Array.from(scroller.children).reduce((a, c) => a + childHeight(c), 0),
+  })
+  return () => { proto.getBoundingClientRect = origRect }
+}
+
+describe('leading chrome under a bottom-pinned reader', () => {
+  let restore: (() => void) | null = null
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { restore?.(); restore = null; vi.useRealTimers() })
+
+  async function mountAtBottom(runActive: boolean) {
+    const scrollerRef = { current: null as HTMLDivElement | null }
+    const items = mkItems(200)
+    const view = render(<Harness items={items} scrollerRef={scrollerRef} headChrome={0} runActive={runActive} />)
+    const el = scrollerRef.current as HTMLDivElement
+    restore = installFakeLayout(el)
+    await act(async () => {
+      el.scrollTop = el.scrollHeight - CLIENT
+      el.dispatchEvent(new Event('scroll'))
+      await vi.advanceTimersByTimeAsync(600)
+    })
+    // jsdom has no ResizeObserver, so a reprice landing after the settle write is
+    // not re-pinned here; the reader may sit a few px above the bottom. That is
+    // the harness, not the contract -- what matters below is where the commit
+    // that mounts the bar leaves them.
+    return { view, el, items, scrollerRef }
+  }
+
+  it('the bar mounting above the rows carries a still IDLE reader to the new bottom', async () => {
+    const { view, el, items, scrollerRef } = await mountAtBottom(false)
+    // No scroll event, no row resize: only the commit that mounts the bar.
+    await act(async () => {
+      view.rerender(<Harness items={items} scrollerRef={scrollerRef} headChrome={46} runActive={false} />)
+    })
+    expect(el.scrollHeight - el.scrollTop - CLIENT).toBe(0)
+  })
+
+  it('a reader who wheeled since the pin is left where they are', async () => {
+    const { view, el, items, scrollerRef } = await mountAtBottom(false)
+    const parked = el.scrollTop
+    await act(async () => { el.dispatchEvent(new Event('wheel')); await vi.advanceTimersByTimeAsync(200) })
+    await act(async () => {
+      view.rerender(<Harness items={items} scrollerRef={scrollerRef} headChrome={46} runActive={false} />)
+    })
+    expect(el.scrollTop).toBe(parked)
+  })
+})

--- a/website/src/test/useVirtualChat.prePaintPinComposer.test.tsx
+++ b/website/src/test/useVirtualChat.prePaintPinComposer.test.tsx
@@ -126,13 +126,29 @@ describe('pre-paint bottom pin and the composer', () => {
     expect(writes.filter((w) => w > parked)).toEqual([])
   })
 
-  it('does not re-target the bottom when nothing is running', () => {
-    // Isolates the idle rule on THIS path: the viewport is unchanged, so the
-    // shrink freeze cannot be what holds the reader. Content grew below the fold
-    // with nobody scrolling, which is the state where follow is still armed and
-    // the reader is no longer at the bottom.
-    const { view, state, writes } = mountAtBottom(false, 'idle')
+  it('carries a STILL reader back when content grows under them with nothing running', () => {
+    // Viewport unchanged, no turn, no input: content grew below the fold with
+    // nobody scrolling. Follow is still armed and the reader is no longer at the
+    // bottom -- but every pixel of that gap is ours, so the idle rule must not
+    // read it as the reader having left. This is the entry case on WebKit, which
+    // has no native scroll anchoring to absorb a post-pin reprice: releasing here
+    // left the transcript open a viewport above the end with nothing to bring it
+    // back.
+    const { view, state, writes, bottom } = mountAtBottom(false, 'idle-still')
+    state.scrollHeight += 300
+    landHeightCommit(view)
+
+    expect(state.scrollTop).toBe(bottom())
+    expect(writes).toContain(bottom())
+  })
+
+  it('does not re-target the bottom when nothing is running and the reader has moved', () => {
+    // Same growth, but the reader touched the scroller since we last placed
+    // them. With nothing running there is no output to follow, so the gap is
+    // theirs to keep: the idle rule releases rather than yanking them down.
+    const { view, el, state, writes } = mountAtBottom(false, 'idle-moved')
     const parked = state.scrollTop
+    act(() => { el.dispatchEvent(new Event('wheel')) })
     state.scrollHeight += 300
     landHeightCommit(view)
 


### PR DESCRIPTION
## Problem / Motivation

On a phone, opening a session lands the transcript **mid-conversation** instead of at the latest message, and scrolling to the bottom by hand leaves the view unsettled. Reported from an iPhone against builds that already carry the recent scroll work (0.6.0-insider.6 includes #7916, #8574, #8001).

Reproduced in Chromium by disabling CSS scroll anchoring (`overflow-anchor: none`), which is how iOS Safari behaves — it has no scroll anchoring at all. Isolated gateway + fake ACP backend, 390×844 touch viewport, a 40-turn session, `/chat?sid=` entry:

| entry (iOS-like, 3 runs) | distance above the end after 6s |
|---|---|
| main | **1007 px, 1119 px**, 0 px |
| this PR | 0 px, 0 px, 0 px |

A 60-turn session (one older page unloaded, so the earlier-messages bar mounts) landed **46 px short on every drawer entry** on main; 0 with this PR. With native anchoring left on, every scenario lands at 0 on both — which is why none of this was visible on a desktop browser.

## Why it matters

Every phone user opening an existing session reads the wrong part of the conversation and has to find the end by hand; a reader who then scrolls to the end does not get followed when the next turn streams. Long sessions with code blocks are the worst case, because the post-entry reprice that opens the gap scales with how much of the transcript above the viewport is still settling.

## What changed (motivation → approach → change)

**Symptom → cause.** Per-frame tracing with `scrollTo`/`scrollTop` hooked and the scroller's children measured each frame:

1. entry pin lands at the bottom (`forcepin 0→18345`);
2. a row above the fold shrinks 112 px (code-block stand-in → highlighted block), the engine clamps scrollTop, still at the bottom;
3. the top spacer reprices −1008 px as rows above the window measure, clamp again;
4. both grow back (+112, +1008) — **no scroll event**, scrollTop stays: the reader is now 1120 px above the end;
5. the ResizeObserver pin evaluates: nothing is running, distance > 0 → the idle rule **releases follow**. Nothing brings the reader back.

On Chromium, native scroll anchoring moves scrollTop through step 4 and the reader never leaves the bottom. On WebKit the whole reprice is paid as displacement.

**Approach.** The idle rule (`evaluateAutoPin`, `runActive`) cannot tell from distance who opened the gap, and it errs toward release. The signal that can tell is **input plus position**: a reader who left the bottom has touched the scroller (wheel / touch / pointer / scrolling key) since we last placed them, or is no longer resting where our last write put them. When neither holds, the gap is content settling under a still reader and they are carried back, live turn or not. Both halves are load-bearing — position alone reads our own write as consent for a reader who wheeled up and stopped on it; input alone would drag back a programmatic reveal (search hit, pinned-prompt jump, find-in-page) whose scroll event has not dispatched yet, since none of those touch the scroller's input listeners.

**Changes** (`FollowController.ts`, `useVirtualChat.ts`):

- `evaluateAutoPin` takes `readerMovedSinceWrite` (default `true` = legacy). With it `false` and scrollTop within epsilon of `lastWriteTop`, a gap is closed regardless of `runActive`; every other branch is unchanged. **This deliberately reverses a pin made in #7916 (`436fe5115`)**, whose idle branch declined an exception for "the reader is resting on our own last write" on the grounds that a content-opened gap was indistinguishable from a reader-opened one. It is distinguishable once input is on record: the absence of any hardware input since our last placement is the evidence that decision said was missing. The released-with-input case that motivated the original pin stays covered by its own tests (`idlePinGuard`, `prePaintPinComposer`, `FollowController`).
- The hook stamps `lastPinAt` at each bottom positioning (pin write, layout-clamp re-baseline, at-bottom observation) and feeds `hardInputAt > lastPinAt` to both call sites (post-paint RO pin, pre-paint height-sync pin).
- **Leading chrome.** Content above the rows inside the scroller (the earlier-messages bar) is observed by nothing — not the row observer, not the scroller's box. A per-commit layout effect measures the leading offset while following and re-evaluates the pin through the same predicate when it changes (gated by the same gesture-settle window as the pre-paint pin).
- **Coverage watchdog misfire.** The watchdog fired `forcePin` **every 500 ms for any reader parked at the bottom**, because the tail spacer and bottom sentinel below the last row read as uncovered list (33 px > 8 px slack). That same-value write re-armed follow the idle rule had released (measured: `WRITE forcepin X->X` every 500 ms in every inspector trace on main). On WebKit a programmatic `scrollTo` also ends an in-flight momentum or rubber-band animation, so this is the likely mechanism behind the bottom jitter — stated as inference: the emulation cannot reproduce WebKit scroll physics and this host cannot run Playwright's WebKit (Amazon Linux 2023, missing libgtk-4 and friends), see Manual verification. A side the window has reached the list's end on is now covered by construction.
- Removing that misfire exposed a latent defect it had been papering over: releasing follow left `lastWriteTop` pointing at the old bottom, so a hand scroll landing on that exact pixel (it is still the maximum scrollTop) read as **our own** scroll and the re-engagement branch was skipped — follow never re-armed after a manual return. The self-scroll reference is now dropped with the release.

## Tests

Each mutation-verified (the mutation named is caught by the named test and by nothing weaker):

- `FollowController.test.ts` — `readerMovedSinceWrite`: idle + still → carried; idle + moved → released (unchanged); no input but scrollTop left our write → not ours (reveal race); resting on a clamp-rebaselined write; never overrides a released stick or an owning restore; omitted = legacy. *(drop the branch / drop either condition → red)*
- `useVirtualChat.idleCarryBack.test.tsx` — clamp then regrow with no input → carried back; wheel-at-bottom then clamp → still carried (clamp re-establishes the bottom; *drop the clamp stamp → red*); programmatic reveal with its scroll event pending → left alone; input in the outgoing session does not disown the incoming entry pin; **scrolling back onto the exact pixel of our last pin re-arms follow** *(drop `releaseFollowBaseline` → red)*.
- `useVirtualChat.leadingChrome.test.tsx` — a 46 px bar mounting above the rows carries a still idle reader to the new bottom; a reader who wheeled is left alone *(disable the effect → red)*.
- `useVirtualChat.coverageWatchdog.test.tsx` — a reader at the bottom with page chrome below the rows gets **no write per tick** *(drop the `end < count` guard → red)*.
- Updated to the new contract, keeping the release case as a sibling with input: `useVirtualChat.prePaintPinComposer.test.tsx`, `useVirtualChat.idlePinGuard.test.tsx`.

Gates: `tsc -b`, `eslint src`, jscpd clean; all 100 virtualizer/chat test files (1082 tests) pass locally.

## Manual verification

Real-browser rig (Playwright, iPhone profile, real touch sequences via CDP, isolated gateway with the fake ACP backend), both with `overflow-anchor: none` (iOS-like) and with native anchoring:

- cold `/chat?sid=` entry, drawer switch short→long, drawer re-entry after a scroll, full reload, entry mid-stream: **0 px from the end in every phase, both modes** (main: 46–1119 px in the iOS-like mode).
- touch scroll up then back to the bottom: follow re-armed (`stick=true`) — on main this only held because the watchdog force-pinned every 500 ms.
- inspector trace shows the entry `forcepin` writes only; the per-500 ms `WRITE forcepin X->X` stream is gone.

Not verified on a physical iPhone, and not under Playwright's WebKit engine either: it does not run on this host (Amazon Linux 2023 — `playwright install webkit` reports libgtk-4, libvulkan, libicu 74, libflite… missing, and installing system libraries is out of scope). The anchoring-off emulation is the same discriminator #7916 used to find the drift class and covers the entry/landing claims exactly (they are pure scroll geometry, no physics). The momentum/rubber-band claim about the watchdog is inference from the mechanism, not a measurement — the same rig scenarios under real WebKit or a physical iPhone would be the confirming step.

## Related Issues

Follow-up to #7916 (which fixed the drift while *reading history* on a phone); this covers *entering* and *returning to the bottom*.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a scroll-position decision that reads "distance from bottom" as evidence of a user move is only correct where native scroll anchoring absorbs content growth; on WebKit it must be paired with an input signal.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no spec covers the follow controller
- [x] No secrets, credentials, or internal references in the diff
