### PR TITLE
refactor(chat-core): route design-critique, design-tweak and mochi sends through sendTurn

### DIFF
--- a/docs/request-for-change/rfc-chat-core-extraction.md
+++ b/docs/request-for-change/rfc-chat-core-extraction.md
@@ -6,8 +6,8 @@ created: 2026-08-22
 last-audited: 2026-09-05
 audited-at: 8ed028b0b
 doc-pr:
-implementation-prs: ["#5128", "#5909", "#8599", "#8631", "#8655", "#8689"]
-tracking-issues: ["#8651"]
+implementation-prs: ["#5128", "#5909", "#8599", "#8631", "#8655", "#8689", "#9576", "#9587"]
+tracking-issues: ["#8651", "#9570"]
 supersedes: []
 superseded-by: []
 ---
@@ -91,12 +91,14 @@ Background: P3's ChatEmbed adoption (#8631) mounts the real `ChatInput`, whose s
 | P3 | ChatEmbed mounts the real `ChatInput` (fail-closed `embedded` preset) | [#8631](https://github.com/kirodotdev/KiroCrew/pull/8631) | merged into #8599's branch |
 | P2 | SideChat → `sendTurn` over a `/side/*` wire; shared core-owned receipt copy; `AcceptedBodyUnreadable` | [#8655](https://github.com/kirodotdev/KiroCrew/pull/8655) | in review (stacked on #8599) |
 | P2 | ChatPage send + steer → `sendTurn` (`steer`, `colorTheme` flags) | [#8689](https://github.com/kirodotdev/KiroCrew/pull/8689) | in review |
-| P2 | `App.tsx`, `useSceneInteraction`, mochi `panelBridge`, design-tweak, design-critique, issue-radar / auto-improvement `agentSession` | — | not started |
+| P2 | issue-radar / auto-improvement `agentSession` seeds → `sendTurn` (#9570 batch A) | [#9576](https://github.com/kirodotdev/KiroCrew/pull/9576) | in review |
+| P2 | design-critique, design-tweak, mochi `panelBridge` → `sendTurn`; receipt defects fixed (#9570 batch B) | [#9587](https://github.com/kirodotdev/KiroCrew/pull/9587) | in review (stacked on #8599) |
+| P2 | `useSceneInteraction` (last `api.steerChat` caller), `App.tsx` feedback → `sendTurn` (#9570 batch C) | — | not started |
 | P3 | Store-free `ChatInput` seam | [#8651](https://github.com/kirodotdev/KiroCrew/issues/8651) | design draft pending |
 | P5-a | `ChatPage.renderMessage` → registry | — | next |
 | P4 | Error hand-off → side panel; `askAgent` default-on | — | after P5-a |
 
-Follow-ups recorded during review, not yet scheduled: route SideChat's four remaining panel-local statuses (queue cancel/edit failure, question-too-long, demotion notice) through the per-slot `sideSendStatus` store channel (#8655 FP); design-critique's `SyntaxError` swallow (its own P2 slot).
+Follow-ups recorded during review, not yet scheduled: route SideChat's four remaining panel-local statuses (queue cancel/edit failure, question-too-long, demotion notice) through the per-slot `sideSendStatus` store channel (#8655 FP).
 
 ### 4.3 P4 scoping — non-destructive error hand-off, `askAgent` default-on (2026-09-05, measured at `main` e76341d16)
 

--- a/website/src/apps/design-critique/api.ts
+++ b/website/src/apps/design-critique/api.ts
@@ -1,10 +1,28 @@
 import { AGENT } from './constants'
 import { toApiError } from '../../api/apiError'
+import { sendTurn, type SendWire } from '../../chat-core/transport/sendTurn'
+import { i18nT } from '../../i18n/t'
 import type { Scope, SlotData } from './types'
 
 // This app's own backend (mounted by the built-in at gateway startup). It does
 // the clone / discover / render work server-side so the agent never runs a tool.
 const DC = '/api/apps/design-critique'
+
+/** The transport's fetch seam for this app's sends: one plain same-origin
+ *  `POST /api/chat?ws=1` (the JSON receipt, not the SSE stream) carrying the
+ *  slot-recreation fields `send` documents, resolving the Response on every HTTP
+ *  status so the shared classifier reads a 4xx/5xx as a refusal, and honouring
+ *  the transport's deadline signal. */
+const critiqueSendWire: SendWire = (payload, signal) =>
+  fetch('/api/chat?ws=1', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: payload.message, slot: payload.slot, agent: AGENT, memory_mode: 'temporary', mode: 'design-critique',
+    }),
+    signal,
+  })
 
 // These hit the dashboard's own chat endpoints (NOT an app-scoped reverse proxy),
 // so they are plain same-origin fetches — the same convention file-explorer's
@@ -68,28 +86,33 @@ export const designCritiqueApi = {
   getSlot: (slotKey: string) =>
     jsonFetch<SlotData>('/api/chat/slots/' + encodeURIComponent(slotKey)),
 
-  // Fire a message at a slot. The response body is not JSON we care about, so a
-  // parse error is swallowed — only a real HTTP/network error propagates.
-  send: (slotKey: string, message: string): Promise<void> =>
-    jsonFetch<void>('/api/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      // memory_mode AND mode must be repeated here, not only at slot creation.
-      // POST /api/chat auto-creates a missing slot, and with neither in the body
-      // it falls back to the persistent default with surface '' — so if the
-      // gateway restarts mid-run (the slot is in memory, not on disk) the next
-      // send would silently recreate this critique slot with memory reads and
-      // writes ENABLED and visible in the chat sidebar (whose allowlist admits
-      // surface ''). Passing them is also safe when the slot exists:
-      // get_or_create_slot only raises on a memory_mode mismatch and ignores
-      // mode for existing slots, and both match what openSlot() asked for.
-      body: JSON.stringify({
-        message, slot: slotKey, agent: AGENT, memory_mode: 'temporary', mode: 'design-critique',
-      }),
-    }).catch((e: unknown) => {
-      if (e instanceof SyntaxError) return
-      throw e
-    }),
+  // Fire a message at a slot through the chat-core transport. The body carries
+  // three fields the generic dashboard wire does not: memory_mode AND mode must
+  // be repeated here, not only at slot creation. POST /api/chat auto-creates a
+  // missing slot, and with neither in the body it falls back to the persistent
+  // default with surface '' — so if the gateway restarts mid-run (the slot is in
+  // memory, not on disk) the next send would silently recreate this critique
+  // slot with memory reads and writes ENABLED and visible in the chat sidebar
+  // (whose allowlist admits surface ''). Passing them is also safe when the slot
+  // exists: get_or_create_slot only raises on a memory_mode mismatch and ignores
+  // mode for existing slots, and both match what openSlot() asked for. Hence an
+  // app-local wire (the same plain same-origin fetch this file uses everywhere)
+  // rather than the transport's default one.
+  //
+  // Receipt policy for a background sender with no composer to restore into:
+  // `refused` and `transport-error` reject (nothing is running -- the caller's
+  // failWith reports it and drops the pending critique, as it did for a non-2xx
+  // before); `unknown` and `response-late` RESOLVE, because the request was or
+  // may have been accepted and the poll that follows will find out -- rejecting
+  // would invite a retry that runs the critique twice. The old send read the SSE
+  // stream the bare endpoint answers with and swallowed its parse error as
+  // success, so a `{ok:false}` refusal inside a 200 never surfaced at all.
+  send: async (slotKey: string, message: string): Promise<void> => {
+    const receipt = await sendTurn({ message, slot: slotKey, wire: critiqueSendWire })
+    if (receipt.status === 'refused' || receipt.status === 'transport-error') {
+      throw new Error(receipt.reason || (i18nT('pages.chatPage.send_failed') as string))
+    }
+  },
 
   deleteSlot: (slotKey: string): Promise<void> =>
     jsonFetch<void>('/api/chat/slots/' + encodeURIComponent(slotKey), { method: 'DELETE' }).catch(() => {}),

--- a/website/src/apps/design-tweak/DesignTweakPage.tsx
+++ b/website/src/apps/design-tweak/DesignTweakPage.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react'
 import Clickable from '../../components/Clickable'
 import ErrorNotice from '../../components/ErrorNotice'
+import { SEND_REFUSED } from '../../chat-core/transport/sendTurn'
 import { FolderBody } from '../../components/FolderBody'
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem,
@@ -887,8 +888,17 @@ export default function DesignTweak() {
       }))
       return true
     } catch (dispatchErr) {
-      // The dispatch threw, so the batch may or may not have landed — the host
-      // could have accepted it and failed on the way back. Say so and stop:
+      if (dispatchErr instanceof Error && dispatchErr.name === SEND_REFUSED) {
+        // The server said no: nothing landed, so there is nothing to verify --
+        // it is an ERROR, rendered through the page's ErrorNotice (the
+        // `bridgeError` slot, whose No hand-off decision covers this too: the
+        // preview overlay's composer may hold an unsent comment), and the
+        // request stays actionable in the rail for a resend.
+        setBridgeError(i18nT('pages.chatPage.send_failed_with_error', { error: dispatchErr.message }))
+        return false
+      }
+      // No receipt, so the batch may or may not have landed — the host could
+      // have accepted it and failed on the way back. Say so and stop:
       // `verifyDelivery` settles it against the session on the next load or
       // refresh, and the rail keeps the request actionable meanwhile.
       setStatus(i18nT('apps.designTweak.status.dispatch_failed_unconfirmed', {

--- a/website/src/apps/design-tweak/api.ts
+++ b/website/src/apps/design-tweak/api.ts
@@ -11,6 +11,8 @@
 // string templates, so an id containing `&` or `#` cannot smuggle a parameter.
 
 import { toApiError } from '../../api/apiError'
+import { SEND_REFUSED, sendTurn } from '../../chat-core/transport/sendTurn'
+import { i18nT } from '../../i18n/t'
 import type {
   AddProjectResponse, ChatSlotResponse, DeleteCommentResponse,
   DetectDevServerResponse, DevServerStartResponse, HealthResponse, HistoryResponse,
@@ -216,14 +218,11 @@ function slotDetailUrl(key: string): string {
   return CHAT_SLOTS + '/' + encodeURIComponent(key)
 }
 
-/**
- * `ws=1` makes the host answer with JSON. Without it the reply is an SSE stream,
- * and the parse error used to be caught and "recovered" by opening a NEW ad-hoc
- * chat — so one request produced two sessions and the app's own per-app session
- * was bypassed.
- */
-const CHAT_SEND = '/api/chat' + '?' + new URLSearchParams({ ws: '1' }).toString()
-
+/** Slot and transcript endpoints only -- all JSON. The SEND goes through the
+ *  chat-core transport (`sendChatMessage` below), which owns `?ws=1`, the
+ *  deadline and the receipt contract; the non-JSON tolerance this helper used
+ *  to carry existed for the SSE stream the bare send endpoint answered with,
+ *  and went with the send. */
 async function chatApi<T = unknown>(url: string, method: string, body?: unknown): Promise<T> {
   const r = await fetch(url, {
     method,
@@ -232,10 +231,7 @@ async function chatApi<T = unknown>(url: string, method: string, body?: unknown)
   })
   if (!r.ok) throw await toApiError(r)
   const t = await r.text()
-  // POST /api/chat answers with an SSE STREAM unless ?ws=1 is set, so the body can
-  // legitimately be `data: {...}` rather than JSON. Parsing that threw, and the
-  // throw is what diverted a request into a brand-new ad-hoc chat.
-  try { return (t ? JSON.parse(t) : null) as T } catch { return { ok: true, raw: t } as T }
+  return (t ? JSON.parse(t) : null) as T
 }
 
 /** Create (or adopt) this app's deterministic chat slot. Idempotent server-side. */
@@ -341,9 +337,43 @@ export async function readSlotTranscript(
   }
 }
 
-/** Send one turn into a slot. */
-export function sendChatMessage(message: string, slot: string): Promise<unknown> {
-  return chatApi(CHAT_SEND, 'POST', { message, slot, agent: '' })
+/**
+ * Send one turn into a slot through the chat-core transport (the dashboard's
+ * own wire: this app runs in the dashboard bundle and sends as the dashboard
+ * does). Resolves ONLY on a confirmed acceptance -- `dispatched` or `queued`
+ * -- because the caller marks the request delivered on resolution, and
+ * `deliveredAt` permanently short-circuits `deliveryVerdict` / `verifyDelivery`.
+ * Every other status rejects, each with its own reason, so the request stays
+ * unacknowledged and ground truth (`verifyDelivery` asking the session) decides:
+ *
+ * - `refused`: the server said no. The old helper only threw on a non-2xx, so a
+ *   `{ok:false}` refusal inside a 200 was marked delivered.
+ * - `transport-error`: no response; as the bare fetch always did.
+ * - `unknown` / `response-late`: accepted, or accepted for all we know, but not
+ *   CONFIRMED -- marking delivered here would strand the sealed edits if the
+ *   POST never landed. The old helper resolved a non-JSON 2xx as `{ok:true}` by
+ *   accident of a parse fallback; it had no deadline at all.
+ */
+export async function sendChatMessage(message: string, slot: string): Promise<void> {
+  const receipt = await sendTurn({ message, slot })
+  switch (receipt.status) {
+    case 'dispatched':
+    case 'queued':
+      return
+    case 'refused': {
+      // Flagged by name: the caller tells a definitive refusal (fix and resend)
+      // apart from an unconfirmed dispatch (verify against the session).
+      const err = new Error(receipt.reason || (i18nT('pages.chatPage.send_failed') as string))
+      err.name = SEND_REFUSED
+      throw err
+    }
+    case 'transport-error':
+      throw new Error(i18nT('pages.chatPage.send_failed') as string)
+    case 'unknown':
+      throw new Error(i18nT('api.client.accepted_body_unreadable') as string)
+    case 'response-late':
+      throw new Error(i18nT('pages.chat.recoveryCard.no_response_returned') as string)
+  }
 }
 
 /** Deep link into the Chat tab at a given slot. */

--- a/website/src/apps/mochi/panel/panelBridge.ts
+++ b/website/src/apps/mochi/panel/panelBridge.ts
@@ -23,6 +23,7 @@ import {
 } from '../api'
 import { approvalRoute } from './approvalActions'
 import { noteStaleOwnerResponse } from '../../../api/staleOwnerSignal'
+import { SEND_REFUSED, SEND_UNCONFIRMED, sendTurn } from '../../../chat-core/transport/sendTurn'
 import { purposeFromToolArgs } from '../../../utils/toolPurpose'
 import type { NotificationPayload, PetMood, PetState } from '../src/shared/types'
 import type { PackManifest, PackMeta } from '../src/shared/appearanceTypes'
@@ -762,25 +763,49 @@ function echoOwnMessage(text: string, screenshot?: string): void {
 }
 
 export async function sendMessage(text: string, screenshot?: string): Promise<void> {
-  echoOwnMessage(text, screenshot)
   // Bind the slot to the mochi agent before the first turn (idempotent).
   await ensureSlot()
   // The pet must react to the SEND, not to the first token: `thinking` is
   // precisely the gap between the two. Reported after the bind so a turn that
   // never gets a slot does not leave the pet thinking about nothing.
   reportPetEvent('user_input')
-  // `ws=1` tells the gateway to fan the turn out over the WebSocket instead of
-  // holding an SSE response open (matching how the dashboard chat works).
-  await fetch('/api/chat?ws=1', {
-    method: 'POST',
-    credentials: 'same-origin',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      message: text,
-      slot: MOCHI_SLOT,
-      ...(screenshot ? { meta: { screenshot } } : {}),
-    }),
+  // The chat-core transport owns `?ws=1` (the JSON receipt instead of a held
+  // SSE response), the deadline and the receipt contract; this app runs in the
+  // dashboard bundle and sends over the dashboard's own wire.
+  const receipt = await sendTurn({
+    message: text,
+    slot: MOCHI_SLOT,
+    ...(screenshot ? { meta: { screenshot } } : {}),
   })
+  // The receipt decides whether the bubble exists. The old send echoed BEFORE
+  // the POST and never read the reply, so a `{ok:false}` refusal (or a 4xx/5xx)
+  // left a user bubble on screen that the server never took and no error
+  // anywhere. Now everything short of a CONFIRMED acceptance REJECTS -- and the
+  // vendored ChatPanel's send paths handle a rejected sendMessage by restoring
+  // the typed text, clearing the waiting state and showing `chat.send_failed`:
+  // `refused` (the server said no), `transport-error` (no response; the one
+  // case the old code did surface) and `response-late` (the deadline passed
+  // with no receipt, so the POST may never have reached the gateway -- echoing
+  // would paint a bubble that vanishes on reload with the draft gone, while a
+  // restored draft is at worst a visible duplicate). Only `dispatched`,
+  // `queued` and `unknown` (a 2xx, so the server took it and only the reply is
+  // mangled) echo, because the panel appends nothing optimistically (upstream
+  // Mochi's main process did this echo) and core does not echo a normal send
+  // over the socket.
+  if (receipt.status === 'refused' || receipt.status === 'transport-error' || receipt.status === 'response-late') {
+    // A refusal is flagged by name, with the SERVER's own reason as the message
+    // when it gave one (the one text fit to show verbatim) and an empty message
+    // otherwise -- so ChatPanel can say "send failed" for a bodyless 4xx/5xx
+    // instead of blaming a healthy connection. A late receipt is flagged too:
+    // the send MAY have landed, so the panel must not tell the user to simply
+    // try again. Everything else (a bind failure from ensureSlot, a browser
+    // TypeError) is developer-voice and unflagged: the connection copy applies.
+    const err = new Error(receipt.reason ?? '')
+    if (receipt.status === 'refused') err.name = SEND_REFUSED
+    if (receipt.status === 'response-late') err.name = SEND_UNCONFIRMED
+    throw err
+  }
+  echoOwnMessage(text, screenshot)
 }
 
 // Whether the slot is currently known to be bound to the mochi agent. NOT a

--- a/website/src/apps/mochi/src/renderer/ChatPanel.tsx
+++ b/website/src/apps/mochi/src/renderer/ChatPanel.tsx
@@ -32,6 +32,8 @@ import {
   X,
 } from 'lucide-react'
 import Clickable from '../../../../components/Clickable'
+import ErrorNotice from '../../../../components/ErrorNotice'
+import { SEND_REFUSED, SEND_UNCONFIRMED } from '../../../../chat-core/transport/sendTurn'
 import { familyGrantIsDistinct, trustBasePattern, truncateCommandLabel } from '../shared/trustPatterns'
 import Markdown from 'react-markdown'
 import type { Components } from 'react-markdown'
@@ -387,6 +389,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onToggleWatch, watchPanelV
   // against the original.
   const [dropActive, setDropActive] = useState(false)
   const [dropError, setDropError] = useState('')
+  // ADDED (not upstream): a send the gateway did not take. Kept apart from
+  // `dropError`, which is a validation hint about a file, not a failure.
+  const [sendError, setSendError] = useState('')
   // Queued attachments live HERE, not in the composer text: the reference
   // markdown is composed only at send time so the box the user types in is
   // never filled with plumbing.
@@ -912,17 +917,38 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onToggleWatch, watchPanelV
     try {
       await api?.sendMessage?.(text, screenshotRef.current || undefined)
       setScreenshot(null)
-    } catch {
+      setSendError('')
+    } catch (e) {
       // Send failed. handleSend already cleared the composer before awaiting, so
       // without this the typed text is lost, no error shows, and the spinner
       // sticks forever. Restore the text (composer is empty on this path), clear
-      // the stuck waiting state, and surface the failure via the existing
-      // error banner — the dashboard AddWatchForm "your input is still here,
-      // try again" recovery.
+      // the stuck waiting state, and surface the failure -- the dashboard
+      // AddWatchForm "your input is still here, try again" recovery. Only a
+      // rejection the bridge flags `SendRefused` carries the SERVER's own reason
+      // and is shown verbatim, so a refusal names its cause instead of sending
+      // the user to debug a connection that is fine; every other rejection (no
+      // receipt, a slot-bind failure, a browser TypeError) is developer-voice
+      // and gets the localized connection copy.
       setIsWaiting(false)
       setTurnActive(false)
       setInput((prev) => (prev ? prev : text))
-      setDropError(i18nT('apps.mochi.chat.send_failed'))
+      const name = e instanceof Error ? e.name : ''
+      const reason = e instanceof Error ? e.message : ''
+      setSendError(
+        name === SEND_REFUSED
+          // The server said no. FRAMED as a failed send (the same core entry
+          // design-tweak and the feature-request path use) with the server's
+          // reason when it gave one; a bodyless refusal is still "Send failed",
+          // never the connection copy -- the network is fine.
+          ? (reason
+            ? i18nT('pages.chatPage.send_failed_with_error', { error: reason })
+            : i18nT('pages.chatPage.send_failed'))
+          // No receipt: the send MAY have landed, so "try again" would invite a
+          // duplicate -- the core's unconfirmed copy says to check first.
+          : name === SEND_UNCONFIRMED
+            ? i18nT('pages.chatPage.delivery_unconfirmed')
+            : i18nT('apps.mochi.chat.send_failed'),
+      )
     }
   }, [])
 
@@ -1007,10 +1033,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onToggleWatch, watchPanelV
       wasNearBottomRef.current = true
       const result = await api?.editResend?.(text, editTsStr)
       if (!result?.ok) {
-        // Fallback: send as normal message — don't add user msg locally,
-        // sendMessage will trigger chat:message event which adds it
-        setIsWaiting(true)
-        await api?.sendMessage?.(text, screenshot || undefined)
+        // Fallback: send as a normal message through the same path the composer
+        // uses -- don't add the user msg locally, sendMessage echoes it on an
+        // accepted receipt. `sendText` also owns the failure branch: a refused or
+        // unconfirmed send restores the text and shows `chat.send_failed` instead
+        // of leaving an unhandled rejection and a stuck spinner here.
+        await sendText(text)
       }
       return
     }
@@ -1405,6 +1433,18 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onToggleWatch, watchPanelV
           120px. Measuring the stack is what makes the gap real in every state
           (upstream's fixed 52 was tuned for its own single layout). */}
       <div ref={composerRef}>
+      {/* ADDED (not upstream): a send the gateway did not take. */}
+      {/* No hand-off: the composer below holds the text this failure handed
+          back — navigating to the chat would discard it. */}
+      {sendError !== '' && (
+        <ErrorNotice
+          variant="inline"
+          message={sendError}
+          onDismiss={() => setSendError('')}
+          className="w-full px-2.5 py-1 border-t border-border text-[11px]"
+        />
+      )}
+
       {/* ADDED (not upstream): why a dropped file was refused. Reporting it is
           the point — the fork discarded such files silently, which reads as the
           app being broken rather than the file being unsupported. */}

--- a/website/src/chat-core/transport/sendTurn.ts
+++ b/website/src/chat-core/transport/sendTurn.ts
@@ -60,6 +60,19 @@ export type SendReceiptStatus =
   | 'response-late'
   | 'transport-error'
 
+/**
+ * `Error.name` values a caller that must REJECT on a receipt can stamp on the
+ * error it throws, so the surface that catches it can tell the two outcomes
+ * that carry their own user copy apart from everything else:
+ * - `SEND_REFUSED`: a `refused` receipt that carried the server's own reason;
+ *   the message is fit to show verbatim.
+ * - `SEND_UNCONFIRMED`: no receipt (`response-late`); delivery indeterminate,
+ *   so the surface must not promise that a retry is safe.
+ * One spelling here rather than one per app.
+ */
+export const SEND_REFUSED = 'SendRefused'
+export const SEND_UNCONFIRMED = 'SendUnconfirmed'
+
 export interface SendReceipt {
   status: SendReceiptStatus
   /** The parsed acceptance body -- `{}` when no readable body exists. Passed

--- a/website/src/test/DesignTweakApiCov80.test.ts
+++ b/website/src/test/DesignTweakApiCov80.test.ts
@@ -397,31 +397,70 @@ describe('createChatSlot', () => {
   })
 })
 
-describe('sendChatMessage', () => {
-  it('POSTs to /api/chat?ws=1 with message, slot, and agent', async () => {
+describe('sendChatMessage — resolves only on a CONFIRMED acceptance', () => {
+  // The caller marks the request delivered on resolution, and `deliveredAt`
+  // permanently short-circuits verification, so anything short of a confirmed
+  // acceptance must reject and leave the request for `verifyDelivery`.
+
+  it('POSTs to /api/chat?ws=1 with message and slot over the dashboard wire, and resolves on dispatch', async () => {
     const fetchMock = vi.fn(async () => jsonResponse({ ok: true }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await sendChatMessage('apply edits', 'dt-slot')
+    await expect(sendChatMessage('apply edits', 'dt-slot')).resolves.toBeUndefined()
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/chat?ws=1')
     expect(init.method).toBe('POST')
-    expect(JSON.parse(String(init.body))).toEqual({
-      message: 'apply edits',
-      slot: 'dt-slot',
-      agent: '',
-    })
+    // `agent` is no longer spelled out: the server default IS the empty agent.
+    expect(JSON.parse(String(init.body))).toEqual({ message: 'apply edits', slot: 'dt-slot' })
   })
 
-  it('tolerates non-JSON response bodies from SSE fallback', async () => {
-    // Without ?ws=1 the host returns SSE — the chatApi helper must not throw.
-    const fetchMock = vi.fn(async () => new Response('data: {"ok":true}', { status: 200 }))
-    vi.stubGlobal('fetch', fetchMock)
+  it('resolves `queued` — the server took custody', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ ok: true, queued: true })))
+    await expect(sendChatMessage('apply edits', 'dt-slot')).resolves.toBeUndefined()
+  })
 
-    const result = await sendChatMessage('test', 'slot')
-    // Falls through JSON.parse catch to a fallback object.
-    expect(result).toHaveProperty('ok', true)
-    expect(result).toHaveProperty('raw', 'data: {"ok":true}')
+  it('rejects a {ok:false} refusal inside a 200 with the server reason', async () => {
+    // The old helper only threw on a non-2xx, so this shape was marked delivered.
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ ok: false, error: 'slot agent mismatch' })))
+    // Flagged so the page can say "send failed" rather than "delivery unconfirmed".
+    await expect(sendChatMessage('apply edits', 'dt-slot')).rejects.toMatchObject({ name: 'SendRefused', message: 'slot agent mismatch' })
+  })
+
+  it('an unconfirmed outcome is NOT flagged as a refusal', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('data: {"ok":true}', { status: 200 })))
+    await expect(sendChatMessage('test', 'slot')).rejects.not.toMatchObject({ name: 'SendRefused' })
+  })
+
+  it('rejects a non-2xx status, as before', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('gateway down', { status: 503 })))
+    await expect(sendChatMessage('apply edits', 'dt-slot')).rejects.toThrow()
+  })
+
+  it('rejects when the fetch itself fails, as before', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Failed to fetch') }))
+    await expect(sendChatMessage('apply edits', 'dt-slot')).rejects.toThrow()
+  })
+
+  it('rejects an accepted 2xx whose body is not JSON — accepted but NOT confirmed', async () => {
+    // The old helper resolved this by a parse fallback and the request was
+    // marked delivered on a receipt nobody could read.
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('data: {"ok":true}', { status: 200 })))
+    await expect(sendChatMessage('test', 'slot')).rejects.toThrow()
+  })
+
+  it('rejects when the deadline passes with no receipt — never marked delivered on a stall', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) => new Promise<Response>((_res, rej) => {
+        init?.signal?.addEventListener('abort', () => rej(new DOMException('aborted', 'AbortError')))
+      })))
+      const outcome = sendChatMessage('apply edits', 'dt-slot')
+      const assertion = expect(outcome).rejects.toThrow()
+      await vi.advanceTimersByTimeAsync(10_500)
+      await assertion
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/website/src/test/MochiPanelBridgeCoverage.test.tsx
+++ b/website/src/test/MochiPanelBridgeCoverage.test.tsx
@@ -42,6 +42,9 @@ interface Reply {
   jsonThrows?: boolean
   /** The request itself never completes. */
   reject?: boolean
+  /** The request hangs until the caller's abort signal fires, then rejects the
+   *  way `fetch` does on abort -- how the transport's deadline is reached. */
+  hang?: boolean
 }
 
 interface Route {
@@ -65,6 +68,11 @@ const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
   )
   const reply = hit?.reply ?? {}
   if (reply.reject === true) throw new Error('network down')
+  if (reply.hang === true) {
+    return await new Promise<never>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+    })
+  }
   const ok = reply.ok ?? true
   return {
     ok,
@@ -155,6 +163,11 @@ beforeEach(() => {
   api.unpinFile.mockClear()
   api.getWatchlist.mockResolvedValue({ items: [] })
   api.getPinned.mockResolvedValue({ pins: [] })
+  // The send now reads its receipt through the chat-core transport, and the
+  // route table's bare `{}` default is a readable body with neither `ok` nor
+  // `queued` -- a refusal. Default the send endpoint to an accepted dispatch so
+  // the tests that only care about slot binding keep sending.
+  route('/api/chat?ws=1', { body: { ok: true } }, 'POST')
   vi.stubGlobal('WebSocket', MockSocket)
   vi.stubGlobal('fetch', fetchMock)
 })
@@ -725,6 +738,87 @@ describe('panelBridge send', () => {
     const bridge = await loadBridge()
     await bridge.sendMessage('plain')
     expect(bodyOf(calls('/api/chat?ws=1', 'POST')[0]).meta).toBeUndefined()
+  })
+
+  // ── the receipt decides whether the bubble exists ───────────────────────
+  //
+  // The old send echoed BEFORE the POST and never read the reply, so a refused
+  // send left a user bubble the server never took and no error anywhere. The
+  // chat-core transport's receipt now gates the echo: a send that provably did
+  // not run rejects (the vendored ChatPanel restores the text and shows
+  // `chat.send_failed` on a rejection), an accepted or indeterminate one echoes.
+
+  it('a `{ok:false}` refusal inside a 200 rejects with the server reason and echoes nothing', async () => {
+    route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+    route('/api/chat?ws=1', { body: { ok: false, error: 'slot is stopping' } }, 'POST')
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    await expect(bridge.sendMessage('hello')).rejects.toMatchObject({ name: 'SendRefused', message: 'slot is stopping' })
+    expect(seen).toHaveLength(0)
+  })
+
+  it('a bodyless non-2xx is still flagged a refusal (empty message) and echoes nothing', async () => {
+    route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+    route('/api/chat?ws=1', { ok: false, status: 503, jsonThrows: true }, 'POST')
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    await expect(bridge.sendMessage('hello')).rejects.toMatchObject({ name: 'SendRefused', message: '' })
+    expect(seen).toHaveLength(0)
+  })
+
+  it('a fetch that never completes rejects and echoes nothing, as the bare fetch did', async () => {
+    route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+    route('/api/chat?ws=1', { reject: true }, 'POST')
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    await expect(bridge.sendMessage('hello')).rejects.toThrow()
+    expect(seen).toHaveLength(0)
+  })
+
+  it('a queued send echoes -- the server took custody, even if not yet running', async () => {
+    route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+    route('/api/chat?ws=1', { body: { ok: true, queued: true } }, 'POST')
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    await bridge.sendMessage('hello')
+    expect(seen).toHaveLength(1)
+  })
+
+  it('an accepted send with an unreadable receipt echoes -- a 2xx means the server took it', async () => {
+    route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+    route('/api/chat?ws=1', { jsonThrows: true }, 'POST')
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    await bridge.sendMessage('hello')
+    expect(seen).toHaveLength(1)
+  })
+
+  it('a send whose receipt never arrives rejects and echoes nothing -- unconfirmed, the panel restores the draft', async () => {
+    // The POST may never have reached the gateway. Echoing would paint a bubble
+    // that vanishes on reload with the typed text gone; a rejection hands the
+    // text back through ChatPanel's existing send_failed path instead.
+    vi.useFakeTimers()
+    try {
+      route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+      route('/api/chat?ws=1', { hang: true }, 'POST')
+      const bridge = await loadBridge()
+      const seen: Record<string, unknown>[] = []
+      bridge.onChatMessage((m) => seen.push(m))
+      const outcome = bridge.sendMessage('hello')
+      // Flagged unconfirmed (empty message: no server reason) so the panel shows
+      // the delivery-unconfirmed copy, never "try again".
+      const assertion = expect(outcome).rejects.toMatchObject({ name: 'SendUnconfirmed', message: '' })
+      await vi.advanceTimersByTimeAsync(10_500)
+      await assertion
+      expect(seen).toHaveLength(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('refuses to send into a slot another agent owns', async () => {

--- a/website/src/test/designCritiqueSendReceipt.test.ts
+++ b/website/src/test/designCritiqueSendReceipt.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Design Critique's `send` goes through the chat-core transport over an
+ * app-local wire, and the RECEIPT decides the outcome.
+ *
+ * The old send hit the bare `/api/chat` (an SSE stream, not a JSON receipt),
+ * then swallowed the resulting parse error as success -- so a `{ok:false}`
+ * refusal inside a 200 never surfaced, and the critique polled a slot whose
+ * turn had never started. Now:
+ *
+ *   - the wire posts to `/api/chat?ws=1` and keeps the slot-recreation fields
+ *     (`agent`, `memory_mode`, `mode`) the app depends on after a gateway restart;
+ *   - `refused` and `transport-error` REJECT (nothing is running; the page's
+ *     failWith reports it and drops the pending critique, as it did for a non-2xx);
+ *   - `unknown` (accepted, receipt unreadable) and `queued` RESOLVE -- the
+ *     request was taken and the poll that follows finds out.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { designCritiqueApi } from '../apps/design-critique/api'
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('designCritiqueApi.send — the transport receipt decides', () => {
+  it('posts the JSON-receipt form with the slot-recreation fields, under the deadline signal', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ ok: true }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(designCritiqueApi.send('dc-1', 'critique this')).resolves.toBeUndefined()
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/chat?ws=1')
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('same-origin')
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+    expect(JSON.parse(String(init.body))).toEqual({
+      message: 'critique this',
+      slot: 'dc-1',
+      agent: 'kirocrew',
+      memory_mode: 'temporary',
+      mode: 'design-critique',
+    })
+  })
+
+  it('rejects a {ok:false} refusal inside a 200 with the server reason (the old swallow)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ ok: false, error: 'slot is stopping' })))
+    await expect(designCritiqueApi.send('dc-1', 'x')).rejects.toThrow(/slot is stopping/)
+  })
+
+  it('rejects a non-2xx status, as before', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('gateway down', { status: 503 })))
+    await expect(designCritiqueApi.send('dc-1', 'x')).rejects.toThrow()
+  })
+
+  it('rejects when the fetch itself fails, as before', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Failed to fetch') }))
+    await expect(designCritiqueApi.send('dc-1', 'x')).rejects.toThrow()
+  })
+
+  it('resolves a queued send — the server took custody', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ ok: true, queued: true })))
+    await expect(designCritiqueApi.send('dc-1', 'x')).resolves.toBeUndefined()
+  })
+
+  it('resolves an accepted 2xx whose body is not JSON — indeterminate, never a refusal', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('data: {"ok":true}', { status: 200 })))
+    await expect(designCritiqueApi.send('dc-1', 'x')).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Chat-core RFC P2, **batch B of #9570**: three app-local senders — `apps/design-critique/api.ts` `send`, `apps/design-tweak/api.ts` `sendChatMessage`, `apps/mochi/panel/panelBridge.ts` `sendMessage` — stop hand-writing `POST /api/chat` and call the chat-core transport `sendTurn`. The `?ws=1` receipt form, the 10 s deadline and the six-way classification are now the core's.

