### PR TITLE
fix(admission): read the plugin require_signature flag strictly

### DIFF
--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -264,7 +264,14 @@ Policy shape (`admission_policy.json`):
 `identity.issuer` in the same `trust_keys` map — one key store, not two. It is a
 **separate** flag from `require_signature` on purpose: a fleet that signs its
 plugins has not thereby promised to sign its governance ceiling, and conflating
-them would break managed fleets on upgrade. The flag lives here rather than inside
+them would break managed fleets on upgrade. The plugin `require_signature`
+flag is read strictly by `_coerce_signature_flag`: only a real JSON boolean is
+honoured, an absent key stays `false`, and any other present value (`"false"`,
+`0`, `null`) is warned about and read fail-closed as `true` — the same rule the
+`boot` flags follow in `governance.md`. `require_policy_signature` keeps the
+raw read on purpose: its fail-open direction is a documented trust-root
+decision, and the governance loader reads the raw value through its own path.
+The flag lives here rather than inside
 the security policy because a document cannot be the authority on whether it must
 be authentic. `canonical_signing_bytes` / `hmac_signature` are shared by both
 checks so the two trust roots cannot drift apart. The governance loader reads

--- a/src/kiro_crew/platform/admission.py
+++ b/src/kiro_crew/platform/admission.py
@@ -136,10 +136,13 @@ def _coerce_signature_flag(d: dict, key: str) -> bool:
     value = d.get(key)
     if isinstance(value, bool):
         return value
+    # Log the TYPE, never the value: a mis-typed flag can carry a secret
+    # (a credential pasted into the policy), and this warning lands in the
+    # persistent gateway log.
     logger.warning(
-        "admission policy %s is %r (not a boolean); reading it fail-closed as True",
+        "admission policy %s must be a boolean, got %s; reading it fail-closed as True",
         key,
-        value,
+        type(value).__name__,
     )
     return True
 

--- a/src/kiro_crew/platform/admission.py
+++ b/src/kiro_crew/platform/admission.py
@@ -118,6 +118,32 @@ def _coerce_str_list(value: object) -> List[str]:
     return []
 
 
