### PR TITLE
fix: restore stripped base64 padding on WeCom media aeskey

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -2986,7 +2986,9 @@ Weixin's scheme (AES-128-**ECB**, shared key) and the two must not be merged: th
 mode, key length and key scope all differ. The `aeskey` arrives in two encodings
 for the same value (base64 of raw bytes, base64 of ASCII hex), discriminated by
 decoded length plus a strict hex check, because guessing wrong yields plausible
-garbage rather than an error. The download cap is enforced on BYTES READ, never on
+garbage rather than an error. It also arrives with its base64 `=` padding
+**stripped** (a 32-byte key as 43 characters), so the padding is restored before
+decoding — a strict decoder rejects the unpadded value as invalid base64 outright. The download cap is enforced on BYTES READ, never on
 `Content-Length` — and it is the plaintext ceiling **plus the padding**, because
 what is read is ciphertext: PKCS#7 to a 32-byte multiple always adds 1–32 bytes, so
 a file at exactly WeCom's 20 MB maximum arrives larger than it is and a cap set to

--- a/src/kiro_crew/wecom/media.py
+++ b/src/kiro_crew/wecom/media.py
@@ -83,7 +83,11 @@ def decode_aes_key(raw: str) -> bytes:
     if not raw:
         raise WeComMediaError("media item carries no aeskey")
     try:
-        decoded = base64.b64decode(raw, validate=True)
+        # WeCom strips the base64 ``=`` padding from the aeskey, so a 32-byte key
+        # arrives as 43 characters — not a multiple of 4, which ``validate=True``
+        # rejects outright. Restore the padding before decoding; a value that was
+        # already correctly padded is unchanged (``-len % 4`` is 0).
+        decoded = base64.b64decode(raw + "=" * (-len(raw) % 4), validate=True)
     except (binascii.Error, ValueError) as exc:
         raise WeComMediaError("aeskey is not valid base64") from exc
     if len(decoded) == _KEY_BYTES:

--- a/test/test_wecom_media.py
+++ b/test/test_wecom_media.py
@@ -52,6 +52,22 @@ class TestKeyDecoding:
         encoded = base64.b64encode(key.hex().encode()).decode()
         assert decode_aes_key(encoded) == key
 
+    def test_aeskey_without_base64_padding(self) -> None:
+        # WeCom delivers the aeskey with its trailing ``=`` padding stripped, so a
+        # 32-byte key arrives as 43 characters. A padding-strict decode rejects
+        # that real, valid key as "not valid base64" and the media is refused —
+        # the padding must be restored before decoding.
+        key = os.urandom(32)
+        unpadded = base64.b64encode(key).decode().rstrip("=")
+        assert "=" not in unpadded
+        assert decode_aes_key(unpadded) == key
+
+    def test_ascii_hex_aeskey_without_base64_padding(self) -> None:
+        # The ascii-hex encoding is delivered the same way — padding stripped.
+        key = os.urandom(32)
+        unpadded = base64.b64encode(key.hex().encode()).decode().rstrip("=")
+        assert decode_aes_key(unpadded) == key
+
     def test_an_empty_key_is_refused(self) -> None:
         with pytest.raises(WeComMediaError, match="no aeskey"):
             decode_aes_key("")


### PR DESCRIPTION
## Problem / Motivation

Sending an image or file to a WeCom AI bot never reaches the agent: it is
refused with the placeholder `[Attachment wecom-image — download failed]`,
even though the media URL, the AES-256-CBC decryption scheme, and the egress
proxy are all correct. The failure is `WeComMediaError: aeskey is not valid
base64`, raised in `decode_aes_key` (`src/kiro_crew/wecom/media.py`).

Root cause: WeCom delivers each media object's `aeskey` as base64 **with its
trailing `=` padding stripped**, so a 32-byte key arrives as 43 characters.
`decode_aes_key` passed that straight to `base64.b64decode(raw,
validate=True)`, which rejects a length that is not a multiple of four — so a
perfectly valid key is treated as malformed and the media is dropped.

## Why it matters

Every inbound image and file on the WeCom channel is silently refused —
image-based workflows (screenshots, scanned documents, photos) are completely
non-functional. The download, decrypt, proxy and ingest machinery are all
already correct; a single padding-strict decode call gates the entire feature.

## What changed (motivation → approach → change)

- **Symptom:** all inbound WeCom media refused as "download failed".
- **Root cause:** `aeskey` arrives without its base64 `=` padding (43 chars for
  a 32-byte key); `base64.b64decode(..., validate=True)` rejects the non-
  multiple-of-four length before decoding.
- **Change:** left-pad the `aeskey` to a multiple of four before decoding:
  `base64.b64decode(raw + "=" * (-len(raw) % 4), validate=True)`. An already-
  padded value is unchanged (`-len % 4 == 0`), so both accepted encodings
  (base64 of raw bytes, base64 of ASCII hex) keep working. `validate=True` and
  the existing error handling are left intact.

## Tests

Added two regression tests to `TestKeyDecoding` in `test/test_wecom_media.py`:

- `test_aeskey_without_base64_padding` — a 32-byte key encoded then stripped of
  its `=` padding decodes back to the exact key.
- `test_ascii_hex_aeskey_without_base64_padding` — same for the ASCII-hex
  encoding.

Both were confirmed to FAIL on the unpatched code (reproducing the shipped
`aeskey is not valid base64`) and pass with the fix. Full file: 53 passed.

## Manual verification

Reproduced end-to-end against a live WeCom AI bot: a real inbound image
(`msgtype: image`, `image.url` + `image.aeskey`) now downloads, AES-256-CBC-
decrypts to a valid JPEG, and reaches the agent, which reads the image content.
Adjacent suites `test_wecom_commands_and_ingest.py` and `test_wecom_dispatch.py`
pass (106), and `./scripts/docs-lint.sh` passes.

## Related Issues

N/A — no tracking issue; fix found in the field.

## Pattern harvest

Rule candidate: review-prompt / agents-md
Pattern: base64 from an external system decoded with `validate=True` without
first restoring stripped `=` padding — a valid padding-less value (common in
compact/URL-style base64) is then rejected as malformed. Worth flagging any
`b64decode(x, validate=True)` on externally-sourced data that does not pad `x`
to a multiple of four first.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
