### PR TITLE
fix: charge the watcher's single-file sweep against the chunk budget (#9398)

### DIFF
--- a/comment-history-baseline.json
+++ b/comment-history-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Comments and docstrings that narrate change history, per file, as a match COUNT. The rule they break is in docs/system-specs/common/code-style.md (\"Comments explain the WHY\"); it predates any enforcement, so the tree is recorded here rather than rewritten in one pass. The gate requires every OTHER file to be clean and none of these counts to grow, so this list can only shrink. Do NOT add or raise an entry to make a red gate green: a new offender means the comment should state CURRENT behavior in present tense. Lower and prune with `python3 scripts/check_comment_history.py --write-baseline`, which never adds or raises one.",
-  "_total": 7592,
+  "_total": 7589,
   "files": {
     "src/kiro_crew/__main__.py": 1,
     "src/kiro_crew/acp/_dispatch.py": 8,
@@ -438,7 +438,6 @@
     "src/kiro_crew/knowledge/kiroignore.py": 1,
     "src/kiro_crew/knowledge/retrieval.py": 1,
     "src/kiro_crew/knowledge/store.py": 21,
-    "src/kiro_crew/knowledge/watcher.py": 2,
     "src/kiro_crew/learn.py": 4,
     "src/kiro_crew/llm_helpers.py": 9,
     "src/kiro_crew/log_redaction.py": 1,

--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -287,6 +287,31 @@ decides how fast. It applies to the confirm- and resume-triggered scans as well 
 because the confirm scan is the largest burst — nothing is ingested yet, so every
 discovered file is new.
 
+The watcher's **single-file `local_file` loop draws from the same global counter**,
+and the two populations **alternate which spends the budget first** on the sweep
+counter's parity — so sustained pressure from one side (a churning folder source,
+or many changed single files) delays the other by at most one sweep, never
+permanently. The single-file loop walks rows **least-recently-attempted first** — every served row (committed,
+deduped, oversized, or failed) stamps `sweep_attempted_at` into its properties and
+rotates to the back, with `last_synced` as the fallback key for never-served rows —
+so under sustained contention every source makes progress and a persistently
+failing row cannot hold the front of the order while its charged attempts consume
+the budget. It checks the remaining
+`sweep_chunk_budget` allowance per row and charges back the
+**attempted** chunk total the pipeline's `on_progress` callback reports for the
+`extracting` phase — the calls the budget meters are extraction calls, and they are
+spent whether or not the write later commits, so a rolled-back partial ingest still
+charges (never a `get_job_status` read-back, which is blocking SQLite on the event
+loop). The gate sits below the existence check and defers with a per-row `continue`
+rather than the folder loop's `break`, so zero-cost `sync_status` upkeep (the
+'missing' marker) still lands on a sweep whose folder sources spent the whole
+budget. A deferred row's `mtime`/`content_hash` stay unrecorded so the next sweep
+resumes from it. Terminal outcomes are latched from the pipeline's `on_committed`
+(fully committed) and `on_duplicate` (pre-ingest gate refusal) callbacks: only those
+persist bookkeeping, so a rolled-back partial ingest stays retryable — bounded by
+the attempted-charge above — instead of being parked behind a recorded hash while
+the superseded document stays searchable.
+
 **Cost visibility.** `POST /api/knowledge/sources` walks a folder before ingesting
 anything and returns `file_count`, `capped_file_count`, `estimated_chunks`,
 `estimated_llm_calls` and `chunk_budget_per_sweep` alongside the

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -89,160 +89,300 @@ class KnowledgeWatcher:
         sweep_budget = self._sweep_chunk_budget()
         sweep_chunks_used = 0
 
-        # Folder sources (local_folder, obsidian_vault)
-        folder_rows = await self._store_rows(
-            "SELECT id, uri, source_type, properties, sync_status FROM sources "
-            "WHERE source_type IN ({})".format(
-                ",".join("?" for _ in FOLDER_SOURCE_TYPES)
-            ),
-            tuple(FOLDER_SOURCE_TYPES),
-        )
-        for row in folder_rows:
-            # Global budget exhausted — defer remaining sources to next sweep.
-            if sweep_budget and sweep_chunks_used >= sweep_budget:
-                logger.info(
-                    "Sweep chunk budget exhausted (%d/%d); deferring %s to next sweep",
-                    sweep_chunks_used, sweep_budget, row["uri"],
-                )
-                break
-            try:
-                source = dict(row)
-                props = self._parse_props(source.get("properties"))
-                # Read from the sync_status COLUMN, the single source of truth
-                # the dashboard and SyncScheduler also read. This used to read a
-                # copy inside the properties JSON, so a pause recorded only in
-                # the column still walked and delete-reconciled the whole folder
-                # every sweep.
-                if source.get("sync_status") in ("paused", "pending_confirmation"):
-                    continue
-                # Every folder source is one the user added by hand, and it is
-                # paced: the whole folder still arrives -- newest files first,
-                # the rest on later sweeps -- but pointing the Library at a
-                # source repo no longer spends the whole bill before anyone can
-                # look at it.
-                budget = folder_chunk_budget(props)
+        async def _scan_folder_sources() -> None:
+            nonlocal sweep_chunks_used
 
-                # Apply global budget as an additional cap on the per-source budget.
-                if sweep_budget:
-                    remaining = sweep_budget - sweep_chunks_used
-                    if budget is None:
-                        budget = remaining
-                    else:
-                        budget = min(budget, remaining)
-
-                stats = await self._folder_watcher.scan_source(
-                    source,
-                    chunk_budget=budget,
-                    embed_priority=PRIORITY_BULK,
-                )
-                # Track consumed chunks against global budget.
-                sweep_chunks_used += stats.get("chunks_ingested", 0)
-                if stats.get("error"):
-                    logger.warning("Folder scan error for %s: %s", source["uri"], stats["error"])
-                elif any(stats.get(k, 0) for k in ("new", "changed", "deleted")):
+            # Folder sources (local_folder, obsidian_vault)
+            folder_rows = await self._store_rows(
+                "SELECT id, uri, source_type, properties, sync_status FROM sources "
+                "WHERE source_type IN ({})".format(
+                    ",".join("?" for _ in FOLDER_SOURCE_TYPES)
+                ),
+                tuple(FOLDER_SOURCE_TYPES),
+            )
+            for row in folder_rows:
+                # Global budget exhausted — defer remaining sources to next sweep.
+                if sweep_budget and sweep_chunks_used >= sweep_budget:
                     logger.info(
-                        "Folder scan %s: +%d ~%d -%d",
-                        source["uri"],
-                        stats.get("new", 0),
-                        stats.get("changed", 0),
-                        stats.get("deleted", 0),
+                        "Sweep chunk budget exhausted (%d/%d); deferring %s to next sweep",
+                        sweep_chunks_used, sweep_budget, row["uri"],
                     )
