### PR TITLE
fix(a11y): expose question card option state via aria-pressed (#9492)

### DIFF
--- a/website/src/components/QuestionCard.tsx
+++ b/website/src/components/QuestionCard.tsx
@@ -210,11 +210,18 @@ function QuestionCard({ questions, onSubmit, onDismiss, busy = false, onDraftCha
                       residual strip that jumps away when the animation ends. */}
                   <div className="pt-2.5 flex flex-col gap-1.5">
                   {q.options.map(opt => {
-                    const isSelected = selections[qIdx]?.has(opt.label)
+                    const isSelected = !!selections[qIdx]?.has(opt.label)
                     return (
                       <button
                         key={opt.label}
                         onClick={() => toggleOption(qIdx, opt.label, q.multiSelect ?? false)}
+                        /* WCAG 4.1.2: the selected state must be programmatic, not
+                           CSS-only. aria-pressed (toggle button) in BOTH modes: it
+                           matches multiSelect's independent toggles exactly, and for
+                           single-select it keeps the intended click-again-to-deselect
+                           honest — role=radio would promise a control that cannot be
+                           unchecked by re-activating it, which this one can. */
+                        aria-pressed={isSelected}
                         className={`text-left px-3 py-2 rounded-lg text-[13px] cursor-pointer transition-all border ${
                           isSelected
                             ? 'border-accent text-text bg-accent-subtle/60'

--- a/website/src/test/QuestionCard.test.tsx
+++ b/website/src/test/QuestionCard.test.tsx
@@ -82,16 +82,47 @@ describe('QuestionCard', () => {
     render(<QuestionCard questions={singleQuestion} onSubmit={vi.fn()} />)
     fireEvent.click(screen.getByText('Red').closest('button')!)
     fireEvent.click(screen.getByText('Blue').closest('button')!)
-    expect(screen.getByText('Red').closest('button')!.className).not.toContain('bg-accent-subtle')
-    expect(screen.getByText('Blue').closest('button')!.className).toContain('bg-accent-subtle')
+    expect(screen.getByText('Red').closest('button')!).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByText('Blue').closest('button')!).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('multi-select allows multiple selections', () => {
     render(<QuestionCard questions={multiQuestion} onSubmit={vi.fn()} />)
     fireEvent.click(screen.getByText('Dark mode').closest('button')!)
     fireEvent.click(screen.getByText('Notifications').closest('button')!)
-    expect(screen.getByText('Dark mode').closest('button')!.className).toContain('border-accent')
-    expect(screen.getByText('Notifications').closest('button')!.className).toContain('border-accent')
+    expect(screen.getByText('Dark mode').closest('button')!).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('Notifications').closest('button')!).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('exposes aria-pressed on every option, tracking single-select transitions including deselect', () => {
+    // WCAG 4.1.2 Name/Role/Value: the selected state must be programmatic, not
+    // CSS-only. aria-pressed (toggle button), not role=radio + aria-checked,
+    // because single-select intentionally allows click-again-to-deselect, which
+    // radio semantics forbid.
+    render(<QuestionCard questions={singleQuestion} onSubmit={vi.fn()} />)
+    const red = screen.getByText('Red').closest('button')!
+    const blue = screen.getByText('Blue').closest('button')!
+    expect(red).toHaveAttribute('aria-pressed', 'false')
+    expect(blue).toHaveAttribute('aria-pressed', 'false')
+    fireEvent.click(red)
+    expect(red).toHaveAttribute('aria-pressed', 'true')
+    expect(blue).toHaveAttribute('aria-pressed', 'false')
+    fireEvent.click(red) // deselect: second click on the selected option
+    expect(red).toHaveAttribute('aria-pressed', 'false')
+    expect(blue).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('multi-select toggles aria-pressed independently per option', () => {
+    render(<QuestionCard questions={multiQuestion} onSubmit={vi.fn()} />)
+    const dark = screen.getByText('Dark mode').closest('button')!
+    const notif = screen.getByText('Notifications').closest('button')!
+    fireEvent.click(dark)
+    fireEvent.click(notif)
+    expect(dark).toHaveAttribute('aria-pressed', 'true')
+    expect(notif).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(dark) // independent toggle off; the other keeps its state
+    expect(dark).toHaveAttribute('aria-pressed', 'false')
+    expect(notif).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('submit button disabled when nothing selected', () => {
@@ -122,7 +153,7 @@ describe('QuestionCard', () => {
     fireEvent.click(screen.getByText('Red').closest('button')!)
     const input = screen.getByPlaceholderText('Or type a custom answer...')
     fireEvent.change(input, { target: { value: 'Yellow' } })
-    expect(screen.getByText('Red').closest('button')!.className).not.toContain('bg-accent-subtle')
+    expect(screen.getByText('Red').closest('button')!).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('selecting option clears custom input', () => {


### PR DESCRIPTION
## Problem / Motivation

The ask_question card shows answer options as buttons. When a user picks one, the card only changes the button's colors. A screen reader never hears about it: every option is announced as a plain button, with no way to tell which one is chosen (WCAG 4.1.2 Name/Role/Value). The card's fold toggle already announces its state via `aria-expanded`; the option buttons were the gap.

## Why it matters

A screen-reader user can pick an answer and get no confirmation it is selected. On a multi-question card they cannot review what they are about to submit. The selection state exists only as pixels.

## What changed (motivation → approach → change)

The option button was rendered with only `key`, `onClick`, and `className`, so the selected state lived in CSS classes alone.

Each option button now sets `aria-pressed={isSelected}`. This is the toggle-button pattern, used in both modes. It matches multiSelect exactly: each option is an independent toggle. It also stays honest for single-select, which deliberately supports click-again-to-deselect — `role=radio` + `aria-checked` would promise a control that cannot be unchecked by re-activating it, and this one can (the issue's own analysis flags this). The same fix class landed in #7495 for the chat pin toggle.

The deselect behavior itself is unchanged — the diff touches only the button's attributes and the tests.

## Tests

- New: single-select `aria-pressed` transitions — all options start `false`, picking one flips it to `true`, a second click on it (deselect) returns it to `false`.
- New: multiSelect toggles `aria-pressed` independently per option; toggling one off leaves the other `true`.
- Updated: the single-select-replaces-previous, multi-select, and custom-input-clears-selection tests now assert `aria-pressed` (the programmatic state) instead of CSS class names.
- Kept: one className assertion pinning the selected-state visual styling.

## Manual verification

N/A — unit coverage sufficient: the change is a single ARIA attribute whose true/false transitions are asserted directly in both modes.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the diff adds a non-rendering ARIA attribute; no pixel changes in any state.

## Related Issues

Closes #9492

## Pattern harvest

Rule candidate: review-prompt
Pattern: interactive element whose selected/active state is styled via className with no matching aria-* state attribute

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
