### PR TITLE
fix(acp): verify the agent the --agent flag selected actually loaded

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -2879,6 +2879,88 @@ class AcpRuntime:
             return True
         return agent in ids
 
+    async def _verify_spawn_agent_active(
+        self,
+        session_id: str,
+        resp: dict[str, Any],
+        *,
+        override: str | None,
+    ) -> None:
+        """Fail closed when the agent the ``--agent`` flag selected never loaded.
+
+        Guard (A2) — the spawn-flag half of Guard (A) in :meth:`create_session`.
+        ``set_mode`` only ever activates an EXPLICIT override (or, on KAS, the
+        injected default), so on kiro-cli the agent chosen by ``--agent`` — the
+        agent of every ordinary session — reaches no availability check at all.
+        It needs one, because that spec can fail to load silently: kiro-cli
+        validates ``~/.kiro/agents/<agent>.json`` with ``deny_unknown_fields``
+        and, on ANY unknown field, rejects the spec wholesale and runs its own
+        default agent instead. :func:`kiro_crew.agent.migrate_agent_specs` exists
+        to strip the two keys already known to trip it; nothing validates the
+        rest, and a spec written by another tool (or by a product this install
+        superseded) can carry more.
+
+        Nothing downstream notices the substitution. The ``set_mode`` response is
+        never read back, ``currentModeId`` is never re-compared, and
+        :mod:`kiro_crew.acp.mcp_session_report` only LOGS — its own docstring
+        forbids reading a missing report as "not mounted". The session then runs
+        with NONE of Kiro Crew's control plane, while the global provider
+        ``mcp.json`` that Kiro Crew pins off only on specs IT writes stays
+        merged. So third-party MCP servers declared there keep working and every
+        Kiro Crew tool the injected prompt names — ``learn_add`` among them —
+        answers "does not exist", which the agent reports to the user as its
+        memory being unavailable.
+
+        Skipped when an override is requested: Guard (A) checks the agent
+        ``set_mode`` will activate.
+
+        ``currentModeId`` is read as PROOF, in both directions. A live probe of
+        this backend settles what it means: a spec that loads is reported as the
+        current mode AND listed in ``availableModes``, while a spec the backend
+        refuses is absent from the list and ``currentModeId`` names the backend's
+        own default instead. So a non-empty ``currentModeId`` naming something
+        OTHER than the spawn agent is positive evidence of the substitution, and
+        fails closed even when no advertised list came back. Treating a
+        current-mode mismatch as an extra ADMIT is the hole this avoids: a
+        ``currentModeId``-only response naming a substituted agent would otherwise
+        sail through the compatibility escape.
+
+        That escape is therefore narrow. It applies only when the response names
+        NO current mode, where the advertised list is the sole signal and its
+        absence is no evidence of a substitution -- so older kiro-cli and the
+        offline fake backend behave exactly as before.
+
+        Scoped to ``ACP_BACKEND_KIRO`` -- the backend whose argv actually carries
+        ``--agent`` -- and written as a POSITIVE identity test, because an
+        inequality would silently capture every harness added later
+        (harness-parity H5). On KAS the agent travels over the wire as an injected
+        custom agent and is activated by ``set_mode``, which Guard (A) already
+        covers. Scoped on the backend rather than on "the KAS projection came back
+        None" so the same call serves :meth:`load_session`, which never builds
+        that projection.
+        """
+        if override or not self._agent:
+            return
+        if self._acp_backend == ACP_BACKEND_KIRO:
+            spawn_agent = self._agent
+            ids, current, _adv = parse_session_modes(resp)
+            if current:
+                if current == spawn_agent:
+                    return
+            elif self._mode_available(spawn_agent, resp):
+                return
+            await self.terminate_session(session_id)
+            raise AcpRuntimeError(
+                f"Agent {spawn_agent!r} was spawned with --agent but is not the "
+                f"agent this session is running (current mode: "
+                f"{current or '(none reported)'}; advertised: {ids or 'none'}). Its "
+                f"~/.kiro/agents/{spawn_agent}.json is missing, or the backend "
+                f"refused to load it. Refusing to run the backend's own default "
+                f"agent in its place, which would silently drop every Kiro Crew "
+                f"tool the agent's prompt relies on. Run `kirocrew setup "
+                f"--agent-only` to rewrite the agent config."
+            )
+
     async def _kas_custom_agents(
         self, agent: str, *, member_dispatch: bool = False
     ) -> list[dict[str, Any]] | None:
@@ -3096,6 +3178,11 @@ class AcpRuntime:
         # rather than silently leaving the session on kiro-cli's default mode: for
         # a restricted/app agent that would run a BROADER agent than requested (a
         # privilege escalation), so we terminate and raise an actionable error.
