### PR TITLE
fix(deps): pin electron js-yaml override to 4.3.2 for GHSA-2883-xcg3-v3hh

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -2403,9 +2403,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -24,7 +24,7 @@
   },
   "overrides": {
     "fast-uri": "3.1.7",
-    "js-yaml": "4.3.1"
+    "js-yaml": "4.3.2"
   },
   "build": {
     "appId": "com.amazon.kiro.crew",


### PR DESCRIPTION
Closes #9670

## Summary

Nightly [Run 34317880062](https://github.com/kirodotdev/KiroCrew/actions/runs/34317880062) (main @ `8113a5ad`) fails only in **Production Dependency Vulnerability Gate**: `website/electron/package-lock.json` resolves `js-yaml@4.3.1`, which is covered by [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) (high, published 2026-09-08 21:24 UTC, fixed in `4.3.2`).

**Root cause:** the version is held by the existing `overrides` pin `"js-yaml": "4.3.1"` in `website/electron/package.json` (added for the previous js-yaml advisory). It is a transitive dependency of `electron-updater`, `app-builder-lib`, `builder-util` and `dmg-builder`. Nothing on our side regressed; a new advisory landed against a version we already shipped.

**Disposition chosen: option 1 (upgrade), not a gate exception.** Upstream already published the patched `4.3.2`, so there is no reason to carry a governed exception with a review deadline. Changes:

- `website/electron/package.json`: bump the `overrides` pin `4.3.1` -> `4.3.2`.
- `website/electron/package-lock.json`: regenerated with `npm install --package-lock-only`; the only diff is the `js-yaml` entry (version / resolved / integrity). No other dependency moved.

`website/` and `site/` also resolve `js-yaml@4.3.1`, but only as dev dependencies, which the production gate deliberately does not audit — left out of scope.

(An earlier revision also reworded the gate's "unexcepted" message; dropped after review — "unexcepted" is the gate's deliberate vocabulary for "not covered by a governed exception", not a typo.)

## Pattern harvest

Not generalizable: newly published upstream advisory against an already-pinned transitive dependency; the fix is a one-line version bump of an existing `overrides` pin. The gate itself worked as designed.

## Verification

- `python scripts/check_npm_audit.py` locally: `Production dependency audit passed: 3 lockfiles, 0 governed exception(s).`
- No tests run locally (owner rule); CI is authoritative.
