### PR TITLE
chore(pipeline-conductor): state the argv constraint in present tense

### DIFF
--- a/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py
@@ -879,7 +879,7 @@ def _is_shell_command_wrapper(argv: list[str], exe_base: str | None) -> bool:
 
     Takes real ARGV, not a joined string. Once NUL separators become spaces, an
     argument containing a space is indistinguishable from two arguments, so the
-    option/operand structure this function has to read is no longer recoverable.
+    option/operand structure this function has to read cannot be recovered.
 
     Three spellings of the same flag all have to be recognised, and each one was
     a live misattribution before it was:


### PR DESCRIPTION
Fixes #9372. Unblocks #9346.

## Symptom

`comment-history-baseline.json` records 2 history-narration spans for
`src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py`, but the file on main
matches 3 of `scripts/check_comment_history.py`'s patterns (`L244` incident date `2026-08-30`,
`L255` "used to", `L882` "no longer"). The gate is diff-scoped, so the gap surfaces as a
`grew from 2 to 3` failure in `Backend Lint & Type Check` for whichever PR touches the file next —
live on #9346, whose failure log ends `0 new offender(s), 1 grown count(s), 0 file(s) with markers
on added lines`: proof that PR added none of the three.

## Root cause

The checker and the baseline both arrived in a single commit (`acfa55d0`, #9328) whose baseline was
snapshotted against a tree older than the one it merged into; because the gate is deliberately
diff-scoped, #9328's own CI could not see drift in files #9328 did not touch. Nobody omitted
anything — a snapshot went stale in flight. (The issue as filed attributes the gap to `aa75a403c` /
#8736 leaving the entry "not raised"; that is chronologically impossible — #9328 landed ~1.5h
after `aa75a403c` — and this PR deliberately does not repeat it.)

fleet_probe.py is one corner of a 33-file drift; the full measured census is filed as #9384 and is
context, not scope.

## Fix

One present-tense reword of the `L882` docstring sentence:

- before: `option/operand structure this function has to read is no longer recoverable.`
- after: `option/operand structure this function has to read cannot be recovered.`

`L882` is a false positive of the `\bno longer\b` pattern: the sentence states a property of the
NUL-to-space transformation (true of the current code, not narration about its past) — the same
distinction the checker's own docstring draws when it exempts a message reading "this token is no
longer valid" (rule-design follow-up: #9387). Rewording removes the match at zero cost to meaning.
The two genuine narration spans (`L244`, `L255`) stay: they are what the baseline entry of 2
legitimately carries.

Per the Main Ratchet Audit policy (#9350: "Fix the drift on main rather than raising the ceiling in
someone else's PR") and `--write-baseline`'s own only-lowers contract, the entry is NOT raised, and
`comment-history-baseline.json` is untouched (no lowering needed — 2 is already the entry; and any
edit there would collide with #9364, which takes the same reword route for two other drifted files
and composes cleanly with this PR).

## Verification

Red before green, with the gate's own entry points (not a re-implemented grep — the gate counts
distinct spans with overlaps collapsed):

- **Red** (file content at main `7177fa44`, file in scope):
  `::error file=...fleet_probe.py::history narration in comments grew from 2 to 3` …
  `comment-history gate FAILED: 0 new offender(s), 1 grown count(s), 0 file(s) with markers on added lines, 0 entr(y/ies) to lower.`
  Corroborated by #9346's `Backend Lint & Type Check (3.12)` CI log (same three lines, same trailer).
- **Green** (this branch):
  `comment-history gate passed: nothing in scope narrates change history outside the baseline (7606 known marker(s) in 1720 file(s) still listed).`
- **Direct measurement** (`violations_in_source` loaded from `scripts/check_comment_history.py`):
  3 spans before → 2 after, level with the baseline entry of 2.
- **Mutation-check:** no guard is added, so there is nothing to mutate. The equivalent revert-direction
  check was run: restoring the original sentence turns the gate red again (`grew from 2 to 3`),
  restoring the fix turns it green.
- **Gates:** `check_black_formatting.py` passed (scope: 1 changed file), flake8 clean, mypy clean on
  the changed file.
- **Zero-regression:** full backend suite (`pytest -q -n auto --dist loadgroup`, the identical bare
  invocation) on this branch and on a `git worktree` at `origin/main`; sorted FAILED/ERROR id sets
  compared both directions after ANSI stripping. Frontend cross-surface guard specs green.
  (Evidence detail below.)

**No new unit test, deliberately:** (a) the gate already enforces this exact invariant in CI for
every PR touching the file — that is precisely how the defect surfaced on #9346, so a unit test
would duplicate an existing enforced check; (b) the tempting stronger test — asserting tree-wide
that no baselined file exceeds its entry — would recreate the very anti-pattern the checker's
docstring rejects ("an unscoped gate reddens a PR because the base branch merged someone else's
file") and would redden every open PR today for all 33 drifted files (#9384). Closing the drift
hole properly is a design question, filed as #9385.

## Follow-ups filed (scope drawn deliberately)

- #9384 — the measured 33-file / 55-span drift census (context for this fix, not its scope).
- #9385 — the structural drift hole: how to detect main drift without reddening innocent PRs.
- #9386 — the grown-count message reads as an accusation when the contributor's diff is clean.
- #9387 — descriptive vs historical "no longer": whether the checker's literal-string exemption
  reasoning should extend to descriptive docstring prose.

## Sequencing

- #9346 (the reddened PR) touches this file in the BANNED-probe print path; this PR touches one
  docstring sentence at `L882` — no textual conflict expected. Landing this unblocks it.
- #9364 edits `comment-history-baseline.json` for `chat_runner.py` / `context.py`; this PR touches
  neither its files nor the baseline, so the two compose cleanly in either order.
- #9333 / #9334 / #9338 do not touch `fleet_probe.py` (verified at branch time).

## Pattern harvest

Rule candidate: when a ratchet gate and its baseline snapshot land as one commit, the snapshot must
be re-taken (or re-verified) against the merge target immediately before merge — a diff-scoped gate
cannot see its own baseline going stale in flight. Knowingly out-of-scope sibling sites: the other
32 drifted files measured in #9384, owned there rather than widened into this diff.

<!-- no-visual-delta -->
Screenshot evidence: none possible — a one-sentence docstring reword has no visual surface.
