### PR TITLE
fix(aws-control): resolve the consent card's key the way the operation does

### DIFF
--- a/docs/system-specs/modules/aws-control.md
+++ b/docs/system-specs/modules/aws-control.md
@@ -46,6 +46,37 @@ registrations, and
 `test_aws_control_app.py::TestDriveGuards.test_consent_refusal_answers_409_before_any_aws_call`
 pins refusal before the drive handler calls AWS.
 
+The confirmation surface and the operations resolve the same key, through one
+policy. `accounts.resolve_default_account_profile` is the strict form: the
+registry default picks the ACCOUNT, and `accounts._pick_profile` picks the key
+within it — healthy first, the default preferred only among the healthy ones,
+which is exactly what `_resolve_target` gives a request-driven operation. The
+nightly backup loop (`hooks.py::_run_once`) calls it and skips the wake on None,
+because a caller about to spend money must read "no working key" as "not now".
+`accounts.resolve_consent_target` is the DISPLAY form the consent handler
+(`dashboard/handlers/aws_consent.py::_effective_target`) calls for S3 and Cost
+Explorer: same resolution, but with no working key it names the registry default
+anyway so the card reports the credential error instead of rendering nothing.
+That fallback reads the agent-writable registry directly, so it is `_safe_field`
+scrubbed on the resolver's side of the return — the profile charset admits the
+shape of an access key id, and the handler emits `profile` and `region` in its
+JSON. If the resolver itself raises (it spawns the AWS CLI), the handler degrades
+to the empty profile and `DEFAULT_REGION`, both module constants, rather than to
+an unscrubbed read.
+Resolving the default directly is a dead end: the card bound to an unhealthy
+default has no account to confirm, `Confirm and enable` requires one, and the
+account's healthy sibling key keeps serving every operation — a working account
+with no way to authorize it. The same read in the unattended loop is worse than a
+dead end, because the grant names the healthy key while the loop resolves the
+broken one, so the backup skips on every wake with only a log line.
+`test_aws_control_app.py::TestConsentTargetTracksTheOperation` pins the shared
+resolution as an equality against `resolve_account_profile`, the key the nightly
+loop gates on, the fallback scrub, and each degraded state.
+The surface stays one grant per service, so the account the default names is
+still the account a confirmation applies to; a grant recorded for one account
+and used under another fails closed in `aws_consent.is_granted`, and the gate's
+own row names the account it would bill so the mismatch is visible.
+
 Registration is reversible from the same surface. `POST /profiles/unregister`
 drops the named profiles from the registry and nothing else: it never reaches
 `deploy.profiles.create_aws_profile` (the module's one `aws configure` writer)

--- a/src/kiro_crew/apps/builtins/aws_control/backend/accounts.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/accounts.py
@@ -74,9 +74,13 @@ def _safe_field(text: str) -> str:
     stdout/stderr, so every string this module serializes is untrusted text on
     an output path. Same double pass the app's HTTP error surface uses.
 
-    This module is a STAGING point, not an egress boundary: it owns no output,
-    and the snapshot reaches a client only through ``routes.py`` (the module
-    registered as this app's redaction sink). It is allowlisted in
+    This module is a STAGING point, not an egress boundary: it owns no output.
+    The snapshot reaches a client through ``routes.py`` (the module registered as
+    this app's redaction sink) and, for the two profile fields the paid-service
+    consent card names, through ``dashboard/handlers/aws_consent.py``. Scrubbing
+    here -- as the snapshot is built, and on
+    :func:`resolve_consent_target`'s registry fallback -- is what makes both of
+    those safe without either one repeating the pass. It is allowlisted in
     ``NON_EGRESS_REDACTION_MODULES`` on exactly that ground.
     """
     from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -388,6 +392,75 @@ async def resolve_account_profile(account: str) -> tuple[str, str] | None:
     if not account:
         return None
     return _pick_profile(await list_accounts(), account)
+
+
+def _default_account(snapshot: dict[str, Any]) -> str:
+    """The account id the registry's default key belongs to, or "".
+
+    Read off the snapshot rather than from a fresh probe, because the case this
+    exists for is a default key whose probe FAILS: ``_fold_profile`` already
+    falls back to the account the registry recorded at verify time, so the row
+    the default sits in still names the right account. A default that has never
+    resolved to any account lands in the unresolved pseudo-row and yields "" —
+    there is no account to pick a key for.
+    """
+    for row in snapshot.get("accounts", []):
+        account = row.get("account") or ""
+        if account and any(p.get("default") for p in row.get("profiles", [])):
+            return account
+    return ""
+
+
+async def resolve_default_account_profile() -> tuple[str, str] | None:
+    """The working (profile, region) for the account the registry default names.
+
+    The resolution every paid-service consumer shares, so the key an operation
+    runs under is the key its grant was recorded against. Goes through
+    :func:`_pick_profile`: a consumer that re-derives this decision with its own
+    reading of the registry gets a DIFFERENT key whenever the default is
+    unhealthy and a sibling is not, which is either a refused grant or a key with
+    no resolvable account.
+
+    STRICT, like :func:`resolve_account_profile`: None means there is no working
+    key, and a caller that is about to spend money must read that as "not now"
+    rather than substituting one. :func:`resolve_consent_target` is the variant
+    for the surface that has to EXPLAIN the absence.
+
+    The account comes from the registry default because the consent surface is
+    not account-scoped — one grant per service — so the default entry is what
+    picks the account. Only WHICH of that account's keys is chosen is decided
+    here.
+    """
+    snapshot = await list_accounts()
+    account = _default_account(snapshot)
+    return _pick_profile(snapshot, account) if account else None
+
+
+async def resolve_consent_target() -> tuple[str, str] | None:
+    """The (profile, region) a paid-service confirmation must be shown for.
+
+    :func:`resolve_default_account_profile` with a display fallback. With no
+    working key to agree with — nothing healthy in that account, or a default
+    that has never resolved to one — it names the registry default anyway, so the
+    card can report WHY nothing is authorizable instead of showing nothing.
+    Returns None only when the registry names no profile at all.
+
+    Every value returned is scrubbed, the fallback included. The registry is
+    agent-writable and the charset it admits is the shape an access key id has,
+    so a profile named after a credential would otherwise flow verbatim into the
+    consent card's JSON: the snapshot path is scrubbed as it is BUILT, and this
+    fallback reads the registry directly, so it is scrubbed on this side of the
+    return rather than by each reader. Consumers therefore all run on the same
+    text -- a name mangled by the scrub fails its identity probe on every path
+    alike, which is the fail-closed answer for a profile named after a secret.
+    """
+    resolved = await resolve_default_account_profile()
+    if resolved is not None:
+        return resolved
+    fallback = await asyncio.to_thread(deploy_profiles.resolve_profile, "")
+    if fallback is None:
+        return None
+    return _safe_field(fallback[0]), _safe_field(fallback[1])
 
 
 def resolve_account_profile_cached(account: str) -> tuple[str, str] | None:

--- a/src/kiro_crew/apps/builtins/aws_control/hooks.py
+++ b/src/kiro_crew/apps/builtins/aws_control/hooks.py
@@ -8,8 +8,9 @@ a log line, never an unconfirmed charge), and the drive is tag-discovered
 per run rather than trusted from memory.
 
 The loop runs against the REGISTRY DEFAULT account only — the same account
-the consent card confirms. Multi-account nightly schedules arrive with the
-per-account grant store (spec §9).
+the consent card confirms, resolved through the same healthy-first policy, so
+the grant it checks names the key it runs under. Multi-account nightly
+schedules arrive with the per-account grant store (spec §9).
 """
 
 from __future__ import annotations
@@ -20,9 +21,9 @@ import logging
 from typing import Any
 
 from kiro_crew import aws_consent
+from kiro_crew.apps.builtins.aws_control.backend import accounts as accounts_mod
 from kiro_crew.apps.builtins.aws_control.backend import backup as backup_mod
 from kiro_crew.apps.builtins.aws_control.backend import storage as storage_mod
-from kiro_crew.deploy import profiles as deploy_profiles
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -55,13 +56,25 @@ def _audit(operation: str, resources: str, outcome: str, *, error: str = "") -> 
 
 async def _run_once() -> None:
     """One due-check + backup attempt. Every failure is a log line, not a crash."""
-    resolved = await asyncio.to_thread(deploy_profiles.resolve_profile, "")
+    # Same resolution the consent card and the HTTP handlers use, so the key this
+    # unattended loop runs under is the key the grant was recorded for. A raw
+    # registry-default read would pick an unhealthy default over the account's
+    # working sibling, and then skip on every wake -- silently, since nobody is
+    # watching a 03:00 loop. The STRICT variant: with no working key there is
+    # nothing to back up, so the loop stops rather than naming one it cannot use.
+    # Costs one probe sweep per wake (free STS calls, concurrency-bounded,
+    # snapshot-cached); the correct key is worth it.
+    resolved = await accounts_mod.resolve_default_account_profile()
     if resolved is None:
-        logger.info("aws-control nightly: no registered profile; skipping")
+        # Covers both "nothing registered" and "the default account has no
+        # working key"; the accounts pane is where the difference is visible.
+        logger.info("aws-control nightly: no healthy registered key; skipping")
         return
     profile, region = resolved
     # Backup state is keyed per account, so the loop resolves which
-    # account the default profile is actually pointing at right now.
+    # account the default profile is actually pointing at right now. The snapshot
+    # above has a TTL, so this live probe is what the account id may be trusted
+    # from -- the same rule the HTTP path's ``_resolve_target`` follows.
     identity = await aws_consent.probe_identity(profile, region)
     if not identity.ok or not identity.account:
         logger.info("aws-control nightly: account unresolved; skipping")

--- a/src/kiro_crew/dashboard/handlers/aws_consent.py
+++ b/src/kiro_crew/dashboard/handlers/aws_consent.py
@@ -106,16 +106,50 @@ async def _effective_target(service: str) -> tuple[str, str]:
         return _vc.aws_profile, _vc.region
 
     if service in (aws_consent.SERVICE_S3, aws_consent.SERVICE_COST_EXPLORER):
-        # AWS Control's paid services run against the deploy profile registry's
-        # default entry — the same resolution the engine will use for the call
-        # itself, so the confirmation names the account that would really bill.
-        # No registered profile resolves to the empty profile (the CLI default
-        # chain), which the card labels explicitly rather than hiding.
+        # AWS Control's paid services run against a HEALTHY key of the account
+        # the deploy profile registry's default entry names, chosen by
+        # ``accounts._pick_profile`` — the same resolution the engine uses for
+        # the call itself, so the confirmation names the key that would really
+        # bill. That resolver also owns the degraded answer (name the registry
+        # default so the card can say why nothing is authorizable) and the
+        # redaction both branches need, which is why this handler reads the
+        # registry through it rather than beside it.
+        #
+        # Reading the registry default DIRECTLY is not equivalent, though it
+        # looks it: the operation filters to healthy keys and prefers the
+        # default only AMONG those. A default key that does not resolve would
+        # bind the card to a key with no account while every operation runs fine
+        # under the account's healthy sibling — and since ``Confirm and enable``
+        # requires a resolved account, that state cannot be confirmed at all: a
+        # working account with no way to grant it consent. Going through the one
+        # policy function is what keeps the card and the call from drifting.
+        #
+        # Cost: that resolution reads the app's account snapshot, which probes
+        # every registered key when cold. It is amortized rather than added --
+        # the snapshot is five-minute cached and the only surface rendering these
+        # two cards loads it first anyway -- and paying it is the point, since
+        # health is exactly what a registry-only read cannot see.
+        from kiro_crew.apps.builtins.aws_control.backend import accounts as aws_accounts
         from kiro_crew.deploy import profiles as deploy_profiles
 
-        resolved = await asyncio.to_thread(deploy_profiles.resolve_profile, "")
+        try:
+            resolved = await aws_accounts.resolve_consent_target()
+        except Exception:
+            # That resolution probes the whole registry through the AWS CLI. A
+            # failure there must not take the consent surface down with it, so
+            # it degrades to the empty profile below.
+            logger.warning(
+                "could not resolve a key for %s; naming the provider default chain",
+                service,
+                exc_info=True,
+            )
+            resolved = None
         if resolved is not None:
             return resolved
+        # No registered profile resolves to the empty profile (the CLI default
+        # chain), which the card labels explicitly rather than hiding. Both
+        # values here are constants, so nothing agent-authored reaches the
+        # response on this branch.
         return "", deploy_profiles.DEFAULT_REGION
 
     from kiro_crew.config.loader import KiroCrewConfig

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1336,8 +1336,12 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # the dashboard only through routes.py, the registered sink.
         "apps/builtins/aws_control/backend/storage.py",
         # Same shape: scrubs profile names and STS-derived account metadata as
-        # the account snapshot is BUILT. It owns no output — the snapshot is
-        # served only through routes.py, the registered sink for this app.
+        # the account snapshot is BUILT, and the registry default that
+        # resolve_consent_target falls back to. It owns no output — the snapshot
+        # is served through routes.py, the registered sink for this app, and the
+        # resolved profile/region reach the paid-service consent card through
+        # dashboard/handlers/aws_consent.py; both read text this module already
+        # scrubbed.
         "apps/builtins/aws_control/backend/accounts.py",
         # Same shape, one layer earlier: scrubs runner-supplied job payload as the
         # run record is BUILT and persisted. `_redact` covers `step`, `error` and

--- a/test/test_aws_control_app.py
+++ b/test/test_aws_control_app.py
@@ -19,8 +19,10 @@ The properties that must hold before anything billable ever ships on this app:
    attacker-shaped names are never echoed into a guidance card.
 5. **The consent enum grew without changing the mechanism**: ``s3``/``ce``
    are gated services with labels, and their (profile, region) target resolves
-   from the deploy registry default — the same resolution the engine will use
-   for the calls those grants authorize.
+   through the SAME healthy-first policy the engine uses for the calls those
+   grants authorize — the registry default picks the account, ``_pick_profile``
+   picks the key, and only a state with no working key at all falls back to
+   naming the default so the card can still explain itself.
 """
 
 from __future__ import annotations
@@ -161,6 +163,29 @@ def _entry(name: str, region: str = "us-east-1", account: str = "") -> dict:
     return {"name": name, "region": region, "account": account, "verified_at": "", "note": ""}
 
 
+def _snapshot_of(
+    registry: dict,
+    identities: dict[str, aws_consent.Identity],
+    kind: str = accounts_mod.KIND_SSO,
+) -> dict:
+    """Build a real account snapshot from a registry plus canned probe results.
+
+    Goes through ``list_accounts`` rather than hand-writing the payload so the
+    grouping, the default marking and the recorded-account fallback under test
+    are the module's own, not the fixture's.
+    """
+
+    async def probe(profile: str, region: str, **_kw) -> aws_consent.Identity:
+        return identities[profile]
+
+    with (
+        mock.patch.object(accounts_mod.deploy_profiles, "load_registry", return_value=registry),
+        mock.patch.object(accounts_mod.aws_consent, "probe_identity", side_effect=probe),
+        mock.patch.object(accounts_mod, "classify_profile", AsyncMock(return_value=kind)),
+    ):
+        return asyncio.run(accounts_mod.list_accounts(refresh=True))
+
+
 # ---------------------------------------------------------------------------
 # Aggregation
 # ---------------------------------------------------------------------------
@@ -168,17 +193,7 @@ def _entry(name: str, region: str = "us-east-1", account: str = "") -> dict:
 
 class TestAggregation:
     def _snapshot(self, registry: dict, identities: dict[str, aws_consent.Identity]) -> dict:
-        async def probe(profile: str, region: str, **_kw) -> aws_consent.Identity:
-            return identities[profile]
-
-        with (
-            mock.patch.object(accounts_mod.deploy_profiles, "load_registry", return_value=registry),
-            mock.patch.object(accounts_mod.aws_consent, "probe_identity", side_effect=probe),
-            mock.patch.object(
-                accounts_mod, "classify_profile", AsyncMock(return_value=accounts_mod.KIND_SSO)
-            ),
-        ):
-            return asyncio.run(accounts_mod.list_accounts(refresh=True))
+        return _snapshot_of(registry, identities)
 
     def test_profiles_group_by_resolved_account(self):
         snap = self._snapshot(
@@ -427,17 +442,6 @@ class TestConsentExtension:
         assert aws_consent.SERVICE_POLLY in aws_consent.GATED_SERVICES
         assert aws_consent.SERVICE_TRANSCRIBE in aws_consent.GATED_SERVICES
 
-    def test_effective_target_resolves_deploy_registry_default(self):
-        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
-        from kiro_crew.deploy import profiles as deploy_profiles
-
-        with mock.patch.object(
-            deploy_profiles, "resolve_profile", return_value=("acct-key", "eu-west-1")
-        ):
-            for service in (aws_consent.SERVICE_S3, aws_consent.SERVICE_COST_EXPLORER):
-                target = asyncio.run(consent_handlers._effective_target(service))
-                assert target == ("acct-key", "eu-west-1")
-
     def test_effective_target_names_the_default_chain_when_registry_is_empty(self):
         from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
         from kiro_crew.deploy import profiles as deploy_profiles
@@ -447,6 +451,264 @@ class TestConsentExtension:
         # Empty profile = the CLI default chain, which the card labels
         # explicitly (credential_source names it); the region still defaults.
         assert target == ("", deploy_profiles.DEFAULT_REGION)
+
+
+class TestConsentTargetTracksTheOperation:
+    """The card must bind to the key the operation would actually run under.
+
+    One policy, three readers: the consent card, the HTTP routes and the nightly
+    backup loop all take a HEALTHY key of the account the registry default names.
+    A second, unfiltered resolution is what these cases guard against — an
+    unhealthy default binds the card to a key with no resolvable account,
+    ``Confirm and enable`` refuses without one, and an account whose healthy
+    sibling key serves every operation then cannot be granted consent at all. The
+    same read in the nightly loop turns that into a silent forever-skip.
+    """
+
+    #: One account, two keys: the registry default is broken, its sibling works.
+    #: This is the shape that deadlocks when health filtering is skipped.
+    ACCOUNT = "111122223333"
+
+    def _broken_default_snapshot(self) -> dict:
+        return _snapshot_of(
+            _registry(
+                [
+                    _entry("broken", region="us-east-1", account=self.ACCOUNT),
+                    _entry("good", region="eu-west-1"),
+                ],
+                default="broken",
+            ),
+            {
+                "broken": _identity(False, detail="ExpiredToken: the security token expired"),
+                "good": _identity(True, account=self.ACCOUNT, arn="arn:good"),
+            },
+        )
+
+    def test_a_broken_default_does_not_hide_the_accounts_healthy_key(self):
+        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
+
+        snapshot = self._broken_default_snapshot()
+        with mock.patch.object(accounts_mod, "list_accounts", AsyncMock(return_value=snapshot)):
+            target = asyncio.run(consent_handlers._effective_target(aws_consent.SERVICE_S3))
+        assert target == ("good", "eu-west-1")
+
+    def test_the_card_and_the_operation_resolve_the_same_key(self):
+        """The invariant, asserted as an equality rather than a literal.
+
+        A change to the resolution policy has to move both sides or fail here —
+        the drift this class exists to catch.
+        """
+        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
+
+        snapshot = self._broken_default_snapshot()
+        with mock.patch.object(accounts_mod, "list_accounts", AsyncMock(return_value=snapshot)):
+            operation = asyncio.run(accounts_mod.resolve_account_profile(self.ACCOUNT))
+            for service in (aws_consent.SERVICE_S3, aws_consent.SERVICE_COST_EXPLORER):
+                card = asyncio.run(consent_handlers._effective_target(service))
+                assert card == operation
+
+    def test_a_healthy_default_still_wins_over_its_siblings(self):
+        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
+
+        snapshot = _snapshot_of(
+            _registry([_entry("first"), _entry("chosen", region="ap-south-1")], default="chosen"),
+            {
+                "first": _identity(True, account=self.ACCOUNT),
+                "chosen": _identity(True, account=self.ACCOUNT),
+            },
+        )
+        with mock.patch.object(accounts_mod, "list_accounts", AsyncMock(return_value=snapshot)):
+            target = asyncio.run(consent_handlers._effective_target(aws_consent.SERVICE_S3))
+        assert target == ("chosen", "ap-south-1")
+
+    def test_another_accounts_healthy_key_is_never_substituted(self):
+        """Health filtering must not walk out of the account the default names.
+
+        Picking any healthy key in the registry would let the card offer a
+        confirmation for someone else's account — a wrong bill, not a dead end.
+        """
+        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
+        from kiro_crew.deploy import profiles as deploy_profiles
+
+        snapshot = _snapshot_of(
+            _registry(
+                [_entry("broken", account=self.ACCOUNT), _entry("elsewhere")], default="broken"
+            ),
+            {
+                "broken": _identity(False, detail="ExpiredToken"),
+                "elsewhere": _identity(True, account="444455556666"),
+            },
+        )
+        with (
+            mock.patch.object(accounts_mod, "list_accounts", AsyncMock(return_value=snapshot)),
+            mock.patch.object(
+                deploy_profiles, "resolve_profile", return_value=("broken", "us-east-1")
+            ),
+        ):
+            target = asyncio.run(consent_handlers._effective_target(aws_consent.SERVICE_S3))
+        assert target == ("broken", "us-east-1")
+
+    def test_nothing_healthy_still_names_the_default_so_the_card_can_explain(self):
+        """The fallback still names a key, so the card can render its error.
+
+        With no working key there is no operation to agree with, so the honest
+        surface is the default's own STS error — that is what tells the reader
+        the account has to be reconnected.
+        """
+        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
+        from kiro_crew.deploy import profiles as deploy_profiles
+
+        snapshot = _snapshot_of(
+            _registry([_entry("broken", account=self.ACCOUNT)], default="broken"),
+            {"broken": _identity(False, detail="ExpiredToken")},
+        )
+        with (
+            mock.patch.object(accounts_mod, "list_accounts", AsyncMock(return_value=snapshot)),
+            mock.patch.object(
+                deploy_profiles, "resolve_profile", return_value=("broken", "us-east-1")
+            ),
+        ):
+            for service in (aws_consent.SERVICE_S3, aws_consent.SERVICE_COST_EXPLORER):
+                target = asyncio.run(consent_handlers._effective_target(service))
+                assert target == ("broken", "us-east-1")
+
+    def test_a_default_that_resolves_to_no_account_falls_back_too(self):
+        """A default in the unresolved pseudo-row names no account to filter within."""
+        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
+        from kiro_crew.deploy import profiles as deploy_profiles
+
+        snapshot = _snapshot_of(
+            _registry([_entry("mystery"), _entry("good")], default="mystery"),
+            {
+                "mystery": _identity(False, detail="no credentials"),
+                "good": _identity(True, account=self.ACCOUNT),
+            },
+        )
+        with (
+            mock.patch.object(accounts_mod, "list_accounts", AsyncMock(return_value=snapshot)),
+            mock.patch.object(
+                deploy_profiles, "resolve_profile", return_value=("mystery", "us-east-1")
+            ),
+        ):
+            target = asyncio.run(consent_handlers._effective_target(aws_consent.SERVICE_S3))
+        assert target == ("mystery", "us-east-1")
+
+    def test_the_fallback_scrubs_a_credential_shaped_profile_name(self):
+        """The registry is agent-writable, and its charset is an access key's shape.
+
+        The snapshot path is scrubbed as it is built; the fallback reads the
+        registry directly, so it has to be scrubbed on the same side of the
+        return or a profile named after a secret reaches the card's JSON verbatim.
+        """
+        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
+        from kiro_crew.deploy import profiles as deploy_profiles
+
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        snapshot = _snapshot_of(
+            _registry([_entry(secret, account=self.ACCOUNT)], default=secret),
+            {secret: _identity(False, detail="ExpiredToken")},
+        )
+        with (
+            mock.patch.object(accounts_mod, "list_accounts", AsyncMock(return_value=snapshot)),
+            mock.patch.object(
+                deploy_profiles, "resolve_profile", return_value=(secret, "us-east-1")
+            ),
+        ):
+            profile, region = asyncio.run(
+                consent_handlers._effective_target(aws_consent.SERVICE_S3)
+            )
+        assert secret not in profile
+        assert profile == "[REDACTED: credential]"
+        assert region == "us-east-1"
+
+    def test_a_failed_probe_sweep_degrades_instead_of_failing_the_surface(self):
+        """The sweep spawns the AWS CLI; it must not be able to 500 the card.
+
+        The degraded answer is the provider default chain, whose two values are
+        module constants — with the resolver unreachable there is no scrubbed
+        registry read to fall back on, and an unscrubbed one must not take its
+        place.
+        """
+        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
+        from kiro_crew.deploy import profiles as deploy_profiles
+
+        with mock.patch.object(
+            accounts_mod,
+            "resolve_consent_target",
+            AsyncMock(side_effect=RuntimeError("no sandbox")),
+        ):
+            target = asyncio.run(consent_handlers._effective_target(aws_consent.SERVICE_S3))
+        assert target == ("", deploy_profiles.DEFAULT_REGION)
+
+    def test_the_nightly_loop_runs_under_the_key_the_grant_names(self):
+        """The unattended path is the one nobody watches fail.
+
+        The loop's consent check compares the grant against the key it is about
+        to use, so a loop resolving the raw default while the grant names the
+        account's healthy sibling skips on every wake, forever, with only a log
+        line to say so.
+        """
+        from kiro_crew.apps.builtins.aws_control import hooks
+
+        snapshot = self._broken_default_snapshot()
+        gated: list[tuple[str, str]] = []
+
+        async def refuse_and_log(service: str, *, profile: str, region: str) -> bool:
+            gated.append((profile, region))
+            return False  # stop before any AWS work; the argv is what is pinned
+
+        with (
+            mock.patch.object(accounts_mod, "list_accounts", AsyncMock(return_value=snapshot)),
+            mock.patch.object(
+                hooks.aws_consent,
+                "probe_identity",
+                AsyncMock(return_value=aws_consent.Identity(ok=True, account=self.ACCOUNT)),
+            ),
+            mock.patch.object(hooks.backup_mod, "due_for_nightly", return_value=True),
+            mock.patch.object(hooks.aws_consent, "refuse_and_log", refuse_and_log),
+        ):
+            asyncio.run(hooks._run_once())
+            operation = asyncio.run(accounts_mod.resolve_account_profile(self.ACCOUNT))
+
+        assert gated == [("good", "eu-west-1")]
+        assert gated[0] == operation
+
+    def test_the_nightly_loop_skips_when_no_key_is_healthy(self):
+        from kiro_crew.apps.builtins.aws_control import hooks
+
+        snapshot = _snapshot_of(
+            _registry([_entry("broken", account=self.ACCOUNT)], default="broken"),
+            {"broken": _identity(False, detail="ExpiredToken")},
+        )
+        with (
+            mock.patch.object(accounts_mod, "list_accounts", AsyncMock(return_value=snapshot)),
+            mock.patch.object(hooks.aws_consent, "probe_identity") as probe,
+            mock.patch.object(hooks.backup_mod, "due_for_nightly") as due,
+            mock.patch.object(hooks, "_audit") as audit,
+        ):
+            asyncio.run(hooks._run_once())
+        # No probe, no due-check, no consent check, no audit: there is no key to
+        # run under, so the loop stops before it can name one.
+        probe.assert_not_called()
+        due.assert_not_called()
+        audit.assert_not_called()
+
+    def test_the_voice_services_do_not_touch_the_account_snapshot(self):
+        """Polly and Transcribe read their own config; only s3/ce use the registry."""
+        from kiro_crew.dashboard.handlers import aws_consent as consent_handlers
+        from kiro_crew.slack.handler import _vc
+
+        swept = AsyncMock(side_effect=AssertionError("voice must not sweep the registry"))
+        with (
+            mock.patch.object(accounts_mod, "list_accounts", swept),
+            mock.patch.object(_vc, "aws_profile", "voice"),
+            mock.patch.object(_vc, "region", "eu-west-1"),
+        ):
+            assert asyncio.run(consent_handlers._effective_target("polly")) == (
+                "voice",
+                "eu-west-1",
+            )
+        swept.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -1955,7 +2217,9 @@ class TestRound22Hardening:
 
         with (
             mock.patch.object(
-                hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
+                hooks.accounts_mod,
+                "resolve_default_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
             mock.patch.object(
                 hooks.aws_consent,
@@ -1984,7 +2248,9 @@ class TestRound22Hardening:
 
         with (
             mock.patch.object(
-                hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
+                hooks.accounts_mod,
+                "resolve_default_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
             mock.patch.object(
                 hooks.aws_consent,

--- a/test/test_aws_control_hooks.py
+++ b/test/test_aws_control_hooks.py
@@ -70,11 +70,15 @@ class TestRunOnceEarlyReturns:
     """Each guard makes the loop fail CLOSED: a missing precondition is a log
     line and a return, never an unconfirmed AWS call. One test per guard."""
 
-    def test_no_registered_profile_skips(self):
-        # With no default profile resolved there is no account to back up, so
-        # the loop must return before probing identity.
+    def test_no_healthy_registered_key_skips(self):
+        # With no working key resolved there is nothing the loop may run under,
+        # so it must return before probing identity. The resolution is the one
+        # the grant was recorded against, so a key it rejects is a key the
+        # consent gate would refuse anyway.
         with (
-            mock.patch.object(hooks.deploy_profiles, "resolve_profile", return_value=None),
+            mock.patch.object(
+                hooks.accounts_mod, "resolve_default_account_profile", AsyncMock(return_value=None)
+            ),
             mock.patch.object(hooks.aws_consent, "probe_identity") as probe,
         ):
             _run(hooks._run_once())
@@ -86,7 +90,9 @@ class TestRunOnceEarlyReturns:
         # returns before the due-check.
         with (
             mock.patch.object(
-                hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
+                hooks.accounts_mod,
+                "resolve_default_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
             mock.patch.object(
                 hooks.aws_consent,
@@ -103,7 +109,9 @@ class TestRunOnceEarlyReturns:
         # both, so this distinct branch must also return before due-check.
         with (
             mock.patch.object(
-                hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
+                hooks.accounts_mod,
+                "resolve_default_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
             mock.patch.object(
                 hooks.aws_consent,
@@ -121,7 +129,9 @@ class TestRunOnceEarlyReturns:
         # never even asked to spend money.
         with (
             mock.patch.object(
-                hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
+                hooks.accounts_mod,
+                "resolve_default_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
             mock.patch.object(
                 hooks.aws_consent,
@@ -140,7 +150,9 @@ class TestRunOnceEarlyReturns:
         # revoked grant produces no S3 read and no upload.
         with (
             mock.patch.object(
-                hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
+                hooks.accounts_mod,
+                "resolve_default_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
             mock.patch.object(
                 hooks.aws_consent,
@@ -160,7 +172,9 @@ class TestRunOnceEarlyReturns:
         # snapshot backup (and before the "invoked" audit).
         with (
             mock.patch.object(
-                hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
+                hooks.accounts_mod,
+                "resolve_default_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
             mock.patch.object(
                 hooks.aws_consent,
@@ -185,7 +199,9 @@ class TestRunOnceCancellation:
     def test_cancelled_backup_is_audited_and_reraised(self):
         with (
             mock.patch.object(
-                hooks.deploy_profiles, "resolve_profile", return_value=("p", "us-west-2")
+                hooks.accounts_mod,
+                "resolve_default_account_profile",
+                AsyncMock(return_value=("p", "us-west-2")),
             ),
             mock.patch.object(
                 hooks.aws_consent,


### PR DESCRIPTION
## Problem / Motivation

AWS Control's paid-service consent card ("Confirm AWS usage before the first
request") resolved *which key to display and authorize* through different code
than the operation the grant is for.

- Card: `dashboard/handlers/aws_consent.py::_effective_target` called
  `deploy_profiles.resolve_profile("")` for `s3` and `ce` -- the registry's
  **default** entry, with **no health filtering**.
- Operation: `aws_control/backend/routes.py::_resolve_target` ->
  `accounts.resolve_account_profile` -> `_pick_profile`, which filters to
  **healthy** keys and prefers the default only *among* those.

With one account holding two registered keys -- a healthy one, and an unhealthy
one that happens to be the registry default -- the account row correctly showed
the healthy key as `Healthy` and every operation ran under it, while the card
bound to the unhealthy default and rendered `AWS account: could not be
resolved`. `api_aws_consent_post` refuses when it cannot resolve an account, so
`Confirm and enable` could never succeed.

The nightly backup loop (`hooks.py::_run_once`) read the default the same
unfiltered way. That is the worse half: its own consent check compares the grant
against the key it is about to use, so once the grant names the account's healthy
sibling, a loop resolving the broken default skips on every wake -- unattended,
with only a log line. Found by the First Principles review on the first revision
of this PR, which counted the sibling the description had missed.

## Why it matters

It is a dead end, not a cosmetic mismatch: a fully working account cannot be
granted consent through the UI at all, and nothing on screen points at the
cause. The Reconnect guidance attached to the failing key points the other way
(`aws configure --profile <name>`, i.e. go enter static keys) when the action
that unblocks the user is to repoint the registry default.

`_pick_profile`'s own docstring already named the hazard -- "two copies of it is
two places for that decision to diverge" -- and the consent handler had become a
third copy.

## What changed (motivation -> approach -> change)

Symptom: `Confirm and enable` is permanently inert on an account that works.
Root cause: two independent resolutions of the same question, one of which does
not filter on health. Change: delete the second resolution rather than teach it
to filter, so there is nothing left to drift.

- `accounts.resolve_default_account_profile()` (new) is the strict resolution:
  read the app's account snapshot, take the account the registry default belongs
  to, hand it to the existing `_pick_profile`. Every paid-service consumer now
  shares that one policy function instead of spelling it out again.
- `accounts.resolve_consent_target()` (new) is the display form: the same
  resolution, but with no working key it names the registry default anyway so the
  card can report the credential error instead of rendering nothing. The split is
  deliberate -- a caller about to spend money must read "no working key" as "not
  now", while the surface whose job is to EXPLAIN the absence needs something to
  name.
- That fallback reads the agent-writable registry directly, so it is
  `_safe_field` scrubbed on the resolver's side of the return: the profile
  charset admits the shape of an access key id, and the handler emits `profile`
  and `region` in its JSON. Scrubbing stays in `accounts.py`, which already owns
  that pass for the snapshot and is allowlisted for it, so the handler gains no
  redactor call of its own and both branches are treated identically. Found by
  the GPT 5.6 review on the second revision.
- `_effective_target` calls it for `s3` and `ce`. The registry default still
  picks the ACCOUNT (the surface is one grant per service, so that is unchanged);
  only WHICH of that account's keys the card binds to changes.
- `hooks.py::_run_once` calls the strict form, before its due-check and its
  consent check, so the unattended loop runs under the key the grant names and
  skips the wake when there is none. Its live `probe_identity` stays as the
  re-verification of the account id, on the same rule `_resolve_target` follows:
  the snapshot has a TTL, the probe does not.
- Two degenerate states fall back to today's behaviour -- naming the plain
  registry default -- so the card keeps explaining why nothing is authorizable
  instead of rendering nothing: no healthy key anywhere in that account, and a
  default that has never resolved to an account (it sits in the unresolved
  pseudo-row, so there is no account to filter within).
- A failure of the resolver itself degrades the card to the empty profile and
  `DEFAULT_REGION` -- both module constants, so no unscrubbed read takes its
  place. It spawns the AWS CLI, and the consent surface must not be able to 500
  because the CLI is missing or sandboxing failed.

Deliberately NOT changed:

- The grant stays keyed by service. Making the card account-scoped would let
  merely VIEWING a second account's pane revoke the first account's grant, since
  `reconcile_drift` treats a differing live account as drift. The issue's milder
  second variant (default points at account B while the app operates on account
  A) therefore still fails closed in `is_granted`, which is what it did before;
  the gate's own row already names the account it would bill so the mismatch is
  visible on screen.
- `reconnect_plan`. Its guidance was misleading only because the reader was
  stuck; with the card bound to the working key there is nothing to unblock, and
  `aws configure` remains the honest advice for an unclassifiable broken key.

Cost note: the consent GET for these two services now reads the account snapshot
rather than one registry entry. It is five-minute cached and the only surface
that renders these cards loads it first anyway, so the probe sweep is amortized
rather than added -- and health is exactly what the old read was missing.

## Tests

`test_aws_control_app.py::TestConsentTargetTracksTheOperation` (new, 8 cases):

- a broken default no longer hides the account's healthy key (was the deadlock);
- the card and the operation resolve the SAME key, asserted as an equality
  against `resolve_account_profile` for both gated services, so a future policy
  change has to move both sides or fail here;
- a healthy default still wins over its healthy siblings;
- another account's healthy key is never substituted (a wrong bill, not a dead
  end);
- nothing healthy in the account still names the default, for both services;
- a default that resolves to no account falls back too;
- a raising probe sweep degrades instead of failing the surface;
- Polly and Transcribe never touch the account snapshot;
- the nightly loop gates consent on the key the operation resolves, asserted
  against `resolve_account_profile`, and skips before probe, due-check and audit
  when no key is healthy;
- a credential-shaped profile name in the fallback comes back
  `[REDACTED: credential]`, and the resolver-raised path returns only constants.

Verified RED->GREEN by reverting each fix alone: reverting the handler fails 3 of
the card cases, reverting `hooks.py` fails the nightly case, and dropping the
`_safe_field` pass on the fallback fails the scrub case. The remaining cases pass
either way by design -- they pin that the degenerate states keep the behaviour
they already had.

`test_aws_control_hooks.py` (7 patch sites) and the two nightly cases in
`test_aws_control_app.py` were repointed at the new resolver; they patched the
raw `deploy_profiles.resolve_profile` the loop does not call.

`TestAggregation`'s snapshot helper moved to a module-level `_snapshot_of` so the
new class builds its snapshots through the real `list_accounts` (grouping,
default marking and the recorded-account fallback under test are the module's
own, not the fixture's) instead of hand-writing a payload.

## Manual verification

N/A -- the defect is entirely in profile resolution, and the new tests drive the
real `list_accounts` fold with canned STS outcomes, which is the reproduction the
issue describes (two keys on one account, the broken one as default). Reaching
the UI state needs two live AWS profiles on one account with one deliberately
expired.

## Screenshots / video

N/A -- no UI change. The card's markup and copy are untouched; only the values
the backend supplies change, from a broken key to the working one.

## Related Issues

Fixes #9479

## Pattern harvest

Rule candidate: review-prompt
Pattern: a second, simpler re-derivation of a policy that a shared function
already owns -- here "which credentials does this run under" resolved once with
health filtering and twice without. Two tells worth grepping for: a comment that
CLAIMS parity with another code path (parity should be a call, not a claim), and
an unattended loop that re-derives a decision its request-driven twin gets from a
shared function -- the loop is where the divergence goes unnoticed longest.
