### PR TITLE
fix(work-ledger): make the path containment checks race-free

### DIFF
--- a/src/kiro_crew/work_ledger.py
+++ b/src/kiro_crew/work_ledger.py
@@ -54,8 +54,10 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import secrets
+import stat
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -482,14 +484,35 @@ def conductor_dir(slot_key: str) -> Path:
         raise WorkLedgerError(
             f"invalid slot key for work ledger: {slot_key!r}", code=CODE_INVALID_VALUE
         )
-    base = _work_ledger_root()
-    resolved = (base / _store_name(slot_key)).resolve()
-    parent = base.resolve()
+    parent = _work_ledger_root().resolve()
+    resolved = parent / _store_name(slot_key)
     if resolved == parent or not resolved.is_relative_to(parent):
         raise WorkLedgerError(
             f"path traversal blocked for slot key: {slot_key!r}", code=CODE_INVALID_VALUE
         )
+    _refuse_planted_link(resolved, "slot key", slot_key)
     return resolved
+
+
+def _refuse_planted_link(child: Path, key_kind: str, slot_key: str) -> None:
+    """Refuse a symlink or junction planted at the composed child path.
+
+    The containment above is lexical and race-free by construction, so it
+    cannot see a pre-existing link at the child; the ledger is a writable
+    leaf, and a link planted there would carry reads and lock writes outside
+    it. ``lstat`` looks at the final component only, so there is no resolve
+    walk here to race the directory's own creation.
+    """
+    try:
+        st = os.lstat(child)
+    except OSError:
+        return  # the child does not exist: nothing planted to refuse
+    reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    if stat.S_ISLNK(st.st_mode) or getattr(st, "st_file_attributes", 0) & reparse:
+        raise WorkLedgerError(
+            f"path traversal blocked for {key_kind}: {slot_key!r}",
+            code=CODE_INVALID_VALUE,
+        )
 
 
 def items_dir(slot_key: str) -> Path:
@@ -524,13 +547,19 @@ def binding_path(worker_slot_key: str) -> Path:
         raise WorkLedgerError(
             f"invalid worker slot key: {worker_slot_key!r}", code=CODE_INVALID_VALUE
         )
-    base = bindings_dir()
-    resolved = (base / f"{_store_name(worker_slot_key)}.json").resolve()
-    if not resolved.is_relative_to(base.resolve()):
+    parent = bindings_dir().resolve()
+    # Lexical containment on purpose: the child is composed from the resolved
+    # parent, so it cannot escape (the store name carries no separators), and
+    # no second filesystem resolve exists to disagree with this one about the
+    # parent's prefix form once the directory appears mid-check — a benign key
+    # is otherwise refused as path traversal on aliased prefixes.
+    resolved = parent / f"{_store_name(worker_slot_key)}.json"
+    if not resolved.is_relative_to(parent):
         raise WorkLedgerError(
             f"path traversal blocked for worker key: {worker_slot_key!r}",
             code=CODE_INVALID_VALUE,
         )
+    _refuse_planted_link(resolved, "worker key", worker_slot_key)
     return resolved
 
 

--- a/test/test_work_ledger.py
+++ b/test/test_work_ledger.py
@@ -13,7 +13,10 @@ stood alone, so that phase reverted by deleting two files).
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess
+import sys
 import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1415,6 +1418,84 @@ def test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding():
         item = wl.read_work_item(key, item_id)
         assert item is not None
         assert (item.worker_session_key == WORKER) == ((key, item_id) == binding)
