### PR TITLE
fix: make run_bounded's timeout kill path Windows-safe (#9455)

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -57,7 +57,6 @@
 2 src/kiro_crew/service/apparmor.py
 4 src/kiro_crew/service/linux.py
 1 src/kiro_crew/service/macos.py
-1 test/installer_test_helpers.py
 2 test/test_acp_backend_kas.py
 1 test/test_agent_home_isolation.py
 1 test/test_agent_import_hoist.py

--- a/test/installer_test_helpers.py
+++ b/test/installer_test_helpers.py
@@ -7,21 +7,133 @@ frame, so a wedged grandchild survives either one: it is reparented to init and
 keeps burning a core until someone kills it by hand. Running the child as a
 session leader makes the whole tree killable as one process group.
 
-Callers are POSIX-only (``cli.sh`` is POSIX shell) and skip on Windows before
-reaching this module, which is what makes the ``killpg`` below safe.
+Not every caller is POSIX-only: the PowerShell tests skip only when no
+``pwsh``/``powershell`` binary exists, so they DO run on Windows CI. There the
+child is wrapped in a kill-on-close Job object at spawn, the tree kill
+terminates the job (falling back to ``taskkill /T /F`` via
+``platform_compat.kill_process_tree``), and the timeout path re-raises
+``TimeoutExpired`` so callers' skip logic keeps working.
 """
 
 from __future__ import annotations
 
-import os
-import signal
+import contextlib
 import subprocess
+
+from kiro_crew import platform_compat
 
 #: A hermetic installer run (fake curl, fake package managers) finishes in
 #: seconds, so this bound only ever trips on a wedge. It sits well under
 #: pytest-timeout's ceiling so that this helper, rather than pytest-timeout, is
 #: what reaps the tree.
 INSTALLER_TIMEOUT = 60.0
+
+#: Bound on draining the pipes after the kill. A reaped tree closes its pipe
+#: write handles immediately, so this only trips if a descendant survived the
+#: kill; without it, ``communicate()`` would block until that survivor exits
+#: and the caller's skip path would never run.
+_POST_KILL_DRAIN_TIMEOUT = 5.0
+
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+_PROCESS_SET_QUOTA = 0x0100
+_PROCESS_TERMINATE = 0x0001
+
+
+class _KillOnCloseJob:
+    """A Windows Job object that guarantees the child's tree cannot leak.
+
+    ``taskkill /T`` walks the live process list and can fail (access denied on
+    a descendant, binary not resolvable), and a direct ``proc.kill()`` reaps
+    only the immediate child. A Job with ``KILL_ON_JOB_CLOSE`` closes both
+    gaps: ``terminate()`` kills every member with creator rights, and if this
+    process dies without ever calling it, the OS kills the members when the
+    last job handle is destroyed. The child must be spawned with
+    ``CREATE_SUSPENDED`` so it is assigned before it can fork anything that
+    would escape the job (same handshake ``platform_compat.apply_job_limits``
+    documents). This lifecycle semantic is exactly what production code must
+    NOT do — ``apply_job_limits`` deliberately omits ``KILL_ON_JOB_CLOSE`` —
+    which is why this small test-only wrapper exists instead of a
+    ``platform_compat`` helper.
+    """
+
+    def __init__(self) -> None:
+        self._kernel32 = None
+        self._job = None
+
+    def assign(self, pid: int) -> bool:
+        """Create the job and put *pid* in it. False (never raises) on failure."""
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            from kiro_crew.platform_compat import (
+                _JOBOBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
+                _JobObjectExtendedLimitInformation,
+            )
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+            kernel32.CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
+            kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+            kernel32.SetInformationJobObject.argtypes = [
+                wintypes.HANDLE,
+                ctypes.c_int,
+                wintypes.LPVOID,
+                wintypes.DWORD,
+            ]
+            kernel32.SetInformationJobObject.restype = wintypes.BOOL
+            kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+            kernel32.OpenProcess.restype = wintypes.HANDLE
+            kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+            kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+            kernel32.TerminateJobObject.argtypes = [wintypes.HANDLE, ctypes.c_uint]
+            kernel32.TerminateJobObject.restype = wintypes.BOOL
+            kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+            kernel32.CloseHandle.restype = wintypes.BOOL
+
+            job = kernel32.CreateJobObjectW(None, None)
+            if not job:
+                return False
+            info = _JobObjectExtendedLimitInformation()
+            info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            if not kernel32.SetInformationJobObject(
+                job,
+                _JOBOBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
+                ctypes.byref(info),
+                ctypes.sizeof(info),
+            ):
+                kernel32.CloseHandle(job)
+                return False
+            proc_handle = kernel32.OpenProcess(_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, False, pid)
+            if not proc_handle:
+                kernel32.CloseHandle(job)
+                return False
+            assigned = bool(kernel32.AssignProcessToJobObject(job, proc_handle))
+            kernel32.CloseHandle(proc_handle)
+            if not assigned:
+                kernel32.CloseHandle(job)
+                return False
+            self._kernel32 = kernel32
+            self._job = job
+            return True
+        except Exception:
+            return False
+
+    def terminate(self) -> bool:
+        """Kill every process in the job. False (never raises) on failure."""
+        if self._kernel32 is None or self._job is None:
+            return False
+        try:
+            return bool(self._kernel32.TerminateJobObject(self._job, 1))
+        except Exception:
+            return False
+
+    def close(self) -> None:
+        """Release the handle; the OS reaps any remaining members."""
+        if self._kernel32 is not None and self._job is not None:
+            with contextlib.suppress(Exception):
+                self._kernel32.CloseHandle(self._job)
+        self._kernel32 = None
+        self._job = None
 
 
 def run_bounded(
@@ -30,32 +142,70 @@ def run_bounded(
     timeout: float = INSTALLER_TIMEOUT,
     cwd: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Run ``argv`` in its own process group; on timeout kill the whole group.
+    """Run ``argv`` bounded by *timeout*; on timeout kill its whole tree.
 
