### PR TITLE
fix(chat): keep the pinned banner on the row that opened the turn

### DIFF
--- a/website/src/test/pinnedPrompt.steer.test.ts
+++ b/website/src/test/pinnedPrompt.steer.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { groupDisplayItems, applyRunningState } from '../pages/chat/groupDisplayItems'
+import { findPinnedPromptIdx, jumpAnchorIdx } from '../utils/pinnedPrompt'
+import type { ChatMessage } from '../types'
+
+/**
+ * A steer carries role `user`, so the pin's role test admits it — but it is
+ * injected INTO a running turn rather than opening one, and its row lays out
+ * between the opener and that turn's reply. `steered` builds that shape; the
+ * flag is `meta.steer`, set by the `steer_push` echo.
+ */
+function steered(opts: { steer: boolean }): ChatMessage[] {
+  const out: ChatMessage[] = []
+  const push = (role: string, content: string, meta?: Record<string, unknown>) =>
+    out.push({ role, content, ts: '2026-09-08T15:00:00Z', meta } as unknown as ChatMessage)
+
+  push('user', 'add the resolution memo too, and draft the PR description')
+  push('tool', 'Find the existing TTL constant')
+  push('assistant', 'partial work')
+  push('user', 'how can i apply it in my local gateway to test ?',
+    opts.steer ? { steer: true } : undefined)
+  push('assistant', "Here's the sequence. The order matters in two places …")
+  return out
+}
+
+/** Display index of the row holding `needle`, or -1. Turn-wrapped rows are
+ *  searched too, so no assertion depends on where grouping put it. */
+function rowIdx(items: ReturnType<typeof applyRunningState>, needle: string): number {
+  return items.findIndex(it => {
+    if (it.kind === 'single') return it.msg.content.includes(needle)
+    if (it.kind === 'group') return it.msgs.some(m => m.content.includes(needle))
+    return it.items.some(t => t.kind === 'single'
+      ? t.msg.content.includes(needle)
+      : t.msgs.some(m => m.content.includes(needle)))
+  })
+}
+
+describe('pinned prompt with a steer inside the turn', () => {
+  it('pins the row that OPENED the turn, not the steer injected into it', () => {
+    const items = applyRunningState(groupDisplayItems(steered({ steer: true })), false)
+    const openerIdx = rowIdx(items, 'add the resolution memo')
+    const steerIdx = rowIdx(items, 'local gateway')
+    expect(openerIdx).toBeGreaterThanOrEqual(0)
+    expect(steerIdx).toBeGreaterThan(openerIdx)
+
+    // Read position: the reply below the steer, so the steer has passed the line.
+    const pinIdx = findPinnedPromptIdx(items, items.length - 1)
+    expect(pinIdx).toBe(openerIdx)
+    expect(pinIdx).not.toBe(steerIdx)
+  })
+
+  it('pins a plain second user row in the same shape, so meta.steer is what discriminates', () => {
+    const items = applyRunningState(groupDisplayItems(steered({ steer: false })), false)
+    const secondIdx = rowIdx(items, 'local gateway')
+    expect(findPinnedPromptIdx(items, items.length - 1)).toBe(secondIdx)
+  })
+
+  it('a steer is never a jump target, so the jump lands on the opener', () => {
+    const items = applyRunningState(groupDisplayItems(steered({ steer: true })), false)
+    const openerIdx = rowIdx(items, 'add the resolution memo')
+    expect(jumpAnchorIdx(items, openerIdx)).toBe(openerIdx)
+  })
+
+  it('falls back to the opener when the steer is the nearest row above the fold', () => {
+    const items = applyRunningState(groupDisplayItems(steered({ steer: true })), false)
+    const steerIdx = rowIdx(items, 'local gateway')
+    expect(findPinnedPromptIdx(items, steerIdx + 1)).toBe(rowIdx(items, 'add the resolution memo'))
+  })
+})

--- a/website/src/utils/pinnedPrompt.ts
+++ b/website/src/utils/pinnedPrompt.ts
@@ -1,4 +1,5 @@
 import type { DisplayItem } from '../pages/chat/types'
+import type { ChatMessage } from '../types'
 import { TURN_OPENER_ROLES } from '../pages/chat/groupDisplayItems'
 import { mdImageDestToPath } from './fileTokens'
 import { type PasteBlock, expandAll } from './pasteTokens'
@@ -69,9 +70,20 @@ export function pinHandoffY(foldY: number, collapsedCardH: number): number {
  * workflow fan-out) otherwise offers no pinnable row cycle after cycle — the walk
  * upward skips every one and lands on the human's last typed message, dozens of
  * turns and tens of thousands of pixels away.
+ *
+ * A STEER is the exception in the other direction. It carries role `user`, so
+ * the role test alone admits it, but `meta.steer` (set by the `steer_push` echo)
+ * marks it as injected INTO a turn already running: its row lays out between the
+ * opener and that turn's reply, so admitting it hands the pin to the
+ * interruption for the rest of the turn.
  */
