### PR TITLE
fix(pipeline-conductor): make fleet-probe link fixtures windows-safe

### DIFF
--- a/test/requires-real-symlinks.txt
+++ b/test/requires-real-symlinks.txt
@@ -121,4 +121,7 @@ test/test_snapshot_manifest_and_links.py::TestSymlinkedTreeRootsAreRefused::test
 test/test_app_manager.py::TestEnabledStateTellsUnreadableFromNotInstalled::test_a_dangling_symlink_is_unknown
 test/test_app_manager.py::TestEnabledStateTellsUnreadableFromNotInstalled::test_a_symlink_loop_is_unknown
 test/test_member_prompt.py::TestMemberBriefing::test_symlink_briefing_is_refused
+# Plants a FILE symlink out of the session store; a file link has no junction
+# form, so an unelevated Windows shell cannot build the fixture at all.
+test/test_pipeline_conductor_agent.py::TestFleetProbe::test_symlink_out_of_the_store_reads_gone
 test/test_security.py::TestKeystonePublishArtifacts::test_a_symlink_aimed_at_a_live_temp_is_caught

--- a/test/test_pipeline_conductor_agent.py
+++ b/test/test_pipeline_conductor_agent.py
@@ -17,7 +17,8 @@ from pathlib import Path
 
 from skill_script_helpers import load_skill_script
 
