### PR TITLE
perf(context): cache agent skill globs on the directory signature

### DIFF
--- a/src/kiro_crew/agent_discovery.py
+++ b/src/kiro_crew/agent_discovery.py
@@ -705,6 +705,24 @@ def expand_skill_uri(uri: str, agent_path: Path) -> str | None:
     return str(agent_path.parent.parent.parent / raw)
 
 
+#: :func:`agent_skill_globs` result cache, mirroring ``_LIST_AGENTS_CACHE``:
+#: keyed by ``(agents_dir, agent)``, guarded by the same stat-only
+#: :func:`_dir_signature` (file count + newest mtime, ``DirEntry.stat``
+#: following symlinks), so adds, removals, and in-place edits invalidate
+#: without reading a file. Not-found results (``[]``) are cached too — an
+#: unmapped agent otherwise re-reads every spec on every session build.
+#: Same staleness trade the ``list_agents`` cache already accepts.
+#:
+#: Bounded: the agent half of the key is caller-influenced (a dashboard
+#: request can name arbitrary agents), so unlike the dir-keyed
+#: ``_LIST_AGENTS_CACHE`` this map could otherwise grow without limit.
+#: At the cap the whole map is dropped — the next call repopulates the
+#: handful of live agents; an LRU would spend list-moves on every hit to
+#: preserve entries a flood has already evicted.
+_SKILL_GLOBS_CACHE: dict[tuple[str, str], tuple[_ListAgentsSig, list[str]]] = {}
+_SKILL_GLOBS_CACHE_MAX = 512
+
+
 def agent_skill_globs(agent: str, agents_dir: Path | None = None) -> list[str]:
     """Return fnmatch globs for the skills mapped to *agent*, or ``[]``.
 
@@ -712,10 +730,30 @@ def agent_skill_globs(agent: str, agents_dir: Path | None = None) -> list[str]:
     treat that as the legacy all-or-nothing default rather than as "no skills".
     Best-effort and never raises: an unreadable, invalid, or sensitive-path
     agent file yields ``[]``.
+
+    Results are cached per ``(agents_dir, agent)`` against the directory
+    signature: the uncached scan reads and security-validates every spec file
+    (~130 ms on a 77-agent dir) and sits on the session-context build path —
+    every session start, subagent spawn, and full-context wake — so a hit
+    must not re-read anything.
     """
     d = agents_dir or _kiro_agents_dir()
     if not agent or not d.is_dir():
         return []
+    sig = _dir_signature(d)
+    cache_key = (str(d), agent)
+    cached = _SKILL_GLOBS_CACHE.get(cache_key)
+    if cached is not None and cached[0] == sig:
+        return list(cached[1])
+    globs = _agent_skill_globs_scan(agent, d)
+    if len(_SKILL_GLOBS_CACHE) >= _SKILL_GLOBS_CACHE_MAX:
+        _SKILL_GLOBS_CACHE.clear()
+    _SKILL_GLOBS_CACHE[cache_key] = (sig, list(globs))
+    return globs
+
+
+def _agent_skill_globs_scan(agent: str, d: Path) -> list[str]:
+    """The uncached scan behind :func:`agent_skill_globs`."""
     try:
         candidates = sorted(d.glob("*.json"))
     except OSError:
@@ -766,12 +804,14 @@ def _dir_signature(d: Path) -> _ListAgentsSig:
 
 
 def clear_list_agents_cache() -> None:
-    """Drop all cached :func:`list_agents` results (forces a fresh scan next call).
+    """Drop all cached :func:`list_agents` AND :func:`agent_skill_globs` results.
 
     Invalidation is normally automatic via the directory signature; call this
     only to force an immediate refresh (e.g. right after writing an agent file).
