### PR TITLE
chore(bundle): re-measure the App chunk ceiling (3360 -> 3530 KB)

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -100,9 +100,14 @@ export const CHUNK_BUDGETS = {
   // of every open PR rather than on a new library or surface — the same
   // recurrence the `t` entry above documents. Attribution was measured, not
   // assumed: main's tip alone, with no PR code, reproduces the failure.
-  // 5% headroom, matching the `all` and `t` entries' convention, so ordinary
-  // first-party growth does not re-trip this within days.
-  App: 3360 * KB, // measured 3201 KB on main @ 701f8f981 (~5% headroom)
+  // Re-measured 2026-09-08: four days of ordinary first-party growth took main
+  // @ 6ae74179d to 3,440,273 B (3360 KB) against the 3360 KB ceiling -- 367 B
+  // of headroom, so a PR adding ONE module to the app core (#9437, +1.7 KB)
+  // fails the gate on its merge ref while main itself still passes by a hair.
+  // Same recurrence, same remedy: 5% headroom, matching the `all` and `t`
+  // entries' convention, so ordinary first-party growth does not re-trip this
+  // within days.
+  App: 3530 * KB, // measured 3360 KB on main @ 6ae74179d (~5% headroom)
 
   // Markdown/math/syntax rendering stack (katex, highlight.js, remark/rehype)
   // -- one deliberate `manualChunks` bucket, see vite.config.ts.


### PR DESCRIPTION
## Summary

One-line unblocker: raise the Bundle Size Gate's `App` chunk ceiling from 3360 KB to 3530 KB (~5% headroom over the measured size), with the re-measure recorded in the entry's comment.

## Why

`main` @ `6ae74179d` builds the App chunk at **3,440,273 B** against a **3,440,640 B** ceiling — **367 bytes** of headroom. `main` itself still passes, but any PR that adds a single module to the app core fails `Bundle Size Gate` on its merge ref. First hit: #9437 (+1.7 KB, one new hook module extracted from the chat page controller).

This is the drift recurrence the `App`, `all` and `t` entries in `website/scripts/check-bundle-size.mjs` already document (last re-measured 2026-09-04 at 3201 KB): the ceiling exists to catch a new library or surface landing in the core, not routine first-party growth. Same remedy as before — measured size plus ~5%.

## Attribution (measured, not assumed)

- Pristine `origin/main` worktree, `npx vite build --mode analyze` → `dist/bundle-report.json` App chunk `size: 3440273` (772 modules); gate passes with 367 B to spare.
- #9437 head `6c1a005c2` on the same base → `size: 3441966` (773 modules); gate fails by 1.3 KB.

## Test

- `node scripts/check-bundle-size.mjs` against both reports above: main and the #9437 build both pass under the new ceiling.
- No runtime change; CI script only.
