### PR TITLE
fix: apply shopper tag filters before limiting search results

### DIFF
--- a/src/kiro_crew/apps/builtins/personal_shopper/backend/store.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/backend/store.py
@@ -19,6 +19,7 @@ import sqlite3
 import struct
 import threading
 import uuid
+from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import NamedTuple
@@ -347,31 +348,38 @@ class PreferenceStore:
         match = _fts_query(query)
         if not match:
             return []
-        with self._lock:
-            rows = self._conn.execute(
+        results: list[SearchResult] = []
+        with self._lock, closing(
+            self._conn.execute(
                 "SELECT f.entry_id, p.text, p.tags, f.rank "
                 "FROM preferences_fts f JOIN preferences p ON p.id = f.entry_id "
-                "WHERE preferences_fts MATCH ? ORDER BY f.rank LIMIT ?",
-                (match, top_k * 3),  # over-fetch, tag filtering happens below
-            ).fetchall()
-
-        results: list[SearchResult] = []
-        for entry_id, text, tags_json, rank in rows:
-            tags = json.loads(tags_json)
-            if not self._matches_tags(tags, tag_filter):
-                continue
-            # bm25 rank is negative and unbounded; map it to a monotonic 0-1
-            # ordering signal. It is NOT a similarity, hence semantic=False.
-            results.append(
-                SearchResult(
-                    id=entry_id,
-                    text=text,
-                    tags=tags,
-                    score=1.0 / (1.0 + abs(float(rank))),
-                    semantic=False,
-                )
+                "WHERE preferences_fts MATCH ? ORDER BY f.rank",
+                (match,),
             )
-        return results[:top_k]
+        ) as rows:
+            # Count eligible results, not candidates from unrelated groups.
+            # Stream under the connection lock so a sparse filter does not
+            # materialize every matching preference in Python.
+            while len(results) < top_k:
+                row = rows.fetchone()
+                if row is None:
+                    break
+                entry_id, text, tags_json, rank = row
+                tags = json.loads(tags_json)
+                if not self._matches_tags(tags, tag_filter):
+                    continue
+                # bm25 rank is negative and unbounded; map it to a monotonic 0-1
+                # ordering signal. It is NOT a similarity, hence semantic=False.
+                results.append(
+                    SearchResult(
+                        id=entry_id,
+                        text=text,
+                        tags=tags,
+                        score=1.0 / (1.0 + abs(float(rank))),
+                        semantic=False,
+                    )
+                )
+        return results
 
     def _find_similar(self, text: str) -> SearchResult | None:
         """The existing entry *text* restates, or None.

--- a/src/kiro_crew/apps/builtins/personal_shopper/tests/test_store.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/tests/test_store.py
@@ -64,6 +64,33 @@ class PreferenceStoreTestCase(unittest.TestCase):
 
 
 class TestKeywordFallbackSafety(PreferenceStoreTestCase):
+    def test_tag_filter_applies_before_result_limit(self) -> None:
+        """Other groups' stronger matches cannot hide the requested group's hits."""
+        with _no_embedder():
+            store = self._store()
+            for _ in range(7):
+                store.add("latex", tags=["other"])
+            first = store.add("avoid latex gloves for cleaning", tags=["health"])
+            second = store.add(
+                "avoid latex in all clothing and household products", tags=["clothing"]
+            )
+
+            # Prove the excluded rows fill the over-fetch window, without ties
+            # between the excluded and requested groups determining the result.
+            unfiltered = store.search("latex", top_k=9)
+            self.assertTrue(all(r.tags == ["other"] for r in unfiltered[:7]))
+            self.assertEqual([r.id for r in unfiltered[7:]], [first, second])
+
+            for limit in (1, 2):
+                with self.subTest(top_k=limit):
+                    results = store.search(
+                        "latex", top_k=limit, tag_filter=["health", "clothing"]
+                    )
+                    self.assertEqual([r.id for r in results], [first, second][:limit])
+                    self.assertTrue(all(not r.semantic for r in results))
+            self.assertEqual(store.search("latex", tag_filter=["missing"]), [])
+            self.assertEqual(store.search("latex", top_k=2, tag_filter=[]), unfiltered[:2])
+
     def test_keyword_fallback_never_dedups(self) -> None:
         """Two preferences that merely SHARE A WORD must both survive.
 


### PR DESCRIPTION
## Problem / Motivation

Personal Shopper's `POST /preferences/search` can return no results for a tag-filtered keyword query even when matching preferences exist. Seven short `latex` preferences in another group rank ahead of two longer `latex` preferences in the requested groups. Asking for one or two results returns an empty list.

## Why it matters

Keyword retrieval is the fallback while the embedding model is unavailable. The API loses relevant stored preferences when enough stronger matches belong to other groups.

## What changed (motivation → approach → change)

The FTS query applies `LIMIT top_k * 3` before Python checks tags. Replace that fixed over-fetch window with cursor iteration until `top_k` eligible rows are collected or the cursor is exhausted. Keep cursor access under the existing connection lock and explicitly close it on early exit. Python retains at most `top_k` results; a sparse filter can require scanning more FTS hits. Ranking, any-tag matching and non-semantic flags keep their existing meanings.

## Tests

- Red-before on main `53987e756432f9778164ea0d182255ff49293ac8`: two failing subtests, `top_k=1` and `top_k=2`, return `[]` instead of eligible IDs. The fixture first proves the unrelated rows rank ahead of both target rows.
- Green-after: all 59 Personal Shopper tests and six subtests pass on Python 3.13.5. Coverage includes the regression, absent tags, empty filters, result order and semantic flags.
- Changed-file isort, flake8, mypy (`--follow-imports=skip`) and diff whitespace checks pass.
- Full backend gate was attempted but interrupted when the local drive filled; no full-suite pass is claimed.
- Local GPT 5.6 review: no findings. Extracted Opus-contract substitute review: no findings; Opus itself was unavailable locally.

## Manual verification

N/A — real SQLite FTS5 and the public `PreferenceStore.search` method exercise this backend correction. Only the embedding boundary is stubbed to select keyword fallback. No external service or UI change is involved.

## Related Issues

Found by tracing the keyword fallback and its API contract; no existing issue identified.

## Pattern harvest

Rule candidate: review-prompt
Pattern: A fixed over-fetch limit before an eligibility filter can falsely return no results; bound eligible results instead.

## Checklist

- [x] One commit with a Conventional Commits title
- [x] Focused existing tests pass and a deterministic regression is added
- [x] Self-review completed
- [x] Documentation assessed: no API or schema change; comments explain filtering and cursor lifetime
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository template contains a placeholder; no CLA wording added.
