### PR TITLE
refactor(locks): route with-scoped lock opens through open_lock_file (#9267)

### DIFF
--- a/comment-history-baseline.json
+++ b/comment-history-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Comments and docstrings that narrate change history, per file, as a match COUNT. The rule they break is in docs/system-specs/common/code-style.md (\"Comments explain the WHY\"); it predates any enforcement, so the tree is recorded here rather than rewritten in one pass. The gate requires every OTHER file to be clean and none of these counts to grow, so this list can only shrink. Do NOT add or raise an entry to make a red gate green: a new offender means the comment should state CURRENT behavior in present tense. Lower and prune with `python3 scripts/check_comment_history.py --write-baseline`, which never adds or raises one.",
-  "_total": 6979,
+  "_total": 6977,
   "files": {
     "src/kiro_crew/__main__.py": 1,
     "src/kiro_crew/acp/_dispatch.py": 8,
@@ -441,7 +441,7 @@
     "src/kiro_crew/mcp_tools/apps.py": 1,
     "src/kiro_crew/mcp_tools/artifacts.py": 2,
     "src/kiro_crew/mcp_tools/browser.py": 1,
-    "src/kiro_crew/mcp_tools/control.py": 6,
+    "src/kiro_crew/mcp_tools/control.py": 5,
     "src/kiro_crew/mcp_tools/learn.py": 2,
     "src/kiro_crew/mcp_tools/sessions.py": 2,
     "src/kiro_crew/mcp_tools/spawn.py": 7,
@@ -578,7 +578,7 @@
     "src/kiro_crew/webex/gateway.py": 1,
     "src/kiro_crew/webex/renderer.py": 1,
     "src/kiro_crew/webex/transport_dispatch.py": 4,
-    "src/kiro_crew/webhooks.py": 4,
+    "src/kiro_crew/webhooks.py": 3,
     "src/kiro_crew/wecom/client.py": 2,
     "src/kiro_crew/wecom/gateway.py": 6,
     "src/kiro_crew/wecom/transport.py": 1,

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -134,12 +134,16 @@ class _McpFileLock:
     async def __aenter__(self) -> None:
         _GLOBAL_MCP_JSON.parent.mkdir(parents=True, exist_ok=True)
         _MCP_LOCK_PATH.touch(exist_ok=True)
-        # Open the lock fd WRITABLE. Windows msvcrt.locking() requires write
-        # access on the handle — an "r" fd fails with EACCES and
+        # Open the lock fd WRITABLE and non-truncating. Windows msvcrt.locking()
+        # requires write access on the handle -- an "r" fd fails with EACCES and
         # platform_compat.acquire_lock swallows that (best-effort semantics),
         # silently degrading this to a no-op and letting concurrent
         # /api/mcp/toggle requests race the atomic-rename write of mcp.json
-        # (one flip is lost). "r+" keeps the shared file present (no truncate).
+        # (one flip is lost). "r+" keeps the shared file present (no truncate);
+        # see platform_compat.open_lock_file for the full Windows rationale
+        # (GH-9248). Kept inline rather than routed through that helper: the fd
+        # is stored on self._fd and released in __aexit__, so it must OUTLIVE
+        # this method -- the with-scoped helper would close it at method return.
         fd = open(_MCP_LOCK_PATH, "r+")
         # Run blocking lock acquire in a thread to avoid blocking the event
         # loop. Bind self._fd ONLY AFTER a successful acquire — otherwise a
@@ -187,6 +191,10 @@ class _McpFileLockSync:
     def __enter__(self) -> None:
         _GLOBAL_MCP_JSON.parent.mkdir(parents=True, exist_ok=True)
         _MCP_LOCK_PATH.touch(exist_ok=True)
+        # Non-truncating "r+", see :class:`_McpFileLock` and
+        # platform_compat.open_lock_file (GH-9248). Kept inline for the same
+        # reason: self._fd outlives __enter__/__exit__, so the with-scoped
+        # helper cannot hold it.
         fd = open(_MCP_LOCK_PATH, "r+")
         try:
             platform_compat.acquire_lock(fd.fileno(), exclusive=True)

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -872,13 +872,11 @@ def register_hook(name: str, args: dict[str, Any]) -> str:
     hook_file = mcp_core.config_dir() / "hooks.json"
     hook_file.parent.mkdir(parents=True, exist_ok=True)
     lock_path = hook_file.parent / "hooks.json.lock"
-    # touch + "r+", never "w": a truncating open of a lock file another holder
-    # already locked raises a sharing violation on Windows instead of waiting.
-    # Same file as webhooks.locked guards; full rationale at
-    # work_ledger._open_lock (issue #9248).
-    lock_path.touch(exist_ok=True)
-    with open(lock_path, "r+") as lock_fd:
-        with platform_compat.flock_exclusive(lock_fd.fileno()):
+    # Open non-truncating; see ``platform_compat.open_lock_file`` for why ``"w"``
+    # loses the lock on Windows (GH-9248). Same file as ``webhooks.locked``
+    # guards. Parent mkdir stays (the helper does not create parent dirs).
+    with platform_compat.open_lock_file(lock_path) as lock_fd:
+        with platform_compat.flock_exclusive(lock_fd):
             # Re-read under lock to avoid lost updates
             hooks = {}
             if hook_file.exists():

--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -145,18 +145,11 @@ def _session_pid_file_lock():  # type: ignore[no-untyped-def]
     """Exclusive file lock for session PID file operations."""
     lock_path = _session_pid_file_path().with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    # ``touch`` + ``"r+"``: WRITABLE, and crucially WITHOUT truncation.
-    # ``msvcrt.locking`` needs a writable handle, so ``"r"`` is not an option;
-    # but ``"w"`` TRUNCATES on open, and on Windows a truncating open of a lock
-    # file whose first byte another holder already locked raises a sharing
-    # violation rather than waiting, so the contending acquirer crashes BEFORE
-    # it reaches ``file_lock`` and the serialisation this lock exists to provide
-    # never happens. POSIX ``flock`` tolerates the truncate, which is why the
-    # defect is Windows-only. Same shape as ``dashboard/handlers/mcp.py``'s
-    # ``_McpFileLock`` and ``work_ledger._open_lock``.
-    lock_path.touch(exist_ok=True)
-    with open(lock_path, "r+") as lock_fd:
-        with platform_compat.file_lock(lock_fd.fileno(), exclusive=True):
+    # Open non-truncating; see ``platform_compat.open_lock_file`` for why ``"w"``
+    # loses the lock on Windows (GH-9248). The helper does the create-or-open in
+    # one syscall; the parent mkdir above stays because it does not.
+    with platform_compat.open_lock_file(lock_path) as lock_fd:
+        with platform_compat.file_lock(lock_fd, exclusive=True):
             yield
 
 
@@ -191,18 +184,11 @@ def _pid_file_lock():  # type: ignore[no-untyped-def]
     """Exclusive file lock for all PID file read-modify-write operations."""
     lock_path = _pid_file_path().with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    # ``touch`` + ``"r+"``: WRITABLE, and crucially WITHOUT truncation.
-    # ``msvcrt.locking`` needs a writable handle, so ``"r"`` is not an option;
-    # but ``"w"`` TRUNCATES on open, and on Windows a truncating open of a lock
-    # file whose first byte another holder already locked raises a sharing
-    # violation rather than waiting, so the contending acquirer crashes BEFORE
-    # it reaches ``file_lock`` and the serialisation this lock exists to provide
-    # never happens. POSIX ``flock`` tolerates the truncate, which is why the
-    # defect is Windows-only. Same shape as ``dashboard/handlers/mcp.py``'s
-    # ``_McpFileLock`` and ``work_ledger._open_lock``.
-    lock_path.touch(exist_ok=True)
-    with open(lock_path, "r+") as lock_fd:
-        with platform_compat.file_lock(lock_fd.fileno(), exclusive=True):
+    # Open non-truncating; see ``platform_compat.open_lock_file`` for why ``"w"``
+    # loses the lock on Windows (GH-9248). The helper does the create-or-open in
+    # one syscall; the parent mkdir above stays because it does not.
+    with platform_compat.open_lock_file(lock_path) as lock_fd:
+        with platform_compat.file_lock(lock_fd, exclusive=True):
             yield
 
 
@@ -521,6 +507,10 @@ def _periodic_pid_sweep(my_gw_pid: int, active_pids: set[int]) -> tuple[set[str]
         # This site is the likeliest of the three to feel it: the sweep runs on a
         # timer while `_track_session_pid` is contending for the same lock, which
         # is exactly the interleaving a truncating open turns into a crash.
+        # Kept inline rather than routed through `platform_compat.open_lock_file`:
+        # this fd takes a SHARED (read) lock and is held across the try/finally
+        # below, not a `with` block -- the with-scoped helper serves exclusive
+        # acquisition only, so forcing this through it would change behaviour.
         lock_path.touch(exist_ok=True)
         lock_fd = open(lock_path, "r+")
     except OSError:

--- a/src/kiro_crew/webhooks.py
+++ b/src/kiro_crew/webhooks.py
@@ -186,12 +186,11 @@ def locked(path: Path) -> Iterator[None]:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.parent / (path.name + ".lock")
-    # touch + "r+", never "w": a truncating open of a lock file another holder
-    # already locked raises a sharing violation on Windows instead of waiting.
-    # Full rationale at work_ledger._open_lock (issue #9248).
-    lock_path.touch(exist_ok=True)
-    with open(lock_path, "r+") as lock_fd:
-        with platform_compat.flock_exclusive(lock_fd.fileno()):
+    # Open non-truncating; see ``platform_compat.open_lock_file`` for why ``"w"``
+    # loses the lock on Windows (GH-9248). Parent mkdir stays (the helper does
+    # not create parent dirs).
+    with platform_compat.open_lock_file(lock_path) as lock_fd:
+        with platform_compat.flock_exclusive(lock_fd):
             yield
 
 


### PR DESCRIPTION
## What is the problem?

The non-truncating lock-open preamble (parent `mkdir`, then open the lock file
WITHOUT truncating, then acquire) exists as hand-rolled copies in several places.
`platform_compat.open_lock_file` was added in #9316 to hold that idiom once, but
the pre-existing copies were never migrated onto it, so the duplication #9267
describes is still in the tree.

## Why this issue matters to the user

Duplicated preambles are how the `hooks.json` pair drifted in the first place:
two modules locking the SAME file, each with its own open, each carrying its own
rationale comment that a later edit can update in one place and miss in the other.
Every copy is a place a future edit can reintroduce the Windows lock-loss defect
(#9248) that the helper's `O_RDWR | O_CREAT` was written to prevent.

## How our fix solves it

Symptom: four-plus hand-rolled copies of the preamble. Root cause: no shared entry
point, so each site open-codes it. Fix: route the sites the helper can actually
serve through `open_lock_file`, and point the rest at it.

Inspection found the "four copies" in #9267 are really **seven open-sites across
three calling shapes**, and the helper serves only one:

- **with-scoped** (fd lives and dies inside a `with`) -- migrated onto the helper:
  `session_pid._session_pid_file_lock`, `session_pid._pid_file_lock`,
  `webhooks.locked`, `mcp_tools.control.register_hook`.
- **acquire-now / release-later** (fd stored on `self._fd`, released in
  `__aexit__`/`__exit__`, so it must outlive the method) -- left inline with a
  pointer comment: `dashboard/handlers/mcp.py::_McpFileLock` and its sync sibling
  `_McpFileLockSync`. A yielding context manager would close the fd at method
  return.
- **shared read** (`try_acquire_lock(exclusive=False)`) -- left inline with a
  pointer comment: `session_pid._periodic_pid_sweep`. The helper serves exclusive
  acquisition; forcing a shared lock through it would be a behaviour change dressed
  as cleanup.

Each migrated site keeps its own `parent.mkdir(...)` (the helper does not create
parent dirs), drops its `touch` + `"r+"` preamble, and replaces its rationale
comment with a one-line pointer to the helper docstring, which now holds the
reasoning once.

**`work_ledger._open_lock` is deliberately excluded.** PR #9374 is open,
MERGEABLE, and edits `work_ledger.py`. Consolidating there would chain two open
PRs on the same file for no benefit a follow-up would not get, and a review change
on #9374 would cost a second rebase. Its canonical docstring stays as the pointer
target until it lands; migrating it is a clean follow-up afterward.

The gap that `open_lock_file` covers only the with-scoped exclusive shape is
`open_lock_file`'s own design (jeeshofone, #9316); this PR does not extend the
helper and notes the gap on the issue instead.

## What tests we did

- `test/test_platform_compat.py` -- the repo-wide contract scan
  `test_no_lock_site_opens_truncating` still passes (275 passed).
- `test/test_pid_lifecycle.py` (172 passed), `test/test_hooks_json_shared_file.py`
  (15 passed), `test/test_webhooks_store.py` (47 passed),
  `test/test_mcp_core_coverage.py` including `TestRegisterHook` (164 passed).
- Mutation proof: reverting one migrated site (`webhooks.locked`) to a truncating
  `open(lock_path, "w")` turned the contract scan RED with `webhooks.py:192`; the
  scan is load-bearing, not decorative. Restored, green again.

## Any other suggestions on the work

The taxonomy is the finding: a duplication issue's stated copy count is a lower
bound, and the shapes hiding inside it decide whether consolidation is even
possible. Five of the seven sites here were never going to collapse onto the
shared helper regardless of who tried. Whoever owns `open_lock_file` can decide
whether to grow it toward the acquire-later and shared-read shapes; that is a
separate item.

Refs #9267
