### PR TITLE
refactor(monitoring): type the probe boundary to a subject, not to GitHub

### DIFF
--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -39,7 +39,7 @@ from contextlib import asynccontextmanager, contextmanager
 from copy import deepcopy
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Callable, Iterator
+from typing import Any, AsyncIterator, Awaitable, Callable, Iterator
 
 from kiro_crew import irq, platform_compat, probes, shutdown_event
 from kiro_crew.atomic_write import replace_with_retry
@@ -65,6 +65,7 @@ from kiro_crew.monitoring.models import (
     MonitorDispatchResult,
     MonitorObservationStatus,
     MonitorOutcome,
+    MonitorProbeResult,
     MonitorState,
     MonitorVerdict,
     monitor_state_from_dict,
@@ -73,9 +74,6 @@ from kiro_crew.monitoring.models import (
 )
 from kiro_crew.probes import targets
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
-
-if TYPE_CHECKING:
-    from kiro_crew.monitoring.github_pull_request import GitHubPullRequestProbeResult
 
 logger = logging.getLogger(__name__)
 
@@ -2374,7 +2372,7 @@ class AutoNudgeService:
     async def apply_monitor_probe(
         self,
         monitor_id: str,
-        result: GitHubPullRequestProbeResult,
+        result: MonitorProbeResult,
         *,
         now: float,
         config_generation: int,

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -72,6 +72,7 @@ from kiro_crew.monitoring.models import (
     monitor_state_to_dict,
     quarantine_monitor_state,
 )
+from kiro_crew.monitoring.registry import REVIEW_READY, kind_supports_objective
 from kiro_crew.probes import targets
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 
@@ -712,7 +713,7 @@ def infer_monitor(message: str, now: float) -> MonitorState | None:
         return MonitorState(
             kind=target.kind,
             target=target.subject,
-            objective="review_ready",
+            objective=REVIEW_READY,
             created_ts=now,
         )
     except ValueError:
@@ -1482,6 +1483,12 @@ class AutoNudgeService:
                             "existing monitor cannot be replaced while a wake is in flight"
                         )
                 due = created + cadence
+                # Refused HERE rather than discovered later. This is the one place a
+                # caller-supplied kind reaches persistence, and a monitor stored under
+                # a kind nothing registered would be probed by whatever provider the
+                # controller happens to hold.
+                if not kind_supports_objective(kind, objective):
+                    raise ValueError(f"no monitored kind {kind!r} supports objective {objective!r}")
                 monitor = MonitorState(
                     kind=kind,
                     target=target,
@@ -2593,6 +2600,16 @@ class AutoNudgeService:
             if target is not None:
                 staged_state.target = target
             if objective is not None:
+                # The objective allowlist upstream is a union across every publicly
+                # armable kind, so it is a first filter and never the whole check.
+                # This is the boundary that knows BOTH halves -- the monitor's kind is
+                # already fixed -- so the pairing is refused here rather than
+                # discovered at probe time.
+                if not kind_supports_objective(staged_state.kind, objective):
+                    raise ValueError(
+                        f"monitored kind {staged_state.kind!r} does not support "
+                        f"objective {objective!r}"
+                    )
                 staged_state.objective = objective
             if cadence_secs is not None:
                 cadence = max(_MIN_IDLE_SECS, min(_MAX_IDLE_SECS, int(cadence_secs)))

--- a/src/kiro_crew/dashboard/handlers/autonudge.py
+++ b/src/kiro_crew/dashboard/handlers/autonudge.py
@@ -46,6 +46,12 @@ from kiro_crew.monitoring.models import (
     MonitorState,
     monitor_state_public_dict,
 )
+from kiro_crew.monitoring.registry import (
+    GITHUB_PULL_REQUEST,
+    REVIEW_READY,
+    kind_supports_objective,
+    publicly_armable_kinds,
+)
 from kiro_crew.platform import redact_via_context
 from kiro_crew.sel import sel
 from kiro_crew.session_ledger import ledger_key, render_snapshot
@@ -363,10 +369,13 @@ def _bounded_int(body: dict[str, Any], name: str, default: int, minimum: int, ma
 def _monitor_config(body: dict[str, Any]) -> MonitorState:
     from kiro_crew.monitoring.github_pull_request import parse_github_pull_request_target
 
-    kind = body.get("kind", "github_pull_request")
-    objective = body.get("objective", "review_ready")
-    if kind != "github_pull_request" or objective != "review_ready":
-        raise ValueError("only github_pull_request review_ready monitors are supported")
+    kind = body.get("kind", GITHUB_PULL_REQUEST)
+    objective = body.get("objective", REVIEW_READY)
+    # Both halves: a caller may only name a PUBLICLY ARMABLE kind, and that kind must
+    # itself declare the objective. The flat allowlists upstream cannot express the
+    # pairing, so this is where it is checked.
+    if kind not in publicly_armable_kinds() or not kind_supports_objective(kind, objective):
+        raise ValueError(f"no monitored kind {kind!r} supports objective {objective!r}")
     target = parse_github_pull_request_target(body.get("target", "")).url
     wake = body.get("wake_instructions", "")
     if not isinstance(wake, str) or len(wake) > MAX_MONITOR_WAKE_INSTRUCTIONS_CHARS:

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -44,6 +44,10 @@ from kiro_crew.monitoring.models import (
     MAX_MONITOR_WAKE_INSTRUCTIONS_CHARS,
     MIN_MONITOR_CADENCE_SECS,
 )
+from kiro_crew.monitoring.registry import (
+    publicly_armable_kinds,
+    publicly_armable_objectives,
+)
 from kiro_crew.security import (
     redact_and_truncate,
     redact_credentials,
@@ -276,9 +280,9 @@ def schemas() -> list[dict[str, Any]]:
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "kind": {"type": "string", "enum": ["github_pull_request"]},
+                    "kind": {"type": "string", "enum": sorted(publicly_armable_kinds())},
                     "target": {"type": "string", "description": "Public GitHub PR URL"},
-                    "objective": {"type": "string", "enum": ["review_ready"]},
+                    "objective": {"type": "string", "enum": sorted(publicly_armable_objectives())},
                     "interval_secs": {
                         "type": "integer",
                         "minimum": MIN_MONITOR_CADENCE_SECS,
@@ -509,7 +513,7 @@ def schemas() -> list[dict[str, Any]]:
                         "type": "string",
                         "description": "New GitHub PR URL for a structured monitor",
                     },
-                    "objective": {"type": "string", "enum": ["review_ready"]},
+                    "objective": {"type": "string", "enum": sorted(publicly_armable_objectives())},
                     "max_agent_turns": {
                         "type": "integer",
                         "minimum": 1,

--- a/src/kiro_crew/monitoring/controller.py
+++ b/src/kiro_crew/monitoring/controller.py
@@ -11,18 +11,17 @@ from typing import Any, Protocol
 
 from kiro_crew.dashboard.state import MONITOR_WAKE_PREFIX
 from kiro_crew.monitoring.decision import monitor_budget_reason
-from kiro_crew.monitoring.github_pull_request import (
-    GitHubPullRequestProbeResult,
-    GitHubPullRequestProvider,
-)
+from kiro_crew.monitoring.github_pull_request import GitHubPullRequestProvider
 from kiro_crew.monitoring.models import (
     MonitorDecision,
     MonitorDispatchResult,
     MonitorObservation,
-    MonitorObservationStatus,
+    MonitorProbe,
+    MonitorProbeResult,
     MonitorState,
     MonitorVerdict,
-    ProviderErrorKind,
+    resolve_probe_result,
+    transient_probe_failure,
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -40,7 +39,7 @@ class _Service(Protocol):
     async def apply_monitor_probe(
         self,
         monitor_id: str,
-        result: GitHubPullRequestProbeResult,
+        result: MonitorProbeResult,
         *,
         now: float,
         config_generation: int,
@@ -85,15 +84,6 @@ class _Service(Protocol):
     ) -> bool: ...
 
 
-class _Provider(Protocol):
-    def probe(
-        self,
-        raw_target: str,
-        *,
-        previous_observation: Mapping[str, object] | None = None,
-    ) -> GitHubPullRequestProbeResult: ...
-
-
 MonitorDispatcher = Callable[[Any, str], Awaitable[MonitorDispatchResult]]
 
 
@@ -105,7 +95,7 @@ class MonitorController:
         service: _Service,
         dispatch: MonitorDispatcher,
         *,
-        provider: _Provider | None = None,
+        provider: MonitorProbe | None = None,
         clock: Callable[[], float] = time.time,
     ) -> None:
         self._service = service
@@ -163,23 +153,20 @@ class MonitorController:
         target = state.target
         previous_observation = deepcopy(state.last_observation)
         try:
-            result = await asyncio.to_thread(
+            results = await asyncio.to_thread(
                 self._provider.probe,
-                target,
-                previous_observation=previous_observation,
+                (target,),
+                previous_observations={target: previous_observation},
             )
         except Exception:
             logger.exception("structured monitor provider raised unexpectedly")
-            result = GitHubPullRequestProbeResult(
-                response=None,
-                canonical={},
-                observation=MonitorObservation(
-                    "",
-                    MonitorObservationStatus.PROVIDER_ERROR,
-                    provider_error=ProviderErrorKind.TRANSIENT,
-                    reason_code="provider_transient",
-                ),
-            )
+            result = transient_probe_failure()
+        else:
+            # resolve_probe_result logs the unusable case itself: a status test here
+            # cannot distinguish its synthesized fallback from a transient the
+            # provider classified correctly, and would log every rate limit as an
+            # error.
+            result = resolve_probe_result(results, target)
         verdict = await self._service.apply_monitor_probe(
             loop.id,
             result,

--- a/src/kiro_crew/monitoring/github_pull_request.py
+++ b/src/kiro_crew/monitoring/github_pull_request.py
@@ -8,7 +8,7 @@ import json
 import re
 import subprocess
 import unicodedata
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from pathlib import PurePosixPath
 from typing import Any
@@ -20,6 +20,7 @@ from kiro_crew.monitoring.models import (
     MAX_MONITOR_CHECK_IDENTITY_CHARS,
     MonitorObservation,
     MonitorObservationStatus,
+    MonitorProbeResult,
     ProviderErrorKind,
 )
 from kiro_crew.security import redact
@@ -115,12 +116,15 @@ class GitHubPullRequestResponse:
 
 
 @dataclass(frozen=True)
-class GitHubPullRequestProbeResult:
-    """Canonical durable facts and their generic monitor classification."""
+class GitHubPullRequestProbeResult(MonitorProbeResult):
+    """One pull request's canonical facts, plus the typed response behind them.
+
+    The engine reads only what :class:`MonitorProbeResult` declares. ``response``
+    is this kind's own detail and stays here rather than on the shared type,
+    which is the line every future kind gets to draw for itself.
+    """
 
     response: GitHubPullRequestResponse | None
-    canonical: dict[str, object]
-    observation: MonitorObservation
 
 
 class GitHubPullRequestProvider:
@@ -137,8 +141,26 @@ class GitHubPullRequestProvider:
 
     def probe(
         self,
-        raw_target: str,
+        subjects: Sequence[str],
         *,
+        previous_observations: Mapping[str, Mapping[str, object]] | None = None,
+    ) -> Mapping[str, GitHubPullRequestProbeResult]:
+        """Return one canonical review-ready observation per subject.
+
+        GitHub answers for one pull request per call, so this loops. The loop is
+        an implementation detail of this kind: the boundary is plural so a host
+        that answers for many subjects at once needs no signature change, and so
+        that adding one later is not a breaking change for every caller.
+
+        Keyed by the subject string as passed, so a caller can always look up
+        what it asked for.
+        """
+        previous = previous_observations or {}
+        return {subject: self._probe_one(subject, previous.get(subject)) for subject in subjects}
+
+    def _probe_one(
+        self,
+        raw_target: str,
         previous_observation: Mapping[str, object] | None = None,
     ) -> GitHubPullRequestProbeResult:
         """Return one canonical review-ready observation."""

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -8,11 +8,15 @@ they can be persisted and evaluated without starting an agent turn.
 from __future__ import annotations
 
 import json
+import logging
 import math
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
-from typing import Any
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
 
 MONITOR_STATE_VERSION = 1
 DEFAULT_MONITOR_RUNTIME_SECS = 14_400
@@ -303,6 +307,104 @@ class MonitorVerdict:
         for entry in self.entries:
             if not isinstance(entry, MonitorObservation):
                 raise ValueError("every verdict entry must be a MonitorObservation")
+
+
+@dataclass(frozen=True)
+class MonitorProbeResult:
+    """What one probe learned about ONE subject, in terms the engine can read.
+
+    Names no host. ``canonical`` holds that subject's durable facts -- shaped by
+    the kind that produced them and opaque to the decision engine, which only
+    ever persists and compares it -- and ``observation`` is the generic
+    classification the engine acts on.
+
+    This is a RECORD rather than a bare list of per-check rows on purpose. A host
+    that publishes its own overall verdict, distinct from the rows a probe
+    enumerates, needs somewhere to put it, and a defaulted field added to a
+    record reaches every caller without changing this type's shape or any
+    signature that names it. A protocol returning a bare sequence would have to
+    change its return type instead, which is the cost this shape avoids.
+    """
+
+    canonical: dict[str, object]
+    observation: MonitorObservation
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.observation, MonitorObservation):
+            raise ValueError("observation must be a MonitorObservation")
+        if not isinstance(self.canonical, dict):
+            raise ValueError("canonical must be a dict")
+
+
+class MonitorProbe(Protocol):
+    """The external probe boundary, shared by every path that observes a subject.
+
+    PLURAL by contract even where an implementation loops internally: it takes a
+    sequence of subjects and returns one result per subject. A monitored kind
+    whose host answers for many subjects in one call -- most review and CI hosts
+    do -- can then satisfy this without the signature changing, and a caller that
+    wants one subject passes a one-element sequence.
+
+    The returned mapping is keyed by the subject string AS PASSED IN, not by any
+    identity the host derives from it. A caller can only look up what it asked
+    for, and a host is free to normalize a subject for its own use without that
+    reshaping the mapping its caller has to read.
+
+    Nothing in this signature names a host. That is what lets a second kind
+    satisfy the same boundary.
+    """
+
+    def probe(
+        self,
+        subjects: Sequence[str],
+        *,
+        previous_observations: Mapping[str, Mapping[str, object]] | None = None,
+    ) -> Mapping[str, MonitorProbeResult]: ...
+
+
+def transient_probe_failure() -> MonitorProbeResult:
+    """The result a probe that could not answer usably is treated as returning."""
+    return MonitorProbeResult(
+        canonical={},
+        observation=MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=ProviderErrorKind.TRANSIENT,
+            reason_code="provider_transient",
+        ),
+    )
+
+
+def resolve_probe_result(results: object, subject: str) -> MonitorProbeResult:
+    """Take one subject's result out of a probe's mapping, or fail closed.
+
+    A plural boundary lets a provider answer for a SUBSET of what it was asked,
+    and lets it answer with the wrong shape. Neither is a verdict: an absent
+    subject leaves no observation to decide from, and the decision engine reads
+    attributes off whatever it is handed, so an untyped value would fail deep
+    inside it rather than at the boundary.
+
+    EVERY consumer of the boundary resolves through here, so the paths cannot
+    disagree about what an unusable answer means -- a guard in one consumer and a
+    bare ``KeyError`` in the other is the same hazard handled two ways.
+
+    The unusable case is logged HERE, not by the caller. A synthesized fallback and
+    a provider's own correctly-classified transient both carry ``PROVIDER_ERROR``
+    and both carry ``provider_transient``, so a caller testing the status cannot
+    tell them apart and would report an ordinary rate limit as "no usable result".
+    This function is the only place that knows which branch it took.
+    """
+    if not isinstance(results, Mapping):
+        logger.error(
+            "structured monitor probe answered with %s, not a mapping",
+            type(results).__name__,
+        )
+        return transient_probe_failure()
+    result = results.get(subject)
+    if not isinstance(result, MonitorProbeResult):
+        logger.error("structured monitor probe gave no usable result for %r", subject)
+        return transient_probe_failure()
+    return result
 
 
 @dataclass

--- a/src/kiro_crew/monitoring/registry.py
+++ b/src/kiro_crew/monitoring/registry.py
@@ -1,0 +1,126 @@
+"""The catalogue of monitored kinds, each registered as DATA.
+
+The four boundaries that gate a kind read this table instead of naming a kind
+themselves: an enum in the tool schema, a frozenset in the validator, an ``if`` in
+the HTTP handler, and the ``if`` on the persistence-only path. Without it, adding a
+kind means finding all four, every one of them a place to forget.
+
+The claim is scoped to those four deliberately. Other spellings of a kind or an
+objective survive elsewhere -- a reason code in the GitHub observation, the irq
+subsystem's own dispatch -- and this module does not reach them.
+
+This module holds one entry per kind and the boundaries ask it. Two properties are
+worth separating carefully, because collapsing them is how a new kind acquires a
+claim nobody checked:
+
+**Objectives are declared BY THE KIND, not drawn from a shared vocabulary.** There
+is no global objective enum here. ``review_ready`` means "the pull request is ready
+for a human to look at", which is not a sentence about a calendar or a ticket, and a
+shared list would make every new kind edit a common set -- the same defect as a
+dispatch branch, moved to a different file.
+
+**A capability is something a kind ANSWERS FOR, not something the registry polices.**
+``supports_shadow`` says the persistence-only path is implemented for this kind. That
+is a statement about what code exists, not about what a caller may ask for, so it
+belongs to the kind. Modelled as an allowlist instead, a kind added later would
+silently inherit a claim about a path it has never run.
+
+Deliberately DATA only: no probe factories and no imports of any kind's
+implementation. ``kiro_crew.validation`` imports this module, and it is imported by
+almost everything, so pulling a provider's transitive dependencies in here would
+make a validator drag a GitHub client behind it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: The structured monitor a caller arms through ``monitor_watch``. Its subject is a
+#: public GitHub pull request and its objective is review readiness.
+GITHUB_PULL_REQUEST = "github_pull_request"
+
+#: The observation-gated babysit watch. Armed only INTERNALLY, from a loop's own
+#: message text via ``probes.targets.infer``, never by a caller naming it, which is
+#: why it is registered but not publicly armable.
+#: Spelled here as data rather than imported: ``probes/__init__.py`` owns the same
+#: string for the irq subsystem, and the two packages have no import edge in either
+#: direction today. Introducing one for a constant would couple them ahead of the
+#: porting work that unifies the vocabularies. ``test_monitor_kind_registry`` asserts
+#: the two spellings agree, so a drift fails loudly instead of silently.
+GH_PR = "gh-pr"
+
+REVIEW_READY = "review_ready"
+
+
+@dataclass(frozen=True)
+class MonitorKind:
+    """One monitored kind and what it answers for."""
+
+    name: str
+    #: The objectives THIS kind supports. Not a slice of a shared enum.
+    objectives: frozenset[str]
+    #: Whether a caller may name this kind when arming a monitor. A kind derived
+    #: internally from a loop's message is registered without being requestable.
+    publicly_armable: bool
+    #: Whether the persistence-only probe path is implemented for this kind.
+    supports_shadow: bool
+
+
+_KINDS: dict[str, MonitorKind] = {
+    GITHUB_PULL_REQUEST: MonitorKind(
+        name=GITHUB_PULL_REQUEST,
+        objectives=frozenset({REVIEW_READY}),
+        publicly_armable=True,
+        supports_shadow=True,
+    ),
+    GH_PR: MonitorKind(
+        name=GH_PR,
+        objectives=frozenset({REVIEW_READY}),
+        publicly_armable=False,
+        supports_shadow=False,
+    ),
+}
+
+
+def monitor_kind(name: object) -> MonitorKind | None:
+    """The entry for *name*, or None when nothing is registered under it."""
+    if not isinstance(name, str):
+        return None
+    return _KINDS.get(name)
+
+
+def publicly_armable_kinds() -> frozenset[str]:
+    """The kinds a caller may name. This is what an entry allowlist should expose."""
+    return frozenset(entry.name for entry in _KINDS.values() if entry.publicly_armable)
+
+
+def publicly_armable_objectives() -> frozenset[str]:
+    """Every objective reachable through a publicly armable kind.
+
+    A union, because a JSON-Schema ``enum`` and a validator's ``allowed`` set are
+    both flat: neither can express "this objective only with that kind". The pairing
+    is enforced by :func:`kind_supports_objective` at the boundary that knows both,
+    so the flat set is a first filter and never the whole check.
+    """
+    return frozenset(
+        objective
+        for entry in _KINDS.values()
+        if entry.publicly_armable
+        for objective in entry.objectives
+    )
+
+
+def kind_supports_objective(kind: object, objective: object) -> bool:
+    """Whether *kind* is registered AND declares *objective*."""
+    entry = monitor_kind(kind)
+    return entry is not None and isinstance(objective, str) and objective in entry.objectives
+
+
+def kind_supports_shadow(kind: object) -> bool:
+    """Whether the persistence-only probe path is implemented for *kind*.
+
+    An unregistered kind answers False: a path nobody registered is a path nobody
+    implemented.
+    """
+    entry = monitor_kind(kind)
+    return entry is not None and entry.supports_shadow

--- a/src/kiro_crew/monitoring/shadow.py
+++ b/src/kiro_crew/monitoring/shadow.py
@@ -3,25 +3,25 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from dataclasses import fields
-from typing import Protocol
 
 from kiro_crew.monitoring.decision import (
     decide_monitor,
     monitor_budget_reason,
     terminal_decision_for_outcome,
 )
-from kiro_crew.monitoring.github_pull_request import GitHubPullRequestProbeResult
 from kiro_crew.monitoring.models import (
     MonitorDecision,
     MonitorObservationStatus,
     MonitorOutcome,
+    MonitorProbe,
     MonitorState,
     MonitorVerdict,
     ProviderErrorKind,
     is_finite_non_negative_number,
+    resolve_probe_result,
 )
 
 ShadowStatePersistence = Callable[[MonitorState], Awaitable[None]]
@@ -31,20 +31,9 @@ class ShadowWakeDeliveryRefused(RuntimeError):
     """Raised when a caller asks the persistence-only path to wake a session."""
 
 
-class GitHubShadowProvider(Protocol):
-    """External probe boundary required by the shadow controller."""
-
-    def probe(
-        self,
-        raw_target: str,
-        *,
-        previous_observation: Mapping[str, object] | None = None,
-    ) -> GitHubPullRequestProbeResult: ...
-
-
 async def run_shadow_probe(
     state: MonitorState,
-    provider: GitHubShadowProvider,
+    provider: MonitorProbe,
     persist: ShadowStatePersistence,
     *,
     now: float,
@@ -78,11 +67,12 @@ async def run_shadow_probe(
         await _persist_and_publish(state, staged, persist)
         return MonitorVerdict(decision=MonitorDecision.STOP_BUDGET)
 
-    result = await asyncio.to_thread(
+    results = await asyncio.to_thread(
         provider.probe,
-        state.target,
-        previous_observation=deepcopy(state.last_observation),
+        (state.target,),
+        previous_observations={state.target: deepcopy(state.last_observation)},
     )
+    result = resolve_probe_result(results, state.target)
     staged = deepcopy(state)
     verdict = decide_monitor(staged, result.observation, now=now)
     decision = verdict.decision

--- a/src/kiro_crew/monitoring/shadow.py
+++ b/src/kiro_crew/monitoring/shadow.py
@@ -23,6 +23,10 @@ from kiro_crew.monitoring.models import (
     is_finite_non_negative_number,
     resolve_probe_result,
 )
+from kiro_crew.monitoring.registry import (
+    kind_supports_objective,
+    kind_supports_shadow,
+)
 
 ShadowStatePersistence = Callable[[MonitorState], Awaitable[None]]
 
@@ -46,8 +50,16 @@ async def run_shadow_probe(
     """
     if wake_delivery:
         raise ShadowWakeDeliveryRefused("wake delivery is unavailable in shadow mode")
-    if state.kind != "github_pull_request" or state.objective != "review_ready":
-        raise ValueError("shadow mode supports only github_pull_request review_ready")
+    # A CAPABILITY the kind declares, not an allowlist of what a caller may request:
+    # this asks whether the persistence-only path is implemented for the kind, which
+    # is a fact about what code exists. A kind registered without it is refused here
+    # rather than silently inheriting a claim about a path it has never run.
+    if not kind_supports_shadow(state.kind):
+        raise ValueError(f"shadow mode is not implemented for monitored kind {state.kind!r}")
+    if not kind_supports_objective(state.kind, state.objective):
+        raise ValueError(
+            f"monitored kind {state.kind!r} does not declare objective {state.objective!r}"
+        )
     if not is_finite_non_negative_number(now):
         raise ValueError("now must be a finite non-negative number")
     if not callable(persist):

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -55,6 +55,10 @@ from kiro_crew.monitoring.models import (
     MAX_MONITOR_WAKE_INSTRUCTIONS_CHARS,
     MIN_MONITOR_CADENCE_SECS,
 )
+from kiro_crew.monitoring.registry import (
+    publicly_armable_kinds,
+    publicly_armable_objectives,
+)
 from kiro_crew.project_scope import SCOPE_FRAGMENT_RE
 
 # ── Constants ──
@@ -1196,9 +1200,9 @@ AUTONUDGE_STOP_SCHEMA = ToolSchema(
 MONITOR_WATCH_SCHEMA = ToolSchema(
     tool_name="monitor_watch",
     fields=[
-        FieldSpec("kind", str, required=True, allowed=frozenset({"github_pull_request"})),
+        FieldSpec("kind", str, required=True, allowed=publicly_armable_kinds()),
         FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
-        FieldSpec("objective", str, required=True, allowed=frozenset({"review_ready"})),
+        FieldSpec("objective", str, required=True, allowed=publicly_armable_objectives()),
         FieldSpec(
             "interval_secs",
             int,
@@ -1259,7 +1263,7 @@ MONITOR_UPDATE_SCHEMA = ToolSchema(
         FieldSpec("max_cycles", int, min_val=0, max_val=1000),
         FieldSpec("max_runtime_secs", int, min_val=0, max_val=604800),
         FieldSpec("target", str, max_len=MAX_SHORT_STRING),
-        FieldSpec("objective", str, allowed=frozenset({"review_ready"})),
+        FieldSpec("objective", str, allowed=publicly_armable_objectives()),
         FieldSpec("max_agent_turns", int, min_val=1, max_val=MAX_MONITOR_AGENT_TURNS),
         FieldSpec("max_tokens", int, min_val=1, max_val=MAX_MONITOR_TOKENS),
         FieldSpec("max_provider_errors", int, min_val=1, max_val=MAX_MONITOR_PROVIDER_ERRORS),

--- a/test/test_github_pull_request_monitor.py
+++ b/test/test_github_pull_request_monitor.py
@@ -13,6 +13,7 @@ import pytest
 from kiro_crew.github_runner import SetupError
 from kiro_crew.monitoring.decision import decide_monitor
 from kiro_crew.monitoring.github_pull_request import (
+    GitHubPullRequestProbeResult,
     GitHubPullRequestProvider,
     GitHubPullRequestTarget,
     parse_github_pull_request_target,
@@ -20,8 +21,11 @@ from kiro_crew.monitoring.github_pull_request import (
 from kiro_crew.monitoring.models import (
     MonitorBudgets,
     MonitorDecision,
+    MonitorObservation,
     MonitorObservationStatus,
     MonitorOutcome,
+    MonitorProbe,
+    MonitorProbeResult,
     MonitorState,
     ProviderErrorKind,
     monitor_state_to_dict,
@@ -29,6 +33,23 @@ from kiro_crew.monitoring.models import (
 from kiro_crew.monitoring.shadow import ShadowWakeDeliveryRefused, run_shadow_probe
 
 _HEAD = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _probe_one(
+    provider: GitHubPullRequestProvider,
+    target: str = "https://github.com/owner/repo/pull/123",
+    *,
+    previous_observation: object = None,
+) -> object:
+    """Probe ONE subject across the plural boundary and return its result.
+
+    These tests are about what the GitHub probe derives from a response, not
+    about the boundary's arity -- that is covered on its own in
+    ``TestPluralProbeBoundary``. Wrapping the one-element call once keeps every
+    assertion below reading as it did.
+    """
+    previous = None if previous_observation is None else {target: previous_observation}
+    return provider.probe((target,), previous_observations=previous)[target]
 
 
 def _primary(**changes: object) -> dict[str, object]:
@@ -183,7 +204,7 @@ def test_clean_pull_request_has_allowlisted_canonical_observation_and_fingerprin
     """Adding provider payload fields or omitting a readiness fact breaks persistence."""
     provider, runner = _provider(_primary(), _threads())
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical == {
         "blocking_review": "none",
@@ -251,8 +272,8 @@ def test_reordered_and_volatile_provider_values_keep_the_fingerprint_stable() ->
         _threads(nodes=[{"isResolved": True}, {"isResolved": True}]),
     )
 
-    first = first_provider.probe("https://github.com/owner/repo/pull/123")
-    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+    first = _probe_one(first_provider)
+    second = _probe_one(second_provider)
 
     assert second.canonical == first.canonical
     assert second.observation.fingerprint == first.observation.fingerprint
@@ -285,7 +306,7 @@ def test_check_identity_is_redacted_before_it_enters_canonical_state() -> None:
         _threads(),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     serialized = json.dumps(result.canonical, sort_keys=True)
     assert token not in serialized
@@ -324,8 +345,8 @@ def test_same_label_check_runs_remain_independent_without_order_affecting_finger
         _threads(),
     )
 
-    first = first_provider.probe("https://github.com/owner/repo/pull/123")
-    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+    first = _probe_one(first_provider)
+    second = _probe_one(second_provider)
 
     assert first.canonical["checks"] == {
         "failed": ["CI / test"],
@@ -357,8 +378,8 @@ def test_duplicate_failed_check_rows_preserve_multiplicity_in_the_fingerprint() 
         _threads(),
     )
 
-    first = first_provider.probe("https://github.com/owner/repo/pull/123")
-    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+    first = _probe_one(first_provider)
+    second = _probe_one(second_provider)
 
     assert first.canonical["checks"]["failed"] == ["CI / test"]
     assert second.canonical["checks"]["failed"] == ["CI / test", "CI / test"]
@@ -384,7 +405,7 @@ def test_distinct_workflow_dispatches_with_same_labels_remain_independent() -> N
         _threads(),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["checks"] == {
         "failed": ["CI / test"],
@@ -416,7 +437,7 @@ def test_independent_workflows_with_same_check_name_remain_distinct() -> None:
         _threads(),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["checks"] == {
         "failed": ["Backend / test"],
@@ -447,7 +468,7 @@ def test_independent_same_workflow_jobs_with_same_name_remain_distinct() -> None
         _threads(),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["checks"] == {
         "failed": ["CI / test"],
@@ -477,7 +498,7 @@ def test_distinct_raw_check_identities_cannot_collapse_during_redaction() -> Non
         _threads(),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.observation.status is MonitorObservationStatus.ACTIONABLE
     assert result.observation.reason_code == "checks_failed"
@@ -497,7 +518,7 @@ def test_same_workflow_checks_without_dispatch_identity_remain_independent() -> 
         _threads(),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["checks"] == {
         "failed": ["CI / test"],
@@ -530,7 +551,7 @@ def test_same_named_workflowless_check_runs_remain_distinct() -> None:
         _threads(),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["checks"] == {
         "failed": ["test"],
@@ -561,7 +582,7 @@ def test_status_context_failure_cannot_be_hidden_by_same_named_check_run() -> No
         _threads(),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["checks"] == {
         "failed": ["test"],
@@ -589,7 +610,7 @@ def test_same_dispatch_queued_attempt_cannot_hide_an_older_completion() -> None:
         _threads(),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["checks"] == {
         "failed": [],
@@ -728,7 +749,7 @@ def test_pull_request_classification_matrix(
     """Changing one readiness fact must select its conservative typed outcome."""
     provider, _ = _provider(_primary(**primary_changes), _threads(nodes=thread_nodes))
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.observation.status is status
     assert result.observation.reason_code == reason
@@ -783,7 +804,7 @@ def test_known_actionable_fact_precedes_simultaneous_pending_or_unknown_fact(
     """Known work must wake the owner even when unrelated provider facts are unsettled."""
     provider, _ = _provider(_primary(**primary_changes), _threads(nodes=thread_nodes))
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.observation.status is MonitorObservationStatus.ACTIONABLE
     assert result.observation.reason_code == reason
@@ -811,8 +832,8 @@ def test_actionable_fingerprint_ignores_unrelated_pending_check_churn() -> None:
         _threads(),
     )
 
-    first = first_provider.probe("https://github.com/owner/repo/pull/123")
-    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+    first = _probe_one(first_provider)
+    second = _probe_one(second_provider)
 
     assert first.canonical != second.canonical
     assert first.observation.status is MonitorObservationStatus.ACTIONABLE
@@ -838,7 +859,7 @@ def test_mergeability_only_accepts_known_settled_merge_states(
     """An empty or future provider enum cannot fall through to review-ready success."""
     provider, _ = _provider(_primary(mergeStateStatus=merge_state), _threads())
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["mergeability"] == mergeability
     assert result.observation.status is status
@@ -857,8 +878,8 @@ def test_review_threads_paginate_and_fold_order_independently() -> None:
         _threads([{"isResolved": True}], has_next=False),
     )
 
-    first = first_provider.probe("https://github.com/owner/repo/pull/123")
-    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+    first = _probe_one(first_provider)
+    second = _probe_one(second_provider)
 
     assert first.canonical["unresolved_review_threads"] == 1
     assert first.canonical["review_threads_complete"] is True
@@ -875,7 +896,7 @@ def test_review_thread_string_variables_use_raw_graphql_fields() -> None:
         _threads(),
     )
 
-    provider.probe("https://github.com/123/true/pull/123")
+    _probe_one(provider, "https://github.com/123/true/pull/123")
 
     first_page = runner.calls[2][0]
     second_page = runner.calls[3][0]
@@ -897,7 +918,7 @@ def test_review_thread_page_cap_is_pending_instead_of_success() -> None:
     ]
     provider, runner = _provider(_primary(), *pages)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["review_threads_complete"] is False
     assert result.observation.status is MonitorObservationStatus.PENDING
@@ -913,7 +934,7 @@ def test_review_thread_missing_next_cursor_is_pending_instead_of_success() -> No
         _threads([{"isResolved": True}], has_next=True, cursor=None),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["review_threads_complete"] is False
     assert result.observation.status is MonitorObservationStatus.PENDING
@@ -927,7 +948,7 @@ def test_review_thread_graphql_errors_make_partial_data_pending() -> None:
     partial["errors"] = [{"message": "provider-controlled detail"}]
     provider, _ = _provider(_primary(), partial)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["review_threads_complete"] is False
     assert result.observation.status is MonitorObservationStatus.PENDING
@@ -942,7 +963,8 @@ def test_review_thread_graphql_errors_without_usable_data_preserve_primary_facts
         {"data": None, "errors": [{"message": "provider-controlled detail"}]},
     )
 
-    result = provider.probe(
+    result = _probe_one(
+        provider,
         "https://github.com/owner/repo/pull/123",
         previous_observation={"head_revision": "previous-head"},
     )
@@ -963,7 +985,8 @@ def test_generic_blocked_state_preserves_supplemental_provider_error() -> None:
         {"data": None, "errors": [{"message": "provider-controlled detail"}]},
     )
 
-    result = provider.probe(
+    result = _probe_one(
+        provider,
         "https://github.com/owner/repo/pull/123",
         previous_observation={"head_revision": "previous-head"},
     )
@@ -1013,7 +1036,7 @@ def test_review_thread_graphql_errors_preserve_observed_unresolved_nodes() -> No
     partial["errors"] = [{"message": "partial review evidence"}]
     provider, _ = _provider(_primary(), partial)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["review_threads_complete"] is False
     assert result.canonical["unresolved_review_threads"] == 1
@@ -1053,7 +1076,7 @@ def test_review_thread_request_failure_preserves_primary_failed_check() -> None:
         runner=lambda *_args, **_kwargs: next(results),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["review_threads_complete"] is False
     assert result.canonical["checks"]["failed"] == ["CI / test"]
@@ -1093,7 +1116,7 @@ def test_raised_check_timeout_preserves_primary_review_blocker() -> None:
         runner=runner,
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.response is not None
     assert result.canonical["checks_complete"] is False
@@ -1141,7 +1164,7 @@ def test_raised_review_setup_error_preserves_primary_review_blocker() -> None:
         runner=runner,
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.response is not None
     assert result.canonical["checks_complete"] is True
@@ -1192,7 +1215,7 @@ def test_later_review_thread_request_failure_preserves_observed_blocker() -> Non
         runner=lambda *_args, **_kwargs: next(results),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["review_threads_complete"] is False
     assert result.canonical["unresolved_review_threads"] == 1
@@ -1208,7 +1231,7 @@ def test_malformed_review_thread_node_cannot_hide_a_later_blocker() -> None:
         _threads([None, {"isResolved": False}]),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["review_threads_complete"] is False
     assert result.canonical["unresolved_review_threads"] == 1
@@ -1250,7 +1273,7 @@ def test_known_review_blocker_precedes_incomplete_thread_evidence(
         partial["errors"] = [{"message": "partial review evidence"}]
     provider, _ = _provider(_primary(**primary_changes), partial)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["review_threads_complete"] is False
     assert result.canonical["blocking_review"] == blocking_review
@@ -1269,8 +1292,8 @@ def test_incomplete_review_fingerprint_distinguishes_known_blockers() -> None:
     )
     unresolved_provider, _ = _provider(_primary(), unresolved)
 
-    first = changes_provider.probe("https://github.com/owner/repo/pull/123")
-    second = unresolved_provider.probe("https://github.com/owner/repo/pull/123")
+    first = _probe_one(changes_provider)
+    second = _probe_one(unresolved_provider)
 
     assert first.observation.fingerprint != second.observation.fingerprint
 
@@ -1278,11 +1301,12 @@ def test_incomplete_review_fingerprint_distinguishes_known_blockers() -> None:
 def test_changed_head_is_explicitly_actionable_even_when_new_facts_are_green() -> None:
     """A green new revision must not terminate before the owner can inspect it."""
     previous_provider, _ = _provider(_primary(), _threads())
-    previous = previous_provider.probe("https://github.com/owner/repo/pull/123")
+    previous = _probe_one(previous_provider)
     new_head = "fedcba9876543210fedcba9876543210fedcba98"
     current_provider, _ = _provider(_primary(headRefOid=new_head), _threads())
 
-    current = current_provider.probe(
+    current = _probe_one(
+        current_provider,
         "https://github.com/owner/repo/pull/123",
         previous_observation=previous.canonical,
     )
@@ -1315,7 +1339,8 @@ def test_missing_current_head_is_pending_without_a_changed_head_wake() -> None:
         last_fingerprint="previous-fingerprint",
     )
 
-    result = provider.probe(
+    result = _probe_one(
+        provider,
         "https://github.com/owner/repo/pull/123",
         previous_observation=state.last_observation,
     )
@@ -1349,7 +1374,8 @@ def test_terminal_pull_request_state_precedes_a_head_revision_change(
         last_observation={"head_revision": "previous-head"},
     )
 
-    result = provider.probe(
+    result = _probe_one(
+        provider,
         "https://github.com/owner/repo/pull/123",
         previous_observation=state.last_observation,
     )
@@ -1410,7 +1436,7 @@ def test_terminal_lifecycle_does_not_query_review_threads(
 
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.observation.status is status
     assert result.observation.reason_code == reason
@@ -1421,7 +1447,7 @@ def test_boolean_pull_request_number_is_a_malformed_primary_response() -> None:
     """Python boolean equality must not let a non-integer provider number pass validation."""
     provider, runner = _provider(_primary(number=True))
 
-    result = provider.probe("https://github.com/owner/repo/pull/1")
+    result = _probe_one(provider, "https://github.com/owner/repo/pull/1")
 
     assert result.observation.status is MonitorObservationStatus.PROVIDER_ERROR
     assert result.observation.reason_code == "provider_malformed_response"
@@ -1470,7 +1496,7 @@ def test_provider_cli_failures_map_to_fixed_nonleaking_categories(
         runner=_FailureRunner(stderr=stderr),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.response is None
     assert result.canonical == {}
@@ -1514,7 +1540,7 @@ def test_provider_setup_and_transport_exceptions_have_typed_categories(
     """Local setup is terminal while network timeouts remain retryable."""
     provider = GitHubPullRequestProvider(resolver=resolver, runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.observation.provider_error is kind
     assert result.observation.reason_code in {"provider_setup", "provider_transient"}
@@ -1534,7 +1560,7 @@ def test_malformed_provider_payload_is_a_retryable_nonleaking_error(
     """Partial JSON is provider uncertainty, not evidence of readiness."""
     provider, _ = _provider(*payloads)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.response is None
     assert result.canonical == {}
@@ -1555,7 +1581,7 @@ def test_secret_bearing_stderr_never_reaches_result_or_logs(
         runner=_FailureRunner(stderr=raw),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     combined = repr(result) + caplog.text
     for forbidden in ("ghp_", "/home/user", "internal.example.test", "request?id"):
@@ -1667,7 +1693,7 @@ async def test_shadow_mode_refuses_wake_delivery_before_probe_or_persistence() -
     persists = 0
 
     class Provider:
-        def probe(self, raw_target: str, **kwargs: object) -> object:
+        def probe(self, subjects: object, **kwargs: object) -> object:
             nonlocal probes
             probes += 1
             raise AssertionError("shadow refusal must happen before the provider boundary")
@@ -1738,7 +1764,7 @@ def test_probe_isolates_checks_from_the_primary_field_set() -> None:
     runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.observation.status is MonitorObservationStatus.SUCCESS
     assert "statusCheckRollup" not in runner.calls[0][-1]
@@ -1752,7 +1778,7 @@ def test_null_check_rollup_is_an_empty_complete_check_set() -> None:
     runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["checks"] == {
         "failed": [],
@@ -1774,7 +1800,7 @@ def test_supplemental_check_permission_failure_preserves_primary_facts() -> None
     )
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.response is not None
     assert result.canonical["review_decision"] == "approved"
@@ -1797,7 +1823,7 @@ def test_nonzero_graphql_with_usable_nodes_preserves_the_blocker_and_error() -> 
     )
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["unresolved_review_threads"] == 1
     assert result.canonical["review_threads_complete"] is False
@@ -1816,7 +1842,7 @@ def test_outdated_unresolved_review_thread_is_not_a_current_blocker() -> None:
     )
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["unresolved_review_threads"] == 0
     assert result.observation.status is MonitorObservationStatus.SUCCESS
@@ -1836,7 +1862,7 @@ def test_repeated_review_thread_cursor_is_incomplete_instead_of_looping() -> Non
     )
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["review_threads_complete"] is False
     assert result.observation.reason_code == "review_threads_incomplete"
@@ -1856,7 +1882,7 @@ def test_check_identity_and_bucket_sizes_are_bounded_before_persistence() -> Non
     runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     failed = result.canonical["checks"]["failed"]
     assert len(failed) == 100
@@ -1883,7 +1909,7 @@ def test_status_context_failure_outranks_duplicate_success_and_stale_is_nonblock
     runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.canonical["checks"]["failed"] == ["ci"]
     assert result.canonical["checks"]["passed"] == ["CI / test"]
@@ -1893,7 +1919,7 @@ def test_status_context_failure_outranks_duplicate_success_and_stale_is_nonblock
 def test_actionable_fingerprint_changes_when_unresolved_thread_count_changes() -> None:
     first_core, first_rollup = _core_and_rollup()
     second_core, second_rollup = _core_and_rollup()
-    first = GitHubPullRequestProvider(
+    first_provider = GitHubPullRequestProvider(
         resolver=lambda: "/trusted/bin/gh",
         runner=_CompletedRunner(
             [
@@ -1902,8 +1928,9 @@ def test_actionable_fingerprint_changes_when_unresolved_thread_count_changes() -
                 _completed(_threads(nodes=[{"isResolved": False, "isOutdated": False}])),
             ]
         ),
-    ).probe("https://github.com/owner/repo/pull/123")
-    second = GitHubPullRequestProvider(
+    )
+    first = _probe_one(first_provider)
+    second_provider = GitHubPullRequestProvider(
         resolver=lambda: "/trusted/bin/gh",
         runner=_CompletedRunner(
             [
@@ -1919,7 +1946,8 @@ def test_actionable_fingerprint_changes_when_unresolved_thread_count_changes() -
                 ),
             ]
         ),
-    ).probe("https://github.com/owner/repo/pull/123")
+    )
+    second = _probe_one(second_provider)
 
     assert first.observation.fingerprint != second.observation.fingerprint
 
@@ -1932,7 +1960,7 @@ def test_draft_state_prevents_failed_checks_from_requesting_a_turn() -> None:
     runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
     provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.observation.status is MonitorObservationStatus.PENDING
     assert result.observation.reason_code == "pull_request_draft"
@@ -1952,7 +1980,7 @@ def test_transient_spawn_os_errors_remain_retryable(error: OSError) -> None:
         runner=_FailureRunner(error=error),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.observation.provider_error is ProviderErrorKind.TRANSIENT
     assert result.observation.reason_code == "provider_transient"
@@ -1979,7 +2007,7 @@ def test_cli_error_classification_uses_structured_status_before_provider_text(
         runner=_FailureRunner(stderr=stderr),
     )
 
-    result = provider.probe("https://github.com/owner/repo/pull/123")
+    result = _probe_one(provider)
 
     assert result.observation.provider_error is kind
 
@@ -2005,7 +2033,7 @@ async def test_shadow_budget_gate_stops_before_provider_execution() -> None:
     snapshots: list[MonitorState] = []
 
     class Provider:
-        def probe(self, raw_target: str, **kwargs: object) -> object:
+        def probe(self, subjects: object, **kwargs: object) -> object:
             nonlocal probes
             probes += 1
             raise AssertionError("budget gate must precede provider execution")
@@ -2085,7 +2113,7 @@ async def test_shadow_terminal_state_never_probes_again_or_changes_outcome() -> 
     persists = 0
 
     class Provider:
-        def probe(self, raw_target: str, **kwargs: object) -> object:
+        def probe(self, subjects: object, **kwargs: object) -> object:
             nonlocal probes
             probes += 1
             raise AssertionError("terminal monitor must not probe")
@@ -2111,3 +2139,211 @@ async def test_shadow_terminal_state_never_probes_again_or_changes_outcome() -> 
     assert probes == 0
     assert persists == 0
     assert state.outcome is MonitorOutcome.SUCCESS
+
+
+class TestPluralProbeBoundary:
+    """The probe boundary's arity and keying, independent of what GitHub derives.
+
+    These are the tests that would have to change if the signature were made
+    plural later instead of now, which is why it is plural now.
+    """
+
+    def test_several_subjects_yield_one_result_each_keyed_as_passed(self) -> None:
+        # The response's own number is validated against the requested target, so
+        # each subject needs a fixture that answers for ITS pull request.
+        first_core, first_rollup = _core_and_rollup(number=1)
+        second_core, second_rollup = _core_and_rollup(
+            number=2, statusCheckRollup=[_check_run(conclusion="FAILURE")]
+        )
+        runner = _CompletedRunner(
+            [
+                _completed(first_core),
+                _completed(first_rollup),
+                _completed(_threads()),
+                _completed(second_core),
+                _completed(second_rollup),
+                _completed(_threads()),
+            ]
+        )
+        provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+        first_url = "https://github.com/owner/repo/pull/1"
+        second_url = "https://github.com/owner/repo/pull/2"
+
+        results = provider.probe((first_url, second_url))
+
+        assert set(results) == {first_url, second_url}
+        assert results[first_url].observation.fingerprint
+        assert (
+            results[first_url].observation.fingerprint
+            != results[second_url].observation.fingerprint
+        )
+
+    def test_the_mapping_is_keyed_by_the_subject_as_passed_not_a_derived_identity(
+        self,
+    ) -> None:
+        """A caller can only look up what it asked for.
+
+        The canonical facts carry GitHub's own normalized identity
+        (``github.com/owner/repo#123``), which is NOT the URL the caller handed
+        over. Keying by the derived form would make the mapping unreadable to the
+        caller that built the request.
+        """
+        core, rollup = _core_and_rollup()
+        runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
+        provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+        url = "https://github.com/owner/repo/pull/123"
+
+        results = provider.probe((url,))
+
+        assert list(results) == [url]
+        assert results[url].canonical["target"] != url
+
+    def test_each_subject_sees_only_its_own_previous_observation(self) -> None:
+        """A head carried against the wrong subject would fake a changed head."""
+        first_core, first_rollup = _core_and_rollup(number=1)
+        second_core, second_rollup = _core_and_rollup(number=2)
+        runner = _CompletedRunner(
+            [
+                _completed(first_core),
+                _completed(first_rollup),
+                _completed(_threads()),
+                _completed(second_core),
+                _completed(second_rollup),
+                _completed(_threads()),
+            ]
+        )
+        provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+        changed = "https://github.com/owner/repo/pull/1"
+        unchanged = "https://github.com/owner/repo/pull/2"
+
+        results = provider.probe(
+            (changed, unchanged),
+            previous_observations={changed: {"head_revision": "a-different-head"}},
+        )
+
+        assert results[changed].observation.head_changed is True
+        assert results[unchanged].observation.head_changed is False
+
+    def test_no_subjects_probes_nothing(self) -> None:
+        runner = _CompletedRunner([])
+        provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+        assert provider.probe(()) == {}
+        assert runner.calls == []
+
+    def test_a_kind_that_is_not_github_satisfies_the_same_boundary(self) -> None:
+        """The shared boundary names no host, so a second kind can satisfy it.
+
+        This implementation touches no GitHub type and is accepted by the shared
+        protocol. A boundary whose return type named one kind's own result would
+        reject it whatever it returned, which is what keeps this test honest
+        about the abstraction rather than about GitHub.
+        """
+
+        class _CalendarProbe:
+            def probe(
+                self,
+                subjects: Sequence[str],
+                *,
+                previous_observations: object = None,
+            ) -> dict[str, MonitorProbeResult]:
+                return {
+                    subject: MonitorProbeResult(
+                        canonical={"kind": "calendar", "target": subject, "slots_free": 0},
+                        observation=MonitorObservation(
+                            f"calendar-{subject}",
+                            MonitorObservationStatus.PENDING,
+                            reason_code="calendar_pending",
+                        ),
+                    )
+                    for subject in subjects
+                }
+
+        probe: MonitorProbe = _CalendarProbe()
+        results = probe.probe(("team-standup",))
+
+        assert set(results) == {"team-standup"}
+        assert results["team-standup"].canonical["kind"] == "calendar"
+        assert results["team-standup"].observation.status is MonitorObservationStatus.PENDING
+
+    def test_the_github_provider_satisfies_the_shared_boundary(self) -> None:
+        probe: MonitorProbe = GitHubPullRequestProvider(
+            resolver=lambda: "/trusted/bin/gh",
+            runner=_CompletedRunner([]),
+        )
+
+        assert probe.probe(()) == {}
+
+    def test_the_github_result_is_an_implementation_of_the_shared_result(self) -> None:
+        """So a caller typed to the shared record can hold this kind's result."""
+        core, rollup = _core_and_rollup()
+        runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
+        provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+        result = _probe_one(provider)
+
+        assert isinstance(result, MonitorProbeResult)
+
+
+@pytest.mark.asyncio
+async def test_shadow_fails_closed_on_a_subset_answer_like_the_controller_does() -> None:
+    """Both boundary consumers must agree on what an unusable answer means.
+
+    A plural boundary lets a provider answer for a subset of what it was asked.
+    Guarding that in one consumer and letting the other raise on the same input
+    would make the hazard's meaning depend on which path observed it.
+    """
+    snapshots: list[MonitorState] = []
+
+    class Provider:
+        def probe(self, subjects: object, **kwargs: object) -> dict[str, object]:
+            return {}
+
+    async def persist(updated: MonitorState) -> None:
+        snapshots.append(deepcopy(updated))
+
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+
+    verdict = await run_shadow_probe(state, Provider(), persist, now=1_100.0)
+
+    assert verdict.decision is MonitorDecision.RETRY_PROVIDER
+    assert state.last_provider_error is ProviderErrorKind.TRANSIENT
+    assert len(snapshots) == 1
+
+
+@pytest.mark.asyncio
+async def test_shadow_fails_closed_on_an_untyped_result() -> None:
+    """An untyped value would fail inside the decision engine, not at the boundary."""
+
+    class Provider:
+        def probe(self, subjects: object, **kwargs: object) -> dict[str, object]:
+            return {subject: "not a probe result" for subject in subjects}  # type: ignore[union-attr]
+
+    async def persist(updated: MonitorState) -> None:
+        return None
+
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+
+    verdict = await run_shadow_probe(state, Provider(), persist, now=1_100.0)
+
+    assert verdict.decision is MonitorDecision.RETRY_PROVIDER
+    assert state.last_provider_error is ProviderErrorKind.TRANSIENT
+
+
+def test_the_github_result_requires_its_response_explicitly() -> None:
+    """No default: a caller that forgets the typed response should not compile past it."""
+    with pytest.raises(TypeError):
+        GitHubPullRequestProbeResult(  # type: ignore[call-arg]
+            canonical={},
+            observation=MonitorObservation("fp", MonitorObservationStatus.PENDING),
+        )

--- a/test/test_monitor_behaviour_golden.py
+++ b/test/test_monitor_behaviour_golden.py
@@ -243,9 +243,9 @@ def _rows() -> list[dict[str, object]]:
             runner=_MatrixRunner(primary, threads),
         )
         result = provider.probe(
-            TARGET_URL,
-            previous_observation={"head_revision": PREVIOUS_HEAD},
-        )
+            (TARGET_URL,),
+            previous_observations={TARGET_URL: {"head_revision": PREVIOUS_HEAD}},
+        )[TARGET_URL]
         observation = result.observation
         rows.append(
             {

--- a/test/test_monitor_controller.py
+++ b/test/test_monitor_controller.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import threading
 import time
 from copy import deepcopy
@@ -22,6 +23,7 @@ from kiro_crew.monitoring.models import (
     MonitorObservationStatus,
     MonitorOutcome,
     ProviderErrorKind,
+    resolve_probe_result,
 )
 
 
@@ -30,13 +32,15 @@ class _Provider:
         self.result = result
         self.previous: list[dict[str, object]] = []
 
-    def probe(self, target: str, *, previous_observation=None):
-        self.previous.append(deepcopy(previous_observation or {}))
-        return self.result
+    def probe(self, subjects, *, previous_observations=None):
+        previous = previous_observations or {}
+        for subject in subjects:
+            self.previous.append(deepcopy(previous.get(subject) or {}))
+        return {subject: self.result for subject in subjects}
 
 
 class _RaisingProvider:
-    def probe(self, target: str, *, previous_observation=None):
+    def probe(self, subjects, *, previous_observations=None):
         raise RuntimeError("provider bug")
 
 
@@ -47,12 +51,12 @@ class _BlockingProvider:
         self.release = threading.Event()
         self.targets: list[str] = []
 
-    def probe(self, target: str, *, previous_observation=None):
-        self.targets.append(target)
+    def probe(self, subjects, *, previous_observations=None):
+        self.targets.extend(subjects)
         self.entered.set()
         if not self.release.wait(timeout=2):
             raise RuntimeError("test did not release provider")
-        return self.result
+        return {subject: self.result for subject in subjects}
 
 
 def _result(
@@ -1405,3 +1409,192 @@ async def test_a_delivered_wake_keeps_the_evidence_that_claimed_it(tmp_path):
     assert verdict.decision is MonitorDecision.WAKE_ACTIONABLE
     assert verdict.entries == (result.observation,)
     service.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_provider_that_omits_the_requested_subject_fails_closed(tmp_path):
+    """A missing key is a fault, not a verdict.
+
+    The plural boundary lets a provider answer for a subset of what it was asked.
+    Reading a mapping that has no entry for this monitor's own target must land
+    on the same transient-provider path as a raised exception, because there is
+    no observation to decide from and silence is not evidence of anything.
+    """
+
+    class _EmptyProvider:
+        def probe(self, subjects, *, previous_observations=None):
+            return {}
+
+    dispatched = AsyncMock()
+    service, loop, controller = await _armed(
+        tmp_path,
+        result=_result(MonitorObservationStatus.PENDING),
+        dispatch=dispatched,
+    )
+    controller._provider = _EmptyProvider()
+
+    verdict = await controller.tick(loop, now=120.0)
+
+    assert verdict.decision is MonitorDecision.RETRY_PROVIDER
+    assert loop.monitor is not None
+    assert loop.monitor.last_provider_error is ProviderErrorKind.TRANSIENT
+    dispatched.assert_not_awaited()
+    service.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_provider_returning_an_untyped_result_fails_closed(tmp_path):
+    """The decision engine cannot reject a wrong-shaped result, so the controller must."""
+
+    class _UntypedProvider:
+        def probe(self, subjects, *, previous_observations=None):
+            return {subject: "not a probe result" for subject in subjects}
+
+    dispatched = AsyncMock()
+    service, loop, controller = await _armed(
+        tmp_path,
+        result=_result(MonitorObservationStatus.PENDING),
+        dispatch=dispatched,
+    )
+    controller._provider = _UntypedProvider()
+
+    verdict = await controller.tick(loop, now=120.0)
+
+    assert verdict.decision is MonitorDecision.RETRY_PROVIDER
+    assert loop.monitor is not None
+    assert loop.monitor.last_provider_error is ProviderErrorKind.TRANSIENT
+    dispatched.assert_not_awaited()
+    service.stop()
+
+
+@pytest.mark.asyncio
+async def test_the_controller_asks_for_exactly_its_own_subject(tmp_path):
+    """One monitor is one subject; the plural call must not widen that."""
+    provider_result = _result(MonitorObservationStatus.PENDING)
+    service, loop, controller = await _armed(
+        tmp_path,
+        result=provider_result,
+        dispatch=AsyncMock(),
+    )
+    assert loop.monitor is not None
+    seen: list[tuple[str, ...]] = []
+
+    class _RecordingProvider:
+        def probe(self, subjects, *, previous_observations=None):
+            seen.append(tuple(subjects))
+            return {subject: provider_result for subject in subjects}
+
+    controller._provider = _RecordingProvider()
+
+    await controller.tick(loop, now=120.0)
+
+    assert seen == [(loop.monitor.target,)]
+    service.stop()
+
+
+class TestTheUnusableAnswerLogNamesOnlyTheUnusableCase:
+    """A provider's own classified transient must not be reported as no answer.
+
+    Both a synthesized fallback and a transient the provider classified correctly
+    carry ``PROVIDER_ERROR`` and the ``provider_transient`` reason code, so a status
+    test cannot tell them apart. These pin the distinction to the branch actually
+    taken rather than to the status.
+    """
+
+    def test_a_provider_classified_transient_logs_nothing(self, caplog) -> None:
+        """The common case: a rate limit or network blip, answered properly."""
+        classified = GitHubPullRequestProbeResult(
+            response=None,
+            canonical={},
+            observation=MonitorObservation(
+                "",
+                MonitorObservationStatus.PROVIDER_ERROR,
+                provider_error=ProviderErrorKind.TRANSIENT,
+                reason_code="provider_transient",
+            ),
+        )
+
+        with caplog.at_level(logging.ERROR):
+            resolved = resolve_probe_result({"pr-1": classified}, "pr-1")
+
+        assert resolved is classified
+        assert "no usable result" not in caplog.text
+        assert caplog.text == "" or "not a mapping" not in caplog.text
+
+    def test_a_missing_subject_does_log(self, caplog) -> None:
+        with caplog.at_level(logging.ERROR):
+            resolved = resolve_probe_result({}, "pr-1")
+
+        assert resolved.observation.status is MonitorObservationStatus.PROVIDER_ERROR
+        assert "no usable result" in caplog.text
+        assert "pr-1" in caplog.text
+
+    def test_an_untyped_answer_does_log(self, caplog) -> None:
+        with caplog.at_level(logging.ERROR):
+            resolved = resolve_probe_result("not a mapping", "pr-1")
+
+        assert resolved.observation.status is MonitorObservationStatus.PROVIDER_ERROR
+        assert "not a mapping" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_tick_on_a_classified_transient_logs_no_unusable_answer(tmp_path, caplog):
+    """A rate limit must not be reported as an absent answer.
+
+    It reaches here as a PROVIDER_ERROR result the provider classified itself, which
+    IS a usable answer. Testing the status rather than the branch actually taken
+    cannot tell it apart from a synthesized fallback, and reports it at ERROR level
+    as "no usable result" on every tick.
+    """
+    classified = _result(MonitorObservationStatus.PROVIDER_ERROR)
+    dispatched: list[object] = []
+
+    async def dispatch(envelope):
+        dispatched.append(envelope)
+        return True
+
+    service, loop, controller = await _armed(tmp_path, result=classified, dispatch=dispatch)
+    try:
+        with caplog.at_level(logging.ERROR):
+            verdict = await controller.tick(loop, now=120.0)
+
+        assert verdict.decision is not MonitorDecision.WAKE_ACTIONABLE
+        assert dispatched == []
+        assert "no usable result" not in caplog.text
+        assert "not a mapping" not in caplog.text
+    finally:
+        service.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_tick_whose_provider_omits_the_subject_does_log(tmp_path, caplog):
+    """The case the message was written for still reports at ERROR."""
+
+    class _OmittingProvider:
+        def probe(self, subjects, *, previous_observations=None):
+            return {}
+
+    service = AutoNudgeService(base_dir=tmp_path)
+    try:
+        loop = await service.add_monitor(
+            slot_key="chat-1",
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            cadence_secs=60,
+            budgets=MonitorBudgets(max_runtime_secs=600),
+            now=100.0,
+        )
+
+        async def dispatch(envelope):
+            return True
+
+        controller = MonitorController(
+            service, dispatch, provider=_OmittingProvider(), clock=lambda: 120.0
+        )
+        with caplog.at_level(logging.ERROR):
+            await controller.tick(loop, now=120.0)
+
+        assert "no usable result" in caplog.text
+    finally:
+        service.stop()

--- a/test/test_monitor_kind_registry.py
+++ b/test/test_monitor_kind_registry.py
@@ -1,0 +1,325 @@
+"""Contract for the monitored-kind registry.
+
+The point of the registry is that adding a kind is DATA, so the tests that matter
+most are the ones that would fail if a kind's objectives leaked into a shared
+vocabulary, or if a capability became something the registry asserts on a kind's
+behalf rather than something the kind answers for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.monitoring import registry
+from kiro_crew.monitoring.registry import (
+    GH_PR,
+    GITHUB_PULL_REQUEST,
+    REVIEW_READY,
+    MonitorKind,
+    kind_supports_objective,
+    kind_supports_shadow,
+    monitor_kind,
+    publicly_armable_kinds,
+    publicly_armable_objectives,
+)
+
+
+class TestTheEntryAllowlistsAreUnchanged:
+    """The four boundaries must expose exactly what they hardcoded before.
+
+    This is the behaviour lock for this change: the registry replaces four literal
+    allowlists, and replacing them is only safe if what a caller may ask for is
+    identical.
+    """
+
+    def test_the_publicly_armable_kind_set_is_the_one_the_schema_hardcoded(self) -> None:
+        assert publicly_armable_kinds() == frozenset({GITHUB_PULL_REQUEST})
+
+    def test_the_publicly_armable_objective_set_is_the_one_the_schema_hardcoded(self) -> None:
+        assert publicly_armable_objectives() == frozenset({REVIEW_READY})
+
+    def test_the_validator_schemas_derive_the_same_values(self) -> None:
+        from kiro_crew.validation import MONITOR_WATCH_SCHEMA
+
+        allowed = {field.name: field.allowed for field in MONITOR_WATCH_SCHEMA.fields}
+        assert allowed["kind"] == frozenset({GITHUB_PULL_REQUEST})
+        assert allowed["objective"] == frozenset({REVIEW_READY})
+
+
+class TestAKindDeclaresItsOwnObjectives:
+    """No shared objective vocabulary. This is the property the change exists for."""
+
+    def test_a_new_kind_declaring_a_new_objective_does_not_widen_another_kind(self) -> None:
+        """The test that would fail if objectives lived in one shared enum."""
+        before = monitor_kind(GITHUB_PULL_REQUEST)
+        assert before is not None
+
+        newcomer = MonitorKind(
+            name="calendar",
+            objectives=frozenset({"free_slot"}),
+            publicly_armable=True,
+            supports_shadow=False,
+        )
+
+        assert newcomer.objectives == frozenset({"free_slot"})
+        assert monitor_kind(GITHUB_PULL_REQUEST) == before
+        assert not kind_supports_objective(GITHUB_PULL_REQUEST, "free_slot")
+
+    def test_an_objective_one_kind_declares_is_not_thereby_legal_for_another(self) -> None:
+        assert kind_supports_objective(GITHUB_PULL_REQUEST, REVIEW_READY)
+        assert not kind_supports_objective(GITHUB_PULL_REQUEST, "free_slot")
+
+    def test_an_unregistered_kind_supports_nothing(self) -> None:
+        assert not kind_supports_objective("calendar", REVIEW_READY)
+        assert monitor_kind("calendar") is None
+
+    def test_a_non_string_kind_is_refused_rather_than_raising(self) -> None:
+        assert monitor_kind(None) is None
+        assert monitor_kind(7) is None
+        assert not kind_supports_objective(GITHUB_PULL_REQUEST, None)
+
+
+class TestShadowSupportIsADeclaredCapability:
+    """A capability is a fact about what code exists, so the kind answers for it.
+
+    Modelled as an allowlist the registry polices, a kind added later would inherit
+    a claim about a path it has never run.
+    """
+
+    def test_the_kind_with_a_shadow_implementation_declares_it(self) -> None:
+        assert kind_supports_shadow(GITHUB_PULL_REQUEST)
+
+    def test_a_registered_kind_without_that_path_declares_false(self) -> None:
+        assert monitor_kind(GH_PR) is not None
+        assert not kind_supports_shadow(GH_PR)
+
+    def test_an_unregistered_kind_answers_false_rather_than_inheriting_a_claim(self) -> None:
+        assert not kind_supports_shadow("calendar")
+
+    def test_capability_is_independent_of_being_publicly_armable(self) -> None:
+        """The two properties answer different questions and must not be conflated.
+
+        One is about what a caller may request; the other about what is implemented.
+        """
+        entry = MonitorKind(
+            name="ticket",
+            objectives=frozenset({"triaged"}),
+            publicly_armable=False,
+            supports_shadow=True,
+        )
+
+        assert not entry.publicly_armable
+        assert entry.supports_shadow
+
+
+class TestRegisteredButNotRequestable:
+    """A kind derived internally is registered without being namable by a caller."""
+
+    def test_the_internally_armed_kind_is_registered(self) -> None:
+        entry = monitor_kind(GH_PR)
+
+        assert entry is not None
+        assert entry.objectives == frozenset({REVIEW_READY})
+
+    def test_but_a_caller_may_not_name_it(self) -> None:
+        assert GH_PR not in publicly_armable_kinds()
+
+    def test_and_it_still_supports_its_objective_for_internal_arming(self) -> None:
+        """Registered-not-requestable must not mean unusable."""
+        assert kind_supports_objective(GH_PR, REVIEW_READY)
+
+
+class TestEveryRegisteredEntryIsWellFormed:
+    """Over ``_KINDS`` rather than in ``__post_init__``.
+
+    Nothing constructs ``MonitorKind`` outside this module's static literal, so a
+    runtime guard would only ever validate a literal. These run over whatever the
+    table holds, so an entry added later is checked without shipping code to do it.
+    """
+
+    def test_each_entry_is_keyed_by_its_own_name(self) -> None:
+        """A mismatch would make a lookup answer about a different kind."""
+        for key, entry in registry._KINDS.items():
+            assert key == entry.name
+
+    def test_each_entry_has_a_non_empty_name(self) -> None:
+        for entry in registry._KINDS.values():
+            assert entry.name
+
+    def test_each_entry_declares_at_least_one_objective(self) -> None:
+        """A kind declaring nothing could be armed for no objective at all."""
+        for entry in registry._KINDS.values():
+            assert entry.objectives
+
+    def test_no_declared_objective_is_empty(self) -> None:
+        for entry in registry._KINDS.values():
+            assert all(entry.objectives), entry.name
+
+
+class TestTheTwoKindVocabulariesAgree:
+    """``MonitorState.kind`` is a union of two vocabularies with no import edge.
+
+    ``probes/__init__.py`` owns ``gh-pr`` for the irq subsystem and this module
+    spells it again, because coupling the two packages for a constant would put an
+    import edge between them ahead of the porting work that unifies them. That makes
+    drift the real hazard, so it is pinned HERE: this test reads the spelling the
+    inference path actually produces and asserts the registry knows it.
+    """
+
+    def test_the_kind_inference_produces_is_registered(self) -> None:
+        from kiro_crew.probes import targets
+
+        target = targets.infer("please babysit https://github.com/owner/repo/pull/4137")
+
+        assert target is not None, "inference must still resolve a single PR URL"
+        assert monitor_kind(target.kind) is not None, (
+            f"probes.targets.infer produced kind {target.kind!r}, which this registry "
+            "does not know -- the two spellings have drifted apart"
+        )
+
+    def test_that_kind_declares_the_objective_the_inference_path_arms(self) -> None:
+        """``infer_monitor`` pairs the inferred kind with ``review_ready``."""
+        from kiro_crew.probes import targets
+
+        target = targets.infer("babysit https://github.com/owner/repo/pull/4137")
+
+        assert target is not None
+        assert kind_supports_objective(target.kind, REVIEW_READY)
+
+    def test_the_two_modules_spell_it_identically(self) -> None:
+        from kiro_crew.probes import GH_PR as PROBES_GH_PR
+
+        assert GH_PR == PROBES_GH_PR
+
+
+@pytest.mark.asyncio
+async def test_shadow_refuses_a_kind_that_does_not_declare_the_capability() -> None:
+    """The refusal names the missing capability, not an allowlist.
+
+    ``gh-pr`` is a REGISTERED kind, so this is not "unknown kind" -- it is a kind
+    whose persistence-only path is not implemented, which is the distinction the
+    declared capability exists to carry.
+    """
+    from kiro_crew.monitoring.models import MonitorState
+    from kiro_crew.monitoring.shadow import run_shadow_probe
+
+    probes = 0
+
+    class Provider:
+        def probe(self, subjects: object, **kwargs: object) -> dict[str, object]:
+            nonlocal probes
+            probes += 1
+            raise AssertionError("the capability check must precede the provider")
+
+    async def persist(updated: MonitorState) -> None:
+        raise AssertionError("nothing may be persisted for an unsupported kind")
+
+    state = MonitorState(
+        kind=GH_PR,
+        target="https://github.com/owner/repo/pull/123",
+        objective=REVIEW_READY,
+        created_ts=1_000.0,
+    )
+
+    with pytest.raises(ValueError, match="shadow mode is not implemented"):
+        await run_shadow_probe(state, Provider(), persist, now=1_100.0)
+    assert probes == 0
+
+
+@pytest.mark.asyncio
+async def test_shadow_refuses_an_objective_the_kind_does_not_declare() -> None:
+    from kiro_crew.monitoring.models import MonitorState
+    from kiro_crew.monitoring.shadow import run_shadow_probe
+
+    class Provider:
+        def probe(self, subjects: object, **kwargs: object) -> dict[str, object]:
+            raise AssertionError("the objective check must precede the provider")
+
+    async def persist(updated: MonitorState) -> None:
+        raise AssertionError("nothing may be persisted")
+
+    state = MonitorState(
+        kind=GITHUB_PULL_REQUEST,
+        target="https://github.com/owner/repo/pull/123",
+        objective="free_slot",
+        created_ts=1_000.0,
+    )
+
+    with pytest.raises(ValueError, match="does not declare objective"):
+        await run_shadow_probe(state, Provider(), persist, now=1_100.0)
+
+
+@pytest.mark.asyncio
+async def test_arming_refuses_an_unregistered_kind_before_it_is_persisted(tmp_path) -> None:
+    """The hole the registry closes: MonitorState itself accepts any non-empty kind.
+
+    A monitor stored under a kind nothing registered would be probed by whatever
+    provider the controller happens to hold, so the refusal belongs at the arming
+    boundary rather than at the point of discovery.
+    """
+    from kiro_crew.autonudge import AutoNudgeService
+    from kiro_crew.monitoring.models import MonitorBudgets, MonitorState
+
+    # The record itself is still permissive, which is why the boundary must check.
+    MonitorState(
+        kind="calendar",
+        target="https://github.com/owner/repo/pull/1",
+        objective=REVIEW_READY,
+        created_ts=1_000.0,
+    )
+
+    service = AutoNudgeService(base_dir=tmp_path)
+    try:
+        with pytest.raises(ValueError, match="no monitored kind 'calendar'"):
+            await service.add_monitor(
+                slot_key="chat-1",
+                kind="calendar",
+                target="https://github.com/owner/repo/pull/1",
+                objective=REVIEW_READY,
+                cadence_secs=60,
+                budgets=MonitorBudgets(),
+                now=100.0,
+            )
+    finally:
+        service.stop()
+
+
+@pytest.mark.asyncio
+async def test_updating_an_objective_the_kind_does_not_declare_is_refused(tmp_path) -> None:
+    """The update path is the other boundary that knows both halves.
+
+    The objective allowlist upstream is a UNION across every publicly armable kind,
+    so it cannot express the pairing: it admits an objective some other kind
+    declares. This test drives update_monitor directly for that reason -- the point
+    is that the pairing holds without the upstream filter's help, which is what will
+    still be true once a second kind widens the union.
+    """
+    from kiro_crew.autonudge import AutoNudgeService
+    from kiro_crew.monitoring.models import MonitorBudgets
+
+    service = AutoNudgeService(base_dir=tmp_path)
+    try:
+        loop = await service.add_monitor(
+            slot_key="chat-1",
+            kind=GITHUB_PULL_REQUEST,
+            target="https://github.com/owner/repo/pull/1",
+            objective=REVIEW_READY,
+            cadence_secs=60,
+            budgets=MonitorBudgets(),
+            now=100.0,
+        )
+        assert loop is not None
+
+        with pytest.raises(ValueError, match="does not support objective 'free_slot'"):
+            await service.update_monitor(loop.id, objective="free_slot")
+
+        # The refusal must not have half-applied.
+        after = service._loops[loop.id].monitor
+        assert after is not None
+        assert after.objective == REVIEW_READY
+
+        # And the objective the kind DOES declare still applies.
+        again = await service.update_monitor(loop.id, objective=REVIEW_READY)
+        assert again is not None
+    finally:
+        service.stop()


### PR DESCRIPTION
## Problem / Motivation

The external probe boundary is declared twice -- `_Provider` in
`monitoring/controller.py` and `GitHubShadowProvider` in `monitoring/shadow.py` --
and both annotate `probe`'s return as `GitHubPullRequestProbeResult`.

**The return type is the defect, not the repetition.** An abstraction typed to its
one concrete implementation is not an abstraction: satisfying either boundary
requires producing a pull request's result type, so a second monitored kind cannot
satisfy either one whatever it returns. The two declarations being near-identical
(they differ by class name, visibility and a docstring) is a symptom worth
tidying, but collapsing them while both still named a GitHub type would leave the
boundary exactly as closed as it is now.

The arity is the second half. `probe` takes one subject and returns one result, so
a host that answers for many subjects in one request -- which most review and CI
hosts do -- cannot express that without changing a signature every implementation
and every caller depends on.

## Why it matters

`docs/request-for-change/rfc-consolidated-monitor.md` describes a substrate where
a kind is registered as data and each kind implements a probe. That is unreachable
while the probe contract names one host in its return type: the registry would
have nothing to register a second kind *as*. This is the change that makes a
second kind possible at all, and the next one (a registry where a kind declares
its own objectives) has no seam to attach to without it.

## What changed

`MonitorProbeResult` in `monitoring/models.py` names no host: the subject's
canonical facts plus the generic `MonitorObservation` the engine classifies.
`GitHubPullRequestProbeResult` becomes an implementation of it and keeps
`response` -- its own typed detail -- on itself rather than on the shared type,
which is the line every future kind gets to draw for itself. The two Protocols
collapse into one public `MonitorProbe`, and the service boundary
(`_Service.apply_monitor_probe` and `AutoNudgeService.apply_monitor_probe`) is
retyped to the shared record, so no path names GitHub in order to describe a probe.

**Plural from the start.** `probe` takes a sequence of subjects and returns a
mapping. GitHub answers for one pull request per call, so its implementation loops
and the per-subject logic is untouched in `_probe_one`. Arity is the one property
that cannot be widened later without touching every implementation and every
caller, so it is settled now; a caller wanting one subject passes a one-element
sequence.

**Keyed by the subject as passed**, not by an identity the host derives. GitHub's
canonical facts carry `github.com/owner/repo#123`, which is not the URL the caller
handed over -- keying by the derived form would make the mapping unreadable to the
caller that built the request, and it lets a host normalize a subject for its own
use without that reshaping what its caller has to read. A test asserts the two
differ so this cannot regress into keying by whichever one happens to be handy.

**A record, not a bare list of rows.** This is the part that keeps a later fix
cheap. The status tool treats a published aggregate verdict as authoritative over
the individual rows, while a provider has no aggregate notion and computes from
row states alone; those two can disagree. Closing that gap is another change's
work, but a probe result shaped as a *record* leaves room for a host's own
aggregate as a defaulted field that reaches every caller without changing this
type or any signature naming it. A protocol returning a bare sequence of rows
would have to change its return type instead -- the same trap this change is
undoing one layer up.

No aggregate field is added here, deliberately. Nothing would read it, and this
probe fetches no published aggregate today -- it enumerates `statusCheckRollup`
rows and never reads a rollup state -- so populating one would mean an additional
request, which is a behaviour change this stack's golden table exists to forbid.
An unread field is unverifiable surface. The structural room is the deliverable;
the field belongs to the change that reads it.

**Two failure modes fail closed, in BOTH consumers.** A plural boundary makes it
possible for a provider to answer for a subset of what it was asked, or to answer
with the wrong shape. Neither is a verdict: an absent subject leaves no observation
to decide from, and the decision engine reads attributes off whatever it is handed,
so an untyped value fails deep inside it rather than at the boundary.

`MonitorController.tick` and `run_shadow_probe` both resolve through one shared
`resolve_probe_result`, so the two cannot disagree about what an unusable answer
means. Guarding one consumer and letting the other raise a bare `KeyError` on the
same input would make the hazard's meaning depend on which path observed it, which
is the asymmetry a shared boundary exists to remove.

`GitHubPullRequestProbeResult.response` carries no default. The shared base's
fields have none either, so nothing forced one, and a default would only let a
future caller silently omit the typed response.

## Tests

`test/test_monitor_behaviour_golden.py` is the behaviour proof and it is unchanged
except for its own call into the new signature. Its digest and all 28 per-group
digests were captured on pristine `kirocrew/main` at `53987e756`, before any edit
in this stack, and do not move.

New `TestPluralProbeBoundary` in `test/test_github_pull_request_monitor.py` covers
the contract that would be expensive to change later:

- several subjects yield one result each, keyed as passed
- the mapping is keyed by the caller's string, asserted against the derived
  canonical identity being different
- each subject sees only its own previous observation, so a head cannot be carried
  against the wrong subject and fake a changed head
- no subjects probes nothing
- a kind that touches no GitHub type satisfies the same protocol -- the claim this
  change actually makes
- the GitHub provider satisfies it, and its result is an instance of the shared
  record

In `test/test_monitor_controller.py`: a provider that omits the requested subject
fails closed, a provider returning an untyped value fails closed, and the
controller asks for exactly its own subject rather than widening the request. The
shadow path has the matching pair, so the shared resolver is asserted at both
consumers rather than only where it was first needed, and one test pins that the
GitHub result cannot be constructed without its response.

The ~60 existing provider tests call the boundary through one named helper rather
than each constructing a one-element sequence and indexing the mapping. Those
tests are about what the probe derives from a response, not about arity, and their
assertions are untouched.

## A green board here does NOT mean the code is verified

Read this before merging. Because this pull request is based on a branch rather
than `main`, it runs a much smaller check set: **18 checks against the 63 that run
on its `main`-based base.** The 18 are the review and policy lanes -- Design,
First Principles, GPT, Opus, UX, SAST, Inclusive Language, PR Hygiene, PR Scope,
Dependency License, Cross-Platform Portability, Automated Rule Check, Screenshot
Evidence and PR Readiness.

All 45 absent checks were enumerated by diffing the two rollups. They include
every test job and every deterministic gate: Backend Tests (all four shards, the
Windows shards and the namespace sandbox), Frontend Tests, Gateway Tests, Electron
Shell Tests, E2E, Build Wheel, Build Desktop, Build Windows Installer, Linux
Packaging, Coverage Gate, Frontend Coverage Merge, Backend and Frontend Lint &
Type Check, CodeQL, the internal-content scan, and the Brand Name, Changelog
History, Docs Lint, Feature Map, Focus Cue, Harness Parity, Loop-Bound Locks,
Builtin Skill Scope, Testpaths Coverage, Bundle Size and Vendored Tree Integrity
gates.

So a green board here means the review lanes are satisfied and says nothing about
whether the code works. `PR Readiness` passing is not equivalent to its passing on
a `main`-based pull request either: it aggregates a set that excludes the tests.

**Merge order, so this is not merged early on a green that does not cover the
code.** The base merges first; GitHub then retargets this to `main`
automatically; the full 63 checks run for the first time at that point; only then
is a green here meaningful.

The stack is still the right shape -- basing this on `main` would recreate the
`monitoring/models.py` and `monitoring/controller.py` conflict the sequencing
exists to prevent, and that conflict is a certainty where this is a deferral. But
it is a deferral, and the deferred half is the tests.

## Manual verification

No user-visible surface, and the behaviour claim rests on the golden digests
captured before the change rather than on inspection. Because CI is not covering
the code here, the local run is doing more work than it normally would, so here is
exactly what it did and did not cover.

Test files run locally, all passing: `test_monitor_behaviour_golden.py`,
`test_github_pull_request_monitor.py`, `test_monitor_controller.py`,
`test_monitor_decision.py`, `test_monitor_persistence.py`, `test_autonudge.py`.
Those are the files this diff touches plus the suites that exercise the changed
boundary. NOT run locally: the rest of the backend suite, all frontend tests, the
builds, E2E, Gateway and Electron tests, CodeQL, and the Windows and
namespace-sandbox shards. Those are the gap, and they close when this retargets to
`main`.

Gates run locally, all passing: the repository's own black gate (diff-scoped),
isort, flake8, `mypy` over `monitoring/` and `autonudge.py` in one invocation, and
the comment-history, sync-IO, subprocess-encoding, brand-name, feature-map,
focus-cue, changelog-history, harness-parity, loop-bound-locks,
builtin-skill-scope, testpaths-coverage, vendored-manifest and docs-lint scans
(the last with its own self-test). NOT run locally: the repository-wide
`mypy src/kiro_crew/`, the frontend gates (this diff has no frontend changes) and
cfn-lint (no templates changed).

## Review rounds

Both design lanes are advisory CONCERNS with no structured findings, so no span
exists and no disposition comment is warranted. Recording the outcomes here.

**Accepted.** `controller.py` logged `ERROR: structured monitor provider gave no
usable result` whenever the resolved result carried `PROVIDER_ERROR`. That status is
carried by BOTH the synthesized fallback and a transient the provider classified
correctly -- and both carry the `provider_transient` reason code -- so a status test
cannot separate them, and every ordinary rate limit was reported at ERROR level as an
absent answer, on every tick. The log moved into `resolve_probe_result`, the only
place that knows which branch it took. No shared type or signature changed, and
`shadow.py`, which logged nothing on that path, now gets the correct log too. The
guard is a controller-level test driving a real tick; it was verified to fail against
the previous behaviour rather than merely to pass against the new one.

**Also declared, previously omitted.** `MonitorProbeResult.__post_init__` refuses a
non-`MonitorObservation` observation and a non-`dict` canonical at construction.

**Held: the spec's monitor section is not stale.** The same-commit rule applies when a
change alters what a spec documents. Measured against
`docs/system-specs/modules/learn-cron-dashboard.md`: it contains ZERO occurrences of
every symbol this PR changes -- `GitHubShadowProvider`, `MonitorProbe`,
`MonitorProbeResult`, `resolve_probe_result`, `GitHubPullRequestProvider`,
`run_shadow_probe`. The probe boundary was never documented at that level, so there is
no single-subject picture in it to correct. What the spec does document is behaviour:
the adapter's URL rules, that `statusCheckRollup` is read in a separate request paired
with `headRefOid`, the ten-page thread cap, and that `MonitorController` accepts only a
public GitHub pull request with the `review_ready` objective. Every one of those
sentences remains true, which the 16,800-row golden table captured on pristine `main`
is the evidence for.

**Held: `MonitorProbeResult.__post_init__` is not subsumed by `resolve_probe_result`.**
The two guard different things at different points. `resolve_probe_result` tests the
object's TYPE (`isinstance(result, MonitorProbeResult)`); `__post_init__` tests its
CONTENTS. Constructing `MonitorProbeResult(canonical="not a dict", observation=None)`
is refused today; without `__post_init__` that same object constructs, satisfies the
type guard, and reaches the decision engine, which reads attributes off `None`.
Verified by running it. The distinction from the sibling change in this stack, which
DID delete a `__post_init__` on the same reasoning, is who constructs the type: there,
a static in-module literal with no external constructor; here, every probe
implementation, which is the extension point this PR exists to create.

**Held: plural arity.** Unchanged from the earlier round. Arity cannot widen later
without touching every implementation and every caller, which is not true of a
defaulted field, so the cost of deferring is not symmetric with the cost of shipping
it now.

## Two commits, and which evidence belongs to which

This PR carries two changes, and the file list flattens a distinction that matters
for reading the second one's evidence. Stating it here because a squash erases it.

**Commit 1 -- `refactor(monitoring): type the probe boundary to a subject, not to
GitHub`.** Owns `monitoring/models.py`, `monitoring/controller.py`,
`monitoring/github_pull_request.py`, `monitoring/shadow.py`, and their tests. This is
the change that is *supposed* to touch shared code: it introduces the shared
`MonitorProbeResult` and the one public `MonitorProbe`, and retypes both consumers
onto them.

**Commit 2 -- `feat(monitoring): register a monitored kind as data, not as four
hardcodes` (#9546).** Owns exactly seven files: `monitoring/registry.py` (new),
`monitoring/shadow.py` (the capability guard only), `validation.py`,
`mcp_tools/control.py`, `dashboard/handlers/autonudge.py`, `autonudge.py`, and
`test/test_monitor_kind_registry.py`.

**Why that split is the acceptance test.** The registry change was accepted on the
condition that registering a kind as data must NOT force a change to the decision
engine, a shared result type, or a shared protocol -- and that if it did, the right
response was to stop rather than to add a branch to a shared layer. It did not.
Commit 2 touches `monitoring/decision.py` zero times, `monitoring/models.py` zero
times, `monitoring/controller.py` zero times, and `monitoring/github_pull_request.py`
zero times. Its only edit to `monitoring/shadow.py` is the capability guard; the
shared protocol in that file was already replaced by commit 1, so commit 2 had no
reason to touch it. The single `class` it adds anywhere is the registry's own
dataclass.

A reader looking at the merged 13-file list sees `models.py` and `controller.py` and
could reasonably conclude the registry reached into shared code. It did not -- those
are commit 1's work. `git show` on either commit separates them.

## Base drift, not authored here

The GPT lane returned `[BLOCK-MERGE]` naming `website/src/apps/aws-control/DrivePage.tsx`
and `website/src/components/FileRenderers.tsx`. This PR touches neither, and touches
nothing under `website/` at all -- all 13 files are under `src/kiro_crew/` or `test/`.
The branch was 50 commits behind main, so the reviewed patch included commits already
merged to main, which is what the First Principles lane independently identified as
base drift. Rebasing onto current main drops that from the reviewed surface. The file
list is byte-identical before and after the rebase, verified by diffing it.

The named finding looks legitimate on its own merits and has been passed to a human as
a candidate issue. It is deliberately NOT fixed here: it is outside this PR's scope,
and an unrelated security change should not ride a refactor.

## A green check set can be computed against a base that no longer exists

Three separate mechanisms produced a misleading result on this pull request in one
day, and they are the same failure wearing three costumes. Recording it because the
next person will meet at least one of them.

1. **A non-main base runs a reduced set.** This PR ran 18 checks while it was stacked,
   against 63 on a main-based one. The 45 absent ones are every test job and every
   deterministic gate, so the reduced board says only that the review lanes are
   satisfied.
2. **A parent merging retargets the child without re-running it.** When the base
   merged, GitHub moved this PR's base pointer to `main` and left the existing check
   runs in place. The page then read `base=main` beside a green computed against the
   old base -- and the one signal a reader had, `base != main`, was gone.
3. **A re-run after an upstream fix replays the ORIGINAL merge ref.** Measured
   directly: the fix for #9675 landed on `main` at 11:04:01Z, a re-run of the failing
   job started at 11:09:59Z, and it failed on the same test with the same
   `Timeout >120.0s`. Re-running never picks up a base-side fix, no matter how long
   you wait.

The shared shape is that **the check set you are reading was computed against a base
that no longer exists**, and in all three the remedy is the same: force a new SHA. A
re-run is not a substitute for a rebase, and a green board is only evidence about the
base it actually ran against.

## Related Issues

no linked issue: this is the second of three sequenced foundation changes for the
monitor substrate, and it closes no tracked defect on its own. The omission is
deliberate.

Based on `feat/monitor-verdict-payload` rather than `main`, because that change is
open and both touch `monitoring/models.py` and `monitoring/controller.py`. The
diff shown here is this change alone; GitHub retargets it to `main` when the base
merges.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, the spec lands separately
- [x] No secrets, credentials, or internal references in the diff