+function isSteer(msg: ChatMessage): boolean {
+  return !!(msg.meta as { steer?: boolean } | undefined)?.steer
+}
+
 function isPrompt(item: DisplayItem | undefined): boolean {
-  return !!item && item.kind === 'single' && TURN_OPENER_ROLES.has(item.msg.role)
+  if (!item || item.kind !== 'single') return false
+  return TURN_OPENER_ROLES.has(item.msg.role) && !isSteer(item.msg)
 }
 
 /**
@@ -123,7 +135,7 @@ export function findNextPromptIdx(items: DisplayItem[], afterIdx: number): numbe
  *
  * The walk deliberately consumes MACHINE turn openers too (nudge and subagent
  * rows — `isPrompt` derives from `TURN_OPENER_ROLES`), not only consecutive
- * user rows like a steer following its prompt. The mechanism-backed case is a
+ * user rows. The mechanism-backed case is a
  * fan-out whose completions drain back to back: each is a turn opener and none
  * of them carries a reply of its own, so they lay out as one run of consecutive
  * opener rows. Consecutive


### PR DESCRIPTION
## Problem / Motivation

The pinned-prompt banner names the row the reader is inside. `TURN_OPENER_ROLES` is
documented as "roles that OPEN a turn, and are therefore the rows a reader can be
anchored to", and `isPrompt` in `website/src/utils/pinnedPrompt.ts` derives from it
so the two lists cannot drift.

A steer carries role `user`, so the role test admits it. But a steer is injected
INTO a turn that is already running rather than opening one, and its row lays out
between the opener and that turn's reply. Once it clears the hand-off line it takes
the pin for the rest of the turn.

## Why it matters

The banner then names the interruption while the reader is inside a response that
answers the opener and the steer together — the one row in that turn that cannot
answer "what am I inside". The reader loses the prompt that actually started the
work they are reading.

`jumpAnchorIdx` was already half-aware of this: its comment cited "consecutive user
rows like a steer following its prompt" and walked up past them, so the *jump*
already landed on the opener while the *label* named the steer. The two disagreed.

## What changed

`isPrompt` rejects a row carrying `meta.steer` — the flag the `steer_push` echo
sets, and the one `UserMessage` already reads to render the bubble distinctly — so
the scan walks past a steer to the row that opened the turn. No new wire contract.
A steer is consequently not a jump target either, so the `jumpAnchorIdx` comment no
longer cites one as a row its walk consumes.

## Tests

`website/src/test/pinnedPrompt.steer.test.ts`:

- The pin lands on the opener, not on the steer injected into the turn.
- **Negative control:** the same transcript shape with the flag removed still pins
  that row, so the assertion discriminates on `meta.steer` rather than on "a second
  user row exists".
- A steer is never a jump target, so the jump lands on the opener.
- A steer as the nearest row above the fold falls back to the opener rather than
  returning -1 and unmounting the banner mid-turn.

Mutation-verified: with the source fix reverted, two of the four fail — the pin
landing on the steer's display index instead of the opener's, which is the reported
symptom reproduced as a red test.

Also verified: `npx tsc -b` clean; `npm run test:website` 1945 files / 30621 passed
/ 0 failed; the four existing pinned-prompt suites (64 tests) unchanged and green.
The electron-suite failures on my host are identical on a clean `main` checkout
(same 42 names), so none is attributable to this change.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a backwards scan for the row that OPENED a turn must exclude a mid-turn
injection carrying the same role. `meta.steer` rides on a `role: 'user'` row, so a
role-only test accepts it silently — both shapes are well-typed `user` rows, which
is why no type and no existing test caught the divergence.

The store already knew this. Four production scans discriminate a steer when they
walk back for a turn's own user row: `isTurnBoundaryUser` and the `lastUserIdx`
walk in `website/src/store/chatSlice.ts`, that file's reconcile loop (which breaks
on a steer as an explicit boundary), and the turn-head walk in
`website/src/app-sdk/turnPolicyBlock.ts`, whose comment states the rule outright —
"A steer is also role `user`, so it must NOT end the scan — it lives INSIDE the
turn it was injected into." `pinnedPrompt.isPrompt` was the one predicate of that
family that had drifted from its siblings.

So the harvest is not a new rule but a drift-detection one: when a role gains a
mid-turn variant distinguished only by meta, every existing role-only predicate
over that role becomes a candidate defect, and the ones that already handle it are
the specification for the ones that do not.

## Alternative considered

Keeping steers pinnable but labelling the banner as a steer. That preserves the
signal that a steer redirected the turn — useful after a long post-steer response —
at the cost of the banner no longer naming the turn opener, which is the contract
the banner is documented against. This PR takes the contract.

