### PR TITLE
ci: denial-differential gate for rule-tightening PRs

### DIFF
--- a/.github/workflows/denial-differential.yml
+++ b/.github/workflows/denial-differential.yml
@@ -1,0 +1,199 @@
+name: Denial Differential
+
+# Fails a deny-rule change that newly refuses an operation the product depends
+# on. A security fix is almost always a rule made stricter, and "stricter" has no
+# upper bound a reviewer can see: the author reads the attack the pattern now
+# catches, nobody reads the ordinary commands it also newly matches. The symptom
+# lands days later as an agent that stopped working, reporting a pattern instead
+# of a cause.
+#
+# Deterministic, no model. `scripts/deny_diff.py` classifies a corpus of golden
+# paths -- operations legitimate BY DECISION, each with the reason -- with the
+# REAL deny composite as it exists at the base ref and at the head ref, and diffs
+# the two verdict sets. Newly refused is a failure; newly allowed is reported and
+# does not block, because loosening is what a revert or a false-positive fix
+# looks like.
+#
+# "The deny composite" is all four checks `hooks.on_tool_call` applies to a shell
+# command -- the path fence, the IMDS/env-credential detectors, the exfil shapes,
+# and the rule catalog with its argv floors -- not just the catalog. A gate that
+# measured only the catalog would go green on a tightening of `paths.py` or
+# `exfil.py`, which its own trigger paths cover, and the green badge would then
+# stand as evidence the question had been asked. `test/test_deny_diff.py` pins
+# that list against the hooks gate itself, so a fifth check added there reds this
+# gate rather than silently escaping it.
+#
+# The corpus is taken from the BASE ref, never the head checkout. The corpus IS
+# the contract the change is judged against, so a head-owned corpus would let the
+# same PR that tightens a rule delete the row that rule breaks -- removing it from
+# BOTH sides and passing. Its path is named in the step below and changing it is a
+# reviewed edit, so no other file can take the contract over on its own.
+#
+# What a green does NOT cover: this gate calls the four `security.*` checks
+# directly, so it measures the RULES, not `hooks.py`'s own composition of them --
+# how targets are built, the raw_params path-fence application, the context-derived
+# enabled set. A tightening implemented inside `hooks.py` itself runs this gate and
+# comes back empty. The tier pin catches a check ADDED there; it cannot catch a
+# behavioural change in how the gate assembles what it checks.
+#
+# That same base-ownership is also the ESCAPE, which is why this gate has no
+# approval label. Withdrawing a golden path is a real thing to want, and it is
+# done by removing the row in its OWN pull request: that PR changes no rule, so
+# this gate is green on it, and the next PR's base no longer carries the row. The
+# withdrawal then gets reviewed on its own merits instead of riding along inside a
+# security diff behind a label -- and there is no waiver mechanism to keep honest.
+#
+# Matrix, and why all three legs: the rules read argv SHAPE and the path fence
+# reads real paths, and both differ per platform -- Windows has its own tokenizer
+# and separators, and the fence's home-directory ordering is macOS-specific
+# (`Library/Application Support`, `/Volumes/<share>`). A Linux-only gate would
+# pass a tightening that breaks every operator on another OS -- the same class of
+# defect the Cross-Platform Portability gate exists for and cannot see, because
+# that one reads added lines rather than behaviour.
+#
+# No dependency install: the composite's import chain is stdlib plus the package's
+# own modules, and the child reaches them through PYTHONPATH at a materialized
+# checkout. Installing the package would add three platform-dependent minutes and
+# a resolution failure mode, and an editable install would put a SECOND copy of
+# `kiro_crew` on the path -- which the script's own tree check would then refuse.
+#
+# Honest red, no continue-on-error: a failing leg shows as failing, and branch
+# protection decides whether that blocks a merge.
+
+on:
+  pull_request:
+    paths:
+      - "src/kiro_crew/security/**"
+      - "src/kiro_crew/deny_guidance.py"
+      - "src/kiro_crew/platform/security_authority.py"
+      - "src/kiro_crew/hooks.py"
+      - "src/kiro_crew/builtin_skills/security-conductor/rules-of-engagement.json"
+      - "scripts/deny_diff.py"
+      - "scripts/deny_diff_fixture.json"
+      - ".github/workflows/denial-differential.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: denial-differential-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  denial-differential:
+    name: Denial Differential (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      # Every leg reports. One platform's regression is not evidence about
+      # another's, so a fail-fast cancel would hide the rows an operator on the
+      # cancelled runner is the only one who can see.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history: BOTH commits must be archivable locally, and a shallow
+          # clone of the merge ref has neither parent's tree.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Run the denial differential
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+
+          # `git archive` needs the OBJECTS, not just the refs. fetch-depth: 0
+          # normally supplies both, so fetch only what is genuinely absent.
+          for sha in "$BASE_SHA" "$HEAD_SHA"; do
+            if ! git cat-file -e "$sha^{commit}" 2>/dev/null; then
+              git fetch --no-tags origin "$sha" || true
+            fi
+          done
+
+          # ONE corpus path, named here. Adopting the security-conductor's seed is an
+          # explicit change to this line, not an automatic preference: a gate that
+          # switched contracts the moment another file appeared would hand coverage
+          # over with nobody's PR showing the handover, and rows this corpus carries
+          # could drop out silently. The adopting PR edits this line, deletes the
+          # fixture, and shows in its own diff that the seed covers these rows.
+          corpus_path="scripts/deny_diff_fixture.json"
+
+          # Read out of the BASE tree: the corpus is the contract being judged and
+          # must not be editable by the change under judgement.
+          owner="base"
+          if git cat-file -e "$BASE_SHA:$corpus_path" 2>/dev/null; then
+            git show "$BASE_SHA:$corpus_path" > corpus.json
+          elif [ -f "$corpus_path" ]; then
+            # Absent at base -- the gate itself is being introduced, or the corpus is
+            # being added. There is no base contract to protect, so nothing can be
+            # withdrawn to escape one; use the head file and say so in the report
+            # rather than failing on a bootstrap.
+            owner="head"
+            cp "$corpus_path" corpus.json
+          else
+            echo "::error::No golden-paths corpus at $corpus_path -- nothing to classify."
+            {
+              echo "### Denial differential"
+              echo
+              echo "**No golden-paths corpus at \`$corpus_path\`.** Not a pass."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          rc=0
+          python scripts/deny_diff.py \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --corpus corpus.json \
+            --platform auto > report.md 2>error.log || rc=$?
+
+          cat report.md
+          {
+            cat report.md
+            echo
+            echo "Corpus: \`$corpus_path\` as it stands at the **$owner** ref."
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -s error.log ]; then
+            cat error.log
+            {
+              echo
+              echo '```'
+              cat error.log
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ "$rc" = "0" ]; then
+            echo "No newly-refused golden paths."
+            exit 0
+          fi
+
+          if [ "$rc" = "2" ]; then
+            # A differential that could not run is not a pass.
+            echo "::error::deny_diff could not run (corpus or ref error) -- see the job summary."
+            {
+              echo
+              echo "**The differential did not run.** A corpus or ref error is not a pass."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          {
+            echo
+            echo "Each row above is an operation the corpus records as legitimate that this"
+            echo "change newly refuses. Either narrow the rule, or -- if the row should no"
+            echo "longer be a golden path -- withdraw it in its own pull request first: that"
+            echo "PR changes no rule, so this gate is green on it, and this PR's base then no"
+            echo "longer carries the row."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Newly-refused golden paths -- see the job summary."
+          exit 1

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -5,6 +5,7 @@ Everything that gates a pull request.
 | Document | Covers |
 |---|---|
 | [ci-and-reviews.md](ci-and-reviews.md) | The Fast Gate barrier, the CI jobs, the AI review workflows, and the aggregate readiness status. |
+| [denial-differential.md](denial-differential.md) | The denial-differential gate: how a deny-rule change is proved not to newly refuse a golden path, why its corpus is read from the base ref, and what a green does not cover. |
 | [e2e-gate.md](e2e-gate.md) | The offline browser E2E gate (`python setup.py test_e2e`). |
 | [harness-parity-gate.md](harness-parity-gate.md) | The added-line gate keeping the Kiro harness first-class: the six rules, and why it reports rather than enforces whole-tree. |
 | [i18n-gates.md](i18n-gates.md) | The i18n gate chain: what fails, what only reports, and the ratchet rule. |

--- a/docs/ci/denial-differential.md
+++ b/docs/ci/denial-differential.md
@@ -1,0 +1,223 @@
+# The denial-differential gate
+
+`Denial Differential` (`.github/workflows/denial-differential.yml`) fails a PR
+that makes a deny rule refuse an operation the product depends on.
+
+## Why it exists
+
+A security fix is almost always a rule made stricter, and "stricter" has no upper
+bound a reviewer can see. The author reads the pattern and the attack it now
+catches. Nobody reads the set of ordinary commands that pattern *also* newly
+matches — a read-only `gh` query, a feature-branch push, a chat start, an
+installed cron. So the failure mode of a security fix is not a missed
+vulnerability: it is a gate that quietly starts refusing legitimate work, and the
+symptom surfaces days later as an agent that stopped working, reporting a pattern
+instead of a cause.
+
+That question is a bad fit for a model review, which would have to simulate a
+17,000-line matcher over a corpus of commands nobody wrote down. It is a good fit
+for a deterministic before/after classification.
+
+## How it answers
+
+`scripts/deny_diff.py` takes a base ref, a head ref, and a corpus of golden
+paths. For each `shell` row whose platform matches the runner, it classifies the
+command **twice** — once with the deny composite as it exists at the base ref,
+once as it exists at the head ref — and diffs the two verdicts:
+
+| Base | Head | Verdict |
+|---|---|---|
+| allowed | refused | **regression** — fails the job |
+| refused | allowed | loosening — reported, informational |
+| same | same | unchanged — counted only |
+
+A loosening does not fail, because loosening is what a revert or a
+false-positive fix looks like.
+
+### "Refused" means the whole composite, not just the rule catalog
+
+A shell command at `hooks.on_tool_call` is refused by four checks, and this gate
+runs all four in the same order, reporting which one decided:
+
+| Tier | Check | Lives in |
+|---|---|---|
+| `sensitive-path` | `is_sensitive_path` — the path fence | `security/paths.py` |
+| `sensitive-bash` | `is_sensitive_bash_command` — scan ceiling, IMDS reach, env-credential detector | `security/paths.py` |
+| `exfil` | `audit_bash_exfiltration` — egress and reverse-shell shapes | `security/exfil.py` |
+| `deny-rules` | `is_denied` — the rule catalog and the argv-structural floors | `security/__init__.py` |
+
+Measuring only the last one would be the specific way this gate could ship a
+meaningless green: its trigger paths cover `paths.py` and `exfil.py`, so a
+tightening there would run it, come back empty, and leave the green badge
+standing as evidence the question had been asked. The tier is reported because
+"the path fence refused it" and "a catalog rule matched it" need different fixes.
+
+The list is **pinned, not asserted**: `test/test_deny_diff.py` reads the checks
+out of the hooks gate's own source and compares them with the script's declared
+tier table, so adding a fifth check over there reds this gate instead of silently
+escaping it.
+
+Every check is called with its default enabled set, which fails closed to every
+built-in rule enabled — the strictest posture an operator can be running, and the
+only one that needs no config on the runner.
+
+### A PR that ADDS a deny check
+
+That is the gate's primary use case, and it needs one rule to work at all. The
+child is always this script at head, so it iterates head's tier table against
+whichever tree it is pointed at — and the base tree of a check-adding PR has no
+such function. Treating that as an error would exit 2 on exactly the tightening
+the gate exists to measure.
+
+So a tier absent at **base** is skipped: a check that did not exist there refused
+nothing there, which is the truth, and the new check's refusals at head then
+surface as regressions — the answer the reviewer wanted. The report names the added
+tiers, because a whole tier's worth of rows appearing at once otherwise looks like
+the differential misfiring.
+
+A tier absent at **head** is the opposite: coverage silently lost. That stays an
+exit-2 error.
+
+### Why the verdicts can be trusted
+
+Both sides are the **real** code: each ref is materialized with `git archive`
+into its own directory, and a child process classifies against it with
+`PYTHONPATH` pointed there. Three properties keep that honest:
+
+- **The parent never imports the product.** The composite is the thing under
+  test, so importing it in the harness would pin the comparison to one side.
+- **Each child proves which tree answered.** It re-reports the file
+  `kiro_crew.security` resolved to and exits 2 when that sits outside the
+  checkout it was given. Without the check, an installed copy of the package
+  shadowing the path would serve *both* refs from one tree and every differential
+  would come back empty — a false green with no symptom.
+- **Each child is hermetic.** Every `KIROCREW_*` variable is stripped and
+  `KIROCREW_HOME` is repointed at a throwaway directory, so the verdict depends
+  on the checkout alone and the best-effort audit writes never reach a real
+  security log.
+
+Exit codes: `0` no regressions, `1` regressions, `2` corpus or ref error. A `2`
+fails the job — a differential that could not run is not a pass.
+
+### What a green does not cover
+
+The gate calls the four `security.*` checks directly, so it measures the **rules**,
+not `hooks.py`'s own composition of them: how the targets are built, the
+`raw_params` application of the path fence, the context-derived enabled set. A
+tightening implemented inside `hooks.py` itself runs this gate — `hooks.py` is in
+its trigger paths — and comes back empty, because none of the four functions
+changed.
+
+The tier pin narrows this but does not close it: it catches a check *added* to the
+gate, not a behavioural change in how the gate assembles what it checks. Closing it
+properly means driving commands through the gate's own target construction, which is
+async and needs a session context — a larger change than this gate, and worth doing
+separately if hooks-internal tightenings turn out to be a real source of false
+denials. Until then: a green here means "no golden path is newly refused by the four
+rule checks", and that is narrower than "no golden path is newly refused".
+
+## The corpus
+
+The corpus is `scripts/deny_diff_fixture.json`, whose rows each name an operation
+that is legitimate **by decision** plus the reason it is:
+
+```json
+{ "kind": "shell", "command_or_flow": "gh pr view 8014 --json state",
+  "platform": "any", "reason": "Read-only PR status query." }
+```
+
+`kind` is `shell`, `flow` or `cron`; `platform` is `any`, `posix` or `windows`.
+Only `shell` rows are classified here — a flow and a cron have no single command
+line to hand a matcher — and the other two are reported as skipped rather than
+dropped. They stay in the file on purpose: the corpus is a contract document as
+well as a gate input, and one that listed only shell rows would read as "these are
+all the golden paths", which is false. Reporting them as skipped is the honest form,
+and it also means a corpus that is mostly unclassifiable says so instead of
+reporting a confident zero. A row that spells its command under any other key is a malformed
+corpus (exit 2), not a tolerated variant: silently classifying nothing is the
+false green this gate exists to prevent.
+
+### It is read from the base ref, not the head checkout
+
+The corpus **is** the contract the change is judged against, so the change must
+not be able to edit it. A head-owned corpus would let the same PR that tightens a
+rule delete the row that rule breaks — removing it from *both* sides of the
+differential and passing.
+
+Two consequences worth knowing. A row **added** by the PR is not classified,
+because the base corpus does not have it — the pinned corpus test (below) is what
+covers a newly-added row, since it reads the head file. And when neither corpus
+exists at the base ref (the gate or the corpus is being introduced) the head file
+is used and the report says so: with no base contract there is no row a PR could
+withdraw to escape one.
+
+The reason a row belongs in the corpus is the reason a reviewer needs when the gate
+goes red, so a row without one is not much use.
+
+The security-conductor's own golden-paths seed is meant to become this corpus. That
+switch is an **explicit PR** that edits the corpus path in the workflow and deletes
+the fixture — not an automatic preference for whichever file exists. A gate that
+changed contracts the moment another file appeared would hand coverage over with
+nobody's diff showing the handover, and rows this corpus carries could drop out
+silently; the adopting PR instead shows that the seed covers them. The script itself
+takes any corpus path, so pointing it at the seed is a one-line change.
+
+## Why a three-platform matrix
+
+The rules read argv **shape** and the path fence reads real paths, and both
+differ per platform: Windows has its own tokenizer and separators, and the
+fence's home-directory ordering is macOS-specific (`Library/Application
+Support`, `/Volumes/<share>`). A Linux-only gate would pass a tightening that
+breaks every operator on another OS. That is the same class of defect the
+[Cross-Platform Portability](ci-and-reviews.md) gate exists for and cannot see,
+because that one reads added lines rather than behaviour.
+
+Legs do not `fail-fast`: one platform's regression is not evidence about
+another's, and a cancelled leg hides rows only that runner can produce.
+
+## When it goes red
+
+Read the job summary. Each listed row is an operation the corpus records as
+legitimate that this change newly refuses, with the reason it is legitimate, the
+tier that refused it, and the refusal text. There are exactly two answers.
+
+**Narrow the rule.** The usual one: the tightening is catching more than it meant
+to, and the row is the evidence of what.
+
+**Withdraw the row, in its own pull request, first.** When the row should no
+longer be a golden path, remove it from the corpus in a PR that changes no rule.
+This gate is green on that PR — nothing is newly refused — and once it lands, this
+PR's base no longer carries the row.
+
+There is deliberately **no approval label**. Unlike the [Cross-Platform
+Portability](ci-and-reviews.md) gate, whose finding is a line of code with nothing
+to edit but the code, this gate's finding is a row in a file that is already
+reviewable — so the base-owned corpus is itself the escape, and it is a better
+one. A withdrawal in its own PR is reviewed on its own merits, with the removed
+row and its stated reason as the whole diff, instead of riding along inside a
+security change behind a label. It also leaves no waiver mechanism to keep honest:
+a label that survives a push, or a scoping comment anyone can author, is a bypass
+of the gate rather than a use of it.
+
+## Its relationship to the pinned corpus test
+
+`test/test_deny_diff.py` also pins every corpus row as allowed at `HEAD`, and
+that test runs in the ordinary suite on Linux and Windows for every PR. The two
+are complementary, and the differential earns its place on attribution: the
+pinned test says "a corpus row is refused", the differential says "*this change*
+newly refuses it". When `main` drifts into refusing a row, the pinned test goes
+red on every subsequent PR and blames whichever one happens to be open, while the
+differential reads base-red plus head-red as unchanged and stays green. It also
+reports loosenings — how a false-positive fix demonstrates it fixed something. In
+the other direction the pinned test covers what the differential deliberately
+cannot: a row the PR *adds*, which the base-owned corpus does not contain.
+
+## Running it locally
+
+```
+python3 scripts/deny_diff.py --base origin/main --head HEAD \
+    --corpus scripts/deny_diff_fixture.json
+```
+
+Add `--json` for machine-readable rows, or `--platform posix|windows` to classify
+another platform's rows than the host's. Stdlib only, no install required.

--- a/scripts/deny_diff.py
+++ b/scripts/deny_diff.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python3
+"""deny_diff — does a tightened deny rule now refuse work the product depends on?
+
+Stdlib only, no third-party deps, cross-platform. Run from the repo root::
+
+    python3 scripts/deny_diff.py --base origin/main --head HEAD \\
+        --corpus src/kiro_crew/builtin_skills/security-conductor/golden-paths.seed.json
+
+Exit 0 = no regressions, exit 1 = regressions, exit 2 = corpus/ref error.
+
+Why this gate exists
+--------------------
+A security fix is almost always a deny rule made stricter, and "stricter" has no
+upper bound that review can see. The rule's author reads the pattern and the
+attack it now catches; nobody reads the set of ordinary commands that pattern
+also newly matches. So the failure mode is not a missed vulnerability -- it is a
+gate that starts refusing a read-only ``gh`` query, a feature-branch push, a
+chat start or an installed cron, and the refusal surfaces days later as an agent
+that "just stopped working" with a message that names a pattern rather than a
+cause.
+
+A model review cannot answer that question reliably: it would have to simulate a
+17,000-line matcher over a corpus of commands nobody wrote down. A before/after
+classification can, deterministically, because both sides of the comparison are
+the REAL classifier -- the code as it exists at each ref -- not a description of
+it.
+
+What counts as "refused"
+------------------------
+The whole composite the tool gate applies to a shell command, in its order, not
+just the rule catalog -- see :data:`_TIERS`. Each of those checks returns a denial
+at ``hooks.on_tool_call``, so a gate that measured only the last would go green on
+a tightening of the first three and the green badge would then stand as evidence
+the question was asked. The reported tier says which one decided, because "the
+path fence refused it" and "a catalog rule matched it" need different fixes.
+``enabled_ids``/``denied_regexes`` are left at their defaults, which fails closed
+to every built-in rule enabled -- the strictest posture an operator can be
+running, and the only one that needs no config.
+
+How the differential stays honest
+---------------------------------
+Four properties matter, and each one is a deliberate cost.
+
+*Both sides are real code.* Each ref is materialized with ``git archive`` into
+its own directory and classified by a child process whose ``PYTHONPATH`` points
+at that checkout, so the verdict comes from that ref's own matcher. A
+re-implementation of the rules in this script would agree with itself forever
+and catch nothing.
+
+*Each side proves which tree it loaded.* The child re-reports the file
+``kiro_crew.security`` actually resolved to and refuses when it sits outside the
+checkout it was pointed at. Without that check an installed copy of the package
+shadowing the path could serve BOTH sides from one tree, and the gate would
+report zero regressions forever while looking like it ran.
+
+*The parent never imports the product.* Two reasons, one of them empirical: the
+classifier is the thing under test, so importing it here would pin the harness
+to one side of the comparison; and an inline ``python -c "import kiro_crew..."``
+is itself refused by the argv floor this gate exists to keep honest. The child
+is this same file re-executed with :data:`_WORKER_FLAG`, which imports the
+product only in that mode.
+
+*The child is hermetic.* Every ``KIROCREW_*`` variable is stripped from the
+child's environment and ``KIROCREW_HOME`` is repointed at a throwaway
+directory, so the verdict depends on the checkout alone and the classifier's
+best-effort SEL audit writes land somewhere disposable instead of in the
+operator's real log. A differential whose result moved with the caller's
+environment would be unfalsifiable.
+
+The corpus
+----------
+Rows come from the security-conductor's golden-paths seed: operations that are
+legitimate BY DECISION, each with the reason it is legitimate. ``kind`` is
+``shell``, ``flow`` or ``cron``; only ``shell`` rows are classified here,
+because a flow and a cron are named by this gate's siblings and have no single
+command line to hand a matcher. They are counted and reported as skipped rather
+than dropped, so a corpus that is mostly unclassifiable says so instead of
+reporting a confident zero.
+
+The corpus is read from the BASE ref by the workflow, never the head checkout.
+The corpus IS the contract a change is judged against, so a head-owned corpus
+would let the same PR that tightens a rule delete the row that rule breaks --
+removing it from both sides and passing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: Re-executes this file as the classification child. A flag rather than a
+#: separate script so the harness is one reviewable file, and prefixed with an
+#: underscore because it is an implementation detail of this script's own
+#: subprocess call, not part of the CLI a caller composes.
+_WORKER_FLAG = "--_classify-worker"
+
+#: Row kinds the seed may carry. Only ``shell`` is classifiable -- see the module
+#: docstring.
+_KINDS = frozenset({"shell", "flow", "cron"})
+
+#: Platform selectors a row may declare.
+_PLATFORMS = frozenset({"any", "posix", "windows"})
+
+#: The deny checks this gate measures, in the order ``hooks.on_tool_call`` applies
+#: them to a shell command, as (tier name, attribute of ``kiro_crew.security``).
+#:
+#: Declared as data rather than inline in the worker so ``test/test_deny_diff.py``
+#: can compare it against the hooks gate itself. The gate's whole claim is that a
+#: green means "no golden path is newly refused AT THE TOOL GATE", and that holds
+#: only while these two sets agree -- nothing about adding a fifth check over there
+#: would otherwise reach this file, so the differential would keep passing while
+#: quietly covering less of the product than it says.
+_TIERS: tuple[tuple[str, str], ...] = (
+    ("sensitive-path", "is_sensitive_path"),
+    ("sensitive-bash", "is_sensitive_bash_command"),
+    ("exfil", "audit_bash_exfiltration"),
+    ("deny-rules", "is_denied"),
+)
+
+#: Reason reported for a tier whose check answers True/False rather than a string.
+#: The path fence is the one such check, and a bare ``True`` would otherwise render
+#: as an empty refusal in the report.
+_BOOL_TIER_REASON = "Blocked: access to sensitive path"
+
+#: Seconds a single classification child may take for the WHOLE corpus. One
+#: child classifies every row, so this bounds the gate at two spawns, not two
+#: per row.
+_WORKER_TIMEOUT = 600
+
+#: How much of a refusal reason is reported per row. The reason names the pattern
+#: that matched, never the payload, but it can carry a diagnostic line and an
+#: operator note, and a job summary with 40 of those is unreadable.
+_REASON_CHARS = 300
+
+
+class DenyDiffError(Exception):
+    """A corpus or ref problem: the differential cannot be computed (exit 2).
+
+    Distinct from "regressions found", which is a RESULT (exit 1). Conflating the
+    two is how a gate reports green because it never ran.
+    """
+
+
+@dataclass(frozen=True)
+class Row:
+    """One golden path: an operation that is legitimate by decision."""
+
+    index: int
+    kind: str
+    command: str
+    platform: str
+    reason: str
+
+    def applies_to(self, platform: str) -> bool:
+        return self.platform in ("any", platform)
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """What one ref's deny composite said about one command.
+
+    ``tier`` names which of :data:`_TIERS` decided, so a reader knows whether to
+    look at the path fence or at the rule catalog. Empty when nothing refused.
+    """
+
+    denied: bool
+    reason: str
+    tier: str = ""
+
+
+@dataclass
+class Report:
+    """The differential, in the form both the text and JSON renderings read."""
+
+    base: str
+    head: str
+    base_sha: str
+    head_sha: str
+    platform: str
+    #: Where the rows came from. Named ``source`` and not ``corpus`` because on an
+    #: attribute access the preceding identifier and that name join into a dotted
+    #: fragment the repo's internal-content scan reads as a hostname. The scan is
+    #: right to be blunt about the shape; renaming the field is the cheap fix.
+    source: str
+    total_rows: int
+    skipped_kind: int = 0
+    skipped_platform: int = 0
+    #: Tiers declared in :data:`_TIERS` that the BASE tree does not carry, i.e. deny
+    #: checks this change introduces. Reported because they are the reason a whole
+    #: tier's worth of rows can turn up as regressions at once.
+    base_absent_tiers: list[str] = field(default_factory=list)
+    regressions: list[tuple[Row, Verdict]] = field(default_factory=list)
+    loosenings: list[tuple[Row, Verdict]] = field(default_factory=list)
+    unchanged_denied: int = 0
+    unchanged_allowed: int = 0
+
+    @property
+    def classified(self) -> int:
+        return (
+            len(self.regressions)
+            + len(self.loosenings)
+            + self.unchanged_denied
+            + self.unchanged_allowed
+        )
+
+    @property
+    def exit_code(self) -> int:
+        return 1 if self.regressions else 0
+
+
+# ---------------------------------------------------------------------------
+# Corpus
+# ---------------------------------------------------------------------------
+
+
+def load_corpus(path: Path) -> list[Row]:
+    """Parse the golden-paths seed at *path* into rows.
+
+    Accepts a bare list or an object wrapping one under ``golden_paths``, which is
+    the seed's own shape.
+
+    Every rejection is a :class:`DenyDiffError`. A corpus that silently dropped a
+    malformed row would report "no regressions" over a subset nobody chose --
+    exactly the false green this gate exists to prevent.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise DenyDiffError(f"cannot read corpus {path}: {exc}") from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DenyDiffError(f"corpus {path} is not valid JSON: {exc}") from exc
+
+    if isinstance(payload, dict):
+        if "golden_paths" not in payload:
+            raise DenyDiffError(f"corpus {path} is an object without a 'golden_paths' key")
+        payload = payload["golden_paths"]
+    if not isinstance(payload, list):
+        raise DenyDiffError(f"corpus {path} must hold a list of rows, got {type(payload).__name__}")
+    if not payload:
+        raise DenyDiffError(f"corpus {path} holds no rows")
+
+    return [_row(path, position, entry) for position, entry in enumerate(payload)]
+
+
+def _row(path: Path, position: int, entry: object) -> Row:
+    """One validated row, or a :class:`DenyDiffError` naming its position."""
+    where = f"corpus {path} row {position}"
+    if not isinstance(entry, dict):
+        raise DenyDiffError(f"{where} is not an object")
+
+    kind = entry.get("kind")
+    if kind not in _KINDS:
+        raise DenyDiffError(f"{where} has kind {kind!r}, expected one of {sorted(_KINDS)}")
+
+    command = entry.get("command_or_flow")
+    if not isinstance(command, str) or not command.strip():
+        raise DenyDiffError(f"{where} has no non-empty 'command_or_flow'")
+
+    platform = entry.get("platform", "any")
+    if platform not in _PLATFORMS:
+        raise DenyDiffError(
+            f"{where} has platform {platform!r}, expected one of {sorted(_PLATFORMS)}"
+        )
+
+    reason = entry.get("reason", "")
+    if not isinstance(reason, str):
+        raise DenyDiffError(f"{where} has a non-string 'reason'")
+
+    return Row(index=position, kind=kind, command=command, platform=platform, reason=reason)
+
+
+# ---------------------------------------------------------------------------
+# Materializing a ref
+# ---------------------------------------------------------------------------
+
+
+def resolve_checkout(repo_root: Path, ref: str, dest: Path) -> Path:
+    """Materialize *ref*'s ``src`` tree under *dest*; return *dest*.
+
+    ``git archive`` piped through stdlib :mod:`tarfile` rather than a ``tar``
+    subprocess or ``git worktree``: ``tar`` is not a portable dependency on the
+    Windows runner, and a worktree mutates the caller's repository -- an
+    administrative write this gate has no business making to answer a read-only
+    question.
+
+    This function is the seam the tests replace. Pointing it at a hand-built tree
+    is what lets the exit-code paths be proven against a few-line fake composite
+    instead of against the real one, whose verdicts are the thing under test and
+    cannot also be the fixture.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    archive = dest.with_suffix(".tar")
+    proc = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "archive",
+            "--format=tar",
+            "-o",
+            str(archive),
+            ref,
+            "src",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise DenyDiffError(f"cannot archive ref {ref!r}: {detail}")
+    try:
+        with tarfile.open(archive) as tar:
+            tar.extractall(dest, filter="data")
+    except (tarfile.TarError, OSError) as exc:
+        raise DenyDiffError(f"cannot unpack archive of ref {ref!r}: {exc}") from exc
+    finally:
+        archive.unlink(missing_ok=True)
+    if not (dest / "src" / "kiro_crew").is_dir():
+        raise DenyDiffError(f"ref {ref!r} has no src/kiro_crew tree")
+    return dest
+
+
+def _rev_parse(repo_root: Path, ref: str) -> str:
+    """*ref*'s commit sha, or the ref itself when it does not resolve.
+
+    Reported for provenance only, so an unresolvable ref falls back to the spelling
+    the caller gave rather than failing: the archive step above is the one that
+    decides whether a ref is usable, and it produces the better message.
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--short", ref],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return proc.stdout.strip() if proc.returncode == 0 else ref
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _child_env(checkout: Path, home: Path) -> dict[str, str]:
+    """Environment for a classification child: hermetic, and pointed at *checkout*.
+
+    Every ``KIROCREW_*`` variable is dropped. The caller's sandbox and port
+    variables leak into any child by default, and a classifier that read them would
+    make the verdict a function of who ran the gate. ``KIROCREW_HOME`` is then set
+    to *home* so the classifier's best-effort audit writes land in a throwaway
+    directory rather than the operator's real security log.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KIROCREW_")}
+    env["KIROCREW_HOME"] = str(home)
+    env["PYTHONPATH"] = str(checkout / "src")
+    # A .pyc for a tree deleted at the end of the run is pure cost, and writing
+    # into the archive dir muddies "the checkout is exactly the ref".
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    return env
+
+
+def classify(
+    checkout: Path, commands: list[str], *, home: Path, side: str = "head"
+) -> tuple[list[Verdict], list[str]]:
+    """Classify *commands* with the deny composite living under *checkout*.
+
+    Returns the verdicts and the names of any declared tiers that tree does not
+    carry. *side* decides what a missing tier MEANS, which is the whole reason it is
+    a parameter -- see :func:`_worker_main`.
+
+    One child for the whole list: the composite's import cost dwarfs its per-command
+    cost, so per-row spawning would make the gate slower than the test suite it
+    guards without changing a single verdict.
+    """
+    if not commands:
+        return [], []
+    request = {
+        "commands": commands,
+        "expect_root": str((checkout / "src").resolve()),
+        "side": side,
+    }
+    proc = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), _WORKER_FLAG],
+        input=json.dumps(request),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=_child_env(checkout, home),
+        timeout=_WORKER_TIMEOUT,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise DenyDiffError(f"classifier under {checkout} failed: {detail}")
+    try:
+        payload = json.loads(proc.stdout)
+        verdicts = payload["verdicts"]
+        absent = [str(name) for name in payload.get("absent_tiers", [])]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise DenyDiffError(
+            f"classifier under {checkout} produced unreadable output: {exc}"
+        ) from exc
+    if len(verdicts) != len(commands):
+        raise DenyDiffError(
+            f"classifier under {checkout} returned {len(verdicts)} verdicts "
+            f"for {len(commands)} commands"
+        )
+    out: list[Verdict] = []
+    for entry in verdicts:
+        if entry.get("error"):
+            raise DenyDiffError(f"classifier under {checkout} errored: {entry['error']}")
+        out.append(
+            Verdict(
+                denied=bool(entry["denied"]),
+                reason=str(entry.get("reason") or ""),
+                tier=str(entry.get("tier") or ""),
+            )
+        )
+    return out, absent
+
+
+def _worker_main() -> int:
+    """The child: run the product's deny composite over each command.
+
+    The ONLY place this file touches product code, reached only via
+    :data:`_WORKER_FLAG`. It reports a classifier failure as a structured ``error``
+    row rather than a traceback, so the parent can say which ref broke instead of
+    surfacing a stack from a tree the reader cannot see.
+    """
+    try:
+        payload = json.loads(sys.stdin.read())
+        commands = list(payload["commands"])
+        expect_root = Path(payload["expect_root"]).resolve()
+        side = str(payload.get("side") or "head")
+    except (KeyError, TypeError, ValueError) as exc:
+        print(f"worker: unreadable request: {exc}", file=sys.stderr)
+        return 2
+    try:
+        import kiro_crew.security as security
+    except Exception as exc:
+        print(f"worker: cannot import kiro_crew.security: {exc}", file=sys.stderr)
+        return 2
+
+    # Which tree actually answered. An installed copy of the package that shadowed
+    # the path would serve both refs from one tree and every differential would
+    # come back empty -- a false green with no symptom, so it is checked rather
+    # than assumed. ``normcase`` first: Windows paths are case-insensitive and
+    # accept either separator, so a raw comparison can report "outside" for the
+    # very tree the child was pointed at.
+    loaded = Path(os.path.normcase(str(Path(security.__file__ or "").resolve())))
+    root = Path(os.path.normcase(str(expect_root)))
+    if not loaded.is_relative_to(root):
+        print(
+            f"worker: kiro_crew.security resolved to {loaded}, outside {root}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # :data:`_TIERS` in ITS order, so the first tier to refuse here is the tier that
+    # would refuse in production.
+    #
+    # A tier the tree does not carry means opposite things on the two sides, and the
+    # difference is the gate's own primary use case. The worker is always THIS file
+    # at head, so it iterates head's tier table against whichever tree it was
+    # pointed at; a PR that adds a deny check adds it to both the table and
+    # ``security``, and the BASE tree then has no such attribute. Refusing there
+    # would exit 2 on exactly the tightening this gate exists to measure. The honest
+    # reading is that a check which did not exist at base refused nothing at base,
+    # so the tier is skipped and its refusals at head surface as regressions -- which
+    # is the answer the reviewer wanted.
+    #
+    # At HEAD the same absence is coverage silently lost, so it stays an error.
+    strict = side != "base"
+    checks: list[tuple[str, Callable[[str], object]]] = []
+    absent: list[str] = []
+    for name, attribute in _TIERS:
+        check = getattr(security, attribute, None)
+        if check is None:
+            if strict:
+                print(f"worker: {attribute} is absent from this tree", file=sys.stderr)
+                return 2
+            absent.append(name)
+            continue
+        checks.append((name, check))
+
+    verdicts: list[dict[str, object]] = []
+    for command in commands:
+        row: dict[str, object] = {"denied": False, "reason": "", "tier": ""}
+        for name, check in checks:
+            try:
+                outcome = check(command)
+            except Exception as exc:
+                row = {"error": f"{type(exc).__name__} in {name} on {command!r}: {exc}"}
+                break
+            if not outcome:
+                continue
+            # The path fence answers True/False; the other three answer a reason or
+            # None. Both shapes mean "refused", and a bare True must not render as
+            # an empty refusal.
+            reason = _BOOL_TIER_REASON if outcome is True else str(outcome)
+            row = {"denied": True, "reason": reason[:_REASON_CHARS], "tier": name}
+            break
+        verdicts.append(row)
+    json.dump({"verdicts": verdicts, "absent_tiers": absent}, sys.stdout)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# The differential
+# ---------------------------------------------------------------------------
+
+
+def resolve_platform(selector: str) -> str:
+    """The platform rows are filtered against. ``auto`` reads the running host."""
+    if selector != "auto":
+        return selector
+    return "windows" if os.name == "nt" else "posix"
+
+
+def differential(
+    repo_root: Path,
+    base: str,
+    head: str,
+    corpus_path: Path,
+    *,
+    platform: str,
+    workdir: Path,
+    resolver: Callable[[Path, str, Path], Path] | None = None,
+) -> Report:
+    """Classify the corpus at *base* and at *head* and diff the two verdict sets.
+
+    *resolver* defaults to the module-level :func:`resolve_checkout` read at CALL
+    time, so a test may either pass a substitute here or monkeypatch the module
+    attribute; both reach the same seam.
+    """
+    resolve = resolver or resolve_checkout
+    rows = load_corpus(corpus_path)
+    report = Report(
+        base=base,
+        head=head,
+        base_sha=_rev_parse(repo_root, base),
+        head_sha=_rev_parse(repo_root, head),
+        platform=platform,
+        source=str(corpus_path),
+        total_rows=len(rows),
+    )
+
+    selected: list[Row] = []
+    for row in rows:
+        if row.kind != "shell":
+            report.skipped_kind += 1
+        elif not row.applies_to(platform):
+            report.skipped_platform += 1
+        else:
+            selected.append(row)
+
+    if not selected:
+        return report
+
+    commands = [row.command for row in selected]
+    base_home = workdir / "home-base"
+    head_home = workdir / "home-head"
+    base_home.mkdir(parents=True, exist_ok=True)
+    head_home.mkdir(parents=True, exist_ok=True)
+    base_tree = resolve(repo_root, base, workdir / "base")
+    head_tree = resolve(repo_root, head, workdir / "head")
+    base_verdicts, report.base_absent_tiers = classify(
+        base_tree, commands, home=base_home, side="base"
+    )
+    head_verdicts, _ = classify(head_tree, commands, home=head_home, side="head")
+
+    for row, before, after in zip(selected, base_verdicts, head_verdicts):
+        if after.denied and not before.denied:
+            report.regressions.append((row, after))
+        elif before.denied and not after.denied:
+            report.loosenings.append((row, before))
+        elif after.denied:
+            report.unchanged_denied += 1
+        else:
+            report.unchanged_allowed += 1
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_text(report: Report) -> str:
+    """The human/job-summary rendering. Markdown, because a job summary renders it."""
+    lines = [
+        "### Denial differential",
+        "",
+        f"- base `{report.base}` (`{report.base_sha}`) -> "
+        f"head `{report.head}` (`{report.head_sha}`)",
+        f"- platform `{report.platform}`, corpus `{report.source}`",
+        f"- {report.total_rows} row(s): {report.classified} classified, "
+        f"{report.skipped_kind} non-shell, {report.skipped_platform} other-platform",
+        "",
+    ]
+    if report.base_absent_tiers:
+        lines.append(
+            "- this change ADDS the "
+            + ", ".join(f"`{name}`" for name in report.base_absent_tiers)
+            + " tier(s); the base ref has no such check, so it refused nothing there"
+        )
+        lines.append("")
+
+    if report.regressions:
+        lines.append(f"**Regressions -- newly refused at head ({len(report.regressions)})**")
+        lines.append("")
+        for row, verdict in report.regressions:
+            lines.append(f"- `{row.command}` _[{row.platform}]_")
+            if row.reason:
+                lines.append(f"    - legitimate because: {row.reason}")
+            lines.append(f"    - head refuses at the `{verdict.tier}` tier: {verdict.reason}")
+        lines.append("")
+    else:
+        lines.append("**No regressions** -- every classified golden path still runs at head.")
+        lines.append("")
+
+    if report.loosenings:
+        lines.append(
+            f"Loosenings -- newly allowed at head ({len(report.loosenings)}), informational:"
+        )
+        lines.append("")
+        for row, verdict in report.loosenings:
+            lines.append(f"- `{row.command}` _[{row.platform}]_")
+            lines.append(f"    - base refused at the `{verdict.tier}` tier: {verdict.reason}")
+        lines.append("")
+
+    lines.append(
+        f"Unchanged: {report.unchanged_allowed} allowed at both refs, "
+        f"{report.unchanged_denied} refused at both."
+    )
+    return "\n".join(lines)
+
+
+def render_json(report: Report) -> str:
+    """The machine rendering. The workflow reads this to extract the exact rows."""
+    return json.dumps(
+        {
+            "base": report.base,
+            "base_sha": report.base_sha,
+            "head": report.head,
+            "head_sha": report.head_sha,
+            "platform": report.platform,
+            "corpus": report.source,
+            "counts": {
+                "total_rows": report.total_rows,
+                "classified": report.classified,
+                "skipped_kind": report.skipped_kind,
+                "skipped_platform": report.skipped_platform,
+                "base_absent_tiers": report.base_absent_tiers,
+                "regressions": len(report.regressions),
+                "loosenings": len(report.loosenings),
+                "unchanged_allowed": report.unchanged_allowed,
+                "unchanged_denied": report.unchanged_denied,
+            },
+            "regressions": [
+                {
+                    "command": row.command,
+                    "platform": row.platform,
+                    "kind": row.kind,
+                    "why_legitimate": row.reason,
+                    "head_tier": verdict.tier,
+                    "head_refusal": verdict.reason,
+                }
+                for row, verdict in report.regressions
+            ],
+            "loosenings": [
+                {
+                    "command": row.command,
+                    "platform": row.platform,
+                    "kind": row.kind,
+                    "why_legitimate": row.reason,
+                    "base_tier": verdict.tier,
+                    "base_refusal": verdict.reason,
+                }
+                for row, verdict in report.loosenings
+            ],
+            "exit_code": report.exit_code,
+        },
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _repo_root() -> Path:
+    """The repo root, from this file's location (``scripts/<me>``)."""
+    return Path(__file__).resolve().parent.parent
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args and args[0] == _WORKER_FLAG:
+        return _worker_main()
+
+    parser = argparse.ArgumentParser(
+        prog="deny_diff",
+        description="Report golden paths a deny-rule change newly refuses.",
+    )
+    parser.add_argument("--base", required=True, help="ref to classify as 'before'")
+    parser.add_argument("--head", required=True, help="ref to classify as 'after'")
+    parser.add_argument("--corpus", required=True, help="path to the golden-paths JSON")
+    parser.add_argument(
+        "--platform",
+        default="auto",
+        choices=sorted(_PLATFORMS | {"auto"}),
+        help="which rows to classify; 'auto' reads the running host",
+    )
+    parser.add_argument("--json", action="store_true", help="emit the report as JSON")
+    parsed = parser.parse_args(args)
+
+    repo_root = _repo_root()
+    try:
+        with tempfile.TemporaryDirectory(prefix="deny-diff-") as tmp:
+            report = differential(
+                repo_root,
+                parsed.base,
+                parsed.head,
+                Path(parsed.corpus),
+                platform=resolve_platform(parsed.platform),
+                workdir=Path(tmp),
+            )
+    except DenyDiffError as exc:
+        print(f"deny_diff: {exc}", file=sys.stderr)
+        return 2
+    except subprocess.TimeoutExpired as exc:
+        print(f"deny_diff: classifier timed out after {exc.timeout}s", file=sys.stderr)
+        return 2
+
+    print(render_json(report) if parsed.json else render_text(report))
+    return report.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deny_diff_fixture.json
+++ b/scripts/deny_diff_fixture.json
@@ -1,0 +1,126 @@
+{
+  "_comment": [
+    "Fallback golden-paths corpus for scripts/deny_diff.py.",
+    "Each row is an operation that is legitimate BY DECISION, with the reason it is.",
+    "The denial-differential gate fails a PR that makes any of these newly refused.",
+    "This file exists because the security-conductor's own golden-paths seed",
+    "(src/kiro_crew/builtin_skills/security-conductor/golden-paths.seed.json) is not",
+    "on main yet. The workflow prefers that seed the moment it lands and falls back",
+    "here until then, so delete this file in the same change that starts using the seed.",
+    "kind: shell rows are classified; flow and cron rows are recorded and reported as",
+    "skipped, because neither has a single command line to hand a matcher.",
+    "A row is classified against the WHOLE deny composite the tool gate applies to a",
+    "shell command: the path fence, the IMDS/env-credential detectors, the exfil",
+    "shapes, and the rule catalog with its argv floors."
+  ],
+  "golden_paths": [
+    {
+      "kind": "shell",
+      "command_or_flow": "gh pr view 8014 --json state,mergeable,statusCheckRollup",
+      "platform": "any",
+      "reason": "Read-only PR status query -- every drive-to-green round starts with it."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "gh issue list --label needs-triage --json number,title,labels",
+      "platform": "any",
+      "reason": "Read-only issue enumeration used by the triage and scanner crons."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "gh pr diff 8014",
+      "platform": "any",
+      "reason": "Read-only diff fetch -- how a review lane reads a change as data."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "git push origin feat/denial-differential-gate",
+      "platform": "any",
+      "reason": "Explicitly-named feature-branch push. Allowed by policy; only protected branches are fenced."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "git push --force-with-lease=feat/x:0123abc origin feat/x",
+      "platform": "any",
+      "reason": "Lease-guarded feature-branch force push -- the sanctioned way to update a PR round."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "git status --porcelain",
+      "platform": "any",
+      "reason": "Read-only working-tree inspection."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "git log --oneline -20",
+      "platform": "any",
+      "reason": "Read-only history read -- the basis of every archaeology step."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "git fetch origin main",
+      "platform": "any",
+      "reason": "Read-only remote sync before a rebase."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "git worktree add --detach /tmp/probe origin/main",
+      "platform": "posix",
+      "reason": "Base-ref probe worktree -- the sanctioned alternative to checking out over live work."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "python3 scripts/docs_lint.py",
+      "platform": "any",
+      "reason": "A repo gate the agent runs locally before every push."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "mypy src/kiro_crew/",
+      "platform": "any",
+      "reason": "A blocking CI gate, run locally first."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "npx eslint src/ --max-warnings 603",
+      "platform": "any",
+      "reason": "The frontend lint ratchet, run at CI's exact ceiling."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "kirocrew status",
+      "platform": "any",
+      "reason": "Own-health read. Named here because the self-protection floor is the rule most often tightened."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "kirocrew cron list",
+      "platform": "any",
+      "reason": "Read-only enumeration of installed jobs, across the same self-protection surface."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "ls -la src/kiro_crew/security",
+      "platform": "posix",
+      "reason": "Read-only directory listing over the governance tree -- a repeat false-positive source."
+    },
+    {
+      "kind": "shell",
+      "command_or_flow": "Get-ChildItem -Path src -Recurse -Filter *.py",
+      "platform": "windows",
+      "reason": "The Windows equivalent read-only listing; proves the fence is not POSIX-shaped."
+    },
+    {
+      "kind": "flow",
+      "command_or_flow": "chat start",
+      "platform": "any",
+      "reason": "Starting a chat session must never be refused; classified by the flow gate, not this one."
+    },
+    {
+      "kind": "cron",
+      "command_or_flow": "gh-issue-scanner",
+      "platform": "any",
+      "reason": "An installed scanner job must keep firing; classified by the cron gate, not this one."
+    }
+  ]
+}

--- a/test/test_deny_diff.py
+++ b/test/test_deny_diff.py
@@ -1,0 +1,539 @@
+"""The denial differential must fail on a newly-refused golden path, and only then.
+
+``scripts/deny_diff.py`` answers one question about a deny-rule change: does the
+tightened rule now refuse an operation the product depends on? The answer is a
+before/after classification, so the thing that can silently break is the
+COMPARISON -- a gate that classifies one tree twice, or that reads a loosening as
+a regression, reports a confident verdict about nothing.
+
+So the exit-code paths are proven against two hand-built classifier trees rather
+than against the real matcher. The real one is what the gate measures; making it
+also the fixture would mean the tests could only assert whatever it happens to do
+today, and a regression could not be staged at all. The fakes travel the SAME
+subprocess path as production -- ``PYTHONPATH`` at a materialized tree, one child
+per side, verdicts diffed in the parent -- with only the ref-to-checkout resolver
+replaced, which is why an exit code proven here is the exit code CI produces.
+
+The fakes carry all FOUR deny checks the tool gate applies to a shell command,
+because covering only the rule catalog is the specific way this gate could ship a
+meaningless green: a tightening of the path fence or the exfil shapes runs it (its
+trigger paths include both) and a catalog-only differential would come back empty.
+One test stages a regression on each non-catalog tier, and another reads the tier
+list back out of ``hooks.py`` -- so the fidelity claim is pinned against the gate
+it claims to mirror rather than asserted in a comment.
+
+Two tests then run the real composite: ``base == head == HEAD`` over the fallback
+corpus must find zero regressions, and no corpus row may be refused at HEAD at
+all. Those are the properties the fakes cannot check -- that the corpus names
+operations the shipped rules actually allow, so a red on a future PR means that
+PR tightened something rather than that the corpus was wrong when written.
+
+The gate has no waiver mechanism to test. A row that stops being a golden path is
+withdrawn in its own pull request, which is what the base-owned corpus makes
+possible.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "deny_diff.py"
+FALLBACK_CORPUS = ROOT / "scripts" / "deny_diff_fixture.json"
+HOOKS = ROOT / "src" / "kiro_crew" / "hooks.py"
+
+
+def _load(name: str, path: Path):
+    """Import a repo script by path.
+
+    Registered in ``sys.modules`` BEFORE exec: a script's dataclasses resolve their
+    own (string) annotations through ``sys.modules[cls.__module__]``, so a module
+    executed without a registration raises at class-creation time rather than at
+    use.
+    """
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+deny_diff = _load("deny_diff", SCRIPT)
+
+
+#: A whole deny composite, in the shape the worker imports it: a package under
+#: ``src/`` exposing the four checks the tool gate applies. Each fake refuses the
+#: commands assigned to its own tier, which is how a test can stage a regression on
+#: a tier other than the rule catalog and watch the differential attribute it.
+_FAKE_HEADER = "TIERS = {tiers!r}\n"
+
+#: Per-tier source, so a tree can OMIT one. A ref that predates a deny check has no
+#: such attribute at all, which is a different tree from one whose check allows
+#: everything -- and the two must not be conflated.
+_FAKE_TIER_SOURCE = {
+    "sensitive-path": """
+
+def is_sensitive_path(value, base_dir=None):
+    return value in TIERS["sensitive-path"]
+""",
+    "sensitive-bash": """
+
+def is_sensitive_bash_command(command, *, enabled_ids=None):
+    return "Blocked: fake sensitive bash" if command in TIERS["sensitive-bash"] else None
+""",
+    "exfil": """
+
+def audit_bash_exfiltration(command, *, enabled_ids=None):
+    return "Blocked: fake exfil shape" if command in TIERS["exfil"] else None
+""",
+    "deny-rules": """
+
+def is_denied(command, *args, **kwargs):
+    return "Blocked by security policy: fake rule" if command in TIERS["deny-rules"] else None
+""",
+}
+
+_TIER_NAMES = ("sensitive-path", "sensitive-bash", "exfil", "deny-rules")
+
+
+def _fake_tree(
+    root: Path,
+    denied: set[str] | dict[str, set[str]],
+    *,
+    omit: tuple[str, ...] = (),
+) -> Path:
+    """A minimal importable ``kiro_crew.security`` under *root*.
+
+    *denied* is either a bare set (assigned to the rule-catalog tier, the common
+    case) or a per-tier mapping, which is how a non-catalog regression is staged.
+    *omit* leaves those tiers' functions out of the tree entirely, which is what a
+    ref predating a deny check looks like.
+    """
+    tiers: dict[str, list[str]] = {name: [] for name in _TIER_NAMES}
+    if isinstance(denied, dict):
+        for name, commands in denied.items():
+            tiers[name] = sorted(commands)
+    else:
+        tiers["deny-rules"] = sorted(denied)
+
+    source = _FAKE_HEADER.format(tiers=tiers) + "".join(
+        body for name, body in _FAKE_TIER_SOURCE.items() if name not in omit
+    )
+    package = root / "src" / "kiro_crew" / "security"
+    package.mkdir(parents=True, exist_ok=True)
+    (root / "src" / "kiro_crew" / "__init__.py").write_text("", encoding="utf-8")
+    (package / "__init__.py").write_text(source, encoding="utf-8")
+    return root
+
+
+def _corpus(path: Path, rows: list[dict]) -> Path:
+    path.write_text(json.dumps({"golden_paths": rows}), encoding="utf-8")
+    return path
+
+
+def _shell(command: str, platform: str = "any") -> dict:
+    return {
+        "kind": "shell",
+        "command_or_flow": command,
+        "platform": platform,
+        "reason": f"golden path: {command}",
+    }
+
+
+@pytest.fixture()
+def staged(tmp_path, monkeypatch):
+    """Stage two classifier trees and point the resolver at them.
+
+    Returns a callable taking the corpus rows and returning the report. The
+    resolver is monkeypatched on the MODULE, which is the same seam production
+    reads, so nothing about the child spawn, the environment scrub or the verdict
+    parsing is bypassed.
+    """
+    runs = 0
+
+    def run(
+        rows: list[dict],
+        *,
+        base_denies,
+        head_denies,
+        platform: str = "posix",
+        base_omits: tuple[str, ...] = (),
+        head_omits: tuple[str, ...] = (),
+    ):
+        nonlocal runs
+        runs += 1
+        base_tree = _fake_tree(tmp_path / f"base-tree-{runs}", base_denies, omit=base_omits)
+        head_tree = _fake_tree(tmp_path / f"head-tree-{runs}", head_denies, omit=head_omits)
+
+        def resolver(repo_root: Path, ref: str, dest: Path) -> Path:
+            return base_tree if ref == "BASE" else head_tree
+
+        monkeypatch.setattr(deny_diff, "resolve_checkout", resolver)
+        workdir = tmp_path / f"work-{runs}"
+        workdir.mkdir()
+        return deny_diff.differential(
+            ROOT,
+            "BASE",
+            "HEAD",
+            _corpus(workdir / "corpus.json", rows),
+            platform=platform,
+            workdir=workdir,
+        )
+
+    return run
+
+
+def test_newly_refused_golden_path_is_a_regression(staged):
+    """A row the base allows and the head refuses fails the gate (exit 1)."""
+    push = "git push origin feat/x"
+    report = staged(
+        [_shell("gh pr view 1 --json state"), _shell(push)],
+        base_denies=set(),
+        head_denies={push},
+    )
+
+    assert report.exit_code == 1
+    assert [row.command for row, _ in report.regressions] == [push]
+    assert report.loosenings == []
+    assert report.unchanged_allowed == 1
+
+    text = deny_diff.render_text(report)
+    assert "Regressions -- newly refused at head (1)" in text
+    # The report has to carry WHY the row is legitimate, not just that it broke:
+    # the reader's next action is to judge the rule against the reason.
+    assert f"legitimate because: golden path: {push}" in text
+    assert "head refuses at the `deny-rules` tier" in text
+
+
+@pytest.mark.parametrize("tier", ["sensitive-path", "sensitive-bash", "exfil"])
+def test_a_regression_on_a_non_catalog_tier_is_caught_and_named(staged, tier):
+    """The path fence and the exfil shapes are deny tiers too, and this gate runs on them.
+
+    A catalog-only differential reads a tightening of ``paths.py`` or ``exfil.py``
+    as clean -- both are inside this workflow's trigger paths -- and the green then
+    stands as evidence the question was asked.
+    """
+    command = "git status --porcelain"
+    report = staged([_shell(command)], base_denies={}, head_denies={tier: {command}})
+
+    assert report.exit_code == 1
+    assert [(row.command, verdict.tier) for row, verdict in report.regressions] == [(command, tier)]
+    assert f"head refuses at the `{tier}` tier" in deny_diff.render_text(report)
+
+
+def test_tier_order_matches_the_tool_gate(staged):
+    """When several tiers refuse, the reported one is the first the gate would hit."""
+    command = "ls -la src"
+    report = staged(
+        [_shell(command)],
+        base_denies={},
+        head_denies={"exfil": {command}, "deny-rules": {command}, "sensitive-bash": {command}},
+    )
+
+    assert [verdict.tier for _, verdict in report.regressions] == ["sensitive-bash"]
+
+
+def test_a_tier_this_change_adds_is_measured_against_a_base_that_lacks_it(staged):
+    """The gate's own primary use case: a PR that adds a deny check.
+
+    The worker is this file at head, so it iterates head's tier table against
+    whichever tree it was pointed at -- and the base tree of a check-adding PR has no
+    such attribute. Refusing there would exit 2 on exactly the tightening the gate
+    exists to measure. A check that did not exist at base refused nothing at base, so
+    the row's refusal at head is a regression and is reported as one.
+    """
+    command = "git status --porcelain"
+    report = staged(
+        [_shell(command)],
+        base_denies={},
+        head_denies={"exfil": {command}},
+        base_omits=("exfil",),
+    )
+
+    assert report.exit_code == 1
+    assert [(row.command, verdict.tier) for row, verdict in report.regressions] == [
+        (command, "exfil")
+    ]
+    assert report.base_absent_tiers == ["exfil"]
+
+    # The reader has to be told, or a whole tier's worth of rows turning up at once
+    # looks like the differential misfiring.
+    text = deny_diff.render_text(report)
+    assert "this change ADDS the `exfil` tier(s)" in text
+    assert json.loads(deny_diff.render_json(report))["counts"]["base_absent_tiers"] == ["exfil"]
+
+
+def test_a_tier_missing_at_head_is_an_error_not_a_skip(staged):
+    """At head the same absence is coverage silently lost, so it must not pass."""
+    with pytest.raises(deny_diff.DenyDiffError) as caught:
+        staged(
+            [_shell("git status --porcelain")],
+            base_denies={},
+            head_denies={},
+            head_omits=("exfil",),
+        )
+    assert "audit_bash_exfiltration is absent" in str(caught.value)
+
+
+def test_the_measured_checks_are_the_checks_the_tool_gate_applies():
+    """Pin the composite against ``hooks.py`` instead of asserting it in a comment.
+
+    The gate's whole claim is that a green means "no golden path is newly refused
+    AT THE TOOL GATE". That holds only while the set of checks measured here equals
+    the set the gate applies, and nothing about adding a fifth check to ``hooks.py``
+    would otherwise reach this script -- the differential would keep passing while
+    quietly covering less of the product than it says.
+    """
+    source = HOOKS.read_text(encoding="utf-8")
+    block = source.split("for target in security_targets:", 1)
+    assert len(block) == 2, "the tool gate must loop over security_targets"
+
+    # The loop body, to its dedent: every check the gate applies per target.
+    body: list[str] = []
+    for line in block[1].splitlines()[1:]:
+        if line.strip() and not line.startswith(" " * 12):
+            break
+        body.append(line)
+    applied = set(re.findall(r"\b(\w+)\(target\b", "\n".join(body)))
+    assert applied == {
+        "is_sensitive_path",
+        "is_sensitive_bash_command",
+        "audit_bash_exfiltration",
+    }, f"the tool gate's per-target checks changed: {sorted(applied)}"
+
+    # ``is_denied`` is applied by the same gate, outside the per-target loop.
+    assert "is_denied(" in source
+
+    # The DECLARED table, not a regex over call sites: a tier dropped from the table
+    # leaves its helper's call behind, so grepping calls would still see four.
+    measured = {attribute for _, attribute in deny_diff._TIERS}
+    assert measured == applied | {"is_denied"}, f"deny_diff measures {sorted(measured)}"
+    assert [name for name, _ in deny_diff._TIERS][:3] == [
+        "sensitive-path",
+        "sensitive-bash",
+        "exfil",
+    ], "tier order must follow the gate's own order"
+
+
+def test_loosening_only_passes_and_is_reported(staged):
+    """A row the base refuses and the head allows is informational, not a failure."""
+    listing = "ls -la src"
+    report = staged(
+        [_shell(listing), _shell("git status --porcelain")],
+        base_denies={listing},
+        head_denies=set(),
+    )
+
+    assert report.exit_code == 0
+    assert report.regressions == []
+    assert [row.command for row, _ in report.loosenings] == [listing]
+
+    text = deny_diff.render_text(report)
+    assert "No regressions" in text
+    assert "Loosenings -- newly allowed at head (1), informational" in text
+    assert f"`{listing}`" in text
+
+
+def test_unchanged_rows_are_counted_on_both_sides(staged):
+    """Refused-at-both is not a regression, and is reported apart from allowed-at-both."""
+    blocked = "rm -rf /"
+    report = staged(
+        [_shell(blocked), _shell("git log --oneline -5")],
+        base_denies={blocked},
+        head_denies={blocked},
+    )
+
+    assert report.exit_code == 0
+    assert (report.unchanged_denied, report.unchanged_allowed) == (1, 1)
+    assert "Unchanged: 1 allowed at both refs, 1 refused at both." in deny_diff.render_text(report)
+
+
+def test_platform_filter_selects_only_matching_rows(staged):
+    """A windows-only row is not classified on posix -- and cannot fail the gate there."""
+    win_only = "Get-ChildItem -Path src"
+    rows = [_shell(win_only, platform="windows"), _shell("ls -la src", platform="posix")]
+
+    posix = staged(rows, base_denies=set(), head_denies={win_only}, platform="posix")
+    assert posix.exit_code == 0
+    assert posix.skipped_platform == 1
+    assert posix.classified == 1
+
+    windows = staged(rows, base_denies=set(), head_denies={win_only}, platform="windows")
+    assert windows.exit_code == 1
+    assert [row.command for row, _ in windows.regressions] == [win_only]
+    assert windows.skipped_platform == 1
+
+
+def test_non_shell_rows_are_skipped_not_dropped(staged):
+    """Flow and cron rows are reported as skipped, so a corpus of them says so."""
+    report = staged(
+        [
+            _shell("git fetch origin main"),
+            {"kind": "flow", "command_or_flow": "chat start", "platform": "any", "reason": "r"},
+            {"kind": "cron", "command_or_flow": "scanner", "platform": "any", "reason": "r"},
+        ],
+        base_denies=set(),
+        head_denies=set(),
+    )
+
+    assert (report.skipped_kind, report.classified, report.total_rows) == (2, 1, 3)
+    assert "2 non-shell" in deny_diff.render_text(report)
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("{ not json", "not valid JSON"),
+        ('{"unrelated": []}', "without a 'golden_paths' key"),
+        ('{"golden_paths": []}', "holds no rows"),
+        ('{"golden_paths": ["a string"]}', "row 0 is not an object"),
+        ('{"golden_paths": [{"kind": "spell", "command_or_flow": "x"}]}', "has kind 'spell'"),
+        ('{"golden_paths": [{"kind": "shell", "command_or_flow": "  "}]}', "no non-empty"),
+        # A row spelling the command under any other key is a MALFORMED row, not a
+        # tolerated alias: silently classifying nothing is the false green.
+        ('{"golden_paths": [{"kind": "shell", "command": "ls"}]}', "no non-empty"),
+        (
+            '{"golden_paths": [{"kind": "shell", "command_or_flow": "x", "platform": "vms"}]}',
+            "has platform 'vms'",
+        ),
+        ('{"golden_paths": 7}', "must hold a list of rows"),
+    ],
+)
+def test_malformed_corpus_is_an_error_not_a_verdict(tmp_path, payload, expected):
+    """Every corpus defect exits 2. Silently classifying a subset would be a false green."""
+    corpus = tmp_path / "corpus.json"
+    corpus.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(deny_diff.DenyDiffError) as caught:
+        deny_diff.load_corpus(corpus)
+    assert expected in str(caught.value)
+
+    assert deny_diff.main(["--base", "HEAD", "--head", "HEAD", "--corpus", str(corpus)]) == 2
+
+
+def test_missing_corpus_file_exits_two(tmp_path):
+    missing = tmp_path / "absent.json"
+    assert deny_diff.main(["--base", "HEAD", "--head", "HEAD", "--corpus", str(missing)]) == 2
+
+
+def test_unresolvable_ref_exits_two(tmp_path):
+    """A ref that cannot be archived is an environment error, never 'no regressions'."""
+    corpus = _corpus(tmp_path / "corpus.json", [_shell("git status --porcelain")])
+    code = deny_diff.main(
+        ["--base", "refs/heads/no-such-ref-deny-diff", "--head", "HEAD", "--corpus", str(corpus)]
+    )
+    assert code == 2
+
+
+def test_child_environment_is_scrubbed_of_crew_variables(tmp_path, monkeypatch):
+    """The verdict must not be a function of the caller's environment."""
+    monkeypatch.setenv("KIROCREW_SANDBOX_ACTIVE", "1")
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "real-home"))
+
+    env = deny_diff._child_env(tmp_path / "checkout", tmp_path / "throwaway-home")
+
+    assert "KIROCREW_SANDBOX_ACTIVE" not in env
+    assert env["KIROCREW_HOME"] == str(tmp_path / "throwaway-home")
+    assert env["PYTHONPATH"] == str(tmp_path / "checkout" / "src")
+
+
+def test_worker_refuses_a_tree_it_was_not_pointed_at(tmp_path):
+    """The shadowing guard: one tree answering for both refs is an error, not a green.
+
+    Without this the differential's failure mode is invisible -- both sides would
+    load the same installed package and every comparison would come back empty.
+    """
+    _fake_tree(tmp_path / "real", set())
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    request = {"commands": ["ls"], "expect_root": str((elsewhere / "src").resolve())}
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), deny_diff._WORKER_FLAG],
+        input=json.dumps(request),
+        capture_output=True,
+        env=deny_diff._child_env(tmp_path / "real", tmp_path / "home"),
+        **UTF8_TEXT,
+    )
+
+    assert proc.returncode == 2
+    assert "outside" in proc.stderr
+
+
+def test_platform_auto_resolves_to_the_running_host(monkeypatch):
+    monkeypatch.setattr(deny_diff.os, "name", "nt")
+    assert deny_diff.resolve_platform("auto") == "windows"
+    monkeypatch.setattr(deny_diff.os, "name", "posix")
+    assert deny_diff.resolve_platform("auto") == "posix"
+    # An explicit selector is never overridden by the host.
+    assert deny_diff.resolve_platform("windows") == "windows"
+
+
+def test_json_rendering_carries_the_rows_and_their_tiers(staged):
+    """The machine surface of the report, for a caller that wants rows rather than prose.
+
+    CI reads the text rendering; this is the shape a local caller or a later consumer
+    gets, and it has to carry the same three facts the prose does -- the command, why
+    it is a golden path, and which tier refused it.
+    """
+    push = "git push origin feat/x"
+    report = staged([_shell(push)], base_denies=set(), head_denies={push})
+
+    payload = json.loads(deny_diff.render_json(report))
+
+    assert payload["exit_code"] == 1
+    assert payload["counts"]["regressions"] == 1
+    assert payload["regressions"][0]["command"] == push
+    assert payload["regressions"][0]["why_legitimate"] == f"golden path: {push}"
+    assert payload["regressions"][0]["head_tier"] == "deny-rules"
+    assert "fake rule" in payload["regressions"][0]["head_refusal"]
+
+
+def test_real_composite_finds_no_regressions_between_head_and_itself():
+    """The corpus names operations the SHIPPED rules allow.
+
+    base == head means every verdict is identical by construction, so this cannot
+    fail on a comparison bug -- it fails when a row of the corpus is not actually a
+    golden path under the current rules, or when the harness cannot materialize a
+    ref and classify it at all. Both are things the fake trees never touch.
+    """
+    code = deny_diff.main(
+        ["--base", "HEAD", "--head", "HEAD", "--corpus", str(FALLBACK_CORPUS), "--json"]
+    )
+    assert code == 0
+
+
+def test_fallback_corpus_rows_are_all_allowed_by_the_shipped_composite(tmp_path):
+    """Stronger than the differential above: no row is refused at HEAD at all.
+
+    A row refused at BOTH refs is 'unchanged' to the differential, so it would ride
+    along green forever while claiming to be a golden path the product depends on.
+    This also proves all four real tiers run outside an event loop in a hermetic
+    child, which the differential alone would not show.
+    """
+    rows = deny_diff.load_corpus(FALLBACK_CORPUS)
+    shell_rows = [r for r in rows if r.kind == "shell" and r.applies_to("posix")]
+    assert shell_rows, "fallback corpus has no posix-applicable shell rows"
+
+    checkout = deny_diff.resolve_checkout(ROOT, "HEAD", tmp_path / "head")
+    verdicts, absent = deny_diff.classify(
+        checkout, [r.command for r in shell_rows], home=tmp_path / "home"
+    )
+    assert absent == [], f"HEAD is missing declared tiers: {absent}"
+
+    refused = [
+        (row.command, verdict.tier, verdict.reason)
+        for row, verdict in zip(shell_rows, verdicts)
+        if verdict.denied
+    ]
+    assert refused == []


### PR DESCRIPTION
## Problem / Motivation

A security fix is almost always a deny rule made stricter, and "stricter" has no upper bound a reviewer can see. The rule's author reads the pattern and the attack it now catches. Nobody reads the set of ordinary commands that pattern *also* newly matches — a read-only `gh` query, a feature-branch push, a chat start, an installed cron.

So the failure mode of a security fix is not a missed vulnerability: it is a gate that quietly starts refusing legitimate work. The symptom lands days later as an agent that "just stopped working", reporting a matched pattern instead of a cause. Today nothing checks for it.

## Why it matters

Every deny-rule tightening ships with an unmeasured blast radius. The repo has already burned real time on this exact class: read-only `ls` on the governance tree, compound `gh` reads blocked by a `kill`-adjacent regex, `git commit && git push` refused as one command, a `python -c "import kiro_crew..."` probe caught by the argv floor. Each was found by an agent hitting it in the middle of unrelated work, not by the change that introduced it.

The question is also a bad fit for the AI review lanes: answering it requires simulating a 17,000-line matcher over a corpus of commands nobody wrote down. It *is* a good fit for a deterministic before/after classification, which is what this adds.

## What changed (motivation → approach → change)

**Approach.** Classify a corpus of golden paths — operations that are legitimate BY DECISION, each with the reason — with the real deny composite as it exists at the base ref *and* as it exists at the head ref, then diff the two verdict sets.

| Base | Head | Verdict |
|---|---|---|
| allowed | refused | **regression** — fails the job |
| refused | allowed | loosening — reported, informational |
| same | same | unchanged — counted only |

A loosening does not fail, because loosening is what a revert or a false-positive fix looks like.

**Alternatives rejected.** A re-implementation of the rules inside the gate would agree with itself forever and catch nothing. A model lane cannot do it reliably (above). A snapshot of expected verdicts checked into the repo would have to be regenerated by the same PR it is meant to judge.

### The composite, not just the rule catalog

A shell command at `hooks.on_tool_call` is refused by **four** checks, and the gate runs all four in that order, reporting which one decided:

| Tier | Check | Lives in |
|---|---|---|
| `sensitive-path` | `is_sensitive_path` — the path fence | `security/paths.py` |
| `sensitive-bash` | `is_sensitive_bash_command` — scan ceiling, IMDS reach, env-credential detector | `security/paths.py` |
| `exfil` | `audit_bash_exfiltration` — egress and reverse-shell shapes | `security/exfil.py` |
| `deny-rules` | `is_denied` — the rule catalog and the argv-structural floors | `security/__init__.py` |

Measuring only the last one would be the specific way this gate could ship a meaningless green: its trigger paths cover `paths.py` and `exfil.py`, so a tightening there would run it, come back empty, and leave the badge standing as evidence the question had been asked.

The list is **pinned, not asserted**: it is declared as data (`deny_diff._TIERS`) and a test reads the checks back out of `hooks.py`'s own `for target in security_targets:` block and asserts the two sets agree — so adding a fifth check there reds this gate instead of silently escaping it. Each check is called with its default enabled set, which fails closed to every built-in rule enabled.

### The corpus comes from the base ref — and that is also the escape

The corpus **is** the contract a change is judged against, so the change must not be able to edit it. A head-owned corpus would let the same PR that tightens a rule delete the row that rule breaks — removing it from *both* sides of the differential and passing.

That same base-ownership is what lets this gate ship with **no approval label**. When a row should stop being a golden path, it is withdrawn in its **own** PR: that PR changes no rule, so the gate is green on it, and the next PR's base no longer carries the row. The withdrawal is then reviewed on its own merits — the removed row and its stated reason as the whole diff — rather than riding along inside a security change behind a label, and there is no waiver mechanism left to keep honest.

The `cross-platform.yml` label precedent does not transfer, and it is worth saying why: that gate's finding is a line of code with nothing to edit but the code, so a label is its only available escape. This gate's finding is a row in a file that is already reviewable.

Two further consequences of base-ownership, both deliberate: a row the PR **adds** is not classified (the pinned corpus test covers that direction, since it reads the head file), and when no corpus exists at base — this PR, and any future one that introduces one — the head file is used and the report says so, because with no base contract there is no row a PR could withdraw to escape one.

The corpus path is named in **one line** of the workflow. Adopting the security-conductor's seed is an explicit PR that edits that line and deletes the fixture — not an automatic preference for whichever file exists. A gate that changed contracts the moment another file appeared would hand coverage over with nobody's diff showing the handover, and rows this corpus carries could drop out silently.

### What a green does not cover

The gate calls the four `security.*` checks directly, so it measures the **rules**, not `hooks.py`'s own composition of them: target construction, the `raw_params` application of the path fence, the context-derived enabled set. A tightening implemented inside `hooks.py` runs this gate — `hooks.py` is in its trigger paths — and comes back empty. The tier pin narrows this (it catches a check *added* there) but cannot catch a behavioural change in how the gate assembles what it checks. Closing it properly means driving commands through the gate's own target construction, which is async and needs a session context — a larger change than this gate. The doc, the workflow header and the commit message all state this, so a green is not mistaken for more than it is.

### What was built

`scripts/deny_diff.py` (repo-level `scripts/`, stdlib only, cross-platform) — `--base --head --corpus [--platform auto|posix|windows] [--json]`. Exit `0` no regressions, `1` regressions, `2` corpus or ref error. Each ref is materialized with `git archive` through stdlib `tarfile` (not a `tar` subprocess, which is not portable to the Windows runner, and not `git worktree`, which mutates the caller's repository to answer a read-only question). Three properties keep the verdicts trustworthy:

- **The parent never imports the product.** The composite is the thing under test, so importing it in the harness would pin the comparison to one side — and an inline `python -c "import kiro_crew..."` is itself refused by the argv floor this gate exists to keep honest. The child is the same file re-executed behind an internal flag, the only place product code is touched.
- **Each child proves which tree answered.** It re-reports the file `kiro_crew.security` actually resolved to and exits 2 when that sits outside the checkout it was given. Without the check, an installed copy shadowing the path would serve *both* refs from one tree and every differential would come back empty — a false green with no symptom.
- **Each child is hermetic.** Every `KIROCREW_*` variable is stripped and `KIROCREW_HOME` is repointed at a throwaway directory, so the verdict depends on the checkout alone and the best-effort SEL writes never reach a real security log.

`.github/workflows/denial-differential.yml` — `pull_request` on the security surfaces (`src/kiro_crew/security/**`, `deny_guidance.py`, `platform/security_authority.py`, `hooks.py`, the security-conductor's `rules-of-engagement.json`, plus this gate's own files). Matrix `ubuntu-latest` / `macos-latest` / `windows-latest`: the rules read argv **shape** and the fence reads real paths, and both differ per platform — Windows has its own tokenizer and separators, and the fence's home-directory ordering is macOS-specific (`Library/Application Support`, `/Volumes/<share>`). Runner pins, `permissions: contents: read` and `persist-credentials: false` mirrored from `cross-platform.yml`; `fetch-depth: 0` because both commits must be archivable locally. No dependency install: the composite's import chain is stdlib plus the package's own modules (verified against an interpreter with no project deps), so installing would add three platform-dependent minutes, a resolution failure mode, and a second copy of `kiro_crew` on the path that the tree check would then refuse. Honest red, no `continue-on-error` — branch protection decides blocking, matching how `Cross-Platform Portability` is wired.

`docs/ci/denial-differential.md` + a row in `docs/ci/README.md` (the gate-docs index).

No file under `src/kiro_crew/security/**` is touched, and neither is the security-conductor's `ledger.py`.

### Corpus, and the one loose end

The gate is designed to consume the security-conductor's `golden-paths.seed.json` **file** directly, so CI needs no ledger. That seed is a sibling work item and has not landed — `origin/feat/security-conductor-golden-paths` does not exist as of this push. So this PR ships `scripts/deny_diff_fixture.json` (16 shell rows, 1 flow, 1 cron) as the corpus, and **the fixture is kept, not deleted**; the PR that adopts the seed edits the corpus path and deletes it, showing in its own diff that the seed covers these rows.

`kind` is `shell`, `flow` or `cron`; only `shell` rows are classified (a flow and a cron have no single command line to hand a matcher), and the other two are reported as *skipped* rather than dropped. They stay on purpose: the corpus is a contract document as well as a gate input, and one listing only shell rows would read as "these are all the golden paths", which is false — starting a chat and an installed scanner cron are golden paths too, just not ones a command-line matcher can judge. A row spelling its command under any other key is a malformed corpus (exit 2), not a tolerated variant.

## Tests

`test/test_deny_diff.py`, 27 tests. The exit-code paths are proven against hand-built classifier trees rather than the real composite — the real one is what the gate *measures*, so making it the fixture too would mean a regression could not be staged at all. The fakes carry all four tiers and travel the same subprocess path as production, with only the ref-to-checkout resolver monkeypatched.

- **Regression → exit 1**, with the row's stated reason, the tier, and the refusal text.
- **A regression on each non-catalog tier** (`sensitive-path`, `sensitive-bash`, `exfil`) is caught and the tier name pinned; another test pins tier **order** when several refuse the same command.
- **The measured checks are the checks the tool gate applies** — read out of `hooks.py` and compared with the declared tier table.
- **Loosening only → exit 0**; **refused at both** counts as unchanged.
- **Platform filter**: a windows-only row cannot fail the gate on posix, and does fail on `--platform windows`.
- **Non-shell rows** counted as skipped, not dropped.
- **Malformed corpus → exit 2** over nine defects; plus missing file and unresolvable ref.
- **Hermetic child env**, and the **shadowing guard** (a worker pointed at one tree while loading another exits 2).
- **`--json` carries the rows and their tiers** — the machine surface of the report. It has no CI consumer (the workflow reads the text rendering); it is an interface of this deliverable and a one-line deletion if a reviewer would rather not have it.
- Real composite: `base == head == HEAD` yields zero regressions, and **no fixture row is refused at HEAD by any of the four tiers** — which also proves all four run outside an event loop in a hermetic child.

**Red-before, two mutations**: replacing the regression predicate with a constant false reds three tests; dropping a tier from the declared table reds the fidelity pin *and* the non-catalog-tier test. (The pin reads the declared table rather than grepping `security.<fn>(` call sites precisely because the regex version survived that mutation — a tier removed from the table leaves its call behind.)

**Relationship to the pinned corpus test.** The last differential test also runs in the ordinary suite on Linux and Windows for every PR, and the two are complementary rather than redundant. The differential earns its place on **attribution**: the pinned test says "a corpus row is refused", the differential says "*this change* newly refuses it". When `main` drifts into refusing a row, the pinned test reddens every subsequent PR and blames whichever one is open — the inherited-red problem this repo hits constantly — while the differential reads base-red plus head-red as unchanged and stays green. It also reports loosenings. In the other direction the pinned test covers the row a PR *adds*, which a base-owned corpus does not contain.

## Manual verification

- End-to-end against the real composite on this branch: `--base origin/main --head HEAD --corpus scripts/deny_diff_fixture.json` → exit 0, 15 classified / 2 non-shell / 1 other-platform on posix, ~4.6s wall for both refs including two `git archive` unpacks. `--platform windows` reclassifies the Windows row. `--json` renders the same report machine-readably.
- Every fixture row probed against all four real tiers individually: none refuses, none raises outside an event loop.
- Corpus error path: an object with no `golden_paths` key → exit 2 with the naming message.
- Confirmed the child needs no third-party dependencies by running the worker under an interpreter without `aiohttp` installed (the reason the workflow has no install step).
- All three matrix legs pass on CI (`ubuntu`, `macos`, `windows`), ~1m per leg.
- Local gates: `black --target-version py310` (and `scripts/check_black_formatting.py`, clean), `isort`, `flake8`, `mypy scripts/deny_diff.py`, `scripts/docs_lint.py`, `scripts/check_comment_history.py`, `scripts/check_subprocess_encoding.py`, `scripts/check_testpaths_coverage.py`, `test_jsondecodeerror_redundancy_ratchet.py`, and the 663 tests of the six workflow/docs-contract suites nearest this change. `push_guard.py --base main --require-single-on-base` → SAFE, single commit on base.
- No `actionlint` step exists in this repo's workflows, so none was run.

## Related Issues

Refs #9195

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
