### PR TITLE
fix: stop rendering an HTML error page as the error message

### DIFF
--- a/website/src/api/apiError.ts
+++ b/website/src/api/apiError.ts
@@ -50,12 +50,23 @@ export const isNotFoundError = (e: unknown): boolean =>
   typeof e === 'object' && e !== null && (e as { status?: unknown }).status === 404
 
 /**
+ * A body whose first markup is a document type: both doctype spellings, plus a
+ * bare `<html>` from a proxy that emits none. Deliberately does NOT match every
+ * `<`-leading body, so an XML error envelope still reaches the caller whole.
+ */
+const HTML_DOCUMENT_START = /^<(?:!doctype\s|html[\s>])/i
+
+/**
  * Map raw edge/proxy error bodies to a human-readable message. A dashboard
  * served through Builder Tunnels sits behind API Gateway, whose throttle
  * response is the opaque `{"message":"Rate exceeded","throttlingReasons":null}`
  * — rendering that verbatim in an error card is a terrible UX. The mapped
  * message only ever shows after the QueryClient's 429 retry ladder
  * (api/queryClient.ts) is exhausted.
+ *
+ * Returns `''` for a body carrying no human message, which is the signal every
+ * caller already turns into `HTTP <status>` — so that wording stays decided in
+ * one place. The raw body remains on `ApiError.body` for diagnostics.
  */
 export const friendlyErrText = (status: number, body: string): string => {
   if (status === 429) {
@@ -72,6 +83,9 @@ export const friendlyErrText = (status: number, body: string): string => {
       if (typeof msg === 'string' && msg.trim()) return msg
     } catch { /* not JSON — fall through to raw body */ }
   }
+  // An error PAGE has no message field to unwrap, so returning it verbatim put
+  // `<!DOCTYPE html><html><head><meta charset="utf…` in the dashboard's topbar.
+  if (HTML_DOCUMENT_START.test(trimmed)) return ''
   return body
 }
 

--- a/website/src/test/apiError.test.ts
+++ b/website/src/test/apiError.test.ts
@@ -37,6 +37,16 @@ describe('toApiError', () => {
     expect(e.message).toBe('upstream said no')
   })
 
