### PR TITLE
fix(connections): migrate the materialized pre-launch opt-out

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -572,6 +572,18 @@ def _write_migration_backup(path: Path) -> None:
 MIGRATE_WORKSPACES = "workspaces"
 MIGRATE_AGENTS = "agents"
 MIGRATE_DEFAULT_AGENT = "default_agent"
+MIGRATE_CONNECTIONS_UI = "connections_ui"
+
+#: Sidecar marker recording that the one-shot ``connections_ui`` launch
+#: migration ran. Pre-launch builds materialized ``connections_ui: false`` into
+#: every config they saved (the key was the opt-in gate then, so a stored false
+#: was default noise, never a choice); post-launch the same bytes are the
+#: deliberate opt-out. The marker is the boundary between those two readings:
+#: a stored false found BEFORE it exists is stripped once, and any false found
+#: AFTER it exists is honoured forever. It lives beside ``config.json`` rather
+#: than inside it for the same reason as the superseded-defaults ack file — a
+#: full ``to_dict()`` rewrite carries only schema fields and would drop it.
+CONNECTIONS_UI_MIGRATION_MARKER = "connections_ui_migrated.json"
 
 
 def _apply_document_migrations(
@@ -642,6 +654,17 @@ def _apply_document_migrations(
                     )
                 )
             }
+            changed = True
+
+    # Strip the pre-launch materialized ``connections_ui: false``. Re-checked
+    # against *data*: only an exact stored ``false`` is touched, so a concurrent
+    # writer that already removed the key, or set it ``true``, is left alone.
+    # The one-shot boundary (a deliberate post-launch ``false`` must survive
+    # every later load) is enforced by the caller via the marker file — this
+    # delta is only ever pending on a load that found no marker.
+    if MIGRATE_CONNECTIONS_UI in pending:
+        if data.get("connections_ui") is False:
+            del data["connections_ui"]
             changed = True
 
     # Point default_agent at an agent that exists. Resolved against the
@@ -3883,10 +3906,25 @@ class KiroCrewConfig:
                     cfg.default_agent = "default"
                 pending.add(MIGRATE_DEFAULT_AGENT)
 
+            # One-shot launch migration for ``connections_ui`` (see the marker
+            # constant's docstring). Decided on the BASE document, not the
+            # merged view: the overlay is user-owned prose we never rewrite,
+            # and the stale materialization only ever landed in config.json.
+            connections_marker = config_dir() / CONNECTIONS_UI_MIGRATION_MARKER
+            connections_migrating = False
+            if not connections_marker.exists():
+                if data.get("connections_ui") is False:
+                    # In-memory half: this very load must already serve the
+                    # launch default — the strip below is the on-disk echo.
+                    cfg.connections_ui = True
+                    pending.add(MIGRATE_CONNECTIONS_UI)
+                connections_migrating = True
+
             needs_migration = bool(pending)
 
+            persisted = True
             if needs_migration and not cfg._degraded_sections:
-                _persist_config_migration(
+                persisted = _persist_config_migration(
                     path,
                     frozenset(pending),
                     default_kiro_agent=cfg.agent.default_agent or "kirocrew",
@@ -3906,6 +3944,30 @@ class KiroCrewConfig:
                     "degraded section(s) %s and writing back would erase the "
                     "evidence; fix the file to clear",
                     sorted(cfg._degraded_sections),
+                )
+
+            # Record the connections_ui boundary only after a pass that was
+            # allowed to act on it AND whose write-back actually landed. A
+            # degraded load skips both the strip and the marker; a contended
+            # lock makes _persist_config_migration return False with nothing
+            # written, and the marker MUST defer with the strip — marker
+            # without strip would freeze the stale false as a deliberate
+            # opt-out forever. (The already-migrated-by-another-writer path
+            # also returns False; the marker then lands on the next load,
+            # which finds nothing to strip. One extra boot, same endpoint.)
+            # Failure to write the marker itself is logged and retried next
+            # load — the strip's own condition makes the retry converge.
+            if connections_migrating and persisted and not cfg._degraded_sections:
+                atomic_write(
+                    connections_marker,
+                    json.dumps(
+                        {
+                            "migrated_at": datetime.now(timezone.utc).isoformat(),
+                            "stripped_stale_false": MIGRATE_CONNECTIONS_UI in pending,
+                        },
+                        indent=2,
+                    )
+                    + "\n",
                 )
         except Exception as e:
             # Migration write-back is best-effort; never block startup.

--- a/test/test_connections_ui_flag.py
+++ b/test/test_connections_ui_flag.py
@@ -77,7 +77,12 @@ def test_flag_absent_defaults_the_gallery_on(tmp_path, monkeypatch):
 
 
 def test_flag_set_false_leaves_the_gallery_off(tmp_path, monkeypatch):
+    """The deliberate opt-out. Post-launch, a bare stored ``false`` is
+    indistinguishable from pre-launch materialized noise, so the honoured
+    opt-out is ``false`` WITH the migration marker present — the state every
+    install reaches after its first post-launch boot."""
     _point_loader_at(tmp_path, monkeypatch, {FLAG: False})
+    (tmp_path / L.CONNECTIONS_UI_MIGRATION_MARKER).write_text("{}", encoding="utf-8")
     masked = _masked(KiroCrewConfig.load())
 
     assert masked.get(FLAG) is False
@@ -207,3 +212,105 @@ async def test_the_wire_response_carries_the_flag(tmp_path, monkeypatch):
         resp = await client.get("/api/config/kirocrew")
         assert resp.status == 200
         assert _frontend_says_enabled(await resp.json())
+
+
+# ---------------------------------------------------------------------------
+# The launch migration: pre-launch builds materialized ``connections_ui: false``
+# into every config they saved (the key was the opt-in gate then, so a stored
+# false was the default's noise, never a choice). Post-launch that same byte
+# pattern is the deliberate opt-out. The migration strips exactly the noise,
+# once: on the first load that finds no marker file, a stored ``false`` is
+# removed (the launch default then applies) and the marker is recorded; every
+# later load honours ``false`` as the opt-out it now is. ``true`` — the only
+# deliberate pre-launch act — is never touched.
+# ---------------------------------------------------------------------------
+
+
+def _marker_path(tmp_path):
+    return tmp_path / L.CONNECTIONS_UI_MIGRATION_MARKER
+
+
+def test_materialized_false_is_stripped_once_and_the_gallery_turns_on(tmp_path, monkeypatch):
+    """The upgrade trap: pre-launch noise must not read as an opt-out."""
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: False, "auto_update": True})
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.connections_ui is True, "stale materialized false still wins the load"
+    on_disk = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert FLAG not in on_disk, "the stale key must be stripped from the document"
+    assert on_disk.get("auto_update") is True, "the delta must not touch other keys"
+    assert _marker_path(tmp_path).exists(), "the one-shot boundary must be recorded"
+
+
+def test_false_after_the_marker_is_a_deliberate_opt_out(tmp_path, monkeypatch):
+    """Post-migration, explicit false is the honoured opt-out — forever."""
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: False})
+    _marker_path(tmp_path).write_text("{}", encoding="utf-8")
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.connections_ui is False
+    on_disk = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert on_disk.get(FLAG) is False, "a marked config is never rewritten"
+
+
+def test_true_is_never_touched_and_still_records_the_marker(tmp_path, monkeypatch):
+    """Pre-launch true was the one deliberate act; it survives, marker lands."""
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: True})
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.connections_ui is True
+    on_disk = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert on_disk.get(FLAG) is True
+    assert _marker_path(tmp_path).exists()
+
+
+def test_absent_key_records_the_marker_without_touching_the_flag(tmp_path, monkeypatch):
+    """Nothing to migrate: no flag key materializes, only the marker is written."""
+    _point_loader_at(tmp_path, monkeypatch, {"auto_update": True})
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.connections_ui is True
+    # Other one-shot migrations (agents seeding) may rewrite the document; the
+    # contract HERE is only that the flag key is not invented on disk.
+    on_disk = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert FLAG not in on_disk
+    assert _marker_path(tmp_path).exists()
+
+
+def test_second_load_after_migration_is_a_no_op(tmp_path, monkeypatch):
+    """Idempotency: the marker makes the migration one-shot."""
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: False})
+    KiroCrewConfig.load()
+    migrated = (tmp_path / "config.json").read_text(encoding="utf-8")
+    marker_stat = _marker_path(tmp_path).stat().st_mtime_ns
+
+    cfg = KiroCrewConfig.load()
+    assert cfg.connections_ui is True
+    assert (tmp_path / "config.json").read_text(encoding="utf-8") == migrated
+    assert _marker_path(tmp_path).stat().st_mtime_ns == marker_stat
+
+
+def test_a_deferred_strip_defers_the_marker_too(tmp_path, monkeypatch):
+    """Lock contention: ``_persist_config_migration`` swallows a contended lock
+    and returns False — the strip is deferred to the next load. The marker MUST
+    defer with it: marker-without-strip freezes the stale ``false`` as a
+    deliberate opt-out forever (the next load sees marker present and honours
+    it). Pins that the marker write is gated on the persist outcome."""
+    _point_loader_at(tmp_path, monkeypatch, {FLAG: False})
+    calls: list[frozenset] = []
+
+    def contended(path, pending, **kwargs):
+        calls.append(pending)
+        return False  # what a BlockingIOError-swallowing persist returns
+
+    monkeypatch.setattr(L, "_persist_config_migration", contended)
+    cfg = KiroCrewConfig.load()
+
+    # This boot still serves the launch default in memory...
+    assert cfg.connections_ui is True
+    # ...but on disk NOTHING moved: false still present, marker absent,
+    # so the next (uncontended) load retries the whole migration.
+    on_disk = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert on_disk.get(FLAG) is False
+    assert not _marker_path(tmp_path).exists()
+    assert any(L.MIGRATE_CONNECTIONS_UI in p for p in calls)


