### PR TITLE
test: second side-effect audit — floor the systemd user session, pin Path.home()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ in the **same commit** when you change what it documents.
 | themes | [themes](docs/system-specs/modules/themes.md) + [theming-contract](website/docs/theming-contract.md) |
 | anything under `website/` | [`website/AGENTS.md`](website/AGENTS.md) |
 | user-facing strings, dates, numbers, sort order | [i18n-catalog](website/docs/i18n-catalog.md) (authoring) + [i18n-gates](docs/ci/i18n-gates.md) (CI) |
-| tests: flakes, hangs, speed, memory, fixtures, sharding, side effects, conftest isolation, Windows | [testing-conventions](docs/system-specs/common/testing-conventions.md) + the [writing-tests](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md) skill; frontend and Electron tests: [website/docs/testing.md](website/docs/testing.md) |
+| tests: flakes, hangs, speed, memory, fixtures, sharding, side effects, host state (`~/.kiro`, `Path.home()`, the systemd user manager), conftest isolation, Windows | [testing-conventions](docs/system-specs/common/testing-conventions.md) + the [writing-tests](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md) skill; frontend and Electron tests: [website/docs/testing.md](website/docs/testing.md) |
 | browser E2E | [e2e-gate](docs/ci/e2e-gate.md) |
 | proving a worktree change against an isolated running gateway | [worktree-verification-recipes](docs/guides/worktree-verification-recipes.md) |
 | CI, PR flow, review gates, commit messages | [ci-and-reviews](docs/ci/ci-and-reviews.md) + [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/conftest.py
+++ b/conftest.py
@@ -863,6 +863,89 @@ def _block_host_service_mutation(request, monkeypatch):
     monkeypatch.setattr(os, "execve", guarded_exec)
 
 
+# ── no systemd user session for the test process tree ─────────────────
+
+
+#: The session-bus locators the operator's shell carried, captured before the floor
+#: removes them. ``real_user_session`` hands exactly these back to the one test that
+#: needs the real user manager.
+_REAL_USER_SESSION_ENV_AT_START: dict[str, str] = {
+    name: os.environ[name]
+    for name in ("XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS")
+    if name in os.environ
+}
+
+
+def _reset_cgroup_scope_probe() -> None:
+    """Drop ``sandbox``'s memoised cgroup-scope probe so the next call re-reads the env."""
+    sb = sys.modules.get("kiro_crew.sandbox")
+    if sb is not None:
+        sb._CGROUP_SCOPE_PROBE = None
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _no_systemd_user_session():
+    """Run the whole session, children included, without a systemd user session.
+
+    ``sandbox.cgroup_scope_argv`` wraps a spawn in ``systemd-run --user --scope
+    --slice=kirocrew-agents-<token>.slice`` whenever its probe finds a user session,
+    and the token is a hash of the data home. This floor pins a FRESH ``KIROCREW_HOME``
+    per test, so on a developer host every test that reaches the wrapper -- and every
+    ``kirocrew`` CLI child a test spawns, which probes for itself -- creates a NEW
+    transient slice, and systemd never garbage-collects a slice: five full runs left
+    over 4,000 ``kirocrew-agents-*.slice`` units loaded in the operator's user manager.
+    The same session bus is what let a late reconcile thread run a real
+    ``systemctl --user set-property`` on the operator's agents slice after its test's
+    monkeypatch was undone.
+
+    The probe's own documented gate is ``XDG_RUNTIME_DIR`` ("no systemd user
+    session"), so removing the bus locators for the session is the whole fix: it
+    reaches children through the inherited environment, it cannot be outrun by a
+    thread, and it matches CI, where the runner has no user session either. The
+    host-service guard above cannot do this job -- it sees in-process spawns only.
+
+    A test that needs the real user manager opts in with :func:`real_user_session`.
+    """
+    for name in _REAL_USER_SESSION_ENV_AT_START:
+        os.environ.pop(name, None)
+    _reset_cgroup_scope_probe()
+    try:
+        yield
+    finally:
+        os.environ.update(_REAL_USER_SESSION_ENV_AT_START)
+        _reset_cgroup_scope_probe()
+
+
+@pytest.fixture
+def real_user_session(monkeypatch):
+    """Opt ONE test back into the operator's real systemd user session.
+
+    Skips where the operator has none. On teardown the per-instance agents slice the
+    test's pinned data home maps to is stopped, because systemd would otherwise keep
+    it loaded forever (see :func:`_no_systemd_user_session`). That stop is issued
+    through ``os.posix_spawn`` on purpose: it is cleanup of a unit this very test
+    created, and the host-service guard's ``Popen`` funnel would refuse the verb.
+    """
+    if "XDG_RUNTIME_DIR" not in _REAL_USER_SESSION_ENV_AT_START:
+        pytest.skip("no systemd user session on this host")
+    for name, value in _REAL_USER_SESSION_ENV_AT_START.items():
+        monkeypatch.setenv(name, value)
+    import kiro_crew.sandbox as sb
+
+    monkeypatch.setattr(sb, "_CGROUP_SCOPE_PROBE", None)
+    try:
+        yield
+    finally:
+        slice_name = sb._agents_slice_name()
+        systemctl = shutil.which("systemctl")
+        if systemctl and slice_name != sb._CGROUP_AGENTS_SLICE:
+            pid = os.posix_spawn(
+                systemctl, [systemctl, "--user", "stop", "-q", slice_name], os.environ
+            )
+            os.waitpid(pid, 0)
+        sb._CGROUP_SCOPE_PROBE = None
+
+
 # ── the process working directory is shared state too ─────────────────
 
 
@@ -2236,6 +2319,15 @@ _SHARED_KIRO_PATHS: tuple[tuple[str, str, str], ...] = (
     # leaked into it. This is the sibling-binding case the ratchet's own docstring says
     # it cannot see, which is why the set is enumerated here by hand.
     ("kiro_crew.dashboard.handlers.mcp", "_MCP_LOCK_PATH", ".kiro/settings/mcp.lock"),
+    # RELATIVE in production (``home / _AUTH_STAGING_RELATIVE``, home = ``Path.home()``),
+    # and it must stay so: the sandbox hides ``~/.kiro/crew-auth-staging`` by that
+    # HOME-relative spelling, so deriving it from the data home instead would leave a
+    # relocated ``KIROCREW_HOME``'s staging tree visible to the sandboxed CLI. Pinning
+    # the constant to an ABSOLUTE tmp path still lands, because ``pathlib`` discards
+    # the left operand when the right one is absolute -- so the mkdir+chmod that
+    # ``KiroPrerequisiteService`` performs on construction stops reaching the
+    # operator's real ``~/.kiro`` (fifteen dashboard-server tests did).
+    ("kiro_crew.kiro_prerequisite", "_AUTH_STAGING_RELATIVE", ".kiro/crew-auth-staging"),
 )
 
 
@@ -2473,8 +2565,26 @@ def _is_under(path: pathlib.Path, root: pathlib.Path) -> bool:
     return resolved == root or root in resolved.parents
 
 
+def _test_owned_roots(tmp_path_factory) -> tuple[pathlib.Path, ...]:
+    """This run's own temp trees: pytest's basetemp and the redirected ``tempfile`` base.
+
+    A path under either was created by a fixture or by the test itself, so it is never
+    the operator's -- even when the tree sits INSIDE a guarded root. That happens
+    routinely: a Kiro Crew agent session sets ``TMPDIR`` to its scratch dir under
+    ``~/.kiro/crew/scratch/``, which puts both trees under the real ``~/.kiro``. A fence
+    keyed on the real home alone would then redirect a test that relocated kiro-cli's
+    home to its OWN ``tmp_path`` away from the tree it just built.
+    """
+    roots = [tmp_path_factory.getbasetemp().resolve()]
+    try:
+        roots.append(pathlib.Path(tempfile.gettempdir()).resolve())
+    except OSError:  # pragma: no cover - no usable temp dir at all
+        pass
+    return tuple(roots)
+
+
 @pytest.fixture(autouse=True)
-def _isolate_kiro_sessions_dir(_isolation_dirs, monkeypatch):
+def _isolate_kiro_sessions_dir(_isolation_dirs, monkeypatch, tmp_path_factory):
     """Pin kiro-cli's transcript store (``<kiro home>/sessions/cli``), for EVERY testpath.
 
     A fourth ``~/.kiro`` isolation axis, distinct from the data home, the import-time
@@ -2524,6 +2634,10 @@ def _isolate_kiro_sessions_dir(_isolation_dirs, monkeypatch):
         paths = None
     if paths is not None:
         real_kiro_home = paths.kiro_home
+        own_roots = _test_owned_roots(tmp_path_factory)
+
+        def _test_owned(path: pathlib.Path) -> bool:
+            return any(_is_under(path, owned) for owned in own_roots)
 
         def _pinned_sessions_dir() -> pathlib.Path:
             # A GUARD, not a redirect. The lazy resolver is deliberately left to
@@ -2534,7 +2648,7 @@ def _isolate_kiro_sessions_dir(_isolation_dirs, monkeypatch):
             # ``~/.kiro`` -- the one place a test may never delete from -- answer
             # the isolation dir instead.
             unpinned = real_kiro_home() / "sessions" / "cli"
-            if _is_under(unpinned, _REAL_KIRO_HOME_AT_START):
+            if _is_under(unpinned, _REAL_KIRO_HOME_AT_START) and not _test_owned(unpinned):
                 return root
             return unpinned
 

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -676,6 +676,125 @@ Two things the survey CANNOT tell you, both of which misled the first pass:
   exposes `_clear_caches()` for a module-scoped teardown, because ~160 MB of parsed source
   held for the life of the worker is paid by every later test on it.
 
+The second full-run audit (five backend + five frontend runs against a clean `main`)
+found these further classes. Each one passed on the host that wrote it.
+
+- **A thread count that rises is not yet a leak.** The per-test census flagged `+3` to
+  `+8` threads on dozens of tests. Classified, every one was either a process-wide
+  singleton pool warming up for the first time on that worker (`mc-gov`, `mc-embed`,
+  `mc-subproc`, `sel-writer` — bounded, by design, and shared by every later test) or a
+  loop's default executor thread still winding down after `loop.close()`'s
+  `shutdown(wait=False)`. Neither grows without bound, and the worker end state is a
+  dozen threads. Stopping a singleton per test to make the number go down is the
+  round-one anti-pattern in reverse: it costs every later test a cold pool. Report a
+  thread leak only when the SAME test, repeated, keeps adding threads.
+- **The systemd user manager is host state.** `sandbox.cgroup_scope_argv` wraps a spawn
+  in `systemd-run --user --scope --slice=kirocrew-agents-<token>.slice`, and the token is a
+  hash of the data home. The floor pins a fresh `KIROCREW_HOME` per test, so every test
+  (and every `kirocrew` CLI child a test spawned, which probes for itself) that reached the
+  wrapper created a NEW transient slice — and systemd never garbage-collects a slice. Five
+  runs left 4,000+ `kirocrew-agents-*.slice` units loaded in the operator's user manager,
+  and a late reconcile thread ran a real `systemctl --user set-property` on the operator's
+  agents slice after its test's monkeypatch was undone. Fix: the rootdir conftest runs the
+  whole session with no systemd user session (`XDG_RUNTIME_DIR` and
+  `DBUS_SESSION_BUS_ADDRESS` removed — the probe's own documented gate, inherited by
+  children, and CI parity). The one test that needs real enforcement opts in with the
+  `real_user_session` fixture, which stops the slice it created on teardown. A test that
+  wants to talk to the real user manager has to name it.
+- **`Path.home()` is not pinned, and a resolver that reads it reads the operator.** The pod
+  boot test staged the operator's real `~/.local/share/kiro-cli` sign-in store into the pod
+  home and then resolved and SPAWNED the real kiro-cli from `known_kiro_cli_dirs(Path.home())`
+  — it passed alone and returned `EX_CONFIG` in every full run, because an earlier test on
+  the worker had poisoned the sandbox probe. A dashboard-server fixture `mkdir`+`chmod`ed the
+  real `~/.kiro/crew-auth-staging` through `KiroPrerequisiteService(home=Path.home())`. The
+  data-home pin cannot reach either: they hang off HOME, not `KIROCREW_HOME`. A test whose
+  code path resolves anything from the operator's HOME pins `pathlib.Path.home` (the
+  classmethod) and `HOME` to a fake host home under `tmp_path`; a HOME-relative constant that
+  production must keep (the sandbox hides `~/.kiro/crew-auth-staging` by that spelling) is
+  rebound per test through the rootdir conftest's `_SHARED_KIRO_PATHS` table instead, which
+  works even for a RELATIVE constant because `pathlib` drops the left operand when the right
+  one is absolute.
+- **A resolver that is unpinned ON PURPOSE.** `PodConfig.load()` roots `pods_dir` at the
+  DEFAULT data home so a pod process finds the host's plane rather than its own
+  `KIROCREW_HOME`; the pin therefore cannot reach it. Two refusal tests wrote
+  `<name>.refused` into the operator's real `~/.kiro/crew/pods` — and were red on the
+  macOS runner, where that directory does not exist and a best-effort note silently
+  vanishes. A deliberately host-rooted resolver needs its own lever in every test that
+  reaches it (`KIROCREW_POD_ROOT`, `KIROCREW_POD_ENV_DIR` under `tmp_path`).
+- **A constant derived from a patchable one at import.** `design_tweak`'s `CONFIG_FILE` was
+  computed from `DATA_DIR` at import; tests (and every pin) repoint `DATA_DIR`, so the
+  registry write still landed in the operator's real app config and left it pointing at a
+  pytest tmp path. Derive it at access time (a module `__getattr__`, or a function), and add
+  a test that the written file sits under the pinned dir.
+- **`monkeypatch.undo()` unwinds the FIXTURE's pins too.** A test that called `undo()` on
+  the same `monkeypatch` its fixture had used to pin `KIROCREW_HOME` unpinned the data home
+  mid-test, and its trailing `empty_trash()` wrote the real `~/.kiro/crew/trash` lock. Scope
+  an ad hoc patch with `pytest.MonkeyPatch.context()`; never `undo()` a shared instance.
+- **A fire-and-forget task drains after the pin.** `_start_channel_transports()` detaches
+  `_replay_spooled_inbound()` on purpose; the test never awaited it, so it resolved
+  `data_home()` after teardown and created the real `~/.kiro/crew/inbound-spool`. The
+  drain `_shutdown()` already performs (cancel + `wait_for`) belongs in the test's teardown
+  too — the same rule as the daemon-thread breadcrumb above, one layer up.
+- **A read-only directory under `tmp_path` outlives the run.** A test `chmod`ed a
+  directory to `0o555` and never restored it; pytest's `rm_rf` cannot unlink inside it,
+  renames the tree to `/tmp/pytest-of-<user>/garbage-<uuid>/` and leaves it there forever,
+  one per run. Restore the mode in a finalizer (`request.addfinalizer`).
+- **A process-wide descriptor census is not a leak check.** Three tests compared
+  `len(os.listdir("/proc/self/fd"))` before and after, or re-probed a closed fd with
+  `os.fstat`; the xdist worker has ten-plus live threads (executors, the SEL writer) that
+  open and close descriptors of their own, and a freed fd NUMBER is reissued to any of
+  them. Assert the code's own open/close pairing: spy (wrap, never stub) the primitive the
+  code uses (`os.open`, `tempfile.mkstemp`, `open_write_nofollow`, `os.close`) and assert
+  every descriptor it opened was closed — or, for ordering, that the pinned fd's FIRST
+  `os.close` happened before `rmtree` was entered. `test/test_bench_download_fd.py`,
+  `test/test_session_image_repair.py` and `test/test_meetings_audio_import.py` are the shapes.
+- **A module-global task set gathered across loops, second half.** Round one pruned tasks
+  whose loop was CLOSED; a task from another still-live loop slipped through and
+  `asyncio.gather` raised `attached to a different loop` once in five runs. Drain only what
+  the running loop can await (`task.get_loop() is asyncio.get_running_loop()`); the test
+  module carries the filter, since production never drains the set.
+- **A test about a cold cache must make it cold.** `TestColdCacheModelFallback` asserted
+  three fallback pushes, but `model_registry._ADVERTISED_MODELS` is a module global another
+  test on the worker had warmed, so the id folded to the served spelling and one push went
+  out. Pin the premise (`monkeypatch.setattr(model_registry, "_ADVERTISED_MODELS", {})`).
+- **A probe that depends on the venv's own packaging.** `_pip_install_channel_available()`
+  reads `importlib.util.find_spec("pip")`; a uv-created venv ships no `pip` module, so two
+  tests that meant to exercise the PEP 668 branch failed on every uv host. Pin every probe
+  the function reads, not just the one the test is about.
+- **A test-only import that CREATES the data home.** `test/conftest.py` imports
+  `slack.handler`, which built `_PHASE_EMOJIS` by calling `KiroCrewConfig.load()` at import —
+  and loading resolves `config_dir()`, which `mkdir`s `~/.kiro/crew`. Import-time reads of
+  the data home peek first (`peek_data_home()`) and load only when the file already exists.
+- **Bytecode written into the checkout by import-by-path.** Loading a script with
+  `spec_from_file_location` + `exec_module` writes `__pycache__` beside it —
+  `packaging/signing/`, `.github/scripts/`. Wrap the `exec_module` in a scoped
+  `sys.dont_write_bytecode = True`.
+- **Unbounded `lru_cache`s in a script under test.** `scripts/leaf_test_scope.py` caches the
+  text of every `.py` it scans, exactly right for one CLI run and wrong for a long-lived
+  worker; the test module clears them at module teardown.
+- **Electron: an unref'd backstop timer, and a lazy binary download.** `stopGatewayGracefully`
+  bounded a never-settling tree kill with a `setTimeout(...).unref()`; an unref'd timer
+  cannot keep the loop alive, so when nothing else was pending the loop drained before the
+  backstop fired — 26 `node:test` cases cancelled on Node 22 (the declared floor), passing
+  on the Node 24 CI runner by accident. A backstop the caller awaits must hold the loop.
+  And `require("electron")` in a plain Node process runs `electron/index.js`, which
+  DOWNLOADS the binary into `node_modules` when `dist/` is absent (electron 43 has no
+  postinstall), so four test files raced the network on a fresh checkout. The `test` script
+  now preloads `website/electron/test/_preload.cjs`, which sets `ELECTRON_OVERRIDE_DIST_PATH`
+  before any source loads. Details: [website/docs/testing.md](../../../website/docs/testing.md).
+- **The basetemp can sit INSIDE a guarded root.** A Kiro Crew agent session sets `TMPDIR`
+  to its scratch dir under `~/.kiro/crew/scratch/`, so pytest's basetemp — and every
+  correctly pinned home — resolves inside the real `~/.kiro` while touching nothing of the
+  operator's. The sessions-dir fence and `test_host_isolation_floor.py`'s guard therefore
+  treat this run's own basetemp and `tempfile` root as test-owned (`_test_owned_roots`)
+  and still catch a pin that escapes to the real tree. Sixteen tests were red in every
+  agent-driven run before this.
+
+Two ways to see all of the above on your own machine: run a touched file under
+`trace_home.py`-style tracing (an `sys.addaudithook` that prints the stack of every
+write under the real home — the recipe is in "The measurement" above), and compare
+`systemctl --user list-units --all | grep -c kirocrew-agents` before and after a run.
+
 ### Coverage that only looks like coverage
 
 - `AsyncMock()` for an object with SYNC methods: every sync call site then gets a

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/request_state.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/request_state.py
@@ -34,11 +34,17 @@ class RecordTooLarge(ValueError):
     """A queue record would serialize past the reader's byte ceiling."""
 
 
+def config_file(runtime: Any) -> Path:
+    """The project registry path, derived from the CURRENT ``runtime.DATA_DIR``."""
+
+    return runtime.DATA_DIR / "config.json"
+
+
 def load_config(runtime: Any) -> JsonObject:
-    """Load the registry from ``runtime.CONFIG_FILE``, tolerating bad state."""
+    """Load the registry from :func:`config_file`, tolerating bad state."""
 
     try:
-        config = runtime.json.loads(runtime.CONFIG_FILE.read_text("utf-8"))
+        config = runtime.json.loads(config_file(runtime).read_text("utf-8"))
         if isinstance(config, dict):
             config.setdefault("projects", [])
             config.setdefault("activeId", "")
@@ -52,7 +58,7 @@ def load_config(runtime: Any) -> JsonObject:
 def save_config(runtime: Any, config: JsonObject) -> None:
     """Atomically persist the project registry without the queue-record cap."""
 
-    runtime._atomic_write_json(runtime.CONFIG_FILE, config)
+    runtime._atomic_write_json(config_file(runtime), config)
 
 
 def active_project(runtime: Any) -> JsonObject | None:

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
@@ -153,7 +153,11 @@ else:
 
 QUEUE_DIR = DATA_DIR / "queue"
 HANDLED_DIR = DATA_DIR / "handled"
-CONFIG_FILE = DATA_DIR / "config.json"
+# The project registry lives at ``DATA_DIR / "config.json"`` and is resolved on
+# every access (``request_state.config_file``), never frozen into a constant: a
+# caller that repoints ``DATA_DIR`` to an isolated directory -- the way this
+# module is sandboxed -- must have registry writes follow it, not land under the
+# ``DATA_DIR`` captured at import.
 # Directory creation stays in main(); imports are side-effect-free and never
 # touch the operator's real data home.
 

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -49,7 +49,7 @@ from kiro_crew.config.loader import (
     config_path,
     update_config_locked,
 )
-from kiro_crew.config.paths import kiro_agents_dir
+from kiro_crew.config.paths import kiro_agents_dir, peek_data_home
 from kiro_crew.context import (
     ContextBuilder,
     build_cancelled_turn_preamble,
@@ -298,8 +298,16 @@ def _build_phase_emojis(
     return result, unknown
 
 
+# Import-time, so it must not CREATE anything: ``KiroCrewConfig.load()`` resolves
+# ``config_dir()``, which mkdirs the data home, and this module is imported by
+# every test collector and by read-only tools. With no ``config.json`` on disk
+# there are no overrides to read, so peek first and load only when the file --
+# and therefore the directory -- already exists.
 try:
-    _overrides = KiroCrewConfig.load().slack.reactions
+    if (peek_data_home() / "config.json").is_file():
+        _overrides = KiroCrewConfig.load().slack.reactions
+    else:
+        _overrides = {}
 except Exception:
     logger.warning("Failed to load reaction overrides from config; using defaults", exc_info=True)
     _overrides = {}

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -11614,6 +11614,22 @@ class TestColdCacheModelFallback:
     fallback spellings from the id itself and lets the adapter judge each.
     """
 
+    @pytest.fixture(autouse=True)
+    def _cold_advertised_cache(self, monkeypatch):
+        """Pin the cache these tests are ABOUT to the state their name claims.
+
+        ``_apply_startup_model`` folds the id onto the advertised spelling through
+        ``model_registry.resolve_wire_model_id`` before it pushes anything, and
+        the advertised set is a module global another test on the same xdist
+        worker may have warmed (``claude-sonnet-4-6`` advertised). Warm, the fold
+        collapses ``global.anthropic.claude-sonnet-4-6[1m]`` to the served
+        spelling and the adapter sees ONE push instead of the three fallbacks --
+        a 1-in-5 failure in full runs. Cold is the premise, so pin it.
+        """
+        from kiro_crew import model_registry
+
+        monkeypatch.setattr(model_registry, "_ADVERTISED_MODELS", {})
+
     @staticmethod
     def _claude_client(model):
         from kiro_crew.acp.client import ACP_BACKEND_CLAUDE, AcpClient

--- a/test/test_agent_sdk_boundary.py
+++ b/test/test_agent_sdk_boundary.py
@@ -43,7 +43,32 @@ def _gate():
 
 @pytest.fixture(scope="module")
 def gate():
-    return _gate()
+    """The gate module, with ``_scan`` memoized for the module's lifetime.
+
+    ``_scan(("src",))`` walks and ``ast.parse``s every module under ``src/`` --
+    ~9s a call -- and this test module calls it twice with the identical
+    argument: once directly (``test_every_recorded_violation_still_exists``)
+    and once inside ``seed_baseline`` (``test_seeding_outside_the_checkout_
+    reports_the_file_it_wrote``). Patched on the module object rather than
+    wrapped at the call site so ``seed_baseline``'s own bare-name call -- which
+    resolves ``_scan`` through this module's globals at call time -- goes
+    through the memo too. Keyed on ``targets`` even though every caller here
+    passes ``DEFAULT_TARGETS``, so a future test with a different target set
+    still gets a real scan instead of the wrong cached answer.
+    """
+    module = _gate()
+    memo: dict[tuple[str, ...], dict[str, dict[int, str]]] = {}
+    uncached = module._scan
+
+    def scan(targets: tuple[str, ...]) -> dict[str, dict[int, str]]:
+        if targets not in memo:
+            memo[targets] = uncached(targets)
+        # A copy of the outer dict (and of each inner one) so a caller that
+        # mutates its result cannot poison the memo for the next caller.
+        return {rel: dict(lines) for rel, lines in memo[targets].items()}
+
+    module._scan = scan
+    return module
 
 
 def test_the_sdk_package_exists_and_is_exempt(gate):

--- a/test/test_bench_download_fd.py
+++ b/test/test_bench_download_fd.py
@@ -7,39 +7,34 @@ because evaluating the header is what raised.
 Its loudest symptom is Windows-only (the surviving handle makes `tmp.unlink()`
 raise `PermissionError [WinError 32]`, so the `CorpusFetchError` the handler
 exists to raise never arrives), and CI's Windows shard caught it. But the leak
-itself is platform-independent, so this counts descriptors rather than asserting
-on a Windows error -- otherwise the fix would only be verifiable on the one
-platform that cannot be run locally.
+itself is platform-independent.
+
+`test_a_failed_download_leaks_no_descriptor` does not count PROCESS-WIDE
+descriptors via `/proc/self/fd`: under `-n auto` the worker process has 10+
+live background threads (executors, the SEL writer, the embedding inference
+pool) opening and closing descriptors of their own concurrently, so a
+process-wide count is not deterministic -- it flakes independently of whether
+`_download` itself leaked anything. The test asserts the module's OWN
+open/close pairing instead: spy `open_write_nofollow` (the one primitive
+`_download` uses to acquire a raw fd) and `os.fdopen` (which takes ownership
+of it), and assert that when `urlopen` fails, `open_write_nofollow` is never
+even reached -- so no fd is opened at all for `_download` to leak. That is
+also a stronger assertion than a fd census: it encodes the exact ordering
+invariant the module docstring above describes (the response must be
+acquired before the staging fd is opened), not merely "the process didn't
+gain a descriptor" (which a census can miss if something else in the worker
+happens to close one at the same moment).
 """
 
 from __future__ import annotations
 
-import os
 import urllib.error
 from pathlib import Path
 
 import pytest
 
+from kiro_crew.eval.bench import datasets as _datasets
 from kiro_crew.eval.bench.datasets import CorpusFetchError, _download
-
-
-def _open_fd_count() -> int:
-    """Descriptors held by this process.
-
-    /proc is Linux-only; the fallback keeps the test meaningful elsewhere by
-    probing which low descriptors are live.
-    """
-    proc_fd = Path("/proc/self/fd")
-    if proc_fd.is_dir():
-        return len(list(proc_fd.iterdir()))
-    live = 0
-    for candidate in range(3, 256):
-        try:
-            os.fstat(candidate)
-        except OSError:
-            continue
-        live += 1
-    return live
 
 
 @pytest.mark.parametrize(
@@ -60,15 +55,28 @@ def test_a_failed_download_leaks_no_descriptor(
 
     monkeypatch.setattr("urllib.request.urlopen", boom)
 
-    before = _open_fd_count()
+    opened: list[int] = []
+    real_open_write_nofollow = _datasets.open_write_nofollow
+
+    def tracking_open_write_nofollow(*args: object, **kwargs: object) -> int:
+        fd = real_open_write_nofollow(*args, **kwargs)  # type: ignore[arg-type]
+        opened.append(fd)
+        return fd
+
+    monkeypatch.setattr(_datasets, "open_write_nofollow", tracking_open_write_nofollow)
+
     for _ in range(5):
         # Repeated so a single leaked descriptor is unambiguous rather than lost in
         # the noise of an unrelated allocation.
         with pytest.raises(CorpusFetchError):
             _download("https://x.invalid/c.json", dest)
-    after = _open_fd_count()
 
-    assert after <= before, f"leaked {after - before} descriptor(s) across 5 failures"
+    # urlopen fails before the staging fd's open is ever reached (see the module
+    # docstring's ordering argument), so nothing was opened for `_download` to
+    # leak. If a future edit hoists the open back above `urlopen`, `opened`
+    # gains an entry here and this assertion catches it directly, rather than
+    # relying on a process-wide census to notice the fd it left behind.
+    assert opened == [], f"open_write_nofollow was reached despite urlopen failing: {opened}"
 
 
 @pytest.mark.parametrize(

--- a/test/test_cli_manifest_signature.py
+++ b/test/test_cli_manifest_signature.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import base64
 import hashlib
-import importlib.util
 import json
 import os
 import re
@@ -19,6 +18,7 @@ from pathlib import Path
 import pytest
 import yaml
 from installer_test_helpers import run_bounded
+from skill_script_helpers import load_skill_script
 
 ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "packaging" / "signing" / "cli-manifest.py"
@@ -780,10 +780,9 @@ def test_kms_signer_requires_matching_non_exportable_key_and_verifies_output(
         stderr=subprocess.DEVNULL,
     ).stdout
 
-    spec = importlib.util.spec_from_file_location("cli_manifest_test_helper", HELPER)
-    assert spec is not None and spec.loader is not None
-    helper = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(helper)
+    # Import-by-path writes bytecode beside the source unless suppressed; the
+    # helper does the suppression, so no __pycache__ lands in packaging/signing/.
+    helper = load_skill_script("cli_manifest_test_helper", HELPER)
 
     key_arn = "arn:aws:kms:us-west-2:000000000000:key/test"
     aws_calls: list[list[str]] = []

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -574,8 +574,17 @@ class TestSttPrereqCommands:
 class TestPipInstallChannel:
     @pytest.fixture(autouse=True)
     def _not_bundled(self, monkeypatch):
-        """Pin the desktop-bundle probe; the bundled case has its own test."""
+        """Pin the desktop-bundle and pip-module probes so this class describes
+        the environment it claims to test rather than inheriting the host's —
+        a uv-created venv (the default for `uv venv`) ships no `pip` module, so
+        an unpinned `find_spec("pip")` returns None on this host and every test
+        below that isn't otherwise exercising that branch would misfire."""
         monkeypatch.setattr(shared_mod.platform_compat, "is_bundled_interpreter", lambda: False)
+        monkeypatch.setattr(
+            shared_mod.importlib.util,
+            "find_spec",
+            lambda name, *a, **kw: object() if name == "pip" else None,
+        )
 
     def test_bundled_desktop_interpreter_has_no_channel(self, monkeypatch) -> None:
         """A pip install into the desktop app's code-signed bundle breaks
@@ -587,11 +596,10 @@ class TestPipInstallChannel:
     def test_pipless_interpreter_has_no_channel(self, monkeypatch) -> None:
         """uv tool installs and some pipx layouts ship no `pip` module, so
         `<python> -m pip` fails immediately — the command must not be shown."""
-        real = shared_mod.importlib.util.find_spec
         monkeypatch.setattr(
             shared_mod.importlib.util,
             "find_spec",
-            lambda name, *a: None if name == "pip" else real(name, *a),
+            lambda name, *a, **kw: None,
         )
         assert core_mod._pip_install_channel_available() is False
 

--- a/test/test_design_tweak_project_routes.py
+++ b/test/test_design_tweak_project_routes.py
@@ -343,6 +343,27 @@ class TestProjectsAdd:
         # Was also appended to _CFG
         assert len(server._CFG["projects"]) == 1
 
+    def test_register_valid_folder_persists_under_the_pinned_data_dir(
+        self, isolated_queue, tmp_path, monkeypatch
+    ):
+        """The registry write lands under the `DATA_DIR` this test pinned, not
+        under whatever real home was captured when the module was imported.
+        A `CONFIG_FILE` frozen from `DATA_DIR` at import ignores every later
+        repoint of `DATA_DIR`, so registering a project rewrites the operator's
+        real ~/.kiro/crew/apps/design-tweak/data/config.json -- this pins the
+        derive-at-access seam that keeps the write under the isolated dir."""
+        proj_dir = tmp_path / "webapp"
+        proj_dir.mkdir()
+        monkeypatch.setattr(server, '_detect_dev_servers', lambda root: [])
+        h, rec = _post("/projects", {"path": str(proj_dir)})
+        h._h_projects_add()
+        assert rec.code == 200
+        registry = server.request_state.config_file(server)
+        assert registry == server.DATA_DIR / "config.json"
+        assert registry.is_relative_to(isolated_queue.parent)
+        saved = json.loads(registry.read_text("utf-8"))
+        assert saved["projects"][0]["path"] == str(proj_dir.resolve())
+
     def test_refuses_sensitive_path_ssh(self, isolated_queue, monkeypatch):
         """_valid_root refuses paths containing .ssh; without this, the preview
         would serve private keys over HTTP."""

--- a/test/test_fix_loop_discipline.py
+++ b/test/test_fix_loop_discipline.py
@@ -16,7 +16,6 @@ still there and still pointed at the same names.
 
 from __future__ import annotations
 
-import importlib.util
 import os
 import re
 import shutil
@@ -26,6 +25,7 @@ from typing import Iterator
 
 import pytest
 import yaml
+from skill_script_helpers import load_skill_script
 
 ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE = ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
@@ -207,11 +207,9 @@ class TestHarvestRecognitionMatchesTheGate:
     """
 
     def _module(self):
-        spec = importlib.util.spec_from_file_location("fix_loop_metrics", METRICS_SCRIPT)
-        assert spec and spec.loader
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
+        # Import-by-path writes bytecode beside the source unless suppressed; the
+        # helper does the suppression, so no __pycache__ lands in .github/scripts/.
+        return load_skill_script("fix_loop_metrics", METRICS_SCRIPT)
 
     def test_patterns_are_transcribed_from_the_gate(self) -> None:
         """Drift is silent: both sides keep working, and only the count is wrong."""
@@ -290,11 +288,9 @@ class TestHarvestDenominator:
     """
 
     def _module(self):
-        spec = importlib.util.spec_from_file_location("fix_loop_metrics", METRICS_SCRIPT)
-        assert spec and spec.loader
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
+        # Import-by-path writes bytecode beside the source unless suppressed; the
+        # helper does the suppression, so no __pycache__ lands in .github/scripts/.
+        return load_skill_script("fix_loop_metrics", METRICS_SCRIPT)
 
     @staticmethod
     def _fake_gh(prs: list[dict], run_created: dict[str, str] | None = None):

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -81,14 +81,54 @@ _GUARDED_ROOTS: tuple[pathlib.Path, ...] = (
 )
 
 
+#: pytest's own basetemp for this run, recorded by :func:`_record_own_basetemp`.
+#:
+#: Whatever the operator's ``TMPDIR`` points at, a path under our basetemp is
+#: test-owned by construction -- the floor's fixtures created it. That matters because
+#: a Kiro Crew agent session sets ``TMPDIR`` to its scratch dir under
+#: ``~/.kiro/crew/scratch/``, so every correctly-pinned home then resolves INSIDE the
+#: guarded ``~/.kiro`` tree while touching nothing of the operator's. The guard asks
+#: whether a pin ESCAPED to the real tree, and a path under our own basetemp did not.
+_OWN_BASETEMP: pathlib.Path | None = None
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _record_own_basetemp(tmp_path_factory):
+    global _OWN_BASETEMP
+    _OWN_BASETEMP = tmp_path_factory.getbasetemp().resolve()
+
+
 def _inside_a_guarded_root(path: pathlib.Path) -> bool:
-    """Whether *path* is, or is under, one of the operator's real guarded paths."""
+    """Whether *path* is, or is under, one of the operator's real guarded paths.
+
+    A path under this run's own basetemp is never "the operator's", even when that
+    basetemp itself sits under a guarded root (see :data:`_OWN_BASETEMP`).
+    """
     resolved = path.resolve()
+    if _OWN_BASETEMP is not None and (
+        resolved == _OWN_BASETEMP or resolved.is_relative_to(_OWN_BASETEMP)
+    ):
+        return False
     for root in _GUARDED_ROOTS:
         candidate = root.resolve()
         if resolved == candidate or resolved.is_relative_to(candidate):
             return True
     return False
+
+
+class TestTheGuardItself:
+    """The guard's two edges, pinned so neither can drift silently."""
+
+    def test_the_real_data_home_is_still_guarded(self) -> None:
+        assert _inside_a_guarded_root(pathlib.Path.home() / ".kiro" / "crew")
+
+    def test_our_own_basetemp_is_test_owned_even_under_a_guarded_root(self, monkeypatch) -> None:
+        """A run whose TMPDIR is a Kiro Crew session scratch dir puts basetemp under
+        ``~/.kiro``; a pin there must read as isolated, not as an escape."""
+        scratch = (pathlib.Path.home() / ".kiro" / "crew" / "scratch" / "runtime-x" / "pytest-0").resolve()
+        monkeypatch.setattr(sys.modules[__name__], "_OWN_BASETEMP", scratch)
+        assert not _inside_a_guarded_root(scratch / "i0" / "1-kirocrew-home")
+        assert _inside_a_guarded_root(pathlib.Path.home() / ".kiro" / "crew")
 
 
 # ── the data home ─────────────────────────────────────────────────────────
@@ -442,7 +482,7 @@ class TestTheKiroSessionsDirIsPinnedForEveryTestpath:
         assert not _inside_a_guarded_root(session_map.kiro_sessions_dir().resolve())
 
     def test_the_pin_is_installed_even_when_paths_was_not_imported_before_setup(
-        self, tmp_path, monkeypatch
+        self, tmp_path, monkeypatch, tmp_path_factory
     ) -> None:
         """The floor imports the leaf itself; it does not wait for a test to.
 
@@ -464,7 +504,7 @@ class TestTheKiroSessionsDirIsPinnedForEveryTestpath:
 
         body = _root._isolate_kiro_sessions_dir
         body = getattr(body, "__wrapped__", body)
-        body(lambda name: tmp_path / name, monkeypatch)
+        body(lambda name: tmp_path / name, monkeypatch, tmp_path_factory)
 
         reimported = importlib.import_module("kiro_crew.config.paths")
         assert reimported is not original, "sys.modules eviction did not take"

--- a/test/test_host_service_guard.py
+++ b/test/test_host_service_guard.py
@@ -26,6 +26,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+import source_corpus
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _ROOT_CONFTEST = _REPO_ROOT / "conftest.py"
@@ -133,14 +134,19 @@ def _service_tools_referenced_in_src() -> dict[str, tuple[str, ...]]:
     needing to model every call shape -- the codebase spawns through several
     wrappers (``_run_cmd``, ``_systemctl``, ``sandboxed_spawn_argv``), so a scan
     anchored on stdlib call sites alone would miss most of them.
+
+    No single literal narrows this gate (any vocabulary word could appear
+    without any other), so it walks the whole tree via
+    ``source_corpus.parsed_candidates()`` -- one shared read of the source text
+    and one parse per module, instead of this file re-reading and re-parsing
+    ``src/`` on its own. The RESULT (file:line strings) is tiny and safe to
+    keep memoized for the rest of this module; the corpus's own ~160 MB text
+    cache is what ``test/conftest.py``'s module-scoped
+    ``_release_source_corpus_after_module`` drops at teardown.
     """
     found: dict[str, list[str]] = {}
-    for path in sorted(_SRC.rglob("*.py")):
+    for path, _text, tree in source_corpus.parsed_candidates():
         if "_vendor" in path.parts:
-            continue
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError):
             continue
         skip = _docstring_nodes(tree)
         for node in ast.walk(tree):

--- a/test/test_lazy_data_home_paths.py
+++ b/test/test_lazy_data_home_paths.py
@@ -34,6 +34,7 @@ Keeping the module-level name means existing ``monkeypatch.setattr(mod,
 from __future__ import annotations
 
 import ast
+from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
 from unittest.mock import patch
@@ -103,6 +104,32 @@ def _transitive_path_factories() -> frozenset[str]:
     return _transitive_path_factories_for(SRC, PATHS_MODULE)
 
 
+def _iter_source(src: Path, require_substring: str | None = None) -> Iterator[tuple[Path, str]]:
+    """Yield ``(path, text)`` for every module under ``src``, one at a time.
+
+    ``require_substring`` drops a file before it is even read into the caller's
+    working set for a *cheap* reason: an AST node this scan is looking for
+    (a ``Path`` return annotation, a call to a named factory) can only exist in
+    a file whose raw text already contains that literal, so a file lacking it
+    is never a false negative to skip.
+
+    Deliberately does not retain or return parsed trees between files (unlike
+    an ``lru_cache`` of the whole tree): ``source_corpus.py`` measured that
+    holding ~1300 parsed ASTs live for the caller inflates the interpreter's own
+    generational GC cost enough to make the SUM of two never-retaining passes
+    faster than one retaining pass over the same tree, because every later
+    collection has to trace the retained set. Each file is read, optionally
+    parsed by the caller, and then eligible for collection before the next one.
+    """
+    for py in sorted(src.rglob("*.py")):
+        if "__pycache__" in py.parts:
+            continue
+        text = py.read_text(encoding="utf-8")
+        if require_substring is not None and require_substring not in text:
+            continue
+        yield py, text
+
+
 @lru_cache(maxsize=None)
 def _transitive_path_factories_for(src: Path, paths_module: Path) -> frozenset[str]:
     """Cached by the actual (src, paths_module) pair, for the same monkeypatch
@@ -112,12 +139,14 @@ def _transitive_path_factories_for(src: Path, paths_module: Path) -> frozenset[s
     # Build a map: function_name -> set of names it calls, for every
     # Path-returning function in the tree. We only need function names (not
     # qualified paths) because the guard's detector matches bare call names.
+    #
+    # `require_substring="Path"`: a function can only carry a return
+    # annotation containing "Path" if that literal is somewhere in the file's
+    # raw text, so a file without it is never a Path-returning-function source.
     candidates: dict[str, set[str]] = {}  # name -> called names
-    for py in sorted(src.rglob("*.py")):
-        if "__pycache__" in py.parts:
-            continue
+    for _py, text in _iter_source(src, require_substring="Path"):
         try:
-            tree = ast.parse(py.read_text(encoding="utf-8"))
+            tree = ast.parse(text)
         except SyntaxError:
             continue
         for node in ast.walk(tree):
@@ -187,15 +216,13 @@ def _frozen_path_constants_for(src: Path, paths_module: Path) -> tuple[str, ...]
     reason as ``_path_factories_for``."""
     factories = _transitive_path_factories_for(src, paths_module)
     offenders: list[str] = []
-    for py in sorted(src.rglob("*.py")):
-        if "__pycache__" in py.parts:
-            continue
+    for py, text in _iter_source(src):
         # App-internal test harnesses legitimately capture the real data-home
         # path before monkeypatching (e.g. spec_builder's _REAL_STATE_DIR).
         if "tests" in py.parts:
             continue
         try:
-            tree = ast.parse(py.read_text(encoding="utf-8"))
+            tree = ast.parse(text)
         except SyntaxError:  # pragma: no cover - syntax is enforced elsewhere
             continue
         rel = py.relative_to(src)

--- a/test/test_leaf_test_scope.py
+++ b/test/test_leaf_test_scope.py
@@ -189,6 +189,21 @@ def test_the_mention_scan_leaves_a_clean_leaf_alone(clean_leaf: str) -> None:
 # ── corpus gates: tests that read the test/ tree as data ──────────────────────
 
 
+@pytest.fixture(autouse=True, scope="module")
+def _release_the_scripts_corpus_after_module():
+    """Drop ``leaf_test_scope``'s file caches once this module is done with them.
+
+    ``_iter_python_cached`` / ``_read_cached`` are unbounded ``lru_cache``s over
+    every ``.py`` under ``src/``, ``test/`` and ``scripts/`` -- exact within one
+    process, which is why the script has them, but in an xdist worker they would
+    hold the whole tree's source text for the rest of the session, paid by every
+    later test on that worker. The tests here still share the caches with each other.
+    """
+    yield
+    mod._iter_python_cached.cache_clear()
+    mod._read_cached.cache_clear()
+
+
 @pytest.fixture(scope="module")
 def all_corpus_gates() -> list[str]:
     """``corpus_gates(REPO_ROOT)`` is a pure function of the immutable repo tree

--- a/test/test_lockdown_before_publish.py
+++ b/test/test_lockdown_before_publish.py
@@ -570,12 +570,33 @@ class TestTheRealTree:
         Both tests below independently re-derive `checker.main`'s per-file
         `scan_path` results over the same `src/kiro_crew` tree; walking and
         re-parsing every file twice per test is what made this class slow.
+
+        Narrowed through ``source_corpus.candidate_sources`` rather than a bare
+        `rglob` + re-read + re-parse of every module: `_lockdown_target` can only
+        report a violation from a call to one of the lockdown primitives
+        (`restrict_to_owner` / `chmod_safe` / `chmod` / `fchmod_safe` / `fchmod`),
+        so a file whose text contains none of those names cannot possibly match
+        and is never a false negative to skip. `candidate_sources` shares the
+        one-time corpus read (and its NFKC-normalised copy) with every other
+        ratchet in the suite instead of re-reading `src/` from disk here.
         """
-        src = REPO_ROOT / "src" / "kiro_crew"
+        from source_corpus import candidate_sources  # noqa: PLC0415
+
         found: list[tuple[str, int, str, str]] = []
-        for py in sorted(src.rglob("*.py")):
-            found.extend(checker.scan_path(py, REPO_ROOT))
-        return tuple(found)
+        for path, text in candidate_sources(
+            require_any=("restrict_to_owner", "chmod_safe", "chmod", "fchmod_safe", "fchmod")
+        ):
+            # Same relative-to convention as `scan_path` (relative to REPO_ROOT,
+            # e.g. `src/kiro_crew/...`), so a KNOWN_UNCONVERTED key built from
+            # this scan matches one built from `checker.main`.
+            rel = (
+                path.relative_to(REPO_ROOT).as_posix()
+                if path.is_relative_to(REPO_ROOT)
+                else path.as_posix()
+            )
+            for line, fn, expr in checker.scan_source(text):
+                found.append((rel, line, fn, expr))
+        return tuple(sorted(found))
 
     def test_src_has_no_unclassified_violation(self) -> None:
         """Same pass/fail as `checker.main(["check", <src dir>])`, off the cached scan."""

--- a/test/test_meetings_audio_import.py
+++ b/test/test_meetings_audio_import.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -1077,22 +1078,52 @@ class TestSnapshotPinning:
         assert ai._open_snapshot_pinned(str(snap), witness) is None
 
     @pytest.mark.asyncio
-    async def test_cleanup_task_closes_the_pin_before_removing_the_directory(self, tmp_path):
+    async def test_cleanup_task_closes_the_pin_before_removing_the_directory(
+        self, tmp_path, monkeypatch
+    ):
         """The descriptor rides the shielded cleanup task and is closed in the
         same worker thread BEFORE ``rmtree`` — never on the event loop (the
         AUTOSDE no-blocking-call rule names ``os.close``, GPT review r22), and
-        before the removal because the held handle would block it on Windows."""
+        before the removal because the held handle would block it on Windows.
+
+        Asserted by SPYING on the two calls in the worker, not by re-probing the
+        fd afterwards: under xdist this worker process has other threads
+        (executors, the SEL writer) opening and closing descriptors of their
+        own, so a freed fd NUMBER can be reissued to any of them before the
+        assertion runs and ``os.fstat(fd)`` succeeds again on a stranger's file
+        — the ``/proc/self/fd``-census flake in another shape. The FIRST
+        ``os.close`` of this number is necessarily ours (nobody else holds it
+        until we release it), and ``rmtree`` must be entered only after it.
+        """
         snap_dir = tmp_path / "snapdir"
         snap_dir.mkdir()
         snap = snap_dir / "recording.wav"
         snap.write_bytes(b"x")
         fd = os.open(str(snap), os.O_RDONLY)
 
+        pin_closed = threading.Event()
+        real_close = os.close
+
+        def _spy_close(fd_arg: int, /) -> None:
+            if fd_arg == fd:
+                pin_closed.set()
+            real_close(fd_arg)
+
+        rmtree_saw_pin_closed: list[bool] = []
+        real_rmtree = ai.shutil.rmtree
+
+        def _spy_rmtree(*args: Any, **kwargs: Any) -> None:
+            rmtree_saw_pin_closed.append(pin_closed.is_set())
+            real_rmtree(*args, **kwargs)
+
+        monkeypatch.setattr(ai.os, "close", _spy_close)
+        monkeypatch.setattr(ai.shutil, "rmtree", _spy_rmtree)
+
         await ai._remove_snapshot_dir(None, str(snap_dir), fd)
 
         assert not snap_dir.exists()
-        with pytest.raises(OSError):
-            os.fstat(fd)  # closed by the cleanup worker, not leaked
+        assert pin_closed.is_set()  # closed by the cleanup worker, not leaked
+        assert rmtree_saw_pin_closed == [True]  # and closed BEFORE the removal began
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_platform_cpp_seam_coverage.py
+++ b/test/test_platform_cpp_seam_coverage.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 import pytest
+from source_corpus import source_texts
 
 import kiro_crew
 from kiro_crew.config.loader import KiroCrewConfig
@@ -163,12 +164,21 @@ def _parsed_core_source_files() -> List[Tuple[Path, ast.AST]]:
     paid once per test session — via ``parsed_core_files`` below — instead of once
     per scanner. A file that fails to parse is skipped here, matching the
     defensive behavior both callers previously implemented individually.
+
+    Reads from ``test/source_corpus.py``'s shared, already-cached text of the
+    whole tree instead of a private ``rglob`` + ``read_text``: this scanner's
+    exclusion set (``platform``/``_vendor``) is a subset of files the corpus
+    already read for the other AST ratchets in this worker, so filtering the
+    shared list avoids a second full-tree read the corpus already paid for.
     """
+    core = set(_core_source_files())
     parsed: List[Tuple[Path, ast.AST]] = []
-    for path in _core_source_files():
+    for path, text in source_texts():
+        if path not in core:
+            continue
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
+            tree = ast.parse(text)
+        except SyntaxError:  # pragma: no cover - defensive
             continue
         parsed.append((path, tree))
     return parsed

--- a/test/test_pod_child_viability.py
+++ b/test/test_pod_child_viability.py
@@ -26,8 +26,22 @@ from kiro_crew.pod.config import EXIT_REFUSED_UNRECOVERABLE, PodConfig
 
 
 @pytest.fixture
-def cfg() -> PodConfig:
-    return PodConfig.load()
+def cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> PodConfig:
+    """A pod plane under ``tmp_path``.
+
+    ``PodConfig.load()`` roots ``pods_dir`` at the DEFAULT data home on purpose
+    (a pod process must find the host's plane, not its own ``KIROCREW_HOME``), so
+    the data-home pin does not reach it. Unpinned, the refusal tests below wrote
+    ``<name>.refused`` notes into the operator's real ``~/.kiro/crew/pods`` -- and
+    failed on a host where that directory did not exist yet, because the note is
+    written best-effort and its absence reads as "no refusal".
+    """
+    monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+    monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "envs"))
+    (tmp_path / "envs").mkdir()
+    loaded = PodConfig.load()
+    assert loaded.pods_dir == tmp_path / "envs", "the pod plane must be this test's own"
+    return loaded
 
 
 def _fake_cli(tmp_path: Path, body: str) -> Path:

--- a/test/test_pod_seed_scenarios.py
+++ b/test/test_pod_seed_scenarios.py
@@ -354,8 +354,58 @@ class TestBootAppliesTheScenario:
 
     @pytest.fixture
     def booted(self, tmp_path: Path, monkeypatch):
-        """Run ``boot`` for a pod with SEED=<value>; return (rc, home, argv)."""
+        """Run ``boot`` for a pod with SEED=<value>; return (rc, home, argv).
+
+        ``boot`` reaches two host-derived resolvers on every call, not just on
+        a real pod host: ``_seed_pod_os_home`` stages the OPERATOR's real
+        ``~/.local/share/kiro-cli`` / ``~/.local/share/amazon-q`` sign-in store
+        via ``_runtime_auth_store_mappings`` -> ``identity_stores.store_mappings
+        (sys.platform, Path.home(), os.environ)``, and
+        ``_probe_pod_child_bootstrap`` resolves and SPAWNS whatever real
+        kiro-cli ``kiro_cli.resolve_kiro_cli`` finds under ``Path.home()``
+        (``acp.client._resolve_kiro_bin`` defaults ``home=None`` to
+        ``Path.home()``). Both read the classmethod, not an
+        ``os.path.expanduser`` call, so pinning it here is what keeps every
+        test in this class from touching the operator's real credentials or
+        spawning their real CLI. ``HOME`` is pinned too because
+        ``build_pod_env`` copies ``os.environ.get("HOME", str(Path.home()))``
+        into the pod's own environment, and ``XDG_DATA_HOME`` is cleared
+        because ``identity_stores._source_root`` honours it as an override on
+        the *source* side of the mapping, which would otherwise still point at
+        a real store even under a fake home. ``KIROCREW_KIRO_BIN`` is cleared
+        because ``build_pod_env`` also inherits the operator's whole
+        ``os.environ`` and an override there is deliberately honoured by
+        ``find_kiro_cli_candidates`` ahead of every directory search. ``PATH``
+        is pinned to an empty directory for the same inheritance reason:
+        ``known_kiro_cli_dirs``'s inherited-PATH branch keeps every entry of
+        the REAL ``PATH`` verbatim (``env.augmented_path`` only APPENDS
+        home-templated extras), so a real kiro-cli install directory sitting
+        on the operator's actual ``PATH`` -- independent of ``home`` -- would
+        still resolve and get spawned even with ``Path.home()`` pinned.
+        """
         monkeypatch.setattr(rt, "IS_MACOS", False)
+        fake_host_home = tmp_path / "fake-host-home"
+        fake_host_home.mkdir()
+        empty_path_dir = tmp_path / "empty-path"
+        empty_path_dir.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_host_home))
+        monkeypatch.setenv("HOME", str(fake_host_home))
+        monkeypatch.setenv("PATH", str(empty_path_dir))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.delenv("KIROCREW_KIRO_BIN", raising=False)
+        # `known_kiro_cli_dirs` keys on the REAL `sys.platform`, not on the
+        # patched `rt.IS_MACOS`, and on darwin it appends the fixed install
+        # prefixes (`/opt/homebrew/bin`, `/usr/local/bin`) that derive from
+        # neither the pinned home nor the emptied PATH -- so a brew-installed
+        # kiro-cli on a macOS developer host would still resolve and be spawned.
+        # Confine the search to the fake home so the resolver has nothing to find.
+        from kiro_crew import kiro_cli
+
+        monkeypatch.setattr(
+            kiro_cli,
+            "known_kiro_cli_dirs",
+            lambda platform_name, home, environ, **_kw: [str(home / ".local" / "bin")],
+        )
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
         monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "envs"))
         checkout = tmp_path / "co"
