### PR TITLE
test(job-sdk): poll for the live entry after the terminal write

### DIFF
--- a/test/test_job_sdk.py
+++ b/test/test_job_sdk.py
@@ -651,8 +651,11 @@ class TestLiveness:
         finally:
             release.set()
         _wait_terminal(sdk, run_id)
-        # The worker recorded the outcome and the live entry is gone.
-        assert sdk.cancelling_and_live_ids() == (frozenset(), frozenset())
+        # The worker recorded the outcome and the live entry is gone. Poll for the
+        # live entry rather than reading it once: `_execute` pops it AFTER its
+        # terminal write lands, so a terminal record does not yet prove the entry
+        # is dropped, and asserting on that instant is a race on a loaded runner.
+        _wait_until(lambda: sdk.cancelling_and_live_ids() == (frozenset(), frozenset()))
 
     def test_stale_running_record_is_not_live(self, sdk: JobSDK) -> None:
         """The issue case: a durable record says ``running``, nothing owns it.


### PR DESCRIPTION
## Problem / Motivation

`test_live_while_a_registered_thread_runs` fails on a loaded CI runner. It says the finished run is still live:

```
AssertionError: assert (frozenset(),...6a6213d7ed'})) == (frozenset(), frozenset())
At index 1 diff: frozenset({'d759f496842d4ab49cde626a6213d7ed'}) != frozenset()
```

The run really did finish. The test just looked too early.

## Why it matters

One red shard fails the whole backend job. Nothing is wrong with the code, so the next person re-runs it, waits 21 minutes, and gets a green. That is a 21-minute tax paid at random.

## What changed (motivation → approach → change)

The test read the live table once, the instant `_wait_terminal` returned.

A terminal record does not mean the live entry is gone. `_execute` writes the terminal record first, then takes the lock and pops the entry. Those are two steps. Between them the run id is still in the live table, and that is exactly what the test caught.

The read is now a bounded poll. `_wait_until` is the helper this file already uses for the same reason elsewhere. It still fails, loudly, if the entry is never dropped.

```mermaid
flowchart LR
  A[_write_terminal lands]:::ctx --> B[test reads live table]:::removed
  A --> C[_live.pop under lock]:::ctx
  A --> D[test polls live table]:::added --> C
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 3 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟥 removed · 🟦 unchanged

*The test now waits for the pop instead of racing it.*

## Tests

`test_live_while_a_registered_thread_runs` is the changed test. It still locks in the same fact: once the worker is done, the run is neither cancelling nor live. It now waits up to 5s for that instead of demanding it in the same instant.

No production code changed, so nothing else needed a new test.

## Manual verification

N/A — the changed test is the verification. `test/test_job_sdk.py` ran three times under `pytest -n 4`, 173 passed each time.

## Related Issues

no linked issue: the failure was reported from a CI run, not filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a test reads shared state the instant a *different* signal goes terminal, when the state it reads is dropped after that signal.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
