### PR TITLE
test(frontend): deflake the linkify linearity guard

### DIFF
--- a/website/src/test/MarkdownRenderer.longUrlLinkify.test.tsx
+++ b/website/src/test/MarkdownRenderer.longUrlLinkify.test.tsx
@@ -197,9 +197,20 @@ describe('fixUnencodedLinkDestinations — repairs a refused [text](url) (#5729)
     // grammar excludes `[`, so a failed start position dies in O(1) instead
     // of rescanning the rest of the line: with no match anywhere the function
     // returns after the preflight, isolating exactly that path. Output is
-    // pinned unchanged, and the shape check is a generous doubling ratio
-    // (quadrupling the input: linear predicts ~4x, quadratic ~16x) because
-    // shared CI runners are noisy.
+    // pinned unchanged.
+    //
+    // Quadrupling the input, a linear scan costs ~4x and a quadratic one ~15.5x
+    // (measured, not predicted: a rescan-the-remainder mutant of this function
+    // lands there). The 10x bound has to stay BETWEEN those two -- widening it
+    // to the 16x a quadratic is loosely said to cost stops the mutant failing
+    // at all, which is a gate that passes while checking nothing.
+    //
+    // Noise is therefore handled in the MEASUREMENT, not in the bound. Each
+    // size is the minimum of several samples: scheduler noise on a shared
+    // runner only ever ADDS time, so a minimum converges on the real cost from
+    // above, where a single reading can land on a spike. One spike in the
+    // larger size alone is enough to redden a build that touched no frontend
+    // code at all.
     const adversarial = (n: number) => '['.repeat(n) + '](https://x.com/?a 1'
     // The `?`+space shape: `[^\s()?]*` pins the FIRST `?` as the only split
     // point, so a run of `a?` repeats offers no restart positions and a
@@ -208,16 +219,20 @@ describe('fixUnencodedLinkDestinations — repairs a refused [text](url) (#5729)
       '[x](https://' + 'a?'.repeat(n / 2) + ' z'.repeat(16)
     expect(fixUnencodedLinkDestinations(adversarial(4096))).toBe(adversarial(4096))
     expect(fixUnencodedLinkDestinations(qAdversarial(4096))).toBe(qAdversarial(4096))
-    const time = (n: number, gen: (n: number) => string) => {
+    const bestOf = (n: number, gen: (n: number) => string) => {
       const s = gen(n)
-      const t0 = performance.now()
-      for (let i = 0; i < 50; i++) fixUnencodedLinkDestinations(s)
-      return performance.now() - t0
+      let best = Infinity
+      for (let sample = 0; sample < 5; sample++) {
+        const t0 = performance.now()
+        for (let i = 0; i < 50; i++) fixUnencodedLinkDestinations(s)
+        best = Math.min(best, performance.now() - t0)
+      }
+      return best
     }
     for (const gen of [adversarial, qAdversarial]) {
-      time(32768, gen) // warm-up
-      const small = time(32768, gen)
-      const big = time(131072, gen)
+      bestOf(32768, gen) // warm-up: let the JIT settle before either measurement
+      const small = bestOf(32768, gen)
+      const big = bestOf(131072, gen)
       expect(big).toBeLessThan(Math.max(small, 1) * 10)
     }
   })


### PR DESCRIPTION
## Problem / Motivation

`MarkdownRenderer.longUrlLinkify.test.tsx` has a linearity guard on
`fixUnencodedLinkDestinations` that fails on unrelated PRs. It timed a 4x input
increase and asserted the larger size cost less than 10x the smaller. Both sides were
a SINGLE `performance.now()` reading, so one scheduler hiccup in the larger
measurement reddened the build.

Observed on a comment-only backend PR that touches no frontend file at all:

```
FAIL src/test/MarkdownRenderer.longUrlLinkify.test.tsx > stays linear on [-heavy adversarial input
AssertionError: expected 79.80330200000003 to be less than 76.14912000000004
```

## Why it matters

A wall-clock ratio between two single samples is one of the six known flake classes.
This one fires on PRs that cannot have caused it, which costs a rerun cycle (~20 min of
CI) and teaches readers that a red Frontend shard is probably noise — the habit that
lets a real regression through.

## What changed (motivation → approach → change)

The obvious fix is to widen the bound, and it is wrong. I measured what a genuinely
quadratic version of this function actually costs by writing a rescan-the-remainder
mutant and running it through the same harness:

| shape | ratio on a 4x input increase |
|---|---|
| linear (current code) | 4.00x, stable across runs |
| quadratic (mutant) | 15.52x |

So the bound must stay strictly between 4 and ~15.5. Raising it to the 16x a quadratic
is loosely said to cost would stop the mutant failing at all — a gate that passes while
checking nothing. **The 10x bound was correctly placed and is unchanged.**

The noise is fixed where it belongs, in the measurement: each size is now the MINIMUM of
five samples instead of one reading. Scheduler noise only ever ADDS time, so a minimum
converges on the real cost from above, while a single sample can land on a spike. The
comment now records the measured numbers and states why the bound cannot be widened, so
the next person who sees this go red does not "fix" it by loosening the gate.

## Tests

No new test. This repairs an existing one; the behaviour under test is unchanged.

## Manual verification

Mutation-verified in both directions with the test's exact harness (best-of-5, 50 inner
reps, 32768 -> 131072, bound `max(small,1) * 10`), repeated across runs:

```
linear    n=32768->131072: small=4.44ms big=17.77ms ratio=4.00x  bound=44.38ms -> pass
quadratic n=1024->4096:    small=1.33ms big=20.69ms ratio=15.52x bound=13.33ms -> FAIL
```

The linear ratio is 4.00x on every repetition, against a 10x bound — 2.5x of headroom
where the old single-sample form had none.

`vitest` could not be run in this worktree (no `node_modules`, and symlinking another
checkout's breaks vite resolution), so the harness was validated standalone under
Node 20. CI runs the real suite.

## Related Issues

N/A. Surfaced while working PR #9333; no tracking issue.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a performance assertion comparing two single wall-clock samples. Sample-of-one
ratios flake on shared runners; take a minimum of several samples, and set the bound
from a measured mutant rather than a predicted complexity class.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — repairs an existing test)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, the rationale lives in the test comment
- [x] No secrets, credentials, or internal references in the diff
