### PR TITLE
fix: make Feishu SDK lifecycle thread-safe

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -4196,7 +4196,18 @@ setting their phone carries, so it is a product decision and not a parity gap.
 connection (a daemon thread pushing normalized `LarkInbound` frames into the
 async event loop via `run_coroutine_threadsafe`); outbound is REST reply
 anchored to the inbound `message_id` (via `run_in_executor` so it never
-blocks the event loop). `lark-oapi` is an OPTIONAL dependency declared as the
+blocks the event loop). The SDK caches its WebSocket event loop in a module
+global when imported, while Kiro Crew imports it on the gateway loop and runs
+`ws.Client.start()` in the receiver thread. The receiver therefore owns a
+separate event loop, rebinds the SDK global, and constructs the client there
+before `start()`; otherwise constructor-time helpers remain bound to the gateway
+loop and the SDK calls `run_until_complete()` on that already-running loop. Shutdown
+uses a public synchronous `stop()` when a future SDK provides one, and falls
+back on current lark-oapi 1.x's async `_disconnect()` on the receiver loop with
+auto-reconnect disabled. In both cases the receiver cancels pending SDK tasks
+and closes its loop before the daemon thread exits.
+
+`lark-oapi` is an OPTIONAL dependency declared as the
 `[feishu]` extra in `setup.cfg` and lazily imported inside the client module;
 `maybe_start_feishu` catches `ImportError` and logs a skip so a missing
 library never takes down the gateway. No public webhook endpoint is required.
@@ -4223,8 +4234,13 @@ by an `await`.
 
 **Security model.** `authorize` is deny-by-default against
 `feishu.allowed_open_ids` (frozen at construction); every denial is
-SEL-audited (`source="feishu"`). Group-chat access is an explicit opt-in
-gated on BOTH `allow_group=True` AND the group's `chat_id` appearing in
+SEL-audited (`source="feishu"`). The Feishu app needs
+`im:message.p2p_msg:readonly` to receive direct-message events and
+`im:message:send_as_bot` to reply; enabling groups additionally needs
+`im:message.group_at_msg.include_bot:readonly`. The broad `im:message` grant
+alone does not activate p2p event delivery in the current Feishu console.
+Group-chat access is an explicit opt-in gated on BOTH `allow_group=True` AND
+the group's `chat_id` appearing in
 `allowed_group_ids`; every other context is denied with a SEL audit record
 (`denied_group_not_allowed`). `FEISHU_APP_SECRET` is on the sandbox agent env
 denylist.

--- a/src/kiro_crew/docs/feishu-integration.md
+++ b/src/kiro_crew/docs/feishu-integration.md
@@ -25,7 +25,11 @@ Lark).
    its **App ID** and **App Secret** from *Credentials & Basic Info*.
 2. **Add the bot capability** — *Add features → Bot*.
 3. **Grant permissions** — under *Permissions & Scopes*, add
-   `im:message` (receive) and `im:message:send_as_bot` (reply).
+   `im:message.p2p_msg:readonly` (receive DMs) and
+   `im:message:send_as_bot` (reply). If you enable group chats, also add
+   `im:message.group_at_msg.include_bot:readonly` (receive group messages that
+   @-mention the bot). The broader `im:message` grant does not replace the
+   explicit p2p event scope in the current Feishu console.
 4. **Use long connection** — under *Events & Callbacks*, choose
    **Long connection** (not a request URL), then subscribe to
    `im.message.receive_v1`.
@@ -171,6 +175,16 @@ Known gaps, all follow-up work rather than defects:
 - **No auto-reconnect beyond the SDK's own.** `lark-oapi` reconnects
   internally; if it gives up, the gateway logs that the receiver is down and you
   restart.
+
+### Bot doesn’t receive direct messages
+
+- Confirm `im:message.p2p_msg:readonly` is granted. A green
+  `im:message.group_at_msg.include_bot:readonly` grant covers group @-mentions,
+  not private messages.
+- Publish a new app version after changing permissions; a draft permission does
+  not affect the installed bot.
+- Confirm `im.message.receive_v1` appears in the subscribed-event list, not only
+  that long connection is selected.
 
 ## How it fits together
 

