### PR TITLE
fix(telegram): require steer-<id> before stripping a STEERING frame

### DIFF
--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -281,12 +281,26 @@ def _extract_options(text: str) -> tuple[str, list[str]]:
 # no parser, so strip it — the user's own steer message already shows the
 # instruction (and gets a steer-ack reaction), so the raw inline marker is just
 # redundant noise in the bubble.
-_STEER_MARKER_RE = re.compile(r"\[STEERING\b[^\]]*\]", re.IGNORECASE)
+#
+# The frame is recognised by its GRAMMAR, and opening with the sentinel is not
+# being a marker: ``messaging.driver._STEER_MARKER_RE`` requires ``steer-<id>``,
+# and so does the dashboard's own parser
+# (``website/src/app-sdk/protocol/steering.ts``). A bare ``[STEERING`` class
+# matched ordinary prose that merely mentions the sentinel and deleted it from
+# the delivered message — and because ``[^\]]*`` does not stop at a line end, it
+# ran on to whatever ``]`` came next, taking the text in between with it.
+#
+# The id class matches driver's ``[0-9a-f-]+`` and is the SAME in both patterns,
+# because the summary is matched at the offset the marker pattern chose — a
+# narrower class there silently drops the summary. That is what the dash did:
+# the marker matched a dashed id through its old catch-all, the summary pattern
+# did not, and the chip lost the one piece of new information it carries.
+_STEER_MARKER_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f-]+(?:\s*:[^\]]*)?\]", re.IGNORECASE)
 # Same marker, capturing the ack SUMMARY kiro-cli embeds after "steer-<id>:".
 # The dashboard renders this summary as its "Steered — …" chip; we prefer it
 # for the Telegram chip too (the user's own words are already on screen as
 # their message — the summary is the only NEW information).
-_STEER_SUMMARY_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f]+\s*:\s*([^\]]*)\]", re.IGNORECASE)
+_STEER_SUMMARY_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f-]+\s*:\s*([^\]]*)\]", re.IGNORECASE)
 
 
 def _strip_steering(text: str) -> str:

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, patch
 from kiro_crew.acp.client import AcpError
 from kiro_crew.acp.types import EVENT_COMPACTION_STATUS, EVENT_COMPLETE, EVENT_TEXT_CHUNK
 from kiro_crew.dashboard.token_auth import parse_duration
