### PR TITLE
ci: stop scheduling the test-durations refresh

### DIFF
--- a/.github/workflows/test-durations.yml
+++ b/.github/workflows/test-durations.yml
@@ -1,17 +1,35 @@
 name: Update Test Durations
 
-# Keeps .test_durations fresh so pytest-split's shards in ci.yml stay balanced
-# by *recorded runtime*. Brand-new tests are auto-assigned the average duration
-# by pytest-split, so sharding degrades gracefully between refreshes -- this job
-# just re-measures periodically and opens a PR with the updated file.
+# Measures per-test runtime into .test_durations so pytest-split's shards in
+# ci.yml can balance by *recorded runtime* instead of by test count.
+#
+# NOT SCHEDULED -- run it by hand when you want fresh numbers. Measured on
+# 2026-09-08 against a full 89,281-test recording:
+#
+#   * balancing by recorded runtime puts every shard at 18.1 min;
+#   * falling back to an even split by COUNT (what pytest-split does when the
+#     file is absent) gives 18.7 / 15.1 / 19.9 / 18.7 -- slowest shard 19.9 min.
+#
+# So the file buys ~1.8 min on the critical path, against a 40-minute shard cap
+# that already has 20 minutes of headroom. It costs an 11.7 MB JSON file whose
+# every value changes on each refresh, so each run rewrote all 89k lines -- a
+# weekly ~90 MB/yr of permanently un-deletable git history, plus a full
+# unsharded suite run and a PR nobody could merge automatically.
+#
+# Trimming the file is NOT a fix: pytest-split charges any test missing from it
+# `sum(kept)/len(kept)`, an average over what SURVIVED the trim. Dropping the
+# fast tests inflates that average (measured 23x), so the slow tests' real
+# signal drowns in fake weight and the split degrades to count-based anyway.
+#
+# Slow tests are still visible without any of this: setup.cfg's addopts carry
+# --durations=5, so every pytest run -- including each CI shard, with coverage
+# on and under real runner contention -- prints its slowest tests.
 #
 # Runs the FULL suite once (no --splits) with --store-durations. main is a
 # protected branch, so instead of committing directly it pushes a feature
 # branch and opens/updates a PR for review.
 
 on:
-  schedule:
-    - cron: "0 7 * * 1" # Mondays 07:00 UTC
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Problem / Motivation

`Update Test Durations` runs the full unsharded suite every Monday to record
per-test runtime into `.test_durations`, so `pytest-split` can balance ci.yml's
four shards by recorded time instead of by test count.

Every value in that file changes on each refresh, so each run rewrote the whole
thing: the last one was **+89,283 / -0** across a single 11.7 MB file. And it
could never land on its own — this org disallows GitHub Actions from opening
pull requests, so the job pushed its branch, downgraded the refusal to a
`::notice::`, and exited green with nothing to show. Both PRs it ever produced
(#7727, #8506) were closed unmerged, so `.test_durations` has never existed on
`main` and the balancing this job exists to enable has never actually been in
effect.

## Why it matters

The cost is permanent: a weekly full-file rewrite of ~89k lines is git history
that cannot be reclaimed later, on the order of 90 MB/yr, plus a full unsharded
suite run and a PR that needs a human every week.

What it buys was never measured. So I measured it.

## What changed (motivation → approach → change)

Measured on 2026-09-08 against the full 89,281-test recording from the branch
that last job produced:

| split strategy | shards (min) | slowest |
|---|---|---|
| by recorded runtime (with the file) | 18.1 / 18.1 / 18.1 / 18.1 | 18.1 |
| by test count (**no file** — the fallback) | 18.7 / 15.1 / 19.9 / 18.7 | 19.9 |

The file buys **~1.8 min** on the critical path, against a shard cap of 40
minutes that already has 20 minutes of headroom. That does not justify the
recording cost, so the schedule goes.

**Shrinking the file instead does not work**, and this is recorded here so it is
not retried. `pytest_split/algorithms.py` charges any test missing from the file
`sum(durations.values()) / len(durations)` — an average over what *survived* the
trim, not over what was removed:

```python
avg_duration_per_test = _get_avg_duration_per_test(durations)
(item, durations.get(item.nodeid, avg_duration_per_test)) for item in items
```

Keeping only tests `>= 50 ms` leaves 9.5% of entries and inflates that average
**23x** (15.7 ms real → 362.1 ms charged). The 80,794 dropped tests then
contribute 487 minutes of fake weight, pytest-split believes the suite takes
538.8 min rather than 72.4, the slow tests' real signal drowns, and the split
degrades to count-based anyway — while still carrying 8,487 entries.

The trigger becomes `workflow_dispatch` only rather than deleting the workflow,
so the measurement stays one click away if the suite ever grows enough to change
this arithmetic. The `refresh` job, its checkout config and its PR-opening step
are all untouched.

`ci.yml` is deliberately **not** modified: `pytest-split` already falls back to
an even count split when the file is absent, which is the state `main` has been
in all along, so `--splits` / `--group` keep working with no change. Four open
PRs currently touch `ci.yml`; staying out of that file keeps this diff
conflict-free.

Slow tests remain visible without any of this — `setup.cfg`'s `addopts` already
carry `--durations=5`, so every pytest run, including each CI shard with
coverage on and under real runner contention, prints its slowest tests.

## Tests

No new tests. Three existing suites assert on this workflow and all keep
passing unchanged, which is why the job was left intact rather than deleted:

- `test/test_ci_failure_annotations.py` — asserts `test-durations.yml:refresh` removes the python problem matcher
- `test/test_coverage_omit_contract.py` — scans every workflow, not just ci.yml
- `test/test_workflow_checkout_credentials.py` — asserts this workflow's `persist-credentials` posture

## Manual verification

- `yaml.safe_load` on the edited file reports triggers `['workflow_dispatch']` — the schedule is gone and nothing else in the `on:` block changed.
- Ran the three suites above: **36 passed**.
- Confirmed no other open PR touches `.github/workflows/test-durations.yml` (checked with `--limit 500`; the four that overlap touch only `ci.yml`).

## Related Issues

no linked issue: CI cost cleanup found while investigating why this job's PRs
were never landing.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a scheduled job that swallows a permission refusal into a `::notice::`
and exits 0 reports success forever while landing nothing — and the value of
what it produces goes unmeasured precisely because nobody sees it fail.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
