### PR TITLE
feat(monitoring): give a monitor verdict room for its evidence

### DIFF
--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -66,6 +66,7 @@ from kiro_crew.monitoring.models import (
     MonitorObservationStatus,
     MonitorOutcome,
     MonitorState,
+    MonitorVerdict,
     monitor_state_from_dict,
     monitor_state_to_dict,
     quarantine_monitor_state,
@@ -2377,23 +2378,29 @@ class AutoNudgeService:
         *,
         now: float,
         config_generation: int,
-    ) -> MonitorDecision:
-        """Persist one probe decision and any wake claim as one transition."""
+    ) -> MonitorVerdict:
+        """Persist one probe decision and any wake claim as one transition.
+
+        A refusal that never reaches the decision engine carries no entries: no
+        observation was judged, so the verdict has nothing to name.
+        """
         async with self._lock:
             loop = self._loops.get(monitor_id)
             state = loop.monitor if loop is not None else None
             if loop is None or state is None or not loop.active or state.outcome is not None:
-                return MonitorDecision.STOP_BLOCKED
+                return MonitorVerdict(decision=MonitorDecision.STOP_BLOCKED)
             staged = deepcopy(loop)
             staged_state = staged.monitor
             assert staged_state is not None
             if state.config_generation != config_generation:
                 self._set_monitor_deadline(staged, now + staged_state.cadence_secs)
                 decision = MonitorDecision.NO_CHANGE
+                verdict = MonitorVerdict(decision=decision)
             elif state.wake_in_flight:
-                return MonitorDecision.NO_CHANGE
+                return MonitorVerdict(decision=MonitorDecision.NO_CHANGE)
             else:
-                decision = decide_monitor(staged_state, result.observation, now=now)
+                verdict = decide_monitor(staged_state, result.observation, now=now)
+                decision = verdict.decision
                 staged_state.probe_count += 1
                 staged_state.last_probe_at = now
                 staged_state.last_decision = decision
@@ -2449,7 +2456,7 @@ class AutoNudgeService:
             if not loop.active:
                 self._sync_terminal_completion_timer(loop)
         self._emit("updated", loop)
-        return decision
+        return verdict
 
     def _set_monitor_deadline(self, loop: NudgeLoop, deadline: float) -> None:
         """Write the scheduler authority and inspection mirror together."""
@@ -4332,8 +4339,8 @@ class AutoNudgeService:
                             #
                             # SKIPPED, not returned from. This block's own comment forbids
                             # an early exit because the rest of the fire cycle still has
-                            # to run, and round 35 was that exact rule being broken by a
-                            # re-raise leaving through the same door.
+                            # to run, and a re-raise leaving through the same door breaks
+                            # that exact rule.
                             monitor.terminal_pending = ""
                             self._persist_soon()
                             logger.info(

--- a/src/kiro_crew/monitoring/controller.py
+++ b/src/kiro_crew/monitoring/controller.py
@@ -21,6 +21,7 @@ from kiro_crew.monitoring.models import (
     MonitorObservation,
     MonitorObservationStatus,
     MonitorState,
+    MonitorVerdict,
     ProviderErrorKind,
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -43,7 +44,7 @@ class _Service(Protocol):
         *,
         now: float,
         config_generation: int,
-    ) -> MonitorDecision: ...
+    ) -> MonitorVerdict: ...
 
     async def record_monitor_dispatch_failure(
         self,
@@ -112,7 +113,13 @@ class MonitorController:
         self._clock = clock
         self._provider = provider or GitHubPullRequestProvider()
 
-    async def tick(self, loop: _Loop, *, now: float) -> MonitorDecision:
+    async def tick(self, loop: _Loop, *, now: float) -> MonitorVerdict:
+        """Run one probe and return its verdict.
+
+        A verdict produced without probing -- a recorded outcome, an
+        undelivered wake still in flight -- carries no entries, because nothing
+        was observed on this tick.
+        """
         state = getattr(loop, "monitor", None)
         if state is None:
             raise ValueError("structured monitor state is required")
@@ -127,19 +134,19 @@ class MonitorController:
                     state.last_wake_fingerprint,
                     now=now,
                 )
-            return MonitorDecision.STOP_BLOCKED
+            return MonitorVerdict(decision=MonitorDecision.STOP_BLOCKED)
         if state.wake_in_flight:
             deadline = state.completion_evidence_deadline
             if state.wake_delivery is MonitorDispatchResult.BUSY:
                 if now < state.next_probe_at:
-                    return MonitorDecision.NO_CHANGE
+                    return MonitorVerdict(decision=MonitorDecision.NO_CHANGE)
                 if monitor_budget_reason(state, now=now):
                     await self._service.record_monitor_dispatch_busy(
                         loop.id,
                         state.last_wake_fingerprint,
                         now=now,
                     )
-                    return MonitorDecision.STOP_BUDGET
+                    return MonitorVerdict(decision=MonitorDecision.STOP_BUDGET)
                 return await self._dispatch_claimed(loop, state, now=now)
             if (
                 state.wake_delivery is MonitorDispatchResult.DISPATCHED
@@ -151,7 +158,7 @@ class MonitorController:
                     state.last_wake_fingerprint,
                     now=now,
                 )
-            return MonitorDecision.NO_CHANGE
+            return MonitorVerdict(decision=MonitorDecision.NO_CHANGE)
         config_generation = state.config_generation
         target = state.target
         previous_observation = deepcopy(state.last_observation)
@@ -173,15 +180,15 @@ class MonitorController:
                     reason_code="provider_transient",
                 ),
             )
-        decision = await self._service.apply_monitor_probe(
+        verdict = await self._service.apply_monitor_probe(
             loop.id,
             result,
             now=now,
             config_generation=config_generation,
         )
-        if decision is not MonitorDecision.WAKE_ACTIONABLE:
-            return decision
-        return await self._dispatch_claimed(loop, state, now=now)
+        if verdict.decision is not MonitorDecision.WAKE_ACTIONABLE:
+            return verdict
+        return await self._dispatch_claimed(loop, state, now=now, entries=verdict.entries)
 
     async def _dispatch_claimed(
         self,
@@ -189,8 +196,14 @@ class MonitorController:
         state: MonitorState,
         *,
         now: float,
-    ) -> MonitorDecision:
-        """Deliver one persisted claim or schedule its typed recovery path."""
+        entries: tuple[MonitorObservation, ...] = (),
+    ) -> MonitorVerdict:
+        """Deliver one persisted claim or schedule its typed recovery path.
+
+        *entries* are the observations that produced the claim, carried through
+        so the delivered verdict still names its evidence. A retry of a claim
+        persisted on an earlier tick has none to carry.
+        """
         envelope = format_monitor_wake(
             monitor_id=loop.id,
             target=state.target,
@@ -204,7 +217,7 @@ class MonitorController:
             loop.id,
             state.last_wake_fingerprint,
         ):