+        #
+        # Guard (A2) runs FIRST: the guard below never sees the agent `--agent`
+        # selected, which on kiro-cli is every ordinary session's agent. See
+        # _verify_spawn_agent_active.
+        await self._verify_spawn_agent_active(session_id, resp, override=agent)
         # The agent to ACTIVATE. An explicit request always applies. When a KAS
         # custom agent was injected (``kas_agents`` non-empty) the runtime
         # default must be activated too: KAS has no --agent flag, so an injected
@@ -3390,6 +3477,13 @@ class AcpRuntime:
         # succeeded so kiro-cli holds it; a plain local unregister would leak it
         # in the shared process (and leave the reader routing late transcript-
         # replay frames to an abandoned queue). terminate_session unregisters too.
+        #
+        # Guard (A2), same as create_session: the check below reads `agent`, and
+        # this method's only caller passes `agent=agent or None`, so a resume with
+        # no override reaches no check at all. A fresh runtime resuming a session
+        # re-reads the spec from disk, so the spawn agent can fail to load here
+        # exactly as it can on a cold start.
+        await self._verify_spawn_agent_active(resume_sid, resp, override=agent)
         if agent and self._mode_available(agent, resp):
             # Same reason as create_session: measured before the request goes
             # out, the only moment "queued" and "pre-switch" mean the same thing.

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -6696,6 +6696,149 @@ async def test_create_session_fails_closed_when_available_modes_empty():
 
 
 @pytest.mark.asyncio