--- a/src/kiro_crew/feishu/client.py
+++ b/src/kiro_crew/feishu/client.py
@@ -38,6 +38,11 @@ logger = logging.getLogger(__name__)
 # replies, never truncated — see send_reply.
 FEISHU_MAX_TEXT = 4000
 
+# Client construction is local and performs no network I/O. A bounded wait
+# prevents a broken SDK import or constructor from leaving gateway startup
+# suspended forever while preserving enough time on a loaded host.
+_WS_CLIENT_READY_TIMEOUT_SECS = 5.0
+
 # The only two chat types this channel serves. The transport gate names them
 # explicitly so an absent or future value is denied rather than falling
 # through the ungated direct-message path.
@@ -132,9 +137,12 @@ class LarkClient:
     ``asyncio.run_coroutine_threadsafe`` so the dispatcher never blocks.
     ``send_reply`` uses ``run_in_executor`` so it never blocks the loop.
 
-    The lark-oapi ``ws.Client`` does not expose a clean async stop; ``close()``
-    sets a flag and calls ``stop()`` -- the daemon thread exits naturally once
-    the WS is closed.
+    The official SDK stores its WebSocket event loop in a module global. The
+    gateway imports the SDK on its own running loop, so the receiver thread must
+    replace that global with a dedicated loop and construct ``ws.Client`` there
+    before calling ``start``. ``close()`` prefers a future public ``stop()``
+    method and otherwise shuts down the current 1.x SDK through its async
+    disconnect coroutine.
     """
 
     def __init__(
@@ -148,6 +156,7 @@ class LarkClient:
         self._app_secret = app_secret
         self._on_message: MessageHandler | None = on_message
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._ws_loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._closed = False
         #: Health observer ``(connected, reason)``, set by ``maybe_start_feishu``
@@ -353,46 +362,82 @@ class LarkClient:
             .register_p2_im_message_receive_v1(self._handle_receive_v1)
             .build()
         )
-        ws = lark.ws.Client(
-            self._app_id,
-            self._app_secret,
-            event_handler=handler_builder,
-            log_level=lark.LogLevel.WARNING,
-        )
-        self._ws_client = ws
+        ws_loop = asyncio.new_event_loop()
+        self._ws_loop = ws_loop
+        client_ready = threading.Event()
+        startup_errors: list[BaseException] = []
 
         def _run() -> None:
-            # lark-oapi's ws.Client owns its own auto-reconnect, so this call
-            # blocks for the life of the channel. Both exits still get a log
-            # line: a RETURN means lark gave up reconnecting, which would
-            # otherwise kill the receiver in total silence.
-            #
-            # Both exits also publish an UNHEALTHY transition, from this thread
-            # (``_notify_state`` only calls a plain callback, which assigns two
-            # attributes on DashboardState -- no loop affinity required). Without
-            # it a rejected app id/secret leaves the badge reading "connected"
-            # forever, because the only evidence of refusal is this thread
-            # ending seconds after start().
+            # lark-oapi binds both its module-global loop and constructor-time
+            # helpers (including ExpiringCache) to the current event loop. The
+            # client therefore has to be constructed here, after this thread
+            # owns its loop; moving only ws.start() leaves SDK state split
+            # across the gateway and receiver loops.
             try:
-                ws.start()
-            except Exception as exc:
+                try:
+                    asyncio.set_event_loop(ws_loop)
+                    from lark_oapi.ws import client as lark_ws_client  # noqa: PLC0415
+
+                    lark_ws_client.loop = ws_loop
+                    ws = lark.ws.Client(
+                        self._app_id,
+                        self._app_secret,
+                        event_handler=handler_builder,
+                        log_level=lark.LogLevel.WARNING,
+                    )
+                    self._ws_client = ws
+                except BaseException as exc:
+                    startup_errors.append(exc)
+                    if not self._closed:
+                        logger.exception("Feishu WS client initialization failed")
+                        self._notify_state(False, f"receiver stopped: {type(exc).__name__}")
+                    return
+                finally:
+                    client_ready.set()
+
+                try:
+                    ws.start()
+                except Exception as exc:
+                    if not self._closed:
+                        logger.exception("Feishu WS loop raised; receiver is down")
+                        self._notify_state(False, f"receiver stopped: {type(exc).__name__}")
+                    return
                 if not self._closed:
-                    logger.exception("Feishu WS loop raised; receiver is down")
-                    self._notify_state(False, f"receiver stopped: {type(exc).__name__}")
-                return
-            if not self._closed:
-                logger.error(
-                    "Feishu WS loop returned without a close() -- receiver is "
-                    "down and will not reconnect; restart the gateway."
-                )
-                self._notify_state(
-                    False,
-                    "receiver stopped (check the app id/secret and that the app "
-                    "has the im:message events subscribed)",
-                )
+                    logger.error(
+                        "Feishu WS loop returned without a close() -- receiver is "
+                        "down and will not reconnect; restart the gateway."
+                    )
+                    self._notify_state(
+                        False,
+                        "receiver stopped (check the app id/secret and that the app "
+                        "has the im:message events subscribed)",
+                    )
+            finally:
+                client_ready.set()
+                self._ws_loop = None
+                pending = asyncio.all_tasks(ws_loop)
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    ws_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                ws_loop.close()
 
         self._thread = threading.Thread(target=_run, daemon=True, name="feishu-ws")
         self._thread.start()
+        ready = await asyncio.to_thread(client_ready.wait, _WS_CLIENT_READY_TIMEOUT_SECS)
+        if not ready:
+            self._closed = True
+            self._executor.shutdown(wait=False)
+            try:
+                ws_loop.call_soon_threadsafe(ws_loop.stop)
+            except RuntimeError:
+                pass
+            raise RuntimeError("Feishu WebSocket client initialization timed out")
+        if startup_errors:
+            self._executor.shutdown(wait=False)
+            startup_error = startup_errors[0]
+            raise RuntimeError("Feishu WebSocket client initialization failed") from startup_error
+
         # Healthy on launch, then corrected by _run's exit. start() proves the
         # thread is up, not that Feishu accepted the app -- but a refused app
         # ends the thread within seconds, so the badge self-corrects rather than
@@ -419,21 +464,40 @@ class LarkClient:
                 logger.debug("Feishu on_state_change observer raised", exc_info=True)
 
     async def close(self) -> None:
-        """Signal shutdown; the daemon thread exits once the WS closes."""
+        """Signal shutdown and release the SDK-owned receiver loop."""
         self._closed = True
         ws = self._ws_client
         if ws is not None:
-            # ws.stop() is lark-oapi's SYNCHRONOUS shutdown — it closes the
-            # socket and can block on a wedged peer. Called directly it would
-            # run on the gateway event loop, and the caller's asyncio.wait_for
-            # could not rescue it: a timeout only fires at an await point, so a
-            # hung peer would freeze every task on the loop rather than just
-            # this shutdown. Offloading keeps the await interruptible; a leaked
-            # worker thread is survivable, a frozen loop is not.
-            try:
-                await asyncio.get_running_loop().run_in_executor(self._executor, ws.stop)
-            except Exception:
-                logger.debug("Feishu WS stop failed", exc_info=True)
+            stop = getattr(ws, "stop", None)
+            if callable(stop):
+                # A future SDK may expose a synchronous stop. Keep it off the
+                # gateway loop because a wedged peer would otherwise freeze all
+                # tasks and make the caller's timeout ineffective.
+                try:
+                    await asyncio.get_running_loop().run_in_executor(self._executor, stop)
+                except Exception:
+                    logger.debug("Feishu WS stop failed", exc_info=True)
+            else:
+                ws_loop = self._ws_loop
+                if ws_loop is not None and not ws_loop.is_closed():
+                    # lark-oapi 1.x exposes only the private async disconnect
+                    # used by its own reconnect path. Disable reconnect before
+                    # closing, then stop the loop that blocks in start().
+                    if hasattr(ws, "_auto_reconnect"):
+                        ws._auto_reconnect = False
+                    disconnect = getattr(ws, "_disconnect", None)
+                    if callable(disconnect) and ws_loop.is_running():
+                        future = asyncio.run_coroutine_threadsafe(disconnect(), ws_loop)
+                        try:
+                            await asyncio.wrap_future(future)
+                        except Exception:
+                            logger.debug("Feishu WS disconnect failed", exc_info=True)
+                    try:
+                        ws_loop.call_soon_threadsafe(ws_loop.stop)
+                    except RuntimeError:
+                        # The disconnect may make a future SDK return from
+                        # start() and close the loop before this signal lands.
+                        pass
         # Do not wait: an in-flight REST reply must not hold up shutdown.
         self._executor.shutdown(wait=False)
         # An intentional shutdown is still "not connected" — with no reason,

--- a/test/test_feishu_client.py
+++ b/test/test_feishu_client.py
@@ -106,15 +106,24 @@ class _FakeEventDispatcherHandler:
 
 
 class _FakeWSClient:
-    """Stub for lark.ws.Client -- start() blocks on an event, stop() sets it."""
+    """Stub for lark.ws.Client with the SDK's module-global loop behavior."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.constructed_thread_id = threading.get_ident()
+        self.constructed_loop = asyncio.get_event_loop()
         self._stop_event = threading.Event()