-            except Exception:
-                logger.exception("Error scanning folder source %s", row["uri"])
+                    break
+                try:
+                    source = dict(row)
+                    props = self._parse_props(source.get("properties"))
+                    # Read from the sync_status COLUMN, the single source of truth
+                    # the dashboard and SyncScheduler also read. Reading a copy
+                    # inside the properties JSON instead would let a pause recorded
+                    # only in the column keep walking and delete-reconciling the
+                    # whole folder every sweep.
+                    if source.get("sync_status") in ("paused", "pending_confirmation"):
+                        continue
+                    # Every folder source is one the user added by hand, and it is
+                    # paced: the whole folder still arrives -- newest files first,
+                    # the rest on later sweeps -- so pointing the Library at a
+                    # source repo cannot spend the whole bill before anyone can
+                    # look at it.
+                    budget = folder_chunk_budget(props)
 
-        # Single-file sources (local_file)
-        rows = await self._store_rows(
-            "SELECT id, uri, properties, sync_status FROM sources "
-            "WHERE source_type = 'local_file'"
-        )
+                    # Apply global budget as an additional cap on the per-source budget.
+                    if sweep_budget:
+                        remaining = sweep_budget - sweep_chunks_used
+                        if budget is None:
+                            budget = remaining
+                        else:
+                            budget = min(budget, remaining)
 
