### PR TITLE
fix(ci): give the fix-loop narrative its own job and clock

### DIFF
--- a/.github/scripts/fix_loop_metrics.py
+++ b/.github/scripts/fix_loop_metrics.py
@@ -29,11 +29,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import statistics
 import subprocess
 import sys
-from datetime import datetime, timezone
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 
 FIX_SUBJECT_RE = re.compile(r"^(fix|revert)([(!:]|\b)", re.I)
 # Trailing '(#N)' of a squash-merge subject; the LAST number is the PR.
@@ -81,21 +83,26 @@ def removed_ranges(fix_sha: str) -> dict[str, list[tuple[int, int]]]:
 def dominant_culprit(fix_sha: str, ranges: dict[str, list[tuple[int, int]]]) -> str | None:
     votes: dict[str, int] = {}
     for path, spans in ranges.items():
-        for a, b in spans:
-            out = git(
-                "blame",
-                "-l",
-                "-w",
-                "-M",
-                "-C",
-                f"-L{a},{b}",
-                f"{fix_sha}^",
-                "--",
-                path,
-                check=False,
-            )
-            for sha in BLAME_SHA_RE.findall(out):
-                votes[sha] = votes.get(sha, 0) + 1
+        # ONE blame per file, every removed hunk as its own -L. Blame walks the
+        # file's history once per invocation regardless of how many lines -L
+        # asks for, so the per-hunk form paid that walk again for every hunk of
+        # the same file (256 hunks across 67 files in a 20-fix sample: 2.6x the
+        # wall time for byte-identical culprits). -M/-C stay: dropping copy
+        # detection changes the dominant culprit on ~10% of fixes.
+        out = git(
+            "blame",
+            "-l",
+            "-w",
+            "-M",
+            "-C",
+            *(f"-L{a},{b}" for a, b in spans),
+            f"{fix_sha}^",
+            "--",
+            path,
+            check=False,
+        )
+        for sha in BLAME_SHA_RE.findall(out):
+            votes[sha] = votes.get(sha, 0) + 1
     if not votes:
         return None
     return max(votes, key=lambda s: votes[s])
@@ -117,6 +124,22 @@ def classify_fix(fix_sha: str) -> tuple[str, str | None, int | None]:
     if m:
         return "traced_to_pr", m.group(1), age_days
     return "no_pr", None, age_days
+
+
+def classify_fixes(shas: list[str]) -> list[tuple[str, str | None, int | None]]:
+    """classify_fix over every sha, in input order, a few fixes at a time.
+
+    Each fix is an independent chain of git subprocesses, so the work is
+    embarrassingly parallel and the GIL is irrelevant. The pool is bounded by
+    the CPU count: blame is CPU-bound in git itself, so more workers than cores
+    only adds contention. Order is preserved so the output is deterministic
+    regardless of which fix finishes first.
+    """
+    workers = max(1, min(8, os.cpu_count() or 1))
+    if workers == 1 or len(shas) < 2:
+        return [classify_fix(s) for s in shas]
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        return list(pool.map(classify_fix, shas))
 
 
 def bucket(age_days: int) -> str:
@@ -247,30 +270,56 @@ def has_harvest_section(body: str) -> bool:
     return bool(HARVEST_HEADING_RE.search(body) and HARVEST_ANSWER_RE.search(body))
 
 
