### PR TITLE
test: pin globals a rebound component impl may load (#9534)

### DIFF
--- a/src/kiro_crew/subagent_manager/_component.py
+++ b/src/kiro_crew/subagent_manager/_component.py
@@ -22,7 +22,12 @@ class ManagerComponent:
 def bind_component_globals(
     component_types: Iterable[type[ManagerComponent]], namespace: dict[str, Any]
 ) -> None:
-    """Bind implementations to ``subagent`` globals for patch compatibility."""
+    """Bind implementations to ``subagent`` globals for patch compatibility.
+
+    A rebound function keeps its own code but runs on ``namespace``, so an import at the
+    top of its defining module is inert for it. Every global it loads must resolve in
+    ``namespace`` -- add the name there, or import it inside the function.
+    """
     for component_type in component_types:
         for name, implementation in tuple(vars(component_type).items()):
             if not name.endswith("_impl") or not isinstance(implementation, FunctionType):

--- a/test/test_subagent_component_globals.py
+++ b/test/test_subagent_component_globals.py
@@ -1,0 +1,74 @@
+"""Pin the globals a rebound component implementation is allowed to load.
+
+``subagent_manager._component.bind_component_globals`` rebinds every ``*_impl`` on the
+``subagent._MANAGER_COMPONENTS`` types onto ``kiro_crew.subagent``'s module globals, so
+one of those functions executes with ``subagent.py``'s globals and an import at the top
+of its own module is invisible to it. Every global it loads has to exist in
+``subagent.py``.
+
+A name that does not resolve there raises ``NameError`` only when its line runs, and
+several of these implementations load theirs inside a ``try:`` whose ``except Exception``
+denies, so the miss presents as a gate that refuses everything rather than as an error.
+The sweep below turns it into a test failure at collection speed instead.
+"""
+
+from __future__ import annotations
+
+import builtins
+import types
+from collections.abc import Iterator
+from dis import get_instructions
+
+import kiro_crew.subagent as subagent_module
+
+_GLOBAL_OPS = frozenset({"LOAD_GLOBAL", "STORE_GLOBAL", "DELETE_GLOBAL"})
+
+
+def _global_names(code: types.CodeType) -> Iterator[str]:
+    """Yield every global name a code object and its nested bodies reference."""
+    for instruction in get_instructions(code):
+        if instruction.opname in _GLOBAL_OPS:
+            yield instruction.argval
+    for constant in code.co_consts:
+        if isinstance(constant, types.CodeType):
+            yield from _global_names(constant)
+
+
+def _rebound_implementations() -> Iterator[tuple[str, types.FunctionType]]:
+    """Yield each ``*_impl`` carrying ``subagent``'s globals, named by its owning type."""
+    namespace = vars(subagent_module)
+    for component_type in subagent_module._MANAGER_COMPONENTS:
+        for name, implementation in vars(component_type).items():
+            if not name.endswith("_impl") or not isinstance(implementation, types.FunctionType):
+                continue
+            if implementation.__globals__ is namespace:
+                yield f"{component_type.__name__}.{name}", implementation
+
+
+def test_component_implementations_are_rebound_onto_subagent_globals() -> None:
+    """The sweep proves nothing unless the rebind put implementations there to sweep."""
+    assert list(_rebound_implementations())
+
+
+def test_the_sweep_reports_a_global_subagent_does_not_define() -> None:
+    """A name that resolves nowhere is what the sweep exists to see, nesting included."""
+
+    def _probe() -> object:
+        def _inner() -> object:
+            return _absent_from_subagent_globals  # noqa: F821
+
+        return _inner
+
+    assert "_absent_from_subagent_globals" in set(_global_names(_probe.__code__))
+
+
+def test_rebound_implementations_only_load_globals_subagent_defines() -> None:
+    """Every global a rebound implementation loads resolves in ``subagent`` or builtins."""
+    namespace = vars(subagent_module)
+    unresolved = [
+        (qualified_name, global_name)
+        for qualified_name, implementation in _rebound_implementations()
+        for global_name in sorted(set(_global_names(implementation.__code__)))
+        if global_name not in namespace and not hasattr(builtins, global_name)
+    ]
+    assert unresolved == []


### PR DESCRIPTION
## Problem / Motivation

`bind_component_globals` in `src/kiro_crew/subagent_manager/_component.py` rebuilds every
function whose name ends in `_impl` with `FunctionType(code, vars(subagent))`. The function
keeps its own code but runs on `subagent.py`'s globals. So an import at the top of the module
that defines the function does nothing for it. The name has to exist in `subagent.py`.

Nothing checked that. A rebound function can load a global `subagent.py` does not define. It
imports fine and it reads fine in review. It raises `NameError` only when that line runs.

## Why it matters

Several of these implementations load a global inside a `try:` whose `except Exception` denies.
The `NameError` is swallowed. The miss then looks like a gate that refuses everything, not like
an error.

#7843 hit this twice in five days. First `HOOK_EVENT_PRE_TOOL_USE`, then `_should_block_results`.
Both times a PreToolUse security gate read as working while it denied every call without ever
consulting a hook.

## What changed (motivation → approach → change)

The symptom is a silent deny. The cause is a name that resolves nowhere, and nobody looks until
the line runs.

Two fixes were on the table. Check at bind time, or check in a test. Bind time adds work to every
start and still only raises after the code has shipped. A test catches it before it ships and
costs nothing at runtime. So the change is a test.

The test walks the bytecode of every rebound `*_impl`, collects each global it loads including the
ones in nested bodies, and asserts the name resolves in `subagent.py` or in builtins. Bytecode,
not `co_names`: `co_names` also holds attribute names, which would report dozens of names that are
not globals. `main` is clean today, so this is a regression test and no runtime behaviour changes.
The docstring on `bind_component_globals` now states the consequence, so the next person adding an
import to one of those modules reads it right there.

## Tests

New `test/test_subagent_component_globals.py`, three tests:

- `test_rebound_implementations_only_load_globals_subagent_defines` — the sweep. Every global a
  rebound `*_impl` loads resolves in `subagent.py` or in builtins. Goes red on both #7843 names.
- `test_component_implementations_are_rebound_onto_subagent_globals` — proves the sweep had
  something to sweep. If the rebind ever stops happening, the sweep would pass while checking
  nothing. This test fails instead.
- `test_the_sweep_reports_a_global_subagent_does_not_define` — proves the detector sees an
  unresolved name inside a nested function, so the recursion into `co_consts` is covered.

Runs in about 4 seconds.

## Manual verification

N/A — unit coverage sufficient. There is no UI surface and no runtime behaviour change: the only
source edit is a docstring. The test leaves nothing behind — no child process, no `chdir`, no
writes outside pytest's own tmp dir — and the repo tree is clean after a run.

## Related Issues

Fixes #9534

## Pattern harvest

Rule candidate: review-prompt
Pattern: a function rebound onto another module's globals loads a name that module does not define

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
