### PR TITLE
fix: word the grown comment-history count as inherited drift (#9386)

### DIFF
--- a/scripts/check_comment_history.py
+++ b/scripts/check_comment_history.py
@@ -359,6 +359,39 @@ def _report(rel: str, found: list[tuple[int, str]]) -> None:
         print(f"  {rel}:{line}: {text}")
 
 
+def _grown_error(
+    rel: str,
+    recorded: int,
+    count: int,
+    found: list[tuple[int, str]],
+    added: dict[str, set[int]] | None,
+) -> str:
+    """The grown-count error line, worded by where the matched lines sit.
+
+    A match on one of this diff's added lines keeps the licensing wording:
+    the diff places a marker on a line it authors. Zero matches on added
+    lines reads as base-branch drift, so the wording must not accuse the
+    diff. The judgment is only as good as ``added``: it reflects committed
+    added lines, and ``None`` means added-line scope is unavailable, so
+    keep the stricter wording rather than assert inherited drift on a
+    guess.
+    """
+    if added is not None:
+        added_lines = added.get(rel, set())
+        if all(line not in added_lines for line, _ in found):
+            return (
+                f"::error file={rel}::history narration in comments grew from "
+                f"{recorded} to {count} on the base branch; this diff adds none "
+                "of the matched lines. Rewording the matched lines is what "
+                "clears it. See docs/system-specs/common/code-style.md."
+            )
+    return (
+        f"::error file={rel}::history narration in comments grew from "
+        f"{recorded} to {count}. The baseline carries the "
+        "existing lines; it does not license new ones."
+    )
+
+
 def run_gate(baseline_path: Path, write: bool) -> int:
     # Baseline first, before the several-thousand-file scan: an absent baseline is
     # a refusal in BOTH modes, and paying for the scan to reach it would make the
@@ -399,11 +432,7 @@ def run_gate(baseline_path: Path, write: bool) -> int:
         )
         _report(rel, violations[rel])
     for rel in grown:
-        print(
-            f"::error file={rel}::history narration in comments grew from "
-            f"{baseline[rel]} to {current[rel]}. The baseline carries the "
-            "existing lines; it does not license new ones."
-        )
+        print(_grown_error(rel, baseline[rel], current[rel], violations[rel], added))
         _report(rel, violations[rel])
     for rel, found in added_line_offenders.items():
         print(

--- a/test/test_check_comment_history.py
+++ b/test/test_check_comment_history.py
@@ -261,6 +261,63 @@ class TestVerdicts:
         assert new == ["src/x.py"]
 
 
+class TestGrownWording:
+    """The grown-count message must accuse only a diff that adds marker lines."""
+
+    def test_grown_with_no_marker_on_added_lines_reads_as_inherited_drift(self) -> None:
+        # The count exceeds baseline on the base branch while this diff adds
+        # none of the matched lines: the wording must not accuse the diff.
+        message = gate._grown_error(
+            "src/x.py", 2, 3, [(1, "a"), (2, "b"), (3, "c")], {"src/x.py": {90}}
+        )
+        assert "this diff adds none of the matched lines" in message
+        assert "does not license new ones" not in message
+        assert "docs/system-specs/common/code-style.md" in message
+
+    def test_grown_with_a_marker_on_an_added_line_keeps_the_licensing_wording(self) -> None:
+        message = gate._grown_error(
+            "src/x.py", 2, 3, [(1, "a"), (2, "b"), (3, "c")], {"src/x.py": {3}}
+        )
+        assert "does not license new ones" in message
+        assert "adds none of the matched lines" not in message
+
+    def test_unavailable_added_line_scope_keeps_the_stricter_wording(self) -> None:
+        # Without added-line scope the two cases cannot be told apart, so the
+        # message must not assert inherited drift on a guess.
+        message = gate._grown_error("src/x.py", 2, 3, [(1, "a"), (2, "b"), (3, "c")], None)
+        assert "does not license new ones" in message
+
+    def test_a_file_absent_from_the_added_map_reads_as_inherited_drift(self) -> None:
+        # Added-line scope exists but records no added lines for this file:
+        # every match sits on a line the diff did not add.
+        message = gate._grown_error("src/x.py", 1, 2, [(1, "a"), (2, "b")], {"src/y.py": {5}})
+        assert "this diff adds none of the matched lines" in message
+
+    def test_run_gate_hands_added_line_scope_to_the_grown_wording(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The helper's branch is only real if run_gate feeds it the added map;
+        # wiring None there would keep every grown message on the licensing
+        # wording with the helper's own tests still green.
+        baseline = tmp_path / "baseline.json"
+        baseline.write_text(json.dumps({"files": {"src/x.py": 1}}), encoding="utf-8")
+
+        class Scope:
+            def changed_paths(self) -> tuple[set[str], str]:
+                return {"src/x.py"}, "stub"
+
+            def added_lines(self, label: str) -> dict[str, set[int]]:
+                return {"src/x.py": {90}}
+
+        monkeypatch.setattr(gate, "_scan", lambda targets: {"src/x.py": [(1, "a"), (2, "b")]})
+        monkeypatch.setattr(gate, "_load_scope", lambda: Scope())
+        assert gate.run_gate(baseline, write=False) == 1
+        assert "this diff adds none of the matched lines" in capsys.readouterr().out
+
+
 class TestBaselineIsShrinkOnly:
     def test_refresh_lowers_counts(self) -> None:
         assert gate._shrunken_baseline({"src/x.py": 5}, {"src/x.py": 2}) == {"src/x.py": 2}


### PR DESCRIPTION
## Problem / Motivation

The comment-history gate prints one message for every file whose
history-narration count grew above its baseline entry: "history narration in
comments grew from N to M. The baseline carries the existing lines; it does not
license new ones." That wording is correct when the diff under judgment added
one of the matched lines. But a grown count can also be inherited baseline
drift: the file's marker count rises on the base branch and the diff adds none
of the matched lines. In that case "it does not license new ones" reads as a
false accusation against a contributor who wrote none of them.

## Why it matters

A contributor hit by inherited drift gets told their change added narration it
did not add. The wrong wording sends them hunting through their own diff for
lines that are not there, and the gate is exactly the surface where trust in
the message determines whether people fix the real thing or fight the tool.

## What changed (motivation → approach → change)

In `_verdicts`, `grown` and `added_line_offenders` are mutually exclusive (the
added-line check sits in an `elif`), so membership in `added_line_offenders`
cannot distinguish the two cases for a grown file. The new helper
`_grown_error` therefore checks the added-line map directly: when added-line
scope exists and none of the file's matched lines are in its added set, the
message reads as base-branch drift ("this diff adds none of the matched
lines") with the remedy and the policy doc pointer; a match on an added line
keeps the licensing wording. When `added` is `None` (scope undeterminable, or
a whole-tree run) the two cases cannot be told apart, so the stricter existing
wording stands rather than asserting inherited drift on a guess.

Two review-lane findings are accepted residue, dispositioned here: (1) in a
local uncommitted-worktree run, `added` reflects committed lines while the
scanner reads the working tree, so an author's own uncommitted marker can
transiently get the inherited wording until committed; CI evaluates a merge
ref where that window does not exist. (2) a file path git quotes in diff
headers (non-ASCII bytes) drops out of the added map; zero such paths exist
under the scanned trees today.

## Tests

Five tests added in `test/test_check_comment_history.py::TestGrownWording`:
inherited wording when no match sits on an added line, licensing wording
retained when one does, stricter fallback when `added` is `None`, inherited
wording when the file is absent from the added map, and a `run_gate` wiring
test pinning that the added map actually reaches the helper.

- `timeout 300 python3 -m pytest -n0 test/test_check_comment_history.py -x -q </dev/null` (52 passed)
- `python3 scripts/check_comment_history.py --test` (self-test: 21 flagged, 15 clean probes)
- `python3 scripts/check_comment_history.py` (gate green on this branch)
- `python3 scripts/check_black_formatting.py && python3 scripts/check_subprocess_encoding.py`
- `isort --check-only` and `flake8` on both changed files
- `mypy src/kiro_crew` (4 pre-existing errors in files this PR does not touch)

## Manual verification

Ran the gate on this branch's own diff (2 changed files in scope): passes.
The self-test and the full gate test module pass; no other file or doc pins
the grown-message wording.

## Related Issues

Closes #9386

## Pattern harvest

Not generalizable: a single gate message worded without regard to which side of the merge base the matched lines come from; the fix is local to that message and no recurring defect class is proposed.

