### PR TITLE
fix(ci): give Backend Lint 25 min so mypy is not cancelled mid-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,11 @@ jobs:
     # not classify as frontend -- docs, a new root file, meta -- still runs it.
     if: needs.changes.outputs.only_frontend != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The job's floor on today's hosted runners is ~14-15 min (black --check
+    # over the whole tree alone takes 7-8 min, flake8 ~2 min, mypy cold ~3 min),
+    # so 15 cancelled mypy mid-run on green PRs. 25 is the budget frontend-test
+    # and bundle-size already run on, and leaves headroom for runner variance.
+    timeout-minutes: 25
     strategy:
       matrix:
         python-version: ["3.12"]


### PR DESCRIPTION
## Summary

One-line CI unblocker: `backend-lint` (`Backend Lint & Type Check`) gets `timeout-minutes: 25` (was 15).

The job's floor on today's hosted runners is ~14–15 min — `check_black_formatting.py` runs `black --check` over the whole tree (7–8 min), the five gate scripts + isort take ~3 min, flake8 ~2 min, and mypy then starts cold with under two minutes of budget left — so a **green** PR gets its mypy step cancelled by the job timeout.

Observed today (all `ubuntu-latest`):

| run | outcome | lint job wall time |
|---|---|---|
| `34211086807` (fix/cron-command-shell-brace-off) | passed | 14m38s |
| `34209554482` attempt 1 (PR #8947, frontend + docs, no Python) | **cancelled**, mypy running | 15m18s |
| `34209554482` attempt 2 | **cancelled**, mypy running | 15m06s |
| `34209554482` attempt 3 | passed | 14m15s |

25 is the budget `frontend-test` and `bundle-size` already run on in this file. Nothing else changes; the job's steps and gates are untouched.

## Why not make the steps faster instead

Black over the whole tree is the deliberate design of the shrinking-baseline gate (`scripts/check_black_formatting.py` — it must see every file to detect a baselined file that has *become* clean). Speeding that up is a real change to the gate; this PR only stops the budget from cancelling a job whose steps all pass.

## Tests

Workflow-only change; `python3 -c "import yaml; yaml.safe_load(...)"` parses. Verification is this PR's own `Backend Lint & Type Check` job finishing.

## Pattern harvest

Rule candidate: a job whose observed floor is within ~10% of its `timeout-minutes` is a flake generator — when a CI job's passing wall time approaches its budget (here 14m38s / 14m15s against 15), raise the budget or split the job *before* a green PR is cancelled, rather than rerunning. Checkable from the Actions API (job `completedAt - startedAt` vs the workflow's `timeout-minutes`).

no linked issue: CI unblocker for an inherited red seen on PR #8947 (and any backend PR on a slow runner).