+from kiro_crew.messaging import driver as messaging_driver
 from kiro_crew.messaging.commands import parse_dashboard_ttl
 from kiro_crew.messaging.link import (
     UNBIND_REASON_UNSPECIFIED,
@@ -38,6 +39,7 @@ from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.session import BACKGROUND_KEY, _opt_out_key
 from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.session_map import ConversationOwnershipConflict
+from kiro_crew.telegram import renderer as telegram_renderer
 from kiro_crew.telegram.client import (
     TELEGRAM_CHUNK_LIMIT,
     TELEGRAM_MAX_TEXT,
@@ -1715,14 +1717,68 @@ class TestRenderer:
         assert "<b>after</b>" in out, "prose around it keeps its formatting"
 
     def test_strip_steering_complete_and_unclosed(self) -> None:
-        # Complete marker is removed anywhere in the text.
-        out = _strip_steering("BANANA [STEERING steer-x: rephrase] tail")
+        # Complete marker is removed anywhere in the text. The id is hex because
+        # that is the grammar `messaging.driver` accepts -- the old "steer-x"
+        # fixture was never a frame the driver would have taken.
+        out = _strip_steering("BANANA [STEERING steer-ab12: rephrase] tail")
         assert "STEERING" not in out and out.startswith("BANANA") and out.endswith("tail")
         # UNCLOSED trailing marker (still streaming, no closing "]") is also
         # removed, so the live draft never previews text that on_done strips.
         assert _strip_steering("BANANA\n\n[STEERING steer-abc: interpreted as wanting") == "BANANA"
         # No marker -> unchanged.
         assert _strip_steering("just text") == "just text"
+
+    def test_prose_that_merely_opens_with_the_sentinel_stays(self) -> None:
+        """Opening with the sentinel is not being a marker.
+
+        ``messaging.driver`` already rules that -- it requires ``steer-<id>`` --
+        and so does the dashboard's own parser. A bare ``[STEERING`` class deleted
+        ordinary prose from the delivered message, and because the class does not
+        stop at a line end it ran on to whatever ``]`` came next: here a Markdown
+        link two lines down, taking the text in between with it.
+        """
+        one_line = "Read the [STEERING] section, then [docs](x) for more."
+        assert _strip_steering(one_line) == one_line
+        across_lines = "[STEERING is the feature I mean\n\nsee the [docs](x) for it"
+        assert _strip_steering(across_lines) == across_lines
+
+    def test_a_dashed_steer_id_is_one_frame_to_both_patterns(self) -> None:
+        """``messaging.driver`` accepts ``[0-9a-f-]+`` for the id, so a dashed id
+        is a real frame -- and the two patterns here have to agree about it.
+
+        ``_rotate_at_markers`` reads the summary at the offset the MARKER pattern
+        chose, so an id class the marker accepts and the summary does not leaves
+        the steer chip with no summary at all, which is the only new information
+        that chip carries.
+        """
+        text = "[STEERING steer-a180-ae7f: checked the job id] tail"
+        marker = telegram_renderer._STEER_MARKER_RE.search(text)
+        assert marker is not None
+        summary = telegram_renderer._STEER_SUMMARY_RE.match(text, marker.start())
+        assert summary is not None and summary.group(1) == "checked the job id"
+        assert _strip_steering(text) == "tail"
+
+    def test_the_renderer_patterns_agree_with_the_driver_on_a_frame_corpus(self) -> None:
+        """``messaging.driver`` is the authority on this grammar, so the renderer
+        must not recognise a frame the driver rejects, or reject one it takes."""
+        frames = [
+            "[STEERING steer-ab12: switching to the job id]",
+            "[STEERING steer-a180-ae7f: checked]",
+            "[STEERING steer-ab12: switching to the job id\nand re-running it]",
+            "[STEERING steer-ab12]",
+        ]
+        for frame in frames:
+            assert messaging_driver._STEER_MARKER_RE.match(frame) is not None, frame
+            assert telegram_renderer._STEER_MARKER_RE.fullmatch(frame) is not None, frame
+            assert _strip_steering(f"before {frame} after") == "before  after"
+        not_frames = [
+            "[STEERING]",
+            "[STEERING is the feature I mean]",
+            "[STEERING steer-: nothing]",
+        ]
+        for frame in not_frames:
+            assert messaging_driver._STEER_MARKER_RE.match(frame) is None, frame
+            assert telegram_renderer._STEER_MARKER_RE.search(frame) is None, frame
 
     def _drive(self, events: list[OutputEvent]) -> FakeClient:
         cli = FakeClient()


### PR DESCRIPTION
## Problem / Motivation

The Telegram renderer recognised kiro-cli's inline steer-ack frame with a bare
`\[STEERING\b[^\]]*\]`. Two things follow, both of them counted on #9631's review
of the identical pattern pair on Discord (`telegram/renderer.py:284,289` — "the
same pair mismatch, and it ships unfixed").

**1. Ordinary prose is deleted from the delivered message.** Anything opening
with the sentinel matched, and `[^\]]*` does not stop at a line end, so the match
ran on to whatever `]` came next and took the text in between with it. Measured
on `origin/main`:

```
'Read the [STEERING] section, then [docs] for more.'
   -> 'Read the  section, then [docs] for more.'
'Use the [STEERING\nblock] and then keep going. [docs] tail'
   -> 'Use the  and then keep going. [docs] tail'
```

**2. A dashed steer id blanks the chip.** The marker class swallowed a dashed id
through its catch-all, but the summary pattern spelled the id `[0-9a-f]+`:

```
'BANANA [STEERING steer-a180ae7f-8b2c-4d1e: rephrase] tail'
   marker: [STEERING steer-a180ae7f-8b2c-4d1e: rephrase]   summary: None
```

`_rotate_at_markers` matches the summary **at the offset the marker pattern
chose**, so it found nothing, `on_steer_consumed("")` was called, and the chip
fell through to the generic seal chip.

## Why it matters

Both land on the path this code exists to cover. `_strip_steering` runs on every
seal, so (1) silently removes words from what the user actually reads in
Telegram — and the cross-line case can swallow a whole paragraph on the way to a
Markdown link. `_rotate_at_markers` is the documented defence for callers that
bypass `TurnDriver`, so (2) costs the ack summary, which is the only NEW
information the steer chip carries (the user's own words are already on screen as
their message).

The same defect pair was just fixed on Discord in #9631; leaving Telegram on the
old spelling keeps the two channels disagreeing about the same wire frame.

## What changed (motivation → approach → change)

**Symptom → cause.** The frame is recognised by its GRAMMAR, and the repo already
has an authority for that grammar. `messaging.driver._STEER_MARKER_RE` is
`^\[STEERING\s+steer-[0-9a-f-]+(?:\s*:\s*(.*?))?\]$` with `re.DOTALL`, and the
dashboard's own parser (`website/src/app-sdk/protocol/steering.ts`) spells the id
`steer-[^\]:]+`. Both require `steer-<id>`; both allow a dash in it. The Telegram
renderer required neither.

**The change** is the two patterns, to the driver's spelling — which is exactly
what #9631 shipped for Discord:

```python
_STEER_MARKER_RE  = re.compile(r"\[STEERING\s+steer-[0-9a-f-]+(?:\s*:[^\]]*)?\]", re.I)
_STEER_SUMMARY_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f-]+\s*:\s*([^\]]*)\]", re.I)
```

The id class is deliberately the **same in both**: the summary is matched at the
offset the marker pattern chose, so a narrower class there silently drops the
summary — which is defect (2).

**What is deliberately not changed.** The unclosed-fragment sub
(`re.sub(r"\[STEERING\b[^\]]*$", ...)`, the surface litigated on #9209) keeps its
current spelling, for a reason rather than for scope: mid-stream the id has not
arrived yet, so `steer-<id>` cannot be required of a fragment. Its class also
still spans lines, where Discord's is bounded to one (`[^\]\r\n]*$`) — that
divergence stands here because #9631 established that kiro-cli's summaries wrap,
and a line-bounded fragment sub would put the second line of a wrapping summary
into the live draft and then remove it on seal, which is the show-then-vanish the
sub exists to prevent. It is a separate call on a separate surface, not part of
this fix.

One existing fixture changed: `test_strip_steering_complete_and_unclosed` used
`steer-x`, which is not an id `messaging.driver` would ever have accepted. It is
now `steer-ab12`. The assertion it makes is unchanged.

No spec update: the grammar is not written down in
`docs/system-specs/modules/messaging.md` (it describes the frame, not its regex),
and #9631 shipped the same change to Discord without one.

## Tests

`test/test_telegram.py`, all in `TestRenderer` beside the existing
`test_strip_steering_complete_and_unclosed`:

- `test_prose_that_merely_opens_with_the_sentinel_stays` — the two shapes from
  the measurement above: `[STEERING]` inline in a sentence, and a `[STEERING`
  that would otherwise run to a Markdown link two lines down. Both must survive
  verbatim.
- `test_a_dashed_steer_id_is_one_frame_to_both_patterns` — a dashed id must be
  matched by the marker pattern, yield its summary from the summary pattern at
  that same offset, and still be stripped from the text.
- `test_the_renderer_patterns_agree_with_the_driver_on_a_frame_corpus` — the
  anti-drift pin: four real frames (plain, dashed id, wrapped summary, no
  summary) must be a frame to `messaging.driver` **and** to the renderer, and
  three near-misses (`[STEERING]`, sentinel-opening prose, `steer-` with no id)
  must be a frame to neither. This is what stops the renderer drifting from the
  authority again.

**Red-before / green-after**, Python 3.13.5 on Windows, tests held fixed and only
`telegram/renderer.py` swapped between `origin/main` and this branch:

| tree | `test/test_telegram.py` |
|---|---|
| `origin/main` (`5df112a35`) | **3 failed**, 311 passed |
| this branch | **314 passed** |

Wider run — `test_telegram.py`, `test_telegram_parity.py`,
`test_messaging_driver.py`, `test_channel_table_rendering.py`,
`test_options_marker_closers.py`, `test_unfinished_marker_prefix_grammar.py`,
`test_discord.py`: **1091 passed**, 0 failed.

Focused gates: `isort`, `flake8`, `mypy --platform linux`, `black --check` (both
changed files are black-clean and neither is in `.github/black-baseline.txt`),
`check_black_formatting.py`, `check_brand_name.py`, `git diff --check` — all
clean.

## Manual verification

N/A — unit coverage sufficient: the change is two module-level regexes, and both
consumers (`_strip_steering` on every seal, `_rotate_at_markers` reading the
summary at the marker's offset) are exercised directly, including against the
driver that defines the grammar.

## Related Issues

Follow-up to #9631, which fixed this same pattern pair on Discord; its
first-principles review counted `telegram/renderer.py:284,289` as the remaining
unfixed sibling ("Clears when: `telegram/renderer.py` gets the same pair").

## Pattern harvest

Rule candidate: review-prompt
Pattern: "one wire grammar, hand-copied per consumer". A protocol frame with an
owning parser (`messaging.driver`) had four independent respellings; each copy
drifts on a different axis — this one on the id class and on whether the sentinel
alone is enough. A narrower variant worth carrying on its own: when two patterns
are applied at the SAME offset (marker chooses, summary reads), any field they
spell differently fails silently rather than loudly — the outer match succeeds
and the inner one just returns nothing.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
