### PR TITLE
docs(review): collapse the First Principles inventory on every verdict

### DIFF
--- a/.github/review-prompts/first-principles.md
+++ b/.github/review-prompts/first-principles.md
@@ -383,7 +383,13 @@ first; omit the heading entirely when every item is justified.>
 
 ### What this change ships
 <ALWAYS present, even on PASS -- it is the evidence for your verdict
-and no other reviewer produces it. Open with `Intent: <one line>` and
+and no other reviewer produces it. ALWAYS COLLAPSED, on every verdict:
+the body of this section is wrapped in
+`<details><summary>Inventory (N items) — M justified</summary>` ...
+`</details>`, so the evidence stays one click away instead of burying
+the punchline. A reader who wants the problems has them above; nobody
+reads a list of things that are fine.
+Inside the collapsed block, open with `Intent: <one line>` and
 whether this is a FIX or an ADDITION, then one line per inventory
 item, in the USER's words, not the code's:
 `N. <the observable difference> — <justified | undeclared | rides
@@ -391,13 +397,10 @@ along | unjustified move | duplicate of <path> | zero consumers | one
 consumer, generalized | symptom-level | oversized>`
 `justified` is exactly that ONE word -- no parenthetical, no reason, no
 praise. Only a NON-justified tag carries a reason. Under ~15 words per
-item. A PASS here is a claim about EVERY item, so the items must be
-visible for a human to check that claim.
-WHEN EVERY ITEM IS TAGGED `justified`, wrap the whole section body in
-`<details><summary>Inventory (N items)</summary>` ... `</details>` so
-the evidence stays one click away instead of burying the punchline. If
-ANY item is not justified, leave the block EXPANDED -- the reader needs
-it beside the `### Not justified as shipped` list above.>
+item. A PASS here is a claim about EVERY item, so the items stay
+listed for a human who opens the block to check that claim. The items
+a human must act on are already expanded under `### Not justified as
+shipped` above; this block is the audit trail, not the summary.>
 
 Then include a section ONLY if it has real content (omit the heading
 entirely when empty -- never write "None" sections, never pad):

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -6715,15 +6715,25 @@ class TestFirstPrinciplesProblemsFirstContract:
         assert "`justified` is exactly that ONE word" in contract
         assert "Only a NON-justified tag carries a reason" in contract
 
-    def test_a_clean_inventory_collapses_and_a_dirty_one_stays_open(self) -> None:
+    def test_the_inventory_is_collapsed_on_every_verdict(self) -> None:
+        # The block was left EXPANDED on CONCERNS/BLOCK -- exactly the verdicts
+        # a human opens the comment for -- so the findings sat under a full
+        # list of the items that were fine. Every item a human must act on is
+        # already under `### Not justified as shipped`, so the inventory is an
+        # audit trail and stays one click away on every verdict, with the
+        # counts in the summary line.
         contract = _fp_contract()
-        assert "<details><summary>Inventory (N items)</summary>" in contract
+        assert "ALWAYS COLLAPSED, on every verdict" in contract
+        assert "<details><summary>Inventory (N items) — M justified</summary>" in contract
         assert "</details>" in contract
-        assert "WHEN EVERY ITEM IS TAGGED `justified`, wrap the whole section body in" in contract
-        assert "leave the block EXPANDED" in contract
+        # The old conditional is gone in both directions.
+        assert "WHEN EVERY ITEM IS TAGGED `justified`" not in contract
+        assert "leave the block EXPANDED" not in contract
         # The inventory is still always emitted -- collapsing is not omitting.
         assert "ALWAYS present, even on PASS" in contract
         assert "A PASS here is a claim about EVERY item" in contract
+        # The findings a human acts on live above the block, not in it.
+        assert "this block is the audit trail, not the summary" in contract
 
     def test_every_finding_states_what_would_clear_it(self) -> None:
         # A finding with no statable resolution is what produced 31 of 57


### PR DESCRIPTION
## Problem / Motivation

The First Principles review comment is long on `🟡 CONCERNS` and `🔴 BLOCK`. The contract collapsed the `### What this change ships` inventory behind `<details>` only on a clean PASS. On any verdict with a finding, the block stayed open. So the comment led with a full list of the items that were fine, and the findings sat under it.

## Why it matters

CONCERNS and BLOCK are the verdicts a human opens. Every item to act on is already under `### Not justified as shipped`, and `### Watch` / `### Blockers` carry the findings with `Clears when:`. The open inventory added scroll and no signal.

## What changed (motivation → approach → change)

One contract file, `.github/review-prompts/first-principles.md`. The inventory is always collapsed, on every verdict. The summary line carries the counts: `Inventory (N items) — M justified`. The items stay listed inside, so a PASS is still a checkable claim about every item. The prose budget is unchanged.

Both lanes read this file. `first-principles-review.yml` and `fork-first-principles-review.yml` each `git show "$BASE_SHA:.github/review-prompts/first-principles.md"` and point the model at it. The output shape is not inlined in either workflow, so no workflow edit is needed and fork PRs get the same comment.

Downstream parsers are unaffected. `_review_contract.py` keeps `What this change ships` out of `DESIGN_ITEM_SECTIONS` on purpose, so `pr_findings.py` reads the same Watch / Blocker / Not-justified items whether the block is wrapped or not.

The contract is read from the base commit. This PR is judged under the old shape; the new shape applies to PRs opened after it merges.

## Tests

`test/test_ai_review_workflows.py`, class `TestFirstPrinciplesProblemsFirstContract`:

- `test_the_inventory_is_collapsed_on_every_verdict` (renamed from `test_a_clean_inventory_collapses_and_a_dirty_one_stays_open`) pins the unconditional collapse and the `— M justified` summary, and asserts the old conditional wording (`WHEN EVERY ITEM IS TAGGED`, `leave the block EXPANDED`) is gone.
- `test_the_output_diet_tightened_and_kept_its_machine_read_lines` is unchanged in what it pins: the ~180-word budget, the `First-Principles-Verdict:` first line and the `[FIRST-PRINCIPLES-REVIEWED] <head sha>` last line.

524 tests in the file pass.

## Manual verification

N/A — the contract is prompt text; the tests pin every changed string and the workflows' grep lines. `scripts/docs_lint.py`, `check_brand_name.py`, `check_comment_history.py` and black pass on the diff.

## Related Issues

no linked issue: observed on live CONCERNS comments, not tracked.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
