### PR TITLE
test(pipeline-conductor): reword comment-history line to unblock certified PRs

### DIFF
--- a/test/test_pipeline_conductor_agent.py
+++ b/test/test_pipeline_conductor_agent.py
@@ -425,7 +425,7 @@ class TestFleetProbe:
 
         A real host resolves ``/proc/<pid>/exe`` to the binary the process is
         actually running, which for every honest process is what ``argv[0]`` names.
-        The wrapper exemption requires that kernel answer and no longer accepts
+        The wrapper exemption requires that kernel answer and rejects
         ``argv[0]`` alone, so a fake /proc that omits ``exe`` now models a process
         hiding its identity rather than an ordinary one -- which would make the
         option-parsing tests assert the spoof path instead of the case they are


### PR DESCRIPTION
## Problem / Motivation

The Backend Lint & Type Check gate runs `scripts/check_comment_history.py`, which forbids comments and docstrings that narrate a past change. `test/test_pipeline_conductor_agent.py` grew from 4 matched lines to 5 when commit aa75a403c landed a docstring that said the wrapper exemption "no longer accepts" `argv[0]` alone. Any PR whose merge ref includes that file now reds on drift it did not introduce. PR 9346 is one such PR: 55 of its own checks pass and it has zero failures of its own, yet it cannot merge because this shared file sits one over its baseline.

## Why it matters

A certified, green delivery is blocked by narration in a test file it does not touch. The same block hits every other diff that includes this file. Rewording the one line that grew restores the file to its baseline of 4 and unblocks all of them.

## What changed (motivation -> approach -> change)

One docstring line in `test/test_pipeline_conductor_agent.py`, in `TestFleetProbe._exe_agrees_with_argv0`, is rewritten from past-change narration to present behaviour. The explanation is preserved whole; only the tense moves, the same shape as the sibling fix that landed in PR 9393 for `scripts/fleet_probe.py` (`is no longer recoverable` -> `cannot be recovered`).

The line went from:

    The wrapper exemption requires that kernel answer and no longer accepts

to:

    The wrapper exemption requires that kernel answer and rejects

The checker counts this file's matched spans at 5 before and 4 after, back to the committed baseline, so no baseline edit is needed.

This is a pragmatic unblock of a certified delivery, not a claim that the gate is right here. The underlying complaint is filed as #9387: the `no longer` pattern cannot tell descriptive prose from narration about a past change. This file has two `no longer` lines with the same surface form; both read as descriptive, and rewording one while the other survives is arbitrary. This change lowers the count the gate measures so a green PR can merge; it does not resolve #9387.

Merging this does not unblock PR 9346 on its own: 9346 clears only after this PR is on main AND 9346 rebases onto it, because the gate evaluates each PR's merge ref.

## Tests

- `scripts/check_comment_history.py` (the gate's own checker): this file's matched-span count drops from 5 to 4, gate passes, exit 0.
- `python3 -m pytest -n0 test/test_pipeline_conductor_agent.py -x -q`: 133 passed. No test asserts on the docstring text that changed.

## Manual verification

Read the line in full context first: it is a docstring inside `_exe_agrees_with_argv0` describing what the wrapper exemption requires. The reword keeps that meaning and states present behaviour instead of a statement about a change.

## Pattern harvest

Rule candidate: when a comment-history ratchet reds a certified PR on a shared file the diff does not touch, reword the one matched line that grew back to its baseline count rather than editing others or raising the baseline; verify the drop with the repository's own checker, not a hand-rolled grep, because the checker scans comments and docstrings only and disagrees with a whole-line grep. Keep numeric issue and PR references in the PR body and commit message, never in the edited prose, because the gate counts a parenthesised reference as narration.

## Related Issues

Refs #9387
