### PR TITLE
fix(usage): report an unreadable sessions directory without dropping the shape

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -18,7 +18,12 @@ returns the same complete zero-valued session statistics as an empty directory,
 including `today`, `this_week`, `this_month`, and an empty `daily_history`.
 Reading usage does not create the directory, and available billing is preserved.
 The normal usage cache TTL applies; later session files are counted on refresh.
-Other directory read failures remain errors and are not cached as zero usage.
+Other directory read failures report the reason ALONGSIDE that same complete
+zero-valued shape rather than instead of it: the response carries `error` and
+`code` next to the statistics, is still not cached, and the client raises the
+server's message rather than reading a period key that is not there. The zeros
+on that path are a shape, not a measurement, which is what the `error` field
+says.
 
 ## Self-Learning (`learn.py`)
 

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -1803,6 +1803,11 @@ def _parse_sessions() -> dict:
     now_dt = datetime.now()
     today_str = now_dt.strftime("%Y-%m-%d")
 
+    # Set when the directory could not be read at all. Carried ALONGSIDE the
+    # statistics rather than instead of them: every consumer of this payload
+    # reads the period keys unconditionally, so an error-only object is not a
+    # degraded answer, it is a differently-shaped one.
+    read_error: dict[str, str] = {}
     try:
         entries = list(sessions_dir.iterdir())
     except FileNotFoundError:
@@ -1810,10 +1815,14 @@ def _parse_sessions() -> dict:
         # complete zero statistics as an existing, empty directory.
         entries = []
     except OSError as exc:
-        # The OSError carries a filesystem path; keep it server-side and return
-        # a generic message (the ``error`` field is rendered verbatim in the UI).
+        # The OSError carries a filesystem path; keep it server-side and report a
+        # generic message (the ``error`` field is rendered verbatim in the UI).
         logger.warning("usage: cannot read sessions directory: %s", exc)
-        return {"error": "cannot read sessions directory", "code": "sessions_dir_unreadable"}
+        entries = []
+        read_error = {
+            "error": "cannot read sessions directory",
+            "code": "sessions_dir_unreadable",
+        }
 
     for f in entries:
         if f.suffix != ".jsonl":
@@ -1945,6 +1954,11 @@ def _parse_sessions() -> dict:
         # session count with a positive refusal count is the exact silent
         # failure this field makes visible.
         "refused_transcripts": refused_transcripts,
+        # Present only when the directory read itself failed. ``api_kiro_usage``
+        # keys its no-cache decision on this, and the zeros above are then a
+        # SHAPE, not a measurement -- which is why the message has to travel with
+        # them rather than replace them.
+        **read_error,
     }
 
 

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -83,6 +83,40 @@ class TestParseSessions:
             assert result["error"] == "cannot read sessions directory"
             assert result["code"] == "sessions_dir_unreadable"
 
+    def test_iterdir_oserror_keeps_the_whole_statistics_shape(self, tmp_path):
+        """An unreadable directory reports the reason WITHOUT changing the shape.
+
+        Consumers read the period keys unconditionally --
+        ``website/src/providers/adapters/acp.ts`` goes straight to
+        ``s.today.sessions`` on the 200 -- so an error-ONLY object is not a
+        degraded answer, it is a differently-shaped one, and it raises a
+        ``TypeError`` in the client instead of showing the message this branch
+        exists to produce. The zeros are a shape, not a measurement, which is why
+        ``error`` has to travel WITH them.
+        """
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with patch.object(usage_mod, "_SESSIONS_DIR", empty):
+            baseline = _parse_sessions()
+        # Guard the guard: a baseline that lost its period keys would make the
+        # comparison below pass while proving nothing.
+        assert {"today", "this_week", "this_month", "daily_history"} <= set(baseline)
+
+        d = tmp_path / "cli"
+        d.mkdir()
+        with patch.object(usage_mod, "_SESSIONS_DIR", d), patch(
+            "pathlib.Path.iterdir", side_effect=OSError("boom")
+        ):
+            result = _parse_sessions()
+
+        assert result["error"] == "cannot read sessions directory"
+        assert result["code"] == "sessions_dir_unreadable"
+        assert "boom" not in result["error"]
+        # Exactly the successful key set plus the two error keys, so a statistic
+        # added later cannot go missing from this branch without failing here.
+        assert set(result) - {"error", "code"} == set(baseline)
+        assert {k: v for k, v in result.items() if k in baseline} == baseline
+
     def test_skips_non_jsonl(self, tmp_path):
         d = tmp_path / "cli"
         d.mkdir()
