### PR TITLE
perf(dashboard): cut the shell's request fan-out from 254 assets to 109

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -115,7 +115,7 @@ export const CHUNK_BUDGETS = {
   App: 3530 * KB, // measured 3360 KB on main @ 6ae74179d (~5% headroom)
 
   // Markdown/math/syntax rendering stack (katex, highlight.js, remark/rehype)
-  // -- one deliberate `manualChunks` bucket, see vite.config.ts.
+  // -- one deliberate `codeSplitting` group, see vite.config.ts.
   'vendor-markdown': 712 * KB, // measured 678 KB
 
   // Mermaid's own prebuilt internal chunk; the name comes from mermaid's build,
@@ -154,7 +154,7 @@ export const CHUNK_BUDGETS = {
   'chunk-K2UTITRG': 550 * KB, // measured 522 KB (excalidraw 0.18.1 font-subsetting internals)
 
   // Graph/network visualization stack (vis-network, sigma, graphology,
-  // cytoscape) -- one deliberate `manualChunks` bucket, see vite.config.ts.
+  // cytoscape) -- one deliberate `codeSplitting` group, see vite.config.ts.
   'vendor-graph': 606 * KB, // measured 577 KB
 
   // The SPA entry chunk: router, providers, and the eager page skeleton.
@@ -232,7 +232,7 @@ export function main(argv = process.argv.slice(2)) {
   }
   fail(
     `${breaches.length} chunk(s) over budget. Either shrink the chunk (prefer a lazy ` +
-      'import() boundary or a manualChunks split -- see website/vite.config.ts), or, if the ' +
+      'import() boundary or a codeSplitting group -- see website/vite.config.ts), or, if the ' +
       'growth is genuinely irreducible, add/adjust its entry in CHUNK_BUDGETS in ' +
       'scripts/check-bundle-size.mjs with a comment saying why, and justify it in the PR.'
   )

--- a/website/scripts/lib/bundleReport.mjs
+++ b/website/scripts/lib/bundleReport.mjs
@@ -177,8 +177,8 @@ export function renderReport(summary, options = {}) {
  * Budgets must be keyed by something stable across builds, and the emitted file
  * name is not: `assets/main-CZ3WY91T.js` carries a content hash that changes on
  * every edit. The logical name (`main`) is what Rollup derived from the entry,
- * the dynamic-import source, or a `manualChunks` label, and only changes when
- * the chunk graph itself changes.
+ * the dynamic-import source, or a `codeSplitting` group name, and only changes
+ * when the chunk graph itself changes.
  */
 export function logicalChunkName(fileName) {
   if (typeof fileName !== 'string' || !fileName) return ''

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -828,59 +828,136 @@ export default defineConfig({
         // eager vendor chunk and regress load time. Monaco (editor.main +
         // *.worker) and mermaid diagrams already emit their own lazy chunks;
         // leave them alone.
-        manualChunks(id) {
-          if (!id.includes('node_modules')) return
-          // React + all context-carrying singletons in ONE chunk so a single
-          // module instance is guaranteed and provider/init ordering is
-          // preserved (mirrors resolve.dedupe above). Splitting these apart
-          // risks "Invalid hook call" / "No QueryClient set".
-          if (/[\\/]node_modules[\\/](react|react-dom|scheduler|react-redux|@reduxjs|redux|redux-thunk|react-router|react-router-dom|@tanstack[\\/]react-query|@tanstack[\\/]query-core|framer-motion)[\\/]/.test(id)) {
-            return 'vendor-react'
-          }
-          // d3 in its OWN chunk: MemoryGraphTab + KnowledgeGraph both defer it
-          // with `import('d3')` (only their type imports are eager), so d3 is a
-          // deliberate lazy boundary. Grouping it with the eager sigma/graphology
-          // stack below would pull d3 into that eager chunk and defeat the lazy
-          // load. Keep it separate so `import('d3')` stays its own async chunk.
-          if (/[\\/]node_modules[\\/](d3|d3-[^\\/]+|internmap|delaunator|robust-predicates)[\\/]/.test(id)) {
-            return 'vendor-d3'
-          }
-          // ForceAtlas2 + Louvain are physics-only: KnowledgeGraph defers both
-          // with `import('graphology-layout-forceatlas2')` / `.../worker` and
-          // `import('graphology-communities-louvain')`, reached only when physics
-          // is toggled on or the one-shot mount layout runs. Route them to their
-          // OWN lazy chunk ahead of the broad graphology rule below, so the eager
-          // vendor-graph chunk (sigma + core graphology, loaded for every graph
-          // view) does not carry code the default physics-off view never touches.
-          if (/[\\/]node_modules[\\/](graphology-layout-forceatlas2|graphology-communities-louvain)[\\/]/.test(id)) {
-            return 'vendor-graph-physics'
-          }
-          // Graph/network visualization stack (vis-network, vis-data, sigma,
-          // graphology, cytoscape) — large and only used by graph views.
-          if (/[\\/]node_modules[\\/](vis-network|vis-data|vis-util|sigma|graphology|graphology-[^\\/]+|cytoscape)[\\/]/.test(id)) {
-            return 'vendor-graph'
-          }
-          // Markdown/math/syntax rendering (katex, highlight.js, and the
-          // remark/rehype/unified pipeline).
-          if (/[\\/]node_modules[\\/](katex|highlight\.js|lowlight|refractor|react-markdown|remark-[^\\/]+|rehype-[^\\/]+|mdast-[^\\/]+|hast-[^\\/]+|micromark[^\\/]*|unified|unist-[^\\/]+)[\\/]/.test(id)) {
-            return 'vendor-markdown'
-          }
-          // The YAML document parser, reached only by the skill editor's
-          // frontmatter round-trip (`SkillForm.tsx`). Bucketed like every other
-          // vendor library here because the App chunk is meant to hold FIRST-PARTY
-          // code -- its budget comment in scripts/check-bundle-size.mjs says as
-          // much -- and it is the ceiling that ordinary feature PRs trip. Measured
-          // 93.7 KB raw / 29 KB gzip, far under the gate's 500 KB default, so it
-          // needs no CHUNK_BUDGETS entry of its own. The leading separator keeps
-          // this off `js-yaml`, which is mermaid's and belongs in mermaid's chunk.
-          if (/[\\/]node_modules[\\/]yaml[\\/]/.test(id)) {
-            return 'vendor-yaml'
-          }
-          // Routed out because this change's sidebar growth pushed the App chunk past the
-          // ceiling the `yaml` note above names; eager at every use site, no lazy boundary to defeat.
-          if (/[\\/]node_modules[\\/]dompurify[\\/]/.test(id)) {
-            return 'vendor-dompurify'
-          }
+        // Named groups, replacing the former `manualChunks` callback. The whole
+        // callback had to move in ONE step, not rule by rule: rolldown IGNORES
+        // `manualChunks` whenever `codeSplitting` is set -- it logs "`manualChunks`
+        // option is ignored because the `codeSplitting` option is specified" and
+        // drops it (rolldown 1.2.3, create-bundler-option:3046) -- so a rule left
+        // behind would have quietly un-split its chunk with only a warning to say
+        // so. `vite.build.rollupOptions` is an alias of `rolldownOptions`
+        // (`buildConfig.rolldownOptions ??= buildConfig.rollupOptions`), so these
+        // reach rolldown from here; setting BOTH keys to different objects is an
+        // error, which is why this stays under the existing one.
+        //
+        // `priority` replaces the callback's first-match-wins order: the highest
+        // number is matched first and a captured module is removed from every
+        // lower group. Two orderings are load-bearing, and both are now encoded as
+        // numbers instead of array position -- react above everything, because the
+        // icon group depends on it, and graph-physics above the broad graph rule.
+        // `includeDependenciesRecursively` is deliberately LEFT AT ITS DEFAULT
+        // (true). Do not set it to false here. An earlier revision did, to stop
+        // the icon group below from swallowing the whole lucide package and
+        // dragging the App chunk into main -- and it produced two import CYCLES
+        // that this base branch does not have: a 71-chunk one spanning App,
+        // client, vendor-react and vendor-icons, and a 3-chunk one across
+        // vendor-graph, vendor-graph-physics and graphology-communities-louvain,
+        // which also breaks the deliberate lazy-physics boundary below. A cycle
+        // there means a chunk body runs before a chunk it references has
+        // initialized, which blanks the page before React mounts. rolldown's own
+        // jsdoc warns about exactly this and asks for `preserveEntrySignatures`
+        // plus `strictExecutionOrder` alongside it; the smaller answer is to not
+        // disable it, because `minShareCount` on the icon group fixes the real
+        // cause. Measured: 0 cycles here, 2 with it off.
+        codeSplitting: {
+          groups: [
+            {
+              // React + all context-carrying singletons in ONE chunk so a single
+              // module instance is guaranteed and provider/init ordering is
+              // preserved (mirrors resolve.dedupe above). Splitting these apart
+              // risks "Invalid hook call" / "No QueryClient set".
+              name: 'vendor-react',
+              priority: 50,
+              test: /[\\/]node_modules[\\/](react|react-dom|scheduler|react-redux|@reduxjs|redux|redux-thunk|react-router|react-router-dom|@tanstack[\\/]react-query|@tanstack[\\/]query-core|framer-motion)[\\/]/,
+            },
+            {
+              // ForceAtlas2 + Louvain are physics-only: KnowledgeGraph defers both
+              // with `import('graphology-layout-forceatlas2')` / `.../worker` and
+              // `import('graphology-communities-louvain')`, reached only when physics
+              // is toggled on or the one-shot mount layout runs. Route them to their
+              // OWN lazy chunk ahead of the broad graphology rule below, so the eager
+              // vendor-graph chunk (sigma + core graphology, loaded for every graph
+              // view) does not carry code the default physics-off view never touches.
+              name: 'vendor-graph-physics',
+              priority: 40,
+              test: /[\\/]node_modules[\\/](graphology-layout-forceatlas2|graphology-communities-louvain)[\\/]/,
+            },
+            {
+              // Every lucide icon in ONE chunk, for REQUEST COUNT rather than byte
+              // size -- the reason this group exists at all. Left to automatic
+              // chunking each icon module became its own file: the served shell
+              // referenced 252 assets, 153 of them a single icon averaging 381 B
+              // (`check-*.js` is 124 B) for 57 KB all told. The bytes do not matter;
+              // the 153 round trips do. A browser reaching the gateway through a
+              // proxied HTTP/2 connection asks for the whole graph at once, and
+              // `tailscale serve` advertises 250 concurrent streams while answering
+              // 502 past roughly 140 -- measured on Windows at 200 streams -> 60x502
+              // and 247 -> 104x502, which is what PR #9518 and #9540 had to retry
+              // around. Nothing lazy is lost: the shell already preloads all 153, so
+              // they were eager regardless.
+              name: 'vendor-icons',
+              priority: 40,
+              // Load-bearing, and the reason `includeDependenciesRecursively`
+              // above can stay on. src/app-sdk/shared-modules.ts registers the
+              // WHOLE lucide-react namespace so an installed app can import it as
+              // a bare specifier, so the entire package is legitimately in the
+              // graph -- not dead code. Unfiltered, this group therefore captured
+              // all of it: 598.9 KiB eager for the 55.5 KB of icons actually
+              // shared, which also distorted the graph enough to pull App into
+              // main. `minShareCount` captures only modules referenced by more
+              // than one entry chunk, which every genuinely shared icon is (its
+              // named consumer plus the namespace). Result: 90.8 KiB. A module the
+              // filter skips is not dropped -- it falls back to automatic
+              // chunking, so no icon can go missing.
+              minShareCount: 2,
+              test: /[\\/]node_modules[\\/]lucide-react[\\/]/,
+            },
+            {
+              // d3 in its OWN chunk: MemoryGraphTab + KnowledgeGraph both defer it
+              // with `import('d3')` (only their type imports are eager), so d3 is a
+              // deliberate lazy boundary. Grouping it with the eager sigma/graphology
+              // stack below would pull d3 into that eager chunk and defeat the lazy
+              // load. Keep it separate so `import('d3')` stays its own async chunk.
+              name: 'vendor-d3',
+              priority: 30,
+              test: /[\\/]node_modules[\\/](d3|d3-[^\\/]+|internmap|delaunator|robust-predicates)[\\/]/,
+            },
+            {
+              // Markdown/math/syntax rendering (katex, highlight.js, and the
+              // remark/rehype/unified pipeline).
+              name: 'vendor-markdown',
+              priority: 30,
+              test: /[\\/]node_modules[\\/](katex|highlight\.js|lowlight|refractor|react-markdown|remark-[^\\/]+|rehype-[^\\/]+|mdast-[^\\/]+|hast-[^\\/]+|micromark[^\\/]*|unified|unist-[^\\/]+)[\\/]/,
+            },
+            {
+              // The YAML document parser, reached only by the skill editor's
+              // frontmatter round-trip (`SkillForm.tsx`). Bucketed like every other
+              // vendor library here because the App chunk is meant to hold FIRST-PARTY
+              // code -- its budget comment in scripts/check-bundle-size.mjs says as
+              // much -- and it is the ceiling that ordinary feature PRs trip. Measured
+              // 93.7 KB raw / 29 KB gzip, far under the gate's 500 KB default, so it
+              // needs no CHUNK_BUDGETS entry of its own. The leading separator keeps
+              // this off `js-yaml`, which is mermaid's and belongs in mermaid's chunk.
+              name: 'vendor-yaml',
+              priority: 30,
+              test: /[\\/]node_modules[\\/]yaml[\\/]/,
+            },
+            {
+              // Routed out because a sidebar change pushed the App chunk past the
+              // ceiling the `yaml` note above names; eager at every use site, no lazy
+              // boundary to defeat.
+              name: 'vendor-dompurify',
+              priority: 30,
+              test: /[\\/]node_modules[\\/]dompurify[\\/]/,
+            },
+            {
+              // Graph/network visualization stack (vis-network, vis-data, sigma,
+              // graphology, cytoscape) — large and only used by graph views. Lowest
+              // priority so graph-physics above claims its two packages first.
+              name: 'vendor-graph',
+              priority: 20,
+              test: /[\\/]node_modules[\\/](vis-network|vis-data|vis-util|sigma|graphology|graphology-[^\\/]+|cytoscape)[\\/]/,
+            },
+          ],
         },
       },
     },


### PR DESCRIPTION
## Problem / Motivation

The dashboard shell asked for **254 files** to paint its first screen. 192 of them were under 2KB, and **153 were a single lucide icon** averaging 372 B — 55.5 KB of icon code spread over 153 round trips.

That count is what made the mobile black screen reachable. A browser behind a proxied HTTP/2 connection asks for the whole module graph at once, and `tailscale serve` advertises 250 concurrent streams while it starts answering 502 past roughly 140. Measured on one connection to a Windows gateway: 120 streams gave 120 OK; 200 gave 140 OK and 60 502s; 247 gave 143 OK and 104 502s.

## Why it matters

[PR #9518](https://github.com/kirodotdev/KiroCrew/pull/9518) and [PR #9540](https://github.com/kirodotdev/KiroCrew/pull/9540) made a 502 on a module *survivable*, by retrying it. They did not reduce how often one happens. This does: ask 109 times instead of 254 and the burst stays under the ceiling, so the retry becomes the backstop it was meant to be rather than the thing standing between the user and a page.

It is also plain waste on every connection. 153 requests whose headers outweigh their payload cost more than the 55.5 KB they carry.

## What changed (motivation → approach → change)

**Motivation.** The 153 icon files are not a bundling accident to work around at the network layer. They are one chunk group that was never declared.

**Approach.** Move `output.manualChunks` to `output.codeSplitting.groups` and add one group for the icons. The move had to be wholesale, not rule by rule: rolldown **ignores** `manualChunks` the moment `codeSplitting` is set — it logs "`manualChunks` option is ignored because the `codeSplitting` option is specified" (rolldown 1.2.3) and drops it. A rule left behind would have silently un-split its chunk with only that line to say so. `advancedChunks` is deprecated in favour of `codeSplitting`, and `build.rollupOptions` is an alias of `rolldownOptions`, so these reach rolldown from where they already live.

**Change.** All seven regexes move across verbatim. `priority` replaces the callback's first-match-wins order, and the one overlap that matters — `vendor-graph-physics` against the broad `graphology-[^\\/]+` rule — is now 40 against 20 instead of line order. The new group is `vendor-icons`.

```mermaid
flowchart LR
  subgraph Before
    B1[shell]:::ctx --> B2["153 icon files<br/>372 B each"]:::removed
    B1 --> B3["101 other assets"]:::ctx
    B2 --> B4["254 streams<br/>past the ~140 ceiling"]:::removed
  end
  subgraph After
    A1[shell]:::ctx --> A2["vendor-icons<br/>one 90.8 KiB chunk"]:::added
    A1 --> A3["108 other assets"]:::ctx
    A2 --> A4["109 streams<br/>under the ceiling"]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 3,5 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The 153 icon files become one chunk, so the shell's opening burst drops below the stream count the proxy in front of the gateway will actually serve.*

### The two settings that are load-bearing

`minShareCount: 2` on the icon group. `website/src/app-sdk/shared-modules.ts` registers the **whole** `lucide-react` namespace so an installed app can import it as a bare specifier, so the entire package is legitimately in the graph — it is not dead code. Unfiltered, the group captured all of it: 598.9 KiB eager for the 55.5 KB actually shared, which also distorted the graph enough to pull the `App` chunk into `main`. Filtered, it is 90.8 KiB. A module the filter skips is not dropped; it falls back to automatic chunking, so no icon can go missing.

`includeDependenciesRecursively` stays at its **default**, and the config now says why in case someone tries otherwise. An earlier revision of this branch set it `false` — to fix the App-into-main symptom before `minShareCount` had addressed the cause — and that produced two import **cycles** this base branch does not have: a 71-chunk one spanning `App`, `client`, `vendor-react` and `vendor-icons`, and a 3-chunk one across `vendor-graph`, `vendor-graph-physics` and `graphology-communities-louvain`, which also broke the deliberate lazy-physics boundary. A cycle there runs a chunk body before a chunk it references has initialized, blanking the page before React mounts — the exact failure this workstream exists to remove.

## Tests

No new automated test. The two properties this change buys are measured at build time and only one of them has a gate today:

- **Bytes** are covered. `scripts/check-bundle-size.mjs` runs against the analyze build in CI and passes: 674 chunks within budget, 14 allowlisted, no unused budget. It also catches the most likely regression here — another whole-namespace import would re-bloat `vendor-icons` past the 500 KB default and fail it.
- **Request count** has no gate. Adding one means reading `dist/index.html`, which widens that script's contract from a bundle report to the shell, and wiring a new gate into `ci.yml` plus the prepare-pr profile floor. That is two more surfaces than this change, so it is named in Pattern harvest instead of bolted on here.

Existing coverage was re-run rather than assumed: `tsc -b`, `eslint src/ --max-warnings 0`, `jscpd` (0 clones) and 47 frontend tests including `checkBundleSize.test.ts`, `dashboardTheme.test.ts` and `hljsCoreOnly.test.ts` all pass.

## Manual verification

Every number here is from two builds of the **same** commit, baseline `ab3a5ac8d1`, re-verified after the rebase onto `d4e5929791c6`:

| | baseline | this branch |
|---|---|---|
| shell assets | 254 | **109** |
| under 2KB | 192 | 48 |
| single-icon chunks | 153 | **0** |
| import cycles | 0 | **0** |
| `main` | 567.8 KiB | 561.7 KiB |
| `App` | 3376.2 KiB | 3337.0 KiB |
| raw total | 18026.9 KB | 17996.6 KB (−0.2%) |

The cycle count is measured, not inferred: chunk-to-chunk static imports were extracted from every `dist/assets/*.js` and run through Tarjan. Baseline 0, this branch 0, and the rejected `includeDependenciesRecursively: false` revision 2 — which is how that revision was caught rather than shipped.

Not verified: a real phone against a packaged build. That is tracked in issue #9542 along with the retry work, and this change is what makes its outcome likely to be "boots" rather than "boots after retries".

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no pixel changes — the diff is bundler chunk configuration plus three comment corrections. Every rendered surface is byte-identical in content; only which file each module ships in changes.

## Related Issues

no linked issue: follow-up to the black-screen work in #9518 and #9540, which is where the 254-asset measurement came from.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a config option whose default the codebase depends on, disabled to treat a symptom, so the real cause stays hidden and the disable introduces a worse one — here `includeDependenciesRecursively: false` masking an over-broad chunk group and producing import cycles instead. The generalizable check is to measure the invariant the default protects (an acyclic chunk graph) before and after, not just the gate that happened to be green.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
