### PR TITLE
fix(dashboard): re-decide mirror-link recipient auth after resolve

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -1647,7 +1647,12 @@ read-your-writes should add it deliberately, with its own tests.
   in `mcp_core._vet_channel_governance`; dashboard cross-surface mirror creation
   in `dashboard.chat_mirror` reuses the fail-closed
   `dashboard.chat_runner._resolve_channel_target` ladder before opaque target
-  resolution and at every outbound send boundary; the per-transport **startup** gate in
+  resolution and at every outbound send boundary (the pre-resolve call carries
+  `check_recipient=False` — its link holds the `user:<id>` configured-target
+  spelling, which a recipient predicate over conversation ids can never match —
+  and the handler re-decides recipient authorization against the resolved
+  conversation id, SEL-audited, immediately after; the `channels` governance
+  decision itself always precedes the resolve's network side effect); the per-transport **startup** gate in
   `slack.gateway._channel_transport_permitted` (a `channels` deny for a member
   keeps that transport — `slack`/`wecom`/`telegram`/`discord`/`webex` — from
   connecting at boot; resolved under `session_key=HOST_SESSION_KEY` so a

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -776,6 +776,24 @@ Four properties are load-bearing:
   and a raising implementation fails **closed**, because an allow-list check that
   errored has authorized nobody.
 
+  One caller opts out of this leg — and only this leg — with
+  `check_recipient=False`: the mirror-link creation pre-check
+  (`chat_mirror.api_chat_slot_mirror_link`), whose link carries the
+  configured-target SPELLING (`user:<id>`) rather than a conversation id, because
+  channel-scope governance must run before `resolve_configured_target`'s possible
+  network side effect. `may_send_to` judges conversation ids, so the prefixed
+  spelling can never match a roster of bare ids and every allow-listed recipient
+  was refused (#9414). The handler re-decides the recipient against the RESOLVED
+  conversation id immediately after resolution, through `_authorize_recipient` —
+  the ONE shared spelling of the recipient decision, the exact function this
+  ladder leg runs — with the same 403 contract and the principal from the target
+  spelling as `_deliver_channel_dm` does, so the decision moves later on that one
+  path; it is never skipped and the two copies cannot drift. That call passes
+  `audit_allowed=True`, so the admission is SEL-recorded on both outcomes (it
+  admits a recipient once per link); the per-send ladder legs keep denial-only,
+  because they run per delivered unit and an allowed record there would write an
+  audit row per mirrored message. Every persisted-link caller keeps the default.
+
   The check gets two inputs, because one alone cannot serve every channel. The
   **conversation id** answers it wherever that id already IS the roster identity:
   **Telegram** (a private `chat_id` IS the `user_id`; a Topic routes through the

--- a/src/kiro_crew/dashboard/chat_mirror.py
+++ b/src/kiro_crew/dashboard/chat_mirror.py
@@ -18,6 +18,7 @@ back to normal dashboard-token + CSRF auth. They must NOT be added to the strict
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import logging
 from typing import Any
@@ -32,7 +33,11 @@ from kiro_crew.dashboard.chat_backfill import (
     select_backfill_messages,
     session_deep_link,
 )
-from kiro_crew.dashboard.chat_runner import _resolve_channel_target, _resolve_mirror_target
+from kiro_crew.dashboard.chat_runner import (
+    _authorize_recipient,
+    _resolve_channel_target,
+    _resolve_mirror_target,
+)
 from kiro_crew.dashboard.chat_slack import list_slack_channels
 from kiro_crew.dashboard.chat_utils import effective_session_key
 from kiro_crew.dashboard.state import DashboardState
@@ -256,13 +261,23 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
     # conversation (for example, Discord creates a DM channel). Re-enter the
     # shared fail-closed governance ladder before that network side effect,
     # including when a profile changed after the transport connected.
+    #
+    # check_recipient=False, deliberately: this provisional link carries the
+    # configured-target SPELLING (``user:<id>``), not a conversation id, and
+    # ``may_send_to`` is a recipient predicate over conversation ids — the
+    # prefixed spelling can never match a roster of bare ids, so the recipient
+    # question is unanswerable at this point. Channel-scope governance and
+    # transport capability still run HERE, before the resolve's side effect;
+    # the recipient leg is decided below, against the resolved conversation id.
     provisional_link = ChannelLink(
         channel_type=channel_type,
         channel_id=target_id,
         thread_id=thread_id,
     )
     governed = await asyncio.to_thread(
-        _resolve_channel_target, state, session_key, provisional_link
+        functools.partial(
+            _resolve_channel_target, state, session_key, provisional_link, check_recipient=False
+        )
     )
     if governed is None:
         return web.json_response(
@@ -293,6 +308,38 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
             status=409,
         )
     conversation_id, thread_id = resolved
+
+    # Recipient authorization, decided against the RESOLVED conversation id —
+    # the leg the pre-resolve ladder call above skipped (check_recipient=False),
+    # because only now does an id of the kind ``may_send_to`` judges exist. One
+    # shared spelling: ``_authorize_recipient`` is the exact function the
+    # ladder's own recipient leg runs, so the two paths cannot drift. The
+    # principal comes from the target spelling, the posture
+    # ``handlers/messaging._deliver_channel_dm`` established for a ``user:<id>``
+    # target: the id came off the transport's own allow-list (the resolver just
+    # enforced membership), which is the authoritative answer a session-key
+    # derivation cannot reach here — a dashboard key names no channel peer. A
+    # non-``user:`` target (Webex ``room:``, Discord ``thread:``) names no single
+    # principal, and the empty string tells the transport so rather than handing
+    # a room id to a check that tests user rosters.
+    #
+    # audit_allowed=True: this decision admits a recipient once per link, sits
+    # beside the resolver's both-outcome audit, and the SEL trail must show the
+    # authorization that admitted the recipient, not only refusals.
+    target_kind, target_sep, target_value = target_id.partition(":")
+    recipient_principal = target_value if (target_sep and target_kind == "user") else ""
+    if not _authorize_recipient(
+        transport,
+        channel_type,
+        conversation_id,
+        thread_id,
+        principal=recipient_principal,
+        session_key=session_key,
+        audit_allowed=True,
+    ):
+        return web.json_response(
+            {"error": "channel is not permitted", "code": "channel_not_permitted"}, status=403
+        )
 
     link = ChannelLink(
         channel_type=channel_type,

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -2839,8 +2839,69 @@ def _audit_name_grant_refusal(
     )
 
 
+def _authorize_recipient(
+    transport: Any,
+    channel_type: str,
+    conversation_id: str,
+    thread_id: str | None,
+    *,
+    principal: str,
+    session_key: str,
+    audit_allowed: bool = False,
+) -> bool:
+    """Decide and SEL-audit RECIPIENT authorization for one proactive target.
+
+    The ONE spelling of the recipient decision, shared by the ladder's own
+    recipient leg and the mirror-link creation handler's post-resolve
+    re-decision, so the two cannot drift: hardening the check (principal
+    derivation, thread semantics, audit shape) lands on both paths at once,
+    and a caller that opts out of the ladder leg is handed the exact function
+    it is obligated to call against the resolved id.
+
+    Fails closed on a raising transport — an allow-list check that errored has
+    authorized nobody, and this feeds a network egress boundary. A denial is
+    always SEL-audited (``channel.proactive_send_authorize`` / ``denied``): a
+    revoked recipient silently losing its messages looks exactly like an idle
+    agent. ``audit_allowed=True`` records the ALLOWED outcome too — the
+    mirror-link creation contract, where the decision sits beside the
+    resolver's both-outcome audit and admits a recipient once per link. The
+    per-send ladder legs keep denial-only, deliberately: they run per delivered
+    unit (a mirror backfill re-enters the ladder for every message), so an
+    allowed record there would write an audit row per mirrored message.
+
+    The SEL write itself is guarded: an audit-log failure must not turn a
+    decided outcome into a crashed send path, and the miss is logged.
+    """
+    try:
+        permitted = bool(transport.may_send_to(conversation_id, thread_id, principal=principal))
+    except Exception:
+        logger.warning(
+            "outbound recipient authorization check failed for %s; refusing (fail-closed)",
+            channel_type,
+            exc_info=True,
+        )
+        permitted = False
+    if not permitted or audit_allowed:
+        try:
+            sel().log_api_access(
+                caller=str(conversation_id or "unknown"),
+                operation="channel.proactive_send_authorize",
+                outcome="allowed" if permitted else "denied",
+                source=channel_type,
+                resources=f"{session_key} -> {channel_type}",
+            )
+        except Exception:
+            logger.debug("SEL logging failed for outbound authz decision", exc_info=True)
+    return permitted
+
+
 def _resolve_channel_target(
-    state: Any, session_key: str, link: Any, *, principal: str | None = None
+    state: Any,
+    session_key: str,
+    link: Any,
+    *,
+    principal: str | None = None,
+    check_recipient: bool = True,
 ) -> Any:
     """Resolve ``(link, transport)`` through the cross-surface send ladder.
 
@@ -2852,6 +2913,20 @@ def _resolve_channel_target(
     Deriving from that key would yield no principal and refuse a send whose
     recipient came off the transport's own allow-list. ``None`` means derive;
     a string is used verbatim.
+
+    *check_recipient* lets the ONE caller whose link does not yet name a
+    conversation opt out of the recipient leg: the mirror-link creation
+    pre-check (``chat_mirror.api_chat_slot_mirror_link``) runs this ladder on the
+    CONFIGURED-TARGET spelling (``user:<id>``) because channel-scope governance
+    must precede ``resolve_configured_target``'s possible network side effect —
+    but ``may_send_to`` is a recipient predicate over conversation ids, so that
+    spelling can never match a roster of bare ids and the leg would refuse
+    every allow-listed recipient. ``False`` skips ONLY the recipient leg;
+    governance and transport capability still gate the resolve, and the caller
+    MUST re-decide recipient authorization against the resolved conversation id
+    via :func:`_authorize_recipient` — the same function this leg runs — or
+    revocation stops being enforced on that path.
+    Every persisted-link caller keeps the default.
 
     This is the shared capability/governance seam for both actual mirror
     delivery and the dashboard's read-only ``links[].live`` projection.  It
@@ -2927,34 +3002,22 @@ def _resolve_channel_target(
     #
     # Fail closed on a raising transport: an allow-list check that errored has not
     # authorized anybody, and this is a network egress boundary.
-    try:
-        permitted = transport.may_send_to(
-            link.channel_id,
-            link.thread_id,
-            principal=(_session_principal(session_key) if principal is None else principal),
-        )
-    except Exception:
-        logger.warning(
-            "cross-surface: outbound authorization check failed for %s; refusing send",
-            link.channel_type,
-            exc_info=True,
-        )
-        permitted = False
-    if not permitted:
-        # Audited: a revoked recipient silently losing its notices looks exactly
-        # like an idle agent, so the refusal has to be observable.
-        try:
-            sel().log_api_access(
-                caller=str(link.channel_id or "unknown"),
-                operation="channel.proactive_send_authorize",
-                outcome="denied",
-                source=link.channel_type,
-                resources=f"{session_key} -> {link.channel_type}",
-            )
-        except Exception:
-            logger.debug("SEL logging failed for outbound authz denial", exc_info=True)
+    #
+    # Skipped only under check_recipient=False (see the docstring): a link that
+    # carries a configured-target id instead of a conversation id cannot be
+    # judged here, and its caller re-decides against the resolved id.
+    if not check_recipient:
+        return link, transport
+    if not _authorize_recipient(
+        transport,
+        link.channel_type,
+        link.channel_id,
+        link.thread_id,
+        principal=(_session_principal(session_key) if principal is None else principal),
+        session_key=session_key,
+    ):
         logger.info(
-            "cross-surface: outbound to %s refused - recipient no longer allow-listed",
+            "cross-surface: outbound to %s refused - recipient not allow-listed",
             link.channel_type,
         )
         return None

--- a/test/test_channel_transport_outbound_authz.py
+++ b/test/test_channel_transport_outbound_authz.py
@@ -727,6 +727,30 @@ class TestTheLadderConsultsTheTransport:
         link = ChannelLink(channel_type="telegram", channel_id="111")
         assert self._resolve(transport, link) is None
 
+    def test_check_recipient_false_skips_only_the_recipient_leg(self) -> None:
+        """The one caller whose link carries a CONFIGURED-TARGET id, not a
+        conversation id (mirror-link creation), opts out: the recipient
+        question is unanswerable in that spelling — ``user:123`` can never match
+        a roster of bare ids — and is re-decided by that caller against the
+        resolved id. Governance and capability still gate the resolve."""
+        transport = _StubTransport(False)
+        link = ChannelLink(channel_type="telegram", channel_id="user:123")
+        from kiro_crew.dashboard.chat_runner import _resolve_channel_target
+
+        resolved = _resolve_channel_target(
+            _StubState(transport), "telegram:kirocrew:direct:123", link, check_recipient=False
+        )
+        assert resolved == (link, transport)
+        # The leg was skipped, not consulted-and-ignored.
+        assert transport.calls == []
+
+    def test_the_recipient_leg_defaults_on(self) -> None:
+        """Every persisted-link caller keeps the check without naming the flag."""
+        transport = _StubTransport(False)
+        link = ChannelLink(channel_type="telegram", channel_id="111")
+        assert self._resolve(transport, link) is None
+        assert transport.calls == [("111", None, "111")]
+
     def test_a_refusal_is_audited(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A revoked recipient losing its notices must not look like an idle agent."""
         recorded: list[dict[str, Any]] = []

--- a/test/test_chat_mirror.py
+++ b/test/test_chat_mirror.py
@@ -453,6 +453,167 @@ class TestMirrorLink:
         link = state.sessions.set_mirror_link.call_args.args[1]
         assert link.thread_id == "T"
 
+    @pytest.mark.asyncio
+    async def test_an_allow_listed_telegram_dm_links(self, tmp_path, monkeypatch):
+        """The dashboard-direction repro, on the REAL transport's authorization.
+
+        The permissive ``_fake_transport`` cannot catch this: its ``may_send_to``
+        answers True for anything, while Telegram's real one tests the id against
+        a roster of BARE user ids. A pre-check that hands it the configured
+        -target spelling (``user:123``) can never match, so it refuses a
+        recipient the user explicitly allow-listed.
+        """
+        from kiro_crew.telegram.transport import TelegramTransport
+
+        client = MagicMock()
+        client.send_message = AsyncMock(return_value=7)
+        transport = TelegramTransport(client, allowed_user_ids=[123])
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(transport)
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as http:
+            resp = await http.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 200
+            assert (await resp.json())["conversation_id"] == "123"
+        link = state.sessions.set_mirror_link.call_args.args[1]
+        assert link == ChannelLink("telegram", channel_id="123", thread_id=None)
+
+    @pytest.mark.asyncio
+    async def test_a_non_allow_listed_telegram_target_is_still_refused(self, tmp_path, monkeypatch):
+        """The companion negative, on the same real transport: the fix must not
+        have widened anything. An id absent from ``allowed_user_ids`` is refused
+        by ``resolve_configured_target`` (409), and the denial is SEL-audited."""
+        from kiro_crew.telegram.transport import TelegramTransport
+
+        recorded: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_mirror.sel",
+            lambda: type("S", (), {"log_api_access": lambda self, **kw: recorded.append(kw)})(),
+        )
+        client = MagicMock()
+        client.send_message = AsyncMock(return_value=7)
+        transport = TelegramTransport(client, allowed_user_ids=[123])
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(transport)
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as http:
+            resp = await http.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:999"},
+            )
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "configured_target_unavailable"
+        state.sessions.set_mirror_link.assert_not_called()
+        client.send_message.assert_not_awaited()
+        assert ("chat.mirror_target_resolve", "denied") in [
+            (kw["operation"], kw["outcome"]) for kw in recorded
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_recipient_refusal_after_resolution_is_403_and_audited(
+        self, tmp_path, monkeypatch
+    ):
+        """Moving the recipient leg after the resolve must not delete it.
+
+        A transport whose resolver still yields a conversation while its roster
+        refuses the recipient (a roster narrowed between the two, or a resolver
+        that does not itself consult it) must be refused with the same 403
+        contract, with nothing sent, nothing persisted, and the denial on the
+        SEL trail — an unaudited authz denial is a security-contract regression.
+        The audit is recorded by the shared ``_authorize_recipient`` helper in
+        ``chat_runner``, which is why the seam patched here is that module's.
+        """
+        recorded: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.sel",
+            lambda: type("S", (), {"log_api_access": lambda self, **kw: recorded.append(kw)})(),
+        )
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram")
+        transport.may_send_to = lambda conversation_id, thread_id=None, principal="": False
+        state.register_channel_transport(transport)
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as http:
+            resp = await http.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 403
+            assert (await resp.json())["code"] == "channel_not_permitted"
+        state.sessions.set_mirror_link.assert_not_called()
+        transport.send_message.assert_not_awaited()
+        assert ("channel.proactive_send_authorize", "denied") in [
+            (kw["operation"], kw["outcome"]) for kw in recorded
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_raising_recipient_check_fails_closed(self, tmp_path, monkeypatch):
+        """An allow-list check that errored has authorized nobody (egress boundary)."""
+
+        def _boom(conversation_id, thread_id=None, principal=""):
+            raise RuntimeError("roster unavailable")
+
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram")
+        transport.may_send_to = _boom
+        state.register_channel_transport(transport)
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as http:
+            resp = await http.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 403
+            assert (await resp.json())["code"] == "channel_not_permitted"
+        state.sessions.set_mirror_link.assert_not_called()
+        transport.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_recipient_check_receives_the_resolved_id_and_principal(
+        self, tmp_path, monkeypatch
+    ):
+        """The re-decision runs against the RESOLVED conversation id, with the
+        principal taken from the target spelling — the posture
+        ``handlers/messaging._deliver_channel_dm`` already established for a
+        ``user:<id>``-shaped target. That is what lets a transport whose
+        conversation id is opaque (Discord's DM channel id) reach its roster.
+        The decision is audited on the ALLOWED outcome too, like the resolver
+        audit beside it: both are authorization decisions at an egress boundary.
+        Recorded by the shared ``_authorize_recipient`` helper in ``chat_runner``,
+        hence the patched seam."""
+        recorded: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.sel",
+            lambda: type("S", (), {"log_api_access": lambda self, **kw: recorded.append(kw)})(),
+        )
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("discord")
+        transport.resolve_configured_target = AsyncMock(return_value=("dm-chan-9", None))
+        calls: list[tuple[str, str | None, str]] = []
+
+        def _may_send_to(conversation_id, thread_id=None, *, principal=""):
+            calls.append((conversation_id, thread_id, principal))
+            return True
+
+        transport.may_send_to = _may_send_to
+        state.register_channel_transport(transport)
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as http:
+            resp = await http.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "discord", "target_id": "user:42"},
+            )
+            assert resp.status == 200
+        assert ("dm-chan-9", None, "42") in calls
+        # And no call ever saw the unresolved configured-target spelling.
+        assert all(not cid.startswith("user:") for cid, _, _ in calls)
+        assert ("channel.proactive_send_authorize", "allowed") in [
+            (kw["operation"], kw["outcome"]) for kw in recorded
+        ]
+
 
 class TestMirrorUnlink:
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #9414

## Symptom

`POST /api/chat/slots/{slot}/mirror-link` with `{"channel_type": "telegram", "target_id": "user:<id>"}` always failed with `403 {"code": "channel_not_permitted"}`, even with the recipient present in `telegram.allowed_user_ids` and the bot connected. The inbound direction (`/session` from within the Telegram DM) worked for the same user and session, so the defect read as dashboard-direction-only.

## Root cause

The handler's pre-check ran the cross-surface ladder (`chat_runner._resolve_channel_target`) on a provisional link whose `channel_id` is the **configured-target spelling** (`user:<id>`) that `/api/chat/channel-targets` advertises. The ladder's recipient leg calls `transport.may_send_to(link.channel_id, ...)`, a recipient predicate over **conversation ids**: Telegram's ends in `conversation_id in self._allowed`, where `_allowed` is a frozenset of bare ids. `"user:<id>" in {"<id>"}` is `False` by construction, so every allow-listed recipient was refused before `resolve_configured_target` ever ran.

## Fix

Split the pre-check so each leg sees an identifier of the right kind — at the mirror-link creation path only:

- **Channel-scope governance and transport capability stay BEFORE the resolve.** Resolving an opaque configured target can itself open a remote conversation (Discord creates a DM channel), so the governance decision must precede that network side effect. This ordering is deliberate and is unchanged.
- **Only the recipient leg moved.** The pre-resolve ladder call now passes a new keyword-only `check_recipient=False` (default `True`, so all persisted-link callers are byte-identical). After `resolve_configured_target` yields the conversation id, the handler decides recipient authorization against the **resolved** id through `_authorize_recipient` — the ONE shared spelling of the recipient decision, extracted per Design/First-Principles round 2 so the ladder leg and this handler run the exact same function and cannot drift. It fails closed on a raising transport, maps a refusal to the same `403 channel_not_permitted` contract, always SEL-audits a denial, and at this one call site passes `audit_allowed=True` so the admission is recorded on both outcomes (GPT round 1, adjudication-upheld: an authorization decision at this egress boundary must be observable on the allowed path too; it admits a recipient once per link). The per-send ladder legs keep denial-only auditing, deliberately — they run per delivered unit, so an allowed record there would write an audit row per mirrored message.
- **Precedent:** `handlers/messaging._deliver_channel_dm`, the in-tree caller that already reasons about a `user:<id>`-shaped link — the principal is supplied from the target spelling rather than derived from the session key (a dashboard key names no channel peer), and a non-`user:` target (`room:`, `thread:`) passes the empty principal per the `may_send_to` contract.
- The `403 channel_not_permitted` / `409 configured_target_unavailable` response contract is untouched. `telegram/transport.py` is untouched: teaching `may_send_to` to accept `user:<id>` would make a recipient predicate accept a non-recipient identifier at an egress chokepoint, and is redundant given `resolve_configured_target`'s own allow-list check.
- Same-commit doc updates: `docs/system-specs/modules/messaging.md` (the "Revocation is re-decided at egress" bullet now names the one opt-out and why it is a move, not a skip) and `docs/system-specs/modules/governance.md` (the mirror-creation citation).

## Verification

- **Red-first:** all five new tests were written first and ran against unmodified main: the exact repro (real `TelegramTransport` with `allowed_user_ids=[123]`, `target_id="user:123"` → got today's 403, expects 200), the resolved-id+principal assertion, the post-resolve refusal audit, the fail-closed raise case, and the ladder-flag test (`TypeError` before the flag existed). 5 failed / 4 passed pre-fix; all green post-fix.
- **Negative cases in the same commit:** a target NOT on the allow-list is still refused 409 with the `chat.mirror_target_resolve` denial on the SEL trail (real transport); a post-resolve recipient refusal is 403 with `channel.proactive_send_authorize`/`denied` audited, nothing sent, nothing persisted; the existing governance-deny test still proves a pre-resolve refusal (`resolve_configured_target` not awaited).
- **Mutation checks (10/10 killed, each by its own test; restore via saved copy, not `git checkout`):**
  1. pre-resolve call flipped back to `check_recipient=True` → repro test red (403).
  2. post-resolve refusal branch disabled → refusal + raise tests red (link persisted).
  3. except arm fails open → raise-case test red.
  4. principal never derived → resolved-id+principal test red (`('dm-chan-9', None, '')`).
  5. ladder ignores the opt-out → flag-skip + repro tests red.
  6. ladder default flipped to `False` → defaults-on + existing refusal tests red (revocation gone ladder-wide).
  7. recipient audit gated back to denial-only → allowed-outcome SEL assertion red.
  8. `_authorize_recipient` fails open on a raising transport → fail-closed tests red on BOTH paths (ladder + handler).
  9. handler call drops `audit_allowed=True` → allowed-outcome assertion red (denial audit rightly stays green — it is unconditional).
  10. helper's denial audit gated on `audit_allowed` → ladder's `test_a_refusal_is_audited` red.
- Gate: `scripts/local-gate.py --base origin/main` legs run individually — full backend suite (identical bare invocation) + 222 frontend guard specs. Zero-regression: sorted FAILED/ERROR id sets diffed both directions against an `origin/main` worktree using the identical bare invocation on both trees, ANSI-stripped. Results below.
- black/flake8/mypy clean on all touched files (black 26.3.1, the CI pin).

## Zero-regression proof

Identical `pytest -q -n auto --dist loadgroup` invocation on both trees (the gate's own backend leg, no path arg), ANSI codes stripped before id extraction, sorted FAILED/ERROR id sets diffed both directions:

- branch: 422 failed + 17 errors → 441 unique ids (90,831 passed)
- `origin/main` worktree: 421 failed + 17 errors → 440 unique ids (90,825 passed)
- main-only ids: **none**. Branch-only ids: exactly one, `test_pod_seed_scenarios.py::TestBootAppliesTheScenario::test_a_scenario_populates_the_home_before_the_exec` — a known xdist ordering flake (seen on prior drives), passes standalone on this branch (`1 passed`).
- Frontend guard leg (backend-only diff plan): 224 spec files / 6,139 tests, all passed.

## Pattern harvest

Rule candidate: an authorization pre-check that runs before an id-resolution step must feed each leg an identifier of the kind that leg judges — a recipient predicate over conversation ids can never be satisfied by a configured-target spelling, and the leg that needs the resolved id must move after resolution (audited) rather than the resolver being taught to accept the unresolved spelling. Knowingly out-of-scope sibling: `_deliver_channel_dm` passes its `user:<id>` link through the ladder's recipient leg pre-resolve with only the principal supplied, which the Telegram arm ignores — tracked as #6101 (native Telegram cron/send_message target parity), deliberately not pulled into this PR's scope.

<!-- no-visual-delta -->
Backend-only change (an API handler's authorization ordering); no pixel changes anywhere, so screenshot evidence cannot show the delta — the evidence is the red-first HTTP-status assertions above.
