### PR TITLE
fix: retain DOCX table content during knowledge ingestion

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -156,7 +156,7 @@ It includes markdown/plain-text (`.md`/`.txt`/`.org`), source-code extensions, a
   and releases each page immediately after extraction so its parsed-layout cache does not
   remain resident until the whole document closes (`Page.close()` when available, with
   `flush_cache()` compatibility for pdfplumber 0.10).
-- `_read_docx` — python-docx; converts `Heading N` paragraph styles to `#`-prefixed markdown (`content_type: 'markdown'`), records `paragraph_count`.
+- `_read_docx` — python-docx; extracts body and table-cell paragraphs in document order, including nested tables and each physical merged cell once. Converts `Heading N` paragraph styles to `#`-prefixed markdown (`content_type: 'markdown'`); `paragraph_count` remains the top-level body paragraph count. Revision-wrapped paragraphs remain excluded.
 - `_read_html` — html2text when importable (`ignore_images=True`, `ignore_links=False`); otherwise a regex fallback strips `<script>`/`<style>` and tags.
 
 Base metadata always carries `format`, `title` (file stem), `file_size`, `extension`, and a computed `line_count`.

--- a/src/kiro_crew/knowledge/readers.py
+++ b/src/kiro_crew/knowledge/readers.py
@@ -19,6 +19,8 @@ except ImportError:
 
 try:
     from docx import Document  # type: ignore[import-untyped]
+    from docx.oxml.ns import qn  # type: ignore[import-untyped]
+    from docx.text.paragraph import Paragraph  # type: ignore[import-untyped]
 except ImportError:
     Document = None  # type: ignore[assignment,misc]
 
@@ -183,7 +185,19 @@ class FileReader:
         try:
             doc = Document(path)
             lines = []
-            for para in doc.paragraphs:
+            # Walk physical paragraphs in body order, including nested tables.
+            # Grid-cell proxies repeat merged cells; revision wrappers stay out,
+            # just as they do in python-docx's top-level paragraphs collection.
+            containers = {qn('w:tbl'), qn('w:tr'), qn('w:tc')}
+            pending = list(reversed(doc.element.body))
+            while pending:
+                element = pending.pop()
+                if element.tag in containers:
+                    pending.extend(reversed(element))
+                    continue
+                if element.tag != qn('w:p'):
+                    continue
+                para = Paragraph(element, doc)
                 style = para.style.name if para.style else ''
                 text = para.text
                 if style.startswith('Heading'):