-            return MonitorDecision.STOP_BLOCKED
+            return MonitorVerdict(decision=MonitorDecision.STOP_BLOCKED, entries=entries)
         try:
             delivered = await self._dispatch(loop, envelope)
         except asyncio.CancelledError:
@@ -238,7 +251,7 @@ class MonitorController:
                 state.last_wake_fingerprint,
                 now=self._clock(),
             )
-        return MonitorDecision.WAKE_ACTIONABLE
+        return MonitorVerdict(decision=MonitorDecision.WAKE_ACTIONABLE, entries=entries)
 
 
 def format_monitor_wake(

--- a/src/kiro_crew/monitoring/decision.py
+++ b/src/kiro_crew/monitoring/decision.py
@@ -14,6 +14,7 @@ from kiro_crew.monitoring.models import (
     MonitorObservationStatus,
     MonitorOutcome,
     MonitorState,
+    MonitorVerdict,
     ProviderErrorKind,
 )
 
@@ -27,8 +28,28 @@ def decide_monitor(
     observation: MonitorObservation,
     *,
     now: float,
-) -> MonitorDecision:
+) -> MonitorVerdict:
     """Return the only controller effect permitted for an observation.
+
+    The effect is returned inside a :class:`MonitorVerdict` so it arrives with
+    the observations it was rendered against. Every path here judged exactly one
+    observation, so the verdict names that one; a probe reporting several
+    independent conditions fills the same tuple with several entries without
+    changing this signature or any caller.
+    """
+    return MonitorVerdict(
+        decision=_decide_effect(state, observation, now=now),
+        entries=(observation,),
+    )
+
+
+def _decide_effect(
+    state: MonitorState,
+    observation: MonitorObservation,
+    *,
+    now: float,
+) -> MonitorDecision:
+    """Select the effect alone.
 
     Budget checks lead because a spent bound must never buy one additional
     unattended turn. Provider failures are classified without a model. For a

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -258,6 +258,53 @@ class MonitorObservation:
             raise ValueError("supplemental_provider_error must be a ProviderErrorKind")
 
 
+@dataclass(frozen=True)
+class MonitorVerdict:
+    """One decision and the observations it was rendered against.
+
+    The decision is a *field* rather than the return value of the decision
+    engine. A bare :class:`MonitorDecision` is an effect SELECTOR: it says what
+    the controller should do, and nothing about what it saw. The evidence is not
+    unreachable -- ``monitoring.controller.format_monitor_wake`` rebuilds both
+    the changed facts and the wake text downstream, from
+    ``MonitorState.last_observation`` and ``MonitorState.wake_instructions`` --
+    but it is reachable only by re-deriving it from persisted state the verdict
+    never named.
+
+    That indirection is what keeps a subject reduced to one comparable
+    fingerprint: a consumer obliged to rebuild the evidence itself cannot be
+    handed a list it never asked for, so a second entry has nowhere to go.
+    Naming the evidence on the verdict is what removes the re-derivation.
+
+    ``entries`` is plural from the start. A subject that reports several
+    independent conditions -- a failing check, a stale review stamp, an
+    un-dispositioned finding -- is the reason this type exists, even though a
+    single-subject probe fills it with exactly one entry today.
+
+    There is deliberately no operator-facing text field here. Delivery composes
+    the wake envelope from durable state in
+    ``monitoring.controller.format_monitor_wake``, so a text field on the verdict
+    would be a second way to say the same thing with nothing reading it. The
+    change that gives such a field a reader is the one that should add it, where
+    a single test can show the text being produced AND consumed.
+
+    Nothing here may name a provider. A fact meaningful to only one monitored
+    kind belongs on that kind's observation, never on the shared verdict.
+    """
+
+    decision: MonitorDecision
+    entries: tuple[MonitorObservation, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.decision, MonitorDecision):
+            raise ValueError("decision must be a MonitorDecision")
+        if not isinstance(self.entries, tuple):
+            raise ValueError("entries must be a tuple")
+        for entry in self.entries:
+            if not isinstance(entry, MonitorObservation):
+                raise ValueError("every verdict entry must be a MonitorObservation")
+
+
 @dataclass
 class MonitorState:
     """Restart-durable state for one structured monitor."""

--- a/src/kiro_crew/monitoring/shadow.py
+++ b/src/kiro_crew/monitoring/shadow.py
@@ -19,6 +19,7 @@ from kiro_crew.monitoring.models import (
     MonitorObservationStatus,
     MonitorOutcome,
     MonitorState,
+    MonitorVerdict,
     ProviderErrorKind,
     is_finite_non_negative_number,
 )
@@ -48,8 +49,12 @@ async def run_shadow_probe(
     *,
     now: float,
     wake_delivery: bool = False,
-) -> MonitorDecision:
-    """Probe and persist one decision without acquiring a delivery capability."""
+) -> MonitorVerdict:
+    """Probe and persist one decision without acquiring a delivery capability.
+
+    A verdict returned before the probe runs carries no entries: refusing a
+    monitor for a recorded outcome or a spent budget observes nothing.
+    """
     if wake_delivery:
         raise ShadowWakeDeliveryRefused("wake delivery is unavailable in shadow mode")
     if state.kind != "github_pull_request" or state.objective != "review_ready":
@@ -61,7 +66,7 @@ async def run_shadow_probe(
 
     terminal = terminal_decision_for_outcome(state.outcome)
     if terminal is not None:
-        return terminal
+        return MonitorVerdict(decision=terminal)
     budget_reason = monitor_budget_reason(state, now=now)
     if budget_reason:
         staged = deepcopy(state)
@@ -71,7 +76,7 @@ async def run_shadow_probe(
         staged.stopped_at = now
         staged.next_probe_at = 0.0
         await _persist_and_publish(state, staged, persist)
-        return MonitorDecision.STOP_BUDGET
+        return MonitorVerdict(decision=MonitorDecision.STOP_BUDGET)
 
     result = await asyncio.to_thread(
         provider.probe,
@@ -79,7 +84,8 @@ async def run_shadow_probe(
         previous_observation=deepcopy(state.last_observation),
     )
     staged = deepcopy(state)
-    decision = decide_monitor(staged, result.observation, now=now)
+    verdict = decide_monitor(staged, result.observation, now=now)
+    decision = verdict.decision
     staged.probe_count += 1
     staged.last_probe_at = now
     staged.last_decision = decision
@@ -108,7 +114,7 @@ async def run_shadow_probe(
     else:
         staged.next_probe_at = now + staged.cadence_secs
     await _persist_and_publish(state, staged, persist)
-    return decision
+    return verdict
 
 
 async def _persist_and_publish(

--- a/test/test_github_pull_request_monitor.py
+++ b/test/test_github_pull_request_monitor.py
@@ -998,7 +998,7 @@ async def test_shadow_graphql_error_without_data_persists_new_primary_facts() ->
 
     decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
 
-    assert decision is MonitorDecision.RETRY_PROVIDER
+    assert decision.decision is MonitorDecision.RETRY_PROVIDER
     assert state.last_observation["head_revision"] == _HEAD
     assert state.last_observation["review_threads_complete"] is False
     assert state.last_fingerprint != "safe-fingerprint"
@@ -1298,7 +1298,7 @@ def test_changed_head_is_explicitly_actionable_even_when_new_facts_are_green() -
     assert current.observation.head_changed is True
     assert current.observation.status is MonitorObservationStatus.SUCCESS
     assert current.observation.fingerprint != previous.observation.fingerprint
-    assert decide_monitor(state, current.observation, now=1_001.0) is (
+    assert decide_monitor(state, current.observation, now=1_001.0).decision is (
         MonitorDecision.WAKE_ACTIONABLE
     )
 
@@ -1322,7 +1322,10 @@ def test_missing_current_head_is_pending_without_a_changed_head_wake() -> None:
 
     assert result.observation.status is MonitorObservationStatus.PENDING
     assert result.observation.head_changed is False
-    assert decide_monitor(state, result.observation, now=1_001.0) is MonitorDecision.RECORD_ONLY
+    assert (
+        decide_monitor(state, result.observation, now=1_001.0).decision
+        is MonitorDecision.RECORD_ONLY
+    )
 
 
 @pytest.mark.parametrize(
@@ -1352,7 +1355,7 @@ def test_terminal_pull_request_state_precedes_a_head_revision_change(
     )
 
     assert result.observation.head_changed is False
-    assert decide_monitor(state, result.observation, now=1_001.0) is expected
+    assert decide_monitor(state, result.observation, now=1_001.0).decision is expected
 
 
 class _FailureRunner:
@@ -1579,7 +1582,7 @@ async def test_shadow_probe_persists_observation_decision_and_metrics_without_a_
 
     decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
 
-    assert decision is MonitorDecision.WAKE_ACTIONABLE
+    assert decision.decision is MonitorDecision.WAKE_ACTIONABLE
     assert state.last_decision is MonitorDecision.WAKE_ACTIONABLE
     assert state.probe_count == 1
     assert state.provider_error_count == 0
@@ -1624,7 +1627,7 @@ async def test_shadow_provider_error_persists_only_fixed_error_metrics() -> None
 
     decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
 
-    assert decision is MonitorDecision.RETRY_PROVIDER
+    assert decision.decision is MonitorDecision.RETRY_PROVIDER
     assert state.last_observation == previous
     assert state.last_fingerprint == "safe-fingerprint"
     assert state.probe_count == 1
@@ -2020,7 +2023,8 @@ async def test_shadow_budget_gate_stops_before_provider_execution() -> None:
 
     decision = await run_shadow_probe(state, Provider(), persist, now=1_100.0)
 
-    assert decision is MonitorDecision.STOP_BUDGET
+    assert decision.decision is MonitorDecision.STOP_BUDGET
+    assert decision.entries == (), "a gate that precedes the probe observed nothing"
     assert probes == 0
     assert len(snapshots) == 1
     assert state.outcome is MonitorOutcome.BUDGET
@@ -2067,7 +2071,7 @@ async def test_shadow_terminal_probe_persists_terminal_outcome_without_rearming(
 
     decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
 
-    assert decision is MonitorDecision.STOP_SUCCESS
+    assert decision.decision is MonitorDecision.STOP_SUCCESS
     assert state.outcome is MonitorOutcome.SUCCESS
     assert state.stopped_reason == "pull_request_merged"
     assert state.stopped_at == 1_100.0
@@ -2102,7 +2106,8 @@ async def test_shadow_terminal_state_never_probes_again_or_changes_outcome() -> 
 
     decision = await run_shadow_probe(state, Provider(), persist, now=10_000.0)
 
-    assert decision is MonitorDecision.STOP_SUCCESS
+    assert decision.decision is MonitorDecision.STOP_SUCCESS
+    assert decision.entries == (), "a recorded outcome is replayed, not re-observed"
     assert probes == 0
     assert persists == 0
     assert state.outcome is MonitorOutcome.SUCCESS

--- a/test/test_monitor_behaviour_golden.py
+++ b/test/test_monitor_behaviour_golden.py
@@ -1,0 +1,327 @@
+"""Golden behaviour table locking the GitHub pull-request probe's output.
+
+The monitoring substrate is being refactored into a plug-in shape across several
+changes: a verdict that carries a payload, a probe result that names no host, and
+a registry of kinds. Every one of those is meant to be behaviour-preserving, and
+"behaviour" here means the exact bytes this provider derives from a gh response:
+the canonical fact dictionary, the observation status, the reason code, and the
+fingerprint the decision engine compares against persisted state.
+
+A table produced *after* a refactor records the new behaviour as if it were the
+old one and proves nothing. So this digest is captured on the pristine tree
+before a change and asserted afterwards. If a refactor is genuinely a refactor,
+:data:`GOLDEN_DIGEST` does not move.
+
+The matrix is driven through the public :meth:`GitHubPullRequestProvider.probe`
+with a fake gh runner, exactly as the rest of the provider's tests are, so it
+covers response normalization as well as canonicalization rather than reaching
+into private helpers.
+
+When a change is *meant* to move the table, re-pin both constants in the same
+commit from the values the failure prints, and say in the pull request which
+groups moved and why.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import json
+import subprocess
+from collections.abc import Sequence
+
+from kiro_crew.monitoring.github_pull_request import (
+    GitHubPullRequestProvider,
+    parse_github_pull_request_target,
+)
+
+TARGET_URL = "https://github.com/owner/repo/pull/123"
+HEAD = "0123456789abcdef0123456789abcdef01234567"
+PREVIOUS_HEAD = "fedcba9876543210fedcba9876543210fedcba98"
+
+#: sha256 over the canonical probe output of every matrix row. Captured on
+#: kirocrew/main at 53987e756 -- before the verdict-payload change -- and
+#: unchanged by it.
+GOLDEN_DIGEST = "2ccba80c98aaf46ec5de2f6180664b0f063fe28c1f3502083a270d1c0e2ef7af"
+
+#: The same output digested per pull-request state and check-rollup shape, so a
+#: mismatch names the shape that moved instead of only the whole table. Captured
+#: on the same pristine tree.
+GOLDEN_GROUP_DIGESTS: dict[str, str] = {
+    "CLOSED/absent": "19569bf418bb733eeba562f4081dd46ff1cce8334ad13269fe802c186b62f533",
+    "CLOSED/cancelled": "2596fce96d8b0a0175a07cb85cf4cb6d57d1931f1bbab0d34474434099bbe85c",
+    "CLOSED/empty": "e25b40e2cd8efeb9a59d6fb3ec504163469ed363a984eb47d189fe992a2b9b29",
+    "CLOSED/green": "d15716691af7ad6b3ac04775dfa9b27ce2ee2a362c863481eb0f9e6afcd7e8f5",
+    "CLOSED/one-red": "92c6f15700e7af3b44af8e6d7e9c1ac9862d22e873bac9163a5cc4c665f59387",
+    "CLOSED/pending": "2769af520bb849ef8aca111d5ea156ee12fcd1f04c326abf2e66603169864f39",
+    "CLOSED/unknown-conclusion": "e51bd441d39b62cd11a5a24e32e4a13cb9a6ce173d336f5cfc580737dc6f25e6",
+    "MERGED/absent": "b2beee0d9d2fe3bb9b6e356075718c37158185e00559926aca60bfeac132e7df",
+    "MERGED/cancelled": "8fd31fa1c61a9184a88a53ed066eda91ecaab26dcec25029d5cc3b912abb31d5",
+    "MERGED/empty": "fde0471c35ce908e27bd80c0d5c0f57c45af771ff7ba8bc5dc4cf3574db2acc3",
+    "MERGED/green": "22417ae5c7382e4d3fe08e9175ea23536af2d9db1a25004aa1c17e4eb800e445",
+    "MERGED/one-red": "3536fe6854e8d9b10c49b09954b7bae49259d49c4acf89790dc4b81f37c7aff3",
+    "MERGED/pending": "b14b7c234c9b263f1d2c826927de8764ef75dd47963a5c0e310a8ab1bc9742cf",
+    "MERGED/unknown-conclusion": "fa71c711557fdc696b963c6c0a8b907d3ac73f69bba4248f2efeabe078984159",
+    "OPEN/absent": "8da02cd1eafa6607b707e340afeb08abe7e209d986da9edd438ce6777cd63625",
+    "OPEN/cancelled": "e53740c00f90ff470750453a963c8b16339e0a09ece5c2ba11303dfce2722c81",
+    "OPEN/empty": "ee0711180b5362fcf823529c7b1bb1fe8c5a6fe20e69db055e995884f15e9d35",
+    "OPEN/green": "d99ab3c3c63fb1d4b7db7ea89aa999843a28de9ba06f81e0860607b7f9d69b9c",
+    "OPEN/one-red": "9156973395e03b051d1332c8848616f7954bc9b0cd6c8dbfc834a7807868c72c",
+    "OPEN/pending": "e44ec8b8bf86c57dd4be7c110730cd0f78b3efa5b46d9d869f637c522bb60926",
+    "OPEN/unknown-conclusion": "dba77d405759eed23d6e096b40623ca51604e37e168c2c8f8c6be072ec99a2c4",
+    "SOMETHING_ELSE/absent": "ea62fb42ed605b0bd939500e7e541a71b8a7cadeb3750668229bad37ebf7a01c",
+    "SOMETHING_ELSE/cancelled": "5e0eb46902fd14f25ff977d1e1ae04f30172f8600c8de44489ad60e5a6c23e4a",
+    "SOMETHING_ELSE/empty": "199cd5dadc65f72e021bf4cad522f12d6380cdb330d0da54aa39e9eec79db510",
+    "SOMETHING_ELSE/green": "f08fbc813748c96f45745627d8b1e8404f4214d8a73769d4f2ea933f1340c64c",
+    "SOMETHING_ELSE/one-red": "91c5ca8eb69e927b6220dd527fc692f96816e4aef5d4f0462e4ff16a7aa89382",
+    "SOMETHING_ELSE/pending": "fd5ffcdcf545d46a478bed51dd97047a7f1391b94efa99f4d1e1ff79973e1ea9",
+    "SOMETHING_ELSE/unknown-conclusion": (
+        "10f49a47b6623badb98a81b2b16a75a3f578092f41a1afa24cdfdc7eab9d63f2"
+    ),
+}
+
+_ROLLUPS: tuple[tuple[str, object], ...] = (
+    ("absent", None),
+    ("empty", []),
+    (
+        "green",
+        [
+            {
+                "__typename": "CheckRun",
+                "name": "test",
+                "workflowName": "CI",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {"__typename": "StatusContext", "context": "lint", "state": "SUCCESS"},
+        ],
+    ),
+    (
+        "one-red",
+        [
+            {
+                "__typename": "CheckRun",
+                "name": "test",
+                "workflowName": "CI",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+            },
+            {"__typename": "StatusContext", "context": "lint", "state": "SUCCESS"},
+        ],
+    ),
+    (
+        "pending",
+        [
+            {
+                "__typename": "CheckRun",
+                "name": "test",
+                "workflowName": "CI",
+                "status": "IN_PROGRESS",
+                "conclusion": None,
+            }
+        ],
+    ),
+    (
+        "unknown-conclusion",
+        [
+            {
+                "__typename": "CheckRun",
+                "name": "test",
+                "workflowName": "CI",
+                "status": "COMPLETED",
+                "conclusion": "NEUTRAL_SOMETHING",
+            }
+        ],
+    ),
+    (
+        "cancelled",
+        [
+            {
+                "__typename": "CheckRun",
+                "name": "test",
+                "workflowName": "CI",
+                "status": "COMPLETED",
+                "conclusion": "CANCELLED",
+            }
+        ],
+    ),
+)
+
+_THREADS: tuple[tuple[str, list[dict[str, object]]], ...] = (
+    ("none", []),
+    ("resolved", [{"isResolved": True, "isOutdated": False}]),
+    ("unresolved", [{"isResolved": False, "isOutdated": False}]),
+    ("outdated-unresolved", [{"isResolved": False, "isOutdated": True}]),
+    (
+        "mixed",
+        [
+            {"isResolved": False, "isOutdated": False},
+            {"isResolved": True, "isOutdated": False},
+            {"isResolved": False, "isOutdated": True},
+        ],
+    ),
+)
+
+_STATES = ("OPEN", "CLOSED", "MERGED", "SOMETHING_ELSE")
+_DRAFTS = (False, True)
+_MERGEABLE = ("MERGEABLE", "CONFLICTING", "UNKNOWN")
+_MERGE_STATE = ("CLEAN", "BEHIND", "BLOCKED", "DIRTY", "UNSTABLE")
+_REVIEW_DECISIONS = ("APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", None)
+
+
+class _MatrixRunner:
+    """Answer the provider's three gh calls from one row's fixtures."""
+
+    def __init__(self, primary: dict[str, object], threads: list[dict[str, object]]) -> None:
+        self._primary = primary
+        self._threads = threads
+
+    def __call__(self, argv: Sequence[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        joined = " ".join(str(part) for part in argv)
+        if "graphql" in joined:
+            payload: object = {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": self._threads,
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            }
+                        }
+                    }
+                }
+            }
+        elif "statusCheckRollup" in joined:
+            payload = {
+                "headRefOid": self._primary["headRefOid"],
+                "statusCheckRollup": self._primary.get("statusCheckRollup"),
+            }
+        else:
+            payload = {
+                key: value for key, value in self._primary.items() if key != "statusCheckRollup"
+            }
+        return subprocess.CompletedProcess(list(argv), 0, stdout=json.dumps(payload), stderr="")
+
+
+def _rows() -> list[dict[str, object]]:
+    """Probe every combination and record only its externally meaningful output."""
+    parse_github_pull_request_target(TARGET_URL)
+    rows: list[dict[str, object]] = []
+    combos = itertools.product(
+        _STATES,
+        _DRAFTS,
+        _MERGEABLE,
+        _MERGE_STATE,
+        _REVIEW_DECISIONS,
+        _ROLLUPS,
+        _THREADS,
+    )
+    for (
+        state,
+        draft,
+        mergeable,
+        merge_state,
+        review,
+        (rollup_label, rollup),
+        (
+            threads_label,
+            threads,
+        ),
+    ) in combos:
+        primary: dict[str, object] = {
+            "number": 123,
+            "state": state,
+            "isDraft": draft,
+            "headRefOid": HEAD,
+            "mergeable": mergeable,
+            "mergeStateStatus": merge_state,
+            "reviewDecision": review,
+            "statusCheckRollup": rollup,
+        }
+        provider = GitHubPullRequestProvider(
+            resolver=lambda: "/usr/bin/gh",
+            runner=_MatrixRunner(primary, threads),
+        )
+        result = provider.probe(
+            TARGET_URL,
+            previous_observation={"head_revision": PREVIOUS_HEAD},
+        )
+        observation = result.observation
+        rows.append(
+            {
+                "key": [
+                    state,
+                    draft,
+                    mergeable,
+                    merge_state,
+                    review or "none",
+                    rollup_label,
+                    threads_label,
+                ],
+                "canonical": result.canonical,
+                "fingerprint": observation.fingerprint,
+                "status": observation.status.value,
+                "reason_code": observation.reason_code,
+                "head_changed": observation.head_changed,
+                "provider_error": (
+                    observation.provider_error.value
+                    if observation.provider_error is not None
+                    else None
+                ),
+                "supplemental_provider_error": (
+                    observation.supplemental_provider_error.value
+                    if observation.supplemental_provider_error is not None
+                    else None
+                ),
+            }
+        )
+    return rows
+
+
+def _digest(rows: list[dict[str, object]]) -> str:
+    encoded = json.dumps(rows, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _group_digests(rows: list[dict[str, object]]) -> dict[str, str]:
+    """Digest each pull-request state and rollup shape on its own.
+
+    One hash over every row says only that something moved. Grouping localizes a
+    mismatch to the shape that caused it, so the next refactor reads a group name
+    instead of regenerating the table blind.
+    """
+    grouped: dict[str, list[dict[str, object]]] = {}
+    for row in rows:
+        key = row["key"]
+        assert isinstance(key, list)
+        grouped.setdefault(f"{key[0]}/{key[5]}", []).append(row)
+    return {name: _digest(members) for name, members in sorted(grouped.items())}
+
+
+def test_probe_behaviour_table_has_not_moved() -> None:
+    """Lock every canonical fact, classification and fingerprint the probe derives."""
+    rows = _rows()
+    assert rows, "the matrix must not be empty"
+
+    groups = _group_digests(rows)
+    moved = sorted(
+        name
+        for name, digest in groups.items()
+        if GOLDEN_GROUP_DIGESTS.get(name) not in (None, digest)
+    )
+    missing = sorted(set(GOLDEN_GROUP_DIGESTS) - set(groups))
+    appeared = sorted(set(groups) - set(GOLDEN_GROUP_DIGESTS))
+    actual = _digest(rows)
+
+    assert (actual, moved, missing, appeared) == (GOLDEN_DIGEST, [], [], []), (
+        "the GitHub pull-request probe's observable output changed.\n"
+        f"  digest now: {actual}\n"
+        f"  digest pinned: {GOLDEN_DIGEST}\n"
+        f"  groups that moved: {moved or 'none'}\n"
+        f"  groups that disappeared: {missing or 'none'}\n"
+        f"  groups that appeared: {appeared or 'none'}\n"
+        "A refactor meant to preserve behaviour must not move any of this. If the "
+        "change is deliberate, re-pin GOLDEN_DIGEST and GOLDEN_GROUP_DIGESTS from "
+        "the values above in the same commit, and say in the pull request which "
+        "groups moved and why."
+    )

--- a/test/test_monitor_controller.py
+++ b/test/test_monitor_controller.py
@@ -153,7 +153,7 @@ async def test_unchanged_probe_dispatches_zero_turns_and_persists_deadline(tmp_p
 
     decision = await controller.tick(loop, now=120.0)
 
-    assert decision is MonitorDecision.NO_CHANGE
+    assert decision.decision is MonitorDecision.NO_CHANGE
     dispatched.assert_not_awaited()
     write_snapshot.assert_awaited_once()
     assert loop.next_due_ts == loop.monitor.next_probe_at == 180.0
@@ -171,7 +171,7 @@ async def test_retry_backoff_is_bounded_and_dispatches_zero_turns(tmp_path):
     first = await controller.tick(loop, now=120.0)
     second = await controller.tick(loop, now=135.0)
 
-    assert first is second is MonitorDecision.RETRY_PROVIDER
+    assert first.decision is second.decision is MonitorDecision.RETRY_PROVIDER
     dispatched.assert_not_awaited()
     assert loop.monitor is not None
     assert loop.next_due_ts == loop.monitor.next_probe_at == 165.0
@@ -189,7 +189,7 @@ async def test_unexpected_provider_failure_persists_retry_without_dispatch(tmp_p
 
     decision = await controller.tick(loop, now=120.0)
 
-    assert decision is MonitorDecision.RETRY_PROVIDER
+    assert decision.decision is MonitorDecision.RETRY_PROVIDER
     dispatched.assert_not_awaited()
     assert loop.monitor is not None
     assert loop.next_due_ts == loop.monitor.next_probe_at == 135.0
@@ -298,7 +298,7 @@ async def test_terminal_transition_queued_during_claim_persistence_prevents_disp
     decision = await tick
     await terminal
 
-    assert decision is MonitorDecision.STOP_BLOCKED
+    assert decision.decision is MonitorDecision.STOP_BLOCKED
     dispatched.assert_not_awaited()
     assert not loop.active
     assert loop.monitor is not None
@@ -649,7 +649,7 @@ async def test_supplemental_provider_failures_advance_the_bounded_error_streak(t
         config_generation=loop.monitor.config_generation,
     )
 
-    assert first is MonitorDecision.RETRY_PROVIDER
+    assert first.decision is MonitorDecision.RETRY_PROVIDER
     assert loop.monitor.provider_error_count == 1
     assert loop.monitor.consecutive_provider_errors == 1
     assert loop.monitor.last_provider_error is ProviderErrorKind.TRANSIENT
@@ -662,7 +662,7 @@ async def test_supplemental_provider_failures_advance_the_bounded_error_streak(t
         config_generation=loop.monitor.config_generation,
     )
 
-    assert second is MonitorDecision.STOP_BLOCKED
+    assert second.decision is MonitorDecision.STOP_BLOCKED
     assert loop.monitor.provider_error_count == 2
     assert loop.monitor.consecutive_provider_errors == 2
     assert loop.monitor.outcome is MonitorOutcome.BLOCKED
@@ -923,7 +923,7 @@ async def test_terminal_claim_expiry_clears_only_the_correlation(tmp_path):
 
     decision = await controller.tick(loop, now=evidence_deadline)
 
-    assert decision is MonitorDecision.STOP_BLOCKED
+    assert decision.decision is MonitorDecision.STOP_BLOCKED
     assert loop.monitor.outcome is MonitorOutcome.USER_STOP
     assert not loop.monitor.wake_in_flight
     assert loop.monitor.completion_evidence_deadline == 0.0
@@ -950,7 +950,7 @@ async def test_session_close_claim_expiry_clears_only_the_correlation(tmp_path):
     assert service._timers.get(loop.id) is not None
     decision = await controller.tick(loop, now=evidence_deadline)
 
-    assert decision is MonitorDecision.STOP_BLOCKED
+    assert decision.decision is MonitorDecision.STOP_BLOCKED
     assert loop.monitor.outcome is MonitorOutcome.SESSION_CLOSE
     assert not loop.monitor.wake_in_flight
     assert loop.monitor.completion_evidence_deadline == 0.0
@@ -1185,7 +1185,7 @@ async def test_restored_accepted_claim_without_delivery_retries_as_busy(tmp_path
     assert loop.monitor is not None
     assert loop.monitor.wake_delivery is MonitorDispatchResult.BUSY
     retry_at = loop.monitor.next_probe_at
-    assert await controller.tick(loop, now=retry_at) is MonitorDecision.WAKE_ACTIONABLE
+    assert (await controller.tick(loop, now=retry_at)).decision is MonitorDecision.WAKE_ACTIONABLE
     dispatched.assert_awaited_once()
     service.stop()
 
@@ -1200,7 +1200,7 @@ async def test_untyped_dispatch_result_fails_closed_without_orphaning_claim(tmp_
 
     decision = await controller.tick(loop, now=120.0)
 
-    assert decision is MonitorDecision.WAKE_ACTIONABLE
+    assert decision.decision is MonitorDecision.WAKE_ACTIONABLE
     assert loop.monitor is not None
     assert loop.monitor.outcome is MonitorOutcome.TARGET_UNAVAILABLE
     assert not loop.monitor.wake_in_flight
@@ -1255,7 +1255,7 @@ async def test_busy_stop_clears_claim_and_allows_a_fresh_monitor(
 
     decision = await MonitorController(service, dispatched, provider=provider).tick(loop, now=180.0)
 
-    assert decision is MonitorDecision.STOP_BLOCKED
+    assert decision.decision is MonitorDecision.STOP_BLOCKED
     assert provider.previous == []
     dispatched.assert_not_awaited()
     assert loop.monitor.agent_turns == 0
@@ -1362,3 +1362,46 @@ def test_monitor_wake_reports_check_counts_without_provider_labels():
     assert "unknown checks: 1" in envelope
     assert "upload secrets" not in envelope
     assert "provider.example" not in envelope
+
+
+@pytest.mark.asyncio
+async def test_a_probed_verdict_names_its_observation_and_an_unprobed_one_does_not(tmp_path):
+    """Entries record what was observed, so a tick that observes nothing has none.
+
+    A recorded outcome short-circuits before the provider is reached. Reporting
+    an entry there would attribute evidence to a tick that never gathered any.
+    """
+    result = _result(MonitorObservationStatus.PENDING)
+    service, loop, controller = await _armed(
+        tmp_path,
+        result=result,
+        dispatch=AsyncMock(),
+    )
+
+    probed = await controller.tick(loop, now=120.0)
+
+    assert probed.entries == (result.observation,)
+
+    await service.stop_monitor(loop.id, now=121.0)
+    unprobed = await controller.tick(loop, now=122.0)
+
+    assert unprobed.decision is MonitorDecision.STOP_BLOCKED
+    assert unprobed.entries == ()
+    service.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_delivered_wake_keeps_the_evidence_that_claimed_it(tmp_path):
+    """Dispatch must not drop the entries on the way to the session."""
+    result = _result(MonitorObservationStatus.ACTIONABLE)
+    service, loop, controller = await _armed(
+        tmp_path,
+        result=result,
+        dispatch=AsyncMock(return_value=MonitorDispatchResult.DISPATCHED),
+    )
+
+    verdict = await controller.tick(loop, now=120.0)
+
+    assert verdict.decision is MonitorDecision.WAKE_ACTIONABLE
+    assert verdict.entries == (result.observation,)
+    service.stop()

--- a/test/test_monitor_decision.py
+++ b/test/test_monitor_decision.py
@@ -11,6 +11,7 @@ from kiro_crew.monitoring.models import (
     MonitorObservation,
     MonitorObservationStatus,
     MonitorState,
+    MonitorVerdict,
     ProviderErrorKind,
 )
 
@@ -74,7 +75,7 @@ def test_observation_changes_control_when_a_model_turn_is_allowed(
     expected: MonitorDecision,
 ) -> None:
     """A model turn is reserved for a new actionable fingerprint."""
-    assert decide_monitor(state, observation, now=1_100.0) is expected
+    assert decide_monitor(state, observation, now=1_100.0).decision is expected
 
 
 def test_changed_head_does_not_wake_while_readiness_is_pending() -> None:
@@ -85,7 +86,9 @@ def test_changed_head_does_not_wake_while_readiness_is_pending() -> None:
         head_changed=True,
     )
 
-    assert decide_monitor(_state(), observation, now=1_100.0) is MonitorDecision.RECORD_ONLY
+    assert (
+        decide_monitor(_state(), observation, now=1_100.0).decision is MonitorDecision.RECORD_ONLY
+    )
 
 
 def test_success_after_a_changed_head_can_reach_terminal_success() -> None:
@@ -97,13 +100,15 @@ def test_success_after_a_changed_head_can_reach_terminal_success() -> None:
     )
     settled = MonitorObservation("green-new-head", MonitorObservationStatus.SUCCESS)
 
-    assert decide_monitor(_state(), changed, now=1_100.0) is MonitorDecision.WAKE_ACTIONABLE
+    assert (
+        decide_monitor(_state(), changed, now=1_100.0).decision is MonitorDecision.WAKE_ACTIONABLE
+    )
     assert (
         decide_monitor(
             _state(last_fingerprint="green-new-head"),
             settled,
             now=1_101.0,
-        )
+        ).decision
         is MonitorDecision.STOP_SUCCESS
     )
 
@@ -150,7 +155,7 @@ def test_provider_failures_never_buy_a_model_turn(
             ),
             observation,
             now=1_100.0,
-        )
+        ).decision
         is expected
     )
 
