### PR TITLE
perf(workflows): stop shipping result payloads in the runs list

### DIFF
--- a/docs/system-specs/modules/workflows.md
+++ b/docs/system-specs/modules/workflows.md
@@ -528,10 +528,15 @@ ancestry, and the driving `task`. Statuses: `running`, `finished`, `failed`,
 
 Two distinct serializations:
 
-- `snapshot(include_events=)` is the **UI view**. The compact form adds derived
-  live progress (`phase` from the last `phase_started`, `last_log` from the last
-  `log`) plus `partial_result_count` / `agent_error_count`; the full form adds
-  `events`, `source`, `partial_results` and `agent_errors`. Partials are keyed on
+- `snapshot(include_events=, include_result=)` is the **UI view**. The compact
+  form (`include_events=False, include_result=False`, what `list()` builds) adds
+  derived live progress (`phase` from the last `phase_started`, `last_log` from
+  the last `log`) plus `partial_result_count` / `agent_error_count`, and omits
+  the `result` payload — a finished run's result can be hundreds of KB, so it
+  rides only on the detail view, exactly like `events` and `source`. The full
+  form adds `result`, `events`, `source`, `partial_results` and `agent_errors`.
+  The `on_done` completion snapshot keeps `include_result=True`, so
+  result-to-chat injection is unaffected. Partials are keyed on
   **status**, not on `result is None`: a run can finish and legitimately return
   `None`, and a running run has no result yet, so neither lost anything and
   reporting partials for them would mislead the reader and resend every payload on
@@ -565,6 +570,14 @@ host lifecycle checkpoint may stall the gateway event loop or move live registry
 state across threads. Cancellation drains an in-flight registration write before
 asynchronously deleting the partial run, so a late atomic replace cannot resurrect an
 identity that was never returned to its host driver.
+
+The read handlers extend the same rule to the response path: the run list, run
+detail, and definition list/get endpoints serialize the payload once
+synchronously on the event loop (an atomic snapshot — no await, so no
+loop-driven mutation can interleave), then a worker thread rebuilds its own
+structure from that immutable string and performs redaction + the final JSON
+serialization. The thread only ever touches objects it created itself, so it
+can never observe or race live registry state.
 
 ### `store.py`
 

--- a/src/kiro_crew/dashboard/handlers/workflows.py
+++ b/src/kiro_crew/dashboard/handlers/workflows.py
@@ -22,6 +22,7 @@ Routes (registered in dashboard/server.py):
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from typing import Any, Optional
 
@@ -57,6 +58,31 @@ def _redact_obj(obj):
     if isinstance(obj, dict):
         return {_redact_obj(k): _redact_obj(v) for k, v in obj.items()}
     return obj
+
+
+async def _json_response_off_loop(payload: Any, *, status: int = 200) -> web.Response:
+    """Redact + serialize ``payload`` on a worker thread, not the event loop.
+
+    ``_redact_obj`` runs two regex redactors over every string in the payload
+    and ``json.dumps`` walks it again. For the run and definition views the
+    payload scales with stored data (a run detail snapshot with its event
+    stream can be MBs; every saved definition carries its script source), so
+    doing that work inline stalls every other request on the single-threaded
+    loop.
+
+    The loop-side ``json.dumps`` below is the detachment boundary: it runs
+    synchronously on the event loop (no await, so no loop-driven mutation can
+    interleave) and produces an immutable string. The worker thread then
+    rebuilds its own structure from that string, so it only ever touches
+    objects it created — it can never observe, or race, live registry state.
+    """
+    unredacted = json.dumps(payload)
+
+    def _redact_and_serialize() -> str:
+        return json.dumps(_redact_obj(json.loads(unredacted)))
+
+    text = await asyncio.to_thread(_redact_and_serialize)
+    return web.Response(text=text, status=status, content_type="application/json")
 
 
 def _svc(request: web.Request):
@@ -151,7 +177,9 @@ async def api_workflow_definitions(request: web.Request) -> web.Response:
     except Exception:
         logger.exception("workflow definition list failed")
         return _error("could not read saved workflows", "workflow_definition_read_failed", 500)