+        self._started_event = threading.Event()
         self.started = False
         self.stopped = False
+        self.started_loop: asyncio.AbstractEventLoop | None = None
 
     def start(self) -> None:
         self.started = True
+        ws_client_mod = sys.modules["lark_oapi.ws.client"]
+        self.started_loop = ws_client_mod.loop  # type: ignore[attr-defined]
+        self._started_event.set()
+        if self.started_loop is not None and self.started_loop.is_running():
+            raise RuntimeError("This event loop is already running")
         self._stop_event.wait(timeout=2.0)
 
     def stop(self) -> None:
@@ -129,6 +138,44 @@ class _FakeWSClientRaising(_FakeWSClient):
         self.stopped = True
         self._stop_event.set()
         raise RuntimeError("ws stop boom")
+
+
+class _FakeWSClientWithoutStop:
+    """Model lark-oapi 1.7.x: module loop, async disconnect, no stop()."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.constructed_thread_id = threading.get_ident()
+        self.constructed_loop = asyncio.get_event_loop()
+        self._auto_reconnect = True
+        self._started_event = threading.Event()
+        self.started = False
+        self.disconnected = False
+        self.started_loop: asyncio.AbstractEventLoop | None = None
+        self._waiter: asyncio.Future[None] | None = None
+
+    def start(self) -> None:
+        self.started = True
+        ws_client_mod = sys.modules["lark_oapi.ws.client"]
+        self.started_loop = ws_client_mod.loop  # type: ignore[attr-defined]
+        self._started_event.set()
+        if self.started_loop is None:
+            raise RuntimeError("SDK event loop was not configured")
+        if self.started_loop.is_running():
+            raise RuntimeError("This event loop is already running")
+        self._waiter = self.started_loop.create_future()
+        self.started_loop.run_until_complete(self._waiter)
+
+    async def _disconnect(self) -> None:
+        self.disconnected = True
+        if self._waiter is not None and not self._waiter.done():
+            self._waiter.set_result(None)
+
+
+class _FakeWSClientInitRaising:
+    """Fail during SDK construction after the receiver loop is installed."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("ws init boom")
 
 
 class _FakeWS:
