### PR TITLE
fix(pod-e2e): drop the full-pytest phase from the harness

### DIFF
--- a/docs/guides/worktree-verification-recipes.md
+++ b/docs/guides/worktree-verification-recipes.md
@@ -123,7 +123,7 @@ printf '%s\n' "$HANDLE" | jq -e '
   .status == "up" and (.base_url | startswith("http://127.0.0.1:"))
 ' >/dev/null
 
-bash "$HARNESS" "$WT" --fe-only --no-suppress-first-run
+bash "$HARNESS" "$WT" --no-suppress-first-run
 
 jq -se '
   any(.[]; .phase == "smoke" and .status == "pass") and

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pod-e2e
-description: "ONLY for developing Kiro Crew itself -- if the project you are working on is anything else, ignore this skill: it drives Kiro Crew's own pod tooling, which does not exist in another repository. Runs end-to-end tests (backend API + frontend Playwright) for a Kiro Crew feature worktree against an ISOLATED throwaway pod instance, without touching the live gateway. Use when asked to e2e-test / smoke-test / verify a Kiro Crew worktree's feature hands-off, run API + browser tests on a pod, or prove a new backend route + UI work together. NOT for testing the live instance, and NOT a general-purpose e2e or smoke-test skill."
+description: "ONLY for developing Kiro Crew itself -- if the project you are working on is anything else, ignore this skill: it drives Kiro Crew's own pod tooling, which does not exist in another repository. Boots a Kiro Crew feature worktree's full stack as an ISOLATED throwaway pod and proves it boots, authenticates and renders (headless Playwright), without touching the live gateway. It does NOT run the worktree's test suite -- run the tests your change touches yourself and let CI own the full suite. Use when asked to e2e-test / smoke-test / verify a Kiro Crew worktree's feature hands-off, drive browser checks on a pod, or prove a new backend route + UI work together. NOT for testing the live instance, and NOT a general-purpose e2e or smoke-test skill."
 triggers: e2e test, smoke test, pod test, verify worktree, test pod, run e2e, end to end
 repo_scope: src/kiro_crew
 ---
@@ -22,9 +22,8 @@ bash <app-skills-dir>/pod-e2e/scripts/pod-e2e.sh <worktree-name> --video
 **Expected success output** — a `POD-E2E SUMMARY` ending like:
 ```
   ✅ auth — GET /api/sessions → 200 with token, 403 without
-  ✅ api-tests — … → exit 0
   ✅ playwright — headless chromium loaded dashboard …
-result:       3 passed, 0 failed
+result:       2 passed, 0 failed
 ARTIFACT_DIR=~/.kirocrew-pods/.e2e-artifacts/<worktree-name>
 ```
 Exit code = number of failed phases (0 = all green). Then **look at the
@@ -96,9 +95,16 @@ green). Flags:
 | flag | effect |
 |---|---|
 | `--keep` / `--no-stop` | leave the pod running after tests (debug) |
-| `--api-only` | skip the Playwright phase |
-| `--fe-only` | skip the API-test phase |
+| `--api-only` | skip the Playwright phase (leaves a boot + auth check) |
+| `--fe-only` | accepted no-op — no test-suite phase exists to skip |
 | `--video` | record the session at 1080p → `.webm` + `.mp4` (finalization is time-capped) |
+
+**It does not run the worktree's test suite.** There is no pytest phase, on
+purpose: the suite is ~62k tests that need no pod, CI runs it on the merge ref,
+and a full local fan-out on a shared box costs far more than the browser check
+this harness exists for. Run the tests your change actually touches yourself,
+in the worktree (see the `kirocrew-worktree-dev` skill), and let CI own the
+full suite.
 
 ## What each phase does
 
@@ -115,10 +121,7 @@ green). Flags:
    and aborts.
 3. **auth** — proves auth: `/api/sessions` → 200 with token, 403 without.
    Token comes from `kirocrew pod up --json` output (no manual minting needed).
-4. **API tests** — runs the fixed command `python -m pytest -q` with cwd=the
-   worktree root, the worktree's `.venv` on PATH, and `POD_BASE_URL` +
-   `POD_TOKEN` in env so tests can hit the live pod.
-5. **Playwright** — `pod-playwright.py` (run with a Playwright venv + bundled
+4. **Playwright** — `pod-playwright.py` (run with a Playwright venv + bundled
    chromium) loads `/?token=` headless, asserts the SPA rendered (screenshots
    `fe-smoke.png`), then exec's the optional `PLAYWRIGHT_SPEC` with a live authed
    `page` in scope.
@@ -137,7 +140,7 @@ green). Flags:
      The per-step cap uses `SIGALRM`, so on a platform without it the teardown
      degrades to unbounded and says so in the log (the harness is POSIX-only
      anyway); the phase-level `timeout` still applies.
-6. **collect** — all logs + screenshots land in
+5. **collect** — all logs + screenshots land in
    `~/.kirocrew-pods/.e2e-artifacts/<wt>/`. Per-phase results are appended to
    `verdict.jsonl` **as they are decided** (and `playwright.log` is unbuffered),
    so a stalled or killed run still leaves a readable verdict. The file is
@@ -145,7 +148,7 @@ green). Flags:
    phase — so it can never show a previous run's rows. The rest of the artifact
    dir DOES persist across runs, so check timestamps before trusting an old
    screenshot.
-7. **stop** — `kirocrew pod down <wt>`: stops the service, waits for its process
+6. **stop** — `kirocrew pod down <wt>`: stops the service, waits for its process
    tree to drain, deletes the isolated HOME, and verifies it is gone — a HOME that
    survives fails the command rather than being reported as zero residue. Skipped
    if `--keep` or if
@@ -166,10 +169,10 @@ PLAYWRIGHT_SPEC=".pod-e2e/feature.spec.py" # frontend spec, relative to the mani
 ### Trust model
 
 The **pod** isolates the gateway under test (own `KIROCREW_HOME`, own port,
-no tunnel, resource caps). The **test runner** is not a sandbox: running a
-worktree's tests executes that worktree's code as your user — exactly like
-running `pytest` in the checkout yourself. Only run pod-e2e against branches
-you would be willing to build and test locally.
+no tunnel, resource caps). The **harness** is not a sandbox: it runs the
+worktree's own gateway, and exec's that branch's `PLAYWRIGHT_SPEC`, as your
+user — exactly like building and running the checkout yourself. Only run
+pod-e2e against branches you would be willing to build and run locally.
 
 ### Playwright spec contract
 
@@ -220,12 +223,12 @@ Rules:
   mints the token internally via the CLI — just run the one command above.
 - After it finishes, READ the artifacts in the printed ARTIFACT_DIR:
   verdict.jsonl (per-phase results, written as decided — trust this even if the
-  run was killed), api-tests.log, playwright.log, fe-*.png screenshots (use the
+  run was killed), playwright.log, fe-*.png screenshots (use the
   Read tool on the .png to actually look at the UI), and boot-fail.log if present.
 
 Then return a QA VERDICT, not a raw dump:
   1. Overall: PASS / FAIL / BLOCKED (couldn't even boot the pod).
-  2. Per check (auth / api-tests / playwright): pass|fail + one-line evidence.
+  2. Per check (auth / playwright): pass|fail + one-line evidence.
   3. For each FAIL: triage it — is it (a) a real regression in the feature,
      (b) a flaky/timing issue, or (c) an environment problem (missing venv,
      missing dist, port clash)? Cite the log line or screenshot that proves it.

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
-# pod-e2e.sh <worktree-name> [--keep] [--no-stop] [--api-only] [--fe-only] [--video] [--no-suppress-first-run]
+# pod-e2e.sh <worktree-name> [--keep] [--no-stop] [--api-only] [--video] [--no-suppress-first-run]
 #
 # Run the full e2e flow for ONE worktree against an ISOLATED pod instance,
 # never touching the live gateway:
 #
-#   kirocrew pod up --json  →  health poll  →  auth check  →  API tests  →  Playwright  →  pod down
+#   kirocrew pod up --json  →  health poll  →  auth check  →  Playwright  →  pod down
+#
+# It does NOT run the worktree's test suite: scoped, change-relevant tests are
+# the dev agent's job in its own worktree, and CI runs the full suite on the
+# merge ref. This harness proves the pod boots, auths and renders.
 #
 # Everything runs on the pod's own port + its own KIROCREW_HOME. The live
 # gateway is never bounced. Teardown deletes the pod's HOME and verifies it is
@@ -20,14 +24,17 @@
 set -uo pipefail
 
 # ---------------------------------------------------------------- args ----
-NAME="" ; KEEP=0 ; NO_STOP=0 ; RUN_API=1 ; RUN_FE=1 ; VIDEO=0
+NAME="" ; KEEP=0 ; NO_STOP=0 ; RUN_FE=1 ; VIDEO=0
 NO_SUPPRESS_FIRST_RUN=0
 for a in "$@"; do
   case "$a" in
     --keep)     KEEP=1 ;;
     --no-stop)  NO_STOP=1 ;;
     --api-only) RUN_FE=0 ;;
-    --fe-only)  RUN_API=0 ;;
+    # Accepted no-op: with no test-suite phase to skip, "frontend only" is
+    # what every run already does. Kept so older invocations and stale agent
+    # prompts do not die on exit 64.
+    --fe-only)  : ;;
     --video)    VIDEO=1 ;;
     # Documented in SKILL.md and accepted by pod-playwright.py; without this
     # arm the catch-all below rejects the documented spelling with exit 64.
@@ -36,7 +43,7 @@ for a in "$@"; do
     *)          NAME="$a" ;;
   esac
 done
-[ -n "$NAME" ] || { echo "usage: pod-e2e.sh <worktree-name> [--keep] [--no-stop] [--api-only] [--fe-only] [--video] [--no-suppress-first-run]" >&2; exit 64; }
+[ -n "$NAME" ] || { echo "usage: pod-e2e.sh <worktree-name> [--keep] [--no-stop] [--api-only] [--video] [--no-suppress-first-run]" >&2; exit 64; }
 # Pod names are [a-zA-Z0-9._-] without leading dots — reject anything that
 # could traverse paths (slashes, '..') before NAME is used in any path.
 case "$NAME" in
@@ -215,7 +222,7 @@ FAILURES=0
 WARNINGS=0
 declare -a RESULTS=()
 
-# Initialize MANIFEST early (before both API and FE phases reference it).
+# Initialize MANIFEST early (before the FE phase references it).
 # Re-discovered below once CHECKOUT is fully resolved.
 MANIFEST=""
 for _m in "$CHECKOUT/.pod-test.sh" "$CHECKOUT/src/kiro_crew/.pod-test.sh"; do
@@ -293,7 +300,7 @@ fi
 # the HTTP code when the process a 127.0.0.1 connect reaches is this pod's own
 # gateway, 0 when nothing answers, and -2 when the responder is provably somebody
 # else's. Curling base_url here would accept a stranger's 200 and hand every
-# later phase -- auth, API tests, Playwright, the artifacts -- a pod this run
+# later phase -- auth, Playwright, the artifacts -- a pod this run
 # never booted.
 log "waiting for health on $NAME ($BASE_URL) ..."
 HEALTHY=0
@@ -362,25 +369,13 @@ if [ "$HEALTHY" -eq 1 ]; then
   fi
 fi
 
