### PR TITLE
fix(deploy): tell a failed profile scan apart from zero profiles

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -369,6 +369,28 @@ def _conflict(message: str, code: str) -> web.Response:
     return web.json_response({"error": message, "code": code}, status=409)
 
 
+def _unavailable(message: str, code: str) -> web.Response:
+    """A probe this handler depends on could not run. Distinct from an empty result.
+
+    503 rather than 200-with-nothing: the client has to be able to tell "this
+    machine has none" from "we could not look", and rather than 500 because
+    nothing here is broken -- the host is simply not answering the question
+    today, so the honest instruction is to retry.
+    """
+    return web.json_response({"error": message, "code": code}, status=503)
+
+
+def _unsupported(message: str, code: str) -> web.Response:
+    """This platform cannot serve the request at all, so retrying never helps.
+
+    The pair with ``_unavailable`` is the point: 503 invites a retry, which is
+    right for a scan that failed and wrong for one that cannot run here. 501
+    with an ``unsupported_*`` code is the shape spec_builder and meetings
+    already answer with, so a client that learned it there reads this too.
+    """
+    return web.json_response({"error": message, "code": code}, status=501)
+
+
 def _ledger_corrupt(code: str) -> web.Response:
     """Map a ledger reader's corruption refusal to a coded response.
 
@@ -668,11 +690,24 @@ async def _handle_profiles_available(request: web.Request) -> web.Response:  # n
     snapshot redacts its own.
     """
     available = await asyncio.to_thread(deploy_profiles.discover_aws_profiles)
+    # Discovery is POSIX-only, so the two reasons it returns nothing get
+    # different answers. On Windows the platform is the more useful thing to
+    # report and the payload already carries it, so that case keeps its 200 and
+    # its own copy (which names WSL). Anywhere else, `None` means the scan could
+    # not run: the frontend has a retryable notice for a failed scan and reads a
+    # 200 as the authoritative list, so returning one here is what turns "could
+    # not look" into "you have no profiles".
+    supported = os.name != "nt"
+    if available is None and supported:
+        return _unavailable(
+            "could not list this machine's AWS profiles",
+            "profiles_unavailable",
+        )
     reg = await asyncio.to_thread(deploy_profiles.load_registry)
     registered = {str(p.get("name", "")) for p in reg.get("profiles", [])}
     rows = [
         {"name": accounts_mod._safe_field(name), "registered": name in registered}
-        for name in available
+        for name in (available or [])
         if aws_consent._PROFILE_RE.match(name)
     ]
     return web.json_response(
@@ -680,10 +715,13 @@ async def _handle_profiles_available(request: web.Request) -> web.Response:  # n
             "profiles": rows,
             "registeredCount": len(registered),
             "max": _MAX_REGISTERED,
-            # An empty list on a host that HAS profiles is the Windows case
-            # (discovery is POSIX-only), and the UI must say so rather than
-            # implying the operator has none.
-            "supported": os.name != "nt",
+            # `profiles` is empty in two cases, and `supported` is what tells
+            # them apart. False: Windows, where discovery cannot run at all, so
+            # the UI says that instead of implying the operator has none. True:
+            # the scan ran and the machine really has nothing left to register.
+            # A scan that could NOT run where it should have never reaches here,
+            # because it answered 503 above.
+            "supported": supported,
         }
     )
 
@@ -696,7 +734,10 @@ async def _handle_profiles_register(request: web.Request) -> web.Response:
     * A name must be one ``aws configure list-profiles`` actually reports. The
       registry is agent-writable and its names reach an argv, so accepting an
       arbitrary string here would let a caller plant one -- the same class the
-      read-side validation in ``accounts.py`` closes from the other end.
+      read-side validation in ``accounts.py`` closes from the other end. When
+      that listing could not run at all the batch is refused on that fact, not
+      as unknown: an unchecked name and an absent one are different refusals,
+      and only one of them tells the operator something true.
     * The name must match the shared profile pattern, checked before it is
       compared against anything.
     * The registry cap is enforced across the whole batch, so a partial batch
@@ -715,7 +756,27 @@ async def _handle_profiles_register(request: web.Request) -> web.Response:
         return _bad_request("names must be a non-empty list", "invalid_names")
     requested = [str(n) for n in raw][:_MAX_REGISTERED]
 