-from kiro_crew import agent
+from conftest import make_dir_link
+from kiro_crew import agent, platform_compat
 from kiro_crew.agent_files import (
     OWNED_KIRO_AGENT_FILES,
     PIPELINE_CONDUCTOR_AGENT_FILENAME,
@@ -1700,8 +1701,9 @@ class TestFleetProbe:
     # ── 2d: cwd-scoped banned scan ────────────────────────────────────────────
 
     def _proc(self, tmp_path: Path, pid: str, argv: bytes, cwd: Path | None) -> Path:
-        """One fake ``/proc/<pid>``. ``cwd`` is written as a SYMLINK because that
-        is what the kernel exposes and what the probe reads.
+        """One fake ``/proc/<pid>``. ``cwd`` is written as a reparse link (a
+        junction on Windows) because that is what the kernel exposes and what
+        the probe reads.
 
         A ``stat`` file is always written: every live process on a real system
         has one, and the probe reads its ``starttime`` (field 22) as the process
@@ -1719,7 +1721,7 @@ class TestFleetProbe:
         (proc / pid / "stat").write_text(f"{pid} (proc) R " + " ".join(stat_tail) + "\n", "ascii")
         if cwd is not None:
             cwd.mkdir(parents=True, exist_ok=True)
-            os.symlink(str(cwd), str(proc / pid / "cwd"))
+            make_dir_link(proc / pid / "cwd", cwd)
         return proc
 
     def test_a_banned_match_outside_the_fleet_is_foreign_not_banned(
@@ -2034,8 +2036,8 @@ class TestFleetProbe:
         for target in (Path(os.sep), store.parent):
             link = tmp_path / f"link-{abs(hash(str(target))) % 1000}"
             if link.is_symlink() or link.exists():
-                link.unlink()
-            os.symlink(str(target), str(link))
+                platform_compat.unlink_link_or_junction(link)
+            make_dir_link(link, target)
             cfg.write_text(
                 json.dumps({"sessions": [], "fleet_worktrees": [str(link)]}), encoding="utf-8"
             )
@@ -2328,7 +2330,7 @@ class TestFleetProbe:
         real = tmp_path / "real-fleet" / "wt-a"
         real.mkdir(parents=True)
         link = tmp_path / "via-link"
-        os.symlink(str(tmp_path / "real-fleet"), str(link))
+        make_dir_link(link, tmp_path / "real-fleet")
         # The process reports the REAL path; the config names the symlinked one.
         proc = self._proc(tmp_path, "5100", b"pytest\x00test/x.py\x00", real)
         cfg = self._config(tmp_path, monkeypatch, [], fleet_worktrees=[str(link / "wt-a")])


### PR DESCRIPTION
## Problem / Motivation

Running `test/test_pipeline_conductor_agent.py` on an unelevated Windows machine fails 8 tests in `TestFleetProbe`, all with the same error: `OSError: [WinError 1314] A required privilege is not held by the client`. None of them is a product bug; the failure happens while the test fixtures are being built, before the assertion under test ever runs.

The suite models the Linux `/proc` filesystem to test the fleet probe's banned-process scan, and several fixtures plant their links with a bare `os.symlink` call:

- the fake `TestFleetProbe._proc` helper writes `/proc/<pid>/cwd` as a symlink (`test/test_pipeline_conductor_agent.py:1722`), and 6 of the 8 failures come through that one line
- `test_symlink_out_of_the_store_reads_gone` plants a file symlink out of the session store (`:1095`)
- `test_a_symlinked_fleet_root_cannot_smuggle_a_wider_scope` (`:2038`) and `test_a_symlinked_fleet_root_still_matches` (`:2331`) spell fleet roots as symlinks

On Windows, `os.symlink` needs `SeCreateSymbolicLinkPrivilege`, which an elevated process or a Developer Mode account holds. GitHub's Windows runners hold it; an ordinary developer shell does not, and every one of those calls raises WinError 1314 there.

## Why it matters

The repo has an explicit policy for this exact situation. The rootdir conftest docstring says the Windows expected-failures list is a burn-down backlog: fixed tests get their line deleted, and anything NOT on the list still fails the job. These 8 tests are on none of the lists (`windows-expected-failures.txt`, `windows-collect-ignore.txt`, `requires-real-symlinks.txt`), so any pull request whose diff runs this file reds the Windows lane, and any contributor on an unelevated Windows shell cannot run the conductor suite at all.

The repo also already prescribes the fix shape. `docs/system-specs/common/testing-conventions.md` (§ Links) tells contributors to use the conftest helpers instead of a bare `Path.symlink_to` plus a skip, and roughly forty test files already do exactly that. These fleet-probe tests were written Linux-first, which is fine for the feature, but their fixtures never met the one platform where path semantics differ most and where the helpers exist precisely for that case. Left as is, every future fix to this file inherits the same red shard.

## What changed (motivation → approach → change)

Symptom: 8 tests crash building their fixtures on unelevated Windows. Root cause: the fixtures use the one link-creation primitive that requires a Windows privilege, while the repo ships a documented helper for the no-privilege case. The change follows the helper:

- `TestFleetProbe._proc` now builds the fake `/proc/<pid>/cwd` through `make_dir_link` from `test/conftest.py`, the helper `test_app_dev_mode.py`, `test_portability.py` and others already use. On POSIX this is still a plain `os.symlink` (with `target_is_directory=True`), so the fixture mechanism is unchanged where `/proc` is real; on Windows it creates a directory junction, which needs no privilege and is traversed by the same reparse machinery. The docstring now says reparse link rather than symlink.
- `test_a_symlinked_fleet_root_cannot_smuggle_a_wider_scope` and `test_a_symlinked_fleet_root_still_matches` use the same helper. The collision-guard cleanup in the smuggle test goes through `platform_compat.unlink_link_or_junction`, since `Path.unlink()` is not the junction-safe removal path on Windows.
- Why junctions are safe for these assertions: the probe reads the cwd link with `os.readlink`, and on Windows that answers the `\\?\`-prefixed absolute target of a junction. `_norm_path` already strips that prefix and normcases the rest, which `test_a_windows_path_spelling_still_matches_its_fleet_root` pins, and `os.path.realpath` resolves junctions too, so the classifier's literal and realpath comparisons see the same strings they see on Linux. I verified both properties directly on a Windows host before writing the fixtures.
- `test_symlink_out_of_the_store_reads_gone` is the one fixture that cannot be junction-based: it plants a FILE link, and a file symlink has no junction equivalent (`docs/guides/windows-install.md` says the same). Its node id is now on `test/requires-real-symlinks.txt`, the inventory the root conftest consults when a host's capability probe fails. GitHub's Windows runners hold the privilege, so the test keeps running on CI; the skip only bites unelevated local shells, which is the trade that list exists for.

Two alternatives, and why I did not take them:

- Adding the 8 node ids to `test/windows-expected-failures.txt` is the two-line fix, but that file is a burn-down backlog: entries are deleted as tests are fixed, and seven of these eight are fully fixable with the junction helpers. Tracking fixable failures as a permanent Windows gap moves the backlog in the wrong direction.
- Marking all 8 `requires_symlinks` would drop 7 assertions on Windows that junctions can fully exercise, which is what testing-conventions § Links tells contributors not to do. Faking `os.readlink` the way the `exe` tests already do was also a poor fit here: the probe following `/proc/<pid>/cwd` IS the behavior under test, so faking the read would test the fake.

What did not change: no production code, no weakened assertions, no unconditional skip, and `windows-expected-failures.txt` stays untouched.

## Tests

Red first, before the change, on an unelevated Windows host:

```
pytest test/test_pipeline_conductor_agent.py::TestFleetProbe
8 failed  (all WinError 1314 from the bare os.symlink calls)
```

After the change, same host:

- `pytest test/test_pipeline_conductor_agent.py::TestFleetProbe` → 108 passed, 1 skipped (the file-link test now on `requires-real-symlinks.txt`)
- combined run of the conductor suites plus the platform floor: `pytest test/test_pipeline_conductor_agent.py test/test_pipeline_conductor_probe_roundtrip.py test/test_pipeline_conductor_claim_preflight.py test/test_pipeline_conductor_skill_contract.py test/test_platform_compat.py` → 806 passed, 44 skipped
- the three junction-based fixture tests also pass at `-n0` (serial), so nothing depends on xdist scheduling
- `isort --check-only`, `black --check` and `flake8` on the changed file are clean

On POSIX `make_dir_link` is a plain symlink, so Linux CI exercises the identical fixture mechanism as before. The branch sits directly on current `main`.

## Manual verification

N/A: the PR changes only test fixtures, so the red-then-green runs above are the verification; there is no runtime surface a unit test cannot reach here.

## Related Issues

No dedicated issue for this. If a maintainer keeps a Windows test-hygiene tracking list, happy to fold it in.

## Pattern harvest

Rule candidate: review-prompt — a test fixture planting a link with bare `os.symlink`/`Path.symlink_to` instead of the conftest `make_dir_link`/`make_escaping_link` helpers (or a `requires-real-symlinks.txt` entry for file links) reds every unelevated Windows host; the helpers and the list are the two documented paths, and new test files keep rediscovering the first one.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass; the PR fixes existing tests rather than adding functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the change follows the rule already documented in `docs/system-specs/common/testing-conventions.md` (§ Links); nothing it documents changes
- [x] No secrets, credentials, or internal references in the diff
