### PR TITLE
fix(apps): keep a fixed-port app backend from sharing its port on Windows

### DIFF
--- a/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
@@ -873,12 +873,31 @@ class Handler(http_api.Handler):
 atexit.register(_stop_all_dev_procs)
 
 
+class _Server(ThreadingHTTPServer):
+    """The listener, with the address-reuse flag bound to the platform.
+
+    ``http.server.HTTPServer`` hardcodes ``allow_reuse_address = 1``, and that flag
+    does not mean the same thing on both families. On POSIX it only waives
+    TIME_WAIT so a restart can rebind. On Windows ``SO_REUSEADDR`` additionally
+    lets a socket bind an address that already has a LIVE listener, so a second
+    Design Tweak backend on ``PORT`` would bind successfully and the two would
+    split incoming requests instead of one failing.
+
+    The gateway detects a port collision by checking that the spawned child died on
+    its initial bind (``kiro_crew/apps/backend.py``), which only works while the
+    bind is actually allowed to fail. So the flag is off on Windows and EADDRINUSE
+    is permitted to surface. This mirrors the workflows backend's ``_Server``.
+    """
+
+    allow_reuse_address = IS_POSIX
+
+
 def main() -> int:
     """Create data directories and run the loopback HTTP server."""
 
     QUEUE_DIR.mkdir(parents=True, exist_ok=True)
     HANDLED_DIR.mkdir(parents=True, exist_ok=True)
-    server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    server = _Server(("127.0.0.1", PORT), Handler)
     print(f"[{APP_NAME}] listening on http://127.0.0.1:{PORT}  data={DATA_DIR}")
     try:
         server.serve_forever()

--- a/src/kiro_crew/apps/builtins/file_explorer/server.py
+++ b/src/kiro_crew/apps/builtins/file_explorer/server.py
@@ -1270,6 +1270,25 @@ class FileExplorerHandler(BaseHTTPRequestHandler):
 # ---------------------------------------------------------------------------
 
 
+class _Server(ThreadingHTTPServer):
+    """The listener, with the address-reuse flag bound to the platform.
+
+    ``http.server.HTTPServer`` hardcodes ``allow_reuse_address = 1``, and that flag
+    does not mean the same thing on both families. On POSIX it only waives
+    TIME_WAIT so a restart can rebind. On Windows ``SO_REUSEADDR`` additionally
+    lets a socket bind an address that already has a LIVE listener, so a second
+    File Explorer backend on ``PORT`` would bind successfully and the two would
+    split incoming requests instead of one failing.
+
+    The gateway detects a port collision by checking that the spawned child died on
+    its initial bind (``kiro_crew/apps/backend.py``), which only works while the
+    bind is actually allowed to fail. So the flag is off on Windows and EADDRINUSE
+    is permitted to surface. This mirrors the workflows backend's ``_Server``.
+    """
+
+    allow_reuse_address = platform_compat.IS_POSIX
+
+
 def main() -> int:
     # Install the platform context before serving. This backend is spawned as
     # its own subprocess by the app backend launcher, so it inherits no context;
@@ -1278,7 +1297,7 @@ def main() -> int:
     # non-standalone edition. Idempotent and fail-closed, mirroring the CLI and
     # gateway entry points (and Dev Fleet's backend).
     boot_platform(KiroCrewConfig.load())
