### PR TITLE
fix(discord): recognise a steer frame whose ack summary wrapped

### DIFF
--- a/src/kiro_crew/discord/renderer.py
+++ b/src/kiro_crew/discord/renderer.py
@@ -174,8 +174,24 @@ _BUTTON_LABEL_CHARS = 80
 
 # kiro-cli's inline "[STEERING steer-<id>: …]" steer-ack marker (see the
 # Telegram renderer for the full rationale — Discord likewise has no parser).
-_STEER_MARKER_RE = re.compile(r"\[STEERING\b[^\]\r\n]*\]", re.IGNORECASE)
-_STEER_SUMMARY_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f]+\s*:\s*([^\]\r\n]*)\]", re.IGNORECASE)
+#
+# The frame is recognised by its GRAMMAR, and that is where the summary is
+# allowed to contain newlines: ``messaging.driver._STEER_MARKER_RE`` reads the
+# same frame with ``re.DOTALL``, ``constants._STEERING_TAIL_PREFIX_RE`` closes
+# that grammar's prefix with ``re.DOTALL`` too, and the dashboard's own parser
+# (``website/src/app-sdk/protocol/steering.ts``) spells the summary
+# ``[\s\S]*?``. kiro-cli's rephrase is free to wrap, so a class that stopped at
+# the first line end left a real marker unrecognised. ``]`` is the terminator
+# this grammar actually has.
+#
+# Requiring ``steer-<id>`` rather than a bare ``[STEERING`` is the ruling
+# ``messaging.driver`` already applies: opening with the sentinel is not being a
+# marker, so prose that merely mentions it stays visible now that the class no
+# longer stops at a line end. The id class matches driver's, and is the SAME in
+# both patterns, because the summary is matched at the offset the marker pattern
+# chose -- a narrower id class there would silently drop the summary.
+_STEER_MARKER_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f-]+(?:\s*:[^\]]*)?\]", re.IGNORECASE)
+_STEER_SUMMARY_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f-]+\s*:\s*([^\]]*)\]", re.IGNORECASE)
 
 
 def _extract_options(text: str) -> tuple[str, list[str]]:

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -33,6 +33,7 @@ from kiro_crew.acp.types import (
 )
 from kiro_crew.autonudge import AutoNudgeService
 from kiro_crew.config import KiroCrewConfig