@@ -378,7 +428,25 @@ class TestBootAppliesTheScenario:
             cfg = PodConfig.load()
             rt.write_env_file(cfg, "wt", {"CHECKOUT": str(checkout), "SEED": seed_value})
             rc = rt.boot(cfg, "wt")
-            return rc, cfg.home_dir("wt"), captured
+            home = cfg.home_dir("wt")
+            # The fake host home never had a kiro-cli sign-in store, so the
+            # child-viability probe must report PROBE_UNAVAILABLE (no real
+            # kiro-cli resolved) rather than finding and spawning the
+            # operator's real binary -- and the staged os-home's identity-
+            # store tree (``.local/share/...``, where the real store would
+            # have been copied to) must be empty, holding no files copied in
+            # from the fake host's non-existent store. The ``.aws/sso/cache``
+            # sibling is excluded: it is unconditionally created EMPTY by
+            # ``_seed_pod_os_home`` for the pod's OWN future grants and is not
+            # host-derived.
+            os_home = home / "os-home"
+            staged_store_root = os_home / ".local" / "share"
+            if staged_store_root.is_dir():
+                assert not any(p.is_file() for p in staged_store_root.rglob("*")), (
+                    f"pod os-home staged host-derived files under {staged_store_root}; "
+                    "the fake host home should have had nothing to copy"
+                )
+            return rc, home, captured
 
         return _run
 