@@ -183,7 +188,7 @@ def test_exhausted_budget_prevents_even_an_actionable_wake(
         MonitorObservationStatus.ACTIONABLE,
     )
 
-    assert decide_monitor(state, observation, now=now) is MonitorDecision.STOP_BUDGET
+    assert decide_monitor(state, observation, now=now).decision is MonitorDecision.STOP_BUDGET
 
 
 @pytest.mark.parametrize(
@@ -277,6 +282,102 @@ def test_unknown_monitor_state_version_fails_closed() -> None:
             _state(version=99),
             observation,
             now=1_100.0,
-        )
+        ).decision
         is MonitorDecision.STOP_BLOCKED
     )
+
+
+class TestVerdictCarriesItsEvidence:
+    """A verdict must name the observations it was rendered against.
+
+    A bare decision selects an effect and says nothing about what was seen, so
+    the evidence had to be re-derived downstream from persisted state the
+    verdict never named. That re-derivation is what kept a subject reduced to
+    one comparable fingerprint, because a consumer rebuilding the evidence
+    itself cannot be handed a list it never asked for.
+    """
+
+    @pytest.mark.parametrize(
+        ("observation", "state"),
+        [
+            (
+                MonitorObservation("pending-b", MonitorObservationStatus.PENDING),
+                _state(last_fingerprint="pending-a"),
+            ),
+            (
+                MonitorObservation("failure-b", MonitorObservationStatus.ACTIONABLE),
+                _state(last_fingerprint="pending-a"),
+            ),
+            (
+                MonitorObservation("ready-c", MonitorObservationStatus.SUCCESS),
+                _state(last_fingerprint="pending-a"),
+            ),
+            (
+                MonitorObservation(
+                    "",
+                    MonitorObservationStatus.PROVIDER_ERROR,
+                    provider_error=ProviderErrorKind.TRANSIENT,
+                ),
+                _state(),
+            ),
+            (
+                MonitorObservation("any", MonitorObservationStatus.PENDING),
+                _state(version=99),
+            ),
+        ],
+    )
+    def test_every_decision_path_names_the_observation_it_judged(
+        self,
+        observation: MonitorObservation,
+        state: MonitorState,
+    ) -> None:
+        """Including the paths that never inspect it, such as a rejected version.
+
+        Callers advance durable probe state for any verdict a probe produced, so
+        a path that returns without reading the observation must still name it.
+        """
+        verdict = decide_monitor(state, observation, now=1_100.0)
+
+        assert verdict.entries == (observation,)
+
+    def test_a_spent_budget_still_names_the_observation_it_refused_to_act_on(self) -> None:
+        state = _state(agent_turns=99, budgets=MonitorBudgets(max_agent_turns=1))
+        observation = MonitorObservation("failure-b", MonitorObservationStatus.ACTIONABLE)
+
+        verdict = decide_monitor(state, observation, now=1_100.0)
+
+        assert verdict.decision is MonitorDecision.STOP_BUDGET
+        assert verdict.entries == (observation,)
+
+
+class TestVerdictRejectsMalformedPayloads:
+    def test_the_decision_must_be_the_enum(self) -> None:
+        with pytest.raises(ValueError, match="decision must be a MonitorDecision"):
+            MonitorVerdict(decision="wake_actionable")  # type: ignore[arg-type]
+
+    def test_entries_must_be_an_immutable_tuple(self) -> None:
+        observation = MonitorObservation("a", MonitorObservationStatus.PENDING)
+        with pytest.raises(ValueError, match="entries must be a tuple"):
+            MonitorVerdict(
+                decision=MonitorDecision.NO_CHANGE,
+                entries=[observation],  # type: ignore[arg-type]
+            )
+
+    def test_an_entry_must_be_an_observation(self) -> None:
+        with pytest.raises(ValueError, match="every verdict entry must be a MonitorObservation"):
+            MonitorVerdict(
+                decision=MonitorDecision.NO_CHANGE,
+                entries=("failure-b",),  # type: ignore[arg-type]
+            )
+
+    def test_several_entries_are_accepted_before_any_probe_reports_them(self) -> None:
+        """The plural shape is the point: it must not need widening later."""
+        first = MonitorObservation("a", MonitorObservationStatus.ACTIONABLE)
+        second = MonitorObservation("b", MonitorObservationStatus.PENDING)
+
+        verdict = MonitorVerdict(
+            decision=MonitorDecision.WAKE_ACTIONABLE,
+            entries=(first, second),
+        )
+
+        assert verdict.entries == (first, second)