-        for row in rows:
-            try:
-                uri = row["uri"]
-                if not uri or uri.startswith(("upload://", "code://", "http://", "https://")):
-                    continue
-                if is_sensitive_path(uri):
-                    logger.warning("Skipping sensitive path: %s", uri)
-                    continue
-                if not Path(uri).exists():
-                    # Mark missing in the COLUMN. Writing it into the properties
-                    # JSON instead left the row's visible state stale -- the
-                    # Library renders the column, so a file that had vanished
-                    # went on showing 'synced'. ``if_sync_status`` because the
-                    # value under test came from the snapshot at the top of the
-                    # sweep: a row a manual sync has moved since is left alone
-                    # and re-examined next sweep.
-                    if row["sync_status"] != "missing":
+                    stats = await self._folder_watcher.scan_source(
+                        source,
+                        chunk_budget=budget,
+                        embed_priority=PRIORITY_BULK,
+                    )
+                    # Track consumed chunks against global budget.
+                    sweep_chunks_used += stats.get("chunks_ingested", 0)
+                    if stats.get("error"):
+                        logger.warning("Folder scan error for %s: %s", source["uri"], stats["error"])
+                    elif any(stats.get(k, 0) for k in ("new", "changed", "deleted")):
+                        logger.info(
+                            "Folder scan %s: +%d ~%d -%d",
+                            source["uri"],
+                            stats.get("new", 0),
+                            stats.get("changed", 0),
+                            stats.get("deleted", 0),
+                        )
+                except Exception:
+                    logger.exception("Error scanning folder source %s", row["uri"])
+
+        async def _scan_single_file_sources() -> None:
+            nonlocal sweep_chunks_used
+
+            # Single-file sources (local_file), least-recently-ATTEMPTED first.
+            # Every served row — committed, deduped, oversized, or failed — stamps
+            # ``sweep_attempted_at`` into its properties, so it rotates to the
+            # back of the next sweep and rows still waiting rise toward the front:
+            # under sustained budget contention the sweep makes progress across
+            # ALL sources, and a persistently failing row cannot hold the front
+            # spot and starve the rest — its retry comes around once per rotation.
+            # ``last_synced`` is the fallback key for rows this ordering has never
+            # served; an empty key (never attempted, never synced) sorts first,
+            # which is also the right priority. No new cursor state or schema —
+            # both keys are ISO timestamps the sweep already maintains.
+            rows = await self._store_rows(
+                "SELECT id, uri, properties, sync_status, last_synced FROM sources "
+                "WHERE source_type = 'local_file'"
+            )
+
+            def _attempt_order_key(row) -> tuple:
+                # ``sweep_attempted_at`` lives in the properties JSON, which
+                # ``store.import_bundle`` accepts verbatim from external content —
+                # so its type is untrusted. A non-string value degrades to the
+                # ``last_synced`` fallback (a typed TEXT column) rather than
+                # poisoning the mixed-type sort and crashing the whole sweep.
+                stamped = self._parse_props(row["properties"]).get("sweep_attempted_at")
+                if not isinstance(stamped, str):
+                    stamped = None
+                return (stamped or row["last_synced"] or "", row["id"])
+
+            rows = sorted(rows, key=_attempt_order_key)
+
+            deferred = 0
+            for row in rows:
+                try:
+                    uri = row["uri"]
+                    if not uri or uri.startswith(("upload://", "code://", "http://", "https://")):
+                        continue
+                    if is_sensitive_path(uri):
+                        logger.warning("Skipping sensitive path: %s", uri)
+                        continue
+                    if not Path(uri).exists():
+                        # Mark missing in the COLUMN. Writing it into the properties
+                        # JSON instead left the row's visible state stale -- the
+                        # Library renders the column, so a file that had vanished
+                        # went on showing 'synced'. ``if_sync_status`` because the
+                        # value under test came from the snapshot at the top of the
+                        # sweep: a row a manual sync has moved since is left alone
+                        # and re-examined next sweep.
+                        if row["sync_status"] != "missing":
+                            await asyncio.to_thread(
+                                self.store.update_source, row["id"],
+                                sync_status="missing", if_sync_status=row["sync_status"])
+                        continue
+
+                    # Global budget exhausted — defer this source's read and ingest
+                    # to the next sweep. Deliberately BELOW the existence check and
+                    # a ``continue`` rather than the folder loop's ``break``, so the
+                    # zero-cost 'missing' marker above still lands for every row
+                    # even on a sweep whose folder sources spent the whole budget.
+                    # Deferral leaves the row's mtime/content_hash bookkeeping
+                    # untouched, so the next sweep sees it as changed and resumes
+                    # from it. This gate is what bounds the loop: without it a
+                    # library with many changed local_file sources re-ingests all
+                    # of them in one unpaced burst -- the burst the sweep budget
+                    # exists to spread.
+                    if sweep_budget and sweep_chunks_used >= sweep_budget:
+                        deferred += 1
+                        continue
+
+                    mtime = os.stat(uri).st_mtime
+                    props = self._parse_props(row["properties"])
+                    stored_mtime = props.get("mtime", 0)
+                    # A row that reads 'missing' has been away, and the mtime gate
+                    # cannot speak for it: a restore preserving the archived mtime
+                    # (cp -p, rsync -t, tar -x) puts different content on disk under
+                    # an mtime that never advanced, so the gate reports 'unchanged'
+                    # about a file it has not read. Deletion is exactly the event
+                    # that breaks the mtime heuristic, so read the content instead.
+                    if mtime > stored_mtime or row["sync_status"] == "missing":
+                        # Check content hash to avoid re-ingesting touched-but-unchanged files
+                        content_hash = await asyncio.get_running_loop().run_in_executor(
+                            None, self._hash_file, Path(uri)
+                        )
+                        if content_hash != props.get("content_hash"):
+                            logger.info("Source changed: %s", uri)
+                            # Three callbacks the pipeline already offers, so no
+                            # signature change and no blocking get_job_status
+                            # read-back on the event loop:
+                            #
+                            # * ``on_progress`` reports the attempted chunk total
+                            #   once extraction is running -- extract_batch has
+                            #   spent one LLM call per chunk by then, so THAT is
+                            #   the number the sweep budget meters ("caps total
+                            #   extraction calls"). Charging only committed chunks
+                            #   would let a post-extraction partial failure spend
+                            #   the calls while charging nothing.
+                            # * ``on_committed`` fires inside the finalize hop,
+                            #   only on the branch that committed the whole group
+                            #   -- the same latch FolderWatcher detects rollbacks
+                            #   with.
+                            # * ``on_duplicate`` fires when the pre-ingest gate
+                            #   refuses byte-identical content: a terminal success
+                            #   for bookkeeping, though nothing new was written.
+                            committed: list[str] | None = None
+                            refused = False
+                            attempted_chunks = 0
+
+                            def _record_committed(ids: list[str]) -> None:
+                                nonlocal committed
+                                committed = list(ids)
+
+                            def _record_refused(_text_hash: str) -> None:
+                                nonlocal refused
+                                refused = True
+
+                            def _note_extraction(phase: str, done: int, total: int) -> None:
+                                nonlocal attempted_chunks
+                                if phase == "extracting":
+                                    attempted_chunks = int(total)
+
+                            try:
+                                await self.pipeline.ingest_file(
+                                    uri,
+                                    source_id=row["id"],
+                                    namespace=props.get("namespace", "default"),
+                                    embed_priority=PRIORITY_BULK,
+                                    on_progress=_note_extraction,
+                                    on_committed=_record_committed,
+                                    on_duplicate=_record_refused,
+                                )
+                            except FileTooLargeError:
+                                # Warning already logged by the pipeline (names the file
+                                # and the config key). Mark the source errored and skip
+                                # persisting mtime/hash so the file is re-evaluated on
+                                # a later scan -- raising knowledge.max_ingest_file_mb
+                                # (config is read live) then recovers it automatically.
+                                # Stamped as an attempt below, so the oversized row
+                                # rotates to the back instead of being re-hashed at
+                                # the front of every sweep.
+                                await asyncio.to_thread(
+                                    self.store.update_source, row["id"], sync_status="error")
+                                await self._stamp_attempt(row["id"])
+                                continue
+                            except Exception:
+                                # Stamp the attempt even when the pipeline raises:
+                                # the charge in the finally below is real spend,
+                                # and an unstamped row would keep the front of the
+                                # rotation while consuming budget -- exactly the
+                                # starvation the ordering exists to prevent. The
+                                # row-level handler logs the error.
+                                await self._stamp_attempt(row["id"])
+                                raise
+                            finally:
+                                # Charge the attempted extraction count against the
+                                # global sweep budget whatever the commit outcome,
+                                # so both loops draw from one counter and a failed
+                                # finalize cannot make its spend invisible. Runs on
+                                # the FileTooLargeError path too, where it is zero
+                                # (the size guard fires before chunking).
+                                sweep_chunks_used += attempted_chunks
+                            if committed is None and not refused:
+                                # The pipeline rolled back a partial ingest -- it
+                                # invokes on_committed only on the fully-committed
+                                # branch -- and its finalize already marked the
+                                # source 'error'. Leave mtime/content_hash
+                                # unrecorded so a later sweep retries, but stamp
+                                # the attempt: the retry waits its turn behind the
+                                # rows still queued, so a persistently failing row
+                                # is bounded to one served slot per rotation and
+                                # cannot starve the sources behind it.
+                                await self._stamp_attempt(row["id"])
+                                continue
+                        # Merged against the current row inside one worker hop,
+                        # never persisted from this sweep's snapshot: a concurrent
+                        # writer (manual sync, ingest finalize) may have committed
+                        # fresh properties while the ingest ran, and a whole-blob
+                        # write of the snapshot would silently clobber them.
+                        await self._merge_source_props(row["id"], {
+                            "mtime": mtime,
+                            "content_hash": content_hash,
+                            "sweep_attempted_at": datetime.now().isoformat(),
+                        })
+                    if row["sync_status"] == "missing":
+                        # The file is back, so the marker has to come off, and the
+                        # CAS on 'missing' is what decides whether this write is the
+                        # one to do it. An ingestion that ran has already written the
+                        # column -- 'synced' when it stored the document, 'error' on
+                        # a partial write -- and moves the row off 'missing', so this
+                        # no-ops. It fires for the outcome that writes NO status: the
+                        # duplicate gate, which refuses the write because a holder
+                        # already holds this exact document (verified under its write
+                        # lock) and deletes this source's superseded items. Without
+                        # this the marker would sit on a file that is present and
+                        # accounted for. Deliberately LAST, after the read: claiming
+                        # 'synced' before reading the file would leave that claim
+                        # standing if the read then failed -- a failed ingest raises,
+                        # so control never reaches here.
                         await asyncio.to_thread(
                             self.store.update_source, row["id"],
-                            sync_status="missing", if_sync_status=row["sync_status"])
-                    continue
+                            sync_status="synced", if_sync_status="missing")
+                except Exception:
+                    # sqlite3.Row has no .get(): the previous spelling raised
+                    # AttributeError from inside the handler, which replaced the real
+                    # error with a confusing one AND escaped the loop, abandoning
+                    # every source after this one for the rest of the sweep.
+                    logger.exception("Error checking source %s", row["uri"] or row["id"])
+            if deferred:
+                logger.info(
+                    "Sweep chunk budget exhausted (%d/%d); deferred %d local_file "
+                    "source(s) to next sweep", sweep_chunks_used, sweep_budget, deferred,
+                )
 
