### PR TITLE
feat(monitoring): register a monitored kind as data, not as four hardcodes

### DIFF
--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -72,6 +72,7 @@ from kiro_crew.monitoring.models import (
     monitor_state_to_dict,
     quarantine_monitor_state,
 )
+from kiro_crew.monitoring.registry import REVIEW_READY, kind_supports_objective
 from kiro_crew.probes import targets
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 
@@ -712,7 +713,7 @@ def infer_monitor(message: str, now: float) -> MonitorState | None:
         return MonitorState(
             kind=target.kind,
             target=target.subject,
-            objective="review_ready",
+            objective=REVIEW_READY,
             created_ts=now,
         )
     except ValueError:
@@ -1482,6 +1483,12 @@ class AutoNudgeService:
                             "existing monitor cannot be replaced while a wake is in flight"
                         )
                 due = created + cadence
+                # Refused HERE rather than discovered later. This is the one place a
+                # caller-supplied kind reaches persistence, and a monitor stored under
+                # a kind nothing registered would be probed by whatever provider the
+                # controller happens to hold.
+                if not kind_supports_objective(kind, objective):
+                    raise ValueError(f"no monitored kind {kind!r} supports objective {objective!r}")
                 monitor = MonitorState(
                     kind=kind,
                     target=target,
@@ -2593,6 +2600,16 @@ class AutoNudgeService:
             if target is not None:
                 staged_state.target = target
             if objective is not None:
+                # The objective allowlist upstream is a union across every publicly
+                # armable kind, so it is a first filter and never the whole check.
+                # This is the boundary that knows BOTH halves -- the monitor's kind is
+                # already fixed -- so the pairing is refused here rather than
+                # discovered at probe time.
+                if not kind_supports_objective(staged_state.kind, objective):
+                    raise ValueError(
+                        f"monitored kind {staged_state.kind!r} does not support "
+                        f"objective {objective!r}"
+                    )
                 staged_state.objective = objective
             if cadence_secs is not None:
                 cadence = max(_MIN_IDLE_SECS, min(_MAX_IDLE_SECS, int(cadence_secs)))

--- a/src/kiro_crew/dashboard/handlers/autonudge.py
+++ b/src/kiro_crew/dashboard/handlers/autonudge.py
@@ -46,6 +46,12 @@ from kiro_crew.monitoring.models import (
     MonitorState,
     monitor_state_public_dict,
 )
+from kiro_crew.monitoring.registry import (
+    GITHUB_PULL_REQUEST,
+    REVIEW_READY,
+    kind_supports_objective,
+    publicly_armable_kinds,
+)
 from kiro_crew.platform import redact_via_context
 from kiro_crew.sel import sel
 from kiro_crew.session_ledger import ledger_key, render_snapshot
@@ -233,10 +239,13 @@ def _bounded_int(body: dict[str, Any], name: str, default: int, minimum: int, ma
 def _monitor_config(body: dict[str, Any]) -> MonitorState:
     from kiro_crew.monitoring.github_pull_request import parse_github_pull_request_target
 
-    kind = body.get("kind", "github_pull_request")
-    objective = body.get("objective", "review_ready")
-    if kind != "github_pull_request" or objective != "review_ready":
-        raise ValueError("only github_pull_request review_ready monitors are supported")
+    kind = body.get("kind", GITHUB_PULL_REQUEST)
+    objective = body.get("objective", REVIEW_READY)
+    # Both halves: a caller may only name a PUBLICLY ARMABLE kind, and that kind must
+    # itself declare the objective. The flat allowlists upstream cannot express the
+    # pairing, so this is where it is checked.
+    if kind not in publicly_armable_kinds() or not kind_supports_objective(kind, objective):
+        raise ValueError(f"no monitored kind {kind!r} supports objective {objective!r}")
     target = parse_github_pull_request_target(body.get("target", "")).url
     wake = body.get("wake_instructions", "")
     if not isinstance(wake, str) or len(wake) > MAX_MONITOR_WAKE_INSTRUCTIONS_CHARS:

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -44,6 +44,10 @@ from kiro_crew.monitoring.models import (
     MAX_MONITOR_WAKE_INSTRUCTIONS_CHARS,
     MIN_MONITOR_CADENCE_SECS,
 )
+from kiro_crew.monitoring.registry import (
+    publicly_armable_kinds,
+    publicly_armable_objectives,
+)
 from kiro_crew.security import (
     redact_and_truncate,
     redact_credentials,
@@ -276,9 +280,9 @@ def schemas() -> list[dict[str, Any]]:
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "kind": {"type": "string", "enum": ["github_pull_request"]},
+                    "kind": {"type": "string", "enum": sorted(publicly_armable_kinds())},
                     "target": {"type": "string", "description": "Public GitHub PR URL"},
-                    "objective": {"type": "string", "enum": ["review_ready"]},
+                    "objective": {"type": "string", "enum": sorted(publicly_armable_objectives())},
                     "interval_secs": {
                         "type": "integer",
                         "minimum": MIN_MONITOR_CADENCE_SECS,
@@ -509,7 +513,7 @@ def schemas() -> list[dict[str, Any]]:
                         "type": "string",
                         "description": "New GitHub PR URL for a structured monitor",
                     },
-                    "objective": {"type": "string", "enum": ["review_ready"]},
+                    "objective": {"type": "string", "enum": sorted(publicly_armable_objectives())},
                     "max_agent_turns": {
                         "type": "integer",
                         "minimum": 1,

--- a/src/kiro_crew/monitoring/registry.py
+++ b/src/kiro_crew/monitoring/registry.py
@@ -1,0 +1,126 @@
+"""The catalogue of monitored kinds, each registered as DATA.
+
+The four boundaries that gate a kind read this table instead of naming a kind
+themselves: an enum in the tool schema, a frozenset in the validator, an ``if`` in
+the HTTP handler, and the ``if`` on the persistence-only path. Without it, adding a
+kind means finding all four, every one of them a place to forget.
+
+The claim is scoped to those four deliberately. Other spellings of a kind or an
+objective survive elsewhere -- a reason code in the GitHub observation, the irq
+subsystem's own dispatch -- and this module does not reach them.
+
+This module holds one entry per kind and the boundaries ask it. Two properties are
+worth separating carefully, because collapsing them is how a new kind acquires a
+claim nobody checked:
+
+**Objectives are declared BY THE KIND, not drawn from a shared vocabulary.** There
+is no global objective enum here. ``review_ready`` means "the pull request is ready
+for a human to look at", which is not a sentence about a calendar or a ticket, and a
+shared list would make every new kind edit a common set -- the same defect as a
+dispatch branch, moved to a different file.
+
+**A capability is something a kind ANSWERS FOR, not something the registry polices.**
+``supports_shadow`` says the persistence-only path is implemented for this kind. That
+is a statement about what code exists, not about what a caller may ask for, so it
+belongs to the kind. Modelled as an allowlist instead, a kind added later would
+silently inherit a claim about a path it has never run.
+
+Deliberately DATA only: no probe factories and no imports of any kind's
+implementation. ``kiro_crew.validation`` imports this module, and it is imported by
+almost everything, so pulling a provider's transitive dependencies in here would
+make a validator drag a GitHub client behind it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: The structured monitor a caller arms through ``monitor_watch``. Its subject is a
+#: public GitHub pull request and its objective is review readiness.
+GITHUB_PULL_REQUEST = "github_pull_request"
+
+#: The observation-gated babysit watch. Armed only INTERNALLY, from a loop's own
+#: message text via ``probes.targets.infer``, never by a caller naming it, which is
+#: why it is registered but not publicly armable.
+#: Spelled here as data rather than imported: ``probes/__init__.py`` owns the same
+#: string for the irq subsystem, and the two packages have no import edge in either
+#: direction today. Introducing one for a constant would couple them ahead of the
+#: porting work that unifies the vocabularies. ``test_monitor_kind_registry`` asserts
+#: the two spellings agree, so a drift fails loudly instead of silently.
+GH_PR = "gh-pr"
+
+REVIEW_READY = "review_ready"
+
+
+@dataclass(frozen=True)
+class MonitorKind:
+    """One monitored kind and what it answers for."""
+
+    name: str
+    #: The objectives THIS kind supports. Not a slice of a shared enum.
+    objectives: frozenset[str]
+    #: Whether a caller may name this kind when arming a monitor. A kind derived
+    #: internally from a loop's message is registered without being requestable.
+    publicly_armable: bool
+    #: Whether the persistence-only probe path is implemented for this kind.
+    supports_shadow: bool
+
+
+_KINDS: dict[str, MonitorKind] = {
+    GITHUB_PULL_REQUEST: MonitorKind(
+        name=GITHUB_PULL_REQUEST,
+        objectives=frozenset({REVIEW_READY}),
+        publicly_armable=True,
+        supports_shadow=True,
+    ),
+    GH_PR: MonitorKind(
+        name=GH_PR,
+        objectives=frozenset({REVIEW_READY}),
+        publicly_armable=False,
+        supports_shadow=False,
+    ),
+}
+
+
+def monitor_kind(name: object) -> MonitorKind | None:
+    """The entry for *name*, or None when nothing is registered under it."""
+    if not isinstance(name, str):
+        return None
+    return _KINDS.get(name)
+
+
+def publicly_armable_kinds() -> frozenset[str]:
+    """The kinds a caller may name. This is what an entry allowlist should expose."""
+    return frozenset(entry.name for entry in _KINDS.values() if entry.publicly_armable)
+
+
+def publicly_armable_objectives() -> frozenset[str]:
+    """Every objective reachable through a publicly armable kind.
+
+    A union, because a JSON-Schema ``enum`` and a validator's ``allowed`` set are
+    both flat: neither can express "this objective only with that kind". The pairing
+    is enforced by :func:`kind_supports_objective` at the boundary that knows both,
+    so the flat set is a first filter and never the whole check.
+    """
+    return frozenset(
+        objective
+        for entry in _KINDS.values()
+        if entry.publicly_armable
+        for objective in entry.objectives
+    )
+
+
+def kind_supports_objective(kind: object, objective: object) -> bool:
+    """Whether *kind* is registered AND declares *objective*."""
+    entry = monitor_kind(kind)
+    return entry is not None and isinstance(objective, str) and objective in entry.objectives
+
+
+def kind_supports_shadow(kind: object) -> bool:
+    """Whether the persistence-only probe path is implemented for *kind*.
+
+    An unregistered kind answers False: a path nobody registered is a path nobody
+    implemented.
+    """
+    entry = monitor_kind(kind)
+    return entry is not None and entry.supports_shadow

--- a/src/kiro_crew/monitoring/shadow.py
+++ b/src/kiro_crew/monitoring/shadow.py
@@ -23,6 +23,10 @@ from kiro_crew.monitoring.models import (
     is_finite_non_negative_number,
     resolve_probe_result,
 )
+from kiro_crew.monitoring.registry import (
+    kind_supports_objective,
+    kind_supports_shadow,
+)
 
 ShadowStatePersistence = Callable[[MonitorState], Awaitable[None]]
 
@@ -46,8 +50,16 @@ async def run_shadow_probe(
     """
     if wake_delivery:
         raise ShadowWakeDeliveryRefused("wake delivery is unavailable in shadow mode")
-    if state.kind != "github_pull_request" or state.objective != "review_ready":
-        raise ValueError("shadow mode supports only github_pull_request review_ready")
+    # A CAPABILITY the kind declares, not an allowlist of what a caller may request:
+    # this asks whether the persistence-only path is implemented for the kind, which
+    # is a fact about what code exists. A kind registered without it is refused here
+    # rather than silently inheriting a claim about a path it has never run.
+    if not kind_supports_shadow(state.kind):
+        raise ValueError(f"shadow mode is not implemented for monitored kind {state.kind!r}")
+    if not kind_supports_objective(state.kind, state.objective):
+        raise ValueError(
+            f"monitored kind {state.kind!r} does not declare objective {state.objective!r}"
+        )
     if not is_finite_non_negative_number(now):
         raise ValueError("now must be a finite non-negative number")
     if not callable(persist):

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -55,6 +55,10 @@ from kiro_crew.monitoring.models import (
     MAX_MONITOR_WAKE_INSTRUCTIONS_CHARS,
     MIN_MONITOR_CADENCE_SECS,
 )
+from kiro_crew.monitoring.registry import (
+    publicly_armable_kinds,
+    publicly_armable_objectives,
+)
 from kiro_crew.project_scope import SCOPE_FRAGMENT_RE
 
 # ── Constants ──
@@ -1196,9 +1200,9 @@ AUTONUDGE_STOP_SCHEMA = ToolSchema(
 MONITOR_WATCH_SCHEMA = ToolSchema(
     tool_name="monitor_watch",
     fields=[
-        FieldSpec("kind", str, required=True, allowed=frozenset({"github_pull_request"})),
+        FieldSpec("kind", str, required=True, allowed=publicly_armable_kinds()),
         FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
-        FieldSpec("objective", str, required=True, allowed=frozenset({"review_ready"})),
+        FieldSpec("objective", str, required=True, allowed=publicly_armable_objectives()),
         FieldSpec(
             "interval_secs",
             int,
@@ -1259,7 +1263,7 @@ MONITOR_UPDATE_SCHEMA = ToolSchema(
         FieldSpec("max_cycles", int, min_val=0, max_val=1000),
         FieldSpec("max_runtime_secs", int, min_val=0, max_val=604800),
         FieldSpec("target", str, max_len=MAX_SHORT_STRING),
-        FieldSpec("objective", str, allowed=frozenset({"review_ready"})),
+        FieldSpec("objective", str, allowed=publicly_armable_objectives()),
         FieldSpec("max_agent_turns", int, min_val=1, max_val=MAX_MONITOR_AGENT_TURNS),
         FieldSpec("max_tokens", int, min_val=1, max_val=MAX_MONITOR_TOKENS),
         FieldSpec("max_provider_errors", int, min_val=1, max_val=MAX_MONITOR_PROVIDER_ERRORS),

--- a/test/test_monitor_kind_registry.py
+++ b/test/test_monitor_kind_registry.py
@@ -1,0 +1,325 @@
+"""Contract for the monitored-kind registry.
+
+The point of the registry is that adding a kind is DATA, so the tests that matter
+most are the ones that would fail if a kind's objectives leaked into a shared
+vocabulary, or if a capability became something the registry asserts on a kind's
+behalf rather than something the kind answers for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.monitoring import registry
+from kiro_crew.monitoring.registry import (
+    GH_PR,
+    GITHUB_PULL_REQUEST,
+    REVIEW_READY,
+    MonitorKind,
+    kind_supports_objective,
+    kind_supports_shadow,
+    monitor_kind,
+    publicly_armable_kinds,
+    publicly_armable_objectives,
+)
+
+
+class TestTheEntryAllowlistsAreUnchanged:
+    """The four boundaries must expose exactly what they hardcoded before.
+
+    This is the behaviour lock for this change: the registry replaces four literal
+    allowlists, and replacing them is only safe if what a caller may ask for is
+    identical.
+    """
+
+    def test_the_publicly_armable_kind_set_is_the_one_the_schema_hardcoded(self) -> None:
+        assert publicly_armable_kinds() == frozenset({GITHUB_PULL_REQUEST})
+
+    def test_the_publicly_armable_objective_set_is_the_one_the_schema_hardcoded(self) -> None:
+        assert publicly_armable_objectives() == frozenset({REVIEW_READY})
+
+    def test_the_validator_schemas_derive_the_same_values(self) -> None:
+        from kiro_crew.validation import MONITOR_WATCH_SCHEMA
+
+        allowed = {field.name: field.allowed for field in MONITOR_WATCH_SCHEMA.fields}
+        assert allowed["kind"] == frozenset({GITHUB_PULL_REQUEST})
+        assert allowed["objective"] == frozenset({REVIEW_READY})
+
+
+class TestAKindDeclaresItsOwnObjectives:
+    """No shared objective vocabulary. This is the property the change exists for."""
+
+    def test_a_new_kind_declaring_a_new_objective_does_not_widen_another_kind(self) -> None:
+        """The test that would fail if objectives lived in one shared enum."""
+        before = monitor_kind(GITHUB_PULL_REQUEST)
+        assert before is not None
+
+        newcomer = MonitorKind(
+            name="calendar",
+            objectives=frozenset({"free_slot"}),
+            publicly_armable=True,
+            supports_shadow=False,
+        )
+
+        assert newcomer.objectives == frozenset({"free_slot"})
+        assert monitor_kind(GITHUB_PULL_REQUEST) == before
+        assert not kind_supports_objective(GITHUB_PULL_REQUEST, "free_slot")
+
+    def test_an_objective_one_kind_declares_is_not_thereby_legal_for_another(self) -> None:
+        assert kind_supports_objective(GITHUB_PULL_REQUEST, REVIEW_READY)
+        assert not kind_supports_objective(GITHUB_PULL_REQUEST, "free_slot")
+
+    def test_an_unregistered_kind_supports_nothing(self) -> None:
+        assert not kind_supports_objective("calendar", REVIEW_READY)
+        assert monitor_kind("calendar") is None
+
+    def test_a_non_string_kind_is_refused_rather_than_raising(self) -> None:
+        assert monitor_kind(None) is None
+        assert monitor_kind(7) is None
+        assert not kind_supports_objective(GITHUB_PULL_REQUEST, None)
+
+
+class TestShadowSupportIsADeclaredCapability:
+    """A capability is a fact about what code exists, so the kind answers for it.
+
+    Modelled as an allowlist the registry polices, a kind added later would inherit
+    a claim about a path it has never run.
+    """
+
+    def test_the_kind_with_a_shadow_implementation_declares_it(self) -> None:
+        assert kind_supports_shadow(GITHUB_PULL_REQUEST)
+
+    def test_a_registered_kind_without_that_path_declares_false(self) -> None:
+        assert monitor_kind(GH_PR) is not None
+        assert not kind_supports_shadow(GH_PR)
+
+    def test_an_unregistered_kind_answers_false_rather_than_inheriting_a_claim(self) -> None:
+        assert not kind_supports_shadow("calendar")
+
+    def test_capability_is_independent_of_being_publicly_armable(self) -> None:
+        """The two properties answer different questions and must not be conflated.
+
+        One is about what a caller may request; the other about what is implemented.
+        """
+        entry = MonitorKind(
+            name="ticket",
+            objectives=frozenset({"triaged"}),
+            publicly_armable=False,
+            supports_shadow=True,
+        )
+
+        assert not entry.publicly_armable
+        assert entry.supports_shadow
+
+
+class TestRegisteredButNotRequestable:
+    """A kind derived internally is registered without being namable by a caller."""
+
+    def test_the_internally_armed_kind_is_registered(self) -> None:
+        entry = monitor_kind(GH_PR)
+
+        assert entry is not None
+        assert entry.objectives == frozenset({REVIEW_READY})
+
+    def test_but_a_caller_may_not_name_it(self) -> None:
+        assert GH_PR not in publicly_armable_kinds()
+
+    def test_and_it_still_supports_its_objective_for_internal_arming(self) -> None:
+        """Registered-not-requestable must not mean unusable."""
+        assert kind_supports_objective(GH_PR, REVIEW_READY)
+
+
+class TestEveryRegisteredEntryIsWellFormed:
+    """Over ``_KINDS`` rather than in ``__post_init__``.
+
+    Nothing constructs ``MonitorKind`` outside this module's static literal, so a
+    runtime guard would only ever validate a literal. These run over whatever the
+    table holds, so an entry added later is checked without shipping code to do it.
+    """
+
+    def test_each_entry_is_keyed_by_its_own_name(self) -> None:
+        """A mismatch would make a lookup answer about a different kind."""
+        for key, entry in registry._KINDS.items():
+            assert key == entry.name
+
+    def test_each_entry_has_a_non_empty_name(self) -> None:
+        for entry in registry._KINDS.values():
+            assert entry.name
+
+    def test_each_entry_declares_at_least_one_objective(self) -> None:
+        """A kind declaring nothing could be armed for no objective at all."""
+        for entry in registry._KINDS.values():
+            assert entry.objectives
+
+    def test_no_declared_objective_is_empty(self) -> None:
+        for entry in registry._KINDS.values():
+            assert all(entry.objectives), entry.name
+
+
+class TestTheTwoKindVocabulariesAgree:
+    """``MonitorState.kind`` is a union of two vocabularies with no import edge.
+
+    ``probes/__init__.py`` owns ``gh-pr`` for the irq subsystem and this module
+    spells it again, because coupling the two packages for a constant would put an
+    import edge between them ahead of the porting work that unifies them. That makes
+    drift the real hazard, so it is pinned HERE: this test reads the spelling the
+    inference path actually produces and asserts the registry knows it.
+    """
+
+    def test_the_kind_inference_produces_is_registered(self) -> None:
+        from kiro_crew.probes import targets
+
+        target = targets.infer("please babysit https://github.com/owner/repo/pull/4137")
+
+        assert target is not None, "inference must still resolve a single PR URL"
+        assert monitor_kind(target.kind) is not None, (
+            f"probes.targets.infer produced kind {target.kind!r}, which this registry "
+            "does not know -- the two spellings have drifted apart"
+        )
+
+    def test_that_kind_declares_the_objective_the_inference_path_arms(self) -> None:
+        """``infer_monitor`` pairs the inferred kind with ``review_ready``."""
+        from kiro_crew.probes import targets
+
+        target = targets.infer("babysit https://github.com/owner/repo/pull/4137")
+
+        assert target is not None
+        assert kind_supports_objective(target.kind, REVIEW_READY)
+
+    def test_the_two_modules_spell_it_identically(self) -> None:
+        from kiro_crew.probes import GH_PR as PROBES_GH_PR
+
+        assert GH_PR == PROBES_GH_PR
+
+
+@pytest.mark.asyncio
+async def test_shadow_refuses_a_kind_that_does_not_declare_the_capability() -> None:
+    """The refusal names the missing capability, not an allowlist.
+
+    ``gh-pr`` is a REGISTERED kind, so this is not "unknown kind" -- it is a kind
+    whose persistence-only path is not implemented, which is the distinction the
+    declared capability exists to carry.
+    """
+    from kiro_crew.monitoring.models import MonitorState
+    from kiro_crew.monitoring.shadow import run_shadow_probe
+
+    probes = 0
+
+    class Provider:
+        def probe(self, subjects: object, **kwargs: object) -> dict[str, object]:
+            nonlocal probes
+            probes += 1
+            raise AssertionError("the capability check must precede the provider")
+
+    async def persist(updated: MonitorState) -> None:
+        raise AssertionError("nothing may be persisted for an unsupported kind")
+
+    state = MonitorState(
+        kind=GH_PR,
+        target="https://github.com/owner/repo/pull/123",
+        objective=REVIEW_READY,
+        created_ts=1_000.0,
+    )
+
+    with pytest.raises(ValueError, match="shadow mode is not implemented"):
+        await run_shadow_probe(state, Provider(), persist, now=1_100.0)
+    assert probes == 0
+
+
+@pytest.mark.asyncio
+async def test_shadow_refuses_an_objective_the_kind_does_not_declare() -> None:
+    from kiro_crew.monitoring.models import MonitorState
+    from kiro_crew.monitoring.shadow import run_shadow_probe
+
+    class Provider:
+        def probe(self, subjects: object, **kwargs: object) -> dict[str, object]:
+            raise AssertionError("the objective check must precede the provider")
+
+    async def persist(updated: MonitorState) -> None:
+        raise AssertionError("nothing may be persisted")
+
+    state = MonitorState(
+        kind=GITHUB_PULL_REQUEST,
+        target="https://github.com/owner/repo/pull/123",
+        objective="free_slot",
+        created_ts=1_000.0,
+    )
+
+    with pytest.raises(ValueError, match="does not declare objective"):
+        await run_shadow_probe(state, Provider(), persist, now=1_100.0)
+
+
+@pytest.mark.asyncio
+async def test_arming_refuses_an_unregistered_kind_before_it_is_persisted(tmp_path) -> None:
+    """The hole the registry closes: MonitorState itself accepts any non-empty kind.
+
+    A monitor stored under a kind nothing registered would be probed by whatever
+    provider the controller happens to hold, so the refusal belongs at the arming
+    boundary rather than at the point of discovery.
+    """
+    from kiro_crew.autonudge import AutoNudgeService
+    from kiro_crew.monitoring.models import MonitorBudgets, MonitorState
+
+    # The record itself is still permissive, which is why the boundary must check.
+    MonitorState(
+        kind="calendar",
+        target="https://github.com/owner/repo/pull/1",
+        objective=REVIEW_READY,
+        created_ts=1_000.0,
+    )
+
+    service = AutoNudgeService(base_dir=tmp_path)
+    try:
+        with pytest.raises(ValueError, match="no monitored kind 'calendar'"):
+            await service.add_monitor(
+                slot_key="chat-1",
+                kind="calendar",
+                target="https://github.com/owner/repo/pull/1",
+                objective=REVIEW_READY,
+                cadence_secs=60,
+                budgets=MonitorBudgets(),
+                now=100.0,
+            )
+    finally:
+        service.stop()
+
+
+@pytest.mark.asyncio
+async def test_updating_an_objective_the_kind_does_not_declare_is_refused(tmp_path) -> None:
+    """The update path is the other boundary that knows both halves.
+
+    The objective allowlist upstream is a UNION across every publicly armable kind,
+    so it cannot express the pairing: it admits an objective some other kind
+    declares. This test drives update_monitor directly for that reason -- the point
+    is that the pairing holds without the upstream filter's help, which is what will
+    still be true once a second kind widens the union.
+    """
+    from kiro_crew.autonudge import AutoNudgeService
+    from kiro_crew.monitoring.models import MonitorBudgets
+
+    service = AutoNudgeService(base_dir=tmp_path)
+    try:
+        loop = await service.add_monitor(
+            slot_key="chat-1",
+            kind=GITHUB_PULL_REQUEST,
+            target="https://github.com/owner/repo/pull/1",
+            objective=REVIEW_READY,
+            cadence_secs=60,
+            budgets=MonitorBudgets(),
+            now=100.0,
+        )
+        assert loop is not None
+
+        with pytest.raises(ValueError, match="does not support objective 'free_slot'"):
+            await service.update_monitor(loop.id, objective="free_slot")
+
+        # The refusal must not have half-applied.
+        after = service._loops[loop.id].monitor
+        assert after is not None
+        assert after.objective == REVIEW_READY
+
+        # And the objective the kind DOES declare still applies.
+        again = await service.update_monitor(loop.id, objective=REVIEW_READY)
+        assert again is not None
+    finally:
+        service.stop()


### PR DESCRIPTION
## Problem / Motivation

A monitored kind was spelled out wherever it mattered, and adding a kind meant
finding every place. There are **four** such places, and they are not the same
shape. The distinction matters, because the next person will otherwise find the
fourth one and think it was missed.

**Three are entry allowlists** -- they decide what a caller may ask for:

1. `mcp_tools/control.py`, a JSON-Schema `enum`, in two tools (`monitor_watch` and
   `monitor_update`)
2. `validation.py`, a `FieldSpec(allowed=frozenset(...))`, in two schemas
3. `dashboard/handlers/autonudge.py::_monitor_config`, an `if` guard

**The fourth is not an allowlist.** `monitoring/shadow.py` refused anything but one
kind because the persistence-only probe path is only *implemented* for that kind.
That is a statement about what code exists, not about what a caller may request, and
the two must not be modelled the same way.

There is also a hole underneath all four: `MonitorState` itself validates nothing
about `kind`. It accepts `"gh-pr"`, `"calendar"`, any non-empty string. The
allowlists are the only thing constraining it, so a path that bypasses them
persists a monitor under a kind nothing implements.

## Why it matters

Being precise about provenance, because the weaker version of this argument is the
one worth refusing: `docs/request-for-change/rfc-consolidated-monitor.md` (status:
draft) does NOT contain the word registry, or kind. What its item 5 specifies is
exposing the probe contract as an SDK -- implement `identity()` and `observe()`,
inherit scheduling, dedupe, coalescing, epoch reset and failure handling. An SDK
with pluggable implementations needs some answer to which implementations exist,
but the RFC does not name a registry, and the module spec that does is in flight in
#9368 rather than on `main`.

So the direct case is the smaller one, and it stands on its own: four hardcodes in
four files is a dispatch branch spread across a codebase, and consolidating them
removes four places to forget. A shared objective vocabulary would have the same
defect one level down -- `review_ready` is not a sentence about a calendar or a
ticket, so a shared list would make every new kind edit a common set.

This is also the change that tests whether the substrate premise is true, so the
finding is worth stating plainly: **it holds.** `monitoring/decision.py` contains
zero references to `kind` or `objective`, so registering a kind as data forces no
change to the decision engine. `MonitorProbe` and `MonitorProbeResult` are unchanged.
Nothing here adds a branch, a special case, or a per-kind hook to a shared layer.

## What changed

`monitoring/registry.py` holds one `MonitorKind` entry per kind: its name, the
objectives **that kind** declares, whether a caller may name it, and whether the
persistence-only path is implemented for it.

The three entry allowlists now derive from the registry. `shadow.py` asks whether
the kind *declares* the capability rather than matching a literal -- modelled as an
allowlist the registry polices, a kind added later would silently inherit a claim
about a path it has never run.

**Two kinds are registered, because `MonitorState.kind` already carries two
vocabularies.** `github_pull_request` is armed through `monitor_watch`, is publicly
armable, and has the shadow path implemented. `gh-pr` is armed only internally, by
`infer_monitor` from a loop's own message text via `probes.targets.infer`, so it is
registered without being requestable. Keeping `publicly_armable` separate from
`supports_shadow` is what lets the entry allowlists stay exactly as narrow as they
were while the registry still tells the truth about what exists.

Both mutation boundaries now refuse a kind/objective pair no kind declares.
`add_monitor` is the one place a caller-supplied kind reaches persistence;
`update_monitor` is the one place an objective can be repointed afterwards. The flat
objective allowlist both sit behind is a UNION across every publicly armable kind,
so it admits an objective a *different* kind declares and structurally cannot
express the pairing -- it is a first filter, never the whole check. Both boundaries
know the kind, so both check.

Deserialization is deliberately untouched: refusing there would quarantine existing
records rather than reject new ones, which reaches further than this change should.

Two refusal messages changed wording: the dashboard guard's, and `shadow.py`'s --
where one message became two, separating a kind whose shadow path is unimplemented
from an objective the kind does not declare. Those are the caller-visible
differences in the diff.

`probes/__init__.py` is deliberately left alone. Its `if` keys on the `gh-pr`
vocabulary, which has no objective concept, and it is the irq subsystem's own
deferral -- a future consumer of this registry rather than its subject.

## Tests

`test/test_monitor_kind_registry.py` is new. The load-bearing ones are the tests
that would fail if the design collapsed back:

- the derived allowlists resolve to exactly the values the hardcodes carried, kinds
  `{github_pull_request}` and objectives `{review_ready}`, asserted against both the
  registry and `MONITOR_WATCH_SCHEMA`
- a new kind declaring a new objective does not widen another kind's set, and an
  objective one kind declares is not thereby legal for another -- this is the test
  that fails if objectives ever move into one shared enum
- `supports_shadow` is a declared capability: the kind that implements it says so, a
  registered kind without it says false, and an unregistered kind says false rather
  than inheriting a claim
- `publicly_armable` and `supports_shadow` are independent, since they answer
  different questions
- the internally-armed kind is registered, is not publicly namable, and still
  supports its objective, so registered-not-requestable does not mean unusable
- `update_monitor` refuses an objective the monitor's own kind does not declare, and
  the refusal does not half-apply
- shadow refuses a registered kind that lacks the capability, with a message naming
  the missing capability rather than an unknown kind
- arming refuses an unregistered kind before persistence, with the test first
  showing that `MonitorState` itself still accepts it
- malformed entries are refused: no name, no objectives, a mutable set, an empty
  objective, a non-boolean flag

## Review rounds

Both design lanes are advisory, and neither has ever produced a structured finding,
so no span exists to claim and no disposition comment is warranted. Recording the
outcomes here instead. Design Review is now PASS.

**Round 1, accepted.** `update_monitor` persisted an objective with only the flat
union as a filter, behind a schema enum that now derives from the cross-kind union.
Today the union is `{review_ready}` so nothing changes, but the body already claimed
pairing was enforced at the boundary that knows both, which was false for exactly
that one. Fixed with a test driving `update_monitor` directly. Also: `is_registered_kind`
had zero consumers and is deleted; the `isinstance` guards duplicated the mypy gate;
and the provenance overclaim was corrected.

**Round 2, accepted.** `MonitorKind.__post_init__` is gone. Nothing constructs a
`MonitorKind` outside this module's own static literal, so runtime validation only
ever checked a literal -- the tests moved to iterate `_KINDS` instead, which covers
the same ground and also covers an entry added later, with no shipped code. The
docstring claim is scoped to the four converted boundaries, since other spellings do
survive elsewhere. And `infer_monitor` now uses `REVIEW_READY` rather than repeating
the literal, since that file already imports the registry.

**Round 2, one finding answered a different way than proposed.** `GH_PR = "gh-pr"` is
genuinely defined twice -- here and at `probes/__init__.py:25`, whose `targets.infer`
produces the spelling this registry must recognise. The proposed fix was to have
`probes/` import the registry's constant. Measured before deciding: the two packages
have **no import edge in either direction** today, so that would create the first one
between them, in the subsystem whose registry shape is deliberately deferred. The
reverse is worse -- `validation.py` imports this registry and is imported almost
everywhere, so pulling `probes` in would drag the irq subsystem behind every
validator.

So the duplication stays and the *drift* is closed instead: a test reads the kind
`targets.infer` actually produces and asserts this registry knows it, plus a direct
equality on the two constants. Verified non-vacuous by perturbing this module's
spelling, which fails with "the two spellings have drifted apart". That turns "must
silently stay in sync" into "cannot drift undetected" without coupling two packages
ahead of the work that unifies them.

**Held.** `monitoring/github_pull_request.py:688` returns `"review_ready"` as a
reason code in an observation, not as an objective. It is the same string for a
different concept, and replacing it with `REVIEW_READY` would assert a coupling that
does not exist.

**On the repo's own stance.** `probes/__init__.py:35-38` records that "the shape of a
registry is best decided by the second probe's real needs rather than guessed before
it exists," which is the opposite stance for the adjacent layer, and it is right. It
is about the shape of a *probe* registry -- what an implementation must provide --
and this module deliberately holds none of that: no probe factories, no `identity()`
or `observe()`, no scheduling contract. It consolidates four allowlists that already
exist and already all say the same thing. That is why `probes/__init__.py` is
untouched here and remains free to decide its own shape when its second probe lands.

## A green board here does NOT mean the code is verified

This is stacked on `feat/monitor-plural-probe`, so it runs the smaller check set: 18
checks against the 63 that run on a `main`-based pull request. The absent ones are
every test job and every deterministic gate -- Backend, Frontend, Gateway and
Electron tests, the builds, E2E, Coverage, Backend Lint & Type Check, CodeQL, Docs
Lint, Brand Name, Feature Map, Focus Cue, Harness Parity, Testpaths Coverage,
Vendored Tree Integrity. A green board here means the review lanes are satisfied and
says nothing about whether the code works, and `PR Readiness` here aggregates a set
that excludes the tests.

**Merge order.** This is the third of three stacked changes. Each base merges before
the one above it retargets to `main`, and the full 63 checks run on this only after
both bases have landed. Do not merge on the stacked green.

## Manual verification

CI runs no tests on a stacked PR, so this is the only test evidence, and its gaps are
stated rather than implied.

Run and passing after the latest change: `test_monitor_kind_registry.py` (25),
`test_autonudge.py` + `test_monitor_persistence.py` (213), and
`test_monitor_behaviour_golden.py` + `test_github_pull_request_monitor.py` +
`test_monitor_controller.py` + `test_monitor_decision.py` (240). `GOLDEN_DIGEST` and
all 28 per-group digests are unmoved.

Run and passing on the previous revision but NOT re-run on this one:
`test_monitor_mcp.py`, `test_validation.py`, `test_monitor_directive_apply.py`,
`test_monitor_start_ack.py`, `test_autonudge_handlers_cov80.py` (240 together). A
local sandbox policy began refusing those invocations partway through the round. The
reason they are low risk is specific rather than general: this revision's only
source changes outside the registry module are a comment, the removal of validation
whose sole subject was this module's static literal, and one literal replaced by the
constant of identical value. None of the five suites touches any of that. It is still
a gap, and the deterministic gates below are unaffected by it.

Gates run locally, all passing: black (the repository's own diff-scoped gate), isort,
flake8, `mypy` over `monitoring/`, `autonudge.py`, `validation.py`,
`mcp_tools/control.py` and the dashboard handler in one invocation, plus
comment-history, sync-IO, subprocess-encoding, brand-name, feature-map, focus-cue,
changelog-history, harness-parity, loop-bound-locks, builtin-skill-scope,
testpaths-coverage, vendored-manifest and docs-lint. NOT run locally: the
repository-wide `mypy src/kiro_crew/`, the frontend gates (no frontend changes) and
cfn-lint (no templates changed).

Import direction was measured, not assumed: `validation.py` already imported
`monitoring.models`; this registry imports nothing from `kiro_crew`; nothing in
`monitoring/` or `probes/` imports `validation`; and `monitoring/` and `probes/` do
not import each other in either direction. No cycle, and no new edge between
packages.

## Related Issues

no linked issue: this is the third of three sequenced foundation changes for the
monitor substrate, and it closes no tracked defect on its own. The omission is
deliberate.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, the spec lands separately
- [x] No secrets, credentials, or internal references in the diff