### PR DESCRIPTION
## Problem / Motivation

`decide_monitor` returns a bare `MonitorDecision`. That is an effect *selector*:
it says what the controller should do and nothing about what it saw.

The evidence is not unreachable today, and it is worth being precise about that.
`format_monitor_wake` in `monitoring/controller.py` already rebuilds both halves
of it downstream -- the changed facts from `MonitorState.last_observation`, and
the text for the woken session from `MonitorState.wake_instructions`. So the
information exists; what does not exist is any statement of it by the verdict
itself. Every consumer re-derives it from persisted state the verdict never
named: `MonitorController.tick`, `AutoNudgeService.apply_monitor_probe` and
`run_shadow_probe` each go back to the probe result for the observation and its
provider error after the decision has already been made.

That indirection is what keeps a subject reduced to one comparable fingerprint. A
consumer obliged to rebuild the evidence for itself cannot be handed a list it
never asked for, so a second entry has nowhere to go, and
`monitoring/github_pull_request.py` must collapse a whole pull request -- every
check, the review decision, the unresolved-thread count -- into a single
`MonitorObservation.fingerprint` that `decide_monitor` compares against
`last_wake_fingerprint`.

## Why it matters

`docs/request-for-change/rfc-consolidated-monitor.md` describes a substrate where
a probe emits named entries and a shared engine decides over them. A verdict that
cannot hold entries keeps that vocabulary unreachable, so this return type blocks
the two changes queued behind it: a generic probe result, and a registry where
each kind declares its own objectives. The module spec that will carry the
paradigm in detail, `docs/system-specs/modules/monitor-architecture.md`, is not in
the tree yet -- it is in flight in PR 9368, so the RFC above is the in-tree
contract this change should be read against.

