### PR TITLE
fix(channels): resume native session generations

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -519,7 +519,6 @@ test/test_consolidation_placeholder_guard.py
 test/test_context_marker_neutralization.py
 test/test_context_ui_language.py
 test/test_continuable_followups.py
-test/test_conversation.py
 test/test_crash_dump_store.py
 test/test_crash_guard.py
 test/test_credential_scrub_sync.py

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -1757,7 +1757,7 @@ answer is not permission: a raised evaluation and a `Decision` without
 - **Inbound token validation is never reordered behind body USE**: `on_activity` verifies the bearer token before the activity is acted on, and the replay-dedupe check runs AFTER the `serviceUrl` attestation so an unattested activity cannot consume a dedupe slot. The body IS read and JSON-parsed first, under a byte cap — that is what bounds it — so the guarantee is about dispatch, not about reading. A hardening step added ahead of the token check would make the perimeter the trust boundary instead of the signature.
 - **Channel identity is asserted POSITIVELY**: `activity.channelId` must equal `msteams`, never "not some other channel". An Azure Bot resource serves Web Chat (enabled by default) and can serve Direct Line off the SAME endpoint with the SAME credential, and on Direct Line the client composes the `from` object — so a negative test would hand a sender-chosen identity to `allowed_emails`, and would fail open on the next channel Microsoft adds.
 - **An approval widget carries a per-prompt nonce, minted from one place**: ACP request ids restart at 1 in every provider process, so a control left in a chat from a previous run names an id that is live again for a DIFFERENT tool. Slack, Discord, Telegram and Teams all mint through `messaging.renderer.new_approval_nonce`, compare with `secrets.compare_digest`, retire the nonce with the prompt, and fail CLOSED when none was armed. Three independent copies of that is how one ends up with a weaker token or none at all — which is the state Telegram shipped in. The session picker's nonce (`PickerRegistry.mint`) comes from the same function: a press on a stale list of sessions is the same hazard, so it is not a reason for a second generator.
-- **Session resume has ONE controller and routing machine, not one per channel**: `SessionResumeController` is the only consumer of `ResumeSurface`; it owns eligibility/search delegation, the picker registry, access audit, transcript existence, both conflict checks around the awaited UI settlement, expectation-before-success ordering, the atomic inbound claim, dashboard push, and the final audit. `SessionBinder` owns routing, refusal settlement, and release. Discord and Teams supply address and owner identity, their widgets/cards and exact copy/display redaction, callback parsing, and channel-local replay. The machine is where a mistake routes somebody's transcript into someone else's chat, and its hazard is timing: between the durable record read and the live session-map read a binding can appear, vanish or move, so ONE call returns ONE `RoutingDecision` — where the message runs, the refusal that stops it, and the settlement owed once that refusal is delivered. Two resolver calls with an await between them let the binding change in the gap and the routing check fall through to the conversation's own session, silently. A second copy of either transaction is not a maintenance cost, it is a second chance to get it wrong.
+- **Session resume has ONE controller and routing machine, not one per channel**: `SessionResumeController` is the only consumer of `ResumeSurface`; it owns eligibility/search delegation, the picker registry, access audit, transcript existence, both conflict checks around the awaited UI settlement, expectation-before-success ordering, the atomic inbound claim, dashboard push, and the final audit. Dashboard keys are the default eligibility. A resume-capable channel passes only its canonical native key; the controller applies one exact-bucket policy with its own `SessionMap`. Discord, Telegram and Teams include generations in the current private conversation's exact durable bucket, resolving irreversible filename folds through `SessionMap.channel_key_for_stem`; only a mapped generation with a real history row is eligible. A zero-turn generation holds no work to recover and creates no picker row. Explicit `new` still records and flushes a monotonic generation floor on every DM channel, so a restart cannot seed the prior generation and append the next message to old history. Other users, agents, shared conversations and channels remain excluded. `SessionBinder` owns routing, refusal settlement, and release. Discord and Teams supply address and owner identity, their widgets/cards and exact copy/display redaction, callback parsing, and channel-local replay. The machine is where a mistake routes somebody's transcript into someone else's chat, and its hazard is timing: between the durable record read and the live session-map read a binding can appear, vanish or move, so ONE call returns ONE `RoutingDecision` — where the message runs, the refusal that stops it, and the settlement owed once that refusal is delivered. Two resolver calls with an await between them let the binding change in the gap and the routing check fall through to the conversation's own session, silently. A second copy of either transaction is not a maintenance cost, it is a second chance to get it wrong.
 - **There is ONE auto-approve grant, and a channel does not get its own**: every surface that can arm it — the dashboard toggle, `/yolo` on seven channels, and Teams' approval card — goes through `safety_override` via `messaging.commands.run_yolo_command`. A channel-local trusted set is a second grant with its own lifetime, its own audit trail and its own answer to "is YOLO on?", and it has to reimplement the expiry, renewal and auditing the shared helper already owns. Slack's `is_slack_session_trusted` predates this and is the one exception; a new channel follows the seven. It also follows that a control which arms the grant must NAME its blast radius: Teams' button says "Approve + auto-approve", not "Trust session", because the effect reaches every surface until the grant expires.
 - **A model-authored label is never interpreted as a command**: an `[OPTIONS:]` chip re-dispatches with `interpret_commands=False`, exactly like a drained queue payload. Display redaction does not strip a leading `/`, so with interpretation on a model that emitted `[OPTIONS: /dashboard | cancel]` renders a chip whose single tap mints a dashboard login credential.
 - **An option button is bound to the session that posted it**: Discord and Telegram encode `opt:<index>:<tag>`, where `session_provenance_tag` is a stable 12-hex SHA-256 digest of the posting session key. The raw key never reaches client-visible callback data. A press is checked before busy handling and again after idle/daily rotation; a mismatch or an untagged legacy button fails closed. A valid press against a busy session is refused rather than queued or steered, because those paths retain only bare text and would replay the choice with no tag to validate.
@@ -1922,6 +1922,18 @@ mismatch (the chat was rebound or `!new`'d since the buttons were posted) and an
 untagged pre-provenance button both fail closed with a refusal naming the
 remedy; queue drains and AutoNudge fires dispatch untagged with commands off and
 keep their native-session affinity.
+
+**Native-generation picker scope.** Discord, Telegram and Teams include persistent
+dashboard sessions plus native generations from the current private conversation's
+exact durable bucket. A native history filename is never reverse-parsed: every row
+must resolve through `SessionMap.channel_key_for_stem`; the canonical candidate must
+fold back to the row and share the current key's durable bucket. Selecting one may
+replace outbound-only origin mirrors from other generations of the same bucket, but
+never an unrelated dashboard mirror. Webex already lists only its current native
+bucket and remains read-only. Explicit `new` records and flushes a monotonic generation
+floor before replying on all nine DM channels; it creates no zero-turn history row,
+and the first real turn creates the recoverable row. A floor-write failure is reported
+without rolling back the completed in-memory rotation.
 
 Every turn closes with a **one-line footer** as Discord subtext (`-#`) on the
 final segment, rendered by the shared `format_turn_status` (see "Turn-status
@@ -2120,23 +2132,24 @@ The channel's transport, forum routing and mid-turn machinery are described in
 the sections above; what follows is what is specific to its rendering and its
 Bot API surface.
 
-### Telegram's read-only session search
+### Telegram session resume
 
-`/sessions` and its singular `/session` alias remain direct-message-only,
-single-operator, and read-only. With no argument they use the shared recent-sessions
-collector, preserving the ten-row newest-first list, live marker and agent label. With
-search words they call `ConversationLog.search_sessions` off the event loop, so title
-and message-content matching, AND-term semantics, CJK handling, recency weighting,
-and ranking are the same as dashboard history search rather than a Telegram-only title
-filter. Incognito and temporary rows are excluded after a bounded over-fetch, before
-the ten-row display cap, so private content cannot leave a match trace and private hits
-cannot starve later public results. Live markers restore dashboard stems through the
-shared history-key helper and resolve irreversible channel filename folds through
-`SessionMap`, never by guessing colon positions. Both successful and failed reads emit
-`telegram.sessions_data_access`; displayed query text, titles, agents and errors are
-redacted and bounded. Search results contain no callback controls and direct users to
-`/kirocrew dashboard`, so this capability does not claim inbound session binding
-before Telegram owns the resume transaction and routing path.
+`/sessions` and its singular `/session` alias are direct-message-only and
+single-operator. With no argument the shared `SessionResumeController` offers the ten
+newest eligible rows; search words delegate to `ConversationLog.search_sessions`, so
+title/content matching, CJK handling, recency weighting and ranking stay identical to
+dashboard history search. Eligibility is persistent dashboard sessions plus native
+generations from this exact Telegram DM bucket. Incognito/temporary rows and every
+other user, agent, Topic or channel are filtered before the ten-row cap.
+
+Results are nonce-bound inline buttons. A press runs the shared atomic bind transaction,
+replays bounded context, and routes later DM messages into the selected session until
+`/unlink` or `/new`. It may replace outbound-only origin mirrors from this native
+bucket, but never an unrelated dashboard mirror. Irreversible history stems resolve
+through `SessionMap`, never guessed colon positions. A zero-turn generation has no
+history row and nothing to recover; its first real turn makes it eligible. Titles,
+query text, errors and replay are redacted and bounded, and every list read emits
+`telegram.sessions_data_access`.
 
 ### Telegram's upload half (`telegram/`)
 

--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -1112,11 +1112,20 @@ gen, dm_scope)`:
 - **Generation reset** rotates on `/new`, an idle window
   (`MessagingConfig.idle_reset_minutes`), or a daily boundary
   (`daily_reset_hour`), decided by `should_rotate_generation()`.
+- **Explicit `/new` is durable on every DM channel.** Discord, Telegram, Teams,
+  Webex, Feishu, iMessage, WhatsApp, Weixin and WeCom persist the new generation as
+  a monotonic floor on the stable `SessionMap` bucket and await its flush before
+  replying. A failed floor write leaves the in-memory bump intact but adds a
+  restart-safety warning. A zero-turn generation creates no conversation-log row:
+  it holds no work to recover, and repeated `/new` calls therefore update one floor
+  integer instead of crowding the newest-first picker with empty placeholders. The
+  first normal turn creates the real history row. Automatic idle/daily rotation still
+  materializes only when its first real turn runs.
 - **Restart-safe generation seeding.** The generation counter is in-memory (per
   `ConversationState`), so it resets on gateway restart. To stop `/new` from
   bumping a reset counter (0→1) straight onto a still-persisted generation and
   resurrecting that old conversation, the counter is seeded on first access to a
-  bucket from the highest persisted generation via
+  bucket from the highest mapped generation or explicit-new floor via
   `SessionMap.max_generation(bucket)` (shared helper
   `messaging.link.seed_generation`, used by every DM dispatcher). A normal
   post-restart message then resumes the latest generation (continuity); `/new`

--- a/src/kiro_crew/discord/commands.py
+++ b/src/kiro_crew/discord/commands.py
@@ -9,7 +9,7 @@ published as real slash commands):
   !compact     — trigger context compaction
   !model       — pick the model from a button list
   !status      — show runtime stats
-  !sessions    — continue a recent dashboard session here (owner only)
+  !sessions    — continue a recent dashboard or same-DM session here (owner only)
   !link        — mirror this conversation's dashboard tab back here
   !unlink      — stop mirroring
   !stop        — stop the current reply and clear the queue (alias: !cancel)
@@ -153,7 +153,7 @@ COMMAND_SPEC: tuple[tuple[str, str], ...] = (
     ("compact", "Compress the context when it gets long"),
     ("model", "Choose the model from a list"),
     ("status", "Show gateway runtime stats and the approval mode"),
-    ("sessions", "Continue a recent or matching dashboard session here (owner only)"),
+    ("sessions", "Continue a recent or matching session here (owner only)"),
     ("link", "Resume mirroring dashboard replies here (on by default)"),
     ("unlink", "Stop mirroring dashboard replies here"),
     ("stop", "Stop the current reply and clear the queue"),

--- a/src/kiro_crew/discord/session_resume.py
+++ b/src/kiro_crew/discord/session_resume.py
@@ -16,6 +16,7 @@ from kiro_crew.messaging.session_resume import (
     RoutingDecision,
     SessionChoice,
     SessionResumeController,
+    same_bucket_origin_keys,
 )
 from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -164,10 +165,10 @@ class _DiscordResumeSurface:
         if normalized:
             label = _safe_discord_text(" ".join(query.split()), 100).replace("`", "ˋ")
             return (
-                f"No dashboard sessions matched `{label}`. Try fewer words, "
+                f"No sessions matched `{label}`. Try fewer words, "
                 f"or run `!sessions` to see up to {PICKER_LIMIT} recent sessions."
             )
-        return "No recent dashboard sessions."
+        return "No recent sessions."
 
     def picker_heading(self, query: str, total: int) -> str:
         normalized = " ".join(query.casefold().split())
@@ -181,17 +182,17 @@ class _DiscordResumeSurface:
                     f"{'s' if total != 1 else ''} (maximum {PICKER_LIMIT})"
                 )
             return (
-                "🔎 **Dashboard session search**\n"
+                "🔎 **Session search**\n"
                 f"{summary} for `{label}`, ranked over titles and message content."
             )
         if total > PICKER_LIMIT:
-            summary = f"Showing {PICKER_LIMIT} of {total} most recent dashboard sessions."
+            summary = f"Showing {PICKER_LIMIT} of {total} most recent sessions."
         else:
             summary = (
-                f"Showing {total} most recent dashboard session"
+                f"Showing {total} most recent session"
                 f"{'s' if total != 1 else ''} (maximum {PICKER_LIMIT})."
             )
-        return f"🧵 **Recent dashboard sessions**\n{summary}"
+        return f"🧵 **Recent sessions**\n{summary}"
 
     def choice_success(self, choice: SessionChoice) -> str:
         return (
@@ -227,7 +228,7 @@ class _DiscordResumeSurface:
 
 
 class DiscordSessionResume:
-    """Lists dashboard sessions and binds one bidirectionally to Discord."""
+    """Lists dashboard + same-DM native sessions and binds one to Discord."""
 
     def __init__(
         self,
@@ -310,6 +311,7 @@ class DiscordSessionResume:
         user_id: str,
         channel_id: str,
         query: str = "",
+        native_key: str = "",
     ) -> None:
         await self._controller.show_picker(
             _DiscordResumeSurface(client, channel_id),
@@ -317,6 +319,7 @@ class DiscordSessionResume:
             picker_owner=_picker_owner(user_id, channel_id),
             is_owner=self.is_owner(user_id),
             query=query,
+            native_key=native_key,
         )
 
     async def choose(
@@ -324,8 +327,10 @@ class DiscordSessionResume:
         client: "DiscordClient",
         interaction: "DiscordInteraction",
         custom_id: str,
+        native_key: str = "",
     ) -> None:
         nonce, index = self._parse_choice(custom_id)
+        link = self.link_for(interaction.channel_id)
         choice = await self._controller.choose(
             _DiscordResumeSurface(client, interaction.channel_id),
             caller=interaction.user_id,
@@ -334,7 +339,8 @@ class DiscordSessionResume:
             message_id=interaction.message_id,
             nonce=nonce,
             index=index,
-            link=self.link_for(interaction.channel_id),
+            link=link,
+            replace_outbound_keys=same_bucket_origin_keys(self.sessions, link, native_key),
         )
         if choice is not None:
             await self._replay(client, interaction.channel_id, choice.key)

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -65,6 +65,7 @@ from kiro_crew.messaging.commands import (
     compact_unsupported_reply,
     stop_running_turn,
 )
+from kiro_crew.messaging.conversation import reserve_new_generation
 from kiro_crew.messaging.dispatch import (
     build_auto_approve,
     build_directive_consumer,
@@ -369,9 +370,17 @@ class DiscordDispatcher:
                 await self.client.send_message(channel_id, _RELEASE_FAILURE)
                 return monitor_result
             self._conv.bump_gen(scope_id)
+            new_session_key = self._session_key(user_id, thread_id)
+            saved = await reserve_new_generation(
+                self.sessions,
+                new_session_key,
+                channel_type="Discord",
+            )
             message = "✅ New conversation started."
             if left_resumed is not None:
                 message = "✅ New conversation started — left the resumed session."
+            if not saved:
+                message += "\n⚠️ The new conversation could not be saved for restart."
             await self.client.send_message(channel_id, message)
             return monitor_result
         if cmd == "compact":
@@ -381,7 +390,7 @@ class DiscordDispatcher:
         if cmd == "sessions":
             # DM-ONLY. The owner gate answers WHO may resume, not WHERE the
             # result may be shown: in an allow-listed guild thread the picker
-            # would post dashboard session TITLES and the bind would replay five
+            # would post private session TITLES and the bind would replay five
             # transcript messages, making private history readable by every
             # member of that thread. Resume is inherently a private-surface
             # operation, so refuse outside a DM rather than redacting harder.
@@ -389,7 +398,7 @@ class DiscordDispatcher:
                 await self.client.send_message(
                     channel_id,
                     "🔒 `!sessions` works only in a direct message — it lists and "
-                    "replays private dashboard conversations, so it will not post "
+                    "replays private conversations, so it will not post "
                     "them into a shared thread. DM me instead.",
                 )
                 return monitor_result
@@ -398,6 +407,7 @@ class DiscordDispatcher:
                 user_id,
                 channel_id,
                 query=parse_command_argument(text),
+                native_key=self._session_key(user_id, thread_id),
             )
             return monitor_result
         if cmd == "link":
@@ -1274,7 +1284,12 @@ class DiscordDispatcher:
         if data.startswith("s:"):
             if itx.guild_id:
                 return
-            await self._session_resume.choose(self.client, itx, data)
+            await self._session_resume.choose(
+                self.client,
+                itx,
+                data,
+                native_key=self._session_key(itx.user_id, thread_id),
+            )
             return
 
         # Tool-approval decision: "a:<request_id>:<nonce>:<1|0>". The nonce is

--- a/src/kiro_crew/docs/discord-integration.md
+++ b/src/kiro_crew/docs/discord-integration.md
@@ -193,7 +193,7 @@ works, including before the `applications.commands` scope is installed.
 | `!compact` | Compress the current conversation context |
 | `!model` / `!models` | Pick the model from a button list of what your account can use |
 | `!status` | Show runtime stats, the active agent, and whether auto-approve is on |
-| `!sessions` / `!session` | In a DM, pick a recent dashboard session and continue it here (owner only) |
+| `!sessions` / `!session` | In a DM, pick a recent dashboard or same-DM session and continue it here (owner only) |
 | `!link` / `!unlink` | Resume or stop mirroring dashboard replies here (on by default) |
 | `!stop` / `!cancel` | Stop the current reply and clear its queue |
 | `!help` | Show commands |
@@ -215,14 +215,17 @@ last exactly until your next message, since a conversation with no binding is
 indistinguishable from one that was never linked. `!link` re-enables it. Neither
 touches a binding you set explicitly from the dashboard to some other target.
 
-### Continuing a dashboard session from Discord
+### Continuing an earlier session from Discord
 
-In a DM, `!sessions` lists your 10 most recent dashboard conversations as buttons. Tap
-one and that session continues in this Discord conversation: the last five
-messages are replayed for context, and everything you send afterwards goes to
-that session instead of your own Discord conversation. `!unlink` releases it and
-returns you to your Discord conversation; `!new` releases it and starts a fresh
-Discord conversation.
+In a DM, `!sessions` lists your 10 most recent dashboard conversations plus earlier
+generations of this same Discord DM. It never exposes native sessions belonging to
+another Discord user, agent, shared thread, or messaging channel. Tap one and that
+session continues in this Discord conversation: the last five messages are replayed
+for context, and everything you send afterwards goes to that session instead of your
+own Discord conversation. `!unlink` releases it and returns you to your Discord
+conversation; `!new` releases it and starts a fresh Discord conversation. `!new`
+persists the new generation before replying, so a gateway restart cannot return the
+next message to the old conversation. The first real turn adds it to `!sessions`.
 
 While a session is resumed, `!compact` compresses **that** session's context and
 `!stop` cancels **its** running turn. Replies from the dashboard for a resumed
@@ -251,8 +254,8 @@ another channel, Kiro Crew refuses and tells you where it lives, rather than
 moving it silently.
 
 `!sessions` is **owner-only and requires exactly one entry in
-`discord.allowed_user_ids`**. Session listing and resume are global operations —
-they can reach any dashboard conversation, not just Discord ones — so with two
+`discord.allowed_user_ids`**. Session listing and resume can reach any dashboard
+conversation plus this DM's native generations, so with two
 or more allowed users Kiro Crew cannot tell which one owns the workspace and
 refuses the command instead of guessing. Incognito and temporary sessions are
 never listed, and session titles plus replayed messages are scrubbed of

--- a/src/kiro_crew/docs/teams-integration.md
+++ b/src/kiro_crew/docs/teams-integration.md
@@ -171,7 +171,7 @@ Send `/help` in the chat for the current list. Today:
 | `/stop` (`/cancel`) | Stop the reply in progress and clear the queue |
 | `/yolo on\|off\|renew` | Auto-approve tools **everywhere** until it expires — see below |
 | `/link` / `/unlink` | Resume / stop mirroring dashboard replies into this chat |
-| `/sessions [search words]` | Continue a recent dashboard chat here (owner only) |
+| `/sessions [search words]` | Continue a recent dashboard or same-chat session here (owner only) |
 | `/dashboard [<N>h\|<N>m]` | Get a **dashboard login link** — see Security notes |
 | `/help` | Show the command list |
 
@@ -185,13 +185,16 @@ progress. A message sent mid-turn is never lost — if it cannot be folded in, i
 held and shown in a single "⏳ Queued (N)" receipt that is edited in place, then
 answered as one combined turn.
 
-### Continuing a dashboard conversation
+### Continuing an earlier conversation
 
-`/sessions` lists your recent dashboard chats as buttons; press one and it continues in
-this Teams chat, with the last few messages replayed so you can see where you left off.
-`/sessions <words>` searches them — over message content as well as titles, so a phrase
-you remember from the conversation finds it. `/unlink` (or `/new`) comes back to your own
-Teams conversation.
+`/sessions` lists your recent dashboard chats plus generations from this exact Teams
+identity bucket; native sessions for another identity, agent, conversation, or channel
+are excluded. Press one and it continues in this Teams chat, with the last few messages
+replayed so you can see where you left off. `/sessions <words>` searches them — over
+message content as well as titles, so a phrase you remember from the conversation finds
+it. `/unlink` comes back to your own Teams conversation. `/new` leaves the resumed
+session and durably records the fresh generation before replying; its first real turn
+adds it to `/sessions`.
 
 It is **owner-only**: a dashboard session is your whole working transcript, so the list
 is available only when `teams.allowed_emails` holds exactly one address. With more than

--- a/src/kiro_crew/docs/telegram-integration.md
+++ b/src/kiro_crew/docs/telegram-integration.md
@@ -98,15 +98,17 @@ At startup the bot publishes the menu commands from `COMMAND_SPEC` through `setM
 - `/session [search words]` (or `/sessions [search words]`) — with no words,
   show the ten most recent eligible conversations; with words, use the same ranked
   title-and-message-content search as dashboard history. Results are inline buttons:
-  tap one and ordinary messages in this DM immediately continue that dashboard
-  conversation. The bot replaces its outbound-only native mirror automatically, so
-  no preparatory `/unlink` is required. `/new` leaves the resumed session and starts
-  a fresh Telegram conversation; `/unlink` returns to the existing Telegram
-  conversation. Incognito and temporary transcripts stay excluded. **Direct message
-  only**: a forum Topic is readable by the whole supergroup, so listing or resuming
-  there would expose host-wide titles to members outside `allowed_user_ids`. It also
-  refuses when `allowed_user_ids` contains several people, because the bot cannot
-  tell which one owns the host-wide history.
+  tap one and ordinary messages in this DM immediately continue it. Eligible rows are
+  dashboard conversations plus generations from this exact Telegram DM bucket; native
+  sessions belonging to another user, agent, forum Topic, or messaging channel are
+  excluded. The bot replaces its outbound-only native mirror automatically, so no
+  preparatory `/unlink` is required. `/new` leaves the resumed session, durably
+  records the fresh Telegram generation before replying, and starts that conversation;
+  its first real turn adds it to `/sessions`. `/unlink` returns to the existing Telegram
+  conversation. Incognito and temporary transcripts stay excluded. **Direct message only**: a forum Topic is readable by the
+  whole supergroup, so listing or resuming there would expose host-wide titles to
+  members outside `allowed_user_ids`. It also refuses when `allowed_user_ids` contains
+  several people, because the bot cannot tell which one owns the host-wide history.
 - `/title <text>` — rename this conversation, so its dashboard sidebar row reads
   as something other than the first forty characters you happened to type. On a
   resumed dashboard session the live sidebar row and durable metadata change

--- a/src/kiro_crew/docs/webex-integration.md
+++ b/src/kiro_crew/docs/webex-integration.md
@@ -80,7 +80,7 @@ and `/sessions` there lists the space's history rather than yours.
 
 | Command | What it does |
 |---|---|
-| `/new` | Start a fresh conversation (new session) |
+| `/new` | Start a fresh, restart-safe conversation; its first turn adds it to `/sessions` |
 | `/compact` | Compress the conversation context |
 | `/model` | List the models this account can use, and pick one |
 | `/sessions` | List this conversation's earlier sessions |

--- a/src/kiro_crew/feishu/transport_dispatch.py
+++ b/src/kiro_crew/feishu/transport_dispatch.py
@@ -31,7 +31,7 @@ from kiro_crew.feishu.renderer import FeishuRenderer
 from kiro_crew.feishu.transport import FEISHU_CAPABILITIES
 from kiro_crew.history import mint_row_mid
 from kiro_crew.messaging.commands import compact_unsupported_backend
-from kiro_crew.messaging.conversation import ConversationState
+from kiro_crew.messaging.conversation import ConversationState, reserve_new_generation
 from kiro_crew.messaging.dispatch import (
     ChannelTurn,
     build_directive_consumer,
@@ -120,7 +120,15 @@ class FeishuDispatcher:
         cmd = (inbound.command_text or text).strip().lower()
         if cmd in ("/new", "/reset"):
             self._conv.bump_gen(route)
-            await self.client.send_reply(inbound.message_id, "✅ 已开始新对话")
+            saved = await reserve_new_generation(
+                self.sessions,
+                self._session_key(route),
+                channel_type="Feishu",
+            )
+            message = "✅ 已开始新对话"
+            if not saved:
+                message += "\n⚠️ 新对话无法保存，重启后可能恢复到上一段对话。"
+            await self.client.send_reply(inbound.message_id, message)
             return
         if cmd == "/compact":
             # Releasing the latch here is what keeps the soft notice a

--- a/src/kiro_crew/imessage/transport_dispatch.py
+++ b/src/kiro_crew/imessage/transport_dispatch.py
@@ -34,6 +34,7 @@ from kiro_crew.imessage.renderer import IMessageRenderer
 from kiro_crew.imessage.rpc import RpcError, RpcTransportError
 from kiro_crew.imessage.transport import IMESSAGE_CAPABILITIES
 from kiro_crew.messaging.commands import compact_unsupported_backend
+from kiro_crew.messaging.conversation import reserve_new_generation
 from kiro_crew.messaging.dispatch import (
     ChannelTurn,
     build_directive_consumer,
@@ -129,7 +130,15 @@ class IMessageDispatcher:
         cmd = parse_command(text)
         if cmd == "new":
             self._conv.bump_gen(handle)
-            await self._notify(handle, "✅ Started a fresh conversation.")
+            saved = await reserve_new_generation(
+                self.sessions,
+                self._session_key(handle),
+                channel_type="iMessage",
+            )
+            message = "✅ Started a fresh conversation."
+            if not saved:
+                message += "\n⚠️ The new conversation could not be saved for restart."
+            await self._notify(handle, message)
             return
         if cmd == "compact":
             self._conv.clear_awaiting(handle)

--- a/src/kiro_crew/messaging/conversation.py
+++ b/src/kiro_crew/messaging/conversation.py
@@ -20,10 +20,41 @@ Stdlib-only apart from the sibling ``link`` helper; the seeding hook is injected
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
-from typing import Callable, Generic, Hashable, Optional, TypeVar
+from typing import Any, Callable, Generic, Hashable, Optional, TypeVar
 
 from kiro_crew.messaging.link import should_rotate_generation
+
+logger = logging.getLogger(__name__)
+
+
+async def reserve_new_generation(
+    sessions: Any,
+    session_key: str,
+    *,
+    channel_type: str,
+) -> bool:
+    """Persist *session_key* before acknowledging an explicit ``/new``.
+
+    ``SessionMap.reserve_generation`` marks the stable bucket dirty without
+    blocking the event loop; ``aflush`` is the durability point whose disk write
+    runs in a worker thread. A failed write leaves the in-memory bump intact but
+    returns ``False`` so the channel can warn that restart safety was not saved.
+    """
+    try:
+        sessions.reserve_generation(session_key)
+        await sessions.aflush()
+    except Exception:
+        logger.warning(
+            "%s: could not reserve new generation session=%s",
+            channel_type,
+            session_key,
+            exc_info=True,
+        )
+        return False
+    return True
+
 
 #: Conversation-identity key type. Channels key by whatever identifies a peer
 #: (Telegram ``user_id`` int, WeCom ``userid`` str).

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -388,6 +388,32 @@ DM_SCOPE_UNIFIED = "unified"
 #: stays separate; ``unified`` opts into one shared bucket per agent.
 DEFAULT_DM_SCOPE = DM_SCOPE_PER_CHANNEL_PEER
 
+
+def split_dm_session_key(key: str) -> tuple[str, int] | None:
+    """Return ``(bucket, generation)`` for a canonical DM session key.
+
+    The strict RFC parser owns normal channel keys. ``dm_scope=unified`` uses
+    the shorter ``unified:{agent}[:genN]`` shape, so this helper recognizes only
+    that one named exception. Keeping both shapes beside the key builder avoids
+    copying generation grammar into picker or persistence code.
+    """
+    parsed = parse_session_key(key)
+    if parsed is not None:
+        return parsed.bucket, parsed.gen
+
+    segments = key.split(":")
+    if len(segments) == 2 and segments[0] == DM_SCOPE_UNIFIED and segments[1]:
+        return key, 0
+    if (
+        len(segments) == 3
+        and segments[0] == DM_SCOPE_UNIFIED
+        and segments[1]
+        and (match := _GEN_SUFFIX_RE.match(segments[2])) is not None
+    ):
+        return ":".join(segments[:2]), int(match.group(1))
+    return None
+
+
 #: ``direct`` (1:1 DM) is the baseline; ``forum`` keys a Telegram supergroup
 #: forum Topic ``(chat_id, thread_id)`` to its own session (Slack-thread style).
 CHAT_TYPE_DIRECT = "direct"

--- a/src/kiro_crew/messaging/session_resume.py
+++ b/src/kiro_crew/messaging/session_resume.py
@@ -1,6 +1,6 @@
-"""Resuming a dashboard session inside a channel conversation, channel-neutrally.
+"""Resuming a persisted session inside a channel conversation, channel-neutrally.
 
-A user picks one of their dashboard chats from a channel and continues it there. Two
+A user picks one of their resumable chats from a channel and continues it there. Two
 channels grew this independently -- Discord first, and Teams would have been a second
 copy of ~600 lines -- so this module is the half that is genuinely shared, split on
 the same line ``queue_receipt.py`` uses:
@@ -33,11 +33,17 @@ import time
 from dataclasses import dataclass
 from typing import Any, Protocol
 
-from kiro_crew.history import is_incognito_transcript, needles_match_text, parse_search_query
+from kiro_crew.history import (
+    is_incognito_transcript,
+    needles_match_text,
+    parse_search_query,
+    transcript_stem,
+)
 from kiro_crew.messaging.link import (
     UNBIND_REASON_ORIGIN_REBIND,
     UNBIND_REASON_USER_UNLINK,
     ChannelLink,
+    split_dm_session_key,
 )
 from kiro_crew.messaging.renderer import new_approval_nonce
 from kiro_crew.messaging.resume_expectation import (
@@ -105,7 +111,7 @@ class ResumeReleaseError(RuntimeError):
 
 @dataclass(frozen=True)
 class SessionChoice:
-    """One offered session: the dashboard key, and the label the user sees."""
+    """One offered session: its canonical key and the label the user sees."""
 
     key: str
     title: str
@@ -206,7 +212,7 @@ def history_dashboard_key(raw_key: object) -> str | None:
 
     A transcript stem is not always the session key: the same session can appear as
     ``dashboard:<slot>`` or as the file-stem form ``dashboard_<slot>``, and a row from
-    some other surface is not resumable at all.
+    some other surface is not resumable by the default resolver.
 
     The stem prefix is stripped in a LOOP, not once: a re-archived transcript can carry
     it stacked (``dashboard_dashboard_<slot>``), and stripping one layer would bind
@@ -223,6 +229,59 @@ def history_dashboard_key(raw_key: object) -> str | None:
     return None
 
 
+def native_generation_bucket(key: str) -> str:
+    """Return the durable DM bucket for a trusted canonical session key."""
+    parsed = split_dm_session_key(key)
+    return parsed[0] if parsed is not None else ""
+
+
+def resumable_history_key(
+    row: dict[str, Any],
+    *,
+    sessions: Any,
+    native_key: str,
+) -> str | None:
+    """Resolve a dashboard or exact-same-bucket native history row.
+
+    A native transcript stem is irreversible: agent and scope segments may
+    contain underscores. Rows therefore require the session map's authoritative
+    resolver; a zero-turn generation has no history row and nothing to recover.
+    """
+    dashboard_key = history_dashboard_key(row.get("key"))
+    if dashboard_key is not None:
+        return dashboard_key
+
+    raw_key = str(row.get("key") or "")
+    if not raw_key:
+        return None
+    resolve_stem = getattr(sessions, "channel_key_for_stem", None)
+    candidate = str(resolve_stem(raw_key) or "") if callable(resolve_stem) else ""
+    if not candidate or raw_key not in {candidate, transcript_stem(candidate)}:
+        return None
+
+    native_bucket = native_generation_bucket(native_key)
+    candidate_bucket = native_generation_bucket(candidate)
+    if not native_bucket or candidate_bucket != native_bucket:
+        return None
+    return candidate
+
+
+def same_bucket_origin_keys(sessions: Any, link: ChannelLink, native_key: str) -> frozenset[str]:
+    """Outbound mirror occupants that are generations of one native DM bucket."""
+    native_bucket = native_generation_bucket(native_key)
+    if not native_bucket:
+        return frozenset()
+    resolve_stem = getattr(sessions, "channel_key_for_stem", None)
+    keys: set[str] = set()
+    for stored_key in sessions.find_mirror_sessions(link):
+        candidate = stored_key
+        if stored_key.startswith("dashboard:") and callable(resolve_stem):
+            candidate = str(resolve_stem(stored_key.removeprefix("dashboard:")) or "")
+        if candidate and native_generation_bucket(candidate) == native_bucket:
+            keys.add(stored_key)
+    return frozenset(keys)
+
+
 async def resolve_session_choices(
     conv_log: Any,
     query: str,
@@ -230,6 +289,8 @@ async def resolve_session_choices(
     *,
     limit: int = PICKER_LIMIT,
     fetch_limit: int = SEARCH_FETCH_LIMIT,
+    sessions: Any | None = None,
+    native_key: str = "",
 ) -> tuple[list[SessionChoice], int]:
     """The offerable sessions for *query* (newest-first when blank), and the total.
 
@@ -241,6 +302,11 @@ async def resolve_session_choices(
 
     Order is already meaningful -- ``search_sessions`` returns best-scored first,
     ``list_sessions`` newest first -- so it is never re-sorted.
+
+    With no native key, only dashboard sessions are admitted. A channel passes its
+    canonical native key and session map to include exact-same-bucket generations;
+    eligibility remains centralized here so privacy filtering, ordering and display
+    budgets do not drift between picker implementations.
 
     Raises whatever the history layer raises; the caller decides what to tell the user.
     """
@@ -271,6 +337,7 @@ async def resolve_session_choices(
         rows = await asyncio.to_thread(conv_log.list_sessions)
 
     eligible: list[SessionChoice] = []
+    seen: set[str] = set()
     for row in rows:
         if not isinstance(row, dict):
             continue
@@ -278,9 +345,13 @@ async def resolve_session_choices(
         # deliberately unpersisted conversation into a channel that does persist.
         if is_incognito_transcript(row.get("memory_mode")):
             continue
-        key = history_dashboard_key(row.get("key"))
-        if key is None:
+        if sessions is not None and native_key:
+            key = resumable_history_key(row, sessions=sessions, native_key=native_key)
+        else:
+            key = history_dashboard_key(row.get("key"))
+        if key is None or key in seen:
             continue
+        seen.add(key)
         raw_title = str(row.get("title") or key.removeprefix("dashboard:"))
         title = display_safe(" ".join(raw_title.split()), TITLE_LIMIT) or "Untitled session"
         eligible.append(SessionChoice(key=key, title=title))
@@ -741,6 +812,7 @@ class SessionResumeController:
         picker_owner: str,
         is_owner: bool,
         query: str = "",
+        native_key: str = "",
     ) -> None:
         """List eligible sessions and register only a picker that reached the surface."""
         operation = f"{self.channel_type}.sessions_data_access"
@@ -762,6 +834,8 @@ class SessionResumeController:
                 self.conv_log,
                 query,
                 surface.display_safe,
+                sessions=self.sessions,
+                native_key=native_key,
             )
         except Exception as exc:
             sel().log_api_access(

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -2536,6 +2536,10 @@ class SessionManager:
     def find_key_by_sid(self, sid: str) -> str | None:
         return self._session_map.find_key_by_sid(sid)
 
+    def reserve_generation(self, session_key: str) -> None:
+        """Persist a generation floor before its first provider turn."""
+        self._session_map.reserve_generation(session_key)
+
     def max_generation(self, bucket: str) -> int:
         """Highest persisted DM generation for a session bucket (see SessionMap)."""
         return self._session_map.max_generation(bucket)

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -31,6 +31,7 @@ from kiro_crew.messaging.link import (
     canonical_key,
     is_channel_session_key,
     legacy_dashboard_mirror_key,
+    split_dm_session_key,
 )
 from kiro_crew.sel import _infer_source, sel
 
@@ -62,6 +63,11 @@ def _kiro_sessions_dir() -> Path:
 # every conversation that had already turned it off.
 MIRROR_OPT_OUT_FLAG = "mirror_opt_out"
 
+# Highest explicit DM generation acknowledged before its first provider turn.
+# Stored on the stable bucket entry so repeated /new commands cost one integer,
+# not one immortal map row per empty generation.
+GENERATION_FLOOR_FIELD = "generation_floor"
+
 # Flags that are durable SETTINGS rather than session-scoped state, and so keep
 # their entry alive through :meth:`SessionMap.prune`. Membership is opt-in
 # BECAUSE immortality has a cost: an entry that prune can never collect is a row
@@ -90,14 +96,18 @@ def _has_durable_flag(entry: dict) -> bool:
 def _survives_prune(entry: dict) -> bool:
     """True iff *entry* holds state that must outlive its native session.
 
-    The ONE predicate behind every stale branch of :meth:`SessionMap.prune`, so
-    they cannot disagree about what a missing session file is allowed to take
-    with it. Two kinds of state qualify: a durable flag (a per-conversation
-    setting) and a channel binding — a Slack thread or a ``mirror`` — which is
-    the identity that routes a conversation back to its channel. Prune may clear
-    a stale ``sid`` on such an entry, but never discards the entry itself.
+    Durable settings, an explicit generation floor, and channel bindings all
+    outlive a provider session. The generation floor prevents a restart from
+    reusing a history key after ``/new`` was acknowledged before the first turn.
     """
-    return bool(_has_durable_flag(entry) or entry.get("slack_thread_ts") or entry.get("mirror"))
+    floor = entry.get(GENERATION_FLOOR_FIELD)
+    has_generation_floor = isinstance(floor, int) and not isinstance(floor, bool) and floor > 0
+    return bool(
+        _has_durable_flag(entry)
+        or has_generation_floor
+        or entry.get("slack_thread_ts")
+        or entry.get("mirror")
+    )
 
 
 # The callable shape a lost-binding announcement is delivered through:
@@ -1631,19 +1641,43 @@ class SessionMap:
         return entry.get("mirror_paused") is True
 
     @_guarded
+    def reserve_generation(self, session_key: str) -> None:
+        """Persist the generation in *session_key* before its first provider turn.
+
+        The watermark lives on the stable bucket entry instead of materializing
+        one map row per empty generation. It is monotonic: a delayed or repeated
+        command can never lower the restart seed and make an older history key
+        reusable.
+        """
+        parsed = split_dm_session_key(canonical_key(session_key))
+        if parsed is None:
+            raise ValueError(f"not a canonical DM session key: {session_key!r}")
+        bucket, generation = parsed
+        if generation <= 0:
+            return
+        entry = self._ensure_entry(bucket)
+        current = entry.get(GENERATION_FLOOR_FIELD)
+        if isinstance(current, int) and not isinstance(current, bool) and current >= generation:
+            return
+        entry[GENERATION_FLOOR_FIELD] = generation
+        self._save()
+
+    @_guarded
     def max_generation(self, bucket: str) -> int:
         """Return the highest persisted DM generation for a session *bucket*.
 
         The bucket is the generation-0 key (e.g.
         ``telegram:<agent>:direct:<user>``); generations persist as ``{bucket}``
-        (gen 0) and ``{bucket}:gen{N}``. Returns the max ``N`` with a persisted
-        entry, or -1 when the bucket has none. Channels seed their in-memory
-        generation counter from this so ``/new`` and idle/daily reset advance
-        past any generation left on disk (restart-safe) instead of colliding
-        with a stale session and resuming it.
+        (gen 0) and ``{bucket}:gen{N}``. An explicit ``/new`` also records a
+        monotonic generation floor on the bucket before the first provider turn.
+        Returns the highest of those sources, or -1 when the bucket has none.
         """
         bucket = canonical_key(bucket)
         best = 0 if bucket in self._data else -1
+        entry = self._data.get(bucket)
+        floor = entry.get(GENERATION_FLOOR_FIELD) if entry else None
+        if isinstance(floor, int) and not isinstance(floor, bool):
+            best = max(best, floor)
         prefix = f"{bucket}:gen"
         for key in self._data:
             if key.startswith(prefix):

--- a/src/kiro_crew/teams/cards.py
+++ b/src/kiro_crew/teams/cards.py
@@ -145,7 +145,7 @@ def options_card(*, prompt: str, options: list[str], nonce: str) -> dict[str, An
 
 
 def session_picker_card(*, prompt: str, choices: Any, nonce: str) -> dict[str, Any]:
-    """The ``/sessions`` picker: one Submit per offered dashboard session.
+    """The ``/sessions`` picker: one Submit per offered session.
 
     The payload carries only the nonce and the INDEX -- never the session key. A submit
     is client input, so a key in it would be an instruction to bind whatever the sender

--- a/src/kiro_crew/teams/session_resume.py
+++ b/src/kiro_crew/teams/session_resume.py
@@ -34,6 +34,7 @@ from kiro_crew.messaging.session_resume import (
     RoutingDecision,
     SessionChoice,
     SessionResumeController,
+    same_bucket_origin_keys,
 )
 from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.teams.cards import resolved_card, session_picker_card
@@ -106,10 +107,10 @@ class _TeamsResumeSurface:
         if normalized:
             label = _safe_teams_text(" ".join(query.split()), 100)
             return (
-                f"No dashboard sessions matched “{label}”. Try fewer words, or run "
+                f"No sessions matched “{label}”. Try fewer words, or run "
                 f"`/sessions` to see up to {PICKER_LIMIT} recent sessions."
             )
-        return "No recent dashboard sessions."
+        return "No recent sessions."
 
     def picker_heading(self, query: str, total: int) -> str:
         return _picker_heading(query, total, " ".join(query.casefold().split()))
@@ -157,7 +158,7 @@ class _TeamsResumeSurface:
 
 
 class TeamsSessionResume:
-    """Lists dashboard sessions and binds one bidirectionally to a Teams chat."""
+    """Lists dashboard + same-chat native sessions and binds one to Teams."""
 
     def __init__(
         self,
@@ -250,6 +251,7 @@ class TeamsSessionResume:
         conversation_id: str,
         service_url: str,
         query: str = "",
+        native_key: str = "",
     ) -> None:
         """Post the session picker, or say why there is nothing to post."""
         await self._controller.show_picker(
@@ -258,6 +260,7 @@ class TeamsSessionResume:
             picker_owner=identity,
             is_owner=self.is_owner(identity),
             query=query,
+            native_key=native_key,
         )
 
     async def choose(
@@ -269,8 +272,10 @@ class TeamsSessionResume:
         activity_id: str,
         nonce: str,
         index: int,
+        native_key: str = "",
     ) -> None:
         """Resolve a picker press: bind the chosen session, or say why not."""
+        link = self.link_for(conversation_id)
         choice = await self._controller.choose(
             _TeamsResumeSurface(client, conversation_id, service_url),
             caller=identity or "unknown",
@@ -279,7 +284,8 @@ class TeamsSessionResume:
             message_id=activity_id,
             nonce=nonce,
             index=index,
-            link=self.link_for(conversation_id),
+            link=link,
+            replace_outbound_keys=same_bucket_origin_keys(self.sessions, link, native_key),
         )
         if choice is not None:
             await self._replay(client, conversation_id, service_url, choice.key)
@@ -345,16 +351,15 @@ def _picker_heading(query: str, total: int, normalized: str) -> str:
         else:
             summary = f"Showing {shown} matching session{'s' if shown != 1 else ''}"
         return (
-            f"🔎 **Dashboard session search**\n{summary} for “{label}”, ranked over "
+            f"🔎 **Session search**\n{summary} for “{label}”, ranked over "
             "titles and message content.\nChoose one to continue here; `/unlink` comes back."
         )
     if total > PICKER_LIMIT:
-        summary = f"Showing {PICKER_LIMIT} of {total} most recent dashboard sessions."
+        summary = f"Showing {PICKER_LIMIT} of {total} most recent sessions."
     else:
-        summary = f"Showing {shown} most recent dashboard session{'s' if shown != 1 else ''}."
+        summary = f"Showing {shown} most recent session{'s' if shown != 1 else ''}."
     return (
-        f"🧵 **Recent dashboard sessions**\n{summary}\nChoose one to continue here; "
-        "`/unlink` comes back."
+        f"🧵 **Recent sessions**\n{summary}\nChoose one to continue here; " "`/unlink` comes back."
     )
 
 

--- a/src/kiro_crew/teams/transport_dispatch.py
+++ b/src/kiro_crew/teams/transport_dispatch.py
@@ -48,7 +48,7 @@ from kiro_crew.messaging.commands import (
     run_yolo_command,
     stop_running_turn,
 )
-from kiro_crew.messaging.conversation import ConversationState
+from kiro_crew.messaging.conversation import ConversationState, reserve_new_generation
 from kiro_crew.messaging.dispatch import (
     ChannelTurn,
     build_directive_consumer,
@@ -254,6 +254,7 @@ class TeamsDispatcher:
                     inbound.conversation_id,
                     inbound.service_url,
                     command_argument(text),
+                    native_key=self._session_key(email),
                 )
                 return
             if cmd == "new":
@@ -611,6 +612,7 @@ class TeamsDispatcher:
                 inbound.reply_to_id or inbound.activity_id,
                 payload["nonce"],
                 int(payload["index"]),
+                native_key=self._session_key(identity),
             )
             return
         # An option chip: resolve the label from what this turn actually offered,
@@ -971,6 +973,12 @@ class TeamsDispatcher:
             self.sessions.clear_queue(session_key)
             await self._queue.finish_cancelled_locked(session_key, self._receipt_surface(inbound))
         self._conv.bump_gen(identity)
+        new_session_key = self._session_key(identity)
+        saved = await reserve_new_generation(
+            self.sessions,
+            new_session_key,
+            channel_type="Teams",
+        )
         # Retire the OLD generation's renderer here. A renderer kept alive for
         # outstanding chips is keyed by the pre-bump session key, and the next turn
         # assigns under the new one -- so nothing else ever pops this entry, and each
@@ -981,6 +989,8 @@ class TeamsDispatcher:
         message = "✅ Started a fresh conversation."
         if left_resumed is not None:
             message = "✅ Started a fresh conversation — left the resumed dashboard session."
+        if not saved:
+            message += "\n⚠️ The new conversation could not be saved for restart."
         await self._reply(inbound, message)
 
     # ── Helpers ────────────────────────────────────────────────────────────

--- a/src/kiro_crew/telegram/session_resume.py
+++ b/src/kiro_crew/telegram/session_resume.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-from kiro_crew.messaging.link import ChannelLink, parse_session_key
+from kiro_crew.messaging.link import ChannelLink
 from kiro_crew.messaging.renderer import display_safe
 from kiro_crew.messaging.session_resume import ResumeReleaseError  # noqa: F401  (re-export)
 from kiro_crew.messaging.session_resume import (
@@ -17,6 +17,7 @@ from kiro_crew.messaging.session_resume import (
     RoutingDecision,
     SessionChoice,
     SessionResumeController,
+    same_bucket_origin_keys,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -35,7 +36,7 @@ _CALLBACK_DATA_MAX_BYTES = 64
 _BUTTON_LABEL_MAX_CHARS = 80
 _QUERY_LABEL_MAX_CHARS = 100
 _ROUTE_OWNER_REFUSAL = (
-    "🔒 This Telegram chat cannot resume a dashboard session because session "
+    "🔒 This Telegram chat cannot resume a persistent session because session "
     "resume requires exactly one configured operator in a private DM. Your "
     "message was NOT processed."
 )
@@ -67,7 +68,7 @@ def _picker_owner(user_id: int, chat_id: int, thread_id: int | None) -> str:
 
 class _TelegramResumeSurface:
     owner_refusal = (
-        "🔒 /session can resume dashboard conversations only from the single "
+        "🔒 /session can resume persistent conversations only from the single "
         "operator's private chat. Configure exactly one telegram.allowed_user_ids entry."
     )
     choice_owner_refusal = "🔒 Session resume is owner-only."
@@ -102,10 +103,10 @@ class _TelegramResumeSurface:
         if normalized:
             label = _safe_telegram_text(" ".join(query.split()), _QUERY_LABEL_MAX_CHARS)
             return (
-                f"No dashboard sessions matched “{label}”. Try fewer words, or run "
+                f"No sessions matched “{label}”. Try fewer words, or run "
                 f"/session to see up to {PICKER_LIMIT} recent sessions."
             )
-        return "No recent dashboard sessions."
+        return "No recent sessions."
 
     def picker_heading(self, query: str, total: int) -> str:
         shown = min(total, PICKER_LIMIT)
@@ -117,21 +118,18 @@ class _TelegramResumeSurface:
             else:
                 summary = f"Showing {shown} matching session{'s' if shown != 1 else ''}"
             return (
-                f"🔎 Dashboard session search\n{summary} for “{label}”, ranked over "
+                f"🔎 Session search\n{summary} for “{label}”, ranked over "
                 "titles and message content."
             )
         if total > PICKER_LIMIT:
-            summary = f"Showing {PICKER_LIMIT} of {total} most recent dashboard sessions."
+            summary = f"Showing {PICKER_LIMIT} of {total} most recent sessions."
         else:
-            summary = (
-                f"Showing {shown} most recent dashboard session" f"{'s' if shown != 1 else ''}."
-            )
-        return f"🧵 Recent dashboard sessions\n{summary}"
+            summary = f"Showing {shown} most recent session{'s' if shown != 1 else ''}."
+        return f"🧵 Recent sessions\n{summary}"
 
     def choice_success(self, choice: SessionChoice) -> str:
         return (
-            f"🔄 Resumed: {choice.title}\n"
-            "Ordinary messages here now continue that dashboard conversation."
+            f"🔄 Resumed: {choice.title}\n" "Ordinary messages here now continue that conversation."
         )
 
     async def post_picker(
@@ -195,7 +193,7 @@ def _decision_says_anything(decision: RoutingDecision) -> bool:
 
 
 class TelegramSessionResume:
-    """List dashboard sessions and bind one to the single operator's private DM."""
+    """List dashboard + same-DM native sessions for the single operator."""
 
     def __init__(
         self,
@@ -315,40 +313,6 @@ class TelegramSessionResume:
                 logger.debug("Telegram resume: title lookup failed", exc_info=True)
         return title or session_key.removeprefix("dashboard:")
 
-    def _native_origin_keys(self, link: ChannelLink, native_key: str = "") -> frozenset[str]:
-        """Outbound occupants that are native generations of this Telegram DM.
-
-        A dashboard session explicitly mirrored to the same DM is not an origin
-        mirror and must remain protected. Legacy origin rows are resolved through
-        ``channel_key_for_stem`` before applying the same canonical-key test.
-
-        *native_key* is the dispatcher's own key for this chat and is matched
-        DIRECTLY, because the namespace test below cannot recognise every scope: with
-        ``dm_scope="unified"`` the native bucket is a ``unified:`` key, so without
-        this a one-click takeover would refuse and demand a preparatory ``/unlink``.
-        Only an occupant of THIS link qualifies, so supplying a key that is not
-        bound here grants nothing.
-        """
-        keys: set[str] = set()
-        stem_resolver = getattr(self.sessions, "channel_key_for_stem", None)
-        for stored_key in self.sessions.find_mirror_sessions(link):
-            if native_key and stored_key == native_key:
-                keys.add(stored_key)
-                continue
-            candidate = stored_key
-            parsed = parse_session_key(candidate)
-            if parsed is None and stored_key.startswith("dashboard:") and callable(stem_resolver):
-                candidate = str(stem_resolver(stored_key.removeprefix("dashboard:")) or "")
-                parsed = parse_session_key(candidate)
-            if (
-                parsed is not None
-                and parsed.surface == "telegram"
-                and parsed.chat_type == "direct"
-                and parsed.scope == (link.channel_id,)
-            ):
-                keys.add(stored_key)
-        return frozenset(keys)
-
     async def show_picker(
         self,
         client: "TelegramClient",
@@ -357,6 +321,7 @@ class TelegramSessionResume:
         chat_type: str,
         thread_id: int | None,
         query: str = "",
+        native_key: str = "",
     ) -> None:
         await self._controller.show_picker(
             _TelegramResumeSurface(client, chat_id, thread_id),
@@ -364,6 +329,7 @@ class TelegramSessionResume:
             picker_owner=_picker_owner(user_id, chat_id, thread_id),
             is_owner=self.is_owner(user_id, chat_id, chat_type),
             query=query,
+            native_key=native_key,
         )
 
     async def choose(
@@ -396,7 +362,7 @@ class TelegramSessionResume:
             nonce=nonce,
             index=index,
             link=link,
-            replace_outbound_keys=self._native_origin_keys(link, native_key),
+            replace_outbound_keys=same_bucket_origin_keys(self.sessions, link, native_key),
         )
 
     @staticmethod

--- a/src/kiro_crew/telegram/transport.py
+++ b/src/kiro_crew/telegram/transport.py
@@ -119,7 +119,7 @@ TELEGRAM_CAPABILITIES = TransportCapabilities(
     max_message_chars=TELEGRAM_CHUNK_LIMIT,
     max_buttons=25,
     supports_proactive_send=True,
-    # /session binds this exact Telegram DM back to a dashboard session, and
+    # /session binds this exact Telegram DM back to a persisted session, and
     # every ordinary inbound message resolves that durable binding first.
     supports_session_resume=True,
 )

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -55,6 +55,7 @@ from kiro_crew.messaging.commands import (
     stop_running_turn,
     task_arg_reply,
 )
+from kiro_crew.messaging.conversation import reserve_new_generation
 from kiro_crew.messaging.dispatch import (
     build_auto_approve,
     build_directive_consumer,
@@ -579,9 +580,17 @@ class TelegramDispatcher:
                 await self._reply(chat_id, _RELEASE_FAILURE, thread=reply_thread)
                 return
             self._conv.bump_gen(route)
+            new_session_key = self._session_key(route)
+            saved = await reserve_new_generation(
+                self.sessions,
+                new_session_key,
+                channel_type="Telegram",
+            )
             message = "✅ New conversation started."
             if left_resumed is not None:
                 message = "✅ New conversation started — left the resumed session."
+            if not saved:
+                message += "\n⚠️ The new conversation could not be saved for restart."
             await self._reply(chat_id, message, thread=reply_thread)
             return
         if cmd == "compact":
@@ -684,6 +693,7 @@ class TelegramDispatcher:
                 getattr(msg, "chat_type", "private"),
                 reply_thread,
                 query=parse_command_argument(text),
+                native_key=self._session_key(route),
             )
             return
         if cmd == "title":

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -58,6 +58,7 @@ from kiro_crew.messaging.approval import PendingApprovals, SessionApprovalDecide
 from kiro_crew.messaging.attachments import append_attachment_context
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
 from kiro_crew.messaging.commands import compact_unsupported_backend, compact_unsupported_reply
+from kiro_crew.messaging.conversation import reserve_new_generation
 from kiro_crew.messaging.dispatch import (
     ChannelTurn,
     build_directive_consumer,
@@ -370,7 +371,15 @@ class WebexDispatcher:
             cmd = parse_command(text)
             if cmd == "new":
                 self._conv.bump_gen(route)
-                await self._reply(inbound, "✅ Started a fresh conversation.")
+                saved = await reserve_new_generation(
+                    self.sessions,
+                    self._session_key(route),
+                    channel_type="Webex",
+                )
+                message = "✅ Started a fresh conversation."
+                if not saved:
+                    message += "\n⚠️ The new conversation could not be saved for restart."
+                await self._reply(inbound, message)
                 return
             if cmd == "compact":
                 self._conv.clear_awaiting(route)

--- a/src/kiro_crew/wecom/transport_dispatch.py
+++ b/src/kiro_crew/wecom/transport_dispatch.py
@@ -34,6 +34,7 @@ from kiro_crew.history import mint_row_mid
 from kiro_crew.messaging.attachments import append_attachment_context
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
 from kiro_crew.messaging.commands import compact_unsupported_backend
+from kiro_crew.messaging.conversation import reserve_new_generation
 from kiro_crew.messaging.dispatch import (
     ChannelTurn,
     build_directive_consumer,
@@ -139,7 +140,15 @@ class WeComDispatcher:
         cmd = None if has_media else parse_command(text)
         if cmd == "new":
             self._conv.bump_gen(userid)
-            await self.client.say(inbound, "✅ 已开始新对话")
+            saved = await reserve_new_generation(
+                self.sessions,
+                self._session_key(userid),
+                channel_type="WeCom",
+            )
+            message = "✅ 已开始新对话"
+            if not saved:
+                message += "\n⚠️ 新对话无法保存，重启后可能恢复到上一段对话。"
+            await self.client.say(inbound, message)
             return
         if cmd == "compact":
             self._conv.clear_awaiting(userid)

--- a/src/kiro_crew/weixin/transport_dispatch.py
+++ b/src/kiro_crew/weixin/transport_dispatch.py
@@ -38,6 +38,7 @@ from kiro_crew.history import mint_row_mid
 from kiro_crew.messaging.attachments import append_attachment_context
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
 from kiro_crew.messaging.commands import compact_unsupported_backend
+from kiro_crew.messaging.conversation import reserve_new_generation
 from kiro_crew.messaging.dispatch import (
     ChannelTurn,
     build_directive_consumer,
@@ -159,7 +160,15 @@ class WeixinDispatcher:
                 await self._say(user_id, _ATTACHMENT_WITH_COMMAND)
             if cmd == "new":
                 self._conv.bump_gen(user_id)
-                await self._say(user_id, _NEW_SESSION)
+                saved = await reserve_new_generation(
+                    self.sessions,
+                    self._session_key(user_id),
+                    channel_type="Weixin",
+                )
+                message = _NEW_SESSION
+                if not saved:
+                    message += "\n⚠️ 新对话无法保存，重启后可能恢复到上一段对话。"
+                await self._say(user_id, message)
                 return
             if cmd == "help":
                 await self._say(user_id, build_help())

--- a/src/kiro_crew/whatsapp/transport_dispatch.py
+++ b/src/kiro_crew/whatsapp/transport_dispatch.py
@@ -22,7 +22,7 @@ from kiro_crew.messaging.approval import (
     pending_for,
 )
 from kiro_crew.messaging.commands import compact_unsupported_backend
-from kiro_crew.messaging.conversation import ConversationState
+from kiro_crew.messaging.conversation import ConversationState, reserve_new_generation
 from kiro_crew.messaging.dispatch import (
     ChannelTurn,
     delivery_is_muted,
@@ -177,7 +177,15 @@ class WhatsAppDispatcher:
         scope = inbound.conversation_id
         if command == "new":
             self._conv.bump_gen(scope)
-            await self._say(scope, NEW_SESSION_TEXT)
+            saved = await reserve_new_generation(
+                self.sessions,
+                self._session_key(scope),
+                channel_type="WhatsApp",
+            )
+            message = NEW_SESSION_TEXT
+            if not saved:
+                message += "\n⚠️ The new conversation could not be saved for restart."
+            await self._say(scope, message)
         elif command == "compact":
             # Clear the nudge flag first, so the soft-threshold nudge can fire
             # again once the context refills after this compaction.

--- a/test/test_conversation.py
+++ b/test/test_conversation.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from kiro_crew.messaging.conversation import ConversationState
+from kiro_crew.messaging.conversation import ConversationState, reserve_new_generation
 from kiro_crew.session_map import SessionMap
 
 
@@ -125,5 +125,44 @@ class TestRestartRegression:
         conv: ConversationState[str] = ConversationState(
             seed_fn=lambda k: session_map.max_generation(b)
         )
-        assert conv.current_gen("U") == 2   # resume the latest, not stale gen0
-        assert conv.bump_gen("U") == 3      # /new → fresh, no collision with gen1/gen2
+        assert conv.current_gen("U") == 2  # resume the latest, not stale gen0
+        assert conv.bump_gen("U") == 3  # /new → fresh, no collision with gen1/gen2
+
+
+class _ReservationSessions:
+    def __init__(self, *, flush_error: Exception | None = None) -> None:
+        self.reserved: list[str] = []
+        self.flushes = 0
+        self.flush_error = flush_error
+
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved.append(session_key)
+
+    async def aflush(self) -> None:
+        self.flushes += 1
+        if self.flush_error is not None:
+            raise self.flush_error
+
+
+class TestReserveNewGeneration:
+    @pytest.mark.asyncio
+    async def test_reserves_and_flushes_before_success(self) -> None:
+        sessions = _ReservationSessions()
+        key = "telegram:kirocrew:direct:u1:gen3"
+
+        assert await reserve_new_generation(sessions, key, channel_type="Telegram") is True
+        assert sessions.reserved == [key]
+        assert sessions.flushes == 1
+
+    @pytest.mark.asyncio
+    async def test_flush_failure_is_reported_to_the_channel(self) -> None:
+        sessions = _ReservationSessions(flush_error=OSError("disk unavailable"))
+
+        assert (
+            await reserve_new_generation(
+                sessions,
+                "telegram:kirocrew:direct:u1:gen3",
+                channel_type="Telegram",
+            )
+            is False
+        )

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -16,6 +16,7 @@ from kiro_crew.discord.client import DISCORD_CHUNK_LIMIT, DiscordInteraction
 from kiro_crew.discord.commands import parse_command, parse_command_argument
 from kiro_crew.discord.renderer import session_provenance_tag
 from kiro_crew.discord.transport_dispatch import DiscordDispatcher
+from kiro_crew.history import transcript_stem
 from kiro_crew.messaging import resume_expectation
 from kiro_crew.messaging import session_resume as session_resume_core
 from kiro_crew.messaging.link import UNBIND_REASON_UNSPECIFIED, ChannelLink
@@ -122,6 +123,7 @@ class _Sessions:
         self.begin_turns = 0
         self.flushed: list[dict] = []
         self.flush_error: Exception | None = None
+        self.reserve_error: Exception | None = None
         self.origin_links: dict[str, ChannelLink] = {}
         self.inbound_keys: set[str] = set()
         self.mirror_opt_outs: set[str] = set()
@@ -130,6 +132,8 @@ class _Sessions:
         self.unbind_reasons: list[str] = []
         self.last_key = ""
         self.targeted: list[tuple[str, str]] = []
+        self.channel_keys: set[str] = set()
+        self.reserved_generations: set[str] = set()
         self.provider = _Provider()
 
     def set_mirror_link(
@@ -209,8 +213,28 @@ class _Sessions:
             self.mirror_links.pop(key, None)
         return cleared
 
+    def reserve_generation(self, session_key: str) -> None:
+        if self.reserve_error is not None:
+            raise self.reserve_error
+        self.reserved_generations.add(session_key)
+        self.channel_keys.add(session_key)
+
     def max_generation(self, bucket: str) -> int:
-        return -1
+        prefix = f"{bucket}:gen"
+        return max(
+            (
+                int(key[len(prefix) :])
+                for key in self.reserved_generations
+                if key.startswith(prefix) and key[len(prefix) :].isdigit()
+            ),
+            default=-1,
+        )
+
+    def channel_key_for_stem(self, stem: str) -> str:
+        for key in self.channel_keys | set(self.mirror_links):
+            if transcript_stem(key) == stem:
+                return key
+        return ""
 
     def is_busy(self, key: str) -> bool:
         return False
@@ -225,6 +249,7 @@ class _Sessions:
     async def get_or_create(self, key: str, **kwargs: Any) -> tuple[Any, bool, bool]:
         self.last_key = key
         self.last_agent = kwargs.get("agent")
+        self.channel_keys.add(key)
         return self.provider, getattr(self, "is_new_result", False), True
 
     def begin_turn(self, key: str) -> None:
@@ -329,6 +354,23 @@ class _ConversationLog:
     ) -> None:
         self.messages.setdefault(key, []).append({"role": role, "content": content})
 
+    def update_metadata(self, key: str, fields: dict) -> None:
+        self.metadata.setdefault(key, {}).update(fields)
+        self.messages.setdefault(key, [])
+        stem = transcript_stem(key)
+        for row in self.rows:
+            if row.get("key") == stem:
+                row.update(fields)
+                break
+        else:
+            self.rows.insert(0, {"key": stem, **fields})
+
+    def update_metadata_if(self, key: str, fields: dict, guard: Any) -> bool:
+        if not guard(self.metadata.get(key, {})):
+            return False
+        self.update_metadata(key, fields)
+        return True
+
     def set_title(self, key: str, title: str) -> None:
         self.titles_set = getattr(self, "titles_set", [])
         self.titles_set.append((key, title))
@@ -370,8 +412,10 @@ def _config() -> Any:
 def _dispatcher(
     allowed: set[str],
     log: _ConversationLog | None,
+    *,
+    sessions: _Sessions | None = None,
 ) -> tuple[DiscordDispatcher, _Client, _Sessions]:
-    sessions = _Sessions()
+    sessions = sessions or _Sessions()
     dispatcher = DiscordDispatcher(
         sessions=sessions,  # type: ignore[arg-type]
         ctx_builder=_Context(),  # type: ignore[arg-type]
@@ -550,7 +594,7 @@ async def test_sessions_keyword_filters_beyond_recent_limit() -> None:
 
     text, _ = client.sent[-1]
     assert _picker_labels(client) == ["1. Codex compaction investigation"]
-    assert "Dashboard session search" in text
+    assert "Session search" in text
     assert "for `codex`" in text
 
 
@@ -572,7 +616,7 @@ async def test_sessions_no_match_is_explicit() -> None:
 
     text, components = client.sent[-1]
     assert components is None
-    assert "No dashboard sessions matched `missing topic`" in text
+    assert "No sessions matched `missing topic`" in text
     assert "Try fewer words" in text
     assert "`!sessions`" in text
     assert len(dispatcher._session_pickers) == 0
@@ -586,7 +630,7 @@ async def test_empty_sessions_query_keeps_recent_order_and_discloses_cap() -> No
     await dispatcher.handle_message(_message("!sessions   "))
 
     assert _picker_labels(client) == [f"{index + 1}. Recent session {index}" for index in range(10)]
-    assert "Showing 10 of 12 most recent dashboard sessions" in client.sent[-1][0]
+    assert "Showing 10 of 12 most recent sessions" in client.sent[-1][0]
 
 
 @pytest.mark.asyncio
@@ -613,8 +657,10 @@ async def test_sessions_requires_exactly_one_allowed_user() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sessions_lists_only_persistent_dashboard_sessions_and_redacts() -> None:
+async def test_sessions_lists_dashboard_and_same_dm_generations_only_and_redacts() -> None:
     secret = "ghp_" + "a" * 36
+    prior_key = "discord:kirocrew:direct:u1:gen4"
+    other_user_key = "discord:kirocrew:direct:u2:gen4"
     log = _ConversationLog(
         [
             {
@@ -628,24 +674,114 @@ async def test_sessions_lists_only_persistent_dashboard_sessions_and_redacts() -
                 "memory_mode": "persistent",
             },
             {
+                "key": transcript_stem(prior_key),
+                "title": "Earlier Discord generation",
+                "memory_mode": "persistent",
+            },
+            {
+                "key": transcript_stem(other_user_key),
+                "title": "Another user's Discord session",
+                "memory_mode": "persistent",
+            },
+            {
                 "key": "dashboard_private",
                 "title": "Incognito",
                 "memory_mode": "temporary",
             },
         ],
-        {"dashboard:chat-1": []},
+        {
+            "dashboard:chat-1": [],
+            "discord:kirocrew:direct:u1": [],
+            prior_key: [],
+            other_user_key: [],
+        },
     )
-    dispatcher, client, _ = _dispatcher({"u1"}, log)
+    dispatcher, client, sessions = _dispatcher({"u1"}, log)
+    sessions.channel_keys.update({dispatcher.current_session_key("u1"), prior_key, other_user_key})
 
     await dispatcher.handle_message(_message("!sessions"))
 
     text, components = client.sent[-1]
     buttons = [button for row in components for button in row["components"]]
-    assert "Recent dashboard sessions" in text
-    assert len(buttons) == 1
+    assert "Recent sessions" in text
+    labels = [button["label"] for button in buttons]
+    assert labels[0].startswith("1. Deploy with [REDACTED")
+    assert labels[1:] == [
+        "2. Current Discord session",
+        "3. Earlier Discord generation",
+    ]
     assert buttons[0]["custom_id"].startswith("s:")
     assert secret not in buttons[0]["label"]
     assert "REDACTED" in buttons[0]["label"]
+
+
+@pytest.mark.asyncio
+async def test_repeated_new_does_not_materialize_empty_history_rows() -> None:
+    log = _log()
+    dispatcher, _, sessions = _dispatcher({"u1"}, log)
+
+    await dispatcher.handle_message(_message("!new"))
+    first_key = dispatcher.current_session_key("u1")
+    await dispatcher.handle_message(_message("!new"))
+    second_key = dispatcher.current_session_key("u1")
+
+    assert first_key != second_key
+    assert not log.has_log(first_key)
+    assert not log.has_log(second_key)
+    assert {first_key, second_key} <= sessions.reserved_generations
+
+
+@pytest.mark.asyncio
+async def test_new_generation_survives_restart_before_its_first_turn() -> None:
+    log = _log()
+    dispatcher, _, sessions = _dispatcher({"u1"}, log)
+
+    await dispatcher.handle_message(_message("!new"))
+    new_key = dispatcher.current_session_key("u1")
+
+    restarted, _, _ = _dispatcher({"u1"}, log, sessions=sessions)
+    assert restarted.current_session_key("u1") == new_key
+
+
+@pytest.mark.asyncio
+async def test_new_reports_generation_floor_failure_without_rolling_back() -> None:
+    log = _log()
+    dispatcher, client, sessions = _dispatcher({"u1"}, log)
+    old_key = dispatcher.current_session_key("u1")
+    sessions.reserve_error = OSError("disk unavailable")
+
+    await dispatcher.handle_message(_message("!new"))
+
+    assert dispatcher.current_session_key("u1") != old_key
+    assert "could not be saved for restart" in client.sent[-1][0]
+
+
+@pytest.mark.asyncio
+async def test_native_generation_pick_replaces_only_same_dm_origin_mirrors() -> None:
+    prior_key = "discord:kirocrew:direct:u1:gen4"
+    log = _ConversationLog(
+        [
+            {
+                "key": transcript_stem(prior_key),
+                "title": "Earlier Discord generation",
+                "memory_mode": "persistent",
+            }
+        ],
+        {prior_key: []},
+    )
+    dispatcher, client, sessions = _dispatcher({"u1"}, log)
+    current_key = dispatcher.current_session_key("u1")
+    sessions.channel_keys.update({current_key, prior_key})
+    link = ChannelLink(channel_type="discord", channel_id="c1")
+    sessions.set_mirror_link(current_key, link)
+    sessions.set_mirror_link(prior_key, link)
+
+    await dispatcher.handle_message(_message("!sessions"))
+    custom_id, message_id = _picker_button(client)
+    await dispatcher.on_interaction(_interaction(custom_id, message_id))
+
+    assert sessions.find_mirror_sessions(link, inbound_only=True) == [prior_key]
+    assert current_key not in sessions.mirror_links
 
 
 @pytest.mark.asyncio

--- a/test/test_feishu_dispatch.py
+++ b/test/test_feishu_dispatch.py
@@ -81,6 +81,7 @@ class FakeSessions:
         self.channels: list = []
         self.last_agent = None
         self._max_gen: dict[str, int] = {}
+        self.reserved_generations: list[str] = []
         # `closing` mirrors SessionManager._closing so begin_turn refuses the
         # dispatch the way the real gate does after close_all.
         self.closing = False
@@ -125,6 +126,12 @@ class FakeSessions:
 
     def is_busy(self, key) -> bool:
         return getattr(self, "_busy", False)
+
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.append(session_key)
+
+    async def aflush(self) -> None:
+        return None
 
     def max_generation(self, bucket: str) -> int:
         return self._max_gen.get(bucket, -1)
@@ -626,6 +633,7 @@ class TestCommands:
         assert client.replies == [("msg1", "✅ 已开始新对话")]
         route = d._route(_inbound("/new"))
         assert d._conv.current_gen(route) == 1
+        assert sessions.reserved_generations == [d._session_key(route)]
         assert sessions.successes == []  # no LLM turn
 
     @pytest.mark.asyncio

--- a/test/test_imessage_dispatch.py
+++ b/test/test_imessage_dispatch.py
@@ -63,6 +63,7 @@ class FakeSessions:
         self.released: list[str] = []
         self.acquire_ok = True
         self.usage_pct = 0.0
+        self.reserved_generations: list[str] = []
 
     def is_busy(self, key: str) -> bool:
         return key in self.busy
@@ -93,6 +94,12 @@ class FakeSessions:
 
     def list_sessions(self) -> list[str]:
         return sorted(self.sessions)
+
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.append(session_key)
+
+    async def aflush(self) -> None:
+        return None
 
     def max_generation(self, *_args: object, **_kwargs: object) -> int:
         """No prior generation to seed from — a fresh install starts at 0."""
@@ -161,10 +168,12 @@ class TestCommandIntercept:
 
     @pytest.mark.asyncio
     async def test_new_bumps_the_generation_so_the_session_key_changes(self) -> None:
-        dispatcher, client, _ = _dispatcher()
+        dispatcher, client, sessions = _dispatcher()
         before = dispatcher._session_key(HANDLE)
         await dispatcher.handle_message(_inbound("/new"))
-        assert dispatcher._session_key(HANDLE) != before
+        after = dispatcher._session_key(HANDLE)
+        assert after != before
+        assert sessions.reserved_generations == [after]
         assert "fresh conversation" in client.sent[0]
 
     @pytest.mark.asyncio

--- a/test/test_messaging_link.py
+++ b/test/test_messaging_link.py
@@ -26,6 +26,7 @@ from kiro_crew.messaging.link import (
     legacy_dashboard_mirror_key,
     rebind_conversation_location,
     should_rotate_generation,
+    split_dm_session_key,
 )
 from kiro_crew.session_map import ConversationOwnershipConflict
 
@@ -69,6 +70,19 @@ class TestBuildDmSessionKey:
             build_dm_session_key("telegram", "a", "1", gen=3, dm_scope=DM_SCOPE_UNIFIED)
             == "unified:a:gen3"
         )
+
+    def test_split_standard_and_unified_generations(self) -> None:
+        assert split_dm_session_key("telegram:a:direct:1:gen3") == (
+            "telegram:a:direct:1",
+            3,
+        )
+        assert split_dm_session_key("unified:a:gen4") == ("unified:a", 4)
+        assert split_dm_session_key("unified:a") == ("unified:a", 0)
+
+    def test_split_rejects_noncanonical_unified_shapes(self) -> None:
+        assert split_dm_session_key("unified") is None
+        assert split_dm_session_key("unified::gen2") is None
+        assert split_dm_session_key("unified:a:extra:gen2") is None
 
     def test_unknown_scope_falls_back_to_per_channel_peer(self) -> None:
         assert build_dm_session_key(

--- a/test/test_session_map_conv_state.py
+++ b/test/test_session_map_conv_state.py
@@ -136,3 +136,33 @@ class TestNoClobber:
         assert sm2.get_agent_override("slack:1.2") == "researcher"
         # reverse index for challenge-redirect resume is intact
         assert sm2.get_session_for_thread("1.2") == "slack:1.2"
+
+
+class TestGenerationFloor:
+    def test_explicit_generation_survives_reload_and_prune(self, patched):
+        tmp, _ = patched
+        bucket = "discord:kirocrew:direct:u1"
+        sm = SessionMap()
+
+        sm.reserve_generation(f"{bucket}:gen4")
+
+        reloaded = SessionMap()
+        assert reloaded.max_generation(bucket) == 4
+        assert reloaded.prune() == 0
+        assert reloaded.max_generation(bucket) == 4
+        raw = json.loads((tmp / "session_map.json").read_text(encoding="utf-8"))
+        assert raw[bucket]["generation_floor"] == 4
+        assert f"{bucket}:gen4" not in raw
+
+    def test_generation_floor_is_monotonic_and_supports_unified_keys(self, patched):
+        sm = SessionMap()
+        sm.reserve_generation("discord:kirocrew:direct:u1:gen5")
+        sm.reserve_generation("discord:kirocrew:direct:u1:gen2")
+        sm.reserve_generation("unified:kirocrew:gen3")
+
+        assert sm.max_generation("discord:kirocrew:direct:u1") == 5
+        assert sm.max_generation("unified:kirocrew") == 3
+
+    def test_non_dm_key_is_rejected(self, patched):
+        with pytest.raises(ValueError, match="not a canonical DM session key"):
+            SessionMap().reserve_generation("dashboard:chat-1")

--- a/test/test_teams_dispatch.py
+++ b/test/test_teams_dispatch.py
@@ -72,6 +72,7 @@ class FakeSessions:
         self.mirror_links: dict = {}
         self.opt_outs: dict = {}
         self.locked = False
+        self.reserved_generations: list[str] = []
 
     # -- dashboard mirror -------------------------------------------------
     def mirror_opt_out(self, key) -> bool:
@@ -162,6 +163,9 @@ class FakeSessions:
 
     def is_busy(self, key) -> bool:
         return self._busy
+
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.append(session_key)
 
     def max_generation(self, bucket: str) -> int:
         return -1
@@ -377,6 +381,7 @@ class TestCommands:
 
         assert client.sent == [("CONV", "✅ Started a fresh conversation.", _SVC)]
         assert d._conv.current_gen(_EMAIL) == 1
+        assert sessions.reserved_generations == [d._session_key(_EMAIL)]
         assert sessions.successes == []
 
     @pytest.mark.asyncio

--- a/test/test_teams_sessions.py
+++ b/test/test_teams_sessions.py
@@ -25,6 +25,7 @@ from typing import Any
 
 import pytest
 
+from kiro_crew.history import transcript_stem
 from kiro_crew.messaging import session_resume as core
 from kiro_crew.messaging.link import ChannelLink
 from kiro_crew.session_map import ConversationOwnershipConflict
@@ -93,6 +94,7 @@ class _ConversationLog:
     def __init__(self, rows: list[dict], logs: dict[str, list[dict]] | None = None) -> None:
         self.rows = rows
         self.logs = logs or {}
+        self.metadata: dict[str, dict] = {}
         self.searched: list[str] = []
 
     def list_sessions(self) -> list[dict]:
@@ -104,10 +106,26 @@ class _ConversationLog:
         return [r for r in self.rows if needle in str(r.get("title", "")).casefold()]
 
     def get_metadata(self, key: str) -> dict:
+        if key in self.metadata:
+            return dict(self.metadata[key])
         for row in self.rows:
             if str(row.get("key", "")).endswith(key.removeprefix("dashboard:")):
                 return {"title": row.get("title", "")}
         return {}
+
+    def update_metadata_if(self, key: str, fields: dict, guard: Any) -> bool:
+        if not guard(self.metadata.get(key, {})):
+            return False
+        self.metadata.setdefault(key, {}).update(fields)
+        self.logs.setdefault(key, [])
+        stem = transcript_stem(key)
+        for row in self.rows:
+            if row.get("key") == stem:
+                row.update(fields)
+                break
+        else:
+            self.rows.insert(0, {"key": stem, **fields})
+        return True
 
     def has_log(self, key: str) -> bool:
         return key in self.logs
@@ -123,6 +141,8 @@ class _Sessions:
         self.flush_fails = flush_fails
         self.cleared: list[str] = []
         self.queues: dict[str, list] = {}
+        self.channel_keys: set[str] = set()
+        self.reserved_generations: set[str] = set()
 
     # -- mirror bindings --
     def find_mirror_sessions(self, link, *, inbound_only: bool = False) -> list:
@@ -157,8 +177,26 @@ class _Sessions:
     def is_busy(self, key) -> bool:
         return False
 
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.add(session_key)
+        self.channel_keys.add(session_key)
+
     def max_generation(self, bucket: str) -> int:
-        return -1
+        prefix = f"{bucket}:gen"
+        return max(
+            (
+                int(key[len(prefix) :])
+                for key in self.reserved_generations
+                if key.startswith(prefix) and key[len(prefix) :].isdigit()
+            ),
+            default=-1,
+        )
+
+    def channel_key_for_stem(self, stem: str) -> str:
+        for key in self.channel_keys | set(self.mirror_links):
+            if transcript_stem(key) == stem:
+                return key
+        return ""
 
     def clear_queue(self, key) -> None:
         self.cleared.append(key)
@@ -293,6 +331,32 @@ class TestThePicker:
         assert titles == ["1. Launch plan", "2. Billing"]
 
     @pytest.mark.asyncio
+    async def test_it_offers_only_this_identity_native_generations(self) -> None:
+        prior_key = "teams:kirocrew:direct:owner@example.com:gen4"
+        other_key = "teams:kirocrew:direct:other@example.com:gen4"
+        rows = _rows("Launch plan") + [
+            {
+                "key": transcript_stem(prior_key),
+                "title": "Earlier Teams generation",
+                "memory_mode": "persistent",
+            },
+            {
+                "key": transcript_stem(other_key),
+                "title": "Another Teams identity",
+                "memory_mode": "persistent",
+            },
+        ]
+        log = _ConversationLog(rows, {"dashboard:chat-1": [], prior_key: [], other_key: []})
+        client, sessions = _Client(), _Sessions()
+        sessions.channel_keys.update({prior_key, other_key})
+        d = _dispatcher(sessions, client, log)
+
+        await d.handle_message(_inbound("/sessions"))
+
+        titles = [a["title"] for a in client.cards[0]["content"]["actions"]]
+        assert titles == ["1. Launch plan", "2. Earlier Teams generation"]
+
+    @pytest.mark.asyncio
     async def test_the_payload_carries_an_index_never_a_session_key(self) -> None:
         """A submit is client input, so a key in it would be an instruction."""
         client = _Client()
@@ -336,7 +400,7 @@ class TestThePicker:
         await d.handle_message(_inbound("/sessions nothing-like-this"))
 
         assert client.cards == []
-        assert "No dashboard sessions matched" in client.sent[-1]
+        assert "No sessions matched" in client.sent[-1]
 
     @pytest.mark.asyncio
     async def test_a_card_that_could_not_be_posted_registers_no_nonce(self) -> None:
@@ -761,6 +825,22 @@ class TestLeaving:
         assert "left the resumed dashboard session" in client.sent[-1]
 
     @pytest.mark.asyncio
+    async def test_repeated_new_does_not_materialize_empty_history_rows(self) -> None:
+        client, sessions = _Client(), _Sessions()
+        log = _ConversationLog(_rows("Launch plan"), {"dashboard:chat-1": []})
+        d = _dispatcher(sessions, client, log)
+
+        await d.handle_message(_inbound("/new"))
+        first_key = d._session_key(_OWNER)
+        await d.handle_message(_inbound("/new"))
+        second_key = d._session_key(_OWNER)
+
+        assert first_key != second_key
+        assert not log.has_log(first_key)
+        assert not log.has_log(second_key)
+        assert {first_key, second_key} <= sessions.reserved_generations
+
+    @pytest.mark.asyncio
     async def test_a_release_that_is_not_durable_changes_nothing_and_says_so(self) -> None:
         """A cleared owner whose flush failed would run natively in silence until the
         persisted binding revived on restart, splitting one history in two."""
@@ -966,7 +1046,7 @@ class TestWhenListingCannotHappen:
 
         await d.handle_message(_inbound("/sessions"))
 
-        assert client.sent[-1] == "No recent dashboard sessions."
+        assert client.sent[-1] == "No recent sessions."
 
     @pytest.mark.asyncio
     async def test_the_heading_says_how_much_was_cut(self) -> None:

--- a/test/test_telegram_parity.py
+++ b/test/test_telegram_parity.py
@@ -1248,7 +1248,7 @@ class TestSessionsCommand:
 
         heading, markup = client.sent[-1]
         labels = [row[0]["text"] for row in markup["inline_keyboard"]]
-        assert "Dashboard session search" in heading
+        assert "Session search" in heading
         assert any("General Q&A" in label for label in labels)
         assert all("Other session" not in label for label in labels)
 
@@ -1261,7 +1261,7 @@ class TestSessionsCommand:
 
         await dispatcher.handle_message(_msg("/session"))
 
-        assert client.sent[-1][0] == "No recent dashboard sessions."
+        assert client.sent[-1][0] == "No recent sessions."
 
     @pytest.mark.asyncio
     async def test_search_failure_is_audited_and_fails_closed(

--- a/test/test_telegram_sessions.py
+++ b/test/test_telegram_sessions.py
@@ -12,7 +12,7 @@ import pytest
 from chat_test_helpers import _make_state
 from test_telegram import FakeClient, FakeCtx, FakeProvider
 
-from kiro_crew.history import ConversationLog
+from kiro_crew.history import ConversationLog, transcript_stem
 from kiro_crew.messaging import auto_title
 from kiro_crew.messaging.link import UNBIND_REASON_UNSPECIFIED, ChannelLink
 from kiro_crew.messaging.renderer import session_provenance_tag
@@ -84,6 +84,8 @@ class _Sessions:
         self.flush_error: Exception | None = None
         self.batch_failures = 0
         self.approval_policies: list[tuple[str, str]] = []
+        self.channel_keys: set[str] = set()
+        self.reserved_generations: set[str] = set()
 
     async def get_or_create(
         self,
@@ -96,6 +98,7 @@ class _Sessions:
         self.last_key = key
         self.last_agent = agent
         self.last_model = model
+        self.channel_keys.add(key)
         return self.provider, self.is_new_result, self.resumed_result
 
     def begin_turn(self, key: str) -> None:
@@ -176,10 +179,25 @@ class _Sessions:
     def mirror_opt_out(self, key: str) -> bool:
         return _opt_out_key(key) in self.mirror_opt_outs
 
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.add(session_key)
+        self.channel_keys.add(session_key)
+
     def max_generation(self, bucket: str) -> int:
-        return -1
+        prefix = f"{bucket}:gen"
+        return max(
+            (
+                int(key[len(prefix) :])
+                for key in self.reserved_generations
+                if key.startswith(prefix) and key[len(prefix) :].isdigit()
+            ),
+            default=-1,
+        )
 
     def channel_key_for_stem(self, stem: str) -> str:
+        for key in self.channel_keys | set(self.mirror_links):
+            if transcript_stem(key) == stem:
+                return key
         return ""
 
     def is_busy(self, key: str) -> bool:
@@ -362,6 +380,43 @@ class TestTelegramSessionPicker:
         await dispatcher.on_callback(_callback(data, message_id=message_id))
         assert sessions.mirror_links == before
         assert "expired" in client.edits[-1][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_lists_only_this_dm_native_generations(self, tmp_path: Any) -> None:
+        dispatcher, client, sessions, log = _dispatcher(tmp_path)
+        prior_key = "telegram:kirocrew:direct:7:gen4"
+        other_key = "telegram:kirocrew:direct:8:gen4"
+        await asyncio.to_thread(log.append, prior_key, "user", "earlier telegram work")
+        await asyncio.to_thread(log.set_title, prior_key, "Earlier Telegram generation")
+        await asyncio.to_thread(log.append, other_key, "user", "somebody else's work")
+        await asyncio.to_thread(log.set_title, other_key, "Another Telegram user")
+        sessions.channel_keys.update({prior_key, other_key})
+
+        await dispatcher.handle_message(_dm("/sessions"))
+
+        labels = [row[0]["text"] for row in client.sent[-1][1]["inline_keyboard"]]
+        # This regression owns eligibility, not the mtime-ranked catalog order.
+        assert sorted(label.partition(". ")[2] for label in labels) == [
+            "Earlier Telegram generation",
+            "Launch plan",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_repeated_new_does_not_materialize_empty_history_rows(
+        self, tmp_path: Any
+    ) -> None:
+        dispatcher, _, sessions, log = _dispatcher(tmp_path)
+        route = ("direct", "7")
+
+        await dispatcher.handle_message(_dm("/new"))
+        first_key = dispatcher._session_key(route)
+        await dispatcher.handle_message(_dm("/new"))
+        second_key = dispatcher._session_key(route)
+
+        assert first_key != second_key
+        assert not await asyncio.to_thread(log.has_log, first_key)
+        assert not await asyncio.to_thread(log.has_log, second_key)
+        assert {first_key, second_key} <= sessions.reserved_generations
 
     @pytest.mark.asyncio
     async def test_failed_post_registers_no_picker(self, tmp_path: Any) -> None:

--- a/test/test_webex_dispatch.py
+++ b/test/test_webex_dispatch.py
@@ -102,6 +102,7 @@ class FakeSessions:
         # dispatch the way the real gate does after close_all.
         self.closing = False
         self.begin_turns = 0
+        self.reserved_generations: set[str] = set()
 
     async def get_or_create(self, key, *, agent, channel_id):
         self.last_agent = agent
@@ -143,8 +144,22 @@ class FakeSessions:
     def is_busy(self, key) -> bool:
         return getattr(self, "_busy", False)
 
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.add(session_key)
+
+    async def aflush(self) -> None:
+        return None
+
     def max_generation(self, bucket: str) -> int:
-        return -1
+        prefix = f"{bucket}:gen"
+        return max(
+            (
+                int(key[len(prefix) :])
+                for key in self.reserved_generations
+                if key.startswith(prefix) and key[len(prefix) :].isdigit()
+            ),
+            default=-1,
+        )
 
     # -- mid-turn queue (drive_turn's drain + /stop) --
     def enqueue(self, key, ts, text, *, force=False, **kw) -> bool:
@@ -242,12 +257,24 @@ class FakeConvLog:
     def __init__(self) -> None:
         self.appended: list[tuple[str, str, str]] = []
         self.titles: dict[str, str] = {}
+        self.metadata: dict[str, dict] = {}
 
     def append(self, key, role, text, agent=None, mid=None) -> None:
         self.appended.append((key, role, text))
 
     def set_title(self, key, title) -> None:
         self.titles[key] = title
+
+    def update_metadata_if(self, key: str, fields: dict, guard) -> bool:
+        if not guard(self.metadata.get(key, {})):
+            return False
+        self.metadata.setdefault(key, {}).update(fields)
+        rows = getattr(self, "_rows", None)
+        if isinstance(rows, list):
+            from kiro_crew.history import transcript_stem
+
+            rows.insert(0, {"key": transcript_stem(key), **fields})
+        return True
 
 
 def _cfg(default_agent: str = "", approval_mode: str = "interactive"):
@@ -2293,6 +2320,18 @@ class TestSessionsCommand:
 
         body = d.client.sent[-1][1]
         assert "newer" in body and "first" in body
+
+    @pytest.mark.asyncio
+    async def test_repeated_new_does_not_materialize_empty_history_rows(self) -> None:
+        log = FakeListingLog([])
+        sessions = FakeSessions(FakeProvider([]))
+        d = _dispatcher(sessions, FakeCtx(), FakeClient(), conv_log=log)
+
+        await d.handle_message(_inbound("/new"))
+        await d.handle_message(_inbound("/new"))
+
+        assert log.list_sessions() == []
+        assert len(sessions.reserved_generations) == 2
 
     @pytest.mark.asyncio
     async def test_another_users_conversations_are_not_listed(self) -> None:

--- a/test/test_wecom_commands_and_ingest.py
+++ b/test/test_wecom_commands_and_ingest.py
@@ -77,6 +77,13 @@ class FakeSessions:
         self.opted_out: dict = {}
         self.mirror_links: dict = {}
         self.origin_links: dict = {}
+        self.reserved_generations: list[str] = []
+
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.append(session_key)
+
+    async def aflush(self) -> None:
+        return None
 
     def is_busy(self, key) -> bool:
         return self._busy
@@ -585,11 +592,13 @@ class TestACaptionIsNeverACommand:
 
         monkeypatch.setattr("kiro_crew.wecom.transport_dispatch.drive_turn", fake_drive_turn)
         client = FakeClient()
-        d = _dispatcher(FakeSessions(), client)
+        sessions = FakeSessions()
+        d = _dispatcher(sessions, client)
 
         await d.handle_message(_inbound("/new"))
 
         assert client.said == ["✅ 已开始新对话"]
+        assert sessions.reserved_generations == [d._session_key("Wei")]
         assert not drove, "a bare command must not become a turn"
 
 

--- a/test/test_wecom_dispatch.py
+++ b/test/test_wecom_dispatch.py
@@ -86,6 +86,7 @@ class FakeSessions:
         # dispatch the way the real gate does after close_all.
         self.closing = False
         self.begin_turns = 0
+        self.reserved_generations: list[str] = []
 
     @contextlib.contextmanager
     def batched_save(self):
@@ -157,6 +158,12 @@ class FakeSessions:
 
     def is_busy(self, key) -> bool:
         return getattr(self, "_busy", False)
+
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.append(session_key)
+
+    async def aflush(self) -> None:
+        return None
 
     def max_generation(self, bucket: str) -> int:
         return -1
@@ -396,6 +403,7 @@ class TestCommands:
 
         assert client.said == ["✅ 已开始新对话"]
         assert d._conv.current_gen("Wei") == 1  # generation bumped
+        assert sessions.reserved_generations == [d._session_key("Wei")]
         assert sessions.successes == []  # no LLM turn
 
     @pytest.mark.asyncio

--- a/test/test_weixin_dispatch.py
+++ b/test/test_weixin_dispatch.py
@@ -112,6 +112,7 @@ class FakeSessions:
         self.acquired = False
         self.mirror_links: dict[str, object] = {}
         self.opted_out = False
+        self.reserved_generations: list[str] = []
 
     def is_busy(self, key):
         return self._busy
@@ -149,6 +150,12 @@ class FakeSessions:
 
     def has_session(self, key):
         return True
+
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.append(session_key)
+
+    async def aflush(self) -> None:
+        return None
 
     def max_generation(self, *a, **kw):
         # seed_generation() probes for the highest existing generation; a fresh
@@ -387,6 +394,7 @@ def test_new_command_starts_a_fresh_session_without_a_turn(tmp_path):
 
     assert provider.prompts == []  # no LLM turn for a command
     assert before != after  # generation advanced
+    assert sessions.reserved_generations == [after]
     assert "新对话" in client.sent[0]["text"]
 
 

--- a/test/test_whatsapp_dispatch.py
+++ b/test/test_whatsapp_dispatch.py
@@ -103,6 +103,7 @@ class FakeSessions:
         #: channel, which is the only case an unseeded counter gets right.
         self.persisted_generations = dict(persisted_generations or {})
         self.generation_lookups: list[str] = []
+        self.reserved_generations: list[str] = []
         self._busy = busy
         self.released = 0
         self.successes = 0
@@ -130,6 +131,12 @@ class FakeSessions:
 
     def has_session(self, key: str) -> bool:
         return self._session_exists
+
+    def reserve_generation(self, session_key: str) -> None:
+        self.reserved_generations.append(session_key)
+
+    async def aflush(self) -> None:
+        return None
 
     def max_generation(self, bucket: str) -> int:
         self.generation_lookups.append(bucket)
@@ -306,13 +313,14 @@ def test_group_scope_uses_forum_chat_type_in_session_key():
 # ── dispatcher: commands ────────────────────────────────────────────────────
 def test_new_command_starts_a_fresh_session_without_a_turn():
     provider = FakeProvider()
-    d, _client, _sessions, transport = _make(provider=provider)
+    d, _client, sessions, transport = _make(provider=provider)
     before = d._session_key(_DM)
     asyncio.run(d.handle_message(_msg("/new")))
     after = d._session_key(_DM)
 
     assert provider.prompts == []  # no LLM turn for a command
     assert before != after  # generation advanced
+    assert sessions.reserved_generations == [after]
     assert any("fresh session" in t.lower() for _, t in transport.sent)
 
 


### PR DESCRIPTION
## Problem / Motivation

A channel session can become impossible to reopen. Discord, Telegram, and Teams session pickers list dashboard sessions but skip generations born in the same private chat.

A `/new` or `!new` can disappear across a gateway restart before its first message. The generation lives only in memory, so the next message can land on an older conversation key.

## Why it matters

People can lose their path back to useful channel work. A restart can mix a fresh chat with a conversation they meant to leave. Recovery must not expose a different user, agent, room, or channel.

## What changed (motivation → approach → change)

The picker treats dashboard history and native history as two safe sources. Dashboard rows keep their owner check. Native rows must fold to the exact private-conversation bucket that opened the picker. Discord, Telegram, and Teams can bind to an eligible row. Duplicate spellings of one session become one choice.

Every shipped DM channel saves a monotonic generation floor in `SessionMap` before it acknowledges an explicit new-session command. A restart seeds from that floor. An empty generation creates no history row, so repeated resets cannot crowd the picker. Its first real turn creates the normal recoverable row.

The channel-neutral resume controller owns the eligibility rule and binding flow. Shared key helpers own generation parsing and same-bucket mirror replacement. Telegram uses that shared path instead of a channel-local copy.

```mermaid
flowchart LR
  subgraph Lost
    A1[DM /new]:::ctx --> B1[Generation only in memory]:::removed --> C1[Restart can reuse an older key]:::removed
  end
  subgraph Saved
    A2[DM /new]:::ctx --> B2[Save generation floor]:::added --> C2[Restart keeps the fresh key]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The new chat saves its generation before it replies, so a restart cannot send the next message to an older conversation.*

## Tests

- 343 Discord, WeCom, Weixin, and WhatsApp session and dispatch tests pass with `pytest -n0`.
- Native-history tests cover exact-bucket eligibility, other-identity exclusion, duplicate collapse, binding conflicts, and resumed-turn routing.
- Generation-floor tests cover all shipped DM command paths, restart before the first turn, pruning, repeated empty resets, and write failure.
- The comment-history gate, baseline-aware Black gate, isort, flake8, and mypy pass for this diff.

## Manual verification

N/A — dispatcher-level tests cover the command, picker, privacy boundary, restart, and persistence paths without live channel credentials.

## Related Issues

no linked issue: the defect was reported directly and is fixed in this PR.

## Pattern harvest

Rule candidate: review-prompt
Pattern: A command that advances durable identity must save the new value before it acknowledges success.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