-    server = ThreadingHTTPServer(("127.0.0.1", PORT), FileExplorerHandler)
+    server = _Server(("127.0.0.1", PORT), FileExplorerHandler)
     logger.info(
         "listening on http://127.0.0.1:%d  rg=%s  allowed=%s",
         PORT,

--- a/src/kiro_crew/apps/scaffold.py
+++ b/src/kiro_crew/apps/scaffold.py
@@ -207,9 +207,9 @@ class Server(HTTPServer):
     ``HTTPServer`` hardcodes ``allow_reuse_address = 1``. On POSIX that only
     waives TIME_WAIT, but on Windows ``SO_REUSEADDR`` also lets a socket bind a
     port that already has a LIVE listener, so a second copy of this backend
-    would start successfully and the two would split incoming requests. KiroCrew
-    decides a port collision happened by seeing the child die on its initial
-    bind, so that bind has to be allowed to fail.
+    would start successfully and the two would split incoming requests.
+    Kiro Crew decides a port collision happened by seeing the child die on its
+    initial bind, so that bind has to be allowed to fail.
     """
 
     allow_reuse_address = not sys.platform.startswith("win")

--- a/src/kiro_crew/apps/scaffold.py
+++ b/src/kiro_crew/apps/scaffold.py
@@ -174,6 +174,7 @@ Or let KiroCrew manage it via the app manifest backend section.
 """
 import json
 import os
+import sys
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -200,9 +201,23 @@ class Handler(BaseHTTPRequestHandler):
         pass
 
 
+class Server(HTTPServer):
+    """The listener, with the address-reuse flag bound to the platform.
+
+    ``HTTPServer`` hardcodes ``allow_reuse_address = 1``. On POSIX that only
+    waives TIME_WAIT, but on Windows ``SO_REUSEADDR`` also lets a socket bind a
+    port that already has a LIVE listener, so a second copy of this backend
+    would start successfully and the two would split incoming requests. KiroCrew
+    decides a port collision happened by seeing the child die on its initial
+    bind, so that bind has to be allowed to fail.
+    """
+
+    allow_reuse_address = not sys.platform.startswith("win")
+
+
 if __name__ == "__main__":
     print(f"{{APP_NAME}} backend on port {{PORT}}")
-    HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+    Server(("127.0.0.1", PORT), Handler).serve_forever()
 '''
 
 _UI_PACKAGE_JSON_TEMPLATE = """\

--- a/test/test_builtin_backend_address_reuse.py
+++ b/test/test_builtin_backend_address_reuse.py
@@ -1,0 +1,154 @@
+"""Every fixed-port app backend binds address reuse to the platform.
+
+``http.server.HTTPServer`` hardcodes ``allow_reuse_address = 1``. That flag does
+not mean the same thing on both families:
+
+* on POSIX it only waives TIME_WAIT, so a restart can rebind a port whose
+  previous listener has already closed;
+* on Windows ``SO_REUSEADDR`` additionally lets a socket bind an address that
+  still has a LIVE listener.
+
+The gateway decides that an app backend hit a port collision by observing that
+the spawned child died on its initial bind (``kiro_crew/apps/backend.py`` --
+``_survived_initial_bind`` and the EADDRINUSE reasoning around it). That signal
+only exists while the bind is allowed to fail, so with the stock flag a second
+backend binds the same fixed port on Windows, the gateway reports a healthy
+start, and the two processes split incoming requests.
+
+Every backend that binds a FIXED port is pinned here rather than once per app,
+because the failure mode is drift: the flag is a stdlib default, so a listener
+that does not opt out inherits it silently, and one module's opt-out says
+nothing about its siblings or about the scaffold that generates new ones.
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.apps import scaffold
+from kiro_crew.apps.builtins.design_tweak.backend import server as design_tweak_server
+from kiro_crew.apps.builtins.file_explorer import server as file_explorer_server
+from kiro_crew.apps.builtins.workflows import server as workflows_server
+
+APPS_ROOT = Path(scaffold.__file__).resolve().parent
+
+#: (label, module, handler symbol as written at the bind site).
+FIXED_PORT_BACKENDS = [
+    ("workflows", workflows_server, "_Handler"),
+    ("design_tweak", design_tweak_server, "Handler"),
+    ("file_explorer", file_explorer_server, "FileExplorerHandler"),
+]
+
+_IDS = [label for label, _module, _handler in FIXED_PORT_BACKENDS]
+
+
+def test_the_stdlib_default_is_what_we_are_overriding() -> None:
+    """Keeps every assertion below non-tautological.
+
+    ``http.server`` really does turn the flag on for every platform, so a
+    per-server subclass is the only way to scope it.
+    """
+    assert bool(HTTPServer.allow_reuse_address) is True
+    assert bool(ThreadingHTTPServer.allow_reuse_address) is True
+
+
+@pytest.mark.parametrize(("label", "module", "handler"), FIXED_PORT_BACKENDS, ids=_IDS)
+def test_listener_binds_address_reuse_to_the_platform(label, module, handler) -> None:
+    assert issubclass(module._Server, ThreadingHTTPServer)
+    assert module._Server.allow_reuse_address is platform_compat.IS_POSIX
+    if platform_compat.IS_WINDOWS:
+        assert module._Server.allow_reuse_address is False
+
+
+@pytest.mark.parametrize(("label", "module", "handler"), FIXED_PORT_BACKENDS, ids=_IDS)
+def test_the_entry_point_binds_through_that_subclass(label, module, handler) -> None:
+    """A subclass nothing constructs would leave the stock flag on the real socket."""
+    src = Path(module.__file__).read_text(encoding="utf-8")
+    assert f'_Server(("127.0.0.1", PORT), {handler})' in src
+    assert f'ThreadingHTTPServer(("127.0.0.1", PORT), {handler})' not in src
+    assert '"0.0.0.0"' not in src
+
+
+def _bind(server_cls, port: int):
+    return server_cls(("127.0.0.1", port), BaseHTTPRequestHandler)
+
+
+@pytest.mark.skipif(
+    not platform_compat.IS_WINDOWS,
+    reason="POSIX SO_REUSEADDR only waives TIME_WAIT, so a live listener already "
+    "refuses a second bind there and the two flag values are indistinguishable",
+)
+@pytest.mark.parametrize(("label", "module", "handler"), FIXED_PORT_BACKENDS, ids=_IDS)
+def test_a_second_windows_backend_cannot_take_the_live_port(label, module, handler) -> None:
+    """The consequence, measured: two backends on one port instead of one failure.
+
+    Both listeners are the SAME class in each half, which is what a duplicate
+    backend actually is. Port 0 only chooses WHICH port is contended; the
+    contention is what the flag decides, so an ephemeral port keeps the test off
+    a possibly busy 9100/9110/9120.
+    """
+    # Negative control -- a listener that keeps the stdlib default: the second
+    # one takes the live port instead of failing, and traffic splits.
+    first_stock = _bind(ThreadingHTTPServer, 0)
+    try:
+        port = first_stock.server_address[1]
+        second_stock = _bind(ThreadingHTTPServer, port)
+        try:
+            assert second_stock.server_address[1] == port
+        finally:
+            second_stock.server_close()
+    finally:
+        first_stock.server_close()
+
+    first = _bind(module._Server, 0)
+    try:
+        with pytest.raises(OSError) as excinfo:
+            _bind(module._Server, first.server_address[1])
+        assert excinfo.value.errno == socket.errno.EADDRINUSE
+    finally:
+        first.server_close()
+
+
+def test_the_scaffolded_backend_template_binds_reuse_to_the_platform() -> None:
+    """A new app copies this template, so the stock flag would keep propagating."""
+    template = scaffold._BACKEND_TEMPLATE
+    assert 'allow_reuse_address = not sys.platform.startswith("win")' in template
+    assert 'Server(("127.0.0.1", PORT), Handler).serve_forever()' in template
+    assert 'HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()' not in template
+
+
+# ``ThreadingHTTPServer(("127.0.0.1", 0), ...)`` -- an ephemeral port cannot
+# collide, so those binds are outside this rule.
+_STOCK_FIXED_BIND_RE = re.compile(
+    r"(?<![A-Za-z0-9_.])(?:Threading)?HTTPServer\(\s*\(\s*[\"'][^\"']+[\"']\s*,(?!\s*0\s*\))"
+)
+
+
+def _stock_fixed_port_binds() -> list[str]:
+    hits = []
+    for path in sorted(APPS_ROOT.rglob("*.py")):
+        if "/tests/" in path.as_posix():
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if _STOCK_FIXED_BIND_RE.search(line):
+                hits.append(f"{path.relative_to(APPS_ROOT).as_posix()}:{lineno}: {line.strip()}")
+    return hits
+
+
+def test_no_app_backend_binds_a_fixed_port_through_the_stock_server() -> None:
+    """A fixed-port listener must opt out of the stdlib flag, not inherit it."""
+    assert _stock_fixed_port_binds() == []
+
+
+def test_the_ratchet_can_actually_fail() -> None:
+    """A scan that matches nothing would pass the test above vacuously."""
+    assert _STOCK_FIXED_BIND_RE.search('server = ThreadingHTTPServer(("127.0.0.1", PORT), H)')
+    assert _STOCK_FIXED_BIND_RE.search('HTTPServer(("127.0.0.1", 9100), H)')
+    assert not _STOCK_FIXED_BIND_RE.search('server = _Server(("127.0.0.1", PORT), H)')
+    assert not _STOCK_FIXED_BIND_RE.search('ThreadingHTTPServer(("127.0.0.1", 0), bound)')

--- a/test/test_design_tweak_project_routes.py
+++ b/test/test_design_tweak_project_routes.py
@@ -1047,11 +1047,11 @@ class TestMain:
         h = tmp_path / "h"
         monkeypatch.setattr(server, 'QUEUE_DIR', q)
         monkeypatch.setattr(server, 'HANDLED_DIR', h)
-        # Patch ThreadingHTTPServer to not actually listen
+        # Patch the listener class so main() binds nothing
         mock_server = MagicMock()
         mock_server.serve_forever.side_effect = KeyboardInterrupt
         monkeypatch.setattr(
-            server, 'ThreadingHTTPServer', lambda addr, handler: mock_server
+            server, '_Server', lambda addr, handler: mock_server
         )
         server.main()
         assert q.is_dir()
@@ -1066,7 +1066,7 @@ class TestMain:
         mock_server = MagicMock()
         mock_server.serve_forever.side_effect = KeyboardInterrupt
         monkeypatch.setattr(
-            server, 'ThreadingHTTPServer', lambda addr, handler: mock_server
+            server, '_Server', lambda addr, handler: mock_server
         )
         assert server.main() == 0
 

--- a/test/test_file_explorer_app.py
+++ b/test/test_file_explorer_app.py
@@ -921,7 +921,7 @@ def test_main_boots_platform_before_serving(monkeypatch):
 
     monkeypatch.setattr(server, "boot_platform", _fake_boot)
     monkeypatch.setattr(server.KiroCrewConfig, "load", classmethod(lambda cls: SimpleNamespace()))
-    monkeypatch.setattr(server, "ThreadingHTTPServer", _FakeServer)
+    monkeypatch.setattr(server, "_Server", _FakeServer)
 
     assert server.main() == 0
     assert calls[0] == "boot", "boot_platform must run before the server binds"


### PR DESCRIPTION
## Problem / Motivation

On Windows, starting a second copy of the Design Tweak or File Explorer backend
on its fixed port **succeeds**. The gateway reports a healthy start, and the two
processes then split incoming requests between them — a request goes to whichever
listener the kernel hands it, so the app behaves as if state randomly disappears.

`http.server.HTTPServer` hardcodes `allow_reuse_address = 1`, and that flag does
not mean the same thing on both families. On POSIX it only waives `TIME_WAIT`, so
a live listener still refuses a second bind. On Windows `SO_REUSEADDR`
additionally lets a socket bind an address that already has a **live** listener.

Measured on this host (Windows 11, Python 3.10) before touching anything:

| first listener | second bind | result |
|---|---|---|
| `SO_REUSEADDR = 1` | `SO_REUSEADDR = 1` | **succeeds** — same port, two listeners |
| `SO_REUSEADDR = 0` | `SO_REUSEADDR = 0` | refused, `WinError 10048` (`EADDRINUSE`) |

## Why it matters

The gateway's whole port-collision story rests on the bind being allowed to fail.
`apps/backend.py` decides a collision happened by observing that the spawned child
**died on its initial bind** (`_survived_initial_bind`, and the EADDRINUSE
reasoning throughout that module). With the stock flag on Windows nothing dies, so:

* the duplicate backend is reported healthy and is never surfaced to the user;
* the reverse proxy routes to one of the two nondeterministically;
* both apps declare `"windows"` in `app.json` today, so this is on the supported
  path, not a theoretical host.

#9413 fixed exactly this for the `workflows` backend and its First Principles
review counted the rest: *"Grepped `ThreadingHTTPServer|allow_reuse_address`
across builtins: 3 fixed-port binds, 1 fixed"*, naming
`design_tweak/backend/server.py:881` and `file_explorer/server.py:1281`, and
recording the clearing condition as *"the same flag lands on both"*. This PR is
that clearing condition, plus the fourth site that generates new ones.

## What changed (motivation → approach → change)

**Symptom** → a duplicate Windows backend binds a live fixed port instead of
failing. **Root cause** → the stdlib's platform-blind `allow_reuse_address = 1` on
a listener whose supervisor needs the bind to be able to fail. **Change** → bind
the flag to the platform at each fixed-port listener, reusing the subclass shape
`workflows` already ships rather than inventing a second spelling.

* `design_tweak/backend/server.py` and `file_explorer/server.py` each gain a
  two-line `_Server(ThreadingHTTPServer)` with `allow_reuse_address = IS_POSIX`,
  and `main()` binds through it. POSIX behaviour is unchanged — the flag stays
  `True` there, so a restart can still rebind out of `TIME_WAIT`.
* `apps/scaffold.py`'s `_BACKEND_TEMPLATE` gets the same treatment. That template
  is what every newly scaffolded app copies, so leaving it alone would keep
  minting the defect; it stays stdlib-only (`sys.platform.startswith("win")`)
  rather than importing `platform_compat` into third-party app code.

The two ephemeral-port binds in `design_tweak` (`dev_preview.py:780`,
`preview_files.py:657`) are deliberately untouched: port `0` cannot collide, so
the flag decides nothing there.

## Tests

`test/test_builtin_backend_address_reuse.py` — new, and deliberately one module
covering all four sites rather than one per app, because the failure this guards
against is drift.

* `test_listener_binds_address_reuse_to_the_platform[workflows|design_tweak|file_explorer]`
  — the listener class subclasses `ThreadingHTTPServer` and its flag is
  `platform_compat.IS_POSIX`.
* `test_the_entry_point_binds_through_that_subclass[...]` — `main()` constructs
  the subclass. A subclass nothing constructs would leave the stock flag on the
  socket that actually binds.
* `test_the_stdlib_default_is_what_we_are_overriding` — guard-the-guard: pins that
  `HTTPServer`/`ThreadingHTTPServer` really do enable the flag, so none of the
  assertions above can pass tautologically.
* `test_a_second_windows_backend_cannot_take_the_live_port[...]` — the
  **consequence**, measured, not the attribute. It first runs the negative control
  (two stock listeners: the second takes the live port), then asserts the shipped
  class is refused with `errno.EADDRINUSE`. Skipped on POSIX with a stated reason:
  there a live listener already refuses the second bind, so the two flag values
  are indistinguishable and a passing test would prove nothing.
* `test_the_scaffolded_backend_template_binds_reuse_to_the_platform` — pins the
  generator's template.
* `test_no_app_backend_binds_a_fixed_port_through_the_stock_server` — ratchet over
  `src/kiro_crew/apps/**`, allowing port-`0` binds. On the unpatched tree it names
  all three violating sites in its failure message.
* `test_the_ratchet_can_actually_fail` — self-check, because a scan that matches
  nothing would pass the ratchet vacuously.

**Red-before**, production files reverted to `origin/main` with the test kept
(Windows host, Python 3.10.6): **8 failed / 5 passed**.

```
FAILED test_listener_binds_address_reuse_to_the_platform[design_tweak]
FAILED test_listener_binds_address_reuse_to_the_platform[file_explorer]
FAILED test_the_entry_point_binds_through_that_subclass[design_tweak]
FAILED test_the_entry_point_binds_through_that_subclass[file_explorer]
FAILED test_a_second_windows_backend_cannot_take_the_live_port[design_tweak]
FAILED test_a_second_windows_backend_cannot_take_the_live_port[file_explorer]
FAILED test_the_scaffolded_backend_template_binds_reuse_to_the_platform
FAILED test_no_app_backend_binds_a_fixed_port_through_the_stock_server
```

The ratchet's own failure text on that tree, verbatim:
`'builtins/design_tweak/backend/server.py:881: server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)'`
plus the `file_explorer` and `scaffold.py` rows.

**Green-after:** 13 passed. **Neighbouring suites:** `test/test_app_scaffold.py`,
`test/test_builtin_app_platform_declarations.py` and the `workflows`,
`design_tweak`, `file_explorer` in-package test packages — **168 passed, 12
skipped**.

**Honest scope of the run:** the three `[workflows]` parametrisations were already
green before this change; they are here so the module is the one place the
invariant lives. No full-suite run is claimed — validation is focused on the
touched surface.

**Gates on the touched files:** `flake8` 0, `isort --check-only` clean,
`mypy --platform linux` (3 source files) `Success: no issues found`,
`git diff --check` clean, `black --check` clean on both non-baselined files and
the new test. `scripts/check_black_formatting.py` passes scoped
`origin/main...HEAD` over the 4 changed files; `apps/scaffold.py` is a
pre-existing baseline entry and is still unformatted after this change, so it
correctly stays listed — no baseline edit, and no collateral reformat.

## Manual verification

The double-bind behaviour was measured directly on native Windows before writing
any code (the table under **Problem / Motivation**), and that same measurement is
now the automated `test_a_second_windows_backend_cannot_take_the_live_port` case.
No further manual step: the remaining assertions are structural and the two apps'
request handling is untouched.

## Related Issues

No linked issue. This closes the residual counted by #9413's First Principles
review; #9413 is merged as `53d14a8ae`.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a stdlib default whose meaning is platform-dependent is fixed at one
call site while its siblings — and the template that generates new ones — keep
inheriting it. When a fix subclasses a stdlib server/client to change a class
attribute, count the other constructions of that stdlib class in the same tree,
and check whether a scaffold/template ships the unfixed original.

The ratchet in this PR is that rule made executable for this specific attribute.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no spec covers the address-reuse flag; `#9413` shipped the same change with no spec edit, and this PR follows that precedent
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