It also caps what a monitor can say today. A subject with three independent
conditions -- a failing check, a stale review stamp, an un-dispositioned finding
-- reaches the decision engine as one hash, so a wake can report that something
changed but not which of the three, and any one of them changing re-rolls the
same single fingerprint.

## What changed

The value of this change is that a verdict names its own evidence instead of
leaving every consumer to re-derive it. The goal was to do that without moving
any behaviour, since two more changes land on top and a behaviour shift here
would be attributed to them.

`MonitorVerdict` is a frozen dataclass in `monitoring/models.py` carrying the
decision as a *field*, beside a plural `entries` tuple. The enum is unchanged and
still the vocabulary; it is no longer the return value. `decide_monitor`,
`MonitorController.tick`, `AutoNudgeService.apply_monitor_probe` and
`run_shadow_probe` now return a verdict.

Two decisions worth naming:

`entries` is a tuple, plural from the start, even though a single-subject probe
fills it with exactly one entry. Widening a field later would touch every
implementation and every caller, so it is plural on day one. `decide_monitor`
names the observation it judged on *every* path, including the ones that return
without inspecting it (a rejected state version, a spent budget), because callers
advance durable probe state for any verdict a probe produced. A verdict reached
*without* probing carries no entries at all: a recorded outcome, a budget gate
that precedes the provider, or an undelivered wake still in flight observed
nothing on that tick, and reporting evidence there would attribute facts to a
tick that never gathered any.

