### PR TITLE
test: third side-effect audit (macOS): undo-proof floor, PTY deadlock

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1416,8 +1416,14 @@ jobs:
                 # the verdict to EOF — the very failure this guard prevents.
                 # Worst case inside the window is a few head lines; the
                 # verdict body below line 8 is untouchable by construction.
-                sed -e '1{/^<!-- codex-ai-review -->$/d;}' \
-                  -e '1,8{/^<!-- codex-stale-notice-begin -->$/,/^<!-- codex-stale-notice-end -->$/d;}' \
+                # ONE address block, not two expressions: with the marker
+                # delete as its own `1{...}` expression, BSD sed never
+                # presents line 1 to the `1,8` range that follows (the `d`
+                # ends the cycle), so that range never opens and the old
+                # notice survives and the two stack. GNU sed opens a numeric
+                # range on any later line; BSD only on the exact one. Inside
+                # a single `1,8{}` block both deletes see the open range.
+                sed -e '1,8{/^<!-- codex-ai-review -->$/d;/^<!-- codex-stale-notice-begin -->$/,/^<!-- codex-stale-notice-end -->$/d;}' \
                   "${RUNNER_TEMP:-/tmp}/codex-existing-comment.md"
               } > "${RUNNER_TEMP:-/tmp}/codex-merged-comment.md"
               gh api --method PATCH "repos/$REPO/issues/comments/$existing" \

--- a/conftest.py
+++ b/conftest.py
@@ -214,6 +214,38 @@ def _redirect_hypothesis_database() -> None:
     _hyp_settings.load_profile(_hyp_settings._current_profile)
 
 
+def _redirect_bytecode_cache() -> None:
+    """Write every ``.pyc`` this run compiles under the per-user cache, not the checkout.
+
+    Importing a module writes its bytecode beside the source, and the suite imports
+    a lot that is not a package: ``scripts/*.py``, ``packaging/signing/*.py``, every
+    skill's ``scripts/`` helper, ``.github/scripts``, all loaded by path through
+    ``spec_from_file_location`` + ``exec_module``. Each such import left a
+    ``__pycache__/`` in the tree (fifteen of them per full run at the last count),
+    after two audits had closed individual sites with a scoped
+    ``sys.dont_write_bytecode`` (``test/skill_script_helpers.py`` is the helper for
+    that). A per-site opt-out is the "remember to" contract this file exists to
+    delete, so the class is closed here instead: ``sys.pycache_prefix`` sends the
+    bytecode of EVERY import to a mirror tree under the cache root, and the env var
+    does the same for every interpreter a test spawns. The cache still persists
+    across runs (it is keyed on the absolute source path), so warm imports stay
+    warm; only WHERE the files land changes. Same cache root, same fallback posture
+    and same tolerance of an unwritable root as the hypothesis redirect above.
+    Runs in ``pytest_configure``, before any test module or ``test/conftest.py`` is
+    imported, so the test tree's own bytecode moves too.
+    """
+    if os.environ.get("PYTHONDONTWRITEBYTECODE"):
+        return  # nothing is written anywhere; nothing to redirect
+    cache_root = os.environ.get("XDG_CACHE_HOME") or os.path.join(os.path.expanduser("~"), ".cache")
+    candidate = os.path.join(cache_root, "kirocrew", "pycache")
+    try:
+        os.makedirs(candidate, exist_ok=True)
+    except OSError:
+        return
+    sys.pycache_prefix = candidate
+    os.environ["PYTHONPYCACHEPREFIX"] = candidate
+
+
 def _root_can_create_real_symlink() -> bool:
     """Probe real-link capability for tests collected outside ``test/`` too.
 
@@ -427,6 +459,25 @@ def _floor_monkeypatch():
         yield mp
     finally:
         mp.undo()
+
+
+@pytest.fixture
+def monkeypatch(_floor_monkeypatch):
+    """pytest's own ``monkeypatch``, re-declared to order it AFTER the floor.
+
+    Body-identical to ``_pytest.monkeypatch.monkeypatch``; the only change is the
+    dependency on ``_floor_monkeypatch``, which is what GUARANTEES the order the
+    docstring above relies on: the floor is set up before the test's ``monkeypatch``
+    and torn down after it, whatever autouse fixture in whatever conftest happens to
+    request ``monkeypatch`` first. A test's ``setenv("KIROCREW_HOME", ...)`` therefore
+    records the pinned value, restores it on the test's undo, and the floor's undo then
+    restores the operator's. A test cannot tell the difference otherwise: same type,
+    same scope, same undo semantics for everything IT patched.
+    ``test_host_isolation_floor.py::TestTheDataHomeIsPinnedForEveryTestpath`` pins it.
+    """
+    mp = pytest.MonkeyPatch()
+    yield mp
+    mp.undo()
 
 
 @pytest.fixture(autouse=True)
@@ -1042,10 +1093,75 @@ def _prefer_short_tmp_base() -> None:
         os.environ[name] = _SHORT_TMP_BASE
 
 
+#: Module nodeids whose COLLECTION built the process-global metrics recorder.
+#:
+#: Filled by :func:`pytest_make_collect_report`, asserted empty by
+#: ``test_host_isolation_floor.py::TestNoMetricIsEmittedAtImport``. A metric emitted
+#: while a test module is being imported (a default argument evaluated at
+#: definition time, a module constant built through a factory that counts itself)
+#: runs ``get_recorder()`` before any test's pins exist. The recorder's first build
+#: reads the OPERATOR's real config; with ``telemetry.enabled`` there, it starts a
+#: ``PeriodicExportingMetricReader`` whose exporter is bound to the real
+#: ``~/.kiro/crew/metrics`` and which exports every minute for the life of the xdist
+#: worker. The per-test exporter-leak guard cannot see it (the thread predates every
+#: test), and the per-test ``KIROCREW_TELEMETRY=0`` pin cannot reach it (it is already
+#: built). The third full-run audit found four worker pids writing the operator's
+#: metrics dir on every run from exactly one such default argument.
+IMPORT_TIME_METRIC_EMITTERS: list[str] = []
+
+
+def _metrics_provider_module():
+    return sys.modules.get("kiro_crew.metrics.provider")
+
+
+def _pin_telemetry_off_for_the_process() -> None:
+    """``KIROCREW_TELEMETRY=0`` from process start, not just from each test's setup.
+
+    The per-test pin (``_no_model_download``) covers the test body; this covers the
+    stretch BEFORE the first test (conftest imports and the collection of every
+    module), which is where an import-time metric emission builds the recorder. With
+    the env pin in force the build is a no-op recorder that reads no config and starts
+    no thread, so even an emitter this guard has not yet named cannot reach the host.
+    Tests that exercise telemetry delete the variable themselves, as they already did.
+    """
+    os.environ["KIROCREW_TELEMETRY"] = "0"
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_make_collect_report(collector):
+    """Name the module whose import built the metrics recorder, and undo it.
+
+    The detection is ``metrics.provider._ever_built`` flipping across one module's
+    collection: the flag is set by every build, including the no-op one the env pin
+    above turns it into, so an emitter is caught whether or not it reached the host.
+    ``reset_for_testing()`` then drops what was built (stopping an exporter thread if
+    one exists), so the next module starts clean and the attribution stays per-module.
+    Recorded per worker under xdist: every worker collects the whole tree.
+    """
+    provider = _metrics_provider_module()
+    built_before = bool(provider is not None and getattr(provider, "_ever_built", False))
+    yield
+    if not isinstance(collector, pytest.Module):
+        return
+    provider = _metrics_provider_module()
+    if provider is None or not getattr(provider, "_ever_built", False):
+        return
+    if built_before:
+        # Built before this module was reached, by a conftest import. Named as such
+        # rather than blamed on whichever module happened to be first.
+        IMPORT_TIME_METRIC_EMITTERS.append(f"conftest import (before {collector.nodeid})")
+    else:
+        IMPORT_TIME_METRIC_EMITTERS.append(collector.nodeid)
+    with contextlib.suppress(Exception):
+        provider.reset_for_testing()
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Record the working directory pytest started in, before any test can move it."""
+    _pin_telemetry_off_for_the_process()
     _prefer_short_tmp_base()
     _redirect_hypothesis_database()
+    _redirect_bytecode_cache()
     global _SESSION_CWD
     try:
         _SESSION_CWD = os.getcwd()
@@ -1288,9 +1404,18 @@ def _join_test_loop_executor(item) -> None:
         return
 
 
-@pytest.hookimpl(tryfirst=True)
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_teardown(item, nextitem):
     """Put the process working directory back, BEFORE any fixture teardown runs.
+
+    A ``tryfirst`` HOOKWRAPPER: everything before the ``yield`` runs before any other
+    teardown impl (so before any fixture unwinds), and the one thing after it (the
+    verdict of ``_refuse_a_resolved_real_default_home``) runs after every fixture has
+    been torn down. That split is load-bearing: the check must READ its evidence before
+    the test's ``monkeypatch`` restores the global, but it must RAISE only once the
+    floor has unwound, because an exception raised before the default teardown impl
+    skips fixture finalization for the whole item and leaves every pin in place for
+    the rest of the worker (1,245 downstream errors when it was first tried).
 
     The CWD is per-PROCESS, so under xdist one test's ``os.chdir`` silently becomes every
     later test's starting directory on that worker. That was survivable while the
@@ -1324,6 +1449,16 @@ def pytest_runtest_teardown(item, nextitem):
     """
     _join_install_receipt_workers()
     _join_test_loop_executor(item)
+    resolved_real_home = (
+        _resolved_real_default_home() if item.stash.get(_HOME_PIN_ARMED, False) else None
+    )
+    _restore_session_cwd()
+    yield
+    if resolved_real_home is not None:
+        _refuse_a_resolved_real_default_home(resolved_real_home)
+
+
+def _restore_session_cwd() -> None:
     if _SESSION_CWD is None:  # pragma: no cover - configure always runs first
         return
     try:
@@ -2197,8 +2332,15 @@ def _isolation_dirs(_isolation_root):
 _isolation_dirs.seq = 0  # type: ignore[attr-defined]
 
 
+#: Set on an item by ``_isolate_kirocrew_home`` once its pins are in force. The
+#: teardown check reads it: a test skipped at setup (a ``skipif`` marker) never ran
+#: the floor, so ``paths._resolved_home`` still holds whatever collection resolved
+#: (the operator's real home, legitimately) and must not be blamed for it.
+_HOME_PIN_ARMED = pytest.StashKey[bool]()
+
+
 @pytest.fixture(autouse=True)
-def _isolate_kirocrew_home(_isolation_dirs, _floor_monkeypatch):
+def _isolate_kirocrew_home(request, _isolation_dirs, _floor_monkeypatch):
     """Pin ``KIROCREW_HOME`` and ``KIROCREW_WORKSPACE`` to per-test tmp dirs, for EVERY testpath.
 
     This lives at the rootdir rather than in ``test/conftest.py`` because the leak it
@@ -2295,6 +2437,96 @@ def _isolate_kirocrew_home(_isolation_dirs, _floor_monkeypatch):
     paths = sys.modules.get("kiro_crew.config.paths")
     if paths is not None:
         monkeypatch.setattr(paths, "_resolved_home", None, raising=False)
+        monkeypatch.setattr(
+            paths,
+            "_write_recovery_breadcrumb",
+            _breadcrumb_guard(paths._write_recovery_breadcrumb),
+            raising=False,
+        )
+    request.node.stash[_HOME_PIN_ARMED] = True
+
+
+def _breadcrumb_guard(real):
+    """Refuse the recovery breadcrumb while ``Path.home()`` is the operator's.
+
+    ``config_dir()`` on its DEFAULT path writes ``~/.kirocrew.breadcrumb`` (outside
+    ``~/.kiro`` on purpose) naming the home it resolved. A test that relocates the
+    default with ``paths._resolve_default_home = lambda: tmp_path / ...`` and nothing
+    else therefore rewrites the operator's real breadcrumb to point at a pytest tmp
+    dir: the third audit found six such writes per run, each repaired only because
+    the live gateway rewrote the file later. The teardown check cannot see this one
+    (``_resolved_home`` holds the tmp stand-in), so the guard sits on the writer:
+    with ``Path.home()`` still the real home it FAILS the test naming the fix; with
+    a faked home (``monkeypatch.setattr(Path, "home", ...)``) it delegates, so the
+    tests OF the breadcrumb keep exercising the real writer against their fake home.
+    """
+
+    def _guarded(data_home):
+        try:
+            home_is_real = pathlib.Path.home().resolve() == _REAL_USER_HOME.resolve()
+        except OSError:  # pragma: no cover - a faked home that does not exist
+            home_is_real = False
+        if home_is_real:
+            raise AssertionError(
+                "this test would write the operator's real ~/.kirocrew.breadcrumb "
+                f"(pointing it at {data_home}): the default-home path was taken with "
+                "Path.home() still the real home. Relocate the WHOLE default, not just the "
+                "resolver: monkeypatch HOME and pathlib.Path.home to a dir under tmp_path, "
+                "or stub paths._write_recovery_breadcrumb when the breadcrumb is not what "
+                "the test is about; see conftest._breadcrumb_guard."
+            )
+        return real(data_home)
+
+    return _guarded
+
+
+def _is_the_operators_default_home(path) -> bool:
+    """Whether *path* is the real ``~/.kiro/crew`` (not a tmp stand-in for it)."""
+    try:
+        return pathlib.Path(path).resolve() == (_REAL_USER_HOME / ".kiro" / "crew").resolve()
+    except OSError:
+        return False
+
+
+def _resolved_real_default_home():
+    """The operator's real home if ``paths._resolved_home`` holds it right now, else None."""
+    paths = sys.modules.get("kiro_crew.config.paths")
+    resolved = getattr(paths, "_resolved_home", None) if paths is not None else None
+    if resolved is not None and _is_the_operators_default_home(resolved):
+        return resolved
+    return None
+
+
+def _refuse_a_resolved_real_default_home(resolved) -> None:
+    """Fail the test that let ``config_dir()`` fall through to the operator's home.
+
+    ``paths._resolved_home`` is only ever written by ``_resolve_default_home()``, i.e.
+    by a ``config_dir()`` / ``data_home()`` call made with NO override in force. So a
+    value equal to the operator's real ``~/.kiro/crew`` at teardown means the test
+    dropped the pin (``monkeypatch.delenv("KIROCREW_HOME")``) to exercise the default
+    path and let production resolve, and CREATE, the real data home, plus the
+    recovery breadcrumb beside it. Five tests did in the third full-run audit; each
+    passed. A test of the default path relocates the default too
+    (``monkeypatch.setattr(paths, "_resolve_default_home", lambda: tmp_path / "d")``,
+    or ``_resolved_home`` itself); ``test_lazy_data_home_paths.py`` is the shape.
+
+    The evidence is read by ``pytest_runtest_teardown`` BEFORE the test's own
+    ``monkeypatch`` unwinds (a test that set ``_resolved_home = None`` through
+    monkeypatch and then resolved the real home would otherwise have it restored to
+    ``None`` before any fixture could look), and the failure is raised AFTER every
+    fixture has been torn down, so the floor's pins are always restored. One attribute
+    read and one path comparison per test, so it costs nothing on the ~92k tests that
+    never touch the global.
+    """
+    raise AssertionError(
+        "this test resolved the operator's REAL default data home "
+        f"({resolved}): it dropped the KIROCREW_HOME pin and let config_dir() / "
+        "data_home() fall through to ~/.kiro/crew, which CREATES that directory. "
+        "A test of the default path pins the default too: "
+        "monkeypatch.setattr(kiro_crew.config.paths, '_resolve_default_home', "
+        "lambda: tmp_path / 'default'); see test_lazy_data_home_paths.py and "
+        "conftest._refuse_a_resolved_real_default_home."
+    )
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -2932,6 +3164,43 @@ def _no_central_policy_fetch(_floor_monkeypatch):
         # next test a different way.
         with contextlib.suppress(Exception):
             module.reset_process_state()