-                mtime = os.stat(uri).st_mtime
-                props = self._parse_props(row["properties"])
-                stored_mtime = props.get("mtime", 0)
-                # A row that reads 'missing' has been away, and the mtime gate
-                # cannot speak for it: a restore preserving the archived mtime
-                # (cp -p, rsync -t, tar -x) puts different content on disk under
-                # an mtime that never advanced, so the gate reports 'unchanged'
-                # about a file it has not read. Deletion is exactly the event
-                # that breaks the mtime heuristic, so read the content instead.
-                if mtime > stored_mtime or row["sync_status"] == "missing":
-                    # Check content hash to avoid re-ingesting touched-but-unchanged files
-                    content_hash = await asyncio.get_running_loop().run_in_executor(
-                        None, self._hash_file, Path(uri)
-                    )
-                    if content_hash != props.get("content_hash"):
-                        logger.info("Source changed: %s", uri)
-                        try:
-                            await self.pipeline.ingest_file(
-                                uri,
-                                source_id=row["id"],
-                                namespace=props.get("namespace", "default"),
-                                embed_priority=PRIORITY_BULK,
-                            )
-                        except FileTooLargeError:
-                            # Warning already logged by the pipeline (names the file
-                            # and the config key). Mark the source errored and skip
-                            # persisting mtime/hash so the file is re-evaluated on
-                            # the next scan -- raising knowledge.max_ingest_file_mb
-                            # (config is read live) then recovers it automatically.
-                            await asyncio.to_thread(
-                                self.store.update_source, row["id"], sync_status="error")
-                            continue
-                        # Re-read props after ingest (ingest may update them)
-                        source = await asyncio.to_thread(
-                            self.store.get_source_by_uri, uri)
-                        if source:
-                            props = self._parse_props(source.get("properties"))
-                    props["mtime"] = mtime
-                    props["content_hash"] = content_hash
-                    await asyncio.to_thread(
-                        self.store.update_source, row["id"], properties=json.dumps(props))
-                if row["sync_status"] == "missing":
-                    # The file is back, so the marker has to come off, and the
-                    # CAS on 'missing' is what decides whether this write is the
-                    # one to do it. An ingestion that ran has already written the
-                    # column -- 'synced' when it stored the document, 'error' on
-                    # a partial write -- and moves the row off 'missing', so this
-                    # no-ops. It fires for the outcome that writes NO status: the
-                    # duplicate gate, which refuses the write because a holder
-                    # already holds this exact document (verified under its write
-                    # lock) and deletes this source's superseded items. Without
-                    # this the marker would sit on a file that is present and
-                    # accounted for. Deliberately LAST, after the read: claiming
-                    # 'synced' before reading the file would leave that claim
-                    # standing if the read then failed -- a failed ingest raises,
-                    # so control never reaches here.
-                    await asyncio.to_thread(
-                        self.store.update_source, row["id"],
-                        sync_status="synced", if_sync_status="missing")
-            except Exception:
-                # sqlite3.Row has no .get(): the previous spelling raised
-                # AttributeError from inside the handler, which replaced the real
-                # error with a confusing one AND escaped the loop, abandoning
-                # every source after this one for the rest of the sweep.
-                logger.exception("Error checking source %s", row["uri"] or row["id"])
+        # Alternate which population spends the shared budget first, on the
+        # sweep counter's parity. Folders and single files draw from one
+        # counter, so whichever runs first can exhaust it; a fixed order would
+        # let sustained folder churn (a folder source pointed at an
+        # actively-changing repo, the exact case folder pacing exists for)
+        # defer every local_file row on every sweep, with no recovery until
+        # the churn subsides. Alternation gives each population first claim
+        # on the full budget every other sweep, so sustained pressure from
+        # one side delays the other by at most one sweep, never permanently.
+        # Ordering is the only thing that changes: each loop's own charging,
+        # per-source caps, and deferral bookkeeping are identical either way.
+        if self._sweep_count % 2:
+            await _scan_single_file_sources()
+            await _scan_folder_sources()
+        else:
+            await _scan_folder_sources()
+            await _scan_single_file_sources()
 
         # After file-level reconciliation, self-heal vectors left stale by an
         # embedding-setup change (model/budget) -- the file gates above never fire
@@ -250,6 +390,43 @@ class KnowledgeWatcher:
         await self._maybe_reembed_stale()
         self._sweep_count += 1
         await self._maybe_dedup_sweep()