There is deliberately no operator-facing text field on the verdict. An earlier
revision of this change carried one, and review was right that it did not belong:
`format_monitor_wake` already composes the wake envelope from
`MonitorState.last_observation` and `MonitorState.wake_instructions`, so a text
field on the verdict was a second way to say the same thing with nothing reading
it. An unread field is unverifiable surface -- a test asserting it arrives proves
nothing about whether a consumer handles it. The change that gives such a field a
reader is the one that should add it, where one test can show the text produced
AND consumed. Adding it later is free: it would be a defaulted scalar and all
twelve `MonitorVerdict(...)` sites pass keyword arguments, so no caller moves.
That asymmetry is exactly why `entries` had to be plural now and this did not.

Nothing on the verdict names a provider. A fact meaningful to only one monitored
kind belongs on that kind's observation.

One edit in `src/kiro_crew/autonudge.py` is unrelated to the verdict and is here
because a gate requires it: the comment-history gate scopes in any file the diff
touches, and that file carries 25 narration markers against a recorded baseline of
24. The excess is not introduced here -- pristine `main` and this branch yield an
identical 25-marker multiset, and the gate itself reports that this diff adds none
of the matched lines -- so one marker is reworded to present tense to bring the
file back to its baseline, which is the remedy the gate prescribes. The baseline
file is deliberately left alone.