+
+
+@pytest.fixture(autouse=True)
+def _reset_platform_context(_floor_monkeypatch):
+    """Clear the process-global PlatformContext between tests, and pin the profile.
+
+    A test that composes a non-default context (e.g. an enterprise-overlay probe)
+    must not leak it into the next test.  ``current_context()`` lazily rebuilds
+    the standalone default on next access.
+
+    Also pins ``KIROCREW_PROFILE=standalone`` so the profile a test boots under
+    comes from the test, never from the operator's shell: a dev box with a real
+    SSO-marker directory, or a shell whose parent process exported
+    ``KIROCREW_PROFILE`` set to the enterprise profile (a Kiro Crew agent session
+    does exactly that for every child it spawns), would otherwise make
+    ``boot_platform`` resolve the enterprise profile and fail CLOSED (no companion installed) for every test
+    that drives ``run_gateway`` / boot / the governance hook.  A test that wants
+    the enterprise profile overrides this env via its own ``monkeypatch.setenv`` (it
+    runs after this autouse fixture), or composes the context directly via
+    ``set_context`` without booting.
+
+    Lives HERE, at the rootdir, for the same reason ``_isolate_kirocrew_home`` does:
+    the ~108 test modules under ``src/kiro_crew/apps/builtins/*/tests/`` never see
+    ``test/conftest.py``.  With the pin only there, an inherited
+    ``KIROCREW_PROFILE=enterprise`` reddens 150+ builtin-app tests (every governance-gated
+    route answers 500, every gated notification is dropped) while ``test/`` stays
+    green.
+    """
+    from kiro_crew.platform.bootstrap import _reset_boot_state
+    from kiro_crew.platform.context import reset_context
+
+    _floor_monkeypatch.setenv("KIROCREW_PROFILE", "standalone")
+    reset_context()
+    _reset_boot_state()
+    yield
+    reset_context()
+    _reset_boot_state()
 
 
 @pytest.fixture(autouse=True)

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -792,10 +792,151 @@ found these further classes. Each one passed on the host that wrote it.
   and still catch a pin that escapes to the real tree. Sixteen tests were red in every
   agent-driven run before this.
 
+The third full-run audit ran five backend and five frontend runs on a **macOS** host,
+from inside a Kiro Crew agent session, with the audit hook attributing every write,
+spawn, connect and kill to a test and a per-test census of duration, RSS, threads and
+descriptors. Both changes of venue mattered: the two earlier audits ran on Linux, and a
+suite that is clean there had 227 deterministic failures and four 120-second hangs on a
+Mac, plus host writes the Linux runs could not see. Zero backend flakes in 5 × 92k
+tests; the classes below are what the rest was made of.
+
+- **`monkeypatch.undo()` in a test body unwound the floor, and the order of the two
+  stacks was luck.** The same class the second pass closed with `_floor_monkeypatch`
+  (below); this pass caught `detect()` creating the real `~/.kiro/crew` through it and
+  added the missing half. Two independent `MonkeyPatch` stacks only nest correctly when
+  the floor's is set up BEFORE the test's `monkeypatch` and torn down AFTER it, and
+  autouse ordering across three conftests does not promise that. The rootdir conftest
+  therefore re-declares the `monkeypatch` fixture with `_floor_monkeypatch` as a
+  dependency, so the order is a dependency edge, not a convention.
+  `test_host_isolation_floor.py::TestTheDataHomeIsPinnedForEveryTestpath` pins both
+  halves: `undo()` in a test body leaves every pin in force, and the fixture in force is
+  the rootdir override. Never `undo()` a shared instance to lift one patch; use
+  `pytest.MonkeyPatch.context()`.
+- **A pin that lives in `test/conftest.py` is not a floor.** `KIROCREW_PROFILE=standalone`
+  was pinned there, so the ~108 modules under `src/kiro_crew/apps/builtins/*/tests/`
+  never saw it. A Kiro Crew agent session exports the enterprise `KIROCREW_PROFILE` to every
+  child it spawns; with no companion installed that profile FAILS CLOSED, and 150+
+  builtin-app tests were red (every governance-gated route 500, every gated
+  notification dropped) while `test/` was green. The pin is a rootdir autouse fixture
+  now (`_reset_platform_context`). The rule generalises: anything an operator's shell
+  can export that changes what production resolves is pinned at the ROOTDIR, and
+  `test_host_isolation_floor.py` asserts it for every testpath.
+- **A metric emitted at import builds the recorder from the operator's config.**
+  `ToolHookResult.allow()` as a module-level DEFAULT ARGUMENT ran during collection,
+  before any pin existed; the recorder's first build read the real `config.json`
+  (`telemetry.enabled: true`) and started a `PeriodicExportingMetricReader` bound to
+  the real `~/.kiro/crew/metrics`, which exported every minute for the life of each
+  xdist worker (four worker pids' shards in the operator's metrics dir per run). The
+  per-test exporter-leak guard cannot see it (the thread predates every test) and the
+  per-test env pin cannot reach it (already built). Two fixes: `pytest_configure` pins
+  `KIROCREW_TELEMETRY=0` for the whole PROCESS, so even an emitter nobody has named
+  yet builds a no-op recorder; and `pytest_make_collect_report` records every module
+  whose collection flipped `metrics.provider._ever_built` into
+  `IMPORT_TIME_METRIC_EMITTERS`, asserted empty by
+  `TestNoMetricIsEmittedAtImport`. Build such values inside the test or fixture.
+- **A maintenance-pool job resolved its path when it RAN.** `cleanup_stale_sandbox_profiles`
+  ran on the `mc-maint` executor and called `config_dir()` there; the test that queued
+  it had torn down its pin by the time the thread was scheduled, so the sweep `mkdir`ed
+  the operator's real `~/.kiro/crew` 60+ times per run and aimed its retired-snapshot
+  `rmtree` and legacy-residue marker at the same tree. Round one's breadcrumb rule,
+  one layer up: the caller resolves the home on ITS thread and hands it in
+  (`SessionManager._cleanup_deps` → `cleanup_stale_sandbox_profiles(data_home=...)`).
+  When a job goes onto a pool, ask what it resolves lazily; the answer must be "nothing".
+  The `mc-maint` pool is the gateway's own, so `_join_test_loop_executor` (which joins
+  the TEST LOOP's default executor at teardown) cannot reach it; the caller-resolves rule
+  is the fix there. The loop's executor is covered: a cache write-through in
+  `test_source_providers.py` scheduled a detached repo-visibility refresh whose
+  `to_thread` resolved the provider CLI through `workspace_root()`; the join drains it,
+  and the module also stubs the scheduler (a recorder, so the calls stay observable),
+  because no test there is about visibility and a side task that never starts has
+  nothing to drain.
+- **Dropping the override to test the DEFAULT home resolves, and creates, the real one.**
+  Five tests `delenv("KIROCREW_HOME")` (or `patch.dict(os.environ, {}, clear=True)`, or
+  ran a module-scoped fixture BEFORE the function-scoped floor) and let `config_dir()`
+  fall through to `~/.kiro/crew` plus the recovery breadcrumb beside it. A test of the
+  default path relocates the default too: `monkeypatch.setattr(paths,
+  "_resolve_default_home", lambda: tmp_path / "d")`, a fake `HOME` + `Path.home`, or
+  keep `KIROCREW_HOME` in the cleared environment. Ratcheted:
+  `pytest_runtest_teardown` reads `paths._resolved_home` BEFORE any fixture unwinds
+  (a test that patched the global itself would otherwise restore the evidence first)
+  and fails the test AFTER the floor has torn down, when it holds the operator's real
+  home (`_refuse_a_resolved_real_default_home`). Relocating only the RESOLVER is not
+  enough: `config_dir()`'s default path also writes `~/.kirocrew.breadcrumb` beside the
+  home, through `Path.home()`, so a tmp stand-in for `_resolve_default_home` alone
+  rewrote the operator's real breadcrumb to point at a pytest directory (six writes per
+  run, repaired only because the live gateway wrote it back). The floor wraps
+  `_write_recovery_breadcrumb` (`_breadcrumb_guard`): with `Path.home()` still the real
+  home it fails the test, with a faked home it delegates. So fake the host home (`HOME`
+  and `pathlib.Path.home`) and let every default derive from it. A module-, class- or
+  session-scoped fixture (`setUpClass` included) runs OUTSIDE the function-scoped floor
+  and pins what it resolves itself.
+- **Bytecode written into the checkout, closed as a class.** Fifteen `__pycache__/`
+  trees per run (`scripts/`, `packaging/signing/`, every skill's `scripts/`), each from
+  an import-by-path that round two had closed one site at a time with a scoped
+  `sys.dont_write_bytecode`. `pytest_configure` now sets `sys.pycache_prefix` (and
+  `PYTHONPYCACHEPREFIX` for children) to `~/.cache/kirocrew/pycache`: every import's
+  bytecode lands in a mirror tree under the cache root, still persistent across runs.
+  A test that wants a module's stale bytecode gone locates it with
+  `importlib.util.cache_from_source`, not by assuming a sibling `__pycache__/`.
+- **A PTY close that deadlocks on macOS: a hang is a lost run.** `_kill_session` closed
+  the PTY's controller descriptor first, to unblock the reader's `os.read()`. True on Linux
+  (the read returns EIO), false on macOS/BSD, where `close()` WAITS for the outstanding
+  read. With an interactive bash holding the terminal end, four terminal tests hit the 120 s
+  timeout on every run, each parking a pool thread forever. The process tree is now
+  hung up (SIGHUP: the signal a vanished terminal delivers, and the one an interactive
+  shell does not ignore) and terminated BEFORE the controller end is closed; the tests run in
+  under a second. A teardown that "unblocks" something by closing a descriptor has to be
+  true on every kernel the suite runs on.
+- **Linux-shaped tests on a Mac.** Ten distinct shapes, one rule: a test that asserts a
+  platform behaviour pins the platform it means, or gates on the SAME predicate
+  production gates on, never on `os.name == "nt"` alone. The frame recorder is
+  Linux-only (`_require_acl_inspectable`), so its 75 logic tests pin the gate open
+  (`IS_LINUX=True`, an `os.listxattr` that reports no ACLs) and only the two tests OF
+  the gate flip it; the unnamed-inode (`O_TMPFILE`) prompt tests skip on the production
+  capability flag `_UNNAMED_CREATE_SUPPORTED`; `/dev/fd/N` is a symlink Linux `realpath`
+  follows and a devfs node macOS leaves alone, so a consumer path is compared by
+  `open`+`fstat` identity; `unlink()` on a directory is `EISDIR` on Linux and `EPERM` on
+  macOS, so `_discard_untracked_files` recognises both; a simulated `O_BINARY` bit is
+  derived from the live `os.O_*` constants (`1 << 20` IS `O_DIRECTORY` on macOS, and
+  every open became a directory open); a `--copies` venv cannot relocate a
+  non-framework shared-lib CPython, so that test skips on `Py_ENABLE_SHARED` without
+  `PYTHONFRAMEWORK`; the darwin-only workspace binding adds a `pass_fds` entry, so the
+  test about the snapshot descriptor pins that seam to the no-descriptor shape;
+  `sys.platform` patched to `"darwin"` on a real Mac lets `get_process_start_id`
+  answer for the pid the test hoped was absent, so the start id is pinned; a
+  `Path.mkdir` stub (record, do nothing) left the pinned data home uncreated for the
+  macOS seatbelt priming that `lstat`s it, so it is a SPY that delegates; and a
+  workflow's `sed -e '1{...}' -e '1,8{...}'` relied on GNU opening a numeric range on
+  a later line (BSD only opens it on the exact one), so the two deletes share one
+  `1,8{}` block.
+- **Real network in a platform-specific test file.** `test_handlers_system_macos_paths.py`
+  reached `8.8.8.8:80` through `_local_ip()`; the Linux siblings had stubbed it in
+  round one, this file was never run there. Stub at the seam the code reads.
+- **A probe that depends on the venv's packaging, again.** `transcribe_unsupported`
+  folds in `_pip_install_channel_available()`, False in every uv-created venv; one
+  test had not pinned it. Same rule as round two: pin every probe the function reads.
+- **Frontend: a fetch chain `act` does not await, and a latch that lags its source.**
+  `AutoNudgePopover`'s watch list is `fetch` → `json()` → `setState`, three promise hops
+  after `await act(render)`, so the positive assertion flaked (1 in 5 runs) and every
+  "not listed" assertion in the block was vacuous (absent BEFORE the fetch resolves
+  whether or not the filter works). Render, wait for the mocked fetch to have been
+  CALLED, drain the chain, then assert (`renderPopoverSettled`). And `App`'s startup
+  video gate read a `startupInterruptionSeen` latch that an effect sets AFTER the commit
+  showing the changelog, while `changelogDecided` is set one microtask later on the
+  same fetch chain: when that microtask landed between the commit and its passive
+  effects, the gate opened beside the changelog (2 in 5 runs). The gate now reads the
+  live conditions in the same commit as well as the latch, the `onboardingOwed` shape.
+
 Two ways to see all of the above on your own machine: run a touched file under
 `trace_home.py`-style tracing (an `sys.addaudithook` that prints the stack of every
 write under the real home — the recipe is in "The measurement" above), and compare
 `systemctl --user list-units --all | grep -c kirocrew-agents` before and after a run.
+On macOS the manager to compare is `launchctl list`, and the metrics dir to watch is
+`ls -la ~/.kiro/crew/metrics`, where a shard named after a pytest worker's pid is the
+import-time-emission class above. A thread that exists at the FIRST test's setup with
+an exporter bound to the real home (`_prev` in an audit plugin's
+`pytest_runtest_protocol`) was started at collection, and the plugin above names the
+module in `IMPORT_TIME_METRIC_EMITTERS`.
 
 ### Coverage that only looks like coverage
 

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_guidance.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_guidance.py
@@ -74,9 +74,13 @@ class TestGateTaskPromptCarriesDesignLenses(unittest.TestCase):
     """The driver's Phase-1 gate prompt must instruct deep design reasoning across
     the same lenses as the skill, so the worker actually performs the deep gate."""
 
-    @classmethod
-    def setUpClass(cls):
-        cls.prompt = build_review_task("CR-12345678")
+    def setUp(self):
+        # Per TEST, not setUpClass: a class-level setup runs before the rootdir
+        # conftest pins KIROCREW_HOME for the test, and build_review_task reads the
+        # app config through config_dir(), which then created the operator's real
+        # ~/.kiro/crew (third side-effect audit). The prompt is a pure function of
+        # the link, so rebuilding it three times costs nothing.
+        self.prompt = build_review_task("https://github.com/o/r/pull/1")
 
     def test_prompt_instructs_deep_thinking(self):
         self.assertIn("THINK DEEPLY", self.prompt)

--- a/src/kiro_crew/apps/builtins/dev_fleet/repository.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/repository.py
@@ -8,6 +8,7 @@ import json
 import locale
 import os
 import re
+import stat
 import subprocess
 from pathlib import Path, PurePosixPath
 
@@ -702,6 +703,20 @@ async def _own_commits_count(path: str) -> int | None:
     return int(out) if out and out.isdigit() else None
 
 
+def _is_directory_at(name: str, dir_fd: int) -> bool:
+    """Whether *name*, resolved relative to the pinned *dir_fd*, is a directory.
+
+    ``lstat`` through the descriptor and without following links, so the answer is
+    about the entry the failed ``unlink`` addressed and not about whatever a link
+    at that name points to. Any error reads as "not a directory": the caller then
+    reports the original failure instead of a guess.
+    """
+    try:
+        return stat.S_ISDIR(os.stat(name, dir_fd=dir_fd, follow_symlinks=False).st_mode)
+    except OSError:
+        return False
+
+
 def _discard_untracked_files(worktree: str, rel_paths: list[str]) -> str | None:
     """Delete exactly the approved untracked files. None on success, else a reason.
 
@@ -803,6 +818,14 @@ def _discard_untracked_files(worktree: str, rel_paths: list[str]) -> str | None:
                     "file that was confirmed"
                 )
             except OSError as exc:
+                if exc.errno == errno.EPERM and _is_directory_at(parts[-1], dir_fds[-1]):
+                    # macOS and the BSDs answer unlink() on a directory with EPERM,
+                    # not Linux's EISDIR, so the type change arrives here instead of
+                    # in the clause above. Same refusal: nothing recurses into it.
+                    return (
+                        f"refusing to discard {rel!r}: it is now a directory, not the "
+                        "file that was confirmed"
+                    )
                 if walked < len(root_parts) - 1 and exc.errno in (errno.ELOOP, errno.ENOTDIR):
                     # A component of the worktree path is a symlink. Could be a
                     # host whose home directory is linked, could be an ancestor

--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -784,34 +784,19 @@ async def _kill_session(sess: _TerminalSession) -> None:
         except (OSError, RuntimeError):
             pass
         return
-    # Close master_fd first — unblocks reader_task's os.read() in executor.
-    #
-    # os.close() on a PTY master fd can BLOCK in the kernel: when the far-end
-    # shell is wedged (uninterruptible sleep), the tty teardown waits on it.
-    # Run it on the dedicated subprocess pool, never the event loop — a wedged
-    # close then costs at most one pool thread instead of freezing the whole
-    # gateway, and shares no workers with the orphan-reaping maintenance sweep.
-    if sess.master_fd >= 0:
-        fd = sess.master_fd
-        # Clear the handle BEFORE the await: if this coroutine is cancelled while
-        # suspended on the executor (e.g. aiohttp cancels the request handler on
-        # client disconnect), the fd must not be left referenced on the session.
-        sess.master_fd = -1
-        try:
-            await asyncio.get_running_loop().run_in_executor(
-                subprocess_executor(), os.close, fd,
-            )
-        except (OSError, RuntimeError):
-            # OSError: close failed. RuntimeError: the subprocess pool was
-            # already torn down (shutdown races interpreter exit) — submit
-            # raises rather than returning a future; the fd is reaped on exit.
-            pass
-    if sess.reader_task is not None:
-        sess.reader_task.cancel()
-        try:
-            await sess.reader_task
-        except (asyncio.CancelledError, Exception):
-            pass
+    # The child goes FIRST, then the PTY's controller descriptor, and the order
+    # is the fix for a real deadlock. Closing the controller end while the reader
+    # task is blocked in os.read() on it behaves differently per kernel: Linux
+    # hangs up the terminal end and the read returns EIO, which is what let the
+    # close come first; macOS (and the BSDs) make close() wait for that
+    # outstanding read, so with an interactive bash still holding the terminal
+    # end the close never returned, and four PTY tests timed out at 120 s on
+    # every macOS run, each parking a pool thread forever. Ending the session's
+    # process tree first releases the terminal end on both, so the read returns
+    # EOF, the close completes. SIGHUP is what a vanished terminal
+    # delivers and the one signal an interactive shell does not ignore (it
+    # ignores SIGTERM, which alone would cost the 5 s escalation wait); SIGTERM
+    # follows for everything else, SIGKILL after the wait as before.
     if sess.proc is not None and sess.proc.returncode is None:
         # Route through platform_compat.kill_process_tree so the whole terminal
         # handler stays platform-portable (killpg on POSIX, taskkill /T on
@@ -819,18 +804,17 @@ async def _kill_session(sess: _TerminalSession) -> None:
         # ws returns an error on Windows before any session is created — but
         # keeping a single shim call site avoids a raw-os.killpg vs shim
         # inconsistency across the module, and the tests all patch the shim.
-        try:
-            # Async variants offload Windows taskkill to subprocess_executor
-            # so this PTY teardown path never blocks the event loop on
-            # taskkill.exe. POSIX os.killpg stays inline.
-            await platform_compat.kill_process_tree_async(
-                sess.proc.pid, platform_compat.SIGTERM
-            )
-        except (ProcessLookupError, PermissionError):
-            # PermissionError (EPERM): the child made the PTY its controlling
-            # terminal (TIOCSCTTY) and leads a session/group we can't signal.
-            # Fall through to wait()/kill the proc directly.
-            pass
+        for sig in (platform_compat.SIGHUP, platform_compat.SIGTERM):
+            try:
+                # Async variants offload Windows taskkill to subprocess_executor
+                # so this PTY teardown path never blocks the event loop on
+                # taskkill.exe. POSIX os.killpg stays inline.
+                await platform_compat.kill_process_tree_async(sess.proc.pid, sig)
+            except (ProcessLookupError, PermissionError):
+                # PermissionError (EPERM): the child made the PTY its controlling
+                # terminal (TIOCSCTTY) and leads a session/group we can't signal.
+                # Fall through to wait()/kill the proc directly.
+                pass
         try:
             await asyncio.wait_for(sess.proc.wait(), timeout=5)
         except asyncio.TimeoutError:
@@ -845,6 +829,33 @@ async def _kill_session(sess: _TerminalSession) -> None:
             except ProcessLookupError:
                 pass
             await sess.proc.wait()
+    # os.close() on a PTY controller fd can still BLOCK in the kernel when the far
+    # end is wedged (uninterruptible sleep, or a child this process may not
+    # signal). Run it on the dedicated subprocess pool, never the event loop, so a
+    # wedged close then costs at most one pool thread instead of freezing the
+    # whole gateway, and shares no workers with the orphan-reaping maintenance
+    # sweep.
+    if sess.master_fd >= 0:  # wokeignore:rule=master
+        fd = sess.master_fd  # wokeignore:rule=master
+        # Clear the handle BEFORE the await: if this coroutine is cancelled while
+        # suspended on the executor (e.g. aiohttp cancels the request handler on
+        # client disconnect), the fd must not be left referenced on the session.
+        sess.master_fd = -1  # wokeignore:rule=master
+        try:
+            await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), os.close, fd,
+            )
+        except (OSError, RuntimeError):
+            # OSError: close failed. RuntimeError: the subprocess pool was
+            # already torn down (shutdown races interpreter exit): submit
+            # raises rather than returning a future; the fd is reaped on exit.
+            pass
+    if sess.reader_task is not None:
+        sess.reader_task.cancel()
+        try:
+            await sess.reader_task
+        except (asyncio.CancelledError, Exception):
+            pass
 
 
 async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.Response:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -146,6 +146,9 @@ SIGKILL: int = getattr(signal, "SIGKILL", 9)
 # the self-check is stable and immune to test-time os.getpgid patching.
 _OWN_PGID: int = os.getpgid(0) if hasattr(os, "getpgid") else 0
 SIGTERM: int = getattr(signal, "SIGTERM", 15)
+# The hangup a vanished controlling terminal delivers. Undefined on Windows, where
+# the ConPTY backend tears a console down by handle rather than by signal.
+SIGHUP: int = getattr(signal, "SIGHUP", 1)
 
 # Portable subprocess creation flags — these constants exist ONLY on Windows
 # (the subprocess module has no such attributes on POSIX). Referencing

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -5003,7 +5003,7 @@ def _parse_pid_segment(pid_str: str) -> int | None:
         return None
 
 
-def cleanup_stale_sandbox_profiles(*, legacy_dir: str | None = None) -> int:
+def cleanup_stale_sandbox_profiles(*, data_home: Path, legacy_dir: str | None = None) -> int:
     """Remove orphan sandbox files from <config_dir>/run/ and legacy /tmp.
 
     A file is removed when EITHER:
@@ -5021,13 +5021,21 @@ def cleanup_stale_sandbox_profiles(*, legacy_dir: str | None = None) -> int:
     Called from the periodic cleanup sweep in session.py, offloaded to the
     maintenance executor (blocking I/O).  Safe to call from sync contexts too.
 
+    *data_home* is the data home every path below is rooted at. The sweep runs on
+    a pool thread, and a pool thread resolves ``config_dir()`` whenever it happens
+    to be scheduled, which, under the test suite, is routinely AFTER the test
+    that queued it has torn down its ``KIROCREW_HOME`` pin, so the sweep then
+    walked (and could stamp or remove under) the operator's real ``~/.kiro/crew``.
+    The caller that knows the home resolves it on ITS thread and passes it in;
+    there is deliberately no default, so no future caller can reopen that path.
+
     Returns:
         Number of stale files removed.
     """
     now = time.time()
     if legacy_dir is None:
         legacy_dir = _LEGACY_LAUNCHER_DIR
-    run_dir = str(config_dir() / "run")
+    run_dir = str(data_home / "run")
     removed = 0
 
     # ── Sweep <config_dir>/run/ (PID + age) ──
@@ -5095,8 +5103,8 @@ def cleanup_stale_sandbox_profiles(*, legacy_dir: str | None = None) -> int:
             pass
 
     removed += _cleanup_stale_sandbox_mount_sources()
-    removed += _cleanup_legacy_mount_source_residue()
-    removed += _cleanup_retired_acp_snapshot_dir()
+    removed += _cleanup_legacy_mount_source_residue(data_home)
+    removed += _cleanup_retired_acp_snapshot_dir(data_home)
     return removed
 
 
@@ -5733,7 +5741,7 @@ def _bound_source_basenames(
     )
 
 
-def _cleanup_legacy_mount_source_residue() -> int:
+def _cleanup_legacy_mount_source_residue(data_home: Path) -> int:
     """One-shot reclaim of the pre-#6268, pid-less bind-mount source residue.
 
     An install that upgraded past #6268 gained a sweep that can never touch what
@@ -5783,7 +5791,7 @@ def _cleanup_legacy_mount_source_residue() -> int:
     Returns:
         Number of entries removed.
     """
-    marker = config_dir() / _LEGACY_RESIDUE_MARKER
+    marker = data_home / _LEGACY_RESIDUE_MARKER
     try:
         if marker.exists():
             return 0
@@ -5937,7 +5945,7 @@ def _cleanup_legacy_mount_source_residue() -> int:
     return removed
 
 
-def _cleanup_retired_acp_snapshot_dir() -> int:
+def _cleanup_retired_acp_snapshot_dir(data_home: Path) -> int:
     """Reclaim `<config_dir>/run/kiro-cli-snapshots` from before the in-place launch.
 
     KiroCrew used to copy the whole kiro-cli binary here per ACP spawn generation
@@ -5950,7 +5958,7 @@ def _cleanup_retired_acp_snapshot_dir() -> int:
     when a tree was removed so the periodic sweep logs it.
     """
 
-    retired = config_dir() / "run" / "kiro-cli-snapshots"
+    retired = data_home / "run" / "kiro-cli-snapshots"
     if not retired.is_dir():
         return 0
     shutil.rmtree(retired, ignore_errors=True)

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -123,6 +123,7 @@ from kiro_crew.config.loader import (
     normalize_agent_model,
     published_autocompact_pct,
 )
+from kiro_crew.config.paths import config_dir
 from kiro_crew.constants import COMPACT_WAIT_TIMEOUT_SECS
 from kiro_crew.executors import maintenance_executor, subprocess_executor
 from kiro_crew.mcp_gateway.abort import schedule_abort
@@ -1116,6 +1117,14 @@ class SessionManager:
         return state
 
     def _cleanup_deps(self) -> CleanupDeps:
+        # Resolved HERE, on the thread that builds the deps, and carried into the
+        # sandbox sweep. That sweep runs on the maintenance pool, and a path a pool
+        # thread resolves for itself is resolved whenever the thread gets scheduled:
+        # under the test suite that is routinely after the test that queued it has
+        # dropped its KIROCREW_HOME pin, so the sweep walked the operator's real
+        # ~/.kiro/crew. The data home does not move during a gateway's life, so
+        # resolving it once at construction loses nothing.
+        data_home = config_dir()
         return CleanupDeps(
             logger=logger,
             get_shutdown_signal=lambda: shutdown_event,
@@ -1123,7 +1132,9 @@ class SessionManager:
             get_subprocess_executor=lambda: subprocess_executor(),
             cleanup_orphaned_mcp_servers=lambda: _cleanup_orphaned_mcp_servers(),
             cleanup_orphaned_session_roots=lambda: cleanup_orphaned_session_roots(),
-            cleanup_stale_sandbox_profiles=lambda: cleanup_stale_sandbox_profiles(),
+            cleanup_stale_sandbox_profiles=lambda: cleanup_stale_sandbox_profiles(
+                data_home=data_home
+            ),
             prune_pycache=lambda: prune_pycache(),
             collect_active_pids=lambda sessions: _collect_active_pids(
                 cast(dict[Any, Any], sessions)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -286,7 +286,7 @@ def cap_project_root_walk(monkeypatch, ceiling: pathlib.Path) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _windows_restrict_to_owner_stub(request, monkeypatch):
+def _windows_restrict_to_owner_stub(request, _floor_monkeypatch):
     """On Windows, no-op the secret lockdown for hermetic tests.
 
     Many tests stub ``subprocess.run`` (or strip PATH) for hermeticity, or
@@ -323,8 +323,8 @@ def _windows_restrict_to_owner_stub(request, monkeypatch):
     ):
         yield
         return
