### PR TITLE
fix: decode link preview HTML entities only once

### DIFF
--- a/src/kiro_crew/link_unfurl.py
+++ b/src/kiro_crew/link_unfurl.py
@@ -25,7 +25,6 @@ import re
 import socket
 from base64 import b64encode
 from dataclasses import dataclass
-from html import unescape
 from html.parser import HTMLParser
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 from urllib.parse import urljoin, urlsplit, urlunsplit
@@ -429,8 +428,8 @@ def normalize_cache_key(url: str) -> str:
 
 
 def clean_text(value: str, cap: int) -> str:
-    """Unescape entities, collapse whitespace runs, trim, and hard-cap length."""
-    collapsed = _WHITESPACE_RUN.sub(" ", unescape(value)).strip()
+    """Normalize already-decoded HTMLParser text and hard-cap its length."""
+    collapsed = _WHITESPACE_RUN.sub(" ", value).strip()
     return collapsed[:cap]
 
 
@@ -489,8 +488,8 @@ class _HeadParser(HTMLParser):
     for tags that cannot appear in it.
 
     ``convert_charrefs`` is left at its default (True) so entity decoding
-    happens in the parser; :func:`clean_text` unescapes again, which is a no-op
-    on already-decoded text and covers the attribute path.
+    happens once in the parser for both text and attributes. Downstream helpers
+    preserve any literal entity spellings that remain after that decoding.
     """
 
     def __init__(self) -> None:
@@ -669,7 +668,7 @@ def _absolutize(href: str, base_url: str) -> str:
     ``data:image/svg+xml`` hole the allowlist exists to close.
     """
     try:
-        resolved = urljoin(base_url, unescape(href).strip())
+        resolved = urljoin(base_url, href.strip())
     except ValueError:
         return ""
     return resolved if urlsplit(resolved).scheme in ALLOWED_SCHEMES else ""

--- a/test/test_link_unfurl.py
+++ b/test/test_link_unfurl.py
@@ -1828,3 +1828,29 @@ def test_the_replaced_category_flag_list_would_have_approved_these(address: str)
     )
     assert old_verdict is False, "the old check already caught this; premise is wrong"
     assert lu.address_is_not_public(address) is True
+
+
+@pytest.mark.parametrize("title_source", ["title", "og:title"])
+def test_endpoint_decodes_html_entities_once(monkeypatch, title_source):
+    escaped = "How to spell &amp;lt; and &amp;#65;"
+    title = f"<title>{escaped}</title>" if title_source == "title" else (
+        f'<meta property="og:title" content="{escaped}">'
+    )
+    html = (
+        f"<head>{title}"
+        f'<meta name="description" content="{escaped}">'
+        f'<meta property="og:site_name" content="{escaped}">'
+        '<link rel="icon" href="/icon.png?name=one&amp;amp;two">'
+        "</head>"
+    ).encode()
+    expected_icon = "https://example.com/icon.png?name=one&amp;two"
+    transport = _install(monkeypatch, {
+        "https://example.com/": (200, _HTML_HEADERS, html),
+        expected_icon: (200, {"Content-Type": "image/png"}, b"\x89PNG"),
+    })
+    status, body = _run(_call("https://example.com/"))
+    assert status == 200
+    for field in ("title", "description", "site_name"):
+        assert body[field] == "How to spell &lt; and &#65;"
+    assert body["icon"].startswith("data:image/png;base64,")
+    assert transport.fetch_count == 2


### PR DESCRIPTION
## Problem / Motivation

An opt-in `/api/link-meta` preview of `<title>How to spell &amp;lt; and &amp;#65;</title>` returns `How to spell < and A` instead of the page's literal `How to spell &lt; and &#65;`. The same extra decode changes metadata attributes and favicon query strings.

## Why it matters

Preview text misrepresents the linked page, and an escaped favicon URL can request a different resource.

## What changed (motivation → approach → change)

`HTMLParser` already decodes character references in text and attributes. Remove the second `html.unescape()` from `clean_text()` and `_absolutize()`, retaining whitespace normalization, truncation, URL resolution, and all existing fetch safety checks. Correct the parser docstring to describe this boundary.

## Tests

- Red-before on main `c02cdd67cd811e24b136efcc531da1bbdfb47082`: both new endpoint cases fail with `<` / `A` instead of literal entity spellings.
- Green-after: `test/test_link_unfurl.py`, **259 passed** on Python 3.13.5 (`-n 2 --dist loadgroup --no-cov`). Parametrized coverage exercises title text and `og:title`, description, site name, and the exact favicon query URL using a fake transport.
- Scoped isort, flake8, Black and mypy checks pass. Local GPT contract and secondary Opus-contract review report no findings; the secondary review uses a substitute model because Opus is unavailable locally.

## Manual verification

N/A — backend endpoint tests assert the returned payload and fetched favicon URL without external network access. No UI layout changes.

## Related Issues

No linked issue. Fresh open-PR file/title search, current main, local worktree/claim registry and both contributor handoffs were checked; no equivalent open fix or overlapping file owner was found.

## Pattern harvest

Rule candidate: review-prompt

Pattern: Decode at the parser boundary once; repeated entity decoding can change intentionally literal content and URL identity.

## Checklist

- [x] One Conventional Commits commit
- [x] Focused existing tests pass and regression tests added
- [x] Self-review and local contract reviews completed
- [x] Parser documentation corrected
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. Do not invent CLA text. -->