-    ``start_new_session`` makes the child a session leader, so its pid is also
-    its process-group id and one ``killpg`` reaps every descendant. Re-raises
-    ``subprocess.TimeoutExpired`` once the group is gone.
+    On POSIX ``start_new_session`` makes the child a session leader, so its
+    pid is also its process-group id and ``kill_process_tree`` reaps every
+    descendant with one ``killpg``. On Windows the child starts suspended in
+    its own process group, is assigned to a kill-on-close Job object, and is
+    then resumed; the tree kill terminates the job, falling back to
+    ``taskkill /T /F`` and then to killing the direct child. Either way the
+    ``subprocess.TimeoutExpired`` is re-raised once the kill is done — callers
+    rely on catching it to skip.
 
     ``cwd`` matters when the thing under test resolves a RELATIVE path: an
     installer that bakes one into a generated wrapper can only be caught by
     running it from a known directory.
     """
-    with subprocess.Popen(
-        argv,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env,
-        cwd=cwd,
-        start_new_session=True,
-    ) as proc:
-        try:
-            stdout, stderr = proc.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
+    is_posix = platform_compat.IS_POSIX
+    creationflags = 0
+    if not is_posix:
+        creationflags = platform_compat.CREATE_NEW_PROCESS_GROUP | platform_compat.CREATE_SUSPENDED
+    job = _KillOnCloseJob()
+    try:
+        with subprocess.Popen(
+            argv,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            cwd=cwd,
+            start_new_session=is_posix,
+            creationflags=creationflags,
+        ) as proc:
+            if not is_posix:
+                # Suspended-spawn handshake: assign to the job while the child
+                # provably has no descendants, then let it run. On a host where
+                # either step fails the child simply stays subject to the
+                # taskkill/direct-kill ladder below (and a never-resumed child
+                # trips the timeout and is reaped the same way).
+                job.assign(proc.pid)
+                platform_compat.resume_process_main_thread(proc.pid)
             try:
-                os.killpg(proc.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass  # Exited between the timeout and the kill; nothing to reap.
-            proc.communicate()
-            raise
+                stdout, stderr = proc.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                if not job.terminate():
+                    try:
+                        platform_compat.kill_process_tree(proc.pid, platform_compat.SIGKILL)
+                    except OSError:
+                        # Already exited (ProcessLookupError), or the platform
+                        # shim cannot run: reap the direct child so the drain
+                        # below cannot block on its own pipe handles.
+                        proc.kill()
+                try:
+                    proc.communicate(timeout=_POST_KILL_DRAIN_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    pass  # A surviving descendant holds the pipes; do not block on it.
+                # Bound the context manager's exit too: Popen.__exit__ calls an
+                # UNBOUNDED wait(), and the raise below runs through it.
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=_POST_KILL_DRAIN_TIMEOUT)
+                raise
+    finally:
+        # KILL_ON_JOB_CLOSE: dropping the last handle makes the OS reap any
+        # member that survived every kill above — and, on the success path, any
+        # straggler the child left behind.
+        job.close()
     return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)

--- a/test/test_installer_test_helpers.py
+++ b/test/test_installer_test_helpers.py
@@ -1,0 +1,88 @@
+"""Pins for ``run_bounded``'s timeout kill path.
+
+The PowerShell installer tests skip only when no ``pwsh``/``powershell``
+binary exists, so they DO run on Windows CI and reach ``run_bounded`` — a
+platform where ``os.killpg`` does not exist. These pins hold the two
+guarantees those callers depend on: ``subprocess.TimeoutExpired`` (never a
+platform ``AttributeError``) propagates from the timeout path on every
+platform shape, so ``except (TimeoutExpired, OSError): pytest.skip(...)``
+guards fire; and the kill reaps the whole tree — observed via an elapsed
+bound, because an unreaped child holding the pipes rides out the post-kill
+drain budget instead of returning promptly.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+from installer_test_helpers import _POST_KILL_DRAIN_TIMEOUT, run_bounded
+
+from kiro_crew import platform_compat
+
+#: Long enough that only the kill path (never the child exiting on its own)
+#: can end the run before the assertion; well above the elapsed bound below
+#: and the helper's post-kill drain budget, so a leak is distinguishable.
+_CHILD_SLEEP_SECS = 30.0
+
+#: Overhead slack on top of ``run_bounded``'s own timeout. A real kill returns
+#: in well under a second; a leaked descendant makes the helper ride out its
+#: full drain budget, so any bound strictly below ``timeout + drain`` separates
+#: the two. Defined against the drain constant so the separation cannot drift
+#: if the budget changes.
+_REAPED_WITHIN_SECS = _POST_KILL_DRAIN_TIMEOUT - 1.0
+
+_SLEEPER = [sys.executable, "-c", f"import time; time.sleep({_CHILD_SLEEP_SECS})"]
+
+# Spawns a grandchild that inherits the stdout/stderr pipes, then wedges. Only
+# a tree kill closes the grandchild's pipe handles; killing the direct child
+# alone leaves the drain blocked until its budget expires.
+_SLEEPER_WITH_GRANDCHILD = [
+    sys.executable,
+    "-c",
+    (
+        "import subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', 'import time; time.sleep({_CHILD_SLEEP_SECS})']); "
+        f"time.sleep({_CHILD_SLEEP_SECS})"
+    ),
+]
+
+
+def _run_expecting_timeout(argv: list[str], timeout: float) -> float:
+    """Run ``run_bounded`` expecting a timeout; return the elapsed seconds."""
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_bounded(argv, env=dict(os.environ), timeout=timeout)
+    return time.monotonic() - started
+
+
+def test_timeout_on_a_windows_shaped_platform_reraises_and_reaps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Windows branch re-raises TimeoutExpired — never AttributeError.
+
+    Forcing ``IS_POSIX = False`` routes the kill through the Windows ladder
+    (job termination is inert here, and on a POSIX host with no ``taskkill``
+    the ``kill_process_tree`` call raises ``OSError`` into the direct-kill
+    fallback) — the platform shape where an unconditional ``os.killpg`` call
+    raises ``AttributeError``.
+    """
+    monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+    elapsed = _run_expecting_timeout(_SLEEPER, timeout=0.2)
+    assert elapsed < 0.2 + _REAPED_WITHIN_SECS, f"child not reaped promptly ({elapsed:.1f}s)"
+
+
+def test_timeout_reaps_the_whole_process_tree() -> None:
+    """A wedged grandchild holding the pipes is reaped with the child.
+
+    If only the direct child died, the grandchild's inherited pipe handles
+    would hold ``communicate()`` open for the full post-kill drain budget and
+    this elapsed bound would trip. The 1s timeout (vs 0.2s above) gives the
+    child time to actually spawn the grandchild on a loaded runner — a kill
+    landing on a still-childless child would make this pin vacuous.
+    """
+    elapsed = _run_expecting_timeout(_SLEEPER_WITH_GRANDCHILD, timeout=1.0)
+    assert elapsed < 1.0 + _REAPED_WITHIN_SECS, f"tree not reaped promptly ({elapsed:.1f}s)"


### PR DESCRIPTION
## Problem / Motivation

The Windows CI shard `Backend Tests (Windows) (3)` intermittently fails on main in `test_powershell_installer_parses` and `test_the_powershell_helpers_behave_when_actually_executed` with `AttributeError: module 'os' has no attribute 'killpg'`. The file had not changed since 9afd8f77f — run 34204689709 redded while later runs on the same code were green.

## Why it matters

Every flake reds a required shard on main and on any PR that inherits the merge ref. People re-run CI or distrust the Windows lanes for a failure no code change caused. The two PowerShell tests are exactly the coverage Windows needs, so ignoring the file is not an option.

## What changed (motivation → approach → change)

The two PowerShell tests skip only when no `pwsh`/`powershell` binary exists, so they DO run on Windows CI. They call `run_bounded` in `test/installer_test_helpers.py`. Its timeout handler called `os.killpg(proc.pid, SIGKILL)` on every platform. `os.killpg` does not exist on Windows. So when the PowerShell cold-start probe ran past its 10s timeout, the handler crashed with `AttributeError` before the intended re-raise. The caller's `except (TimeoutExpired, OSError): pytest.skip(...)` never fired, and the test failed instead of skipping. The failure is timing-dependent, which is why the file was innocent and the shard red.

On POSIX the kill is unchanged: `platform_compat.kill_process_tree` resolves to the same `os.killpg` group kill (the child is a session leader, so its pgid is its pid). On Windows the fix is a three-rung ladder, and the review rounds are why each rung exists. The child is spawned `CREATE_SUSPENDED` in its own process group, assigned to a kill-on-close **Job object** (`_KillOnCloseJob`, ~110 lines of test-only ctypes reusing `platform_compat`'s struct definitions and suspended-spawn handshake), then resumed. On timeout the kill is `TerminateJobObject` first — creator rights kill every member, including an access-denied descendant `taskkill` cannot touch — then `taskkill /T /F` via `kill_process_tree`, then `proc.kill()`. `KILL_ON_JOB_CLOSE` is the backstop: any survivor is reaped by the OS when the job handle drops, at the latest when the test process exits, so no failure combination can leak a process past the run. The GPT security lane blocked the plain `taskkill`-with-`proc.kill()`-fallback shape for exactly that leak; the Job layer is that finding's fix, not incidental hardening.

The degraded paths keep coverage honest rather than eroding it: if `job.assign` or the resume fails, the child simply stays subject to the `taskkill`/direct-kill rungs (an unresumed child trips the timeout and is reaped the same way), and the callers' skip guards behave exactly as they do today when PowerShell itself is wedged. The post-kill pipe drain and the `Popen` context exit are bounded so a surviving descendant cannot hold `communicate()` open past the caller's skip path. The `TimeoutExpired` re-raise is preserved exactly. The docstring's false POSIX-only-callers claim is corrected, and pinning `encoding="utf-8"` on the spawn graduates the file's `subprocess-encoding` baseline entry.

```mermaid
flowchart LR
  subgraph Before
    A1[timeout fires]:::ctx --> B1["os.killpg — AttributeError on Windows"]:::removed --> C1[test FAILS]:::removed
  end
  subgraph After
    A2[timeout fires]:::ctx --> B2["Job terminate → taskkill /T → proc.kill"]:::added --> C2[TimeoutExpired re-raised → pytest.skip]:::ctx
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟥 removed · 🟦 unchanged

*On timeout the helper walks a kill ladder that ends at an OS-guaranteed reap, and the test skips as designed instead of crashing on a missing POSIX call.*

## Tests

New `test/test_installer_test_helpers.py`, red-before-green (the first pin failed with `AttributeError` against the unfixed helper; the tree pin was mutation-verified red at 5.2s against a direct-child-only kill):

- `test_timeout_on_a_windows_shaped_platform_reraises_and_reaps` — forces `IS_POSIX = False` so the kill walks the Windows ladder (on a POSIX host: inert job, `OSError` from the missing `taskkill`, direct-kill fallback), and asserts `TimeoutExpired`, never `AttributeError`, within an elapsed bound.
- `test_timeout_reaps_the_whole_process_tree` — the child spawns a grandchild that inherits the pipes; the elapsed bound proves the whole tree died, because a surviving grandchild would hold the drain for its full budget. Its 1s timeout gives the child time to spawn the grandchild on a loaded runner.

The bounds are symbolic (`_POST_KILL_DRAIN_TIMEOUT - 1.0` of slack on top of each test's timeout), so a leak and a slow runner stay separated even if the drain budget changes. Live-kernel evidence for the Job handshake: all four `Backend Tests (Windows)` shards are green on this head at normal runtime (~16 min, 20k+ tests each) — a broken assign/resume would stall every `run_bounded` child for its full 60s timeout and blow those times up.

## Manual verification

N/A — unit coverage sufficient: the regression tests exercise the Windows-shaped ladder directly, the three consumer suites (`test_playwright_cli_installer.py`, `test_installer_distro.py`, `test_cli_manifest_signature.py`, 181 tests) pass against the new helper, and the green Windows shards above are the real-kernel check. The POSIX kill path is byte-equivalent to the old behavior.

## Related Issues

Fixes #9455

## Pattern harvest

Rule candidate: review-prompt
Pattern: a test helper's docstring claims "callers are POSIX-only" while its callers' skip guards only check binary presence — platform reachability must be derived from the skip conditions, not asserted in prose.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
