### PR TITLE
refactor(chat-core): route scene popover and feedback sends through sendTurn; drop api.steerChat

### DIFF
--- a/docs/request-for-change/rfc-chat-core-extraction.md
+++ b/docs/request-for-change/rfc-chat-core-extraction.md
@@ -6,7 +6,7 @@ created: 2026-08-22
 last-audited: 2026-09-05
 audited-at: 8ed028b0b
 doc-pr:
-implementation-prs: ["#5128", "#5909", "#8599", "#8631", "#8655", "#8689", "#9576"]
+implementation-prs: ["#5128", "#5909", "#8599", "#8631", "#8655", "#8689", "#9576", "#9593"]
 tracking-issues: ["#8651", "#9570"]
 supersedes: []
 superseded-by: []
@@ -93,7 +93,7 @@ Background: P3's ChatEmbed adoption (#8631) mounts the real `ChatInput`, whose s
 | P2 | ChatPage send + steer → `sendTurn` (`steer`, `colorTheme` flags) | [#8689](https://github.com/kirodotdev/KiroCrew/pull/8689) | in review |
 | P2 | issue-radar / auto-improvement `agentSession` seeds → `sendTurn` (#9570 batch A) | [#9576](https://github.com/kirodotdev/KiroCrew/pull/9576) | in review |
 | P2 | design-critique, design-tweak, mochi `panelBridge` → `sendTurn`; receipt defects fixed (#9570 batch B) | — | not started |
-| P2 | `useSceneInteraction` (last `api.steerChat` caller), `App.tsx` feedback → `sendTurn` (#9570 batch C) | — | not started |
+| P2 | `useSceneInteraction` (last `api.steerChat` caller), `App.tsx` feedback → `sendTurn`; `api.steerChat` deleted (#9570 batch C) | [#9593](https://github.com/kirodotdev/KiroCrew/pull/9593) | in review (stacked on #9576) |
 | P3 | Store-free `ChatInput` seam | [#8651](https://github.com/kirodotdev/KiroCrew/issues/8651) | design draft pending |
 | P5-a | `ChatPage.renderMessage` → registry (`resolveRenderer` over `mergeRenderers`; page chrome as host entries) | [#8713](https://github.com/kirodotdev/KiroCrew/pull/8713) | merged |
 | P5-b | One dashboard row set: ChatPage spreads `createTranscriptRenderers`, the factory ChatPane already used; page-specific behaviour becomes factory options | [#8733](https://github.com/kirodotdev/KiroCrew/pull/8733) | merged |

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -16,7 +16,7 @@ import { setNavIntentHandler as setArtifactNavIntentHandler } from './utils/arti
 import { applyNavIntentInMain, chatDeepLinkSlot } from './utils/navIntent'
 import { installSoftNavigate } from './utils/errorReport'
 import { agentSwitchFailureMessage } from './utils/agentSwitchFeedback'
-import { readSendReceipt } from './utils/sendDelivery'
+import { sendTurn } from './chat-core/transport/sendTurn'
 import { updateAffordance } from './utils/updateAffordance'
 import { isNewSection } from './utils/releaseVersion'
 import { metricColor } from './utils/metricColor'
@@ -2951,17 +2951,20 @@ export default function App() {
       // feature-request workflow to a later, unrelated message.
       await api.chatSlotContext(slot, FEATURE_REQUEST_PROMPT_FALLBACK, { source: 'feature-request', maxAge: 60 })
     } catch { /* Send the visible request even if hidden context is unavailable. */ }
-    try {
-      const r = await api.sendChat(visibleMessage, slot, colorTheme)
-      const { body, outcome } = await readSendReceipt(r)
-      // Resolution is not success: the server accepted neither `ok` nor
-      // `queued`, so no turn started and no WS response is coming. An UNKNOWN
-      // outcome (a 2xx whose body would not parse) is deliberately silent — the
-      // request WAS accepted, so a turn may be running, and this row is the only
-      // signal the pill has: claiming a failure it cannot prove tells the user to
-      // resend a request that already went out.
-      if (outcome === 'refused') reportFailedSend(typeof body.error === 'string' ? body.error : undefined)
-    } catch { reportFailedSend() }
+    // The chat-core transport owns the receipt contract (`?ws=1` JSON receipt,
+    // HTTP 4xx/5xx RESOLVE rather than reject, deadline) and never rejects.
+    const receipt = await sendTurn({ message: visibleMessage, slot, colorTheme })
+    // Resolution is not success: `refused` means the server accepted neither
+    // `ok` nor `queued`, so no turn started and no WS response is coming, and
+    // `transport-error` means the request never left. Both get the error row.
+    // The indeterminate statuses are deliberately silent -- `unknown` (a 2xx
+    // whose body would not parse) means the request WAS accepted, and
+    // `response-late` (deadline before a receipt) means it may have been; in
+    // both a turn may be running, and this row is the only signal the pill
+    // has: claiming a failure it cannot prove tells the user to resend a
+    // request that already went out.
+    if (receipt.status === 'refused') reportFailedSend(receipt.reason)
+    else if (receipt.status === 'transport-error') reportFailedSend()
   }, [dispatch, navigate, colorTheme, appStore])
 
   const toggleNav = () => {

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1511,6 +1511,27 @@ const apiFailure = (r: Response, errText: string): ApiError => {
   return new ApiError(r.status, message, errText, authRequired || staleOwnerSession)
 }
 
+/**
+ * The auth-recovery half of `j` for a response that is handed back RAW instead
+ * of parsed (the chat-core transport's wire): the pre-body 403 `X-Auth-Required`
+ * hook, and the body-borne stale-owner code a 401 carries -- read off a CLONE so
+ * the caller's own `json()` still works. Fire-and-forget: the recovery prompts
+ * are idempotent and the receipt read must not wait on them. A 2xx also clears
+ * a stale session-expired banner, exactly as `j` does -- a send that succeeds
+ * after auth was restored elsewhere must not leave the banner up.
+ */
+function sendResponseAuthRecovery(r: Response): Response {
+  checkSessionExpired(r)
+  if (r.ok) removeAuthBanner()
+  if (r.status === 401) {
+    // Best-effort: a wire may hand back a Response-like without `clone`.
+    try {
+      void r.clone().text().then((body) => noteStaleOwnerResponse(r.status, body)).catch(() => {})
+    } catch { /* not a real Response; nothing to read */ }
+  }
+  return r
+}
+
 const j = async (r: Response) => {
   checkSessionExpired(r)
   if (r.ok) removeAuthBanner()
@@ -3202,26 +3223,24 @@ export const api = {
     // whenever Browser Mode is enabled in Settings (a durable capability),
     // gated there rather than per turn.
     //
-    // `steer` carries the user's "act on this now" intent into a send that
-    // starts its OWN turn. The slot is idle, so there is no running turn to
-    // inject into; the flag's only effect server-side is to skip the hold that
-    // parks a user message behind still-running sub-agents. Sent through this
-    // endpoint rather than steerChat because a new turn needs `ws=1` to stream.
+    // `steer` carries the user's "act on this now" intent. Mid-turn it injects
+    // into the RUNNING turn instead of queueing (the backend falls back to the
+    // queue if steer is unavailable, so the text is never dropped, and answers
+    // `{ok, steered}`); on an idle slot there is no running turn to inject into
+    // and the flag's only effect server-side is to skip the hold that parks a
+    // user message behind still-running sub-agents. One wire for both: this is
+    // the fetch seam under the chat-core `sendTurn`, which every steer now
+    // rides (there is no separate steer helper).
+    //
+    // The response is handed back RAW (the chat-core transport reads the
+    // receipt itself; a 4xx/5xx must resolve, not throw like `j`), but it still
+    // runs the same auth recovery every `j`-parsed call has -- see
+    // `sendResponseAuthRecovery` -- instead of surfacing an expired or
+    // stale-owner session as a bare "refused" send. The steer helper this
+    // replaced went through `j` and had both; the transport must not lose them.
     const themeConsent = themeConsentSha(colorTheme)
-    return fetch('/api/chat?ws=1', { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify({ message, slot, ...(colorTheme ? { color_theme: colorTheme } : {}), ...(themeConsent ? { theme_consent_sha: themeConsent } : {}), ...(meta ? { meta } : {}), ...(steer ? { steer: true } : {}) }), signal })
+    return fetch('/api/chat?ws=1', { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify({ message, slot, ...(colorTheme ? { color_theme: colorTheme } : {}), ...(themeConsent ? { theme_consent_sha: themeConsent } : {}), ...(meta ? { meta } : {}), ...(steer ? { steer: true } : {}) }), signal }).then(sendResponseAuthRecovery)
   },
-  // Mid-turn steer: inject into the RUNNING turn instead of queueing. Fire-and-forget
-  // JSON response ({ok, steered}); the backend falls back to queue if steer is
-  // unavailable so the text is never dropped.
-  // `ws=1` because a steer that races `chat_done` falls through to the plain send
-  // path, whose JSON receipt is gated on it — without it that arm streams SSE.
-  // `sendId` is the client-minted correlation id stamped on the optimistic steer
-  // bubble (same convention as the plain send path). It rides in `meta`, which
-  // BOTH backend paths persist — the accepted-steer row and the new-turn row a
-  // steer that races chat_done falls onto — so the bubble is reconcilable, and
-  // its accepted-vs-new-turn ambiguity resolvable, by id identity (#6075).
-  steerChat: (message: string, slot?: string, sendId?: string) =>
-    fetch('/api/chat?ws=1', { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify({ message, slot, steer: true, ...(sendId ? { meta: { sendId } } : {}) }) }).then(j),
   sessionsHealth: () => fetch('/api/sessions/health').then(j),
   // Knowledge
   knowledgeSearch: (q: string) => get(`/api/knowledge/search-for-context?q=${encodeURIComponent(q)}`).then(j),

--- a/website/src/hooks/useSceneInteraction.tsx
+++ b/website/src/hooks/useSceneInteraction.tsx
@@ -1,13 +1,14 @@
 import React, { useState, useCallback, useEffect, useRef, type RefObject } from 'react'
-import { Circle, Pause, MessageSquare, X, Check } from 'lucide-react'
+import { Circle, Pause, MessageSquare, X, Check, AlertTriangle } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from '../store'
 import { switchSlot } from '../store/chatSlice'
 import { api } from '../api/client'
-import { readSendReceipt } from '../utils/sendDelivery'
+import { sendTurn } from '../chat-core/transport/sendTurn'
 import type { AgentSource } from './useAgentSync'
 import { useImeGuard } from './useImeGuard'
 import { KIRO_GHOST_PIXELS } from './sceneText'
+import ErrorNotice from '../components/ErrorNotice'
 
 import { i18nT } from '../i18n/t'
 /** Minimal agent shape for hit-testing — all scene agent types satisfy this */
@@ -243,6 +244,12 @@ export function useSceneInteraction(
   // under the composer so the scene surface keeps the reason the App path
   // already surfaces.
   const [sendFailReason, setSendFailReason] = useState('')
+  // A failed send is framed "Send failed: <reason>"; an UNCONFIRMED one is not a
+  // failure claim and renders its own copy unwrapped (the same distinction
+  // ChatPage draws with its warn-tone notice).
+  const [sendUnconfirmed, setSendUnconfirmed] = useState(false)
+  /** A send that FAILED (refused / never left) -- the state the Retry treatment is for. */
+  const sendFailedHard = sendState === 'failed' && !sendUnconfirmed
   const [approvalState, setApprovalState] = useState<'idle' | 'resolving' | 'failed'>('idle')
   // Which agent the composer state (draft + sendState) belongs to RIGHT NOW,
   // and a GENERATION for that binding. `sendToAgent` is deliberately
@@ -317,10 +324,11 @@ export function useSceneInteraction(
     // is newer work: the restore APPENDS with whole-occurrence de-duplication
     // rather than replacing — clobbering newer text to recover older is the
     // regression class PR #4180 hit.
-    const reportFailedSend = (reason?: string) => {
+    const reportFailedSend = (reason?: string, opts?: { unconfirmed?: boolean }) => {
       if (!sameComposer()) return
       setSendState('failed')
       setSendFailReason(reason || '')
+      setSendUnconfirmed(!!opts?.unconfirmed)
       setDraft(prev => {
         const keep = prev.replace(/\s+$/, '')
         if (!keep.trim()) return msg
@@ -338,61 +346,69 @@ export function useSceneInteraction(
         return [keep, msg].join(' ')
       })
     }
-    try {
-      const src = sourceFor(agent)
-      if (src?.running) {
-        // Mid-turn: steer the running turn (backend queues if steer unavailable).
-        // steerChat parses through `j`, which throws on an HTTP error, so the
-        // catch below covers both failure shapes for this branch.
-        await api.steerChat(msg, slotKey)
-      } else {
-        // Idle or waiting for input: start/continue the turn. `?ws=1` answers
-        // with a JSON receipt ({ok, queued, error}) and the turn itself streams
-        // over WS. An HTTP 4xx/5xx RESOLVES rather than rejecting, so the
-        // receipt must be read: without this check every refused send fell
-        // through to 'sent' below — the state asserting the opposite of what
-        // happened, for precisely the errors that matter.
-        const r = await api.sendChat(msg, slotKey)
-        const { body, outcome } = await readSendReceipt(r)
-        if (outcome === 'refused') {
-          reportFailedSend(typeof body.error === 'string' ? body.error : undefined)
-          return
-        }
-        if (outcome === 'unknown') {
-          // A 2xx whose body would not parse says the request was ACCEPTED and
-          // only its answer is mangled, so this send may well be running. It
-          // gets neither verdict: 'failed' would hand the payload back and
-          // invite a retry that duplicates a delivered turn, and the 'sent' tick
-          // plus the mini-thread echo below would assert a delivery nothing
-          // proves. The composer drops back to idle with whatever newer text it
-          // holds, the same silence the other send paths keep for this state.
-          if (sameComposer()) setSendState('idle')
-          return
-        }
-      }
-      lastSentRef.current = { slotKey, content: msg, at: Date.now() }
-      // Composer state belongs to the composer open NOW: after a mid-flight
-      // retarget — or a close-and-reopen of the same agent — the state is a
-      // NEW composer's, and an older send may not acknowledge into it. The
-      // draft is NOT cleared here: it was cleared at send start, so whatever
-      // it holds now was typed while this send was in flight and is newer
-      // work an acceptance must not erase.
-      if (sameComposer()) {
-        setSendState('sent')
-        // Reset only if the tick still shows: a later send (same agent or a
-        // retargeted popover) has moved the state to 'sending'/'failed' by the
-        // time this fires, and an unconditional reset would re-enable submit
-        // while that request is still in flight (review finding on #4198).
-        setTimeout(() => setSendState(s => (s === 'sent' ? 'idle' : s)), 1500)
-      }
-      // Optimistically append to the mini thread — only on acceptance: an
-      // echo of a message the server refused would assert it was delivered.
-      setThreadView(tv => tv && tv.agent.id === agent.id
-        ? { ...tv, messages: [...tv.messages, { role: 'user', content: msg }].slice(-THREAD_VIEW_MESSAGES) }
-        : tv)
-    } catch {
-      reportFailedSend()
+    // One transport call for both branches. Mid-turn the message is a STEER --
+    // "act on this now", injected into the running turn (the backend queues it
+    // if steer is unavailable) -- and idle it starts or continues the turn;
+    // `steer` is a flag of the same endpoint, not a different receipt shape.
+    // The chat-core transport owns the receipt contract (`?ws=1` JSON receipt,
+    // HTTP 4xx/5xx RESOLVE rather than reject, deadline) and never rejects, so
+    // every outcome is branched on below. Without a receipt read every refused
+    // send fell through to 'sent' -- the state asserting the opposite of what
+    // happened, for precisely the errors that matter.
+    const src = sourceFor(agent)
+    const receipt = await sendTurn({ message: msg, slot: slotKey, steer: !!src?.running })
+    switch (receipt.status) {
+      case 'refused':
+        // The server said no; nothing was sent, so the payload is safe to hand back.
+        reportFailedSend(receipt.reason)
+        return
+      case 'transport-error':
+        // The request never left (offline, DNS): restore-and-report is safe.
+        reportFailedSend()
+        return
+      case 'unknown':
+        // A 2xx whose body would not parse: the request was ACCEPTED and only
+        // its answer is mangled, so this send may well be running. It gets
+        // neither verdict: 'failed' would hand the payload back and invite a
+        // retry that duplicates a delivered turn, and the 'sent' tick plus the
+        // mini-thread echo below would assert a delivery nothing proves. The
+        // composer drops back to idle with whatever newer text it holds, the
+        // same silence the other send paths keep for this state.
+        if (sameComposer()) setSendState('idle')
+        return
+      case 'response-late':
+        // The deadline fired before ANY receipt: unlike `unknown`, nothing
+        // proves the gateway ever saw the request. The draft was cleared at send
+        // start, so silence here would discard the user's text with no evidence
+        // of delivery. Hand it back with the core's delivery-unconfirmed copy
+        // (check the transcript before sending again) -- a visible duplicate is
+        // user-repairable, a dropped message is not. Same policy as ChatPage.
+        reportFailedSend(i18nT('pages.chatPage.delivery_unconfirmed') as string, { unconfirmed: true })
+        return
+      case 'dispatched':
+      case 'queued':
+        break
     }
+    lastSentRef.current = { slotKey, content: msg, at: Date.now() }
+    // Composer state belongs to the composer open NOW: after a mid-flight
+    // retarget — or a close-and-reopen of the same agent — the state is a
+    // NEW composer's, and an older send may not acknowledge into it. The
+    // draft is NOT cleared here: it was cleared at send start, so whatever
+    // it holds now was typed while this send was in flight and is newer
+    // work an acceptance must not erase.
+    if (sameComposer()) {
+      setSendState('sent')
+      // Reset only if the tick still shows: a later send (same agent or a
+      // retargeted popover) has moved the state to 'sending'/'failed' by the
+      // time this fires, and an unconditional reset would re-enable submit
+      // while that request is still in flight (review finding on #4198).
+      setTimeout(() => setSendState(s => (s === 'sent' ? 'idle' : s)), 1500)
+    }
+    // Optimistically append to the mini thread — only on acceptance: an
+    // echo of a message the server refused would assert it was delivered.
+    setThreadView(tv => tv && tv.agent.id === agent.id
+      ? { ...tv, messages: [...tv.messages, { role: 'user', content: msg }].slice(-THREAD_VIEW_MESSAGES) }
+      : tv)
   }, [])
 
   const resolvePendingApproval = useCallback(async (agent: SceneAgent, action: 'approve' | 'reject') => {
@@ -547,22 +563,43 @@ export function useSceneInteraction(
           aria-label={i18nT('hooks.useSceneInteraction.message', { name: threadView.agent.name })}
           style={{ flex: 1, background: '#0d0d15', border: '1px solid #444', borderRadius: 4, color: '#ddd', fontSize: 11, padding: '4px 7px', outline: 'none' }}
         />
+        {/* The red Retry treatment is for a send that FAILED. An unconfirmed one
+            keeps the neutral Send button: the warn line below says to check the
+            transcript first, and a red "Retry" would invite the duplicate it
+            warns against. */}
         <button
           onClick={() => sendToAgent(threadView.agent, draft)}
           disabled={sendState === 'sending' || !draft.trim()}
-          aria-label={sendState === 'sending' ? i18nT('hooks.useSceneInteraction.sending_message') : sendState === 'sent' ? i18nT('hooks.useSceneInteraction.message_sent') : sendState === 'failed' ? i18nT('hooks.useSceneInteraction.retry_sending_message') : i18nT('hooks.useSceneInteraction.send_message')}
-          style={{ background: '#2a2a3a', border: '1px solid #555', borderRadius: 4, color: sendState === 'failed' ? '#f88' : '#ddd', fontSize: 10, padding: '2px 9px', cursor: 'pointer', opacity: draft.trim() ? 1 : 0.5 }}
+          aria-label={sendState === 'sending' ? i18nT('hooks.useSceneInteraction.sending_message') : sendState === 'sent' ? i18nT('hooks.useSceneInteraction.message_sent') : sendFailedHard ? i18nT('hooks.useSceneInteraction.retry_sending_message') : i18nT('hooks.useSceneInteraction.send_message')}
+          style={{ background: '#2a2a3a', border: '1px solid #555', borderRadius: 4, color: sendFailedHard ? '#f88' : '#ddd', fontSize: 10, padding: '2px 9px', cursor: 'pointer', opacity: draft.trim() ? 1 : 0.5 }}
         >
-          {sendState === 'sending' ? '…' : sendState === 'sent' ? <Check size={12} aria-hidden /> : sendState === 'failed' ? i18nT('hooks.useSceneInteraction.retry') : i18nT('hooks.useSceneInteraction.send')}
+          {sendState === 'sending' ? '…' : sendState === 'sent' ? <Check size={12} aria-hidden /> : sendFailedHard ? i18nT('hooks.useSceneInteraction.retry') : i18nT('hooks.useSceneInteraction.send')}
         </button>
       </div>
       {/* Visible to everyone, not hover-only: a tooltip on the Retry button is
           unreachable for keyboard, touch, and AT users (UX review on #4198).
-          role="status" announces the refusal when it lands. Framed by the same
-          core-owned entry the feature-request path uses — no new string. */}
-      {sendState === 'failed' && sendFailReason ? (
-        <div role="status" style={{ padding: '0 8px 6px', color: '#f88', fontSize: 10 }}>
-          {i18nT('pages.chatPage.send_failed_with_error', { error: sendFailReason })}
+          Framed by the same core-owned entry the feature-request path uses — no
+          new string. */}
+      {/* No hand-off: the composer above holds the unsent draft this failure
+          handed back — navigating to the chat would discard it. */}
+      {sendFailedHard && sendFailReason ? (
+        <ErrorNotice
+          variant="inline"
+          message={i18nT('pages.chatPage.send_failed_with_error', { error: sendFailReason }) as string}
+          // The popover is fixed dark chrome in every theme, so the theme's
+          // `text-danger` (dark red on light themes) is not legible here; the
+          // popover's own dark-safe red wins over the component's token.
+          className="px-2 pb-1.5 !text-[#f88]"
+        />
+      ) : null}
+      {/* An UNCONFIRMED delivery is a warning, not an error (nothing failed for
+          certain), so it is not dressed as one: a warn-tone status line with a
+          warn glyph, never ErrorNotice's red. Explicit dark-safe colour: the
+          popover chrome is dark in every theme (see the ErrorNotice above). */}
+      {sendState === 'failed' && sendFailReason && sendUnconfirmed ? (
+        <div role="status" className="flex items-start gap-1.5 px-2 pb-1.5 text-[12px]" style={{ color: '#fb0' }}>
+          <AlertTriangle size={14} className="shrink-0 mt-px" aria-hidden="true" />
+          <span style={{ overflowWrap: 'anywhere' }}>{sendFailReason}</span>
         </div>
       ) : null}
     </div>

--- a/website/src/test/ApiClient.coverage.test.tsx
+++ b/website/src/test/ApiClient.coverage.test.tsx
@@ -33,6 +33,7 @@ import {
   __resetAuthRecoveryStateForTests,
   SEARCH_MIN_CHARS,
 } from '../api/client'
+import { STALE_OWNER_SESSION_CODE, __resetStaleOwnerHandlerForTests, installStaleOwnerHandler } from '../api/staleOwnerSignal'
 import { recentErrors, __resetErrorJournalForTests } from '../utils/errorReport'
 import { copyToClipboard } from '../utils/clipboard'
 import { resizeImageForModel } from '../utils/resizeImage'
@@ -68,6 +69,7 @@ function res(
     json: async () => (typeof body === 'string' ? JSON.parse(body) : body),
     text: async () => text,
     blob: async () => new Blob([text]),
+    clone: () => res(status, body, opts),
   } as unknown as Response
 }
 
@@ -1127,10 +1129,52 @@ describe('sendChat theme consent', () => {
     expect(call().init?.signal).toBe(ctl.signal)
   })
 
-  it('steerChat always injects into the running turn', async () => {
-    await api.steerChat('now', 'chat-1')
-    expect(call().url).toBe('/api/chat?ws=1')
-    expect(call().body).toEqual({ message: 'now', slot: 'chat-1', steer: true })
+  it('hands the raw response back but still runs session-expiry recovery on a 403 auth challenge', async () => {
+    // The transport reads the receipt itself, so a 4xx must RESOLVE -- but an
+    // expired session must not degrade into a bare "refused" send: the same
+    // silent-refresh path every `j`-parsed call takes runs first. (The steer
+    // helper this wire replaced went through `j` and had it.)
+    __resetAuthRecoveryStateForTests()
+    fetchMock.mockResolvedValueOnce(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+    fetchMock.mockResolvedValue(okJson({ ok: true }))
+    const r = await api.sendChat('hi', 'chat-1')
+    expect(r.status).toBe(403)
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/auth/refresh', expect.anything()))
+  })
+
+  it('clears a stale session-expired banner when the send itself succeeds', async () => {
+    // `j` dismisses the banner on any 2xx; the raw-response wire must too, or a
+    // steer that succeeds after auth was restored in another tab leaves the
+    // banner up until some unrelated parsed request happens to land.
+    __resetAuthRecoveryStateForTests()
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+    await vi.waitFor(() => expect(document.getElementById('mc-session-expired')).not.toBeNull())
+    try {
+      fetchMock.mockResolvedValue(okJson({ ok: true }))
+      const r = await api.sendChat('hi', 'chat-1')
+      expect(r.ok).toBe(true)
+      expect(document.getElementById('mc-session-expired')).toBeNull()
+    } finally {
+      document.getElementById('mc-session-expired')?.remove()
+    }
+  })
+
+  it('raises the stale-owner prompt on a 401 stale-session body, and the receipt stays readable', async () => {
+    // The stale-owner code travels in the BODY, which the pre-body hook cannot
+    // read; the wire reads it off a clone so the transport's own `json()` still
+    // works. (`steerChat` reached this through `j`; the transport must too.)
+    const onStale = vi.fn()
+    installStaleOwnerHandler(onStale)
+    try {
+      fetchMock.mockResolvedValueOnce(res(401, { error: 'sign in again', code: STALE_OWNER_SESSION_CODE }))
+      const r = await api.sendChat('hi', 'chat-1')
+      expect(r.status).toBe(401)
+      await expect(r.json()).resolves.toMatchObject({ code: STALE_OWNER_SESSION_CODE })
+      await vi.waitFor(() => expect(onStale).toHaveBeenCalled())
+    } finally {
+      __resetStaleOwnerHandlerForTests()
+    }
   })
 })
 

--- a/website/src/test/App.featureRequestFailure.test.tsx
+++ b/website/src/test/App.featureRequestFailure.test.tsx
@@ -3,12 +3,14 @@
  * (#4198).
  *
  * The flow dispatches an optimistic user bubble and `setSlotRunning(true)`,
- * then awaits `api.sendChat` — and an HTTP 4xx/5xx RESOLVES rather than
- * rejecting, so the old `catch { /* WS will handle response *\/ }` never saw
- * the errors that matter: a refused send left the bubble on screen next to a
- * slot stuck `running`, with nothing said. These tests pin the fix on both
- * failure shapes (a resolved not-ok receipt and a transport reject): an error
- * row lands in the transcript that owns the bubble, reusing the existing
+ * then sends through the chat-core transport `sendTurn` — whose wire is
+ * `api.sendChat`, mocked here, so these tests drive the REAL receipt
+ * classification. An HTTP 4xx/5xx RESOLVES rather than rejecting, so the old
+ * `catch { /* WS will handle response *\/ }` never saw the errors that matter:
+ * a refused send left the bubble on screen next to a slot stuck `running`,
+ * with nothing said. These tests pin the fix on both failure shapes (a
+ * `refused` receipt and a `transport-error`): an error row lands in the
+ * transcript that owns the bubble, reusing the existing
  * `pages.chatPage.send_failed` catalog entry, and the optimistic running state
  * is undone. The accepted-receipt case pins that success stays untouched.
  */
@@ -157,5 +159,8 @@ describe('Request a Feature — failed send is reported (#4198)', () => {
     const chat = store.getState().chat
     expect(chat.messages.some(m => m.role === 'error')).toBe(false)
     expect(chat.slotRunning).toBe(true)
+    // The send rides the transport: the wire is handed the deadline signal
+    // (message, slot, colorTheme, signal, meta, steer).
+    expect(sendChatMock).toHaveBeenCalledWith(expect.any(String), 'fr-slot', expect.anything(), expect.any(AbortSignal), undefined, undefined)
   })
 })

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -1332,10 +1332,14 @@ describe('App routing', () => {
         // cannot leave it queued for a later, unrelated message.
         { source: 'feature-request', maxAge: 60 },
       )
+      // sendTurn's dashboard wire passes (message, slot, agent, signal, memoryMode, steer).
       expect(api.sendChat).toHaveBeenCalledWith(
         'I’d like to request a feature!',
         'feature-slot',
         expect.any(String),
+        expect.any(AbortSignal),
+        undefined,
+        undefined,
       )
     })
     expect(api.sendChat).not.toHaveBeenCalledWith(

--- a/website/src/test/ChatPage.steerQueuedReceipt.test.tsx
+++ b/website/src/test/ChatPage.steerQueuedReceipt.test.tsx
@@ -34,7 +34,6 @@ vi.mock('react-virtuoso', () => ({
 }))
 
 const sendChat = vi.fn()
-const steerChat = vi.fn()
 const slotRow = () => ({
   key: 'slot-a', messages: 1, running: true, mode: '',
   pending_approval: false, waiting_for_input: false, last_activity_ts: undefined,
@@ -45,7 +44,6 @@ vi.mock('../api/client', () => ({
     chatSlots: vi.fn().mockImplementation(() => Promise.resolve([slotRow()])),
     chatSlotDetail: vi.fn().mockImplementation(() => Promise.resolve({ messages: [{ role: 'assistant', content: 'hi', cls: '' }], running: true, has_more: false, total: 1 })),
     sendChat: (...a: unknown[]) => sendChat(...a),
-    steerChat: (...a: unknown[]) => steerChat(...a),
     chatHistory: vi.fn().mockResolvedValue({ sessions: [] }),
     models: vi.fn().mockResolvedValue([]),
     agents: vi.fn().mockResolvedValue([]),
@@ -150,7 +148,6 @@ beforeEach(() => {
   localStorage.clear()
   sendChat.mockReset()
   sendChat.mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) })
-  steerChat.mockReset()
 })
 
 describe('optimistic steer bubble vs the steer receipt', { timeout: 20_000 }, () => {

--- a/website/src/test/ChatPage.steerWithSubagents.test.tsx
+++ b/website/src/test/ChatPage.steerWithSubagents.test.tsx
@@ -34,7 +34,6 @@ vi.mock('react-virtuoso', () => ({
 }))
 
 const sendChat = vi.fn()
-const steerChat = vi.fn()
 /** ChatPage re-reads both the slot list and the slot detail after mount, so the
  *  fixtures have to agree with the store seed or the refresh erases the state
  *  under test (the wave flag, or `running`). */
@@ -50,7 +49,6 @@ vi.mock('../api/client', () => ({
     chatSlots: vi.fn().mockImplementation(() => Promise.resolve(slotsFixture.rows)),
     chatSlotDetail: vi.fn().mockImplementation(() => Promise.resolve({ messages: [{ role: 'assistant', content: 'hi', cls: '' }], running: detail.running, has_more: false, total: 1 })),
     sendChat: (...a: unknown[]) => sendChat(...a),
-    steerChat: (...a: unknown[]) => steerChat(...a),
     chatHistory: vi.fn().mockResolvedValue({ sessions: [] }),
     models: vi.fn().mockResolvedValue([]),
     agents: vi.fn().mockResolvedValue([]),
@@ -147,7 +145,6 @@ beforeEach(() => {
   localStorage.clear()
   sendChat.mockReset()
   sendChat.mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) })
-  steerChat.mockReset()
 })
 
 describe('steer default while sub-agents run', { timeout: 20_000 }, () => {
@@ -192,8 +189,6 @@ describe('steer default while sub-agents run', { timeout: 20_000 }, () => {
     expect(steerArgOf(sendChat.mock.calls[0])).toBe(true)
     expect(sendChat.mock.calls[0][2]).toBeUndefined()
     expect((sendChat.mock.calls[0][4] as { sendId?: string }).sendId).toBeTruthy()
-    // The bespoke mid-turn helper is no longer a send path on this surface.
-    expect(steerChat).not.toHaveBeenCalled()
   })
 
   it('leaves an ordinary idle send unflagged', async () => {

--- a/website/src/test/SideSlashCommand.steer.test.tsx
+++ b/website/src/test/SideSlashCommand.steer.test.tsx
@@ -22,16 +22,15 @@ import { ThemeProvider } from '../hooks/useTheme'
 import type { ChatSlot } from '../types'
 import type { RootState } from '../store'
 
-const { mockSideOpen, mockSideTurn, mockSteerChat, mockSendChat } = vi.hoisted(() => ({
+const { mockSideOpen, mockSideTurn, mockSendChat } = vi.hoisted(() => ({
   mockSideOpen: vi.fn().mockResolvedValue({ ok: true, open: true, messages: 0, last_run_id: '', created_at: '' }),
   mockSideTurn: vi.fn().mockResolvedValue({ ok: true, run_id: 'r1', messages: 1 }),
-  mockSteerChat: vi.fn().mockResolvedValue({ ok: true }),
   mockSendChat: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true, steered: true }) }),
 }))
 
 vi.mock('../api/client', () => ({
   api: new Proxy(
-    { sideOpen: mockSideOpen, sideTurn: mockSideTurn, steerChat: mockSteerChat, sendChat: mockSendChat },
+    { sideOpen: mockSideOpen, sideTurn: mockSideTurn, sendChat: mockSendChat },
     {
       get: (t, prop) => {
         if (prop in t) return (t as Record<string, unknown>)[prop as string]
@@ -168,15 +167,14 @@ describe('/side while a turn is running', () => {
     // The steer is the same `/api/chat` POST as a send, flagged `steer`
     // (6th argument), through the chat-core transport; `meta.sendId` is the
     // client-minted correlation id the steer path stamps on its optimistic
-    // bubble (#6075) — pin its shape, not its random value. The bespoke
-    // `steerChat` helper is no longer a path on this surface.
+    // bubble (#6075) — pin its shape, not its random value. There is no
+    // bespoke steer helper; the flag is the whole difference.
     await waitFor(() => expect(mockSendChat).toHaveBeenCalled())
     const call = mockSendChat.mock.calls[0]
     expect(call[0]).toBe('plain steer text')
     expect(call[1]).toBe(SLOT)
     expect((call[4] as { sendId?: string }).sendId).toMatch(/^s-/)
     expect(call[5]).toBe(true)
-    expect(mockSteerChat).not.toHaveBeenCalled()
   })
 
   it('/side opens the side chat instead of being steered into the turn', async () => {
@@ -191,7 +189,6 @@ describe('/side while a turn is running', () => {
     await waitFor(() => expect((input as HTMLTextAreaElement).value).toBe('/side '))
     fireEvent.keyDown(input, { key: 'Enter' })
     await waitFor(() => expect(mockSideOpen).toHaveBeenCalledWith(SLOT))
-    expect(mockSteerChat).not.toHaveBeenCalled()
     expect(mockSendChat).not.toHaveBeenCalled()
     expect(store.getState().chat.activityTab).toBe('side')
   })
@@ -203,7 +200,6 @@ describe('/side while a turn is running', () => {
     await armRunning(store)
     fireEvent.keyDown(input, { key: 'Enter' })
     await waitFor(() => expect(mockSideTurn).toHaveBeenCalledWith(SLOT, 'what is this error about'))
-    expect(mockSteerChat).not.toHaveBeenCalled()
   })
 
   it('restores the composer text when the side turn is rejected', async () => {
@@ -215,7 +211,6 @@ describe('/side while a turn is running', () => {
     fireEvent.keyDown(input, { key: 'Enter' })
     // Cleared optimistically, then restored once the rejection lands.
     await waitFor(() => expect((input as HTMLTextAreaElement).value).toBe('/side my precious question'))
-    expect(mockSteerChat).not.toHaveBeenCalled()
   })
 
   it('merges the rejected question below text typed while the rejection was in flight', async () => {

--- a/website/src/test/UseSceneInteractionCoverage.test.tsx
+++ b/website/src/test/UseSceneInteractionCoverage.test.tsx
@@ -29,7 +29,6 @@ import { i18nT } from '../i18n/t'
 const apiMocks = vi.hoisted(() => ({
   chatSlotDetail: vi.fn(),
   sendChat: vi.fn(),
-  steerChat: vi.fn(),
   resolveApproval: vi.fn(),
   createChatSlot: vi.fn(),
 }))
@@ -144,7 +143,6 @@ beforeEach(() => {
   HTMLCanvasElement.prototype.getContext = vi.fn(stubCtx) as unknown as HTMLCanvasElement['getContext']
   apiMocks.chatSlotDetail.mockResolvedValue({ messages: [] })
   apiMocks.sendChat.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({ ok: true }) })
-  apiMocks.steerChat.mockResolvedValue({})
   apiMocks.resolveApproval.mockResolvedValue({})
   apiMocks.createChatSlot.mockResolvedValue({})
 })
@@ -521,8 +519,9 @@ describe('useSceneInteraction — composer', () => {
     fireEvent.click(sendButton())
     await flush()
 
-    expect(apiMocks.sendChat).toHaveBeenCalledWith('ship it', 'a')
-    expect(apiMocks.steerChat).not.toHaveBeenCalled()
+    // Through the chat-core transport: (message, slot, colorTheme, deadline
+    // signal, meta, steer). An idle agent is a plain send, not a steer.
+    expect(apiMocks.sendChat).toHaveBeenCalledWith('ship it', 'a', undefined, expect.any(AbortSignal), undefined, false)
     expect(screen.getByText('ship it')).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: i18nT('hooks.useSceneInteraction.message_sent') }),
@@ -544,8 +543,62 @@ describe('useSceneInteraction — composer', () => {
     fireEvent.click(sendButton())
     await flush()
 
-    expect(apiMocks.steerChat).toHaveBeenCalledWith('stop there', 'a')
-    expect(apiMocks.sendChat).not.toHaveBeenCalled()
+    // Same transport call, `steer: true`: a flag of the endpoint, not a
+    // separate helper (the dedicated steer helper is gone).
+    expect(apiMocks.sendChat).toHaveBeenCalledWith('stop there', 'a', undefined, expect.any(AbortSignal), undefined, true)
+  })
+
+  it('a refused steer reports on the composer like a refused send', async () => {
+    apiMocks.sendChat.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({ ok: false, error: 'turn already ended' }) })
+    renderScene({ sources: [source({ id: 'slot-a', running: true })] })
+    await clickAt(100, 100)
+
+    fireEvent.change(messageBox(), { target: { value: 'stop there' } })
+    fireEvent.click(sendButton())
+    await flush()
+
+    expect(
+      screen.getByRole('button', { name: i18nT('hooks.useSceneInteraction.retry_sending_message') }),
+    ).toBeInTheDocument()
+    expect(messageBox()).toHaveValue('stop there')
+  })
+
+  it('a send whose receipt is late hands the text back with the delivery-unconfirmed copy', async () => {
+    // The transport's deadline fires before ANY receipt. Nothing proves the
+    // gateway saw the request, and the draft was cleared at send start, so
+    // silence would discard the user's text: it comes back as a failed send
+    // whose reason says to check the transcript before sending again.
+    apiMocks.sendChat.mockImplementation((...args: unknown[]) => new Promise((_res, rej) => {
+      const signal = args[3] as AbortSignal
+      signal.addEventListener('abort', () => rej(new DOMException('aborted', 'AbortError')))
+    }))
+    renderScene({ sources: [] })
+    await clickAt(100, 100)
+
+    fireEvent.change(messageBox(), { target: { value: 'ship it' } })
+    fireEvent.click(sendButton())
+    await flush()
+    await act(async () => { vi.advanceTimersByTime(10_500) })
+    await flush()
+
+    // Not the red Retry treatment: unconfirmed keeps the neutral Send button so
+    // the warn line, not the button, is the signal.
+    expect(
+      screen.queryByRole('button', { name: i18nT('hooks.useSceneInteraction.retry_sending_message') }),
+    ).not.toBeInTheDocument()
+    expect(sendButton()).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: i18nT('hooks.useSceneInteraction.message_sent') }),
+    ).not.toBeInTheDocument()
+    // Handed back, not echoed as delivered.
+    expect(messageBox()).toHaveValue('ship it')
+    expect(screen.queryByText('ship it')).not.toBeInTheDocument()
+    // Unconfirmed is a warning, not an error: a warn-tone status line carries
+    // the delivery-unconfirmed copy UNWRAPPED; no ErrorNotice, no "Send failed".
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    const notice = screen.getByRole('status')
+    expect(notice).toHaveTextContent(i18nT('pages.chatPage.delivery_unconfirmed') as string)
+    expect(notice).not.toHaveTextContent(i18nT('pages.chatPage.send_failed') as string)
   })
 
   it('uses the plain message placeholder with no live source', async () => {
@@ -587,7 +640,7 @@ describe('useSceneInteraction — composer', () => {
 
     fireEvent.keyDown(messageBox(), { key: 'Enter' })
     await flush()
-    expect(apiMocks.sendChat).toHaveBeenCalledWith('via keyboard', 'a')
+    expect(apiMocks.sendChat).toHaveBeenCalledWith('via keyboard', 'a', undefined, expect.any(AbortSignal), undefined, false)
   })
 
   it('disables the send button until the draft has content', async () => {
@@ -906,9 +959,11 @@ describe('useSceneInteraction — composer', () => {
     fireEvent.click(sendButton())
     await flush()
 
-    // Visible (role=status), not a hover-only tooltip, and FRAMED so the raw
-    // backend reason reads as a refused send rather than an agent error.
-    const status = screen.getByRole('status')
+    // Visible (an ErrorNotice, role=alert), not a hover-only tooltip, and FRAMED
+    // so the raw backend reason reads as a refused send rather than an agent
+    // error. No hand-off button: the composer holds the restored draft.
+    const status = screen.getByRole('alert')
+    expect(status.querySelector('button')).toBeNull()
     expect(status).toHaveTextContent(
       i18nT('pages.chatPage.send_failed_with_error', { error: 'slot agent mismatch' }) as string,
     )


### PR DESCRIPTION
## Summary

Chat-core RFC P2, **batch C of #9570** — the last two hand-rolled dashboard senders move onto the chat-core transport `sendTurn`, and `api.steerChat` is deleted (no caller left).

**Stacked on #9576** (base `refactor/chat-core-p2-app-seeds`) so the two batches do not collide on the RFC §4.2 table; GitHub retargets this PR to `main` when #9576 merges.

### `hooks/useSceneInteraction.tsx` (scene agent popover composer)

The running/idle fork — `api.steerChat` mid-turn, `api.sendChat` + a local `readSendReceipt` otherwise — becomes **one** call: `sendTurn({ message, slot, steer: !!src?.running })`. `steer` is a flag of the same endpoint (#8689), not a different receipt shape.

| `receipt.status` | Composer |
|---|---|
| `dispatched` / `queued` | `sent` tick, mini-thread echo (as before) |
| `refused` | `failed` + retry, payload appended back (as before) |
| `transport-error` | same as `refused` (as before, via the outer `catch`) |
| `unknown` | back to `idle`, nothing claimed, payload not restored (as before) |
| `response-late` | retry offered, payload appended back, and the core's `pages.chatPage.delivery_unconfirmed` copy shown **unwrapped** as a warn status line (lucide `AlertTriangle` glyph, the popover's own dark-safe `#fb0` — the popover is fixed dark chrome in every theme, so theme tokens are not legible there) and the Send button kept neutral (no red Retry — the copy says to check the transcript first) — not an `ErrorNotice`, because an unconfirmed delivery is a warning, not an error (`errors-use-error-notice` says warnings must not be dressed as errors; ChatPage draws the same distinction with its ⚠️ notice) — **new**: the old path awaited without bound. Nothing proves the gateway saw the request and the draft was cleared at send start, so silence would discard the text; a visible duplicate is user-repairable (GPT r1, UX r3) |

Two things change on the steer branch and both are receipt-defect fixes the RFC names: a refused steer used to surface only through the outer `catch` (`steerChat` parsed via `j`, which throws on a non-2xx) — now it is a `refused` receipt with the same on-screen result; and a `{ok:false}` steer **inside a 200**, which `j` passed through silently as success, is now reported on the composer.

### `App.tsx` feature-request send

`refused` → error row with the server's reason; `transport-error` → error row; `unknown` / `response-late` → silent (the request was or may have been accepted; the row is the pill's only signal and claiming a failure it cannot prove tells the user to resend a request that already went out).

### Failed-send line → `ErrorNotice`

The composer's failure line (`Send failed: <reason>` under the Retry button) was a hand-written `role="status"` div. This PR touches its condition (`response-late` now feeds it), so per `errors-use-error-notice` it migrates to `ErrorNotice variant="inline"` with the same string; `askAgent` stays off with a `No hand-off` comment naming the restored draft the composer holds (GPT, round 2).

### `api/client.ts`

`steerChat` deleted; `sendChat`'s comment now describes the `steer` flag it carries as the transport's wire. `sendChat` still hands the **raw** response back (the transport reads the receipt; a 4xx must resolve) but now runs the same auth recovery every `j`-parsed call has — `sendResponseAuthRecovery`: the pre-body 403 `X-Auth-Required` hook (silent refresh / banner), the body-borne 401 stale-owner code, read off a clone so the receipt stays readable, and the 2xx banner-clear so a send that succeeds after auth was restored elsewhere dismisses a stale banner. The deleted `steerChat` went through `j` and had both; this keeps them for the steer path and extends them to every `sendTurn` caller on the dashboard wire (GPT r1, r3).

## Tests

- `UseSceneInteractionCoverage.test.tsx` mocks the transport's **wire** (`api.sendChat`), so the real `sendTurn` classifier runs. Asserts `steer` is forwarded `true` from a running agent and `false` idle; adds a refused-steer case and a deadline (`response-late`) case driven by the transport's abort signal under fake timers, asserting the text comes back with a retry. Every existing assertion's intent is kept.
- `ApiClient.coverage.test.tsx`: `sendChat` on a 403 `X-Auth-Required` resolves with the raw response **and** triggers the silent refresh; on a 401 stale-session body it raises the stale-owner prompt while `json()` still reads. A 2xx clears an already-shown session-expired banner.
- `App.featureRequestFailure.test.tsx` (and the existing `App.test.tsx` feature-request assertion now matches `sendTurn`'s six-argument wire call): header updated; the accepted case now also pins that the wire is handed the deadline signal.
- Dead `steerChat` stubs removed from `ApiClient.coverage.test.tsx` (its `steerChat` `it` deleted), `ChatPage.steerQueuedReceipt.test.tsx`, `ChatPage.steerWithSubagents.test.tsx`, `SideSlashCommand.steer.test.tsx`.

## Tested

- `npx tsc --noEmit -p .` — clean (before and after the rebase onto #9576).
- `npx eslint` on the nine changed source/test files — clean.
- `node scripts/check-i18n-strings.mjs` and `npm run i18n:check` — clean (no new literals).
- Unit tests are left to CI (repo rule for this workstream).

<!-- no-visual-delta -->
**Why no screenshot:** no layout change; the styling deltas are the scene composer's failed-send line moving from a hand-written 10px red div to the shared `ErrorNotice` inline variant at its stock size (icon, same string, same position under the Retry button; colour pinned to the popover's dark-safe `#f88` because the chrome is dark in every theme), and the new unconfirmed state, a `text-warn` status line with a lucide warn glyph in the same slot (Send button stays neutral). The other deltas are existing states appearing where they were silent (`failed`/retry on a refused steer or a late receipt).

Refs #9570 (batches A #9576 and B #9587 carry the other senders).

Closes #9570