-    return web.json_response(_redact_obj({"definitions": definitions}))
+    # Every saved definition carries its full script source, so this payload
+    # scales with the library — serialize it off-loop like the run views.
+    return await _json_response_off_loop({"definitions": definitions})
 
 
 async def api_workflow_definitions_create(request: web.Request) -> web.Response:
@@ -217,7 +245,7 @@ async def api_workflow_definition_get(request: web.Request) -> web.Response:
         return _error("could not read saved workflow", "workflow_definition_read_failed", 500)
     if definition is None:
         return _error("no such saved workflow", "workflow_definition_not_found", 404)
-    return web.json_response(_redact_obj({"definition": definition}))
+    return await _json_response_off_loop({"definition": definition})
 
 
 async def api_workflow_definition_update(request: web.Request) -> web.Response:
@@ -416,11 +444,15 @@ async def api_workflow_run_intent(request: web.Request) -> web.Response:
 
 
 async def api_workflow_runs(request: web.Request) -> web.Response:
-    """GET /api/workflows/runs — list runs (compact, newest first)."""
+    """GET /api/workflows/runs — list runs (compact, newest first).
+
+    Compact means no event bodies, no source, and no result payloads — the
+    detail endpoint (``GET /api/workflows/runs/{id}``) carries the result.
+    """
     svc = _svc(request)
     if svc is None:
         return web.json_response({"error": "workflows not available"}, status=503)
-    return web.json_response(_redact_obj({"runs": svc.list_runs()}))
+    return await _json_response_off_loop({"runs": svc.list_runs()})
 
 
 async def api_workflow_run_get(request: web.Request) -> web.Response:
@@ -432,7 +464,7 @@ async def api_workflow_run_get(request: web.Request) -> web.Response:
     snap = svc.result(run_id)
     if snap is None:
         return web.json_response({"error": "no such run"}, status=404)
-    return web.json_response(_redact_obj(snap))
+    return await _json_response_off_loop(snap)
 
 
 async def api_workflow_run_promote(request: web.Request) -> web.Response:

--- a/src/kiro_crew/workflows/registry.py
+++ b/src/kiro_crew/workflows/registry.py
@@ -104,13 +104,21 @@ class RunHandle:
     )
     _persist_generation: int = field(default=0, init=False, repr=False, compare=False)
 
-    def snapshot(self, *, include_events: bool = True) -> dict:
-        """JSON-serializable view of this run (never leaks the asyncio.Task)."""
+    def snapshot(self, *, include_events: bool = True, include_result: bool = True) -> dict:
+        """JSON-serializable view of this run (never leaks the asyncio.Task).
+
+        ``include_result=False`` omits the ``result`` payload. A finished run's
+        result can be hundreds of KB (a report, an RCA, a large JSON blob), so
+        the LIST view leaves it out and the detail view
+        (``GET /api/workflows/runs/{id}``) carries the payload — the same split
+        ``events``/``source``/``partial_results`` already follow. Completion
+        injection (``on_done``) and the single-run endpoints keep the default
+        and still see the full result.
+        """
         snap: dict[str, Any] = {
             "run_id": self.run_id,
             "name": self.name,
             "status": self.status,
-            "result": self.result,
             "error": self.error,
             "author": self.author,
             "session_key": self.session_key,
@@ -137,6 +145,8 @@ class RunHandle:
             "phase": self._current_phase(),
             "last_log": self._last_log(),
         }
+        if include_result:
+            snap["result"] = self.result
         # Work that outlived a run which ENDED WITHOUT a usable return value
         # (ceiling / cancel / crash). Keyed on STATUS, not on ``result is None``:
         # a run can finish and legitimately return None (a script with no return,
@@ -565,8 +575,12 @@ class RunRegistry:
         return h.snapshot(include_events=include_events) if h else None
 
     def list(self) -> list[dict]:
-        # Newest first; compact (no event bodies) for the list view.
-        return [h.snapshot(include_events=False) for h in reversed(self._runs.values())]
+        # Newest first; compact (no event bodies, no result payloads) for the
+        # list view — the detail snapshot carries the result.
+        return [
+            h.snapshot(include_events=False, include_result=False)
+            for h in reversed(self._runs.values())
+        ]
 
     async def cancel(self, run_id: str) -> bool:
         h = self._runs.get(run_id)