+
+    async def _merge_source_props(self, source_id: str, updates: dict) -> None:
+        """Read-merge-write the source's properties in ONE worker hop.
+
+        ``update_source`` replaces the whole properties blob, so persisting a
+        dict snapshot taken earlier in the sweep would silently clobber
+        whatever a concurrent writer (a manual sync, an ingest finalize)
+        committed to the same source since the snapshot — and the window
+        spans a full ingest attempt. Reading the CURRENT row and applying
+        only the named keys inside the same worker hop keeps every other
+        field as the latest writer left it. ``store.db`` is a per-thread
+        connection, so the read and the write share the hop's own connection.
+        """
+
+        def _apply() -> None:
+            row = self.store.db.execute(
+                "SELECT properties FROM sources WHERE id = ?", (source_id,)).fetchone()
+            if row is None:
+                # Source deleted concurrently; nothing to stamp.
+                return
+            props = self._parse_props(row["properties"])
+            props.update(updates)
+            self.store.update_source(source_id, properties=json.dumps(props))
+
+        await asyncio.to_thread(_apply)
+
+    async def _stamp_attempt(self, source_id: str) -> None:
+        """Persist the attempt timestamp that rotates a served row to the back.
+
+        Written WITHOUT mtime/content_hash, so the row still reads as changed
+        and is retried -- just behind every row that has waited longer. This is
+        what keeps a persistently failing source from holding the front of the
+        sweep order while its charged attempts consume the budget. Merged
+        against the current row (never a snapshot), so only this key changes.
+        """
+        await self._merge_source_props(
+            source_id, {"sweep_attempted_at": datetime.now().isoformat()})
 
     @staticmethod
     def _sweep_chunk_budget() -> int:
@@ -436,12 +613,21 @@ class KnowledgeWatcher:
 
     @staticmethod
     def _parse_props(raw) -> dict:
+        """The source's properties as a dict, whatever shape is stored.
+
+        Always a dict: a legacy row can hold a JSON value that parses to a
+        non-dict (``"[]"``, a string, a number), and callers chain ``.get``
+        straight onto the result — inside the sweep's sort key that raise
+        aborts the entire sweep, every interval, with no self-correction.
+        A non-dict parse reads as empty instead.
+        """
         if isinstance(raw, str):
             try:
-                return json.loads(raw)
+                parsed = json.loads(raw)
             except Exception:
                 return {}
-        return raw or {}
+            return parsed if isinstance(parsed, dict) else {}
+        return raw if isinstance(raw, dict) else {}
 
     @staticmethod
     def _hash_file(path: Path) -> str:

--- a/test/test_knowledge_budget.py
+++ b/test/test_knowledge_budget.py
@@ -8,8 +8,12 @@ Covers:
 - extraction_pool_size in LLMPool
 """
 import asyncio
+import json
+import os
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from kiro_crew.config.loader import KnowledgeConfig
 
@@ -103,6 +107,375 @@ class TestSweepChunkBudget:
         with patch("kiro_crew.knowledge.watcher.KiroCrewConfig") as mock_cfg:
             mock_cfg.load.return_value.knowledge.sweep_chunk_budget = 0
             assert KnowledgeWatcher._sweep_chunk_budget() == 0
+
+
+# --- Single-file (local_file) sweep budget ---
+#
+# The folder loop checks the global sweep budget before every source and charges
+# scan_source's chunks_ingested back after each scan. The single-file local_file
+# loop shares that counter: without the gate, a library with many changed
+# local_file sources re-ingests everything in one unpaced burst — and a source
+# registered with no mtime/content_hash bookkeeping reads as changed to every
+# sweep, so the burst repeats until each such source is read.
+
+
+def _single_file_watcher(store, budget: int, chunks_per_file: int = 1, commit: bool = True):
+    """A KnowledgeWatcher whose pipeline reports ``chunks_per_file`` per ingest.
+
+    The fake ``ingest_file`` reports extraction progress through ``on_progress``
+    (the attempted count the watcher charges) and, when ``commit`` is true, the
+    committed chunk ids through ``on_committed`` — the same callbacks the real
+    pipeline invokes. ``commit=False`` models a post-extraction partial failure:
+    the LLM calls were spent but the pipeline rolled the write back and never
+    invoked ``on_committed``.
+    """
+    from kiro_crew.knowledge.watcher import KnowledgeWatcher
+
+    pipeline = MagicMock()
+    pipeline.embedder = None
+    ingested_uris: list[str] = []
+
+    async def fake_ingest(path, **kwargs):
+        ingested_uris.append(path)
+        on_progress = kwargs.get("on_progress")
+        if on_progress is not None:
+            for i in range(chunks_per_file):
+                on_progress("extracting", i + 1, chunks_per_file)
+        if commit:
+            on_committed = kwargs.get("on_committed")
+            if on_committed is not None:
+                on_committed(
+                    [f"item-{len(ingested_uris)}-{i}" for i in range(chunks_per_file)])
+            # The real finalize hop stamps last_synced on the source; the
+            # watcher's least-recently-synced-first ordering rotates on it.
+            sid = kwargs.get("source_id")
+            if sid:
+                store.update_source(
+                    sid, last_synced=f"2026-01-01T00:00:{len(ingested_uris):02d}")
+        return "job-id"
+
+    pipeline.ingest_file = AsyncMock(side_effect=fake_ingest)
+    watcher = KnowledgeWatcher(store=store, pipeline=pipeline)
+    watcher._maybe_reembed_stale = AsyncMock()  # type: ignore[method-assign]
+    watcher._maybe_dedup_sweep = AsyncMock()  # type: ignore[method-assign]
+    watcher._sweep_chunk_budget = lambda: budget  # type: ignore[method-assign]
+    return watcher, ingested_uris
+
+
+def _add_local_files(store, tmp_path, count: int) -> list[str]:
+    """Register ``count`` changed local_file sources (no mtime/hash recorded).
+
+    No stored mtime/content_hash is exactly the state a deferred explicit
+    import leaves behind, so every one of these reads as changed to the sweep.
+    """
+    sids = []
+    for i in range(count):
+        f = tmp_path / f"doc{i}.md"
+        f.write_text(f"# doc {i}")
+        sids.append(store.add_source(f"doc{i}.md", "local_file", str(f)))
+    return sids
+
+
+def _props_of(store, sid: str) -> dict:
+    raw = store.db.execute(
+        "SELECT properties FROM sources WHERE id = ?", (sid,)).fetchone()["properties"]
+    return json.loads(raw or "{}")
+
+
+class TestSingleFileSweepBudget:
+    @pytest.fixture()
+    def store(self, tmp_path):
+        from kiro_crew.knowledge.store import KnowledgeStore
+
+        s = KnowledgeStore(str(tmp_path / "knowledge.db"))
+        yield s
+        s.close()
+
+    @pytest.mark.asyncio
+    async def test_sweep_stops_at_budget(self, store, tmp_path):
+        """A sweep over many changed local_file sources stops at the budget."""
+        _add_local_files(store, tmp_path, 5)
+        watcher, ingested = _single_file_watcher(store, budget=2, chunks_per_file=1)
+
+        await watcher._scan()
+
+        assert len(ingested) == 2
+
+    @pytest.mark.asyncio
+    async def test_attempted_chunk_count_is_charged(self, store, tmp_path):
+        """The charge is the per-file attempted chunk count, not one per file.
+
+        Budget 10 with 6 chunks per file: after the first file 6 < 10 so the
+        second still runs; after the second 12 >= 10 so the third is deferred.
+        (On the commit path attempted == committed, so this also pins the
+        committed count.)
+        """
+        _add_local_files(store, tmp_path, 3)
+        watcher, ingested = _single_file_watcher(store, budget=10, chunks_per_file=6)
+
+        await watcher._scan()
+
+        assert len(ingested) == 2
+
+    @pytest.mark.asyncio
+    async def test_deferred_sources_keep_no_bookkeeping_and_resume(self, store, tmp_path):
+        """Deferral records no mtime/content_hash, so the next sweep resumes.
+
+        Asserted as a partition (exactly two ingested, the rest untouched)
+        rather than by identity: the driving query has no ORDER BY, so which
+        two rows a sweep reaches first is a query-plan detail, not a contract.
+        """
+        sids = _add_local_files(store, tmp_path, 4)
+        watcher, ingested = _single_file_watcher(store, budget=2, chunks_per_file=1)
+
+        await watcher._scan()
+
+        assert len(ingested) == 2
+        with_bookkeeping = [sid for sid in sids if "mtime" in _props_of(store, sid)]
+        assert len(with_bookkeeping) == 2
+        for sid in sids:
+            props = _props_of(store, sid)
+            if sid in with_bookkeeping:
+                assert "content_hash" in props
+            else:
+                assert "mtime" not in props, "a deferred source must stay resumable"
+                assert "content_hash" not in props
+
+        # The next sweep (fresh budget) picks up where this one stopped.
+        await watcher._scan()
+        assert len(ingested) == 4
+
+    @pytest.mark.asyncio
+    async def test_folder_loop_consumption_defers_single_files(self, store, tmp_path):
+        """Both loops share one counter: a folder that spends the whole budget
+        leaves nothing for the single-file loop's ingests that sweep."""
+        folder = tmp_path / "vault"
+        folder.mkdir()
+        store.add_source("vault", "local_folder", str(folder))
+        _add_local_files(store, tmp_path, 2)
+
+        watcher, ingested = _single_file_watcher(store, budget=5, chunks_per_file=1)
+        watcher._folder_watcher.scan_source = AsyncMock(  # type: ignore[method-assign]
+            return_value={"chunks_ingested": 5})
+
+        await watcher._scan()
+
+        assert ingested == []
+
+    @pytest.mark.asyncio
+    async def test_zero_budget_leaves_the_sweep_unbounded(self, store, tmp_path):
+        """budget=0 disables the bound, matching the folder loop's contract."""
+        _add_local_files(store, tmp_path, 4)
+        watcher, ingested = _single_file_watcher(store, budget=0, chunks_per_file=100)
+
+        await watcher._scan()
+
+        assert len(ingested) == 4
+
+    @pytest.mark.asyncio
+    async def test_exhausted_budget_still_marks_vanished_files_missing(self, store, tmp_path):
+        """Zero-cost status upkeep survives budget exhaustion.
+
+        The gate defers reads and ingests with a per-row ``continue`` below the
+        existence check, never a loop-level ``break``, so a vanished file's
+        'missing' marker still lands on a sweep whose folder sources spent the
+        whole budget.
+        """
+
+        folder = tmp_path / "vault"
+        folder.mkdir()
+        store.add_source("vault", "local_folder", str(folder))
+        gone = tmp_path / "gone.md"
+        gone.write_text("# gone")
+        sid = store.add_source("gone.md", "local_file", str(gone))
+        store.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (sid,))
+        store.db.commit()
+        gone.unlink()
+
+        watcher, ingested = _single_file_watcher(store, budget=5, chunks_per_file=1)
+        watcher._folder_watcher.scan_source = AsyncMock(  # type: ignore[method-assign]
+            return_value={"chunks_ingested": 5})
+
+        await watcher._scan()
+
+        assert ingested == []
+        status = store.db.execute(
+            "SELECT sync_status FROM sources WHERE id = ?", (sid,)).fetchone()["sync_status"]
+        assert status == "missing"
+
+    @pytest.mark.asyncio
+    async def test_contended_sweeps_rotate_across_sources(self, store, tmp_path):
+        """Under sustained contention every source makes progress.
+
+        The sweep orders local_file rows least-recently-synced first, and a
+        served source's fresh ``last_synced`` moves it behind rows still
+        waiting — so even when every source changes every sweep and the budget
+        admits one file per sweep, three sweeps serve three DIFFERENT sources
+        rather than re-serving whichever row a stable query order puts first.
+        """
+        paths = [tmp_path / f"doc{i}.md" for i in range(3)]
+        _add_local_files(store, tmp_path, 3)
+        watcher, ingested = _single_file_watcher(store, budget=1, chunks_per_file=1)
+
+        for sweep in range(3):
+            # Every file changes before every sweep: new content, newer mtime.
+            for p in paths:
+                p.write_text(f"# rev {sweep} of {p.name}")
+                os.utime(p, (2_000_000_000 + sweep, 2_000_000_000 + sweep))
+            await watcher._scan()
+
+        assert len(ingested) == 3
+        assert len(set(ingested)) == 3, (
+            "a contended sweep must rotate, not re-serve the same source")
+
+    @pytest.mark.asyncio
+    async def test_folder_churn_cannot_permanently_starve_single_files(self, store, tmp_path):
+        """Sustained folder churn delays a changed local_file by at most one sweep.
+
+        The two populations alternate which spends the shared budget first, so
+        a folder that consumes the entire budget on every sweep still leaves
+        the next sweep's first claim to the single-file rows — deferral is
+        recoverable without waiting for the folder churn to subside.
+        """
+        folder = tmp_path / "vault"
+        folder.mkdir()
+        store.add_source("vault", "local_folder", str(folder))
+        _add_local_files(store, tmp_path, 1)
+
+        watcher, ingested = _single_file_watcher(store, budget=5, chunks_per_file=1)
+        # The folder consumes the WHOLE budget on every single sweep.
+        watcher._folder_watcher.scan_source = AsyncMock(  # type: ignore[method-assign]
+            return_value={"chunks_ingested": 5})
+
+        await watcher._scan()  # folders first: budget exhausted, file deferred
+        assert ingested == []
+        await watcher._scan()  # single files first: the deferred file ingests
+
+        assert len(ingested) == 1
+
+    @pytest.mark.asyncio
+    async def test_bookkeeping_merges_against_concurrent_writes(self, store, tmp_path):
+        """The persist is a read-merge-write of the CURRENT row, not a snapshot.
+
+        The watcher reads a source's properties at the top of the sweep, and a
+        full ingest can run between that read and the bookkeeping write. A key
+        a concurrent writer (a manual sync) commits in that window must
+        survive the watcher's write — a whole-blob write of the sweep's
+        snapshot would silently clobber it.
+        """
+        sids = _add_local_files(store, tmp_path, 1)
+        watcher, ingested = _single_file_watcher(store, budget=0, chunks_per_file=1)
+
+        orig_ingest = watcher.pipeline.ingest_file.side_effect
+
+        async def ingest_with_concurrent_write(path, **kwargs):
+            # A concurrent manual sync lands mid-ingest.
+            row = store.db.execute(
+                "SELECT properties FROM sources WHERE id = ?", (sids[0],)).fetchone()
+            props = json.loads(row["properties"] or "{}")
+            props["concurrent_key"] = "must-survive"
+            store.update_source(sids[0], properties=json.dumps(props))
+            return await orig_ingest(path, **kwargs)
+
+        watcher.pipeline.ingest_file = AsyncMock(side_effect=ingest_with_concurrent_write)
+
+        await watcher._scan()
+
+        props = _props_of(store, sids[0])
+        assert props.get("concurrent_key") == "must-survive"
+        assert "mtime" in props and "content_hash" in props
+        assert "sweep_attempted_at" in props
+
+    @pytest.mark.asyncio
+    async def test_non_dict_properties_do_not_crash_the_sweep(self, store, tmp_path):
+        """A legacy row whose properties JSON parses to a non-dict reads as {}.
+
+        ``_parse_props`` feeds the sort key, which chains ``.get`` onto the
+        result — a stored ``"[]"`` would otherwise raise ``AttributeError``
+        inside ``sorted()`` and abort the whole sweep every interval with no
+        self-correction. The poison row participates as if it had no
+        properties, and every other source still ingests.
+        """
+        legacy = tmp_path / "legacy.md"
+        legacy.write_text("# legacy")
+        sid = store.add_source("legacy.md", "local_file", str(legacy))
+        store.db.execute("UPDATE sources SET properties = '[]' WHERE id = ?", (sid,))
+        store.db.commit()
+        _add_local_files(store, tmp_path, 1)
+        watcher, ingested = _single_file_watcher(store, budget=0, chunks_per_file=1)
+
+        await watcher._scan()
+
+        assert len(ingested) == 2, "both sources ingest; the sweep must not crash"
+
+    @pytest.mark.asyncio
+    async def test_corrupt_attempt_stamp_does_not_crash_the_sweep(self, store, tmp_path):
+        """A non-string ``sweep_attempted_at`` degrades to the fallback key.
+
+        ``store.import_bundle`` accepts a source's properties JSON verbatim
+        from external content, so the stamp's type is untrusted: a numeric
+        value must not poison the mixed-type sort and abort the sweep before
+        any single-file reconciliation runs — it reads as never-attempted and
+        the row sorts by ``last_synced`` instead.
+        """
+        poisoned = tmp_path / "poisoned.md"
+        poisoned.write_text("# poisoned")
+        store.add_source(
+            "poisoned.md", "local_file", str(poisoned),
+            properties={"sweep_attempted_at": 123})
+        _add_local_files(store, tmp_path, 1)
+        watcher, ingested = _single_file_watcher(store, budget=0, chunks_per_file=1)
+
+        await watcher._scan()
+
+        assert len(ingested) == 2, "both sources ingest; the sweep must not crash"
+
+    @pytest.mark.asyncio
+    async def test_failing_source_does_not_starve_later_sources(self, store, tmp_path):
+        """A persistently failing row rotates like any served row.
+
+        A partial-ingest failure charges its spent extraction calls but never
+        advances ``last_synced`` (only the committed branch writes it), so an
+        ordering keyed on last_synced alone re-serves the failing row first
+        every sweep while its charge exhausts the budget — later changed
+        sources never run. The attempt stamp is what breaks that: the failed
+        row's retry waits its turn behind the rows still queued.
+        """
+        _add_local_files(store, tmp_path, 3)
+        watcher, ingested = _single_file_watcher(
+            store, budget=1, chunks_per_file=1, commit=False)
+
+        for _ in range(3):
+            await watcher._scan()
+
+        assert len(ingested) == 3
+        assert len(set(ingested)) == 3, (
+            "each contended sweep must serve a source the failing row was not")
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_charges_and_stays_resumable(self, store, tmp_path):
+        """A rolled-back ingest still charges its spent extraction calls, and
+        keeps no bookkeeping so the next sweep can retry it.
+
+        The pipeline invokes ``on_committed`` only on the fully-committed
+        branch; extraction already spent one LLM call per chunk by then. If the
+        watcher charged only committed chunks, repeated post-extraction
+        failures would spend without bound; if it persisted mtime/content_hash
+        anyway, the changed file would never be re-read.
+        """
+        sids = _add_local_files(store, tmp_path, 3)
+        watcher, ingested = _single_file_watcher(
+            store, budget=4, chunks_per_file=2, commit=False)
+
+        await watcher._scan()
+
+        # Charged 2 attempted chunks per failed ingest: 2, then 4 >= 4 — the
+        # third source is deferred, so the failure loop is budget-bounded.
+        assert len(ingested) == 2
+        # And nothing was recorded, so every source stays retryable.
+        for sid in sids:
+            assert "mtime" not in _props_of(store, sid)
+            assert "content_hash" not in _props_of(store, sid)
 
 
 # --- Pool size from config ---