@@ -395,6 +463,27 @@ class TestBootAppliesTheScenario:
         assert captured["argv"][0].endswith(rt.prov.venv_bin(Path(".")).name)
         assert captured["env"]["KIROCREW_HOME"] == str(home)
         assert "seeded home from scenario 'minimal'" in capsys.readouterr().out
+
+    def test_the_child_probe_finds_no_real_host_kiro_cli(self, booted) -> None:
+        """The fixture's fake host home must starve the child-viability probe.
+
+        An unpinned ``Path.home()`` here lets
+        ``_probe_pod_child_bootstrap`` resolve and spawn whatever kiro-cli is
+        really installed on the operator's machine. With the fake home in
+        place ``resolve_kiro_cli`` must find nothing under it, so the boot
+        reaches ``rc == 0`` via ``PROBE_UNAVAILABLE`` rather than by actually
+        launching a real binary.
+        """
+        from kiro_crew import kiro_cli as kiro_cli_mod
+
+        # Confirms the premise directly: nothing under the fake host home (or
+        # any directory a real KIROCREW_KIRO_BIN would point at) resolves to
+        # an executable, so a passing boot below is not silently spawning the
+        # operator's real CLI.
+        assert kiro_cli_mod.resolve_kiro_cli() is None
+        rc, _, captured = booted("minimal")
+        assert rc == 0
+        assert "argv" in captured
 
     def test_the_seeded_config_is_sanitized(self, booted) -> None:
         _, home, _ = booted("minimal")

