### PR TITLE
test: bind self in the mkdir patch and drop the simulated O_BINARY bit

### DIFF
--- a/test/test_acp_spawn_offload.py
+++ b/test/test_acp_spawn_offload.py
@@ -82,11 +82,18 @@ class TestClientSpawnOffLoop:
         # thread identity alone does not name the regressing call site.
         mkdir_stacks: list[str] = []
 
-        def _rec_mkdir(*a, **kw):
+        # ``patch("pathlib.Path.mkdir")`` installs a plain MagicMock, which is not
+        # a descriptor, so the recorder never receives ``self`` and cannot create
+        # anything. autospec hands it the Path; calling through keeps the
+        # directories the spawn prelude promises to create.
+        real_mkdir = Path.mkdir
+
+        def _rec_mkdir(self, *a, **kw):
             t = threading.current_thread()
             mkdir_threads.append(t)
             if t is loop_thread:
                 mkdir_stacks.append("".join(traceback.format_stack()))
+            return real_mkdir(self, *a, **kw)
 
         client = AcpClient(work_dir=tmp_path / "workspace", session_key="k")
 
@@ -144,8 +151,10 @@ class TestClientSpawnOffLoop:
                 "inject_xdist_auto_cap",
                 side_effect=lambda env: xdist_threads.append(threading.current_thread()),
             ),
-            patch(
-                "pathlib.Path.mkdir",
+            patch.object(
+                Path,
+                "mkdir",
+                autospec=True,
                 side_effect=_rec_mkdir,
             ),
         ):
@@ -274,6 +283,15 @@ class TestRuntimeSpawnOffLoop:
             cgroup_threads.append(threading.current_thread())
             return argv
 
