### PR TITLE
fix(security): cover chmod 777 flag variants in the chmod-777 deny rule

### DIFF
--- a/src/kiro_crew/security/denied_rules.py
+++ b/src/kiro_crew/security/denied_rules.py
@@ -982,14 +982,15 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
         # mode, so the pattern stays ONE fragment with exact full-input
         # semantics (all three units are ReDoS-screen invisible: ``?``-only
         # groups and a bare ``*`` over a quantifier-free body).
-        # Residuals: long-flag padding (``--verbose``), packs after
-        # ``--recursive``, 4+-letter packs, and quoted operands.
-        pattern=r"chmod(?: -[a-z][a-z]?[a-z]?)?(?: --recursive)?(?: -[a-z])* 777.*",
+        # Residuals: symbolic modes (``a+rwx``/``a=rwx`` are a different grammar),
+        # long-flag padding (``--verbose``), packs after ``--recursive``,
+        # 4+-letter packs, and quoted operands.
+        pattern=r"chmod(?: -[a-z][a-z]?[a-z]?)?(?: --recursive)?(?: -[a-z])* 0?777.*",
         category="local-destructive",
         description=(
             "Blocks chmod 777, which grants world read/write/execute permissions and creates a "
-            "serious security exposure. Packed (-Rv), split (-R -v), and --recursive spellings "
-            "match, with runs of single-letter flags allowed around them."
+            "serious security exposure. Packed (-Rv), split (-R -v), --recursive, and leading-zero "
+            "(0777) spellings match, with runs of single-letter flags allowed around them."
         ),
     ),
     DeniedCommandRule(

--- a/src/kiro_crew/security/denied_rules.py
+++ b/src/kiro_crew/security/denied_rules.py
@@ -977,11 +977,19 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
     ),
     DeniedCommandRule(
         id="local-destructive-chmod-777",
-        pattern="chmod 777.*",
+        # Flag-spelling tolerant with NO ``.*`` gap: one packed flag token, one
+        # ``--recursive``, and any run of single-letter flags may precede the
+        # mode, so the pattern stays ONE fragment with exact full-input
+        # semantics (all three units are ReDoS-screen invisible: ``?``-only
+        # groups and a bare ``*`` over a quantifier-free body).
+        # Residuals: long-flag padding (``--verbose``), packs after
+        # ``--recursive``, 4+-letter packs, and quoted operands.
+        pattern=r"chmod(?: -[a-z][a-z]?[a-z]?)?(?: --recursive)?(?: -[a-z])* 777.*",
         category="local-destructive",
         description=(
             "Blocks chmod 777, which grants world read/write/execute permissions and creates a "
-            "serious security exposure."
+            "serious security exposure. Packed (-Rv), split (-R -v), and --recursive spellings "
+            "match, with runs of single-letter flags allowed around them."
         ),
     ),
     DeniedCommandRule(

--- a/test/fixtures/denied_commands_golden.json
+++ b/test/fixtures/denied_commands_golden.json
@@ -403,9 +403,9 @@
   },
   {
     "id": "local-destructive-chmod-777",
-    "pattern": "chmod(?: -[a-z][a-z]?[a-z]?)?(?: --recursive)?(?: -[a-z])* 777.*",
+    "pattern": "chmod(?: -[a-z][a-z]?[a-z]?)?(?: --recursive)?(?: -[a-z])* 0?777.*",
     "category": "local-destructive",
-    "description": "Blocks chmod 777, which grants world read/write/execute permissions and creates a serious security exposure. Packed (-Rv), split (-R -v), and --recursive spellings match, with runs of single-letter flags allowed around them."
+    "description": "Blocks chmod 777, which grants world read/write/execute permissions and creates a serious security exposure. Packed (-Rv), split (-R -v), --recursive, and leading-zero (0777) spellings match, with runs of single-letter flags allowed around them."
   },
   {
     "id": "local-destructive-chmod-usr",

--- a/test/fixtures/denied_commands_golden.json
+++ b/test/fixtures/denied_commands_golden.json
@@ -403,9 +403,9 @@
   },
   {
     "id": "local-destructive-chmod-777",
-    "pattern": "chmod 777.*",
+    "pattern": "chmod(?: -[a-z][a-z]?[a-z]?)?(?: --recursive)?(?: -[a-z])* 777.*",
     "category": "local-destructive",
-    "description": "Blocks chmod 777, which grants world read/write/execute permissions and creates a serious security exposure."
+    "description": "Blocks chmod 777, which grants world read/write/execute permissions and creates a serious security exposure. Packed (-Rv), split (-R -v), and --recursive spellings match, with runs of single-letter flags allowed around them."
   },
   {
     "id": "local-destructive-chmod-usr",

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -8659,3 +8659,49 @@ class TestHostsAliasPublicationWindow:
         # ``ssh dev-dsk`` shape).
         assert _denied_by("ssh farbox uptime") is None
         assert started == []
+
+
+class TestChmod777FlagVariantsStayDenied:
+    """The chmod-777 rule must not depend on the exact ``chmod 777`` spelling.
+
+    A recursive ``-R`` (packed, split, or ``--recursive``) turns the same mode
+    change into a whole-tree exposure, and padding with ordinary single-letter
+    flags changes nothing about that.
+    """
+
+    def test_flag_variants_are_denied(self):
+        for cmd in (
+            "chmod 777 ~",
+            "chmod 777 /tmp/x",
+            "chmod -R 777 ~",
+            "chmod -R 777 /",
+            "chmod -Rv 777 ~",
+            "chmod -vR 777 ~",
+            "chmod -Rvf 777 ~",
+            "chmod -Rvf 777",
+            "chmod -v -R 777 ~",
+            "chmod -R -v 777 ~",
+            "chmod -R -v -f 777 ~",
+            "chmod -R -v -f -c -v 777 ~",
+            "chmod --recursive 777 ~",
+            "chmod --recursive -v 777 ~",
+            "chmod --recursive -v -v -v 777 ~",
+            "chmod -v --recursive 777 ~",
+            "chmod -f -R 777 ~",
+            "chmod -Rv --recursive -v -v 777 ~",
+            # A quoted program is the same program; an empty word is elided
+            # by the third view -- both reach the rule.
+            '"chmod" -R 777 ~',
+            'chmod "" 777 ~',
+        ):
+            assert is_denied(cmd) is not None, cmd
+
+    def test_other_modes_and_tools_stay_allowed(self):
+        for cmd in (
+            "chmod 775 ~",
+            "chmod -R 775 ~",
+            "chmod +x foo",
+            "chmod -R u+rw ~",
+            "ls -la",
+        ):
+            assert is_denied(cmd) is None, cmd

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -8689,6 +8689,9 @@ class TestChmod777FlagVariantsStayDenied:
             "chmod -v --recursive 777 ~",
             "chmod -f -R 777 ~",
             "chmod -Rv --recursive -v -v 777 ~",
+            # Leading-zero octal is the same mode.
+            "chmod 0777 ~",
+            "chmod -R 0777 ~",
             # A quoted program is the same program; an empty word is elided
             # by the third view -- both reach the rule.
             '"chmod" -R 777 ~',


### PR DESCRIPTION
## Problem / Motivation

The `local-destructive-chmod-777` rule only recognizes the exact `chmod 777` spelling. The same exposure with flags sails through the PreToolUse gate — verified via `is_denied` on current `main`: `chmod -R 777 ~`, `-Rv`/`-vR` packs, split pairs (`-R -v`), and `--recursive` all return None, while bare `chmod 777 ~` is denied.

## Why it matters

`chmod -R 777 ~` makes every file under home (including `~/.ssh`) world-readable and writable. A single flag defeats the rule, and recursive chmod is exactly the shape agents reach for when "fixing" permission problems.

## What changed

One packed flag token, one `--recursive`, and any run of single-letter flags may now precede the mode — with NO `.*` gap, so the pattern stays one fragment with exact full-input semantics (the units are ReDoS-screen invisible: `?`-only groups and a bare `*` over a quantifier-free body). A quoted program (`"chmod" -R 777 ~`) and an empty word (`chmod "" 777 ~`) reach the rule through the existing views. Other modes (`775`, `+x`, symbolic) stay allowed. Residuals documented in-code (long-flag padding, packs after `--recursive`, 4+-letter packs, quoted operands). Golden fixture synced (111 rows, count unchanged).

## Tests

- New `TestChmod777FlagVariantsStayDenied`: 20 deny + 5 allow shapes (red without the fix, green with it).
- Full neighbor suites green: `test_denied_commands_security.py` + `test_security.py` + `test_deny_guidance.py` + `test_denied_commands_hooks.py` + `test_heartbeat_safe_tools.py` + `test_security_regex_linearity.py` — 1931 passed, 2 skipped (pre-existing).
- black gate green.

Fixes 9516


## Pattern harvest
Rule candidate: static check for deny-rule regexes that pin one spelling of equivalent invocations
Pattern: exact-spelling literals like `chmod 777` missing packed/split/long-option flag variants