**Stacked on #8599** (base `feat/chat-core-p2-embed`): design-critique needs the injectable `SendWire` seam that PR adds. GitHub retargets this PR to `main` when #8599 merges.

Zero behaviour change except the three receipt defects the RFC §2.1 names, each fixed here:

| Caller | Defect on `main` | Now |
|---|---|---|
| design-critique `send` | posted to the **bare** endpoint (an SSE stream, not a JSON receipt) and `.catch(SyntaxError)` swallowed every unreadable reply as success — a `{ok:false}` refusal inside a 200 never surfaced, the critique polled a slot whose turn never started | app-local `SendWire` posts `/api/chat?ws=1` keeping the slot-recreation fields (`agent`, `memory_mode`, `mode`) the app depends on after a gateway restart; `refused` / `transport-error` **reject** with the server's reason, falling back to the core `pages.chatPage.send_failed` copy (the page's `failWith` reports it and drops the pending critique, as for a non-2xx before); `unknown` / `response-late` resolve |
| design-tweak `sendChatMessage` | threw only on a non-2xx, so a refusal inside a 200 was **marked delivered**; a non-JSON 2xx resolved as `{ok:true}` via a parse fallback; no deadline | dashboard wire (`agent: ''` was the server default, so the body is equivalent); returns `void` and resolves **only** on `dispatched` / `queued`. Every other status rejects with its own reason — `refused` (server reason, flagged `SendRefused`), `transport-error`, `unknown`, `response-late` — because the caller marks the request delivered on resolution and `deliveredAt` permanently short-circuits `deliveryVerdict` / `verifyDelivery`; an unconfirmed send must stay unacknowledged so ground truth decides (GPT, round 1). The page tells the two apart: a flagged refusal is an error and renders `Send failed: <reason>` through the page's existing `ErrorNotice` (`bridgeError`, whose `No hand-off` comment covers the preview overlay's unsent comment) (GPT r5); an unconfirmed dispatch keeps the muted `dispatch_failed_unconfirmed` status line (verify against the session) (UX r4). `chatApi`'s non-JSON fallback, which existed for the SSE send, is deleted; its four remaining callers are JSON endpoints |
| mochi `sendMessage` | echoed the user bubble **before** the POST and never read the reply — a refused send left a bubble the server never took and no error anywhere | the receipt gates the echo: only a confirmed acceptance echoes (`dispatched`, `queued`, and `unknown` — a 2xx, so the server took it). `refused`, `transport-error` and `response-late` reject and echo nothing; the vendored `ChatPanel`'s send path restores the text and reports the failure, and its edit-resend fallback now routes through that same `sendText` path instead of awaiting `sendMessage` bare (Design, round 2). A `response-late` echo would paint a bubble that vanishes on reload with the draft gone (GPT, round 2). The failure report is a new `sendError` state rendered through `ErrorNotice variant="inline"` (`askAgent` off, `No hand-off` comment naming the restored draft) — separate from the panel's pre-existing `dropError` banner, which is a file-validation hint, not an error (GPT, round 3) — and it shows the **server's refusal reason** — framed as `Send failed: <reason>` (`pages.chatPage.send_failed_with_error`, the same entry design-tweak uses) — when the bridge flags the rejection `SEND_REFUSED` (every refusal is flagged; a bodyless 4xx/5xx renders the plain `Send failed` copy — the network is fine, so never the connection copy); a late receipt is flagged `SEND_UNCONFIRMED` and shows the core `delivery_unconfirmed` copy ("check the transcript before sending again") rather than "try again", which could duplicate a send that landed (UX r5); every other rejection — a slot-bind failure, a browser `TypeError` — falls back to the localized `chat.send_failed` copy instead of leaking developer-voice text (UX r3–4) |

