### PR TITLE
fix(members): commit the roster display order per membership, not per refetch

### DIFF
--- a/website/src/pages/members/MembersPage.test.tsx
+++ b/website/src/pages/members/MembersPage.test.tsx
@@ -1150,6 +1150,51 @@ describe('MembersPage default member, memory and URL', () => {
     expect(localStorage.getItem(LAST_MEMBER_KEY)).toBe('fresh-talker')
   })
 
+  it('a refresh-frame refetch never reorders the roster; a membership change re-sorts it', async () => {
+    const membersMock = api.members as ReturnType<typeof vi.fn>
+    const utils = await renderPage([
+      row({ name: 'alpha', slug: 'alpha', last_active_ts: 100 }),
+      row({ name: 'beta', slug: 'beta', last_active_ts: 50 }),
+    ])
+    const names = () =>
+      roster()
+        .getAllByRole('listitem')
+        .map((li) => within(li).queryByText(/^(alpha|beta|gamma)$/)?.textContent)
+        .filter(Boolean)
+    await waitFor(() => expect(names()).toEqual(['alpha', 'beta']))
+    // beta's activity advances server-side and a refresh-frame refetch lands
+    // it. The ORDER must hold: re-sorting here moves rows under the cursor
+    // mid-click, so the click opens a different member's durable thread.
+    membersMock.mockResolvedValue({
+      members: [
+        row({ name: 'alpha', slug: 'alpha', last_active_ts: 100 }),
+        row({ name: 'beta', slug: 'beta', last_active_ts: 999, last_message: 'fresh row content' }),
+      ],
+      default_agent: 'kirocrew',
+    })
+    act(() => {
+      void utils.queryClient.invalidateQueries({ queryKey: ['kirocrew-agents'] })
+    })
+    // Content updated in place…
+    await roster().findByText('fresh row content')
+    // …but the order did not move.
+    expect(names()).toEqual(['alpha', 'beta'])
+    // A membership change (a new crew appears) re-sorts from scratch by recency.
+    membersMock.mockResolvedValue({
+      members: [
+        row({ name: 'alpha', slug: 'alpha', last_active_ts: 100 }),
+        row({ name: 'beta', slug: 'beta', last_active_ts: 999 }),
+        row({ name: 'gamma', slug: 'gamma', last_active_ts: 500 }),
+      ],
+      default_agent: 'kirocrew',
+    })
+    act(() => {
+      void utils.queryClient.invalidateQueries({ queryKey: ['kirocrew-agents'] })
+    })
+    await rosterRow('gamma')
+    expect(names()).toEqual(['beta', 'gamma', 'alpha'])
+  })
+
   it('restores the remembered member on return (and after a reload)', async () => {
     localStorage.setItem(LAST_MEMBER_KEY, 'beta')
     await renderPage(alphaBeta())

--- a/website/src/pages/members/MembersPage.tsx
+++ b/website/src/pages/members/MembersPage.tsx
@@ -459,15 +459,29 @@ export default function MembersPage() {
   }, [members])
   // Display order before the search filter — this is what "the first member"
   // means for the default-open below, so a typed filter never changes which
-  // member a fresh visit lands on.
-  const orderedMembers = useMemo(
-    () =>
-      [...members].sort(
-        (a, b) =>
-          (b.last_active_ts ?? 0) - (a.last_active_ts ?? 0) || compareText(a.name, b.name),
-      ),
-    [members],
-  )
+  // member a fresh visit lands on. The ORDER is committed per MEMBERSHIP, not
+  // per refetch: the roster query refetches on every server refresh frame, on
+  // window focus and on staleness, and re-sorting when a last_active_ts
+  // advances would move rows under the cursor mid-click — opening a different
+  // member's durable pinned thread. Row CONTENT (star, last-message preview,
+  // presence) still updates live from every refetch; only the ordering is held
+  // until a member is added, removed or renamed, which re-sorts from scratch.
+  const committedOrderRef = useRef<string[]>([])
+  const orderedMembers = useMemo(() => {
+    const byName = new Map(members.map((m) => [m.name, m]))
+    const prev = committedOrderRef.current
+    const sameMembership = prev.length === byName.size && prev.every((n) => byName.has(n))
+    const names = sameMembership
+      ? prev
+      : [...members]
+          .sort(
+            (a, b) =>
+              (b.last_active_ts ?? 0) - (a.last_active_ts ?? 0) || compareText(a.name, b.name),
+          )
+          .map((m) => m.name)
+    committedOrderRef.current = names
+    return names.map((n) => byName.get(n)).filter((m): m is MemberRosterRow => !!m)
+  }, [members])
   const sortedMembers = useMemo(() => {
     const q = filter.trim().toLowerCase()
     return orderedMembers.filter(


### PR DESCRIPTION
## Problem / Motivation

On the Crew Members page the roster re-sorted itself while the user was pointing at
it. The list now lives in the React Query cache and refetches on every server
refresh frame, on window focus and on staleness, but `orderedMembers` still sorted
by `last_active_ts` on each render. A refetch landing between aiming at a row and
clicking it moved the active member to row 1 and shifted every row below, so the
click opened a **different member's durable pinned thread**.

## Why it matters

Opening the wrong member's durable thread is a trust-level failure for this page,
and the trigger needs no unusual conditions -- an active crew and a user browsing
the roster is enough. The comment that documented the guarantee was DELETED by
the same migration: `af52805f7` (#6616) added the two lines saying the list was
sorted once from the roster snapshot because live re-sorting mid-session would
move rows under the cursor, and `f3d739546` (#9442) removed exactly those lines
while keeping the per-render sort they described. Base therefore carried the
behaviour with no warning left in the file.

## What changed (motivation -> approach -> change)

Symptom: rows move under the cursor and the click lands on the wrong member.
Root cause: the sort key advances with member activity, and the sort re-runs on
every refetch, so ordering is a function of refetch timing rather than of the
roster.

The change makes the display order a function of MEMBERSHIP instead of of time.
The committed order is held in a ref: it re-sorts from scratch only when the set
of member names changes (add / remove / rename), and otherwise maps the committed
name order over the fresh rows. Row CONTENT stays live -- star, last-message
preview and presence all still update from every refetch -- while positions hold.

Rejected alternative: freezing the query (longer `staleTime`, or refetch off).
That would fix the movement by making the roster stale, losing the live presence
and preview the refetch exists to deliver. Ordering and content have different
requirements here, so only ordering is pinned.

## Tests

`a refresh-frame refetch never reorders the roster; a membership change re-sorts it`
in `website/src/pages/members/MembersPage.test.tsx` locks both halves: after a
refetch that advances a lower row's `last_active_ts` and changes its preview text,
the new content is on screen while the order is unchanged; then a new member
appears and the roster re-sorts by recency.

The test is mutation-proven: with the previous per-render sort restored it fails
with `expected [ 'beta', 'alpha' ] to deeply equal [ 'alpha', 'beta' ]` -- the
row swap that causes the misroute.

## Manual verification

N/A -- the defect is a timing race between a background refetch and a click, which
the test reproduces deterministically by invalidating the query mid-assertion; a
manual attempt would be less reliable than the test, not more.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** there is no visual delta to capture. No styling, layout,
markup or component changes -- the roster renders the same rows, with the same
classes, in the same positions at first paint. What changes is purely temporal:
whether a BACKGROUND REFETCH is allowed to reorder those rows afterwards. A still
of before and after is byte-identical, and a recording would have to reproduce a
refetch landing inside a click, which is exactly what the regression test does
deterministically (and it is mutation-proven: with the old sort restored it fails
on the row swap).

Disclosed rather than omitted: I also could not produce a recording locally even
had one been meaningful -- `npm ci` in this environment fails `E401` against the
configured package registry, so the dev server cannot build a complete bundle. If
a maintainer wants a capture anyway, say so and I will get one from a working
environment.

## Related Issues

Fixes #9524

## Pattern harvest

Rule candidate: review-prompt
Pattern: a comment asserting an invariant ("sorted once from the snapshot") that a
later migration silently invalidated -- when data moves from a one-shot fetch to a
live cache, every derived value whose comment claims stability needs re-deriving,
because nothing fails when the claim stops being true.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


<sub>**Correction (post-merge).** An earlier revision of this description said the
comment above the sort *still* promised that, which implied it was present in base.
It was not, and the First Principles lane was right to grep for it: the comment was
added in `af52805f7` (#6616) and removed by `f3d739546` (#9442). The paragraph above
now cites both commits instead of quoting base. The fix itself rests on #9524 and
the mutation-proven test, neither of which depended on that quote.</sub>