--- a/test/test_knowledge_docx_tables.py
+++ b/test/test_knowledge_docx_tables.py
@@ -1,0 +1,88 @@
+"""DOCX ingestion must retain table text in its surrounding document order."""
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.knowledge.readers import FileReader
+
+docx = pytest.importorskip("docx")
+
+
+def test_table_only_document_retains_cell_text(tmp_path: Path) -> None:
+    doc = docx.Document()
+    table = doc.add_table(rows=2, cols=2)
+    for cell, text in zip(table._cells, ["Product", "Price", "Widget", "$42"]):
+        cell.text = text
+    path = tmp_path / "price-list.docx"
+    doc.save(path)
+
+    text, meta = FileReader().read(str(path))
+
+    assert text == "Product\nPrice\nWidget\n$42"
+    assert meta["format"] == "docx"
+    assert meta["content_type"] == "markdown"
+    assert meta["line_count"] == 4
+
+
+def test_table_paragraphs_keep_body_order_and_nested_content(tmp_path: Path) -> None:
+    doc = docx.Document()
+    doc.add_heading("Inventory", level=1)
+    table = doc.add_table(rows=1, cols=2)
+    table.cell(0, 0).text = "First cell"
+    table.cell(0, 0).add_paragraph("Second paragraph")
+    cell = table.cell(0, 1)
+    cell.text = "Before nested table"
+    cell.add_table(rows=1, cols=1).cell(0, 0).text = "Nested value"
+    cell.add_paragraph("After nested table")
+    doc.add_paragraph("After outer table")
+    path = tmp_path / "inventory.docx"
+    doc.save(path)
+
+    text, meta = FileReader().read(str(path))
+
+    assert text.splitlines() == [
+        "# Inventory",
+        "First cell",
+        "Second paragraph",
+        "Before nested table",
+        "Nested value",
+        "",
+        "After nested table",
+        "After outer table",
+    ]
+    assert meta["paragraph_count"] == 2
+
+
+def test_merged_cell_text_is_not_repeated(tmp_path: Path) -> None:
+    doc = docx.Document()
+    table = doc.add_table(rows=2, cols=2)
+    table.cell(0, 0).merge(table.cell(1, 1)).text = "Shared decision"
+    path = tmp_path / "merged.docx"
+    doc.save(path)
+
+    text, _ = FileReader().read(str(path))
+
+    # Vertical-merge continuation cells may carry empty physical paragraphs.
+    assert text.strip() == "Shared decision"
+
+
+def test_revision_wrapped_paragraphs_remain_excluded(tmp_path: Path) -> None:
+    from docx.oxml import OxmlElement
+
+    doc = docx.Document()
+    doc.add_paragraph("Visible paragraph")
+    table = doc.add_table(rows=1, cols=1)
+    cell = table.cell(0, 0)
+    cell.text = "Visible cell"
+    for parent in (doc, cell):
+        para = parent.add_paragraph("Unaccepted insertion")
+        wrapper = OxmlElement("w:ins")
+        para._p.addprevious(wrapper)
+        wrapper.append(para._p)
+    path = tmp_path / "revisions.docx"
+    doc.save(path)
+
+    text, _ = FileReader().read(str(path))
+
+    assert text == "Visible paragraph\nVisible cell"


### PR DESCRIPTION
## Problem / Motivation

Knowledge ingestion reads only `Document.paragraphs`, which excludes every table cell. A DOCX price list containing only a table is extracted as an empty string; a report with paragraphs around a table silently loses the table's values before hashing, chunking and indexing.

## Why it matters

The Knowledge library cannot retrieve facts that exist only in document tables, despite accepting DOCX files as a supported format.

## What changed (motivation → approach → change)

Walk physical body/table/row/cell nodes in document order and pass their paragraphs through the existing text/heading conversion. This retains nested table content and avoids repeating merged-cell proxies. Keep revision wrappers excluded and preserve the existing top-level `paragraph_count` metadata. Update the reader specification.

## Tests

- Red-before on main `c02cdd67cd811e24b136efcc531da1bbdfb47082`: three real DOCX fixtures fail because table-only/merged content is empty and interleaved/nested text is missing.
- Green-after: **19 passed**, covering the new real-file regression suite and existing `TestFileReader*` / `TestDocxContentType` tests in `test/test_knowledge.py`, using Python 3.13.5 and two xdist workers without coverage.
- Added revision-wrapper coverage to retain the existing exclusion behavior. All fixtures stay under `tmp_path`.
- Scoped isort, flake8, mypy and Black for the new test pass; the existing reader is on the repository's Black baseline. Both local review contracts report no findings (secondary review uses a substitute model; Opus unavailable).

## Manual verification

N/A — real DOCX archives are written and reopened through `FileReader.read`, the production extraction boundary. Tests assert extracted values, ordering and metadata without network or host-state changes.

## Related Issues

No linked issue. Fresh main, open PRs, both contributor handoffs and local claims/worktrees have no equivalent fix or owner of `knowledge/readers.py`. Other open changes to the shared Knowledge specification affect unrelated sections; their patches do not touch the DOCX reader entry.

## Pattern harvest

Rule candidate: review-prompt

Pattern: Document paragraph collections may exclude table content; verify extraction with table-only documents and interleaved body/table content.

## Checklist

- [x] One Conventional Commits commit
- [x] Relevant existing tests pass and real-file regression tests added
- [x] Self-review and local contract reviews completed
- [x] Reader specification updated
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. Do not invent CLA text. -->