@@ -521,6 +555,43 @@ class TestApiKiroUsage:
                 assert "error" in data
                 # Cache should NOT be set
                 assert usage_mod._CACHE == {}
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_directory_still_answers_the_full_shape(self, tmp_path):
+        """The reason rides WITH the statistics, and billing is unaffected.
+
+        A file where the transcript directory should be makes ``iterdir()`` raise
+        a real ``NotADirectoryError`` -- no mock -- which is the branch a
+        roaming-profile or permission-denied home takes. The route answers 200
+        because billing is a separate half of the payload, so the sessions half
+        has to stay readable by a client that goes straight to ``today``.
+        """
+        invalid_directory = tmp_path / "cli"
+        invalid_directory.write_text("not a directory", encoding="utf-8")
+        billing = {"credits_used": 10, "credits_plan": 100, "plan": "Pro"}
+        with (
+            patch.object(usage_mod, "_SESSIONS_DIR", invalid_directory),
+            patch.object(usage_mod, "get_usage_cache", return_value=billing),
+        ):
+            app = web.Application()
+            app.router.add_get("/api/usage/kiro", api_kiro_usage)
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get("/api/usage/kiro")
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["error"] == "cannot read sessions directory"
+        assert data["sessions"]["code"] == "sessions_dir_unreadable"
+        assert data["sessions"]["total_sessions"] == 0
+        for period in ("today", "this_week", "this_month"):
+            assert data["sessions"][period] == {
+                "sessions": 0,
+                "messages": 0,
+                "tool_calls": 0,
+            }
+        assert data["sessions"]["daily_history"] == []
+        assert data["billing"]["plan"] == "Pro"
+        assert usage_mod._CACHE == {}
 
     @pytest.mark.asyncio
     async def test_unavailable_sentinel_yields_empty_billing(self, tmp_path):

