### PR TITLE
feat: add GPT-6 Astra context-window floor to the model registry

### DIFF
--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -148,6 +148,11 @@ _SUPPLEMENTARY_WINDOWS: dict[str, int] = {
     "gpt-5.6-sol": 272_000,
     "gpt-5.6-terra": 272_000,
     "gpt-5.6-luna": 272_000,
+    # GPT-6 Astra window per OpenAI's model catalogue (1.05M, not 1.1M). The
+    # kiro-list cache overrides this once /api/models seeds it; this is the
+    # headless-start floor (Slack/cron) so the context assembler does not fall
+    # through to the 1M reference and over-assemble.
+    "gpt-6-astra": 1_050_000,
     "qwen3-coder-next": 256_000,
     # Legacy / not-currently-served kiro ids, kept as harmless static floors.
     "kimi-k2.5": 256_000,

--- a/test/test_model_registry.py
+++ b/test/test_model_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 
 from kiro_crew import model_registry as mr
+from kiro_crew.effort import EFFORT_LEVELS, model_supports_effort
 
 
 class TestModelRegistry:
@@ -107,6 +108,17 @@ class TestModelRegistry:
         assert mr.model_window("gpt-5.6-sol") == 272_000
         assert mr.model_window("gpt-5.6-terra") == 272_000
         assert mr.model_window("gpt-5.6-luna") == 272_000
+        # GPT-6 Astra carries a 1.05M window floor for headless starts.
+        assert mr.model_window("gpt-6-astra") == 1_050_000
+        assert mr.has_known_window("gpt-6-astra") is True
+        assert mr.window_source("gpt-6-astra") == "supplementary"
+        # Astra is effort-capable via the GPT heuristic; its live levels come
+        # from the model itself and carry no "none" tier.
+        assert model_supports_effort("gpt-6-astra") is True
+        assert "none" not in EFFORT_LEVELS
+        # The kiro id passes through translation unchanged, so a picked Astra
+        # actually runs on kiro rather than a folded default.
+        assert mr.to_acp_id("gpt-6-astra") == "gpt-6-astra"
         assert mr.model_window("qwen3-coder-next") == 256_000
         assert mr.model_window("qwen3-coder-480b") == 256_000
         assert mr.model_window("glm-4.7-flash") == 128_000


### PR DESCRIPTION
## Problem / Motivation

OpenAI shipped GPT-6 Astra and KiroCrew had no window floor for it. On the acp (kiro-cli) backend the dashboard model picker is built from live `kiro-cli chat --list-models`, so Astra already appears in the picker the moment kiro-cli serves it; KiroCrew's registry does not gate the picker. What KiroCrew does own for a served model is its context-window floor for headless starts (Slack/cron) that never call `/api/models`. Without a floor, Astra resolves to the 1M reference and the context assembler over-assembles.

## Why it matters

A headless session (Slack, cron, task-runner) never hits `/api/models`, so the kiro-list window cache is unseeded and `model_window("gpt-6-astra")` returns None, giving the 1M reference. Astra's real window is larger (1.05M), so the wrong floor is a silent budget error in exactly the sessions that cannot self-correct from a live `usage_update`.

## What changed

Added `"gpt-6-astra": 1_050_000` to `_SUPPLEMENTARY_WINDOWS` in `src/kiro_crew/model_registry.py`, beside the GPT-5.6 family. This is the single place a served model's window floor belongs; the kiro-list cache overrides it once `/api/models` runs.

Nothing else needed a change, and this was verified rather than assumed:

- Picker: on the acp backend `api_models` returns live `--list-models` rows; the registry supplies windows and effort only, not the row list. Astra shows up with no registry row.
- `validation.py`: model ids are validated by shape (`_MODEL_NAME_RE` / `MODEL_ID_RE`); `gpt-6-astra` matches. There is no model allowlist to extend.
- `website/src/providers/adapters/acp.ts`: reads per-model windows from `/api/models`; no per-model list to edit.
- Effort: the effort-capability heuristic covers any `gpt` id, and the effort level set is reported live by the running model via its ACP `configOptions`; KiroCrew never hardcodes a per-model level set, so it cannot advertise a level the model rejects.

Two facts in the issue were wrong against OpenAI's live catalogue and are corrected here so a later reader does not re-inherit them:

- Context window is 1.05M, not the 1.1M the issue states; the floor uses 1.05M.
- The issue's `$1.00/M` cached-input price is unverified against the catalogue and is not carried anywhere. This repo's window map holds no price field, so nothing was added; a wrong number in a pricing table would be silent.

Subagent / cron / task-runner overrides were left out on purpose: they validate model ids by the same shape rule and read the same registry, so they need no per-subsystem entry.

## Tests

Extended `test_supplementary_windows_cover_headless_non_anthropic_models` in `test/test_model_registry.py` to assert Astra's window (1.05M), `has_known_window`, `window_source == "supplementary"`, effort capability, that `EFFORT_LEVELS` has no `none` tier, and that `to_acp_id("gpt-6-astra")` is an identity passthrough so a picked Astra runs on kiro.

Targeted only, `-n0`:

```
timeout 900 python3 -m pytest -n0 test/test_model_registry.py -x -q </dev/null   # 62 passed
timeout 900 python3 -m pytest -n0 test/test_effort.py -x -q </dev/null           # 80 passed
```

## Pattern harvest

The picker on the acp backend is live-driven, not registry-driven, so "add a model to the picker" is mostly a no-op in this fork: the one thing the repo owns is the window floor and the effort capability, both of which a served GPT id already gets for free except the static floor.

Rule candidate: on KiroCrew's acp (kiro-cli) backend the dashboard model picker is built from live `kiro-cli chat --list-models`, so a newly-served model appears with no registry row; the model registry supplies only the context-window floor (`_SUPPLEMENTARY_WINDOWS`, for headless starts) and effort capability, and `validation.py` gates model ids by shape not by allowlist, so "add a model to the picker" usually reduces to a single window-floor entry plus its test, not edits across registry/validation/adapter.

Closes #9467
