### PR TITLE
refactor(skill-providers): one search body, and drop the dead text fetch

### DIFF
--- a/src/kiro_crew/skill_providers/base.py
+++ b/src/kiro_crew/skill_providers/base.py
@@ -188,31 +188,13 @@ class ProviderRegistry:
         failures are caught and logged — a single provider timeout does not
         break the entire search.
         """
-        if provider:
-            p = self._providers.get(provider)
-            if p is None or not provider_available(p):
-                return []
-            try:
-                return _stamp_provenance(
-                    await asyncio.wait_for(
-                        p.search(query, limit=limit), timeout=_SEARCH_TIMEOUT_SECS
-                    ),
-                    provider,
-                )
-            except asyncio.TimeoutError:
-                logger.warning("Provider %s timed out for query %r", provider, query)
-                return []
-            except Exception:
-                logger.warning("Provider %s failed for query %r", provider, query, exc_info=True)
-                return []
 
-        # Iterate (key, provider) pairs so failure logs name the vetted
-        # registration key instead of re-reading a provider-controlled
-        # ``name`` property inside an exception handler.
-        available = [(n, p) for n, p in self._providers.items() if provider_available(p)]
-        if not available:
-            return []
-
+        # The timeout budget, the provenance re-stamp and the two failure
+        # handlers are one contract, so the single-provider request and every
+        # fan-out leg go through this one body: a divergence here would let a
+        # provider's own ``provider`` string survive on one path but not the
+        # other. *name* is the vetted registration key, never a re-read of the
+        # provider-controlled ``name`` property.
         async def _search_one(name: str, p: SkillProvider) -> list[SkillSearchResult]:
             try:
                 return _stamp_provenance(
@@ -227,6 +209,23 @@ class ProviderRegistry:
             except Exception:
                 logger.warning("Provider %s failed for query %r", name, query, exc_info=True)
                 return []
+
+        if provider:
+            p = self._providers.get(provider)
+            if p is None or not provider_available(p):
+                return []
+            # This path applies no ``[:limit]``: the provider was ASKED for at
+            # most *limit* rows and is trusted to honour it. The fan-out below
+            # re-caps because it merges several providers, not because any one
+            # of them is checked — a provider that ignores *limit* is capped
+            # nowhere on this path.
+            return await _search_one(provider, p)
+
+        # Iterate (key, provider) pairs so failure logs name the vetted
+        # registration key.
+        available = [(n, p) for n, p in self._providers.items() if provider_available(p)]
+        if not available:
+            return []
 
         results_per_provider = await asyncio.gather(*[_search_one(n, p) for n, p in available])
         merged: list[SkillSearchResult] = []

--- a/src/kiro_crew/skill_providers/skillsh.py
+++ b/src/kiro_crew/skill_providers/skillsh.py
@@ -1,8 +1,8 @@
 """skills.sh provider — public skill registry search and fetch.
 
 skills.sh exposes a public REST API (no auth for reads) that returns
-skill metadata including GitHub repo URLs. Installation fetches the
-SKILL.md from the repo directly.
+skill metadata including GitHub repo URLs. Installation reads the skill's
+files out of the registry's own download bundle (``fetch_skill_bundle``).
 """
 
 from __future__ import annotations
@@ -11,7 +11,6 @@ import asyncio
 import ipaddress
 import json
 import logging
-import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -32,14 +31,29 @@ _TIMEOUT = 5
 # User-Agent for our requests (good citizenship)
 _USER_AGENT = "KiroCrew/1.0 (skill-discovery)"
 
-# Maximum response body size (1 MiB) — prevents disk exhaustion from
-# oversized responses. SKILL.md files are typically <50 KB.
+# Maximum response body size (1 MiB) — ``_read_bounded`` accumulates the body
+# in memory, so this bounds the bytes one fetch RETAINS. It is not a peak-memory
+# figure: joining the chunks and decoding them each allocate another copy.
+# It is also what bounds DISK: a download response carries the install bundle,
+# and the discover handler writes those files out under a looser 5 MiB guard of
+# its own, so this ceiling is the one that binds first. Raise it only having
+# accounted for both. SKILL.md files are typically <50 KB.
 _MAX_RESPONSE_BYTES = 1 * 1024 * 1024
 
-# Internal/private IP ranges that must never be fetched (SSRF mitigation).
-# NOTE: _API_BASE is hardcoded — if it becomes user-configurable, it must
-# be validated against this same check. Do NOT make api_base configurable
-# without adding SSRF validation on the base URL itself.
+# Per-chunk read size while draining a response body (64 KiB).
+_HTTP_READ_CHUNK_BYTES = 64 * 1024
+
+
+def _s(v: Any) -> str:
+    """Coerce one provider-supplied value to str — non-strings become ''.
+
+    skills.sh rows are external input, and a non-string that survives into a
+    ``SkillSearchResult`` crashes a consumer far from here: a numeric ``id``
+    reaches ``_slugify``'s ``raw.strip()`` in the discover handler and 500s the
+    request. Coercing to '' is what lets one falsiness test at the call site
+    drop the row; this helper never drops anything itself.
+    """
+    return v if isinstance(v, str) else ""
 
 
 @dataclass
@@ -47,6 +61,14 @@ class SkillsShConfig:
     """Configuration for the skills.sh provider."""
 
     enabled: bool = True
+
+    # This module's SSRF host allowlist does not reach the base: `_is_allowed_host`
+    # gates redirect targets only, so an initial URL built from this field is
+    # checked by `_is_internal_url` alone. That rejects internal, private and
+    # loopback addresses, but it does not require HTTPS and does not hold the host
+    # to `_ALLOWED_HOSTS`. Any caller that lets a user set this must validate the
+    # base URL itself before constructing the provider. The platform `discovery`
+    # policy allowlist that `api_base` below feeds is a separate, policy-level gate.
     api_base: str = _API_BASE
 
 
@@ -102,30 +124,19 @@ class SkillsShProvider:
             # skills.sh search response shape:
             # {"id": "owner/repo/skill-name", "skillId": "skill-name",
             #  "name": "skill-name", "installs": N, "source": "owner/repo"}
-            source = item.get("source", "") if isinstance(item.get("source"), str) else ""
+            source = _s(item.get("source"))
             repo_url = f"https://github.com/{source}" if source else ""
             try:
                 installs = int(item.get("installs", 0) or 0)
             except (TypeError, ValueError):
                 installs = 0
-            # Provider metadata is external input: a numeric id would reach
-            # _slugify().strip(), non-string tags reach the redactors — either
-            # 500s the discovery request. Coerce/drop instead of trusting.
-
-            def _s(v: Any) -> str:
-                return v if isinstance(v, str) else ""
-
-            skill_ident = (
-                _s(item.get("id")) or _s(item.get("skillId")) or _s(item.get("name"))
-            )
+            skill_ident = _s(item.get("id")) or _s(item.get("skillId")) or _s(item.get("name"))
             if not skill_ident:
                 continue  # entry without a usable string identifier — drop it
+            # A non-string tag reaches the discover handler's per-field
+            # redactor and 500s the whole response, so drop it here.
             raw_tags = item.get("tags", [])
-            tags = (
-                [t for t in raw_tags if isinstance(t, str)]
-                if isinstance(raw_tags, list)
-                else []
-            )
+            tags = [t for t in raw_tags if isinstance(t, str)] if isinstance(raw_tags, list) else []
             results.append(
                 SkillSearchResult(
                     id=skill_ident,
@@ -133,7 +144,10 @@ class SkillsShProvider:
                     description=_s(item.get("description")),
                     provider=self.name,
                     repo_url=repo_url,
-                    author=source.split("/")[0] if isinstance(source, str) and source else "",
+                    # `source` is the registry's "owner/repo" identifier, not a
+                    # filesystem path, so the separator is always "/". Take the
+                    # owner segment without building the whole list.
+                    author=source.partition("/")[0],
                     tags=tags,
                     installs=installs,
                 )
@@ -151,21 +165,15 @@ class SkillsShProvider:
         if bundle is None:
             return None
 
-        # Find SKILL.md first, fall back to AGENTS.md
-        skill_md = next((f for f in bundle if f[0] == "SKILL.md"), None)
-        if skill_md:
-            return skill_md[1]
-
-        agents_md = next((f for f in bundle if f[0] == "AGENTS.md"), None)
-        if agents_md:
-            return agents_md[1]
-
-        # Last resort: return the first .md file
+        # SKILL.md first, then AGENTS.md, then any .md. First match in bundle
+        # order wins at each tier, so a bundle carrying two SKILL.md entries
+        # resolves deterministically to the earlier one.
+        for wanted in ("SKILL.md", "AGENTS.md"):
+            named = next((f for f in bundle if f[0] == wanted), None)
+            if named:
+                return named[1]
         any_md = next((f for f in bundle if f[0].endswith(".md")), None)
-        if any_md:
-            return any_md[1]
-
-        return None
+        return any_md[1] if any_md else None
 
     async def fetch_skill_bundle(self, skill_id: str) -> list[tuple[str, str]] | None:
         """Fetch the full skill bundle (all files) from skills.sh.
@@ -225,31 +233,6 @@ class SkillsShProvider:
         return result if result else None
 
 
-def _github_raw_url(repo_url: str, file_path: str) -> str | None:
-    """Convert a GitHub repo URL to a raw content URL.
-
-    Handles:
-    - https://github.com/user/repo
-    - https://github.com/user/repo.git
-    - github.com/user/repo
-    """
-    # Defense-in-depth: file_path must not contain traversal sequences.
-    # Currently always called with literal "SKILL.md" but this guards
-    # against future misuse if the parameter becomes caller-controlled.
-    if ".." in file_path or file_path.startswith("/"):
-        return None
-    match = re.match(
-        r"(?:https?://)?github\.com/([^/]+)/([^/.\s]+?)(?:\.git)?/?$",
-        repo_url.strip(),
-    )
-    if not match:
-        return None
-    user, repo = match.group(1), match.group(2)
-    # Try the "main" default branch first (most common); caller can retry with
-    # the legacy default branch name if this 404s.
-    return f"https://raw.githubusercontent.com/{user}/{repo}/main/{file_path}"
-
-
 async def _fetch_json(url: str) -> Any | None:
     """Fetch JSON from a URL. Returns None on any failure."""
     try:
@@ -278,37 +261,6 @@ def _sync_fetch_json(url: str) -> Any | None:
             return None
         return json.loads(data.decode("utf-8"))
     except (urllib.error.URLError, json.JSONDecodeError, OSError):
-        return None
-
-
-async def _fetch_text(url: str) -> str | None:
-    """Fetch text content from a URL. Returns None on any failure."""
-    try:
-        return await asyncio.get_running_loop().run_in_executor(None, _sync_fetch_text, url)
-    except Exception:
-        logger.debug("Failed to fetch text from %s", url, exc_info=True)
-        return None
-
-
-def _sync_fetch_text(url: str) -> str | None:
-    """Synchronous text fetch (for run_in_executor)."""
-    # Pre-connect SSRF check on the initial URL
-    if _is_internal_url(url):
-        return None
-    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
-    try:
-        resp = _open_no_internal_redirect(req)
-        if resp is None:
-            return None
-        if resp.status != 200:
-            resp.close()
-            return None
-        data = _read_bounded(resp, _MAX_RESPONSE_BYTES)
-        resp.close()
-        if data is None:
-            return None
-        return data.decode("utf-8")
-    except (urllib.error.URLError, OSError):
         return None
 
 
@@ -404,9 +356,12 @@ def _is_internal_url(url: str) -> bool:
         return True  # parse failure = suspicious, block
 
 
-# Hosts a fetch may start at or be redirected to. Everything this module
-# requests lives on skills.sh or GitHub raw content; GitHub serves raw file
-# redirects via its media/objects CDN hosts. A redirect to ANY other host —
+# Hosts a fetch may be REDIRECTED to; the initial URL is checked by
+# `_is_internal_url` alone (see `SkillsShConfig.api_base`). Every request this
+# module makes starts at the configured skills.sh API base, so the GitHub hosts
+# are here only as redirect targets of the download endpoint, which serves
+# bundle payloads from GitHub's raw, media and objects CDNs. A redirect to ANY
+# other host —
 # including an internal DNS name that would resolve to a private address
 # (DNS-rebinding style SSRF) — is refused. Keep this list tight: add hosts
 # only for a concrete, observed redirect target.
@@ -465,13 +420,14 @@ def _open_no_internal_redirect(req: urllib.request.Request):
 def _read_bounded(resp, max_bytes: int) -> bytes | None:
     """Read response body up to max_bytes. Returns None if exceeded.
 
-    Prevents disk exhaustion from oversized responses. Reads in chunks
-    to avoid holding unbounded data in memory.
+    The check is against the RUNNING total, so an oversized body is abandoned
+    mid-stream rather than accumulated whole — *max_bytes* bounds the bytes
+    retained here, not just a verdict on the finished body.
     """
     chunks: list[bytes] = []
     total = 0
     while True:
-        chunk = resp.read(65536)
+        chunk = resp.read(_HTTP_READ_CHUNK_BYTES)
         if not chunk:
             break
         total += len(chunk)

--- a/test/test_skill_providers.py
+++ b/test/test_skill_providers.py
@@ -11,40 +11,9 @@ from kiro_crew.skill_providers.base import ProviderRegistry, SkillSearchResult
 from kiro_crew.skill_providers.skillsh import (
     SkillsShConfig,
     SkillsShProvider,
-    _github_raw_url,
     _is_allowed_host,
     _is_internal_url,
 )
-
-
-class TestGithubRawUrl:
-    """Test GitHub URL resolution."""
-
-    def test_https_url(self):
-        assert _github_raw_url("https://github.com/user/repo", "SKILL.md") == \
-            "https://raw.githubusercontent.com/user/repo/main/SKILL.md"
-
-    def test_https_with_git_suffix(self):
-        assert _github_raw_url("https://github.com/user/repo.git", "SKILL.md") == \
-            "https://raw.githubusercontent.com/user/repo/main/SKILL.md"
-
-    def test_bare_github_url(self):
-        assert _github_raw_url("github.com/user/repo", "SKILL.md") == \
-            "https://raw.githubusercontent.com/user/repo/main/SKILL.md"
-
-    def test_trailing_slash(self):
-        assert _github_raw_url("https://github.com/user/repo/", "SKILL.md") == \
-            "https://raw.githubusercontent.com/user/repo/main/SKILL.md"
-
-    def test_non_github_url(self):
-        assert _github_raw_url("https://gitlab.com/user/repo", "SKILL.md") is None
-
-    def test_empty_string(self):
-        assert _github_raw_url("", "SKILL.md") is None
-
-    def test_nested_path(self):
-        assert _github_raw_url("https://github.com/org/repo", "src/SKILL.md") == \
-            "https://raw.githubusercontent.com/org/repo/main/src/SKILL.md"
 
 
 class TestSkillsShProvider:
@@ -230,13 +199,6 @@ class TestProviderRegistry:
              patch("kiro_crew.skill_providers.base._SEARCH_TIMEOUT_SECS", 0.05):
             results = await reg.search("test")
             assert results == []
-
-
-# Helpers not exported but worth testing
-def test_slugify_repo_name():
-    """Verify the skillsh module doesn't export _slugify_repo_name (it's in skill_sync.py)."""
-    # Our discover handler has its own _slugify — test the github URL helper instead
-    assert _github_raw_url("https://github.com/my-org/my-repo", "SKILL.md") is not None
 
 
 class TestRedirectHostAllowlist:


### PR DESCRIPTION
## Problem / Motivation

The skill-discovery registry wrote the same search contract twice, and the
skills.sh provider carried a whole fetch path nothing reaches.

`ProviderRegistry.search` had two copies of one body. The single-provider
branch and the `_search_one` fan-out leg both spelled out the timeout budget,
the `_stamp_provenance` re-stamp, and the same two failure handlers. Only the
name holding the registration key differed. `_stamp_provenance` exists because
a result row's `provider` field is provider-authored data, so a contributed
catalog could claim another provider's identity. Two copies of that stamp is
two places for it to go missing.

`skillsh.py` also held the direct-GitHub raw-fetch path: `_fetch_text` and
`_sync_fetch_text` did the fetching, `_github_raw_url` built the URL they would
fetch. Nothing in the package calls any of the three. Installation reads the
registry's download bundle instead.

Several comments in the file said things that are not true of the code.

## Why it matters

A guard written twice drifts. `_sync_fetch_text` had its own `_is_internal_url`
pre-connect check, its own redirect handler, and its own size ceiling — a
tightening applied to the live path would have silently missed it, and no test
would fail, because no test reaches it.

Half-deleting the path would have been worse than leaving it. `_github_raw_url`
alone is a URL builder for a fetch that no longer exists, with a traversal guard
protecting a call that never happens — and the next reader has to re-derive that
from scratch.

The false comments cost a reader real time, and one of them was load-bearing.
`_ALLOWED_HOSTS` said a fetch "may start at" one of its hosts. It may not:
`_is_allowed_host` has exactly one call site and it is the redirect handler, so
an initial URL is checked by `_is_internal_url` alone — which rejects private and
loopback addresses but permits plain `http://` to any public host. A maintainer
who read the allowlist and concluded the start URL was already vetted would wire
`api_base` to operator config without the validation it needs.

## What changed (motivation → approach → change)

The single-provider branch now calls `_search_one`. `_search_one` moves above
the branch so both paths can reach it, and takes the vetted registration key as
a parameter. Same timeout, same stamp, same two handlers, same log strings —
one body.

The dead GitHub fetch path is deleted whole: `_fetch_text`, `_sync_fetch_text`,
`_github_raw_url`, the now-unused `import re`, and the tests that were those
functions' only callers. Removing an unreachable duplicate of a guard removes a
drift risk, not a control. The live path (`_fetch_json` → `_sync_fetch_json`)
keeps the whole chain and is now the module's only caller of
`_open_no_internal_redirect`. The GitHub hosts stay in `_ALLOWED_HOSTS`: a
skills.sh download redirects to them, so they have a live reason, and narrowing
an SSRF allowlist is a behaviour change rather than a readability one.

The rest is local. `_s` was a function object rebuilt on every result row, so
it moves to module scope. `source` was read twice out of one dict, and the
`author` field then re-checked it with an `isinstance` its own construction
already guarantees; it now reads once and takes the owner segment with
`partition("/")`, which is the same string for every input including `""`.
`fetch_skill_content`'s three sequential lookups become one loop over the two
named tiers plus the `.md` fallback, keeping first-match-in-bundle-order at
each tier. `_read_bounded`'s chunk size gets the name the sibling registry
module already uses.

The comments now say what the code does, and two constraints are stated where
they bind instead of being dropped. `_MAX_RESPONSE_BYTES` bounds retained
memory, and it is also the ceiling on what one install writes to disk — a
download response carries the bundle, and the discover handler's own guard on
those files is looser at 5 MiB, so this one binds first. The `tags` filter keeps
its reason: a non-string tag reaches the handler's per-field redactor and fails
the whole response.

```mermaid
flowchart LR
  subgraph Before
    A1[search provider=x]:::ctx --> B1[inline body: timeout + stamp + handlers]:::removed --> R1[rows]:::ctx
    A2[search fan-out]:::ctx --> B2[_search_one: timeout + stamp + handlers]:::ctx --> R1
  end
  subgraph After
    C1[search provider=x]:::ctx --> D1[_search_one]:::added
    C2[search fan-out]:::ctx --> D1
    D1 --> R2[rows]:::ctx
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 4,5 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*Both search paths now run the one body that stamps provenance, instead of two copies of it.*

## Tests

Deletions only, and they are the deleted code's own callers: `TestGithubRawUrl`
(7 cases) and `test_slugify_repo_name`, whose docstring said it was testing the
wrong helper and whose body tested `_github_raw_url` instead. No test asserts on
the deleted functions from anywhere else — the whole repo, including `dist/`,
returns zero references to `_github_raw_url`, `_fetch_text` and
`_sync_fetch_text`.

Nothing else changes, so the surviving tests are the check on the rewrites: if a
rewrite were not equivalent, they should say so. 158 passed across every test
module that names `skillsh` or `skill_providers` (`test_skill_providers.py`,
`test_skill_discover.py`, `test_skill_discovery_seam.py`,
`test_discover_handlers_cov80.py`, `test_external_access_seam.py`,
`test_mcp_skill_registry.py`).

The 17 sites that patch `kiro_crew.skill_providers.skillsh._sync_fetch_json`,
the 2 that patch `_audit_ssrf_blocked`, and the 1 that patches
`base._SEARCH_TIMEOUT_SECS` all still resolve — none of those three symbols
moved. `_SEARCH_TIMEOUT_SECS` is still read as a global at `await` time inside
`_search_one`, and `_search_one` is rebuilt per `search()` call, so moving its
`def` cannot capture a stale patched value. `TestRedirectHostAllowlist` and
`TestIsInternalUrlSSRF`, including the SEL-audit and encoded-IP cases, are
untouched.

## Manual verification

N/A — no runtime surface changes, and the equivalence of each rewrite is what
the existing tests already cover.

Gates green on the Python 3.12 CI-parity venv: `flake8`, `isort --check-only`,
`mypy src/kiro_crew`, `check_black_formatting.py`,
`check_subprocess_encoding.py`, `check_sync_io_in_async.py`,
`check_comment_history.py`, `check_brand_name.py`, `check_harness_parity.py`,
`check_per_file_coverage.py`, `verify_vendor_manifest.py`, `docs-lint.sh`,
`docs_lint.py`.

Backend-only: the diff touches nothing under `website/`, `.github/` or
`scripts/`, so CI's `changes` job reports `only_backend=true` and the frontend
suites cannot newly fail.

Coverage: `skillsh.py` is a listed exemption in
`.github/coverage-baselines/backend.txt` at 64.0% (137/214). Measured on an
identical basis (the six test modules above, `--cov` on this one file) it goes
from 61% (217 statements, 77 missed) on `origin/main` to 69% (181 statements, 52
missed) here — the deleted fetch pair was uncovered, `_github_raw_url` was
covered, and the net is a rise. Above the recorded value, so no regression;
below the 80% floor plus its noise band, so it does not graduate and the
baseline needs no edit.

### Pre-push review fleet

Four read-only reviewers ran against the diff before this push, each on its own
lens (repo blocking rules, behaviour equivalence, deletion and import safety,
security controls and comment truthfulness).

Fixed, all comment-accuracy findings and all in files already being edited: the
`_ALLOWED_HOSTS` "may start at" claim (raised independently by two lenses); its
"everything this module requests lives on GitHub raw content" claim, which this
diff itself made false; the dropped disk-exhaustion reach of
`_MAX_RESPONSE_BYTES`; and the dropped reason for the `tags` filter.

Dropped: the suggestion to also delete the four GitHub entries from
`_ALLOWED_HOSTS`. Those are the redirect targets of the live skills.sh download
route, so removing them would narrow the redirect surface a working install
depends on — a behaviour change, and one that would break installs. The lens
that raised it and the lens reviewing repo rules both said explicitly not to.

No blocking AUTOSDE rule matched adversely; behaviour equivalence came back with
no findings, including a brute-force comparison of the tiered lookup and of
`split("/")` versus `partition("/")` across every edge input.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only refactor with no rendered output; the diff touches no frontend file and no user-visible string.

## Related Issues

no linked issue: readability sweep of one module, not a reported defect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
