### PR TITLE
fix(ci): re-measure the drifted t-chunk bundle ceiling

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -75,7 +75,12 @@ export const CHUNK_BUDGETS = {
   // the growth is main's accumulated English strings, and headroom is what was
   // actually missing. 5% headroom, matching the `all` entry's convention above,
   // so the next English string does not re-trip this for the third time.
-  t: 777 * KB, // measured 740 KB on main @ 1cd64b8c9 (~5% headroom)
+  // Re-measured 2026-09-08: main @ 9af9543b0 alone builds the chunk at
+  // 795,127 B (776.5 KB) against the 777 KB ceiling -- 0.07% headroom, the
+  // same drift again (~36 KB of English strings in four days). A feature PR
+  // adding ~40 keys (#8307) trips it on its merge ref while main's own gate
+  // stays green, so the ceiling moves back to the 5% convention.
+  t: 815 * KB, // measured 776.5 KB on main @ 9af9543b0 (~5% headroom)
 
   // Pierre editor implementation (PR #4072 replaced Monaco, whose
   // 'editor.api2' chunk this entry set used to carry) -- the code-editor


### PR DESCRIPTION
## Problem

The `t` chunk (i18n runtime + English catalog) ceiling is 777 KB. Pristine `main` @ `9af9543b0` builds it at **795,127 B = 776.5 KB** — 0.07% headroom (verified locally with `npx vite build --mode analyze` + `node scripts/check-bundle-size.mjs`; same `t-lertjcbp.js` content hash as main's own CI run). Any PR adding a normal set of English keys now fails Bundle Size Gate on its merge ref while main's own gate stays green — first seen on #8307 (+40 keys, 778.9 KB).

This is the third recurrence the file's own comment describes (#8412 for `t`, #8519 for `App`, #8935 for `all`): a ceiling that drifted to <1% headroom fails on routine string growth instead of on the new library it exists to catch.

## Change

One line: `t: 777 * KB` → `t: 815 * KB` (776.5 KB × 1.05, matching the 5% convention used by the `all` and `App` entries), plus the re-measurement note.

## Verification

- `node scripts/check-bundle-size.mjs` on pristine main: 817 chunks within budget.
- `npx eslint scripts/check-bundle-size.mjs`: clean.

Unblocks #8307.


## Pattern harvest

Rule candidate: ci (`main-ratchet-audit.yml`)
Pattern: an allowlisted `CHUNK_BUDGETS` ceiling drifts to <1% headroom on main, so the next feature PR with routine string growth reds Bundle Size Gate on its merge ref while main's own gate stays green. Third occurrence in four days (#8412 `t`, #8519 `App`, #8935 `all`, now `t` again). The audit that already runs on every push to main can build once, compare each allowlisted chunk against its ceiling, and open/flag a re-measure when headroom falls under ~1% — catching the drift before it lands on a contributor's PR.