+    Both caches invalidate on the same trigger, so one clear covers them.
     """
     _LIST_AGENTS_CACHE.clear()
+    _SKILL_GLOBS_CACHE.clear()
 
 
 def _with_edition_agents(disk_agents: list[AgentInfo]) -> list[AgentInfo]:

--- a/test/test_agent_discovery.py
+++ b/test/test_agent_discovery.py
@@ -925,17 +925,23 @@ class TestSkillGlobsCache:
         first.append("mutation")
         assert "mutation" not in agent_skill_globs("a1", d)
 
-    def test_cache_is_bounded(self, tmp_path: Path) -> None:
-        """Arbitrary agent names cannot grow the cache without limit."""
+    def test_cache_is_bounded(self, tmp_path: Path, monkeypatch) -> None:
+        """Arbitrary agent names cannot grow the cache without limit.
+
+        The cap is patched small so the test exercises the drop-at-cap
+        mechanism without hundreds of directory scans: the mechanism, not
+        the production constant, is what needs pinning.
+        """
         from kiro_crew import agent_discovery as ad
 
         clear_list_agents_cache()
+        monkeypatch.setattr(ad, "_SKILL_GLOBS_CACHE_MAX", 8)
         d = tmp_path / "agents"
         d.mkdir()
         self._write(d, "real", "one")
-        for i in range(ad._SKILL_GLOBS_CACHE_MAX + 10):
+        for i in range(8 + 4):
             agent_skill_globs(f"flood-{i}", d)
-        assert len(ad._SKILL_GLOBS_CACHE) <= ad._SKILL_GLOBS_CACHE_MAX
+        assert len(ad._SKILL_GLOBS_CACHE) <= 8
         # Correctness survives the flood: the real agent still resolves.
         assert "one" in agent_skill_globs("real", d)[0]
 

--- a/test/test_agent_discovery.py
+++ b/test/test_agent_discovery.py
@@ -22,6 +22,7 @@ from kiro_crew.agent_discovery import (
     SCOPE_GLOBAL,
     SCOPE_PROJECT,
     AgentInfo,
+    agent_skill_globs,
     clear_list_agents_cache,
     clear_project_agent_cache,
     list_agents,
@@ -857,6 +858,101 @@ def _discovery_warnings(caplog):
         and r.levelno >= logging.WARNING
         and "parsed 0" in r.getMessage()
     ]
+
+
+class TestSkillGlobsCache:
+    """agent_skill_globs caches per (dir, agent) against the same stat-only
+    directory signature the list_agents cache uses. The uncached scan reads and
+    security-validates every spec file and sits on the session-context build
+    path, so hits must not re-read, and edits/adds must invalidate."""
+
+    def _write(self, d: Path, name: str, skill: str) -> Path:
+        f = d / f"{name}.json"
+        f.write_text(
+            json.dumps({"name": name, "resources": [f"skill://~/{skill}/SKILL.md"]}),
+            encoding="utf-8",
+        )
+        return f
+
+    def test_cache_hit_skips_rescan(self, tmp_path: Path) -> None:
+        """An unchanged signature returns the cached globs without re-reading."""
+        clear_list_agents_cache()
+        d = tmp_path / "agents"
+        d.mkdir()
+        f = self._write(d, "a1", "one")
+        file_stat = f.stat()
+
+        first = agent_skill_globs("a1", d)
+        assert first and "one" in first[0]
+
+        # Rewrite the content but restore the original mtime: a re-scan would
+        # yield "two"; a cache hit yields "one".
+        self._write(d, "a1", "two")
+        os.utime(f, ns=(file_stat.st_atime_ns, file_stat.st_mtime_ns))
+        assert (
+            agent_skill_globs("a1", d) == first
+        ), "unchanged signature must return the cached globs"
+
+    def test_cache_invalidates_on_edit(self, tmp_path: Path) -> None:
+        """An mtime-visible edit is reflected immediately."""
+        clear_list_agents_cache()
+        d = tmp_path / "agents"
+        d.mkdir()
+        f = self._write(d, "a1", "one")
+        assert "one" in agent_skill_globs("a1", d)[0]
+        self._write(d, "a1", "two")
+        bumped = f.stat().st_mtime_ns + 2_000_000_000
+        os.utime(f, ns=(bumped, bumped))
+        assert "two" in agent_skill_globs("a1", d)[0]
+
+    def test_not_found_is_cached_and_invalidated_on_add(self, tmp_path: Path) -> None:
+        """A [] miss is cached, and adding the agent's file is seen at once."""
+        clear_list_agents_cache()
+        d = tmp_path / "agents"
+        d.mkdir()
+        self._write(d, "other", "x")
+        assert agent_skill_globs("late", d) == []
+        self._write(d, "late", "arrived")
+        assert "arrived" in agent_skill_globs("late", d)[0]
+
+    def test_hit_returns_a_copy(self, tmp_path: Path) -> None:
+        """Mutating a returned list must not poison the cache."""
+        clear_list_agents_cache()
+        d = tmp_path / "agents"
+        d.mkdir()
+        self._write(d, "a1", "one")
+        first = agent_skill_globs("a1", d)
+        first.append("mutation")
+        assert "mutation" not in agent_skill_globs("a1", d)
+
+    def test_cache_is_bounded(self, tmp_path: Path) -> None:
+        """Arbitrary agent names cannot grow the cache without limit."""
+        from kiro_crew import agent_discovery as ad
+
+        clear_list_agents_cache()
+        d = tmp_path / "agents"
+        d.mkdir()
+        self._write(d, "real", "one")
+        for i in range(ad._SKILL_GLOBS_CACHE_MAX + 10):
+            agent_skill_globs(f"flood-{i}", d)
+        assert len(ad._SKILL_GLOBS_CACHE) <= ad._SKILL_GLOBS_CACHE_MAX
+        # Correctness survives the flood: the real agent still resolves.
+        assert "one" in agent_skill_globs("real", d)[0]
+
+    def test_clear_drops_the_globs_cache(self, tmp_path: Path) -> None:
+        """clear_list_agents_cache() also forces a fresh globs scan."""
+        clear_list_agents_cache()
+        d = tmp_path / "agents"
+        d.mkdir()
+        f = self._write(d, "a1", "one")
+        file_stat = f.stat()
+        agent_skill_globs("a1", d)
+        self._write(d, "a1", "two")
+        os.utime(f, ns=(file_stat.st_atime_ns, file_stat.st_mtime_ns))
+        clear_list_agents_cache()
+        assert (
+            "two" in agent_skill_globs("a1", d)[0]
+        ), "after clear(), the same signature must re-scan"
 
 
 class TestSystematicScanFailureWarning:


### PR DESCRIPTION
## Problem / Motivation

`agent_skill_globs` re-read and re-security-validated every agent spec file
on every call — 77 files, ~115 ms measured — and it sits on the
session-context build path, so the cost was paid at every session start,
subagent spawn, full-context cron/monitor wake, and the dashboard prompts
listing.

## Why it matters

Session start and subagent spawn are among the most latency-visible moments
in the product. On a machine with a populated agents dir this one scan was
~85% of the warm session-context build (87 ms of ~100 ms), multiplied across
every spawn in a wave.

## What changed (motivation → approach → change)

The module already solves exactly this shape for `list_agents`: a result
cache keyed on a stat-only directory signature (`_dir_signature`: JSON file
count + newest mtime). `agent_skill_globs` now uses the same mechanism —
cached per `(agents_dir, agent)`, `[]` misses cached too (an unmapped agent
otherwise re-reads every spec per build), hits return a copy so callers
cannot poison the cache, and `clear_list_agents_cache()` drops both caches
(same write-an-agent-file trigger). Same staleness trade the existing
`list_agents` cache already accepts, documented on the cache constant.

Measured on a 77-agent `~/.kiro/agents` (Apple Silicon):

| Path | Before | After |
|---|---|---|
| `agent_skill_globs` (mapped agent) | 114.9 ms/call | 0.49 ms/call |
| `agent_skill_globs` (unmapped) | 111.0 ms/call | 0.63 ms/call |
| `build_session_context` warm | ~87 ms | ~14 ms |

## Tests

`TestSkillGlobsCache` (5 cases) mirrors the existing `TestListAgentsCache`
style: hit skips re-scan (content rewritten, mtime restored), edit
invalidates, `[]` miss cached and invalidated on add, hit returns a copy,
`clear_list_agents_cache()` covers the globs cache. 64/64 in
`test_agent_discovery.py`. black ratchet, flake8, isort,
mypy (--platform linux): clean.

## Manual verification

Benchmarked in-process against a real 77-agent directory (numbers above);
invalidation exercised by editing a spec and observing fresh globs.
