### PR TITLE
fix(work-ledger): retry a contended record read; make a test's ids salt-free

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -28,7 +28,6 @@ src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_lint_findings.py
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_checks.py
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_profile_capture.py
-src/kiro_crew/apps/builtins/auto_improvement/tests/test_reconcile_and_publish.py
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_spine_scope_cov80.py
 src/kiro_crew/apps/builtins/auto_research/handlers.py

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_reconcile_and_publish.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_reconcile_and_publish.py
@@ -15,6 +15,7 @@ network is involved.
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -30,11 +31,23 @@ def registry(tmp_path: Path) -> W.PRWatcherRegistry:
     )
 
 
+def _pr_number(fp: str) -> int:
+    """A PR number derived from the fingerprint by a SALT-FREE digest.
+
+    ``hash()`` on a str is salted per interpreter process, so two fingerprints can
+    share one PR url in some processes and not others -- and a test that tells its
+    findings apart BY url then fails on that draw alone. Each xdist shard is its own
+    process drawing its own salt, so the failure looks like one shard being special.
+    sha256 gives the same mapping in every process.
+    """
+    return int(hashlib.sha256(fp.encode()).hexdigest()[:8], 16) % 9000 + 1
+
+
 def _finding(fp: str, *, status: str = "filed", pr: str | None = None) -> dict:
     return {
         "fp": fp,
         "status": status,
-        "pr": pr if pr is not None else f"https://github.com/o/r/pull/{abs(hash(fp)) % 9000 + 1}",
+        "pr": pr if pr is not None else f"https://github.com/o/r/pull/{_pr_number(fp)}",
         "kind": "bug",
         "target": "src/m.py::f",
     }
@@ -252,14 +265,14 @@ class TestOrphanCloneSweep:
         # The rmtree must not be dedented back out of the `with` block: everything from the lock
         # to the rmtree stays in one block, so no `return`-then-delete-outside pattern.
         between = src[lock_at:rmtree_at]
-        assert "reg._lock" not in between.replace("with reg._lock:", "", 1), (
-            "the lock is released and re-taken between the check and the delete"
-        )
+        assert "reg._lock" not in between.replace(
+            "with reg._lock:", "", 1
+        ), "the lock is released and re-taken between the check and the delete"
         # Must read thread state directly, not via the lock-taking helpers.
         assert "reg._threads.get(" in src, "does not inspect thread state directly under the lock"
-        assert "reg.is_alive(" not in src, (
-            "calls is_alive() inside the held non-reentrant lock — self-deadlock"
-        )
+        assert (
+            "reg.is_alive(" not in src
+        ), "calls is_alive() inside the held non-reentrant lock — self-deadlock"
 
     def test_a_watcher_registering_during_the_sweep_is_not_swept(self, tmp_path, monkeypatch):
         """Behavioral race check: a watcher whose registration lands WHILE the sweep holds the

--- a/src/kiro_crew/work_ledger.py
+++ b/src/kiro_crew/work_ledger.py
@@ -62,7 +62,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterator
 
-from kiro_crew.atomic_write import atomic_write
+from kiro_crew.atomic_write import atomic_write, read_bytes_with_retry
 from kiro_crew.config.paths import data_home
 from kiro_crew.platform_compat import file_lock
 from kiro_crew.session_ledger import _store_name, resolved_within
@@ -604,6 +604,17 @@ def _read_json_record(path: Path, *, strict: bool = False) -> Any | None:
     the same way, because a two-writer store's reader must not be what crashes when
     the other writer was interrupted mid-write. The ceiling is checked before the
     read so a hand-grown file cannot be pulled into memory first.
+
+    The bytes come from ``read_bytes_with_retry`` because a strict read here is
+    LOCK-FREE across writers: :func:`_refuse_if_worker_holds_open_item` reads the
+    prior item's file under the WORKER's binding lock, while that item's own
+    conductor may be replacing it under a different item lock. On Windows a read of
+    a file another handle holds open for write raises ``PermissionError``, so one
+    correct concurrent writer is enough to turn a strict read into a bare
+    ``OSError`` — which the dashboard route maps to a transient 503 "try again"
+    instead of the permanent already-bound refusal the guard exists to raise. The
+    retry closes that window. POSIX permits the read, and there a
+    ``PermissionError`` is a genuine access fault the helper re-raises at once.
     """
     try:
         if path.stat().st_size > MAX_RECORD_BYTES:
@@ -612,7 +623,7 @@ def _read_json_record(path: Path, *, strict: bool = False) -> Any | None:
                 path.name,
             )
             return None
-        return json.loads(path.read_text(encoding="utf-8"))
+        return json.loads(read_bytes_with_retry(path).decode("utf-8"))
     except FileNotFoundError:
         return None
     except OSError:

--- a/test/test_work_ledger.py
+++ b/test/test_work_ledger.py
@@ -17,9 +17,12 @@ import re
 import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 import pytest
+from windows_sim import read_sharing_violation
 
+from kiro_crew import atomic_write, platform_compat
 from kiro_crew import work_ledger as wl
 
 CONDUCTOR = "chat-1-conductor"
@@ -1019,23 +1022,45 @@ def test_an_item_file_storing_a_different_id_reads_as_absent(caplog):
     assert wl.item_path(CONDUCTOR, b).read_bytes() == b_before
 
 
+def _fault_record_read(monkeypatch, *, name: str | None = None, parent: Path | None = None):
+    """Make a record read raise a Windows-style sharing violation, and undo it.
+
+    Records are read through ``atomic_write.read_bytes_with_retry``, so the fault
+    belongs on ``Path.read_bytes``. On POSIX that helper treats ``PermissionError``
+    as a genuine access fault and re-raises on the first attempt, so a test pinning
+    the fail-closed contract sees the error directly. Returns the callable that
+    restores the real reader.
+
+    Exactly one selector: ``name`` faults a single file, ``parent`` faults every
+    read inside one directory.
+    """
+    real_read_bytes = Path.read_bytes
+
+    def flaky(self, *a, **kw):
+        if (name is not None and self.name == name) or (
+            parent is not None and self.parent == parent
+        ):
+            raise PermissionError("sharing violation")
+        return real_read_bytes(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_bytes", flaky)
+
+    def restore() -> None:
+        monkeypatch.setattr(Path, "read_bytes", real_read_bytes)
+
+    return restore
+
+
 def test_the_bind_guard_fails_closed_on_a_transient_read_error(monkeypatch):
     """GPT round 5 F2: a prior item that is present but momentarily unreadable must
     NOT read as stale, or the worker is rebound and its open item stranded."""
     first = _new_item(title="first")
     second = _new_item(title="second")
     wl.apply_conductor_action(CONDUCTOR, "bind", item_id=first, worker_session_key=WORKER)
-    real_read_text = Path.read_text
-
-    def flaky(self, *a, **kw):
-        if self.name == f"{first}.json":
-            raise PermissionError("sharing violation")
-        return real_read_text(self, *a, **kw)
-
-    monkeypatch.setattr(Path, "read_text", flaky)
+    restore = _fault_record_read(monkeypatch, name=f"{first}.json")
     with pytest.raises(PermissionError):
         wl.apply_conductor_action(CONDUCTOR, "bind", item_id=second, worker_session_key=WORKER)
-    monkeypatch.setattr(Path, "read_text", real_read_text)
+    restore()
     assert wl.read_binding(WORKER) == (CONDUCTOR, first)
     second_item = wl.read_work_item(CONDUCTOR, second)
     assert second_item is not None and second_item.worker_session_key is None
@@ -1048,21 +1073,14 @@ def test_the_bind_guard_fails_closed_when_the_binding_itself_is_unreadable(monke
     second = _new_item(title="second")
     wl.apply_conductor_action(CONDUCTOR, "bind", item_id=first, worker_session_key=WORKER)
     binding_before = wl.binding_path(WORKER).read_bytes()
-    real_read_text = Path.read_text
-
-    def flaky(self, *a, **kw):
-        if self.parent == wl.bindings_dir():
-            raise PermissionError("sharing violation")
-        return real_read_text(self, *a, **kw)
-
-    monkeypatch.setattr(Path, "read_text", flaky)
+    restore = _fault_record_read(monkeypatch, parent=wl.bindings_dir())
     with pytest.raises(PermissionError):
         wl.apply_conductor_action(CONDUCTOR, "bind", item_id=second, worker_session_key=WORKER)
-    monkeypatch.setattr(Path, "read_text", real_read_text)
+    restore()
     assert wl.binding_path(WORKER).read_bytes() == binding_before
     assert wl.read_binding(WORKER) == (CONDUCTOR, first)
     # The lenient reader still answers 'unbound' for a worker tool.
-    monkeypatch.setattr(Path, "read_text", flaky)
+    _fault_record_read(monkeypatch, parent=wl.bindings_dir())
     assert wl.read_binding(WORKER) is None
 
 
@@ -1072,14 +1090,7 @@ def test_a_transient_read_error_does_not_reset_the_conductor_header(monkeypatch)
     wl.ensure_conductor(CONDUCTOR, goal="keep me", depth=1)
     wl.apply_conductor_action(CONDUCTOR, "goal", round_number=4)
     before = (wl.conductor_dir(CONDUCTOR) / "conductor.json").read_bytes()
-    real_read_text = Path.read_text
-
-    def flaky(self, *a, **kw):
-        if self.name == "conductor.json":
-            raise PermissionError("sharing violation")
-        return real_read_text(self, *a, **kw)
-
-    monkeypatch.setattr(Path, "read_text", flaky)
+    restore = _fault_record_read(monkeypatch, name="conductor.json")
     with pytest.raises(PermissionError):
         wl.ensure_conductor(CONDUCTOR, goal="other")
     # The action entry point's lenient pre-lock read answers ``no_ledger`` first;
@@ -1088,7 +1099,7 @@ def test_a_transient_read_error_does_not_reset_the_conductor_header(monkeypatch)
         wl.apply_conductor_action(CONDUCTOR, "goal", goal="other")
     with pytest.raises(PermissionError):
         wl._write_goal(CONDUCTOR, wl.ConductorRecord(slot_key=CONDUCTOR), "other", None)
-    monkeypatch.setattr(Path, "read_text", real_read_text)
+    restore()
     assert (wl.conductor_dir(CONDUCTOR) / "conductor.json").read_bytes() == before
     record = wl.read_conductor(CONDUCTOR)
     assert record is not None and (record.goal, record.round, record.depth) == ("keep me", 4, 1)
@@ -1139,14 +1150,7 @@ def test_an_interrupted_bind_can_be_retried(caplog):
 
 def test_lenient_reads_still_treat_a_transient_error_as_absent(monkeypatch):
     item_id = _new_item()
-    real_read_text = Path.read_text
-
-    def flaky(self, *a, **kw):
-        if self.name == f"{item_id}.json":
-            raise PermissionError("sharing violation")
-        return real_read_text(self, *a, **kw)
-
-    monkeypatch.setattr(Path, "read_text", flaky)
+    _fault_record_read(monkeypatch, name=f"{item_id}.json")
     assert wl.read_work_item(CONDUCTOR, item_id) is None
     assert wl.list_work_items(CONDUCTOR) == []
 
@@ -1513,6 +1517,51 @@ def test_the_guards_share_one_containment_helper(monkeypatch):
     with pytest.raises(wl.WorkLedgerError) as excinfo:
         wl.conductor_dir(CONDUCTOR)
     assert excinfo.value.code == wl.CODE_INVALID_VALUE
+
+
+def test_a_contended_item_read_still_refuses_with_already_bound():
+    """A losing bind must refuse PERMANENTLY, not fail as if the write broke.
+
+    ``_refuse_if_worker_holds_open_item`` reads the prior item under the WORKER's
+    binding lock, while that item's own conductor holds a DIFFERENT lock, so the
+    read is unserialized against a correct concurrent writer. On Windows that read
+    raises ``PermissionError``, which escapes the guard's ``WorkLedgerError`` arm and
+    reaches the dashboard route as a transient 503 "try again" -- telling a conductor
+    to retry a binding that is legitimately taken until the item closes.
+
+    ``read_sharing_violation`` reproduces the fault on any OS, so this drives the
+    exact path a Windows host takes. It does NOT prove the real OS behaviour, only
+    that the read survives one contended window and the refusal stays permanent.
+    """
+    holder, loser = "chat-hold-c", "chat-lose-c"
+    for key in (holder, loser):
+        wl.ensure_conductor(key, goal="g")
+    held_item = wl.apply_conductor_action(holder, "create", title="t", acceptance={})[
+        "item"
+    ].item_id
+    loser_item = wl.apply_conductor_action(loser, "create", title="t", acceptance={})[
+        "item"
+    ].item_id
+    wl.apply_conductor_action(holder, "bind", item_id=held_item, worker_session_key=WORKER)
+
+    with (
+        mock.patch.object(platform_compat, "IS_WINDOWS", True),
+        mock.patch.object(atomic_write, "_REPLACE_BACKOFF_SECONDS", 0),
+        read_sharing_violation(match=f"{held_item}.json", times=1) as state,
+    ):
+        with pytest.raises(wl.WorkLedgerError) as caught:
+            wl.apply_conductor_action(loser, "bind", item_id=loser_item, worker_session_key=WORKER)
+
+    assert caught.value.code == wl.CODE_ALREADY_BOUND, (
+        f"a contended read of the prior item must still refuse with "
+        f"{wl.CODE_ALREADY_BOUND!r}, got {caught.value.code!r}: {caught.value}"
+    )
+    assert state["n"] >= 2, (
+        "the guard's read of the prior item must be retried after the simulated "
+        f"sharing violation; intercepted reads: {state['n']}"
+    )
+    # The loser's own item keeps no binding, and the holder's keeps the one it won.
+    assert wl.read_binding(WORKER) == (holder, held_item)
 
 
 def test_acquiring_a_lock_does_not_truncate_the_lock_file():


### PR DESCRIPTION
Two reds on `Backend Tests (Windows) (4)`, seen while driving an unrelated PR to green. Only one of them is a Windows fact.

## 1. A losing bind is told to retry a binding that is permanently taken

`work_ledger._read_json_record` reads with a bare `read_text`. A **strict** read there is lock-free across writers: `_refuse_if_worker_holds_open_item` reads the prior item under the **worker's binding lock**, while that item's own conductor may be replacing it under a **different item lock**. Nothing serializes the two.

On Windows a read of a file another handle holds open for write raises `PermissionError`, and the winner's `os.replace` is exactly such a window. The guard catches only `WorkLedgerError`, so the `PermissionError` escapes `apply_conductor_action`. `dashboard/handlers/work_ledger.py` maps `WorkLedgerError` to a 409 `already_bound` but any `OSError` to a **503 `ledger_write_failed` "ledger write failed; try again"**.

So a conductor that loses the race is told the failure is transient, and retries a binding that is legitimately taken until the item closes. A permanent refusal reported as retryable is a product defect, not a test that is too strict.

**Fix** is one line in the store: read through `atomic_write.read_bytes_with_retry`, the read-side twin of `replace_with_retry` that `members.py` already uses for this same window. `_read_json_record` is the one choke point every record read passes through.

Fail-closed still holds: a `PermissionError` that outlives the bounded retry escapes exactly as before, and on POSIX the helper treats it as a genuine access fault and re-raises on the first attempt. The docstring already named "a Windows rename race" as the case strict mode must not mistake for absence; the code now actually survives one.

## 2. A test that mints its own identifiers from a salted hash

Not Windows-specific at all. `test_reconcile_and_publish._finding` builds each finding's PR url from `abs(hash(fp)) % 9000 + 1`. `hash()` on a `str` is salted per interpreter process, so about one process in 9000 gives two fingerprints the **same** url. The status fetch then raises for both, nothing starts, and the test reads `assert [] == ['aa']`. Each xdist shard is its own process drawing its own salt, which is the entire reason this looks like one shard being special.

Reproduced on Linux:

```
$ PYTHONHASHSEED=17494 python3 -c "print(abs(hash('aa'))%9000+1, abs(hash('bb'))%9000+1)"
1344 1344
$ PYTHONHASHSEED=17494 pytest '...::TestReconcile::test_a_status_fetch_failure_does_not_abort_the_sweep'
E   AssertionError: assert [] == ['aa']
```

Production behaved correctly: it skipped the url whose fetch raised. The fix belongs in the test fixture, which now derives the number from a sha256 digest. Salt-free, so the mapping is identical in every process and shard (`aa`→8988, `bb`→3558, `bbb`→1926, `cccc`→3750, all distinct and now fixed constants).

## Tests

- New `test_a_contended_item_read_still_refuses_with_already_bound` drives the guard through the repo's existing `windows_sim.read_sharing_violation`, so the fault is deterministic on any OS, and asserts the refusal stays `already_bound` and the read was retried. **Negative control:** reverting only the retry line makes it fail with the injected `PermissionError: [WinError 32] simulated sharing violation`.
- The four existing fail-closed tests move their injected fault from `Path.read_text` to `Path.read_bytes`, through one shared `_fault_record_read` helper, because that is the call the record reader now makes. Their assertions are unchanged and still pass on POSIX, where the helper does not retry: the fail-closed contract is re-proven, not relaxed.
- `test/test_work_ledger.py` 130 passed. `TestReconcile` passes at `PYTHONHASHSEED` 17494, 0, 1, 42, 999 and `random`.
- 18 tests under `src/kiro_crew/apps/builtins/auto_improvement/tests/` fail identically with and without this diff on my host, with `PlatformCompositionError: profile resolved to 'enterprise'`. That is my machine's own config, not this change.
- `black`, `flake8` and `scripts/check_comment_history.py` clean.

## Pattern harvest

Rule candidate: semgrep

Pattern: `hash()` of a `str`/`bytes`/`tuple` used to mint a value a test then relies on for IDENTITY or UNIQUENESS. `hash()` is salted per process (PEP 456), so any such value is a per-process draw and any test distinguishing records by it is flaky at a rate set by its modulus. A rule flagging `hash(` inside `test/**` and `**/tests/**` when the result feeds an f-string, a path, or a url would catch it; `hashlib` is the fix.

I audited the other 10 `abs(hash(...))` sites in the test tree and left them: they mint a temp directory or repo name where a collision is unobservable (each case has its own `tmp_path`, or the code unlinks before re-creating), or the modulus is large enough that the draw is not the failure mode. `test_memory_smoke.py` calls its salted `hash(text) % 1000` embedding "deterministic", which is inaccurate, but its assertions only check that a context is returned and the embedder was called, so nothing there depends on the value.