+
+
+def _racing_resolve(tmp_path, monkeypatch):
+    """Make the second resolve under the data home land on a sibling prefix.
+
+    Models the Windows-shard misfire in
+    ``test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding``:
+    the containment checks resolve the child and then the base, and on a runner
+    whose temp path carries a short (8.3) component those two resolves can read
+    different prefix forms once the directory appears between them, so a benign
+    key is refused as path traversal. Flipping one resolve onto a sibling
+    prefix reproduces the divergence deterministically on any machine.
+    """
+    root = str(wl._work_ledger_root())
+    other = str(tmp_path / "aliased-prefix")
+    real_resolve = Path.resolve
+    state = {"resolves": 0}
+
+    def racing_resolve(self, strict=False):
+        result = real_resolve(self, strict=strict)
+        if str(result).startswith(root):
+            state["resolves"] += 1
+            if state["resolves"] == 2:
+                return Path(str(result).replace(root, other, 1))
+        return result
+
+    monkeypatch.setattr(Path, "resolve", racing_resolve)
+
+
+def test_binding_path_does_not_refuse_a_benign_key_when_the_prefix_flips(tmp_path, monkeypatch):
+    """The containment guard compares one resolved base against a child that
+    is composed from it, so no second filesystem resolve can race the
+    directory's own creation and split the prefix forms."""
+    _racing_resolve(tmp_path, monkeypatch)
+    wl.binding_path(WORKER)
+
+
+def test_conductor_dir_does_not_refuse_a_benign_key_when_the_prefix_flips(tmp_path, monkeypatch):
+    """Same containment shape as :func:`binding_path`, same guarantee."""
+    _racing_resolve(tmp_path, monkeypatch)
+    wl.conductor_dir(CONDUCTOR)
+
+
+def _plant_link(path: Path, target: Path) -> None:
+    """Plant a link at *path* pointing at *target*; junction on Windows."""
+    try:
+        os.symlink(target, path, target_is_directory=target.is_dir())
+    except OSError:
+        if sys.platform == "win32" and target.is_dir():
+            subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(path), str(target)],
+                check=True,
+                capture_output=True,
+                cwd=str(path.parent),
+            )
+        else:
+            pytest.skip("this host cannot plant the link")
+
+
+def test_binding_path_refuses_a_link_planted_at_the_child(tmp_path):
+    """The ledger is a writable leaf, so a link planted at the composed child
+    name would carry reads and lock writes outside it. The containment guard
+    must reject the link even though the composed name itself is clean."""
+    wl.bindings_dir().mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _plant_link(wl.bindings_dir() / f"{wl._store_name(WORKER)}.json", outside)
+    with pytest.raises(wl.WorkLedgerError):
+        wl.binding_path(WORKER)
+
+
+def test_conductor_dir_refuses_a_link_planted_at_the_child(tmp_path):
+    wl._work_ledger_root().mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _plant_link(wl._work_ledger_root() / wl._store_name(CONDUCTOR), outside)
+    with pytest.raises(wl.WorkLedgerError):
+        wl.conductor_dir(CONDUCTOR)
 
 
 def test_acquiring_a_lock_does_not_truncate_the_lock_file():


### PR DESCRIPTION
## Problem / Motivation

`test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding` fails intermittently on the Windows CI shard with a refusal that names a perfectly innocent key:

```text
chat-1-c=invalid_value (field=None msg=path traversal blocked for worker key: 'chat-2-worker')
```

`chat-2-worker` contains no separators and no dot segments; nothing about it traverses anything. The two path constructors behind it, `binding_path()` and `conductor_dir()` in `src/kiro_crew/work_ledger.py`, guarded themselves by resolving the child path and then the parent as two separate filesystem walks:

```python
resolved = (base / f"{_store_name(worker_slot_key)}.json").resolve()
if not resolved.is_relative_to(base.resolve()):
```

On a host whose temp path carries a short (8.3) component — the GitHub Windows runners hand pytest a `RUNNER~1`-style prefix — those two walks can disagree. `Path.resolve()` finalizes everything that already exists on disk, so a resolve that runs after `bindings/` was created returns the long form; a resolve whose final component does not exist yet falls back to the lexical form and keeps the short prefix. When the two sides of one containment check straddle the directory's creation, `is_relative_to` compares `RUNNER~1` against `runneradmin` and refuses the key.

## Why it matters

The failure is intermittent in exactly the way that wastes the most time. The binding race starts four threads at once; the first write creates `bindings/`, so whichever threads resolve after that moment see the expanded prefix and whichever resolve ran before it kept the short one. One thread gets refused with a "path traversal" error that accuses a benign key, the shard goes red, and a re-run burns half an hour of CI to pass or fail on thread timing. The same shape sits in `conductor_dir()` for any concurrent first access to a conductor's ledger.