@@ -198,7 +245,13 @@ def _fake_lark_sdk():
     lark_mod.Client = _FakeRestClient  # type: ignore[attr-defined]
     lark_mod.LogLevel = _FakeLogLevel  # type: ignore[attr-defined]
     lark_mod.EventDispatcherHandler = _FakeEventDispatcherHandler  # type: ignore[attr-defined]
-    lark_mod.ws = _FakeWS  # type: ignore[attr-defined]
+
+    ws_mod = types.ModuleType("lark_oapi.ws")
+    ws_mod.Client = _FakeWSClient  # type: ignore[attr-defined]
+    ws_client_mod = types.ModuleType("lark_oapi.ws.client")
+    ws_client_mod.loop = None  # type: ignore[attr-defined]
+    ws_mod.client = ws_client_mod  # type: ignore[attr-defined]
+    lark_mod.ws = ws_mod  # type: ignore[attr-defined]
 
     im_v1_mod = types.ModuleType("lark_oapi.api.im.v1")
     im_v1_mod.ReplyMessageRequest = _FakeReplyMessageRequest  # type: ignore[attr-defined]
@@ -208,11 +261,20 @@ def _fake_lark_sdk():
     im_mod = types.ModuleType("lark_oapi.api.im")
 
     originals = {}
-    keys = ["lark_oapi", "lark_oapi.api", "lark_oapi.api.im", "lark_oapi.api.im.v1"]
+    keys = [
+        "lark_oapi",
+        "lark_oapi.ws",
+        "lark_oapi.ws.client",
+        "lark_oapi.api",
+        "lark_oapi.api.im",
+        "lark_oapi.api.im.v1",
+    ]
     for k in keys:
         originals[k] = sys.modules.get(k)
 
     sys.modules["lark_oapi"] = lark_mod
