### PR TITLE
test(chat): pin that credential redaction cannot manufacture a phantom diff

### DIFF
--- a/test/test_file_change_snapshots.py
+++ b/test/test_file_change_snapshots.py
@@ -285,6 +285,51 @@ class TestFlushFileChanges:
         changes = slot.messages[-1]["meta"]["file_changes"]
         assert "AKIAIOSFODNN7EXAMPLE" not in changes[0]["before"]
 
+    def test_an_unchanged_credential_line_is_not_turned_into_a_phantom_diff(
+        self, tmp_path: Path
+    ) -> None:
+        """Redaction must not decide changed-ness.
+
+        Both sides go through the SAME pass, so a line the redactor rewrites is
+        rewritten identically on both — an untouched line stays equal and the UI
+        renders no diff. Redacting one side only (or twice on one side) would
+        render an unchanged docs line as
+        ``- Bearer <value>`` / ``+ [REDACTED: credential]``: a phantom
+        modification, with the real text hidden on the very surface meant to
+        review it.
+        """
+        f = tmp_path / "AGENTS.md"
+        unchanged = '  "headers": { "Authorization": "Bearer lp_dummy_placeholder_value" }\n'
+        f.write_text(unchanged, encoding="utf-8")
+        slot = _make_slot_with_assistant_message()
+        # Same bytes on both sides: the turn touched the file without changing
+        # this line (the reported case is a docs/config example).
+        slot._file_changes = [{"path": str(f), "content": unchanged}]
+        _flush_file_changes(slot)
+        changes = slot.messages[-1]["meta"]["file_changes"]
+        assert (
+            changes[0]["before"] == changes[0]["after"]
+        ), "identical text redacted asymmetrically -> the UI shows a diff on an unchanged line"
+        # The guard is only meaningful because the redactor DID fire here.
+        assert "lp_dummy_placeholder_value" not in changes[0]["after"]
+
+    def test_a_real_change_beside_a_credential_line_still_redacts_both_sides(
+        self, tmp_path: Path
+    ) -> None:
+        """The symmetry guard must not be satisfiable by skipping redaction."""
+        cred = '  "Authorization": "Bearer lp_dummy_placeholder_value"\n'
+        f = tmp_path / "conf.json"
+        f.write_text(cred + "changed-line\n", encoding="utf-8")
+        slot = _make_slot_with_assistant_message()
+        slot._file_changes = [{"path": str(f), "content": cred + "original-line\n"}]
+        _flush_file_changes(slot)
+        changes = slot.messages[-1]["meta"]["file_changes"]
+        assert "lp_dummy_placeholder_value" not in changes[0]["before"]
+        assert "lp_dummy_placeholder_value" not in changes[0]["after"]
+        # The genuine change survives redaction on both sides.
+        assert "original-line" in changes[0]["before"]
+        assert "changed-line" in changes[0]["after"]
+
     def test_synthetic_message_created_when_no_assistant_text(self, short_tmp_dir: Path):
         """User stopped before any assistant chunk: still surface modified files."""
         d = short_tmp_dir


### PR DESCRIPTION
## Problem / Motivation

#9390 reports the diff viewer rendering an UNCHANGED line as a modification,
with the two sides redacted differently:

```
- "headers": { "Authorization": "Bearer <placeholder>" }
+ "headers": { "[REDACTED: credential]" }
```

I could not reproduce that asymmetry on `main`, and this PR does not claim to fix
it -- see below. What it does close is the coverage gap the report exposes: the
property whose violation produces exactly that output was not asserted anywhere.

`_flush_file_changes` redacts `before` and `after` with the same pass, so an
untouched line comes out equal on both sides and the UI renders no diff for it.
The suite asserted that each side IS redacted (one test per side) but never that
the two agree, so an edit that redacted one side, or one side twice, would pass.

## Why it matters

This one fails silently in the direction that matters. Redaction deciding
changed-ness means a reviewer sees a modification that did not happen, cannot see
the line's real text on the surface built to review it, and cannot tell that from
a real edit. Nothing in the suite would object.

## What changed (motivation -> approach -> change)

Test-only. Two cases in `test/test_file_change_snapshots.py`:

- an unchanged line carrying an `Authorization: Bearer <placeholder>` example
  must come out EQUAL on both sides -- plus an assertion that the redactor
  actually fired on it, so the equality is not vacuously true of text the
  redactor ignored;
- a genuine change sitting beside such a line must still be redacted on both
  sides, so the symmetry guard cannot be satisfied by skipping redaction
  altogether.

Mutation-proven: deleting the `before` redaction -- the exact asymmetry shape the
issue reports -- turns 4 tests red (57 passed -> 4 failed / 53 passed).

## What this deliberately does NOT do

Two halves of #9390 are left alone, on purpose:

1. **The match itself.** The report suggests exempting well-known placeholder
   values (`your_token_here`, `xxxxx`, `<token>`) from credential redaction. That
   is a security-posture decision, and an allow-list of dummy values is a
   miss vector, so it needs a maintainer rather than a contributor's judgement.

2. **The reported asymmetry.** I read the producers and could not find one that
   redacts a single side on `main`: `_flush_file_changes` redacts both
   symmetrically; the ACP client renders the unified diff FIRST and redacts the
   rendered string, so an unchanged line is never in the diff to begin with;
   `handleOpenDiff` passes both sides straight from the chip; `DiffPanel` is pure
   and fetches nothing. I also checked whether the redactor is context-sensitive
   -- which would let the same line redact differently in two framings -- and it
   is not: the reported line redacts identically alone, inside JSON, after prose,
   and inside a fence.

   So the asymmetry is either on a surface I have not identified or specific to
   the reporter's build. What that means for this PR: the guard below would catch
   the defect if it were introduced in this producer, and it does not close the
   issue. #9390 should stay open for the reporter's exact surface.

## Tests

Described above. Existing behaviour unchanged: `57 passed` in
`test/test_file_change_snapshots.py`, with no source file touched.

## Manual verification

N/A -- no behaviour change; this PR adds assertions only.

## Related Issues

Refs #9390

## Pattern harvest

Rule candidate: review-prompt
Pattern: a sanitizer applied independently to the two sides of a comparison. When
redaction, normalization or truncation runs per-side, "each side is sanitized" is
not the property that matters -- the property is that identical input stays
identical, and asserting the former while omitting the latter leaves the
comparison free to invent differences.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
