### PR TITLE
fix(assets): never cache a /assets/ 404 as immutable; heal a poisoned pane cache

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -988,6 +988,7 @@ async def _vendor_preflight_handler(request: web.Request) -> web.Response:
 # /sprites: those use stable, un-hashed filenames.
 _IMMUTABLE_PATH_PREFIXES = ("/assets/",)
 _IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+_NO_STORE_CACHE_CONTROL = "no-store, no-cache, must-revalidate, max-age=0"
 
 # Max size of a single incoming HTTP header field, raised from aiohttp's
 # 8190-byte default. Browser cookies are not port-isolated (RFC 6265), so on
@@ -1111,11 +1112,19 @@ def _apply_security_headers(
     # responses for hashed assets: a 304's headers merge into the stored
     # cache entry, so answering it with no-store would degrade the cached
     # immutable bundle.
+    #
+    # This check is NOT sufficient on its own for the static route: aiohttp's
+    # ``FileResponse`` is built with status 200 and only stats the file inside
+    # ``prepare()``, after the middleware chain has returned. A missing chunk
+    # therefore passes through here as a 200 and becomes a 404 later, still
+    # wearing the immutable header. ``_finalize_asset_cache_control`` (an
+    # ``on_response_prepare`` handler, which runs once the status is final)
+    # closes that hole; this early decision stays as the common path.
     status = getattr(resp, "status", None)
     if status in (200, 206, 304) and path.startswith(_IMMUTABLE_PATH_PREFIXES):
         resp.headers.setdefault("Cache-Control", _IMMUTABLE_CACHE_CONTROL)
     else:
-        resp.headers.setdefault("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+        resp.headers.setdefault("Cache-Control", _NO_STORE_CACHE_CONTROL)
         resp.headers.setdefault("Pragma", "no-cache")
         resp.headers.setdefault("Expires", "0")
 
@@ -1167,6 +1176,41 @@ def _apply_security_headers(
     resp.headers.setdefault("X-Content-Type-Options", "nosniff")
     resp.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
     resp.headers.setdefault("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+
+
+async def _finalize_asset_cache_control(request: web.Request, response: web.StreamResponse) -> None:
+    """``on_response_prepare`` hook: never let an error under ``/assets/`` out
+    with ``immutable``.
+
+    ``_apply_security_headers`` runs in middleware, when a ``FileResponse``
+    still reports status 200 — aiohttp defers the ``stat`` to ``prepare()``.
+    A request for a chunk the running ``dist/`` does not have (mid-upgrade, or
+    a stale bundle asking for a chunk the new build renamed) thus reached the
+    wire as ``404`` + ``public, max-age=31536000, immutable``, and Chromium
+    kept that 404 for a year under the request URL. Lucide icon chunks keep
+    their content hash across releases, so one poisoned entry breaks the module
+    graph of every later bundle that imports it: the entry ``<script
+    type=module>`` fails silently and the page never boots — tunnel rebuilds and
+    gateway restarts cannot fix it because the cache key is the local URL. This
+    hook runs after the status is final and overwrites (not ``setdefault``) the
+    header for exactly that case: an immutable-prefixed path whose final status
+    is not one the immutable policy admits.
+    """
+    if response.status in (200, 206, 304):
+        return
+    if not request.path.startswith(_IMMUTABLE_PATH_PREFIXES):
+        return
+    if response.headers.get("Cache-Control") != _IMMUTABLE_CACHE_CONTROL:
+        return
+    response.headers["Cache-Control"] = _NO_STORE_CACHE_CONTROL
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+
+
+def _install_asset_cache_control_finalizer(app: web.Application) -> None:
+    """Register ``_finalize_asset_cache_control`` on ``app``. Idempotent."""
+    if _finalize_asset_cache_control not in app.on_response_prepare:
+        app.on_response_prepare.append(_finalize_asset_cache_control)
 
 
 # URL prefix for app-shipped standalone HTML windows. One namespace keeps app
@@ -3730,6 +3774,11 @@ async def start_dashboard(
         if hasattr(resp, "headers"):
             _apply_security_headers(resp, request.app, request.path, request)
         return resp  # type: ignore[return-value]
+
+    # The static handler's FileResponse decides 200-vs-404 only in prepare(),
+    # after the middleware above has already stamped immutable. This hook sees
+    # the final status and strips immutable from any /assets/ error.
+    _install_asset_cache_control_finalizer(app)
 
     # SPA fallback: serve index.html for client-side React Router paths.
     # Uses the same _is_spa_shell_request predicate as the auth middleware so

--- a/test/test_dashboard_asset_404_cache.py
+++ b/test/test_dashboard_asset_404_cache.py
@@ -1,0 +1,126 @@
+"""Regression: a 404 under ``/assets/`` must never leave with ``immutable``.
+
+The unit tests in ``test_dashboard_security_headers.py`` feed
+``_apply_security_headers`` a ``web.Response`` whose status is already final,
+so they cannot see this bug: aiohttp's ``FileResponse`` (what ``add_static``
+returns) is constructed with status 200 and only discovers the file is missing
+inside ``prepare()`` -- AFTER every middleware has run. The middleware therefore
+stamps ``public, max-age=31536000, immutable`` on what becomes a 404, and
+Chromium stores that 404 for a year under the request URL. Because lucide icon
+chunks keep the same content hash across releases, a 404 cached while a gateway
+was mid-swap of its ``dist/`` poisons the module graph of every later bundle
+that imports the same chunk: the ``<script type=module>`` fails silently and the
+pane never boots. Observed on the desktop app's remote-crew panes (one origin
+stuck for days while its siblings on other ports loaded fine).
+
+These tests drive a real ``add_static`` mount through the real middleware and a
+real ``TestClient`` so the headers asserted are the ones that went on the wire.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard import server as srv
+
+
+def _dist(tmp_path: Path) -> Path:
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "assets" / "main-krfrL6rl.js").write_text("export const x = 1\n", encoding="utf-8")
+    return dist
+
+
+def _make_app(dist: Path) -> web.Application:
+    """The production wiring in miniature: static mount + header middleware
+    + the prepare-time finalizer, nothing else."""
+    app = web.Application()
+    srv._register_dist_static_routes(app, dist)
+
+    @web.middleware  # type: ignore[misc]
+    async def no_cache_middleware(request: web.Request, handler: object) -> web.StreamResponse:
+        resp = await handler(request)  # type: ignore[operator]
+        if hasattr(resp, "headers"):
+            srv._apply_security_headers(resp, request.app, request.path, request)
+        return resp  # type: ignore[return-value]
+
+    app.middlewares.append(no_cache_middleware)
+    srv._install_asset_cache_control_finalizer(app)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_missing_hashed_asset_is_not_cached(tmp_path: Path) -> None:
+    async with TestClient(TestServer(_make_app(_dist(tmp_path)))) as client:
+        resp = await client.get("/assets/check-BiXj6uGO.js")
+        assert resp.status == 404
+        cc = resp.headers["Cache-Control"]
+        assert "immutable" not in cc, cc
+        assert "no-store" in cc, cc
+        assert resp.headers.get("Pragma") == "no-cache"
+        assert resp.headers.get("Expires") == "0"
+
+
+@pytest.mark.asyncio
+async def test_present_hashed_asset_stays_immutable(tmp_path: Path) -> None:
+    async with TestClient(TestServer(_make_app(_dist(tmp_path)))) as client:
+        resp = await client.get("/assets/main-krfrL6rl.js")
+        assert resp.status == 200
+        cc = resp.headers["Cache-Control"]
+        assert "immutable" in cc, cc
+        assert "no-store" not in cc, cc
+
+
+@pytest.mark.asyncio
+async def test_conditional_hit_on_hashed_asset_stays_immutable(tmp_path: Path) -> None:
+    """A 304 is a FileResponse too, and its headers merge into the browser's
+    stored entry -- downgrading it would un-cache a good bundle."""
+    async with TestClient(TestServer(_make_app(_dist(tmp_path)))) as client:
+        first = await client.get("/assets/main-krfrL6rl.js")
+        etag = first.headers["ETag"]
+        resp = await client.get("/assets/main-krfrL6rl.js", headers={"If-None-Match": etag})
+        assert resp.status == 304
+        assert "immutable" in resp.headers["Cache-Control"]
+
+
+@pytest.mark.asyncio
+async def test_finalizer_leaves_non_asset_paths_alone(tmp_path: Path) -> None:
+    """A handler-produced 404 outside /assets/ is already no-store from the
+    middleware; the finalizer must not touch it (and must not raise)."""
+    app = _make_app(_dist(tmp_path))
+
+    async def missing(_request: web.Request) -> web.Response:
+        return web.Response(status=404, headers={"X-Probe": "1"})
+
+    app.router.add_get("/api/missing", missing)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/api/missing")
+        assert resp.status == 404
+        assert resp.headers["X-Probe"] == "1"
+        assert "no-store" in resp.headers["Cache-Control"]
+
+
+@pytest.mark.asyncio
+async def test_without_finalizer_the_404_is_immutable(tmp_path: Path) -> None:
+    """Pins the mechanism this file exists for: with only the middleware, the
+    missing-file 404 really does leave with ``immutable``. If aiohttp ever
+    moves the existence check back before the handler returns, this test
+    fails and the finalizer can be retired."""
+    app = web.Application()
+    srv._register_dist_static_routes(app, _dist(tmp_path))
+
+    @web.middleware  # type: ignore[misc]
+    async def mw(request: web.Request, handler: object) -> web.StreamResponse:
+        resp = await handler(request)  # type: ignore[operator]
+        srv._apply_security_headers(resp, request.app, request.path, request)
+        return resp  # type: ignore[return-value]
+
+    app.middlewares.append(mw)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/assets/check-BiXj6uGO.js")
+        assert resp.status == 404
+        assert "immutable" in resp.headers["Cache-Control"]

--- a/website/electron/ipc-registrar.js
+++ b/website/electron/ipc-registrar.js
@@ -17,6 +17,7 @@ const { initAutoUpdate } = require("./auto-update");
 const { makeUpdaterLogger } = require("./update-logger");
 const { detectWsl2 } = require("./wsl-detection");
 const { crashNoticeSummary } = require("./crash-collector");
+const { PREFIX: PANE_ASSETS_PREFIX, purgeableOrigin } = require("./pane-asset-journal");
 
 /**
  * Register the Electron shell's renderer bridges without taking ownership of
@@ -230,6 +231,44 @@ function createIpcRegistrar({
       } catch (e) {
         log(`crash-reports:reveal failed: ${e && e.message}`);
         return { ok: false, error: String((e && e.message) || e) };
+      }
+    });
+
+    // Purge the HTTP cache of ONE remote-crew pane origin. The renderer asks for
+    // this when a pane's entry `<script type=module>` fires `error` (relayed as
+    // `mc-embedded-boot stage=script-error`) and again on an explicit Retry:
+    // a chunk 404 the gateway once served with `Cache-Control: immutable` is
+    // replayed from this cache on every load, so no tunnel rebuild, re-mint or
+    // gateway restart can ever get that pane past Loading -- only evicting the
+    // entry can. Scope is the pane's ORIGIN and the `cache` data type only:
+    // cookies, storage and the service worker are untouched, and the shell's
+    // own origin is refused (see `purgeableOrigin`). Sender-gated like every
+    // other channel that acts on this machine: the same preload serves a
+    // connection window pointed at a REMOTE gateway, and only the local
+    // dashboard shell -- the one that frames remote panes -- may evict a
+    // loopback origin's cache; `purgeableOrigin` bounds WHICH origin, the gate
+    // bounds WHO asks. After the gate, resolves to whether a purge ran and
+    // never throws into the renderer: the reload that follows must go ahead
+    // either way.
+    ipcMain.handle("pane:clear-http-cache", async (event, origin) => {
+      await assertLocalDashboard(event, "pane:clear-http-cache");
+      const target = purgeableOrigin(origin, backendUrl);
+      if (!target) {
+        log(`${PANE_ASSETS_PREFIX} clear-http-cache refused origin=${String(origin).slice(0, 128)}`);
+        return false;
+      }
+      const ses = event && event.sender && event.sender.session;
+      if (!ses || typeof ses.clearData !== "function") {
+        log(`${PANE_ASSETS_PREFIX} clear-http-cache unavailable origin=${target}`);
+        return false;
+      }
+      try {
+        await ses.clearData({ origins: [target], dataTypes: ["cache"] });
+        log(`${PANE_ASSETS_PREFIX} clear-http-cache origin=${target} cleared`);
+        return true;
+      } catch (e) {
+        log(`${PANE_ASSETS_PREFIX} clear-http-cache origin=${target} failed: ${e && e.message}`);
+        return false;
       }
     });
 

--- a/website/electron/pane-asset-journal.js
+++ b/website/electron/pane-asset-journal.js
@@ -27,6 +27,21 @@
  * that never settles and shows one STALLED line is this bug; a pane whose graph
  * settled and still never announced readiness is a different one.
  *
+ * The second failure, found by reading that "different one": a graph that settles
+ * with `done=N failed=0` and still never boots. `onCompleted` fires for EVERY
+ * response, a 404 included, so a chunk the gateway did not have -- served, once,
+ * with `Cache-Control: immutable`, and replayed from the local HTTP cache forever
+ * after -- counted as `done`. One 404 anywhere in the graph fails the whole
+ * `<script type=module>` with no console line. So a completion whose status is
+ * not 2xx is now counted under `failed=` and journaled on its own line with the
+ * path and whether it came from cache:
+ *
+ *   `[pane-assets] origin=http://localhost:7778 started=252 done=245 failed=7
+ *    inflight=0 ERROR=/assets/check-BiXj6uGO.js status=404 fromCache=true`
+ *
+ * `fromCache=true` on a 404 is the poisoned-cache signature; the same 404 fresh
+ * from the network is the gateway genuinely lacking the chunk (a dist/ mid-swap).
+ *
  * Scope is deliberately narrow: loopback origins only, `/assets/` paths only (the
  * content-hashed chunks the module graph is made of), and never the dashboard's own
  * origin — its bundle is served by the local gateway and is not the surface that
@@ -59,6 +74,12 @@ const LOG_LINES_MAX = 2_000;
 
 const PREFIX = "[pane-assets]";
 
+/** True for the hostnames a remote-crew pane can be reached on: loopback only. */
+function isLoopbackHost(host) {
+  return host === "localhost" || host === "127.0.0.1" || host === "[::1]"
+    || host.endsWith(".localhost");
+}
+
 /** Origin + path of a request URL, or null when it is not a loopback hashed asset. */
 function classifyUrl(url) {
   let parsed;
@@ -68,12 +89,40 @@ function classifyUrl(url) {
     return null;
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
-  const host = parsed.hostname;
-  const loopback = host === "localhost" || host === "127.0.0.1" || host === "[::1]"
-    || host.endsWith(".localhost");
-  if (!loopback) return null;
+  if (!isLoopbackHost(parsed.hostname)) return null;
   if (!parsed.pathname.startsWith("/assets/")) return null;
   return { origin: parsed.origin, path: parsed.pathname };
+}
+
+/**
+ * The one origin string the renderer may ask the main process to purge the HTTP
+ * cache for, or null. Exactly a loopback http(s) ORIGIN (no path, no query --
+ * the renderer sends `MessageEvent.origin`, which is already that shape) and
+ * never the dashboard's own: the local bundle is not the surface that gets
+ * poisoned, and a hostile pane must not be able to evict the shell's assets.
+ * The purge is bounded to `dataTypes: ["cache"]` -- the HTTP cache, which is
+ * only ever a copy of what the gateway will serve again -- so the worst a
+ * mis-aimed call can do is re-download one pane's chunks.
+ */
+function purgeableOrigin(candidate, dashboardOrigin) {
+  const text = String(candidate || "");
+  let parsed;
+  try {
+    parsed = new URL(text);
+  } catch {
+    return null;
+  }
+  if (parsed.origin !== text) return null;
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  if (!isLoopbackHost(parsed.hostname)) return null;
+  let skip = "";
+  try {
+    skip = new URL(String(dashboardOrigin)).origin;
+  } catch {
+    skip = "";
+  }
+  if (skip && parsed.origin === skip) return null;
+  return parsed.origin;
 }
 
 /**
@@ -139,7 +188,7 @@ function createPaneAssetTracker({
     s.inflight.set(requestId, { path: c.path, startedAt, timer });
   };
 
-  const finish = (requestId, url, outcome) => {
+  const finish = (requestId, url, outcome, detail) => {
     const c = classifyUrl(url);
     if (!c || c.origin === skipOrigin) return;
     const s = origins.get(c.origin);
@@ -156,15 +205,34 @@ function createPaneAssetTracker({
     }
     if (outcome === "done") s.done += 1;
     else s.failed += 1;
+    if (detail) emit(`${PREFIX} ${summary(c.origin, s)} ERROR=${c.path} ${detail}`);
     if (s.hadInflight && s.inflight.size === 0 && s.untracked === 0) {
       s.hadInflight = false;
       emit(`${PREFIX} ${summary(c.origin, s)} settled stalled=${s.stalled}`);
     }
   };
 
+  /**
+   * A response that arrived is not a chunk that loaded: a 404 (or any non-2xx)
+   * for a module in the graph fails the graph exactly like a dropped connection,
+   * and the module loader reports neither. `statusCode` is Electron's
+   * `onCompleted` field; a completion without one (older runtime, fake) keeps
+   * the historical reading of "completed = done". `fromCache` says whether the
+   * bad status was replayed from the local HTTP cache -- the poisoned-entry case
+   * a tunnel rebuild can never fix.
+   */
+  const onCompleted = (requestId, url, statusCode, fromCache) => {
+    const status = Number(statusCode);
+    if (!Number.isFinite(status) || status <= 0 || (status >= 200 && status < 300) || status === 304) {
+      finish(requestId, url, "done");
+      return;
+    }
+    finish(requestId, url, "failed", `status=${status} fromCache=${fromCache === true}`);
+  };
+
   return {
     onStart,
-    onCompleted: (requestId, url) => finish(requestId, url, "done"),
+    onCompleted,
     onError: (requestId, url) => finish(requestId, url, "failed"),
     /** Test/inspection hook: a snapshot of one origin's counters. */
     snapshot(origin) {
@@ -221,7 +289,7 @@ function attachPaneAssetJournal(session, log, dashboardOrigin) {
     tracker.onStart(details.id, details.url);
   });
   wr.onCompleted(filter, (details) => {
-    tracker.onCompleted(details.id, details.url);
+    tracker.onCompleted(details.id, details.url, details.statusCode, details.fromCache);
   });
   wr.onErrorOccurred(filter, (details) => {
     tracker.onError(details.id, details.url);
@@ -235,4 +303,5 @@ module.exports = {
   attachPaneAssetJournal,
   classifyUrl,
   createPaneAssetTracker,
+  purgeableOrigin,
 };

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -28,6 +28,13 @@ contextBridge.exposeInMainWorld("kirocrew", {
 });
 
 contextBridge.exposeInMainWorld("electronAPI", {
+  // Evict the HTTP cache of one remote-crew pane origin (a loopback tunnel
+  // port) before reloading it. Used when the pane's module graph reports a
+  // load error: a hashed chunk the gateway once answered 404+immutable is
+  // replayed from cache forever, and only eviction gets the pane past Loading.
+  // Resolves to whether a purge ran; the caller reloads regardless.
+  clearPaneHttpCache: (origin) =>
+    ipcRenderer.invoke("pane:clear-http-cache", String(origin || "")),
   onStatus: (cb) => {
     const handler = (_e, msg) => cb(msg);
     ipcRenderer.on("status", handler);

--- a/website/electron/test/ipc-registrar.test.js
+++ b/website/electron/test/ipc-registrar.test.js
@@ -36,6 +36,7 @@ const SHELL_HANDLES = [
   "global-hotkey:get",
   "local-gateway:get",
   "local-gateway:set",
+  "pane:clear-http-cache",
   "wsl:detect",
   "zoom:get",
   "zoom:set",
@@ -449,13 +450,13 @@ test("registerShell owns the exact shell channel set and is idempotent", () => {
 
   assert.deepEqual([...h.handlers.keys()].sort(), SHELL_HANDLES);
   assert.deepEqual([...h.listeners.keys()].sort(), SHELL_LISTENERS);
-  assert.equal(h.handlers.size + h.listeners.size, 33);
+  assert.equal(h.handlers.size + h.listeners.size, 34);
 
   // boot-complete is a further non-update host channel, but it is deliberately
   // gateway-owned and scoped to a single connecting WebContents. Registering it
   // globally here would weaken its sender check and leak listeners.
   assert.match(GATEWAY_SOURCE, /ipcMain\.on\("boot-complete", onComplete\)/);
-  assert.equal(h.handlers.size + h.listeners.size + 1, 34);
+  assert.equal(h.handlers.size + h.listeners.size + 1, 35);
   assert.equal(h.handlers.has("boot-complete"), false);
   assert.equal(h.listeners.has("boot-complete"), false);
 
@@ -1134,4 +1135,69 @@ test("updater initialization is fail-open and still installs all IPC", async () 
   assert.deepEqual(h.handlers.get("update:download")(), { ok: true });
   assert.deepEqual(await h.handlers.get("update:install")(), { ok: true });
   assert.equal(h.gatewayCalls.length, 0, "fail-open registration must not boot or stop gateway");
+});
+
+test("pane:clear-http-cache purges only a loopback pane origin's HTTP cache", async () => {
+  const h = harness();
+  h.registrar.registerShell();
+  const handler = h.handlers.get("pane:clear-http-cache");
+  const purges = [];
+  // A sender the three-gate local-dashboard check accepts: served by this
+  // shell's own gateway URL, in a window whose gateway is local, primary port
+  // held by kirocrew (the harness defaults).
+  const event = {
+    sender: { session: { clearData: async (opts) => { purges.push(opts); } } },
+    senderFrame: { url: "http://localhost:5476/instances" },
+  };
+
+  assert.equal(await handler(event, "http://localhost:7778"), true);
+  assert.deepEqual(purges, [{ origins: ["http://localhost:7778"], dataTypes: ["cache"] }]);
+  assert.ok(h.logs.some((l) => l.includes("clear-http-cache origin=http://localhost:7778 cleared")));
+
+  // The shell's own origin, a non-loopback host, a URL with a path, and junk
+  // are all refused without touching the session.
+  for (const bad of ["http://localhost:5476", "https://example.com", "http://localhost:7778/x", "", 42]) {
+    assert.equal(await handler(event, bad), false, `refused ${String(bad)}`);
+  }
+  assert.equal(purges.length, 1);
+
+  // A session that cannot purge, or one whose purge throws, answers false
+  // rather than rejecting into the renderer.
+  const local = { senderFrame: { url: "http://localhost:5476/instances" } };
+  assert.equal(await handler({ ...local, sender: {} }, "http://localhost:7778"), false);
+  const throwing = { ...local, sender: { session: { clearData: async () => { throw new Error("boom"); } } } };
+  assert.equal(await handler(throwing, "http://localhost:7778"), false);
+  assert.ok(h.logs.some((l) => l.includes("clear-http-cache origin=http://localhost:7778 failed: boom")));
+});
+
+test("pane:clear-http-cache is gated to the local dashboard sender", async () => {
+  // The same preload serves a connection window pointed at a REMOTE gateway;
+  // it must not be able to evict a loopback origin's cache on this machine.
+  const h = harness();
+  h.registrar.registerShell();
+  const handler = h.handlers.get("pane:clear-http-cache");
+  const purges = [];
+  const session = { clearData: async (opts) => { purges.push(opts); } };
+  for (const url of ["http://localhost:7778/", "https://crew.example.com/instances", "about:blank"]) {
+    await assert.rejects(
+      handler({ sender: { session }, senderFrame: { url } }, "http://localhost:7779"),
+      /pane:clear-http-cache is restricted to the local dashboard/,
+      `rejected sender ${url}`,
+    );
+  }
+  assert.equal(purges.length, 0);
+  assert.ok(h.logs.some((l) => l.includes("pane:clear-http-cache rejected for sender origin")));
+
+  // Gate 3: a primary port held by something other than this shell's gateway
+  // refuses even a correctly-originated sender.
+  const foreign = harness({ primaryPortOwner: "unknown" });
+  foreign.registrar.registerShell();
+  await assert.rejects(
+    foreign.handlers.get("pane:clear-http-cache")(
+      { sender: { session }, senderFrame: { url: "http://localhost:5476/instances" } },
+      "http://localhost:7779",
+    ),
+    /restricted to the local dashboard/,
+  );
+  assert.equal(purges.length, 0);
 });

--- a/website/electron/test/pane-asset-journal.test.js
+++ b/website/electron/test/pane-asset-journal.test.js
@@ -9,6 +9,7 @@ const {
   attachPaneAssetJournal,
   classifyUrl,
   createPaneAssetTracker,
+  purgeableOrigin,
 } = require("../pane-asset-journal");
 
 /** A manual clock + timer queue so stall detection runs without real waiting. */
@@ -232,5 +233,63 @@ describe("aggregate log budget", () => {
     time.advance(1000);
     assert.equal(lines.length, 3);
     assert.match(lines[2], /budget-exhausted/);
+  });
+});
+
+describe("non-2xx completions", () => {
+  it("counts a 404 completion as failed and journals its path and cache provenance", () => {
+    const { tr, lines } = tracker();
+    tr.onStart(1, `${PANE}/assets/main-abc.js`);
+    tr.onStart(2, `${PANE}/assets/check-BiXj6uGO.js?token=nope`);
+    tr.onCompleted(1, `${PANE}/assets/main-abc.js`, 200, false);
+    tr.onCompleted(2, `${PANE}/assets/check-BiXj6uGO.js?token=nope`, 404, true);
+    assert.equal(lines.length, 2);
+    assert.match(lines[0], /started=2 done=1 failed=1 inflight=0 ERROR=\/assets\/check-BiXj6uGO\.js status=404 fromCache=true$/);
+    assert.ok(!lines[0].includes("token"), "query string never reaches the journal");
+    assert.match(lines[1], /done=1 failed=1 inflight=0 settled stalled=0/);
+    assert.deepEqual(tr.snapshot(PANE), { started: 2, done: 1, failed: 1, stalled: 0, inflight: 0 });
+  });
+
+  it("treats 2xx, 304 and a missing status as done", () => {
+    const { tr, lines } = tracker();
+    const outcomes = [[1, 200], [2, 206], [3, 304], [4, undefined]];
+    for (const [id] of outcomes) tr.onStart(id, `${PANE}/assets/c${id}.js`);
+    for (const [id, status] of outcomes) tr.onCompleted(id, `${PANE}/assets/c${id}.js`, status, false);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /started=4 done=4 failed=0 inflight=0 settled/);
+  });
+
+  it("forwards statusCode and fromCache from the webRequest details", () => {
+    const listeners = {};
+    const s = {
+      webRequest: {
+        onSendHeaders(filter, fn) { listeners.before = fn; },
+        onCompleted(filter, fn) { listeners.completed = fn; },
+        onErrorOccurred(filter, fn) { listeners.error = fn; },
+      },
+    };
+    const lines = [];
+    assert.equal(attachPaneAssetJournal(s, (l) => lines.push(l), "http://localhost:5476"), true);
+    listeners.before({ id: 7, url: `${PANE}/assets/folder-BGvEsjbu.js` });
+    listeners.completed({ id: 7, url: `${PANE}/assets/folder-BGvEsjbu.js`, statusCode: 404, fromCache: true });
+    assert.match(lines[0], /ERROR=\/assets\/folder-BGvEsjbu\.js status=404 fromCache=true/);
+  });
+});
+
+describe("purgeableOrigin", () => {
+  const DASH = "http://localhost:5476/?token=abc";
+  it("accepts a bare loopback origin that is not the dashboard's", () => {
+    assert.equal(purgeableOrigin("http://localhost:7778", DASH), "http://localhost:7778");
+    assert.equal(purgeableOrigin("http://127.0.0.1:7778", DASH), "http://127.0.0.1:7778");
+    assert.equal(purgeableOrigin("https://gian.localhost:7778", DASH), "https://gian.localhost:7778");
+  });
+  it("refuses the dashboard origin, remote hosts, paths, and non-strings", () => {
+    assert.equal(purgeableOrigin("http://localhost:5476", DASH), null);
+    assert.equal(purgeableOrigin("http://10.0.0.5:7778", DASH), null);
+    assert.equal(purgeableOrigin("http://localhost:7778/assets/a.js", DASH), null);
+    assert.equal(purgeableOrigin("http://localhost:7778/", DASH), null);
+    assert.equal(purgeableOrigin("file:///tmp", DASH), null);
+    assert.equal(purgeableOrigin(null, DASH), null);
+    assert.equal(purgeableOrigin({}, DASH), null);
   });
 });

--- a/website/electron/test/shell-contract.test.js
+++ b/website/electron/test/shell-contract.test.js
@@ -136,8 +136,8 @@ test("the WSL preload invoke is registered by the IPC owner", () => {
   );
 });
 
-// The three-gate local-dashboard check guards `wsl:detect` and both
-// `crash-reports:*` channels. It was briefly written out twice, and two
+// The three-gate local-dashboard check guards `wsl:detect`, both
+// `crash-reports:*` channels and `pane:clear-http-cache`. It was briefly written out twice, and two
 // hand-maintained spellings of a security check is one of them being tightened
 // while the other is not. The port probe is gate 3 and appears in no other code
 // path, so counting its call sites counts the copies.
@@ -149,7 +149,7 @@ test("the local-dashboard gate has exactly one spelling", () => {
     "gate 3 must be reached through the single assertLocalDashboard helper; "
       + `found ${probes.length} probe call sites, so the gate has been copied`,
   );
-  for (const channel of ["wsl:detect", "crash-reports:get", "crash-reports:reveal"]) {
+  for (const channel of ["wsl:detect", "crash-reports:get", "crash-reports:reveal", "pane:clear-http-cache"]) {
     assert.match(
       IPC_REGISTRAR_SOURCE,
       new RegExp(`assertLocalDashboard\\(event, "${channel}"\\)`),

--- a/website/index.html
+++ b/website/index.html
@@ -36,6 +36,47 @@
   <noscript><link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" /></noscript>
   <title>Kiro Crew</title>
   <script>
+    // The entry module (the module tag Vite appends to the document head on
+    // build; the /src/main.tsx tag in the body in dev) is an ES module with a
+    // few hundred statically imported chunks, and Chromium evaluates the graph
+    // only once EVERY edge has loaded. One chunk that fails to fetch (a 404 --
+    // live from the gateway mid-upgrade, or replayed from a poisoned HTTP cache)
+    // fails the whole graph: no console line, no exception, none of our
+    // JavaScript runs, so main.tsx's own `mc-embedded-boot stage=entry` never
+    // fires and a pane is just "Loading" forever. The loader does fire `error`
+    // on the script element itself. Resource errors do not bubble, but a
+    // capture-phase listener on window still sees them -- that is the one
+    // renderer-side signal that survives, so it is taken here, in the shell,
+    // before the module is even requested. Vite rewrites the module tag's src
+    // on build and drops its attributes, so this cannot be an onerror= on the
+    // tag. Wildcard target is safe: the payload is a stage name plus the
+    // failing script's own path (query stripped), and the parent validates the
+    // origin. Standalone, it logs. Placed in the document head ahead of the
+    // module tag, so the listener exists before the module can possibly fail
+    // -- a replayed-from-cache 404 fails fast.
+    //
+    // Keep this comment free of a literal script OPENING TAG, above all one
+    // with a module type: Vite relocates the import map to just before the
+    // first module script it finds with a regex over the raw HTML, so that
+    // text spelled out in prose here once received the import map mid-comment,
+    // its closing tag ended this script early, and the remainder ran as an
+    // inline module that threw. `npm run i18n:render` renders the built shell
+    // and is what catches that; `vite build` alone exits 0.
+    window.addEventListener('error', function (e) {
+      var t = e && e.target;
+      if (!t || t.tagName !== 'SCRIPT' || t.type !== 'module') return;
+      var src = String(t.src || '').split('?')[0];
+      try { console.error('[boot] module script failed to load: ' + src); } catch (err) {}
+      var embedded = false;
+      try { embedded = window.self !== window.top; } catch (err) { embedded = true; }
+      if (!embedded) return;
+      try {
+        // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+        window.parent.postMessage({ type: 'mc-embedded-boot', v: 1, stage: 'script-error', src: src }, '*');
+      } catch (err) {}
+    }, true);
+  </script>
+  <script>
     // Set data-ui from localStorage before React hydrates to prevent flash of
     // chat layout when the user's preferred mode is 'cli'. Mirrors the
     // pattern used by data-theme bootstrapping. Synced by useUIMode.

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -41,6 +41,7 @@ import { clearPaneReady, removeWarm, setActiveId, setPaneReady, setUnread, setWa
 import InstanceTabBar, { visibleInstanceTabs, useCrewPins, toggleCrewPin, useCrewSwitcherStableOrder, setStableOrder } from './InstanceTabBar'
 import { parseLoopbackOriginPort, resolveTunnelOrigin } from '../lib/tunnelOrigin'
 import { frameDocumentState, paneLog, safePaneUrl } from '../lib/paneLog'
+import { clearPaneHttpCache, paneOriginFor } from '../lib/paneCache'
 import { connectInstanceInto } from '../lib/connectInstance'
 import { LINUX_CAPTION_CONTROLS_WIDTH, TRAFFIC_LIGHT_INSET_PX, WIN_CAPTION_OVERLAY_WIDTH } from '../lib/electron'
 import { isEmbeddedPane } from '../lib/embedded'
@@ -170,6 +171,14 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // Reactive (mc-auth-expired) re-mints answered per pane since its last Retry
   // — see MAX_REACTIVE_REMINTS.
   const reactiveMintsRef = useRef<Map<string, number>>(new Map())
+  // Load watchdog verdict + forced-reload sequence, documented at their consumer
+  // (the watchdog effect below); declared here because the relay listener also
+  // bumps `reloadSeq` for the one-shot script-error heal.
+  const [timedOut, setTimedOut] = useState<Record<string, boolean>>({})
+  const [reloadSeq, setReloadSeq] = useState<Record<string, number>>({})
+  // Panes already granted their one automatic cache-evict-and-reload after a
+  // `script-error` (see the relay listener). Cleared by Retry.
+  const scriptErrorHealsRef = useRef<Set<string>>(new Set())
   // Live iframe elements by id, so the parent can postMessage the switcher model
   // into each embedded pane. Set/cleared by the iframe ref cb.
   const iframeRefs = useRef<Map<string, HTMLIFrameElement>>(new Map())
@@ -288,6 +297,12 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     })
     for (const id of iframeRefCallbacks.current.keys()) {
       if (!warm[id]) iframeRefCallbacks.current.delete(id)
+    }
+    // The one-shot script-error heal is per LOAD: an evicted pane that re-warms
+    // is a new load and gets its budget back, otherwise its next poisoned-cache
+    // failure could only be healed by a manual Retry.
+    for (const id of scriptErrorHealsRef.current) {
+      if (!warm[id]) scriptErrorHealsRef.current.delete(id)
     }
   }, [warm])
 
@@ -421,8 +436,35 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         // failure the journal could not: a pane whose shell loaded (200,
         // cross-origin) but never announced readiness was either a bundle that
         // never ran (no `boot`) or an App that mounted and got stuck before the
-        // bridge (a `boot` with no `ready`). Journal only, no state change.
-        paneLog('boot', { id, stage: typeof data.stage === 'string' ? data.stage : 'unknown' })
+        // bridge (a `boot` with no `ready`). Journal only, no state change --
+        // except `script-error`, below.
+        const stage = typeof data.stage === 'string' ? data.stage : 'unknown'
+        const src = typeof data.src === 'string' ? safePaneUrl(data.src) : undefined
+        paneLog('boot', { id, stage, src })
+        if (stage === 'script-error') {
+          // Posted by the pane's index.html shell (not its bundle, which never
+          // ran): the entry <script type=module> fired `error`, i.e. some chunk
+          // in its graph failed to FETCH. Whatever happens next, this pane is
+          // NOT ready: it may have been (a ready pane reloads itself after a
+          // bundle change and can land on a mid-swap 404), and a stale `ready`
+          // keeps the load watchdog off and the error panel unreachable, so a
+          // failed heal would leave a blank pane with no Retry. Retract first.
+          // The one cause a reload cannot fix by itself is a 404 the desktop's
+          // HTTP cache is replaying under this origin, so evict that origin's
+          // cache and reload once. ONCE: a 404 the gateway is really serving
+          // right now (dist/ mid-swap) would otherwise loop clear/reload
+          // forever; after the one attempt the (now armed) watchdog surfaces
+          // the error panel, and Retry re-opens the budget.
+          dispatch(clearPaneReady(id))
+          if (!scriptErrorHealsRef.current.has(id)) {
+            scriptErrorHealsRef.current.add(id)
+            paneLog('script-error-heal', { id, origin: e.origin })
+            const cleared = clearPaneHttpCache(e.origin)
+            const reload = () => setReloadSeq(prev => ({ ...prev, [id]: (prev[id] || 0) + 1 }))
+            if (cleared) void cleared.then(reload, reload)
+            else reload()
+          }
+        }
       } else if (data.type === 'mc-embedded-ready') {
         // The pane just (re)mounted and asked for the current model — send it now
         // rather than waiting for the next input-driven broadcast. Also record
@@ -503,8 +545,8 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // never stranded). `reloadSeq[id]` is bumped by Retry to force an iframe
   // remount even when the backend returns the SAME cached port+token (identical
   // src would otherwise not reload a dead frame).
-  const [timedOut, setTimedOut] = useState<Record<string, boolean>>({})
-  const [reloadSeq, setReloadSeq] = useState<Record<string, number>>({})
+  // (`timedOut`, `reloadSeq` and `scriptErrorHealsRef` are declared up by
+  // reactiveMintsRef: the relay listener above reaches them too.)
   // Live mirror of `timedOut` for `retry`, which must read the verdict at press
   // time without re-creating itself on every watchdog flip.
   const timedOutRef = useRef(timedOut)
@@ -621,20 +663,33 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
       // that never navigated (`about:blank`) or whose connect itself failed
       // keeps the cheap path: there is no stalled stream to escape.
       const rebuild = !!timedOutRef.current[id] && frame === 'cross-origin'
+      const port = warmRef.current[id]?.port
       // Clear the stale verdict and force a reload even if the re-mint returns
       // an identical token (setWarm would be a no-op for the iframe src).
       paneLog('retry', {
         id,
-        port: warmRef.current[id]?.port,
+        port,
         frame,
         rebuild: rebuild || undefined,
       })
-      setTimedOut(prev => ({ ...prev, [id]: false }))
-      setReloadSeq(prev => ({ ...prev, [id]: (prev[id] || 0) + 1 }))
-      // An explicit user press is a fresh start: re-open the reactive budget so
-      // a pane that recovers on the next token can still self-heal afterwards.
-      reactiveMintsRef.current.delete(id)
-      connectMutation.mutate({ id, rebuild })
+      const proceed = () => {
+        setTimedOut(prev => ({ ...prev, [id]: false }))
+        setReloadSeq(prev => ({ ...prev, [id]: (prev[id] || 0) + 1 }))
+        // An explicit user press is a fresh start: re-open the reactive budget so
+        // a pane that recovers on the next token can still self-heal afterwards,
+        // and the one-shot script-error heal likewise.
+        reactiveMintsRef.current.delete(id)
+        scriptErrorHealsRef.current.delete(id)
+        connectMutation.mutate({ id, rebuild })
+      }
+      // Desktop only: evict this origin's HTTP cache BEFORE the reload, so a
+      // chunk 404 the cache is replaying (the failure a tunnel rebuild cannot
+      // reach) is re-fetched rather than replayed again. Resolves fast (one IPC
+      // round-trip) and the reload proceeds whatever it answers. A pane that
+      // never navigated has no port to name and nothing cached to evict.
+      const cleared = typeof port === 'number' ? clearPaneHttpCache(paneOriginFor(port)) : null
+      if (cleared) void cleared.then(proceed, proceed)
+      else proceed()
     },
     [connectMutation],
   )

--- a/website/src/lib/paneCache.ts
+++ b/website/src/lib/paneCache.ts
@@ -1,0 +1,34 @@
+/**
+ * Evict the desktop shell's HTTP cache for one remote-crew pane origin.
+ *
+ * Why a pane can need this: its bundle is an ES module graph of ~240
+ * content-hashed chunks. A chunk the gateway did not have at request time
+ * (dist/ mid-swap during an upgrade) was answered 404 -- and, before the
+ * gateway-side fix, with `Cache-Control: immutable`, so Chromium stored the
+ * 404 for a year under that URL. Icon chunks keep their hash across releases,
+ * so every later bundle that imports the same chunk hits the cached 404, the
+ * whole `<script type=module>` fails silently, and the pane never boots. The
+ * cache key is the LOCAL loopback URL, so re-minting the token, rebuilding the
+ * tunnel or restarting the remote gateway can never clear it -- only eviction
+ * of that origin's cache can, and only the main process can do that.
+ *
+ * Returns null when no desktop bridge is present (plain browser, tests), so a
+ * caller can keep its synchronous path there and only await in Electron.
+ */
+export function clearPaneHttpCache(origin: string): Promise<boolean> | null {
+  const fn = typeof window !== 'undefined' ? window.electronAPI?.clearPaneHttpCache : undefined
+  if (typeof fn !== 'function') return null
+  try {
+    return fn(origin).then(
+      v => v === true,
+      () => false,
+    )
+  } catch {
+    return Promise.resolve(false)
+  }
+}
+
+/** The loopback origin the parent frames pane `port` on (see InstancesViewport.srcFor). */
+export function paneOriginFor(port: number): string {
+  return `http://${window.location.hostname}:${port}`
+}

--- a/website/src/test/InstancesViewport.test.tsx
+++ b/website/src/test/InstancesViewport.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders, createTestStore } from './helpers'
@@ -1349,4 +1349,180 @@ describe('InstancesViewport', () => {
     expect(screen.queryByText(/ssh unreachable/i)).toBeNull()
   })
 
+
+  describe('script-error heal (poisoned HTTP cache)', () => {
+    // The pane's index.html shell posts this when its entry <script type=module>
+    // fires `error`: a chunk in the graph failed to fetch. On the desktop the one
+    // cause a plain reload cannot fix is a 404 the shell's HTTP cache is
+    // replaying under that origin, so the parent evicts the origin's cache and
+    // reloads -- exactly once per Retry, so a 404 the gateway is really serving
+    // cannot spin clear/reload forever.
+    const scriptError = (origin = 'http://127.0.0.1:7778') =>
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'mc-embedded-boot', v: 1, stage: 'script-error', src: `${origin}/assets/main-krfrL6rl.js?token=x` },
+          origin,
+        }),
+      )
+    const withBridge = (impl: (origin: string) => Promise<boolean>) => {
+      const clear = vi.fn(impl)
+      ;(window as unknown as { electronAPI: unknown }).electronAPI = { clearPaneHttpCache: clear }
+      return clear
+    }
+    afterEach(() => {
+      delete (window as unknown as { electronAPI?: unknown }).electronAPI
+    })
+
+    it('evicts the pane origin cache and reloads the iframe once, journaling the src without its query', async () => {
+      mockConnectedCd1()
+      const clear = withBridge(async () => true)
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+      try {
+        const store = createTestStore({
+          instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+        })
+        renderWithProviders(<InstancesViewport />, { store })
+        expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+        const before = document.querySelector('iframe') as HTMLIFrameElement
+
+        scriptError()
+        await waitFor(() => expect(clear).toHaveBeenCalledWith('http://127.0.0.1:7778'))
+        await waitFor(() => expect(document.querySelector('iframe')).not.toBe(before))
+        const lines = info.mock.calls.map(c => String(c[0]))
+        const boot = lines.find(l => l.includes('boot id=cd-1 stage=script-error'))
+        expect(boot).toBeDefined()
+        expect(boot).toContain('src=http://127.0.0.1:7778/assets/main-krfrL6rl.js?token=<redacted>')
+        expect(boot).not.toContain('token=x')
+        expect(lines.some(l => l.includes('script-error-heal id=cd-1 origin=http://127.0.0.1:7778'))).toBe(true)
+
+        // A second script-error on the same load is NOT healed again: the
+        // watchdog owns it from here, and only Retry re-opens the budget.
+        const healed = document.querySelector('iframe') as HTMLIFrameElement
+        scriptError()
+        await new Promise(r => setTimeout(r, 20))
+        expect(clear).toHaveBeenCalledTimes(1)
+        expect(document.querySelector('iframe')).toBe(healed)
+      } finally {
+        info.mockRestore()
+      }
+    })
+
+    it('retracts readiness on script-error so the watchdog can arm again for a pane that WAS ready', async () => {
+      // A ready pane reloads itself (bundle change) and lands on a chunk 404: its
+      // shell posts script-error while the store still says ready. Left alone,
+      // the watchdog stays off (it skips ready panes) and a failed heal would be
+      // a blank pane with no Retry.
+      mockConnectedCd1()
+      const clear = withBridge(async () => true)
+      const store = createTestStore({
+        instances: {
+          warm: { 'cd-1': { port: 7778, token: 'tok' } },
+          activeId: 'cd-1',
+          mru: ['cd-1'],
+          unread: {},
+          ready: { 'cd-1': true },
+        },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      expect(screen.queryByText(/Loading pane/i)).toBeNull()
+      scriptError()
+      await waitFor(() => expect(store.getState().instances.ready['cd-1']).toBeUndefined())
+      await waitFor(() => expect(clear).toHaveBeenCalledTimes(1))
+      // Readiness retracted -> the loading overlay is back and the watchdog owns the pane.
+      expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+      // The retraction is not gated on the heal budget: a second script-error
+      // (budget spent, no reload) still leaves the pane un-ready.
+      window.dispatchEvent(
+        new MessageEvent('message', { data: { type: 'mc-embedded-ready', v: 1 }, origin: 'http://127.0.0.1:7778' }),
+      )
+      await waitFor(() => expect(store.getState().instances.ready['cd-1']).toBe(true))
+      scriptError()
+      await waitFor(() => expect(store.getState().instances.ready['cd-1']).toBeUndefined())
+      expect(clear).toHaveBeenCalledTimes(1)
+    })
+
+    it('gives an evicted-then-re-warmed pane its one-shot heal back', async () => {
+      // The budget is per load. Eviction (removeWarm) ends the load; a later
+      // re-warm is a new one and must be able to heal a poisoned cache again
+      // without a manual Retry.
+      mockConnectedCd1()
+      const clear = withBridge(async () => true)
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+      scriptError()
+      await waitFor(() => expect(clear).toHaveBeenCalledTimes(1))
+      // Budget spent for this load.
+      scriptError()
+      await new Promise(r => setTimeout(r, 20))
+      expect(clear).toHaveBeenCalledTimes(1)
+
+      await act(async () => { store.dispatch(removeWarm('cd-1')) })
+      await waitFor(() => expect(document.querySelector('iframe')).toBeNull())
+      await act(async () => { store.dispatch(setWarm({ id: 'cd-1', conn: { port: 7778, token: 'tok2' } })) })
+      await waitFor(() => expect(document.querySelector('iframe')).not.toBeNull())
+      scriptError()
+      await waitFor(() => expect(clear).toHaveBeenCalledTimes(2))
+    })
+
+    it('still reloads once when the bridge is absent or refuses (browser, non-Electron)', async () => {
+      mockConnectedCd1()
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+      const before = document.querySelector('iframe') as HTMLIFrameElement
+      scriptError()
+      await waitFor(() => expect(document.querySelector('iframe')).not.toBe(before))
+    })
+
+    it('ignores a script-error from an origin that is not a warm pane', async () => {
+      mockConnectedCd1()
+      const clear = withBridge(async () => true)
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      expect(await screen.findByText(/Loading pane/i)).toBeInTheDocument()
+      const before = document.querySelector('iframe') as HTMLIFrameElement
+      scriptError('http://127.0.0.1:9999')
+      scriptError('https://evil.example.com')
+      await new Promise(r => setTimeout(r, 20))
+      expect(clear).not.toHaveBeenCalled()
+      expect(document.querySelector('iframe')).toBe(before)
+    })
+
+    it('Retry evicts the pane origin cache before reloading and re-opens the heal budget', async () => {
+      mockConnectedCd1()
+      vi.mocked(api.connectInstance).mockResolvedValue({ state: 'connected', local_port: 7778, token: 'tok' })
+      const clear = withBridge(async () => true)
+      vi.useFakeTimers()
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      await act(async () => {
+        vi.advanceTimersByTime(15_000)
+      })
+      expect(screen.getByText(/Pane failed to load/i)).toBeInTheDocument()
+      vi.useRealTimers()
+
+      const u = userEvent.setup()
+      await u.click(screen.getByRole('button', { name: /Retry/i }))
+      await waitFor(() => expect(clear).toHaveBeenCalledWith(`http://${window.location.hostname}:7778`))
+      await waitFor(() => expect(api.connectInstance).toHaveBeenCalledWith('cd-1'))
+      // The evict resolved BEFORE the reconnect was issued.
+      expect(clear.mock.invocationCallOrder[0]).toBeLessThan(vi.mocked(api.connectInstance).mock.invocationCallOrder[0])
+      await waitFor(() => expect(screen.queryByText(/Pane failed to load/i)).toBeNull())
+
+      // Budget re-opened: a script-error after Retry is healed again.
+      const before = document.querySelector('iframe') as HTMLIFrameElement
+      scriptError()
+      await waitFor(() => expect(clear).toHaveBeenCalledTimes(2))
+      await waitFor(() => expect(document.querySelector('iframe')).not.toBe(before))
+    })
+  })
 })

--- a/website/src/types/electron-bridge.d.ts
+++ b/website/src/types/electron-bridge.d.ts
@@ -60,6 +60,8 @@ declare global {
     reportMemorySample: (sample: ElectronMemorySample) => void
     heapStatisticsKB: () => { usedHeapKB: number | null } | null
     getGlobalHotkey: () => Promise<ElectronGlobalHotkeyInfo>
+    /** Evict the HTTP cache of one loopback pane origin; resolves to whether a purge ran. */
+    clearPaneHttpCache?: (origin: string) => Promise<boolean>
   }
 
   interface LocalGatewayAPI {


### PR DESCRIPTION
## Problem / Motivation

A remote-crew pane in the desktop app sits on "Loading pane…" forever, while sibling crews on other loopback ports load fine. Retry, tunnel rebuild (#9382), token re-mint and a gateway restart on the remote all leave it stuck. The pane journal shows the module graph *settling* (`[pane-assets] … started=252 done=252 failed=0 … settled`) with no `boot` line and no `/api/*` request ever reaching the remote gateway: none of our JavaScript ran in that frame.

Reading the desktop's Chromium disk cache for the stuck origin: ten `/assets/*.js` entries with **status 404** and `Cache-Control: public, max-age=31536000, immutable`, all written in the same second a gateway was swapping its `dist/`. Seven are lucide icon chunks whose content hash does not change across releases, so every later bundle still imports them by the same URL, Chromium replays the cached 404, and the whole `<script type=module>` fails silently (module-graph fetch errors produce no console line). Sibling ports had zero such entries.

## Why it matters

The cache key is the local loopback URL, so nothing on the remote side can ever fix it — the user's only way out is to blow away the desktop's HTTP cache by hand, and nothing in the logs points there. Any crew that lands on a poisoned port (the instances feature hands ports out round-robin) is stuck for days. #9382's stalled-stream hypothesis covered a different failure; this one was invisible to it because a 404 counts as a completed request.

## What changed (motivation → approach → change)

**Why the 404 was cacheable at all.** `_apply_security_headers` already grants `immutable` only for 200/206/304. But aiohttp's `FileResponse` is constructed with status 200 and only `stat`s the file inside `prepare()` — *after* the middleware chain. The middleware stamps immutable on a 200 that becomes a 404 a moment later. The existing unit test hands the function a `web.Response` with a final status, so it could not see this. Verified against all four remote gateways and the local one: `GET /assets/does-not-exist.js` → `404` + `immutable`.

Three layers, each closing the failure where it can be seen:

1. **Gateway (root cause)** — `src/kiro_crew/dashboard/server.py`: `_finalize_asset_cache_control`, an `on_response_prepare` handler, runs once the status is final and overwrites the immutable header with no-store on any `/assets/` response that is not 200/206/304. Registered right next to the middleware it completes. `_apply_security_headers` keeps its early decision as the common path and documents the hole.
2. **Desktop journal (make it visible next time)** — `website/electron/pane-asset-journal.js`: `onCompleted` now reads Electron's `statusCode` and `fromCache`. A non-2xx completion counts under `failed=` and gets its own line: `ERROR=/assets/check-BiXj6uGO.js status=404 fromCache=true` is the poisoned-cache signature; the same with `fromCache=false` is a gateway genuinely mid-swap.
3. **Renderer heal (clear the caches already out there)** — `website/index.html` installs a capture-phase `error` listener in the document head (Vite drops attributes from the module tag and hoists it into the head, so an `onerror=` cannot work and the listener must precede the tag). When the entry module fires `error`, an embedded pane posts `mc-embedded-boot stage=script-error` to its parent. `InstancesViewport` journals it, **retracts the pane's readiness** (a pane that was ready and reloaded itself into a chunk 404 must not keep the load watchdog disabled), and, **once per load**, asks the main process to evict that origin's HTTP cache and reloads the iframe. Retry evicts too, before its reload, and re-opens the one-shot budget; so does eviction from the warm set, since a re-warm is a new load. A 404 the gateway is genuinely serving cannot loop: after the one heal the existing load watchdog surfaces the error panel with Retry as before.
   - New IPC `pane:clear-http-cache` (`ipc-registrar.js` → `session.clearData({origins:[o], dataTypes:["cache"]})`). **Sender-gated** by the same three-gate `assertLocalDashboard` check as `wsl:detect` and `crash-reports:*` — the preload is shared with connection windows pointed at a remote gateway, and only the local dashboard shell (the one that frames remote panes) may evict a loopback origin's cache. The *target* is bounded by `purgeableOrigin`: a bare loopback http(s) origin only, never the shell's own; `cache` data type only (cookies, storage and the service worker are untouched). Refusals and failures are logged and return `false`; the reload proceeds either way.
   - `preload.js` exposes `electronAPI.clearPaneHttpCache`; `lib/paneCache.ts` returns `null` when no bridge is present so the browser path stays synchronous.
   - The listener's comment deliberately spells no literal `<script type=module`: Vite relocates the import map to just before the first such tag its regex finds in the raw HTML, and a literal in prose once received the map mid-comment, splitting the script. `i18n:render` (which renders the built shell) catches that; `vite build` alone does not.

## Tests

- `test/test_dashboard_asset_404_cache.py` (new, 5): real `add_static` mount + real middleware + `TestClient`. Missing chunk → 404 with no-store/Pragma/Expires; present chunk stays immutable; 304 stays immutable; non-asset 404 untouched; and `test_without_finalizer_the_404_is_immutable` pins the mechanism so the hook can be retired if aiohttp ever moves the stat.
- `website/electron/test/pane-asset-journal.test.js` (+5): 404 completion → `failed=1` + `ERROR=` line with path and `fromCache`, query never journaled; 2xx/304/missing status → done; `details.statusCode`/`fromCache` forwarded from `webRequest`; `purgeableOrigin` accepts loopback origins and refuses the shell origin, remote hosts, paths, non-strings.
- `website/electron/test/ipc-registrar.test.js` (+2, channel set updated): a local-dashboard sender's purge calls `clearData` with exactly `{origins:[o], dataTypes:["cache"]}`; refuses shell origin / remote / path / junk without touching the session; a session without `clearData` or one that throws answers `false`; senders from a pane origin, a remote host or `about:blank`, and a primary port held by a foreign process, are rejected with `restricted to the local dashboard` and purge nothing. `shell-contract.test.js` now lists the channel among those routed through the single `assertLocalDashboard` spelling.
- `website/src/test/InstancesViewport.test.tsx` (+6): script-error → evict + remount once, `boot … stage=script-error src=…` journaled with token redacted, second script-error not healed; readiness retracted on script-error for a pane that was ready (and again when the heal budget is spent); an evicted-then-re-warmed pane gets its one-shot heal back; heals without a bridge; ignores unknown origins; Retry evicts *before* `connectInstance` and re-opens the budget.

Local gate pass (full profile): vitest green (30599 on the round-1 full run, targeted suites since); electron 1761 passed; `pytest` 91575 passed with 299 reds that fail identically on pristine `origin/main` on this host (path/sensitive-dir/port-occupancy environment — none in the touched areas); `tsc`, `eslint`, `black`, `isort`, `flake8`, `mypy`, build, bundle-size, jscpd, i18n:check, i18n:render and every diff-scoped gate green. Both local reviewer lanes (gpt-5.6-sol, claude-opus-4.8) cleared each pushed head; the server GPT lane's round-3 findings (IPC sender authorization; heal budget surviving eviction) are fixed above with revert-verified tests.

## Manual verification

- Built `dist/index.html` inspected: the listener block is a single intact script, the import map is outside it, and the injected module tag follows it (`i18n:render` renders the built shell and passes).
- Still required, and the one thing unit tests cannot prove: on the affected desktop, open the stuck crew and confirm the launch log shows `[pane] boot … stage=script-error` → `[pane] script-error-heal` → `[pane-assets] clear-http-cache origin=… cleared` → `boot stage=entry` → `ready`. That is the end-to-end proof that Electron's `session.clearData({origins, dataTypes:["cache"]})` evicts the poisoned entries on the shipped runtime. Until the remote gateways run this fix, the desktop-side heal is what clears the already-poisoned entries.

<!-- no-visual-delta -->
**Why no screenshot:** the `website/src/` change is pane-recovery logic (message handling, cache eviction, readiness bookkeeping) with no new or changed rendered surface; the error panel and loading overlay it reaches are the existing ones.

## Related Issues

Follows #9382 (stalled-stream hypothesis for the same symptom; this is the other cause).

no linked issue: diagnosed from the desktop launch log and disk cache directly, no tracking issue was filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: cache/security headers decided in middleware on a response whose status is only final in `prepare()` (aiohttp `FileResponse`, streaming responses) — the decision must be made in `on_response_prepare`, and the test must go through the real handler, not a hand-built `web.Response`.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — inline rationale in each touched module; no user-facing docs describe this surface
- [x] No secrets, credentials, or internal references in the diff