+def _coerce_signature_flag(d: dict, key: str) -> bool:
+    """Read the plugin ``require_signature`` flag strictly.
+
+    A real boolean is honoured; an absent key keeps the default (``False`` —
+    verification is advisory unless a fleet opts in).  Any other present value
+    — ``"false"``, ``"true"``, ``0``, ``1``, explicit ``null`` — is NOT
+    interpreted: ``bool()`` on a raw JSON value reads the string ``"false"``
+    as ``True`` and reads ``0`` or ``null`` as silently OFF.  Such a value is
+    warned about and read fail-closed as ``True`` (the signature IS
+    required), matching the ``boot`` gate flags in ``governance.py``.
+    ``require_policy_signature`` is deliberately excluded — see the inline
+    note at its read site in ``from_dict``.
+    """
+    if key not in d:
+        return False
+    value = d.get(key)
+    if isinstance(value, bool):
+        return value
+    logger.warning(
+        "admission policy %s is %r (not a boolean); reading it fail-closed as True",
+        key,
+        value,
+    )
+    return True
+
+
 def canonical_signing_bytes(body: Mapping[str, object]) -> bytes:
     """The ONE canonicalization every KiroCrew trust-root signature is taken over.
 
@@ -267,7 +293,12 @@ class AdmissionPolicy:
         approved = d.get("approved", None)
         return AdmissionPolicy(
             mode=str(d.get("mode", MODE_OPEN)),
-            require_signature=bool(d.get("require_signature", False)),
+            require_signature=_coerce_signature_flag(d, "require_signature"),
+            # Deliberately NOT the strict coercer: this flag gates the security
+            # policy's own authenticity, where a hand-edit typo reading as
+            # "require it" would make the host unbootable — the trust-root
+            # docstrings at _policy_trust_settings() own that decision, and the
+            # governance loader reads the raw value through its own path anyway.
             require_policy_signature=bool(d.get("require_policy_signature", False)),
             trust_keys=_coerce_trust_keys(d.get("trust_keys")),
             approved=(_coerce_str_list(approved) if approved is not None else None),

--- a/test/test_platform_admission.py
+++ b/test/test_platform_admission.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
 
 import pytest
 
@@ -161,6 +162,47 @@ class TestManifestParsing:
             {"mode": "enforce", "capability_ceiling": {"egress": "*.amazon.com"}}
         )
         assert p.capability_ceiling["egress"] == ["*.amazon.com"]
+
+
+class TestSignatureFlagStrictness:
+    """The plugin ``require_signature`` flag rejects non-boolean JSON.
+
+    ``bool()`` on a raw JSON value reads the string ``"false"`` as ``True`` and
+    reads ``0`` / ``null`` as silently OFF.  A present-but-not-boolean value
+    must be warned about and read fail-closed as ``True`` (require the
+    signature), matching the ``boot`` gate flags in ``governance.py``.
+    ``require_policy_signature`` keeps the raw read on purpose: its fail-open
+    direction is a documented trust-root decision (a hand-edit typo must not
+    make the host unbootable), and the governance loader consumes the raw
+    value through its own path.
+    """
+
+    _FLAGS = ("require_signature",)
+
+    @pytest.mark.parametrize("flag", _FLAGS)
+    @pytest.mark.parametrize("junk", ["false", "true", None, 0, 1])
+    def test_non_boolean_reads_fail_closed_on(self, flag, junk):
+        policy = AdmissionPolicy.from_dict({"mode": "enforce", flag: junk})
+        assert getattr(policy, flag) is True
+
+    @pytest.mark.parametrize("flag", _FLAGS)
+    @pytest.mark.parametrize("real", [True, False])
+    def test_real_boolean_is_honoured(self, flag, real):
+        policy = AdmissionPolicy.from_dict({"mode": "enforce", flag: real})
+        assert getattr(policy, flag) is real
+
+    @pytest.mark.parametrize("flag", _FLAGS)
+    def test_absent_key_defaults_off(self, flag):
+        policy = AdmissionPolicy.from_dict({"mode": "enforce"})
+        assert getattr(policy, flag) is False
+
+    def test_non_boolean_is_warned_about(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.admission"):
+            AdmissionPolicy.from_dict({"mode": "enforce", "require_signature": "false"})
+        assert any(
+            "require_signature" in rec.message and "fail-closed" in rec.message
+            for rec in caplog.records
+        )
 
 
 class TestAllowlist:

--- a/test/test_platform_admission.py
+++ b/test/test_platform_admission.py
@@ -199,10 +199,14 @@ class TestSignatureFlagStrictness:
     def test_non_boolean_is_warned_about(self, caplog):
         with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.admission"):
             AdmissionPolicy.from_dict({"mode": "enforce", "require_signature": "false"})
-        assert any(
-            "require_signature" in rec.message and "fail-closed" in rec.message
+        matching = [
+            rec.message
             for rec in caplog.records
-        )
+            if "require_signature" in rec.message and "fail-closed" in rec.message
+        ]
+        assert matching
+        # Secret hygiene: the junk VALUE must not reach the persistent log.
+        assert not any("false" in m for m in matching)
 
 
 class TestAllowlist:


### PR DESCRIPTION
## Problem / Motivation

`AdmissionPolicy.from_dict` read the plugin `require_signature` flag with
`bool()` on the raw JSON value: the string `"false"` turned signature
enforcement ON accidentally, while `0` or explicit `null` switched it OFF
silently. Found while fixing the same shape in the governance boot flags
(#9588).

## Why it matters

This flag decides whether plugin manifests must be signature-verified. A
stringified boolean flips enforcement in whichever direction the truthiness
happens to land — surprising a fleet with enforcement it did not opt into, or
silently dropping verification it thought it had.

## What changed (motivation → approach → change)

Same defect family as #9588, same cure at this gate: a new
`_coerce_signature_flag` honours only real JSON booleans; an absent key keeps
the default (`False` — verification is advisory unless a fleet opts in); any
other present value is warned about and read **fail-closed as `True`**.

Scope note (from the fork Design Review, which was right): the sibling
`require_policy_signature` flag deliberately KEEPS the raw read. Its fail-open
direction is a documented trust-root decision (a hand-edit typo must not make
the host unbootable), and the governance loader consumes the raw value through
its own path — so routing it through the strict coercer would have changed a
value its real gate never reads while contradicting that documented decision.
An inline comment at the read site and the spec paragraph now say so.

## Tests

`TestSignatureFlagStrictness` in `test/test_platform_admission.py`:
parametrized matrix pinning `"false"`, `"true"`, `null`, `0`, `1` for
`require_signature` (fail-closed ON), real booleans honoured, absent key
defaults OFF, warning logged. Full file: 63 passed. black ratchet, flake8,
isort, mypy (--platform linux), docs-lint: clean.

## Manual verification

N/A — unit coverage sufficient: pure parse function, full input matrix pinned.

## Pattern harvest

Rule candidate: semgrep
Pattern: `bool(<mapping>.get(...))` on untrusted JSON reads the string `"false"` as `True` — boolean config flags must be read with an `isinstance(v, bool)` check and an explicit fail-closed direction. Sibling of #9588 (same rule candidate covers both).
