### PR TITLE
fix: drop already-required spellings from search ranking-hint alts (#9443)

### DIFF
--- a/comment-history-baseline.json
+++ b/comment-history-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Comments and docstrings that narrate change history, per file, as a match COUNT. The rule they break is in docs/system-specs/common/code-style.md (\"Comments explain the WHY\"); it predates any enforcement, so the tree is recorded here rather than rewritten in one pass. The gate requires every OTHER file to be clean and none of these counts to grow, so this list can only shrink. Do NOT add or raise an entry to make a red gate green: a new offender means the comment should state CURRENT behavior in present tense. Lower and prune with `python3 scripts/check_comment_history.py --write-baseline`, which never adds or raises one.",
-  "_total": 7605,
+  "_total": 7600,
   "files": {
     "src/kiro_crew/__main__.py": 1,
     "src/kiro_crew/acp/_dispatch.py": 8,
@@ -412,7 +412,7 @@
     "src/kiro_crew/history_cache.py": 3,
     "src/kiro_crew/history_consolidation.py": 2,
     "src/kiro_crew/history_projection.py": 1,
-    "src/kiro_crew/history_search.py": 25,
+    "src/kiro_crew/history_search.py": 24,
     "src/kiro_crew/hooks.py": 24,
     "src/kiro_crew/identity_stores.py": 3,
     "src/kiro_crew/imessage/client.py": 2,

--- a/src/kiro_crew/history_search.py
+++ b/src/kiro_crew/history_search.py
@@ -770,10 +770,29 @@ def parse_search_query(query: str) -> tuple[list[SearchNeedle], str, bool]:
                 bigram = run[i : i + 2]
                 extras.setdefault(bigram, SearchNeedle(bigram, 1.0, False, adjacency=True))
     # A spelling that is already REQUIRED must not also score as a ranking hint:
-    # a query naming the same item twice ("#4411 4411") would count its hits
-    # twice over.
+    # a query naming the same item twice — the bare number and then its GitHub
+    # sigil form — would count its hits twice over. The by-key sweep catches the
+    # SAME-FAMILY repeat, where the hint's own key is the required spelling.
     for text in [t for t in ranking if t in required]:
         del ranking[text]
+    # A CROSS-FAMILY repeat ("4411 !4411") slips past that sweep: the sigil
+    # gates the GitLab spelling while the bare number's hint stays keyed on the
+    # GitHub form, so the required spelling survives inside the hint's ALTS and
+    # one mention would be scored by the required needle AND the hint. Required
+    # needles carry alts of their own (count_needle scores every spelling), so
+    # the purge covers those too, not only the keys. A hint whose every
+    # spelling is already required contributes nothing and is dropped whole —
+    # built-in spellings alone cannot get there (the hint's canonical form is
+    # only ever a required KEY, which the by-key sweep already handled), but a
+    # provider's alts can blanket the rest. A hint that keeps any spelling
+    # still ranks on what survives.
+    required_spellings = {s for n in required.values() for s in (n.text, *n.alts)}
+    for key, needle in list(ranking.items()):
+        spellings = tuple(s for s in (needle.text, *needle.alts) if s not in required_spellings)
+        if not spellings:
+            del ranking[key]
+        elif spellings != (needle.text, *needle.alts):
+            ranking[key] = needle._replace(text=spellings[0], alts=spellings[1:])
     needles = list(required.values())[:SEARCH_MAX_TOKENS]
     needles.extend(list(extras.values())[:_SEARCH_MAX_SCORING_EXTRAS])
     needles.extend(ranking.values())

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -1472,6 +1472,70 @@ class TestForgeReferenceSearch:
         assert sorted(n.text for n in needles if n.required) == ["#4411", "4411"]
         assert [n for n in needles if not n.required] == []
 
+    @pytest.mark.parametrize("query", ["4411 !4411", "!4411 4411"])
+    def test_a_cross_family_repeat_does_not_score_a_required_spelling(self, query):
+        """"4411 !4411" gates the GitLab family; the hint must not re-score it.
+
+        The bare number's ranking hint is keyed on the GitHub spelling, so the
+        by-key sweep leaves it alone — but its alts carry BOTH families, and the
+        GitLab ones are exactly what the sigil made required. Every required
+        spelling (keys and the alts required needles carry) must be purged from
+        the hint, in either token order; the hint still ranks on the GitHub
+        spellings that survive.
+        """
+        needles, _, _ = history.parse_search_query(query)
+
+        required_spellings = {
+            s for n in needles if n.required for s in (n.text, *n.alts)
+        }
+        hints = [n for n in needles if not n.required]
+        assert hints, "the hint must survive on its remaining family"
+        for hint in hints:
+            assert not ({hint.text, *hint.alts} & required_spellings)
+        # The surviving hint still carries the OTHER family's spellings, at the
+        # forge weight, digit-bounded, and NOT as adjacency evidence — the
+        # rebuild must preserve the flags, not only the spellings.
+        assert any("#4411" in (n.text, *n.alts) for n in hints)
+        for hint in hints:
+            assert hint.weight == history_search._FORGE_REF_WEIGHT
+            assert hint.digit_bounded and not hint.adjacency
+
+    def test_a_provider_that_gates_every_hint_spelling_drops_the_hint(self, monkeypatch):
+        """A hint left with NO spelling of its own contributes nothing and goes.
+
+        Built-in spellings alone cannot empty a hint — its canonical form is
+        only ever a required KEY, which the by-key sweep already removes — but
+        a registered provider's alts can blanket the remainder. The purge must
+        drop the whole entry rather than emit a needle with zero effective
+        spellings.
+        """
+        gh = history_search._forge_spellings(history_search._ForgeRef("4411", False, None))
+        mr = history_search._forge_spellings(history_search._ForgeRef("4411", True, None))
+        spellings = {
+            "acme-a4411": (gh[0], *gh[1]),
+            "acme-b4411": (mr[0], *mr[1]),
+        }
+        monkeypatch.setattr(
+            history_search,
+            "_search_ref_resolver",
+            lambda token: (token, spellings[token]) if token in spellings else None,
+        )
+
+        needles, _, _ = history.parse_search_query("acme-a4411 acme-b4411 4411")
+
+        assert [n for n in needles if not n.required] == []
+        # The bare number still gates as a plain literal term.
+        assert any(n.required and n.text == "4411" for n in needles)
+
+    def test_a_single_form_query_keeps_its_ranking_hint(self):
+        """The purge must not touch a hint whose item was named only once."""
+        needles, _, _ = history.parse_search_query("4411")
+
+        hints = [n for n in needles if not n.required]
+        assert len(hints) == 1
+        assert "#4411" in (hints[0].text, *hints[0].alts)
+        assert "!4411" in (hints[0].text, *hints[0].alts)
+
     def test_a_glued_mr_token_is_the_gitlab_family(self):
         """The glued form carries no sigil, so its WORD names the family."""
         assert self._needle("mr-12").text == "!12"


### PR DESCRIPTION
## Problem / Motivation

A query naming the same forge item once as a bare number and once with a sigil ("4411 !4411", either order) counts one transcript mention twice at forge weight. `parse_search_query` de-duplicates required-vs-scoring needles BY KEY only: the bare number's ranking hint is keyed on the GitHub spelling (`#4411`), the sigil gates the GitLab family (`!4411`), so the key sweep leaves the hint in place while its alts still carry the required GitLab spellings.

## Why it matters

Session search ranking is shared by the dashboard history filter, the `search_chat_history` MCP tool, and Discord session resume. A double-counted mention inflates one session's relevance score, pushing sessions the user actually wants below a session that merely repeats the reference.

## What changed (motivation -> approach -> change)

Symptom: one hit scored twice for queries like "4411 !4411". Root cause: the de-dup sweep compares ranking-hint KEYS against required KEYS, but required needles carry alt spellings of their own and the hint's alts span BOTH forge families, so a cross-family repeat overlaps in the alts where the sweep never looks. Change: after the by-key sweep, build the set of every required spelling (needle text + alts) and filter each surviving hint's spellings against it; a hint left with no spelling is dropped whole, one that keeps any is rebuilt with `_replace`, preserving weight / digit-bounded / adjacency flags, and still ranks on the surviving family. The by-key sweep stays; together they guarantee no spelling is both required and scoring regardless of family.

## Tests

- `test_a_cross_family_repeat_does_not_score_a_required_spelling` (parametrized over both token orders): no spelling is both required and scoring; the hint survives on the other family with its weight and flags intact.
- `test_a_provider_that_gates_every_hint_spelling_drops_the_hint`: when a registered source provider's required spellings blanket every hint spelling, the emptied hint is dropped rather than emitted with zero effective spellings.
- `test_a_single_form_query_keeps_its_ranking_hint`: a query naming the item once keeps its full both-families hint - the purge only removes what is required.
- Full `test/test_history.py`: 334 passed.

## Manual verification

N/A - unit coverage sufficient: the defect and fix are fully observable through `parse_search_query`'s returned needle set, which the new tests assert directly.

## Related Issues

Fixes #9443

## Pattern harvest

Rule candidate: review-prompt
Pattern: de-dup that compares container KEYS misses overlap carried in the entries' alt/alias lists

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) - N/A, the spec's "up to" spelling caps and accepted limitations are unchanged
- [x] No secrets, credentials, or internal references in the diff