-    monkeypatch.setattr(platform_compat, "restrict_to_owner", lambda p: None)
-    monkeypatch.setattr(platform_compat, "restrict_dir_to_owner", lambda p: None)
+    _floor_monkeypatch.setattr(platform_compat, "restrict_to_owner", lambda p: None)
+    _floor_monkeypatch.setattr(platform_compat, "restrict_dir_to_owner", lambda p: None)
     yield
 
 
@@ -349,7 +349,7 @@ def _release_source_corpus_after_module():
 
 
 @pytest.fixture(autouse=True)
-def _isolate_aim_skills_dir(monkeypatch):
+def _isolate_aim_skills_dir(_floor_monkeypatch):
     """Prevent SkillsLoader from discovering edition-contributed skill roots.
 
     SkillsLoader now sources extra skill roots from the CPP seam
@@ -365,7 +365,7 @@ def _isolate_aim_skills_dir(monkeypatch):
     """
     from kiro_crew.platform.defaults import DefaultMcpToolingProvider
 
-    monkeypatch.setattr(DefaultMcpToolingProvider, "extra_skills", lambda self: [])
+    _floor_monkeypatch.setattr(DefaultMcpToolingProvider, "extra_skills", lambda self: [])
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -672,7 +672,7 @@ def _reset_reasoning_effort_globals():
 
 
 @pytest.fixture(autouse=True)
-def _disable_dev_fleet_background_tasks(monkeypatch):
+def _disable_dev_fleet_background_tasks(_floor_monkeypatch):
     """Stop dev-fleet's app-startup hook from starting its background loops.
 
     A test that boots the real app via ``dev_fleet.server.create_app()`` (to
@@ -683,7 +683,7 @@ def _disable_dev_fleet_background_tasks(monkeypatch):
     (issue #1832). A test that wants the real refresher overrides this itself
     via ``monkeypatch.setattr(worktree_ops, "_background_tasks_disabled", lambda: False)``.
     """
-    monkeypatch.setenv("KIROCREW_DEVFLEET_NO_BACKGROUND", "1")
+    _floor_monkeypatch.setenv("KIROCREW_DEVFLEET_NO_BACKGROUND", "1")
 
 
 @pytest.fixture(autouse=True)
@@ -921,7 +921,7 @@ def _restore_default_child_watcher():
 
 
 @pytest.fixture(autouse=True)
-def _git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+def _git_identity(_floor_monkeypatch) -> None:
     """Make git tests hermetic: pin identity AND neutralize host global/system config.
 
     Two independent host-environment bleeds must be closed for git-backed tests
@@ -937,22 +937,22 @@ def _git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
        ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` at ``/dev/null`` so no
        host-level config (excludes, aliases, hooks, signing) leaks into tests.
     """
-    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
-    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
-    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
-    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+    _floor_monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    _floor_monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+    _floor_monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    _floor_monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
     # Isolate from the host's global/system git config (Git >= 2.32). An empty
     # file (/dev/null) means git reads no global or system settings.
-    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
-    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    _floor_monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    _floor_monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
 
 
 @pytest.fixture(autouse=True)
-def _enterprise_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
+def _enterprise_bypass(_floor_monkeypatch) -> None:
     """Set a default validated team_id so _route_message doesn't reject messages."""
-    monkeypatch.setattr("kiro_crew.slack.enterprise._validated_team_id", "TTEST")
-    monkeypatch.setattr("kiro_crew.slack.enterprise._validated_enterprise_id", "ETEST")
-    monkeypatch.setattr("kiro_crew.slack.enterprise._allowed_team_ids", {"TTEST"})
+    _floor_monkeypatch.setattr("kiro_crew.slack.enterprise._validated_team_id", "TTEST")
+    _floor_monkeypatch.setattr("kiro_crew.slack.enterprise._validated_enterprise_id", "ETEST")
+    _floor_monkeypatch.setattr("kiro_crew.slack.enterprise._allowed_team_ids", {"TTEST"})
 
 
 @pytest.fixture(autouse=True)
@@ -1181,31 +1181,11 @@ def _fake_computer_use_backend():
     reset_shared_backend()
 
 
-@pytest.fixture(autouse=True)
-def _reset_platform_context(monkeypatch):
-    """Clear the process-global PlatformContext between tests.
-
-    A test that composes a non-default context (e.g. an Amazon-overlay probe)
-    must not leak it into the next test.  ``current_context()`` lazily rebuilds
-    the standalone default on next access.
-
-    Also pins ``KIROCREW_PROFILE=standalone`` by default so a dev box that has a
-    real SSO-marker directory does not make ``boot_platform`` resolve the
-    ``amazon`` profile and fail closed (no companion installed) for the many
-    pre-existing tests that drive ``run_gateway`` / boot.  A test that wants the
-    amazon profile overrides this env via its own ``monkeypatch.setenv`` (it
-    runs after this autouse fixture), or composes the context directly via
-    ``set_context`` without booting.
-    """
-    from kiro_crew.platform.bootstrap import _reset_boot_state
-    from kiro_crew.platform.context import reset_context
-
-    monkeypatch.setenv("KIROCREW_PROFILE", "standalone")
-    reset_context()
-    _reset_boot_state()
-    yield
-    reset_context()
-    _reset_boot_state()
+# ``_reset_platform_context`` (the per-test PlatformContext reset and the
+# ``KIROCREW_PROFILE=standalone`` pin) lives in the ROOTDIR conftest, not here:
+# the ~108 test modules under ``src/kiro_crew/apps/builtins/*/tests/`` never see
+# this file, and an inherited enterprise ``KIROCREW_PROFILE`` failed 150+ of them
+# closed on an operator's box while ``test/`` stayed green.
 
 
 @pytest.fixture
@@ -1237,7 +1217,7 @@ def short_sock_dir(tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def _no_release_feed_network(monkeypatch: pytest.MonkeyPatch) -> None:
+def _no_release_feed_network(_floor_monkeypatch) -> None:
     """Make the update check's network seam unreachable for the whole suite.
 
     ``handlers.updates._do_update_check`` now has a second branch: any install
@@ -1266,13 +1246,13 @@ def _no_release_feed_network(monkeypatch: pytest.MonkeyPatch) -> None:
             "kiro_crew.dashboard.handlers.updates._fetch_feed_bytes instead"
         )
 
-    monkeypatch.setattr(
+    _floor_monkeypatch.setattr(
         "kiro_crew.dashboard.handlers.updates._fetch_feed_bytes", _refuse, raising=True
     )
 
 
 @pytest.fixture(autouse=True)
-def _no_live_catalog_network(monkeypatch: pytest.MonkeyPatch):
+def _no_live_catalog_network(_floor_monkeypatch):
     """Make the official app catalog's network seam unreachable for the suite.
 
     ``official_catalog._open_catalog`` is THE seam every catalog fetch goes
@@ -1314,7 +1294,7 @@ def _no_live_catalog_network(monkeypatch: pytest.MonkeyPatch):
             "seam such as inventory_for_install) instead"
         )
 
-    monkeypatch.setattr(official_catalog, "_open_catalog", _refuse, raising=True)
+    _floor_monkeypatch.setattr(official_catalog, "_open_catalog", _refuse, raising=True)
     yield original
 
 
@@ -1462,7 +1442,7 @@ class _InertGatewayPosts(list):
 
 
 @pytest.fixture(autouse=True)
-def gateway_posts(request, monkeypatch):
+def gateway_posts(request, _floor_monkeypatch):
     """Record ``mcp_core._post`` calls instead of letting them reach a gateway.
 
     ``mcp_tools.control._emit_directive`` publishes every directive out of band
@@ -1503,7 +1483,7 @@ def gateway_posts(request, monkeypatch):
                 " loopback_urlopen/_api_urlopen (or _post) in the test itself"
             )
 
-        monkeypatch.setattr(mcp_core, "loopback_urlopen", _refuse_network)
+        _floor_monkeypatch.setattr(mcp_core, "loopback_urlopen", _refuse_network)
         yield _InertGatewayPosts()
         return
 
@@ -1513,7 +1493,7 @@ def gateway_posts(request, monkeypatch):
         posted.append((path, json.loads(json.dumps(body)) if body is not None else None))
         return {}
 
-    monkeypatch.setattr(mcp_core, "_post", _capture)
+    _floor_monkeypatch.setattr(mcp_core, "_post", _capture)
     yield posted
 
 

--- a/test/metrics/test_otlp_wire_e2e.py
+++ b/test/metrics/test_otlp_wire_e2e.py
@@ -140,6 +140,15 @@ def _drive_live_build(tmp_path, monkeypatch, readings=None):
     fidelity assertion compare them rather than restate a fixed list.
     """
     monkeypatch.setenv("KIROCREW_TELEMETRY", "1")
+    # The MODULE-scoped `exported` fixture drives this before the function-scoped
+    # rootdir floor has pinned KIROCREW_HOME for the first test, and the live build
+    # reads config through config_dir(), which then created the operator's real
+    # ~/.kiro/crew (third side-effect audit). A fixture outside the floor pins what
+    # it resolves itself.
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "kirocrew-home"))
+    import kiro_crew.config.paths as _paths
+
+    monkeypatch.setattr(_paths, "_resolved_home", None)
     for name, value in (readings if readings is not None else _PINNED_READINGS).items():
         if value is _REAL:
             continue

--- a/test/test_acp_frame_record.py
+++ b/test/test_acp_frame_record.py
@@ -48,8 +48,28 @@ def _isolated_recorder(monkeypatch):
     """
     _frame_record._reset_for_tests()
     monkeypatch.delenv(_frame_record.ENV_RECORD_FRAMES, raising=False)
+    _pin_acl_gate_open(monkeypatch)
     yield
     _frame_record._reset_for_tests()
+
+
+def _pin_acl_gate_open(monkeypatch) -> None:
+    """Run the recorder's LOGIC on any POSIX host; only the gate tests flip it back.
+
+    Production refuses to record anywhere but Linux (``_require_acl_inspectable``:
+    only Linux exposes ACLs through ``os.listxattr``). Left unpinned, that gate made
+    75 tests in this module and its provider-safety sibling FAIL on every macOS dev
+    box while CI (Linux) was green, a platform-dependent failure rather than a skip. The
+    redaction, the owner-only modes, the symlink and hardlink refusals and the drain
+    are POSIX-generic and are exactly what a developer on a Mac wants checked before
+    pushing, so the gate is pinned to the platform the feature targets and, where the
+    host has no ``os.listxattr`` at all, an inspector that reports no ACLs (a Linux
+    filesystem without xattrs). The two tests OF the gate set ``IS_LINUX`` False
+    themselves and are unaffected.
+    """
+    monkeypatch.setattr(_frame_record.platform_compat, "IS_LINUX", True)
+    if not hasattr(os, "listxattr"):
+        monkeypatch.setattr(_frame_record.os, "listxattr", lambda *_a, **_k: [], raising=False)
 
 
 @asynccontextmanager
@@ -494,10 +514,11 @@ def test_a_bare_code_field_is_not_a_credential(monkeypatch, key):
 
 
 def test_a_credential_in_a_header_map_leaves_valid_json(monkeypatch, tmp_path):
-    """Redacting the SERIALIZED frame let one pattern span key, quote, colon and
-    value -- ``"Authorization": "Bearer …"`` collapsed to a single token and the
-    line no longer parsed. Redaction is per string leaf now, so the header key
-    survives, the value is redacted, and the corpus loader can read the line."""
+    """Redaction is per string leaf, never over the SERIALIZED frame: a pattern
+    spanning key, quote, colon and value would collapse ``"Authorization":
+    "Bearer …"`` to a single token and leave a line that does not parse. Per leaf,
+    the header key survives, the value is redacted, and the corpus loader can read
+    the line."""
     _clean(monkeypatch)
     frame = {
         "params": {

--- a/test/test_acp_frame_record_provider_safety.py
+++ b/test/test_acp_frame_record_provider_safety.py
@@ -165,6 +165,12 @@ def _runtime_frame(session_id: str, **extra_params) -> dict:
 def _fresh_recorder(monkeypatch):
     _frame_record._reset_for_tests()
     monkeypatch.delenv(_frame_record.ENV_RECORD_FRAMES, raising=False)
+    # Pin the Linux-only ACL gate open so a macOS dev box runs the provider-safety
+    # logic instead of failing 48 tests on the gate; see
+    # test_acp_frame_record._pin_acl_gate_open for the reasoning.
+    monkeypatch.setattr(_frame_record.platform_compat, "IS_LINUX", True)
+    if not hasattr(os, "listxattr"):
+        monkeypatch.setattr(_frame_record.os, "listxattr", lambda *_a, **_k: [], raising=False)
     yield
     # Never leave a writer thread behind for the next test module.
     loop = asyncio.new_event_loop()

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -1109,6 +1109,15 @@ async def test_runtime_spawn_passes_installed_path_through_exact_wrappers(
         "cgroup_scope_argv",
         lambda argv: ["/usr/bin/cgroup-wrapper", *argv],
     )
+    # The claim below is about the SNAPSHOT descriptor (there must be none, the
+    # binary is exec'd in place). On macOS the darwin-only workspace binding adds
+    # its own descriptor to pass_fds, so pin that seam to the no-descriptor shape
+    # every other platform already produces, or the assertion reads the wrong fd.
+
+    async def _unbound_workspace(work_dir):
+        return work_dir, None
+
+    monkeypatch.setattr(runtime_mod, "bind_voice_safe_agent_workspace_async", _unbound_workspace)
     monkeypatch.setattr(asyncio, "create_subprocess_exec", stop_spawn)
 
     runtime = AcpRuntime(work_dir=tmp_path / "workspace")

--- a/test/test_computer_use_registration.py
+++ b/test/test_computer_use_registration.py
@@ -1308,6 +1308,17 @@ class TestSpecEmissionGate:
 # ── The data-home pin ──
 
 
+def _fake_host_home(monkeypatch, host_home: Path) -> None:
+    """Point every default-home resolver at *host_home* instead of the operator's.
+
+    ``HOME`` for ``expanduser``, ``Path.home`` for ``paths._default_home()`` and for
+    the recovery breadcrumb ``config_dir()`` writes BESIDE the default home.
+    """
+    host_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(host_home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: host_home))
+
+
 class TestDataHomePin:
     """``KIROCREW_HOME`` must reach the stdio shims, or they read a DIFFERENT home.
 
@@ -1324,7 +1335,7 @@ class TestDataHomePin:
     """
 
     @staticmethod
-    def _entries(monkeypatch, home: "str | None") -> dict:
+    def _entries(monkeypatch, home: "str | None", default_home: Path) -> dict:
         """Build a fresh spec with (or without) an override in effect."""
         import kiro_crew.config.paths as paths
 
@@ -1333,27 +1344,32 @@ class TestDataHomePin:
         else:
             monkeypatch.setenv("KIROCREW_HOME", home)
         monkeypatch.setattr(paths, "_resolved_home", None)
+        # With no (valid) override the resolver falls through to the DEFAULT home.
+        # Relocate the WHOLE host home, not just the resolver: left alone, this helper
+        # resolved, and created, the operator's real ~/.kiro/crew, and a resolver-only
+        # stand-in still wrote the real ~/.kirocrew.breadcrumb beside it (audit 3).
+        _fake_host_home(monkeypatch, default_home)
         with patch.multiple("kiro_crew.agent", _MANAGED_MCP_SERVERS=_MANAGED):
             with patch("kiro_crew.agent._prompt_path", return_value=Path("/tmp/p.md")):
                 return agent.build_agent_config()["mcpServers"]
 
     def test_every_managed_server_is_pinned_under_an_override(self, tmp_path, monkeypatch):
-        servers = self._entries(monkeypatch, str(tmp_path))
+        servers = self._entries(monkeypatch, str(tmp_path), tmp_path / "default")
         for name in _MANAGED:
             assert servers[name]["env"]["KIROCREW_HOME"] == str(tmp_path.resolve()), name
 
-    def test_a_default_install_emits_no_env_at_all(self, monkeypatch):
+    def test_a_default_install_emits_no_env_at_all(self, tmp_path, monkeypatch):
         """The emitted spec must be byte-for-byte unchanged where there is no override.
 
         An empty ``env`` is a launch-behaviour no-op but a real diff in the file, and
         ``_prune_empty`` treats present-but-empty as equivalent — so emitting one
         would churn every existing user's ``kirocrew.json`` for nothing.
         """
-        servers = self._entries(monkeypatch, None)
+        servers = self._entries(monkeypatch, None, tmp_path)
         for name in _MANAGED:
             assert "env" not in servers[name], name
 
-    def test_a_ROOT_override_is_not_propagated(self, monkeypatch):
+    def test_a_ROOT_override_is_not_propagated(self, tmp_path, monkeypatch):
         """``config_dir()`` refuses a filesystem root and falls back to the default.
 
         Propagating one would INVERT the bug — the shim would honour a home the
@@ -1361,12 +1377,12 @@ class TestDataHomePin:
         root test is the portable ``p == p.parent`` one (``/`` → ``/``, ``D:\\`` →
         ``D:\\``), so ``"/"`` is refused on Windows too.
         """
-        servers = self._entries(monkeypatch, "/")
+        servers = self._entries(monkeypatch, "/", tmp_path)
         assert "env" not in servers[CU_SERVER]
 
     @pytest.mark.skipif(not IS_POSIX, reason="POSIX system-directory prefixes only")
     @pytest.mark.parametrize("bad", ["/usr", "/System"])
-    def test_an_INVALID_POSIX_SYSTEM_override_is_not_propagated(self, bad, monkeypatch):
+    def test_an_INVALID_POSIX_SYSTEM_override_is_not_propagated(self, bad, tmp_path, monkeypatch):
         """The named-system-directory half of the same refusal.
 
         POSIX-gated because the resolver matches on ``p.parts[:2] == ("/", "usr")``
@@ -1383,7 +1399,7 @@ class TestDataHomePin:
         gateway and the shim still agree on whatever it decides. Asserting a refusal
         here would be asserting behaviour the resolver does not have.)
         """
-        servers = self._entries(monkeypatch, bad)
+        servers = self._entries(monkeypatch, bad, tmp_path)
         assert "env" not in servers[CU_SERVER]
 
     def test_the_pin_always_AGREES_with_the_resolver(self, tmp_path, monkeypatch):
@@ -1422,7 +1438,7 @@ class TestDataHomePin:
         # A user's own variable must survive the merge.
         assert env["MY_VAR"] == "keep"
 
-    def test_a_refresh_CLEARS_a_stale_pin_when_the_override_is_gone(self, monkeypatch):
+    def test_a_refresh_CLEARS_a_stale_pin_when_the_override_is_gone(self, tmp_path, monkeypatch):
         """A config written under an override, refreshed on a default install.
 
         Leaving the old value would point the shims at a home the gateway is no
@@ -1432,6 +1448,7 @@ class TestDataHomePin:
 
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.setattr(paths, "_resolved_home", None)
+        _fake_host_home(monkeypatch, tmp_path / "default")
         cfg = {
             "mcpServers": {
                 CU_SERVER: {"command": "old", "args": [], "env": {"KIROCREW_HOME": "/stale"}},

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -234,9 +234,13 @@ async def _answer_approval(
         await asyncio.sleep(_ANSWER_POLL_SECS)
 
 
-def _context_builder(hook_result: ToolHookResult = ToolHookResult.allow()) -> MagicMock:
+def _context_builder(hook_result: ToolHookResult | None = None) -> MagicMock:
+    # ``allow()`` counts itself through kiro_crew.metrics. As a DEFAULT ARGUMENT it
+    # ran at import, before any pin existed, and built the process-global recorder
+    # from the operator's real config: an exporter bound to the real
+    # ~/.kiro/crew/metrics for the life of the worker. Built per call instead.
     cb = MagicMock()
-    cb.hooks.on_tool_call.return_value = hook_result
+    cb.hooks.on_tool_call.return_value = hook_result if hook_result is not None else ToolHookResult.allow()
     cb.build_message.return_value = ("hello", None)
     return cb
 

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -837,7 +837,11 @@ class TestSttConfigEndpoint:
         assert not isinstance(stt["idle_evict_secs"], bool)
 
     @pytest.mark.asyncio
-    async def test_get_advertises_capabilities(self, seeded_config) -> None:
+    async def test_get_advertises_capabilities(self, seeded_config, monkeypatch) -> None:
+        # The unsupported flag folds in the venv's own packaging: a uv-created venv
+        # ships no `pip` module, so the channel probe reads False there and the
+        # flag flips True on every uv host. Pin the probe, as the sibling tests do.
+        monkeypatch.setattr(core_mod, "_pip_install_channel_available", lambda: True)
         async with TestClient(TestServer(_stt_app())) as client:
             resp = await client.get("/api/config/stt")
             assert resp.status == 200
@@ -857,8 +861,8 @@ class TestSttConfigEndpoint:
         assert "en-US" in body["language_codes"]
         assert body["available"] is False
         assert body["prereqs"] == []
-        # This test venv has a working pip channel, so the unsupported flag
-        # must be False regardless of installed extras.
+        # The pip channel is pinned open above, so the unsupported flag must be
+        # False regardless of installed extras.
         assert body["transcribe_unsupported"] is False
         # Cause discriminator for the unsupported notice: the desktop bundle
         # needs different guidance than a pip-less/PEP 668 interpreter. A test

--- a/test/test_ensure_python_symlink.py
+++ b/test/test_ensure_python_symlink.py
@@ -80,6 +80,29 @@ def test_records_the_resolved_path_when_python_on_path_is_a_symlink(tmp_path):
     assert Path(recorded).exists(), recorded
 
 
+def _copies_venv_cannot_relocate_this_interpreter() -> bool:
+    """A macOS CPython that links ``@rpath/libpython`` cannot be copied out of its tree.
+
+    ``--copies`` duplicates the launcher binary alone; a shared-library build that
+    is not a framework (uv's python-build-standalone, Homebrew's) then dies in dyld
+    looking for ``libpython3.x.dylib`` beside the copy: before any ``pyvenv.cfg``
+    logic this test is about gets a chance to run. The python.org framework build,
+    which the docstring below describes, references its framework by absolute path
+    and relocates fine. A property of the host interpreter, so a skip, not a fail.
+    """
+    if sys.platform != "darwin":
+        return False
+    import sysconfig
+
+    return bool(sysconfig.get_config_var("Py_ENABLE_SHARED")) and not sysconfig.get_config_var(
+        "PYTHONFRAMEWORK"
+    )
+
+
+@pytest.mark.skipif(
+    _copies_venv_cannot_relocate_this_interpreter(),
+    reason="macOS: a non-framework shared-lib CPython cannot be copied into a --copies venv",
+)
 def test_a_venv_built_from_the_recorded_path_can_import_the_stdlib(tmp_path):
     """The reported symptom: ``make build`` died inside ensurepip.
 

--- a/test/test_handlers_system_macos_paths.py
+++ b/test/test_handlers_system_macos_paths.py
@@ -75,6 +75,9 @@ class TestMacOsSysctlPaths:
 
         with (
             patch.object(handlers_system, "_get_static_system_info", return_value={}),
+            # _local_ip() opens a UDP socket to 8.8.8.8:80 to learn the host's outbound
+            # address: a real network dependency the Linux siblings already stub.
+            patch.object(handlers_system, "_local_ip", return_value="127.0.0.1"),
             patch(
                 "kiro_crew.dashboard.handlers_system.subprocess.check_output",
                 side_effect=fake_check_output,
@@ -115,6 +118,9 @@ class TestMacOsSysctlPaths:
 
         with (
             patch.object(handlers_system, "_get_static_system_info", return_value={}),
+            # _local_ip() opens a UDP socket to 8.8.8.8:80 to learn the host's outbound
+            # address: a real network dependency the Linux siblings already stub.
+            patch.object(handlers_system, "_local_ip", return_value="127.0.0.1"),
             patch(
                 "kiro_crew.dashboard.handlers_system.subprocess.check_output",
                 side_effect=fake_check_output,

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -34,6 +34,7 @@ import pathlib
 import queue
 import sys
 import tempfile
+import threading
 from logging.handlers import QueueListener
 
 import pytest
@@ -174,6 +175,164 @@ class TestTheDataHomeIsPinnedForEveryTestpath:
         monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
 
         assert config_dir().resolve() == mine.resolve()
+
+    def test_a_tests_own_undo_cannot_lift_the_floor(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``monkeypatch.undo()`` in a test body unwinds the TEST's patches only.
+
+        The floor's pins ride on their own ``MonkeyPatch`` (``conftest._floor_monkeypatch``),
+        not on the ``monkeypatch`` fixture the test holds. Before that split, the third
+        full-run audit caught ``test_browser_cli_install.py`` calling ``undo()`` to lift
+        an ``os.name`` patch and then running ``detect()`` against the operator's real
+        ``~/.kiro/crew``: ``undo()`` had lifted ``KIROCREW_HOME`` with it. Every pin
+        named here is one the audit saw a real host write through.
+        """
+        pinned = {
+            key: os.environ[key]
+            for key in ("KIROCREW_HOME", "KIROCREW_WORKSPACE", "KIROCREW_PROFILE", "KIROCREW_TELEMETRY")
+        }
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "mine"))
+        monkeypatch.setattr(os, "name", os.name)  # the shape the real call site undid
+
+        monkeypatch.undo()
+
+        for key, value in pinned.items():
+            assert os.environ.get(key) == value, f"{key} was unpinned by the test's own undo()"
+        assert not _inside_a_guarded_root(pathlib.Path(os.environ["KIROCREW_HOME"]).resolve())
+
+    def test_the_floor_is_set_up_before_and_torn_down_after_the_tests_monkeypatch(
+        self, request: pytest.FixtureRequest
+    ) -> None:
+        """The two undo stacks nest, so a same-key override restores the PIN, not the host.
+
+        Pinned structurally rather than by observing one teardown: the ``monkeypatch``
+        fixture is re-declared at the rootdir with ``_floor_monkeypatch`` as a dependency,
+        which is what orders its setup after, and its teardown before, the floor's.
+        """
+        definition = request._fixturemanager.getfixturedefs("monkeypatch", request.node)
+        assert definition, "no monkeypatch fixture resolved"
+        active = definition[-1]
+        assert "_floor_monkeypatch" in active.argnames, (
+            "the monkeypatch fixture in force here is not the rootdir override; a test's "
+            "undo would race the floor's teardown"
+        )
+        assert pathlib.Path(active.func.__code__.co_filename).resolve() == _ROOT_CONFTEST.resolve()
+
+
+class TestThePlatformProfileIsPinnedForEveryTestpath:
+    """``KIROCREW_PROFILE`` is ``standalone`` for every test, whatever the shell exported.
+
+    A Kiro Crew agent session exports the enterprise ``KIROCREW_PROFILE`` to every child it
+    spawns, and a dev box with an SSO marker resolves the same profile on its own. With
+    no companion installed that profile FAILS CLOSED: ``current_context()`` raises
+    ``PlatformCompositionError``, every governance-gated route answers 500, every gated
+    notification is dropped. A pin in ``test/conftest.py`` reaches ``test/`` alone:
+    ``test/`` stays green while 150+ tests under ``src/kiro_crew/apps/builtins/*/tests/``
+    are red on exactly that box. The pin is a rootdir floor, like the data home.
+    """
+
+    def test_the_profile_is_standalone(self) -> None:
+        assert os.environ.get("KIROCREW_PROFILE") == "standalone"
+
+    def test_the_pin_is_an_autouse_fixture_of_the_rootdir_conftest(self) -> None:
+        definition = getattr(_root, "_reset_platform_context")
+        marker = getattr(definition, "_fixture_function_marker", None) or getattr(
+            definition, "_pytestfixturefunction", None
+        )
+        assert marker is not None and marker.autouse
+
+    def test_the_context_composes_the_open_source_default(self) -> None:
+        """The observable consequence: no fail-closed refusal on an unbooted process."""
+        from kiro_crew.platform.context import current_context
+
+        assert current_context() is not None
+
+
+class TestNoMetricIsEmittedAtImport:
+    """Collecting a test module must not build the process-global metrics recorder.
+
+    An import-time emission (``ToolHookResult.allow()`` as a DEFAULT ARGUMENT of a
+    module-level helper was the real case) runs ``get_recorder()`` before any pin
+    exists. The recorder's first build read the operator's real config, and with
+    ``telemetry.enabled`` there it started an exporter bound to the real
+    ``~/.kiro/crew/metrics`` that wrote every minute for the life of the worker --
+    invisible to the per-test leak guard (the thread predates every test) and to the
+    per-test env pin (already built). The rootdir conftest now pins
+    ``KIROCREW_TELEMETRY=0`` from process start AND records every module whose
+    collection flipped ``metrics.provider._ever_built``; this asserts that record.
+    """
+
+    @staticmethod
+    def _live_root_conftest(config: pytest.Config):
+        """The rootdir conftest AS PYTEST LOADED IT, found by path, not by name.
+
+        ``_root`` above is a second copy loaded for its definitions; the record this
+        test reads is runtime state, so it has to come from the plugin instance that
+        actually ran the collection hooks.
+        """
+        for plugin in config.pluginmanager.get_plugins():
+            file = getattr(plugin, "__file__", None)
+            if file and pathlib.Path(file).resolve() == _ROOT_CONFTEST.resolve():
+                return plugin
+        raise AssertionError("the rootdir conftest is not a registered plugin")
+
+    def test_the_process_starts_with_telemetry_pinned_off(self) -> None:
+        assert os.environ.get("KIROCREW_TELEMETRY") == "0"
+
+    def test_no_module_built_the_recorder_while_being_collected(self, request) -> None:
+        live = self._live_root_conftest(request.config)
+        emitters = list(live.IMPORT_TIME_METRIC_EMITTERS)
+        assert emitters == [], (
+            "importing these test modules emitted a metric (a module-level default "
+            "argument or constant that goes through kiro_crew.metrics): "
+            f"{emitters}. Build the value inside the test or fixture instead; an "
+            "import-time build binds the exporter to the operator's real data home."
+        )
+
+    def test_the_guard_names_a_module_that_emits_at_import(self, request, monkeypatch) -> None:
+        """Negative control, driven on the standalone copy so the live record stays clean.
+
+        The hookwrapper is a plain generator: enter it, emit a metric where the module
+        import would have, leave it, and the module is recorded and the build undone.
+        """
+        from kiro_crew.hooks import ToolHookResult
+        from kiro_crew.metrics import provider
+
+        provider.reset_for_testing()
+        monkeypatch.setattr(_root, "IMPORT_TIME_METRIC_EMITTERS", [])
+        module = request.node.getparent(pytest.Module)
+        assert module is not None
+
+        wrapper = _root.pytest_make_collect_report(module)
+        next(wrapper)
+        ToolHookResult.allow()  # the import-time emission, with the process pin in force
+        assert provider._ever_built, "the emission did not build a recorder; control is vacuous"
+        with pytest.raises(StopIteration):
+            next(wrapper)
+
+        assert _root.IMPORT_TIME_METRIC_EMITTERS == [module.nodeid]
+        assert not provider._ever_built, "the guard must undo the build it recorded"
+        assert not any("Otel" in t.name for t in threading.enumerate())
+
+    def test_a_build_that_predates_the_module_is_blamed_on_the_conftest_import(
+        self, request, monkeypatch
+    ) -> None:
+        from kiro_crew.hooks import ToolHookResult
+        from kiro_crew.metrics import provider
+
+        provider.reset_for_testing()
+        monkeypatch.setattr(_root, "IMPORT_TIME_METRIC_EMITTERS", [])
+        module = request.node.getparent(pytest.Module)
+        ToolHookResult.allow()  # already built when the module is reached
+
+        wrapper = _root.pytest_make_collect_report(module)
+        next(wrapper)
+        with pytest.raises(StopIteration):
+            next(wrapper)
+
+        assert _root.IMPORT_TIME_METRIC_EMITTERS == [f"conftest import (before {module.nodeid})"]
+        assert not provider._ever_built
 
 
 class TestTheWorkspaceRootIsPinnedForEveryTestpath:

--- a/test/test_mcp_messaging_discord.py
+++ b/test/test_mcp_messaging_discord.py
@@ -16,6 +16,7 @@ ship a tool that looks right and delivers nothing:
 
 from __future__ import annotations
 
+import os
 import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -40,6 +41,18 @@ from kiro_crew.validation import SEND_MESSAGE_SCHEMA, ValidationError, validate_
 CRON_CALLER = "cron:abc123"
 OWNER_ID = "424242424242424242"
 DM_CHANNEL = "999000111222333444"
+
+
+def _PINNED_HOME_ONLY() -> dict[str, str]:
+    """An otherwise-empty environment that KEEPS the suite's data-home pin.
+
+    ``patch.dict(os.environ, {}, clear=True)`` is the right shape for "no caller
+    identity in the environment", but it also dropped ``KIROCREW_HOME``, so the
+    session-key resolver inside the call fell through to, and created, the
+    operator's real ``~/.kiro/crew`` (audit 3). The pin is not an identity.
+    """
+    home = os.environ.get("KIROCREW_HOME")
+    return {"KIROCREW_HOME": home} if home else {}
 
 
 def _descriptor() -> dict:
@@ -231,7 +244,10 @@ def test_an_addressed_send_is_refused_without_a_verifiable_identity() -> None:
     no benign default to fall back to (the gateway would vet it as the host), so it
     is refused rather than sent under a borrowed identity. Nothing is posted.
     """
-    with patch.dict("os.environ", {}, clear=True), patch("kiro_crew.mcp_core._post") as post:
+    with (
+        patch.dict("os.environ", _PINNED_HOME_ONLY(), clear=True),
+        patch("kiro_crew.mcp_core._post") as post,
+    ):
         result = _call_tool(
             "send_message",
             {"text": "hi", "channel_type": "webex", "target_id": "room:Y2lzY29z"},
@@ -248,7 +264,7 @@ def test_a_bare_send_still_works_without_a_verifiable_identity() -> None:
     it would break the default path for every unidentified caller.
     """
     with (
-        patch.dict("os.environ", {}, clear=True),
+        patch.dict("os.environ", _PINNED_HOME_ONLY(), clear=True),
         patch("kiro_crew.mcp_core._post", return_value={"ok": True}) as post,
     ):
         result = _call_tool("send_message", {"text": "hi"})

--- a/test/test_meetings_audio_import.py
+++ b/test/test_meetings_audio_import.py
@@ -60,6 +60,28 @@ def _owner(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ai, "is_owner_dashboard_request", lambda _request: True)
 
 
+def _consumed(path: str) -> "tuple[int, int] | str":
+    """The identity of the file *path* names, as ``(st_dev, st_ino)``.
+
+    Works for a plain path and for a ``/dev/fd/N`` descriptor path alike, on
+    Linux (a symlink) and on macOS (a devfs node), because OPENING either yields
+    a descriptor on the underlying file and ``fstat`` reports that file. (A bare
+    ``stat`` of the devfs node on macOS reports the file's inode under devfs's own
+    ``st_dev``, so it is not the same identity.) Falls back to the string when the
+    path cannot be opened, so a refusal test that logs a never-opened name still
+    compares.
+    """
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return path
+    try:
+        st = os.fstat(fd)
+    finally:
+        os.close(fd)
+    return (st.st_dev, st.st_ino)
+
+
 def _patch(monkeypatch: pytest.MonkeyPatch, **over: Any) -> dict[str, list]:
     """Patch the route's external dependencies. Returns a call log.
 
@@ -72,9 +94,14 @@ def _patch(monkeypatch: pytest.MonkeyPatch, **over: Any) -> dict[str, list]:
     into the route's snapshot dir (named like the real helper's output): the
     route pins that file with one descriptor and hands both consumers a
     ``/dev/fd`` path, so the stub must produce something openable. The probe
-    and transcribe stubs log the CALL-TIME realpath of what they were handed —
+    and transcribe stubs log the CALL-TIME resolution of what they were handed :
     the descriptor is closed before the response returns, so a later resolve
-    would fail. The real copy helper has its own tests below.
+    would fail. Resolution is by INODE (``_consumed``), not ``realpath``: Linux's
+    ``/dev/fd/N`` is a symlink that realpath follows to the snapshot file, but on
+    macOS it is a devfs node that realpath leaves as ``/dev/fd/N``, so a realpath
+    comparison passed on Linux CI and failed on every Mac. ``stat`` on the
+    descriptor path returns the open file's identity on both, and identity is the
+    guarantee the route actually makes. The real copy helper has its own tests below.
     """
     import kiro_crew.transcribe as transcribe_mod
 
@@ -87,6 +114,7 @@ def _patch(monkeypatch: pytest.MonkeyPatch, **over: Any) -> dict[str, list]:
         "config_loads": [],
         "snapshots": [],
         "snapshot_files": [],
+        "snapshot_idents": [],
         "ready_config": [],
         "cap_config": [],
         "split_calls": [],
@@ -115,16 +143,20 @@ def _patch(monkeypatch: pytest.MonkeyPatch, **over: Any) -> dict[str, list]:
             fh.write(over.get("snapshot_bytes", b"fake recording bytes"))
         log["snapshot_files"].append(dst)
         st = os.stat(dst)
+        # Recorded NOW: the route removes the snapshot dir before it answers, so
+        # an assertion cannot stat the file afterwards. Compared against what
+        # the consumers logged via ``_consumed``.
+        log["snapshot_idents"].append((st.st_dev, st.st_ino))
         return dst, (st.st_dev, st.st_ino)
 
     async def _transcribe(path: str, *a: Any, **kw: Any) -> str | None:
-        log["transcribed"].append((os.path.realpath(path), a[0] if a else kw.get("stt_config")))
+        log["transcribed"].append((_consumed(path), a[0] if a else kw.get("stt_config")))
         return over.get("transcript", "we decided to ship on Friday")
 
     async def _split(path: str, cap_secs: int, segment_dir: str, cfg: Any) -> str | None:
-        # The route hands the pinned descriptor path; realpath it so the assertion
-        # matches the snapshot the same way ``_transcribe`` does.
-        log["split_calls"].append((os.path.realpath(path), cap_secs, segment_dir))
+        # The route hands the pinned descriptor path; resolve it by inode so the
+        # assertion matches the snapshot the same way ``_transcribe`` does.
+        log["split_calls"].append((_consumed(path), cap_secs, segment_dir))
         if "split_transcript" in over:
             return over["split_transcript"]
         return over.get("transcript", "we decided to ship on Friday")
@@ -139,7 +171,7 @@ def _patch(monkeypatch: pytest.MonkeyPatch, **over: Any) -> dict[str, list]:
         return over.get("splits", True)
 
     async def _exceeds(path: str, max_secs: int, **kw: Any) -> bool | None:
-        log["probed"].append((os.path.realpath(path), max_secs))
+        log["probed"].append((_consumed(path), max_secs))
         log["probe_timeouts"].append(kw.get("timeout_secs"))
         return over.get("exceeds", False)
 
@@ -595,10 +627,10 @@ class TestRefusals:
             assert body["lines"] == 2
         # The probe and the split BOTH consumed the PINNED snapshot, never the
         # user-writable original name; the whole-file transcriber was NOT called.
-        assert log["probed"] == [(os.path.realpath(log["snapshot_files"][0]), 3600)]
+        assert log["probed"] == [(log["snapshot_idents"][0], 3600)]
         assert len(log["split_calls"]) == 1
         split_path, split_cap, _seg_dir = log["split_calls"][0]
-        assert split_path == os.path.realpath(log["snapshot_files"][0])
+        assert split_path == log["snapshot_idents"][0]
         assert split_cap == 3600
         assert log["transcribed"] == []
 
@@ -768,7 +800,7 @@ class TestRefusals:
             )
             assert resp.status == 200
         assert log["probed"] == []
-        assert [p for p, _cfg in log["transcribed"]] == [os.path.realpath(log["snapshot_files"][0])]
+        assert [p for p, _cfg in log["transcribed"]] == [log["snapshot_idents"][0]]
 
     @pytest.mark.asyncio
     async def test_one_config_snapshot_feeds_readiness_cap_and_transcription(

--- a/test/test_module_loader.py
+++ b/test/test_module_loader.py
@@ -340,6 +340,7 @@ class TestModuleUnload:
     def test_reload_after_unload_gets_fresh_code(self, tmp_path: Path) -> None:
         """After unload, re-loading gets fresh module code."""
         import importlib
+        import importlib.util
         import uuid
         work_dir = tmp_path / uuid.uuid4().hex
         work_dir.mkdir()
@@ -351,13 +352,13 @@ class TestModuleUnload:
 
         unload_app_modules("test-app-reload")
 
-        # Update the file — also invalidate any bytecode cache
+        # Update the file: also invalidate any bytecode cache. Located through
+        # cache_from_source, which honours sys.pycache_prefix (the suite redirects
+        # bytecode off the checkout), rather than assuming a sibling __pycache__/.
         mod_path.write_text("def func(ctx): return 'v2'")
-        # Remove __pycache__ if it exists
-        pycache = work_dir / "__pycache__"
-        if pycache.exists():
-            import shutil
-            shutil.rmtree(pycache)
+        cached = Path(importlib.util.cache_from_source(str(mod_path)))
+        if cached.exists():
+            cached.unlink()
         # Invalidate importlib caches
         importlib.invalidate_caches()
 

--- a/test/test_papyrus_latex.py
+++ b/test/test_papyrus_latex.py
@@ -978,12 +978,19 @@ class TestSensitivePathsFollowTheLiveDataHome:
         assert default_anchored, "the default-home entries were dropped"
 
     def test_no_duplicates_when_the_home_is_the_default(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """With no override the two anchors coincide, and the list must not double."""
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        # The "default" home is exercised against a FAKE host home, so both anchors
+        # (expanduser("~") and the resolver's default) coincide there instead of on the
+        # operator's real ~/.kiro/crew, which the bare delenv resolved and created.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
         hidden = latex._sensitive_hidden_dirs()
         assert len(hidden) == len(set(hidden))
+        assert any(h.startswith(str(tmp_path)) for h in hidden), "the fake home was not the anchor"
 
 
 @pytest.mark.asyncio

--- a/test/test_pid_sweep_helpers.py
+++ b/test/test_pid_sweep_helpers.py
@@ -672,12 +672,35 @@ class TestPidAgeSeconds:
         assert age is not None
         assert abs(age - age_desired) < 1.0
 
-    def test_non_linux_returns_none(self) -> None:
-        """On non-Linux, _pid_age_seconds returns None immediately."""
+    def test_non_linux_without_a_start_id_returns_none(self) -> None:
+        """Off Linux the age comes from ``get_process_start_id``; no id, no age.
+
+        The start id is pinned to ``None`` rather than assumed: on a real macOS host
+        the darwin backend answers for any live pid, so the old shape of this test
+        (patch ``sys.platform`` and hope pid 1234 has no start time) passed on Linux
+        CI and failed on every Mac that happened to be running pid 1234.
+        """
         from kiro_crew.session_pid import _pid_age_seconds
 
-        with patch("kiro_crew.session_pid.sys.platform", "darwin"):
+        with (
+            patch("kiro_crew.session_pid.sys.platform", "darwin"),
+            patch("kiro_crew.session_pid.platform_compat.get_process_start_id", return_value=None),
+        ):
             assert _pid_age_seconds(1234) is None
+
+    def test_non_linux_with_a_start_id_derives_the_age(self) -> None:
+        from kiro_crew.session_pid import _pid_age_seconds
+
+        now = 1_000_000.0
+        with (
+            patch("kiro_crew.session_pid.sys.platform", "darwin"),
+            patch(
+                "kiro_crew.session_pid.platform_compat.get_process_start_id",
+                return_value=f"{now - 42.5:.6f}",
+            ),
+            patch("kiro_crew.session_pid.time.time", return_value=now),
+        ):
+            assert _pid_age_seconds(1234) == pytest.approx(42.5)
 
 
 class TestPidInSpawnGrace:

--- a/test/test_prompts.py
+++ b/test/test_prompts.py
@@ -3351,6 +3351,10 @@ class TestCreateAndDeletePinTheDirectory:
             "bool",
         }, f"boot-path constant calls something that may touch the filesystem: {sorted(calls)}"
 
+    @pytest.mark.skipif(
+        not _prompts_mod._UNNAMED_CREATE_SUPPORTED or not os.path.isdir("/proc/self/fd"),
+        reason="platform cannot build an unnamed inode (O_TMPFILE + /proc/self/fd)",
+    )
     def test_the_body_is_durable_before_the_name_appears(self, tmp_path, mock_sel, monkeypatch):
         """The flush precedes the publish, and the DIRECTORY is flushed too.
 
@@ -3506,6 +3510,10 @@ class TestCreateAndDeletePinTheDirectory:
         ).exists(), "the fallback left behind a prompt whose entry it could not flush"
         assert _outcomes(mock_sel)[-1] == "error"
 
+    @pytest.mark.skipif(
+        not _prompts_mod._UNNAMED_CREATE_SUPPORTED or not os.path.isdir("/proc/self/fd"),
+        reason="platform cannot build an unnamed inode (O_TMPFILE + /proc/self/fd)",
+    )
     def test_a_create_cannot_disturb_a_prompt_already_at_the_name(
         self, tmp_path, mock_sel, monkeypatch
     ):

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -2031,7 +2031,7 @@ class TestCleanupStaleSandboxProfiles:
 
         with patch("kiro_crew.sandbox.config_dir", return_value=tmp_path / ".kirocrew"):
             with patch("kiro_crew.sandbox.platform_compat.pid_exists", return_value=False):
-                removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent"))
+                removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent"), data_home=sandbox_mod.config_dir())
 
         assert not stale_file.exists()
         assert removed == 1
@@ -2053,13 +2053,13 @@ class TestCleanupStaleSandboxProfiles:
         (holder / "kiro-cli").write_bytes(b"orphaned copy")
 
         with patch("kiro_crew.sandbox.config_dir", return_value=home):
-            removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent"))
+            removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent"), data_home=sandbox_mod.config_dir())
 
         assert not (home / "run" / "kiro-cli-snapshots").exists()
         assert removed == 1
         # The rest of run/ is untouched, and a second pass is a no-op.
         with patch("kiro_crew.sandbox.config_dir", return_value=home):
-            assert cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent")) == 0
+            assert cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent"), data_home=sandbox_mod.config_dir()) == 0
 
     def test_preserves_live_pid_profile(self, tmp_path):
         """Profile file whose PID is alive (current process) is preserved."""
@@ -2071,7 +2071,7 @@ class TestCleanupStaleSandboxProfiles:
         live_file.write_text("(version 1)")
 
         with patch("kiro_crew.sandbox.config_dir", return_value=tmp_path / ".kirocrew"):
-            removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent"))
+            removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent"), data_home=sandbox_mod.config_dir())
 
         assert live_file.exists()
         assert removed == 0
@@ -2086,7 +2086,7 @@ class TestCleanupStaleSandboxProfiles:
         other_file.write_text("keep me")
 
         with patch("kiro_crew.sandbox.config_dir", return_value=tmp_path / ".kirocrew"):
-            removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent"))
+            removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "nonexistent"), data_home=sandbox_mod.config_dir())
 
         assert other_file.exists()
         assert removed == 0

--- a/test/test_sandbox_launcher_sweep.py
+++ b/test/test_sandbox_launcher_sweep.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
+import kiro_crew.sandbox as sandbox_mod
 from kiro_crew.sandbox import (
     _LAUNCHER_MAX_AGE_SECONDS,
     _ensure_run_dir,
@@ -139,7 +140,7 @@ class TestCleanupSweep:
         dead_file = run_dir / "kirocrew_sandbox_99999999_abc123.py"
         dead_file.write_text("# dead launcher")
 
-        removed = cleanup_stale_sandbox_profiles()
+        removed = cleanup_stale_sandbox_profiles(data_home=sandbox_mod.config_dir())
         assert not dead_file.exists()
         assert removed == 1
 
@@ -149,7 +150,7 @@ class TestCleanupSweep:
         dead_file = run_dir / "kirocrew_sandbox_99999999_xyz789.sb"
         dead_file.write_text("(version 1)")
 
-        removed = cleanup_stale_sandbox_profiles()
+        removed = cleanup_stale_sandbox_profiles(data_home=sandbox_mod.config_dir())
         assert not dead_file.exists()
         assert removed == 1
 
@@ -164,7 +165,7 @@ class TestCleanupSweep:
         old_time = time.time() - _LAUNCHER_MAX_AGE_SECONDS - 100
         os.utime(live_file, (old_time, old_time))
 
-        removed = cleanup_stale_sandbox_profiles()
+        removed = cleanup_stale_sandbox_profiles(data_home=sandbox_mod.config_dir())
         assert not live_file.exists()
         assert removed == 1
 
@@ -175,7 +176,7 @@ class TestCleanupSweep:
         live_file = run_dir / f"kirocrew_sandbox_{os.getpid()}_fresh123.py"
         live_file.write_text("# fresh launcher")
 
-        removed = cleanup_stale_sandbox_profiles()
+        removed = cleanup_stale_sandbox_profiles(data_home=sandbox_mod.config_dir())
         assert live_file.exists()
         assert removed == 0
 
@@ -185,7 +186,7 @@ class TestCleanupSweep:
         live_file = run_dir / f"kirocrew_sandbox_{os.getpid()}_live456.sb"
         live_file.write_text("(version 1)")
 
-        removed = cleanup_stale_sandbox_profiles()
+        removed = cleanup_stale_sandbox_profiles(data_home=sandbox_mod.config_dir())
         assert live_file.exists()
         assert removed == 0
 
@@ -201,7 +202,7 @@ class TestCleanupSweep:
         normal_dead = run_dir / "kirocrew_sandbox_99999999_y.py"
         normal_dead.write_text("# dead")
 
-        removed = cleanup_stale_sandbox_profiles()
+        removed = cleanup_stale_sandbox_profiles(data_home=sandbox_mod.config_dir())
         # Both should be removed (huge via age fallback or error, normal via dead-PID)
         assert not normal_dead.exists()
         assert removed >= 1  # at least the normal dead one
@@ -219,7 +220,7 @@ class TestCleanupSweep:
         fresh_legacy = legacy_dir / "kirocrew_sandbox_fresh.py"
         fresh_legacy.write_text("# fresh legacy")
 
-        removed = cleanup_stale_sandbox_profiles(legacy_dir=str(legacy_dir))
+        removed = cleanup_stale_sandbox_profiles(legacy_dir=str(legacy_dir), data_home=sandbox_mod.config_dir())
         assert not old_legacy.exists()
         assert fresh_legacy.exists()
         assert removed == 1
@@ -233,7 +234,7 @@ class TestCleanupSweep:
         old_time = time.time() - _LAUNCHER_MAX_AGE_SECONDS - 100
         os.utime(non_py, (old_time, old_time))
 
-        removed = cleanup_stale_sandbox_profiles(legacy_dir=str(legacy_dir))
+        removed = cleanup_stale_sandbox_profiles(legacy_dir=str(legacy_dir), data_home=sandbox_mod.config_dir())
         assert non_py.exists()
         assert removed == 0
 
@@ -253,7 +254,7 @@ class TestCleanupSweep:
         f4 = run_dir / "kirocrew_sandbox_notapid_abc.py"
         f4.write_text("# unrelated")
 
-        removed = cleanup_stale_sandbox_profiles()
+        removed = cleanup_stale_sandbox_profiles(data_home=sandbox_mod.config_dir())
         assert f1.exists()
         assert f2.exists()
         assert f3.exists()
@@ -262,5 +263,63 @@ class TestCleanupSweep:
 
     def test_no_run_dir_is_noop(self, fake_home: Path):
         """If ~/.kirocrew/run/ doesn't exist, no crash."""
-        removed = cleanup_stale_sandbox_profiles()  # should not raise
+        removed = cleanup_stale_sandbox_profiles(data_home=sandbox_mod.config_dir())  # should not raise
         assert removed == 0
+
+
+class TestTheSweepIsRootedAtTheHomeItIsHanded:
+    """``cleanup_stale_sandbox_profiles(data_home=...)`` never asks ``config_dir()``.
+
+    The sweep runs on the maintenance pool. A pool thread that resolves the data
+    home for itself resolves it whenever it is scheduled: under the suite, that
+    was routinely after the queuing test had dropped its ``KIROCREW_HOME`` pin,
+    and the third full-run audit counted 60+ ``mkdir`` calls on the operator's
+    real ``~/.kiro/crew`` from ``mc-maint`` threads, plus the retired-snapshot
+    ``rmtree`` and the legacy-residue marker aimed at the same tree. The caller
+    that knows the home resolves it on its own thread and hands it in.
+    """
+
+    def test_an_explicit_home_is_used_and_config_dir_is_never_consulted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import kiro_crew.sandbox as sandbox
+
+        def _forbidden():
+            raise AssertionError("the sweep resolved the data home on the pool thread")
+
+        monkeypatch.setattr(sandbox, "config_dir", _forbidden)
+        home = tmp_path / "handed-home"
+        retired = home / "run" / "kiro-cli-snapshots"
+        retired.mkdir(parents=True)
+        (retired / "gen-1").write_bytes(b"old binary copy")
+
+        removed = cleanup_stale_sandbox_profiles(
+            legacy_dir=str(tmp_path / "no-legacy"), data_home=home
+        )
+
+        assert removed >= 1, "the retired snapshot tree under the handed home was not reclaimed"
+        assert not retired.exists()
+
+    def test_the_session_manager_resolves_the_home_when_it_builds_the_deps(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The deps lambda carries a home resolved at construction, not at run time."""
+        import kiro_crew.session as session_mod
+
+        pinned = tmp_path / "pinned-home"
+        pinned.mkdir()
+        monkeypatch.setattr(session_mod, "config_dir", lambda: pinned)
+        seen: list[Path | None] = []
+        monkeypatch.setattr(
+            session_mod,
+            "cleanup_stale_sandbox_profiles",
+            lambda *, data_home=None, **_kw: seen.append(data_home) or 0,
+        )
+        manager = session_mod.SessionManager.__new__(session_mod.SessionManager)
+        deps = session_mod.SessionManager._cleanup_deps(manager)
+
+        # Simulate the pool thread running the job AFTER the home has moved on.
+        monkeypatch.setattr(session_mod, "config_dir", lambda: tmp_path / "somewhere-else")
+        deps.cleanup_stale_sandbox_profiles()
+
+        assert seen == [pinned]

--- a/test/test_sandbox_mount_source_sweep.py
+++ b/test/test_sandbox_mount_source_sweep.py
@@ -46,6 +46,7 @@ from pathlib import Path
 
 import pytest
 
+from kiro_crew.config.paths import config_dir
 from kiro_crew.sandbox import (
     _MOUNT_SOURCE_MAX_AGE_SECONDS,
     _build_launcher_script,
@@ -383,7 +384,7 @@ class TestMountSourceSweep:
         legacy = tmp_path / "legacy"
         legacy.mkdir()
 
-        removed = cleanup_stale_sandbox_profiles(legacy_dir=str(legacy))
+        removed = cleanup_stale_sandbox_profiles(legacy_dir=str(legacy), data_home=config_dir())
 
         assert removed >= 1
         assert not (root / f"kirocrew_sb_{_DEAD_PID}_wired").exists()
@@ -1185,7 +1186,7 @@ class TestLegacyResidueSweep:
         empty = self._legacy_dir(tmp_path)
         plain = self._legacy_file(tmp_path)
 
-        removed = _cleanup_legacy_mount_source_residue()
+        removed = _cleanup_legacy_mount_source_residue(data_home=config_dir())
 
         assert removed == 1
         assert not empty.exists()
@@ -1195,7 +1196,7 @@ class TestLegacyResidueSweep:
         assert plain.exists()
         # Second call is a no-op: no current build creates the shape, so a
         # completed pass is final and must not re-walk the tmpfs forever.
-        assert _cleanup_legacy_mount_source_residue() == 0
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 0
 
     def test_a_planted_symlink_at_the_marker_is_not_followed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1212,7 +1213,7 @@ class TestLegacyResidueSweep:
         marker.symlink_to(target)
         self._legacy_dir(tmp_path)
 
-        assert _cleanup_legacy_mount_source_residue() == 1
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 1
         assert not target.exists()
         assert marker.is_symlink()  # untouched, so the pass is not retired
 
@@ -1226,7 +1227,7 @@ class TestLegacyResidueSweep:
         self._fence(monkeypatch, tmp_path, complete=False, covered=True)
         empty = self._legacy_dir(tmp_path)
 
-        assert _cleanup_legacy_mount_source_residue() == 1
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 1
         assert not empty.exists()
 
     def test_a_cohort_under_the_age_fence_withholds_the_marker(
@@ -1239,15 +1240,15 @@ class TestLegacyResidueSweep:
         old = self._legacy_dir(tmp_path)
         young = self._legacy_dir(tmp_path, "tmpyoung001", old=False)
 
-        assert _cleanup_legacy_mount_source_residue() == 1
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 1
         assert not old.exists() and young.exists()
         stale = time.time() - _MOUNT_SOURCE_MAX_AGE_SECONDS - 100
         os.utime(young, (stale, stale))
         # Not retired: the aged cohort is reclaimed by the next pass, which
         # then finds nothing young and stamps.
-        assert _cleanup_legacy_mount_source_residue() == 1
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 1
         assert not young.exists()
-        assert _cleanup_legacy_mount_source_residue() == 0
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 0
 
     def test_unproven_bind_coverage_removes_nothing_and_does_not_retire_the_pass(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -1259,14 +1260,14 @@ class TestLegacyResidueSweep:
         held = self._legacy_dir(tmp_path)
 
         with caplog.at_level(logging.INFO, logger="kiro_crew.sandbox"):
-            assert _cleanup_legacy_mount_source_residue() == 0
+            assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 0
         assert held.exists()
         retained = [r for r in caplog.records if "legacy pass retained" in r.getMessage()]
         assert len(retained) == 1
         assert retained[0].levelno == logging.WARNING
 
         self._fence(monkeypatch, tmp_path, complete=True)
-        assert _cleanup_legacy_mount_source_residue() == 1
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 1
 
     def test_an_absent_root_skips_the_pin_scan_without_a_warning(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -1295,14 +1296,14 @@ class TestLegacyResidueSweep:
         monkeypatch.setattr("kiro_crew.sandbox._bound_source_basenames", _fake)
 
         with caplog.at_level(logging.INFO, logger="kiro_crew.sandbox"):
-            assert _cleanup_legacy_mount_source_residue() == 0
+            assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 0
         assert scanned == []  # the pin scan never ran
         assert not [r for r in caplog.records if "legacy pass retained" in r.getMessage()]
 
         # Not retired: a root that does appear is still swept.
         self._fence(monkeypatch, tmp_path)
         held = self._legacy_dir(tmp_path)
-        assert _cleanup_legacy_mount_source_residue() == 1
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 1
         assert not held.exists()
 
     def test_bound_entry_is_preserved(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -1311,7 +1312,7 @@ class TestLegacyResidueSweep:
         self._fence(monkeypatch, tmp_path, bound={name})
         held = self._legacy_dir(tmp_path, name)
 
-        assert _cleanup_legacy_mount_source_residue() == 0
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 0
         assert held.exists()
 
     def test_non_empty_dir_survives(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -1324,7 +1325,7 @@ class TestLegacyResidueSweep:
         populated = self._legacy_dir(tmp_path, "tmpshadow12")
         (populated / "known_hosts").write_text("example.com ssh-ed25519 AAAA\n")
 
-        assert _cleanup_legacy_mount_source_residue() == 0
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 0
         assert (populated / "known_hosts").exists()
 
     def test_bound_scan_keys_on_the_tmpfs_relative_root_field(
@@ -1379,7 +1380,7 @@ class TestLegacyResidueSweep:
         named.mkdir(mode=0o700)
         keyed = _make_dir(tmp_path, f"kirocrew_sb_{_DEAD_PID}_keyed01")
 
-        assert _cleanup_legacy_mount_source_residue() == 0
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 0
         for path in (fresh, loose, sized, named, keyed):
             assert path.exists(), path
 
@@ -1398,12 +1399,12 @@ class TestLegacyResidueSweep:
         monkeypatch.setattr("kiro_crew.sandbox._LEGACY_PILE_THRESHOLD", 4)
         strays = [self._legacy_dir(tmp_path, f"tmpstray00{i}") for i in range(3)]
 
-        assert _cleanup_legacy_mount_source_residue() == 0
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 0
         for stray in strays:
             assert stray.exists(), stray
         # Retired: a later pass is a no-op even once more candidates appear.
         self._legacy_dir(tmp_path, "tmpstray003")
-        assert _cleanup_legacy_mount_source_residue() == 0
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 0
 
     def test_at_the_pile_threshold_the_buffered_candidates_are_reclaimed_too(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1413,7 +1414,7 @@ class TestLegacyResidueSweep:
         monkeypatch.setattr("kiro_crew.sandbox._LEGACY_PILE_THRESHOLD", 4)
         pile = [self._legacy_dir(tmp_path, f"tmppile000{i}") for i in range(6)]
 
-        assert _cleanup_legacy_mount_source_residue() == 6
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 6
         for entry in pile:
             assert not entry.exists(), entry
 
@@ -1436,7 +1437,9 @@ class TestLegacyResidueSweep:
         )
         legacy = self._legacy_dir(tmp_path)
 
-        removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "absent"))
+        removed = cleanup_stale_sandbox_profiles(
+            legacy_dir=str(tmp_path / "absent"), data_home=config_dir()
+        )
 
         assert removed >= 1
         assert not legacy.exists()
@@ -1543,13 +1546,13 @@ class TestSweepTimeBudget:
 
         budget = self._spent_budget()
         try:
-            assert _cleanup_legacy_mount_source_residue() == 1
+            assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 1
         finally:
             budget.undo()
         assert len(list(tmp_path.iterdir())) == 2
 
         # The marker was NOT stamped, so the next pass finishes the residue.
-        assert _cleanup_legacy_mount_source_residue() == 2
+        assert _cleanup_legacy_mount_source_residue(data_home=config_dir()) == 2
         assert not list(tmp_path.iterdir())
 
 

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import threading
 import time
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -3016,9 +3018,13 @@ class TestCleanupLoop:
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
 
         sweep_threads: list[str] = []
+        sweep_homes: list[object] = []
 
-        def _fake_sweep() -> int:
+        def _fake_sweep(*, data_home=None) -> int:
+            # The deps hand the sweep the data home the manager resolved on ITS
+            # thread (the pool thread must not resolve it itself); record it too.
             sweep_threads.append(threading.current_thread().name)
+            sweep_homes.append(data_home)
             return 3
 
         with (
@@ -3050,6 +3056,13 @@ class TestCleanupLoop:
         assert sweep_threads, "sweep never executed"
         assert all(name != threading.main_thread().name for name in sweep_threads)
         assert sweep_threads[0].startswith("mc-maint")
+        # The home reached the pool thread pre-resolved and pinned: a sweep that
+        # resolved config_dir() for itself, after the queuing test's pin was gone,
+        # walked the operator's real ~/.kiro/crew (third side-effect audit).
+        assert sweep_homes and all(
+            h is not None and Path(h).resolve() == Path(os.environ["KIROCREW_HOME"]).resolve()
+            for h in sweep_homes
+        ), sweep_homes
         # Verify: non-zero return produces the info log
         assert "removed 3 stale sandbox artifacts" in caplog.text
         await mgr.close_all()

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -1991,6 +1991,33 @@ class TestScanCache:
                 assert got == expected, f"disagreement on {a!r} vs {b!r}"
 
 
+def _pin_a_fake_default_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, legacy: bool = False
+) -> None:
+    """Put the process in the DEFAULT-home posture, against a fake host home.
+
+    These tests need ``data_home()`` to BE the default (or the legacy default), so
+    ``reclaim_block_reason`` takes its shared-store branch. Pinning ``_resolved_home``
+    to ``paths._default_home()`` under the operator's real ``HOME`` achieved that by
+    pointing the process at the operator's real ``~/.kiro/crew``: the next
+    ``config_dir()`` then ``mkdir``s it and drops the recovery breadcrumb beside it,
+    and the rootdir floor now fails a test that leaves the real default resolved. So
+    the host home is faked first: every resolver here reads ``Path.home()``
+    (``session_storage`` for both defaults and the pod root, ``paths`` for the data
+    home), so the posture holds exactly as before, one directory over.
+    """
+    host_home = tmp_path / "host-home"
+    host_home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HOME", str(host_home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: host_home))
+    monkeypatch.delenv("KIROCREW_HOME", raising=False)
+    monkeypatch.delenv("KIRO_HOME", raising=False)
+    monkeypatch.setattr(
+        paths, "_resolved_home", paths.legacy_home() if legacy else paths._default_home()
+    )
+    monkeypatch.setattr(paths, "_config_dir_memo", None)
+
+
 class TestCotenantCache:
     """The co-tenant lookup follows the scan cache's rules: reads may reuse, mutations never.
 
@@ -2176,8 +2203,7 @@ class TestCotenantCache:
         monkeypatch.delenv("KIRO_HOME", raising=False)
         # Pin the default home rather than clearing the memo; see
         # TestSharedStoreRefusal for why re-resolving on a real machine is unsafe.
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         session_storage.cotenant_sids(cached=True)  # prime
         calls = self._count_pod_scans(monkeypatch)
@@ -2193,8 +2219,7 @@ class TestCotenantCache:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         session_storage.cotenant_sids(cached=True)  # prime
         calls = self._count_pod_scans(monkeypatch)
@@ -2210,8 +2235,7 @@ class TestCotenantCache:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         session_storage.cotenant_sids(cached=True)  # prime
         calls = self._count_pod_scans(monkeypatch)
@@ -2256,8 +2280,7 @@ class TestSharedStoreRefusal:
         # next data_home() RE-RESOLVE, which on a real machine initializes or
         # migrates the operator's actual data home — and leaves that resolution
         # memoized for every later test in the same worker.
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         assert session_storage.reclaim_block_reason() == ""
 
@@ -2273,8 +2296,7 @@ class TestSharedStoreRefusal:
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
-        monkeypatch.setattr(paths, "_resolved_home", paths.legacy_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path, legacy=True)
 
         assert session_storage.reclaim_block_reason() == ""
 
@@ -2386,8 +2408,7 @@ class TestSharedStoreRefusal:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         assert session_storage.reclaim_block_reason() == ""
         protected, refusals = session_storage.cotenant_sids()
@@ -2414,8 +2435,7 @@ class TestSharedStoreRefusal:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         reason = session_storage.reclaim_block_reason()
         assert "wt-legacy-shared" in reason
@@ -2440,8 +2460,7 @@ class TestSharedStoreRefusal:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         assert session_storage.reclaim_block_reason() == ""
         assert session_storage.cotenant_sids() == (frozenset(), ())
@@ -2469,8 +2488,7 @@ class TestSharedStoreRefusal:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         protected, refusals = session_storage.cotenant_sids()
         assert protected == frozenset({"legacysid01"})
@@ -2600,8 +2618,7 @@ class TestSharedStoreRefusal:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         reason = session_storage.reclaim_block_reason()
         assert "make reclaiming unsafe" in reason
@@ -2637,8 +2654,7 @@ class TestSharedStoreRefusal:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "no-pods-here"))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
 
         assert session_storage.reclaim_block_reason() == ""
 
@@ -2922,8 +2938,7 @@ class TestCotenantNamesAreLogSafe:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
         return pod_root
 
     def _make_forged_pod(self, pod_root: Path) -> Path:
@@ -3054,8 +3069,7 @@ class TestCotenantRefusalTextIsForgeSafe:
         monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        _pin_a_fake_default_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             session_storage, "cotenant_sids", lambda *, cached=False: (frozenset(), self._REFUSALS)
         )

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -28,6 +28,34 @@ def _mock_source_sel(monkeypatch):
     return audit
 
 
+@pytest.fixture(autouse=True)
+def _no_visibility_refresh_side_task(monkeypatch):
+    """Keep the repo-visibility refresh out of tests that are not about it.
+
+    A cache write-through schedules ``_refresh_repo_visibility`` as a detached
+    task; nothing in this module awaits it, so it ran on into the NEXT test and
+    past this one's pins. Its ``_run_provider`` resolves the provider CLI on a
+    worker thread, and that resolution reads ``workspace_root()``, which reached
+    ``config_dir()`` after ``KIROCREW_HOME`` had been unpinned and created the
+    operator's real ``~/.kiro/crew`` (third side-effect audit, four tests here).
+    No test in this module asserts anything about visibility
+    (``test_public_repo_chip_status.py`` owns that surface and drains the set
+    itself), so the scheduler is a recorder here: the calls are observable, the
+    task is never spawned, and nothing outlives the test.
+    """
+    scheduled: list[tuple] = []
+    monkeypatch.setattr(
+        source,
+        "schedule_visibility_refresh",
+        lambda urls, *a, **k: scheduled.append((tuple(urls), a, k)),
+    )
+    yield scheduled
+    for task in list(source._VISIBILITY_TASKS):
+        if not task.get_loop().is_closed():
+            task.cancel()
+    source._VISIBILITY_TASKS.clear()
+
+
 def test_parse_github_pull_request() -> None:
     ref = source.parse_source_url("https://github.com/kirodotdev/KiroCrew/pull/58?tab=checks")
     assert ref.provider == "github"

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -451,6 +451,36 @@ class TestKillSession:
         mock_kill.assert_any_call(12345, platform_compat.SIGTERM)
 
     @pytest.mark.asyncio