+        # See the note in TestClientSpawnOffLoop: the recorder must receive
+        # ``self`` and call through, or the work dir it claims to observe is
+        # never created and the macOS-only spawn guard stats a missing path.
+        real_mkdir = Path.mkdir
+
+        def _rec_mkdir(self, *a, **kw):
+            mkdir_threads.append(threading.current_thread())
+            return real_mkdir(self, *a, **kw)
+
         monkeypatch.setattr(runtime_mod, "_resolve_kiro_bin_for_spawn", resolve_bin)
         monkeypatch.setattr(runtime_mod, "ensure_agent_materialized", lambda agent: None)
         monkeypatch.setattr(
@@ -294,9 +312,11 @@ class TestRuntimeSpawnOffLoop:
 
         runtime = AcpRuntime(work_dir=tmp_path / "workspace")
         with (
-            patch(
-                "pathlib.Path.mkdir",
-                side_effect=lambda *a, **kw: mkdir_threads.append(threading.current_thread()),
+            patch.object(
+                Path,
+                "mkdir",
+                autospec=True,
+                side_effect=_rec_mkdir,
             ),
             pytest.raises(_StopSpawn),
         ):

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -2313,7 +2313,12 @@ class TestNotificationCopyWhenNoLiveFileExists(_NotificationCopyFixtures):
 
         def recording(path, flags, *args, **kwargs):
             seen.append(flags)
-            return real_open(path, flags, *args, **kwargs)
+            # Record the flags as the product composed them, then STRIP the
+            # simulated bit before the real syscall sees it. The value above is
+            # a stand-in for a constant this platform does not have, so it is
+            # free to collide with one it does: on Darwin ``O_DIRECTORY`` IS
+            # ``1 << 20``, and passing it for a regular file answers ENOTDIR.
+            return real_open(path, flags & ~os.O_BINARY, *args, **kwargs)
 
         snap, home = self._snap(tmp_path, self.GOOD)
         monkeypatch.setattr(os, "open", recording)


### PR DESCRIPTION
## Problem / Motivation

Three tests fail on macOS and pass everywhere CI runs. On `main` `9c2b4b678`, on a Darwin 25.6.0 / arm64 host:

```
pytest -q --no-cov -n0 -p no:randomly test/test_acp_spawn_offload.py test/test_snapshot.py
->  3 failed, 144 passed
```

Same command on Amazon Linux 2023: `147 passed`. This is Group 3 of #9060.

The three:

- `test_acp_spawn_offload.py::TestClientSpawnOffLoop::test_spawn_env_resolution_and_mkdir_run_off_loop` — `FileNotFoundError: [Errno 2] No such file or directory: '…/2-kirocrew-home'`
- `test_acp_spawn_offload.py::TestRuntimeSpawnOffLoop::test_spawn_mkdir_and_krb5_run_off_loop` — same
- `test_snapshot.py::TestNotificationCopyWhenNoLiveFileExists::test_both_descriptors_ask_for_binary_mode` — `NotADirectoryError: [Errno 20] Not a directory: '…/snap/notifications.jsonl'`

Both causes are in the tests. No `src/` file changes here.

## Why it matters

A macOS contributor cannot get a green local run, so the signal they use to decide whether their own change broke something is already red before they start. Both failures also *look* like product bugs from the traceback — one lands inside `sandbox.py`'s fail-closed sandbox-isolation refusal, which is exactly the kind of message you do not want to teach people to ignore.

I also want to correct something I put in #9060 myself. I wrote there that these paths "all sit under `/private/tmp` … a lexical-vs-canonical path mismatch is the obvious suspect on a platform where `/tmp` is a symlink." **That is not the cause.** `/private/tmp` is incidental. I reproduced the same two failures on Amazon Linux under a plain `/tmp`, with no symlink anywhere in the path and a byte-identical traceback, by neutralising nothing but the platform gate (below). Retracting that guess.

## What changed (motivation → approach → change)

### `test_acp_spawn_offload.py` — the mkdir recorder never receives `self`

`patch("pathlib.Path.mkdir", side_effect=_rec_mkdir)` installs a plain `MagicMock` on the class. A `MagicMock` is not a descriptor, so the bound-method protocol never runs and the recorder is called with no instance. Measured:

```
patch("pathlib.Path.mkdir")                 -> recorder saw ((), {'parents': True, 'exist_ok': True})
patch.object(Path, "mkdir", autospec=True)  -> recorder saw ((PosixPath('…'),), {'parents': True, 'exist_ok': True})
```

So the recorder cannot know which path was asked for, let alone create it. Two directories the spawn prelude promises therefore never exist for the rest of the test:

- the work dir — `acp/client.py:4792` / `acp/runtime.py:1196`, `await asyncio.to_thread(self._work_dir.mkdir, parents=True, exist_ok=True)`
- the Kiro Crew data home — `config/paths.py:274`, `p.mkdir(parents=True, exist_ok=True)` inside `config_dir()`

**Why only macOS.** `client.py:4799` then calls `assert_voice_runtime_outside_agent_workspace`, whose first statement is `sandbox.py:1584`:

```python
if sys.platform != "darwin":
    return
```

That early return is deliberate and its docstring explains it (Kiro's internal macOS sandbox replaces rather than nests inside Crew's Seatbelt profile). Its consequence is that on macOS — and only on macOS — `_spawn` goes on to stat both of those directories using raw `os` calls the `pathlib` patch cannot intercept:

```
src/kiro_crew/sandbox.py:1398: in prime_voice_runtime_sandbox_paths
    home_info = os.lstat(canonical_home)
E   FileNotFoundError: [Errno 2] No such file or directory: '…/i0/1-kirocrew-home'
```

and once the home is supplied by hand, the *next* missing path surfaces at `sandbox.py:1626` (`os.stat` over `raw_workspace_paths`) and becomes the fail-closed refusal at `:1644`. I found that second one by pre-creating only the data home and re-running — it moved the failure forward instead of fixing it, which is what told me the missing directory was general and not specific to the voice runtime.

**The sibling that shares the identical patch and passes confirms the trigger.** `TestEnsureReadyWorkDir` (class at `:228`, patch at `:243`) patches `pathlib.Path.mkdir` exactly the same way and passes on macOS, because it pre-sets `_process` and `_session_id`, so `ensure_ready` takes the warm path and never re-enters `_spawn`. Measured with a wrapper around the guard: **guard called 0 times** in that test.

**Change:** `patch.object(Path, "mkdir", autospec=True, side_effect=…)`, and the recorder takes `self` and calls through, so it still records the thread but the directory actually appears.

### `test_snapshot.py` — the simulated constant collides with a real one

`test_snapshot.py:2310` simulates a constant this platform does not have:

```python
monkeypatch.setattr(os, "O_BINARY", 1 << 20, raising=False)
```

The docstring is explicit that the value is a stand-in. The chosen value is not free, though:

| | macOS 15 / arm64 | Amazon Linux 2023 / x86_64 |
|---|---|---|
| real `os.O_*` equal to `1 << 20` | **`['O_DIRECTORY']`** | `[]` |
| `os.O_DIRECTORY` | **`0x100000`** | `0x10000` |
| `1<<20` inside a named flag | — | `O_SYNC` / `O_FSYNC` / `O_RSYNC` (`__O_SYNC`) |
| `os.open(<regular file>, O_RDONLY \| 0x100000)` | **`NotADirectoryError [Errno 20]`** | OK, no error |

On Darwin `O_DIRECTORY` **is** `1 << 20`. The recorder at `:2314-2316` passes the composed flags straight to the real `os.open`, and the product ORs `getattr(os, "O_BINARY", 0)` into both triples (`snapshot.py:2988` destination, `:3015` source), so `snapshot.py:3028` opens a regular file with `O_DIRECTORY` set and the kernel answers `ENOTDIR`.

It is the collision and not the platform: on Linux, `os.open(<regular file>, O_RDONLY | os.O_DIRECTORY)` gives the same `NotADirectoryError [Errno 20]`. Linux just spells `O_DIRECTORY` as `0x10000`, so the fake bit lands on `__O_SYNC`, which an `open` accepts.

**Change:** record the flags as the product composed them — which is the entire assertion — then strip the simulated bit before the real syscall sees it.

## Tests

No new test cases; this repairs three existing ones so they test what they claim. Each keeps its original assertion, and I checked both are still load-bearing by breaking the product under them:

| mutation | result |
|---|---|
| move the mkdir back onto the loop thread (`client.py:4792`, `runtime.py:1196` → direct `self._work_dir.mkdir(...)`) | both fixed tests fail with **their own** assertions — `AssertionError: mkdir ran on the loop thread`, `AssertionError: blocking spawn-prelude syscall ran on the loop thread` — on macOS, and on Linux with the guard forced live |
| delete `\| getattr(os, "O_BINARY", 0)` from the source triple (`snapshot.py:3015`) | the snapshot test still fails |

Full runs, both files together, at base `9c2b4b678`:

| | macOS 15 (Darwin 25.6.0) arm64, py3.12.12 | Amazon Linux 2023 x86_64, py3.11.14 |
|---|---|---|
| before | **3 failed, 144 passed** | 147 passed |
| after | **147 passed** | 147 passed |

Linux is unchanged in both columns, which is the point: this adds no behaviour there.

**Two-sided proof for 3a.** On Linux, replacing only the two-line `sys.platform != "darwin"` early return at `sandbox.py:1584-1585` with a no-op and changing nothing else:

```
CONTROL   pristine, guard inert off-darwin   ->  17 passed
ROUTE D   guard forced live on Linux         ->   2 failed, 15 passed   (same two tests)
ROUTE D + this PR                            ->  17 passed
```

with the traceback line-for-line the macOS one, under a plain `/tmp` on a filesystem where `/tmp` is a real directory. That is what retires the `/private/tmp` story.

Gates, run against `origin/main...HEAD` (2 changed files) on Linux:

```
flake8 src/kiro_crew test conftest.py xdist_budget.py     -> clean
isort --check-only src/kiro_crew test conftest.py …       -> clean
scripts/check_black_formatting.py                         -> passed (1140 baselined files still listed)
scripts/check_comment_history.py                          -> passed (7600 baselined markers still listed)
```

`test_acp_spawn_offload.py` is already in `.github/black-baseline.txt:371` on pristine `main`, and black's only complaint in it is on a line I did not touch — so this adds no formatting debt and graduates none. `mypy src/kiro_crew/` and the per-file coverage gate are unaffected: no `src/` line changes.

## Manual verification

N/A — the failures *are* the unit suite, and the fix is verified by running it on both platforms plus the mutation and Route D runs above. Reproduction:

```bash
git checkout 9c2b4b678
# macOS
pytest -q --no-cov -n0 -p no:randomly test/test_acp_spawn_offload.py   # 2 failed, 15 passed
pytest -q --no-cov -n0 -p no:randomly test/test_snapshot.py            # 1 failed, 129 passed
# Linux: neutralise the two-line early return at sandbox.py:1584-1585, then
pytest -q --no-cov -n0 -p no:randomly test/test_acp_spawn_offload.py   # 2 failed, 15 passed
```

## Related Issues

Refs #9060 — this is Group 3 of that issue. Group 2 landed as #9061. Groups 1 and 4 are not in this PR: Group 4 is root-caused but the gate shape is an owner's call, and Group 1 needs a maintainer's decision on Darwin's intended ACL behaviour first.

## Pattern harvest

Rule candidate: `semgrep`
Pattern: `patch("<module>.<Class>.<method>", side_effect=…)` where the `side_effect` signature expects `self` — patching by string installs a non-descriptor `MagicMock`, so the instance is silently dropped and a recorder that means to call through cannot. `autospec=True` (or `patch.object(..., autospec=True)`) is the fix. Grep-able and, in this repo, checkable: a `side_effect` whose first parameter is `self` under a string-target `patch` of a dotted class attribute is always wrong.

Second, narrower candidate: `review-prompt`
Pattern: a test that simulates a platform-absent constant with a hand-picked value, then passes the composed value to the real syscall. The stand-in must either be checked against `os.O_*` on the running platform or stripped before the call — otherwise it is one `1 << n` away from meaning something the kernel enforces. This one is a judgement call rather than a mechanical rule, so I have it as a prompt item, not semgrep.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`) — one commit, `test: …`
- [x] Existing tests pass and new tests added for new functionality — three existing tests go from failing to passing on macOS, unchanged on Linux; no new functionality, so no new cases
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing behaviour change
- [x] No secrets, credentials, or internal references in the diff