--- a/test/test_knowledge_sync_status_column.py
+++ b/test/test_knowledge_sync_status_column.py
@@ -283,8 +283,18 @@ class TestSingleFileMissingMarker:
         store.db.commit()
 
         watcher = _watcher(store)
-        # The duplicate gate's shape: returns a terminal job id, writes no status.
-        watcher.pipeline.ingest_file = AsyncMock(return_value="dupe-job-id")
+
+        # The duplicate gate's shape: returns a terminal job id, writes no status,
+        # and reports the refusal through on_duplicate inside its transaction
+        # (ingestion._skip_as_duplicate) -- the latch the watcher reads to tell a
+        # terminal dedup from a rolled-back partial ingest.
+        async def _dupe_gate(path, **kwargs):
+            on_duplicate = kwargs.get("on_duplicate")
+            if on_duplicate is not None:
+                on_duplicate("text-hash-held-by-another-source")
+            return "dupe-job-id"
+
+        watcher.pipeline.ingest_file = AsyncMock(side_effect=_dupe_gate)
         await watcher._scan()
 
         watcher.pipeline.ingest_file.assert_awaited_once()


### PR DESCRIPTION
## Problem / Motivation

The knowledge watcher's sweep walks two source populations, and only one is paced. The folder loop checks the global `knowledge.sweep_chunk_budget` before each source and charges its ingested chunks back after every scan. The single-file `local_file` loop that follows does neither: it calls `pipeline.ingest_file` with no budget check and no accounting.