+    sys.modules["lark_oapi.ws"] = ws_mod
+    sys.modules["lark_oapi.ws.client"] = ws_client_mod
     sys.modules["lark_oapi.api"] = api_mod
     sys.modules["lark_oapi.api.im"] = im_mod
     sys.modules["lark_oapi.api.im.v1"] = im_v1_mod
@@ -857,6 +919,54 @@ class TestStart:
         client._thread.join(timeout=1.0)
         assert not client._thread.is_alive()
 
+    @pytest.mark.asyncio
+    async def test_start_rebinds_sdk_loop_to_receiver_thread(self) -> None:
+        """The SDK must not drive the gateway's already-running event loop."""
+        from kiro_crew.feishu.client import LarkClient
+
+        gateway_loop = asyncio.get_running_loop()
+        gateway_thread_id = threading.get_ident()
+        ws_client_mod = sys.modules["lark_oapi.ws.client"]
+        ws_client_mod.loop = gateway_loop  # type: ignore[attr-defined]
+
+        client = LarkClient(app_id="a", app_secret="s")
+        await client.start()
+        await asyncio.wait_for(
+            asyncio.to_thread(client._ws_client._started_event.wait),
+            timeout=1.0,
+        )
+
+        assert client._thread.is_alive()
+        assert client._ws_client.constructed_thread_id == client._thread.ident
+        assert client._ws_client.constructed_thread_id != gateway_thread_id
+        assert client._ws_client.constructed_loop is client._ws_loop
+        assert client._ws_client.started_loop is client._ws_loop
+        assert client._ws_client.started_loop is not gateway_loop
+
+        await client.close()
+        client._thread.join(timeout=1.0)
+        assert not client._thread.is_alive()
+
+    @pytest.mark.asyncio
+    async def test_start_propagates_sdk_constructor_failure(self) -> None:
+        """A constructor failure is reported and leaves no receiver loop alive."""
+        from kiro_crew.feishu.client import LarkClient
+
+        lark_mod = sys.modules["lark_oapi"]
+        original_client = lark_mod.ws.Client  # type: ignore[attr-defined]
+        lark_mod.ws.Client = _FakeWSClientInitRaising  # type: ignore[attr-defined]
+        try:
+            client = LarkClient(app_id="a", app_secret="s")
+            with pytest.raises(RuntimeError, match="initialization failed"):
+                await client.start()
+            client._thread.join(timeout=1.0)
+
+            assert client._ws_client is None
+            assert client._ws_loop is None
+            assert not client._thread.is_alive()
+        finally:
+            lark_mod.ws.Client = original_client  # type: ignore[attr-defined]
+
 
 # ---------------------------------------------------------------------------
 # Tests: health transitions (on_state_change)
@@ -965,6 +1075,31 @@ class TestClose:
         # Thread should exit since stop() sets the event
         client._thread.join(timeout=1.0)
         assert not client._thread.is_alive()