--- a/website/src/providers/adapters/acp.ts
+++ b/website/src/providers/adapters/acp.ts
@@ -255,6 +255,13 @@ export class AcpAdapter implements ProviderAdapter {
   async fetchUsage(): Promise<NormalizedUsage> {
     const data = await api.kiroUsage()
     const s = data.sessions
+    // The route answers 200 even when the transcript directory could not be
+    // read, because billing is a separate half of the payload. `error` is the
+    // server's own message for that failure, and the statistics beside it are
+    // a zero SHAPE rather than a measurement -- so reporting the reason is the
+    // only honest reading. Raising here puts it on the same channel a non-2xx
+    // takes, which the Usage tab already renders verbatim.
+    if (s?.error) throw new Error(String(s.error))
     const b = data.billing || {}
     return {
       sessions: {

--- a/website/src/test/AcpAdapter.usageSessionsError.test.ts
+++ b/website/src/test/AcpAdapter.usageSessionsError.test.ts
@@ -1,0 +1,122 @@
+// `GET /api/usage/kiro` answers 200 even when the transcript directory itself
+// could not be read, because billing is a separate half of the payload. The
+// sessions half then carries the server's own `error` string, and the zeros
+// beside it are a SHAPE rather than a measurement.
+//
+// Reading `s.today.sessions` straight off that response is what turned a
+// server-side diagnostic into `Cannot read properties of undefined (reading
+// 'sessions')` in the Usage tab — the tab renders `queryErr.message` verbatim,
+// so whatever this method rejects with is what the user is told.
+
+vi.mock('../api/client', () => ({
+  api: {
+    kiroUsage: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+import { AcpAdapter } from '../providers/adapters/acp'
+
+const kiroUsage = api.kiroUsage as unknown as ReturnType<typeof vi.fn>
+
+/** The route's payload when the directory read failed: complete zero statistics
+ *  plus the reason. Mirrors `_parse_sessions`, whose shape
+ *  `test_usage.py::test_an_unreadable_directory_still_answers_the_full_shape`
+ *  pins on the backend side. */
+function unreadableSessionsPayload() {
+  return {
+    username: 'someone',
+    error: 'cannot read sessions directory',
+    billing: { plan: 'Pro', credits_used: 10, credits_plan: 100 },
+    sessions: {
+      error: 'cannot read sessions directory',
+      code: 'sessions_dir_unreadable',
+      total_sessions: 0,
+      total_messages: 0,
+      total_tool_calls: 0,
+      all_time_sessions: 0,
+      daily_history: [],
+      today: { sessions: 0, messages: 0, tool_calls: 0 },
+      this_week: { sessions: 0, messages: 0, tool_calls: 0 },
+      this_month: { sessions: 0, messages: 0, tool_calls: 0 },
+      avg_msgs_per_session: 0,
+      avg_tools_per_session: 0,
+      refused_transcripts: 0,
+    },
+  }
+}
+
+/** The shape the route answered BEFORE the statistics contract was restored:
+ *  the reason INSTEAD of the numbers. Kept as its own case because a client that
+ *  survives only the complete shape still breaks on a gateway that has not been
+ *  updated yet, and the wire is where the two meet. */
+function errorOnlySessionsPayload() {
+  return {
+    username: 'someone',
+    error: 'cannot read sessions directory',
+    billing: { plan: 'Pro', credits_used: 10, credits_plan: 100 },
+    sessions: {
+      error: 'cannot read sessions directory',
+      code: 'sessions_dir_unreadable',
+    },
+  }
+}
+
+function healthySessionsPayload() {
+  const p = unreadableSessionsPayload()
+  delete (p.sessions as Record<string, unknown>).error
+  delete (p.sessions as Record<string, unknown>).code
+  delete (p as Record<string, unknown>).error
+  p.sessions.today = { sessions: 3, messages: 9, tool_calls: 4 }
+  return p
+}
+
+describe('AcpAdapter.fetchUsage — an unreadable sessions directory', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('rejects with the message the server sent', async () => {
+    kiroUsage.mockResolvedValue(unreadableSessionsPayload())
+    await expect(new AcpAdapter().fetchUsage()).rejects.toThrow(
+      'cannot read sessions directory',
+    )
+  })
+
+  it('does not reject with a property-access TypeError', async () => {
+    // The distinguishing assertion: reading `s.today.sessions` off this payload
+    // also rejects, but with the client's own "Cannot read properties of
+    // undefined (reading 'sessions')" instead of the server's diagnostic. The
+    // message is what the Usage tab prints, so equality is the property that
+    // matters, not merely that something was thrown.
+    kiroUsage.mockResolvedValue(unreadableSessionsPayload())
+    const err = await new AcpAdapter().fetchUsage().then(
+      () => null,
+      (e: unknown) => e,
+    )
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toBe('cannot read sessions directory')
+    expect((err as Error).message).not.toMatch(/undefined/)
+  })
+
+  it('reports the reason for an error-only payload too, not a TypeError', async () => {
+    // A gateway that has not shipped the statistics contract yet answers the
+    // reason INSTEAD of the numbers. Reaching for `s.today.sessions` there is
+    // what produced "Cannot read properties of undefined (reading 'sessions')"
+    // in the Usage tab, in place of the message the server had already written.
+    kiroUsage.mockResolvedValue(errorOnlySessionsPayload())
+    const err = await new AcpAdapter().fetchUsage().then(
+      () => null,
+      (e: unknown) => e,
+    )
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toBe('cannot read sessions directory')
+  })
+
+  it('still normalizes a healthy response', async () => {
+    // Guard the guard: a method that rejected unconditionally would pass both
+    // assertions above.
+    kiroUsage.mockResolvedValue(healthySessionsPayload())
+    const usage = await new AcpAdapter().fetchUsage()
+    expect(usage.sessions.today).toEqual({ sessions: 3, messages: 9, toolCalls: 4 })
+    expect(usage.billing?.plan).toBe('Pro')
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

When the kiro transcript directory cannot be read — a roaming-profile (UNC) home,
a permission denial, or a plain file sitting where the directory should be —
`_parse_sessions` answers

```json
{"error": "cannot read sessions directory", "code": "sessions_dir_unreadable"}
```

and nothing else. `GET /api/usage/kiro` still answers **200**, because billing is
a separate half of the payload. The dashboard's own client then reads the shape
it was promised:

```ts
// website/src/providers/adapters/acp.ts
today: { sessions: s.today.sessions, messages: s.today.messages, ... }
```

`s.today` is not there, so the Usage tab shows

> Cannot read properties of undefined (reading 'sessions')

instead of the sentence the branch exists to produce. The code comment beside
that `return` says the `error` field "is rendered verbatim in the UI"; on this
path it never reaches a person at all.

## Why it matters

This is the branch that fires on exactly the hosts least able to diagnose
themselves. The same module already carries `refused_transcripts` for the
roaming-profile case precisely so the page can say the numbers are incomplete
rather than render a confident zero — and one directory-level failure earlier,
the page instead prints a JavaScript property-access error with the server's
diagnostic discarded.

It is also a contract break, not only a display bug: the route documents a
complete statistics object and answers 200 with a differently-shaped one, so any
consumer that follows the documentation breaks the same way.

Counted by the First Principles review of merged #9305, against the author's own
pattern harvest ("an error-only sentinel can violate an otherwise complete
statistics contract"): *"the `OSError` branch at
`src/kiro_crew/dashboard/handlers/usage.py:1812` still returns an error-only
sessions object, and `fetchUsage` ... still reads `s.today.sessions`
unconditionally on the 200 response ... Count: 1 remaining error-sentinel return
in `_parse_sessions`."*

## What changed (motivation → approach → change)

**Symptom** → the Usage tab prints a client TypeError where the server had
already written a diagnostic. **Root cause** → the failure branch replaces the
statistics instead of annotating them, so a 200 response carries a shape no
consumer expects. **Change** → make the reason travel *with* the statistics, and
let the client report it.

* `dashboard/handlers/usage.py` — the `OSError` branch now sets `entries = []`
  and records `read_error`, falling through to the one return that builds the
  full payload; `**read_error` merges `error`/`code` onto it. That is the same
  complete zero-valued shape the `FileNotFoundError` branch already produces, so
  there is no second spelling of "no sessions". `api_kiro_usage` keys its
  no-cache decision on `"error" in sessions`, which is unchanged, so a failed
  read is still never cached and still surfaces at the top level.
* `providers/adapters/acp.ts` — `fetchUsage` raises when `sessions.error` is
  present rather than normalizing zeros it has just been told are not a
  measurement. That puts the message on the same channel a non-2xx already takes
  (`j()` → `apiFailure` → react-query), and `UsageTab` already renders
  `queryErr.message` verbatim — so the server's sentence arrives with no UI
  change. It also covers a client talking to an older gateway that still sends
  the error-only object, which is the case the TypeError came from.
* `docs/system-specs/modules/learn-cron-dashboard.md` — the paragraph that said
  "Other directory read failures remain errors and are not cached as zero usage"
  now states the shape as well, in the same commit.

Deliberately **not** changed: the status code stays 200 (billing is a real,
independent half of the payload and a 5xx would take the billing card down with
the session counts), and no new field or i18n string is introduced — the string
rendered is the server's own, as the module comment always claimed.

## Tests

**Backend — `test/test_usage.py`**

* `TestParseSessions::test_iterdir_oserror_keeps_the_whole_statistics_shape` —
  builds a baseline from a real empty directory, then compares the OSError
  payload against it: `set(result) - {"error", "code"} == set(baseline)` and
  every shared key equal. A statistic added later cannot go missing from this
  branch without failing here. Guard-the-guard: the baseline is first asserted to
  contain `today` / `this_week` / `this_month` / `daily_history`, so a degenerate
  baseline cannot make the comparison pass vacuously.
* `TestApiKiroUsage::test_an_unreadable_directory_still_answers_the_full_shape` —
  route level, and the trigger is real rather than mocked: a *file* where the
  transcript directory should be, so `iterdir()` raises a genuine
  `NotADirectoryError`. Asserts 200, top-level `error`, the three period objects,
  an empty `daily_history`, that billing survives, and that `_CACHE` stays empty.
* The existing `test_iterdir_oserror` and `test_error_not_cached` are unchanged
  and still pass, so the properties this PR must not break are pinned by tests it
  did not write.

**Frontend — `website/src/test/AcpAdapter.usageSessionsError.test.ts`** (4 cases)

* rejects with the server's message on the new complete-shape payload;
* rejects with that message and nothing mentioning `undefined` — the assertion is
  equality, because the message is what the tab prints;
* rejects with the same message on the **error-only** payload an older gateway
  sends — this is the case that produced the TypeError;
* guard-the-guard: a healthy payload still normalizes (`today` and `billing.plan`
  asserted), so a method that rejected unconditionally would not pass.

**Red-before**, each half measured with only that half reverted to `origin/main`:

Backend (Python 3.10.6):
```
FAILED test_usage.py::TestParseSessions::test_iterdir_oserror_keeps_the_whole_statistics_shape
E       AssertionError: assert set() == {'all_time_se...s_month', ...}
FAILED test_usage.py::TestApiKiroUsage::test_an_unreadable_directory_still_answers_the_full_shape
>       assert data["sessions"]["total_sessions"] == 0     (KeyError)
```

Frontend (`adapters/acp.ts` at `origin/main`) — 3 failed / 1 passed, including
the defect verbatim:
```
AssertionError: promise resolved "{ sessions: { total: +0, …(6) }, …(1) }" instead of rejecting
AssertionError: expected 'Cannot read properties of undefined (…' to be 'cannot read sessions directory'
Received: "Cannot read properties of undefined (reading 'sessions')"
```

**Green-after:** `test/test_usage.py` **97 passed**; the frontend file 4 passed,
and the whole `AcpAdapter*` + `UsageTab*` set **35 passed / 5 files**.

**Gates:** `flake8` 0 and `isort --check-only` clean on both Python files;
`mypy --platform linux` on `usage.py` `Success: no issues found`;
`black --check` clean on `usage.py` (`test/test_usage.py` is a pre-existing
baseline entry and is untouched by black here);
`scripts/check_black_formatting.py` and `scripts/check_comment_history.py` pass
scoped `origin/main...HEAD`; `git diff --check` clean. Frontend `tsc -b` exit 0
and `eslint` exit 0 on both changed files. No full-suite run is claimed —
validation is focused on the touched surface.

## Manual verification

N/A — unit coverage is sufficient here because the whole defect is a wire shape
and its one consumer, and both ends are asserted directly, including the exact
TypeError string the fix removes.

Worth stating plainly since no screenshot is attached: the only user-visible
delta is the **text** inside the error card `UsageTab` already renders for a
failed usage query — no panel, component, layout or theme changes, and the diff
touches none of the paths the Screenshot Evidence workflow watches
(`website/src/{components,pages,apps}/**`, `website/src/**/*.css`,
`website/index.html`).

## Related Issues

No linked issue. This closes the residual counted by merged #9305's First
Principles review.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a handler that answers 2xx with an error-only object where its success
path returns a documented composite. The status code says "read the body", the
body then omits the keys the documented shape promises, and every consumer that
trusts the documentation raises a property-access error instead of showing the
message the branch was written to deliver. When a failure branch returns early
from a function whose success path builds a fixed key set, check whether the
error belongs *beside* those keys rather than instead of them — and check the
client, because the shape is only a contract where something reads it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `learn-cron-dashboard.md`'s "other directory read failures" paragraph, in the same commit
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