--- a/test/test_workflow_definition_handlers.py
+++ b/test/test_workflow_definition_handlers.py
@@ -362,9 +362,14 @@ async def test_definition_disk_operations_are_offloaded_from_the_gateway_loop(
             )
         ).status == 200
 
+    # The definition read paths serialize their response off-loop too
+    # (_json_response_off_loop's worker), so each GET contributes two
+    # to_thread hops: the disk read, then redact + json.dumps.
     assert calls == [
         "list_definitions",
+        "_redact_and_serialize",
         "save_definition",
         "get_definition",
+        "_redact_and_serialize",
         "update_definition",
     ]

--- a/test/test_workflow_handler_json_contract.py
+++ b/test/test_workflow_handler_json_contract.py
@@ -102,3 +102,38 @@ async def test_mutation_handlers_keep_valid_object_path(
 
     assert response.status == 200
     method.assert_awaited_once()
+
+
+async def test_runs_list_is_compact_and_detail_carries_result() -> None:
+    """GET /api/workflows/runs ships no result payloads; the detail does.
+
+    A finished run's result can be hundreds of KB, so the list view carries
+    metadata only and the payload rides on ``GET /api/workflows/runs/{id}``.
+    Both read endpoints redact + serialize on a worker thread; the response
+    must still be well-formed JSON.
+    """
+    from kiro_crew.dashboard.handlers.workflows import (
+        api_workflow_run_get,
+        api_workflow_runs,
+    )
+
+    big_result = {"report": "x" * 50_000}
+    compact_row = {"run_id": "wf_1", "name": "d", "status": "finished"}
+    detail = {"run_id": "wf_1", "status": "finished", "result": big_result, "events": []}
+    svc = SimpleNamespace(list_runs=lambda: [compact_row], result=lambda _rid: detail)
+    app = web.Application()
+    app["state"] = SimpleNamespace(workflow_service=svc)
+    app.router.add_get("/api/workflows/runs", api_workflow_runs)
+    app.router.add_get("/api/workflows/runs/{run_id}", api_workflow_run_get)
+
+    async with TestClient(TestServer(app)) as client:
+        listing = await client.get("/api/workflows/runs")
+        assert listing.status == 200
+        assert listing.content_type == "application/json"
+        rows = (await listing.json())["runs"]
+        assert rows == [compact_row]
+        assert "result" not in rows[0]
+
+        got = await client.get("/api/workflows/runs/wf_1")
+        assert got.status == 200
+        assert (await got.json())["result"] == big_result

--- a/test/test_workflows_registry.py
+++ b/test/test_workflows_registry.py
@@ -147,6 +147,30 @@ async def test_list_newest_first_and_running_not_evicted() -> None:
     assert runs[0]["run_id"] == "wf_l2"  # newest first
 
 
+async def test_list_is_compact_no_result_payload() -> None:
+    """The list view never ships result payloads.
+
+    A finished run's result can be hundreds of KB. The payload rides only on
+    the detail snapshot (``status``/``result``), and the ``on_done``
+    completion snapshot keeps it too.
+    """
+    reg = RunRegistry()
+    done_snapshots: list[dict] = []
+    reg.set_on_done(lambda _rid, snap: done_snapshots.append(snap))
+    runner = WorkflowRunner(agent_fn=_echo, audit=lambda *a, **k: None)
+    rid = await runner.run_background(GOOD, registry=reg, run_id="wf_c1", now=NOW, name="d")
+    await _wait_terminal(reg, rid)
+
+    (row,) = reg.list()
+    assert "result" not in row
+
+    # The detail snapshot (compact-or-full) still carries the payload …
+    assert reg.status(rid)["result"] == {"done": True}
+    assert reg.status(rid, include_events=True)["result"] == {"done": True}
+    # … and so does the completion-injection snapshot.
+    assert done_snapshots and done_snapshots[0]["result"] == {"done": True}
+
+
 async def test_cancel_unknown_run_is_false() -> None:
     reg = RunRegistry()
     assert await reg.cancel("nope") is False

--- a/website/src/apps/workflows/WorkflowsRuns.tsx
+++ b/website/src/apps/workflows/WorkflowsRuns.tsx
@@ -69,7 +69,6 @@ export interface RunSummary {
   run_id: string
   name: string
   status: RunStatus
-  result: unknown
   error: string | null
   author: string | null
   session_key: string | null
@@ -84,6 +83,7 @@ export interface RunSummary {
 }
 
 export interface RunDetail extends RunSummary {
+  result: unknown
   source?: string
   events: WfEvent[]
 }


### PR DESCRIPTION
## Problem / Motivation

The dashboard polls `GET /api/workflows/runs` for the run list. On a live gateway with 15 stored runs, one poll took ~664 ms and carried ~204 KB. Almost all of it — 195,611 bytes, measured — was the full `result` payload of every finished run, sent in rows the code calls "compact". The list UI never shows those payloads.

## Why it matters

The response is redacted and serialized on the gateway's single-threaded event loop, so every poll stalls every other request. A Chrome trace showed this endpoint contending with `POST /api/chat/slots` during New Chat and inflating visible chat-creation latency. The run registry keeps up to 200 runs, so the payload only grows.

## What changed (motivation → approach → change)

The list rows carried one field the list never uses: `result`. `RunHandle.snapshot()` already keeps `events`, `source`, and `partial_results` out of the compact view for exactly this reason — `result` was the one big field that slipped through.

`snapshot()` gains an `include_result` flag. `RunRegistry.list()` passes `include_result=False`, so a list row now omits the payload entirely. The detail endpoint (`GET /api/workflows/runs/{id}`) and the `on_done` completion-injection snapshot keep the full result — those readers need it. No list consumer reads `result` from rows (Workflows tab, chat reconcile, and the MCP `workflow_list` tool were each checked).

The read handlers also stop doing redaction + `json.dumps` inline. A new `_json_response_off_loop` helper runs both on a worker thread via `asyncio.to_thread`. The run list, run detail, and the definitions list/get endpoints route through it — a run detail with its event stream can be MBs, and every saved definition carries its full script source. Payloads are built and detached from loop-affine state before the thread sees them, so the thread only reads; `docs/system-specs/modules/workflows.md` now states that invariant and the compact/full serialization split.

```mermaid
flowchart LR
  subgraph Before
    A1[list poll]:::ctx --> B1["result payloads in every row"]:::removed --> C1["redact + dumps on event loop"]:::removed
  end
  subgraph After
    A2[list poll]:::ctx --> B2["metadata-only rows"]:::added --> C2["redact + dumps on worker thread"]:::added
    D2["detail GET /runs/{id}"]:::ctx --> E2["full result"]:::ctx
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟥 removed · 🟦 unchanged

*The list sends metadata only; the payload rides on the detail endpoint, and both serialize off the loop.*

On the frontend, `RunSummary` drops `result`; `RunDetail` keeps it. The Workflows tab already read `result` only from the detail fetch, so no component behavior changes.

## Tests

- `test_list_is_compact_no_result_payload` — a finished run's list row has no `result` key, while the detail snapshot and the `on_done` completion snapshot still carry the full result. Locks in the split so the payload cannot creep back.
- `test_runs_list_is_compact_and_detail_carries_result` — wire-level: `GET /api/workflows/runs` returns compact rows as well-formed JSON (exercising the off-loop serialization path), and `GET /api/workflows/runs/{id}` returns the full 50 KB result.
- `test_definition_disk_operations_are_offloaded_from_the_gateway_loop` — updated: the definitions read paths now contribute a serialization `to_thread` hop alongside the disk read.

All 1,554 workflow-related backend tests pass; tsc, eslint, i18n gates, and the affected frontend tests pass.

## Manual verification

Measured the live store that motivated this: 15 runs, 195,611 bytes of `result` across list rows before; after the change the same rows serialize to a few KB. Full backend suite failures on the dev host (74) reproduce identically on clean `origin/main` (missing optional host deps — pods, playwright), so they are environmental, not from this diff.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** type-only frontend change (`RunSummary`/`RunDetail` interfaces); no component renders differently.

## Related Issues

Fixes #9633

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
