### PR TITLE
fix(dashboard): pin regenerate and switch-variant truncating saves to their transcript

### DIFF
--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -2582,6 +2582,7 @@ def _save_slot_to_history(
     rewrite: bool = False,
     expected_history_key: str | None = None,
     expected_disk_older_count: int | None = None,
+    expected_slot_name: str | None = None,
     rows_only: bool = False,
 ) -> bool:
     """Persist slot messages to JSONL history (append-safe).
@@ -3097,6 +3098,29 @@ def _save_slot_to_history(
                     "permanently deleted while this save awaited the lock",
                     history_key,
                     slot.key,
+                )
+                return False
+            # ── Recreate-won guard ──────────────────────────────────────────
+            # Re-read the live occupant of the slot's map key INSIDE the lock,
+            # after the patient off-loop acquire. A truncating caller checks
+            # object identity before dispatching this write, but the executor
+            # wait between that check and here frees the event loop, and a
+            # same-name close-and-recreate is not serialized against the slot's
+            # own lock (the cleanup pops ``state._slots[name]`` and
+            # ``get_or_create_slot`` re-inserts, neither taking it). A recreate
+            # that resumes the SAME transcript keeps ``history_key`` identical,
+            # so the routing guard above waves it through. Confirming the map
+            # still holds THIS slot object, at the commit boundary with no await
+            # before the write, is what catches it: if the map now holds a
+            # replacement the original slot is being torn down and its
+            # truncation has no future, so refuse the whole save (``False``,
+            # nothing written) rather than land the stale snapshot on the
+            # replacement's transcript.
+            if expected_slot_name is not None and state._slots.get(expected_slot_name) is not slot:
+                logger.warning(
+                    "Slot %s save refused: slot %s was replaced before the write committed",
+                    history_key,
+                    expected_slot_name,
                 )
                 return False
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -3691,6 +3715,7 @@ async def save_slot_off_loop(
     rewrite: bool = False,
     best_effort: bool = True,
     expected_history_key: str | None = None,
+    expected_slot_name: str | None = None,
     rows_only: bool = False,
 ) -> bool:
     """Persist a slot from the event loop without blocking or dropping the save.
