### PR TITLE
fix(chat): don't arm a tab-reorder drag on a non-primary mouse button

### DIFF
--- a/website/src/hooks/useLongPressReorder.ts
+++ b/website/src/hooks/useLongPressReorder.ts
@@ -95,6 +95,16 @@ export function useLongPressReorder(): { itemProps: LongPressReorderItemProps; d
   const onPointerDown = useCallback((e: React.PointerEvent) => {
     clearPending()
     if (e.pointerType !== 'touch') {
+      // A precise pointer starts the drag on press — but only the primary
+      // button. Arming a reorder on button 1 or 2 is meaningless: there is no
+      // middle- or right-drag gesture, so a non-primary press has nothing to
+      // reorder and must fall through untouched. This was also a suspect for
+      // the side-panel middle-click-to-close report — the theory being that
+      // starting the drag here swallowed the chip's auxclick — but a real-
+      // browser test ruled that out: with this guard removed, a middle-click
+      // (clean and past the pan threshold) still closed the tab. The guard is
+      // a correctness fix on its own, not a fix for that symptom.
+      if (e.button !== 0) return
       setDragging(true)
       dragControls.start(e)
       return

--- a/website/src/test/longPressReorder.test.tsx
+++ b/website/src/test/longPressReorder.test.tsx
@@ -55,6 +55,27 @@ describe('useLongPressReorder', () => {
     expect(start).toHaveBeenCalledTimes(2)
   })
 
+  // A middle- or right-button press must not arm a drag: there is no middle-
+  // or right-drag gesture, so a non-primary press has nothing to reorder. This
+  // was also a suspect for the side-panel middle-click-to-close report, but a
+  // real-browser test ruled it out (with the guard removed, a middle-click
+  // still closed the tab), so this test pins correctness, not that symptom.
+  // Only the primary button reorders.
+  it('does not arm a drag for a non-primary mouse button', () => {
+    const { chip, start } = mount()
+    fireEvent.pointerDown(chip, { pointerType: 'mouse', button: 1, clientX: 10, clientY: 10 })
+    expect(start).not.toHaveBeenCalled()
+    expect(captured!.dragging).toBe(false)
+
+    fireEvent.pointerDown(chip, { pointerType: 'mouse', button: 2, clientX: 10, clientY: 10 })
+    expect(start).not.toHaveBeenCalled()
+
+    // The primary button on the same element still reorders.
+    fireEvent.pointerDown(chip, { pointerType: 'mouse', button: 0, clientX: 10, clientY: 10 })
+    expect(start).toHaveBeenCalledTimes(1)
+    expect(captured!.dragging).toBe(true)
+  })
+
   it('arms a touch drag only after a stationary hold', () => {
     vi.useFakeTimers()
     const { chip, start } = mount()


### PR DESCRIPTION
## Problem / Motivation

`useLongPressReorder` - the hook that makes side-panel and bottom-terminal tab chips drag-to-reorder - armed a reorder drag on **any** mouse button press. Its `onPointerDown` mouse/pen branch called `dragControls.start(e)` without checking `e.button`, so a middle-click or right-click on a tab began a drag gesture that no code ever wants (there is no middle- or right-button reorder).

## Why it matters

A drag armed by the wrong button is a latent correctness bug: the primary button is the only one that should start a reorder, and letting button 1 or 2 begin the gesture is behaviour no consumer of the hook relies on. Both consumers are close-on-middle-click tab strips, so a middle-press should fall straight through to the chip's close binding, not open a reorder the user never asked for.

## What changed

One-line guard in the shared hook: the mouse/pen branch returns early unless `e.button === 0`. Middle and right presses no longer arm a drag; they fall through untouched so the chip's own `onAuxClick` can act. The fix is in the one shared hook, not copied into each strip - it covers both call sites at once:

- `website/src/pages/chat/SidePanel.tsx:1239` - the opened file/document tabs.
- `website/src/components/BottomTerminalPanel.tsx:79` - the terminal tabs.

The pinned Changes/Files/Artifacts strip renders a bare `TabChip` and does not use the hook, so it is unaffected. Neither consumer starts a long-press on a non-primary button, so the filter is safe for both.

**This is NOT demonstrated to fix the reported symptom in #9406.** The issue reports that middle-click closes a side-panel file tab when a pinned view is active but not when a document tab is active, and a natural theory is that the reorder hook (the only structural difference between the two strips) eats the middle-click before the chip's `onAuxClick` runs. I tested that theory in a real Chromium against the **unfixed** hook - the same `Reorder.Item` + `useLongPressReorder` + `onAuxClick` path - with a genuine middle-click, both a clean press and one that moves 10px between down and up (past framer's 3px pan threshold, so a drag actually starts). The tab closed in both cases. So arming the drag does not suppress middle-click-to-close in Chromium, and this PR is a related correctness fix, not a proven fix for #9406's symptom. `Refs`, not `Closes`, deliberately - see the falsification comment on the issue for the two remaining possibilities (Electron delivering middle-clicks differently, or the symptom being gone from current main).

## Tests

- Added `does not arm a drag for a non-primary mouse button` to `website/src/test/longPressReorder.test.tsx`: a button-1 and button-2 press do not call `dragControls.start`, while button 0 on the same element still does. Fails on the unfixed hook (`start` called once for button 1), passes after the guard.
- The existing 9 hook tests still pass (mouse/pen start on press, touch long-press arm, slop cancellation, pan blocking, unmount cleanup, the every-Reorder.Item-uses-the-hook guard).
- Real-browser proof (not committed): an esbuild bundle of the actual hook path driven by Playwright, run against both the unfixed and fixed hook, clean and jittery middle-clicks - the basis for the under-claim above.

## Pattern harvest

**Structural fit is not causation.** `useLongPressReorder` was the only structural difference between the two tab strips, it accepted every pointer button, and the theory that it ate the middle-click fit the reported view-dependence exactly. It was still wrong: exercising the unfixed path in a real browser - clean, and with 10px of movement past framer's 3px pan threshold so a drag genuinely starts - closed the tab both times.

Transferable review prompt: **when exactly one structural difference explains a state-dependent symptom, that is a reason to test it, not a reason to believe it.** The one candidate that explains a symptom perfectly is the easiest to accept without checking. The cheap check is usually to exercise the unfixed path directly and observe the outcome, rather than to reason about what the difference ought to do - a synthetic bundle of the real code plus a scripted event settled here in minutes what static reading could not.

Rule candidate: when exactly one structural difference explains a state-dependent symptom, test that difference by exercising the unfixed path directly before accepting it as the cause; a perfect structural fit is a reason to test, not to believe.

## Other notes

The instrument that would settle #9406 is the reporter: which build they saw it on, and whether it still reproduces on current main. A pod running the real dashboard is the only synthetic instrument that separates Electron's `WebContentsView` from Chromium-over-`file://`, but that is disproportionate when the reporter can answer the same question directly.

Refs #9406