-def harvest_metrics(repo: str, since_iso: str) -> dict:
-    """since_iso is the exact UTC timestamp of the window start; the gh search
-    uses its date as a coarse pre-filter and mergedAt enforces the precise
-    boundary, keeping this window identical to the git-history window."""
-    prs = gh_json(
-        "pr",
-        "list",
-        "--repo",
-        repo,
-        "--state",
-        "merged",
-        "--search",
-        f"merged:>={since_iso[:10]}",
-        "--limit",
-        "1000",
-        "--json",
-        "title,body,mergedAt,baseRefName,headRefOid",
-    )
-    if len(prs) >= 1000:
-        raise RuntimeError(
-            "gh pr list hit its 1000-item cap; the harvest denominator would be "
-            "truncated. Narrow the window or paginate before publishing."
+def merged_prs_since(repo: str, since_iso: str) -> list[dict]:
+    """Every PR merged at or after since_iso, one search per calendar day.
+
+    GitHub search returns at most 1000 items per query and the repo merges
+    ~950 PRs a week, so a single `merged:>=<date>` search overflows on any
+    window past seven days (and will on a busy seven). Per-day chunks stay far
+    under the cap; each is still checked, because a day that overflows would
+    silently truncate the denominator this metric exists to make trustworthy.
+    """
+    start = datetime.strptime(since_iso[:10], "%Y-%m-%d").date()
+    end = datetime.now(timezone.utc).date()
+    prs: list[dict] = []
+    seen: set[str] = set()
+    day = start
+    while day <= end:
+        chunk = gh_json(
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "merged",
+            "--search",
+            f"merged:{day.isoformat()}",
+            "--limit",
+            "1000",
+            "--json",
+            "number,title,body,mergedAt,baseRefName,headRefOid",
         )
-    prs = [p for p in prs if (p.get("mergedAt") or "") >= since_iso]
+        if len(chunk) >= 1000:
+            raise RuntimeError(
+                f"gh pr list hit its 1000-item cap for merged:{day}; the harvest "
+                "denominator would be truncated. Chunk finer before publishing."
+            )
+        for p in chunk:
+            # A PR merged near midnight UTC can be returned by two adjacent
+            # day searches; identity is the PR number, head sha as fallback.
+            key = str(p.get("number") or p.get("headRefOid") or "")
+            if key and key not in seen:
+                seen.add(key)
+                prs.append(p)
+        day += timedelta(days=1)
+    return [p for p in prs if (p.get("mergedAt") or "") >= since_iso]
+
+
+def harvest_metrics(repo: str, since_iso: str) -> dict:
+    """since_iso is the exact UTC timestamp of the window start; the per-day gh
+    searches use its date as a coarse pre-filter and mergedAt enforces the
+    precise boundary, keeping this window identical to the git-history window."""
+    prs = merged_prs_since(repo, since_iso)
     fix_prs = [p for p in prs if FIX_SUBJECT_RE.match(p.get("title") or "")]
 
     # Two exclusions, both answering "was this PR ever asked for a section?".
@@ -342,8 +391,7 @@ def main() -> int:
     ages: list[int] = []
     age_counts = {name: 0 for name, _ in AGE_BUCKETS}
     culprit_votes: dict[str, int] = {}
-    for sha in capped:
-        cls, culprit_pr, age = classify_fix(sha)
+    for cls, culprit_pr, age in classify_fixes(capped):
         classes[cls] += 1
         if age is not None:
             ages.append(age)

--- a/.github/workflows/fix-loop-analysis.yml
+++ b/.github/workflows/fix-loop-analysis.yml
@@ -6,16 +6,30 @@
 # computes volume, the SZZ culprit trace (git blame of each fix's removed
 # lines), deferred-finding discipline, and Pattern-harvest adoption. The model
 # (Fable 5 via Bedrock, same invocation shape as ux-review.yml) then reads the
-# window's fix-commit bodies in the checkout, classifies them against the
-# closed root-cause / detection-gap rubrics, compares against the 2026-08
-# full-coverage baseline, and narrates. The report is filed as a GitHub issue
-# labeled `fix-loop-report`, so history lives where it is subscribable and the
-# next run can diff against it.
+# window's fix-commit bodies, classifies them against the closed root-cause /
+# detection-gap rubrics, compares against the 2026-08 full-coverage baseline,
+# and narrates. The report is filed as a GitHub issue labeled
+# `fix-loop-report`, so history lives where it is subscribable and the next run
+# can diff against it.
+#
+# TWO JOBS, TWO CLOCKS. The halves have nothing in common except the files
+# they hand over: the metrics half is a git-history walk whose cost scales with
+# the window (28 min on 08-31, 57 min on 09-07), the model half needs 10-30 min
+# of its own. Under one job-level `timeout-minutes: 60` the slow half of the
+# week starved the other, and it was always the narrative that died because it
+# ran second -- both scheduled runs published "metrics only". Each job now has
+# a budget sized for ITS worst case; a slow week in either half can no longer
+# cost the other. The hand-over is a workflow artifact: the metrics job never
+# holds AWS credentials and the model job never holds git history.
 #
 # FAIL-SOFT ON THE MODEL, FAIL-HARD ON THE NUMBERS: if the metrics script
 # fails the run fails; if the model step fails the issue is still filed with
 # the deterministic table and an honest note that the narrative half did not
-# run.
+# run. Either failure then opens or bumps ONE tracking issue (the same
+# fixed-title pattern add-contributor.yml uses), because a red scheduled run
+# is otherwise seen by nobody. That is a per-workflow copy of a repo-wide gap
+# -- 11 other scheduled workflows have no surfacing at all; the shared
+# watcher that would replace these copies is tracked in issue 9562.
 name: Fix Loop Analysis
 
 on:
@@ -36,13 +50,23 @@ permissions:
   # because a report that silently drops PRs understates its own denominator and
   # so must fail loudly instead.
   actions: read
-  id-token: write # OIDC role assumption for Bedrock
+  # No `id-token` here: the OIDC grant for Bedrock is job-scoped to `analyze`
+  # below, so the git-history job never holds a credential it does not use.
+
+# One artifact name, one place to change it: the download in `analyze` must
+# match the upload in `metrics` byte for byte or the model reads nothing.
+env:
+  HANDOVER_ARTIFACT: fix-loop-handover
 
 jobs:
-  analyze:
-    name: Weekly fix-loop deep dive
+  metrics:
+    name: Deterministic metrics
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Sized for the worst observed week (57 min) twice over: SZZ cost scales
+    # with fix volume and `window_days` is a dispatch input.
+    timeout-minutes: 120
+    outputs:
+      since_iso: ${{ steps.metrics.outputs.since_iso }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -57,28 +81,97 @@ jobs:
         run: |
           set -euo pipefail
           SINCE_ISO="$(date -u -d "$WINDOW_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)"
+          # Every deliverable lands in the workspace root under a fix-loop-*
+          # name: that is the set the artifact carries, and the model step's
+          # Read tool operates on the workspace root of the OTHER job.
           python3 .github/scripts/fix_loop_metrics.py \
             --since "$WINDOW_DAYS days ago" \
             --since-iso "$SINCE_ISO" \
             --repo "$GITHUB_REPOSITORY" \
             --max-fixes 600 \
-            --out "$RUNNER_TEMP/metrics.json" \
-            --summary "$RUNNER_TEMP/metrics.md" \
+            --out fix-loop-metrics.json \
+            --summary fix-loop-metrics.md \
             --bodies-out fix-loop-commits.txt
-          # The model step's Read tool operates on the workspace, and its
-          # prompt: block does NOT expand shell variables — a $RUNNER_TEMP
-          # literal would leave the model unable to read the numbers it is
-          # told are authoritative. Stage the JSON where Read can reach it.
-          cp "$RUNNER_TEMP/metrics.json" fix-loop-metrics.json
           # Prefetch the previous weekly report for trend comparison. All
           # git/gh access the model needs happens HERE, deterministically and
-          # BEFORE any AWS credentials exist in the job — the model itself
-          # gets no shell at all.
+          # in a job that never holds AWS credentials -- the model itself gets
+          # no shell at all.
           gh issue list --repo "$GITHUB_REPOSITORY" --label fix-loop-report \
             --state all --limit 1 --json body \
             --jq '.[0].body // ""' > fix-loop-previous-report.md || true
           echo "since_iso=$SINCE_ISO" >> "$GITHUB_OUTPUT"
-          cat "$RUNNER_TEMP/metrics.md" >> "$GITHUB_STEP_SUMMARY"
+          cat fix-loop-metrics.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Hand the numbers to the analysis job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.HANDOVER_ARTIFACT }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            fix-loop-metrics.json
+            fix-loop-metrics.md
+            fix-loop-commits.txt
+            fix-loop-previous-report.md
+
+      # A scheduled workflow that fails is easy to miss: the metrics half going
+      # red means NO issue at all is filed this week, and nothing else notices.
+      # Same fixed-title tracking issue as add-contributor.yml, deduped so a
+      # run that fails every Monday does not open a new issue every Monday.
+      # `cancelled()` too: a job killed by its own timeout is cancelled, not
+      # failed, and that is exactly the week with the most to report.
+      - name: Surface failure as an issue
+        if: always() && (failure() || cancelled())
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Fix Loop Analysis workflow is failing"
+          existing="$(gh issue list --repo "$REPO" --state open --search "in:title \"$TITLE\"" \
+            --json number --jq '.[0].number // empty')"
+          body="The scheduled \`fix-loop-analysis.yml\` run failed in its METRICS job, so no weekly report was filed: $RUN_URL
+
+          The metrics script fails loud rather than publish a false zero (a 403 from
+          the Actions API, a \`gh\` search cap, a git failure). Check the run log."
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "Still failing (metrics job): $RUN_URL"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --label bug --label "area: ci" --body "$body"
+          fi
+
+  analyze:
+    name: Classify and narrate
+    needs: metrics
+    runs-on: ubuntu-latest
+    # The model half alone. 09-07 was cut off two minutes into it because the
+    # metrics half had spent 57 of the shared 60.
+    timeout-minutes: 40
+    # A job-level block REPLACES the workflow-level one, so the reads are
+    # restated; `id-token: write` is the OIDC role assumption for Bedrock and
+    # exists only here.
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+      id-token: write
+    steps:
+      # The model reads staged files only; a shallow checkout gives the action
+      # the repository it expects without the history it does not need.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      # What the model reads. Everything on this runner's disk is reachable by
+      # the model's Write tool (it takes absolute paths), so nothing downloaded
+      # HERE is trusted after the model step -- see the re-fetch below.
+      - name: Receive the numbers
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.HANDOVER_ARTIFACT }}
+          path: .
 
       - uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
@@ -93,6 +186,11 @@ jobs:
       - name: Classify and narrate (Fable 5)
         id: narrate
         continue-on-error: true # the issue is still filed from the numbers
+        # A STEP timeout, inside the job's 40: a step that runs out of time is
+        # a failed step the filing below handles normally, where a job that runs
+        # out of time is CANCELLED and the always() tail runs on a 5-minute
+        # grace clock with the model's orphan processes still being torn down.
+        timeout-minutes: 30
         uses: anthropics/claude-code-action@24dcd50c0568f0fc9e9211213a4fd2d9eb15c4e0 # v1
         with:
           # Model id form (bare regional `us.` inference profile) is
@@ -118,7 +216,7 @@ jobs:
 
             TASK — weekly fix-loop deep dive for ${{ github.repository }},
             window: the last ${{ github.event.inputs.window_days || '7' }} days
-            (since ${{ steps.metrics.outputs.since_iso }}).
+            (since ${{ needs.metrics.outputs.since_iso }}).
 
             Everything you need is already staged in the workspace root — you
             have no shell and need none:
@@ -166,13 +264,31 @@ jobs:
                discipline mechanisms are not yet landed or not yet adopted; one
                concrete recommendation. No emojis. Percentages to one decimal.
 
+      # The numbers the issue publishes as "deterministic" are fetched AGAIN
+      # from GitHub after the model has run, into a directory that did not
+      # exist while it ran. The model had Write on this runner, and Write takes
+      # absolute paths, so no copy that was on disk during the model step --
+      # workspace or RUNNER_TEMP -- can be trusted afterwards; the artifact
+      # store is the only copy the model's tools cannot have reached. An
+      # injected commit body can therefore corrupt the narrative (which is
+      # labelled as model output) but never the table above it.
+      - name: Re-fetch the authoritative numbers
+        if: always()
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.HANDOVER_ARTIFACT }}
+          path: ${{ runner.temp }}/authoritative
+
+      # `always()` so the numbers land even when this job's own timeout cancels
+      # the model step mid-flight -- that is the 09-07 shape, and the artifact
+      # was already downloaded before any model work began.
       - name: File the weekly report issue
         id: file_issue
-        if: always() && steps.metrics.outcome == 'success'
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
           NARRATE_OUTCOME: ${{ steps.narrate.outcome }}
-          SINCE_ISO: ${{ steps.metrics.outputs.since_iso }}
+          SINCE_ISO: ${{ needs.metrics.outputs.since_iso }}
         run: |
           set -euo pipefail
           # Neutralize notification/cross-reference/credential surfaces in
@@ -214,7 +330,9 @@ jobs:
           {
             echo "## Deterministic metrics (window since $SINCE_ISO)"
             echo ""
-            sanitize < "$RUNNER_TEMP/metrics.md"
+            # From the copy re-fetched AFTER the model step, never from anything
+            # that was on this runner while the model held Write.
+            sanitize < "$RUNNER_TEMP/authoritative/fix-loop-metrics.md"
             echo ""
             if [ "$ANALYSIS_OK" = "1" ]; then
               echo "## Analysis"
@@ -236,6 +354,37 @@ jobs:
             --label fix-loop-report \
             --body-file "$RUNNER_TEMP/issue-body.md"
 
+      # A red run is still a signal nobody receives (two scheduled runs went
+      # metrics-only before anyone looked), so a missing narrative also becomes
+      # a tracking issue a human sees -- the same fixed-title, deduped pattern
+      # add-contributor.yml uses. It runs BEFORE the re-raise so the run's last
+      # word is the red exit, and it keys on the same flag: `failure()` alone
+      # would miss a job cancelled by its own timeout (cancelled is not failed),
+      # and an unset analysis_ok means the filing step itself never ran.
+      - name: Surface failure as an issue
+        if: always() && (failure() || steps.file_issue.outputs.analysis_ok != '1')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Fix Loop Analysis workflow is failing"
+          existing="$(gh issue list --repo "$REPO" --state open --search "in:title \"$TITLE\"" \
+            --json number --jq '.[0].number // empty')"
+          body="The scheduled \`fix-loop-analysis.yml\` run failed in its ANALYSIS job: $RUN_URL
+
+          The weekly issue was still filed from the deterministic numbers (look for
+          a \`(metrics only — no analysis)\` title under the \`fix-loop-report\`
+          label); the model half produced no report. Check the model step's log:
+          \`is_error: true\` with \`num_turns: 1\` and zero cost is an IAM mismatch on
+          the Bedrock role, a cancellation is this job's own timeout."
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "Still failing (analysis job): $RUN_URL"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --label bug --label "area: ci" --body "$body"
+          fi
+
       # The model step is fail-soft so a broken narrative can never cost the
       # deterministic numbers -- but `continue-on-error` also made the whole run
       # report SUCCESS, and a weekly job nobody has reason to open is exactly
@@ -244,10 +393,9 @@ jobs:
       # green.
       #
       # So the failure is re-raised AFTER the issue is filed: the numbers still
-      # land (that step is `if: always()`), and the run goes red, which is the
-      # only signal anyone actually receives. It keys on the filing step's
-      # `analysis_ok`, not on the model step's outcome, because the action can
-      # exit 0 having written nothing.
+      # land (that step is `if: always()`), and the run goes red. It keys on the
+      # filing step's `analysis_ok`, not on the model step's outcome, because
+      # the action can exit 0 having written nothing.
       - name: Re-raise a missing analysis
         if: always() && steps.file_issue.outputs.analysis_ok == '0'
         run: |


### PR DESCRIPTION
## Problem / Motivation

`fix-loop-analysis.yml` has run on schedule twice (08-31 run 33418308283 → #7324, 09-07 run 34146597651 → #9278) and both issues carry the `(metrics only — no analysis)` title. The narrative half — the classification of *why each bug happened* and *why it escaped* — has never landed.

On 09-07 the timeline inside the single 60-minute job was: checkout 17:15 → "Compute deterministic metrics" **57 min** (17:15:44–18:12:59; SZZ blamed 595 fix commits one hunk at a time over a 967-commit window) → "Classify and narrate" started 18:13:03 and was **cancelled by the job timeout at 18:15:10** with `claude` still working → the issue was filed metrics-only → "Re-raise a missing analysis" went red, and nothing consumes a red scheduled run. On 08-31 metrics took 28 min and the model step returned `is_error: true, num_turns: 1, cost 0` after 3m24s — a different failure, but with the same result and, back then, no re-raise at all.

## Why it matters

The weekly report exists to tell the team what kind of bugs it is shipping and which countermeasure to fund. Two consecutive Mondays produced a table of counts and a placeholder paragraph, and the Actions list gave nobody a reason to look. A `workflow_dispatch` with `window_days=14` — the obvious way to catch up — would have failed too: the harvest search trips `gh`'s 1000-item cap on a two-week window.

## What changed (motivation → approach → change)

**One clock for two unrelated halves** → each half gets its own job and budget. `metrics` (120 min; git history, no AWS credentials) writes `fix-loop-metrics.json` / `.md`, `fix-loop-commits.txt` and the previous report into the workspace root and uploads them as one artifact. `analyze` (40 min job, **30 min step timeout** on the model) does a shallow checkout, downloads the artifact to the workspace root — so the prompt's "everything is staged in the workspace root" contract is unchanged — assumes the Bedrock role, narrates, then **re-downloads the artifact from GitHub into a fresh `$RUNNER_TEMP/authoritative` directory** and files the issue with the metrics table from that copy. The model's `Write` tool takes absolute paths, so no file that was on the runner during the model step — workspace or `$RUNNER_TEMP` — is trustworthy afterwards; the artifact store is the one copy its tools cannot have reached. (On `main` the table lived in `$RUNNER_TEMP` of the same job, which the GPT lane correctly pointed out is not a fence either; two earlier revisions of this PR moved it into the workspace and then back into `$RUNNER_TEMP` before landing on the re-fetch.) An injected commit body can still corrupt the narrative, which is labelled as model output, but never the numbers above it. A step timeout is a *failed* step the filing already handles; a *job* timeout is a cancellation whose `always()` tail runs on a 5-minute grace clock while orphan `bun`/`claude` processes are torn down — which is what happened on 09-07. Splitting jobs rather than raising the single timeout was the cleaner option: OIDC needs only `id-token: write`, which is now a job-level grant on `analyze` alone (the job-level block restates the reads, since it replaces the workflow-level one); the git-history job holds no cloud credential and the trust shape of the role did not move.

**SZZ does redundant work** → `dominant_culprit` now runs **one `git blame` per file** with every removed hunk as its own `-L`, instead of one blame per hunk (blame re-walks the file's history per invocation regardless of how many lines are requested). `-M -C` are kept: dropping copy detection changes the dominant culprit on ~10% of fixes. `classify_fixes` runs the per-fix chains in a CPU-bounded `ThreadPoolExecutor` (input order preserved, output deterministic). Local timing on the same 40 fixes, same window, same repo:

| variant | 40 fixes | s/fix | culprits vs. current |
|---|---|---|---|
| current (per-hunk blame, serial) | 138.1 s | 3.45 | — |
| per-file blame, serial (`cpu_count` forced to 1) | 55.2 s | 1.38 | byte-identical on all 40 |
| per-file blame + pool, `cpu_count` forced to 4 (hosted runner) | 32.4 s / 33.3 s (two runs) | 0.81 | byte-identical |
| per-file blame + pool, 8 workers | 29.1 s | 0.73 | byte-identical |

So the two levers are separable and both real: per-file blame is 2.5x on its own, the 4-worker pool is a further 1.66x on the same 40 fixes (55.2 s -> 33.3 s). The pool's premise is that each fix is an independent chain of git subprocesses; a 4-vCPU runner runs four of those chains at once. (A 20-fix blame-only probe run earlier -- 41.8 s per-hunk vs 15.9 s per-file -- measured only the blame calls and is not comparable to the 40-fix full-classification rows above.)

Full run of the script on a 14-day window (1120 fixes, capped at 600) completed locally, SZZ included, in under 3 minutes before the harvest phase; the 09-07 run spent 57 minutes on 595.

**Harvest search cannot take a two-week window** → `merged_prs_since` searches `merged:<day>` per calendar day and dedupes by PR number (head sha as fallback), each chunk still checked against the cap. The repo merges ~950 PRs a week, so the single `merged:>=<date>` search was already one busy week from failing on the default window.

**A red scheduled run is invisible** → there is no repo-wide `workflow_run`-failure → issue/Slack mechanism for scheduled workflows; the only precedent is `add-contributor.yml`'s "Surface failure as an issue" step (fixed title, deduped, comment on repeat). Both jobs now end with that same step: the metrics job on `failure() || cancelled()`, the analyze job on `failure() || analysis_ok != '1'` (a job cancelled by its own timeout is *cancelled*, not failed, and an unset flag means the filing step never ran). It runs before the re-raise so the run's last word is still the red exit the existing ratchet test pins. This is deliberately the per-workflow copy and not the repo-wide fix: 11 of 13 `schedule:` workflows (including `ship-report.yml`, which shares this one's shape) have no surfacing at all, and the shared `workflow_run` watcher that would replace all the copies is scoped in #9562 -- out of scope here so this PR stays a fix to the workflow that is actually broken.

## Tests

No new tests; the existing `test/test_fix_loop_discipline.py` ratchets still apply and were checked statically against the new file: `jobs.analyze.steps` keeps `file_issue` followed by an `analysis_ok`-gated `exit 1` step as its last such step; `-s fix-loop-report.md` and `echo "analysis_ok=` remain in the filing step; `metrics only` remains in the text; the workflow-level `permissions:` block still grants `actions: read` for the `/actions/` reads; every `$NAME` in every `run:` block resolves against workflow/job/step `env`. `TestHarvestDenominator`'s fake `gh` (returns the same PR list for every call, PRs without a `number`) still works with the per-day chunking because dedup falls back to `headRefOid`.

## Manual verification

- `python3 .github/scripts/fix_loop_metrics.py --since '14 days ago' --since-iso 2026-08-25T19:19:39Z --repo kirodotdev/KiroCrew --max-fixes 600 ...` on `origin/main` @ 6ae74179d: completes; 1858 commits, 1120 fix (60.3%), SZZ 473/95/32, median age 13.5 d, deferrals 74/70/0, harvest 654/657. The same command on the unmodified script raises `gh pr list hit its 1000-item cap`.
- `black --check`, `isort --check-only`, `scripts/check_black_formatting.py` (post-commit) clean on the script. `mypy` reports one pre-existing `union-attr` on `default_branch` that is identical on `main`.
- The workflow itself can only be exercised by a `workflow_dispatch` after merge; I will dispatch `window_days=14` then and link the resulting issue here.

## Related Issues

Closes #9528

## Pattern harvest

Rule candidate: review-prompt
Pattern: "one `timeout-minutes` shared by a deterministic pre-step and an LLM step — the slow half of the week starves the other; give each its own job or step budget"
