### PR TITLE
fix(mcp): make a large edition MCP registry searchable

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -305,7 +305,6 @@ src/kiro_crew/mcp_tools/apps.py
 src/kiro_crew/mcp_tools/artifacts.py
 src/kiro_crew/mcp_tools/knowledge.py
 src/kiro_crew/mcp_tools/skills.py
-src/kiro_crew/mcp_utils.py
 src/kiro_crew/metrics/http_metrics.py
 src/kiro_crew/metrics/provider.py
 src/kiro_crew/metrics/recorder.py
@@ -314,7 +313,6 @@ src/kiro_crew/notifications/resource_pressure.py
 src/kiro_crew/notifications/settings.py
 src/kiro_crew/perf_sampler.py
 src/kiro_crew/platform/admission.py
-src/kiro_crew/platform/capability_bound.py
 src/kiro_crew/platform/update_layout.py
 src/kiro_crew/pod/config.py
 src/kiro_crew/pod/launchd.py

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -947,12 +947,24 @@ is byte-identical) with no `CONTRACT_VERSION` bump.
   > through read and does NOT auto-reconcile — the sweep + idempotent re-apply are
   > the recovery path.
 
-  `async registry() -> List[Dict]` (the manager parses its own registry output
-  into entries; the core passes them through as `{"servers": [...]}`). The public
+  `async registry(query: str | None = None) -> List[Dict]` (the manager parses its
+  own registry output into entries; the core passes them through as
+  `{"servers": [...]}`). The public
   `DefaultCapabilityManager.available()` is `False` → the handlers return HTTP 503;
   a companion implements registry-backed management. This is the operations-based
   Protocol the prior binary-name seam's contract note anticipated — chosen now,
   pre-launch, so no external CLI grammar fossilizes in the core.
+
+  > `query` is an optional free-text filter HINT, sent only by MCP discovery
+  > search (`mcp_providers/capability.py`); the browse endpoint
+  > `GET /api/capability/mcp/registry` omits it and gets the full listing. The
+  > provider consumes at most `_LIST_LIMIT_GUARD` (500) rows, so a manager whose
+  > registry is larger MUST filter server-side or every row past that cap is
+  > unsearchable. Ignoring the hint stays correct — the provider filters again —
+  > it only costs reach. The hint is feature-detected on the signature
+  > (`mcp_utils.registry_accepts_query`) and forwarded by
+  > `BoundedCapabilityManager`, so an edition still on the zero-arg signature
+  > keeps working.
 
   **Second consumer — App Kit dependency resolution.** `apps/dependencies.py`
   resolves an app manifest's `dependencies.capabilities.{mcp,skills}` through

