### PR TITLE
refactor(chat-core): route issue-radar and auto-improvement seeds through sendTurn

### DIFF
--- a/.github/coverage-baselines/frontend.txt
+++ b/.github/coverage-baselines/frontend.txt
@@ -18,7 +18,6 @@ src/app-sdk/shared-modules.ts 0.0   # 0/1
 src/apps/auto-improvement/AutoImprovementPage.tsx 58.0   # 47/81
 src/apps/auto-improvement/FindingDetail.tsx 8.3   # 2/24
 src/apps/auto-improvement/SetupPanel.tsx 53.7   # 36/67
-src/apps/auto-improvement/lib/agentSession.ts 32.6   # 28/86
 src/apps/code-review-sage/api.ts 12.7   # 9/71
 src/apps/crew-companion/LottieRenderer.tsx 9.5   # 2/21
 src/apps/crew-companion/SpriteRenderer.tsx 39.6   # 19/48

--- a/docs/request-for-change/rfc-chat-core-extraction.md
+++ b/docs/request-for-change/rfc-chat-core-extraction.md
@@ -6,8 +6,8 @@ created: 2026-08-22
 last-audited: 2026-09-05
 audited-at: 8ed028b0b
 doc-pr:
-implementation-prs: ["#5128", "#5909", "#8599", "#8631", "#8655", "#8689"]
-tracking-issues: ["#8651"]
+implementation-prs: ["#5128", "#5909", "#8599", "#8631", "#8655", "#8689", "#9576"]
+tracking-issues: ["#8651", "#9570"]
 supersedes: []
 superseded-by: []
 ---