-# ---------------------------------------------------------------- API -----
-if [ "$RUN_API" -eq 1 ] && [ "$HEALTHY" -eq 1 ]; then
-  log "running API tests (cwd=$CHECKOUT) ..."
-  pushd "$CHECKOUT" >/dev/null
-  API_PY="$CHECKOUT/.venv/bin/python"
-  if [ ! -x "$API_PY" ]; then
-    fail "api-tests — worktree venv python not found at $API_PY (run: kirocrew pod provision $NAME)"
-  else
-    API_TEST_CMD="$API_PY -m pytest -q"
-    export POD_BASE_URL="$BASE_URL"
-    export POD_TOKEN="$TOKEN"
-    if "$API_PY" -m pytest -q > "$ARTIFACT_DIR/api-tests.log" 2>&1; then
-      pass "api-tests — $API_TEST_CMD → exit 0"
-    else
-      fail "api-tests — $API_TEST_CMD → exit $? (see api-tests.log)"
-    fi
-  fi
-  popd >/dev/null
-fi
+# There is deliberately NO test-suite phase here, and adding one is a
+# regression. A `python -m pytest -q` from the checkout root is the wrong tool
+# in the wrong place: ~62k tests that need no pod at all, that CI runs on the
+# merge ref anyway, and whose fan-out on a shared dev box costs more than the
+# browser check this harness exists for. Scoped, change-relevant tests belong
+# to the dev agent in its own worktree (see the kirocrew-worktree-dev skill);
+# pod-e2e proves the pod BOOTS, AUTHS and RENDERS.
 
 # ---------------------------------------------------------------- FE ------
 if [ "$RUN_FE" -eq 1 ] && [ "$HEALTHY" -eq 1 ]; then

--- a/test/test_pod_e2e_harness_paths.py
+++ b/test/test_pod_e2e_harness_paths.py
@@ -264,6 +264,38 @@ def test_usage_text_lists_the_flag():
 
 
 # --------------------------------------------------------------------------
+# no test-suite phase
+# --------------------------------------------------------------------------
+
+
+def test_the_harness_never_runs_the_worktrees_test_suite():
+    """No executable line in the harness may invoke the checkout's test suite.
+
+    A `python -m pytest -q` from the checkout root is ~62k tests that need no
+    pod, that CI runs on the merge ref anyway, and whose fan-out costs far more
+    than the browser check this harness exists for. Only the comment explaining
+    the absence may name pytest, so an executable line that invokes it fails
+    here.
+    """
+    offenders = [
+        ln
+        for ln in SCRIPT.read_text(encoding="utf-8").splitlines()
+        if "pytest" in ln and not ln.lstrip().startswith("#")
+    ]
+    assert not offenders, f"the test-suite phase came back: {offenders}"
+
+
+def test_fe_only_is_still_accepted_after_the_phase_was_removed(tmp_path):
+    """Older invocations pass ``--fe-only``; with no suite phase left to skip it
+    is a no-op, and must not become an exit-64 unknown flag."""
+    res = _driver_argv(tmp_path, "smoke", "--fe-only")
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "unknown flag" not in res.stderr, res.stderr
+    # And it may not be mistaken for the worktree NAME by the loop's `*)` arm.
+    assert "NAME=--fe-only" not in res.stdout
+
+
+# --------------------------------------------------------------------------
 # resolver: must mirror pod/runtime.py resolve_checkout() exactly
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## 1. What is the problem?

`pod-e2e.sh`, the e2e harness bundled with the Dev Fleet app, ran the worktree's
**entire** test suite as a phase called `api-tests`:

```sh
API_TEST_CMD="$API_PY -m pytest -q"
export POD_BASE_URL="$BASE_URL"
export POD_TOKEN="$TOKEN"
if "$API_PY" -m pytest -q > "$ARTIFACT_DIR/api-tests.log" 2>&1; then
```

`python -m pytest -q` with cwd = the checkout root collects all ~62k backend
tests. `SKILL.md` documented it as phase 4 of 7, so an agent told to
"e2e-test this worktree against a pod" ran the full suite as a side effect of
asking for a browser check.

## 2. Why this issue matters to the user

The phase was not a pod test, and it was the most expensive thing the harness
did.

It exported `POD_BASE_URL` and `POD_TOKEN` "so tests can hit the live pod", but
**no test in the repository reads either variable** (`grep` across the tree
returns only the harness itself; the driver's own `KIROCREW_POD_TOKEN` is a
different variable). So it booted a pod, then ran 62k pod-independent unit
tests that ignore the pod entirely.

Those are tests CI already runs, on the merge ref, on its own hardware -- so
the local run duplicated a check that happens anyway. On a shared dev box it
also dominated the harness's cost: `--collect-only` alone is ~100s and a full
xdist fan-out is minutes of every core, against seconds for the Playwright
check the harness exists for. It also cut directly against the project's own
rule that local runs stay scoped to the change.

