### PR TITLE
docs(locks): correct the kept-inline lock-open comments (#9267)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -191,10 +191,8 @@ class _McpFileLockSync:
     def __enter__(self) -> None:
         _GLOBAL_MCP_JSON.parent.mkdir(parents=True, exist_ok=True)
         _MCP_LOCK_PATH.touch(exist_ok=True)
-        # Non-truncating "r+", see :class:`_McpFileLock` and
-        # platform_compat.open_lock_file (GH-9248). Kept inline for the same
-        # reason: self._fd outlives __enter__/__exit__, so the with-scoped
-        # helper cannot hold it.
+        # Non-truncating "r+", kept inline for the same reason as
+        # :class:`_McpFileLock` above.
         fd = open(_MCP_LOCK_PATH, "r+")
         try:
             platform_compat.acquire_lock(fd.fileno(), exclusive=True)

--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -508,9 +508,8 @@ def _periodic_pid_sweep(my_gw_pid: int, active_pids: set[int]) -> tuple[set[str]
         # timer while `_track_session_pid` is contending for the same lock, which
         # is exactly the interleaving a truncating open turns into a crash.
         # Kept inline rather than routed through `platform_compat.open_lock_file`:
-        # this fd takes a SHARED (read) lock and is held across the try/finally
-        # below, not a `with` block -- the with-scoped helper serves exclusive
-        # acquisition only, so forcing this through it would change behaviour.
+        # this fd is held across the try/finally below, not a `with` block, so a
+        # with-scoped opener that closes the fd at block exit does not fit.
         lock_path.touch(exist_ok=True)
         lock_fd = open(lock_path, "r+")
     except OSError:


### PR DESCRIPTION
## What is the problem?

Two kept-inline lock-open comments that #9647 landed are wrong or redundant:

- `session_pid._periodic_pid_sweep` says the with-scoped helper "serves
  exclusive acquisition only" -- but `try_acquire_lock(lock_fd.fileno(),
  exclusive=False)` sits twelve lines below it, so the comment is refuted by
  the code directly beneath it.
- `_McpFileLockSync.__enter__` repeats the kept-inline rationale that
  `_McpFileLock` already states fifty lines above.

## Why this issue matters to the user

A comment outlives the PR. The sweep comment does not merely go stale; it states
a false fact about `platform_compat.open_lock_file` in the same module. A reader
who trusts it concludes the helper cannot serve a shared lock and leaves a correct
migration undone. The duplicated `_McpFileLockSync` comment is exactly the kind of
copy-drift this consolidation item exists to reduce.

## How our fix solves it

- Sweep comment: `open_lock_file` only OPENS non-truncating; the lock mode is a
  separate choice at `file_lock(fd, exclusive=...)`. The real reason the sweep
  stays inline is fd LIFETIME -- the fd is held across the try/finally, not a
  `with` block. The original comment already said that; the fix deletes the added
  false clause and keeps the correct reason.
- `_McpFileLockSync`: shrink to a pointer at `_McpFileLock` above.

No code change; the migrations #9647 landed are untouched.

## What tests we did

One file at a time, `-n0`, `</dev/null`:

- `timeout 900 python3 -m pytest -n0 test/test_platform_compat.py -x -q </dev/null` -- 275 passed, 23 skipped (contract scan included)
- `timeout 900 python3 -m pytest -n0 test/test_pid_lifecycle.py -x -q </dev/null` -- 172 passed
- `timeout 900 python3 -m pytest -n0 test/test_mcp_core_coverage.py -x -q </dev/null` -- 164 passed

Comment-history gate passes; the deletions moved no baseline entry.

## Any other suggestions on the work

The lesson from the false clause: `open_lock_file` is an opener, not a lock.
Whether a site can adopt it turns on the fd lifetime it needs, never on the lock
mode -- the mode is chosen at the acquire. The census of remaining siblings lives
on #9267 (still open because #9647 used `Refs`, not `Closes`).

Refs #9267