-    available = set(await asyncio.to_thread(deploy_profiles.discover_aws_profiles))
+    discovered = await asyncio.to_thread(deploy_profiles.discover_aws_profiles)
+    if discovered is None:
+        # Nothing can be checked against a scan that did not run, and refusing
+        # the names as absent is the one answer the operator cannot act on: the
+        # profiles ARE on the machine, and the message would say they are not.
+        # Refuse the batch on the real reason instead, split the way the listing
+        # above splits it -- 503 asks for a retry, which clears a failed scan and
+        # never clears a platform that cannot scan at all. The listing answers
+        # Windows with a 200 because a list plus `supported: false` is a complete
+        # answer; registering is an action this platform cannot perform, so here
+        # it is an error either way and only the retry semantics differ.
+        if os.name == "nt":
+            return _unsupported(
+                "profile discovery is not supported on Windows, so no name can be checked",
+                "unsupported_platform",
+            )
+        return _unavailable(
+            "could not list this machine's AWS profiles, so no name can be checked",
+            "profiles_unavailable",
+        )
+    available = set(discovered)
     unknown = [n for n in requested if n not in available]
     if unknown:
         # Deliberately does not echo the rejected names: they are caller-supplied

--- a/src/kiro_crew/deploy/handlers.py
+++ b/src/kiro_crew/deploy/handlers.py
@@ -1575,8 +1575,14 @@ async def _handle_profiles_get(_request: web.Request) -> web.Response:
     return web.json_response({
         "profiles": _redact_profile_fields(reg["profiles"]),
         "default": _redact_text(str(reg["default"])),
+        # `discovered or []` deliberately does NOT carry the could-not-ask state:
+        # this endpoint feeds a profile picker, and both readers hide their
+        # section on an empty list, so a field for the difference would ship with
+        # no consumer. Narrowing `None` here is still required -- iterating it
+        # raised TypeError. The distinction an operator acts on lives on the
+        # aws-control profile routes, which answer 503 or 501 instead.
         "available": [_redact_text(str(n))
-                      for n in discovered if n not in registered],
+                      for n in (discovered or []) if n not in registered],
     })
 
 

--- a/src/kiro_crew/deploy/profiles.py
+++ b/src/kiro_crew/deploy/profiles.py
@@ -273,22 +273,34 @@ def resolve_profile(requested: str = "") -> tuple[str, str] | None:
 
 # --- discovery (read-only, names only) --------------------------------------
 
-def discover_aws_profiles() -> list[str]:
+def discover_aws_profiles() -> list[str] | None:
     """Profile names known to the AWS CLI (``aws configure list-profiles``).
 
     Names only — the CLI enumerates sections itself; we never read the files.
 
-    On native Windows the sandboxed subprocess backend is unavailable (deploy
-    features are POSIX-only, fail-loud policy) — degrade to an empty list
-    instead of surfacing a sandbox error through the profiles endpoint.
+    ``None`` means could not ask, and it is deliberately not ``[]``. "Asked, and
+    there are none" is a fact about the machine, "could not ask" is a fact about
+    this process, and a caller handed the same empty list for both reports the
+    second as the first. That is not a corner case: ``configure list-profiles``
+    arrived in AWS CLI v2 and exits non-zero on v1, so an ordinary host with
+    profiles configured takes the failing branch, and a route that compares a
+    requested name against an empty set then answers that the operator's own
+    profiles are not on this machine. ``cli_doctor._aws_profile_names`` draws the
+    same line for the doctor report, for the same reason.
+
+    Windows is the other ``None``: the sandboxed subprocess backend deploy needs
+    is POSIX-only (fail-loud policy), so discovery cannot run there rather than
+    running and finding nothing. A caller with something more useful to say about
+    the platform than about the failure branches on ``os.name`` itself, which is
+    how the aws-control listing gets to name WSL.
     """
     if os.name == "nt":
         logger.debug("deploy-web: profile discovery unsupported on Windows")
-        return []
+        return None
     rc, out, err = engine.run_aws(["configure", "list-profiles"], "")
     if rc != 0:
         logger.debug("deploy-web: list-profiles failed: %s", (err or "")[:200])
-        return []
+        return None
     names: list[str] = []
     for line in (out or "").splitlines():
         line = line.strip()

--- a/test/test_aws_control_app.py
+++ b/test/test_aws_control_app.py
@@ -2681,6 +2681,110 @@ class TestProfileDiscovery:
         assert _payload(resp) == {"added": 0, "skipped": 1}
         assert len(reg["profiles"]) == routes_mod._MAX_REGISTERED
 
