### PR TITLE
fix(dashboard): dismiss Connect-your-phone modal on nav and outside click

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1308,6 +1308,16 @@ export default function App() {
   // returned none, policy denied all, seam degraded) hides the row entirely —
   // the endpoint is the authority, the frontend never guesses.
   const [mobileConnectOpen, setMobileConnectOpen] = useState(false)
+  // The dialog is a transient overlay opened from a rail row that does not
+  // navigate (path="#"), so a navigation — clicking another nav tab or
+  // switching chat sessions — must dismiss it, the same as Escape or a
+  // backdrop click. Its open flag lives here at the owner rather than in the
+  // modal, so nothing inside the modal sees navigation. Key this off
+  // location.key, not location.pathname: switching between untitled /chat
+  // sessions changes only the key/query, so a pathname dep would leave the
+  // dialog stranded over the newly selected session. location.key changes on
+  // every history entry, so this closes it on ANY navigation at once.
+  useEffect(() => { setMobileConnectOpen(false) }, [location.key])
   const mobileConnectQuery = useQuery({
     queryKey: ['mobile-connect-methods'],
     queryFn: api.mobileConnectMethods,

--- a/website/src/components/MobileConnectModal.tsx
+++ b/website/src/components/MobileConnectModal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
@@ -51,6 +51,22 @@ export default function MobileConnectModal({
   // The repo's modal keyboard contract: focus-in on mount, focus-restore on
   // close, Tab trapped inside the dialog, Escape dismisses.
   useDialogFocusTrap(dialogRef, onClose)
+  // Dismiss on any pointer-down OUTSIDE the dialog — the backdrop, the main
+  // content, AND the nav rail, which renders ABOVE the backdrop so a click on
+  // empty sidebar space never reaches the backdrop's own handler (the dead zone
+  // this closes). A nav row's own click still fires, so clicking a tab both
+  // dismisses and navigates. Attached from an effect (after mount) so the very
+  // click that opened the dialog — already dispatched before this runs — cannot
+  // immediately close it; capture phase so a child that stops propagation can't
+  // hide the outside click from us.
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      const dialog = dialogRef.current
+      if (dialog && !dialog.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('pointerdown', onPointerDown, true)
+    return () => document.removeEventListener('pointerdown', onPointerDown, true)
+  }, [onClose])
 
   const hasQr = kinds.includes('tailnet_qr')
   // Only renderers whose kind this deployment actually offers: the endpoint has
@@ -62,7 +78,6 @@ export default function MobileConnectModal({
     <div
       className="fixed inset-0 z-50 bg-bg/80 backdrop-blur-sm flex items-center justify-center animate-rise"
       role="presentation"
-      onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
         ref={dialogRef}


### PR DESCRIPTION
## Problem / Motivation

The "Connect your phone" dialog stayed open after you left it. Click another
sidebar tab, switch chat sessions, or click empty space in the sidebar, and the
dialog stayed on top of the new view. The only ways to close it were the X
button and Escape.

## Why it matters

A dialog that outlives the screen it belongs to sits over what you just
navigated to and reads as broken. You have to hunt for the X every time.

## What changed (motivation → approach → change)

The dialog's open flag lives in `App`, and nothing reset it on a route change,
so navigating away left it open. The backdrop closed the dialog only for clicks
in the main content area. The nav rail renders above the backdrop, so a click on
empty sidebar space never reached the backdrop's handler.

Now the dialog closes on any navigation and on any click outside the card. An
effect in `App` keyed on `location.key` clears the flag on every history entry,
including switching between untitled `/chat` sessions, which changes only the
key, not the pathname. A document-level capture `pointerdown` listener in the
modal closes it for a click anywhere outside the card, the sidebar included,
replacing the backdrop-only `onClick`. A click on a nav row still navigates.

Escape, the X button, and the focus trap are unchanged. This matches the
Notification Center popover, which already closes on navigation and on an
outside click.

## Tests

No new automated test. The existing `website/src/components/MobileConnectModal.test.tsx`
(17 tests) still passes with the change. The `App` close-on-navigation effect is
not unit-covered — `App.tsx` is not unit-tested in isolation — so it was checked
manually (below).

## Manual verification

Ran the frontend dev server. With the dialog open, each of these dismisses it:
clicking another nav tab, switching chat sessions, clicking empty sidebar space,
clicking the backdrop, and pressing Escape. Clicking a nav row still navigates to
that view. `tsc -b`, `eslint`, and the modal test suite all pass.

## Screenshots / video

No visual delta: the dialog itself is unchanged; only its dismissal behavior
changed, so a still frame would look identical before and after. The behavior is
verified manually (above). I can add a short GIF of the dismissal if a reviewer
prefers one.

## Related Issues

no linked issue: found via dogfooding; no GitHub issue filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a modal/popover with a dimming backdrop must dismiss on all three of
Escape, an outside `pointerdown` (not just a backdrop `onClick`, which misses
clicks on siblings that render above the backdrop), and navigation. Wiring only
some of the three leaves dead zones where the overlay is stranded.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality — existing 17 modal tests pass; no new test added (rationale in Tests section)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
