### PR TITLE
fix(security): arm the case-pattern span rule only in command position (#9620)

### DIFF
--- a/src/kiro_crew/security/shell_normalizer.py
+++ b/src/kiro_crew/security/shell_normalizer.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 _SHELL_ACTIVE_CHARS = frozenset("$`(){}<>|;&\n\r")
 
 
-# Used to *split* a command into independently-evaluatable segments.
+# Splits a command into independently-evaluatable segments.
 # Splits on every shell separator that can chain commands or carve out a
 # subshell:
 #   ;  - sequential
@@ -601,7 +601,7 @@ def _argv_programs(tokens: "list[str]") -> "list[str]":
 
     Walks the argv tracking command boundaries (``_ends_argv``) and skipping
     leading ``VAR=value`` assignments, which precede the program rather than being
-    it.  Used to ask "what command is this name an argument OF?" -- the difference
+    it.  Asks "what command is this name an argument OF?" -- the difference
     between ``echo <name> <verb>`` (data) and ``ssh host <name> <verb>`` (executed).
     """
     programs: list[str] = []
@@ -1638,7 +1638,7 @@ def _iter_shell_chars(text: str, state: int = 0, ansi: bool = False) -> "Iterato
 # comment marker the span walk has to recognise. Bash reads ``case`` / ``esac`` as
 # reserved only when they stand alone, so ``lowercase)`` must not arm the pattern
 # rule, and ``a#b`` must not open a comment.
-_SHELL_WORD_BREAK = frozenset(" \t\n;&|()<>")
+_SHELL_WORD_BREAK = frozenset(" \t\n;&|()<>`")
 
 
 def _skip_continuations(text: str, index: int) -> int:
@@ -1711,6 +1711,18 @@ def _in_command_position(text: str, index: int) -> bool:
     argument and must not disarm the pattern rule. Parity matters -- ``\\\\`` then a
     newline is a literal backslash followed by a real newline, which does separate.
     """
+    k = _prev_significant(text, index)
+    return k < 0 or text[k] in ";&|(\n"
+
+
+def _prev_significant(text: str, index: int) -> int:
+    """Offset of the previous REAL character before *index*, or -1.
+
+    Blanks are stepped over, and a backslash-newline pair is a line
+    CONTINUATION the shell removes while reading, so it is stepped over too --
+    but only an ODD run of backslashes folds; an even run leaves a literal
+    backslash before a real newline, which separates.
+    """
     k = index - 1
     while k >= 0:
         if text[k] in " \t":
@@ -1724,7 +1736,150 @@ def _in_command_position(text: str, index: int) -> bool:
                 k -= slashes + 1
                 continue
         break
-    return k < 0 or text[k] in ";&|(\n"
+    return k
+
+
+#: Reserved words after which bash still reads the NEXT word in command
+#: position.  ``case`` is a reserved word ONLY in command position, so
+#: ``if true; then case x in ...`` must arm the pattern rule while
+#: ``echo case`` must not -- and the hand-through is INHERITED: ``then`` only
+#: passes command position when it stands in command position itself
+#: (``echo then case ...`` is three arguments).  Block ENDERS (``fi``,
+#: ``done``, ``}``, ``esac``) are deliberately absent: bash refuses a keyword
+#: directly after them (``fi case ...`` is a syntax error, measured), so not
+#: arming there is exact.  Cross-pinned against
+#: ``argv_floor._SHELL_RESERVED_WORDS`` by test, so the two keyword tables
+#: cannot drift apart silently.
+_KEEPS_COMMAND_POSITION = frozenset(
+    {"if", "then", "else", "elif", "while", "until", "do", "!", "{", "time", "coproc"}
+)
+
+
+def _prev_word(text: str, index: int) -> "tuple[str, int] | None":
+    """The FOLDED word ending just before *index* and its start offset, else None.
+
+    None means the previous real character is a separator or absent -- the
+    caller has already classified those through :func:`_prev_significant`.
+    Word boundaries are :data:`_SHELL_WORD_BREAK`, the same set the forward
+    walk reads, so the two directions cannot disagree about where a word ends.
+
+    A backslash-newline pair INSIDE the word is a line continuation bash
+    removes while reading, so ``th\\`` + newline + ``en`` is the one word
+    ``then`` and is returned folded -- stopping at the raw newline would read
+    the fragment ``en``, misclassify the keeper, and reopen the early-close
+    under-scan on ``th\\<newline>en case x in x) ...``.  Only the innermost
+    pair of an ODD backslash run folds; an even run is escaped literal
+    backslashes before a REAL newline, which separates.  The start offset is
+    the first fragment's, so chained walks resume before the whole word.
+    """
+    k = _prev_significant(text, index)
+    if k < 0 or text[k] in _SHELL_WORD_BREAK:
+        return None
+    parts: "list[str]" = []
+    seg_end = k + 1
+    while k >= 0:
+        ch = text[k]
+        if ch == "\n":
+            slashes = 0
+            while k - 1 - slashes >= 0 and text[k - 1 - slashes] == "\\":
+                slashes += 1
+            if slashes % 2 == 1:
+                # Fold the innermost ``\\<newline>`` pair away; any even
+                # remainder stays as literal word characters.
+                parts.append(text[k + 1 : seg_end])
+                k -= 2
+                seg_end = k + 1
+                continue
+            break
+        if ch in _SHELL_WORD_BREAK:
+            break
+        k -= 1
+    parts.append(text[k + 1 : seg_end])
+    return ("".join(reversed(parts)), k + 1)
+
+
+def _arms_case_context(text: str, index: int, in_case_body: bool = False) -> bool:
+    """True if the standalone ``case`` at *index* can be bash's reserved word.
+
+    bash recognises ``case`` only in command position, and every measured
+    non-command position -- ``echo case``, ``v=1 case``, ``command case``,
+    ``eval case``, a redirect-target prefix -- either treats it as data or
+    refuses the line outright, so the pattern-paren rule must not arm there:
+    arming spans the body past the ``)`` bash actually closes on, which is the
+    over-scan (false-positive) direction on ordinary commands that merely say
+    the word.  Command position is CHAINED, not spelling-matched: a reserved
+    word hands it through only when it holds it itself, a ``function NAME`` /
+    ``coproc NAME`` prefix passes it to the definition body, and a POSIX
+    ``f()`` definition (empty parens, blanks allowed) restores it -- all forms
+    bash was measured spanning.  Every ambiguity ARMS: an over-armed span only
+    feeds the extractors more text, while a missed arm reopens the early-close
+    truncation this rule exists to prevent.
+
+    *in_case_body* is the caller's live case counter: inside an armed case, a
+    ``)`` before this word is a PATTERN TERMINATOR and the word opens the
+    clause body -- command position (``case a in a) case b in ...`` spans in
+    bash, and missing that arm desynchronises the flat counter into a span
+    SHORTER than the ungated walk: the inner ``esac`` eats the outer arm and
+    the outer's next pattern paren closes the body).
+    Outside a case, the same ``)`` is a substitution closer mid-arguments
+    (``echo $(foo) case x in y`` -- data) or a subshell join bash refuses, so
+    not arming there is exact and keeps the over-arm fix.
+    """
+    at = index
+    for _ in range(8):
+        if _in_command_position(text, at):
+            return True
+        k = _prev_significant(text, at)
+        # _in_command_position returned False, so text[k] is a real char
+        # outside ";&|(\n".
+        ch = text[k]
+        if ch == "`":
+            return True  # a backtick opens a command substitution body
+        if ch in "<>":
+            # A redirect prefix before a compound command is a bash syntax
+            # error (measured): the line never runs, so not arming is exact.
+            return False
+        if ch == ")":
+            if in_case_body:
+                return True  # the ``)`` is a pattern terminator -- clause body
+            # ``f() case`` / ``f ( ) case``: an EMPTY paren pair after a word
+            # is a function definition whose body is command position (both
+            # spellings measured spanning).  A subshell needs a separator
+            # before another command, so content between the parens means no.
+            j = _prev_significant(text, k)
+            if j >= 0 and text[j] == "(":
+                return True
+            return False
+        prev = _prev_word(text, at)
+        if prev is None:
+            return False
+        w, start = prev
+        if "\\" in w:
+            return True  # folded spelling -- undecidable cheaply, arm (long is safe)
+        if w.startswith("-"):
+            # An OPTION word is transparent: the decision rests on what
+            # precedes it.  ``time -p case`` / ``time -- case`` then chain to
+            # ``time`` (a keeper -- bash's grammar reads the reserved word
+            # there, so the arm fails long on the substitution spelling its
+            # own parser refuses), while ``echo -n case`` chains to ``echo``
+            # and correctly stays data.
+            at = start
+            continue
+        two_back = _prev_word(text, start)
+        if two_back is not None and two_back[0] in ("function", "coproc"):
+            # *w* is the definition/coproc NAME.  This check runs BEFORE
+            # keeper semantics because bash accepts any reserved word as a
+            # ``function`` name (``function do`` / ``function time`` parse,
+            # measured) -- reading such a name as the keeper would chain to
+            # ``function``, which keeps nothing, refuse the arm, and truncate
+            # the substitution body at the pattern ``)`` bash spans past.
+            at = two_back[1]
+            continue
+        if w in _KEEPS_COMMAND_POSITION:
+            at = start  # inherited: the keeper must hold position itself
+            continue
+        return False
+    return True  # chain too deep to decide -- arm, the long direction
 
 
 def _matching_close_paren(text: str, open_end: int) -> "tuple[int, bool]":
@@ -1755,9 +1910,12 @@ def _matching_close_paren(text: str, open_end: int) -> "tuple[int, bool]":
     keeps a ``(x|y)`` pattern balanced-neutral as well. ARMING is generous and
     DISARMING is strict on purpose: missing a real ``case`` closes the body EARLY,
     which is the bypass, while missing a real ``esac`` only runs it long, which is
-    imprecision. So ``case`` arms on any standalone word and ``esac`` disarms only
-    in command position -- an ``esac`` passed to a command as an ARGUMENT would
-    otherwise end the rule early and let the next paren close.
+    imprecision. So ``case`` arms on any standalone word IN COMMAND POSITION
+    (:func:`_arms_case_context` -- bash only reads the reserved word there, so
+    ``echo case x in y`` does not arm on ordinary commands, and every
+    undecidable position still arms) and ``esac`` disarms only in command
+    position -- an ``esac`` passed to a command as an ARGUMENT would otherwise
+    end the rule early and let the next paren close.
 
     ``proven`` is False when the parens never balance before the text ends. The
     caller must fail CLOSED on that: for an extractor the safe reading is the
@@ -1789,7 +1947,7 @@ def _matching_close_paren(text: str, open_end: int) -> "tuple[int, bool]":
                 state, ansi = 0, False
                 jumped = True
                 break
-            if _word_at(text, off, "case"):
+            if _word_at(text, off, "case") and _arms_case_context(text, off, cases > 0):
                 cases += 1
                 continue
             if _word_at(text, off, "esac") and _in_command_position(text, off):

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -8255,6 +8255,251 @@ class TestSubstitutionCloserReadsCommandGrammar:
         assert f"printf {self.VERB}" in body, body
 
 
+class TestCaseArmingRequiresCommandPosition:
+    """``case`` is a reserved word only in COMMAND POSITION, so the
+    pattern-paren rule must not arm on the word as data. Every vector is
+    bash-verified live: the non-arming forms are ones bash reads as data (or
+    refuses outright), and the arming forms are ones bash spans."""
+
+    @pytest.mark.parametrize(
+        ("command", "body"),
+        [
+            # ``case`` as an ARGUMENT: bash closes at the first unquoted ``)``.
+            ("echo $(echo case x in y) tail", "echo case x in y"),
+            ("echo $(echo then case x in y) tail", "echo then case x in y"),
+            # A quoted spelling is data even in command position.
+            ("echo $('case' x in y) tail", "'case' x in y"),
+            # An assignment prefix removes command position (bash: syntax
+            # error at the pattern paren, the line never parses).
+            ("echo $(v=1 case x in y) tail", "v=1 case x in y"),
+            # ``command case`` / ``eval case``: operands, not the keyword.
+            ("echo $(command case x in y) tail", "command case x in y"),
+        ],
+    )
+    def test_case_as_data_no_longer_over_arms(self, command: str, body: str) -> None:
+        assert security._substitution_bodies(command) == [body]
+        assert security.is_denied(command) is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Command position hands through reserved words -- INHERITED, so
+            # each keeper must hold position itself.
+            "kill $(if true; then case x in x) : ;; esac; fi; pgrep -f kirocrew)",
+            "kill $({ case x in x) : ;; esac; }; pgrep -f kirocrew)",
+            # Both function-definition forms make the body command position.
+            "kill $(function f case x in x) : ;; esac; pgrep -f kirocrew)",
+            "kill $(f() case x in x) : ;; esac; f; pgrep -f kirocrew)",
+            "kill $(f ( ) case x in x) : ;; esac; f; pgrep -f kirocrew)",
+            # ``coproc [NAME] compound-command``.
+            "kill $(coproc c case x in x) : ;; esac; pgrep -f kirocrew)",
+            # A nested case in a clause body opens after ``)`` -> command position.
+            "kill $(case a in a) case b in b) : ;; esac ;; esac; pgrep -f kirocrew)",
+            # The MULTI-CLAUSE form: an outer pattern paren
+            # AFTER the inner esac is what a missed inner arm hands to the
+            # desynchronised counter as the closer -- this vector is red on a
+            # gate that skips the clause-body position.
+            "kill $(case a in a) case b in b) : ;; esac ;; c) : ;; esac; pgrep -f kirocrew)",
+            # ``case`` GLUED to a backtick opener: the
+            # opener both breaks the word and starts a command, so the word
+            # must still be recognised and armed.
+            "kill $(`case x in x) : ;; esac`; pgrep -f kirocrew)",
+        ],
+    )
+    def test_every_bash_spanning_form_still_arms(self, command: str) -> None:
+        (body,) = security._substitution_bodies(command)
+        assert "pgrep -f kirocrew" in body, body
+        assert security._is_self_kill(command)
+
+    def test_a_redirect_prefixed_case_is_not_armed(self) -> None:
+        """bash REFUSES a redirect prefix before a compound command (measured:
+        syntax error, the line never runs), so the exact reading closes at the
+        pattern paren rather than spanning a command that cannot execute."""
+        body, *_rest = security._substitution_bodies("echo $( > f case x in y) tail")
+        assert body == " > f case x in y", body
+
+    def test_esac_after_in_stays_safe_but_unproven(self) -> None:
+        """``$(case z in esac; echo after)`` -- bash ends the case at that
+        ``esac``, but disarming there needs subject/``in`` state the flat
+        counter deliberately does not carry: any cheaper rule (e.g. 'esac
+        after the word in') disarms on ``echo in esac`` inside a clause body,
+        which is the BYPASS direction. Pinned to the fail-closed fallback:
+        unproven span, whole remainder, extractors scan more."""
+        (body,) = security._substitution_bodies("$(case z in esac; echo after)")
+        assert "echo after" in body, body
+
+    def test_option_words_are_transparent_in_the_chain(self) -> None:
+        """Option words pass the decision through to what precedes them.
+
+        ``time -p case`` / ``time -- case``: bash's OWN substitution parser
+        refuses these spellings (measured live: syntax error, the tail prints
+        as literal text and never executes), so no executable bypass exists
+        either way -- but the grammar reads the reserved word there, and
+        arming keeps the walk uniform with the bare ``time case`` form at the
+        cost of a longer span on input bash never runs (the documented safe
+        direction). ``echo -n case`` chains to ``echo`` and stays data."""
+        from kiro_crew.security.shell_normalizer import _matching_close_paren
+
+        for text in (
+            "$(time -p case x in x) : ;; esac; pgrep -f kirocrew)",
+            "$(time -- case x in x) : ;; esac; pgrep -f kirocrew)",
+        ):
+            assert _matching_close_paren(text, 2) == (len(text), True), text
+        assert security._substitution_bodies("echo $(echo -n case x in y) tail") == [
+            "echo -n case x in y"
+        ]
+
+    def test_heredoc_bodies_extract_whole_and_the_consumer_convicts(self) -> None:
+        """A ``)`` inside heredoc DATA must not end the extracted body early.
+
+        These pins hold on this branch and on the base alike: the span is
+        unproven through the heredoc, so the extractor falls back to the whole
+        remainder (scan more, never less) and the payload after the heredoc IS
+        scanned — the self-kill consumer convicts. bash runs the tail in both
+        shapes (verified live)."""
+        for cmd in (
+            "kill $(echo <<X\ncase x in y)\nX\npgrep -f kirocrew)",
+            "kill $(cat <<X\ncase a in a) : ;; esac\nX\npgrep -f kirocrew)",
+        ):
+            (body,) = security._substitution_bodies(cmd)
+            assert "pgrep -f kirocrew" in body, body
+            assert security._is_self_kill(cmd)
+
+    def test_the_two_keyword_tables_are_cross_pinned(self) -> None:
+        """The command-position keepers and ``_SHELL_RESERVED_WORDS`` answer
+        the same 'is this word shell syntax?' question for different purposes
+        (grammar model here, fail-closed bail in the redirect skip). Every
+        membership difference is intentional and named, so an edit to one
+        table trips this pin and the editor rules on the other deliberately."""
+        from kiro_crew.security.argv_floor import _SHELL_RESERVED_WORDS
+        from kiro_crew.security.shell_normalizer import _KEEPS_COMMAND_POSITION
+
+        only_reserved = _SHELL_RESERVED_WORDS - _KEEPS_COMMAND_POSITION
+        only_keeps = _KEEPS_COMMAND_POSITION - _SHELL_RESERVED_WORDS
+        assert only_reserved == {
+            # handled structurally by the span walk, not as position-keepers:
+            "case",  # arms the pattern rule (command position gated)
+            "esac",  # disarms it (command position gated)
+            "in",  # case grammar, never hands position on
+            "function",  # name-consuming prefix, chained in _arms_case_context
+            # loop/conditional heads whose operands are NOT command position;
+            # their bodies re-enter it via do/then, which ARE in the set:
+            "for",
+            "select",
+            # bracket commands whose operands are test expressions:
+            "[[",
+            "]]",
+            # block ENDERS: bash refuses a keyword directly after each
+            # (``fi case`` / ``done case`` / ``} case`` are syntax errors,
+            # measured), so none of them hands command position on:
+            "fi",
+            "done",
+            "}",
+        }
+        assert only_keeps == set()
+
+    def test_block_enders_do_not_hand_position_on(self) -> None:
+        """``fi case`` / ``done case`` are bash SYNTAX ERRORS (measured), so
+        the exact reading closes at the first paren rather than spanning a
+        line that can never run."""
+        for command, body in (
+            ("echo $(if true; then :; fi case x in y) tail", "if true; then :; fi case x in y"),
+            (
+                "echo $(for i in 1; do :; done case x in y) tail",
+                "for i in 1; do :; done case x in y",
+            ),
+        ):
+            assert security._substitution_bodies(command)[0] == body, command
+
+    def test_a_continuation_split_keeper_still_arms(self) -> None:
+        """A keeper split by a line continuation hands command position on.
+
+        bash removes ``\\`` + newline while READING, so ``th\\`` + newline +
+        ``en case x in x) ...`` runs as ``then case ...`` (measured). The
+        backward word parser must join across the continuation the same way:
+        stopping at the raw newline reads the fragment ``en``, refuses to arm,
+        and the pattern ``)`` then closes substitution scanning early -- the
+        under-scan direction the self-protection consumers cannot afford.
+        """
+        from kiro_crew.security.shell_normalizer import _arms_case_context
+
+        for keeper_split in ("th\\\nen", "i\\\nf true; then", "d\\\no"):
+            head = {
+                "th\\\nen": f"if true; {keeper_split}",
+                "i\\\nf true; then": keeper_split,
+                "d\\\no": f"while true; {keeper_split}",
+            }[keeper_split]
+            text = f"{head} case x in x) echo BODY;; esac"
+            idx = text.rindex("case")
+            assert _arms_case_context(text, idx), text
+
+    def test_a_continuation_split_keeper_spans_the_whole_body(self) -> None:
+        """The substitution body survives the pattern ``)`` when the keeper is split."""
+        command = 'kill -9 $(if true; th\\\nen case x in x) pgrep -f "kiro""crew";; esac; fi)'
+        (body,) = security._substitution_bodies(command)
+        assert 'pgrep -f "kiro""crew"' in body, body
+        assert body.endswith("fi"), body
+        assert security.is_denied(command) is not None
+
+    def test_a_split_keeper_word_is_joined_not_fragmented(self) -> None:
+        """``_prev_word`` reads ``th\\`` + newline + ``en`` as one word.
+
+        The joined word must carry its continuation glue (so the arming walk
+        can classify it) and start at the FIRST fragment, so chained walks
+        (``then`` -> ``if``) resume before the whole keeper, not mid-word.
+        """
+        from kiro_crew.security.shell_normalizer import _prev_word
+
+        text = "th\\\nen case"
+        got = _prev_word(text, text.index("case"))
+        assert got is not None
+        word, start = got
+        assert word.replace("\\\n", "") == "then", got
+        assert start == 0, got
+
+    def test_a_keeper_word_as_function_name_still_arms(self) -> None:
+        """``function time case ...``: ``time`` is the definition NAME, not the keyword.
+
+        bash accepts any reserved word as a function name after ``function``
+        (``function do`` / ``function if`` parse, measured), and the definition
+        body is command position -- so the ``case`` there is bash's reserved
+        word and must arm.  The name-prefix check has to run BEFORE keeper
+        semantics: reading ``time`` as the keeper chains to ``function``, which
+        keeps nothing, and the refused arm truncates the substitution body at
+        the pattern ``)`` -- the under-scan direction.
+        """
+        from kiro_crew.security.shell_normalizer import _arms_case_context
+
+        for text in (
+            "function time case",
+            "function do case",
+            "function if case",
+            "coproc time case",
+        ):
+            assert _arms_case_context(text, text.rindex("case")), text
+
+    def test_a_function_named_keeper_body_spans_and_convicts(self) -> None:
+        """The review vector: the pgrep under a function-named keeper is scanned.
+
+        bash defines the function (never runs it) and the substitution result
+        still reaches the outer command (measured), so a truncated body hides
+        the pgrep from the scan while bash evaluates it.  The clause-position
+        spelling both spans and convicts.  The esac-tail spelling
+        (``... :;; esac; pgrep ...``) is pinned for SPAN only: its conviction
+        depends on how the consumer segments a command list after ``esac``,
+        which behaves the same with this gate present or absent (identical on
+        the base branch, measured) and is tracked separately.
+        """
+        clause = 'kill -9 $(function time case x in x) pgrep -f "kiro""crew";; esac)'
+        (body,) = security._substitution_bodies(clause)
+        assert 'pgrep -f "kiro""crew"' in body, body
+        assert security.is_denied(clause) is not None
+
+        tail = 'kill -9 $(function time case x in x) :;; esac; pgrep -f "kiro""crew")'
+        (body,) = security._substitution_bodies(tail)
+        assert 'pgrep -f "kiro""crew"' in body, body
+
+
 class TestSelfTokensFoldLineContinuations:
     """``_self_tokens`` folds ``\\`` + newline away BEFORE tokenizing.
 


### PR DESCRIPTION
## Problem / Motivation

Follow-up to #8830 / PR #9164 (closed as superseded by 7169c9522). Main's span finder carries the security substance, but its case-pattern rule arms on ANY standalone `case` word, so ordinary commands that merely say the word — `echo $(echo case x in y) tail` — are over-scanned past the paren bash actually closes on. That is the false-positive direction: the extractors are handed text bash never runs as case syntax, and legitimate commands get scanned (and can be denied) more widely than bash's own reading.

## Why it matters

Precision on the deny gate's hottest path. bash recognizes the reserved word only in command position; every measured non-command position (argument, assignment prefix, `command`/`eval` operand, redirect prefix) treats it as data or refuses the line outright. Matching bash's reading removes a standing false-positive source without touching the security substance — every ambiguity still fails toward the longer span, so the #8830 bypass direction stays impossible.

## What changed (motivation → approach → change)

Symptom: over-armed spans on `case`-as-data. Root cause: spelling-only keyword recognition. Change: arming is gated on a new `_arms_case_context` — backward command-position resolution with INHERITED hand-through (a reserved word passes position only when it holds it itself, so `echo then case …` stays three arguments), `function NAME`/`coproc NAME` prefix chaining, both POSIX `f()` / `f ( )` definition spellings, and a clause-body rule threaded from the walk's live case counter (a `)` inside an armed case is a pattern terminator, so a nested `case` there arms — the multi-clause form desynchronizes the flat counter into a shorter-than-base span otherwise, found in review). Undecidable positions (folded spellings, deep chains) always arm.

Two review-round hardenings beyond the gate: the backtick joined `_SHELL_WORD_BREAK` (a glued `` `case … `` was not recognized as a standalone word at all — an under-deny present on main, found in review and fixed here since it is one set member in the same machinery), and `fi`/`done` were dropped from the keeps table (bash refuses `fi case` / `done case` outright, measured — the cross-pin names them as block enders now).

Every arming and non-arming vector in the tests was executed against live bash first.

## Tests

`TestCaseArmingRequiresCommandPosition` in `test/test_security.py` (18 tests, red-before-green proven in two stages — 6 fail without the gate, 4 more fail without the review-round fixes):

- Over-arm fixes: `case` as argument / after reserved-word-spelled arguments / quoted / assignment-prefixed / `command`-prefixed — each pinned to the exact body bash closes on, plus `is_denied` None.
- Spanning forms still arm (the bypass guard): `then`/`{` hand-through, both function-definition spellings, `coproc` with and without name, nested case, the multi-clause nested form, glued-backtick form — each through `_substitution_bodies` AND `_is_self_kill`.
- Block enders (`fi`/`done`) pinned as non-position-keepers; redirect-prefix pinned to bash's refusal reading; `esac`-after-`in` pinned to the deliberate fail-closed fallback (a cheap disarm rule there is the bypass direction — rationale in the test).
- A cross-pin between `_KEEPS_COMMAND_POSITION` and `argv_floor._SHELL_RESERVED_WORDS` with every intentional membership difference named.

## Manual verification

All vectors bash-verified live before pinning (spanning forms print their reachable tails; non-arming forms are data or syntax errors). Full local gates: isort, flake8, mypy, black, 1,803 security-path tests, and the full suite (91,819 passed; the 143 failures + 17 errors reproduce identically on pristine main in this host environment — verified in a clean worktree).

Pre-push review: two model-pinned reviewer subagents (GPT and Opus charters) each found the nested-case clause-body gap (fixed via the live-counter thread-through); GPT additionally found the glued-backtick recognition gap and Opus the `fi`/`done` table contradiction — all fixed red-before-green in this commit.

## Related Issues

Closes #9620

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a keyword-recognition gate added to a security scanner must be probed at every grammar position that HANDS command position on (clause bodies, definition bodies, substitution openers) — the miss is silent and lands in the under-deny direction"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: internal helper, behavior documented in code and tests
- [x] No secrets, credentials, or internal references in the diff