@@ -91,7 +91,9 @@ Background: P3's ChatEmbed adoption (#8631) mounts the real `ChatInput`, whose s
 | P3 | ChatEmbed mounts the real `ChatInput` (fail-closed `embedded` preset) | [#8631](https://github.com/kirodotdev/KiroCrew/pull/8631) | merged into #8599's branch |
 | P2 | SideChat → `sendTurn` over a `/side/*` wire; shared core-owned receipt copy; `AcceptedBodyUnreadable` | [#8655](https://github.com/kirodotdev/KiroCrew/pull/8655) | in review (stacked on #8599) |
 | P2 | ChatPage send + steer → `sendTurn` (`steer`, `colorTheme` flags) | [#8689](https://github.com/kirodotdev/KiroCrew/pull/8689) | in review |
-| P2 | `App.tsx`, `useSceneInteraction`, mochi `panelBridge`, design-tweak, design-critique, issue-radar / auto-improvement `agentSession` | — | not started |
+| P2 | issue-radar / auto-improvement `agentSession` seeds → `sendTurn` (#9570 batch A) | [#9576](https://github.com/kirodotdev/KiroCrew/pull/9576) | in review |
+| P2 | design-critique, design-tweak, mochi `panelBridge` → `sendTurn`; receipt defects fixed (#9570 batch B) | — | not started |
+| P2 | `useSceneInteraction` (last `api.steerChat` caller), `App.tsx` feedback → `sendTurn` (#9570 batch C) | — | not started |
 | P3 | Store-free `ChatInput` seam | [#8651](https://github.com/kirodotdev/KiroCrew/issues/8651) | design draft pending |
 | P5-a | `ChatPage.renderMessage` → registry | — | next |
 | P4 | Error hand-off → side panel; `askAgent` default-on | — | after P5-a |

--- a/website/src/apps/auto-improvement/lib/agentSession.ts
+++ b/website/src/apps/auto-improvement/lib/agentSession.ts
@@ -22,7 +22,8 @@ import { useCallback, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { api } from '../../../api/client'
-import { readSendReceipt } from '../../../utils/sendDelivery'
+import { sendTurn } from '../../../chat-core/transport/sendTurn'
+import { settleSeedReceipt } from '../../../utils/seedReceipt'
 import { isMissingSlotError } from '../../../utils/thunkError'
 import { useAppDispatch } from '../../../store'
 import { createSlot, deleteSlot, switchSlot } from '../../../store/chatSlice'
@@ -237,25 +238,22 @@ export function useAgentSession(): UseAgentSession {
         // once the POST may have been accepted the agent is starting, and
         // deleting the slot would cancel real work over a metadata hiccup.
         createdSlotKey = slot.key
-        const seedInFlight = api.sendChat(prompt, slot.key)
+        // The chat-core transport owns the receipt contract (`POST /api/chat?ws=1`
+        // RESOLVES on 4xx/5xx, a 200 can still decline with `{ok:false}`, a hung
+        // POST is bounded by its deadline) and never rejects: every outcome is
+        // a receipt status.
+        const seedInFlight = sendTurn({ message: prompt, slot: slot.key })
         createdSlotKey = null
-        const seeded = await seedInFlight
-        // A REFUSAL, not merely a non-2xx: `/api/chat` also declines inside a 200
-        // by answering `{ok:false}`, and a status-only check passed that as a
-        // success -- recording and navigating to exactly the empty session this
-        // guard exists to prevent. `readSendReceipt` owns that distinction for
-        // every send site. An UNREADABLE 2xx receipt deliberately does NOT land
-        // here: the request was accepted, so the seed may be running, and
-        // deleting the slot would cancel real work over a mangled reply.
-        if (seeded && typeof seeded === 'object' && 'ok' in seeded) {
-          const { body, outcome } = await readSendReceipt(seeded as Response)
-          if (outcome === 'refused') {
-            await dispatch(deleteSlot(slot.key)).unwrap().catch(() => {})
-            const reason = typeof body.error === 'string' && body.error
-              ? body.error
-              : `HTTP ${(seeded as Response).status}`
-            throw new Error(`could not seed the session (${reason})`)
-          }
+        const receipt = await seedInFlight
+        // `settleSeedReceipt` owns the seed policy (shared with the other app
+        // seeder): only a seed that provably never ran -- refused, or no receipt
+        // and the slot stays empty -- tears the empty slot down; recording and
+        // navigating to it would be exactly the empty session this guard exists
+        // to prevent. Everything else is, or may be, running and is recorded.
+        const verdict = await settleSeedReceipt(receipt, slot.key)
+        if (!verdict.ran) {
+          await dispatch(deleteSlot(slot.key)).unwrap().catch(() => {})
+          throw new Error(verdict.reason)
         }
         const record = await saveRecord(key, {
           slot_key: slot.key,

--- a/website/src/apps/issue-radar/lib/agentSession.ts
+++ b/website/src/apps/issue-radar/lib/agentSession.ts
@@ -27,7 +27,8 @@ import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from '../../../store'
 import { createSlot, switchSlot, deleteSlot } from '../../../store/chatSlice'
 import { api } from '../../../api/client'
-import { readSendReceipt } from '../../../utils/sendDelivery'
+import { sendTurn } from '../../../chat-core/transport/sendTurn'
+import { settleSeedReceipt } from '../../../utils/seedReceipt'
 import { isMissingSlotError } from '../../../utils/thunkError'
 import { issueRadarApi, type InvestigationRecord, type ItemKind, RepoRef } from '../api'
 import { repoScopeKey } from './links'
@@ -276,31 +277,22 @@ export function useAgentSession(): UseAgentSession {
         createdSlotKey = slot.key
         // Seed + auto-run the first turn (background task; persisted + survives
         // the navigation). await ensures the user message is stored before we
-        // switch, so it paints immediately on arrival.
-        // api.sendChat hands back the raw fetch response, and fetch RESOLVES on
-        // 4xx/5xx — so without this check a rejected prompt still got recorded and
-        // navigated to, leaving a resumable but empty session.
-        const seedInFlight = api.sendChat(prompt, slot.key)
+        // switch, so it paints immediately on arrival. The chat-core transport
+        // owns the receipt contract (`POST /api/chat?ws=1` RESOLVES on 4xx/5xx,
+        // a 200 can still decline with `{ok:false}`, a hung POST is bounded by
+        // its deadline) and never rejects: every outcome is a receipt status.
+        const seedInFlight = sendTurn({ message: prompt, slot: slot.key })
         createdSlotKey = null
-        const seeded = await seedInFlight
-        // A REFUSAL, not merely a non-2xx: `/api/chat` also declines inside a 200
-        // by answering `{ok:false}`, and a status-only check passed that as a
-        // success -- recording and navigating to exactly the empty session this
-        // guard exists to prevent. `readSendReceipt` owns that distinction for
-        // every send site. An UNREADABLE 2xx receipt deliberately does NOT land
-        // here: the request was accepted, so the seed may be running, and
-        // deleting the slot would cancel real work over a mangled reply.
-        if (seeded && typeof seeded === 'object' && 'ok' in seeded) {
-          const { body, outcome } = await readSendReceipt(seeded as Response)
-          if (outcome === 'refused') {
-            // Rejected outright, so nothing is running: the empty slot is safe
-            // (and wrong) to remove.
-            await dispatch(deleteSlot(slot.key)).unwrap().catch(() => {})
-            const reason = typeof body.error === 'string' && body.error
-              ? body.error
-              : `HTTP ${(seeded as Response).status}`
-            throw new Error(`could not seed the session (${reason})`)
-          }
+        const receipt = await seedInFlight
+        // `settleSeedReceipt` owns the seed policy (shared with the other app
+        // seeder): only a seed that provably never ran -- refused, or no receipt
+        // and the slot stays empty -- tears the empty slot down; recording and
+        // navigating to it would be exactly the empty session this guard exists
+        // to prevent. Everything else is, or may be, running and is recorded.
+        const verdict = await settleSeedReceipt(receipt, slot.key)
+        if (!verdict.ran) {
+          await dispatch(deleteSlot(slot.key)).unwrap().catch(() => {})
+          throw new Error(verdict.reason)
         }
         const res = await issueRadarApi.saveInvestigation(repoRef, number, {
           slot_key: slot.key,

--- a/website/src/apps/issue-radar/lib/investigate.prompt.ts
+++ b/website/src/apps/issue-radar/lib/investigate.prompt.ts
@@ -9,10 +9,10 @@
 // Why the exemption exists: this prompt is functional payload. The agent reads
 // the instructions and acts on them, so a translated copy would change agent
 // BEHAVIOUR, not the interface language. It is nonetheless shown to the user —
-// `agentSession.openSession` sends it with `api.sendChat`, so it lands in the
-// transcript as the seeding user message — which is exactly why it cannot be
-// hidden behind a shape rule and pretended to be invisible: the boundary is the
-// honest form of the claim.
+// `agentSession.openSession` sends it through the chat-core `sendTurn`, so it
+// lands in the transcript as the seeding user message — which is exactly why it
+// cannot be hidden behind a shape rule and pretended to be invisible: the
+// boundary is the honest form of the claim.
 //
 // A `words.exclude` shape rule cannot do this job. The
 // exclusion IS consulted for a template literal — eslint-plugin-i18next

--- a/website/src/chat-core/transport/sendTurn.ts
+++ b/website/src/chat-core/transport/sendTurn.ts
@@ -1,11 +1,14 @@
 import { api } from '../../api/client'
 import { confirmedDelivered, readSendReceipt, SendReceiptBody } from '../../utils/sendDelivery'
 
-/** Stop waiting on a send's response. Reaching this bound means the request
- *  was received and only the reply is late: the turn is running and its output
- *  arrives over the WebSocket, not through this promise. It is NOT a failure
- *  signal, which is why the receipt below gives it its own status instead of
- *  folding it into the error shapes. */
+/** Stop waiting on a send's response. Reaching this bound says only that no
+ *  receipt arrived in time: usually the request was received and the reply is
+ *  late (the turn is running and its output arrives over the WebSocket, not
+ *  through this promise), but a POST that never reached the gateway looks the
+ *  same from here. Delivery is INDETERMINATE -- not a failure signal and not a
+ *  delivery receipt -- which is why the receipt below gives it its own status
+ *  (`response-late`) instead of folding it into either the accepted or the
+ *  error shapes. */
 export const SEND_ABORT_MS = 10_000
 
 /**
@@ -39,8 +42,16 @@ export const SEND_ABORT_MS = 10_000
  *                        optimistic row pending to avoid a duplicate, while a
  *                        caller that has already destroyed the only visible
  *                        copy may choose to recover it.
- * - `transport-error` -- the fetch itself rejected (offline, DNS, CORS). The
- *                        send never left, so restore-and-report is safe.
+ * - `transport-error` -- the fetch itself rejected without a response. Usually
+ *                        the request never left (offline, DNS, CORS), but a
+ *                        connection reset AFTER the server took the POST rejects
+ *                        the same way, so delivery is INDETERMINATE -- the
+ *                        request may have started a turn. What to do is
+ *                        call-site policy: a composer restores the text and
+ *                        reports (a visible duplicate beats a silent loss); a
+ *                        caller whose retry would destroy or duplicate work
+ *                        (a seeder deleting its slot) must not treat this as
+ *                        proof that nothing ran.
  */
 export type SendReceiptStatus =
   | 'dispatched'

--- a/website/src/test/agentSessionConcludedNoRerun.test.ts
+++ b/website/src/test/agentSessionConcludedNoRerun.test.ts
@@ -20,14 +20,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 
-const { dispatch, apiMock, saveInvestigation, getInvestigation } = vi.hoisted(() => ({
+const { dispatch, apiMock, sendTurn, saveInvestigation, getInvestigation } = vi.hoisted(() => ({
   dispatch: vi.fn(),
   apiMock: {
     chatFolders: vi.fn(),
     createChatFolder: vi.fn(),
-    sendChat: vi.fn(),
     chatSlotDetail: vi.fn(),
   },
+  sendTurn: vi.fn(),
   saveInvestigation: vi.fn(),
   getInvestigation: vi.fn(),
 }))
@@ -40,6 +40,7 @@ vi.mock('../store/chatSlice', () => ({
 }))
 vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
 vi.mock('../api/client', () => ({ api: apiMock }))
+vi.mock('../chat-core/transport/sendTurn', () => ({ sendTurn }))
 vi.mock('../apps/issue-radar/api', () => ({ issueRadarApi: { saveInvestigation, getInvestigation } }))
 
 import { useAgentSession, itemKey } from '../apps/issue-radar/lib/agentSession'
@@ -60,7 +61,7 @@ function harness() {
   apiMock.chatSlotDetail.mockImplementation((key: string) =>
     key === SLOT_KEY ? Promise.reject(slotGone) : Promise.resolve({ messages: [] }))
   apiMock.chatFolders.mockResolvedValue([{ id: 'f1', name: 'Issue Radar - demo-repo' }])
-  apiMock.sendChat.mockResolvedValue({ status: 200, ok: true } as unknown as Response)
+  sendTurn.mockResolvedValue({ status: 'dispatched', body: {} })
   saveInvestigation.mockResolvedValue({ investigation: { slot_key: 'slot-new' } })
   // Default: the server agrees with the record the case passed in, so the re-read
   // is a no-op and each case still exercises the status it names.
@@ -86,7 +87,7 @@ const open = async (status: string, force = false) => {
 
 const createdSlot = () =>
   dispatch.mock.calls.some((c) => (c[0] as { type: string }).type === 'createSlot')
-const seeded = () => apiMock.sendChat.mock.calls.length > 0
+const seeded = () => sendTurn.mock.calls.length > 0
 
 describe('Issue Radar - a concluded investigation is not silently re-run', () => {
   beforeEach(() => {

--- a/website/src/test/agentSessionResumeMissingSlot.test.ts
+++ b/website/src/test/agentSessionResumeMissingSlot.test.ts
@@ -36,14 +36,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
-const { dispatch, apiMock, saveInvestigation, getInvestigation } = vi.hoisted(() => ({
+const { dispatch, apiMock, sendTurn, saveInvestigation, getInvestigation } = vi.hoisted(() => ({
   dispatch: vi.fn(),
   apiMock: {
     chatFolders: vi.fn(),
     createChatFolder: vi.fn(),
-    sendChat: vi.fn(),
     chatSlotDetail: vi.fn(),
   },
+  sendTurn: vi.fn(),
   saveInvestigation: vi.fn(),
   getInvestigation: vi.fn(),
 }))
@@ -56,6 +56,7 @@ vi.mock('../store/chatSlice', () => ({
 }))
 vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
 vi.mock('../api/client', () => ({ api: apiMock }))
+vi.mock('../chat-core/transport/sendTurn', () => ({ sendTurn }))
 vi.mock('../apps/issue-radar/api', () => ({ issueRadarApi: { saveInvestigation, getInvestigation } }))
 
 import { useAgentSession } from '../apps/issue-radar/lib/agentSession'
@@ -83,7 +84,7 @@ function harness(rejection: unknown) {
     key === 'slot-closed' ? Promise.reject(rejection) : Promise.resolve({ messages: [] }))
   getInvestigation.mockResolvedValue({ investigation: null })
   apiMock.chatFolders.mockResolvedValue([{ id: 'f1', name: 'Issue Radar - demo-repo' }])
-  apiMock.sendChat.mockResolvedValue({ status: 200, ok: true } as unknown as Response)
+  sendTurn.mockResolvedValue({ status: 'dispatched', body: {} })
   saveInvestigation.mockResolvedValue({ investigation: { slot_key: 'slot-new' } })
 }
 

--- a/website/src/test/agentSessionSeedReceipt.test.ts
+++ b/website/src/test/agentSessionSeedReceipt.test.ts
@@ -1,30 +1,44 @@
 /**
- * A seed prompt the server REFUSED must not leave a recorded, empty session.
+ * A seed prompt that provably never ran must not leave a recorded, empty
+ * session -- and a seed that MAY be running must never be torn down.
  *
- * Two app seeders guard this -- Issue Radar and Auto Improvement -- and both
- * used to guard it with a status-only check (`!(seeded as Response).ok`).
- * `/api/chat` also declines inside a 200 by answering `{ok:false}`, so that
- * check passed a refusal as a success: the slot survived, the record was
- * written, and the user was navigated to exactly the empty session the guard
- * exists to prevent. Both now read the receipt through the shared
- * `readSendReceipt`; the Issue Radar seeder is exercised here, and the Auto
- * Improvement one is the same three lines against its own record store.
+ * Two app seeders guard this -- Issue Radar and Auto Improvement. Both used to
+ * read the raw `api.sendChat` response through `readSendReceipt` themselves;
+ * both now call the chat-core transport `sendTurn` and branch on its receipt
+ * status. This file pins that mapping for BOTH seeders, so the contract cannot
+ * drift between them again:
  *
- * The other half matters as much: an UNREADABLE 2xx receipt must NOT take the
- * failure path. The request was accepted, so the seed may be running, and
- * deleting the slot there would cancel real work over a mangled reply.
+ *   - `refused`         -> slot deleted, nothing recorded, the server's own
+ *                          reason surfaces (a refusal inside a 200 is the case a
+ *                          status-only check used to miss).
+ *   - `unknown`         -> NOT deleted, recorded. Accepted, receipt unreadable:
+ *                          deleting would cancel real work over a mangled reply.
+ *   - `transport-error` / `response-late` -> no receipt, indeterminate (a reset
+ *                          after the server took the POST rejects the fetch like
+ *                          a request that never left; a stalled POST may still
+ *                          land), so the seeder ASKS the slot: an empty slot
+ *                          after bounded re-reads means the seed never landed ->
+ *                          torn down + reported like a refusal; a message, or a
+ *                          probe the server cannot answer, means it is or may be
+ *                          running -> recorded and opened, never cancelled and
+ *                          never left orphaned. The policy lives once, in
+ *                          `utils/seedReceipt.ts`, and both seeders call it.
+ *   - `dispatched` / `queued` -> recorded normally.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
+import type { SendReceipt } from '../chat-core/transport/sendTurn'
+import { i18nT } from '../i18n/t'
 
-const { dispatch, apiMock, saveInvestigation, getInvestigation } = vi.hoisted(() => ({
+const { dispatch, apiMock, sendTurn, saveInvestigation, getInvestigation } = vi.hoisted(() => ({
   dispatch: vi.fn(),
   apiMock: {
     chatFolders: vi.fn(),
     createChatFolder: vi.fn(),
     renameSlot: vi.fn(),
-    sendChat: vi.fn(),
+    chatSlotDetail: vi.fn(),
   },
+  sendTurn: vi.fn(),
   saveInvestigation: vi.fn(),
   getInvestigation: vi.fn(),
 }))
@@ -37,95 +51,233 @@ vi.mock('../store/chatSlice', () => ({
 }))
 vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
 vi.mock('../api/client', () => ({ api: apiMock }))
+vi.mock('../chat-core/transport/sendTurn', () => ({ sendTurn }))
 vi.mock('../apps/issue-radar/api', () => ({ issueRadarApi: { saveInvestigation, getInvestigation } }))
 
-import { useAgentSession } from '../apps/issue-radar/lib/agentSession'
+import { useAgentSession as useIssueRadarSession } from '../apps/issue-radar/lib/agentSession'
+import { useAgentSession as useAutoImproveSession } from '../apps/auto-improvement/lib/agentSession'
+
+const receipt = (status: SendReceipt['status'], reason?: string): SendReceipt =>
+  ({ status, body: {}, ...(reason ? { reason } : {}) })
 
 /** Did the SUT ask for the freshly created slot to be deleted? */
 const deletedSlot = () =>
   dispatch.mock.calls.some((c) => (c[0] as { type: string }).type === 'deleteSlot')
 
-/** Open a session and hand back the result plus the LIVE hook handle:
- *  `openSession` swallows the throw, returns null, and reports through `error`
- *  — which lands in a later render, so it is read via `waitFor`, never off the
- *  snapshot taken before the await. */
-async function open() {
-  const { result } = renderHook(() => useAgentSession())
-  const opened = await result.current.openSession({
-    repoRef: { host: 'github.com', owner: 'acme', repo: 'demo-repo' } as never,
-    number: 4237,
-    title: '#4237 · seed refused',
-    prompt: 'seed',
-    existing: null,
-  })
-  return { opened, result }
-}
+beforeEach(() => {
+  vi.resetAllMocks()
+  dispatch.mockImplementation((action: { type: string }) => ({
+    unwrap: () =>
+      action.type === 'createSlot'
+        ? Promise.resolve({ key: 'slot-1' })
+        : Promise.resolve(undefined),
+  }))
+  apiMock.chatFolders.mockResolvedValue([
+    { id: 'repo-1', name: 'Issue Radar - demo-repo' },
+    { id: 'repo-2', name: 'Auto-Improve - acme/demo-repo' },
+  ])
+})
 
-describe('Issue Radar seed — the receipt decides, not the status alone', () => {
+describe('Issue Radar seed — the sendTurn receipt decides', () => {
+  /** Open a session and hand back the result plus the LIVE hook handle:
+   *  `openSession` swallows the throw, returns null, and reports through `error`
+   *  — which lands in a later render, so it is read via `waitFor`, never off the
+   *  snapshot taken before the await. */
+  async function open() {
+    const { result } = renderHook(() => useIssueRadarSession())
+    const opened = await result.current.openSession({
+      repoRef: { host: 'github.com', owner: 'acme', repo: 'demo-repo' } as never,
+      number: 4237,
+      title: '#4237 · seed refused',
+      prompt: 'seed',
+      existing: null,
+    })
+    return { opened, result }
+  }
+
   beforeEach(() => {
-    vi.resetAllMocks()
-    dispatch.mockImplementation((action: { type: string }) => ({
-      unwrap: () =>
-        action.type === 'createSlot'
-          ? Promise.resolve({ key: 'slot-1' })
-          : Promise.resolve(undefined),
-    }))
     getInvestigation.mockResolvedValue({ investigation: null })
-  apiMock.chatFolders.mockResolvedValue([{ id: 'repo-1', name: 'Issue Radar - demo-repo' }])
     saveInvestigation.mockResolvedValue({ investigation: { slot_key: 'slot-1' } })
   })
 
-  it('tears down the slot when a 200 answers {ok:false}', async () => {
-    // The case a status-only check missed entirely.
-    apiMock.sendChat.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ ok: false, error: 'slot is stopping' }),
-    })
+  it('sends the seed through the transport, addressed to the new slot', async () => {
+    sendTurn.mockResolvedValue(receipt('dispatched'))
+    await open()
+    expect(sendTurn).toHaveBeenCalledWith({ message: 'seed', slot: 'slot-1' })
+  })
+
+  it('tears down the slot on `refused` and keeps the server\'s reason', async () => {
+    // The refusal-inside-a-200 case a status-only check missed entirely.
+    sendTurn.mockResolvedValue(receipt('refused', 'slot is stopping'))
 
     const { opened, result } = await open()
     expect(opened).toBeNull()
-    // The server's own reason survives — "HTTP 200" would be actively misleading
-    // for a refusal that arrived inside a success status.
-    await waitFor(() => expect(result.current.error?.message).toMatch(/slot is stopping/))
+    await waitFor(() => expect(result.current.error?.message).toBe(
+      `${i18nT('pages.chatPage.could_not_start_a_new_session')} (slot is stopping)`,
+    ))
     expect(deletedSlot()).toBe(true)
     // ...and nothing is recorded, so no row points at a session that never ran.
     expect(saveInvestigation).not.toHaveBeenCalled()
   })
 
-  it('still tears down on a plain non-2xx', async () => {
-    // The case it did catch, kept green.
-    apiMock.sendChat.mockResolvedValue({
-      ok: false,
-      status: 503,
-      json: () => Promise.reject(new Error('not json')),
-    })
+  it('still tears down on a reasonless refusal (a plain non-2xx), in human words', async () => {
+    sendTurn.mockResolvedValue(receipt('refused'))
 
     const { opened, result } = await open()
     expect(opened).toBeNull()
-    await waitFor(() => expect(result.current.error?.message).toMatch(/503/))
+    // No raw status enum and no English wrapper around a localized fragment:
+    // the whole message is the core's own "could not start" copy.
+    await waitFor(() => expect(result.current.error?.message).toBe(String(i18nT('pages.chatPage.could_not_start_a_new_session'))))
     expect(deletedSlot()).toBe(true)
     expect(saveInvestigation).not.toHaveBeenCalled()
   })
 
-  it('does NOT tear down on an unreadable 2xx — the seed may be running', async () => {
-    // Deleting here would cancel real work over a mangled reply.
-    apiMock.sendChat.mockResolvedValue({
-      ok: true,
-      json: () => Promise.reject(new Error('unexpected end of JSON input')),
+  describe.each(['transport-error', 'response-late'] as const)('`%s` asks the slot instead of guessing', (status) => {
+    beforeEach(() => sendTurn.mockResolvedValue(receipt(status)))
+
+    it('tears down and reports when the slot stays empty — the seed never landed', async () => {
+      // Bounded re-reads (a late arrival gets a second) then the verdict; the
+      // polling itself is pinned in seedReceipt.test.ts.
+      apiMock.chatSlotDetail.mockResolvedValue({ messages: [], total: 0 })
+
+      const { opened, result } = await open()
+      expect(opened).toBeNull()
+      await waitFor(() => expect(result.current.error?.message).toBe(String(i18nT('pages.chatPage.could_not_start_a_new_session'))))
+      expect(apiMock.chatSlotDetail).toHaveBeenCalledWith('slot-1', 1)
+      expect(deletedSlot()).toBe(true)
+      expect(saveInvestigation).not.toHaveBeenCalled()
+    }, 10_000)
+
+    it('records and opens when the slot already holds the seed — it is running', async () => {
+      apiMock.chatSlotDetail.mockResolvedValue({ messages: [{ role: 'user', content: 'seed' }], total: 1 })
+
+      const { result } = await open()
+      expect(result.current.error).toBeNull()
+      expect(deletedSlot()).toBe(false)
+      expect(saveInvestigation).toHaveBeenCalled()
     })
 
+    it('records and opens when the probe itself fails — never cancel or orphan what may be running', async () => {
+      apiMock.chatSlotDetail.mockRejectedValue(new Error('HTTP 503'))
+
+      const { result } = await open()
+      expect(result.current.error).toBeNull()
+      expect(deletedSlot()).toBe(false)
+      expect(saveInvestigation).toHaveBeenCalled()
+    })
+
+    it('reports at once when the slot is already gone — nothing can be running in it', async () => {
+      apiMock.chatSlotDetail.mockRejectedValue({ status: 404, message: 'not found' })
+
+      const { opened, result } = await open()
+      expect(opened).toBeNull()
+      await waitFor(() => expect(result.current.error).toBeTruthy())
+      expect(apiMock.chatSlotDetail).toHaveBeenCalledTimes(1)
+      expect(saveInvestigation).not.toHaveBeenCalled()
+    })
+  })
+
+  it.each([
+    ['unknown', 'the seed may be running'],
+  ] as const)('does NOT tear down on `%s` — %s', async (status) => {
+    sendTurn.mockResolvedValue(receipt(status))
+
     const { result } = await open()
     expect(result.current.error).toBeNull()
     expect(deletedSlot()).toBe(false)
     expect(saveInvestigation).toHaveBeenCalled()
   })
 
-  it('records normally on an accepted seed', async () => {
-    apiMock.sendChat.mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) })
+  it.each(['dispatched', 'queued'] as const)('records normally on `%s`', async (status) => {
+    sendTurn.mockResolvedValue(receipt(status))
 
     const { result } = await open()
     expect(result.current.error).toBeNull()
     expect(deletedSlot()).toBe(false)
     expect(saveInvestigation).toHaveBeenCalled()
   })
+})
+
+describe('Auto Improvement seed — the same receipt contract', () => {
+  const saved = vi.fn()
+
+  /** The record store is this app's own backend, reached with bare `fetch`:
+   *  GET answers "no record yet", PUT is captured so the test can tell whether a
+   *  session was recorded. */
+  beforeEach(() => {
+    saved.mockReset()
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') {
+        saved(init.body)
+        return { ok: true, json: async () => ({ session: { slot_key: 'slot-1', status: 'open' } }) }
+      }
+      return { ok: true, json: async () => ({ session: null }) }
+    }))
+  })
+
+  async function open() {
+    const { result } = renderHook(() => useAutoImproveSession())
+    const opened = await result.current.openSession({
+      kind: 'pr',
+      id: 42,
+      repo: 'acme/demo-repo',
+      title: 'PR #42 · seed',
+      prompt: 'seed',
+    })
+    return { opened, result }
+  }
+
+  it('sends the seed through the transport, addressed to the new slot', async () => {
+    sendTurn.mockResolvedValue(receipt('dispatched'))
+    await open()
+    expect(sendTurn).toHaveBeenCalledWith({ message: 'seed', slot: 'slot-1' })
+  })
+
+  it.each([
+    ['with the server\'s reason', 'slot agent mismatch', /slot agent mismatch/],
+    ['with the core\'s own copy when the body carried none', undefined, String(i18nT('pages.chatPage.could_not_start_a_new_session'))],
+  ] as const)('tears down and records nothing on `refused` %s', async (_label, reason, expected) => {
+    sendTurn.mockResolvedValue(receipt('refused', reason))
+
+    const { opened, result } = await open()
+    expect(opened).toBeNull()
+    await waitFor(() => expect(result.current.error?.message).toMatch(expected))
+    expect(deletedSlot()).toBe(true)
+    expect(saved).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['transport-error', 'empty', { messages: [], total: 0 }, true],
+    ['transport-error', 'seeded', { messages: [{ role: 'user' }], total: 1 }, false],
+    ['response-late', 'empty', { messages: [], total: 0 }, true],
+    ['response-late', 'seeded', { messages: [{ role: 'user' }], total: 1 }, false],
+  ] as const)('on `%s` asks the slot: %s -> tears down %s', async (status, _label, detail, tornDown) => {
+    sendTurn.mockResolvedValue(receipt(status))
+    apiMock.chatSlotDetail.mockResolvedValue(detail)
+
+    const { opened, result } = await open()
+    if (tornDown) {
+      expect(opened).toBeNull()
+      await waitFor(() => expect(result.current.error).toBeTruthy())
+      expect(saved).not.toHaveBeenCalled()
+    } else {
+      expect(opened).not.toBeNull()
+      expect(result.current.error).toBeNull()
+      expect(saved).toHaveBeenCalled()
+    }
+    expect(deletedSlot()).toBe(tornDown)
+  }, 10_000)
+
+  it.each(['unknown', 'dispatched', 'queued'] as const)(
+    'keeps the slot and records the session on `%s`',
+    async (status) => {
+      sendTurn.mockResolvedValue(receipt(status))
+
+      const { opened, result } = await open()
+      expect(opened).not.toBeNull()
+      expect(result.current.error).toBeNull()
+      expect(deletedSlot()).toBe(false)
+      expect(saved).toHaveBeenCalled()
+    },
+  )
 })

--- a/website/src/test/chatCoreTransport.contract.test.ts
+++ b/website/src/test/chatCoreTransport.contract.test.ts
@@ -81,7 +81,7 @@ describe('sendTurn receipt contract', () => {
     expect(receipt.status).toBe('queued')
   })
 
-  it('maps a transport rejection (never left the machine) to transport-error', async () => {
+  it('maps a transport rejection (no response -- delivery indeterminate) to transport-error', async () => {
     fetchMock.mockRejectedValue(new TypeError('Failed to fetch'))
     const receipt = await sendTurn({ message: 'hi', slot: 'chat-1' })
     expect(receipt.status).toBe('transport-error')

--- a/website/src/test/seedReceipt.test.ts
+++ b/website/src/test/seedReceipt.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `settleSeedReceipt` -- the one seed-receipt policy both app seeders call.
+ *
+ * Pins the mapping and, for the two no-receipt statuses, the bounded slot
+ * probe: an empty slot is re-read `SEED_PROBE_ATTEMPTS` times with
+ * `SEED_PROBE_GAP_MS` between reads so a POST that reaches the gateway after
+ * the transport's deadline still gets counted, and only sustained emptiness
+ * rules the seed never-landed. A gone slot short-circuits (nothing can be
+ * running in it); a probe the server cannot answer reads as "may be running".
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SendReceipt } from '../chat-core/transport/sendTurn'
+import { i18nT } from '../i18n/t'
+
+const { chatSlotDetail } = vi.hoisted(() => ({ chatSlotDetail: vi.fn() }))
+vi.mock('../api/client', () => ({ api: { chatSlotDetail } }))
+
+import { SEED_PROBE_ATTEMPTS, SEED_PROBE_GAP_MS, settleSeedReceipt } from '../utils/seedReceipt'
+
+const receipt = (status: SendReceipt['status'], reason?: string): SendReceipt =>
+  ({ status, body: {}, ...(reason ? { reason } : {}) })
+
+const couldNotStart = String(i18nT('pages.chatPage.could_not_start_a_new_session'))
+
+beforeEach(() => {
+  chatSlotDetail.mockReset()
+  vi.useFakeTimers()
+})
+afterEach(() => vi.useRealTimers())
+
+describe('settleSeedReceipt', () => {
+  it.each(['dispatched', 'queued', 'unknown'] as const)('`%s` ran, without touching the slot', async (status) => {
+    await expect(settleSeedReceipt(receipt(status), 'slot-1')).resolves.toEqual({ ran: true })
+    expect(chatSlotDetail).not.toHaveBeenCalled()
+  })
+
+  it('`refused` never ran, carrying the server reason', async () => {
+    await expect(settleSeedReceipt(receipt('refused', 'slot is stopping'), 'slot-1')).resolves.toEqual({
+      ran: false, reason: `${couldNotStart} (slot is stopping)`,
+    })
+    expect(chatSlotDetail).not.toHaveBeenCalled()
+  })
+
+  it('`refused` with no reason falls back to the core copy alone -- never a raw status', async () => {
+    await expect(settleSeedReceipt(receipt('refused'), 'slot-1')).resolves.toEqual({ ran: false, reason: couldNotStart })
+  })
+
+  describe.each(['transport-error', 'response-late'] as const)('`%s` asks the slot', (status) => {
+    it('ran when the slot already holds the seed', async () => {
+      chatSlotDetail.mockResolvedValue({ total: 1, messages: [{ role: 'user' }] })
+      await expect(settleSeedReceipt(receipt(status), 'slot-1')).resolves.toEqual({ ran: true })
+      expect(chatSlotDetail).toHaveBeenCalledTimes(1)
+      expect(chatSlotDetail).toHaveBeenCalledWith('slot-1', 1)
+    })
+
+    it('ran when the probe itself cannot be answered -- never cancel or orphan what may be running', async () => {
+      chatSlotDetail.mockRejectedValue(new Error('HTTP 503'))
+      await expect(settleSeedReceipt(receipt(status), 'slot-1')).resolves.toEqual({ ran: true })
+      expect(chatSlotDetail).toHaveBeenCalledTimes(1)
+    })
+
+    it('never ran, at once, when the slot is gone', async () => {
+      chatSlotDetail.mockRejectedValue({ status: 404, message: 'not found' })
+      await expect(settleSeedReceipt(receipt(status), 'slot-1')).resolves.toEqual({ ran: false, reason: couldNotStart })
+      expect(chatSlotDetail).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-reads an empty slot a bounded number of times before ruling never-ran', async () => {
+      chatSlotDetail.mockResolvedValue({ total: 0, messages: [] })
+      const settled = settleSeedReceipt(receipt(status), 'slot-1')
+      await vi.advanceTimersByTimeAsync(SEED_PROBE_GAP_MS * SEED_PROBE_ATTEMPTS)
+      await expect(settled).resolves.toEqual({ ran: false, reason: couldNotStart })
+      expect(chatSlotDetail).toHaveBeenCalledTimes(SEED_PROBE_ATTEMPTS)
+    })
+
+    it('counts a seed that lands during the re-reads as ran', async () => {
+      chatSlotDetail
+        .mockResolvedValueOnce({ total: 0, messages: [] })
+        .mockResolvedValueOnce({ total: 1, messages: [{ role: 'user' }] })
+      const settled = settleSeedReceipt(receipt(status), 'slot-1')
+      await vi.advanceTimersByTimeAsync(SEED_PROBE_GAP_MS)
+      await expect(settled).resolves.toEqual({ ran: true })
+      expect(chatSlotDetail).toHaveBeenCalledTimes(2)
+    })
+
+    it('reads message rows when the detail carries no total', async () => {
+      chatSlotDetail.mockResolvedValue({ messages: [{ role: 'user' }] })
+      await expect(settleSeedReceipt(receipt(status), 'slot-1')).resolves.toEqual({ ran: true })
+    })
+  })
+})

--- a/website/src/utils/seedReceipt.ts
+++ b/website/src/utils/seedReceipt.ts
@@ -1,0 +1,90 @@
+/**
+ * Receipt policy for a NON-INTERACTIVE SEED -- a first message an app sends into
+ * a slot it just created, with no composer to restore into (issue-radar and
+ * auto-improvement `agentSession.openSession`). The statuses' MEANINGS live on
+ * `SendReceiptStatus` in chat-core; this module is only what a seeder does with
+ * them, kept in one place so the two seeders cannot drift apart:
+ *
+ * - `refused`: the server said no, so nothing is running -- the seed never ran.
+ * - `transport-error` / `response-late`: no receipt at all (the fetch rejected,
+ *   or the deadline passed first). Delivery is indeterminate -- a connection
+ *   reset AFTER the server took the POST rejects exactly like a request that
+ *   never left, and a stalled POST may still land -- so instead of guessing the
+ *   seeder ASKS the slot. The seed is stored as the slot's first message before
+ *   its turn runs, so a one-row slot read settles it: a message means the seed
+ *   is (or may be) running; an empty slot, re-read a bounded number of times to
+ *   let a late arrival land, means it did not. A probe the server cannot
+ *   answer reads as "may be running" -- deleting on a guess would cancel real
+ *   work, and leaving a live slot unrecorded would orphan it for the next click
+ *   to duplicate. A slot the server reports GONE is not running the seed.
+ *
+ *   Accepted residual: the verdict is only as good as the probe window. A POST
+ *   that reaches the gateway AFTER the last re-read (held by a proxy or buffer
+ *   past the client-side reset or abort) finds the slot deleted, and
+ *   `/api/chat` re-creates a missing slot, so that seed runs in an unrecorded
+ *   session while the user was told it did not start. For a rejected fetch this
+ *   is the old always-orphan outcome confined to a corner; for the deadline it
+ *   is a NEW corner, bought deliberately: the old seeder had no deadline, so a
+ *   stalled POST hung the launch until it resolved and was then recorded. The
+ *   trade is a bounded wait plus a small late-landing window against an
+ *   unbounded hang. The window (`SEED_PROBE_ATTEMPTS` x `SEED_PROBE_GAP_MS`) is
+ *   a judgement, not a measurement; widen it if late landings turn up. Closing
+ *   the corner outright needs the send to opt out of slot auto-create
+ *   server-side, which is not this caller's to add.
+ * - `unknown`: a 2xx whose body could not be read -- accepted; the seed ran.
+ * - `dispatched` / `queued`: the seed ran.
+ */
+import { api } from '../api/client'
+import type { SendReceipt } from '../chat-core/transport/sendTurn'
+import { i18nT } from '../i18n/t'
+import { isMissingSlotError } from './thunkError'
+
+/** How many times an empty slot is re-read before a no-receipt send is ruled
+ *  never-landed, and the gap between reads. A judgement call sizing the
+ *  late-landing window described above, not a measured figure. */
+export const SEED_PROBE_ATTEMPTS = 3
+export const SEED_PROBE_GAP_MS = 1000
+
+export type SeedVerdict =
+  | { ran: true }
+  /** The seed provably never ran; `reason` is the user-facing text. */
+  | { ran: false; reason: string }
+
+/** The user-facing text of a seed that did not start: the core's own "could not
+ *  start" copy, with the server's reason appended when it gave one. Never a raw
+ *  status enum -- this lands in the launch button's error notice. */
+function seedFailureText(reason?: string): string {
+  const base = i18nT('pages.chatPage.could_not_start_a_new_session') as string
+  return reason ? `${base} (${reason})` : base
+}
+
+/** What the slot says about the seed: it is there, the slot is still empty, the
+ *  slot is gone, or the server could not answer. */
+async function probeSlot(slotKey: string): Promise<'landed' | 'empty' | 'gone' | 'unknown'> {
+  try {
+    const detail = (await api.chatSlotDetail(slotKey, 1)) as { total?: unknown; messages?: unknown }
+    const count = typeof detail.total === 'number'
+      ? detail.total
+      : Array.isArray(detail.messages) ? detail.messages.length : 0
+    return count > 0 ? 'landed' : 'empty'
+  } catch (e) {
+    return isMissingSlotError(e) ? 'gone' : 'unknown'
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Settle a seed's receipt into "ran" or "never ran". Only `never ran` may tear
+ * the slot down; see the module comment for why each status lands where it does.
+ */
+export async function settleSeedReceipt(receipt: SendReceipt, slotKey: string): Promise<SeedVerdict> {
+  if (receipt.status === 'refused') return { ran: false, reason: seedFailureText(receipt.reason) }
+  if (receipt.status !== 'transport-error' && receipt.status !== 'response-late') return { ran: true }
+  for (let attempt = 1; ; attempt++) {
+    const probe = await probeSlot(slotKey)
+    if (probe === 'landed' || probe === 'unknown') return { ran: true }
+    if (probe === 'gone' || attempt >= SEED_PROBE_ATTEMPTS) return { ran: false, reason: seedFailureText() }
+    await sleep(SEED_PROBE_GAP_MS)
+  }
+}


### PR DESCRIPTION
## Summary

Chat-core RFC P2, **batch A of #9570**: the two non-interactive seed senders — `apps/issue-radar/lib/agentSession.ts` and `apps/auto-improvement/lib/agentSession.ts` — stop calling `api.sendChat` and reading the raw `Response` through `readSendReceipt` themselves, and instead call the chat-core transport `sendTurn` and branch on its receipt status. The 10 s deadline and the six-way classification are now the core's, not re-derived per app.

Behaviour is unchanged on every path the old code classified except the two **no-receipt** outcomes — a rejected fetch (`transport-error`) and the transport's new 10 s deadline (`response-late`). Both are indeterminate: a connection reset *after* the server took the POST rejects exactly like a request that never left, and a stalled POST may still land. The old code threw on the first and waited forever on the second. Instead of guessing, the seeder now **asks the slot**: the seed is stored as the slot's first message before its turn runs, so a one-row slot read settles it — an empty slot, re-read up to 3 times a second apart so a late arrival still counts, means the seed never landed and the empty slot is torn down like a refusal; a message, or a probe the server cannot answer, means the seed is or may be running, so the session is recorded and opened (never cancelled, never left orphaned for a retry to duplicate); a slot that is gone short-circuits. This is the invariant behind rounds 1–4 of review: never delete what may be running (GPT/Opus r1), never silently open an empty session (Design/FP/UX r2), never orphan a live one (GPT r3), never record an unseeded one (GPT r4). The policy lives once, in `website/src/utils/seedReceipt.ts` (`settleSeedReceipt`), and both seeders call it (First Principles r4). One accepted residual, named in the helper's comment: the verdict is only as good as the probe window — a POST that reaches the gateway after the last re-read finds the slot deleted and `/api/chat` re-creates it, so that seed runs unrecorded while the user was told it did not start. For a rejected fetch that is the old always-orphan outcome confined to a corner; for the deadline it is a **new** corner, bought deliberately — the old seeder had no deadline, so a stalled POST hung the launch until it resolved and was then recorded. The trade is a bounded wait plus a small, judgement-sized late-landing window (3 × 1 s) against an unbounded hang. Closing it outright needs the send to opt out of slot auto-create server-side (Design r5, First Principles r6). Two other things move:

- The core contract text for `transport-error` in `chat-core/transport/sendTurn.ts` said "the send never left, so restore-and-report is safe", and the `SEND_ABORT_MS` comment said reaching the deadline means "the turn is running". Both are over-strong, and the seeders' handling would have contradicted it in app comments; the doc (and the contract test's label) now states the status as **indeterminate**, with restore-vs-proceed left to the call site (Design / First Principles, round 2). The composers that restore on it (ChatPane, ChatPage) are unchanged — for a composer a visible duplicate still beats a silent loss.
- The user-facing failure text is the core's own `pages.chatPage.could_not_start_a_new_session` copy, with the server's reason appended when it gave one — no more `could not seed the session (HTTP 503)` (raw status; "seed" is developer vocabulary; the transport does not expose the status line anyway).

## Receipt mapping (both seeders, identical)

| `receipt.status` | Slot | Record + navigate | Error surfaced |
|---|---|---|---|
| `dispatched` / `queued` | kept | yes | — |
| `refused` | **deleted** | no | `Could not start a new session (<server reason>)`; just the sentence when the body carried none |
| `transport-error` / `response-late`, slot stays **empty** across the bounded re-reads (or the slot is gone) | **deleted** | no | `Could not start a new session` — the seed provably never landed |
| `transport-error` / `response-late`, slot holds **≥1 message** or the read itself fails | kept | yes | — (the seed is, or may be, running) |
| `unknown` | kept | yes | — (accepted, receipt unreadable — deleting would cancel real work) |

`createdSlotKey` is still cleared the moment the send is *started* (before the await), so a rollback triggered by a later metadata failure can never destroy a slot whose turn may have begun. Only a seed that provably never ran — `refused`, or a no-receipt send whose slot stays empty — tears a slot down.

## Also

- `chat-core/transport/sendTurn.ts` + `test/chatCoreTransport.contract.test.ts`: the `transport-error` doc / label correction above (comment and test-name only; no runtime change).
- `apps/issue-radar/lib/investigate.prompt.ts`: stale comment that named `api.sendChat`.
- `.github/coverage-baselines/frontend.txt`: `apps/auto-improvement/lib/agentSession.ts` now clears the 80% per-file floor (86.7% in CI, was 32.6%), so its baseline entry is removed as the Coverage Gate requires.
- `docs/request-for-change/rfc-chat-core-extraction.md`: the §4.2 "not started" P2 row is split into the three #9570 batches (this one `in review`); `#9570` added to `tracking-issues`, this PR to `implementation-prs`.

## Tests

New `website/src/test/seedReceipt.test.ts` pins `settleSeedReceipt` under fake timers: the mapping, the bounded re-read count and gap, a seed landing mid-probe, the gone-slot short-circuit. `website/src/test/agentSessionSeedReceipt.test.ts` mocks `sendTurn` (the #5909 / #8599 pattern) and pins the table above for **both** seeders through the shared helper — it previously exercised only issue-radar and stubbed `api.sendChat`. `agentSessionConcludedNoRerun.test.ts` and `agentSessionResumeMissingSlot.test.ts` swap their `api.sendChat` stub for a `sendTurn` stub (their `seeded()` probe now counts transport calls); every assertion is unchanged.

## Tested

- `npx tsc --noEmit -p .` — clean.
- `npx eslint` on the changed files — clean.
- `npm run i18n:check` and `node scripts/check-i18n-strings.mjs` (the CI added-lines gate) — clean; the fallback reuses an existing key, no new literal.
- Unit tests are left to CI (repo rule for this workstream).

<!-- no-visual-delta -->
**Why no screenshot:** no component, layout or styling changes; the only rendered delta is the fallback reason text inside the existing `AgentSessionButton` error notice (`could not seed the session (HTTP <n>)` → the `pages.chatPage.could_not_start_a_new_session` copy) on a refused seed whose body carried no reason.

Refs #9570