`SEND_REFUSED` / `SEND_UNCONFIRMED` are defined once, beside `sendTurn` in `chat-core/transport/sendTurn.ts`, and imported by both apps (First Principles r5).

Why the dashboard wire is equivalent for design-tweak and mochi: both run in the dashboard bundle on the same origin; `/api/chat` reads no `X-Session-Key` (auth is the middleware's), and the only body difference is the omitted `agent: ''`, which `body.get("agent", "")` already defaults to.

## Tests

- New `website/src/test/designCritiqueSendReceipt.test.ts`: the wire's URL / credentials / signal / body fields, and the six-way mapping through the real transport on a stubbed `fetch`.
- `DesignTweakApiCov80.test.ts`: the `sendChatMessage` block becomes a receipt-contract block (dispatched / queued resolve; refusal-in-200 rejects with reason; non-2xx, fetch failure, non-JSON 2xx and a 10 s stall with no receipt all reject). The old "tolerates SSE fallback" assertion on `{ok:true, raw}` is gone with the fallback.
- `MochiPanelBridgeCoverage.test.tsx`: the route table defaults the send endpoint to `{ok:true}` (its bare `{}` default now reads as a refusal) and gains a `hang` reply for the deadline; six cases pin that the echo follows the receipt, including a 10 s stall rejecting with nothing echoed.

## Tested

- `npx tsc --noEmit -p .` — clean.
- `npx eslint` on the six changed files — clean.
- `npm run i18n:check` and `node scripts/check-i18n-strings.mjs` — clean (every new user-facing fallback reuses an existing key: `pages.chatPage.send_failed`, `api.client.accepted_body_unreadable`, `pages.chat.recoveryCard.no_response_returned`).
- Unit tests are left to CI (repo rule for this workstream).

<!-- no-visual-delta -->
**Why no screenshot:** no layout change. Rendered deltas: existing error surfaces now firing where they were silent before (design-critique's rail notice on a refused send), and mochi's send-failure line moving from the panel's file-drop banner to the shared `ErrorNotice` inline variant (icon + `text-danger`, dismiss ✕, same slot above the composer) — the stock rendering every other inline notice already has.

Refs #9570