+  it('shows HTTP <status> for an edge HTML error page, not its markup', async () => {
+    // What a tunnel or proxy serves while the gateway restarts: the document
+    // reached the message verbatim, so the dashboard topbar rendered the markup.
+    const page = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>502</title></head><body>Bad Gateway</body></html>'
+    const e = await toApiError(res(502, page))
+    expect(e.message).toBe('HTTP 502')
+    expect(e.message).not.toContain('<')
+    expect(e.body).toBe(page)
+  })
+
   it('flags an auth-expiry refusal so callers can drop futile retries', async () => {
     const e = await toApiError(res(403, 'invalid signature', { 'X-Auth-Required': 'true' }))
     expect(e.authRequired).toBe(true)

--- a/website/src/test/devFleetApi.test.ts
+++ b/website/src/test/devFleetApi.test.ts
@@ -39,10 +39,19 @@ describe('devFleetApi error shape', () => {
   })
 
   it('falls back to the raw text when the body is not JSON', async () => {
+    mockResponse('upstream refused the connection', 502)
+    const err = await failureOf(api.get('/fleet'))
+    expect(err.status).toBe(502)
+    expect(err.message).toBe('upstream refused the connection')
+  })
+
+  it('shows HTTP <status> for an edge HTML error page rather than its markup', async () => {
     mockResponse('<html>502 Bad Gateway</html>', 502)
     const err = await failureOf(api.get('/fleet'))
     expect(err.status).toBe(502)
-    expect(err.message).toContain('502 Bad Gateway')
+    expect(err.message).toBe('HTTP 502')
+    // The page itself stays readable for diagnostics.
+    expect(err.body).toContain('502 Bad Gateway')
   })
 
   it('falls back to the status when the body is empty', async () => {

--- a/website/src/test/friendlyErrText.test.ts
+++ b/website/src/test/friendlyErrText.test.ts
@@ -28,4 +28,19 @@ describe('friendlyErrText', () => {
   it('keeps the 429 friendly message', () => {
     expect(friendlyErrText(429, '{"error":"x"}')).toContain('Rate limited')
   })
+
+  it('reports no message for an HTML error page, whichever doctype it carries', () => {
+    // The whole document used to become the message, so a tunnel 502 rendered as
+    // `<!DOCTYPE html><html><head><meta charset="utf…` inside the error banner.
+    expect(friendlyErrText(502, '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>502</body></html>')).toBe('')
+    expect(friendlyErrText(503, '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">\n<html><body>oops</body></html>')).toBe('')
+    expect(friendlyErrText(502, '<html>\n<head><title>502 Bad Gateway</title></head>\n</html>')).toBe('')
+    expect(friendlyErrText(502, '\n  <!doctype html><html></html>')).toBe('')
+  })
+
+  it('leaves a non-HTML markup body alone, so a widened guard cannot swallow a reason', () => {
+    const xml = '<?xml version="1.0"?><Error><Message>Access Denied</Message></Error>'
+    expect(friendlyErrText(403, xml)).toBe(xml)
+    expect(friendlyErrText(400, 'expected <html> but got json')).toBe('expected <html> but got json')
+  })
 })


### PR DESCRIPTION
## Problem / Motivation

`friendlyErrText` returned any non-JSON body verbatim, so an **HTML error page became the user-visible error message**. Observed on a tunnel-served dashboard while the gateway restarted — the topbar rendered

```
<!DOCTYPE html><html><head><meta charset="utf…
```

where a reason belonged.

An edge or proxy error page is a document, not an API payload: it has no `error` / `detail` / `message` field to unwrap and no prose worth surfacing. The existing function handled 429 and JSON envelopes and fell through to `return body` for everything else.

## Why it matters

This is the single chokepoint every dashboard API failure passes through, so the failure is not confined to one banner — any surface that renders `ApiError.message` shows the markup. It fires exactly when the gateway is unavailable (restart, edge 502/503), i.e. the moment a user most needs a legible reason, and the raw document crowds out every other error on screen.

## What changed

Report an HTML document as carrying **no message** (`''`), which is the signal all three callers already turn into `HTTP <status>`:

| Caller | Fallback |
|---|---|
| `api/apiError.ts` → `toApiError` | `friendlyErrText(...) \|\| ` + `` `HTTP ${r.status}` `` |
| `api/client.ts` → `apiFailure` | same |
| `pages/devFleetApi.ts` | same |

Leaving that wording in the callers keeps it decided in one place rather than adding a fourth spelling. The raw document is still recoverable on `ApiError.body`, and in the error journal's `detail`, for diagnostics.

The guard is deliberately narrow — both doctype spellings plus a bare `<html>` from a proxy that emits none, and **not** any `<`-leading body, because an XML error envelope carries its reason in the markup and should still reach the caller whole.

One pre-existing contract moved with it. `src/test/devFleetApi.test.ts` asserted that a `<html>502 Bad Gateway</html>` body reached `message` verbatim — the behaviour this fix removes. That case now pins `HTTP 502` with the page still readable on `.body`, and a sibling case keeps the file's original intent by passing a genuinely plain-text non-JSON body straight through.

Not done here: no new user-facing string, so no catalog change — the fix routes into an existing untranslated protocol token. Widening to XML envelopes, or keying off `Content-Type` instead of sniffing the body, would both be larger changes than the defect warrants.

## Tests

- `src/test/friendlyErrText.test.ts` — four HTML shapes return `''` (both doctypes, bare `<html>`, leading whitespace); one **negative control** pins the guard's width and fails if it is widened to any `<`.
- `src/test/apiError.test.ts` — end-to-end: a 502 HTML page yields `message === 'HTTP 502'` with the document preserved on `.body`. This pins the composition rather than the internal `''`.
- **Mutation-verified:** with the guard line removed, exactly the two new positive tests fail and the negative control stays green.
- `src/test/devFleetApi.test.ts` — the third caller: HTML page → `HTTP 502`, plain-text body → verbatim.
- **Caller sweep:** every file that models an HTML error body or touches `friendlyErrText` / `toApiError` — 13 files, 993 tests — passes. That is what establishes the guard changes exactly one contract rather than several silently.
- `eslint`, `tsc --noEmit`, `lint:i18n` and `jscpd` all clean.

`Build Desktop (ubuntu-22.04-arm)` is red at its **"Upload desktop artifact (Linux)"** step, and that step is unreachable from this diff. The change is one module plus three test files under `website/src`, none of which desktop packaging or artifact upload reads. Its own log shows the app built (step 5 succeeded) and the artifact uploaded whole — 380,384,446 bytes, digest computed, "Finished uploading artifact content to blob storage!" — then failed only at `FinalizeArtifact` with `(403) Forbidden: Error from intermediary`. The x86 sibling `Build Desktop (ubuntu-22.04)` ran the same steps on the same commit and passed, so the commit cannot be the discriminator.

## Pattern harvest

Rule candidate: a wire body is not a message. When a client maps a response body onto user-facing text, a body that is a *document* — an HTML doctype, or a bare `<html>` — carries no human message at all, so passing it through verbatim renders markup where a reason belongs. Report "no message" and let the caller's existing status fallback speak, keeping the raw body on the error object for diagnostics.

Rule candidate: a change to a shared chokepoint must be validated against every caller's tests, not only the files it edits. Here the two edited test files could not reveal that a third caller's suite already pinned the old passthrough — CI found it instead, and clearing it was a deliberate contract change rather than a surprise.

Pattern: the defect shape is *unrecognised-input passthrough at a normalisation boundary*. A mapper that unwraps the shapes it knows (here 429 and JSON envelopes) and returns anything else unchanged is safe only while every unknown input happens to be human-readable. The moment an intermediary — proxy, tunnel edge, load balancer, WAF — injects a response of its own, the unknown branch becomes the common branch, and it is exactly the branch that reaches the user during an outage. The remedy generalises to any such boundary: classify the unknown input, and prefer a short honest token over raw bytes.