--- a/test/test_public_repo_chip_status.py
+++ b/test/test_public_repo_chip_status.py
@@ -23,6 +23,18 @@ ISSUE_URL = "https://github.com/acme/repo/issues/9"
 GLAB_URL = "https://gitlab.com/grp/sub/-/merge_requests/4"
 
 
+def _visibility_tasks_for(loop: asyncio.AbstractEventLoop) -> list[asyncio.Task]:
+    """The subset of ``source._VISIBILITY_TASKS`` this loop can legally await.
+
+    The set is process-wide, and a task is awaitable only on the loop that created
+    it. ``schedule_visibility_refresh`` prunes entries whose loop is CLOSED, but a
+    task from another still-live loop (the previous test's, torn down a moment
+    later) can sit in the set at drain time, and gathering it raises ``attached to
+    a different loop`` -- once in five full runs here. Drain only what is ours.
+    """
+    return [task for task in list(source._VISIBILITY_TASKS) if task.get_loop() is loop]
+
+
 @pytest.fixture(autouse=True)
 def _clear_caches():
     source._visibility_cache.clear()
@@ -305,7 +317,7 @@ async def test_schedule_dedups_by_repo_and_skips_issue_and_jira(monkeypatch):
         [PR_URL, ISSUE_URL, "https://github.com/acme/repo/pull/99", "not-a-url"]
     )
     # Let the created tasks run.
