### PR TITLE
fix(meetings): keep supplementary Unicode in a dictionary term from clearing the dictionary

### DIFF
--- a/docs/system-specs/modules/meetings.md
+++ b/docs/system-specs/modules/meetings.md
@@ -159,6 +159,10 @@ never overwrites, so user edits survive every restart. A second `on_startup`
 hook launches the calendar poller (below); its `on_cleanup` partner runs before
 the session teardown hook, so no poll tick can pre-create a meeting mid-shutdown.
 
+Dictionary terms and aliases round-trip through UTF-8 TOML, including supplementary
+Unicode characters. Quotes, backslashes, and control characters remain escaped;
+the serializer does not emit JSON surrogate-pair escapes that TOML rejects.
+
 ## Lifecycle
 
 ```

--- a/docs/system-specs/modules/meetings.md
+++ b/docs/system-specs/modules/meetings.md
@@ -163,6 +163,14 @@ Dictionary terms and aliases round-trip through UTF-8 TOML, including supplement
 Unicode characters. Quotes, backslashes, and control characters remain escaped;
 the serializer does not emit JSON surrogate-pair escapes that TOML rejects.
 
+Writing those characters literally means a term has to BE encodable, so `add_term`
+refuses a code point in the surrogate range U+D800–U+DFFF — which a JSON request
+body can spell (`{"correct": "\ud800"}`) but UTF-8 cannot represent. The refusal
+sits next to the empty-term and length checks, BEFORE the process-wide dictionary
+is replaced, so a term the file can never hold does not become the one live
+transcript lines are corrected against. The route maps that `ValueError` to a 400
+like any other invalid term.
+
 ## Lifecycle
 
 ```

--- a/src/kiro_crew/apps/builtins/meetings/backend/domain/dictionary.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/domain/dictionary.py
@@ -154,18 +154,17 @@ class DomainDictionary:
     def render_toml(self) -> str:
         """Render the current terms back to TOML.
 
-        Values go through ``json.dumps`` because TOML basic strings and JSON
-        strings share an escaping grammar for the characters that matter here —
-        so a quote or backslash in a term can never break out of its string and
-        inject a new ``[[term]]`` table.
+        JSON quoting protects quotes, backslashes, and control characters.
+        Non-ASCII characters stay literal: TOML does not accept JSON's UTF-16
+        surrogate-pair escapes. DEL must still be escaped for a TOML basic string.
         """
         parts = [_DICTIONARY_HEADER]
         for correct, aliases in self.terms:
             parts.append(
-                f"\n[[term]]\ncorrect = {json.dumps(correct)}\n"
-                f"aliases = {json.dumps(aliases)}\n"
+                f"\n[[term]]\ncorrect = {json.dumps(correct, ensure_ascii=False)}\n"
+                f"aliases = {json.dumps(aliases, ensure_ascii=False)}\n"
             )
-        return "".join(parts)
+        return "".join(parts).replace("\x7f", "\\u007f")
 
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/kiro_crew/apps/builtins/meetings/backend/domain/dictionary.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/domain/dictionary.py
@@ -53,6 +53,17 @@ _MAX_ALIAS_LEN = 120
 _MAX_CORRECT_LEN = 120
 _DICTIONARY_HEADER = "# Domain dictionary for meetings speech-to-text correction\n"
 
+# A code point in U+D800–U+DFFF is half of a UTF-16 pair and is not a character.
+# Python's JSON decoder still produces one from a request body spelling it out
+# (``{"correct": "\ud800"}``), and a `str` can hold it — but UTF-8 has no encoding
+# for it, so such a term can never round-trip through the dictionary file. It is
+# refused at the mutation boundary, where `add_term` already rejects the empty and
+# the over-long term, rather than at the serializer: raising once the in-memory
+# terms have been replaced would leave the shared dictionary holding a term that
+# `save` can never write, so the corrections applied to live transcripts and the
+# document on disk would disagree until the next reload.
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
 
 def _literal_replacement(value: str) -> Callable[[re.Match[str]], str]:
     """A ``re.sub`` replacement that inserts *value* verbatim.
@@ -154,9 +165,22 @@ class DomainDictionary:
     def render_toml(self) -> str:
         """Render the current terms back to TOML.
 