## Tests

`test/test_monitor_behaviour_golden.py` is new and is the load-bearing one. It
drives a 16800-row matrix through the public `GitHubPullRequestProvider.probe`
with a fake gh runner -- states, draft flag, mergeability pairs, review
decisions, seven check-rollup shapes and five review-thread shapes -- and digests
the canonical facts, observation status, reason code, fingerprint, `head_changed`
and both provider-error fields of every row.

The order matters and is the point: those digests were captured on pristine
`kirocrew/main` at `53987e756`, before any edit in this branch, and are asserted
unchanged afterwards. A golden table produced after a change records the new
behaviour as if it were the old one and proves nothing. The two changes queued
behind this one inherit the same guard, which is why it is a committed test
rather than a scratch script.

It pins two things, so a mismatch is diagnosable rather than only detectable: one
digest over the whole table, and 28 per-group digests keyed by pull-request state
and check-rollup shape. A failure names which groups moved, which disappeared and
which appeared, and prints the values to re-pin, so the next refactor reads a
group name instead of regenerating blind. The assertion was verified to be
non-vacuous by perturbing a group digest and the overall digest in turn and
confirming each fails and reports the right group.

Added to `test/test_monitor_decision.py`:

- every decision path names the observation it judged, including a rejected state
  version and a spent budget