-    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+    await asyncio.gather(*_visibility_tasks_for(asyncio.get_running_loop()), return_exceptions=True)
     assert calls == [source._visibility_key(source.parse_source_url(PR_URL))]
 
 
@@ -321,7 +333,7 @@ async def test_schedule_respects_fresh_ttl(monkeypatch):
 
     monkeypatch.setattr(source, "_refresh_repo_visibility", fake_refresh)
     source.schedule_visibility_refresh([PR_URL])
-    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+    await asyncio.gather(*_visibility_tasks_for(asyncio.get_running_loop()), return_exceptions=True)
     assert called is False
 
 
@@ -349,7 +361,7 @@ async def test_force_synchronously_invalidates_public_before_refresh(monkeypatch
     await started.wait()
     assert source.is_repo_public(PR_URL) is None
     release.set()
-    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+    await asyncio.gather(*_visibility_tasks_for(asyncio.get_running_loop()), return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -409,7 +421,7 @@ async def test_stale_inflight_positive_cannot_restore_public_across_force(monkey
     # Let the stale positive read complete.
     release.set()
     await asyncio.gather(task, return_exceptions=True)
-    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+    await asyncio.gather(*_visibility_tasks_for(asyncio.get_running_loop()), return_exceptions=True)
     # The stale positive did NOT restore public — is_repo_public stays fail-closed.
     assert source.is_repo_public(PR_URL) is None
 
@@ -457,7 +469,7 @@ async def test_force_public_to_private_transition_queues_hide_update(monkeypatch
         fired["n"] += 1
 
     source.schedule_visibility_refresh([PR_URL], on_update=on_update, force=True)
-    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+    await asyncio.gather(*_visibility_tasks_for(asyncio.get_running_loop()), return_exceptions=True)
     # The hide-the-chip update was queued (public -> private is a rendered flip).
     assert on_update in source._check_update_callbacks or fired["n"] >= 1
     assert source.is_repo_public(PR_URL) is False
@@ -667,3 +679,26 @@ def test_non_owner_public_status_grant_is_sel_audited(monkeypatch):
     # Deduped within the window.
     _project_source_links([_link(PR_URL_2)], False, dashboard_user=True)
     assert len(events) == 1
+
+
+def test_visibility_tasks_for_skips_a_live_foreign_loops_task():
+    """A task another LIVE loop registered must not be handed to this loop's gather.
+
+    The dead-loop prune in ``schedule_visibility_refresh`` cannot see it (its loop is
+    still open), and gathering it raises ``attached to a different loop`` -- the
+    1-in-5 failure the loop-scoped drain exists to remove.
+    """
+    mine = asyncio.new_event_loop()
+    other = asyncio.new_event_loop()
+    try:
+        foreign = other.create_task(asyncio.sleep(0))
+        own = mine.create_task(asyncio.sleep(0))
+        source._VISIBILITY_TASKS.update({foreign, own})
+
+        assert _visibility_tasks_for(mine) == [own]
+        assert _visibility_tasks_for(other) == [foreign]
+        mine.run_until_complete(own)
+        other.run_until_complete(foreign)
+    finally:
+        mine.close()
+        other.close()

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -2470,10 +2470,15 @@ class TestCgroupScopeArgv:
             assert sb._default_max_memory_mb() == sb._CGROUP_FALLBACK_MAX_MEMORY_MB
 
     @pytest.mark.skipif(sys.platform != "linux", reason="cgroup v2 scope enforcement is Linux-only")
+    @pytest.mark.usefixtures("real_user_session")
     def test_real_pids_max_enforced_when_available(self):
         """If this host actually has cgroup delegation, the scope must ENFORCE
         pids.max — a child under a tiny TasksMax cannot fork past it. Skips
-        cleanly where delegation is unavailable (the probe returns False)."""
+        cleanly where delegation is unavailable (the probe returns False).
+
+        The floor runs the suite without a systemd user session, so this is the
+        one test that opts back in (``real_user_session``), and that fixture stops
+        the transient slice the real ``systemd-run`` creates."""
         import kiro_crew.sandbox as sb
 
         self._reset_probe()

--- a/test/test_session_image_repair.py
+++ b/test/test_session_image_repair.py
@@ -12,9 +12,11 @@ imported at module level with no skipif guard.
 
 from __future__ import annotations
 
+import errno
 import io
 import json
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -867,6 +869,13 @@ class TestReplacementTranscriptIsLockedDown:
         Same descriptor-ownership hazard as the backup path: the raw fd is ours
         until fdopen takes it, and Windows refuses to unlink a file with an open
         handle -- which would leave a .tmp behind on every failed repair.
+
+        Asserted by tracking the exact descriptor `tempfile.mkstemp` hands back
+        and confirming it is closed, rather than by a process-wide `/proc/self/fd`
+        census: the census counts descriptors opened and closed by the xdist
+        worker's own background threads too, so it flakes independently of
+        whether THIS repair leaked anything. Tracking the one fd this call path
+        owns is deterministic and still fails if the close is ever dropped.
         """
         p = tmp_path / "s.jsonl"
         _write_transcript(p, [_prompt_record((3000, 1200))])
@@ -878,15 +887,26 @@ class TestReplacementTranscriptIsLockedDown:
             raise OSError("icacls failed")
 
         monkeypatch.setattr(sir.platform_compat, "restrict_to_owner", boom)
-        fds_before = len(os.listdir("/proc/self/fd")) if os.path.isdir("/proc/self/fd") else None
+
+        opened: list[int] = []
+        real_mkstemp = tempfile.mkstemp
+
+        def tracking_mkstemp(*args, **kwargs):
+            fd, name = real_mkstemp(*args, **kwargs)
+            opened.append(fd)
+            return fd, name
+
+        monkeypatch.setattr(tempfile, "mkstemp", tracking_mkstemp)
 
         with pytest.raises(OSError, match="icacls failed"):
             sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
 
         assert p.read_bytes() == before  # transcript untouched
         assert not list(tmp_path.glob("*.tmp"))
-        if fds_before is not None:
-            assert len(os.listdir("/proc/self/fd")) <= fds_before
+        assert len(opened) == 1
+        with pytest.raises(OSError) as info:
+            os.fstat(opened[0])
+        assert info.value.errno == errno.EBADF, "the temp file's descriptor was leaked"
 
 
 class TestBackupIsNeverOverwritten:
@@ -962,29 +982,45 @@ class TestBackupIsNeverOverwritten:
         remove. If the fd outlived that, Windows would refuse the unlink (open
         handle) and the stranded empty sidecar would make every later --apply
         raise BackupExistsError -- a permanent block created by a failure that
-        changed nothing. Asserted by count of open descriptors as well as by the
-        absent file, because a leak is invisible from the filesystem alone.
+        changed nothing.
+
+        Asserted by tracking the exact descriptor `os.open` hands back for the
+        sidecar and confirming it is closed, rather than by a process-wide
+        `/proc/self/fd` census: the census counts descriptors opened and closed
+        by the xdist worker's own background threads too, so it flakes
+        independently of whether THIS repair leaked anything.
         """
         p = tmp_path / "s.jsonl"
         _write_transcript(p, [_prompt_record((3000, 1200))])
         report, lines = sir.scan_file(p)
         assert lines is not None
+        sidecar = p.with_suffix(".jsonl.pre-image-repair.bak")
 
         def boom(_path):
             raise OSError("icacls failed")
 
         monkeypatch.setattr(sir.platform_compat, "restrict_to_owner", boom)
 
-        fds_before = len(os.listdir("/proc/self/fd")) if os.path.isdir("/proc/self/fd") else None
+        opened: list[int] = []
+        real_open = os.open
+
+        def tracking_open(target, *args, **kwargs):
+            fd = real_open(target, *args, **kwargs)
+            if str(target) == str(sidecar):
+                opened.append(fd)
+            return fd
+
+        monkeypatch.setattr(os, "open", tracking_open)
 
         with pytest.raises(OSError, match="icacls failed"):
             sir.apply_repair(p, lines, backup=True, expect=report.source_stat)
 
-        sidecar = p.with_suffix(".jsonl.pre-image-repair.bak")
         assert not sidecar.exists()  # nothing stranded to block the retry
         assert not list(tmp_path.glob("*.tmp"))
-        if fds_before is not None:
-            assert len(os.listdir("/proc/self/fd")) <= fds_before  # no leak
+        assert len(opened) == 1
+        with pytest.raises(OSError) as info:
+            os.fstat(opened[0])
+        assert info.value.errno == errno.EBADF, "the sidecar's descriptor was leaked"
 
         # And the retry it would have blocked now works.
         monkeypatch.undo()

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -717,21 +717,30 @@ class TestRestoreIsAllOrNothing:
         def _no_writes_here(*args: object, **kwargs: object) -> None:
             raise AssertionError(f"the full-restore path wrote by name: {args!r}")
 
-        monkeypatch.setattr(session_storage, "atomic_write", _no_writes_here)
-        # A cleanup that DECLINES, which is what makes the stale listing reachable: the
-        # batch stays instead of going away with its manifest.
-        monkeypatch.setattr(session_storage, "_remove_emptied_batch", lambda *a, **k: False)
+        # Scoped to just these two patches: `monkeypatch` is the same instance
+        # the `stores` fixture pins KIROCREW_HOME/KIRO_HOME with, and
+        # `monkeypatch.undo()` unwinds its WHOLE stack in LIFO order, including
+        # entries pushed before this test ever ran. An `undo()` here to restore
+        # `atomic_write` also unpins the data home, and the `empty_trash()` call
+        # below then resolves `trash_root()` against the operator's real
+        # `~/.kiro/crew` and writes a real `trash/session-storage.lock`.
+        with pytest.MonkeyPatch.context() as scoped:
+            scoped.setattr(session_storage, "atomic_write", _no_writes_here)
+            # A cleanup that DECLINES, which is what makes the stale listing reachable: the
+            # batch stays instead of going away with its manifest.
+            scoped.setattr(session_storage, "_remove_emptied_batch", lambda *a, **k: False)
 
-        assert session_storage.restore(batch.batch_id) == 1
+            assert session_storage.restore(batch.batch_id) == 1
 
-        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").read_bytes() == b"c" * 8
-        kept = session_storage.list_trash()
-        assert [b.batch_id for b in kept] == [batch.batch_id], "kept, not removed"
-        # The accepted residual, pinned so that clearing it later is a deliberate change.
-        assert kept[0].sessions == 1, "the listing goes stale rather than being rewritten"
+            assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").read_bytes() == b"c" * 8
+            kept = session_storage.list_trash()
+            assert [b.batch_id for b in kept] == [batch.batch_id], "kept, not removed"
+            # The accepted residual, pinned so that clearing it later is a deliberate change.
+            assert kept[0].sessions == 1, "the listing goes stale rather than being rewritten"
 
         # And the user is not stuck with it: the explicit empty still takes the batch.
-        monkeypatch.undo()
+        # KIROCREW_HOME/KIRO_HOME (set by the `stores` fixture, outside the `with`
+        # above) are still pinned here.
         session_storage.empty_trash()
         assert session_storage.list_trash() == []
 

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import contextlib
 import inspect
 import json
 import logging
@@ -8718,6 +8719,18 @@ class TestChannelSkipReasonAtTransportStart:
 
         monkeypatch.setattr(gw, "_channel_transport_permitted", lambda member: False)
         await orch._start_channel_transports()
+        # `_start_channel_transports` detaches `_replay_spooled_inbound` as a
+        # background task on purpose (a slow platform send must not hold the
+        # gateway's start open), so it can still be resolving `data_home()` on
+        # the event loop after this test's `KIROCREW_HOME` pin is torn down —
+        # the same "background worker resolves its path when it runs" class as
+        # the safety-override breadcrumb publisher. Drain it here the same way
+        # `_shutdown()` does, so no write happens once the pin is gone.
+        replay = orch._inbound_replay_task
+        if replay is not None and not replay.done():
+            replay.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                await asyncio.wait_for(replay, timeout=1.0)
 
     def _channel_records(self, caplog) -> list[logging.LogRecord]:
         names = {f"kiro_crew.{c}.gateway" for c in _UNCREDENTIALED_CHANNEL_TYPES}

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -75,6 +75,8 @@ import ast
 import functools
 from pathlib import Path
 
+from source_corpus import candidate_sources, parsed_candidates
+
 _SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
 
 
@@ -1459,13 +1461,19 @@ def _collect_first_party_flag_sites() -> frozenset[str]:
     ``sandbox.py`` is excluded by design: it OWNS the parameter (``wrap_argv``
     defines it; ``sandboxed_spawn_argv`` threads it through), so its internal
     forwarding is the mechanism under audit, not a spawn site.
+
+    Parses only files whose text already contains ``first_party_fixed_argv``
+    (``test/source_corpus.py``'s shared, narrowed read) instead of re-``rglob``
+    + re-``read_text``-ing the whole tree: the literal must appear verbatim for
+    a keyword of that name to exist, so no candidate is dropped. Cached like
+    the sibling scans, and released with the rest of the corpus by
+    ``test/conftest.py::_release_source_corpus_after_module`` at module end.
     """
     out: set[str] = set()
-    for path in _SRC_ROOT.rglob("*.py"):
+    for path, source in candidate_sources(require_all=(_FIRST_PARTY_KWARG,)):
         rel = path.relative_to(_SRC_ROOT).as_posix()
         if rel == "sandbox.py" or _is_bundled_skill_asset(path):
             continue
-        source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, str(path))
         funcs = [
             n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
@@ -1523,18 +1531,24 @@ def _collect_spawn_functions() -> dict[str, str]:
     function containing a subprocess spawn. ``<module>`` marks a module-level
     spawn (no enclosing function).
 
-    Cached: all six audit tests derive from this one rglob+ast.parse scan of
-    the whole source tree (~2s), so re-scanning per test multiplies pure
-    duplicated wall-clock. The source tree cannot change mid-run and callers
-    only read the mapping, so a shared instance is safe.
+    Cached: all six audit tests derive from this one scan, so re-scanning per
+    test multiplies pure duplicated wall-clock. The source tree cannot change
+    mid-run and callers only read the mapping, so a shared instance is safe.
+    Parses only files whose text already contains one of the spawn attribute
+    or bare-name tokens (``test/source_corpus.py``'s shared, narrowed read)
+    instead of a private ``rglob`` + ``read_text`` of the whole tree: the
+    matched ``ast.Call`` always spells one of these tokens verbatim in the
+    source, so narrowing cannot drop a real spawn site. Released with the rest
+    of the corpus by ``test/conftest.py::_release_source_corpus_after_module``
+    at module end.
     """
     out: dict[str, str] = {}
-    for path in _SRC_ROOT.rglob("*.py"):
+    needles = tuple(_SPAWN_ATTRS | _SPAWN_NAMES)
+    for path, source in candidate_sources(require_any=needles):
         # A skill's own helper scripts are not gateway runtime code paths --
         # see ``_is_bundled_skill_asset`` for why they are out of scope.
         if _is_bundled_skill_asset(path):
             continue
-        source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, str(path))
         funcs = [
             n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
@@ -1790,10 +1804,9 @@ def test_bundled_skill_assets_are_not_imported():
     }
 
     offenders: list[str] = []
-    for path in _SRC_ROOT.rglob("*.py"):
+    for path, _source, tree in parsed_candidates():
         if _is_bundled_skill_asset(path):
             continue
-        tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
         rel = path.relative_to(_SRC_ROOT).as_posix()
         for node in ast.walk(tree):
             names: list[str] = []

--- a/test/test_status_reactions.py
+++ b/test/test_status_reactions.py
@@ -1106,3 +1106,68 @@ class TestConcurrentSwapsAreSerialized:
         sink.live.add("eyes")
         await ladder._swap_emoji(None)
         assert sink.live == set()
+
+
+class TestImportDoesNotCreateTheDataHome:
+    """Importing the handler reads reaction overrides but must not ``mkdir`` the home.
+
+    ``_PHASE_EMOJIS`` is built at import from ``slack.reactions``. Loading the
+    config resolves ``config_dir()``, which CREATES ``~/.kiro/crew`` -- so a plain
+    import (every test collector does one, through ``test/conftest.py``) wrote to the
+    operator's real home. With no ``config.json`` there are no overrides to apply, so
+    the import peeks for the file and loads only when it already exists.
+    """
+
+    _PROBE = (
+        "import os, sys, traceback\n"
+        "def hook(ev, args):\n"
+        "    if ev == 'os.mkdir' and str(args[0]).startswith(sys.argv[1]):\n"
+        "        sys.stderr.write('mkdir %s\\n' % args[0])\n"
+        "        sys.stderr.write(''.join(traceback.format_stack(limit=12)[:-1]))\n"
+        "sys.addaudithook(hook)\n"
+        "import json\n"
+        "import kiro_crew.slack.handler as h\n"
+        "from kiro_crew.config import paths\n"
+        "print(json.dumps(h._PHASE_EMOJIS))\n"
+        "sys.exit(1 if paths._default_home().exists() != (sys.argv[2] == 'seeded') else 0)\n"
+    )
+
+    def _import_in_a_fresh_interpreter(self, tmp_path, *, seeded: bool):
+        import json
+        import os
+        import subprocess
+        import sys
+
+        home = tmp_path / "home"
+        home.mkdir()
+        if seeded:
+            data = home / ".kiro" / "crew"
+            data.mkdir(parents=True)
+            (data / "config.json").write_text(
+                json.dumps({"slack": {"reactions": {"thinking": "brain"}}}), encoding="utf-8"
+            )
+        env = {k: v for k, v in os.environ.items() if k != "KIROCREW_HOME"}
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        proc = subprocess.run(
+            # ``-B``: the child imports the source package; without it the import
+            # leaves ``__pycache__`` in the checkout.
+            [sys.executable, "-B", "-c", self._PROBE, str(home), "seeded" if seeded else "bare"],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=120,
+        )
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(proc.stdout.strip().splitlines()[-1]), home
+
+    def test_a_fresh_interpreter_import_leaves_an_absent_home_absent(self, tmp_path):
+        emojis, home = self._import_in_a_fresh_interpreter(tmp_path, seeded=False)
+        assert not (home / ".kiro").exists()
+        assert emojis["thinking"] == handler_mod._DEFAULT_PHASE_EMOJIS["thinking"]
+
+    def test_an_existing_config_still_supplies_the_overrides(self, tmp_path):
+        emojis, _ = self._import_in_a_fresh_interpreter(tmp_path, seeded=True)
+        assert emojis["thinking"] == "brain"

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -87,23 +87,26 @@ class TestAgentCanRewrite:
     """Ownership, not current mode bits, decides whether a path is rewritable: the
     owner of a 0555 directory can chmod it writable in one syscall."""
 
-    def test_a_directory_the_caller_owns_is_rewritable_even_at_mode_0555(self, tmp_path):
+    def test_a_directory_the_caller_owns_is_rewritable_even_at_mode_0555(self, tmp_path, request):
         d = tmp_path / "bin"
         d.mkdir()
         d.chmod(0o555)
+        request.addfinalizer(lambda: d.chmod(0o755))
         assert terminal._agent_can_rewrite(str(d), os.geteuid()) is True
 
-    def test_a_directory_owned_by_someone_else_is_not(self, tmp_path):
+    def test_a_directory_owned_by_someone_else_is_not(self, tmp_path, request):
         d = tmp_path / "bin"
         d.mkdir()
         d.chmod(0o555)
+        request.addfinalizer(lambda: d.chmod(0o755))
         assert terminal._agent_can_rewrite(str(d), os.geteuid() + 1) is False
 
-    def test_a_rewritable_ancestor_taints_the_path(self, tmp_path):
+    def test_a_rewritable_ancestor_taints_the_path(self, tmp_path, request):
         outer = tmp_path / "outer"
         inner = outer / "bin"
         inner.mkdir(parents=True)
         inner.chmod(0o555)
+        request.addfinalizer(lambda: inner.chmod(0o755))
         # The caller owns `outer`, so it can rename it and substitute everything
         # underneath, whatever `inner`'s own bits say.
         assert terminal._agent_can_rewrite(str(inner), os.geteuid()) is True
@@ -123,8 +126,17 @@ class TestResolveFenceShells:
         stand in for a system one without needing root to create it."""
         monkeypatch.setattr(os, "geteuid", lambda: os.getuid() + 1)
 
-    def _sysdir(self, tmp_path, names):
-        """A read-only directory of read-only executables, like /usr/bin."""
+    def _sysdir(self, tmp_path, names, request=None):
+        """A read-only directory of read-only executables, like /usr/bin.
+
+        Restores the directory to a writable mode on teardown via a finalizer:
+        left at 0o555, pytest's own tmp_path cleanup cannot unlink entries
+        inside it, so it renames the tree to a `garbage-<uuid>` directory under
+        the shared pytest temp root and leaves it there forever. `request` is
+        optional so a caller with no fixture request (there are none left, but
+        this keeps the helper safe to call standalone) still gets a directory,
+        just without the guaranteed restore.
+        """
         d = tmp_path / "bin"
         d.mkdir(parents=True)
         for name in names:
@@ -132,39 +144,41 @@ class TestResolveFenceShells:
             p.write_text("#!/bin/sh\n")
             p.chmod(0o555)
         d.chmod(0o555)
+        if request is not None:
+            request.addfinalizer(lambda: d.chmod(0o755))
         return d
 
-    def test_reports_shells_beside_the_launched_one(self, tmp_path, monkeypatch):
-        d = self._sysdir(tmp_path, ("bash", "zsh", "fish"))
+    def test_reports_shells_beside_the_launched_one(self, tmp_path, monkeypatch, request):
+        d = self._sysdir(tmp_path, ("bash", "zsh", "fish"), request)
         self._foreign_uid(monkeypatch)
         found = terminal._resolve_fence_shells(str(d / "bash"))
         assert found == {
             "bash": str(d / "bash"), "zsh": str(d / "zsh"), "fish": str(d / "fish"),
         }
 
-    def test_ignores_a_shell_in_another_directory(self, tmp_path, monkeypatch):
-        d = self._sysdir(tmp_path, ("bash",))
-        elsewhere = self._sysdir(tmp_path / "other", ("fish",))
+    def test_ignores_a_shell_in_another_directory(self, tmp_path, monkeypatch, request):
+        d = self._sysdir(tmp_path, ("bash",), request)
+        elsewhere = self._sysdir(tmp_path / "other", ("fish",), request)
         assert (elsewhere / "fish").exists()
         self._foreign_uid(monkeypatch)
         assert terminal._resolve_fence_shells(str(d / "bash")) == {"bash": str(d / "bash")}
 
-    def test_probes_the_directory_rather_than_the_search_path(self, tmp_path, monkeypatch):
-        shims = self._sysdir(tmp_path / "s", ("fish",))
-        d = self._sysdir(tmp_path / "r", ("bash", "fish"))
+    def test_probes_the_directory_rather_than_the_search_path(self, tmp_path, monkeypatch, request):
+        shims = self._sysdir(tmp_path / "s", ("fish",), request)
+        d = self._sysdir(tmp_path / "r", ("bash", "fish"), request)
         monkeypatch.setenv("PATH", str(shims))
         self._foreign_uid(monkeypatch)
         found = terminal._resolve_fence_shells(str(d / "bash"))
         assert found["fish"] == str(d / "fish")
 
-    def test_offers_nothing_from_a_directory_the_gateway_user_owns(self, tmp_path):
+    def test_offers_nothing_from_a_directory_the_gateway_user_owns(self, tmp_path, request):
         # The swap window, and the Homebrew/workspace prefix case: the caller owns
         # this directory, so read-only mode bits are one chmod from irrelevant.
-        d = self._sysdir(tmp_path, ("bash", "fish"))
+        d = self._sysdir(tmp_path, ("bash", "fish"), request)
         assert terminal._resolve_fence_shells(str(d / "bash")) == {}
 
-    def test_skips_a_world_writable_candidate(self, tmp_path, monkeypatch):
-        d = self._sysdir(tmp_path, ("bash",))
+    def test_skips_a_world_writable_candidate(self, tmp_path, monkeypatch, request):
+        d = self._sysdir(tmp_path, ("bash",), request)
         d.chmod(0o755)
         (d / "fish").write_text("#!/bin/sh\n")
         (d / "fish").chmod(0o757)  # anyone may overwrite it before invocation
@@ -174,9 +188,9 @@ class TestResolveFenceShells:
         assert "fish" not in found
         assert found == {"bash": str(d / "bash")}
 
-    def test_skips_a_symlinked_candidate(self, tmp_path, monkeypatch):
-        d = self._sysdir(tmp_path, ("bash",))
-        target = self._sysdir(tmp_path / "elsewhere", ("fish",))
+    def test_skips_a_symlinked_candidate(self, tmp_path, monkeypatch, request):
+        d = self._sysdir(tmp_path, ("bash",), request)
+        target = self._sysdir(tmp_path / "elsewhere", ("fish",), request)
         d.chmod(0o755)
         (d / "fish").symlink_to(target / "fish")
         d.chmod(0o555)

--- a/test/test_windows_kill_probe_audit.py
+++ b/test/test_windows_kill_probe_audit.py
@@ -36,6 +36,8 @@ import ast
 import functools
 from pathlib import Path
 
+from source_corpus import candidate_sources
+
 _SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
 
 # ``file::function`` sites allowed to keep a raw signal-0 probe, with the reason
@@ -90,17 +92,22 @@ def _enclosing_functions(tree: ast.AST) -> list[tuple[str, ast.AST]]:
 def _find_raw_probes() -> dict[str, tuple[int, ...]]:
     """Map ``file::function`` -> line numbers of raw signal-0 probes.
 
-    Cached: the rglob + ast.parse of the whole tree is the same answer for
-    every one of this module's three tests, and the source tree cannot change
-    mid-run. Values are tuples so a cached entry cannot be mutated in place.
+    Cached: the scan is the same answer for every one of this module's three
+    tests, and the source tree cannot change mid-run. Values are tuples so a
+    cached entry cannot be mutated in place. Parses only files whose text
+    already contains ``.kill(`` (``test/source_corpus.py``'s shared, narrowed
+    read) instead of a private ``rglob`` + ``read_text`` of the whole tree: an
+    ``os.kill(pid, 0)`` call always spells ``.kill(`` verbatim, so narrowing
+    cannot drop a real probe. Released with the rest of the corpus by
+    ``test/conftest.py::_release_source_corpus_after_module`` at module end.
     """
     found: dict[str, list[int]] = {}
-    for path in sorted(_SRC_ROOT.rglob("*.py")):
+    for path, source in sorted(candidate_sources(require_any=(".kill(",))):
         rel = path.relative_to(_SRC_ROOT).as_posix()
         if rel.startswith("_vendor/"):
             continue  # vendored third-party code is excluded from all linters
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
+            tree = ast.parse(source)
         except (SyntaxError, UnicodeDecodeError):
             continue
         funcs = _enclosing_functions(tree)

--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -304,6 +304,28 @@ one is a rule:
   the work is real and how it is bounded (the frame budgets), and leave the file-wide
   `testTimeout` alone for everything else.
 
+A later audit ran the Electron `node:test` suite five times on Node 22 — the declared
+floor (`engines.node >=22`), while CI runs 24 — and added two rules:
+
+- **A backstop timer the caller awaits must keep the loop alive.**
+  `stopGatewayGracefully` raced a never-settling tree kill against
+  `setTimeout(...).unref()`. An unref'd timer cannot hold the event loop on its own, so
+  the moment nothing else was pending the loop drained and the surrounding
+  `Promise.race` never resolved; `node --test` then reported "Promise resolution is
+  still pending but the event loop has already resolved" and cancelled every later
+  test in the file (26 of 38). It passed on Node 24 only because that runner happened
+  to keep something else alive. `unref()` a timer only when the process exiting early
+  is the desired outcome — never on a path that is itself awaited.
+- **`require("electron")` in a Node test process downloads the binary.** Outside
+  Electron, `node_modules/electron/index.js` returns the executable path and, when
+  `dist/` is absent, runs `install.js` — a network download and an extract into
+  `node_modules`. Electron 43 has no postinstall, so a fresh `npm ci` leaves `dist/`
+  absent and four test files raced the download concurrently ("File exists (os error
+  17)"). The `test` script preloads `website/electron/test/_preload.cjs` via
+  `node --require`, which sets `ELECTRON_OVERRIDE_DIST_PATH` before any source loads;
+  with that variable set `index.js` returns a path without touching the network. A test
+  never needs the real binary — if yours seems to, it is testing Electron, not our code.
+
 ## Manual procedures
 
 A few flows are deliberately not automated. They are documented rather than

--- a/website/electron/gateway-stop.js
+++ b/website/electron/gateway-stop.js
@@ -312,10 +312,14 @@ async function stopGatewayGracefully(
   if (treeKillInFlight) {
     await Promise.race([
       treeKillInFlight,
-      new Promise((r) => {
-        const t = setTimeout(r, timeoutMs);
-        if (typeof t.unref === "function") t.unref();
-      }),
+      // Deliberately NOT unref()'d. This function is awaited by its caller on a
+      // shutdown path (quit / auto-update), so a live timer here is exactly what
+      // should hold the process open until the backstop fires or the tree kill
+      // settles. An unref'd timer cannot keep the event loop alive on its own;
+      // once nothing else is pending (the common case in a test process, and any
+      // real caller once this is the last outstanding thing) the loop drains and
+      // resolves the surrounding Promise.race before the backstop ever runs.
+      new Promise((r) => { setTimeout(r, timeoutMs); }),
     ]);
   }
 }

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -7,7 +7,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "node --test test/*.test.js mochi/test/*.test.js crew-companion/test/*.test.js",
+    "test": "node --require ./test/_preload.cjs --test test/*.test.js mochi/test/*.test.js crew-companion/test/*.test.js",
     "postinstall": "node scripts/patch-nsis-template.js",
     "dist": "electron-builder",
     "dist:mac": "electron-builder --mac",

--- a/website/electron/test/_preload.cjs
+++ b/website/electron/test/_preload.cjs
@@ -1,0 +1,36 @@
+"use strict";
+
+// Registered via `node --require` in package.json's `test` script, so this
+// runs before ANY test file (or the source it requires) can `require("electron")`.
+//
+// On a plain `node --test` run there is no real Electron process, so
+// `node_modules/electron/index.js` only ever runs its OWN getElectronPath()
+// logic to resolve the path to the Electron *binary* — it is never the
+// Electron runtime's own module, so every named export (app, BrowserWindow,
+// ipcMain, ...) source files destructure from `require("electron")` is
+// `undefined` here regardless of what we do. Tests already work around that by
+// injecting their own fakes for what they need; what THIS file protects is the
+// bare `require("electron")` call not being allowed to reach the network.
+//
+// getElectronPath() downloads the real binary (via install.js, over the
+// network, writing into node_modules/electron/dist) whenever it needs to
+// resolve a dist path and the target file is missing — which is exactly what
+// happens on a fresh `npm ci`: the `electron` package ships no postinstall any
+// more, so `dist/` does not exist until something first resolves the module.
+// With multiple test files requiring "electron" concurrently under `node
+// --test`'s parallel workers, several of them raced that download and the
+// underlying extraction stepped on itself ("File exists (os error 17)").
+//
+// Setting ELECTRON_OVERRIDE_DIST_PATH short-circuits getElectronPath() before
+// it ever looks at dist/ or path.txt, so it returns a path string without
+// touching the network — see node_modules/electron/index.js. The directory
+// need not exist or contain a real binary: nothing under test actually spawns
+// this path, only requires the module for its exports.
+if (!process.env.ELECTRON_OVERRIDE_DIST_PATH) {
+  const os = require("os");
+  const path = require("path");
+  process.env.ELECTRON_OVERRIDE_DIST_PATH = path.join(
+    os.tmpdir(),
+    "kirocrew-electron-test-stub"
+  );
+}


### PR DESCRIPTION
## Problem / Motivation

A second five-run audit of the full suite (backend 91,509 tests × 5, vitest 30,311 × 5, Electron `node:test` × 5) against a clean `main` (`8a9c269b4`), instrumented with an `sys.addaudithook` plugin, inotify on the real home, and before/after snapshots of `~/.kiro`, `/tmp`, the crontab and the systemd user manager. It still touches the operator's machine, still flakes, and still burns CPU on repeated whole-tree scans:

- **Host state.** Every backend run left ~110 `kirocrew-agents-<hex>.slice` units loaded in the user's systemd manager (4,084 accumulated on the audit host). One test **rewrote the operator's real** `~/.kiro/crew/apps/design-tweak/data/config.json` (it now points at a pytest tmp path). The pod boot test staged the operator's real `~/.local/share/kiro-cli` sign-in store into its pod home and **spawned the real kiro-cli**. Fifteen dashboard-server tests `mkdir`+`chmod`ed the real `~/.kiro/crew-auth-staging`; others created `~/.kiro/crew/inbound-spool` and `~/.kiro/crew/trash/…lock`; a read-only tmp dir left a `garbage-<uuid>` tree in `/tmp` every run; import-by-path wrote `__pycache__` into `packaging/` and `.github/`.
- **Deterministic failures on a clean host.** Two `TestPipInstallChannel` tests (a uv venv has no `pip` module), two `test_pod_seed_scenarios` tests (rc 78 once the worker's sandbox probe is poisoned), and 16 `test_host_isolation_floor` tests whenever `TMPDIR` is a Kiro Crew session scratch dir under `~/.kiro` — i.e. whenever an agent runs the suite.
- **Flakes** (1–3 of 5 runs): three `/proc/self/fd` descriptor-census tests, the meetings snapshot-pin test, two `test_public_repo_chip_status` cross-loop drains, `TestColdCacheModelFallback`.
- **Cost.** Nine ratchet files re-scan `src/` per test (15–29 CPU-s each; `test_platform_cpp_seam_coverage` retained ~1 GB per worker).
- **Electron.** 26 tests `cancelledByParent` on Node 22 (the declared `engines` floor; CI runs 24), and `require("electron")` in a test process downloads the binary over the network on a fresh checkout, racing across files.

## Why it matters

The suite is the thing every contributor and every agent runs. A run that edits the operator's live app config, spawns their real kiro-cli, or leaves thousands of units in their systemd manager is not safe to run on a real machine — and an agent session, whose `TMPDIR` lives under `~/.kiro`, could not get the isolation floor green at all. The Electron gap means the frontend suite is red on the minimum supported Node.

## What changed (motivation → approach → change)

Every fix is at the root (a resolver, a seam, a fixture), carries a test that fails when the fix is reverted, and its class is written into [`docs/system-specs/common/testing-conventions.md` § Side effects](docs/system-specs/common/testing-conventions.md) (15 new bullets) and, for Electron, [`website/docs/testing.md`](website/docs/testing.md).

**Floor (rootdir `conftest.py`)**
- `_no_systemd_user_session` (session-scoped): removes `XDG_RUNTIME_DIR`/`DBUS_SESSION_BUS_ADDRESS` — the cgroup-scope probe's own documented gate, inherited by CLI children, CI parity — so no test creates a transient slice. `real_user_session` opts one test back in and stops its slice on teardown (`test_sandbox_argv` real pids.max test uses it). Verified: the 14 heaviest slice-creating files now create 0 slices (was ~110/run).
- `_test_owned_roots`: the sessions-dir fence, and `test_host_isolation_floor`'s guard, treat this run's basetemp/tempfile root as test-owned, so a basetemp inside `~/.kiro` (a Kiro Crew session) is not read as an escape — while a pin landing in the real `~/.kiro/crew` still trips (`TestTheGuardItself` pins both edges).
- `_SHARED_KIRO_PATHS` gains `kiro_prerequisite._AUTH_STAGING_RELATIVE`. Production keeps the HOME-relative spelling (the sandbox hides `~/.kiro/crew-auth-staging` by that path); pinning the relative constant to an absolute tmp path still lands because `pathlib` drops the left operand.

**Production seams**
- `design_tweak/backend/server.py`: `CONFIG_FILE` was frozen from `DATA_DIR` at import, so pins of `DATA_DIR` never reached it — now derived at access time (module `__getattr__`).
- `slack/handler.py`: import-time `KiroCrewConfig.load()` (the round-1 follow-up) peeks for `config.json` first; a fresh interpreter import no longer creates `~/.kiro/crew`.
- `website/electron/gateway-stop.js`: the backstop timer racing a never-settling tree kill is no longer `unref()`'d — an unref'd timer cannot keep the loop alive, so the backstop could never fire when nothing else was pending.
- `website/electron/test/_preload.cjs` (+ `package.json` `test` script): sets `ELECTRON_OVERRIDE_DIST_PATH` before any source loads, so `require("electron")` never downloads.

**Tests fixed at their seam** — `test_pod_seed_scenarios` (fake host home: `Path.home`, `HOME`, empty `PATH`, no `KIROCREW_KIRO_BIN`; asserts nothing host-derived is staged and no real kiro-cli resolves), `test_dashboard_handlers_core_coverage` (pins `find_spec("pip")`), `test_slack_gateway` (drains the fire-and-forget spool replay), `test_session_storage` (`MonkeyPatch.context()` instead of `undo()` on the fixture's instance), `test_terminal_handler` (restores `0o555` dirs), `test_cli_manifest_signature`/`test_fix_loop_discipline` (no bytecode into the checkout), the three fd-census tests and the meetings pin test (spy the code's own open/close; first-close-before-rmtree), `test_acp_client::TestColdCacheModelFallback` (pins `_ADVERTISED_MODELS` cold), `test_public_repo_chip_status` (a test-local loop-scoped drain, `_visibility_tasks_for`, so a live foreign loop's task never reaches `gather`), `test_pod_child_viability` (pod plane under `tmp_path`; the refusal notes went into the real `~/.kiro/crew/pods`), and nine ratchet files reading through `test/source_corpus.py` with identical assertions (`test_platform_cpp_seam_coverage`, `test_spawn_audit`, `test_windows_kill_probe_audit`, `test_host_service_guard`, `test_agent_sdk_boundary`, `test_lockdown_before_publish`, `test_lazy_data_home_paths`, `test_leaf_test_scope` cache release).

**Investigated, deliberately not changed** — the `+3…+8 threads` census hits are singleton pools warming (`mc-*`, `sel-writer`) or a loop's default executor winding down after `shutdown(wait=False)`; worker end state is ~12 threads. Documented as "a rising count is not yet a leak". The load-flipping skips in `test_worktree_create` could not be reproduced at 32 workers after the sandbox `_backend` reset already on `main`; the `test_playwright_cli_installer` skip is a real host defect (a hanging mise-shimmed `npm`).

## Tests

- New: `test_host_isolation_floor.py::TestTheGuardItself` (both guard edges), `test_pod_child_viability.py::cfg` pins with a plane assertion, `test_status_reactions.py::TestImportDoesNotCreateTheDataHome` (fresh-interpreter import leaves `~/.kiro` absent; an existing config still supplies overrides), `test_public_repo_chip_status.py::test_visibility_tasks_for_skips_a_live_foreign_loops_task`, `test_design_tweak_project_routes.py::test_register_valid_folder_persists_under_the_pinned_data_dir`, `test_pod_seed_scenarios.py::test_the_child_probe_finds_no_real_host_kiro_cli`, `test_dashboard_handlers_core_coverage.py::test_pipless_interpreter_has_no_channel`, `TestColdCacheModelFallback::_cold_advertised_cache`.
- Every fix mutation-verified (fix reverted → red → restored), including: warming `_ADVERTISED_MODELS` reproduces the cold-cache failure; swapping close/rmtree order reproduces the meetings failure; re-`unref()`ing the timer reproduces exactly the 26 cancellations; renaming `electron/dist` with the preload shows no download.
- Local: all 24 touched test files + the dependent files (3,838 tests) green under an audit tracer with zero writes under the real `~/.kiro`/`~/workplace`/`~/Repos` and zero new systemd slices; `test_host_isolation_floor` green with `TMPDIR=/tmp` and with a Kiro Crew session scratch `TMPDIR`; Electron `npm test` on Node 22: 1809 pass / 0 cancelled, with and without `dist/`. Gates: black-baseline, isort, flake8, mypy, subprocess-encoding, brand, harness-parity, docs-lint.

## Manual verification

`systemctl --user list-units --all | grep -c kirocrew-agents` before/after the slice-creating files: unchanged (was +110 per full run). The audit data (per-run logs, per-test side-effect attribution, analysis) is on the audit host, not in the PR.

## Related Issues

Follows #9123 / #9139 (round one). Closes the `slack/handler.py` import-time config-load follow-up listed in #9123.

## Pattern harvest

Rule candidate: agents-md / testing-conventions (done in this PR) — "a resolver that reads `Path.home()` or the systemd user manager is host state; pin it per test or fence it in the floor". Lint candidate for later: an import-time `KiroCrewConfig.load()` / `config_dir()` reachable from module top level.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff
