### PR TITLE
fix(cron): classify ACP handshake timeout as transient by exception type

### DIFF
--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -411,7 +411,23 @@ class AcpRequestTimeout(AcpRuntimeError):
     the request was waiting on can attach that context before it reaches the
     user. Subclasses the base so existing ``except AcpRuntimeError`` handlers
     keep catching it.
+
+    ``transient = True`` is the retry-eligibility verdict read structurally by
+    ``llm_helpers.acp_error_is_transient`` (via ``getattr(exc, "transient",
+    None)``), the same channel ``AcpError.transient`` uses. Every request that
+    can time out here is a control-plane one — ``_send_and_await`` serves only
+    ``initialize`` / ``session/new`` / ``session/load`` / ``set_mode`` / teardown,
+    never the prompt stream (that path raises ``AcpTimeoutError``). A timeout on
+    any of those means the runtime was slow to answer a handshake, not that the
+    work failed: no prompt was dispatched, so nothing was attempted to fail. A
+    cold-start stall is transient host weather, so the retry layer should try
+    again rather than count it. Carrying the verdict on the type — instead of a
+    ``"timed out"`` string added to ``_TRANSIENT_MARKERS`` — decides eligibility
+    by exception type rather than by message wording, so a reword of the timeout
+    message cannot flip retryability.
     """
+
+    transient = True
 
 
 class AcpRuntimeProtocol(Protocol):

--- a/test/test_acp_handshake_timeout_transient.py
+++ b/test/test_acp_handshake_timeout_transient.py
@@ -1,0 +1,70 @@
+"""A control-plane handshake timeout is transient by exception TYPE.
+
+``_send_and_await`` serves only control-plane requests — ``initialize`` /
+``session/new`` / ``session/load`` / ``set_mode`` / teardown — and raises
+``AcpRequestTimeout`` when the runtime is slow to answer one. No prompt is
+dispatched at any of those stages, so a timeout there means the work was never
+attempted, not that it failed. A cron cold-start stall is transient host
+weather that the retry layer should retry rather than count as a job failure.
+
+The verdict rides on the type: ``AcpRequestTimeout.transient`` is ``True``,
+which ``acp_error_is_transient`` reads structurally (the same channel
+``AcpError.transient`` uses), so the cron callback's transient-retry arm
+(``acp_error_is_transient(exc) and not _prompt_dispatched``) fires. Deciding by
+type rather than by a ``"timed out"`` string in ``_TRANSIENT_MARKERS`` keeps a
+reword of the message from flipping retryability.
+"""
+
+from kiro_crew.acp.client import AcpTimeoutError
+from kiro_crew.acp.session_handle import AcpRequestTimeout, AcpRuntimeError
+from kiro_crew.llm_helpers import acp_error_is_transient
+
+
+class TestHandshakeTimeoutIsStructurallyTransient:
+    def test_request_timeout_is_transient(self) -> None:
+        # The message the runtime raises (runtime.py:_send_and_await).
+        exc = AcpRequestTimeout("Request initialize timed out after 30s")
+        assert acp_error_is_transient(exc)
+
+    def test_verdict_comes_from_type_not_wording(self) -> None:
+        # Message carries no word in _TRANSIENT_MARKERS ("timed out" is not a
+        # marker), so a True verdict can only come from the structural flag.
+        from kiro_crew.llm_helpers import is_transient_backend_error
+
+        exc = AcpRequestTimeout("Request initialize took too long")
+        assert not is_transient_backend_error(str(exc))  # string classifier says no
+        assert acp_error_is_transient(exc)  # type says yes
+
+    def test_flag_lives_on_the_class(self) -> None:
+        # Attribute is on the type, so every instance and subclass-constructed
+        # replacement inherits it without the raise site setting it.
+        assert AcpRequestTimeout.transient is True
+
+    def test_enriched_replacement_stays_transient(self) -> None:
+        # runtime._session_start_stalled raises a fresh AcpRequestTimeout
+        # wrapping the original plus MCP progress; the class attribute survives.
+        original = AcpRequestTimeout("Request session/new timed out after 90s")
+        enriched = AcpRequestTimeout(f"{original} (mcp-server-foo: awaiting)")
+        assert acp_error_is_transient(enriched)
+
+    def test_bare_runtime_error_is_not_transient(self) -> None:
+        # The base class carries no flag and no transient wording, so a plain
+        # AcpRuntimeError fails fast — only the timeout subclass is retried.
+        assert not acp_error_is_transient(AcpRuntimeError("runtime is dead"))
+
+    def test_prompt_timeout_unaffected(self) -> None:
+        # The prompt stream raises AcpTimeoutError (an AcpError), not
+        # AcpRequestTimeout. Its transient verdict is decided elsewhere (raw
+        # error / message); the default is unclassified.
+        assert getattr(AcpTimeoutError("ACP prompt timed out"), "transient", None) is None
+
+
+class TestCronTransientArmFires:
+    """The gateway cron callback retries when
+    ``acp_error_is_transient(exc) and not _prompt_dispatched`` — pin that a
+    handshake timeout satisfies both halves."""
+
+    def test_handshake_timeout_satisfies_the_retry_condition(self) -> None:
+        exc = AcpRequestTimeout("Request initialize timed out after 30s")
+        _prompt_dispatched = False  # no prompt is dispatched at handshake
+        assert acp_error_is_transient(exc) and not _prompt_dispatched


### PR DESCRIPTION
## Problem / Motivation

An agent cron (`persistent_session: true`, `silent: true`) was found `enabled=false, auto_paused=true, consecutive_failures=5, last_error="Request initialize timed out after 30s"` - nine days after it died. Five consecutive wakes each failed at the ACP `initialize` handshake: the freshly spawned `kiro-cli acp` process did not answer the protocol handshake within the 30s control-plane budget. No prompt was dispatched in any of the five runs. A sibling hourly cron on the same gateway ran fine in the same window, so the backend, auth, and agent config were healthy - this was transient cold-start slowness on the host. Nine days later `cron resume` + `cron trigger` succeeded on the first try, confirming nothing about the job was broken.

The root cause this PR fixes (issue #9522, gaps 1 and 2): `AcpRequestTimeout` (`acp/session_handle.py`) subclasses `AcpRuntimeError`, not `AcpError`, so it carries no `.transient` flag. `acp_error_is_transient()` then falls back to string-matching `_TRANSIENT_MARKERS` (`llm_helpers.py`), which has no marker for `timed out`. So the cron callback's transient-retry arm never fired, and a handshake timeout - a state that *prevented* the run rather than a failure *of* it - went straight to `record_failure()`, marching `consecutive_failures` to `_AUTO_PAUSE_THRESHOLD = 5` on pure host weather.

## Why it matters

A silent agent cron is exactly the shape people use for monitoring and audit loops ("only tell me when there is something to act on"). This combination makes such a loop the *least* observable when it dies: the more disciplined the job is about not chattering, the less likely anyone notices it stopped. In the reported case a release-gate label audit was silently offline for nine days.

## What changed

`AcpRequestTimeout` gets a class attribute `transient = True`, which `acp_error_is_transient()` reads structurally via `getattr(exc, "transient", None)` - the same channel `AcpError.transient` uses. With the flag set, the cron callback's existing transient arm (`acp_error_is_transient(exc) and not _prompt_dispatched`, `slack/gateway.py`) fires and retries with the `_CRON_TRANSIENT_RETRIES` backoff instead of recording a failure. No new string marker; no new classifier.

**Why marking a whole exception type transient is safe, not reckless.** `_send_and_await` (`acp/runtime.py`) is the only site that raises `AcpRequestTimeout`, and it serves only control-plane requests - `initialize`, `session/new`, `session/load`, `set_mode`, and teardown. The prompt stream raises a *different* type, `AcpTimeoutError` (an `AcpError`), on a separate path. So every `AcpRequestTimeout` is pre-prompt by construction: no tools have run, nothing was attempted to fail, and a resubmit cannot cause duplicate side effects. Marking the type transient therefore cannot make a mid-prompt failure retryable. `_session_start_stalled` constructs a fresh `AcpRequestTimeout` wrapping the original plus MCP progress; it inherits the class attribute, so the enriched message stays transient.

**Why this is the structural route and not another string marker.** The issue's own diagnosis is that retry eligibility was being decided by *wording* instead of exception type, and it names #7395 as the same root pattern. Adding a `"timed out"` marker to `_TRANSIENT_MARKERS` would fix this instance while extending the mechanism that caused it - a later reword of the timeout message would silently flip retryability. Carrying the verdict on the type removes that failure mode.

**Why the two "prevented run" paths stay separate.** The scheduler already encodes the same principle one layer out: `cron.py`'s `_run_with_timeout` guards `record_failure()` with `run_never_started` ("a state that PREVENTED the run is not a defect OF the run"). This PR does *not* reuse that marker. `run_never_started` is set by the gateway's queue-budget path to mean "every pool worker was busy for the whole queue budget"; reusing it for a handshake stall would mislabel a cold-start timeout as pool saturation in history. Same principle, two mechanisms, deliberately kept at their own layers - the scheduler guard for pre-callback starvation, the transient arm for a control-plane timeout inside the callback.

### Deliberately out of scope - gaps 3 and 4 of #9522 remain open

This PR fixes gaps 1 and 2 only, and uses `Refs #9522` (not `Closes`) on purpose.

- **Gap 3 - `silent: true` jobs auto-pause with zero notification.** The issue argues persuasively that a job disabling itself forever is a different class of event from result chatter and should ring the bell (and Slack DM) even under `silent`. This is a real defect independent of the handshake cause: *any* other source of five failures still auto-pauses a silent job with no notification. It is left open on purpose because it overrides a flag the user explicitly set, which is a product decision, not an oversight. Gaps 1 and 2 remove one *cause*; gap 3 is what would have made the *next* cause visible - so closing the issue on a cause fix while the visibility fix is outstanding is the trade the issue itself argues against.
- **Gap 4 - `kirocrew doctor` / Schedule-page surfacing of `auto_paused` jobs.** Same reasoning: a product-surface decision, left open under #9522.

A reader should not have to infer this: both remain tracked under #9522, which is why this PR references rather than closes it.

### Pre-existing noise observed but not touched

- `mypy` reports two errors in `src/kiro_crew/transcribe.py` (boto3-stub type drift, `Credentials` args). That file is untouched by this PR; `session_handle.py` itself is mypy-clean.
- `black` (the locally installed version) would reformat regions of `session_handle.py` *outside* my change - it is targeting a newer Python and disagrees with the repo's pinned version. My added block is already conformant. Reformatting a file to satisfy a tool whose version disagrees with the repository's is not this PR's job, so it is left alone.

## Tests

New `test/test_acp_handshake_timeout_transient.py`, 7 tests, all passing:

- `AcpRequestTimeout` is transient via `acp_error_is_transient` (the real `"Request initialize timed out after 30s"` message).
- The verdict comes from the *type*, not the wording: a message containing no `_TRANSIENT_MARKERS` word is still transient (the #7395 guard).
- The `transient` flag lives on the class, so subclass-constructed replacements inherit it.
- `_session_start_stalled`'s enriched replacement stays transient.
- A bare `AcpRuntimeError` is *not* transient - only the timeout subclass is retried.
- The prompt-path `AcpTimeoutError` is unaffected (its verdict is decided elsewhere).
- A handshake timeout satisfies both halves of the cron retry condition (`acp_error_is_transient(exc) and not _prompt_dispatched`).

**Mutation check.** Stripping `transient = True` from the class turns **5 of the 7 red** and correctly leaves **2 green** (the string-classifier and prompt-path guards, which do not depend on the flag) - evidence the tests test the fix rather than passing regardless of it.

Command (per host policy): `timeout 900 python3 -m pytest -n0 <file> -x -q`.

- New file: 7 passed.
- Adjacent suites unaffected: `test_llm_helpers.py` 136, `test_session_start_timeout_diagnostics.py` 17, `test_acp_error_surface.py` 34, `test_cron_autopause_persist.py` 15.
- `isort` / `flake8` clean on both changed files.

## Pattern harvest

Rule candidate: When retry eligibility is decided by matching words in an error *message*, a later reword silently flips the behavior - carry the verdict on the exception *type* (a `transient` attribute the classifier reads via `getattr`) so eligibility is structural. Before marking a whole exception type retryable, confirm every raise site of that type is pre-side-effect (here: `_send_and_await` serves only control-plane requests, never the prompt stream), so a retry cannot duplicate work.

Rule candidate: State the structural reason a change is safe, not the history of the change. A structural reason is a fact about the code (here: this timeout type is only ever raised before a prompt is dispatched), so it is present-tense by nature and stays true after the pull request that introduced it is forgotten; a history sentence goes stale the moment the next change lands, and a comment-history gate rejects it.

Refs #9522

