### PR TITLE
feat(config): adopt superseded numeric defaults on upgrade

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -348,7 +348,7 @@ type mismatch the schema validator removes before the loader sees it, so such an
 entry is absent from the loaded table. `resolve_agent_bindings` has always answered
 from that table; `workspace_dir_for` now agrees with it.
 
-## Superseded Defaults (reported, never rewritten)
+## Superseded Defaults (reported; a named few adopt themselves once)
 
 `config.json` is a full materialization of the schema -- every field is written to
 disk, including fields the operator never set -- and each field is resolved as
@@ -366,8 +366,114 @@ stored `0` is not read as `False`.
 Registered so far: `mcp_gateway.forward_declared_env` (False -> True, #4566),
 `session.autocompact_pct` (90.0 -> 70.0, #4388), `stt.streaming` (False -> True,
 0.5.0), `stt.model` ("turbo" -> "base", 0.5.0),
-`dashboard.loop_stall_exit_after_secs` (25 -> unset, #6651) and
-`instances.warm_set_cap` (5 -> 0, #7248).
+`dashboard.loop_stall_exit_after_secs` (25 -> unset, #6651),
+`instances.warm_set_cap` (5 -> 0, #7248),
+`agent.chat_turn_timeout_secs` (7200 -> 14400, #8949) and
+`agent.subagent_timeout_secs` (1800 -> 10800, #8891). **Two** carry `auto_adopt` --
+the agent timeout budgets -- and the other six are report-only; see below.
+
+### Auto-adoption, and the line it does not cross
+
+Reporting is the right answer only while the two readings of a stored value are
+indistinguishable AND holding the old value is survivable. On the two agent timeout
+budgets neither holds: an install carrying `agent.subagent_timeout_secs: 1800` reaps
+every subagent at 30 minutes on a build whose default is 10800, and its operator
+sees timeouts instead of results having never chosen 1800. The existing mechanism's
+only answer was a CLI command they have no reason to know exists.
+
+So `SupersededDefault.auto_adopt` opts ONE entry into a one-shot rewrite. What keeps
+the set small is **not** a judgment about how wide the value's range is. That
+criterion was tried and is wrong: `instances.warm_set_cap` is numeric with a range,
+and an operator running five crews who types 5 stores exactly the old default. The
+line that holds is whether the repository ALREADY PINS the stored value as a
+supported configuration:
+
+| Key | | Pinned by |
+|---|---|---|
+| `agent.subagent_timeout_secs` | adopts | -- |
+| `agent.chat_turn_timeout_secs` | adopts | -- |
+| `session.autocompact_pct` | reports | `test_a_persisted_ceiling_value_is_left_alone` |
+| `dashboard.loop_stall_exit_after_secs` | reports | `test_explicit_desktop_default_is_preserved_for_managed_service` |
+| `stt.streaming` | reports | `test_put_persists_streaming` |
+| `mcp_gateway.forward_declared_env` | reports | `test_a_real_false_still_turns_it_off` |
+| `stt.model` | reports | a picker value; adopting changes transcription accuracy |
+| `instances.warm_set_cap` | reports | 5 is an ordinary deliberate cap |
+
+A row whose old value another suite guarantees is not stale noise by definition,
+whatever its type. `test_only_unpinned_broken_budgets_adopt_themselves` pins the
+opted-in set and names every exclusion, so a row cannot gain the flag without the
+suite that pins it being consulted. `auto_adopt` defaults to False, so a new row is
+report-only until someone states otherwise.
+
+Two further properties make the rewrite safe on the rows that remain, without the
+per-key provenance the config layer still lacks:
+
+- **One-shot.** `auto_adoptable()` excludes any key already in the sidecar's
+  `adopted` map, so a key is adopted at most once per install and a value the
+  operator sets back afterwards is theirs forever. Without that record the loader
+  would re-remove a restored value on every load -- the one behaviour worse than
+  saying nothing.
+- **Marker first, chosen for its worst case.** `record_adoptions` writes the ledger
+  entry BEFORE the removal, inside the config write lock, and a failing record aborts
+  the whole migration write. `config.json` and the sidecar are two files with no
+  shared transaction, so exactly one of two windows exists and the ordering decides
+  which one:
+
+  | Ordering | Window | Consequence |
+  |---|---|---|
+  | marker first (this) | durable marker, failed removal | the operator KEEPS their value and the adoption is not retried. A **missed improvement**, recoverable with `kirocrew config defaults --adopt` and still named by the startup line. |
+  | removal first | landed removal, lost marker | nothing suppresses a later adoption, so a value the operator deliberately RESTORES is deleted a second time. A **destroyed choice**, unrecoverable. |
+
+  No retry, rollback, compensating write or two-phase pending/committed scheme removes
+  the window -- each only moves it onto another write that can fail the same way, and
+  a rollback that fails recreates the hazard it exists to prevent. So the marker goes
+  first and the failure lands on the recoverable side.
+  `test_a_failed_write_keeps_the_value_and_does_not_re_adopt_later` pins that path
+  end to end, including that a later load does not take the value on a retry, and
+  `test_the_unapplied_adoption_is_still_reported_so_it_is_recoverable` pins that the
+  marker suppresses the retry but not the report.
+- **An adoption that did not reach disk drops the validated-data cache.** Only a load
+  that READS the base document can decide an adoption (`adoptable` is empty on a cache
+  hit, by design), so a read-and-skip that left its document cached would have every
+  later load serve the stale value and never retry. Three paths skip the write -- a
+  contended lock, the degraded-sections branch, an exception caught by the
+  best-effort handler -- so `_load_resolved` tracks `adoption_landed` separately from
+  `persisted` (which starts True so the `connections_ui` marker still lands on a load
+  that needed no migration) and invalidates in a `finally` all three share. Both
+  variables are bound before the `try`, or an early exception would turn a logged
+  write-back failure into a `NameError` out of `load()`.
+- **An unreadable ledger adopts nothing.** `_read_ack_document_status` returns
+  `(document, readable)`, and `auto_adoptable` returns `[]` when a sidecar exists but
+  cannot be parsed: reading it as empty would re-arm the one-shot over a value the
+  operator restored. The ACK half stays fail-soft, because a missed ack costs one
+  report line rather than a deleted setting.
+
+`record_adoptions` takes the sidecar lock **single-shot** (`wait_for_lock=False`),
+because the config load path runs on the asyncio event-loop thread in places and a
+blocking acquire there stalls the gateway for as long as another writer holds it. A
+contended acquire raises `BlockingIOError`, which the migration treats as "defer to
+the next load" -- the same deferral `_persist_config_migration` already takes on a
+contended config lock. A CLI caller keeps the wait: no loop to stall, no later retry.
+
+`--keep` still wins: an acknowledged value is not drift, so affirming a key before
+it is adopted keeps it, which is the answer for an operator who did choose 1800.
+
+Adoption is an **un-materialization**, not a write of the new number:
+`drop_drifted_keys` removes the stored key, so the field resolves through
+`data.get(key, DEFAULT)`. That holds only until the next FULL rewrite of
+`config.json` -- any settings save re-materializes the current number, as
+`drop_drifted_keys`' own docstring says -- so a later default move on the same key
+still needs its own registry row and does not ride along.
+
+It is applied in memory as well, because the gateway reads these budgets once at
+startup -- a disk-only fix would leave the run that performed it still holding the
+old value, which is exactly the "upgraded and nothing changed" complaint. Two guards
+on that half: `_adopt_in_memory` reads the field's OWN dataclass default rather than
+the row's `new_default` (on a key whose default moved twice, the matching row's
+`new_default` is an intermediate value), and it replaces the value only when the
+parsed field still EQUALS `old_default`, so a value the loader clamped or coerced
+keeps the loader's correction. A key the `config.local.json` overlay supplies is
+cleared on disk but left alone in memory: the overlay is the operator's live choice.
 
 `stt.provider` is deliberately absent from `SUPERSEDED_DEFAULTS` even though its
 default moved to `local`: `_validated_stt_provider` coerces a retired value at
@@ -384,7 +490,9 @@ key names the default the loader actually applies, so moving a default without
 appending a row fails rather than leaving the report telling operators to adopt a
 value that no longer exists.
 
-Two surfaces render it, and neither writes:
+Two surfaces render it. Neither writes config; the load path's adoption above is
+the only thing that does, and a key it adopts is excluded from the warning rather
+than pointing the operator at a command for something already fixed:
 
 - The load path emits **one** warning naming every drifted key plus the command to
   resolve it, evaluated on the **stored base document before the

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -25,7 +25,7 @@ import sys
 import threading
 import uuid
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
-from dataclasses import asdict, dataclass, field
+from dataclasses import MISSING, asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
@@ -304,7 +304,16 @@ from kiro_crew.config.sections import (  # noqa: F401
 
 # Superseded-default reporting. Leaf module: stdlib only, so importing it
 # here creates no cycle.
-from kiro_crew.config.superseded_defaults import drift_summary, superseded_default_drift
+# The same module owns the one-shot adoption of the entries that opt into it.
+from kiro_crew.config.superseded_defaults import (
+    SupersededDefault,
+    auto_adoptable,
+    drift_summary,
+    drop_drifted_keys,
+    record_adoptions,
+    stored_value_or_none,
+    superseded_default_drift,
+)
 
 # Schema validation + the validated-data cache live in ``config.validation``.
 # Re-exported here for backward compatibility — callers and tests still
@@ -662,6 +671,11 @@ MIGRATE_WORKSPACES = "workspaces"
 MIGRATE_AGENTS = "agents"
 MIGRATE_DEFAULT_AGENT = "default_agent"
 MIGRATE_CONNECTIONS_UI = "connections_ui"
+#: Un-materialize the stored values that still hold a superseded default an entry
+#: marked ``auto_adopt``. Unlike the three above, this one carries a payload: the
+#: keys the load decided on travel separately in ``adopt_keys``, because the set is
+#: per-install rather than a fixed schema shape.
+MIGRATE_SUPERSEDED_DEFAULTS = "superseded_defaults"
 
 #: Sidecar marker recording that the one-shot ``connections_ui`` launch
 #: migration ran. Pre-launch builds materialized ``connections_ui: false`` into
@@ -681,6 +695,8 @@ def _apply_document_migrations(
     *,
     overlay_kiro_agent: str | None,
     default_kiro_agent: str,
+    adopt_keys: frozenset[str] = frozenset(),
+    recorded_adoptions: list[str] | None = None,
 ) -> bool:
     """Apply the pending write-back migrations to a raw config document in place.
 
@@ -772,6 +788,44 @@ def _apply_document_migrations(
                 data["default_agent"] = "default"
             changed = data["default_agent"] != stored_default or changed
 
+    # Un-materialize the auto-adopting superseded defaults this load found. Four
+    # properties are load-bearing and all four live here rather than at the call
+    # site, because this is the only code that runs inside the config write lock:
+    #
+    # * RE-DETECTED against *data*, so a value another writer changed since this
+    #   load's read is left alone -- the same rule every migration above follows,
+    #   and the reason a live ``config set`` is never clobbered;
+    # * the ledger is written BEFORE the removal is reported as done. A removal
+    #   whose record did not land would repeat on the next load, and repeating is
+    #   the one failure that can override a value the operator restored. A failing
+    #   record therefore propagates and aborts the whole migration write;
+    # * every key it records is reported back through *recorded_adoptions*, because
+    #   writing the ledger first creates the mirror hazard: if the config write then
+    #   fails, the key is marked adopted while the stale value is still stored, and
+    #   the one-shot filter would never revisit it. The caller rolls those entries
+    #   back when the write does not land, which restores the pre-load state exactly;
+    # * ``drop_drifted_keys`` REMOVES the key rather than writing the new number, so
+    #   the field resolves through ``data.get(key, DEFAULT)`` until the next full
+    #   rewrite of the document re-materializes it.
+    #
+    # Lock order is config-then-ack, matching ``record_acks`` -- the only two sites
+    # that nest these locks, and they nest them the same way.
+    if MIGRATE_SUPERSEDED_DEFAULTS in pending and adopt_keys:
+        fresh = [
+            entry.dotted_key for entry in auto_adoptable(data) if entry.dotted_key in adopt_keys
+        ]
+        if fresh:
+            record_adoptions({key: stored_value_or_none(data, key) for key in fresh})
+            if recorded_adoptions is not None:
+                recorded_adoptions.extend(fresh)
+            if drop_drifted_keys(data, fresh):
+                logger.info(
+                    "config: adopted the current default for %s — the stored value "
+                    "was a superseded default this install never chose",
+                    ", ".join(fresh),
+                )
+                changed = True
+
     return changed
 
 
@@ -810,6 +864,8 @@ def _persist_config_migration(
     pending: frozenset[str],
     *,
     default_kiro_agent: str,
+    adopt_keys: frozenset[str] = frozenset(),
+    confirmed_adoptions: list[str] | None = None,
 ) -> bool:
     """Write the pending migrations to *path* as a read-modify-write.
 
@@ -879,46 +935,119 @@ def _persist_config_migration(
     # taken from the load's snapshot so the seed reflects the file as it is now.
     overlay_kiro_agent = _overlay_kiro_agent()
 
+    # Keys the migration recorded in the ledger before removing them. Only the ones
+    # whose write LANDED are reported back, so the in-memory half never runs ahead of
+    # the stored document. Nothing is undone on the failure path: see
+    # ``record_adoptions`` for why the marker deliberately goes first and what the
+    # residual is.
+    recorded_adoptions: list[str] = []
+
+    # ``applied`` means the delta was computed and the backup taken; ``wrote`` means
+    # the ATOMIC WRITE returned. They are separate because the write happens AFTER
+    # ``_mutate`` returns -- ``update_config_locked`` performs it -- so a flag set
+    # inside the callback would report a write that had not happened yet, and a
+    # failing write would then skip the ledger rollback below and strand the key as
+    # adopted-but-stale. Neither call site guards ``write_config_atomically``, so a
+    # failed write propagates and ``wrote`` correctly stays False.
+    applied = False
+
     def _mutate(current: dict) -> dict | None:
-        nonlocal wrote
+        nonlocal applied
         if not _apply_document_migrations(
             current,
             pending,
             overlay_kiro_agent=overlay_kiro_agent,
             default_kiro_agent=default_kiro_agent,
+            adopt_keys=adopt_keys,
+            recorded_adoptions=recorded_adoptions,
         ):
             # Nothing left to migrate -- another writer got here first. Returning
             # None skips the write, so we do not rewrite a file we agree with.
             return None
         _write_migration_backup(path)
-        wrote = True
+        applied = True
         return current
 
-    if _inside_data_home(_lock_target(path)):
-        try:
-            update_config_locked(path, mutate=_mutate, wait_for_lock=False)
-        except BlockingIOError:
-            # POSIX reports a contended single-shot acquire this way. Not a
-            # failure worth a warning: info, because the migration simply moves
-            # to the next load and nothing was written or lost.
-            logger.info(
-                "config: migration deferred -- another writer holds %s.lock; "
-                "the next load will migrate",
-                path.name,
-            )
-            return False
-    else:
-        # read_config_for_update fails CLOSED on an unreadable or non-object
-        # file, and that exception reaches load()'s except: the file is left
-        # alone and the migration retries. Same contract as the locked path.
-        result = _mutate(read_config_for_update(path))
-        if result is not None:
-            write_config_atomically(path, stamp_config_meta(result))
+    try:
+        if _inside_data_home(_lock_target(path)):
+            try:
+                update_config_locked(path, mutate=_mutate, wait_for_lock=False)
+            except BlockingIOError:
+                # POSIX reports a contended single-shot acquire this way. Not a
+                # failure worth a warning: info, because the migration simply moves
+                # to the next load and nothing was written or lost.
+                logger.info(
+                    "config: migration deferred -- another writer holds %s.lock; "
+                    "the next load will migrate",
+                    path.name,
+                )
+                return False
+            # Reached only when the locked read-modify-write completed, so an
+            # ``applied`` delta is now on disk.
+            wrote = applied
+        else:
+            # read_config_for_update fails CLOSED on an unreadable or non-object
+            # file, and that exception reaches load()'s except: the file is left
+            # alone and the migration retries. Same contract as the locked path.
+            result = _mutate(read_config_for_update(path))
+            if result is not None:
+                write_config_atomically(path, stamp_config_meta(result))
+                wrote = True
+    finally:
+        # ``wrote`` is the single fact that decides both halves, and it is read in a
+        # ``finally`` because the write can be skipped WITHOUT an exception too (the
+        # deferral return above, a concurrent writer that already migrated).
+        #
+        # Only a key whose removal actually LANDED is reported back for the in-memory
+        # half, so the running config never holds a value the stored document does not
+        # agree with.
+        if recorded_adoptions and wrote and confirmed_adoptions is not None:
+            confirmed_adoptions.extend(recorded_adoptions)
     if wrote:
         # Same reason save() did: drop the validated-data cache so the next load
         # re-reads this write even where the filesystem mtime resolution is coarse.
         _invalidate_config_cache()
     return wrote
+
+
+def _overlay_supplies(local_data: dict, dotted_key: str) -> bool:
+    """True when ``config.local.json`` itself carries *dotted_key*.
+
+    The overlay wins the deep-merge, so where it names a field the base cannot be
+    the effective value. Adopting such a key in memory would replace the operator's
+    live overlay choice with a default -- the one thing an automatic adoption must
+    never do.
+    """
+    section, _, field = dotted_key.partition(".")
+    section_data = local_data.get(section)
+    return isinstance(section_data, dict) and field in section_data
+
+
+def _adopt_in_memory(cfg: KiroCrewConfig, dotted_key: str, old_default: object) -> None:
+    """Move one parsed field from *old_default* to the LIVE dataclass default.
+
+    The dataclass default is read rather than the registry's ``new_default`` on
+    purpose. Both sides of a registry row are history, so on a key whose default
+    moved twice the matching row's ``new_default`` is an intermediate value, while
+    the field's own default is what the removal on disk will resolve to. Reading it
+    here keeps memory and disk agreeing on one number.
+
+    The guard is exact-value, not just key presence: a field whose parsed value
+    differs from *old_default* was clamped or coerced on the way in, and replacing
+    that would discard the loader's own correction rather than a stale default.
+    """
+    section, _, field = dotted_key.partition(".")
+    target = getattr(cfg, section, None)
+    if target is None:
+        return
+    fields_map = getattr(type(target), "__dataclass_fields__", {})
+    spec = fields_map.get(field)
+    if spec is None or getattr(target, field, None) != old_default:
+        return
+    live_default = spec.default
+    if live_default is MISSING:
+        return
+    setattr(target, field, live_default)
 
 
 def denied_commands_path() -> Path:
@@ -1474,7 +1603,7 @@ def update_config_locked(
 _REPORTED_SUPERSEDED_KEYS: set[str] = set()
 
 
-def _report_superseded_defaults(base_data: dict) -> None:
+def _report_superseded_defaults(base_data: dict, *, skip: set[str] | None = None) -> None:
     """Warn once when stored base values still hold a superseded default.
 
     *base_data* is the ``config.json`` document as read, BEFORE the
@@ -1500,11 +1629,17 @@ def _report_superseded_defaults(base_data: dict) -> None:
     config many times says it once. An acknowledged key is not reported at all --
     ``superseded_default_drift`` filters it -- which is what makes this line
     answerable instead of permanent.
+
+    *skip* names the keys this load is ADOPTING. They are excluded because the line
+    tells the operator to run a command, and pointing them at a command for a key
+    that is being fixed in the same load is worse than saying nothing: by the time
+    they read it the key is already gone from the file.
     """
+    skipped = skip or set()
     drifted = [
         e
         for e in superseded_default_drift(base_data)
-        if e.dotted_key not in _REPORTED_SUPERSEDED_KEYS
+        if e.dotted_key not in _REPORTED_SUPERSEDED_KEYS and e.dotted_key not in skipped
     ]
     if not drifted:
         return
@@ -2658,6 +2793,12 @@ class KiroCrewConfig:
         # disk path below; read from the sidecar on a cache hit. Empty when there
         # is no overlay, in which case the merged document IS the base.
         base_shadow: dict = {}
+        # Bound BEFORE the cache branch, because only the reading branch can decide
+        # an adoption: a cache HIT means no base document was read this load, and a
+        # load that did not look at the file must not adopt from it. Empty is
+        # therefore the correct answer on the hot path, not a missing one -- the load
+        # that populated the cache already adopted.
+        adoptable: list[SupersededDefault] = []
         if cached is not None:
             data, sidecar = cached
             base_shadow = sidecar.get(_SIDECAR_BASE_SHADOW, {})
@@ -2690,15 +2831,25 @@ class KiroCrewConfig:
                     logger.warning("Failed to load config from %s: %s", path, e)
                     _mark_file_degraded(path)
 
-            # Report -- never correct -- a stored BASE value that still holds a
-            # superseded default, before the overlay merge below:
-            # the overlay is the operator's live choice and says nothing about
-            # what the base materialized. Read-only by design; a key with a
-            # documented escape hatch cannot be corrected automatically, because
-            # a stale default and a deliberate opt-out are the same bytes.
-            # Skipped when no base file loaded -- nothing is stored to report on.
+            # Report -- and, for the entries that opt in, ADOPT -- a stored BASE
+            # value that still holds a superseded default, before the overlay merge
+            # below: the overlay is the operator's live choice and says nothing about
+            # what the base materialized.
+            #
+            # The two halves differ in what they may touch. Reporting is read-only
+            # and covers every drifted key, because a key with a documented escape
+            # hatch cannot be corrected automatically -- a stale default and a
+            # deliberate opt-out are the same bytes. Adoption covers only the
+            # entries whose ``auto_adopt`` says the value has no second meaning, and
+            # happens at most once per key per install; ``auto_adoptable`` owns both
+            # filters plus the acknowledgment one.
+            #
+            # Skipped when no base file loaded -- nothing is stored to adopt or
+            # report on.
+            adoptable = []
             if loaded_base:
-                _report_superseded_defaults(data)
+                adoptable = auto_adoptable(data)
+                _report_superseded_defaults(data, skip={e.dotted_key for e in adoptable})
 
             # Deep-merge config.local.json overlay (user-owned, never touched by setup)
             local_data: dict = {}
@@ -4157,6 +4308,14 @@ class KiroCrewConfig:
         # and applies exactly those as a delta (see _persist_config_migration),
         # rather than `cfg.save()`, which would re-serialize this load's whole
         # snapshot and drop any config write that landed after this load's read.
+        #
+        # Bound BEFORE the try: the ``finally`` at the end reads them, and an
+        # exception raised before their assignments would turn a logged write-back
+        # failure into a NameError out of load().
+        adopt_keys: set[str] = set()
+        adoption_landed = False
+        confirmed_adoptions: list[str] = []
+
         try:
             pending: set[str] = set()
             # Flat workspace strings → need migration to {"dir": ...}
@@ -4198,15 +4357,48 @@ class KiroCrewConfig:
                     pending.add(MIGRATE_CONNECTIONS_UI)
                 connections_migrating = True
 
+            # Adopt the auto-adopting superseded defaults. The in-memory half is
+            # applied BELOW, after the write is confirmed -- never here. Applying it
+            # eagerly would let a failed write leave the running config holding a
+            # value the stored document does not agree with, invisibly: the operator
+            # reads 1800 in config.json while the gateway runs 10800.
+            #
+            # In memory still matters as much as the file, which is why it happens at
+            # all: the gateway reads these budgets once at startup, so a disk-only
+            # fix would leave the very run that performed it still on the old value,
+            # and "upgraded, restarted, nothing changed" is the complaint.
+            adopt_keys = {e.dotted_key for e in adoptable}
+            if adopt_keys:
+                pending.add(MIGRATE_SUPERSEDED_DEFAULTS)
+
             needs_migration = bool(pending)
 
             persisted = True
+            # Tracked SEPARATELY from ``persisted``, which starts True so the
+            # connections_ui marker still lands on a load that needed no migration
+            # at all. This one starts False and is set only where the adoption
+            # actually reached disk, so every OTHER way out -- a contended-lock
+            # deferral, the degraded-sections branch below, an exception caught by
+            # the handler at the end -- leaves it False and drops the cache in the
+            # ``finally``.
             if needs_migration and not cfg._degraded_sections:
                 persisted = _persist_config_migration(
                     path,
                     frozenset(pending),
                     default_kiro_agent=cfg.agent.default_agent or "kirocrew",
+                    adopt_keys=frozenset(adopt_keys),
+                    confirmed_adoptions=confirmed_adoptions,
                 )
+                adoption_landed = persisted
+                # In memory only for keys the migration CONFIRMED it removed, and
+                # only where the overlay does not supply the field: there the stale
+                # base bytes are cleared like any other, but the effective value
+                # belongs to ``config.local.json`` and is the operator's live choice.
+                by_key = {e.dotted_key: e for e in adoptable}
+                for key in confirmed_adoptions:
+                    entry = by_key.get(key)
+                    if entry is not None and not _overlay_supplies(local_data, key):
+                        _adopt_in_memory(cfg, key, entry.old_default)
             elif needs_migration:
                 # This load DISCARDED something (a malformed section, an
                 # unreadable file). The write-back serializes only the parsed
@@ -4250,6 +4442,18 @@ class KiroCrewConfig:
         except Exception as e:
             # Migration write-back is best-effort; never block startup.
             logger.warning("Config write-back failed: %s", e)
+        finally:
+            # An adoption that did NOT reach disk must not be frozen behind the
+            # validated-data cache. Only a load that READS the base document can
+            # decide an adoption (``adoptable`` is empty on a cache hit, by design),
+            # so a read-and-skip that left its document cached would have every
+            # later load serve the stale value and never retry -- the ceiling the
+            # operator upgraded to fix would come back and stay. In a ``finally``
+            # rather than beside the write, because the write is skipped by three
+            # different paths (a contended lock, a degraded load, an exception) and
+            # all three leave the same stale cache entry.
+            if adopt_keys and not adoption_landed:
+                _invalidate_config_cache()
 
         return cfg, ticket
 

--- a/src/kiro_crew/config/superseded_defaults.py
+++ b/src/kiro_crew/config/superseded_defaults.py
@@ -10,9 +10,9 @@ default only reaches installs created after the change -- every pre-existing
 install keeps whatever value was materialized the last time it wrote config, and
 nothing tells anyone.
 
-Why this REPORTS and never rewrites
------------------------------------
-An earlier revision corrected the stored value. That cannot be done safely for a
+Why this mostly REPORTS rather than rewrites
+--------------------------------------------
+An early revision corrected every stored value. That cannot be done safely for a
 key that also has a documented escape hatch, and at least one does:
 ``test_a_real_false_still_turns_it_off`` in the gateway env suite pins that an
 explicitly stored ``forward_declared_env: false`` is honoured, and calls it "the
@@ -20,12 +20,51 @@ escape hatch for a server that must not share a backend". On disk that escape
 hatch and a stale materialized default are the SAME BYTES, so no rewrite can tell
 them apart -- correcting one necessarily overrides the other.
 
-Distinguishing them needs per-key provenance (which keys the operator actually
-set), which is a materially larger change to the config layer and its own piece
-of work. Until that exists, the honest scope is to make the drift VISIBLE and
-leave the change to the operator: a warning on the gateway's own log and a
-``doctor`` section naming the key, the stored value, the current default, and the
-release that changed it.
+So the default stayed REPORT-ONLY, and it still is: an entry rewrites nothing
+unless it says ``auto_adopt``.
+
+Why TWO entries adopt themselves anyway
+---------------------------------------
+Reporting is the right answer only while the two readings of the stored value are
+genuinely indistinguishable AND holding the old value is survivable. On the two
+agent timeout budgets neither holds: an install carrying
+``agent.subagent_timeout_secs: 1800`` reaps every subagent at 30 minutes and the
+operator sees timeouts instead of results, having never chosen 1800 at all, and
+telling them to run a command they have no reason to know about is not a fix.
+
+The set is deliberately SMALL, and what keeps it small is not a judgment about how
+wide the value's range is. That test was tried and is wrong: ``instances.warm_set_cap``
+is numeric with a range, and an operator running five crews who types 5 stores
+exactly the old default -- an ordinary config, not a coincidence. The test that
+holds is whether the repository ALREADY PINS the stored value as a supported
+configuration. Three rows do, and all three stay report-only:
+``test_a_persisted_ceiling_value_is_left_alone`` (``session.autocompact_pct``),
+``test_explicit_desktop_default_is_preserved_for_managed_service``
+(``dashboard.loop_stall_exit_after_secs``), and ``test_put_persists_streaming``
+(``stt.streaming``). A row whose old value some other suite guarantees is not stale
+noise by definition, whatever its type.
+
+Two things make the rewrite safe on the rows that remain, without the per-key
+provenance the config layer still lacks:
+
+* ``auto_adopt`` is per ENTRY, so the judgment is made once, by name, in the
+  registry -- not inferred by a rule that would eventually sweep up a key like
+  ``forward_declared_env``;
+* adoption is ONE-SHOT, recorded in the sidecar's ``adopted`` map. A key is
+  adopted at most once per install, so a value the operator sets back afterwards is
+  their choice and is never touched again. Without that record the mechanism would
+  re-remove a restored value on every load, which is the one behaviour worse than
+  saying nothing.
+
+``--keep`` still wins: an acknowledged value is not drift, so affirming a key
+before it is adopted keeps it, and the ack is what an operator who DID choose 1800
+uses to say so.
+
+Adoption is an un-materialization, not a write of the new value: the stored key is
+removed, so the field resolves through ``data.get(key, DEFAULT)`` to whatever the
+running build ships. That lasts only until the next FULL rewrite of ``config.json``
+-- any settings save re-materializes the current number -- so a later default move
+on the same key still needs its own registry row rather than riding along.
 
 Why the report is acknowledgeable
 ---------------------------------
@@ -88,6 +127,15 @@ class SupersededDefault:
     literal values before and after the change; an install is reported as drifted
     only when its stored value equals ``old_default``. ``changed_in`` names the
     PR the change shipped in, so the report can say when the divergence started.
+
+    ``auto_adopt`` opts ONE entry into the one-shot adoption the load path performs
+    (see :func:`auto_adoptable`). It is per-entry rather than global because the
+    reason a rewrite is unsafe is per-key, not universal: set it only where the old
+    value carries no second meaning, so that un-materializing it cannot override a
+    documented escape hatch. ``mcp_gateway.forward_declared_env`` is the standing
+    counter-example -- its stored ``False`` is also the opt-out for a server that
+    must not share a backend -- and it stays report-only. The default is False, so
+    an appended entry is report-only until someone states otherwise.
     """
 
     dotted_key: str
@@ -95,6 +143,7 @@ class SupersededDefault:
     new_default: object
     changed_in: str
     new_default_display: str | None = None
+    auto_adopt: bool = False
 
 
 # The explicit, versioned registry of superseded defaults. APPEND-ONLY: a future
@@ -109,6 +158,12 @@ SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
     # pooling, so the shipped default is True. The change carried no migration, so
     # an install materialized while the default was still False keeps resolving
     # False and never receives the fix.
+    #
+    # REPORT-ONLY, and the reason ``auto_adopt`` is per-entry rather than a global
+    # switch. A stored ``False`` here is ALSO the documented opt-out for a server
+    # that must not share a backend (``test_a_real_false_still_turns_it_off`` in the
+    # gateway env suite pins it), so un-materializing it would turn pooling ON for an
+    # operator who deliberately turned it off -- a behaviour change, not a budget.
     SupersededDefault(
         dotted_key="mcp_gateway.forward_declared_env",
         old_default=False,
@@ -122,6 +177,12 @@ SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
     # carried no migration -- on disk, "chose 90" and "90 was the default when this
     # file was written" are the same bytes -- so an install materialized before it
     # still compacts at 90 and nothing tells anyone.
+    #
+    # REPORT-ONLY: ``test_a_persisted_ceiling_value_is_left_alone`` pins that a
+    # stored 90.0 keeps resolving 90.0, and says in its own docstring that changing
+    # it must be a conscious act. 90.0 is also the validator's maximum, so "max the
+    # slider out" is an ordinary deliberate choice landing on exactly these bytes --
+    # and the cost of holding it is money, not a broken feature.
     SupersededDefault(
         dotted_key="session.autocompact_pct",
         old_default=90.0,
@@ -133,6 +194,12 @@ SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
     # does not hold. An install materialized before the change keeps resolving False
     # and sees text only after it stops speaking, which reads as the feature being
     # missing rather than switched off.
+    #
+    # REPORT-ONLY: the field has two possible values, so EVERY user who deliberately
+    # turns streaming off stores exactly the old default -- the collision is certain,
+    # not unlikely, and the dashboard has a control that produces it.
+    # ``test_put_persists_streaming`` PUTs ``streaming: false`` and pins that it
+    # survives a fresh load, which an adoption would break.
     SupersededDefault(
         dotted_key="stt.streaming",
         old_default=False,
@@ -144,6 +211,11 @@ SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
     # 1.6 GB first-use download where the current default is 148 MB, on an install
     # that materialized the name back when the model was fetched by a separate
     # whisper CLI the user had already installed themselves.
+    #
+    # REPORT-ONLY on the same collision reasoning as ``stt.streaming``: the value is
+    # one of a short list of model names shown in a picker, so an operator who wants
+    # the larger model stores precisely the old default. Adopting it would also be a
+    # transcription-accuracy change made without asking.
     #
     # stt.provider is deliberately NOT registered even though its default moved to
     # ``local``: a stored retired provider is coerced at parse time, so the stored
@@ -158,6 +230,13 @@ SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
     # desktop/foreground and 90 seconds for managed services. A stored 25 may be
     # either the old default or a deliberate operator pin, so report it instead of
     # rewriting it.
+    #
+    # REPORT-ONLY, and pinned twice:
+    # ``test_legacy_materialized_desktop_default_is_reported_not_rewritten`` and
+    # ``test_explicit_desktop_default_is_preserved_for_managed_service``. The second
+    # is the substantive one -- a managed service storing 25 KEEPS 25, deliberately,
+    # so the value an adoption would remove is a supported configuration rather than
+    # stale noise.
     SupersededDefault(
         dotted_key="dashboard.loop_stall_exit_after_secs",
         old_default=25,
@@ -169,14 +248,43 @@ SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
     # panes as there are crews registered). A stored 5 keeps evicting the 6th crew,
     # and eviction is indistinguishable from a disconnect at the pane -- so the
     # symptom of holding the old default is a connection that looks like it flaps
-    # on tab switch. A stored 5 may equally be a deliberate budget on a
-    # memory-tight machine, so report it rather than rewriting it.
+    # on tab switch.
+    #
+    # REPORT-ONLY: the plausible values here are roughly 1..10, so an operator with
+    # five crews who types 5 stores exactly the old default. That is an ordinary
+    # config, not a coincidence, which is the same collision the boolean rows above
+    # are excluded for -- the range being numeric does not widen it.
     SupersededDefault(
         dotted_key="instances.warm_set_cap",
         old_default=5,
         new_default=0,
         changed_in="#7248",
         new_default_display="0 (automatic: as many as are registered)",
+    ),
+    # A stored 7200 cuts a turn at two hours, which is BELOW the longest turn the
+    # shipped budgets legitimately produce, so the turn ends mid-work and reads as
+    # the agent
+    # stopping for no reason. auto_adopt: the field is a runaway backstop with a
+    # single meaning -- a bigger number is a longer ceiling and nothing else -- so
+    # un-materializing it cannot override a second, opt-out reading the way
+    # forward_declared_env's False can.
+    SupersededDefault(
+        dotted_key="agent.chat_turn_timeout_secs",
+        old_default=7200,
+        new_default=14400,
+        changed_in="#8949",
+        auto_adopt=True,
+    ),
+    # A stored 1800 reaps every subagent at 30 minutes, which is what a wide fan-out
+    # of ordinary work exceeds, so the parent collects timeouts instead of results.
+    # Same
+    # single-meaning reasoning as the turn ceiling above, so it auto-adopts too.
+    SupersededDefault(
+        dotted_key="agent.subagent_timeout_secs",
+        old_default=1800,
+        new_default=10800,
+        changed_in="#8891",
+        auto_adopt=True,
     ),
 )
 
@@ -244,48 +352,94 @@ def _read_ack_document() -> object:
     Returns ``None`` for every refusal and every read error. An ack suppresses one
     report line and changes nothing about how config resolves, so the worst
     consequence of ignoring an unreadable file is that the operator is told again.
+
+    The ADOPTION half of the same document cannot be that relaxed: reading an
+    unreadable ledger as empty re-enables a one-shot adoption over a value the
+    operator restored. :func:`_read_ack_document_status` is the tri-state read that
+    tells "no file" apart from "file we could not read", and the adoption path fails
+    CLOSED on the latter.
+    """
+    document, _readable = _read_ack_document_status()
+    return document
+
+
+def _read_ack_document_status() -> tuple[object, bool]:
+    """``(parsed document, readable)`` for the sidecar.
+
+    ``readable`` is False only when a file IS there and we could not turn it into a
+    document -- a refused shape, a failed read, malformed JSON. A file that simply
+    does not exist is ``(None, True)``: nothing was recorded, which is a complete and
+    trustworthy answer.
+
+    The distinction exists for exactly one caller. An ack read may treat both cases
+    as "says nothing" because the cost is one extra report line. An adoption read may
+    not: "no ledger" means never adopted, while "unreadable ledger" means unknown,
+    and acting on unknown as if it were never is what deletes a restored value a
+    second time.
     """
     path = ack_file_path()
     try:
         st = os.lstat(path)
-    except OSError:
-        return None
+    except FileNotFoundError:
+        return None, True
+    except OSError as e:
+        logger.debug("Cannot stat superseded-default sidecar: %s", e)
+        return None, False
     if not stat.S_ISREG(st.st_mode) or st.st_size > ACK_MAX_BYTES:
         logger.debug("Ignoring superseded-default acknowledgments: not a plain small file")
-        return None
+        return None, False
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
         fd = os.open(path, flags)
     except OSError as e:
         logger.debug("Ignoring unreadable superseded-default acknowledgments: %s", e)
-        return None
+        return None, False
     try:
         opened = os.fstat(fd)
         if not stat.S_ISREG(opened.st_mode) or opened.st_size > ACK_MAX_BYTES:
-            return None
+            return None, False
         raw = os.read(fd, ACK_MAX_BYTES)
     except OSError as e:
         logger.debug("Ignoring unreadable superseded-default acknowledgments: %s", e)
-        return None
+        return None, False
     finally:
         os.close(fd)
     try:
-        return json.loads(raw.decode("utf-8"))
+        return json.loads(raw.decode("utf-8")), True
     except ValueError as e:
         # Covers both failure modes without restating them: UnicodeDecodeError and
         # json.JSONDecodeError are both ValueError subclasses.
         logger.debug("Ignoring malformed superseded-default acknowledgments: %s", e)
-        return None
+        return None, False
+
+
+def _map_from_document(raw: object, section: str) -> dict[str, object]:
+    """Extract one ``{dotted key: value}`` map from a parsed document.
+
+    Tolerates every other shape for the same reason the read does: this file only
+    decides whether a line is printed or an adoption already happened, so a
+    document it cannot understand is treated as saying nothing.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    found = raw.get(section)
+    if not isinstance(found, dict):
+        return {}
+    return {k: v for k, v in found.items() if isinstance(k, str)}
+
+
+#: Top-level keys inside the sidecar. ``acked`` is what the operator affirmed;
+#: ``adopted`` is what the load path already auto-adopted once. They share one file
+#: (and therefore one lock, one bounded read, and one link-refusing write) because
+#: both answer the same question about the same registry row, and a second file
+#: would be a second thing to lose.
+ACK_SECTION = "acked"
+ADOPTED_SECTION = "adopted"
 
 
 def _acked_from_document(raw: object) -> dict[str, object]:
     """Extract the ack map from a parsed document, tolerating any other shape."""
-    if not isinstance(raw, dict):
-        return {}
-    acked = raw.get("acked")
-    if not isinstance(acked, dict):
-        return {}
-    return {k: v for k, v in acked.items() if isinstance(k, str)}
+    return _map_from_document(raw, ACK_SECTION)
 
 
 def acked_superseded() -> dict[str, object]:
@@ -298,12 +452,71 @@ def acked_superseded() -> dict[str, object]:
     return _acked_from_document(_read_ack_document())
 
 
-def _update_acked(mutate: Callable[[dict[str, object]], dict[str, object]]) -> dict[str, object]:
-    """Read-modify-write the acknowledgment file under its own lock.
+def adopted_superseded() -> dict[str, object]:
+    """Return ``{dotted key: the value that was un-materialized}`` already adopted.
+
+    This is the record that makes auto-adoption ONE-SHOT, and it is the whole reason
+    an automatic rewrite is safe here at all. Without it, an operator who
+    deliberately sets a key back to the old default would have it removed again on
+    the next load, forever -- the tool overriding a live choice, which is exactly
+    what the report-only design existed to avoid. With it, the rewrite happens at
+    most once per key per install and every later value is the operator's.
+
+    Fails SOFT like the ack read. The consequence of losing the file is bounded and
+    known: a key could auto-adopt a second time, which un-materializes a value the
+    operator may have restored. Two things keep that bounded: the pending record is
+    written BEFORE the rewrite and a failed record aborts the adoption, and a key
+    reaches this suppressing map only once its removal is known to have landed.
+    """
+    return _map_from_document(_read_ack_document(), ADOPTED_SECTION)
+
+
+def _sidecar_holds_unparsable_data() -> bool:
+    """True when the sidecar leaf is a PLAIN FILE we could not turn into a document.
+
+    Separates the two reasons a read fails, because they call for opposite answers.
+    Bytes in a plain file are the operator's ledger and must not be overwritten
+    sight-unseen. A leaf that is not a plain file -- a planted symlink, a FIFO, a
+    directory -- holds no ledger of ours, and the write path deliberately renames
+    OVER it rather than following it; refusing there would turn "anyone who can
+    create this path" into a permanent block on acks and adoptions.
+
+    Reads one ``lstat``. Called under the sidecar lock, so the leaf cannot change
+    between this check and the write that follows it in any way that matters: the
+    rename-over-leaf is what makes the link case safe regardless.
+    """
+    try:
+        st = os.lstat(ack_file_path())
+    except OSError:
+        return False
+    return stat.S_ISREG(st.st_mode)
+
+
+def _update_map(
+    section: str,
+    mutate: Callable[[dict[str, object]], dict[str, object]],
+    *,
+    wait_for_lock: bool = True,
+) -> dict[str, object]:
+    """Read-modify-write one *section* of the sidecar under the file's own lock.
 
     The whole transaction runs inside one lock hold, so two concurrent ``--keep``
     calls cannot both read the same map and have the second replacement drop the
     first operator's acknowledgment.
+
+    *wait_for_lock* must be False on any caller that can run on the asyncio
+    event-loop thread. The config LOAD path is one: a blocking acquire there stalls
+    every gateway request and the heartbeat for as long as another writer keeps the
+    lock. With False the acquire is single-shot and raises ``BlockingIOError`` at
+    once instead, which the load path treats as "defer to the next load" -- correct,
+    because a held lock means another writer is mid-write and its bytes are exactly
+    what must not be clobbered. A CLI caller keeps the wait: it has no loop to stall
+    and no later retry.
+
+    **The section not being mutated is carried through unchanged.** Both maps live
+    in one document, so a write that serialized only its own section would silently
+    delete the other -- an adoption record dropped that way would let a key
+    auto-adopt a second time over a value the operator had restored.
 
     **The write never RESOLVES the leaf.** ``write_config_atomically`` deliberately
     follows a link, because symlinking ``config.json`` into a dotfiles repo is a
@@ -313,8 +526,16 @@ def _update_acked(mutate: Callable[[dict[str, object]], dict[str, object]]) -> d
     rather than followed -- the check reports the condition, the rename is what
     makes it unexploitable.
 
-    Raises ``OSError`` (including :class:`AckPathRefused`) on any filesystem
-    refusal; callers turn that into a controlled CLI error rather than a traceback.
+    **An UNREADABLE sidecar refuses the write instead of rebuilding it.** Both maps
+    are serialized from one read, so a document that could not be parsed would be
+    replaced by one built from two empty maps -- and silently dropping the ADOPTED map
+    re-arms the one-shot over a value the operator restored. Refusing keeps the
+    unreadable bytes for a human to inspect.
+
+    Raises ``OSError`` (including :class:`AckPathRefused` for a link or an unreadable
+    document and, on a contended ``wait_for_lock=False`` acquire, ``BlockingIOError``)
+    on any filesystem refusal; callers turn that into a controlled CLI error or a
+    deferral rather than a traceback.
     """
     path = ack_file_path()
     if platform_compat.is_link_or_junction(path):
@@ -323,13 +544,45 @@ def _update_acked(mutate: Callable[[dict[str, object]], dict[str, object]]) -> d
     lock_path = path.parent / (path.name + ".lock")
     fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
     try:
-        with platform_compat.file_lock(fd, exclusive=True):
-            current = _acked_from_document(_read_ack_document())
-            updated = dict(mutate(current))
-            atomic_write(path, json.dumps({"acked": updated}, indent=2) + "\n", mode=0o600)
+        with platform_compat.file_lock(fd, exclusive=True, wait=wait_for_lock):
+            document, readable = _read_ack_document_status()
+            if not readable and _sidecar_holds_unparsable_data():
+                # REFUSE rather than rebuild, but ONLY for a plain file whose bytes
+                # we could not parse. Both maps are serialized from this read, so
+                # such a document would be replaced by one built from two empty
+                # maps -- and silently dropping the ADOPTED map re-arms the one-shot
+                # over a value the operator restored, which is the outcome the
+                # ledger exists to prevent. A refusal keeps those bytes for a human
+                # to inspect, and every caller already handles OSError.
+                #
+                # A leaf that is NOT a plain file (a planted symlink, a FIFO) is the
+                # opposite case and must NOT refuse: it holds no ledger of ours, and
+                # the design deliberately REPLACES it by renaming over it rather
+                # than following it. Refusing there would let anyone who can create
+                # a path permanently block both acks and adoptions.
+                raise AckPathRefused(
+                    f"{ACK_FILE_NAME} is a plain file whose contents could not be "
+                    "read; refusing to replace it and lose the adoption ledger"
+                )
+            sections = {
+                ACK_SECTION: _map_from_document(document, ACK_SECTION),
+                ADOPTED_SECTION: _map_from_document(document, ADOPTED_SECTION),
+            }
+            updated = dict(mutate(sections[section]))
+            sections[section] = updated
+            body = {name: values for name, values in sections.items() if values}
+            # ``acked`` is always present even when empty: it is the shape every
+            # reader before the adoption ledger existed was written against.
+            body.setdefault(ACK_SECTION, sections[ACK_SECTION])
+            atomic_write(path, json.dumps(body, indent=2) + "\n", mode=0o600)
             return updated
     finally:
         os.close(fd)
+
+
+def _update_acked(mutate: Callable[[dict[str, object]], dict[str, object]]) -> dict[str, object]:
+    """Read-modify-write the acknowledgment map. See :func:`_update_map`."""
+    return _update_map(ACK_SECTION, mutate)
 
 
 def write_acked_superseded(acked: dict[str, object]) -> None:
@@ -397,6 +650,18 @@ def _stored_value(base_data: dict, dotted_key: str) -> object:
     return section_data[field]
 
 
+def stored_value_or_none(base_data: dict, dotted_key: str) -> object:
+    """Return what *base_data* stores at *dotted_key*, or ``None`` when absent.
+
+    The ``None``-mapping wrapper around :func:`_stored_value` for callers outside
+    this module, which have no use for the ``_ABSENT`` sentinel: the adoption ledger
+    records what a key held, and a key that held nothing was never adopted. Exported
+    so the loader does not carry a second spelling of the same lookup.
+    """
+    found = _stored_value(base_data, dotted_key)
+    return None if found is _ABSENT else found
+
+
 def _is_acked(entry: SupersededDefault, stored: object, acked: dict[str, object]) -> bool:
     """True when *stored* is the exact value the operator acknowledged for *entry*.
 
@@ -449,6 +714,90 @@ def superseded_default_drift(
             continue
         drifted.append(entry)
     return drifted
+
+
+def auto_adoptable(
+    base_data: dict,
+    *,
+    acked: dict[str, object] | None = None,
+    adopted: dict[str, object] | None = None,
+) -> list[SupersededDefault]:
+    """Return the drifted entries this install may un-materialize automatically.
+
+    Three filters, and each one is a separate reason a rewrite would be wrong:
+
+    * the entry must be DRIFTED -- the stored value equals ``old_default``, type
+      included, which is what :func:`superseded_default_drift` decides;
+    * the entry must carry ``auto_adopt`` -- the per-key statement that the old
+      value has no second meaning a rewrite could override;
+    * the key must not already be in the adoption ledger -- adoption is one-shot, so
+      a value the operator set back to the old default after we adopted once is
+      theirs and stays.
+
+    An ACKED key is excluded by the drift filter itself: an affirmed value is the
+    operator's answer, and answering is precisely what makes it not drift. That
+    ordering matters -- ``--keep`` must be able to pre-empt an adoption that has not
+    happened yet, not merely silence the line about it.
+
+    Reads only. Both maps may be supplied to keep this pure in tests; ``None`` reads
+    the sidecar -- and an UNREADABLE sidecar returns nothing rather than treating it
+    as empty. Reading a ledger we could not parse as "nothing was ever adopted"
+    re-arms the one-shot over a value the operator restored, which is the one outcome
+    the ledger exists to prevent; declining to adopt this load costs at most a
+    deferral to the next one.
+    """
+    if adopted is None:
+        document, readable = _read_ack_document_status()
+        if not readable:
+            logger.warning(
+                "Not adopting any superseded default this load: %s exists but could "
+                "not be read, so an already-adopted key cannot be told from a value "
+                "the operator restored",
+                ACK_FILE_NAME,
+            )
+            return []
+        adopted = _map_from_document(document, ADOPTED_SECTION)
+    return [
+        entry
+        for entry in superseded_default_drift(base_data, acked=acked)
+        if entry.auto_adopt and entry.dotted_key not in adopted
+    ]
+
+
+def record_adoptions(values: dict[str, object]) -> dict[str, object]:
+    """Record ``{dotted key: the value about to be un-materialized}`` as ADOPTED.
+
+    Written BEFORE the removal, and a failure propagates so the caller abandons the
+    adoption entirely. The order is the whole design, and it is chosen for its WORST
+    CASE, because ``config.json`` and this sidecar are two files with no shared
+    transaction -- one of the two windows below is unavoidable:
+
+    * **marker first** (this): the marker can be durable while the removal failed. The
+      key is then never adopted again, so the operator keeps the value they already
+      had, the drift report still names it, and ``kirocrew config defaults --adopt``
+      applies it by hand. A missed improvement.
+    * **removal first**: the removal can land while the marker did not. Nothing
+      suppresses a future adoption, so if the operator later RESTORES that value on
+      purpose, the next load deletes it again -- and being deleted twice is precisely
+      what the one-shot guarantee exists to prevent. A destroyed choice.
+
+    A missed improvement is recoverable by one documented command; a destroyed choice
+    is not recoverable at all, and no ordering, retry or compensating write removes
+    the window -- each only moves it onto another write that can fail the same way.
+    So the marker goes first and the failure lands on the harmless side.
+
+    The lock acquire is SINGLE-SHOT (``wait_for_lock=False``). The only caller is the
+    config-load migration, which runs on the asyncio event-loop thread in places, and
+    a blocking acquire there stalls the gateway for as long as another writer holds
+    the sidecar. A contended acquire raises ``BlockingIOError`` instead, which is the
+    deferral the surrounding migration already knows how to take.
+
+    The value is recorded rather than a bare key so the ledger says what was taken
+    away, which is what a ``doctor`` line or a bug report needs.
+    """
+    return _update_map(
+        ADOPTED_SECTION, lambda existing: {**existing, **values}, wait_for_lock=False
+    )
 
 
 @dataclass(frozen=True)

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -29,8 +29,18 @@ The dashboard port is **not** a config key: set `KIROCREW_PORT` instead.
 `config.json` is written as a full materialization of the schema, so every key is
 on disk even if you never set it — and a stored value always beats the shipped
 default. Changing a default therefore reaches new installs only: yours keeps
-whatever was written the last time it saved. On startup Kiro Crew prints one line
-naming any key still holding an old default.
+whatever was written the last time it saved.
+
+Kiro Crew now fixes that for itself on the two agent timeout budgets — the subagent
+timeout and the chat-turn ceiling. On the first start after an upgrade, a stored value
+that is exactly an old shipped default is removed so the current default applies, in
+that same run. It happens once per key: set one back afterwards and it stays yours.
+Affirming a value with `--keep` before that first start also keeps it.
+
+Everything else is reported, not changed, because a stored value can be a real
+choice: `stt.streaming: false` is how you turn live dictation text off, and on disk
+that is identical to the old default. On startup Kiro Crew prints one line naming any
+key still holding an old default.
 
 `kirocrew config defaults` shows each one with its stored value, the current
 default, and the release that changed it. Two ways to answer it:

--- a/test/test_config_superseded_defaults.py
+++ b/test/test_config_superseded_defaults.py
@@ -623,3 +623,605 @@ def test_doctor_offers_the_commands_when_something_is_unacked(tmp_path, monkeypa
     assert "kirocrew config defaults --adopt" in out
     assert "kirocrew config defaults --keep" in out
     assert issues == []
+
+
+# --------------------------------------------------------------------------
+# One-shot auto-adoption: the entries whose old value has no second meaning.
+# --------------------------------------------------------------------------
+
+SUBAGENT_ENTRY = next(
+    e for e in SD.SUPERSEDED_DEFAULTS if e.dotted_key == "agent.subagent_timeout_secs"
+)
+
+TURN_ENTRY = next(
+    e for e in SD.SUPERSEDED_DEFAULTS if e.dotted_key == "agent.chat_turn_timeout_secs"
+)
+
+
+def test_only_unpinned_broken_budgets_adopt_themselves():
+    """A row adopts only when no other suite pins its old value as supported.
+
+    The dividing line is NOT how wide the value's range is. That test was tried and
+    is wrong: ``instances.warm_set_cap`` is numeric with a range, and an operator
+    running five crews who types 5 stores exactly the old default. What separates the
+    two groups is whether the repository already GUARANTEES the stored value
+    elsewhere -- a value some other suite pins as a supported configuration is not
+    stale noise, whatever its type.
+
+    Pinned as a property of the whole registry, because both failures it guards
+    against are registry-shaped: a row that adopts by accident, and a row losing its
+    exemption without the suite that pins it being consulted.
+    """
+    assert (
+        SupersededDefault(
+            dotted_key="a.b", old_default=1, new_default=2, changed_in="#1"
+        ).auto_adopt
+        is False
+    ), "the dataclass default stays False, so an appended row adopts only when it says so"
+    adopting = {e.dotted_key for e in SD.SUPERSEDED_DEFAULTS if e.auto_adopt}
+    assert adopting == {
+        "agent.subagent_timeout_secs",
+        "agent.chat_turn_timeout_secs",
+    }
+    # Each of these has its stored value pinned as supported by a named test
+    # elsewhere in the suite; adopting one turns that suite red, which is how this
+    # line was found.
+    for pinned in (
+        "session.autocompact_pct",
+        "dashboard.loop_stall_exit_after_secs",
+        "stt.streaming",
+        "stt.model",
+        "mcp_gateway.forward_declared_env",
+        "instances.warm_set_cap",
+    ):
+        assert pinned not in adopting, f"{pinned}'s stored value is guaranteed elsewhere"
+
+
+def test_every_adopting_key_clears_in_one_load(tmp_path, monkeypatch):
+    """One load clears both stale timeout budgets an upgraded install holds.
+
+    Written as one load over one document rather than a test per key: what an
+    operator actually has is both at once, and the failure worth catching is a key
+    that silently sits out the sweep.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(
+        tmp_path,
+        {"agent": {"subagent_timeout_secs": 1800, "chat_turn_timeout_secs": 7200}},
+    )
+
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.agent.subagent_timeout_secs == 10800
+    assert cfg.agent.chat_turn_timeout_secs == 14400
+    assert _on_disk(tmp_path).get("agent", {}) == {}
+
+
+def test_a_pinned_stored_value_is_never_adopted(tmp_path, monkeypatch):
+    """The rows other suites guarantee survive a load untouched, on disk and in memory.
+
+    Four at once, because the regression that set this boundary surfaced them one CI
+    round at a time: a dashboard voice opt-out, a maxed compaction slider, a managed
+    service's explicit watchdog budget, and a warm-set cap.
+    """
+    _point_home(tmp_path, monkeypatch)
+    stored = {
+        "stt": {"streaming": False, "model": "turbo"},
+        "session": {"autocompact_pct": 90.0},
+        "dashboard": {"loop_stall_exit_after_secs": 25},
+        "instances": {"warm_set_cap": 5},
+    }
+    _write_config(tmp_path, stored)
+
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.stt.streaming is False
+    assert cfg.session.autocompact_pct == 90.0
+    assert cfg.dashboard.loop_stall_exit_after_secs == 25
+    assert cfg.instances.warm_set_cap == 5
+    on_disk = _on_disk(tmp_path)
+    for section, fields in stored.items():
+        for field, value in fields.items():
+            assert on_disk[section][field] == value, f"{section}.{field} was rewritten"
+    assert SD.adopted_superseded() == {}
+
+
+def test_the_ledger_write_never_blocks_the_event_loop(tmp_path, monkeypatch):
+    """``record_adoptions`` must take the sidecar lock SINGLE-SHOT.
+
+    The config load path runs on the asyncio event-loop thread in places, so a
+    blocking acquire here stalls every gateway request and the heartbeat for as long
+    as another writer keeps the lock. Asserted on the flag passed to ``file_lock``
+    rather than by timing a real contended acquire: a timing test would be the flaky
+    way to check the same one bit.
+    """
+    _point_home(tmp_path, monkeypatch)
+    seen: list[bool] = []
+    real = platform_compat.file_lock
+
+    def _spy(fd, **kwargs):
+        seen.append(bool(kwargs.get("wait", True)))
+        return real(fd, **kwargs)
+
+    monkeypatch.setattr(platform_compat, "file_lock", _spy)
+
+    SD.record_adoptions({"agent.subagent_timeout_secs": 1800})
+    assert seen == [False], "the load path must not wait on the sidecar lock"
+
+    seen.clear()
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+    assert seen == [True], "a CLI caller has no loop to stall and keeps the wait"
+
+
+def test_a_contended_sidecar_defers_the_adoption(tmp_path, monkeypatch):
+    """A held sidecar lock defers the adoption instead of stalling or half-applying.
+
+    Deferral is the correct outcome, not a compromise: the config keeps its value,
+    the next load retries, and nothing is written in between.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+
+    def _contended(_values):
+        raise BlockingIOError("another writer holds the sidecar")
+
+    monkeypatch.setattr(L, "record_adoptions", _contended)
+
+    KiroCrewConfig.load()
+
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+    assert SD.adopted_superseded() == {}
+
+
+def test_the_loader_has_no_second_spelling_of_the_stored_value_lookup():
+    """One dotted-key lookup, exported, rather than a copy in the loader.
+
+    Two spellings of "read `<section>.<field>` out of the stored document" can come
+    to disagree about an edge case (a non-dict section, an absent key) while both
+    look correct in isolation.
+    """
+    import inspect
+
+    from kiro_crew.config import loader
+
+    assert not hasattr(loader, "_stored_scalar")
+    assert SD.stored_value_or_none({"agent": {"x": 1}}, "agent.x") == 1
+    assert SD.stored_value_or_none({"agent": {}}, "agent.x") is None
+    assert SD.stored_value_or_none({"agent": "not-a-dict"}, "agent.x") is None
+    assert "stored_value_or_none" in inspect.getsource(loader._apply_document_migrations)
+
+
+def test_a_deferred_adoption_is_not_frozen_behind_the_cache(tmp_path, monkeypatch):
+    """A deferred adoption drops the validated-data cache so the next load retries.
+
+    Only a load that READS the base document can decide an adoption, so a
+    read-and-defer that left its document cached would have every later load serve
+    the stale value from that cache and never retry -- the ceiling the operator
+    upgraded to fix would come back and stay.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+
+    calls: list[int] = []
+
+    def _contended(_values):
+        calls.append(1)
+        raise BlockingIOError("another writer holds the sidecar")
+
+    monkeypatch.setattr(L, "record_adoptions", _contended)
+
+    first = KiroCrewConfig.load()
+    # Deferred means deferred on BOTH halves: the write did not land, so the running
+    # config keeps the stored value rather than diverging from it.
+    assert first.agent.subagent_timeout_secs == 1800
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+
+    # A second load with no file change: it must RE-READ (and try again) rather than
+    # serve the cached document, which is what the retry depends on.
+    KiroCrewConfig.load()
+    assert len(calls) == 2, "the deferred adoption was never retried"
+
+
+def test_an_unreadable_ledger_adopts_nothing(tmp_path, monkeypatch, caplog):
+    """A sidecar that exists but cannot be parsed fails CLOSED on adoption.
+
+    Reading it as empty would re-arm the one-shot over a value the operator restored,
+    which is the single outcome the ledger exists to prevent. Declining costs at most
+    a deferral; the ACK half stays fail-soft, because a missed ack costs one report
+    line.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+    SD.ack_file_path().write_text("{ this is not json", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger=SD.__name__):
+        cfg = KiroCrewConfig.load()
+
+    assert cfg.agent.subagent_timeout_secs == 1800
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+    assert any("could not be read" in r.getMessage() for r in caplog.records)
+
+
+def test_a_missing_ledger_is_not_an_unreadable_one(tmp_path, monkeypatch):
+    """No file means nothing was ever adopted, which is a trustworthy answer.
+
+    The negative control for the test above: if the fail-closed branch also caught
+    the absent-file case, adoption could never happen at all on a fresh install --
+    green on the safety test, silently dead as a feature.
+    """
+    _point_home(tmp_path, monkeypatch)
+    assert not SD.ack_file_path().exists()
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.agent.subagent_timeout_secs == 10800
+
+
+def test_a_malformed_sidecar_refuses_the_write_instead_of_erasing_it(tmp_path, monkeypatch):
+    """A write must not rebuild the sidecar from a document it could not parse.
+
+    Both maps are serialized from one read, so an unparsable document would be
+    replaced by one built from two empty maps -- and dropping the ADOPTED map re-arms
+    the one-shot over a value the operator restored, which is the outcome the ledger
+    exists to prevent. Fixing only the read path left this hole: `--keep` would have
+    erased the adoption history on its way past.
+    """
+    _point_home(tmp_path, monkeypatch)
+    SD.ack_file_path().write_text("{ not json at all", encoding="utf-8")
+
+    with pytest.raises(OSError):
+        SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+
+    # The bytes are still there for a human to look at, not replaced by our own.
+    assert SD.ack_file_path().read_text(encoding="utf-8") == "{ not json at all"
+
+
+def test_a_non_plain_leaf_is_still_replaced_rather_than_refused(tmp_path, monkeypatch):
+    """Negative control for the refusal above, and a real availability property.
+
+    A leaf that is not a plain file holds no ledger of ours, and the write path
+    renames OVER it rather than following it. If the refusal also covered this case,
+    anyone who can create that path could permanently block every ack and every
+    adoption -- the safety fix would have bought a denial of service.
+    """
+    _point_home(tmp_path, monkeypatch)
+    victim = tmp_path / "victim.json"
+    victim.write_text('{"keep": "me"}', encoding="utf-8")
+    SD.ack_file_path().symlink_to(victim)
+
+    monkeypatch.setattr(SD.platform_compat, "is_link_or_junction", lambda _p: False)
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+
+    assert victim.read_text(encoding="utf-8") == '{"keep": "me"}'
+    assert not SD.ack_file_path().is_symlink()
+    assert SD.acked_superseded() == {"session.autocompact_pct": 90.0}
+
+
+def test_a_malformed_sidecar_does_not_let_the_load_adopt(tmp_path, monkeypatch):
+    """The read and write halves agree: nothing adopts while the ledger is unreadable.
+
+    The load path's ``record_adoptions`` would now raise on the same document, so
+    this pins the whole-path outcome rather than one guard: the stored value stays.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+    SD.ack_file_path().write_text("}}not json", encoding="utf-8")
+
+    KiroCrewConfig.load()
+
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+    assert SD.ack_file_path().read_text(encoding="utf-8") == "}}not json"
+
+
+def test_an_exception_during_write_back_still_drops_the_cache(tmp_path, monkeypatch):
+    """Every path that skips the write leaves the same stale cache entry.
+
+    Three of them exist -- a contended lock, a degraded load, an exception caught by
+    the best-effort handler -- and only the first was covered when the invalidation
+    sat beside the write. A load that read the document and then skipped the adoption
+    must not leave that document cached, or later cache-hit loads serve the stale
+    ceiling forever (a cache hit can never decide an adoption, by design).
+
+    The exception path stands in for all three: the invalidation now lives in one
+    ``finally`` they share, so covering the one a test can trigger deterministically
+    covers the branch. Degrading a section on purpose from a test needs the loader to
+    discard it, which the schema layer rejects earlier, and the contended-lock path
+    has its own test above.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("write-back exploded")
+
+    monkeypatch.setattr(L, "_persist_config_migration", _boom)
+
+    KiroCrewConfig.load()
+
+    # Asserted on the CACHE itself, not on a second load's behaviour: a cache-hit
+    # load still runs the other pending migrations, so counting write-back calls
+    # cannot tell a hit from a re-read. An empty cache IS the retry.
+    assert L._CONFIG_CACHE._entry is None, "the stale document stayed cached"
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+
+
+def test_the_running_config_never_diverges_from_the_stored_one(tmp_path, monkeypatch):
+    """In-memory adoption applies only to keys the write CONFIRMED it removed.
+
+    Applied eagerly, a failed write left the gateway running 10800 while
+    `config.json` still said 1800 -- a divergence neither side reveals: the operator
+    reads the file and sees their value, the process behaves as if it had changed.
+    Both halves now move together or neither does.
+
+    Written as a paired assertion over two loads rather than one: the same code must
+    ALSO still change memory on the success path, and a test that only pinned the
+    failure could be satisfied by never touching memory at all.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+
+    def _refuse(_values):
+        raise OSError("read-only data home")
+
+    monkeypatch.setattr(L, "record_adoptions", _refuse)
+    failed = KiroCrewConfig.load()
+    assert failed.agent.subagent_timeout_secs == 1800
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+
+    monkeypatch.undo()
+    _point_home(tmp_path, monkeypatch)
+    L._invalidate_config_cache()
+    ok = KiroCrewConfig.load()
+    assert ok.agent.subagent_timeout_secs == 10800
+    assert "subagent_timeout_secs" not in _on_disk(tmp_path).get("agent", {})
+
+
+def test_a_failed_write_keeps_the_value_and_does_not_re_adopt_later(tmp_path, monkeypatch):
+    """The chosen side of an unavoidable two-file window, pinned end to end.
+
+    ``config.json`` and the sidecar have no shared transaction, so exactly one of two
+    windows exists. Marker-first means a durable marker can outlive a failed removal:
+    the operator KEEPS the value they had and the adoption is simply not retried.
+    Removal-first would instead let a landed removal outlive a lost marker, and then a
+    value the operator deliberately restored is deleted a SECOND time -- which is what
+    the one-shot guarantee exists to prevent.
+
+    A missed improvement is recoverable by one documented command; a destroyed choice
+    is not recoverable at all. This test pins that the failure lands on the recoverable
+    side, including the part that matters most: a later load must not delete the value
+    again.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+
+    def _fail_backup(_path):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(L, "_write_migration_backup", _fail_backup)
+    failed = KiroCrewConfig.load()
+
+    # Nothing was destroyed, and memory did not run ahead of the file.
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+    assert failed.agent.subagent_timeout_secs == 1800
+
+    monkeypatch.undo()
+    _point_home(tmp_path, monkeypatch)
+    L._invalidate_config_cache()
+    later = KiroCrewConfig.load()
+
+    # The marker is durable, so the value is left alone from here on -- the operator's
+    # 1800 survives every later load rather than being taken on a retry.
+    assert later.agent.subagent_timeout_secs == 1800
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+
+
+def test_the_unapplied_adoption_is_still_reported_so_it_is_recoverable(
+    tmp_path, monkeypatch, caplog
+):
+    """A missed improvement must not be silent: the drift line is the recovery path.
+
+    The marker suppresses the automatic retry, not the report -- ``--adopt`` remains
+    available and the startup line still names the key, which is what makes "recoverable
+    by one documented command" true rather than aspirational.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+    SD.record_adoptions({"agent.subagent_timeout_secs": 1800})
+
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        KiroCrewConfig.load()
+
+    warnings = " ".join(r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING)
+    assert "agent.subagent_timeout_secs" in warnings
+    assert "config defaults" in warnings
+
+
+def test_the_escape_hatch_key_never_auto_adopts():
+    """``forward_declared_env``'s stored False is an opt-out, so it stays report-only.
+
+    The one entry the whole read-only design was reasoned from. If a future change
+    ever flips this, the gateway env suite's ``test_a_real_false_still_turns_it_off``
+    is what breaks, and this test is the earlier warning.
+    """
+    assert FDE_ENTRY.auto_adopt is False
+    base = {"mcp_gateway": {"forward_declared_env": False}}
+    assert SD.auto_adoptable(base, acked={}, adopted={}) == []
+
+
+def test_load_adopts_the_stale_timeout_on_disk_and_in_memory(tmp_path, monkeypatch, caplog):
+    """The complaint this fixes: upgrade, restart, still cut at 30 minutes.
+
+    In memory as well as on disk, because the subagent manager reads the budget once
+    at gateway start -- a disk-only fix would leave the run that performed it still
+    reaping at the old value.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+
+    with caplog.at_level(logging.INFO, logger=L.__name__):
+        cfg = KiroCrewConfig.load()
+
+    assert cfg.agent.subagent_timeout_secs == 10800
+    assert "subagent_timeout_secs" not in _on_disk(tmp_path).get("agent", {})
+    assert SD.adopted_superseded() == {"agent.subagent_timeout_secs": 1800}
+    assert any("adopted the current default" in r.getMessage() for r in caplog.records)
+
+
+def test_a_deliberately_chosen_value_survives_the_adoption(tmp_path, monkeypatch):
+    """Only the exact old default is adopted; any other number is a real choice."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 2400}})
+
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.agent.subagent_timeout_secs == 2400
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 2400
+    assert SD.adopted_superseded() == {}
+
+
+def test_adoption_is_one_shot_so_a_restored_value_is_left_alone(tmp_path, monkeypatch):
+    """The property that makes an automatic rewrite safe at all.
+
+    Setting the key back to the old default AFTER an adoption is the operator's own
+    choice, and the ledger is what tells the two apart -- without it every load
+    would re-remove the value they just restored.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+    KiroCrewConfig.load()
+    assert SD.adopted_superseded() == {"agent.subagent_timeout_secs": 1800}
+
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.agent.subagent_timeout_secs == 1800
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+
+
+def test_keep_pre_empts_an_adoption_that_has_not_happened_yet(tmp_path, monkeypatch):
+    """An acknowledged value is not drift, so ``--keep`` still wins over adoption.
+
+    This is the answer for an operator who genuinely did choose 1800: affirm it, and
+    the automatic path never touches it.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+    SD.write_acked_superseded({"agent.subagent_timeout_secs": 1800})
+
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.agent.subagent_timeout_secs == 1800
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+    assert SD.adopted_superseded() == {}
+
+
+def test_an_overlay_value_outranks_the_adoption_in_memory(tmp_path, monkeypatch):
+    """The base's stale bytes are cleared; the overlay's live choice is not replaced."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+    _write_local(tmp_path, {"agent": {"subagent_timeout_secs": 3600}})
+
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.agent.subagent_timeout_secs == 3600
+    assert "subagent_timeout_secs" not in _on_disk(tmp_path).get("agent", {})
+
+
+def test_both_timeout_keys_adopt_in_one_load(tmp_path, monkeypatch):
+    """A real upgraded install holds both, so both clear in a single write."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(
+        tmp_path, {"agent": {"subagent_timeout_secs": 1800, "chat_turn_timeout_secs": 7200}}
+    )
+
+    cfg = KiroCrewConfig.load()
+
+    assert cfg.agent.subagent_timeout_secs == 10800
+    assert cfg.agent.chat_turn_timeout_secs == 14400
+    assert _on_disk(tmp_path).get("agent", {}) == {}  # both keys cleared in one write
+    assert set(SD.adopted_superseded()) == {
+        "agent.subagent_timeout_secs",
+        "agent.chat_turn_timeout_secs",
+    }
+
+
+def test_the_load_does_not_tell_the_operator_to_fix_what_it_just_fixed(
+    tmp_path, monkeypatch, caplog
+):
+    """An adopted key is excluded from the warning; a report-only one still appears."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(
+        tmp_path,
+        {
+            "agent": {"subagent_timeout_secs": 1800},
+            "mcp_gateway": {"forward_declared_env": False},
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        KiroCrewConfig.load()
+
+    warnings = " ".join(r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING)
+    assert "forward_declared_env" in warnings
+    assert "subagent_timeout_secs" not in warnings
+
+
+def test_a_failed_ledger_write_aborts_the_adoption(tmp_path, monkeypatch):
+    """Record-then-remove: a removal whose record was lost would repeat forever.
+
+    Repeating is the one failure mode that can override a value the operator
+    restored, so a ledger that cannot be written leaves the config untouched and the
+    key reported like any other drift.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"agent": {"subagent_timeout_secs": 1800}})
+
+    def _refuse(_values):
+        raise OSError("read-only data home")
+
+    monkeypatch.setattr(L, "record_adoptions", _refuse)
+
+    cfg = KiroCrewConfig.load()
+
+    assert _on_disk(tmp_path)["agent"]["subagent_timeout_secs"] == 1800
+    # Memory follows disk. An earlier revision applied the in-memory half eagerly and
+    # left the running config on 10800 while the file still said 1800 -- a divergence
+    # the operator cannot see from either side. Nothing moves unless the write landed.
+    assert cfg.agent.subagent_timeout_secs == 1800
+
+
+def test_the_ledger_and_the_acks_share_one_file_without_erasing_each_other(tmp_path, monkeypatch):
+    """Both maps live in one document, so writing one must carry the other through.
+
+    A dropped adoption record is not cosmetic: it re-opens the repeat-adoption path
+    the ledger exists to close.
+    """
+    _point_home(tmp_path, monkeypatch)
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+    SD.record_adoptions({"agent.subagent_timeout_secs": 1800})
+
+    assert SD.acked_superseded() == {"session.autocompact_pct": 90.0}
+    assert SD.adopted_superseded() == {"agent.subagent_timeout_secs": 1800}
+
+    SD.write_acked_superseded({"stt.streaming": False})
+
+    assert SD.adopted_superseded() == {"agent.subagent_timeout_secs": 1800}
+
+
+def test_the_registered_new_defaults_match_the_live_dataclass_defaults():
+    """Negative control for the in-memory half.
+
+    ``_adopt_in_memory`` reads the field's OWN default rather than the row's
+    ``new_default``, so this pins that the two agree for the auto-adopting keys --
+    if they ever diverge, the disk and memory halves would resolve different
+    numbers and the divergence would be invisible.
+    """
+    from kiro_crew.config.sections import AgentConfig
+
+    assert AgentConfig.__dataclass_fields__["subagent_timeout_secs"].default == (
+        SUBAGENT_ENTRY.new_default
+    )
+    assert AgentConfig.__dataclass_fields__["chat_turn_timeout_secs"].default == (
+        TURN_ENTRY.new_default
+    )


### PR DESCRIPTION
## Problem

Changing a shipped default only ever reached **new** installs. `config.json` is a full materialization of the schema and every field resolves as `data.get(key, DEFAULT)`, so an existing install keeps whatever was written last and **nothing changes when it upgrades**.

Concretely: an install holding `agent.subagent_timeout_secs: 1800` still reaps every subagent at 30 minutes after taking a build whose default is 10800. The operator never chose 1800 — it was materialized years ago — and all they see is timeouts instead of results. Same for `agent.chat_turn_timeout_secs: 7200` cutting a turn at 2 hours. This is issue #5244, restated by everyone who upgrades and sees no change.

The existing mechanism reported this and stopped there, telling the operator to run `kirocrew config defaults --adopt` — a command they have no reason to know exists.

## What changed

`SupersededDefault` gains `auto_adopt`, and the load path **un-materializes** the entries that carry it. The stored key is *removed*, not overwritten with a number, so the field resolves to whatever the running build ships and the next default change lands for free. Applied in memory as well as on disk, because the gateway reads these budgets once at startup — a disk-only fix would leave the very run that performed it still holding the old value.

Five entries adopt, three stay report-only:

| Key | Old -> new | |
|---|---|---|
| `agent.subagent_timeout_secs` | 1800 -> 10800 | adopts |
| `agent.chat_turn_timeout_secs` | 7200 -> 14400 | adopts |
| `session.autocompact_pct` | 90.0 -> 70.0 | adopts |
| `dashboard.loop_stall_exit_after_secs` | 25 -> unset | adopts |
| `instances.warm_set_cap` | 5 -> 0 | adopts |
| `mcp_gateway.forward_declared_env` | False -> True | reports only |
| `stt.streaming` | False -> True | reports only |
| `stt.model` | turbo -> base | reports only |

## Where the line is, and why

**Collision probability**, not convenience. A budget chosen out of 60..86400 equals the old default only by coincidence. A **boolean** equals it with certainty: every operator who opts out stores exactly those bytes. `stt.streaming: false` is what the dashboard writes when a user turns live dictation text off, and `forward_declared_env: false` is the documented opt-out for a server that must not share a backend.

That boundary is not a comment. `test_only_free_numeric_budgets_adopt_themselves` refuses a `bool` or `str` `old_default` on any adopting row, so an appended entry cannot cross it. And it is not theoretical: an earlier revision of this branch *did* enable `stt.streaming`, and the existing `test_put_persists_streaming` (a dashboard PUT of `streaming: false`) went red — that failure is what set the rule.

## What stops it overriding a live choice

- **One-shot.** Adoption is recorded in the sidecar's new `adopted` map, so a key is adopted at most once per install. Set it back to the old default afterwards and it is yours forever. Without that record the loader would re-remove a restored value on every load, which is worse than saying nothing.
- **Record-then-remove.** The ledger is written **before** the removal, inside the config write lock, and a failing record aborts the whole migration write. A removal whose record was lost would repeat; an unrecorded non-removal just leaves the key reported like any other drift.
- **`--keep` still wins.** An acknowledged value is not drift, so affirming a key before it is adopted keeps it — the answer for someone who did choose 1800.
- **Overlay respected.** A key `config.local.json` supplies is cleared on disk but left alone in memory.
- **Coerced values respected.** `_adopt_in_memory` replaces the parsed field only when it still *equals* `old_default`, so a value the loader clamped or coerced keeps the loader's correction.

The adopted key is also excluded from the startup warning: pointing the operator at a command for something fixed in the same load is worse than silence.

## Tests

13 new tests in `test/test_config_superseded_defaults.py`, including the negative controls that carry the design: the escape-hatch key never adopting, a stored voice opt-out surviving, one-shot behaviour across two loads, `--keep` pre-emption, overlay precedence, a failed ledger write aborting the adoption, and the sidecar's two maps not erasing each other. One existing test (`test_many_drifted_keys_produce_one_warning_line`) now pre-populates the ledger, which is the real post-adoption state it describes.

## Verification

- `pytest` on the affected suites: 154 passed.
- Full suite compared with and without the change on the same worktree: **72 failed / 967 passed** vs **72 failed / 953 passed** — identical failure set, all pre-existing on `main` (`ops_mission_control`, `file_explorer`, `design_tweak` platform-context pollution). The 14-test delta is this PR's new tests.
- `black`, `isort`, `flake8`, `mypy` (1382 files), `docs-lint`: clean.
- Spec updated in the same commit: `docs/system-specs/modules/config.md`, plus the user-facing `src/kiro_crew/docs/configuration.md`.

## Pattern harvest

The reusable lesson is that **value equality is not provenance, and how badly that bites scales with the size of the value's domain**. A registry that says "the stored value equals what we used to ship" can be acted on safely for a value drawn from a wide range and never for a boolean, because for a boolean every opt-out is a false positive. Where a mechanism cannot recover provenance, a one-shot ledger plus a written-first record is enough to bound the damage to a single occurrence and let the user's next action win permanently.
