### PR TITLE
fix(dashboard): retry the /vendor import-map stubs too, not just /assets

### DIFF
--- a/website/public/sw.js
+++ b/website/public/sw.js
@@ -1,6 +1,7 @@
 // Minimal service worker for PWA installability.
-// Network-first for the SPA shell; hashed assets go to the network with a bounded
-// 5xx retry; everything else goes straight to network.
+// Network-first for the SPA shell; boot-critical modules (hashed /assets and the
+// /vendor import-map stubs) go to the network with a bounded 5xx retry;
+// everything else goes straight to network.
 //
 // Cache contains ONLY the shell (/ and /index.html). No other responses are
 // cached — hashed assets rely on HTTP immutable caching, and app/API routes
@@ -30,10 +31,11 @@ self.addEventListener('activate', e => {
   self.clients.claim()
 })
 
-// ── Hashed-asset retry ──────────────────────────────────────────────
-// Assets are still NOT cached here — the immutable HTTP cache owns them. What
-// this adds is a bounded retry, because one 502 on a module script is not a
-// degraded page, it is a dead one.
+// ── Boot-critical module retry ──────────────────────────────────────
+// Nothing is cached here — the immutable HTTP cache owns hashed assets, and the
+// /vendor stubs have stable filenames. What this adds is a bounded retry, because
+// one 502 on a module a document imports is not a degraded page, it is a dead
+// one.
 //
 // A page load asks for the entire module graph at once, and the hop in front of
 // the gateway has a lower real concurrency ceiling than it advertises:
@@ -104,8 +106,24 @@ self.addEventListener('fetch', e => {
     e.respondWith(fetchAssetWithRetry(e.request))
     return
   }
-  // Vendor shims, fonts, sprites — stable filenames, no SW caching needed
-  if (url.pathname.startsWith('/vendor/')) return
+  // Vendor module stubs get the SAME retry as hashed assets, and for the same
+  // reason. `index.html` carries an import map pointing bare specifiers at
+  // /vendor/*.mjs (react, react-dom, react-dom/client, react/jsx-runtime, the app
+  // SDK, its ui entry, lucide-react), each a 0.2-1.0 KB stub. Any document that
+  // imports one cannot boot without it, so a single 502 there is the same dead
+  // page this retry exists to prevent. The dashboard SPA itself is not the
+  // exposed surface — it has no /vendor/ modulepreload and bundles React into
+  // /assets/vendor-react-*.js — but the standalone app-window documents are, and
+  // they are same-origin so this worker controls them. Nothing is cached here
+  // either. (A sandboxed widget iframe has an opaque origin and is not
+  // SW-controlled at all, so it is unaffected either way.)
+  if (url.pathname.startsWith('/vendor/')) {
+    e.respondWith(fetchAssetWithRetry(e.request))
+    return
+  }
+  // Fonts and sprites are skipped deliberately, not by omission: a font or icon
+  // sprite that fails degrades the page's looks, it does not stop it booting, so
+  // it does not earn retry attempts.
   if (url.pathname.startsWith('/fonts/')) return
   if (url.pathname.startsWith('/sprites/')) return
   // Backend-served brand assets: the sidebar logo + favicon (/logo.png) and the

--- a/website/src/test/serviceWorkerSkipRules.test.ts
+++ b/website/src/test/serviceWorkerSkipRules.test.ts
@@ -138,8 +138,11 @@ describe('the shell cache refresh is scoped to the shell', () => {
 // coming from the cache above so no reload escapes it. Hence the retry, and hence
 // these tests: the SW is the only layer that runs when the app cannot boot, so
 // staleShellHeal (a boot-time probe) can never reach this failure.
-/** Drive one asset request with a scripted fetch, and report the attempts made. */
-function assetRequest(steps: Array<number | 'throw'>): {
+/** Drive one retryable request with a scripted fetch, and report the attempts. */
+function assetRequest(
+  steps: Array<number | 'throw'>,
+  path = '/assets/App-abc123.js',
+): {
   result: Promise<{ status?: number }>
   attempts: () => number
 } {
@@ -171,7 +174,7 @@ function assetRequest(steps: Array<number | 'throw'>): {
   )
   let captured: Promise<{ status?: number }> = Promise.resolve({})
   listeners.fetch({
-    request: { method: 'GET', url: ORIGIN + '/assets/App-abc123.js', mode: 'no-cors' },
+    request: { method: 'GET', url: ORIGIN + path, mode: 'no-cors' },
     respondWith: (p: Promise<{ status?: number }>) => { captured = p },
   })
   return { result: captured, attempts: () => calls }
@@ -221,5 +224,29 @@ describe('hashed-asset 5xx retry', () => {
     const r = assetRequest([502, 'throw'])
     expect((await r.result).status).toBe(502)
     expect(r.attempts()).toBe(3)
+  })
+
+  it('retries a /vendor module stub, which is boot-critical too', async () => {
+    // index.html carries an import map pointing bare specifiers at /vendor/*.mjs.
+    // A document that imports one cannot boot without it, so leaving this prefix
+    // out would let a 502 on react.mjs reproduce the same dead page on the
+    // standalone app-window documents.
+    const r = assetRequest([502, 200], '/vendor/react.mjs')
+    expect((await r.result).status).toBe(200)
+    expect(r.attempts()).toBe(2)
+  })
+})
+
+describe('what deliberately gets no retry', () => {
+  it('takes over /vendor, which boot depends on', () => {
+    expect(intercepts('/vendor/react.mjs', 'no-cors')).toBe(true)
+    expect(intercepts('/vendor/kirocrew-app-sdk.mjs', 'no-cors')).toBe(true)
+  })
+
+  it('leaves fonts and sprites alone — they cost looks, not boot', () => {
+    // Skipped on purpose, not by omission: a font or sprite that fails makes the
+    // page plainer, it does not stop it running, so it earns no retry attempts.
+    expect(intercepts('/fonts/Inter-Regular.woff2', 'no-cors')).toBe(false)
+    expect(intercepts('/sprites/icons.svg', 'no-cors')).toBe(false)
   })
 })


### PR DESCRIPTION
## Problem / Motivation

[PR #9518](https://github.com/kirodotdev/KiroCrew/pull/9518) gave hashed `/assets` a bounded 5xx retry, so one 502 in the boot burst could no longer leave a phone on a permanently dark page. It picked the files to protect by path prefix. That prefix is narrower than the set of files a page cannot boot without.

`index.html` carries an import map. It points bare specifiers at `/vendor/*.mjs`:

```json
{"react":"/vendor/react.mjs","react-dom":"/vendor/react-dom.mjs",
 "react-dom/client":"/vendor/react-dom-client.mjs","react/jsx-runtime":"/vendor/react-jsx-runtime.mjs",
 "@kirocrew/app-sdk":"/vendor/kirocrew-app-sdk.mjs","@kirocrew/app-sdk/ui":"/vendor/kirocrew-ui.mjs",
 "lucide-react":"/vendor/lucide-react.mjs"}
```

Each is a stub of 0.2–1.0 KB. A document that imports one cannot start without it. The worker still said `if (url.pathname.startsWith('/vendor/')) return`, so a 502 on `react.mjs` produced the same dead page #9518 was written to stop.

Design Review found this on #9518 and it merged before the gap was closed.

## Why it matters

The surface at risk is the standalone app-window documents (`/app-windows/<app>/<name>.html`). Those are the ones that import the bare specifiers, and they are same-origin, so the worker controls them. Without this, an app window opened during a burst can come up blank with no error, and the retry that already protects the dashboard does not apply to it.

The dashboard SPA is **not** exposed here, and the PR does not claim it is: the shell has no `/vendor/` modulepreload and React is bundled into `/assets/vendor-react-*.js`, so the SPA's own boot burst never fetches these stubs.

## What changed (motivation → approach → change)

**Motivation.** The fix scope in #9518 was "which prefix", when the question is "which fetches stop the page booting".

**Approach.** Reuse the mechanism rather than add a second one. `/vendor/` goes through the same `fetchAssetWithRetry` that `/assets/` already uses — same jittered backoff, same two extra attempts, same rule that a 404 is never retried, same nothing-is-cached. No new code path, no new tuning knob.

**Change.** `/vendor/` is routed into the retry. Fonts and sprites stay skipped, and the reason is now written down instead of implied: a font or sprite that fails costs the page its looks, not its boot, so it earns no retry attempts.

```mermaid
flowchart LR
  subgraph Before
    B1[app window imports react]:::ctx --> B2["/vendor/react.mjs<br/>skipped by the worker"]:::removed
    B2 --> B3[502 in the burst]:::ctx
    B3 --> B4[window never boots]:::removed
  end
  subgraph After
    A1[app window imports react]:::ctx --> A2["/vendor/react.mjs<br/>same retry as /assets"]:::added
    A2 --> A3[502 in the burst]:::ctx
    A3 --> A4[jittered retry, max 2]:::added
    A4 --> A5[window boots]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1,2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 3,4,5,6 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*An app window's `react` import now gets retried like any other module, so a 502 during the burst no longer leaves the window blank.*

## Tests

`website/src/test/serviceWorkerSkipRules.test.ts`, which runs the real `public/sw.js` rather than grepping it, so a rule that is present but unreachable still fails. The retry driver takes a path now, so the same scripted-fetch harness covers both prefixes.

Three new cases:

- a `/vendor/react.mjs` that 502s then succeeds recovers, in two attempts
- `/vendor/react.mjs` and `/vendor/kirocrew-app-sdk.mjs` are taken over by the worker
- `/fonts/*` and `/sprites/*` are still left to the browser

15 cases in the file pass.

## Manual verification

The import map, the stub sizes, and the absence of a `/vendor/` modulepreload were all read out of the built `dist/` rather than assumed. `dist/vendor/` also holds `mermaid.min.js` (3.4 MB) and `tailwindcss-browser.js` (254 KB); both were checked and neither changes the picture. The retry re-issues only on a 5xx or a throw, and returns a `200` before the body is read or cloned, so a large file is never re-downloaded or buffered. `tailwindcss-browser.js` is loaded only by the null-origin sandboxed iframe, which has no controlling worker at all and so is untouched either way.

The backend's `/vendor/` route was read for the same reason. Its `Access-Control-Allow-Origin` and Private-Network-Access headers pass through unchanged, because the response object goes straight to `respondWith`; and the consumer the worker actually mediates is same-origin, which needs neither. `/vendor/` is public static JS, auth-exempt via `token_auth._BYPASS_PREFIXES`, with no single-use token in the URL, so an idempotent GET retry cannot fail the way a `/sandbox-doc/` re-fetch would.

N/A for a device run — same as #9518, confirming this on a phone needs a packaged build and install, tracked separately.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no pixel changes — the diff is service-worker request routing plus its unit tests, with no component, layout, theme or user-visible string touched.

## Related Issues

no linked issue: closes a Design Review concern raised on #9518, which merged before the concern was addressed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a protective mechanism scoped by path prefix when the property that matters is a behaviour — here "retry what the page cannot boot without", where `/assets` and `/vendor` share the property and only one shared the prefix.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