A library with many changed `local_file` sources re-ingests all of them in one sweep, in one unpaced burst. Each chunk costs one LLM extraction call, so the burst is billed work — exactly the burst the sweep budget exists to spread.

## Why it matters

The sweep runs unattended every 5 minutes. Anyone with many registered single files (or a batch of sources registered without bookkeeping, which all read as changed) pays the whole extraction bill at once, with no ceiling and nobody watching. The budget knob the user sets does not do what it says for this path.

## What changed (motivation → approach → change)

The single-file loop had no bound because it had no way to know what an ingest cost: the folder path gets its count from `scan_source`'s stats, and reading the job row back (`get_job_status`) is blocking SQLite that must not run on the event loop (#7019 / #8329).

The fix uses three callbacks `ingest_file` already offers, so its signature does not change. `on_progress` reports the attempted chunk total once extraction runs — extraction has spent one LLM call per chunk by then, so that is the number the budget meters, and a rolled-back partial ingest still charges what it spent. `on_committed` and `on_duplicate` latch the terminal outcomes: only those persist `mtime`/`content_hash`, so a rolled-back partial ingest is no longer parked behind a recorded hash (which left the changed file never re-read while the superseded document stayed searchable) — it stays retryable, bounded by the charge above.

The gate sits below the file-existence check and defers with a per-row `continue` rather than the folder loop's `break`, so the zero-cost `sync_status` upkeep (marking a vanished file `missing`) still lands even on a sweep whose folder sources spent the whole budget. Deferred rows keep no bookkeeping, so the next sweep resumes from them. `sweep_chunk_budget = 0` still means unbounded.

```mermaid
flowchart LR
  subgraph Before
    A1[sweep starts]:::ctx --> B1[folder loop<br/>budget-checked]:::ctx --> C1[single-file loop<br/>no budget, no charge]:::removed --> D1[unpaced billed burst]:::removed
  end
  subgraph After
    A2[sweep starts]:::ctx --> B2[folder loop<br/>budget-checked]:::ctx --> C2[single-file loop<br/>same counter, charges<br/>attempted chunks]:::added --> D2[over-budget rows deferred,<br/>resumed next sweep]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 1,2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 4,5 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟥 removed · 🟦 unchanged

*Both loops now draw from one budget counter; what does not fit in this sweep is picked up by the next one.*

## Tests

All in `test/test_knowledge_budget.py` (red before the fix):

- `test_sweep_stops_at_budget` — a sweep over many changed `local_file` sources stops at the budget.
- `test_attempted_chunk_count_is_charged` — the charge is the per-file chunk count reported by the pipeline, not one per file.
- `test_deferred_sources_keep_no_bookkeeping_and_resume` — deferred rows record no `mtime`/`content_hash` and the next sweep resumes them (asserted as a partition; row order is a query-plan detail).
- `test_folder_loop_consumption_defers_single_files` — both loops share one counter.
- `test_exhausted_budget_still_marks_vanished_files_missing` — zero-cost `missing` marking survives budget exhaustion.
- `test_partial_failure_charges_and_stays_resumable` — a rolled-back ingest charges its spent extraction calls and stays retryable.
- `test_zero_budget_leaves_the_sweep_unbounded` — `0` still disables the bound.

`test_knowledge_sync_status_column.py`'s duplicate-gate fake now fires `on_duplicate`, matching the real gate's contract (`_skip_as_duplicate` invokes it inside its refusal transaction).

`docs/system-specs/modules/knowledge.md` is updated in the same commit.

## Manual verification

N/A — unit coverage sufficient: the changed behavior is loop accounting and bookkeeping persistence, both pinned directly by the tests above against a real `KnowledgeStore`.

## Related Issues

Fixes #9398

## Pattern harvest

Rule candidate: review-prompt
Pattern: a budget/quota enforced on one loop over a resource but not on the sibling loop that consumes the same resource (grep every caller of the metered operation when adding a ceiling)

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