+async def test_create_session_fails_closed_when_spawn_agent_not_advertised():
+    """Guard (A2): the agent `--agent` selected is absent from the advertised
+    modes, so its spec never loaded (missing, or rejected wholesale on an unknown
+    field) and kiro-cli silently fell back to its own default agent. That default
+    mounts none of Kiro Crew's control plane while the global provider mcp.json
+    stays merged, so third-party servers keep working and every Crew tool the
+    injected prompt names -- learn_add among them -- answers "does not exist".
+    No override is passed, which is exactly why Guard (A) cannot catch it."""
+    rt, _, _ = _make_runtime()
+    rt._agent = "kirocrew"
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    resp = _new_resp({"currentModeId": "default", "availableModes": [{"id": "default"}]})
+    # session/new response, then the terminate roundtrip from the fail-closed path
+    rt._send_and_await = AsyncMock(side_effect=[resp, {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        with pytest.raises(AcpRuntimeError, match="spawned with --agent"):
+            await rt.create_session(mcp_servers=[])
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert METHOD_SET_MODE not in methods  # never activated the wrong mode
+    assert METHOD_SESSION_TERMINATE in methods  # created session cleaned up
+    assert "s1" not in rt._session_queues  # unregistered
+
+
+@pytest.mark.asyncio
+async def test_create_session_admits_spawn_agent_when_advertised():
+    """Guard (A2) admits the ordinary case: the spawn agent IS advertised, so the
+    session stands and no set_mode fires (nothing to switch to)."""
+    rt, _, _ = _make_runtime()
+    rt._agent = "kirocrew"
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    resp = _new_resp(
+        {"currentModeId": "kirocrew", "availableModes": [{"id": "kirocrew"}, {"id": "ops"}]}
+    )
+    rt._send_and_await = AsyncMock(side_effect=[resp, {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        handle = await rt.create_session(mcp_servers=[])
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert METHOD_SET_MODE not in methods
+    assert METHOD_SESSION_TERMINATE not in methods
+    assert handle.session_id == "s1"
+
+
+@pytest.mark.asyncio
+async def test_create_session_fails_closed_when_current_mode_names_another_agent():
+    """A `currentModeId`-only response naming a DIFFERENT agent is positive evidence
+    of the substitution, so it fails closed even with no advertised list. Admitting
+    a current-mode mismatch would let exactly this response through the
+    compatibility escape: `_mode_available` returns True whenever no list was
+    advertised, so the substituted agent would run with none of Kiro Crew's tools.
+    A live probe of kiro-cli pins the meaning of the field -- a spec that loads is
+    reported as the current mode, and a spec the backend refuses reports the
+    backend's own default instead."""
+    rt, _, _ = _make_runtime()
+    rt._agent = "kirocrew"
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    # No availableModes at all -> parse_session_modes reports advertised=False.
+    resp = _new_resp({"currentModeId": "kiro_default"})
+    rt._send_and_await = AsyncMock(side_effect=[resp, {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        with pytest.raises(AcpRuntimeError, match="not the agent this session is running"):
+            await rt.create_session(mcp_servers=[])
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert METHOD_SET_MODE not in methods
+    assert METHOD_SESSION_TERMINATE in methods
+    assert "s1" not in rt._session_queues
+
+
+@pytest.mark.asyncio
+async def test_create_session_spawn_agent_guard_admits_when_no_modes_advertised():
+    """Guard (A2) is judged on the same evidence as Guard (A): a backend that
+    advertises no `modes` list at all (older kiro-cli / offline fake backend) is
+    no evidence of substitution, so the session is admitted."""
+    rt, _, _ = _make_runtime()
+    rt._agent = "kirocrew"
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    rt._send_and_await = AsyncMock(side_effect=[_new_resp(None), {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        handle = await rt.create_session(mcp_servers=[])
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert METHOD_SESSION_TERMINATE not in methods
+    assert handle.session_id == "s1"
+
+
+@pytest.mark.asyncio
+async def test_create_session_admits_spawn_agent_named_as_current_mode():
+    """Guard (A2) admits an agent the response names as the CURRENT mode even when
+    the advertised list omits it. The guard asks "did my agent load", not "is the
+    advertised list complete", so a backend that reports the active mode without
+    listing it must not have its session torn down over that gap."""
+    rt, _, _ = _make_runtime()
+    rt._agent = "kirocrew"
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    resp = _new_resp({"currentModeId": "kirocrew", "availableModes": [{"id": "other"}]})
+    rt._send_and_await = AsyncMock(side_effect=[resp, {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        handle = await rt.create_session(mcp_servers=[])
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert METHOD_SESSION_TERMINATE not in methods
+    assert handle.session_id == "s1"
+
+
+@pytest.mark.asyncio
+async def test_create_session_spawn_agent_guard_skipped_on_kas_backend():
+    """Guard (A2) is restricted to the backend whose argv carries `--agent`. On KAS
+    the agent travels over the wire and is activated by set_mode, which Guard (A)
+    covers, so an advertised list without the runtime agent must not fail closed
+    here."""
+    from kiro_crew.acp.types import ACP_BACKEND_KAS
+
+    rt, _, _ = _make_runtime()
+    rt._agent = "kirocrew"
+    rt._acp_backend = ACP_BACKEND_KAS
+    assert (
+        await rt._verify_spawn_agent_active(
+            "s1",
+            _new_resp({"currentModeId": "kas", "availableModes": [{"id": "kas"}]}),
+            override=None,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_session_fails_closed_when_spawn_agent_not_advertised():
+    """Guard (A2) on the resume path. `load_session`'s own check reads `agent`, and
+    its sole caller passes `agent=agent or None`, so a no-override resume reached no
+    check at all — yet a fresh runtime re-reads the spec from disk, so the spawn
+    agent can fail to load on resume exactly as on a cold start."""
+    rt, _, _ = _make_runtime()
+    rt._agent = "kirocrew"
+    rt._can_load_session = True
+    rt._finish_session_init = MagicMock(return_value=[])  # type: ignore[method-assign]
+    resp = {"modes": {"currentModeId": "default", "availableModes": [{"id": "default"}]}}
+    rt._send_and_await = AsyncMock(side_effect=[resp, {}])  # type: ignore[method-assign]
+    with patch.object(AcpSessionHandle, "drain_init", AsyncMock()):
+        with pytest.raises(AcpRuntimeError, match="spawned with --agent"):
+            await rt.load_session("/home/u/.kiro/sessions/cli/sid-9.json", "sid-9", cwd="/w")
+    methods = [c.args[0] for c in rt._send_and_await.call_args_list]
+    assert METHOD_SET_MODE not in methods
+    assert METHOD_SESSION_TERMINATE in methods
+
+
+@pytest.mark.asyncio
 async def test_create_session_sets_mode_when_no_modes_advertised():
     """Backward compat: a backend that omits `modes` (older kiro-cli / fake
     backend) still gets set_mode attempted."""


### PR DESCRIPTION
## Problem / Motivation

A session can run with none of Kiro Crew's own tools, and nothing says so. The agent still receives the prompt telling it to call `learn_add`, so it calls it, gets `A tool with the name 'learn_add' does not exist`, and tells the user its memory is unavailable and the lesson was not saved. The memory write was never the problem. The whole `kirocrew-core` server is absent.

Kiro Crew starts kiro-cli with `--agent <name>`, and kiro-cli reads `~/.kiro/agents/<name>.json` itself. A spec it refuses to load is dropped in silence: no error, a normal session, and the backend's own default agent running in that agent's place.

That default agent mounts no Kiro Crew server. It does still merge the user's global `~/.kiro/settings/mcp.json`, because Kiro Crew pins `includeMcpJson: false` only on specs it writes itself. So a third-party MCP server declared there keeps working while every Kiro Crew tool is missing. To the user that reads as "my other tools are fine, so Kiro Crew removed `learn_add`".

## Why it matters

A user correction is dropped and the user is told it was dropped for the wrong reason. They go looking for a missing tool, or edit a prompt, when the session simply ran the wrong agent. Every Kiro Crew tool is gone the same way — `spawn_run`, `monitor_start`, the cron tools — so a session can also fail to schedule, delegate or report back, each time looking like a separate bug.

## What changed (motivation → approach → change)

`create_session` already refuses this substitution. Guard (A) terminates the session and raises when a requested agent is absent from the modes the backend advertised, rather than letting it run the backend's default in that agent's place. It just never looks at the right agent: `mode_agent = agent or (self._agent if kas_agents else None)`, so it inspects the agent `set_mode` will activate. On kiro-cli with no override that is `None`, and the agent `--agent` picked — every ordinary session's agent — is checked by nothing. `load_session` has the same shape: its check reads `agent`, and its only caller passes `agent=agent or None`.

So the fix reuses the guard rather than inventing a check. `_verify_spawn_agent_active()` applies the same test to the spawn-flag agent on both session-start paths. It runs before `set_mode`, so the wrong mode is never activated, and it terminates the created session so the backend does not hold an orphan.

`currentModeId` is the proof, in both directions. Naming the spawn agent admits the session. Naming anything else fails closed — even when the response carried no advertised list, which is the case a mismatch would otherwise slip through. Only a response naming NO current mode falls back to the advertised list, so older kiro-cli and the offline fake backend behave exactly as before. The check is scoped to `ACP_BACKEND_KIRO`, the backend whose argv carries `--agent`, by a positive identity test so a harness added later is skipped rather than captured.

```mermaid
flowchart LR
  subgraph Before
    A1["spawn --agent kirocrew"]:::ctx --> B1["backend refuses the spec, silently"]:::ctx
    B1 --> C1["runs the backend's own default"]:::removed
    C1 --> D1["no Kiro Crew tools"]:::removed
  end
  subgraph After
    A2["spawn --agent kirocrew"]:::ctx --> B2["backend refuses the spec, silently"]:::ctx
    B2 --> E2["Guard A2 reads currentModeId"]:::added
    E2 --> F2["terminate + actionable error"]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1,2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 3,4,5 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟥 removed · 🟦 unchanged

*A session whose agent never loaded now stops with a message naming the spec, instead of running on with no Kiro Crew tools.*

## Tests

Six tests in `test/test_acp_runtime.py`.

Three lock in fail-closed. Two cover a rejected spec on each session-start path (`test_create_session_fails_closed_when_spawn_agent_not_advertised`, `test_load_session_fails_closed_when_spawn_agent_not_advertised`), asserting `set_mode` never fires, the session is terminated, and its queue is unregistered. The third, `test_create_session_fails_closed_when_current_mode_names_another_agent`, covers a response that names a substituted current mode and no advertised list — the shape a current-mode admit would let through.

Three lock in what must still be admitted: the agent is advertised, the agent is named as the current mode, and the response names no modes at all.

One locks in the backend scope, so a KAS session whose advertised list omits the runtime agent is not torn down.

Mutation-verified twice. Neutering the guard fails the three fail-closed tests. Admitting a current-mode mismatch fails exactly the substituted-current-mode test.

## Manual verification

Verified live against `kiro-cli` on an isolated workspace agent, two cases, reading the raw `session/new` result.

**Healthy admit.** A valid `probeagent.json` yields `modes.currentModeId == "probeagent"`, with `probeagent` present in `availableModes` (43 entries). The guard admits.

**Refused spec, fail-closed.** The same spec with a type error (`"tools": "not-a-list"`) yields `modes.currentModeId == "kiro_default"` and no `probeagent` in `availableModes` (42 entries). No JSON-RPC error, a normal `sessionId`, the process runs on, and `stderr` is byte-identical to the healthy run — nothing names the agent, the file, or the validation failure. That is the silent substitution this guard now stops.

One correction the probe forced, worth stating because it narrows the trigger: an unknown TOP-LEVEL key is **ignored**, not rejected — `"totallyUnknownField": 1` loaded fine. A **type** error is what makes the backend refuse the spec. The guard does not depend on which validation failure occurred; it reads only whether the agent is the one running.

## Related Issues

no linked issue: reported directly rather than through a GitHub issue.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a guard whose subject is computed from one selection path, added to a call site that has two — the second path silently gets no guard.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