- the verdict rejects a non-enum decision, a list for `entries`, and a
  non-observation entry
- several entries are accepted before any probe reports them, so the plural shape
  needs no widening later

Added to `test/test_monitor_controller.py`:

- a probed verdict names its observation and an unprobed one carries none
- a delivered wake keeps the evidence that claimed it, so dispatch does not drop
  entries on the way to the session

`test/test_github_pull_request_monitor.py` gains the no-entries assertion on the
two shadow paths that stop before probing. Its other edits, and those in the
controller and decision suites, read `.decision` where they previously compared
the bare enum.

Existing test count is unchanged at 427 across
`test_monitor_decision.py test_monitor_controller.py test_monitor_persistence.py
test_github_pull_request_monitor.py test_autonudge.py` -- 427 passing on pristine
`main` and 427 passing here, with the new tests on top.

## Manual verification

N/A -- no user-visible surface changes, and the behaviour claim is covered by the
golden digest captured before the edit rather than by inspection.

Gates run locally: the repository's own black gate (diff-scoped, 9 files),
isort, flake8, `mypy` over the five changed modules in one invocation (which is
what checks the `_Service` protocol against `AutoNudgeService`'s implementation),
and the changelog, feature-map, testpaths-coverage, per-file-coverage, sync-IO
and subprocess-encoding scans. The repository-wide `mypy src/kiro_crew/` and the
backend scoped-test surface were not run locally; CI covers both.

## Related Issues

no linked issue: this is the first of three sequenced foundation changes for the
monitor substrate described in `docs/request-for-change/rfc-consolidated-monitor.md`,
and it closes no tracked defect on its own. The omission is deliberate.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, the spec lands separately
- [x] No secrets, credentials, or internal references in the diff