It also misleads diagnosis. The refusal says "path traversal blocked", so the natural reaction is to audit the key for separators — and there are none. The real defect is that the guard's two inputs were taken from the filesystem at two different moments.

## What changed (motivation → approach → change)

Symptom: a benign key refused as traversal. Root cause: containment decided by comparing two filesystem resolves that are not atomic with respect to each other. Fix: resolve the parent once and compose the child from it, then check containment lexically.

```python
parent = bindings_dir().resolve()
resolved = parent / f"{_store_name(worker_slot_key)}.json"
if not resolved.is_relative_to(parent):
```

The guard keeps its full strength, including the part the composed form alone cannot see. The child's name comes from `_store_name()`, which sanitizes every unsafe character and appends a digest, so a composed child can never escape the parent — the lexical check still refuses anything that would, and the null-byte and shape checks upstream of it stay untouched. What is removed is the second walk, which was the only thing that could race. What the second walk could catch is restored separately: a symlink or junction planted at the composed child is rejected via `os.lstat` (a link or reparse point at the final component), which looks at one entry instead of walking the tree, so it carries none of the race back. Writes and reads through the returned path land in the same directory as before: `Path.resolve()` finalizes junctions and symlinks for existing prefixes either way, and every caller derives paths through these constructors, so no caller ever mixes the two forms.

One behavior note for reviewers: the returned path is now the composed `resolved-parent / name` rather than the fully-finalized path. On hosts without aliased prefixes the two are byte-identical, and on aliased hosts the composed form is actually the more stable choice — it does not flip between boots depending on whether the directory happened to exist at resolve time.

The change is two files:

- `src/kiro_crew/work_ledger.py` — both constructors resolve the parent once and compose the child lexically
- `test/test_work_ledger.py` — two regression tests plus a shared `_racing_resolve()` helper

## Tests

I wrote the regression tests first and watched them fail with the exact CI error — `WorkLedgerError: path traversal blocked for worker key: 'chat-2-worker'` — reproduced deterministically on a machine where the real race cannot trigger, then watched them pass after the fix. That is the part that matters most: the old code's misfire no longer depends on runner luck to demonstrate.

The helper `_racing_resolve()` models the runner deterministically. It flips the second resolve under the data home onto a sibling prefix, which is precisely the divergence the 8.3 form produces when the directory appears between the two walks; on hosts without aliased prefixes the same flip is the only way to observe the two-resolve disagreement at all.

Two more tests pin the link guard: they plant a link at the composed child name, point it outside the ledger, and assert both constructors refuse it, watched to fail with "DID NOT RAISE" before the guard existed.

```text
python -m pytest test/test_work_ledger.py
127 passed
```

The flaky binding-race test itself ran three times back to back, clean each time, and the full file covers the lock-ordering, cap, and torn-file criteria unchanged. `python -m mypy src/kiro_crew` is clean, and the repo's `check_black_formatting.py` / `check_subprocess_encoding.py` gates plus flake8, isort, and black pass on the touched files.

## Manual verification

There is nothing to eyeball in the app: the observable behavior change is that a refusal stops happening. The honest reproduction of the original failure needs the runner's short-form temp path, which is why it only surfaced on the Windows shard; the deterministic flip test is the reviewer-accessible stand-in, and the binding-race test is the end-to-end check that the shard gate exercises on every run.

## Pattern harvest

Not generalizable: the defect is a two-resolve ordering inside one path constructor, not a recurring API misuse — a static rule cannot tell a containment check that must survive directory creation from an ordinary resolve. The durable guard is the regression test, which flips the prefix between the two resolves deterministically.

## Related Issues

No dedicated issue. The failing shard is visible directly on `main`'s own CI runs, so this PR also unsticks the Windows lane for every open PR that inherited the flake.

## Checklist

- [x] Regression tests written first, watched fail with the CI error, then pass
- [x] mypy and the repo's format/subprocess gates pass
- [x] Self-review done; the traversal guard still refuses anything that would escape the parent