### PR DESCRIPTION
## What

One-shot migration for the launch upgrade trap: pre-launch builds materialized `connections_ui: false` into every `config.json` they saved, and after #9149 that stale key reads as the deliberate opt-out — every upgrading install boots with a silently empty Connections gallery. (Hit the project owner's own gateway on launch day; diagnosis was manual key deletion.)

## How

The two readings of `false` are byte-identical; what distinguishes them is **when** the key was written. A sidecar boundary marker (`connections_ui_migrated.json`, beside `config.json` — same placement rationale as the superseded-defaults ack file) records the first post-launch load:

- **No marker + stored `false`** → stale noise: stripped as a delta through the existing `_persist_config_migration` machinery (re-checked against the on-disk document inside the write lock, other keys untouchable), in-memory value corrected the same load, marker recorded.
- **No marker + stored `true`** → the only deliberate pre-launch act: never touched; marker recorded.
- **Marker present + `false`** → the deliberate post-launch opt-out: honored, forever.
- **Degraded load** → skips both strip and marker, retries on the first clean load (matches the existing #4057 write-back gate).
- **Contended lock / already-migrated-by-another-writer** → `_persist_config_migration` returns False with nothing written; the marker defers WITH the strip (gated on the persist outcome) and the whole migration retries on the next load. Marker-without-strip would freeze the stale `false` as a deliberate opt-out forever.

## Why not the superseded-defaults registry

That mechanism (report, never rewrite — #5244's lesson) exists for keys where stale-default and deliberate-choice are *permanently* indistinguishable. Pre-launch `connections_ui: false` had no deliberate meaning at all — the flag was the opt-in gate and `false` was both default and only behavior — so a *bounded* rewrite with a recorded boundary is sound where the generic rewrite was not. The one lossy edge: a user who upgraded in the launch→migration window and deliberately opted out gets flipped on once and must opt out again; the migration cannot distinguish that write, and the population is bounded by the window.

## Verification

- New truth table in `test/test_connections_ui_flag.py` (red-first): strip-once with delta isolation (`auto_update` survives untouched), marked `false` honored, `true` untouched, absent-key marker-only, second-load no-op, **contended-persist defers the marker with the strip** — suite 15/15.
- Existing opt-out test updated to the marked semantics (the honest post-migration state of every install).
- `test_config_loader.py` + `test_config_baseline.py` + `test_config_meta_stamp.py`: 529 passed (no schema change — the marker is a sidecar, so no baseline regeneration).
- `test_config_superseded_defaults.py`: 46 passed (registry untouched).
- `test_sandbox_governance_mask.py` + `test_security_posture.py`: 588 passed (new data-home leaf is a non-sensitive sidecar, same class as the ack file).
- isort / flake8 / mypy / black gate clean.

## Pattern harvest

Rule candidate: semgrep — a boolean-returning
persistence/write helper called for its side effect with the return value
discarded — `_persist_config_migration(...)` already encoded
"deferred, nothing written" as `False`, and the defect was ignoring it while
writing a dependent durable record (the marker). The general shape: any
"record that step X happened" write must be gated on step X's own reported
outcome, not on having reached the code path that requested it. Same family
as fsync-then-rename ordering bugs; a semgrep rule flagging bare-statement
calls to known bool-returning writers would have caught this at authoring
time.