+    def test_available_reports_a_failed_scan_rather_than_an_empty_list(self):
+        # A 200 carrying no profiles is the page's authoritative "none left to
+        # add", so a scan that could not run must not borrow it -- on AWS CLI v1
+        # that would report every configured profile as absent.
+        handlers = _registered()
+        p1, p2 = self._env()
+        with (
+            p1,
+            p2,
+            mock.patch.object(routes_mod.os, "name", "posix"),
+            mock.patch.object(
+                routes_mod.deploy_profiles, "discover_aws_profiles", return_value=None
+            ),
+            mock.patch.object(routes_mod.deploy_profiles, "load_registry") as registry,
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/profiles/available")](  # type: ignore[operator]
+                    _request("GET", "/profiles/available")
+                )
+            )
+        assert resp.status == 503
+        assert _payload(resp)["code"] == "profiles_unavailable"
+        # Nothing was read either: the answer does not depend on the registry.
+        registry.assert_not_called()
+
+    def test_available_on_windows_keeps_the_platform_answer(self):
+        # Windows cannot enumerate profiles at all, and the page has copy naming
+        # WSL for exactly that. It stays a 200 so the operator reads the remedy
+        # instead of a retryable failure they cannot clear by retrying.
+        handlers = _registered()
+        p1, p2 = self._env()
+        with (
+            p1,
+            p2,
+            mock.patch.object(routes_mod.os, "name", "nt"),
+            mock.patch.object(
+                routes_mod.deploy_profiles, "discover_aws_profiles", return_value=None
+            ),
+            mock.patch.object(
+                routes_mod.deploy_profiles,
+                "load_registry",
+                return_value={"version": 2, "profiles": [], "default": ""},
+            ),
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/profiles/available")](  # type: ignore[operator]
+                    _request("GET", "/profiles/available")
+                )
+            )
+        assert resp.status == 200
+        body = _payload(resp)
+        assert body["supported"] is False
+        assert body["profiles"] == []
+
+    def test_register_refuses_the_batch_when_the_scan_could_not_run(self):
+        # The refusal an operator cannot act on is "not profiles on this
+        # machine", when the profiles are there and only the listing failed.
+        handlers = _registered()
+        p1, p2 = self._env()
+        with (
+            p1,
+            p2,
+            mock.patch.object(routes_mod.os, "name", "posix"),
+            mock.patch.object(
+                routes_mod.deploy_profiles, "discover_aws_profiles", return_value=None
+            ),
+            mock.patch.object(routes_mod.deploy_profiles, "locked_registry") as locked,
+            mock.patch.object(routes_mod.accounts_mod, "invalidate_cache") as invalidated,
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/profiles/register")](  # type: ignore[operator]
+                    self._post({"names": ["real"]})
+                )
+            )
+        assert resp.status == 503
+        payload = _payload(resp)
+        assert payload["code"] == "profiles_unavailable"
+        assert "not profiles on this machine" not in payload["error"]
+        locked.assert_not_called()
+        invalidated.assert_not_called()
+
+    def test_register_does_not_ask_windows_to_retry(self):
+        # 503 means "try again", which clears a failed scan and never clears a
+        # platform that cannot scan. Windows gets the answer that stays true.
+        handlers = _registered()
+        p1, p2 = self._env()
+        with (
+            p1,
+            p2,
+            mock.patch.object(routes_mod.os, "name", "nt"),
+            mock.patch.object(
+                routes_mod.deploy_profiles, "discover_aws_profiles", return_value=None
+            ),
+            mock.patch.object(routes_mod.deploy_profiles, "locked_registry") as locked,
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/profiles/register")](  # type: ignore[operator]
+                    self._post({"names": ["real"]})
+                )
+            )
+        assert resp.status == 501
+        assert _payload(resp)["code"] == "unsupported_platform"
+        locked.assert_not_called()
+
 
 class TestProfileUnregister:
     """Removing a key is registry-only: it must never reach ``~/.aws`` or AWS,

--- a/test/test_deploy_handlers_coverage.py
+++ b/test/test_deploy_handlers_coverage.py
@@ -1075,6 +1075,17 @@ class TestProfilesControlPlane:
         assert body["default"] == "p" and body["available"] == ["other"]
 
     @pytest.mark.asyncio
+    async def test_get_survives_a_scan_that_could_not_run(self, monkeypatch):
+        # `discover_aws_profiles` returns None when it could not ask, and this
+        # handler iterates its result -- so without narrowing it, the endpoint
+        # raises TypeError on exactly the hosts that cannot list profiles.
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(profiles_mod, "discover_aws_profiles", lambda: None)
+        body = _payload(await handlers._handle_profiles_get(_FakeReq()))
+        assert body["available"] == []
+        assert body["default"] == "p"
+
+    @pytest.mark.asyncio
     async def test_post_rejects_empty_name(self):
         resp = await handlers._handle_profiles_post(_FakeReq({"name": ""}))
         assert resp.status == 400 and "must not be empty" in _payload(resp)["error"]

--- a/test/test_deploy_profiles_cov80.py
+++ b/test/test_deploy_profiles_cov80.py
@@ -222,19 +222,27 @@ class TestResolveProfile:
 
 
 class TestDiscoverAwsProfiles:
-    def test_windows_degrades_to_empty_list(self, monkeypatch) -> None:
+    def test_windows_reports_could_not_ask(self, monkeypatch) -> None:
         monkeypatch.setattr(profiles_mod.os, "name", "nt")
 
         def _unexpected(*_a, **_k):
             pytest.fail("ran an aws command on an unsupported platform")
 
         monkeypatch.setattr(profiles_mod.engine, "run_aws", _unexpected)
-        assert profiles_mod.discover_aws_profiles() == []
+        assert profiles_mod.discover_aws_profiles() is None
 
-    def test_cli_failure_degrades_to_empty_list(self, monkeypatch) -> None:
+    def test_cli_failure_reports_could_not_ask(self, monkeypatch) -> None:
+        # `configure list-profiles` is AWS CLI v2 only, so v1 exits non-zero on a
+        # host whose profiles are all present. `[]` here would say the opposite.
         monkeypatch.setattr(
             profiles_mod.engine, "run_aws", lambda *a, **k: (1, "", "could not be found")
         )
+        assert profiles_mod.discover_aws_profiles() is None
+
+    @_POSIX_ONLY
+    def test_a_successful_empty_listing_stays_empty(self, monkeypatch) -> None:
+        # The other half of the contract: asked, and there are none.
+        monkeypatch.setattr(profiles_mod.engine, "run_aws", lambda *a, **k: (0, "", ""))
         assert profiles_mod.discover_aws_profiles() == []
 
     @_POSIX_ONLY

--- a/website/src/apps/aws-control/types.ts
+++ b/website/src/apps/aws-control/types.ts
@@ -83,6 +83,11 @@ export interface AvailableProfile {
  * read as "can't tell", not "none" — the UI says so instead of implying the
  * operator has no accounts. `registeredCount`/`max` bound the registry so the
  * picker can show a count hint and stop offering more once the cap is reached.
+ *
+ * A scan that FAILS on a supported platform answers 503 `profiles_unavailable`
+ * rather than a 200 carrying an empty list, so this payload is only ever the
+ * real listing: `profiles: []` with `supported: true` does mean none are left to
+ * register. The failed scan surfaces through the query's error state instead.
  */
 export interface AvailableProfilesResponse {
   profiles: AvailableProfile[]
@@ -94,7 +99,10 @@ export interface AvailableProfilesResponse {
 /**
  * Payload of `POST /profiles/register`. A batch registers the prefix that fits
  * under the cap, so `added + skipped` counts the whole request, not just the
- * winners. Error codes: `invalid_names` (400), `unknown_profile` (400).
+ * winners. Error codes: `invalid_names` (400), `unknown_profile` (400),
+ * `profiles_unavailable` (503, the local profile scan could not run, so no name
+ * could be checked and nothing was registered), `unsupported_platform` (501, the
+ * same but on a platform that cannot scan at all, so retrying never clears it).
  */
 export interface RegisterProfilesResult {
   added: number


### PR DESCRIPTION
> **This issue is already claimed.** At 22:33 UTC on 8 Sep, CrysisDeu's Kiro Crew
> Auto-Pipeline claimed #9560, took the assignment, and said an automated fix was
> starting. This branch was written and locally reviewed before that landed, so it is
> offered as one candidate and not as a competing claim. Close it without ceremony if
> the claimed fix lands first.
>
> One detail is worth keeping whichever fix ships. The claim comment names the two
> `aws_control` routes. There is a third production caller, `_handle_profiles_get` in
> `src/kiro_crew/deploy/handlers.py`, which iterates the return value directly. A fix
> that changes the signature and misses that site raises
> `TypeError: 'NoneType' object is not iterable` on exactly the hosts this issue is
> about.

## Problem / Motivation

`discover_aws_profiles()` in `src/kiro_crew/deploy/profiles.py` returned `[]` in two
different cases. One: the AWS CLI listed no profiles. Two: the call to list them
failed. No caller could tell those apart.

`aws configure list-profiles` arrived in AWS CLI v2. On v1 it exits non-zero with an
invalid-choice usage error, so the failing case happens on an ordinary host whose
profiles are all configured. There the empty list says the opposite of the truth.

That empty list reached `_handle_profiles_register` in
`src/kiro_crew/apps/builtins/aws_control/backend/routes.py`, which checks each
requested name against the listed set. So it refused every real profile with
`N name(s) are not profiles on this machine`. `_handle_profiles_available` returned
the same empty set while still reporting `supported: true`, so the page showed a
normal empty state rather than a failure.

## Why it matters

The operator gets a wrong answer about their own machine instead of an error. Their
profiles exist. The message says the machine does not have them.

A wrong answer costs more than a failure. Nothing on screen says a command failed,
so the hunt starts at the profile names, and they are fine.

## What changed (motivation -> approach -> change)

**Motivation.** One value stood for two different facts. "Asked, and there are none"
is a fact about the machine. "Could not ask" is a fact about this process.

**Approach.** The repo already draws this line, so follow it instead of inventing a
second shape. `_aws_profile_names()` in `src/kiro_crew/cli_doctor.py` returns
`list[str] | None`, its docstring says `None` means could not ask, and its caller
prints a different line for each of the three states. Reading `~/.aws/config` is not
an option here: the module docstring says profile names come from the CLI on purpose
and the files are never opened.

**Change.** `discover_aws_profiles()` now returns `list[str] | None`, where `None`
means could not ask. Each of its three callers takes the state it can act on.

- `GET /profiles/available` answers `503 profiles_unavailable` when the scan could
  not run on a platform where it should have. Windows keeps its `200` and its
  `supported: false`, because there a list plus that marker is already a complete
  answer and the page has copy naming WSL. The page needed no change: it already
  treats a failed scan as retryable and distinct from "none left to add", and a
  `200` carrying an empty list was the only thing making it say the opposite.
- `POST /profiles/register` refuses the batch instead of reporting unchecked names
  as absent. It splits the refusal the same way, because `503` asks for a retry:
  that clears a failed scan and never clears a platform that cannot scan, so Windows
  answers `501 unsupported_platform`. The registry is untouched on both paths.
- `GET /api/deploy/profiles` narrows `None` before iterating it, which is what
  stops a `TypeError` on the hosts this issue is about. It deliberately does not
  carry the could-not-ask state any further: that endpoint feeds a profile picker,
  both of its readers hide their section on an empty list, so a field for the
  difference would have shipped with no consumer.

## Tests

- `test_deploy_profiles_cov80.py`: the two tests that pinned the old collapse now
  assert the `None` contract, and a new one pins that a successful empty listing
  still reads as `[]`. Both halves of the contract are locked, not just the new one.
- `test_aws_control_app.py`: three new route tests: the `available` `503`, the
  `register` `503` with the old "not profiles on this machine" wording asserted
  absent, and the `register` Windows `501`. A fourth pins that the `available`
  Windows answer did not change.
- `test_deploy_handlers_coverage.py`: a new test drives the endpoint with a scan
  that could not run. Without the `None` narrowing it fails with
  `TypeError: 'NoneType' object is not iterable`, which is the regression that
  signature change would otherwise have introduced there.

Each new route guard was reverted on its own to check the tests fail for the right
reason. Removing the `available` guard and the `register` guard failed exactly those
two tests. Removing the Windows branch failed only the Windows register test. The
`available` Windows test passed under every mutation, which is correct: that handler
is unchanged.

## Manual verification

N/A: unit coverage is sufficient, and the trigger is a CLI version rather than a
code path a reviewer can step through. No UI file changed except a doc comment in
`website/src/apps/aws-control/types.ts` recording the new error codes, so there is
nothing to screenshot.

Gates run locally on this commit: the full backend suite, `mypy`, `flake8`, `isort`,
the black baseline gate, `tsc -b`, `eslint`, `i18n:check`, the phantom-class gate,
the vendor-manifest gate, and the `aws-control` frontend specs (306 tests).

<!-- no-visual-delta -->
**Why no screenshot:** the only frontend edit is a doc comment in
`website/src/apps/aws-control/types.ts`; no component, layout, theme or user-visible
string changes, so a before/after would be identical.

## Related Issues

Closes #9560

## Pattern harvest

Rule candidate: `semgrep` or `review-prompt`

Pattern: a helper that shells out returns the same empty collection on failure as on
a genuinely empty result, so the caller cannot tell "could not ask" from "nothing
there".

The repo holds both answers already. `cli_doctor._aws_profile_names()` returns
`list[str] | None`, and `_branch_names()` in
`src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py` returns
`([], reason)`, which keeps the two states apart a second way. A rule would catch the
shape early and let the author pick one of those.

Two sites in `src/kiro_crew/cloud/ec2.py` (`describe-stack-events`, around lines 850
and 905) have the same shape. Their consumers were not traced, so this is a shape
match rather than a reported defect, and nothing here changes them.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable): the docstrings and the frontend type
      comments that state this contract are part of the diff
- [x] No secrets, credentials, or internal references in the diff
