### PR TITLE
feat(mcp): hash config snapshot into the gateway pool key

### DIFF
--- a/src/kiro_crew/mcp_gateway/hashing.py
+++ b/src/kiro_crew/mcp_gateway/hashing.py
@@ -12,6 +12,7 @@ those heavy submodules into CLI/test/MCP startup.
 from __future__ import annotations
 
 import hashlib
+import json
 from typing import Collection, Mapping
 
 
@@ -33,6 +34,35 @@ def hash_command(command: str, args: list[str]) -> str:
         h.update(a.encode("utf-8"))
         h.update(b"\0")
     return h.hexdigest()
+
+
+def hash_config_snapshot(snapshot_json: str) -> str:
+    """SHA-256 hex digest of the preserved operator-config snapshot.
+
+    Single source of truth for the ``config_snapshot_hash`` dimension of
+    :class:`kiro_crew.mcp_gateway.pool.PoolKey`. The rewriter writes the
+    passthrough fields it preserves on the wrapper (``disabledTools`` tool
+    allowlist, ``timeout``, ``initializationOptions``, vendor keys — the
+    config no other PoolKey dimension represents) to a 0600 sidecar in the
+    owner-only sidecar directory, and the stub hashes the sidecar contents
+    with this function: free-form server config can carry secret-bearing
+    vendor keys, so neither the values nor their digest ever touch argv, which
+    is world-readable via /proc/<pid>/cmdline. An overlay without the sidecar
+    hashes the empty snapshot, so every register carries a deterministic
+    digest.
+
+    The input is a JSON encoding of the snapshot and is CANONICALIZED here —
+    parsed and re-dumped with sorted keys and tight separators — so equivalent
+    spellings hash equally. Non-JSON input is hashed as raw bytes, keeping the
+    digest deterministic for any spelling.
+    """
+    try:
+        canonical = json.dumps(
+            json.loads(snapshot_json), sort_keys=True, separators=(",", ":"), default=str
+        )
+    except (ValueError, TypeError):
+        canonical = snapshot_json
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 #: Env-key prefixes treated as ROTATING SECRETS and excluded from the

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -516,12 +516,65 @@ def _build_stub_entry(
     # honours; a fixed-shape return silently dropped them, so e.g. a declared
     # `timeout` was lost and a slow pooled backend timed out where the
     # un-pooled config did not. Override only the pooling-relevant keys below.
-    wrapped: dict[str, Any] = {
+    # This same set is the config_snapshot_hash PoolKey payload: it is exactly
+    # the operator config no other PoolKey dimension represents (command/args
+    # and env have their own hashes, autoApprove the permission-profile hash),
+    # so two agents whose allowlist/timeout/initializationOptions drifted land
+    # in separate pool partitions. The snapshot travels through a 0600 sidecar
+    # in the same owner-only directory as the declared-env sidecars and argv
+    # carries only the path: argv is world-readable via /proc/<pid>/cmdline and
+    # free-form server config can carry secret-bearing vendor keys. The stub
+    # hashes the sidecar contents with hashing.hash_config_snapshot, the shared
+    # leaf that also serves the other PoolKey hashes. Canonical JSON keeps the
+    # file stable across dict-insertion order, which also keeps the rewrite
+    # fingerprint's skip path byte-identical.
+    passthrough: dict[str, Any] = {
         k: v
         for k, v in original.items()
         if k not in ("command", "args", "env", "poolable", "autoApprove",
                      _WRAPPER_MARKER, _WRAPPER_MARKER_LEGACY)
     }
+    if passthrough:
+        snapshot_json = json.dumps(
+            passthrough, sort_keys=True, separators=(",", ":"), default=str
+        )
+        snapshot_dir = env_sidecar_dir_for_stubs(stubs_dir)
+        platform_compat.make_owner_only_dir(snapshot_dir)
+        cfg_file = snapshot_dir / config_sidecar_name(
+            agent_name, server_name, snapshot_json
+        )
+        if sidecars_written is not None:
+            # Registering before the write keeps the prune pass and the
+            # fingerprint's protect list aligned with the env sidecars; a
+            # failed write marks the pass uncacheable below, so the fingerprint
+            # is never stored with a vanished sidecar.
+            sidecars_written.add(cfg_file.name)
+        fd_owned = True
+        wrote_snapshot = False
+        try:
+            fd, tmp = tempfile.mkstemp(
+                prefix=f".{cfg_file.stem}-", suffix=".json", dir=str(snapshot_dir)
+            )
+            try:
+                platform_compat.fchmod_safe(fd, 0o600)
+                if not platform_compat.IS_POSIX:
+                    platform_compat.restrict_to_owner(tmp)
+                with os.fdopen(fd, "w") as fh:
+                    fd_owned = False
+                    fh.write(snapshot_json)
+                os.replace(tmp, cfg_file)
+                wrote_snapshot = True
+            finally:
+                if fd_owned:
+                    with contextlib.suppress(OSError):
+                        os.close(fd)
+        except OSError:
+            logger.warning("rewriter: failed to write config sidecar %s", cfg_file)
+            if notes is not None:
+                notes.sidecar_write_failed = True
+        if wrote_snapshot:
+            stub_args.extend(["--config-snapshot-file", str(cfg_file)])
+    wrapped: dict[str, Any] = dict(passthrough)
     wrapped.update({
         _WRAPPER_MARKER: True,
         "command": sys.executable,
@@ -2162,6 +2215,24 @@ def env_sidecar_name(agent_name: str, server_name: str) -> str:
         f"{agent_name}\0{server_name}".encode("utf-8")
     ).hexdigest()[:12]
     return f"{_san(agent_name)}.{_san(server_name)}.{digest}.json"
+
+
+def config_sidecar_name(agent_name: str, server_name: str, snapshot_json: str) -> str:
+    """Return the config-snapshot sidecar FILE NAME for a snapshot.
+
+    Shape: ``cfg.<sanitized-agent>.<sanitized-server>.<content-digest>.json`` —
+    the declared-env name with a ``cfg.`` prefix, and a trailing digest of the
+    pair AND the snapshot content, so the name addresses what the file holds.
+    That keeps a retained overlay and its snapshot consistent through a
+    partial write failure: a config change publishes the new snapshot under a
+    NEW name while the retained overlay still points at the old file, instead
+    of both names resolving to whichever content landed last. The rewriter
+    writes the snapshot into this file inside the owner-only sidecar directory
+    and the stub reads it back from the ``--config-snapshot-file`` argv path;
+    the pruning and protection passes treat it like any other written sidecar.
+    """
+    content_digest = hashlib.sha256(snapshot_json.encode("utf-8")).hexdigest()[:12]
+    return "cfg." + env_sidecar_name(agent_name, server_name)[:-5] + "." + content_digest + ".json"
 
 
 def forward_declared_env_enabled() -> bool:

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -38,7 +38,7 @@ from kiro_crew.executors import configure_default_executor, subprocess_executor
 from kiro_crew.jsonl_util import bounded_records, rotate_jsonl_at
 from kiro_crew.mcp_caller import CallerContext, _parent_pid
 from kiro_crew.mcp_gateway import transport
-from kiro_crew.mcp_gateway.hashing import hash_command, hash_effective_env
+from kiro_crew.mcp_gateway.hashing import hash_command, hash_config_snapshot, hash_effective_env
 from kiro_crew.mcp_gateway.pool import READ_BUFFER_LIMIT_BYTES, PoolKey
 from kiro_crew.metrics.events import MCP_RECONNECTS, emit_counter
 
@@ -96,15 +96,14 @@ _ENSURE_BACKEND_TIMEOUT_SECS = 25.0
 # path — a 64 MiB hash blocked the stub event loop ~150-300 ms — they fall
 # back to a cheap (size, mtime) token, which is still a stable pool-split key.
 _BINARY_HASH_CAP_BYTES = 4 * 1024 * 1024
-# Placeholder: stub does not yet observe a config snapshot, so all
-# same-session stubs agree on this value (never a false split).
-# Safety note: approval_mode and sandbox_mode are already separate PoolKey
-# dimensions, so the dangerous config divergences (permission escalation,
-# sandbox escape) are already covered by distinct pool entries.
-# TODO: Hash relevant config fields (e.g. tool allowlists,
-# hook settings) in a future iteration to detect non-security config drift
-# that could cause subtle behavioral differences across pooled sessions.
-_CONFIG_SNAPSHOT_PLACEHOLDER = "0" * 64
+# ``config_snapshot_hash`` carries the digest of the preserved operator config
+# the rewriter writes to a 0600 sidecar and the stub reads via
+# ``--config-snapshot-file`` (see ``hashing.hash_config_snapshot``).
+# approval_mode and sandbox_mode are already separate PoolKey dimensions, so
+# the dangerous config divergences (permission escalation, sandbox escape) stay
+# covered by distinct pool entries; this dimension adds the non-security drift
+# (tool allowlists, timeouts, initializationOptions) that would otherwise pool
+# onto one backend silently.
 
 
 def _crew_home() -> Path:
@@ -214,6 +213,21 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         ),
     )
     p.add_argument(
+        "--config-snapshot-file",
+        default=None,
+        dest="config_snapshot_file",
+        help=(
+            "Path to the 0600 sidecar holding the preserved operator config "
+            "(disabledTools allowlist, timeout, initializationOptions, vendor "
+            "keys) written by the rewriter. The contents are hashed with "
+            "hashing.hash_config_snapshot and registered as the "
+            "config_snapshot_hash PoolKey dimension, so sessions whose config "
+            "drifted pool onto separate backends. The path is all argv "
+            "carries: argv is world-readable via /proc/<pid>/cmdline, and the "
+            "sidecar lives in the owner-only sidecar directory."
+        ),
+    )
+    p.add_argument(
         "--socket",
         default=os.environ.get("KIROCREW_MCP_SOCKET") or os.environ.get("MC_MCP_SOCKET") or _default_socket_path(),
     )
@@ -276,6 +290,45 @@ def _parse_env_file(path: str) -> dict[str, str]:
         logger.warning("stub --env-file unreadable; dropping env block")
         return {}
     return _parse_env_json(raw)
+
+
+def _read_config_snapshot(args: argparse.Namespace) -> str | None:
+    """Read the config-snapshot sidecar the rewriter wrote, for hashing into
+    the ``config_snapshot_hash`` PoolKey dimension.
+
+    Returns the sidecar contents, or ``None`` when the sidecar exists but
+    cannot be read: the caller then registers a per-register digest so the
+    session pools onto nothing instead of reusing a partition that belongs to
+    some other config. A missing flag is a different case — the overlay has no
+    snapshot at all — and hashes to the empty-snapshot digest, which is
+    reserved for exactly that.
+    """
+    if not args.config_snapshot_file:
+        return ""
+    try:
+        return Path(args.config_snapshot_file).read_text(encoding="utf-8")
+    except OSError:
+        logger.warning(
+            "stub --config-snapshot-file unreadable; registering a unique digest"
+        )
+        return None
+
+
+def _config_snapshot_digest(args: argparse.Namespace) -> str:
+    """Register digest for the ``config_snapshot_hash`` PoolKey dimension.
+
+    No sidecar means the config is genuinely absent, and the empty-snapshot
+    digest is reserved for that case. A readable sidecar hashes its contents.
+    A sidecar that exists but cannot be read leaves the config unknown, so the
+    digest is per-register and the session pools onto nothing instead of
+    inheriting a partition that belongs to some other config.
+    """
+    contents = _read_config_snapshot(args)
+    if contents is None:
+        # Two concatenated UUID hexes: 64-hex like every other digest on this
+        # dimension, unique per register.
+        return uuid.uuid4().hex + uuid.uuid4().hex
+    return hash_config_snapshot(contents)
 
 
 def _parse_auto_approve(raw: str) -> list[str]:
@@ -481,7 +534,13 @@ def build_register_payload(args: argparse.Namespace) -> dict:
         # the key. Safe to drop once no pre-#3604 daemon can be adopted.
         "user_identity": caller["principal_id"] or "unknown",
         "channel_id": channel_id,
-        "config_snapshot_hash": _CONFIG_SNAPSHOT_PLACEHOLDER,
+        # The empty-snapshot digest is RESERVED for registers without a
+        # --config-snapshot-file: their config is genuinely absent, so they
+        # share one partition by construction. A sidecar that exists but
+        # cannot be read is a different case — the config is unknown, and an
+        # unknown config must not reuse any valid partition — so that register
+        # carries a per-register digest and pools onto nothing.
+        "config_snapshot_hash": _config_snapshot_digest(args),
         "caller": caller,
         # Claim-push (gateway → gatewayd ``claim`` frame): the ancestor PID
         # chain of this stub, nearest first. gatewayd indexes the connection

--- a/test/test_mcp_gateway_config_snapshot.py
+++ b/test/test_mcp_gateway_config_snapshot.py
@@ -1,0 +1,231 @@
+"""``config_snapshot_hash``: the PoolKey dimension that detects non-security
+config drift across pooled MCP backends.
+
+The stub registers a digest of the rewriter's passthrough config as the
+``config_snapshot_hash`` PoolKey dimension. Without it, two agents pooling the
+same backend share one backend even when their preserved operator config (the
+``disabledTools`` tool allowlist, ``timeout``, ``initializationOptions``,
+vendor keys, ...) diverges. The snapshot itself travels through a 0600 sidecar
+in the owner-only sidecar directory, the same home the declared env uses;
+argv carries only the sidecar path because /proc/<pid>/cmdline is
+world-readable and free-form server config can carry secret-bearing vendor
+keys. The stub hashes the sidecar contents with the shared hashing leaf.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from kiro_crew.mcp_gateway import stub as stub_mod
+from kiro_crew.mcp_gateway.hashing import hash_config_snapshot
+from kiro_crew.mcp_gateway.rewriter import _rewrite_single_spec
+
+
+def _rewrite(spec: dict, tmp_path: Path) -> tuple[dict, int]:
+    return _rewrite_single_spec(
+        spec,
+        stubs_dir=tmp_path / "stubs",
+        socket_path=tmp_path / "gw.sock",
+        work_dir=tmp_path / "wd",
+        sandbox_mode="auto",
+        approval_mode="interactive",
+        stub_servers=frozenset({"shareable"}),
+        pooling_enabled=True,
+    )
+
+
+def _spec(disabled_tools: list[str] | None = None) -> dict:
+    # No declared env: a poolable server whose env would be withheld from a
+    # shared backend is deliberately left unwrapped by the rewriter, so the
+    # snapshot tests exercise the wrappable shape.
+    entry: dict = {
+        "command": sys.executable,
+        "args": ["-m", "some_server"],
+    }
+    if disabled_tools is not None:
+        entry["disabledTools"] = disabled_tools
+    return {"name": "agent-a", "mcpServers": {"shareable": entry}}
+
+
+def _argv_flag(args: list[str], flag: str) -> str | None:
+    if flag not in args:
+        return None
+    return args[args.index(flag) + 1]
+
+
+def test_rewriter_ships_the_passthrough_config_through_a_protected_sidecar(
+    tmp_path: Path,
+) -> None:
+    new_spec, _ = _rewrite(_spec(disabled_tools=["dangerous_tool"]), tmp_path)
+    argv = new_spec["mcpServers"]["shareable"]["args"]
+    sidecar = _argv_flag(argv, "--config-snapshot-file")
+    assert sidecar is not None, "rewriter must pass --config-snapshot-file"
+    assert (
+        _argv_flag(argv, "--config-snapshot-hash") is None
+    ), "the config digest never belongs on world-readable argv"
+    sidecar_path = Path(sidecar)
+    assert sidecar_path.is_file()
+    if sys.platform != "win32":
+        assert sidecar_path.stat().st_mode & 0o077 == 0, "the config sidecar must be owner-only"
+    assert sidecar_path.read_text(encoding="utf-8") == json.dumps(
+        {"disabledTools": ["dangerous_tool"]},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    # The stub hashes exactly those contents into the PoolKey dimension.
+    assert hash_config_snapshot(sidecar_path.read_text(encoding="utf-8")) == hash_config_snapshot(
+        json.dumps(
+            {"disabledTools": ["dangerous_tool"]},
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+    )
+
+
+def test_rewriter_snapshot_ignores_command_args_env(tmp_path: Path) -> None:
+    """command/args already carry their own PoolKey dimensions; an entry whose
+    snapshot is empty ships no sidecar and no flag, so specs differing only in
+    already-hashed fields stay poolable onto one backend."""
+    spec_b = _spec()
+    spec_b["mcpServers"]["shareable"]["args"] = ["-m", "other_server"]
+    argv_a = _rewrite(_spec(), tmp_path)[0]["mcpServers"]["shareable"]["args"]
+    argv_b = _rewrite(spec_b, tmp_path)[0]["mcpServers"]["shareable"]["args"]
+    assert _argv_flag(argv_a, "--config-snapshot-file") is None
+    assert _argv_flag(argv_b, "--config-snapshot-file") is None
+
+
+def test_rewriter_snapshot_tracks_passthrough_drift(tmp_path: Path) -> None:
+    """Sidecar names are content-addressed, so a config drift publishes the
+    new snapshot under a new name and both files coexist: a retained overlay
+    keeps pointing at the snapshot it was written with, and a fresh overlay
+    reads the fresh one."""
+    sidecar_a = Path(
+        _argv_flag(
+            _rewrite(_spec(disabled_tools=["tool_a"]), tmp_path)[0]["mcpServers"]["shareable"][
+                "args"
+            ],
+            "--config-snapshot-file",
+        )
+    )
+    sidecar_b = Path(
+        _argv_flag(
+            _rewrite(_spec(disabled_tools=["tool_b"]), tmp_path)[0]["mcpServers"]["shareable"][
+                "args"
+            ],
+            "--config-snapshot-file",
+        )
+    )
+    assert sidecar_a != sidecar_b, "the sidecar name must address the content"
+    assert sidecar_a.is_file() and sidecar_b.is_file()
+    assert sidecar_a.read_text(encoding="utf-8") != sidecar_b.read_text(encoding="utf-8")
+
+
+def test_rewriter_registers_the_sidecar_against_the_prune_pass(
+    tmp_path: Path,
+) -> None:
+    """The prune pass sweeps every sidecar the rewrite did not write, and the
+    fingerprint's protect list keys off the same names. A config sidecar left
+    out of ``sidecars_written`` would be deleted on the next boot and the
+    stub would silently fall back to the empty-snapshot partition."""
+    written: set[str] = set()
+    spec = {
+        "name": "agent-a",
+        "mcpServers": {
+            "shareable": {
+                "command": sys.executable,
+                "args": ["-m", "some_server"],
+                "disabledTools": ["dangerous_tool"],
+            }
+        },
+    }
+    _rewrite_single_spec(
+        spec,
+        stubs_dir=tmp_path / "stubs",
+        socket_path=tmp_path / "gw.sock",
+        work_dir=tmp_path / "wd",
+        sandbox_mode="auto",
+        approval_mode="interactive",
+        stub_servers=frozenset({"shareable"}),
+        pooling_enabled=True,
+        sidecars_written=written,
+    )
+    assert any(
+        name.startswith("cfg.") for name in written
+    ), "the config sidecar must be registered as a written sidecar"
+
+
+def test_hash_config_snapshot_is_canonical_over_key_order() -> None:
+    hash_first = hash_config_snapshot('{"b": 1, "a": 2}')
+    hash_second = hash_config_snapshot('{"a": 2, "b": 1}')
+    assert hash_first == hash_second
+    assert len(hash_first) == 64
+    int(hash_first, 16)  # hex
+    # Deterministic for the empty snapshot too (the stale-overlay default).
+    assert hash_config_snapshot("") == hash_config_snapshot("")
+
+
+def test_stub_register_hashes_the_snapshot_sidecar(tmp_path: Path) -> None:
+    snapshot = tmp_path / "cfg.json"
+    snapshot.write_text(
+        json.dumps({"disabledTools": ["dangerous_tool"]}, sort_keys=True),
+        encoding="utf-8",
+    )
+    base = [
+        "--server",
+        "s",
+        "--agent",
+        "a",
+        "--target-command",
+        "echo",
+        "--work-dir",
+        "/tmp",
+        "--socket",
+        "/tmp/gw.sock",
+    ]
+    payload = stub_mod.build_register_payload(
+        stub_mod._parse_args(base + ["--config-snapshot-file", str(snapshot)])
+    )
+    assert payload["config_snapshot_hash"] == hash_config_snapshot(
+        snapshot.read_text(encoding="utf-8")
+    )
+
+
+def test_stub_register_defaults_to_the_empty_snapshot_digest(tmp_path: Path) -> None:
+    base = [
+        "--server",
+        "s",
+        "--agent",
+        "a",
+        "--target-command",
+        "echo",
+        "--work-dir",
+        "/tmp",
+        "--socket",
+        "/tmp/gw.sock",
+    ]
+    # An overlay without --config-snapshot-file registers the empty-snapshot
+    # digest: that partition is RESERVED for sessions whose config is absent,
+    # so a session with a real config never lands on it.
+    payload_no_flag = stub_mod.build_register_payload(stub_mod._parse_args(base))
+    assert payload_no_flag["config_snapshot_hash"] == hash_config_snapshot("")
+
+    # A sidecar the stub cannot read is a different case entirely: the config
+    # is unknown, so the session gets its own per-register digest and pools
+    # onto nothing rather than reusing the valid empty-config partition.
+    payload_missing = stub_mod.build_register_payload(
+        stub_mod._parse_args(base + ["--config-snapshot-file", str(tmp_path / "absent.json")])
+    )
+    digest_missing = payload_missing["config_snapshot_hash"]
+    assert len(digest_missing) == 64
+    int(digest_missing, 16)  # hex
+    assert digest_missing != hash_config_snapshot("")
+    payload_missing_again = stub_mod.build_register_payload(
+        stub_mod._parse_args(base + ["--config-snapshot-file", str(tmp_path / "absent.json")])
+    )
+    assert (
+        payload_missing_again["config_snapshot_hash"] != digest_missing
+    ), "each unreadable-snapshot register pools onto its own backend"


### PR DESCRIPTION
## Problem / Motivation

The gateway pools MCP backends by a twelve-dimension `PoolKey`: server and agent identity, command args, effective env, work dir, binary version, OS uid, sandbox mode, the auto-approve set, approval mode, and trust-all. One of the twelve is not like the others. `config_snapshot_hash` was registered as a constant:

```python
_CONFIG_SNAPSHOT_PLACEHOLDER = "0" * 64
```

Right above it, the source carried a TODO saying exactly what was missing: "Hash relevant config fields (e.g. tool allowlists, hook settings) in a future iteration to detect non-security config drift that could cause subtle behavioral differences across pooled sessions."

The practical consequence: two sessions whose preserved operator config differs, say one sets `disabledTools` on the server and the other does not, or one declares a `timeout` or `initializationOptions`, still compute the same PoolKey and land on one shared backend process.

## Why it matters

The dangerous divergences are already handled. `approval_mode` and `sandbox_mode` are their own PoolKey dimensions, so the permission and isolation boundaries cannot collapse into one pool; the comment above the placeholder said as much. What slips through is the middle band: config that changes backend behavior without touching permissions. The symptom reads like a flake. A tool that one session cannot use is available to another, and which one is right depends on which session pooled the backend first. Nobody writes that down, so it surfaces as "sometimes it works" reports that are miserable to reproduce.

The placeholder also made the TODO permanently stale. Every future consumer of `config_snapshot_hash` reads a constant, so the dimension exists in the wire format while measuring nothing.

## What changed (motivation → approach → change)

Symptom: sessions with drifted operator config share one pooled backend. Root cause: the one PoolKey dimension reserved for that config was a constant, because nothing in the stub could see the config. Fix: the component that already owns the config now hashes it, and the stub registers the digest.

The rewriter (`mcp_gateway/rewriter.py`) is that component. It already preserves the original entry's passthrough fields on the wrapper (`timeout`, `type`, `initializationOptions`, `disabledTools`, vendor keys) while replacing `command`/`args`/`env`. That preserved set is exactly the config no other PoolKey dimension represents, so the rewriter writes its canonical JSON to a 0600 sidecar in the same owner-only directory the declared-env sidecars already live in, and hands the stub only the sidecar path on `--config-snapshot-file`. The sidecar name is content-addressed (`cfg.<agent>.<server>.<pair-digest>.<content-digest>.json`), so a config change publishes the new snapshot under a new name while a retained overlay keeps pointing at the snapshot it was written with, even if one of the two writes fails. The stub reads the sidecar and hashes its contents. Neither the config values nor their digest ever touch argv, because argv is world-readable via `/proc/<pid>/cmdline`; the sidecar is the same answer the tree already gives for declared env.

Canonicalization lives in one place, `hash_config_snapshot()` in `mcp_gateway/hashing.py`, the shared hashing leaf that `hash_command` and `hash_effective_env` already use. The function parses the JSON and re-dumps it with sorted keys and tight separators, so two spellings of the same config hash equally, and non-JSON input hashes as raw bytes so the digest stays deterministic for anything a future caller passes. The sidecar writer and the hashing reader cannot drift, which is the same property the other two hashes get from living there.

The stub grew the matching flag and registers the hash of the sidecar it was handed. Two edge cases get explicit treatment. The empty-snapshot digest is reserved for registers without a sidecar path, whose config is genuinely absent, so they share one partition by construction. A sidecar that exists but cannot be read leaves the config unknown, and an unknown config must not reuse any valid partition, so that register carries a unique per-register digest and pools onto nothing; a later successful read re-registers the correct digest. Every register still carries a deterministic 64-hex value in the normal paths, and the placeholder is gone.

What the snapshot deliberately does not include, since a reviewer will ask:

- `command`, `args`, and `env`: each already carries its own PoolKey dimension (`command_args_hash`, `effective_env_hash`, computed by the same leaf), so folding them in again would double-count and split pools that belong together. The new tests pin this.
- Hook settings: hooks are evaluated at the gateway's own tool gate, not per pooled backend, so putting them in a per-server key would split pools without changing anything the backend does. If a future hook surface moves into the backend spawn, it belongs in the snapshot then.
- `autoApprove`: already hashed into `autoapprove_set_hash` together with `approval_mode` and `trust_all`.

The change is four files:

- `src/kiro_crew/mcp_gateway/hashing.py` — new `hash_config_snapshot()` helper
- `src/kiro_crew/mcp_gateway/rewriter.py` — compute the passthrough set, pass the digest; the wrapper now reuses that same dict instead of rebuilding it
- `src/kiro_crew/mcp_gateway/stub.py` — the `--config-snapshot-hash` flag and the register field
- `test/test_mcp_gateway_config_snapshot.py` — new, pins the contract

Wire compatibility survived on purpose. `PoolKey.from_register` already required the field as a string and `gatewayd` partitions on whatever arrives, so an adopted older daemon keeps accepting registers from the new stub, and a newer daemon just sees real values. Overlays written before this change carry no sidecar path, and their sessions register the empty-snapshot digest, so pools re-form once at upgrade; the prewarm pinning code already anticipates exactly this in its comment ("prevents unbounded pin accumulation across hot-set drift and config_snapshot_hash changes"). Keys are runtime-only; nothing persists them.

## Tests

I wrote the new test file first and watched it fail before implementing, so the assertions are proven to bite:

- `test_rewriter_ships_the_passthrough_config_through_a_protected_sidecar` pins that the snapshot reaches the stub through the sidecar, that the sidecar is owner-only, and that no digest lands on argv.
- `test_rewriter_registers_the_sidecar_against_the_prune_pass` pins that the sidecar is registered as a written sidecar, so the prune pass and the fingerprint protect list keep it.
- `test_rewriter_snapshot_ignores_command_args_env` pins that an entry whose snapshot is empty ships no sidecar, so specs differing only in already-hashed fields stay poolable together.
- `test_rewriter_snapshot_tracks_passthrough_drift` pins that sidecar names are content-addressed: a `disabledTools` change publishes under a new name, and both snapshots coexist.
- `test_hash_config_snapshot_is_canonical_over_key_order` pins canonicalization and the deterministic empty-snapshot default.
- `test_stub_register_hashes_the_snapshot_sidecar` and `test_stub_register_defaults_to_the_empty_snapshot_digest` register through the real `_parse_args`/`build_register_payload` path: a readable sidecar hashes its contents, the missing-flag case hashes the empty snapshot, and an unreadable sidecar gets a unique 64-hex digest per register so it pools onto nothing.

Sweep across the gateway family around the change (rewriter, rewriter fingerprint, stub recaller, stub admission fallback, poolkey, claim, gatewayd coverage, bluegreen, exclusive backend, apps spool, cluster fixes, backend coverage, shutdown/env, apps e2e, apps call endpoint):

```text
677 passed, 6 skipped
```

`python -m mypy src/kiro_crew` is clean (1332 files), and the repo gates (`check_black_formatting.py`, `check_subprocess_encoding.py`) plus flake8, isort, and black on the touched files all pass. `stub.py` and `rewriter.py` sit on the formatting baseline, so the diff touches only the lines this change owns.

## Notes for reviewers

For a two-minute eyeball: point two sessions at the same poolable server with different `disabledTools` across two gateway boots and watch the daemon's pool hold two backends instead of one. Within a single boot, sessions of one agent share the sidecar and the backend, which is the intended sharing.

## Related Issues

There is no dedicated issue. The in-source TODO (visible in history at the placeholder) was the tracker for this one.

## Checklist

- [x] Tests written first, watched fail, then pass
- [x] mypy and the repo's black/subprocess gates pass; wire compatibility preserved
- [x] Self-review done; the digest never puts config values on argv


