### PR TITLE
fix(chat): drop replayed streaming chunks so live text can't stutter

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -1490,6 +1490,16 @@ export function useWebSocket() {
               const buf = chunkBufRef.current
               let entry = buf.get(cs)
               if (!entry) { entry = { content: '', lastSeq: undefined, thinking: '' }; buf.set(cs, entry) }
+              // Idempotency guard: drop a replayed/repeated chunk (seq <= lastSeq).
+              // WS delivery is at-least-once (reconnect replay, retry re-stream), so a
+              // chunk can arrive twice. missedChunkMarker below only flags FORWARD gaps
+              // (curSeq - prevSeq - 1 > 0), so a repeat slips through and its content is
+              // appended a second time with no marker — the silent mid-stream "stutter".
+              // chat_done deletes the buffer entry, so lastSeq resets each turn and a
+              // fresh turn's seq is never suppressed.
+              if (entry.lastSeq !== undefined && data.seq !== undefined && data.seq <= entry.lastSeq) {
+                break
+              }
               // Cross-chunk gap detection via the shared missedChunkMarker,
               // single-sourced with the reducer so the two copies can't drift.
               if (entry.lastSeq !== undefined && data.seq !== undefined) {

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1091,6 +1091,13 @@ function applyNonActiveFrame(
     return
   }
   if (role === 'chunk') {
+    // Idempotency guard (direct/non-batched path): drop a replayed chunk so a
+    // redelivered seq is not appended twice. Batched frames are pre-deduped by
+    // the WS flush buffer (see useWebSocket), matching the missedChunkMarker
+    // `!batched` gating below.
+    if (!batched && seq !== undefined && run.lastChunkSeq !== undefined && seq <= run.lastChunkSeq) {
+      return
+    }
     run.state = 'streaming'
     syncOriginRun(state, slot, 'streaming')
     // Drop only the EMPTY thinking placeholder (mirror the active
@@ -5015,6 +5022,13 @@ const chatSlice = createSlice({
       }
       // WS chunk — accumulate into streaming message, preserve rawText
       if (role === 'chunk') {
+        // Idempotency guard (direct/non-batched path): drop a replayed chunk so a
+        // redelivered seq is not appended twice. Batched frames are pre-deduped by
+        // the WS flush buffer (see useWebSocket), matching the missedChunkMarker
+        // `!batched` gating below.
+        if (!batched && seq !== undefined && state.lastChunkSeq !== undefined && seq <= state.lastChunkSeq) {
+          return
+        }
         state.slotState = 'streaming'
         state._wsChunkedDuringFetch = true
         // Drop only the empty "Thinking…" placeholder; keep content-bearing

--- a/website/src/test/chatSlice.replayedChunkDedup.test.ts
+++ b/website/src/test/chatSlice.replayedChunkDedup.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import reducer, { sseChatMessage } from '../store/chatSlice'
+import './mockApiClient'
+
+/**
+ * Replayed-chunk idempotency guard.
+ *
+ * WS delivery is at-least-once: a reconnect replay or a retry re-stream can
+ * redeliver a streaming chunk the client already applied. missedChunkMarker
+ * only flags FORWARD gaps (curSeq - prevSeq - 1 > 0), so a repeated/backward
+ * seq produced NO marker and its content was appended a second time — the
+ * silent mid-stream "stutter" (e.g. "So opus-4.8 ISSo opus-4.8 IS...").
+ *
+ * Both reducer chunk paths (active `sseChatMessage` and background
+ * `applyNonActiveFrame`) drop a chunk whose seq <= the last-seen seq on the
+ * non-batched path. Batched frames are pre-deduped by the WS flush buffer
+ * (useWebSocket), so the guard is gated with `!batched` — mirroring the
+ * missedChunkMarker gating so the two cannot drift.
+ */
+
+const SLOT = 'active-slot'
+const OTHER = 'focused-slot'
+const init = () => reducer(undefined, { type: '@@INIT' })
+
+describe('replayed-chunk dedup (active path)', () => {
+  it('does not double-append a chunk redelivered with the same seq', () => {
+    let s = { ...init(), activeSlot: SLOT }
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'So opus-4.8 IS', seq: 5 }))
+    // Same seq redelivered (reconnect replay / retry re-stream).
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'So opus-4.8 IS', seq: 5 }))
+
+    const text = s.messages.map(m => m.content).join('')
+    expect(text.match(/So opus-4.8 IS/g)?.length).toBe(1)
+  })
+
+  it('drops a backward-seq replay but keeps the forward chunk that followed', () => {
+    let s = { ...init(), activeSlot: SLOT }
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'A', seq: 5 }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'B', seq: 6 }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'A', seq: 5 })) // stale replay
+
+    expect(s.messages.map(m => m.content).join('')).toBe('AB')
+  })
+
+  it('still appends normal forward-progress chunks (guard does not over-drop)', () => {
+    let s = { ...init(), activeSlot: SLOT }
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'a', seq: 1 }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'b', seq: 2 }))
+
+    expect(s.messages.map(m => m.content).join('')).toBe('ab')
+  })
+})
+
+describe('replayed-chunk dedup (background / applyNonActiveFrame path)', () => {
+  it('does not double-append a redelivered chunk for a non-active slot', () => {
+    let s = { ...init(), activeSlot: OTHER }
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'So opus-4.8 IS', seq: 5 }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'chunk', content: 'So opus-4.8 IS', seq: 5 }))
+
+    const streamed = (s.slotMessages[SLOT] ?? []).map(m => m.content).join('')
+    expect(streamed.match(/So opus-4.8 IS/g)?.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

A streaming reply could render its first words repeated in the live view — e.g. `So opus-4.8 ISSo opus-4.8 IS...` — a mid-stream "stutter" the user watches as the reply types out. It was render-only: the persisted transcript was always clean and the glitch self-healed on refresh, but to the user it looked like data corruption.

## Why it matters

It reads as a correctness / data-integrity bug — users reasonably assume the saved reply is also corrupted — and undermines trust in the transcript, even though nothing is actually lost. It surfaces intermittently during live streaming, so it is easy to hit and hard to explain away.

## What changed (motivation → approach → change)

- **Symptom:** the same leading text appeared multiple times in a streaming message, with no `[N chunk(s) missed]` marker.
- **Root cause:** WS chunk delivery is at-least-once — a reconnect replay or retry re-stream can redeliver a chunk the client already applied. The ingestion path appended every chunk and relied on `missedChunkMarker`, which only detects FORWARD gaps (`curSeq - prevSeq - 1 > 0`). A repeated or backward `seq` therefore produced no marker and its content was appended a second time.
- **Change:** add a seq-regression idempotency guard (drop when `seq <= last-seen seq`) at the WS flush buffer in `website/src/hooks/useWebSocket.ts` (the live path — primary fix) and at both reducer chunk paths in `website/src/store/chatSlice.ts` (active `sseChatMessage` + background `applyNonActiveFrame`), gated with `!batched` to mirror the existing `missedChunkMarker` gating so the two cannot drift. `chat_done` resets last-seen seq per turn, so a fresh turn's `seq` is never suppressed.

## Tests

New `website/src/test/chatSlice.replayedChunkDedup.test.ts` locks in, on both the active and background reducer paths:
- a same-`seq` replay is dropped (content appears exactly once);
- a stale backward-`seq` replay is dropped while the forward chunk that followed is kept;
- normal forward-progress chunks still append (the guard does not over-drop).

`vitest run` on the new test + the sibling `chatSlice.batchedMissedMarker.test.ts`: **7/7 pass**.

## Manual verification

N/A — the redelivery is timing/transport-dependent and not reliably reproducible on demand; unit coverage exercises the exact ingestion guard on both reducer paths. `eslint` is clean on all changed files.

## Pattern harvest

Rule candidate: `review-prompt` / `agents-md`
Pattern: at-least-once stream/event ingestion must be idempotent against **replays** (guard `seq <= last-seen`), not only against forward gaps — a gap-only check silently double-applies a redelivered item.

## Checklist

- [x] At most two commits (one), Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing or build docs affected
- [x] No secrets, credentials, or internal references in the diff
