### PR TITLE
fix(crash): stop child processes inheriting Crashpad, and delete their dumps

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -2717,6 +2717,14 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         # DashboardContributor.start_services (which never fires for `token`
         # and only inside gateway async startup). Public default = no checks.
         run_preflight_checks()
+        # Under the desktop shell this process inherited Electron's Crashpad
+        # exception port, and so would every child it spawns (kiro-cli, MCP
+        # servers, and whatever THEY run). Their crashes would then land in
+        # OUR Crashpad database as foreign dumps nobody prunes. Cleared here,
+        # before the first child, so children fall back to the OS default.
+        from kiro_crew.crashpad_inherit import detach_inherited_crash_handler
+
+        detach_inherited_crash_handler()
         # Enable faulthandler for the long-lived gateway process: it makes
         # `kill -ABRT <pid>` dump every thread's stack to stderr (the gateway
         # log) on demand, and it is the signal the dashboard's stall watchdog

--- a/src/kiro_crew/crashpad_inherit.py
+++ b/src/kiro_crew/crashpad_inherit.py
@@ -1,0 +1,101 @@
+"""Stop Electron's Crashpad handler from following us into every child process.
+
+Problem
+-------
+The desktop shell starts Electron's ``crashReporter`` (``native-logging.js``)
+so a crash of the app itself leaves a minidump behind. On macOS Crashpad
+registers itself as the task's Mach exception port for ``EXC_CRASH`` and
+``EXC_RESOURCE``. Mach exception ports are INHERITED across ``fork``/``exec``,
+so every process the gateway launches — kiro-cli, node, an MCP server, and the
+``brazil``/``ruby``/``python``/``chrome-headless-shell`` those in turn spawn —
+still reports to *our* handler, which faithfully writes *their* dumps into
+*our* ``Crashpad/pending/``. Measured on one developer machine: 585 dumps,
+zero of them this app, 539 of them a Ruby child aborting on ``fork()`` in its
+own ``at_exit`` (``objc_initializeAfterForkError``), a dozen an hour, forever.
+
+That is not a diagnostic; it is a disk leak (Crashpad with ``uploadToServer``
+off never prunes ``pending/``), and it makes the crash collector do real work
+every launch to prove each dump is somebody else's.
+
+Fix
+---
+Clear the two inherited exception ports on THIS task (the gateway) before any
+child is spawned. ``task_set_exception_ports(mach_task_self(), mask, MACH_PORT_NULL, …)``
+resets the entries to the null port, and the null port is what our children then
+inherit — so a child crash is handled by the ordinary path (the kernel's
+``ReportCrash`` writes an ``.ips`` under the child's OWN name, exactly as if the
+process had been launched from a terminal). The Electron parent is untouched:
+its port is a per-task setting, and only the gateway's task is edited.
+
+Scope
+-----
+macOS only; every other platform is a no-op. Best-effort: a failure to load
+libSystem or a non-zero ``kern_return_t`` is logged and ignored — inheriting a
+crash handler is a nuisance, and refusing to start over it would be worse.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+# <mach/exception_types.h>: EXC_MASK_<type> == 1 << EXC_<type>.
+EXC_CRASH = 10
+EXC_RESOURCE = 11
+EXC_MASK_CRASH = 1 << EXC_CRASH
+EXC_MASK_RESOURCE = 1 << EXC_RESOURCE
+# The two masks Crashpad claims (crashpad/util/mach/exc_server_variants.h,
+# ExcServerSuccessfulReturnValue + CrashpadClient::SetHandlerMachPort). Nothing
+# else in the app registers exception ports, so nothing else is disturbed.
+CRASHPAD_MASKS = EXC_MASK_CRASH | EXC_MASK_RESOURCE
+
+MACH_PORT_NULL = 0
+EXCEPTION_DEFAULT = 1
+THREAD_STATE_NONE = 0
+_KERN_SUCCESS = 0
+
+
+def detach_inherited_crash_handler(*, platform: str = sys.platform) -> bool:
+    """Reset the inherited Crashpad exception ports on this task.
+
+    Returns True when the ports were cleared, False when nothing was done
+    (not macOS, libSystem unavailable, or the Mach call failed). Never raises.
+    """
+    if platform != "darwin":
+        return False
+    try:
+        libc = ctypes.CDLL("/usr/lib/libSystem.dylib", use_errno=True)
+    except OSError as exc:
+        logger.debug("crashpad detach: libSystem unavailable: %s", exc)
+        return False
+    try:
+        libc.mach_task_self.restype = ctypes.c_uint32
+        libc.mach_task_self.argtypes = []
+        libc.task_set_exception_ports.restype = ctypes.c_int32
+        libc.task_set_exception_ports.argtypes = [
+            ctypes.c_uint32,  # task_t
+            ctypes.c_uint32,  # exception_mask_t
+            ctypes.c_uint32,  # mach_port_t new_port
+            ctypes.c_int32,  # exception_behavior_t
+            ctypes.c_int32,  # thread_state_flavor_t
+        ]
+        # mach_task_self() is a name the task owns, not a fresh send right; it
+        # must not be deallocated (same rule as _macos_current_rss_bytes).
+        kern_return = libc.task_set_exception_ports(
+            libc.mach_task_self(),
+            CRASHPAD_MASKS,
+            MACH_PORT_NULL,
+            EXCEPTION_DEFAULT,
+            THREAD_STATE_NONE,
+        )
+    except (AttributeError, OSError, ValueError) as exc:
+        logger.debug("crashpad detach: Mach call unavailable: %s", exc)
+        return False
+    if kern_return != _KERN_SUCCESS:
+        logger.debug("crashpad detach: task_set_exception_ports kr=%d", kern_return)
+        return False
+    logger.debug("crashpad detach: cleared inherited EXC_CRASH|EXC_RESOURCE ports")
+    return True

--- a/test/test_crashpad_inherit.py
+++ b/test/test_crashpad_inherit.py
@@ -1,0 +1,155 @@
+"""The gateway must stop Electron's Crashpad handler from following it into children."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import kiro_crew
+from kiro_crew import crashpad_inherit
+from kiro_crew.crashpad_inherit import (
+    CRASHPAD_MASKS,
+    EXC_MASK_CRASH,
+    EXC_MASK_RESOURCE,
+    MACH_PORT_NULL,
+    detach_inherited_crash_handler,
+)
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+
+class _FakeLibc:
+    """Records the Mach call instead of making it."""
+
+    def __init__(self, kern_return: int = 0) -> None:
+        self.calls: list[tuple] = []
+        self._kr = kern_return
+        self.mach_task_self = _Fn(lambda: 0x103)
+        self.task_set_exception_ports = _Fn(self._set)
+
+    def _set(self, task, mask, port, behavior, flavor):
+        self.calls.append((task, mask, port, behavior, flavor))
+        return self._kr
+
+
+class _Fn:
+    def __init__(self, fn):
+        self._fn = fn
+        self.restype = None
+        self.argtypes = None
+
+    def __call__(self, *a):
+        return self._fn(*a)
+
+
+def test_noop_off_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    loaded: list[tuple] = []
+
+    def _load(*a, **k):
+        loaded.append(a)
+        return _FakeLibc()
+
+    monkeypatch.setattr(ctypes, "CDLL", _load)
+    assert detach_inherited_crash_handler(platform="linux") is False
+    assert detach_inherited_crash_handler(platform="win32") is False
+    assert loaded == []
+
+
+def test_clears_exactly_the_crashpad_masks_to_the_null_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    libc = _FakeLibc()
+    monkeypatch.setattr(ctypes, "CDLL", lambda *a, **k: libc)
+    assert detach_inherited_crash_handler(platform="darwin") is True
+    assert len(libc.calls) == 1
+    task, mask, port, behavior, flavor = libc.calls[0]
+    assert task == 0x103
+    assert mask == CRASHPAD_MASKS == EXC_MASK_CRASH | EXC_MASK_RESOURCE
+    # Only the two masks Crashpad registers; a wider mask would also wipe any
+    # port a debugger or the runtime itself installed.
+    assert mask & ~(EXC_MASK_CRASH | EXC_MASK_RESOURCE) == 0
+    assert port == MACH_PORT_NULL
+    assert behavior == crashpad_inherit.EXCEPTION_DEFAULT
+    assert flavor == crashpad_inherit.THREAD_STATE_NONE
+
+
+def test_reports_failure_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ctypes, "CDLL", lambda *a, **k: _FakeLibc(kern_return=4))
+    assert detach_inherited_crash_handler(platform="darwin") is False
+
+    def _boom(*a, **k):
+        raise OSError("no libSystem")
+
+    monkeypatch.setattr(ctypes, "CDLL", _boom)
+    assert detach_inherited_crash_handler(platform="darwin") is False
+
+
+# Runs in a throwaway child process, never in the pytest worker: the detach
+# edits process-global Mach exception ports, and a worker running under a
+# debugger or its own Crashpad must keep whatever handler it had. The child
+# detaches, reads its own ports, then spawns a grandchild that reads ITS ports
+# -- the grandchild is the shape the fix exists for (kiro-cli, MCP servers).
+_CHILD_SCRIPT = """\
+import ctypes, json, subprocess, sys
+from kiro_crew.crashpad_inherit import CRASHPAD_MASKS, detach_inherited_crash_handler
+
+
+def read_crashpad_ports():
+    libc = ctypes.CDLL("/usr/lib/libSystem.dylib", use_errno=True)
+    libc.mach_task_self.restype = ctypes.c_uint32
+    masks = (ctypes.c_uint32 * 32)()
+    ports = (ctypes.c_uint32 * 32)()
+    behaviors = (ctypes.c_int32 * 32)()
+    flavors = (ctypes.c_int32 * 32)()
+    count = ctypes.c_uint32(32)
+    kr = libc.task_get_exception_ports(
+        libc.mach_task_self(), CRASHPAD_MASKS, masks, ctypes.byref(count), ports, behaviors, flavors
+    )
+    return {"kr": kr, "entries": [[masks[i], ports[i]] for i in range(count.value)]}
+
+
+if sys.argv[1] == "grandchild":
+    print(json.dumps(read_crashpad_ports()))
+else:
+    detached = detach_inherited_crash_handler()
+    own = read_crashpad_ports()
+    grandchild = subprocess.run(
+        [sys.executable, sys.argv[0], "grandchild"], capture_output=True, text=True, timeout=60, check=True
+    )
+    print(json.dumps({"detached": detached, "own": own, "grandchild": json.loads(grandchild.stdout)}))
+"""
+
+
+def _assert_crashpad_ports_null(report: dict) -> None:
+    assert report["kr"] == 0
+    for mask, port in report["entries"]:
+        if mask & CRASHPAD_MASKS:
+            assert port == MACH_PORT_NULL
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="reads a real task's Mach exception ports")
+def test_child_task_and_its_children_read_null_ports_afterwards(tmp_path: Path) -> None:
+    script = tmp_path / "detach_probe.py"
+    script.write_text(_CHILD_SCRIPT, encoding="utf-8")
+    src_root = str(Path(kiro_crew.__file__).resolve().parent.parent)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(p for p in (src_root, env.get("PYTHONPATH")) if p)
+    proc = subprocess.run(
+        [sys.executable, str(script), "detach"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        **UTF8_TEXT,
+        timeout=120,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    report = json.loads(proc.stdout)
+    assert report["detached"] is True
+    _assert_crashpad_ports_null(report["own"])
+    _assert_crashpad_ports_null(report["grandchild"])

--- a/website/electron/crash-collector.js
+++ b/website/electron/crash-collector.js
@@ -295,6 +295,26 @@ function isOwnModule(moduleName, appNames) {
 }
 
 /**
+ * Is this module name an Electron runtime -- ours or not?
+ *
+ * `crashDumps` is `<userData>/Crashpad`, so it is per-app, not machine-wide; but
+ * "per-app" is keyed on `app.getName()`, and a dev `npm start` of this SAME app
+ * shares the directory with the installed build while its main module is
+ * `Electron`, which `isOwnModule` rightly refuses to claim. That dump is a
+ * genuine Electron crash that the other build's collector will read as its own
+ * on its next launch. So an electron-shaped foreign dump is acknowledged (not
+ * ours to report) but never deleted (not ours to destroy). The children this
+ * fix exists for -- ruby, python, node, chrome-headless-shell -- are not
+ * electron-shaped and stay deletable. This is the ONE place a bare `electron`
+ * prefix test is right: it decides what to keep, never what to claim.
+ */
+function isElectronShaped(moduleName) {
+  const base = normalizeName(anyBasename(moduleName));
+  if (!base) return false;
+  return base === "electron" || base.startsWith("electronhelper") || base.startsWith("electron.");
+}
+
+/**
  * Read a UTF-16LE MINIDUMP_STRING at `rva`.
  *
  * Returns "" rather than throwing on a length that runs past EOF: a truncated
@@ -414,6 +434,10 @@ function parseMinidump(read) {
  * `pending/` before it has finished filling it in, so an unreadable dump is
  * routinely one we are simply too early for — the most likely moment for that
  * being the launch right after the crash, which is when this runs.
+ *
+ * `deletable` is set only on the PROVEN not-ours verdicts, and only when the dump
+ * cannot be another Electron build's real crash (`isElectronShaped`). It is what
+ * gates the unlink in `collectCrashReports`; `readable` alone never does.
  */
 function classifyMinidump(parsed, appNames) {
   if (!parsed) return { crash: false, readable: false, reason: "not-a-minidump" };
@@ -423,7 +447,12 @@ function classifyMinidump(parsed, appNames) {
     return { crash: false, readable: false, reason: "module-unreadable" };
   }
   if (!isOwnModule(parsed.mainModule, appNames)) {
-    return { crash: false, readable: true, reason: "foreign-process" };
+    return {
+      crash: false,
+      readable: true,
+      reason: "foreign-process",
+      deletable: !isElectronShaped(parsed.mainModule),
+    };
   }
   if (parsed.exceptionCode === null) {
     // The exception stream was absent or too short to read. Crashpad publishes
@@ -434,7 +463,7 @@ function classifyMinidump(parsed, appNames) {
   }
   if (parsed.exceptionCode === 0) {
     // DumpWithoutCrashing(): a deliberate snapshot. The process kept running.
-    return { crash: false, readable: true, reason: "not-a-crash" };
+    return { crash: false, readable: true, reason: "not-a-crash", deletable: true };
   }
   return { crash: true, readable: true, reason: "" };
 }
@@ -848,6 +877,7 @@ function inspectCandidate(candidate, { fs, appNames, log = () => {} }) {
           outcome: verdict.readable ? INSPECT_FOREIGN : INSPECT_PENDING,
           name: candidate.name,
           reason: verdict.reason,
+          deletable: verdict.deletable === true,
         };
       }
       return {
@@ -921,7 +951,7 @@ function inspectCandidate(candidate, { fs, appNames, log = () => {} }) {
  * @returns {{crashLogPath: string, logsDir: string, baseline: boolean,
  *            newCrashes: Array<object>, candidates: number, inspected: number,
  *            skipped: number, deferred: number, unparsed: number, aged: number,
- *            recorded: number}}
+ *            removed: number, recorded: number}}
  */
 function collectCrashReports({
   logsDir,
@@ -947,6 +977,7 @@ function collectCrashReports({
     deferred: 0,
     unparsed: 0,
     aged: 0,
+    removed: 0,
     recorded: 0,
   };
   if (!fs) return summary;
@@ -1065,7 +1096,7 @@ function collectCrashReports({
   const lines = [];
   const records = [];      // outcome `crash`: announced AND acknowledged on write
   const notes = [];        // outcome `unparsed`: acknowledged on write, not announced
-  const provenForeign = []; // outcome `foreign`: acknowledged unconditionally
+  const provenForeign = []; // outcome `foreign`: acknowledged unconditionally, then deleted
   const pendingKeys = [];   // read short THIS run: aged out once the count trips
   for (const candidate of toInspect) {
     let result = null;
@@ -1084,7 +1115,7 @@ function collectCrashReports({
       continue;
     }
     if (result.outcome === INSPECT_FOREIGN) {
-      provenForeign.push(candidate.key);
+      provenForeign.push({ candidate, deletable: result.deletable === true });
       continue;
     }
     lines.push(formatCrashLine({ at: result.at, ...result.fields }));
@@ -1106,7 +1137,35 @@ function collectCrashReports({
 
   // Proven-foreign needs no ledger line, so its acknowledgement does not depend
   // on the write landing.
-  for (const key of provenForeign) seen.add(key);
+  //
+  // A proven-foreign dump is also DELETED when `deletable`. A dump in this
+  // database that is not ours got here because a child process inherited our
+  // Crashpad handler (a Mach exception port on macOS), so the handler faithfully
+  // wrote the child's crash into our `pending/`. Crashpad only prunes a dump it
+  // has uploaded, and `uploadToServer` is off, so nothing ever removes them: one
+  // machine accumulated 585 (129 MB) in four days, a dozen an hour, none of
+  // them this app. Acknowledging alone kept them out of the ledger but left the
+  // leak. Deletion is gated on the same PROOF as the acknowledgement — a
+  // readable dump whose first module is someone else's, or whose exception code
+  // is zero — never on a failure to read, and never when the stranger is itself
+  // an Electron build (`isElectronShaped`): `crashDumps` is per-`app.getName()`,
+  // so a dev run of this same app shares it, and its real crash belongs to that
+  // build's own collector. Our own dumps are never touched: an own-app crash is
+  // `records`, an own-app snapshot (code 0) is the one foreign case that IS
+  // ours, and it is a deliberate `DumpWithoutCrashing()` nobody asked to keep
+  // either. Best-effort: an unlink that fails leaves the dump acknowledged
+  // exactly as before, so a read-only database degrades to the old behaviour
+  // rather than to a retry loop.
+  for (const { candidate, deletable } of provenForeign) {
+    seen.add(candidate.key);
+    if (!deletable || candidate.kind !== "minidump") continue;
+    try {
+      fs.unlinkSync(candidate.filePath);
+      summary.removed += 1;
+    } catch (e) {
+      log(`crash scan could not remove foreign ${candidate.name}: ${e && e.message}`);
+    }
+  }
   if (durable) {
     for (const { candidate, record } of records) {
       seen.add(candidate.key);
@@ -1175,7 +1234,8 @@ function collectCrashReports({
   log(
     `crash scan: candidates=${summary.candidates} new=${summary.newCrashes.length} `
       + `inspected=${summary.inspected} skipped=${summary.skipped} deferred=${summary.deferred} `
-    + `unparsed=${summary.unparsed} aged=${summary.aged} recorded=${summary.recorded}`
+    + `unparsed=${summary.unparsed} aged=${summary.aged} removed=${summary.removed} `
+    + `recorded=${summary.recorded}`
   );
   return summary;
 }
@@ -1215,6 +1275,7 @@ module.exports = {
   ipsBelongsToApp,
   ipsTimestampToIso,
   isOwnModule,
+  isElectronShaped,
   appendCrashLog,
   readSeenState,
   writeSeenState,

--- a/website/electron/test/crash-collector.test.js
+++ b/website/electron/test/crash-collector.test.js
@@ -14,6 +14,7 @@ const {
   parseIpsHead,
   ipsBelongsToApp,
   isOwnModule,
+  isElectronShaped,
   appendCrashLog,
   readSeenState,
   writeSeenState,
@@ -140,6 +141,7 @@ function fakeFs(initial = {}) {
   const api = {
     files,
     writes: [],
+    unlinked: [],
     readdirSync(dir) {
       const prefix = dir.endsWith(path.sep) ? dir : dir + path.sep;
       const names = [];
@@ -174,6 +176,11 @@ function fakeFs(initial = {}) {
       if (!buf) throw new Error(`ENOENT: ${from}`);
       files.delete(from);
       files.set(to, buf);
+    },
+    unlinkSync(p) {
+      if (!files.has(p)) throw new Error(`ENOENT: ${p}`);
+      files.delete(p);
+      api.unlinked.push(p);
     },
     openSync(p) {
       const buf = files.get(p);
@@ -795,6 +802,98 @@ describe("collectCrashReports — filtering", () => {
     assert.equal(fs.files.has(LOG), false);
     assert.match(messages.join("\n"), /foreign-process/);
     assert.match(messages.join("\n"), /not-a-crash/);
+  });
+
+  it("deletes a proven-foreign dump so the inherited-handler leak stops growing", () => {
+    // Crashpad never prunes `pending/` when uploads are off, and every dump a
+    // child wrote through our inherited handler stays there forever. Proof of
+    // foreignness is what licenses the delete, the same proof that licenses
+    // the acknowledgement.
+    const ruby = path.join(PENDING, "r1.dmp");
+    const rubyCrash = path.join(PENDING, "r2.dmp");
+    const ownSnapshot = path.join(PENDING, "self-snapshot.dmp");
+    const fs = fakeFs({
+      [ruby]: buildMinidump({ moduleName: "/usr/bin/ruby", exceptionCode: 0 }),
+      [rubyCrash]: buildMinidump({ moduleName: "/usr/bin/ruby", exceptionCode: 0x8000000b }),
+      [ownSnapshot]: buildMinidump({ exceptionCode: 0 }),
+    });
+    const scan = collectCrashReports(withBaseline(fs));
+    assert.equal(scan.removed, 3);
+    assert.deepEqual(fs.unlinked.sort(), [ruby, rubyCrash, ownSnapshot].sort());
+    assert.equal(fs.files.has(ruby), false);
+    // Still acknowledged, so a later scan does not look for the vanished file.
+    const state = JSON.parse(fs.readFileSync(STATE));
+    assert.ok(state.seen.includes("minidump:r1.dmp"));
+  });
+
+  it("never deletes our own crash, an unreadable dump, or a pending one", () => {
+    const own = path.join(PENDING, "own.dmp");
+    const torn = path.join(PENDING, "torn.dmp");
+    const fs = fakeFs({
+      [own]: buildMinidump(),
+      [torn]: buildMinidump().subarray(0, 40),
+    });
+    const scan = collectCrashReports(withBaseline(fs));
+    assert.equal(scan.newCrashes.length, 1);
+    assert.equal(scan.removed, 0);
+    assert.deepEqual(fs.unlinked, []);
+    assert.equal(fs.files.has(own), true);
+    assert.equal(fs.files.has(torn), true);
+  });
+
+  it("keeps the acknowledgement when a foreign dump cannot be removed", () => {
+    const ruby = path.join(PENDING, "r1.dmp");
+    const fs = fakeFs({ [ruby]: buildMinidump({ moduleName: "/usr/bin/ruby" }) });
+    fs.unlinkSync = () => { throw new Error("EROFS"); };
+    const messages = [];
+    const scan = collectCrashReports(withBaseline(fs, { log: (m) => messages.push(m) }));
+    assert.equal(scan.removed, 0);
+    assert.match(messages.join("\n"), /could not remove foreign r1\.dmp/);
+    const state = JSON.parse(fs.readFileSync(STATE));
+    assert.ok(state.seen.includes("minidump:r1.dmp"));
+    assert.equal(fs.files.has(ruby), true);
+  });
+
+  it("keeps, but acknowledges, another Electron build's crash in the shared database", () => {
+    // `crashDumps` is `<userData>/Crashpad`, keyed on `app.getName()`, so a dev
+    // `npm start` of this same app writes into the installed build's database
+    // with main module `Electron`. That is a REAL crash belonging to the other
+    // build; not ours to report, and not ours to destroy. Children that
+    // inherited our handler (ruby here) are still removed in the same scan.
+    const devElectron = path.join(PENDING, "dev.dmp");
+    const devHelper = path.join(PENDING, "helper.dmp");
+    const ruby = path.join(PENDING, "r1.dmp");
+    const fs = fakeFs({
+      [devElectron]: buildMinidump({
+        moduleName: "/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron",
+        exceptionCode: 0x8000000b,
+      }),
+      [devHelper]: buildMinidump({
+        moduleName: "/repo/node_modules/electron/dist/Electron Helper (Renderer)",
+        exceptionCode: 0x8000000b,
+      }),
+      [ruby]: buildMinidump({ moduleName: "/usr/bin/ruby", exceptionCode: 0x8000000b }),
+    });
+    const scan = collectCrashReports(withBaseline(fs));
+    assert.deepEqual(scan.newCrashes, []);
+    assert.equal(scan.removed, 1);
+    assert.deepEqual(fs.unlinked, [ruby]);
+    assert.equal(fs.files.has(devElectron), true);
+    assert.equal(fs.files.has(devHelper), true);
+    // Acknowledged all the same: the other build's collector owns the report.
+    const state = JSON.parse(fs.readFileSync(STATE));
+    assert.ok(state.seen.includes("minidump:dev.dmp"));
+    assert.ok(state.seen.includes("minidump:helper.dmp"));
+  });
+
+  it("isElectronShaped keeps electron runtimes and nothing else", () => {
+    assert.equal(isElectronShaped("/x/Electron"), true);
+    assert.equal(isElectronShaped("C:\\x\\electron.exe"), true);
+    assert.equal(isElectronShaped("/x/Electron Helper (GPU)"), true);
+    assert.equal(isElectronShaped("/usr/bin/ruby"), false);
+    assert.equal(isElectronShaped("/x/chrome-headless-shell"), false);
+    assert.equal(isElectronShaped("/x/electron-updater-thing"), false);
+    assert.equal(isElectronShaped(""), false);
   });
 
   it("never re-reads a rejected dump on the next launch", () => {


### PR DESCRIPTION
## Problem / Motivation

On macOS, every process the gateway spawns inherits Electron's Crashpad handler through the task's Mach exception port (`EXC_CRASH|EXC_RESOURCE`). So does everything *they* spawn. Their crashes are written into **our** `Crashpad/pending/`. With `uploadToServer: false` Crashpad never prunes that directory. Nothing in the app does either.

Measured on one developer machine over four days: 585 dumps, 129 MB, zero of them this app. 539 were `brazil`'s Ruby aborting on `fork()` inside its own `at_exit` metrics hook (`objc_initializeAfterForkError`, "crashed on child side of fork pre-exec"), 39 Playwright `chrome-headless-shell`, 7 pytest venv `python`. Rate: 10-50 per hour whenever an agent session runs a `brazil` command via builder-mcp. Chain: `KiroCrew -> python3.12 (gateway) -> kiro-cli -> node -> toolbox-exec -> builder-mcp -> brazil/ruby`.

This is macOS-only. Linux Crashpad is an in-process signal handler that `exec` resets. Windows Crashpad is an in-process unhandled-exception filter that does not cross `CreateProcess`. Only Mach exception ports are inherited by the kernel across fork/exec.

## Why it matters

- Unbounded disk growth in the user's Application Support directory.
- The crash collector (#8501) opens and parses each dump every launch to prove it is foreign. Its `seen` set (capped at 2000 keys) fills with other programs' dumps.
- Diagnostic noise: anyone looking at the Crashpad database concludes the app crashes constantly.

## What changed (motivation → approach → change)

Foreign dumps appear in our database. The cause is that Mach exception ports are inherited across fork/exec, and Crashpad registers one on the Electron task that the gateway child and its whole tree inherit. `src/kiro_crew/crashpad_inherit.py` adds `detach_inherited_crash_handler()`. It calls `task_set_exception_ports(mach_task_self(), EXC_MASK_CRASH|EXC_MASK_RESOURCE, MACH_PORT_NULL, …)` on the **gateway's own task**. `cli.py` calls it once in the gateway dispatch, after `run_preflight_checks()` and before anything spawns. Children then inherit the null port and crash the ordinary way: ReportCrash writes an `.ips` under their own name. Electron's own port is untouched. No-op off macOS. Best-effort with debug logging.

**Boot-path statement (AUTOSDE `no-new-work-on-gateway-boot-path`).** This step runs before `asyncio.run()` on purpose. It cannot be deferred: it must precede the first `fork`, and the first children are spawned during gateway startup (child watcher, MCP servers, ACP runtime). Placing it after the socket binds would need a gate on every spawn site to hold the bug closed. Worst-case bound: one `dlopen` of the already-mapped `libSystem.dylib` plus one Mach trap. Measured 15 µs total (1.5 µs trap, 13 µs symbol lookup). The cost is O(1). It does not read config, touch disk, or scale with any user data, so it is the same on an empty profile and a large one. It is one of the rule's allowed "bounded fail-closed safety checks that must precede serving traffic".

Dumps already there, and any that still arrive from a gateway started outside the shell, stay forever. The cause is that the collector acknowledged proven-foreign dumps into `seen` but never removed them. `website/electron/crash-collector.js` now deletes a candidate classified `INSPECT_FOREIGN` (readable, someone else's first module or exception code 0) with `unlinkSync` and still acknowledges it. The same proof gates both. Unreadable or pending dumps and own-app crashes are never deleted. One more thing is never deleted: a foreign dump whose main module is itself an Electron runtime (`isElectronShaped`: `Electron`, `Electron Helper*`, `electron.exe`). `crashDumps` is `<userData>/Crashpad`, keyed on `app.getName()`, so a dev `npm start` of this same app writes into the installed build's database. Its real crash is acknowledged (not ours to report) but kept (not ours to destroy). The children this fix targets (ruby, python, node, chrome-headless-shell) are not Electron-shaped and are still removed. A failed unlink logs and leaves the dump acknowledged exactly as before. The scan log line gains a `removed=N` counter.

Verified empirically before writing: `task_set_exception_ports` on a Python child of this Electron tree returns KERN_SUCCESS, `task_get_exception_ports` then reads `0x0` for the CRASH|RESOURCE entry, and a `subprocess` child of that process also reads `0x0`.

## Tests

- `test/test_crashpad_inherit.py` (4): no-op off darwin; exact masks and null port passed; non-zero kern_return and missing libSystem return False without raising; a darwin-only real-task check that runs in a **throwaway child process** with `cwd=tmp_path`, detaches there, and asserts both that child and its grandchild read the null port for CRASH|RESOURCE. The pytest worker's own exception ports are never modified.
- `website/electron/test/crash-collector.test.js` (+5): foreign dumps deleted and still acknowledged; own crash / torn dump never deleted; EROFS on unlink keeps the acknowledgement; another Electron build's real crash is acknowledged but kept while a ruby dump in the same scan is removed (fails without the `deletable` gate); `isElectronShaped` keeps electron runtimes only.
- `node --test test/crash-collector.test.js`: 86/86. Full `npm test`: 1721 pass / 30 fail. The same 30 fail on `origin/main` with this change stashed (`build-config-schema`, `store-rename-migration`); unrelated.
- flake8 / black / isort / mypy clean on the touched Python.

## Manual verification

Not yet run in the installed app (requires `make desktop` + relaunch). Expected after relaunch: the `gateway-launch.log` crash scan line shows `removed=N` for foreign dumps this build inspects for the first time, at most 25 per launch. Dumps an earlier build already acknowledged into `seen` (including the baselined pre-existing set) are not re-opened and stay on disk; draining that history is tracked in #9447. After the next `brazil` invocation from an agent session, a new `ruby-*.ips` appears under `~/Library/Logs/DiagnosticReports/` and **no** new `.dmp` under `kirocrew-desktop/Crashpad/pending/`.

## Related Issues

no linked issue: found during the remote-crew loading investigation, no issue was filed for the dump leak.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a parent-process crash reporter or exception port inherited by every spawned child, so children's failures are attributed to and stored by the parent

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