+from kiro_crew.discord import renderer as discord_renderer
 from kiro_crew.discord.attachments import process_discord_attachments
 from kiro_crew.discord.client import (
     _INTENT_DIRECT_MESSAGES,
@@ -68,6 +69,7 @@ from kiro_crew.discord.transport_dispatch import (
     _STEER_ACK_EMOJI,
     DiscordDispatcher,
 )
+from kiro_crew.messaging import driver as messaging_driver
 from kiro_crew.messaging.attachments import cleanup
 from kiro_crew.messaging.link import (
     UNBIND_REASON_UNSPECIFIED,
@@ -1139,6 +1141,78 @@ class TestStripSteering:
     def test_an_unclosed_marker_cannot_span_table_rows(self) -> None:
         text = "[STEERING steer-deadbeef |\n| --- | --- |"
         assert _strip_steering(text) == text
+
+    def test_removes_a_marker_whose_summary_wrapped(self) -> None:
+        """kiro-cli's rephrase is free to wrap, and the frame is still a frame.
+
+        Every other reader of this frame says so: ``messaging.driver`` matches it
+        with ``re.DOTALL``, ``constants._STEERING_TAIL_PREFIX_RE`` closes the same
+        grammar's prefix with ``re.DOTALL``, and the dashboard's parser spells the
+        summary ``[\\s\\S]*?``. A class that stopped at the first line end left the
+        marker in the delivered Discord message.
+        """
+        text = "before [STEERING steer-ab12: switching to the job id\nand re-running it] after"
+        out = _strip_steering(text)
+        assert "STEERING" not in out
+        assert out.startswith("before") and out.endswith("after")
+
+    def test_the_chip_summary_survives_a_wrapped_marker(self) -> None:
+        """``_rotate_at_markers`` reads the summary at the offset the marker
+        pattern chose, so the two must agree on the same frame: a summary the
+        marker matched but this one did not leaves the steer chip blank."""
+        text = "[STEERING steer-ab12: switching to the job id\nand re-running it]"
+        marker = discord_renderer._STEER_MARKER_RE.search(text)
+        assert marker is not None
+        summary = discord_renderer._STEER_SUMMARY_RE.match(text, marker.start())
+        assert summary is not None
+        assert summary.group(1) == "switching to the job id\nand re-running it"
+
+    def test_a_dashed_steer_id_is_one_frame_to_both_patterns(self) -> None:
+        """``messaging.driver`` accepts ``[0-9a-f-]+`` for the id, so a dashed id
+        is a real frame; the two patterns here have to agree about it."""
+        text = "[STEERING steer-a180-ae7f: checked] tail"
+        marker = discord_renderer._STEER_MARKER_RE.search(text)
+        assert marker is not None
+        summary = discord_renderer._STEER_SUMMARY_RE.match(text, marker.start())
+        assert summary is not None and summary.group(1) == "checked"
+        assert _strip_steering(text).strip() == "tail"
+
+    def test_prose_that_merely_opens_with_the_sentinel_stays(self) -> None:
+        """The counterpart to allowing newlines, and the reason it is safe.
+
+        ``messaging.driver`` already rules that opening with the sentinel is not
+        being a marker. Without the id requirement, a class that spans lines would
+        swallow from ``[STEERING`` to any later ``]`` -- here a Markdown link two
+        lines down.
+        """
+        text = "[STEERING is the feature I mean\n\nsee the [docs](x) for it"
+        assert _strip_steering(text) == text
+
+    def test_the_grammar_agrees_with_the_messaging_driver(self) -> None:
+        """One frame, two readers: a corpus both must classify the same way.
+
+        This renderer is defence for callers that bypass ``TurnDriver``, so the
+        two spellings answer the same question about the same bytes; a divergence
+        is how one surface starts delivering what the other removes.
+        """
+        frames = [
+            "[STEERING steer-ab12: checked]",
+            "[STEERING steer-a180ae7f: 已并行查询悉尼天气,一并答复。]",
+            "[STEERING steer-a180-ae7f: checked]",
+            "[STEERING steer-ab12: line one\nline two]",
+            "[STEERING steer-ab12]",
+        ]
+        not_frames = [
+            "[STEERING is the feature I mean]",
+            "[STEERING steer-: empty id]",
+            "[STEERING steer-zzzz: not hex]",
+        ]
+        for text in frames:
+            assert discord_renderer._STEER_MARKER_RE.fullmatch(text), text
+            assert messaging_driver._STEER_MARKER_RE.match(text), text
+        for text in not_frames:
+            assert discord_renderer._STEER_MARKER_RE.fullmatch(text) is None, text
+            assert messaging_driver._STEER_MARKER_RE.match(text) is None, text
 
 
 class TestFindButtonLabel:


### PR DESCRIPTION
## Problem / Motivation

kiro-cli folds a mid-turn steer and emits an inline frame in the text stream:

```
[STEERING steer-<id>: <what it did in response>]
```

That ack summary is free-form prose and may wrap. Every reader of the frame in
this repo says so:

| Reader | Summary spelling |
|---|---|
| `messaging/driver.py::_STEER_MARKER_RE` | `(.*?)` with **`re.DOTALL`** |
| `constants._STEERING_TAIL_PREFIX_RE` (the prefix closure of that grammar) | `.*` with **`re.DOTALL`** |
| `website/src/app-sdk/protocol/steering.ts::STEER_ACK_RE` | **`[\s\S]*?`** |
| `telegram/renderer.py::_STEER_MARKER_RE` | `[^\]]*` |
| **`discord/renderer.py::_STEER_MARKER_RE`** | **`[^\]\r\n]*`** |

Discord is the one spelling that stops at the first line end, so a frame whose
summary wrapped is not a frame to it.

## Why it matters

Two consequences, both on paths this module owns:

1. **The raw marker is delivered in the Discord message.** `_strip_steering`
   runs at every seal (`renderer.py` :653, :822, :838), and `messaging.md` states
   the invariant plainly — *"Steering frames never become text"*. A wrapped frame
   becomes text on Discord.
2. **The steer chip loses its summary, and the rotation never happens.**
   `_rotate_at_markers` searches with `_STEER_MARKER_RE` and, on a hit, calls
   `on_steer_consumed(summary)` with `_STEER_SUMMARY_RE` read at that offset. No
   marker match means no `STEER_CONSUMED` event at all. Its own docstring names
   the reachable case: *"Defence for callers that bypass TurnDriver and pass raw
   markers."*

Telegram's renderer handles the identical input today, so the two channels
disagree about the same bytes from the same producer.

## What changed (motivation → approach → change)

**Symptom** → a wrapped ack frame is delivered raw on Discord and raises no chip.
**Root cause** → the frame is recognised by "has no newline" rather than by its
grammar, and the grammar's terminator is `]`. **Change** → recognise the grammar,
in `discord/renderer.py` only:

```python
_STEER_MARKER_RE  = re.compile(r"\[STEERING\s+steer-[0-9a-f-]+(?:\s*:[^\]]*)?\]", re.IGNORECASE)
_STEER_SUMMARY_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f-]+\s*:\s*([^\]]*)\]", re.IGNORECASE)
```

Three things move, and the second is what makes the first safe:

* the summary class ends at `]`, the terminator this grammar actually has;
* the pattern now requires `steer-<id>` instead of a bare `[STEERING`. This is
  the ruling `messaging/driver.py` already applies (merged #9209: *"Starting with
  the sentinel is not the same as being a marker"*), and without it a class that
  spans lines would swallow from `[STEERING` to any later `]` — a Markdown link
  two lines down, say. Prose that merely mentions the sentinel stays visible, and
  a test pins that;
* the id class is now identical in both patterns. The summary is matched at the
  offset the marker pattern chose, so a narrower id class there silently drops
  the summary — a dashed id (`steer-a180-ae7f`, which `messaging/driver.py`
  accepts as `[0-9a-f-]+`) matched the marker and not the summary.

**Deliberately out of scope, and stated rather than silently left:** the
*unclosed* trailing sub on the next line (`r"\[STEERING\b[^\]\r\n]*$"`) is
unchanged. It has no terminator, so widening it is the over-stripping question
merged #9209 litigated, and `test_an_unclosed_marker_cannot_span_table_rows`
exists because a Markdown table was eaten there. That test stays green. This PR
does not touch `telegram/renderer.py`, whose unclosed sub *does* span lines —
an asymmetry this change neither creates nor removes, and one that belongs with
whoever revisits #9209's rule for the renderers.

## Tests

Five cases added to `test/test_discord.py::TestStripSteering`:

* `test_removes_a_marker_whose_summary_wrapped` — the delivered-text
  consequence: the frame with a newline in its summary is gone, and the prose on
  both sides of it survives.
* `test_the_chip_summary_survives_a_wrapped_marker` — the chip consequence,
  asserted through the exact two-step `_rotate_at_markers` performs
  (`_STEER_MARKER_RE.search`, then `_STEER_SUMMARY_RE.match` at that offset), and
  on the summary's value, not merely on a match.
* `test_a_dashed_steer_id_is_one_frame_to_both_patterns` — the id-class
  agreement, again through both patterns at one offset.
* `test_prose_that_merely_opens_with_the_sentinel_stays` — **guard-the-guard.**
  It passes before *and* after, and it is here precisely for that: it is what
  says the widened class did not buy its fix with a new prose-eating bug. It
  fails if the `steer-<id>` requirement is dropped.
* `test_the_grammar_agrees_with_the_messaging_driver` — a corpus of 5 frames and
  3 non-frames that both spellings must classify identically. This is the
  anti-drift pin: the renderer is defence for callers that bypass `TurnDriver`,
  so a divergence is exactly how one surface starts delivering what the other
  removes.

**Red-before** — production file reverted to `origin/main`, tests kept
(Windows host, Python 3.10.6): **4 failed / 4 passed** in `TestStripSteering`.

```
FAILED test_discord.py::TestStripSteering::test_removes_a_marker_whose_summary_wrapped
FAILED test_discord.py::TestStripSteering::test_the_chip_summary_survives_a_wrapped_marker
FAILED test_discord.py::TestStripSteering::test_a_dashed_steer_id_is_one_frame_to_both_patterns
FAILED test_discord.py::TestStripSteering::test_the_grammar_agrees_with_the_messaging_driver
```

with the defect visible in the failure output:

```
E  AssertionError: assert 'STEERING' not in 'before [STE...ng it] after'
E    'STEERING' is contained here:
E      before [STEERING steer-ab12: switching to the job id
E      and re-running it] after
E  assert None
E   + where None = re.compile('\\[STEERING\\b[^\\]\\r\\n]*\\]', re.IGNORECASE).fullmatch
```

The 4 that pass on base are the three pre-existing `TestStripSteering` cases plus
the guard-the-guard above — stated explicitly rather than counted as evidence.

**Green-after:** `test/test_discord.py` **233 passed**; together with
`test_discord_outbound_files.py`, `test_messaging_driver.py` and
`test_channel_table_rendering.py`, **476 passed**. No pre-existing Discord test
changed: all 228 that existed before still pass unmodified, which is what pins
that the added `steer-<id>` requirement narrowed nothing anyone relied on.

**Gates:** `flake8` 0 and `isort --check-only` clean on both files;
`mypy --platform linux` on `renderer.py` `Success: no issues found`;
`black --check` clean on both (neither is a baseline entry);
`scripts/check_black_formatting.py` and `scripts/check_comment_history.py` pass
scoped `origin/main...HEAD`; `git diff --check` clean. No full-suite run is
claimed — validation is focused on the touched surface.

## Manual verification

N/A — unit coverage is sufficient: the defect is entirely in two module-level
patterns, and both consequences are asserted through the exact call shapes the
production code uses (`_strip_steering`, and `_rotate_at_markers`' search-then-
match-at-offset pair) rather than through a re-derivation of them.

## Related Issues

No linked issue. Found by comparing the repo's spellings of one protocol frame
against each other; #9209 and #9117 are the merged PRs that established the
grammar-over-substring rule this follows.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: one wire frame, several hand-written recognisers. When a producer's
frame is parsed in more than one place — here five, across Python and TypeScript
— the spellings drift, and the divergence surfaces only on the input the
strictest one rejects. Ask which reader is the grammar's authority, and pin the
others against it with a shared corpus (as
`test_the_grammar_agrees_with_the_messaging_driver` now does) rather than by
inspection. The related trap is a *pair* of patterns applied at one offset: a
narrower field class in the second silently yields an empty capture instead of a
no-match.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — none needed: `messaging.md`'s "Steering frames never become text" already states the invariant this restores, and no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