@@ -3726,6 +3751,14 @@ async def save_slot_off_loop(
     the worker's routing snapshot, and without this pin the durable write
     would target a transcript the caller never authorized.
 
+    ``expected_slot_name``: the ``state._slots`` map key the caller checked its
+    slot object against before dispatching. The save refuses (returns ``False``,
+    nothing written) when the map holds a different slot object at the locked
+    commit boundary -- a same-name close-and-recreate that resumes the
+    same transcript keeps ``expected_history_key`` identical and slips past the
+    routing pin, so this object-identity recheck under the lock stops the
+    truncating snapshot from landing on the replacement's transcript.
+
     ``rows_only``: write the window but leave the metadata line's slot-owned
     fields as they stand on disk when the line was published by ANOTHER slot --
     for a caller persisting a slot's rows onto a transcript another live slot now
@@ -3752,6 +3785,7 @@ async def save_slot_off_loop(
             force=force,
             rewrite=rewrite,
             expected_history_key=expected_history_key,
+            expected_slot_name=expected_slot_name,
             rows_only=rows_only,
         )
 

--- a/src/kiro_crew/dashboard/chat_regenerate.py
+++ b/src/kiro_crew/dashboard/chat_regenerate.py
@@ -8,7 +8,7 @@ import logging
 
 from aiohttp import web
 
-from kiro_crew.dashboard.chat_persistence import _save_slot_to_history, save_slot_off_loop
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_runner import _run_chat, _start_next_queued_turn
 from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
@@ -111,9 +111,30 @@ async def api_chat_slot_regenerate(request: web.Request) -> web.Response:
         slot._pending_rewrite = True
         slot._pending_variants = variants
 
+        # The transcript this truncation was authorized against. Captured
+        # BEFORE the write's await: that await frees the event loop while the
+        # worker thread runs, and a same-name close-and-recreate is NOT
+        # serialized against this slot._lock (the cleanup pops state._slots[name]
+        # and get_or_create_slot re-inserts, neither taking the original lock).
+        # Without the pin the truncating rewrite would resolve its file from the
+        # object it was handed -- the original slot -- and land on the
+        # replacement's transcript. save_slot_off_loop refuses (returns False,
+        # nothing written) when the routing no longer resolves to this key,
+        # exactly the guard edit-resend below already carries. On refusal the
+        # original slot is being torn down and its regeneration has no future,
+        # so nothing that would otherwise persist is lost; the refusal is
+        # recorded in the save's own "routing moved" log line. best_effort keeps
+        # the site fire-and-forget: a genuine transient failure re-arms _dirty
+        # (and _pending_rewrite is already set) so the periodic flush retries.
+        expected_history_key = slot_history_key(slot)
         try:
             msgs_snapshot = list(slot.messages)
-            await asyncio.to_thread(_save_slot_to_history, state, slot, msgs_snapshot)
+            await save_slot_off_loop(
+                state,
+                slot,
+                msgs_snapshot,
+                expected_history_key=expected_history_key,
+            )
         except Exception:
             logger.warning("Regenerate: failed to rewrite session history", exc_info=True)
 
@@ -210,9 +231,24 @@ async def api_chat_slot_switch_variant(request: web.Request) -> web.Response:
         target_dict["variant_idx"] = idx
         slot._dirty = True
         slot._resumed_count = 0
+        # Same slot-identity pin as regenerate above and edit-resend below: a
+        # same-name close-and-recreate can swap state._slots[name] while this
+        # save is parked in its worker thread (the recreate does not take this
+        # slot._lock), and _save_slot_to_history resolves its target file from
+        # the object it was handed. Pin the transcript this switch was
+        # authorized against so the write refuses (False, nothing written)
+        # rather than rewriting the replacement's transcript. Captured before
+        # the await. best_effort re-arms _dirty on a transient failure so the
+        # periodic flush retries the write.
+        expected_history_key = slot_history_key(slot)
         try:
             msgs_snapshot = list(slot.messages)
-            await asyncio.to_thread(_save_slot_to_history, state, slot, msgs_snapshot)
+            await save_slot_off_loop(
+                state,
+                slot,
+                msgs_snapshot,
+                expected_history_key=expected_history_key,
+            )
         except Exception:
             logger.warning("switch-variant: failed to persist", exc_info=True)
         sel().log_api_access(

--- a/src/kiro_crew/dashboard/chat_regenerate.py
+++ b/src/kiro_crew/dashboard/chat_regenerate.py
@@ -111,32 +111,67 @@ async def api_chat_slot_regenerate(request: web.Request) -> web.Response:
         slot._pending_rewrite = True
         slot._pending_variants = variants
 
-        # The transcript this truncation was authorized against. Captured
-        # BEFORE the write's await: that await frees the event loop while the
-        # worker thread runs, and a same-name close-and-recreate is NOT
-        # serialized against this slot._lock (the cleanup pops state._slots[name]
-        # and get_or_create_slot re-inserts, neither taking the original lock).
-        # Without the pin the truncating rewrite would resolve its file from the
-        # object it was handed -- the original slot -- and land on the
-        # replacement's transcript. save_slot_off_loop refuses (returns False,
-        # nothing written) when the routing no longer resolves to this key,
-        # exactly the guard edit-resend below already carries. On refusal the
-        # original slot is being torn down and its regeneration has no future,
-        # so nothing that would otherwise persist is lost; the refusal is
-        # recorded in the save's own "routing moved" log line. best_effort keeps
-        # the site fire-and-forget: a genuine transient failure re-arms _dirty
-        # (and _pending_rewrite is already set) so the periodic flush retries.
+        # Pin the transcript and the slot object this truncation was authorized
+        # against. Both are read BEFORE the write's await: that await frees the
+        # event loop while the worker thread runs, and a same-name
+        # close-and-recreate is NOT serialized against this slot._lock (the
+        # cleanup pops state._slots[name] and get_or_create_slot re-inserts,
+        # neither taking the original lock).
+        #
+        # Two axes can move, and they need two checks, matching the pair
+        # edit-resend below carries:
+        #   * routing -- save_slot_off_loop refuses the write (returns False,
+        #     nothing written) when the slot's routing resolves to a different
+        #     key at write time. This catches a RENAMED replacement.
+        #   * object identity -- a same-name recreate that resumes the same
+        #     transcript keeps the history key identical, so the routing check
+        #     passes and the stale rewrite would land on the replacement anyway.
+        #     expected_slot_name carries this slot's map key into the save, where
+        #     state._slots[name] is re-read at the locked commit boundary with no
+        #     await before the write: if the map holds a different slot the
+        #     save refuses (returns False). A pre-dispatch check cannot cover it
+        #     because the recreate can land inside the executor wait, after the
+        #     check and before the write.
+        #
+        # On either refusal the original slot is being torn down and its
+        # regeneration has no future, so nothing that would otherwise persist is
+        # lost; both refusals are recorded in the save's own log lines.
+        # best_effort keeps the site fire-and-forget: a genuine transient
+        # failure re-arms _dirty (and _pending_rewrite is already set) so the
+        # periodic flush retries.
         expected_history_key = slot_history_key(slot)
         try:
             msgs_snapshot = list(slot.messages)
-            await save_slot_off_loop(
+            committed = await save_slot_off_loop(
                 state,
                 slot,
                 msgs_snapshot,
                 expected_history_key=expected_history_key,
+                expected_slot_name=name,
             )
         except Exception:
             logger.warning("Regenerate: failed to rewrite session history", exc_info=True)
+            committed = True
+        if not committed:
+            # The save's own guards refused the write: the slot was rebound to
+            # another transcript, or a same-name recreate replaced it, while the
+            # write awaited its lock. The truncation exists only in this popped
+            # slot's in-memory window. Dispatching _run_chat now would run a turn
+            # on a removed slot and persist its truncated branch over the
+            # replacement's transcript, so abort without dispatching.
+            logger.warning(
+                "Regenerate: history save refused for %s (concurrent delete or recreate); "
+                "not dispatching the turn",
+                slot.key,
+            )
+            state.push_slots_update()
+            return web.json_response(
+                {
+                    "error": "the conversation changed while saving; retry",
+                    "code": "regenerate_save_refused",
+                },
+                status=409,
+            )
 
         sel().log_api_access(
             caller="dashboard",
@@ -231,26 +266,46 @@ async def api_chat_slot_switch_variant(request: web.Request) -> web.Response:
         target_dict["variant_idx"] = idx
         slot._dirty = True
         slot._resumed_count = 0
-        # Same slot-identity pin as regenerate above and edit-resend below: a
-        # same-name close-and-recreate can swap state._slots[name] while this
-        # save is parked in its worker thread (the recreate does not take this
-        # slot._lock), and _save_slot_to_history resolves its target file from
-        # the object it was handed. Pin the transcript this switch was
-        # authorized against so the write refuses (False, nothing written)
-        # rather than rewriting the replacement's transcript. Captured before
-        # the await. best_effort re-arms _dirty on a transient failure so the
-        # periodic flush retries the write.
+        # Same two-axis pin as regenerate above, matching the pair edit-resend
+        # carries: routing (save_slot_off_loop refuses when the slot resolves to
+        # a different transcript at write time -- a renamed replacement) and
+        # object identity (expected_slot_name carries this slot's map key into
+        # the save, where state._slots[name] is re-read at the locked commit
+        # boundary with no await before the write -- a same-name recreate that
+        # resumes the same transcript keeps the key identical, so only the
+        # identity check catches it, and it must run at the write not before it
+        # because the recreate can land inside the executor wait). best_effort
+        # re-arms _dirty on a transient failure so the periodic flush retries.
         expected_history_key = slot_history_key(slot)
         try:
             msgs_snapshot = list(slot.messages)
-            await save_slot_off_loop(
+            committed = await save_slot_off_loop(
                 state,
                 slot,
                 msgs_snapshot,
                 expected_history_key=expected_history_key,
+                expected_slot_name=name,
             )
         except Exception:
             logger.warning("switch-variant: failed to persist", exc_info=True)
+            committed = True
+        if not committed:
+            # The save's guards refused: the slot was rebound or a same-name
+            # recreate replaced it while the write awaited its lock. The chosen
+            # variant exists only in this popped slot's in-memory window;
+            # broadcasting the switch would announce a state no transcript holds,
+            # so abort without broadcasting.
+            logger.warning(
+                "switch-variant: history save refused for %s (concurrent delete or recreate)",
+                slot.key,
+            )
+            return web.json_response(
+                {
+                    "error": "the conversation changed while saving; retry",
+                    "code": "switch_variant_save_refused",
+                },
+                status=409,
+            )
         sel().log_api_access(
             caller="dashboard",
             operation="chat.switch_variant",

--- a/test/test_chat_regenerate_cov80.py
+++ b/test/test_chat_regenerate_cov80.py
@@ -139,8 +139,8 @@ async def test_regenerate_survives_a_history_write_failure(state, caplog) -> Non
 
     with (
         patch(
-            "kiro_crew.dashboard.chat_regenerate._save_slot_to_history",
-            side_effect=OSError("disk full"),
+            "kiro_crew.dashboard.chat_regenerate.save_slot_off_loop",
+            new=AsyncMock(side_effect=OSError("disk full")),
         ),
         patch("kiro_crew.dashboard.chat_regenerate._run_chat", new=AsyncMock()),
     ):
@@ -301,8 +301,8 @@ async def test_switch_variant_survives_a_persist_failure(state, caplog) -> None:
     slot.messages[-1]["variants"] = [{"content": "v1", "ts": "t1"}, {"content": "v2"}]
 
     with patch(
-        "kiro_crew.dashboard.chat_regenerate._save_slot_to_history",
-        side_effect=OSError("disk full"),
+        "kiro_crew.dashboard.chat_regenerate.save_slot_off_loop",
+        new=AsyncMock(side_effect=OSError("disk full")),
     ):
         with caplog.at_level("WARNING"):
             async with _client(state) as client:
@@ -311,6 +311,61 @@ async def test_switch_variant_survives_a_persist_failure(state, caplog) -> None:
     assert resp.status == 200
     assert "switch-variant: failed to persist" in caplog.text
     assert slot.messages[-1]["content"] == "v1"
+
+
+# ── recreate-race slot-identity guard ──
+#
+# Both truncating saves run under slot._lock but dispatch the write to a worker
+# thread; the event loop is free across that one await, and a same-name
+# close-and-recreate is NOT serialized against this lock (the cleanup pops
+# state._slots[name] and get_or_create_slot re-inserts, neither taking the
+# original lock). Without a pin the rewrite resolves its target file from the
+# slot object it was handed and lands the truncation on the replacement's
+# transcript. The fix passes expected_history_key = slot_history_key(slot),
+# captured BEFORE the await, so _save_slot_to_history refuses (returns False,
+# nothing written) when the routing has moved -- the same guard edit-resend
+# already carries. These tests assert the pin reaches the write and names the
+# transcript the slot was authorized against; the disk-side refusal itself is
+# covered by _save_slot_to_history's own expected_history_key tests.
+
+
+@pytest.mark.asyncio
+async def test_regenerate_pins_the_truncating_write_to_its_transcript(state) -> None:
+    slot = state.get_or_create_slot("s1", linked_session_key="orig:key")
+    slot.append("user", "hi")
+    slot.append("assistant", "keep-me")
+    slot.drain()
+
+    saved = AsyncMock(return_value=True)
+    with (
+        patch("kiro_crew.dashboard.chat_regenerate.save_slot_off_loop", new=saved),
+        patch("kiro_crew.dashboard.chat_regenerate._run_chat", new=AsyncMock()),
+    ):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/slots/s1/regenerate")
+            assert resp.status == 200
+            await asyncio.sleep(0)
+
+    # The write carried the slot's own transcript as its authorization pin.
+    assert saved.await_count == 1
+    assert saved.await_args.kwargs["expected_history_key"] == "orig:key"
+
+
+@pytest.mark.asyncio
+async def test_switch_variant_pins_the_persist_to_its_transcript(state) -> None:
+    slot = state.get_or_create_slot("s1", linked_session_key="orig:key")
+    slot.append("assistant", "v2")
+    slot.messages[-1]["variants"] = [{"content": "v1", "ts": "t1"}, {"content": "v2", "ts": "t2"}]
+    slot.drain()
+
+    saved = AsyncMock(return_value=True)
+    with patch("kiro_crew.dashboard.chat_regenerate.save_slot_off_loop", new=saved):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/slots/s1/switch-variant", json={"index": 0})
+            assert resp.status == 200
+
+    assert saved.await_count == 1
+    assert saved.await_args.kwargs["expected_history_key"] == "orig:key"
 
 
 # ── edit-resend ──

--- a/test/test_chat_regenerate_cov80.py
+++ b/test/test_chat_regenerate_cov80.py
@@ -319,14 +319,18 @@ async def test_switch_variant_survives_a_persist_failure(state, caplog) -> None:
 # thread; the event loop is free across that one await, and a same-name
 # close-and-recreate is NOT serialized against this lock (the cleanup pops
 # state._slots[name] and get_or_create_slot re-inserts, neither taking the
-# original lock). Without a pin the rewrite resolves its target file from the
-# slot object it was handed and lands the truncation on the replacement's
-# transcript. The fix passes expected_history_key = slot_history_key(slot),
-# captured BEFORE the await, so _save_slot_to_history refuses (returns False,
-# nothing written) when the routing has moved -- the same guard edit-resend
-# already carries. These tests assert the pin reaches the write and names the
-# transcript the slot was authorized against; the disk-side refusal itself is
-# covered by _save_slot_to_history's own expected_history_key tests.
+# original lock). The rewrite resolves its target file from the slot object it
+# was handed, so an unguarded write lands the truncation on the replacement's
+# transcript. The fix carries the same PAIR edit-resend carries:
+#   * expected_history_key = slot_history_key(slot), captured before the await,
+#     so the save refuses when the routing resolves to a different key -- a
+#     RENAMED replacement;
+#   * a state._slots[name] object-identity check immediately before the write,
+#     so a SAME-NAME recreate (which keeps the key identical, waving the routing
+#     check through) skips the write instead.
+# These tests assert the pin reaches the write, and that a same-name swap before
+# the write suppresses it. The disk-side routing refusal itself is covered by
+# _save_slot_to_history's own expected_history_key tests.
 
 
 @pytest.mark.asyncio
@@ -346,9 +350,58 @@ async def test_regenerate_pins_the_truncating_write_to_its_transcript(state) -> 
             assert resp.status == 200
             await asyncio.sleep(0)
 
-    # The write carried the slot's own transcript as its authorization pin.
+    # The write carried the slot's own transcript and map key as its
+    # authorization pins.
     assert saved.await_count == 1
     assert saved.await_args.kwargs["expected_history_key"] == "orig:key"
+    assert saved.await_args.kwargs["expected_slot_name"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_regenerate_skips_the_write_when_the_slot_is_recreated(state) -> None:
+    """A same-name recreate that lands INSIDE the executor wait -- after the
+    caller dispatches the write, while the worker thread holds the lock --
+    keeps the history key identical, so only an object-identity recheck at the
+    locked commit boundary catches it. The truncating write must not commit
+    onto the replacement's transcript."""
+    slot = state.get_or_create_slot("s1", linked_session_key="orig:key")
+    slot.append("user", "hi")
+    slot.append("assistant", "keep-me-1")
+    slot.append("user", "again")
+    slot.append("assistant", "keep-me-2")
+    slot.drain()
+    # A replacement bound to the SAME transcript key -- what a recreate that
+    # resumes the same session produces, so the routing check alone waves it
+    # through.
+    replacement = state.get_or_create_slot("s1b", linked_session_key="orig:key")
+
+    real_status = state.conversation_log.get_metadata_status
+
+    def _swap_inside_the_locked_write(key):
+        # get_metadata_status runs inside the save's _locked region, before the
+        # identity recheck -- model the recreate landing in that window.
+        if state._slots.get("s1") is slot:
+            state._slots["s1"] = replacement
+        return real_status(key)
+
+    with (
+        patch.object(
+            state.conversation_log,
+            "get_metadata_status",
+            side_effect=_swap_inside_the_locked_write,
+        ),
+        patch("kiro_crew.dashboard.chat_regenerate._run_chat", new=AsyncMock()) as run,
+    ):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/slots/s1/regenerate")
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "regenerate_save_refused"
+            await asyncio.sleep(0)
+
+    # The truncation never reached disk for the transcript the replacement holds.
+    assert state.conversation_log.get_metadata("orig:key") == {}
+    # And the turn was not dispatched onto the removed slot.
+    assert run.await_count == 0
 
 
 @pytest.mark.asyncio
@@ -366,6 +419,43 @@ async def test_switch_variant_pins_the_persist_to_its_transcript(state) -> None:
 
     assert saved.await_count == 1
     assert saved.await_args.kwargs["expected_history_key"] == "orig:key"
+    assert saved.await_args.kwargs["expected_slot_name"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_switch_variant_skips_the_write_when_the_slot_is_recreated(state) -> None:
+    """Switch-variant carries the same object-identity recheck at the save's
+    locked commit boundary: a same-name recreate landing inside the executor
+    wait suppresses the persist onto the replacement's transcript."""
+    slot = state.get_or_create_slot("s1", linked_session_key="orig:key")
+    slot.append("assistant", "v2")
+    slot.messages[-1]["variants"] = [{"content": "v1", "ts": "t1"}, {"content": "v2", "ts": "t2"}]
+    slot.drain()
+    replacement = state.get_or_create_slot("s1b", linked_session_key="orig:key")
+
+    real_status = state.conversation_log.get_metadata_status
+
+    def _swap_inside_the_locked_write(key):
+        if state._slots.get("s1") is slot:
+            state._slots["s1"] = replacement
+        return real_status(key)
+
+    with patch.object(
+        state.conversation_log,
+        "get_metadata_status",
+        side_effect=_swap_inside_the_locked_write,
+    ):
+        async with _client(state) as client:
+            resp = await client.post("/api/chat/slots/s1/switch-variant", json={"index": 0})
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "switch_variant_save_refused"
+
+    assert state.conversation_log.get_metadata("orig:key") == {}
+    # A refused persist must not announce a switch no transcript holds.
+    assert not any(
+        call.args and call.args[0] == "chat_variant_switch"
+        for call in state.broadcast_ws.call_args_list
+    )
 
 
 # ── edit-resend ──


### PR DESCRIPTION
## What is the problem?

`chat_regenerate.py` has two truncating history saves -- regenerate and
switch-variant -- that run under `slot._lock` but dispatch the write to a worker
thread. Each checked slot object identity (`state._slots.get(name) is not slot`)
BEFORE the `await`, then dispatched the write. That await frees the event loop
while the worker thread commits, and a same-name close-and-recreate is not
serialized against `slot._lock`: cleanup pops `state._slots[name]` and
`get_or_create_slot` re-inserts, neither taking the original lock.

So a recreate can land after the pre-dispatch check passed and before the write
commits. A recreate that resumes the same transcript keeps the history key
identical, so it also slips past the `expected_history_key` routing pin and the
`created_at` delete-won guard. The stale truncated snapshot then commits onto the
replacement conversation's transcript.

## Why this issue matters to the user

A regenerate or a variant switch truncates the window and persists that
truncation. If the write lands on a replacement conversation's transcript, that
conversation's history is silently rewritten with another conversation's
truncated window -- a cross-conversation data corruption the user does not see
until they reopen the clobbered chat, with turns missing.

## How our fix solves it

The chain is: the check was at the wrong boundary. A check placed before an
await guards the moment of evaluation, not the moment of use; the pre-dispatch
identity check was stale by the time the worker thread committed. The fix moves
the check to the point of use, inside the lock that serializes the write, and
makes both call sites honor a refused save.

- `save_slot_off_loop` takes a new keyword-only `expected_slot_name` -- the
  `state._slots` map key the caller authorized against.
- `_save_slot_to_history` re-reads `state._slots.get(expected_slot_name)` inside
  its `_locked` region, at the commit boundary. When the map holds a different
  slot object the save refuses: returns `False`, writes nothing, logs the
  refusal -- the same shape as the routing pin and the delete-won guard already
  sitting there.
- Both `chat_regenerate` sites pass `expected_slot_name=name`, drop their
  pre-dispatch identity check, and check the return value. On a refused save,
  regenerate aborts WITHOUT dispatching `_run_chat` (a turn on a removed slot
  would persist its truncated branch over the replacement) and switch-variant
  aborts WITHOUT broadcasting the switch; both return `409`. Refusal is the safe
  half: the original slot is being torn down and its truncation lived only in the
  popped slot's in-memory window, so nothing that would otherwise persist is lost.

## What tests we did

`test/test_chat_regenerate_cov80.py`, both recreate tests, land the swap INSIDE
the save's `_locked` region (patching `get_metadata_status`, which runs there)
and assert the transcript is never written (`get_metadata("orig:key") == {}`),
the turn is not dispatched (`_run_chat` await count 0), and no
`chat_variant_switch` is broadcast; both endpoints return `409`. This reproduces
the exact race the finding describes -- a recreate during the executor wait --
which the pre-dispatch guard could not catch. Both tests FAIL against the
pre-dispatch source (the stale truncated snapshot commits) and PASS against the
commit-boundary guard; verified by stashing both source files and running the
two tests against the un-fixed tree.

    timeout 900 python3 -m pytest -n0 test/test_chat_regenerate_cov80.py -x -q

70 passed. `black`, `isort`, `flake8`, and the comment-history gate are clean on
the three changed files; `mypy` reports no errors in them.

## Residual window this PR does not close

This PR closes the pre-dispatch-to-commit gap. One narrower window remains, and
it is inherent to the current locking, not a miss.

The transcript FILE is serialized by `_locked(history_key)`. The slot-identity
map `state._slots` is mutated on the event loop with NO lock and is not coupled
to that file lock. The save's read-modify-`atomic_write` runs on a WORKER THREAD
(via `save_slot_off_loop` -> `asyncio.to_thread`) while holding
`_locked(history_key)`; the recreate mutates `state._slots` on the EVENT LOOP,
taking no file lock. The two run in true parallel.

So the losing interleaving is: the worker thread passes the in-lock identity
recheck, then the event loop runs a same-name recreate that swaps
`state._slots[name]` to a replacement bound to the same transcript, then the
worker thread's `atomic_write` commits the truncated snapshot onto that
replacement's transcript. The staleness comes from the other thread, not from an
`await`, so no amount of pre-write checking on the worker thread closes it.

No existing token distinguishes incarnations at the commit boundary: `created_at`
is file identity and a same-transcript recreate preserves it; `tab_id` is 1:1
with the file (`chat_persistence.py:2619`) and is inherited on resume. Closing
this needs an ownership predicate persisted in the transcript metadata and
re-validated inside `_locked(history_key)` on both the write and the resume
read-then-clear -- a durable-metadata contract change, named for the sibling
close path at `chat_handlers.py` around line 4913. The close path tolerates its
own version of this residual because its payload is a `closed` metadata flag that
the replacement's next full save drops and `api_chat_slot_resume` compare-and-clears;
regenerate and switch-variant persist a content truncation, which resume cannot
restore, so their residual is data loss. Tracked in #9905.

## Pattern harvest

A check placed before an await guards the moment of evaluation, not the moment
of use. The prior revision added an identity check to cover the routing check's
blind spot, but placed it in the same pre-await block, so it inherited the same
blind spot one level in -- it could not see the slot at commit time. Moving it
into the lock that serializes the write is what closes the pre-dispatch window;
adding a third pre-await check would only have moved it again. The guard belongs
at the point of use, beside the routing and delete-won guards that already
re-validate there. The last window is narrower still and cannot close at the
same layer, because the identity map and the transcript file are under different
locks -- so it is tracked as a durable-metadata change rather than patched here.

Rule candidate: review-prompt -- when a concurrency guard reads live state
(a session map, a slot table) and the value it protects is used after an await,
place the check after the last await, under the lock that serializes the use,
not in a pre-await block; and when the guarded state and the committed resource
sit under different locks, note that no same-layer check closes the parallel
window rather than adding another check that only moves it.

Closes #9321
Refs #9905