--- a/src/kiro_crew/mcp_providers/capability.py
+++ b/src/kiro_crew/mcp_providers/capability.py
@@ -17,6 +17,7 @@ dashboard layer so ``kiro_crew.mcp_providers`` stays importable standalone
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, Callable
 
 from kiro_crew.mcp_providers.base import (
@@ -24,13 +25,25 @@ from kiro_crew.mcp_providers.base import (
     McpServerDetail,
     ProviderUnavailableError,
 )
+from kiro_crew.mcp_utils import registry_accepts_query
 
 if TYPE_CHECKING:
     from kiro_crew.platform.interfaces import CapabilityManager
 
+logger = logging.getLogger(__name__)
+
 _LIST_LIMIT_GUARD = 500
 """Upper bound on registry rows consumed per call — a misbehaving edition
-manager can't flood the fan-out with an unbounded list."""
+manager can't flood the fan-out with an unbounded list.
+
+This bound is why :meth:`CapabilityProvider.search` passes the query DOWN to the
+manager (see :func:`_accepts_query`): a registry larger than the guard is
+truncated before any client-side filter runs, so without the hint the searchable
+window is the first 500 rows in whatever order the manager listed them, and every
+row past it is unreachable. Measured on an internal registry of 5612 servers: a
+search for a bundle sorted past the cap returned only substring noise from the
+rows inside it. The guard stays — a manager that IGNORES the hint is still
+bounded, it just keeps the old reach."""
 
 
 def _normalize_row(row: Any) -> dict[str, str | bool] | None:
@@ -79,11 +92,20 @@ class CapabilityProvider:
         except Exception:
             return False
 
-    async def _list_entries(self) -> list[dict[str, str | bool]]:
+    async def _list_entries(self, query: str | None = None) -> list[dict[str, str | bool]]:
+        """Registry rows, optionally asking the manager to filter first.
+
+        ``query`` is a HINT, not a contract: a manager may filter server-side,
+        narrow its own truncation, or ignore it entirely. Callers must still
+        filter the result themselves.
+        """
         mgr = self._manager_factory()
         if not mgr.available():
             raise ProviderUnavailableError("capability manager not available")
-        rows = await mgr.registry()
+        if query and registry_accepts_query(mgr.registry):
+            rows = await mgr.registry(query=query)
+        else:
+            rows = await mgr.registry()
         if not isinstance(rows, list):
             return []
         entries: list[dict[str, str | bool]] = []
@@ -91,17 +113,31 @@ class CapabilityProvider:
             entry = _normalize_row(row)
             if entry is not None:
                 entries.append(entry)
+        if query and len(rows) > _LIST_LIMIT_GUARD:
+            # Reachable only when the manager ignored the hint or its filter still
+            # overflows the guard: results past the cap are invisible to search, so
+            # say so instead of reporting a silently partial catalog.
+            logger.info(
+                "capability registry returned %d rows for query %r; searching the " "first %d only",
+                len(rows),
+                query,
+                _LIST_LIMIT_GUARD,
+            )
         return entries
 
     async def search(self, query: str, *, limit: int = 20) -> list[McpSearchResult]:
-        """List the edition registry and filter client-side (the seam has no
-        search parameter — registries behind it are small, hundreds not
-        millions)."""
+        """List the edition registry and filter client-side.
+
+        The needle is also passed DOWN to the manager, which may filter
+        server-side — without that a registry larger than
+        :data:`_LIST_LIMIT_GUARD` is truncated before this filter ever runs. The
+        client-side pass stays regardless, so a manager that ignores the hint is
+        still correct."""
         needle = query.strip().lower()
         if not needle:
             return []
         results: list[McpSearchResult] = []
-        for entry in await self._list_entries():
+        for entry in await self._list_entries(needle):
             haystack = f"{entry['id']} {entry['title']} {entry['description']}".lower()
             if needle not in haystack:
                 continue
@@ -126,8 +162,13 @@ class CapabilityProvider:
     async def fetch_detail(self, server_id: str) -> McpServerDetail | None:
         """Find one registry entry by id. install_plan is always None — the
         edition manager owns the install recipe (``install_mcp``), so there
-        is no spec to preview core-side."""
-        for entry in await self._list_entries():
+        is no spec to preview core-side.
+
+        The id doubles as the query hint: on a registry larger than
+        :data:`_LIST_LIMIT_GUARD` an unfiltered listing may not contain the row
+        the user just clicked in search results, which would 404 a server that
+        exists."""
+        for entry in await self._list_entries(server_id):
             if entry["id"] == server_id:
                 return McpServerDetail(
                     id=str(entry["id"]),

--- a/src/kiro_crew/mcp_utils.py
+++ b/src/kiro_crew/mcp_utils.py
@@ -9,6 +9,7 @@ that workaround.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import re
 from typing import Any
@@ -28,6 +29,35 @@ INTERNAL_CLIENT_ID_KEY = "clientId"
 #: with the provider's default grant instead of the scopes the card promised.
 KIRO_SCOPES_KEY = "oauthScopes"
 KIRO_OAUTH_KEY = "oauth"
+
+
+def registry_accepts_query(registry_op: Any) -> bool:
+    """True when a ``CapabilityManager.registry`` op takes the ``query`` hint.
+
+    Feature-detected rather than assumed: the seam's original signature was
+    zero-arg, so an edition pinned to an older core -- and every test double
+    written against it -- still satisfies the Protocol without the parameter.
+    Calling with the hint regardless and catching ``TypeError`` would be worse: a
+    genuine ``TypeError`` raised INSIDE the manager would be silently retried as
+    an unfiltered listing, hiding a real edition bug behind a degraded search.
+
+    A ``**kwargs`` op counts as accepting -- it swallows the hint without error,
+    which is the ignore-and-stay-correct case the caller's own filter covers.
+
+    Lives here, in the dependency-free helper module, because BOTH ends of the
+    seam need it: ``mcp_providers.capability`` to decide whether to send the hint,
+    and ``platform.capability_bound`` to decide whether to forward it inward.
+    """
+    try:
+        params = inspect.signature(registry_op).parameters
+    except (TypeError, ValueError):  # builtins / C callables expose no signature
+        return False
+    for param in params.values():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if param.name == "query" and param.kind is not inspect.Parameter.POSITIONAL_ONLY:
+            return True
+    return False
 
 
 def _scopes_shape(raw: object) -> str:
@@ -75,9 +105,7 @@ def _wire_scopes(raw: object, *, server: str = "") -> list[str] | None:
     """
     if raw is None or raw == []:
         return None
-    if isinstance(raw, list) and all(
-        isinstance(scope, str) and scope.strip() for scope in raw
-    ):
+    if isinstance(raw, list) and all(isinstance(scope, str) and scope.strip() for scope in raw):
         return list(raw)
     if server:
         logger.warning(

--- a/src/kiro_crew/platform/capability_bound.py
+++ b/src/kiro_crew/platform/capability_bound.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Dict, List
 
+from kiro_crew.mcp_utils import registry_accepts_query
+
 if TYPE_CHECKING:
     from kiro_crew.platform.interfaces import CapabilityManager, CapabilityResult
 
@@ -79,24 +81,28 @@ class BoundedCapabilityManager:
         return self._inner.available()
 
     async def list_mcp(self) -> List[Dict[str, Any]]:
-        return await asyncio.wait_for(
-            self._inner.list_mcp(), timeout=CAPABILITY_READ_TIMEOUT
-        )
+        return await asyncio.wait_for(self._inner.list_mcp(), timeout=CAPABILITY_READ_TIMEOUT)
 
     async def list_skills(self) -> List[Dict[str, Any]]:
-        return await asyncio.wait_for(
-            self._inner.list_skills(), timeout=CAPABILITY_READ_TIMEOUT
-        )
+        return await asyncio.wait_for(self._inner.list_skills(), timeout=CAPABILITY_READ_TIMEOUT)
 
     async def list_agents(self) -> List[Dict[str, Any]]:
-        return await asyncio.wait_for(
-            self._inner.list_agents(), timeout=CAPABILITY_READ_TIMEOUT
-        )
+        return await asyncio.wait_for(self._inner.list_agents(), timeout=CAPABILITY_READ_TIMEOUT)
 
-    async def registry(self) -> List[Dict[str, Any]]:
-        return await asyncio.wait_for(
-            self._inner.registry(), timeout=CAPABILITY_READ_TIMEOUT
-        )
+    async def registry(self, query: "str | None" = None) -> List[Dict[str, Any]]:
+        """Forward the optional search hint, but only to an inner op that takes it.
+
+        The wrapper must advertise ``query`` in its OWN signature: every caller
+        reaches the manager through this bind, so a wrapper that dropped the
+        parameter would make the hint undetectable and every edition registry
+        unsearchable past the caller's row guard. Forwarding is feature-detected
+        so an edition still on the zero-arg signature is called the old way
+        instead of raising ``TypeError`` — the hint is dropped, which the caller's
+        own filter already tolerates.
+        """
+        inner = self._inner.registry
+        call = inner(query=query) if query and registry_accepts_query(inner) else inner()
+        return await asyncio.wait_for(call, timeout=CAPABILITY_READ_TIMEOUT)
 
     async def install_mcp(self, server_id: str) -> "CapabilityResult":
         return await asyncio.wait_for(
@@ -129,9 +135,7 @@ class BoundedCapabilityManager:
         )
 
     async def list_plugins(self) -> List[Dict[str, Any]]:
-        return await asyncio.wait_for(
-            self._inner.list_plugins(), timeout=CAPABILITY_READ_TIMEOUT
-        )
+        return await asyncio.wait_for(self._inner.list_plugins(), timeout=CAPABILITY_READ_TIMEOUT)
 
     async def plugins_out_of_sync(self) -> List[str]:
         return await asyncio.wait_for(

--- a/src/kiro_crew/platform/defaults.py
+++ b/src/kiro_crew/platform/defaults.py
@@ -393,7 +393,7 @@ class DefaultCapabilityManager:
     async def uninstall_mcp(self, server_id: str) -> "CapabilityResult":
         return CapabilityResult(ok=False, message="capability manager not available")
 
-    async def registry(self) -> List[Dict[str, Any]]:
+    async def registry(self, query: Optional[str] = None) -> List[Dict[str, Any]]:
         return []
 
     async def list_skills(self) -> List[Dict[str, Any]]:

--- a/src/kiro_crew/platform/interfaces.py
+++ b/src/kiro_crew/platform/interfaces.py
@@ -896,13 +896,24 @@ class CapabilityManager(Protocol):
 
     async def uninstall_mcp(self, server_id: str) -> "CapabilityResult": ...
 
-    async def registry(self) -> List[Dict[str, Any]]:
+    async def registry(self, query: Optional[str] = None) -> List[Dict[str, Any]]:
         """Available MCP servers from the registry.
 
         The manager parses its own registry output into entries; the core passes
         them through verbatim as ``{"servers": [...]}``. Conventional keys the
         dashboard consumes: ``id``, ``installed``, ``title``, ``tier``,
         ``description`` (plus any extra fields the edition includes).
+
+        ``query`` is an OPTIONAL free-text filter HINT, passed only by MCP
+        discovery search (``mcp_providers.capability``); the browse endpoint
+        ``GET /api/capability/mcp/registry`` omits it and still gets the full
+        listing. A manager MAY use it to filter server-side, and SHOULD when its
+        registry is large enough that it truncates: the caller consumes at most
+        ``_LIST_LIMIT_GUARD`` rows, so on a big registry every row past that cap
+        is unsearchable unless the filter runs manager-side. Ignoring the hint
+        stays CORRECT — the caller filters again — it only costs reach. Because
+        the hint is feature-detected on the signature, an older zero-arg
+        implementation keeps working unchanged.
         """
         ...
 

--- a/test/test_mcp_capability_search_reach.py
+++ b/test/test_mcp_capability_search_reach.py
@@ -1,0 +1,178 @@
+"""MCP discovery search over the CapabilityManager seam.
+
+The regression these pin: ``CapabilityProvider`` consumes at most
+``_LIST_LIMIT_GUARD`` registry rows, so on a registry bigger than that guard the
+client-side filter only ever sees the head of the list and every row past it is
+unfindable. Measured on an internal registry of 5612 servers before the fix: a
+search for a bundle sorted past the cap returned only substring noise.
+
+The fix passes the query DOWN to the manager as a HINT. These tests cover both
+sides of that contract -- a manager that filters server-side becomes fully
+searchable, and a manager that ignores the hint (including one still on the
+older zero-arg signature) keeps working with its old reach.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.mcp_providers.capability import _LIST_LIMIT_GUARD, CapabilityProvider
+from kiro_crew.mcp_utils import registry_accepts_query
+from kiro_crew.platform.capability_bound import BoundedCapabilityManager
+
+
+def _rows(count: int, *, prefix: str = "srv") -> list[dict[str, object]]:
+    """A registry big enough to overflow the row guard, ids sorted a-z."""
+    return [
+        {
+            "id": f"{prefix}-{i:05d}-mcp",
+            "title": f"Server {i}",
+            "description": "d",
+            "installed": False,
+        }
+        for i in range(count)
+    ]
+
+
+class QueryAwareManager:
+    """A manager that filters server-side, like a large real registry must."""
+
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+        self.queries: list[str | None] = []
+
+    def available(self) -> bool:
+        return True
+
+    async def registry(self, query: str | None = None) -> list[dict[str, object]]:
+        self.queries.append(query)
+        if not query:
+            return self._rows
+        needle = query.lower()
+        return [r for r in self._rows if needle in str(r["id"]).lower()]
+
+
+class LegacyManager:
+    """A manager still on the original zero-arg signature."""
+
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+        self.calls = 0
+
+    def available(self) -> bool:
+        return True
+
+    async def registry(self) -> list[dict[str, object]]:
+        self.calls += 1
+        return self._rows
+
+
+@pytest.mark.asyncio
+async def test_search_finds_a_row_past_the_row_guard():
+    """The whole point: a server sorted past the guard is still findable."""
+    rows = _rows(_LIST_LIMIT_GUARD * 4)
+    target = str(rows[-1]["id"])
+    mgr = QueryAwareManager(rows)
+
+    results = await CapabilityProvider(lambda: mgr).search(target)
+
+    assert [r.id for r in results] == [target]
+    assert mgr.queries == [target.lower()]
+
+
+@pytest.mark.asyncio
+async def test_unfiltered_browse_sends_no_query():
+    """fetch_detail hints with the id; a plain listing must not invent a query."""
+    rows = _rows(3)
+    mgr = QueryAwareManager(rows)
+    provider = CapabilityProvider(lambda: mgr)
+
+    detail = await provider.fetch_detail(str(rows[2]["id"]))
+
+    assert detail is not None and detail.id == rows[2]["id"]
+    assert mgr.queries == [str(rows[2]["id"])]
+
+
+@pytest.mark.asyncio
+async def test_detail_reaches_a_row_past_the_row_guard():
+    rows = _rows(_LIST_LIMIT_GUARD * 3)
+    target = str(rows[-1]["id"])
+
+    detail = await CapabilityProvider(lambda: QueryAwareManager(rows)).fetch_detail(target)
+
+    assert detail is not None
+    assert detail.id == target
+
+
+@pytest.mark.asyncio
+async def test_legacy_zero_arg_manager_still_searches():
+    """No TypeError, and the head of the list stays searchable as before."""
+    rows = _rows(_LIST_LIMIT_GUARD * 2)
+    mgr = LegacyManager(rows)
+
+    results = await CapabilityProvider(lambda: mgr).search(str(rows[0]["id"]))
+
+    assert [r.id for r in results] == [rows[0]["id"]]
+    assert mgr.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_client_side_filter_survives_a_manager_that_ignores_the_hint():
+    """The hint is advisory: a manager returning everything must not leak rows."""
+
+    class IgnoringManager(QueryAwareManager):
+        async def registry(self, query: str | None = None):
+            self.queries.append(query)
+            return self._rows
+
+    mgr = IgnoringManager(_rows(10))
+    results = await CapabilityProvider(lambda: mgr).search("srv-00003")
+
+    assert [r.id for r in results] == ["srv-00003-mcp"]
+
+
+@pytest.mark.asyncio
+async def test_bounded_wrapper_forwards_the_hint():
+    """Every caller reaches the manager through the bind, so it must pass it on."""
+    rows = _rows(_LIST_LIMIT_GUARD * 2)
+    target = str(rows[-1]["id"])
+    inner = QueryAwareManager(rows)
+    bound = BoundedCapabilityManager(inner)
+
+    assert registry_accepts_query(bound.registry)
+    results = await CapabilityProvider(lambda: bound).search(target)
+
+    assert [r.id for r in results] == [target]
+    assert inner.queries == [target.lower()]
+
+
+@pytest.mark.asyncio
+async def test_bounded_wrapper_does_not_break_a_legacy_manager():
+    inner = LegacyManager(_rows(5))
+    bound = BoundedCapabilityManager(inner)
+
+    assert await bound.registry(query="srv") == inner._rows
+    assert await bound.registry() == inner._rows
+    assert inner.calls == 2
+
+
+def test_registry_accepts_query_shapes():
+    async def zero_arg():
+        return []
+
+    async def keyword(query=None):
+        return []
+
+    async def kwargs_only(**kw):
+        return []
+
+    async def positional_only(query=None, /):
+        return []
+
+    assert not registry_accepts_query(zero_arg)
+    assert registry_accepts_query(keyword)
+    assert registry_accepts_query(kwargs_only)
+    # Positional-only cannot take ``query=`` as a keyword, so it is not accepting.
+    assert not registry_accepts_query(positional_only)
+    # Nothing to introspect degrades to "does not accept" rather than raising.
+    assert not registry_accepts_query(None)


### PR DESCRIPTION
## Problem

MCP discovery search over the `CapabilityManager` seam can only ever see the first 500 registry rows.

`CapabilityProvider._list_entries` asks the manager for its whole registry, truncates at `_LIST_LIMIT_GUARD = 500`, and only then applies the search needle client-side. On a registry larger than that guard every row past it is unfindable, and `fetch_detail` can 404 a server the user just clicked in results.

Measured on an internal registry of 5612 servers before this change:

* the searchable window ended at the 500th id,
* a search for a bundle sorted past the cap returned only substring noise from the rows inside the window,
* the bundle itself (`quip-mcp`, id 4264 of 5612) was unreachable at any query.

## Fix

Pass the query DOWN to the manager as an optional hint, so a manager with a large registry can filter server-side before the guard applies.

* `CapabilityManager.registry(query=None)` — a HINT, not a contract. The provider still filters the result itself, so a manager that ignores it stays correct and only keeps its old reach.
* The hint is feature-detected on the signature (`mcp_utils.registry_accepts_query`) rather than sent blind and retried on `TypeError`: a `TypeError` raised inside a manager must not silently degrade to an unfiltered listing. An edition on the older zero-arg signature keeps working unchanged.
* `BoundedCapabilityManager` advertises and forwards the parameter, because every caller reaches the manager through that bind — a wrapper that dropped it would make the hint undetectable.
* `fetch_detail` hints with the server id, for the same 404 reason.
* `GET /api/capability/mcp/registry` (browse) sends no query and still gets the full listing.

The row guard is unchanged, so a misbehaving manager is still bounded. A listing that overflows the guard under a query now logs that search saw only part of it, instead of looking like a complete catalog.

## Tests

New `test/test_mcp_capability_search_reach.py` (8 tests) covers both sides of the hint contract: a row past the guard becomes findable in search and in detail, a manager that ignores the hint still gets a correctly filtered result, a legacy zero-arg manager does not raise, the bounded wrapper forwards the hint, and the signature probe's shapes.

Negative control: reverting only the pass-through in `_list_entries` fails 4 of the 8 new tests; restoring it passes all 8.

Local gates: 209 tests green across `test_mcp_providers.py`, `test_mcp_discover_api.py`, `test_capability_*.py`, `test_dependencies.py`, `test_platform_context.py`; `flake8`, `isort`, `mypy src/kiro_crew` (1344 files) clean; the black baseline gate passes (two files graduated to black-clean and were pruned per `scripts/check_black_formatting.py --update-baseline`).

## Notes

Public-build behavior is unchanged: `DefaultCapabilityManager.available()` is still `False`, so the provider is never registered there.

## Pattern harvest

Rule candidate: semgrep
Pattern: a collection truncated by a constant cap and THEN filtered by a caller-supplied predicate in the same call path — the cap silently bounds what the filter can ever match, so the filter looks like it searched everything.

Shape to flag: a slice by a module-level `*_LIMIT`/`*_GUARD`/`*_CAP` constant whose result is consumed by a comprehension or loop testing a parameter-derived needle. Here it was `rows[:_LIST_LIMIT_GUARD]` in `_list_entries` feeding the needle test in `search`; the same shape recurs whenever a paging/DoS guard sits upstream of a query. The fix pattern is to push the predicate to the producer, keep the guard, and log when a guarded listing overflowed under a query.

Not covered by a lint rule alone: whether the cap is smaller than the real collection is a runtime fact, so the rule can only flag the shape for review, not prove the bug.