+
+    @pytest.mark.asyncio
+    async def test_close_supports_sdk_without_public_stop(self) -> None:
+        """lark-oapi 1.7.x closes through _disconnect on its worker loop."""
+        from kiro_crew.feishu.client import LarkClient
+
+        lark_mod = sys.modules["lark_oapi"]
+        original_client = lark_mod.ws.Client  # type: ignore[attr-defined]
+        lark_mod.ws.Client = _FakeWSClientWithoutStop  # type: ignore[attr-defined]
+        try:
+            client = LarkClient(app_id="a", app_secret="s")
+            await client.start()
+            await asyncio.wait_for(
+                asyncio.to_thread(client._ws_client._started_event.wait),
+                timeout=1.0,
+            )
+
+            await client.close()
+            client._thread.join(timeout=1.0)
+
+            assert client._ws_client.disconnected is True
+            assert client._ws_client._auto_reconnect is False
+            assert not client._thread.is_alive()
+        finally:
+            lark_mod.ws.Client = original_client  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_ws_stop_is_offloaded_off_the_event_loop_thread(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

Enabling the Feishu channel with the supported `lark-oapi` 1.7.x SDK starts the receiver thread, but the SDK tries to call `run_until_complete()` on the gateway's already-running event loop. The receiver exits with `This event loop is already running`, so Settings can briefly report a connection while no inbound message can reach Kiro Crew.

The setup guide also names the broad `im:message` permission but omits Feishu's explicit direct-message event scope. A bot can connect and send messages while private-message events are never delivered.

## Why it matters

Every Feishu installation using the documented dependency range can fail before receiving its first message. The failure is not recoverable through App ID, secret, allow-list, or event-subscription changes alone, and the optimistic Connected badge obscures the SDK lifecycle error.

Without the explicit p2p permission, an otherwise healthy long connection silently receives no direct messages.

## What changed (motivation → approach → change)

- Give the Feishu receiver thread a dedicated asyncio event loop.
- Rebind the SDK's module-global WebSocket loop and construct `lark.ws.Client` inside that thread, so constructor-created helpers such as `ExpiringCache` and all WebSocket tasks share one loop.
- Wait for bounded client initialization before reporting startup success and propagate constructor failures without leaking the receiver loop.
- Prefer a future public synchronous `stop()` API, while supporting current lark-oapi 1.x through `_disconnect()` on the receiver loop with reconnect disabled.
- Cancel and gather every remaining SDK task before closing the receiver loop.
- Document `im:message.p2p_msg:readonly` for direct messages and `im:message.group_at_msg.include_bot:readonly` for optional group @-mentions.

## Tests

- Added a regression test that starts from the SDK's cached gateway loop and proves client construction plus `start()` both run on the receiver thread/loop.
- Added coverage for lark-oapi 1.7.x without a public `stop()` method and for constructor-failure cleanup.
- Proved the constructor-affinity regression test passes on this branch and fails against `origin/main` production code at pytest call phase.
- `167 passed` across all Feishu client/config/dispatch/gateway/renderer/transport tests.
- Real `lark-oapi==1.7.3` no-network smoke test verified `ExpiringCache._cron.get_loop()` is the receiver loop and shutdown leaves no receiver thread.
- Black, isort, flake8, mypy, docs lint, vendor manifest, CFn lint, frontend build/tsc/eslint/i18n/bundle guards, and 95 cross-surface frontend tests passed.
- Full local backend floor: 91,037 passed, 282 failed, 183 skipped, 9 xfailed. Representative session-storage and auto-improvement failures reproduce on a clean `origin/main` worktree and do not traverse changed Feishu code.
- Electron floor: 1,774 passed; 26 tests in unchanged `gateway-stop.test.js` were cancelled by the parent after its pre-existing hung-tree test left a promise pending. The Electron surface is byte-identical to `origin/main`.

## Manual verification

- Reproduced the original failure on a real gateway with `lark-oapi==1.7.3`.
- Applied the lifecycle fix to the installed package, restarted the gateway, and verified a persistent WebSocket connection to `msg-frontier.feishu.cn` with no event-loop error.
- Verified proactive bot delivery through the official Feishu API and successful inbound DM processing after granting `im:message.p2p_msg:readonly` and publishing the app version.

## Related Issues

no linked issue: reproduced during an end-to-end Feishu channel setup.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a third-party async client constructed on one event loop must not be started or mutated from a different loop-owning thread.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality — affected tests pass; unrelated clean-main baseline failures are documented above
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