## 3. How our fix solves it

Symptom: asking for a pod screenshot burns a full test suite.
Cause: the harness owned a test-suite phase that needs no pod and duplicates
CI. Fix: delete the phase, and pin its absence.

- The `api-tests` block is gone from `pod-e2e.sh`, replaced by a comment saying
  why it must not come back. `RUN_API` is gone with it. The harness now runs
  `up -> health -> auth -> Playwright -> down`: what only a pod can prove.
- `SKILL.md` drops the phase from the phase list, the sample summary
  (`3 passed` -> `2 passed`), the artifact list (`api-tests.log`) and the QA
  verdict template, and states plainly that the harness does not run the
  suite -- scoped tests belong to the dev agent in its own worktree
  (`kirocrew-worktree-dev`), the full suite belongs to CI. The frontmatter
  description says the same, since that is what an agent reads when deciding
  whether to load the skill.
- `--fe-only` keeps parsing, as a no-op: with no suite phase left to skip,
  "frontend only" is what every run already does, and existing invocations plus
  stale agent prompts must not die on exit 64. `--api-only` is unchanged and
  still skips the Playwright phase, leaving a boot + auth check.
- The trust-model section no longer justifies itself by "running `pytest` in the
  checkout" -- it now names what actually executes branch-controlled code: the
  worktree's own gateway and that branch's `PLAYWRIGHT_SPEC`.
- `docs/guides/worktree-verification-recipes.md` drops the now-meaningless
  `--fe-only` from its recipe.

## 4. What tests we did

- New `test_the_harness_never_runs_the_worktrees_test_suite` -- a ratchet: no
  executable line in the shipped script may name `pytest` (only the comment
  explaining the absence may). This is what stops the phase from being
  reintroduced.
- New `test_fe_only_is_still_accepted_after_the_phase_was_removed` -- drives the
  real argument-parsing fragment out of the shipped script and asserts
  `--fe-only` exits 0, is not reported as an unknown flag, and is not mistaken
  for the worktree name.
- `test/test_pod_e2e_harness_paths.py` + `test/test_pod_e2e_video_guard.py`:
  51 passed. The pre-existing `--api-only` guards still hold, so the graceful
  FE-skip path is unchanged.
- `test_builtin_skill_packaging.py`, `test_builtin_skill_scope.py`,
  `test_builtin_skill_sync_safety.py`, `test_brand_name_gate.py`: 191 passed
  (these are the suites that validate a bundled skill's shipped text).
- `bash -n` on the script; flake8 / isort / black / mypy clean on the changed
  test file.

## 5. Any other suggestions on the work

Two things noticed but deliberately left out of scope:

- `.pod-test.sh` still only declares `PLAYWRIGHT_SPEC`. If a worktree ever has
  genuinely pod-dependent backend tests, the right shape is a manifest-declared
  scoped command (a specific file or marker), not a rediscovered full-suite
  phase. Worth its own change if a caller actually needs it.
- The `kirocrew-worktree-dev` skill still names a full `python -m pytest -q` as
  its local gate floor, which is the same tension one layer up. Separate skill,
  separate PR.

## Pattern harvest

Rule candidate: lint
Pattern: a bundled skill/automation script invoking an UNSCOPED test-suite run
(`pytest` / `vitest` with no path, marker or file argument).

This generalizes past this one script. A harness that shells out to the whole
suite is invisible in review -- it reads as one line of setup -- while every
caller pays minutes of CPU for a check CI already owns, and an agent that was
asked for a screenshot has no way to know it opted into a 62k-test run. The
ratchet added here (`test_the_harness_never_runs_the_worktrees_test_suite`) only
covers `pod-e2e.sh`; widening it to every script under a bundled skill
directory is the generalizable form, and is the reason this is filed as a rule
candidate rather than a one-off.
The ratchet is presence-shaped rather than semantic on purpose: a script that
names `pytest` with no path argument is mechanically detectable, while judging
whether a given suite invocation is "too broad" is not.

Fixes #9557