-        JSON quoting protects quotes, backslashes, and control characters.
-        Non-ASCII characters stay literal: TOML does not accept JSON's UTF-16
-        surrogate-pair escapes. DEL must still be escaped for a TOML basic string.
+        Values go through ``json.dumps`` because TOML basic strings and JSON
+        strings share an escaping grammar for the characters that matter here —
+        so a quote or backslash in a term can never break out of its string and
+        inject a new ``[[term]]`` table.
+
+        They are dumped with ``ensure_ascii=False`` because the two grammars part
+        company above U+FFFF: JSON escapes a supplementary character as a UTF-16
+        surrogate PAIR, which TOML refuses ("Escaped character is not a Unicode
+        scalar value"), and the whole document was then discarded on the next
+        load. Written literally it round-trips. DEL is the one character JSON
+        leaves raw that a TOML basic string forbids, so it is escaped by hand.
+
+        Writing them literally means the terms have to BE encodable, which is why
+        :meth:`add_term` refuses a surrogate code point (``_SURROGATE_RE``) and the
+        parse in :meth:`load` cannot produce one — ``read_text`` would have failed
+        on the bytes first.
         """
         parts = [_DICTIONARY_HEADER]
         for correct, aliases in self.terms:
@@ -180,6 +204,8 @@ class DomainDictionary:
             raise ValueError("correct and at least one alias are required")
         if len(correct) > _MAX_CORRECT_LEN or any(len(a) > _MAX_ALIAS_LEN for a in clean):
             raise ValueError("term or alias is too long")
+        if _SURROGATE_RE.search(correct) or any(_SURROGATE_RE.search(a) for a in clean):
+            raise ValueError("term or alias contains an unpaired surrogate code point")
         if len(self.terms) >= k.MAX_DICTIONARY_TERMS:
             raise ValueError(f"dictionary is limited to {k.MAX_DICTIONARY_TERMS} terms")
         existing = [(c, a) for c, a in self.terms if c.lower() != correct.lower()]

--- a/test/test_meetings_dictionary.py
+++ b/test/test_meetings_dictionary.py
@@ -179,6 +179,28 @@ class TestMutation:
 
 
 class TestSerialization:
+    @pytest.mark.parametrize(
+        "correct, aliases",
+        [
+            ("\U00020bb7田", ["yoshida"]),
+            ("Yoshida", ["\U00020bb7田"]),
+            ("Launch \U0001f680", ["launch team"]),
+            ("delete\x7fmarker", ["control\x7falias"]),
+        ],
+    )
+    def test_unicode_terms_survive_save_and_reload(self, tmp_path, correct, aliases):
+        path = tmp_path / "dictionary.toml"
+        first = DomainDictionary()
+        first.add_term("DynamoDB", ["dynamo db"])
+        first.add_term(correct, aliases)
+        first.save(path)
+
+        second = DomainDictionary()
+        second.load(path)
+
+        assert second.as_list() == first.as_list()
+        assert second.correct("use dynamo db") == "use DynamoDB"
+
     def test_roundtrip_through_disk(self, tmp_path: Path):
         path = tmp_path / "d.toml"
         first = DomainDictionary()

--- a/test/test_meetings_dictionary.py
+++ b/test/test_meetings_dictionary.py
@@ -201,6 +201,50 @@ class TestSerialization:
         assert second.as_list() == first.as_list()
         assert second.correct("use dynamo db") == "use DynamoDB"
 
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "\ud800",  # a lone HIGH surrogate
+            "\udfff",  # a lone LOW surrogate
+            "Lone\ud83dEnd",  # the high half of an emoji pair, on its own
+        ],
+    )
+    @pytest.mark.parametrize("field", ["correct", "alias"])
+    def test_a_surrogate_code_point_is_refused_before_anything_is_mutated(
+        self, tmp_path: Path, bad: str, field: str
+    ):
+        """A surrogate has no UTF-8 encoding, so it can never round-trip.
+
+        The JSON body ``{"correct": "\\ud800"}`` decodes to exactly this string, so
+        it reaches ``add_term`` from a plain HTTP request. Refusing it there — with
+        the ValueError the route already maps to 400 — is what keeps the shared
+        in-memory dictionary and the document on disk from disagreeing.
+        """
+        path = tmp_path / "dictionary.toml"
+        d = DomainDictionary()
+        d.add_term("DynamoDB", ["dynamo db"])
+        d.save(path)
+        before = d.as_list()
+        on_disk = path.read_bytes()
+
+        with pytest.raises(ValueError):
+            if field == "correct":
+                d.add_term(bad, ["some alias"])
+            else:
+                d.add_term("Some Term", [bad])
+
+        # The unrelated term is untouched, in memory and on disk...
+        assert d.as_list() == before
+        assert path.read_bytes() == on_disk
+        # ...the refusal did not stop a later, legitimate edit...
+        d.add_term("PostgreSQL", ["postgres q l"])
+        d.save(path)
+        # ...and what was persisted still parses.
+        reloaded = DomainDictionary()
+        reloaded.load(path)
+        assert reloaded.as_list() == d.as_list()
+        assert reloaded.correct("use dynamo db") == "use DynamoDB"
+
     def test_roundtrip_through_disk(self, tmp_path: Path):
         path = tmp_path / "d.toml"
         first = DomainDictionary()

--- a/test/test_meetings_routes.py
+++ b/test/test_meetings_routes.py
@@ -231,6 +231,50 @@ class TestDictionaryRoutes:
             ).status == 400
 
     @pytest.mark.asyncio
+    async def test_a_refused_surrogate_term_never_reaches_the_shared_dictionary(
+        self, app, root: Path
+    ):
+        """``"\\ud800"`` is legal JSON but has no UTF-8 encoding.
+
+        Sent as raw bytes rather than through ``json=``: the client's own encoder
+        would refuse it, while a real HTTP client puts the escape on the wire and
+        the SERVER's ``json.loads`` is what materializes the surrogate.
+
+        The status was already 400 before the fix — ``UnicodeEncodeError`` is a
+        ``ValueError``, so the write blew up into the handler's own 400 branch and
+        wore a codec message. What that hid is the ordering: ``add_term`` had
+        already replaced the terms on the PROCESS-WIDE dictionary
+        (``domain.session._dictionary``, which every transcript line is corrected
+        against at ``session.py``'s ``_dictionary.correct``) and only then failed to
+        write, leaving live corrections running against a term no file holds.
+        """
+        async with client_for(app) as client:
+            resp = await client.post(
+                f"{BASE}/dictionary", json={"correct": "DynamoDB", "aliases": ["dynamo db"]}
+            )
+            assert resp.status == 200
+            before = store.dictionary_path(root).read_bytes()
+
+            resp = await client.post(
+                f"{BASE}/dictionary",
+                data=b'{"correct": "\\ud800", "aliases": ["lone half"]}',
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+            # Asserted BEFORE any further dictionary route: every one of them
+            # reloads from disk first, which would wash the bad term back out.
+            assert all("\ud800" not in c for c, _ in sess.shared_dictionary().terms)
+            # A validation message, not whatever the codec happened to say.
+            assert "surrogate" in (await resp.json())["error"]
+            assert "codec" not in (await resp.json())["error"]
+
+            resp = await client.get(f"{BASE}/dictionary")
+            assert any(t["correct"] == "DynamoDB" for t in (await resp.json())["terms"])
+
+        # ...and nothing was written.
+        assert store.dictionary_path(root).read_bytes() == before
+
+    @pytest.mark.asyncio
     async def test_remove_unknown_is_404(self, app):
         async with client_for(app) as client:
             resp = await client.post(f"{BASE}/dictionary/remove", json={"correct": "Ghost"})


### PR DESCRIPTION
## Problem / Motivation

A Meetings domain-dictionary term containing a supplementary Unicode character —
`𠮷田`, an emoji — is saved successfully and then silently loses **the whole
dictionary** on the next load.

`dictionary.toml` is rendered with `json.dumps`, whose default `ensure_ascii=True`
spells a supplementary character as a UTF-16 **surrogate pair** (`"𠮷"`).
TOML has no such escape; `tomllib` refuses it with

```
Escaped character is not a Unicode scalar value (at line 8, column 18)
```

and `DomainDictionary.load` is deliberately tolerant — a parse failure logs a
warning and degrades to "no corrections". So every other term the user had
configured disappears too, and nothing surfaces except a line in the log.

Measured on `origin/main`, saving `DynamoDB` and then `𠮷田`:

```
BASE: save OK, tail: correct = "\ud800" ...
BASE reloaded: []          # DynamoDB is gone as well
```

## Why it matters

The dictionary is how a user teaches Meetings the project nouns speech
recognition mangles. Non-Latin scripts are exactly the case where it earns its
keep, and CJK above the BMP plus emoji are ordinary content for a meeting title
or a person's name. The failure is silent (HTTP 200 on the save), delayed (it
only shows on the next load) and total (one bad term discards the file), so the
user's read of it is "Meetings stopped correcting anything".

## What changed (motivation → approach → change)

**Symptom → cause.** The escape grammar of JSON and TOML agree on quotes,
backslashes and the C0 controls — which is why `json.dumps` was used here in the
first place, and it is still what stops a term breaking out of its string to
inject a `[[term]]` table. They part company above U+FFFF, where JSON emits a
surrogate pair and TOML accepts only scalar values.

**Change 1 — write the characters, don't escape them.** `ensure_ascii=False`
keeps every scalar literal; the file is UTF-8 and TOML reads it back exactly.
DEL (U+007F) is the one character JSON leaves raw that a TOML basic string still
forbids, so it is escaped by hand.

**Change 2 — a term now has to BE encodable.** Writing literally makes the
surrogate range a real constraint rather than an escaping detail. A code point in
U+D800–U+DFFF is half of a UTF-16 pair, not a character, and UTF-8 cannot encode
it — but Python's JSON decoder happily produces one from a body that spells it
out, so `{"correct": "\ud800"}` reaches `add_term` from a plain HTTP request.

The interesting part is the ordering, not the exception. `add_term` accepted such
a term and replaced the terms on the **process-wide** dictionary
(`domain.session._dictionary`); only the `save` that followed failed, on the
encode. Measured at the pre-fix head of this branch:

```
PROBE_STATUS 400 BODY {"error": "'utf-8' codec can't encode character '\\ud800'
                       in position 227: surrogates not allowed", ...}
PROBE_SHARED [('Kiro Crew', [...]), ('DynamoDB', ['dynamo db']), ('\ud800', ['lone half'])]
```

Note it is **not** a 500: `UnicodeEncodeError` is a `ValueError`, so the route's
existing invalid-term branch already caught it — wearing a codec message instead
of a validation one. What that masked is `PROBE_SHARED`: the shared object every
transcript line is corrected against (`session.py`'s `_dictionary.correct`) was
left holding a term no file can hold, diverging from disk until something
reloaded.

So the refusal goes at the mutation boundary, beside the empty-term and
over-long-term checks that are already there, raising the same `ValueError` the
route already maps to 400 — not at the serializer, and not by suppressing the
encode error after the fact.

Scope is deliberately narrow: no new field validator, no change to the tolerant
`load`/`load_terms` path (a surrogate cannot arrive from disk — `read_text` would
have failed on the bytes, and `tomllib` rejects the escape), and no other change
to the term grammar.

**Bounds check.** Every one of the 1,112,064 non-surrogate Unicode scalar values
was rendered through `render_toml` and parsed back with `tomllib` in batches of
200 terms: zero parse failures, zero round-trip mismatches. The surrogate range
is exactly the excluded set, and DEL is the only extra escape needed. (One-off
verification, not a shipped test — too slow for the suite.)

## Tests

`test/test_meetings_dictionary.py`

- `TestSerialization::test_unicode_terms_survive_save_and_reload` — 4 cases:
  a supplementary character as the correct spelling, as an alias, an emoji, and
  DEL. Each asserts the reload equals what was saved *and* that an unrelated
  `DynamoDB` term still corrects, which is the part that was being destroyed.
- `TestSerialization::test_a_surrogate_code_point_is_refused_before_anything_is_mutated`
  — 6 cases (lone high, lone low, and the high half of an emoji pair × correct/alias).
  Locks the whole contract: `ValueError`, in-memory terms unchanged, file bytes
  unchanged, a later legitimate edit still succeeds, and what was persisted parses.

`test/test_meetings_routes.py`

- `TestDictionaryRoutes::test_a_refused_surrogate_term_never_reaches_the_shared_dictionary`
  — sends the escape as raw bytes (the client's own encoder would refuse `json=`;
  a real client puts the escape on the wire and the *server's* `json.loads`
  materializes the surrogate). Asserts 400, then asserts the shared dictionary
  **before** touching any other dictionary route, since every one of them reloads
  from disk first and would wash the bad term back out. Also asserts the error
  text is a validation message rather than the codec's.

**Red-before / green-after**, Python 3.13.5 on Windows:

| tree | result |
|---|---|
| `origin/main` (this branch's own merge base, `02921dfc1`) | **9 failed**, 37 passed — the 3 supplementary cases + all 6 surrogate cases |
| pre-fix head of this branch (`1550ea3f9`, change 1 only) | **7 failed**, 46 passed — the 6 surrogate cases + the route test |
| this branch | **54 passed** across both files |

Wider run, `test_meetings_dictionary.py test_meetings_routes.py
test_meetings_session.py`: 333 passed, 1 skipped, 1 failed — the failure is
`test_the_server_and_client_transition_tables_agree`, which reads a `.ts` file
with the locale default encoding and dies with `UnicodeDecodeError: 'cp950'`
before reaching any changed code. It is a pre-existing host-environment failure
on a non-UTF-8-codepage Windows box, unrelated to this diff.

Focused gates: `isort --check-only`, `flake8`, `mypy --platform linux`,
`check_black_formatting.py` (both changed `.py` files are in the existing
`.github/black-baseline.txt`, so they are deliberately not reformatted),
`check_brand_name.py`, `docs_lint.py`, `git diff --check` — all clean.

## Manual verification

N/A — unit coverage sufficient: both the domain object and the HTTP route are
exercised end to end, including the on-disk bytes and the process-wide shared
state, which is where the defect actually lived.

## Related Issues

None.

## Pattern harvest

Rule candidate: review-prompt
Pattern: "two serializers with *nearly* the same escape grammar" — reusing
`json.dumps` to quote a value for a different format is safe only over the subset
where the grammars agree; the disagreement shows up on the inputs nobody tests
(here, everything above U+FFFF). A second, narrower one worth carrying: catching
`ValueError` at a route makes `UnicodeEncodeError` look like input validation,
so an encode failure downstream of a mutation can be reported as a clean 400
while leaving shared state already changed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
