### PR TITLE
fix(dashboard): retry a 5xx on hashed assets so a burst cannot black-screen the SPA

### DIFF
--- a/website/public/sw.js
+++ b/website/public/sw.js
@@ -1,5 +1,6 @@
 // Minimal service worker for PWA installability.
-// Network-first for the SPA shell; everything else goes straight to network.
+// Network-first for the SPA shell; hashed assets go to the network with a bounded
+// 5xx retry; everything else goes straight to network.
 //
 // Cache contains ONLY the shell (/ and /index.html). No other responses are
 // cached — hashed assets rely on HTTP immutable caching, and app/API routes
@@ -29,6 +30,55 @@ self.addEventListener('activate', e => {
   self.clients.claim()
 })
 
+// ── Hashed-asset retry ──────────────────────────────────────────────
+// Assets are still NOT cached here — the immutable HTTP cache owns them. What
+// this adds is a bounded retry, because one 502 on a module script is not a
+// degraded page, it is a dead one.
+//
+// A page load asks for the entire module graph at once, and the hop in front of
+// the gateway has a lower real concurrency ceiling than it advertises:
+// `tailscale serve` announces 250 concurrent HTTP/2 streams and starts answering
+// 502 past roughly 140. Measured against a Windows gateway on one connection —
+// 120 streams: 120 OK; 200 streams: 140 OK + 60x502; 247 streams: 143 OK +
+// 104x502. The 502s land on module scripts, so the shell paints its dark skeleton
+// and the app never boots. On a phone that reads as a black screen that no reload
+// clears, because the navigation keeps being served from the shell cache above
+// while the modules keep failing.
+//
+// The failure is capacity-shaped, so the backoff is JITTERED — retrying a whole
+// failed wave on one tick just rebuilds the burst that caused it. Only 5xx and
+// network errors are retried: a 404 means the asset is genuinely gone (a stale
+// shell pointing at a pruned build) and must surface at once instead of costing
+// three round trips. Safe to re-issue `request` without cloning because the fetch
+// handler already returned for every non-GET, and a GET carries no body to
+// consume.
+const ASSET_RETRIES = 2
+const ASSET_RETRY_BASE_MS = 150
+
+async function fetchAssetWithRetry(request) {
+  let lastResponse = null
+  for (let attempt = 0; attempt <= ASSET_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const spread = ASSET_RETRY_BASE_MS * attempt + Math.random() * ASSET_RETRY_BASE_MS
+      await new Promise(resolve => setTimeout(resolve, spread))
+    }
+    try {
+      const resp = await fetch(request)
+      if (resp.status < 500) return resp
+      lastResponse = resp
+    } catch {
+      // Deliberately keeps any 5xx already captured. Clearing it here would let a
+      // later throw downgrade a real status into the synthetic network error the
+      // return below exists to avoid, so a 502-then-dropped-connection sequence
+      // would misreport the gateway's actual answer. A throw itself carries no
+      // status worth recording.
+    }
+  }
+  // Out of attempts. Hand back the last real response when there was one, so the
+  // browser reports the true status rather than a synthetic network failure.
+  return lastResponse || Response.error()
+}
+
 self.addEventListener('fetch', e => {
   if (e.request.method !== 'GET') return
   const url = new URL(e.request.url)
@@ -47,8 +97,13 @@ self.addEventListener('fetch', e => {
   if (url.pathname.startsWith('/sandbox-doc/')) return
   // App backends (e.g. /apps/dev-fleet/api/*)
   if (url.pathname.startsWith('/apps/')) return
-  // Vite content-hashed assets — immutable HTTP cache handles them
-  if (url.pathname.startsWith('/assets/')) return
+  // Vite content-hashed assets — the immutable HTTP cache still owns them, so
+  // nothing is cached here. They are routed through the SW only so a 5xx can be
+  // retried; see fetchAssetWithRetry for why one 502 here is a black screen.
+  if (url.pathname.startsWith('/assets/')) {
+    e.respondWith(fetchAssetWithRetry(e.request))
+    return
+  }
   // Vendor shims, fonts, sprites — stable filenames, no SW caching needed
   if (url.pathname.startsWith('/vendor/')) return
   if (url.pathname.startsWith('/fonts/')) return

--- a/website/src/test/serviceWorkerSkipRules.test.ts
+++ b/website/src/test/serviceWorkerSkipRules.test.ts
@@ -66,10 +66,17 @@ describe('service worker skip rules', () => {
     expect(intercepts('/artifacts')).toBe(true)
   })
 
-  it('leaves the API, app backends and hashed assets to the browser', () => {
+  it('leaves the API and app backends to the browser', () => {
     expect(intercepts('/api/artifacts')).toBe(false)
     expect(intercepts('/apps/dev-fleet/api/state')).toBe(false)
-    expect(intercepts('/assets/App-abc123.js', 'no-cors')).toBe(false)
+  })
+
+  it('DOES take hashed assets over, so a 5xx can be retried', () => {
+    // Not for caching — the immutable HTTP cache still owns them. The worker sits
+    // in the path only so that one 502 on a module script does not kill the page.
+    // The shell above is served from cache, so a module graph that fails leaves a
+    // dark skeleton that no reload clears.
+    expect(intercepts('/assets/App-abc123.js', 'no-cors')).toBe(true)
   })
 })
 
@@ -119,5 +126,100 @@ describe('the shell cache refresh is scoped to the shell', () => {
     const r = shellPutsFor('/app-windows/mochi/panel.html') as unknown as { puts: string[]; settled: Promise<unknown> }
     await r.settled
     expect(r.puts).toEqual([])
+  })
+})
+
+// A page load asks for the whole module graph at once, and the hop in front of the
+// gateway has a lower real concurrency ceiling than it advertises: `tailscale
+// serve` announces 250 concurrent HTTP/2 streams and starts answering 502 past
+// roughly 140. Measured against a Windows gateway on one connection — 120 streams:
+// all 120 OK; 200 streams: 140 OK + 60x502; 247 streams: 143 OK + 104x502. A 502 on
+// a module script is not a degraded page, it is a dead one, and the shell keeps
+// coming from the cache above so no reload escapes it. Hence the retry, and hence
+// these tests: the SW is the only layer that runs when the app cannot boot, so
+// staleShellHeal (a boot-time probe) can never reach this failure.
+/** Drive one asset request with a scripted fetch, and report the attempts made. */
+function assetRequest(steps: Array<number | 'throw'>): {
+  result: Promise<{ status?: number }>
+  attempts: () => number
+} {
+  let calls = 0
+  const listeners: Record<string, (e: unknown) => void> = {}
+  const fakeSelf = {
+    addEventListener: (kind: string, fn: (e: unknown) => void) => { listeners[kind] = fn },
+    location: { origin: ORIGIN },
+    skipWaiting: () => {},
+    clients: { claim: () => {} },
+  }
+  const fakeCaches = {
+    open: async () => ({ addAll: async () => {}, put: async () => {} }),
+    keys: async () => [] as string[],
+    match: async () => undefined,
+    delete: async () => {},
+  }
+  // Past the end of the script the LAST step repeats, so a one-element script
+  // means "always this".
+  const fetchStub = () => {
+    const step = steps[Math.min(calls, steps.length - 1)]
+    calls += 1
+    return step === 'throw'
+      ? Promise.reject(new TypeError('network error'))
+      : Promise.resolve({ status: step })
+  }
+  new Function('self', 'caches', 'fetch', readFileSync(SW_PATH, 'utf8'))(
+    fakeSelf, fakeCaches, fetchStub,
+  )
+  let captured: Promise<{ status?: number }> = Promise.resolve({})
+  listeners.fetch({
+    request: { method: 'GET', url: ORIGIN + '/assets/App-abc123.js', mode: 'no-cors' },
+    respondWith: (p: Promise<{ status?: number }>) => { captured = p },
+  })
+  return { result: captured, attempts: () => calls }
+}
+
+describe('hashed-asset 5xx retry', () => {
+  it('passes a first-try 200 straight through, with no second attempt', async () => {
+    const r = assetRequest([200])
+    expect((await r.result).status).toBe(200)
+    expect(r.attempts()).toBe(1)
+  })
+
+  it('recovers a 502 that succeeds on retry — the black-screen case', async () => {
+    const r = assetRequest([502, 200])
+    expect((await r.result).status).toBe(200)
+    expect(r.attempts()).toBe(2)
+  })
+
+  it('does NOT retry a 404, which is a genuinely missing asset', async () => {
+    // A stale shell pointing at a pruned build must surface at once instead of
+    // costing three round trips per missing module.
+    const r = assetRequest([404])
+    expect((await r.result).status).toBe(404)
+    expect(r.attempts()).toBe(1)
+  })
+
+  it('gives up after a bounded number of attempts and reports the real status', async () => {
+    // Bounded, so a genuinely broken gateway is not hammered; and the LAST real
+    // response is handed back rather than a synthetic network error, so the
+    // browser's console names the actual failure.
+    const r = assetRequest([503])
+    expect((await r.result).status).toBe(503)
+    expect(r.attempts()).toBe(3)
+  })
+
+  it('retries a thrown network error too, and still resolves', async () => {
+    const r = assetRequest(['throw', 200])
+    expect((await r.result).status).toBe(200)
+    expect(r.attempts()).toBe(2)
+  })
+
+  it('keeps a captured 5xx when a later attempt throws', async () => {
+    // The give-up branch promises the browser the TRUE status. A dropped
+    // connection on a later attempt must not downgrade an already-seen 502 into a
+    // synthetic network error — during the burst this fix is for, a 5xx and a
+    // dropped connection arrive together, so this ordering is the common one.
+    const r = assetRequest([502, 'throw'])
+    expect((await r.result).status).toBe(502)
+    expect(r.attempts()).toBe(3)
   })
 })


### PR DESCRIPTION
## Problem / Motivation

On a phone, the dashboard opens over a Tailscale link and shows a black page. Nothing loads. The first scan after setup works. Every later open of the same link is black. Reloading does not clear it.

Only a Windows gateway does this. The same phone against a Mac gateway is fine.

## Why it matters

The phone is unusable. Nothing is shown on screen, so the user has nothing to act on and no reason to suspect the network. It does not recover on its own — every later visit is black too, so the only escape is clearing the site's data by hand.

## What changed (motivation → approach → change)

**Symptom.** The page shell arrives, then no code runs. `index.html` opens with `<html data-theme="dark">`, so an empty shell is a dark rectangle. That is the black screen. The browser console is full of one line: `Failed to load resource: 502` on `/assets/*.js`.

**Root cause.** The shell asks for its whole module graph at once — 252 files on this base. `tailscale serve` tells the browser it allows 250 streams on one connection, then starts answering 502 past about 140. Measured on one HTTP/2 connection to a Windows gateway: 120 streams gave 120 OK; 200 streams gave 140 OK and 60 502s; 247 streams gave 143 OK and 104 502s. The gateway is not the slow part — 247 requests at once over HTTP/1.1 finished in 0.73s, all 200, and 400 connections opened at the same instant were all accepted. The 502s land on module scripts, so the app never boots. It stays black because the service worker keeps handing back the shell it cached on the first visit while the modules keep failing. `website/src/lib/staleShellHeal.ts` cannot reach this: it is a boot-time probe, and this breaks before boot. A desktop browser never sees it, because it talks to `127.0.0.1` over HTTP/1.1 and opens only 6 connections per origin.

**Change.** `/assets` now goes through the service worker, for one reason only: to retry a 5xx or a dropped connection. The backoff is jittered, because the failure is a capacity failure and retrying the whole wave on one tick would rebuild the burst that caused it. Two extra attempts, then it gives up and returns the real status. Nothing is cached there — the immutable HTTP cache still owns hashed assets. A 404 is not retried, because a 404 means the asset is genuinely gone and must fail fast.

```mermaid
flowchart LR
  subgraph Before
    B1[browser asks for a module]:::ctx --> B2[tailscale serve]:::ctx
    B2 --> B3[502 past ~140 streams]:::ctx
    B3 --> B4[app never boots<br/>black screen]:::removed
  end
  subgraph After
    A1[browser asks for a module]:::ctx --> A2[service worker]:::added
    A2 --> A3[tailscale serve]:::ctx
    A3 --> A4[502]:::changed
    A4 --> A5[jittered retry, max 2]:::added
    A5 --> A6[app boots]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 4,5,6 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The worker now sits in front of module requests and asks again when the answer is a 502, so the page boots instead of staying dark.*

## Tests

All in `website/src/test/serviceWorkerSkipRules.test.ts`, which runs the real `public/sw.js` through `new Function` rather than grepping it, so a rule that is present but unreachable still fails.

One assertion changed: hashed assets used to be left to the browser, and are now taken over. It is split into its own case that says why.

Six new cases lock in the retry:

- a first-try 200 passes straight through, with no second attempt
- a 502 that succeeds on retry recovers — the black-screen case
- a 404 is not retried
- it gives up after a bounded number of attempts and hands back the real status
- a thrown network error is retried too
- a 5xx already seen survives a later throw, so a dropped connection cannot downgrade a real 502 into a synthetic network error

## Manual verification

The root cause was measured, not inferred. A Node `http2` client reproduced the 502 knee on the live tailnet host at 120 / 200 / 247 concurrent streams (numbers above). The gateway was cleared the same way: 247 parallel HTTP/1.1 requests, all 200 in 0.73s; 400 simultaneous connects, all accepted; and `mimetypes`, the listen backlog and ephemeral-port exhaustion were each tested and ruled out.

**Not yet verified end to end on a phone.** The fix ships inside the packaged frontend, so confirming it on the device needs a desktop build and install. The retry is covered by unit tests against the real worker file; the device check is still outstanding.

One limit worth stating: a service worker only runs from the second visit onward, so the very first load of a fresh install is not retried. That first load is also the one the user reported as working.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no pixel changes — the diff is service-worker request handling plus its unit tests, with no component, layout, theme or user-visible string touched.

## Related Issues

no linked issue: reported directly, not filed as an issue first.

## Pattern harvest

Rule candidate: review-prompt
Pattern: an offline fallback that caches a shell but not the sub-resources the shell needs, so one transient sub-resource failure becomes a permanent blank page that no reload clears.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