+    async def test_the_process_tree_is_hung_up_and_ended_before_the_pty_is_closed(self):
+        """Signals first, close second, HUP among the signals: and the order is the fix.
+
+        Closing the PTY's controller end while the reader is blocked in ``os.read()``
+        on it only unblocks that read on Linux; on macOS/BSD ``close()`` WAITS for the
+        read, so with an interactive bash still holding the terminal end the close never
+        returned and four PTY tests timed out at 120 s on every macOS run. Ending the
+        process tree first releases the terminal end on both. SIGHUP is included because an interactive
+        shell ignores SIGTERM, which alone would cost the 5 s SIGKILL escalation on
+        every terminal close.
+        """
+        order: list[str] = []
+        sess = _make_session(alive=True)
+        sess.master_fd = 42  # wokeignore:rule=master
+
+        def _kill(pid, sig):
+            order.append(f"kill:{sig}")
+            return True
+
+        with patch("os.close", side_effect=lambda fd: order.append("close")), patch(
+            "kiro_crew.dashboard.handlers.terminal.platform_compat.kill_process_tree",
+            side_effect=_kill,
+        ):
+            await terminal._kill_session(sess)
+
+        assert "close" in order and f"kill:{platform_compat.SIGHUP}" in order
+        assert order.index(f"kill:{platform_compat.SIGHUP}") < order.index("close")
+        assert order.index(f"kill:{platform_compat.SIGTERM}") < order.index("close")
+
+    @pytest.mark.asyncio
     async def test_skips_kill_when_process_already_exited(self):
         sess = _make_session(alive=False)
         with patch("os.close"), \

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -2830,12 +2830,22 @@ export default function App() {
   // spends the launch. Sampling would let the video open the instant the user
   // closed the changelog, which is the back-to-back pair the policy forbids.
   const [startupInterruptionSeen, setStartupInterruptionSeen] = useState(false)
+  // The LIVE reading of the same conditions the latch is fed from. The gate reads
+  // both, and the live one is load-bearing: the latch is written by the effect
+  // below, which runs AFTER the commit that showed the changelog, while
+  // `changelogDecided` is set one microtask later on the same fetch chain. When
+  // that microtask lands between the commit and its passive effects, the gate's
+  // own effect runs in a render where `changelogDecided` is already true and the
+  // latch still false: and opened the video beside the changelog (flaked in 2
+  // of 5 frontend runs). Same shape as `onboardingOwed` above: derive from the
+  // authoritative flags in the same commit, keep the latch for after they clear.
+  const startupInterruptionLive = showChangelog || updateAvailable || updateStaged
+    || showOnboarding || showAgentImport || showPrivacy
   useEffect(() => {
-    if (showChangelog || updateAvailable || updateStaged
-      || showOnboarding || showAgentImport || showPrivacy) {
+    if (startupInterruptionLive) {
       setStartupInterruptionSeen(true)
     }
-  }, [showChangelog, updateAvailable, updateStaged, showOnboarding, showAgentImport, showPrivacy])
+  }, [startupInterruptionLive])
 
   const [startupVideoOpen, setStartupVideoOpen] = useState(false)
   const [startupVideoDone, setStartupVideoDone] = useState(false)
@@ -2848,7 +2858,7 @@ export default function App() {
     if (!canShowStartupVideo({
       // Either an interruption already appeared this launch, or first-run is still
       // owed and is about to. Both spend the launch.
-      interruptionShown: startupInterruptionSeen || onboardingOwed,
+      interruptionShown: startupInterruptionSeen || startupInterruptionLive || onboardingOwed,
       // Three separate authorities, and the video waits for ALL of them: onboarding's
       // three modals are decided by the `themeBootReady` effect above, the changelog
       // decides across its own fetch, and the slot list decides whether this session
@@ -2860,8 +2870,8 @@ export default function App() {
     markStartupVideoHandled()
     setStartupVideoOpen(true)
   }, [
-    startupVideoOpen, startupVideoDone, startupInterruptionSeen, onboardingOwed,
-    themeBootReady, changelogDecided, slotsLoaded, activeSlotMemoryMode,
+    startupVideoOpen, startupVideoDone, startupInterruptionSeen, startupInterruptionLive,
+    onboardingOwed, themeBootReady, changelogDecided, slotsLoaded, activeSlotMemoryMode,
   ])
 
   // Browser tab title badge — sums every built-in surface's badge (chat,

--- a/website/src/test/AutoNudgePopover.test.tsx
+++ b/website/src/test/AutoNudgePopover.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { useState } from 'react'
-import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, act, cleanup, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AutoNudgePopover, { type AutoNudgeLoop } from '../components/AutoNudgePopover'
 import { __resetForTests, loadGoalDraft, saveGoalDraft } from '../utils/goalDrafts'
@@ -272,13 +272,35 @@ describe('AutoNudgePopover — zero-token watches armed on this slot', () => {
   beforeEach(() => { localStorage.clear(); __resetForTests() })
   afterEach(() => { vi.unstubAllGlobals() })
 
+  /**
+   * Render, then wait for the crons read to have been ANSWERED, not just issued.
+   *
+   * The section is populated by `fetch` -> `json()` -> `setState`, three promise
+   * hops that `act` does not wait for, so a bare `await act(render)` samples the
+   * popover before the answer lands. That made the positive test below flake
+   * (1 in 5 full runs on a loaded host) and every "not listed" assertion in this
+   * block vacuous: the section is absent BEFORE the fetch resolves whether or not
+   * the filter works. Waiting on the mocked fetch having been called, then
+   * draining the chain, makes both kinds of assertion about the rendered answer.
+   */
+  async function renderPopoverSettled() {
+    await act(async () => { renderPopover(null) })
+    const fetchMock = vi.mocked(fetch)
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(c => String(c[0]).startsWith('/api/crons'))).toBe(true),
+    )
+    for (let i = 0; i < 4; i++) {
+      await act(async () => { await Promise.resolve() })
+    }
+  }
+
   it('lists a script cron this slot owns, so an armed watch is visible in chat', async () => {
     // The reported gap: a watch is deliberately NOT an autonudge loop, so the
     // popover showed "Set a goal" and nothing else while a watch was polling --
     // the one surface a user opens to confirm something is running.
     stubCrons([cron()])
-    await act(async () => { renderPopover(null) })
-    expect(screen.getByText(/Zero-token watches/i)).toBeTruthy()
+    await renderPopoverSettled()
+    expect(await screen.findByText(/Zero-token watches/i)).toBeTruthy()
     expect(screen.getByText('pr watch #6234')).toBeTruthy()
   })
 
@@ -288,7 +310,7 @@ describe('AutoNudgePopover — zero-token watches armed on this slot', () => {
     // must still match, and that is the property worth pinning: another
     // conversation's watch appearing here is worse than showing none.
     stubCrons([cron({ session_key: 'dashboard:chat-9-999', name: 'someone elses watch' })])
-    await act(async () => { renderPopover(null) })
+    await renderPopoverSettled()
     expect(screen.queryByText('someone elses watch')).toBeNull()
     expect(screen.queryByText(/Zero-token watches/i)).toBeNull()
   })
@@ -297,14 +319,14 @@ describe('AutoNudgePopover — zero-token watches armed on this slot', () => {
     // A cron with no script wakes the agent every fire. Listing it here would
     // make the heading lie about what it costs.
     stubCrons([cron({ script: '', name: 'daily reminder' })])
-    await act(async () => { renderPopover(null) })
+    await renderPopoverSettled()
     expect(screen.queryByText('daily reminder')).toBeNull()
     expect(screen.queryByText(/Zero-token watches/i)).toBeNull()
   })
 
   it('never lists a disabled watch as if it were armed', async () => {
     stubCrons([cron({ enabled: false, name: 'paused watch' })])
-    await act(async () => { renderPopover(null) })
+    await renderPopoverSettled()
     expect(screen.queryByText('paused watch')).toBeNull()
   })
 
@@ -323,7 +345,7 @@ describe('AutoNudgePopover — zero-token watches armed on this slot', () => {
         }),
       ) as unknown as typeof fetch,
     )
-    await act(async () => { renderPopover(null) })
+    await renderPopoverSettled()
     // A bare array is NOT the contract, so nothing should be read out of it.
     expect(screen.queryByText(/Zero-token watches/i)).toBeNull()
   })
@@ -337,7 +359,7 @@ describe('AutoNudgePopover — zero-token watches armed on this slot', () => {
           : Promise.resolve({ ok: true, json: () => Promise.resolve({ loop: null }) }),
       ) as unknown as typeof fetch,
     )
-    await act(async () => { renderPopover(null) })
+    await renderPopoverSettled()
     expect(screen.queryByText(/Zero-token watches/i)).toBeNull()
     // The popover's actual job is still fully usable.
     expect(screen.getByPlaceholderText(/Describe what you want the agent to accomplish/i)).toBeTruthy()


### PR DESCRIPTION
## Summary

Third full-run side-effect audit, this time on a **macOS** host from inside a Kiro Crew agent session: five full backend runs (92,261 tests each) and five full frontend runs under an audit hook that attributes every host write, spawn, connect and kill to the test that made it, plus a per-test census of duration, RSS, threads and descriptors. Zero backend flakes in 5 x 92k; two frontend flakes; 227 deterministic failures and four 120-second hangs that every Linux run had been blind to; and host writes the earlier audits could not see. Every fix carries a test that goes red when it is reverted, and the classes are written into `testing-conventions` "Side effects" (a new "third full-run audit" block) so they cannot recur unnoticed.

Complements #9614 and #9632 (a parallel pass on a different host that landed while this ran): the `_floor_monkeypatch` split and the `Path.mkdir` / `O_BINARY` fixes are theirs; this PR rebases onto them and adds what they did not reach.

### Host state the suite touched, and what pins it now

- **`monkeypatch.undo()` ordering.** #9614 moved the pins onto a private `MonkeyPatch`; the nesting of the two stacks still depended on autouse order across three conftests. The `monkeypatch` fixture is re-declared at the rootdir with `_floor_monkeypatch` as a dependency, so the floor is set up first and torn down last by construction. `test/conftest.py`'s autouse pins ride the same instance.
- **A metric emitted at IMPORT** (`ToolHookResult.allow()` as a module-level default argument) built the recorder from the operator's real config before any pin existed and exported to the real `~/.kiro/crew/metrics` every minute for the life of each worker. `KIROCREW_TELEMETRY=0` is now pinned for the whole process in `pytest_configure`, and every module whose collection builds the recorder is recorded in `IMPORT_TIME_METRIC_EMITTERS` and asserted empty.
- **The `mc-maint` sweep resolved `config_dir()` when it RAN**, after the queuing test's pin was gone: 60+ mkdirs of the real home per run, plus a `rmtree` and a marker aimed at it. `cleanup_stale_sandbox_profiles` takes the home its caller resolved; `SessionManager` resolves it once at construction.
- **Dropping the override to test the default home** created the real `~/.kiro/crew`, and a resolver-only stand-in rewrote the real `~/.kirocrew.breadcrumb`. The teardown hook reads `paths._resolved_home` before any fixture unwinds and fails the test after the floor has torn down; the floor wraps the breadcrumb writer to refuse while `Path.home()` is the operator's; the affected tests fake the host home. Class- and module-scoped setups (`setUpClass`, a module fixture) run outside the floor and now pin what they resolve.
- **Bytecode into the checkout**, closed as a class: `sys.pycache_prefix` / `PYTHONPYCACHEPREFIX` point at `~/.cache/kirocrew/pycache`.
- **`KIROCREW_PROFILE=amazon` inherited from the agent session** failed 150+ builtin-app tests closed, because the pin lived in `test/conftest.py`, which those testpaths never see. It is a rootdir floor now.

### macOS, where the Linux-green suite had 227 failures and four hangs

- **`_kill_session` closed the PTY master before ending the shell.** On macOS/BSD `close()` waits for the reader's outstanding `read()`, so four terminal tests hit the 120 s timeout on every run. The process tree is hung up (SIGHUP, the one signal an interactive shell honours) and terminated before the master is closed; the tests run in under a second.
- **Linux-shaped tests, one rule each**: the frame recorder's 75 logic tests pin its Linux-only ACL gate open; `O_TMPFILE` prompt tests skip on the production capability flag; `/dev/fd/N` is compared by `open`+`fstat` identity; `unlink()` on a directory is `EPERM` here, so `_discard_untracked_files` recognises it; a `--copies` venv cannot relocate a non-framework shared-lib CPython; the darwin workspace binding's `pass_fds` entry is pinned away in the snapshot-descriptor test; a pinned `sys.platform` needs a pinned start id; and `codex-review.yml`'s two `sed` expressions become one `1,8{}` block, because BSD sed opens a numeric range only on its exact line.
- `test_handlers_system_macos_paths` reached `8.8.8.8:80` through `_local_ip()`; stubbed at the seam the Linux siblings already use.

### Frontend

- `AutoNudgePopover`'s watch list is three promise hops past `act(render)`, so the positive test flaked (1 in 5) and every negative was vacuous; the block now waits for the fetch to be answered.
- `App`'s startup-video gate read an interruption latch that an effect sets a commit after the changelog shows, while `changelogDecided` lands a microtask later (2 in 5); the gate reads the live conditions in the same commit too.

## Verification

- Audit: 5 backend runs (227 deterministic failures, 0 flakes) + 5 frontend runs (2 flakes) on `main` at 6c24f116e, macOS, `PYTEST_XDIST_AUTO_NUM_WORKERS=4`.
- Fix branch, before rebase: two full backend runs, `91797 passed, 516 skipped, 9 xfailed, 0 failed` each, with the inherited `KIROCREW_PROFILE=amazon` in the environment; no test-worker shard in `~/.kiro/crew/metrics`, no `__pycache__` in the tree, no write under the real home outside the sanctioned cache; two full frontend runs, `30600 passed` each.
- After rebase onto #9614/#9632: the touched modules (1,670 tests) green; black, isort, flake8, `mypy --platform linux`, comment-history, subprocess-encoding, sync-io, agent-sdk-boundary, brand, harness-parity, feature-map, changelog-history, docs-lint, tsc, eslint, i18n, phantom-classes, scoped frontend tests, electron tests all pass locally. A third full backend run on the rebased head is in progress and will be reported on this PR.

Refs #9060.
