### PR TITLE
fix(chat): keep transcript images renderable after their scratch file is reclaimed

### DIFF
--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -1240,9 +1240,40 @@ JSON never carries base64.
   to an unauthenticated requester.
 - 404 when the slug does not resolve, is not an image artifact, its sidecar is
   missing, or its mime is not in the allowlist.
+- **Optional owner check — `?session=<slot>`.** Image slugs derive from
+  (message ts, ordinal) alone, so two sessions that finalize in the same instant
+  can collide on a slug. The chat transcript's durable-image fallback (see
+  "Chat image fallback" below) names its own session, and the endpoint then
+  returns 404 unless the copy's recorded `session_key` is that session or one it
+  descends from by fork lineage — a fork copies its source's messages with
+  their `ts` intact, so it legitimately renders the source's copies. Descent is
+  decided by `kiro_crew.dashboard.fork_lineage.descends_from` (the same walker
+  the session-delete reap uses), reading `forked_from` / `fork_ancestors` from
+  transcript metadata through `_safe_key`-sanitised reads; an unreadable link
+  fails CLOSED (404). Every dashboard spelling of a session
+  (`<slot>`, `dashboard:<slot>`, `dashboard_<slot>`) folds to one identity.
+  Callers that name no session — the artifact library — are unaffected.
 - The read is offloaded with `asyncio.to_thread`: the sidecar may be up to
   `MAX_CONTENT_BYTES` and a synchronous read would stall every other gateway
   task, the liveness heartbeat included.
+
+### Chat image fallback (transcript consumer of the asset endpoint)
+
+A local markdown image in a chat message (`![alt](/…/scratch/…/chart.png)`) is
+served from `/api/file-raw`. When that load fails — the agent's scratch
+directory was reclaimed — the renderer retries the durable copy registered at
+finalize time: `/api/artifacts/<slug>/asset?session=<slot>` with
+`slug = derive_widget_slug(f"{ts}#image", ordinal)`. The ordinal is the image's
+position among ALL direct `![…](` openers in the RAW message text, exactly as
+`register_images` numbered it; the dashboard derives it with a byte-for-byte
+port of `IMAGE_MD_RE` / `md_destination`
+(`website/src/lib/imageArtifactSlug.ts`, pinned to the Python grammar by
+`test/fixtures/image_grammar_parity.json`, which drives both test suites).
+Resolution is exact-or-nothing: a destination
+that appears once is unambiguous; a repeated destination is resolved only when
+the block's raw span is known and preprocessing removed nothing from it; any
+other case gets the broken-image chip rather than a guessed picture. Only after
+every candidate fails does the chip render.
 
 ### Auto-registration from chat (`kiro_crew.image_artifacts`)
 
@@ -1270,10 +1301,17 @@ cannot strip them.
   the cap one batch at a time. Pruning runs after the loop, so without these a
   single message could fill the disk.
 - **Retention.** Auto-registered images are `auto_registered=True` and unpinned,
-  so they ride the **same** count-based sweep as auto-registered widgets
-  (`prune_auto_widgets(keep=MAX_AUTO_WIDGET_ARTIFACTS)`) — the predicate is
-  kind-agnostic. Images and widgets therefore share one budget; pinning
-  ("Save permanently"), filing, tagging, or commenting exempts a record.
+  but they are **exempt** from the count-based widget sweep
+  (`_is_sweepable_auto_widget` returns false for `kind == "image"`): a chat
+  image is a durable transcript asset, and a still-existing chat must never
+  render a broken image because a rolling preview budget ran out. Their
+  lifetime is the owning chat's: every handler that permanently deletes a
+  transcript (`DELETE /api/sessions/{key}` and the bulk `DELETE /api/sessions`)
+  calls `ArtifactStore.delete_auto_images_for_sessions`, which removes only the
+  copies that carry no investment signal — the same
+  `_is_unclaimed_auto_artifact` test the widget sweep uses, so pinning
+  ("Save permanently"), filing, tagging, describing, editing, or commenting
+  exempts a record from both.
 - **Never raises.** A failure to register a chat image is a lost convenience, not
   a reason to fail the turn that produced it; per-image failures are logged and
   skipped individually. Dispatch uses `asyncio.to_thread` rather than the shared

--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -37,6 +37,7 @@ import json
 import logging
 import os
 import re
+import stat
 import tempfile
 import threading
 import unicodedata
@@ -48,7 +49,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterator
 from typing import List as _List
 
-from kiro_crew import hooks
+from kiro_crew import hooks, platform_compat
 from kiro_crew.artifact_source import is_verifiable_root
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.deploy.webapp_types import (  # noqa: F401 — re-export for API compatibility
@@ -82,6 +83,16 @@ MAX_VERSIONS = 50
 #: ``validation.ARTIFACT_CONTENT_MAX`` (the MCP tool-arg cap) so a save's limit
 #: doesn't depend on its entry path — guarded by a regression test.
 MAX_CONTENT_BYTES = 26_214_400  # 25 MiB
+
+#: What pins an image sidecar between the locked metadata read and the unlocked
+#: byte read: ``(st_dev, st_ino, st_size, st_mtime_ns)``. See
+#: :meth:`ArtifactStore._sidecar_identity`.
+_SidecarIdentity = tuple[int, int, int, int]
+
+
+def _stat_identity(st: os.stat_result) -> _SidecarIdentity:
+    return (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
 
 #: Maximum length of human-readable name / description fields.
 MAX_NAME_LEN = 200
@@ -1415,6 +1426,17 @@ class ArtifactStore:
         routed through the gated :meth:`_read_bytes` so the sensitive-path
         denylist fires here as on every other store read.
         """
+        data, mime, _owner = self.read_image_bytes_with_owner(slug)
+        return data, mime
+
+    def read_image_bytes_with_owner(self, slug: str) -> tuple[bytes, str, str]:
+        """``(bytes, mime, session_key)`` from ONE metadata snapshot.
+
+        The owner is read under the same lock that resolves the asset path, so a
+        caller authorizing by session compares against the record whose bytes it
+        then serves — a delete/recreate of the slug between two separate reads
+        cannot pair one record's owner with another record's bytes.
+        """
         slug = _validate_slug(slug)
         with self._lock:
             meta = self._load_meta(slug)
@@ -1436,11 +1458,21 @@ class ArtifactStore:
             if not asset.exists():
                 raise ArtifactNotFoundError(f"image asset missing for {slug!r}")
             mime = norm_mime
+            owner = meta.session_key or ""
+            # Pin the sidecar's inode WHILE the metadata is locked: the bytes are
+            # read after the lock is released (an asset can be tens of MiB), and a
+            # delete + recreate of this slug in that window would otherwise pair
+            # the owner captured here with another record's bytes. The read below
+            # authorizes the descriptor it actually opened against this identity.
+            identity = self._sidecar_identity(asset)
+            if identity is None:
+                raise ArtifactNotFoundError(f"image asset is not readable: {asset.name}")
         # Read OUTSIDE the lock: an asset can be tens of MiB, and holding the
         # store-wide lock across it would block every concurrent artifact
         # operation for the duration of the read. The path was resolved under
-        # the lock and an image artifact's bytes are never rewritten in place.
-        return self._read_image_asset_bytes(asset), mime
+        # the lock and an image artifact's bytes are never rewritten in place;
+        # the identity check refuses a sidecar swapped in since.
+        return self._read_image_asset_bytes(asset, identity=identity), mime, owner
 
     def get(self, slug: str, *, version: int | None = None) -> Artifact:
         """Return an artifact (with content) by slug, optionally a specific version.
@@ -2051,6 +2083,20 @@ class ArtifactStore:
         A widget that is merely *rendered* is not claimed; a widget that was
         touched in any of the above ways is.
         """
+        # Chat images are durable transcript assets, not rolling widget previews.
+        # Their lifecycle is the owning session; count-based pruning must never
+        # make a still-existing chat render a broken image.
+        if art.kind == "image":
+            return False
+        return self._is_unclaimed_auto_artifact(art)
+
+    def _is_unclaimed_auto_artifact(self, art: Artifact) -> bool:
+        """True when ``art`` is auto-registered and carries NO investment signal.
+
+        The single spelling of the "nobody has claimed this" test, shared by the
+        widget sweep and the per-session image reap so the two can never drift.
+        The signals are documented on :meth:`_is_sweepable_auto_widget`.
+        """
         if not art.auto_registered or art.pinned:
             return False
         if art.folder_id or art.publication is not None or art.fork_metadata is not None:
@@ -2125,6 +2171,45 @@ class ArtifactStore:
                 logger.warning("auto-widget prune skipped %s: %s", art.slug, exc)
                 continue
             # Fired outside the lock, matching ``delete()``.
+            self._fire_change("delete", art.slug)
+            deleted += 1
+        return deleted
+
+    def delete_auto_images_for_sessions(self, session_keys: set[str]) -> int:
+        """Delete untouched chat-image copies owned by permanently deleted sessions.
+
+        Saved/invested images survive: pinning, filing, publishing, editing,
+        describing, tagging, forking, or commenting turns an automatic transcript
+        copy into a user-owned artifact. The eligibility re-check and removal share
+        one lock acquisition so a concurrent pin cannot be overwritten.
+        """
+        keys = {key for key in session_keys if key}
+        if not keys:
+            return 0
+
+        def eligible(art: Artifact) -> bool:
+            return (
+                art.kind == "image"
+                and art.session_key in keys
+                and self._is_unclaimed_auto_artifact(art)
+            )
+
+        deleted = 0
+        for art in self.list():
+            if not eligible(art):
+                continue
+            try:
+                with self._lock:
+                    fresh = self._load_meta(art.slug)
+                    if not eligible(fresh):
+                        continue
+                    adir = self._artifact_dir(art.slug)
+                    if not adir.exists():
+                        continue
+                    self._rmtree(adir)
+            except (ArtifactNotFoundError, ArtifactError, OSError) as exc:
+                logger.warning("session image cleanup skipped %s: %s", art.slug, exc)
+                continue
             self._fire_change("delete", art.slug)
             deleted += 1
         return deleted
@@ -3533,7 +3618,9 @@ class ArtifactStore:
             raise ArtifactError(f"refusing to read sensitive path: {resolved}")
         return resolved.read_bytes()
 
-    def _read_image_asset_bytes(self, path: Path) -> bytes:
+    def _read_image_asset_bytes(
+        self, path: Path, *, identity: _SidecarIdentity | None = None
+    ) -> bytes:
         """Read an image sidecar with the open descriptor as the unit of trust.
 
         :meth:`_read_bytes` resolves the path, checks it, then opens it by name —
@@ -3543,6 +3630,12 @@ class ArtifactStore:
         the open is ``O_NOFOLLOW`` and the inode it actually opened is validated
         (regular file, not hardlinked), so a swapped sidecar is refused rather
         than followed.
+
+        With ``identity`` — the inode identity a caller captured while it
+        held the metadata lock — the descriptor is additionally required to BE
+        that inode, so a sidecar replaced after the lock was released (a slug
+        deleted and recreated) is refused rather than served under the earlier
+        record's owner.
 
         ``within_root`` is deliberately NOT passed to the helper: its containment
         check reads the descriptor's real path via ``/proc/self/fd`` or
@@ -3558,12 +3651,67 @@ class ArtifactStore:
         resolved = Path(os.path.realpath(path))
         if resolved != root and root not in resolved.parents:
             raise ArtifactNotFoundError(f"image asset escapes the store root: {path.name}")
-        data = hooks.safe_read_file_bytes_nolink(str(resolved), max_bytes=MAX_CONTENT_BYTES)
+        if identity is not None:
+            data = self._read_pinned_sidecar(resolved, identity)
+        else:
+            data = hooks.safe_read_file_bytes_nolink(str(resolved), max_bytes=MAX_CONTENT_BYTES)
         if data is None:
-            # Refused: not a regular file, hardlinked, or unreadable.
+            # Refused: not a regular file, hardlinked, unreadable, or (with an
+            # identity) not the inode the caller pinned under the lock.
             # Indistinguishable from "gone" to the caller by design.
             raise ArtifactNotFoundError(f"image asset is not readable: {path.name}")
         return data
+
+    @staticmethod
+    def _sidecar_identity(asset: Path) -> _SidecarIdentity | None:
+        """Identity of the sidecar as it is NOW, for pinning under the lock.
+
+        ``(st_dev, st_ino)`` alone is not enough: a file deleted and rewritten a
+        moment later commonly gets the same inode number back, so size and
+        ``mtime_ns`` are part of the identity too. ``None`` when the path is
+        refused or unstattable.
+        """
+        if is_sensitive_path(str(asset)):
+            return None
+        try:
+            return _stat_identity(os.stat(asset, follow_symlinks=False))
+        except OSError:
+            return None
+
+    @staticmethod
+    def _read_pinned_sidecar(resolved: Path, identity: _SidecarIdentity) -> bytes | None:
+        """Read ``resolved`` only if the descriptor opened IS the pinned inode.
+
+        Every check runs on the one ``fstat`` of the descriptor that is read —
+        the same set :func:`hooks.safe_read_file_bytes_nolink` applies (regular
+        file, not hardlinked, under ``MAX_CONTENT_BYTES``) PLUS the ``(st_dev,
+        st_ino)`` captured under the metadata lock — so neither a hardlinked
+        alias nor a sidecar swapped in after the lock was released can be served.
+        ``None`` means refused, for any reason.
+        """
+        if is_sensitive_path(str(resolved)):
+            return None
+        try:
+            fd = platform_compat.open_file_no_reparse(resolved)
+        except OSError:
+            return None
+        try:
+            st = os.fstat(fd)
+            if _stat_identity(st) != identity:
+                return None
+            if st.st_nlink > 1 or not stat.S_ISREG(st.st_mode):
+                return None
+            if st.st_size > MAX_CONTENT_BYTES:
+                return None
+            with os.fdopen(fd, "rb") as fh:
+                fd = -1  # consumed by fdopen
+                data = fh.read(MAX_CONTENT_BYTES + 1)
+        except OSError:
+            return None
+        finally:
+            if fd != -1:
+                os.close(fd)
+        return None if len(data) > MAX_CONTENT_BYTES else data
 
     def _write_bytes(self, path: Path, data: bytes) -> None:
         """Binary sibling of :meth:`_write_text` (image asset writes).

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -15,6 +15,7 @@ from kiro_crew.dashboard.chat_utils import (
     history_corpus_unreadable,
     slot_history_key,
 )
+from kiro_crew.dashboard.fork_lineage import ancestry_chain, materialize_ancestors
 from kiro_crew.dashboard.state import (
     MAX_LIVE_SLOTS,
     VALID_MEMORY_MODES,
@@ -875,6 +876,16 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
         count_user_session=True,
     )
     new_slot.forked_from = effective_session_key(slot)
+    # The FULL chain, so lineage stays provable after an intermediate fork is
+    # deleted (its own metadata goes with it). A source forked before the chain
+    # was recorded carries only `forked_from`; walk the catalog once so the new
+    # fork records every ancestor, not one link. See dashboard/fork_lineage.py.
+    source_chain: list[str] | None = getattr(slot, "fork_ancestors", None) or None
+    if not source_chain and getattr(slot, "forked_from", None) and state.conversation_log:
+        source_chain = await asyncio.to_thread(
+            ancestry_chain, state.conversation_log, new_slot.forked_from
+        )
+    new_slot.fork_ancestors = materialize_ancestors(new_slot.forked_from, source_chain)
     new_slot.reasoning_effort = slot.reasoning_effort
     # Inherit the active project directory so the fork keeps the parent's working
     # context (agent resolution, steering files, CWD) instead of falling back to

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -9145,6 +9145,11 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         state._restricted_keys.discard(f"dashboard:{name}")
     if meta.get("forked_from") is not None:
         slot.forked_from = meta["forked_from"]
+    # The fork's materialized chain travels with `forked_from`: it is a
+    # slot-owned field, so a save after a resume that skipped it would rewrite
+    # the meta line without it and the fork would lose its ancestry.
+    if isinstance(meta.get("fork_ancestors"), list):
+        slot.fork_ancestors = [str(a) for a in meta["fork_ancestors"] if a]
     disk_total = len(all_messages)
     max_resume = 500
     messages = all_messages[-max_resume:] if disk_total > max_resume else all_messages

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -1095,6 +1095,8 @@ def _rehydrate_slot_from_history(
             state._restricted_keys.add(f"dashboard:{slot_name}")
         if meta.get("forked_from") is not None:
             slot.forked_from = meta["forked_from"]
+        if isinstance(meta.get("fork_ancestors"), list):
+            slot.fork_ancestors = [str(a) for a in meta["fork_ancestors"] if a]
         if meta.get("linked_session_key"):
             # Rebind the slot to the session its conversation actually runs on.
             # Skipped, the slot would answer from a dashboard-only session and the
@@ -1630,6 +1632,8 @@ def _apply_recent_session(
         state._restricted_keys.add(f"dashboard:{slot_name}")
     if meta.get("forked_from") is not None:
         slot.forked_from = meta["forked_from"]
+    if isinstance(meta.get("fork_ancestors"), list):
+        slot.fork_ancestors = [str(a) for a in meta["fork_ancestors"] if a]
     if meta.get("linked_session_key"):
         slot.linked_session_key = str(meta["linked_session_key"])
     elif is_channel_session_key(key) and state.sessions:
@@ -2892,6 +2896,8 @@ def _save_slot_to_history(
                     fields["channel_origin"] = True
                 if slot.forked_from is not None:
                     fields["forked_from"] = slot.forked_from
+                if slot.fork_ancestors:
+                    fields["fork_ancestors"] = list(slot.fork_ancestors)
                 if slot.executor == "remote" and slot.instance_id and slot.remote_slot:
                     # All three or none, exactly like the full save: a newborn
                     # bound to a peer has an EMPTY window until the first relayed
@@ -3297,6 +3303,8 @@ def _save_slot_to_history(
             retired_drop_ids = dropped_note_ids if not rows_only else set()
             if slot.forked_from is not None:
                 meta_line["forked_from"] = slot.forked_from
+            if slot.fork_ancestors:
+                meta_line["fork_ancestors"] = list(slot.fork_ancestors)
             if slot.linked_session_key:
                 # The slot's conversation lives on another session (a channel
                 # thread, a cron job). Nothing recreates that binding on

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -203,7 +203,7 @@ from kiro_crew.hooks import (
     safe_read_file_bytes_nolink,
     validate_file_path,
 )
-from kiro_crew.image_artifacts import register_images_off_loop
+from kiro_crew.image_artifacts import register_images_off_loop, track_registration
 from kiro_crew.llm_helpers import (
     TRANSIENT_RETRIES,
     TURN_FALLBACK_ATTR,
@@ -3596,6 +3596,8 @@ def _schedule_widget_registration(
         image_task = asyncio.create_task(register_images_off_loop(text, message_ts, slot.key))
         state._background_tasks.add(image_task)
         image_task.add_done_callback(state._background_tasks.discard)
+        # A permanent delete of this session drains this before reaping copies.
+        track_registration(slot.key, image_task)
 
 
 def _strip_yaml_frontmatter(content: str) -> str:

--- a/src/kiro_crew/dashboard/fork_lineage.py
+++ b/src/kiro_crew/dashboard/fork_lineage.py
@@ -1,0 +1,240 @@
+"""Fork lineage of chat sessions, in one place.
+
+A fork copies its source's messages with their ``ts`` intact, and a chat
+image's durable copy is keyed by ``ts`` alone, so a fork legitimately renders
+the copies registered under any ancestor's session key. Two things depend on
+that fact and MUST agree about it:
+
+* the artifact asset endpoint, which serves a copy to its owner or to a session
+  descended from the owner and to nobody else;
+* the permanent-delete reap, which keeps an ancestor's copies while any
+  descendant survives.
+
+Both consult this module. Lineage is read from transcript metadata:
+``forked_from`` (the immediate source, written by the fork handler) and
+``fork_ancestors`` (the FULL chain, materialized at fork time from the source's
+own chain). The materialized chain is what makes ancestry provable after an
+intermediate fork has been deleted — its metadata is gone with it, so a walk
+over ``forked_from`` alone would stop short; the descendant's own record still
+names every ancestor.
+
+Every key is compared as a transcript stem (:func:`fold`): catalog entries are
+stems, ``forked_from`` is a live key, and the dashboard spells one session as
+``dashboard:<slot>``, ``dashboard_<slot>`` or the bare slot.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable
+
+from kiro_crew.history import transcript_stem, transcript_stems
+
+__all__ = [
+    "fold",
+    "recorded_chain",
+    "owner_spellings",
+    "strip_dashboard_prefix",
+    "walk_ancestors",
+    "ancestors_of",
+    "ancestry_chain",
+    "descends_from",
+    "materialize_ancestors",
+    "legacy_aliases",
+]
+
+
+def strip_dashboard_prefix(key: str) -> str:
+    """``key`` without its dashboard transport prefix (``dashboard:`` or one or
+    more ``dashboard_``) — the bare slot name."""
+    bare = key.removeprefix("dashboard:")
+    while bare.startswith("dashboard_"):
+        bare = bare[len("dashboard_") :]
+    return bare
+
+
+#: A cron job's tab is named ``cron-<job_id>`` (``cron_inject.py``) while its
+#: session key is ``cron:<job_id>`` — and ``transcript_stem`` keeps ``-`` but
+#: folds ``:`` to ``_``, so the two spellings do NOT meet at the stem. Image
+#: copies are owned by the slot name (``register_images`` receives ``slot.key``)
+#: while ``forked_from`` and the catalog carry the session key, so the slot
+#: spelling is mapped onto the session here. ``dashboard_slot_key`` in
+#: ``chat_utils`` owns the forward mapping for open tabs; this is its inverse
+#: for sessions whose tab may be closed or gone.
+_CRON_TAB_PREFIX = "cron-"
+_CRON_KEY_PREFIXES = ("cron:", "cron_")
+
+
+def _tab_to_session(bare: str) -> str:
+    """A linked tab's name spelled as its session key; other keys unchanged."""
+    if bare.startswith(_CRON_TAB_PREFIX):
+        return "cron:" + bare[len(_CRON_TAB_PREFIX) :]
+    return bare
+
+
+def owner_spellings(key: str) -> set[str]:
+    """Every spelling under which an image copy may record session ``key``.
+
+    The copy carries the bare slot name; the caller usually holds the transcript's
+    history key or file stem. Both dashboard forms are returned, plus the tab
+    name of a linked (cron) session, whose slot is not a fold of its key.
+    """
+    bare = strip_dashboard_prefix(key)
+    out = {key, bare}
+    for prefix in _CRON_KEY_PREFIXES:
+        if bare.startswith(prefix):
+            out.add(_CRON_TAB_PREFIX + bare[len(prefix) :])
+    return out
+
+
+def fold(key: str) -> str:
+    """One canonical spelling of a session for lineage comparison."""
+    return transcript_stem(_tab_to_session(strip_dashboard_prefix(key)))
+
+
+def recorded_chain(meta: Any) -> list[str]:
+    """The ``fork_ancestors`` chain in ``meta``, or ``[]``.
+
+    Transcript metadata is user-editable JSON: a value that is not a list (or a
+    non-dict ``meta``) is treated as "no chain recorded" so a corrupt record
+    degrades to the ``forked_from`` walk instead of raising into a request.
+    """
+    if not isinstance(meta, dict):
+        return []
+    chain = meta.get("fork_ancestors")
+    if not isinstance(chain, list):
+        return []
+    return [str(a) for a in chain if a]
+
+
+def walk_ancestors(
+    start: str,
+    parent_of: Callable[[str], str | None],
+    known_of: Callable[[str], Iterable[str]],
+) -> set[str]:
+    """THE ancestry walk, over folded stems.
+
+    From ``start``, union each visited node's materialized chain (``known_of``)
+    and follow its immediate edge (``parent_of``). Cycle-safe by visited set,
+    no depth cap. Both the catalog-backed :func:`ancestors_of` and the reap's
+    snapshot walk call this, so there is one definition of "ancestor".
+    """
+    out: set[str] = set()
+    visited: set[str] = set()
+    cur: str | None = fold(start)
+    while cur and cur not in visited:
+        visited.add(cur)
+        out.update(fold(a) for a in known_of(cur))
+        parent = parent_of(cur)
+        cur = fold(parent) if parent else None
+        if cur:
+            out.add(cur)
+    out.discard(fold(start))
+    return out
+
+
+def _read_meta(log: Any, session: str) -> tuple[dict, bool]:
+    """Metadata for ``session``, trying every spelling the catalog answers to.
+
+    Returns ``({}, False)`` when NO spelling could be read; a readable but empty
+    record (a bare slot name that is not a transcript) is skipped in favour of
+    one that carries data.
+    """
+    bare = strip_dashboard_prefix(session)
+    readable = False
+    found: dict = {}
+    spellings = (session, f"dashboard:{bare}", bare, _tab_to_session(bare))
+    for spelling in dict.fromkeys(spellings):
+        try:
+            meta, ok = log.get_metadata_status(spelling)
+        except Exception:
+            continue
+        if ok and isinstance(meta, dict):
+            readable = True
+            if meta and not found:
+                found = meta
+    return found, readable
+
+
+def ancestors_of(log: Any, session: str) -> set[str]:
+    """Ancestor stems of ``session``, read from the catalog.
+
+    Combines the materialized ``fork_ancestors`` of each visited node with the
+    ``forked_from`` walk (for forks made before the chain was recorded). An
+    unreadable link ends the walk there: the result is what is PROVABLE, so a
+    caller that needs a positive match fails closed on its own.
+    """
+    cache: dict[str, dict] = {}
+
+    def _meta(stem: str) -> dict:
+        if stem not in cache:
+            meta, _readable = _read_meta(log, stem)
+            cache[stem] = meta
+        return cache[stem]
+
+    return walk_ancestors(
+        session,
+        parent_of=lambda s: (lambda p: str(p) if p else None)(_meta(s).get("forked_from")),
+        known_of=lambda s: recorded_chain(_meta(s)),
+    )
+
+
+def ancestry_chain(log: Any, session_key: str) -> list[str]:
+    """The ancestor chain of ``session_key`` as RAW keys, nearest first.
+
+    Used at fork time to materialize a new fork's ``fork_ancestors`` from a
+    source that is itself a fork. Prefers the source's own recorded chain; a
+    pre-upgrade source (``forked_from`` only) is walked through the catalog so
+    the new fork records the FULL chain rather than one link. Stops at an
+    unreadable link (records what is provable).
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    cur = session_key
+    while cur:
+        stem = fold(cur)
+        if stem in seen:
+            break
+        seen.add(stem)
+        meta, readable = _read_meta(log, cur)
+        if not readable:
+            break
+        chain = recorded_chain(meta)
+        if chain:
+            for a in chain:
+                if a and fold(str(a)) not in seen:
+                    out.append(str(a))
+                    seen.add(fold(str(a)))
+            break
+        parent = meta.get("forked_from")
+        if not parent:
+            break
+        out.append(str(parent))
+        cur = str(parent)
+    return out
+
+
+def descends_from(log: Any, session: str, owner: str) -> bool:
+    """Whether ``session`` is ``owner`` or descends from it. Fails CLOSED when
+    the chain cannot be read completely."""
+    target = fold(owner)
+    if fold(session) == target:
+        return True
+    # Only a positive match is accepted; an unreadable link contributes nothing.
+    return target in ancestors_of(log, session)
+
+
+def materialize_ancestors(source_key: str, source_ancestors: list[str] | None) -> list[str]:
+    """The ``fork_ancestors`` list for a new fork of ``source_key``: the source
+    itself followed by the source's own chain, deduplicated, nearest first."""
+    out: list[str] = [source_key]
+    for a in source_ancestors or ():
+        if a and a not in out:
+            out.append(str(a))
+    return out
+
+
+def legacy_aliases(key: str) -> dict[str, str]:
+    """``{legacy stem: canonical stem}`` for a key that may also log under a
+    pre-canonical stem (Slack threads predating ``slack:<ts>``)."""
+    stems = transcript_stems(key)
+    return {s: stems[0] for s in stems[1:]}

--- a/src/kiro_crew/dashboard/handlers/artifacts.py
+++ b/src/kiro_crew/dashboard/handlers/artifacts.py
@@ -59,6 +59,7 @@ from kiro_crew.artifacts import (
     webapp_metadata_from_dict,
 )
 from kiro_crew.dashboard.chat_folders import generate_emoji_for_name
+from kiro_crew.dashboard.fork_lineage import descends_from
 from kiro_crew.dashboard.handlers._shared import _is_restricted_session
 from kiro_crew.dashboard.state import _normalize_slot_key
 from kiro_crew.executors import subprocess_executor
@@ -1646,12 +1647,30 @@ async def api_artifact_asset(request: web.Request) -> web.Response:
     404 when the slug does not resolve or is not an image artifact.
     """
     slug = request.match_info.get("slug", "")
+    # Optional owner check. Image slugs derive from (message ts, ordinal) alone,
+    # so two sessions that finalize in the same instant can collide on a slug;
+    # the transcript fallback names its own session and must never be handed
+    # another session's picture. A FORK renders its source's copies (messages
+    # keep their ts), so a caller descended from the owner is accepted too.
+    # Fail CLOSED (404) on anything else. Callers that name no session (the
+    # artifact library) are unaffected.
+    session = getattr(request, "query", {}).get("session", "")
     try:
         store = get_default_store()
         # Off the loop: the sidecar can be up to MAX_CONTENT_BYTES, and a
         # synchronous read of that size would stall every other gateway task
-        # (the user's chat turn and the liveness heartbeat included).
-        data, mime = await asyncio.to_thread(store.read_image_bytes, slug)
+        # (the user's chat turn and the liveness heartbeat included). Bytes and
+        # owner come from ONE metadata snapshot, so the owner the check below
+        # authorizes is the record whose bytes are served — a slug deleted and
+        # recreated between two separate reads cannot pass one owner's check
+        # and return another's picture.
+        data, mime, owner = await asyncio.to_thread(store.read_image_bytes_with_owner, slug)
+        if session:
+            state = request.app.get("state") if hasattr(request, "app") else None
+            log = getattr(state, "conversation_log", None)
+            owned = await asyncio.to_thread(descends_from, log, session, owner)
+            if not owned:
+                return _err("artifact not found", status=404)
     except ArtifactNotFoundError as exc:
         return _err(str(exc), status=404)
     except ArtifactValidationError as exc:

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -9,6 +9,8 @@ import logging
 import os
 import re
 import time
+from dataclasses import dataclass
+from dataclasses import field as _dc_field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,15 +28,17 @@ from aiohttp import web
 import kiro_crew.dashboard.handlers as _h
 from kiro_crew import session_directive, session_ledger
 from kiro_crew.acp.client import _resolve_kiro_bin_for_spawn
+from kiro_crew.artifacts import get_default_store
 from kiro_crew.config.paths import kiro_agents_dir
-from kiro_crew.dashboard import directive_queue
+from kiro_crew.dashboard import directive_queue, fork_lineage
 from kiro_crew.dashboard.handlers import kiro_usage_api
 from kiro_crew.dashboard.handlers._shared import SESSION_SEARCH_TEXT_FIELDS
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.session_memory import SessionMemorySampler
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, _normalize_slot_key
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.history import SEARCH_MIN_CHARS, _archive_dir, is_incognito_transcript
+from kiro_crew.image_artifacts import drain_registrations
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.mcp_discovery import sync_discovered_servers
 from kiro_crew.sandbox import (
@@ -1275,20 +1279,257 @@ async def api_session_detail(request: web.Request) -> web.Response:
     return web.json_response(messages)
 
 
+def _image_artifact_session_keys(keys: set[str]) -> set[str]:
+    """The spellings under which an image copy may record one of ``keys``.
+
+    ``register_images`` has one caller (``chat_runner``) and it passes
+    ``slot.key`` — the tab name. For a dashboard-born tab that is the bare slot,
+    whose transcript stem is ``dashboard_<slot>``; the delete handlers receive
+    that transcript's history key (``dashboard:<slot>``) or its file stem, so the
+    copy's key is the input with the transport prefix removed. A cron-born tab is
+    named ``cron-<id>`` while its transcript is ``cron:<id>`` / ``cron_<id>``, so
+    that spelling is added too. All forms are kept so a record written with the
+    history key itself (none today) is still found. One owner:
+    :func:`fork_lineage.owner_spellings`.
+    """
+    out: set[str] = set()
+    for key in keys:
+        if key:
+            out |= fork_lineage.owner_spellings(key)
+    return out
+
+
+@dataclass
+class _ForkLineage:
+    """Fork edges over the session catalog, as transcript stems.
+
+    ``parent_of`` is the immediate ``forked_from`` edge; ``known_ancestors`` is
+    the materialized ``fork_ancestors`` chain each fork carries, which keeps
+    ancestry provable after an intermediate fork's own record is gone.
+    ``unreadable`` lists sessions whose metadata could not be read; the reap
+    fails CLOSED on any of them, since a missing edge could expose an image copy
+    a surviving fork still renders.
+    """
+
+    keys: set[str] = _dc_field(default_factory=set)
+    parent_of: dict[str, str] = _dc_field(default_factory=dict)
+    known_ancestors: dict[str, set[str]] = _dc_field(default_factory=dict)
+    unreadable: set[str] = _dc_field(default_factory=set)
+
+
+def _fork_lineage(log: Any) -> _ForkLineage:
+    """Read the fork edges of every session in the catalog.
+
+    Taken BEFORE a permanent delete: an unlinked transcript takes its
+    ``forked_from`` with it, which would break any chain that runs through a
+    deleted intermediate. Blocking (reads every session's metadata) — call off
+    the loop.
+    """
+    # (stem, forked_from, fork_ancestors, readable)
+    entries: list[tuple[str, str | None, list[str], bool]] = []
+    for entry in log.list_sessions():
+        key = str(entry.get("key") or "")
+        if not key:
+            continue
+        try:
+            meta, ok = log.get_metadata_status(key)
+        except Exception:
+            meta, ok = {}, False
+        if not ok or not isinstance(meta, dict):
+            entries.append((fork_lineage.fold(key), None, [], False))
+            continue
+        parent = meta.get("forked_from")
+        chain = fork_lineage.recorded_chain(meta)
+        entries.append(
+            (
+                fork_lineage.fold(key),
+                str(parent) if parent else None,
+                chain,
+                True,
+            )
+        )
+    # A `forked_from` key may name a transcript that still lives under a legacy
+    # stem (pre-canonical Slack threads); alias each legacy stem onto the
+    # canonical one so the catalog entry and the edge meet.
+    alias: dict[str, str] = {}
+    for _stem, parent, chain, _ok in entries:
+        for k in [parent, *chain]:
+            if k:
+                alias.update(fork_lineage.legacy_aliases(k))
+    out = _ForkLineage()
+    for stem, parent, chain, ok in entries:
+        stem = alias.get(stem, stem)
+        out.keys.add(stem)
+        if not ok:
+            out.unreadable.add(stem)
+            continue
+        if parent:
+            out.parent_of[stem] = fork_lineage.fold(parent)
+        if chain:
+            out.known_ancestors[stem] = {fork_lineage.fold(a) for a in chain}
+    return out
+
+
+def _ancestors(lineage: _ForkLineage, start: str) -> set[str]:
+    """Every ancestor of ``start`` in the snapshot — the shared
+    :func:`fork_lineage.walk_ancestors` fed by the snapshot's edges, so the
+    reap and the asset endpoint share one definition of "ancestor"."""
+    return fork_lineage.walk_ancestors(
+        start,
+        parent_of=lineage.parent_of.get,
+        known_of=lambda s: lineage.known_ancestors.get(s, ()),
+    )
+
+
+def _image_reap_set(
+    before: _ForkLineage, after: _ForkLineage, deleted: set[str]
+) -> set[str] | None:
+    """Which sessions' image copies to reap after ``deleted`` were unlinked.
+
+    A fork copies messages with their ``ts`` intact, and an image copy's slug is
+    derived from ``ts`` alone, so a fork renders the very same artifacts as its
+    source (and its source's source, …). Therefore:
+
+    * a deleted session with a SURVIVING descendant is kept;
+    * an ancestor that is itself already gone from the catalog (it was kept
+      earlier because of a fork) is reaped as soon as its last descendant goes;
+    * ``None`` (reap nothing) when any lineage metadata was unreadable, because
+      an unknown edge could hide a live descendant.
+
+    ``after`` is read once the unlink has happened: a fork acknowledged between
+    the snapshot and the delete shows up there, and the merged edge set (fresh
+    reads win) is what the decision uses. Everything is compared as transcript
+    stems (:func:`_lineage_key`); the result is the set of stems to reap plus the
+    caller's own spellings of them.
+    """
+    if before.unreadable or after.unreadable:
+        return None
+    merged = _ForkLineage(
+        keys=before.keys | after.keys,
+        parent_of={**before.parent_of, **after.parent_of},
+        known_ancestors={**before.known_ancestors, **after.known_ancestors},
+    )
+    deleted_stems = {fork_lineage.fold(k) for k in deleted}
+    # ``after`` is authoritative for what is live NOW. A deleted stem that is
+    # back in it was recreated under the same key while the delete ran (a
+    # channel session receiving a new message, a slot re-registered), so its
+    # images — including any the new incarnation registered — must stay.
+    survivors = set(after.keys)
+    protected: set[str] = set()
+    for s in survivors:
+        protected |= _ancestors(merged, s)
+    candidates = set(deleted_stems)
+    for d in deleted_stems:
+        # Ancestors absent from the catalog were kept for this line's sake.
+        candidates |= {a for a in _ancestors(merged, d) if a not in survivors}
+    reap_stems = candidates - protected - survivors
+    return reap_stems | {k for k in deleted if fork_lineage.fold(k) in reap_stems}
+
+
+#: Reaps deferred behind a straggling image registration. Held here so the task
+#: is not garbage-collected mid-flight; each removes itself when done.
+_DEFERRED_REAPS: set["asyncio.Task[None]"] = set()
+#: How long a deferred reap waits for a straggling registration before giving
+#: up loudly. A registration copies local files, so ten minutes is far past any
+#: honest run — beyond it the task is wedged and parking the reap behind it
+#: forever would just hide the leak.
+_DEFERRED_REAP_WAIT_SECS = 600.0
+
+
+async def _reap_session_images(log: Any, before: _ForkLineage, keys: set[str]) -> None:
+    """Delete the untouched chat-image copies of permanently deleted sessions.
+
+    Chat images are exempt from the widget-preview sweep, so this is their ONLY
+    reclamation path: every handler that permanently deletes a transcript must
+    call it, passing the :func:`_fork_lineage` snapshot it took BEFORE deleting.
+    The decision is :func:`_image_reap_set`; the store singleton's first
+    construction does ``resolve``+``mkdir``, so the whole call runs off the loop.
+    """
+    if not keys:
+        return
+    # Image registration is dispatched as a detached task at finalize time. A
+    # delete issued right after a turn ends must wait for it, or the late copy
+    # would land after the reap and outlive the transcript. Registrations are
+    # keyed by the slot key (what `register_images` receives). The delete
+    # request itself waits a bounded time; if a registration is still running
+    # past that, the reap is DEFERRED behind it (a background task with its own,
+    # much longer bound) rather than dropped, so the late copy is still reclaimed.
+    bare = _image_artifact_session_keys(keys)
+    drained = await drain_registrations(bare)
+    if not drained:
+        logger.warning(
+            "image cleanup for %s deferred: an image registration is still running",
+            sorted(keys),
+        )
+
+        async def _deferred() -> None:
+            # Generous second wait: a registration is a local file copy, so
+            # anything still running after this is wedged. Fail LOUD rather than
+            # park the reap forever behind it.
+            if not await drain_registrations(bare, timeout=_DEFERRED_REAP_WAIT_SECS):
+                logger.error(
+                    "image cleanup for %s abandoned: an image registration is wedged "
+                    "(%ss); its copies may outlive the deleted transcript",
+                    sorted(keys),
+                    _DEFERRED_REAP_WAIT_SECS,
+                )
+                return
+            await _reap_session_images(log, before, keys)
+
+        task = asyncio.create_task(_deferred())
+        _DEFERRED_REAPS.add(task)
+        task.add_done_callback(_DEFERRED_REAPS.discard)
+        return
+
+    def _run() -> int:
+        after = _fork_lineage(log)
+        reap = _image_reap_set(before, after, keys)
+        if reap is None:
+            logger.warning(
+                "image cleanup skipped for %s: fork lineage unreadable for %s",
+                sorted(keys),
+                sorted(before.unreadable | after.unreadable),
+            )
+            return 0
+        kept = {k for k in keys if fork_lineage.fold(k) not in reap}
+        if kept:
+            logger.info("image cleanup: keeping copies of %s (surviving forks)", sorted(kept))
+        if not reap:
+            return 0
+        return get_default_store().delete_auto_images_for_sessions(
+            _image_artifact_session_keys(reap)
+        )
+
+    try:
+        await asyncio.to_thread(_run)
+    except Exception:
+        logger.warning("image artifact cleanup failed for sessions %s", sorted(keys), exc_info=True)
+
+
 async def api_session_delete(request: web.Request) -> web.Response:
     """DELETE /api/sessions/{key} — permanently delete a history session."""
     state: DashboardState = request.app["state"]
     key = request.match_info["key"]
     if not state.conversation_log:
         return web.json_response({"error": "no conversation log"}, status=400)
+    # Fork lineage must be read BEFORE the unlink (the deleted transcript's own
+    # `forked_from` goes with it); one metadata pass, off the loop.
+    lineage = await asyncio.to_thread(_fork_lineage, state.conversation_log)
     # delete_session enters _locked (flock acquire + os.close); offload off the
     # loop so a wedged cross-process peer can't freeze chat/WS/heartbeat.
     ok = await asyncio.to_thread(state.conversation_log.delete_session, key)
     if ok:
+        # Quiesce FIRST: removing the slot kills its kiro-cli session, so no
+        # further turn can finalize and schedule a registration behind the
+        # drain below. Only then wait for what is already in flight and reap.
         try:
             await _remove_slot_for_history_key(state, key)
         except Exception:
             logger.warning("cleanup failed for session %s", key, exc_info=True)
+        # Auto-registered image artifacts are chat-owned durable copies. Keep
+        # them across agent/runtime cleanup, but reap untouched copies when the
+        # transcript itself is permanently deleted.
+        await _reap_session_images(state.conversation_log, lineage, {key})
         state.push_slots_update()
         state.push_refresh("history")
     return web.json_response({"ok": ok})
@@ -1303,8 +1544,6 @@ async def _remove_slot_for_history_key(state: DashboardState, key: str) -> None:
     first, then the stripped variant.  Also kills the kiro-cli session
     to prevent orphaned processes.
     """
-    from kiro_crew.dashboard.state import _normalize_slot_key
-
     stripped = key
     if stripped.startswith("dashboard:"):
         stripped = stripped[len("dashboard:") :]
@@ -1440,10 +1679,13 @@ async def api_sessions_clear(request: web.Request) -> web.Response:
     # permanently unlinks.
     # It globs and stats every session file, so it stays off the event loop.
     clearable, skipped = await asyncio.to_thread(_clearable_history_keys, state, log)
+    # Fork lineage snapshot BEFORE any unlink — see api_session_delete.
+    lineage = await asyncio.to_thread(_fork_lineage, log)
 
     count = 0
     failed = 0
     cleanup_tasks = []
+    deleted_keys: set[str] = set()
     for key in clearable:
         # Re-check per iteration: a resume publishing a slot during the selector's
         # scan OR during an earlier delete-await now appears here. The selector
@@ -1464,6 +1706,7 @@ async def api_sessions_clear(request: web.Request) -> web.Response:
                 skipped += 1
             elif result:
                 cleanup_tasks.append(_remove_slot_for_history_key(state, key))
+                deleted_keys.add(key)
                 count += 1
             else:
                 failed += 1
@@ -1472,6 +1715,10 @@ async def api_sessions_clear(request: web.Request) -> web.Response:
             logger.warning("api_sessions_clear: delete raised for %s", key, exc_info=True)
     if cleanup_tasks:
         await asyncio.gather(*cleanup_tasks, return_exceptions=True)
+    # Same lifetime rule as the single delete: a transcript that is gone for
+    # good takes its untouched image copies with it. One store pass for the
+    # whole batch rather than one per session.
+    await _reap_session_images(log, lineage, deleted_keys)
     if count:
         state.push_slots_update()
         state.push_refresh("history")

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3357,6 +3357,7 @@ class _ChatSlot:
         "_pending_variants",
         "_lock",
         "forked_from",
+        "fork_ancestors",
         "_fork_lock",
         "_model_pick_lock",
         "_remote_pick_lock",
@@ -3886,6 +3887,8 @@ class _ChatSlot:
         self._pending_variants: list[dict] = []
         self._lock = asyncio.Lock()
         self.forked_from: str | None = None  # parent slot key if this is a fork
+        # Full fork chain, nearest ancestor first (see dashboard/fork_lineage.py).
+        self.fork_ancestors: list[str] = []
         self._fork_lock: asyncio.Lock = asyncio.Lock()  # serialises concurrent forks on this slot
         # Serialises explicit model-pick transactions (check → mutate → live
         # switch → rollback) on this slot: picks interleaving at the set_model

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -205,6 +205,7 @@ SLOT_OWNED_META_KEYS: frozenset[str] = frozenset(
         "color_theme",
         "tags",
         "forked_from",
+        "fork_ancestors",
         "linked_session_key",
         "tab_id",
     }

--- a/src/kiro_crew/image_artifacts.py
+++ b/src/kiro_crew/image_artifacts.py
@@ -258,8 +258,10 @@ def register_images(text: str, message_ts: str, session_key: str) -> list[str]:
         copied_bytes += len(data)
 
     if registered:
-        # Image artifacts are auto_registered=True, so they ride the SAME
-        # unpinned-widget sweep — its predicate is kind-agnostic.
+        # Registering images can only ADD records, so give the widget sweep its
+        # turn. The sweep skips kind == "image": chat images are durable
+        # transcript assets reclaimed with their session
+        # (ArtifactStore.delete_auto_images_for_sessions), not rolling previews.
         try:
             pruned = store.prune_auto_widgets(keep=MAX_AUTO_WIDGET_ARTIFACTS)
             if pruned:
@@ -283,3 +285,50 @@ async def register_images_off_loop(text: str, message_ts: str, session_key: str)
     no reason to share a queue with subprocess teardown.
     """
     return await asyncio.to_thread(register_images, text, message_ts, session_key)
+
+
+#: In-flight registrations by session key. Registration is dispatched as a
+#: detached task at finalize time, so a permanent delete issued right after a
+#: turn ends could reap the session's copies BEFORE a late registration lands
+#: and leave a copy of a deleted transcript's image behind. The delete path
+#: drains these first (:func:`drain_registrations`).
+_PENDING_REGISTRATIONS: dict[str, set["asyncio.Task[object]"]] = {}
+
+
+def track_registration(session_key: str, task: "asyncio.Task[object]") -> None:
+    """Record ``task`` as an in-flight registration for ``session_key``."""
+    if not session_key:
+        return
+    tasks = _PENDING_REGISTRATIONS.setdefault(session_key, set())
+    tasks.add(task)
+
+    def _done(t: "asyncio.Task[object]") -> None:
+        pending = _PENDING_REGISTRATIONS.get(session_key)
+        if pending is not None:
+            pending.discard(t)
+            if not pending:
+                _PENDING_REGISTRATIONS.pop(session_key, None)
+
+    task.add_done_callback(_done)
+
+
+def pending_registrations(session_keys: set[str]) -> list["asyncio.Task[object]"]:
+    """The in-flight registration tasks for any of ``session_keys``."""
+    out: list[asyncio.Task[object]] = []
+    for key in session_keys:
+        out.extend(t for t in _PENDING_REGISTRATIONS.get(key, ()) if not t.done())
+    return out
+
+
+async def drain_registrations(session_keys: set[str], *, timeout: float | None = 30.0) -> bool:
+    """Wait for in-flight registrations of ``session_keys`` to finish.
+
+    Returns ``False`` when the wait timed out (some task still running) so the
+    caller can decide not to reap yet; ``timeout=None`` waits for them all.
+    Exceptions inside the tasks are theirs to log; this only waits.
+    """
+    tasks = pending_registrations(session_keys)
+    if not tasks:
+        return True
+    _done, still = await asyncio.wait(tasks, timeout=timeout)
+    return not still

--- a/src/kiro_crew/messaging/outbound_files.py
+++ b/src/kiro_crew/messaging/outbound_files.py
@@ -108,6 +108,12 @@ logger = logging.getLogger(__name__)
 #: caption may legally contain an escaped bracket -- ``![Revenue \[Q1\]](p.png)``.
 #: A plain ``[^\]]*`` stops at that escaped ``]``, the whole pattern then fails to
 #: match, and the image is never seen at all.
+#:
+#: KEEP IN SYNC: ``website/src/lib/imageArtifactSlug.ts`` ports this pattern,
+#: ``_MD_ESCAPABLE`` and ``md_destination`` byte for byte. The dashboard uses the
+#: port to find a chat image's durable artifact by its ordinal in the raw
+#: message, so a grammar change here that is not mirrored there silently breaks
+#: the image fallback. ``test/test_image_grammar_parity.py`` drives both.
 IMAGE_MD_RE = re.compile(r"!\[((?:[^\]\\]|\\.)*)\]\(")
 
 #: Unwraps a markdown backslash escape to the character it escaped.

--- a/test/fixtures/image_grammar_parity.json
+++ b/test/fixtures/image_grammar_parity.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "Markdown image grammar parity corpus. Drives test/test_image_grammar_parity.py (kiro_crew.messaging.outbound_files) AND website/src/test/imageGrammarParity.test.ts (website/src/lib/imageArtifactSlug.ts). Add a case here when either side's grammar changes; both suites must agree with the expectations below.",
+  "destinations": [
+    { "rest": "/tmp/a.png)", "expect": "/tmp/a.png" },
+    { "rest": "/tmp/a.png \"shot\")", "expect": "/tmp/a.png" },
+    { "rest": "/tmp/a.png\t'shot')", "expect": "/tmp/a.png" },
+    { "rest": "  /tmp/padded.png  )", "expect": "/tmp/padded.png" },
+    { "rest": "/tmp/shot(1).png)", "expect": "/tmp/shot(1).png" },
+    { "rest": "/tmp/a\\).png)", "expect": "/tmp/a).png" },
+    { "rest": "/tmp/a\\(.png)", "expect": "/tmp/a(.png" },
+    { "rest": "/tmp/a\\\\b.png)", "expect": "/tmp/a\\b.png" },
+    { "rest": "C:\\Users\\me\\shot.png)", "expect": "C:\\Users\\me\\shot.png" },
+    { "rest": "</tmp/generated images/c.png>)", "expect": "/tmp/generated images/c.png" },
+    { "rest": "< /tmp/spaced.png >)", "expect": "/tmp/spaced.png" },
+    { "rest": "</tmp/unterminated)", "expect": null },
+    { "rest": "/tmp/never-closes.png", "expect": null },
+    { "rest": "/tmp/a\n.png)", "expect": null },
+    { "rest": "/tmp/a\r.png)", "expect": null },
+    { "rest": "/tmp/a\u0001.png)", "expect": null },
+    { "rest": "/tmp/a\u007f.png)", "expect": null },
+    { "rest": ")", "expect": null },
+    { "rest": "https://example.com/x.png?w=1)", "expect": "https://example.com/x.png?w=1" },
+    { "rest": "file:///tmp/a.png)", "expect": "file:///tmp/a.png" }
+  ],
+  "openers": [
+    { "text": "![a](/x.png)", "count": 1 },
+    { "text": "![a\\]b](/x.png)", "count": 1 },
+    { "text": "![a][ref]", "count": 0 },
+    { "text": "[a](/x.png)", "count": 0 },
+    { "text": "![](/x.png) ![](/y.png)", "count": 2 },
+    { "text": "```\n![in-fence](/x.png)\n```", "count": 1 },
+    { "text": "<mcwidget title=\"![t](/x.png)\"></mcwidget>", "count": 1 },
+    { "text": "![unclosed", "count": 0 },
+    { "text": "![a](", "count": 1 }
+  ]
+}

--- a/test/test_dashboard_sessions_clear.py
+++ b/test/test_dashboard_sessions_clear.py
@@ -25,6 +25,7 @@ from kiro_crew.dashboard.handlers import api_sessions_clear
 
 def _history_key_for(key: str) -> str:
     from kiro_crew.dashboard.chat import _history_key_for as _hkf
+
     return _hkf(key)
 
 
@@ -80,7 +81,10 @@ def _make_request(
     raising_keys = raising_keys or set()
 
     conv_log = MagicMock()
-    conv_log.list_sessions.return_value = sessions
+    # Like the real catalog, a listing taken after a delete omits the deleted key.
+    conv_log.list_sessions.side_effect = lambda *a, **kw: [
+        s for s in sessions if s.get("key") not in deleted_keys
+    ]
     conv_log.get_metadata.side_effect = lambda k: metadata.get(k, {})
 
     def _get_metadata_status(k: str) -> tuple[dict, bool]:
@@ -447,3 +451,383 @@ async def test_skips_session_with_transient_unreadable_metadata() -> None:
     assert k_pinned not in deleted, "Pinned session with unreadable metadata was deleted!"
     assert deleted == [k_normal]
     assert body == {"ok": True, "cleared": 1, "skipped": 1, "failed": 0}
+
+
+@pytest.mark.asyncio
+async def test_bulk_clear_reaps_untouched_image_copies_of_deleted_sessions() -> None:
+    """Chat images are exempt from the widget sweep, so a permanent delete is their
+    only reclamation path — the bulk clear must take them with the transcript,
+    exactly like the single-session delete, and only for the sessions it removed."""
+    from unittest.mock import patch
+
+    k1, k2 = _history_key_for("chat-1"), _history_key_for("chat-2")
+    k_pinned = _history_key_for("chat-pinned")
+    sessions = [{"key": k1}, {"key": k2}, {"key": k_pinned}]
+    request, _state, deleted = _make_request(sessions, metadata={k_pinned: {"pinned": True}})
+
+    store = MagicMock()
+    with patch("kiro_crew.dashboard.handlers.sessions.get_default_store", return_value=store):
+        status, body = await _call_and_parse(request)
+
+    assert status == 200
+    assert body["cleared"] == 2 and set(deleted) == {k1, k2}
+    store.delete_auto_images_for_sessions.assert_called_once()
+    (keys,), _ = store.delete_auto_images_for_sessions.call_args
+    # The bare spelling of each deleted session is present; the pinned one is not.
+    assert {"chat-1", "chat-2"} <= keys
+    assert not any("chat-pinned" in k for k in keys)
+
+
+@pytest.mark.asyncio
+async def test_bulk_clear_with_nothing_deleted_does_not_touch_the_store() -> None:
+    from unittest.mock import patch
+
+    k_pinned = _history_key_for("chat-pinned")
+    request, _state, _deleted = _make_request(
+        [{"key": k_pinned}], metadata={k_pinned: {"pinned": True}}
+    )
+    with patch("kiro_crew.dashboard.handlers.sessions.get_default_store") as gds:
+        await _call_and_parse(request)
+    gds.assert_not_called()
+
+
+def test_every_permanent_delete_handler_reaps_image_copies() -> None:
+    """Chat images are exempt from the widget sweep, so the per-session reap is
+    their ONLY reclamation. This pins the invariant in code: every dashboard
+    function that calls ``delete_session`` on the conversation log must also
+    call ``_reap_session_images`` — unless it is listed below with the reason
+    it owns no image copies. Adding a new permanent-delete path without the
+    reap (or without a reasoned entry here) fails this test."""
+    import ast
+    import inspect
+
+    from kiro_crew.dashboard import chat_fork
+    from kiro_crew.dashboard.handlers import sessions
+
+    # The fork rollback removes a transcript that was never acknowledged and
+    # never ran a turn, so `register_images` never wrote a copy under its key.
+    exempt = {"chat_fork.api_chat_slot_fork"}
+
+    deleting: dict[str, bool] = {}
+    for mod in (sessions, chat_fork):
+        tree = ast.parse(inspect.getsource(mod))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            # `delete_session` is handed to asyncio.to_thread rather than called
+            # directly, so look at every name/attribute the body references.
+            names = {
+                n.attr if isinstance(n, ast.Attribute) else n.id
+                for n in ast.walk(node)
+                if isinstance(n, (ast.Attribute, ast.Name))
+            }
+            if "delete_session" in names:
+                qual = f"{mod.__name__.rsplit('.', 1)[-1]}.{node.name}"
+                deleting[qual] = "_reap_session_images" in names or qual in exempt
+    assert set(deleting) == {
+        "sessions.api_session_delete",
+        "sessions.api_sessions_clear",
+        "chat_fork.api_chat_slot_fork",
+    }, deleting
+    assert all(deleting.values()), deleting
+
+
+def test_image_session_key_spellings_match_what_register_images_records() -> None:
+    """``register_images`` records the bare ``slot.key``; the delete handlers get
+    the transcript's history key or file stem. The lookup set must contain the
+    bare form for either input and nothing invented."""
+    from kiro_crew.dashboard.handlers.sessions import _image_artifact_session_keys
+
+    assert _image_artifact_session_keys({"dashboard:chat-1"}) == {"dashboard:chat-1", "chat-1"}
+    assert _image_artifact_session_keys({"dashboard_chat-1"}) == {"dashboard_chat-1", "chat-1"}
+    assert _image_artifact_session_keys({"chat-1", ""}) == {"chat-1"}
+    # A cron transcript is `cron:<id>` / `cron_<id>`; its copies are owned by the
+    # tab, `cron-<id>`. Deleting the transcript must reach them.
+    assert "cron-42" in _image_artifact_session_keys({"cron:42"})
+    assert "cron-42" in _image_artifact_session_keys({"cron_42"})
+
+
+# --- fork lineage and the image reap -------------------------------------
+#
+# A fork copies messages with their ts intact and an image copy's slug derives
+# from ts alone, so a fork renders its source's artifacts. The reap must never
+# remove a copy a surviving descendant still renders, must fail closed when it
+# cannot know, and must eventually reclaim ancestors once their line dies out.
+
+
+def _catalog(
+    sessions: dict[str, str | list[str] | None],
+    unreadable: set[str] = frozenset(),
+    *,
+    materialized: bool = True,
+) -> MagicMock:
+    """A conversation-log stand-in: ``{bare_key: forked_from | full_chain | None}``.
+
+    A ``str`` value is the immediate source; the persisted chain is derived from
+    the dict while its links are present. A ``list`` value is the chain exactly
+    as the fork's own record carries it (nearest first) — the production shape
+    that survives deletion of an intermediate. With ``materialized=False`` only
+    ``forked_from`` is written, the shape of forks made before the chain was
+    recorded.
+    """
+    log = MagicMock()
+    log.list_sessions.return_value = [{"key": _history_key_for(k)} for k in sessions]
+
+    def _parent(bare: str) -> str | None:
+        v = sessions.get(bare)
+        if isinstance(v, list):
+            return v[0] if v else None
+        return v
+
+    def _chain(bare: str) -> list[str]:
+        v = sessions.get(bare)
+        if isinstance(v, list):
+            return [_history_key_for(x) for x in v]
+        out: list[str] = []
+        cur = v
+        while cur and cur not in out:
+            out.append(cur)
+            cur = _parent(cur)
+        return [_history_key_for(x) for x in out]
+
+    def _status(key: str) -> tuple[dict, bool]:
+        bare = key.removeprefix("dashboard:").removeprefix("dashboard_")
+        if bare in unreadable:
+            return {}, False
+        parent = _parent(bare)
+        if not parent:
+            return {}, True
+        # The fork handler records `effective_session_key(source)`, i.e. the
+        # history key (`dashboard:<slot>`), never a bare slot name.
+        meta: dict = {"forked_from": _history_key_for(parent)}
+        if materialized:
+            meta["fork_ancestors"] = _chain(bare)
+        return meta, True
+
+    log.get_metadata_status.side_effect = _status
+    return log
+
+
+def _reaped(before_log: MagicMock, after_log: MagicMock, deleted: set[str]) -> set[str] | None:
+    """Run the reap the way a handler does and return the bare keys it reaped
+    (``None`` when it did not touch the store)."""
+    import asyncio
+    from unittest.mock import patch
+
+    from kiro_crew.dashboard.handlers.sessions import _fork_lineage, _reap_session_images
+
+    before = _fork_lineage(before_log)
+    store = MagicMock()
+    with patch("kiro_crew.dashboard.handlers.sessions.get_default_store", return_value=store):
+        asyncio.run(_reap_session_images(after_log, before, {_history_key_for(k) for k in deleted}))
+    if not store.delete_auto_images_for_sessions.called:
+        return None
+    (keys,), _ = store.delete_auto_images_for_sessions.call_args
+    # Reduce every spelling the store was handed to the bare session name.
+    return {k.removeprefix("dashboard:").removeprefix("dashboard_") for k in keys}
+
+
+def test_channel_transcript_stems_and_live_keys_fold_to_one_lineage() -> None:
+    """The catalog lists a channel transcript by its file stem (``slack_<ts>``)
+    while a fork's ``forked_from`` carries the live key (``slack:<ts>``). Both
+    must fold to the same lineage node, or the fork's protection is missed."""
+    import asyncio
+    from unittest.mock import patch
+
+    from kiro_crew.dashboard.handlers.sessions import _fork_lineage, _reap_session_images
+
+    def _log(entries: dict[str, str | None]) -> MagicMock:
+        log = MagicMock()
+        log.list_sessions.return_value = [{"key": k} for k in entries]
+
+        def _status(key: str) -> tuple[dict, bool]:
+            parent = entries.get(key)
+            return ({"forked_from": parent} if parent else {}), True
+
+        log.get_metadata_status.side_effect = _status
+        return log
+
+    before = _log({"slack_1700.42": None, "dashboard_fork": "slack:1700.42"})
+    after = _log({"dashboard_fork": "slack:1700.42"})
+    store = MagicMock()
+    with patch("kiro_crew.dashboard.handlers.sessions.get_default_store", return_value=store):
+        asyncio.run(_reap_session_images(after, _fork_lineage(before), {"slack:1700.42"}))
+    store.delete_auto_images_for_sessions.assert_not_called()
+
+    # A Slack thread that predates the canonical key still logs under its bare
+    # thread_ts stem; the fork's `forked_from` names the canonical key. They
+    # must still meet as one lineage node.
+    before = _log({"1700.42": None, "dashboard_fork": "slack:1700.42"})
+    after = _log({"dashboard_fork": "slack:1700.42"})
+    store = MagicMock()
+    with patch("kiro_crew.dashboard.handlers.sessions.get_default_store", return_value=store):
+        asyncio.run(_reap_session_images(after, _fork_lineage(before), {"slack:1700.42"}))
+    store.delete_auto_images_for_sessions.assert_not_called()
+
+
+def test_deleting_a_fork_source_keeps_images_a_surviving_fork_still_renders() -> None:
+    before = _catalog({"src": None, "fork": "src"})
+    after = _catalog({"fork": "src"})
+    assert _reaped(before, after, {"src"}) is None
+
+
+def test_deleting_source_and_fork_together_reaps_both() -> None:
+    before = _catalog({"src": None, "fork": "src"})
+    after = _catalog({})
+    assert _reaped(before, after, {"src", "fork"}) == {"src", "fork"}
+
+
+def test_fork_chain_protects_the_grandparent_through_a_deleted_intermediate() -> None:
+    before = _catalog({"a": None, "b": "a", "c": "b"})
+    after = _catalog({"c": "b"})
+    assert _reaped(before, after, {"a", "b"}) is None
+
+
+def test_deleting_the_last_fork_reaps_the_ancestor_kept_for_it() -> None:
+    # `src` was deleted earlier while `fork` survived, so its copies were kept.
+    # Now `fork` goes: nothing descends from `src` any more -> reap both lines.
+    before = _catalog({"fork": "src"})  # src is already gone from the catalog
+    after = _catalog({})
+    assert _reaped(before, after, {"fork"}) == {"fork", "src"}
+
+
+def test_a_sibling_fork_keeps_the_shared_ancestor_alive() -> None:
+    before = _catalog({"f1": "src", "f2": "src"})  # src already gone
+    after = _catalog({"f2": "src"})
+    assert _reaped(before, after, {"f1"}) == {"f1"}
+
+
+def test_unreadable_fork_metadata_fails_closed() -> None:
+    # `fork` may descend from `src`; we cannot tell -> reap nothing.
+    before = _catalog({"src": None, "fork": None}, unreadable={"fork"})
+    after = _catalog({"fork": None}, unreadable={"fork"})
+    assert _reaped(before, after, {"src"}) is None
+
+
+def test_a_fork_acknowledged_after_the_snapshot_still_protects_its_source() -> None:
+    before = _catalog({"src": None})  # fork not yet in the catalog
+    after = _catalog({"fork": "src"})  # it landed between snapshot and delete
+    assert _reaped(before, after, {"src"}) is None
+
+
+def test_a_session_recreated_under_the_deleted_key_is_not_reaped() -> None:
+    """The post-delete read is authoritative: a stem back in the catalog was
+    recreated under the same key while the delete ran (a channel session that
+    received a new message), and the new incarnation's images must stay."""
+    before = _catalog({"chan": None, "other": None})
+    after = _catalog({"chan": None})  # recreated during cleanup
+    assert _reaped(before, after, {"chan", "other"}) == {"other"}
+
+
+def test_reap_handles_a_forked_from_cycle_without_hanging() -> None:
+    before = _catalog({"a": "b", "b": "a", "c": None})
+    after = _catalog({"a": "b", "b": "a"})
+    assert _reaped(before, after, {"c"}) == {"c"}
+
+
+def test_a_very_deep_fork_chain_still_protects_its_root() -> None:
+    # root <- f1 <- f2 <- … <- f200 (only the leaf survives): deleting the root
+    # and every intermediate must reap nothing — no depth cap may cut the walk.
+    chain = {"root": None}
+    prev = "root"
+    for i in range(1, 201):
+        chain[f"f{i}"] = prev
+        prev = f"f{i}"
+    before = _catalog(chain)
+    after = _catalog({"f200": "f199"})
+    deleted = set(chain) - {"f200"}
+    assert _reaped(before, after, deleted) is None
+
+
+def test_root_kept_earlier_stays_protected_after_the_intermediate_is_gone() -> None:
+    # A <- B <- C. A was deleted earlier (kept for B/C). Now B is deleted while C
+    # survives. B's record is gone, but C's own `fork_ancestors` names A, so A
+    # remains protected and only B is reaped.
+    before = _catalog({"b": ["a"], "c": ["b", "a"]})  # a already absent
+    after = _catalog({"c": ["b", "a"]})
+    assert _reaped(before, after, {"b"}) is None  # b is c's ancestor too
+
+
+def test_legacy_forks_without_a_materialized_chain_still_use_the_snapshot() -> None:
+    # Forks made before `fork_ancestors` existed carry only `forked_from`; the
+    # pre-delete snapshot still links the chain for the delete that follows.
+    before = _catalog({"a": None, "b": "a", "c": "b"}, materialized=False)
+    after = _catalog({"c": "b"}, materialized=False)
+    assert _reaped(before, after, {"a", "b"}) is None
+
+
+@pytest.mark.asyncio
+async def test_single_delete_quiesces_the_slot_before_draining_and_reaping() -> None:
+    """A turn that finalizes AFTER the drain snapshot would register a copy behind
+    the reap. Removing the slot first (which kills its kiro-cli session) closes
+    that window, so the order must be: remove slot -> drain -> reap."""
+    from unittest.mock import AsyncMock, patch
+
+    from kiro_crew.dashboard.handlers import api_session_delete
+
+    order: list[str] = []
+    conv_log = MagicMock()
+    conv_log.delete_session.return_value = True
+    conv_log.list_sessions.return_value = []
+    state = MagicMock()
+    state.conversation_log = conv_log
+    request = MagicMock(spec=web.Request)
+    request.app = {"state": state}
+    request.match_info = {"key": _history_key_for("chat-1")}
+
+    async def _remove(_state: object, _key: str) -> None:
+        order.append("remove_slot")
+
+    async def _drain(_keys: set[str], **_kw: object) -> bool:
+        order.append("drain")
+        return True
+
+    store = MagicMock()
+    store.delete_auto_images_for_sessions.side_effect = lambda _k: order.append("reap") or 0
+    with (
+        patch("kiro_crew.dashboard.handlers.sessions._remove_slot_for_history_key", new=_remove),
+        patch(
+            "kiro_crew.dashboard.handlers.sessions.drain_registrations",
+            new=AsyncMock(side_effect=_drain),
+        ),
+        patch("kiro_crew.dashboard.handlers.sessions.get_default_store", return_value=store),
+    ):
+        resp = await api_session_delete(request)
+    assert resp.status == 200
+    assert order == ["remove_slot", "drain", "reap"]
+
+
+@pytest.mark.asyncio
+async def test_a_slow_registration_defers_the_reap_instead_of_dropping_it(monkeypatch) -> None:
+    """If an image registration outlives the delete request's bounded wait, the
+    reap must run once it finishes — never be skipped — or the late copy would
+    outlive its deleted transcript for good."""
+    import asyncio
+    from unittest.mock import patch
+
+    from kiro_crew import image_artifacts as ia
+    from kiro_crew.dashboard.handlers import sessions as mod
+
+    gate = asyncio.Event()
+    task = asyncio.create_task(gate.wait())
+    ia.track_registration("chat-slow", task)
+
+    # First wait is capped very short so the delete path takes the deferred branch.
+    real_drain = ia.drain_registrations
+
+    async def _short_first(keys: set[str], *, timeout: float | None = 30.0) -> bool:
+        return await real_drain(keys, timeout=0.01 if timeout is not None else None)
+
+    monkeypatch.setattr(mod, "drain_registrations", _short_first)
+    store = MagicMock()
+    lineage = mod._fork_lineage(_catalog({"slow": None}))
+    with patch("kiro_crew.dashboard.handlers.sessions.get_default_store", return_value=store):
+        await mod._reap_session_images(_catalog({}), lineage, {_history_key_for("chat-slow")})
+        # Not reaped yet: the registration is still running.
+        store.delete_auto_images_for_sessions.assert_not_called()
+        assert mod._DEFERRED_REAPS, "no deferred reap was scheduled"
+        gate.set()
+        await asyncio.gather(*mod._DEFERRED_REAPS)
+    store.delete_auto_images_for_sessions.assert_called_once()
+    (keys,), _ = store.delete_auto_images_for_sessions.call_args
+    assert "chat-slow" in {k.removeprefix("dashboard:").removeprefix("dashboard_") for k in keys}

--- a/test/test_fork_lineage.py
+++ b/test/test_fork_lineage.py
@@ -1,0 +1,175 @@
+"""``kiro_crew.dashboard.fork_lineage`` — the one fork-ancestry helper both the
+artifact asset endpoint and the permanent-delete reap consult."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from kiro_crew.dashboard import fork_lineage as fl
+
+
+def _log(meta_by_key: dict[str, dict], unreadable: set[str] = frozenset()) -> MagicMock:
+    log = MagicMock()
+
+    def _status(key: str) -> tuple[dict, bool]:
+        if key in unreadable:
+            return {}, False
+        return meta_by_key.get(key, {}), True
+
+    log.get_metadata_status.side_effect = _status
+    return log
+
+
+def test_fold_unifies_every_spelling_of_one_session() -> None:
+    assert fl.fold("chat-1") == fl.fold("dashboard:chat-1") == fl.fold("dashboard_chat-1")
+    assert fl.fold("slack:1700.42") == fl.fold("slack_1700.42")
+    assert fl.fold("chat-1") != fl.fold("chat-2")
+
+
+def test_fold_maps_a_cron_tab_onto_its_session() -> None:
+    """A cron job's tab is ``cron-<id>`` while its session is ``cron:<id>``; the
+    stem keeps ``-`` and folds ``:`` to ``_``, so without the bridge an image
+    copy owned by the tab would never match the session in ``forked_from``."""
+    assert fl.fold("cron-42") == fl.fold("cron:42") == fl.fold("cron_42")
+    assert fl.fold("dashboard:cron-42") == fl.fold("cron:42")
+    # A per-run key is a different session from the job's own.
+    assert fl.fold("cron-42") != fl.fold("cron:42:run7")
+
+
+def test_owner_spellings_cover_dashboard_and_cron_tab_names() -> None:
+    assert fl.owner_spellings("dashboard:chat-1") == {"dashboard:chat-1", "chat-1"}
+    assert fl.owner_spellings("cron:42") == {"cron:42", "cron-42"}
+    assert fl.owner_spellings("cron_42") == {"cron_42", "cron-42"}
+    assert fl.owner_spellings("dashboard:cron_42") == {"dashboard:cron_42", "cron_42", "cron-42"}
+    assert fl.owner_spellings("slack:1.2") == {"slack:1.2"}
+
+
+def test_descends_from_accepts_a_fork_of_a_cron_session() -> None:
+    """The fork records the cron SESSION key; the copy is owned by the cron TAB."""
+    log = _log({"dashboard:fork": {"forked_from": "cron:42", "fork_ancestors": ["cron:42"]}})
+    assert fl.descends_from(log, "fork", "cron-42")
+    assert fl.descends_from(log, "cron-42", "cron:42")
+    assert not fl.descends_from(log, "fork", "cron-43")
+
+
+def test_malformed_fork_ancestors_degrades_to_the_forked_from_walk() -> None:
+    """Transcript metadata is user-editable JSON; a non-list chain must not raise
+    into an asset request — the walk falls back to ``forked_from``."""
+    for bad in (1, "dashboard:a", {"x": 1}, None):
+        log = _log({"dashboard:b": {"forked_from": "dashboard:a", "fork_ancestors": bad}})
+        assert fl.descends_from(log, "b", "a")
+        assert fl.ancestry_chain(log, "dashboard:b") == ["dashboard:a"]
+    assert fl.recorded_chain("not a dict") == []
+    assert fl.recorded_chain({"fork_ancestors": ["dashboard:a", "", None]}) == ["dashboard:a"]
+
+
+def test_materialize_ancestors_prepends_the_source_and_keeps_order() -> None:
+    assert fl.materialize_ancestors("dashboard:b", ["dashboard:a"]) == [
+        "dashboard:b",
+        "dashboard:a",
+    ]
+    assert fl.materialize_ancestors("dashboard:a", None) == ["dashboard:a"]
+    # Duplicates and blanks are dropped.
+    assert fl.materialize_ancestors("dashboard:b", ["dashboard:b", "", "dashboard:a"]) == [
+        "dashboard:b",
+        "dashboard:a",
+    ]
+
+
+def test_descends_from_accepts_owner_forks_and_grandforks() -> None:
+    log = _log(
+        {
+            "dashboard:fork": {"forked_from": "dashboard:src", "fork_ancestors": ["dashboard:src"]},
+            "dashboard:grand": {
+                "forked_from": "dashboard:fork",
+                "fork_ancestors": ["dashboard:fork", "dashboard:src"],
+            },
+        }
+    )
+    assert fl.descends_from(log, "src", "src")
+    assert fl.descends_from(log, "fork", "src")
+    assert fl.descends_from(log, "dashboard_grand", "src")
+    assert not fl.descends_from(log, "other", "src")
+
+
+def test_descends_from_survives_a_deleted_intermediate_via_the_materialized_chain() -> None:
+    # `fork` is gone from the catalog; `grand` still names `src` in its own chain.
+    log = _log(
+        {
+            "dashboard:grand": {
+                "forked_from": "dashboard:fork",
+                "fork_ancestors": ["dashboard:fork", "dashboard:src"],
+            }
+        }
+    )
+    assert fl.descends_from(log, "grand", "src")
+
+
+def test_descends_from_walks_forked_from_for_legacy_forks_without_a_chain() -> None:
+    log = _log(
+        {
+            "dashboard:fork": {"forked_from": "dashboard:src"},
+            "dashboard:grand": {"forked_from": "dashboard:fork"},
+        }
+    )
+    assert fl.descends_from(log, "grand", "src")
+
+
+def test_descends_from_fails_closed_on_unreadable_lineage() -> None:
+    log = _log(
+        {"dashboard:fork": {"forked_from": "dashboard:src"}}, unreadable={"dashboard:fork", "fork"}
+    )
+    assert not fl.descends_from(log, "fork", "src")
+
+
+def test_ancestors_of_terminates_on_a_cycle() -> None:
+    log = _log(
+        {
+            "dashboard:a": {"forked_from": "dashboard:b"},
+            "dashboard:b": {"forked_from": "dashboard:a"},
+        }
+    )
+    assert fl.ancestors_of(log, "a") == {fl.fold("b")}
+
+
+def test_ancestry_chain_reconstructs_a_legacy_source_before_materializing() -> None:
+    # A <- B <- C where B and C predate `fork_ancestors` (forked_from only).
+    # Forking C must record [C, B, A], not just [C].
+    log = _log(
+        {
+            "dashboard:b": {"forked_from": "dashboard:a"},
+            "dashboard:c": {"forked_from": "dashboard:b"},
+        }
+    )
+    chain = fl.ancestry_chain(log, "dashboard:c")
+    assert chain == ["dashboard:b", "dashboard:a"]
+    assert fl.materialize_ancestors("dashboard:c", chain) == [
+        "dashboard:c",
+        "dashboard:b",
+        "dashboard:a",
+    ]
+
+
+def test_ancestry_chain_prefers_a_recorded_chain_and_stops_when_unreadable() -> None:
+    log = _log(
+        {
+            "dashboard:c": {
+                "forked_from": "dashboard:b",
+                "fork_ancestors": ["dashboard:b", "dashboard:a"],
+            },
+            "dashboard:z": {"forked_from": "dashboard:y"},
+        },
+        unreadable={"dashboard:y", "y"},
+    )
+    assert fl.ancestry_chain(log, "dashboard:c") == ["dashboard:b", "dashboard:a"]
+    # y is unreadable: what is provable (z's parent) is recorded, no further.
+    assert fl.ancestry_chain(log, "dashboard:z") == ["dashboard:y"]
+
+
+def test_walk_ancestors_merges_recorded_chains_along_the_edge_walk() -> None:
+    parent = {"c": "b", "b": "a"}
+    known = {"c": ["b", "a"], "b": ["a"], "a": []}
+    assert fl.walk_ancestors("c", parent.get, lambda s: known.get(s, [])) == {"b", "a"}
+    # A chain recorded on a deleted intermediate still reaches the root when the
+    # surviving node carries it itself.
+    assert fl.walk_ancestors("c", {}.get, lambda s: {"c": ["b", "a"]}.get(s, [])) == {"b", "a"}

--- a/test/test_image_artifacts.py
+++ b/test/test_image_artifacts.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import os
 import sys
 import types
 from pathlib import Path
@@ -645,14 +646,14 @@ class TestAssetReadHardening:
         seen: dict[str, bool] = {}
         original = store._read_image_asset_bytes
 
-        def _spy(path: Path) -> bytes:
+        def _spy(path: Path, **kw: object) -> bytes:
             # The lock must be free at read time: acquiring it here would
             # deadlock if it were still held by the caller.
             acquired = store._lock.acquire(blocking=False)
             seen["lock_free"] = acquired
             if acquired:
                 store._lock.release()
-            return original(path)
+            return original(path, **kw)  # type: ignore[arg-type]
 
         store._read_image_asset_bytes = _spy  # type: ignore[method-assign]
         try:
@@ -775,6 +776,191 @@ class TestAssetReadHardening:
         assert "public" not in cache
         assert offloaded["used"] is True
 
+    def test_asset_refuses_another_sessions_copy_when_the_caller_names_its_session(
+        self, store: ArtifactStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Image slugs derive from (message ts, ordinal) only, so two sessions can
+        collide. A transcript fallback names its own session; a copy recorded for
+        a different session must 404 rather than render the wrong picture."""
+        from kiro_crew.dashboard.handlers import artifacts as handlers
+
+        art = store.create_image(
+            name="Pic", image_bytes=_png_bytes(2, 2), mime="image/png", session_key="chat-7"
+        )
+        monkeypatch.setattr(handlers, "get_default_store", lambda: store)
+
+        def _req(session: str) -> types.SimpleNamespace:
+            return types.SimpleNamespace(match_info={"slug": art.slug}, query={"session": session})
+
+        # Owner, in every spelling the dashboard uses.
+        for spelling in ("chat-7", "dashboard:chat-7", "dashboard_chat-7"):
+            resp = asyncio.run(handlers.api_artifact_asset(_req(spelling)))  # type: ignore[arg-type]
+            assert resp.status == 200, spelling
+        # Another session.
+        resp = asyncio.run(handlers.api_artifact_asset(_req("chat-8")))  # type: ignore[arg-type]
+        assert resp.status == 404
+        # No session named (artifact library): unchanged behaviour.
+        resp = asyncio.run(handlers.api_artifact_asset(types.SimpleNamespace(match_info={"slug": art.slug})))  # type: ignore[arg-type]
+        assert resp.status == 200
+
+    def test_asset_is_served_to_a_fork_of_the_owning_session(
+        self, store: ArtifactStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fork keeps its source's message ts, so it renders the source's copies;
+        the owner check must follow `forked_from` (any depth) and still refuse an
+        unrelated session or one whose lineage cannot be read."""
+        from unittest.mock import MagicMock
+
+        from kiro_crew.dashboard.handlers import artifacts as handlers
+
+        art = store.create_image(
+            name="Pic", image_bytes=_png_bytes(2, 2), mime="image/png", session_key="chat-src"
+        )
+        monkeypatch.setattr(handlers, "get_default_store", lambda: store)
+        lineage = {"dashboard:chat-fork": "dashboard:chat-src", "dashboard:chat-grand": "dashboard:chat-fork"}
+        log = MagicMock()
+        log.get_metadata_status.side_effect = lambda k: (
+            ({"forked_from": lineage[k]}, True) if k in lineage else ({}, True)
+        )
+        state = types.SimpleNamespace(conversation_log=log)
+
+        def _req(session: str) -> types.SimpleNamespace:
+            return types.SimpleNamespace(
+                match_info={"slug": art.slug}, query={"session": session}, app={"state": state}
+            )
+
+        assert asyncio.run(handlers.api_artifact_asset(_req("chat-fork"))).status == 200  # type: ignore[arg-type]
+        assert asyncio.run(handlers.api_artifact_asset(_req("chat-grand"))).status == 200  # type: ignore[arg-type]
+        assert asyncio.run(handlers.api_artifact_asset(_req("chat-other"))).status == 404  # type: ignore[arg-type]
+        # The intermediate fork is deleted: its record is gone, but the grandchild
+        # carries the materialized chain and still proves descent from the owner.
+        surviving = {
+            "dashboard:chat-grand": {
+                "forked_from": "dashboard:chat-fork",
+                "fork_ancestors": ["dashboard:chat-fork", "dashboard:chat-src"],
+            }
+        }
+        log.get_metadata_status.side_effect = lambda k: (surviving.get(k, {}), True)
+        assert asyncio.run(handlers.api_artifact_asset(_req("chat-grand"))).status == 200  # type: ignore[arg-type]
+        # Unreadable lineage fails closed.
+        log.get_metadata_status.side_effect = lambda k: ({}, False)
+        assert asyncio.run(handlers.api_artifact_asset(_req("chat-fork"))).status == 404  # type: ignore[arg-type]
+
+    def test_owner_check_and_bytes_come_from_one_store_snapshot(
+        self, store: ArtifactStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The owner the endpoint authorizes must be the owner of the bytes it
+        serves. Deleting the slug and recreating it under another session between
+        the two would otherwise let the old owner's check pass and the new owner's
+        picture be served."""
+        from kiro_crew.dashboard.handlers import artifacts as handlers
+
+        art = store.create_image(
+            name="Pic", image_bytes=_png_bytes(2, 2), mime="image/png", slug="shared-slug", session_key="chat-a"
+        )
+        monkeypatch.setattr(handlers, "get_default_store", lambda: store)
+        # `read_image_bytes_with_owner` reports the owner from the same locked
+        # metadata read that resolves the asset path.
+        data, mime, owner = store.read_image_bytes_with_owner(art.slug)
+        assert (data, mime, owner) == (_png_bytes(2, 2), "image/png", "chat-a")
+
+        # Recreate under another session: the endpoint must now judge by chat-b.
+        store.delete(art.slug)
+        store.create_image(
+            name="Pic2", image_bytes=_png_bytes(3, 3), mime="image/png", slug="shared-slug", session_key="chat-b"
+        )
+        req_a = types.SimpleNamespace(match_info={"slug": "shared-slug"}, query={"session": "chat-a"})
+        req_b = types.SimpleNamespace(match_info={"slug": "shared-slug"}, query={"session": "chat-b"})
+        assert asyncio.run(handlers.api_artifact_asset(req_a)).status == 404  # type: ignore[arg-type]
+        resp = asyncio.run(handlers.api_artifact_asset(req_b))  # type: ignore[arg-type]
+        assert resp.status == 200 and resp.body == _png_bytes(3, 3)
+
+    def test_asset_bytes_are_refused_if_the_sidecar_changed_after_the_owner_was_captured(
+        self, store: ArtifactStore
+    ) -> None:
+        """The owner is captured under the metadata lock; the bytes are read after
+        it. The read pins the sidecar's inode from under the lock and refuses any
+        other inode, so a slug deleted and recreated in that window can never pair
+        the earlier owner with the later record's picture."""
+        art = store.create_image(
+            name="Pic", image_bytes=_png_bytes(2, 2), mime="image/png", session_key="chat-a"
+        )
+        asset = next(store._artifact_dir(art.slug).glob("asset.*"))
+        pinned = store._sidecar_identity(asset)
+        assert pinned is not None
+        # Same inode: served.
+        assert store._read_image_asset_bytes(asset, identity=pinned) == _png_bytes(2, 2)
+        # Sidecar replaced (delete + recreate): even if the filesystem hands the
+        # new file the same inode number, its size/mtime differ — refused.
+        asset.unlink()
+        asset.write_bytes(_png_bytes(3, 3))
+        with pytest.raises(ArtifactNotFoundError):
+            store._read_image_asset_bytes(asset, identity=pinned)
+
+    def test_pinned_read_still_refuses_a_hardlinked_sidecar(self, store: ArtifactStore) -> None:
+        """The identity pin is an ADDITIONAL check, not a replacement: the
+        regular-file and link-count checks of the unpinned read apply to the
+        same descriptor, so an aliased sidecar is refused even when its inode
+        is the one captured under the lock."""
+        art = store.create_image(
+            name="Pic", image_bytes=_png_bytes(2, 2), mime="image/png", session_key="chat-a"
+        )
+        asset = next(store._artifact_dir(art.slug).glob("asset.*"))
+        pinned = store._sidecar_identity(asset)
+        assert pinned is not None
+        try:
+            os.link(asset, asset.with_name("alias.bin"))
+        except OSError:
+            pytest.skip("filesystem does not support hardlinks")
+        with pytest.raises(ArtifactNotFoundError):
+            store._read_image_asset_bytes(asset, identity=pinned)
+
+    def test_delete_waits_for_an_in_flight_registration(self) -> None:
+        """A permanent delete right after finalize must not reap before the
+        detached registration lands, or the late copy outlives the transcript."""
+        from kiro_crew import image_artifacts as ia
+
+        async def _scenario() -> tuple[bool, list[str]]:
+            order: list[str] = []
+            gate = asyncio.Event()
+
+            async def _register() -> None:
+                await gate.wait()
+                order.append("registered")
+
+            task = asyncio.create_task(_register())
+            ia.track_registration("chat-1", task)
+            assert ia.pending_registrations({"chat-1"}) == [task]
+
+            async def _delete() -> bool:
+                ok = await ia.drain_registrations({"chat-1"})
+                order.append("reaped")
+                return ok
+
+            deleter = asyncio.create_task(_delete())
+            await asyncio.sleep(0)
+            gate.set()
+            ok = await deleter
+            return ok, order
+
+        ok, order = asyncio.run(_scenario())
+        assert ok is True
+        assert order == ["registered", "reaped"]
+
+    def test_drain_reports_a_registration_that_outlives_the_timeout(self) -> None:
+        from kiro_crew import image_artifacts as ia
+
+        async def _scenario() -> bool:
+            hang = asyncio.Event()
+            task = asyncio.create_task(hang.wait())
+            ia.track_registration("chat-2", task)
+            try:
+                return await ia.drain_registrations({"chat-2"}, timeout=0.01)
+            finally:
+                task.cancel()
+
+        assert asyncio.run(_scenario()) is False
+
 
 class TestLinkedAncestorGate:
     """On Windows, a registration destination beneath a linked ANCESTOR must
@@ -859,3 +1045,63 @@ class TestLinkedAncestorGate:
 
         monkeypatch.setattr(Path, "is_file", _boom_is_file)
         assert image_artifacts._local_file(str(f)) is None
+
+
+class TestChatImageLifetime:
+    def test_widget_pruning_never_deletes_unpinned_chat_images(
+        self, store: ArtifactStore
+    ) -> None:
+        image = store.create_image(
+            name="chat screenshot",
+            image_bytes=_png_bytes(),
+            mime="image/png",
+            session_key="chat-1",
+            auto_registered=True,
+        )
+        for i in range(3):
+            store.create(
+                name=f"widget {i}",
+                content=f"<p>{i}</p>",
+                kind="widget",
+                slug=f"widget-{i}",
+                session_key="chat-1",
+                auto_registered=True,
+            )
+
+        store.prune_auto_widgets(keep=0)
+
+        assert store.get(image.slug).kind == "image"
+
+    def test_session_delete_cleanup_preserves_invested_images(
+        self, store: ArtifactStore
+    ) -> None:
+        untouched = store.create_image(
+            name="temporary screenshot",
+            image_bytes=_png_bytes(),
+            mime="image/png",
+            session_key="chat-1",
+            auto_registered=True,
+        )
+        pinned = store.create_image(
+            name="saved screenshot",
+            image_bytes=_png_bytes(),
+            mime="image/png",
+            slug="saved-screenshot",
+            session_key="chat-1",
+            auto_registered=True,
+        )
+        store.set_pinned(pinned.slug, True)
+        other = store.create_image(
+            name="other chat",
+            image_bytes=_png_bytes(),
+            mime="image/png",
+            slug="other-chat",
+            session_key="chat-2",
+            auto_registered=True,
+        )
+
+        assert store.delete_auto_images_for_sessions({"chat-1"}) == 1
+        with pytest.raises(ArtifactNotFoundError):
+            store.get(untouched.slug)
+        assert store.get(pinned.slug).pinned is True
+        assert store.get(other.slug).session_key == "chat-2"

--- a/test/test_image_grammar_parity.py
+++ b/test/test_image_grammar_parity.py
@@ -1,0 +1,30 @@
+"""The markdown image grammar the dashboard ports must match the backend's.
+
+``website/src/lib/imageArtifactSlug.ts`` re-implements :data:`IMAGE_MD_RE` and
+:func:`md_destination` so the dashboard can find a chat image's durable artifact
+by its ordinal in the raw message.  Both suites consume
+``test/fixtures/image_grammar_parity.json``; a grammar change on either side
+that is not mirrored fails here or in ``imageGrammarParity.test.ts``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.messaging.outbound_files import IMAGE_MD_RE, md_destination
+
+_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "image_grammar_parity.json"
+_CORPUS = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("case", _CORPUS["destinations"], ids=lambda c: repr(c["rest"]))
+def test_destination_parity(case: dict) -> None:
+    assert md_destination(case["rest"]) == case["expect"]
+
+
+@pytest.mark.parametrize("case", _CORPUS["openers"], ids=lambda c: repr(c["text"]))
+def test_opener_count_parity(case: dict) -> None:
+    assert len(IMAGE_MD_RE.findall(case["text"])) == case["count"]

--- a/test/test_resume_publishes_hydrated_slot.py
+++ b/test/test_resume_publishes_hydrated_slot.py
@@ -853,3 +853,35 @@ async def test_resuming_a_session_that_never_existed_is_not_refused(tmp_path, mo
         f"resuming a never-existed session returned {resp.status}; an absent key is a new "
         "conversation, not a deletion"
     )
+
+
+@pytest.mark.asyncio
+async def test_resume_restores_the_fork_chain_and_the_next_save_keeps_it(tmp_path, monkeypatch):
+    """A fork reopened from history via ``api_chat_slot_resume`` must carry its
+    ``fork_ancestors``. The field is slot-owned (``SLOT_OWNED_META_KEYS``): a
+    resume that skipped it would let the next save rewrite the metadata line
+    without the chain, and the fork's images would stop resolving through fork
+    descent — the failure this PR fixes, reopened on a different path."""
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    log = state.conversation_log
+    log.append("dashboard:fork1", "user", "history-1")
+    log.append("dashboard:fork1", "assistant", "history-2")
+    chain = ["dashboard:src", "dashboard:root"]
+    log.update_metadata(
+        "dashboard:fork1", {"forked_from": "dashboard:src", "fork_ancestors": chain}
+    )
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat/slots/fork1/resume", json={"key": "dashboard:fork1"})
+        assert resp.status == 200
+
+    slot = state._slots["fork1"]
+    assert slot.forked_from == "dashboard:src"
+    assert slot.fork_ancestors == chain
+
+    await save_slot_off_loop(state, slot, force=True)
+    meta = log.get_metadata("dashboard:fork1")
+    assert meta.get("fork_ancestors") == chain, "the chain was dropped by the save after resume"

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -2690,6 +2690,9 @@ def test_the_empty_window_merge_mirrors_the_full_saves_slot_owned_fields(tmp_pat
         "closed_at",
         "app",
         "forked_from",
+        # The fork's materialized chain: written beside `forked_from` by both
+        # saves, and like it absent on a plain newborn (not a fork).
+        "fork_ancestors",
         "linked_session_key",
         # The remote-execution binding, written all-three-or-none by both the
         # full save and the merge. A plain local newborn carries none of it; the

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -42,6 +42,7 @@ import { useBranding } from '../hooks/useBranding'
 import { fileIcon } from '../utils/fileIcons'
 import { urlTransform, ALLOWED_PROTOCOLS, WINDOWS_ABS_PATH_RE, decodeLocalPath } from '../utils/urlTransform'
 import { safeHttpUrl } from '../lib/safeUrl'
+import { buildImageOrdinalMap, deriveImageArtifactSlug, imageOrdinalCandidates } from '../lib/imageArtifactSlug'
 import { useLinkMeta, type LinkMeta } from '../lib/linkMeta'
 import { LinkChip, LinkCard } from './LinkPreview'
 import { parseSourceLinkUrl, forgeChipLabel, type PullRequestLink } from '../utils/pullRequestLinks'
@@ -331,6 +332,25 @@ export const CompactImagesCtx = createContext<boolean>(false)
  * Stable within a message, so re-renders and streaming do not re-request.
  */
 export const ImageVersionCtx = createContext<string | null>(null)
+
+/** Destination -> zero-based ordinal of every direct image in the RAW message,
+ * numbered as the backend numbers them (see buildImageOrdinalMap). `null` when
+ * unknown: images then never guess an artifact ordinal. */
+export const ImageOrdinalsCtx = createContext<ReadonlyMap<string, readonly number[]> | null>(null)
+
+/** The whole raw message text (what the backend scanned), for the image ordinal
+ * lookup to locate this block's raw slice. */
+export const RawMessageCtx = createContext<string | null>(null)
+
+/** This markdown block's [start, end) span in the raw message, when the block
+ * assembler recorded it. Lets an image prefer its exact raw ordinal. */
+export const RawBlockSpanCtx = createContext<{ start: number; end: number } | null>(null)
+
+/** The chat session (slot key) whose transcript is being rendered, so the image
+ * fallback can name its owner: image slugs derive from (message ts, ordinal)
+ * alone and two sessions can collide, so the asset endpoint refuses a copy that
+ * belongs to another session. `null` outside a chat transcript. */
+export const ImageSessionCtx = createContext<string | null>(null)
 
 /** The exact markdown string handed to ReactMarkdown, so components can map a
  *  node's source position back to the original text. ImgWithFallback uses it
@@ -1779,9 +1799,27 @@ function ImgWithFallback({
 }: React.ImgHTMLAttributes<HTMLImageElement> & ExtraProps) {
   const [errored, setErrored] = useState(false)
   const [loaded, setLoaded] = useState(false)
+  // -1 = the original file; otherwise the index into `artifactCandidates` being tried.
+  const [artifactAttempt, setArtifactAttempt] = useState(-1)
   const basePath = useContext(BasePathCtx)
   const compact = useContext(CompactImagesCtx)
   const version = useContext(ImageVersionCtx)
+  // The component can be reused for a different image without remounting
+  // (variant browsing swaps the message ts; an edit swaps `src`). Fallback
+  // state belongs to the OLD identity, so start over from the original file.
+  // Not user-facing text: a composite key of (message version, src).
+  const identity = [version ?? '', src ?? ''].join('\u0000')
+  const [seenIdentity, setSeenIdentity] = useState(identity)
+  if (seenIdentity !== identity) {
+    setSeenIdentity(identity)
+    setErrored(false)
+    setLoaded(false)
+    setArtifactAttempt(-1)
+  }
+  const imageOrdinals = useContext(ImageOrdinalsCtx)
+  const rawMessage = useContext(RawMessageCtx)
+  const rawBlockSpan = useContext(RawBlockSpanCtx)
+  const imageSession = useContext(ImageSessionCtx)
   const source = useContext(MdSourceCtx)
   if (!src) return null
   // A Windows drive/UNC path (`C:/…` — urlTransform passes it through for
@@ -1824,6 +1862,28 @@ function ImgWithFallback({
   } else {
     url = src
   }
+  const nodeOffset = node?.position?.start?.offset
+  // The backend registers only DIRECT `![alt](dest)` images, keyed by their
+  // ordinal in the raw message. Look this node up by the destination written at
+  // its own source position: a reference-style `![alt][ref]` has no direct
+  // opener there and gets no fallback, and nothing depends on how much of the
+  // block's text was stripped or repaired before rendering. Same-destination
+  // duplicates yield the ordinal for THIS occurrence first, then the others.
+  const artifactCandidates = isLocal && version && source != null && nodeOffset != null
+    ? imageOrdinalCandidates(
+      source,
+      nodeOffset,
+      imageOrdinals,
+      rawMessage != null && rawBlockSpan
+        ? { message: rawMessage, blockStart: rawBlockSpan.start, blockEnd: rawBlockSpan.end }
+        : undefined,
+    )
+    : []
+  const artifactUrl = artifactAttempt >= 0 && artifactAttempt < artifactCandidates.length
+    ? `/api/artifacts/${deriveImageArtifactSlug(version as string, artifactCandidates[artifactAttempt])}/asset`
+      + (imageSession ? `?session=${encodeURIComponent(imageSession)}` : '')
+    : null
+  const resolvedUrl = artifactUrl ?? url
   if (errored) {
     return <BrokenImage path={diskPath} alt={alt} probeUrl={isLocal ? url : undefined} />
   }
@@ -1858,7 +1918,7 @@ function ImgWithFallback({
   // first successful load (keyed by resolved URL, same mechanism as the
   // artifact gallery's thumbnails) lets every later mount reserve the real
   // aspect box before any bytes arrive.
-  const learned = !isSvg ? getImageDims(url) : undefined
+  const learned = !isSvg ? getImageDims(resolvedUrl) : undefined
   // The reserved box must resolve to EXACTLY the size the loaded image will
   // take, or the difference shows as a border wrapping empty space with the
   // image floated centered inside (object-contain letterboxing). The loaded
@@ -1909,7 +1969,7 @@ function ImgWithFallback({
           preview is presentational here. */}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
       <img
-        src={url} alt={alt || ''} loading="lazy"
+        src={resolvedUrl} alt={alt || ''} loading="lazy"
         // Sent-prompt images align to the END edge, matching the bubble they
         // were sent from. `ms-auto` (logical, RTL-correct) sits on the IMG, never
         // on its wrapper: preflight makes <img> display:block so text-align is
@@ -1933,10 +1993,17 @@ function ImgWithFallback({
         title={alt || src}
         onLoad={(e) => {
           const el = e.currentTarget
-          if (el.naturalWidth > 0 && el.naturalHeight > 0) rememberImageDims(url, el.naturalWidth, el.naturalHeight)
+          if (el.naturalWidth > 0 && el.naturalHeight > 0) rememberImageDims(resolvedUrl, el.naturalWidth, el.naturalHeight)
           setLoaded(true)
         }}
-        onError={() => setErrored(true)}
+        onError={() => {
+          if (artifactAttempt + 1 < artifactCandidates.length) {
+            setLoaded(false)
+            setArtifactAttempt(artifactAttempt + 1)
+          } else {
+            setErrored(true)
+          }
+        }}
         {...props}
       />
     </span>
@@ -3692,7 +3759,7 @@ function deferIncompleteStreamingTable(content: string): string {
   return lines.slice(0, start).join('\n')
 }
 
-const MarkdownBlock = memo(function MarkdownBlock({ content, sourcePos, startLine, glow, smooth, softBreaks, live, unfurl }: { content: string; sourcePos?: boolean; startLine?: number; glow?: boolean; smooth?: boolean; softBreaks?: boolean; live?: boolean; unfurl?: boolean }) {
+const MarkdownBlock = memo(function MarkdownBlock({ content, sourcePos, startLine, glow, smooth, softBreaks, live, unfurl, rawStart }: { content: string; sourcePos?: boolean; startLine?: number; rawStart?: number; glow?: boolean; smooth?: boolean; softBreaks?: boolean; live?: boolean; unfurl?: boolean }) {
   useLanguageGeneration() // memo() bails out of the provider-level repaint; subscribe directly
   // Declared before the early return below — Rules of Hooks.
   //
@@ -3705,6 +3772,12 @@ const MarkdownBlock = memo(function MarkdownBlock({ content, sourcePos, startLin
   const unfurlCtx = useMemo<LinkUnfurl>(
     () => ({ enabled: !!unfurl && !sourcePos, live: !!live }),
     [unfurl, sourcePos, live],
+  )
+  // This block's span in the raw message (block content is a verbatim slice of
+  // the raw text, so its length is the span length). See RawBlockSpanCtx.
+  const rawSpan = useMemo(
+    () => (rawStart != null ? { start: rawStart, end: rawStart + content.length } : null),
+    [rawStart, content],
   )
   // Strip any <mcwidget> or <tool_use> tags that leak through during
   // streaming transitions or when the agent emits protocol markup as text.
@@ -3748,11 +3821,13 @@ const MarkdownBlock = memo(function MarkdownBlock({ content, sourcePos, startLin
   // sourcePos mode together.
   const prepared = sourcePos ? fenced : fixCjkAutolinkBoundaries(fixUnencodedLinkDestinations(fenced))
   const md = (
+    <RawBlockSpanCtx.Provider value={rawSpan}>
     <MdSourceCtx.Provider value={prepared}>
       <ReactMarkdown remarkPlugins={softBreaks ? REMARK_PLUGINS_WITH_BREAKS : REMARK_PLUGINS} rehypePlugins={rehypePlugins} urlTransform={urlTransform} components={MD_COMPONENTS}>
         {prepared}
       </ReactMarkdown>
     </MdSourceCtx.Provider>
+    </RawBlockSpanCtx.Provider>
   )
   const body = sourcePos ? <div data-block-start={startLine ?? 1}>{md}</div> : md
   // The provider carries no DOM node, so sourcepos / lightbox scoping upstream
@@ -3922,7 +3997,7 @@ function BlockRenderer({ block, prevBlock, onFileOpen, sourcePos, messageTs, wid
       // `live` = this block is the streaming tail (see MarkdownRenderer). ORed
       // with the block's own `complete` flag so a provisional block is treated
       // as live too, whatever produced it.
-      return <MarkdownBlock content={block.content} sourcePos={sourcePos} startLine={block.startLine} glow={glow} smooth={smooth} softBreaks={softBreaks} live={!block.complete || !!live} unfurl={unfurl} />
+      return <MarkdownBlock content={block.content} sourcePos={sourcePos} startLine={block.startLine} glow={glow} smooth={smooth} softBreaks={softBreaks} live={!block.complete || !!live} unfurl={unfurl} rawStart={block.startOffset} />
   }
 }
 
@@ -3969,6 +4044,14 @@ export default memo(function MarkdownRenderer({ content, streaming = false, onFi
   // Must run before any conditional return — Rules of Hooks. (rawMode flips
   // via a settings toggle which usually re-mounts this component anyway,
   // but we keep hook order strict for safety.)
+  // Destination -> ordinal for every direct image in the RAW message: the same
+  // string the backend's IMAGE_MD_RE scans when it registers image artifacts,
+  // numbered the same way. Built once per message and read by ImgWithFallback.
+  const imageOrdinals = useMemo(
+    () => (messageTs ? buildImageOrdinalMap(content) : null),
+    [content, messageTs],
+  )
+
   const widgetIndices = useMemo(() => {
     const out: number[] = new Array(blocks.length).fill(-1)
     let n = 0
@@ -4055,6 +4138,9 @@ export default memo(function MarkdownRenderer({ content, streaming = false, onFi
           rewriting one file across turns is not served the previous bytes from
           the in-document resource cache. */}
       <ImageVersionCtx.Provider value={messageTs ?? null}>
+      <ImageOrdinalsCtx.Provider value={imageOrdinals}>
+      <RawMessageCtx.Provider value={imageOrdinals ? content : null}>
+      <ImageSessionCtx.Provider value={slotKey ?? null}>
         {blocks.map((block, i) => (
           // Key on startLine (stable across streaming) instead of block.type, so
           // a code -> diff reclassification mid-stream doesn't unmount the
@@ -4081,6 +4167,9 @@ export default memo(function MarkdownRenderer({ content, streaming = false, onFi
             mdCardToggle={mdCardToggle}
           />
         ))}
+      </ImageSessionCtx.Provider>
+      </RawMessageCtx.Provider>
+      </ImageOrdinalsCtx.Provider>
       </ImageVersionCtx.Provider>
       </CompactImagesCtx.Provider>
       </SessionActionCtx.Provider>

--- a/website/src/hooks/useBlockAssembler.ts
+++ b/website/src/hooks/useBlockAssembler.ts
@@ -150,13 +150,19 @@ export function parseBlocks(raw: string, streaming: boolean): ContentBlock[] {
   let widgetSlug = ''
   let widgetFenceTick = ''
   let mdStart = 1
+  let mdStartOffset = 0
   let codeStart = 1
   let widgetStart = 1
+  // Raw character offset of the start of line `i` — lines are split on '\n',
+  // so each line contributes its length plus the separator.
+  let lineOffset = 0
 
   const flushMd = () => {
     if (mdBuf.length === 0) return
     const text = mdBuf.join('\n')
-    if (text.trim()) blocks.push({ type: 'markdown', content: text, complete: true, startLine: mdStart })
+    if (text.trim()) {
+      blocks.push({ type: 'markdown', content: text, complete: true, startLine: mdStart, startOffset: mdStartOffset })
+    }
     mdBuf = []
   }
 
@@ -193,8 +199,13 @@ export function parseBlocks(raw: string, streaming: boolean): ContentBlock[] {
     widgetFenceTick = ''
   }
 
-  const pushMd = (text: string, lineIdx: number) => {
-    if (mdBuf.length === 0) mdStart = lineIdx + 1
+  // `column` is where `text` begins within line `lineIdx` (0 for a whole line
+  // or a line prefix; the suffix start for text after a same-line close tag).
+  const pushMd = (text: string, lineIdx: number, column = 0) => {
+    if (mdBuf.length === 0) {
+      mdStart = lineIdx + 1
+      mdStartOffset = lineOffset + column
+    }
     mdBuf.push(text)
   }
 
@@ -227,7 +238,7 @@ export function parseBlocks(raw: string, streaming: boolean): ContentBlock[] {
             widgetBuf.push(afterTag.slice(0, wClose.index))
             flushWidget(true)
             const afterClose = afterTag.slice(wClose.index + wClose[0].length)
-            if (afterClose) pushMd(afterClose, i)
+            if (afterClose) pushMd(afterClose, i, line.length - afterClose.length)
           } else {
             if (afterTag) widgetBuf.push(afterTag)
             state = 'widget'
@@ -289,7 +300,7 @@ export function parseBlocks(raw: string, streaming: boolean): ContentBlock[] {
           if (before) widgetBuf.push(before)
           flushWidget(true)
           const afterClose = line.slice(wClose.index + wClose[0].length)
-          if (afterClose) pushMd(afterClose, i)
+          if (afterClose) pushMd(afterClose, i, line.length - afterClose.length)
           state = 'outside'
           break
         }
@@ -312,6 +323,8 @@ export function parseBlocks(raw: string, streaming: boolean): ContentBlock[] {
         break
       }
     }
+    // Every `break` above lands here: account for this line and its '\n'.
+    lineOffset += line.length + 1
   }
 
   // End of input: flush any open state.

--- a/website/src/lib/imageArtifactSlug.ts
+++ b/website/src/lib/imageArtifactSlug.ts
@@ -1,0 +1,167 @@
+import { deriveWidgetSlug } from './widgetSlug'
+
+/**
+ * Derive the artifact slug used by the backend for a markdown image impression.
+ *
+ * Keep this paired with `kiro_crew.image_artifacts._derive_image_slug`: the
+ * backend namespaces the message id with `#image`, then applies the shared
+ * widget slug function to the image's zero-based ordinal in the message.
+ */
+export function deriveImageArtifactSlug(messageTs: string, imageIndex: number): string {
+  return deriveWidgetSlug(`${messageTs}#image`, imageIndex)
+}
+
+// Mirrors `IMAGE_MD_RE` in kiro_crew/messaging/outbound_files.py: a DIRECT
+// image opener `![alt](`, alt may contain backslash-escaped characters.
+const IMAGE_OPENER_RE = /!\[(?:\\.|[^\]\\])*\]\(/g
+const IMAGE_OPENER_AT_RE = /^!\[(?:\\.|[^\]\\])*\]\(/
+// `_MD_ESCAPABLE` there: a backslash escapes only these inside a destination,
+// so a native Windows path keeps its separators.
+const MD_ESCAPABLE = new Set(['(', ')', '[', ']', '\\', '<', '>', '"', "'"])
+
+/**
+ * The markdown destination in `rest`, the text right after `![alt](` — a port
+ * of `md_destination` (`_walk_destination` + `_finish_destination`) in
+ * kiro_crew/messaging/outbound_files.py. `null` when the destination never
+ * closes or is malformed. Parity with the backend is the whole point: the
+ * same text must yield the same key on both sides.
+ */
+export function parseMarkdownImageDestination(rest: string): string | null {
+  let depth = 1
+  let out = ''
+  for (let i = 0; i < rest.length; i++) {
+    const ch = rest[i]
+    if (ch === '\\' && i + 1 < rest.length && MD_ESCAPABLE.has(rest[i + 1])) {
+      out += rest[i + 1]
+      i++
+      continue
+    }
+    if (ch === '(') depth++
+    else if (ch === ')') {
+      depth--
+      if (depth === 0) return finishDestination(out)
+    }
+    out += ch
+  }
+  return null
+}
+
+function finishDestination(raw: string): string | null {
+  if (raw.includes('\r') || raw.includes('\n')) return null
+  let dest = raw.trim()
+  if (dest.startsWith('<')) {
+    const end = dest.indexOf('>')
+    if (end === -1) return null
+    dest = dest.slice(1, end).trim()
+  } else if (dest.includes(' ') || dest.includes('\t')) {
+    dest = dest.split(/[ \t]/, 1)[0]
+  }
+  for (const ch of dest) {
+    const code = ch.charCodeAt(0)
+    if (code < 32 || code === 127) return null
+  }
+  return dest || null
+}
+
+/**
+ * Destination → zero-based ordinals of every direct image in the RAW message
+ * text, numbered exactly as `register_images` numbers them (position among
+ * ALL openers, whether or not each one was stored). Keyed by destination
+ * rather than position because the renderer preprocesses each block (strips
+ * stray protocol tags, repairs fences…) before it sees node offsets, so no
+ * position in the rendered tree can be trusted to line up with the raw scan.
+ * A destination that appears more than once lists each ordinal in order: the
+ * backend normally copies the same bytes under each, but a replay after a
+ * per-message budget stop can store a LATER ordinal from a since-changed
+ * file, so the caller matches its own occurrence and falls through the rest.
+ */
+export function buildImageOrdinalMap(raw: string): Map<string, readonly number[]> {
+  const out = new Map<string, number[]>()
+  IMAGE_OPENER_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  let index = 0
+  while ((m = IMAGE_OPENER_RE.exec(raw)) !== null) {
+    const dest = parseMarkdownImageDestination(raw.slice(m.index + m[0].length))
+    if (dest !== null) {
+      const list = out.get(dest)
+      if (list) list.push(index)
+      else out.set(dest, [index])
+    }
+    index++
+  }
+  return out
+}
+
+/** Number of direct image openers in `text` — every position the backend numbers. */
+export function countImageOpeners(text: string): number {
+  IMAGE_OPENER_RE.lastIndex = 0
+  let n = 0
+  while (IMAGE_OPENER_RE.exec(text) !== null) n++
+  return n
+}
+
+/**
+ * How many direct image openers with destination `dest` begin before `end` in
+ * `text` — this node's occurrence index among same-destination images.
+ */
+function countImageOccurrencesBefore(text: string, dest: string, end: number): number {
+  const prefix = text.slice(0, Math.max(0, end))
+  IMAGE_OPENER_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  let count = 0
+  while ((m = IMAGE_OPENER_RE.exec(prefix)) !== null) {
+    // The destination may run past `prefix`; parse against the full text.
+    if (parseMarkdownImageDestination(text.slice(m.index + m[0].length)) === dest) count++
+  }
+  return count
+}
+
+/**
+ * Artifact ordinals to try for the image at `offset` in the rendered block
+ * text, best candidate first. Empty when the node is not a direct
+ * `![alt](dest)` opener, the destination is unknown to the map, or the exact
+ * ordinal cannot be determined.
+ *
+ * Exact or nothing: a wrong artifact is worse than the broken-image chip, so
+ * this never guesses. A destination that appears ONCE in the raw message is
+ * unambiguous. A repeated destination needs the block's raw span (`raw`), and
+ * is resolved only when the raw slice of this block holds the same number of
+ * `dest` openers as the rendered block text — nothing was stripped or added by
+ * preprocessing — so the node's in-block occurrence maps onto the raw
+ * occurrences before the block. Copies stored for the same destination are
+ * appended as fallbacks AFTER the exact ordinal (they normally hold identical
+ * bytes; they are only reached when the exact copy is missing).
+ */
+export function imageOrdinalCandidates(
+  text: string,
+  offset: number,
+  ordinals: ReadonlyMap<string, readonly number[]> | null,
+  raw?: { message: string; blockStart: number; blockEnd: number },
+): number[] {
+  const dest = imageDestinationAt(text, offset)
+  if (dest === null || !ordinals) return []
+  const list = ordinals.get(dest)
+  if (!list || list.length === 0) return []
+  if (list.length === 1) return [list[0]]
+  if (!raw) return []
+  const before = countImageOccurrencesBefore(raw.message, dest, raw.blockStart)
+  const inRawBlock = countImageOccurrencesBefore(raw.message, dest, raw.blockEnd) - before
+  const inRendered = countImageOccurrencesBefore(text, dest, text.length)
+  if (inRawBlock !== inRendered) return []
+  const k = before + countImageOccurrencesBefore(text, dest, offset)
+  if (k >= list.length) return []
+  const exact = list[k]
+  return [exact, ...list.filter(i => i !== exact)]
+}
+
+/**
+ * The destination of the direct image opener that begins exactly at `offset`
+ * in `text`, or `null` when the text there is not a direct `![alt](` opener
+ * (a reference-style image, for instance, which the backend never registers).
+ */
+export function imageDestinationAt(text: string, offset: number): string | null {
+  const head = text.slice(Math.max(0, offset))
+  const m = IMAGE_OPENER_AT_RE.exec(head)
+  if (!m) return null
+  return parseMarkdownImageDestination(head.slice(m[0].length))
+}

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -177,6 +177,12 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
   const hasVariants = variants && variants.length > 1
   const activeIdx = onSwitchVariant ? (typeof variantIdx === 'number' ? variantIdx : (variants?.length ?? 1) - 1) : (localIdx ?? (typeof variantIdx === 'number' ? variantIdx : (variants?.length ?? 1) - 1))
   const effectiveContent = hasVariants && localIdx !== null && !onSwitchVariant ? (variants[localIdx]?.content ?? content) : content
+  // The message id MarkdownRenderer keys images by (cache-busting `&v=` and
+  // the durable-artifact fallback) must name the variant being SHOWN: a
+  // regenerated reply registers its own image copies under its own ts, so
+  // browsing back to an older variant with the active variant's ts would
+  // resolve that variant's pictures.
+  const effectiveTs = hasVariants ? (variants[activeIdx]?.ts ?? messageTs) : messageTs
   // Reset the "Applied to Tasks" flag only when the message content changes.
   // `applied` is intentionally omitted: including it would re-run this effect
   // the instant `applied` flips to true and immediately clear it, making the
@@ -458,7 +464,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
     {/* 'message-bubble' is a stable theming hook — see website/docs/theming-contract.md */}
     <div ref={contentRef} className="message-bubble msg-content group/bubble relative text-sm leading-6 text-text overflow-hidden" style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
       <MessageErrorBoundary rawContent={smoothedText}>
-        <MarkdownRenderer content={smoothedText} streaming={isStreaming} onFileOpen={onFileOpen} onFolderOpen={onFolderOpen} onArtifactOpen={onArtifactOpen} onSessionOpen={onSessionOpen} sessions={sessions} activeSession={activeSession} rawMode={rawMode} messageTs={messageTs} slotKey={slotKey} glow={isStreaming} smooth={smooth} linkPreviews={linkPreviews && !draining} collapseDiffs mdCardToggle />
+        <MarkdownRenderer content={smoothedText} streaming={isStreaming} onFileOpen={onFileOpen} onFolderOpen={onFolderOpen} onArtifactOpen={onArtifactOpen} onSessionOpen={onSessionOpen} sessions={sessions} activeSession={activeSession} rawMode={rawMode} messageTs={effectiveTs} slotKey={slotKey} glow={isStreaming} smooth={smooth} linkPreviews={linkPreviews && !draining} collapseDiffs mdCardToggle />
       </MessageErrorBoundary>
       {/* Render the steer ack the moment kiro-cli emits the [STEERING …] marker
           — including mid-stream — so the user sees the agent acknowledge the

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -9,7 +9,9 @@ import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
 
 // Mock MarkdownRenderer to avoid complex markdown parsing in tests
 vi.mock('../components/MarkdownRenderer', () => ({
-  default: ({ content }: { content: string }) => <div data-testid="md">{content}</div>,
+  default: ({ content, messageTs }: { content: string; messageTs?: string }) => (
+    <div data-testid="md" data-message-ts={messageTs}>{content}</div>
+  ),
 }))
 // Mock useSmoothStream to passthrough — its rAF loop conflicts with vi.useFakeTimers()
 vi.mock('../hooks/useSmoothStream', () => ({
@@ -243,6 +245,23 @@ describe('AssistantMessage', () => {
     fireEvent.click(screen.getByTitle('Previous version'))
     expect(screen.getByText('1/2')).toBeInTheDocument()
     expect(screen.getByTestId('md')).toHaveTextContent('version one text')
+  })
+
+  it('keys the rendered markdown to the ts of the variant being shown', () => {
+    // Images are cache-busted and fall back to durable copies by message ts;
+    // a regenerated reply registers its own copies under its own ts, so an
+    // older variant must render with ITS ts, not the active variant's.
+    const variants = [{ content: 'v1', ts: 'ts-1' }, { content: 'v2', ts: 'ts-2' }]
+    render(<AssistantMessage content="v2" isStreaming={false} variants={variants} variantIdx={1} messageTs="ts-2" />)
+    expect(screen.getByTestId('md')).toHaveAttribute('data-message-ts', 'ts-2')
+    fireEvent.click(screen.getByTitle('Previous version'))
+    expect(screen.getByTestId('md')).toHaveTextContent('v1')
+    expect(screen.getByTestId('md')).toHaveAttribute('data-message-ts', 'ts-1')
+    // A variant without its own ts falls back to the message's.
+    cleanup()
+    render(<AssistantMessage content="v2" isStreaming={false} variants={[{ content: 'v1' }, { content: 'v2', ts: 'ts-2' }]} variantIdx={1} messageTs="ts-2" />)
+    fireEvent.click(screen.getByTitle('Previous version'))
+    expect(screen.getByTestId('md')).toHaveAttribute('data-message-ts', 'ts-2')
   })
 
   it('calls onSwitchVariant for last message but uses local state for older messages', () => {

--- a/website/src/test/MarkdownRenderer.imageArtifactFallback.test.tsx
+++ b/website/src/test/MarkdownRenderer.imageArtifactFallback.test.tsx
@@ -1,0 +1,234 @@
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+
+import MarkdownRenderer from '../components/MarkdownRenderer'
+import { ThemeProvider } from '../hooks/useTheme'
+import { api } from '../api/client'
+import { deriveImageArtifactSlug } from '../lib/imageArtifactSlug'
+
+describe('MarkdownRenderer durable chat image fallback', () => {
+  it('retries a missing local image from its deterministic artifact asset', async () => {
+    const ts = '1779995123.456789'
+    const { container } = render(
+      <MarkdownRenderer content="![screenshot](/tmp/shot.png)" messageTs={ts} />,
+    )
+    const image = container.querySelector('img')!
+    expect(image.getAttribute('src')).toContain('/api/file-raw?path=')
+
+    fireEvent.error(image)
+
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 0)}/asset`,
+      )
+    })
+  })
+
+  it('uses each image ordinal and falls back to the broken-image chip only after artifact failure', async () => {
+    const ts = 'ts-two-images'
+    const { container } = render(
+      <MarkdownRenderer
+        content={'![first](/tmp/first.png)\n\n![second](/tmp/second.png)'}
+        messageTs={ts}
+      />,
+    )
+    const images = Array.from(container.querySelectorAll('img'))
+    expect(images).toHaveLength(2)
+
+    fireEvent.error(images[1])
+    await waitFor(() => {
+      expect(container.querySelectorAll('img')[1]?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 1)}/asset`,
+      )
+    })
+
+    fireEvent.error(container.querySelectorAll('img')[1])
+    await waitFor(() => expect(container.textContent).toContain('second'))
+    expect(container.querySelectorAll('img')).toHaveLength(1)
+  })
+
+  it('counts openers hidden in widget markup the way the backend does', async () => {
+    // The backend scans the RAW persisted text, so the opener inside the widget
+    // title is ordinal 0 there and the real image is ordinal 1. The frontend must
+    // not renumber from stripped block bodies.
+    const ts = 'ts-widget-title'
+    const md = '<mcwidget title="![ghost](/tmp/ghost.png)"><div>x</div></mcwidget>\n\n![real](/tmp/real.png)'
+    // A real <WidgetFrame> mounts for the widget block; mirror the app's providers.
+    vi.spyOn(api, 'sandboxDocUrl').mockResolvedValue({ url: '/sandbox-doc/test/tok' })
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <MarkdownRenderer content={md} messageTs={ts} />
+        </ThemeProvider>
+      </QueryClientProvider>,
+    )
+    const real = container.querySelector('img[src*="real.png"]') as HTMLImageElement
+    expect(real).not.toBeNull()
+
+    fireEvent.error(real)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 1)}/asset`,
+      )
+    })
+  })
+
+  it('prefers its exact raw ordinal, then the other copies, never a different image', async () => {
+    // Backend raw-text order: fence body (0), widget title (1), rendered image (2).
+    // The block's raw span is known and nothing in it was stripped, so the
+    // rendered image resolves to its own ordinal 2 first; ordinal 0 (same
+    // destination) is the fallback; the ghost (1) is never tried.
+    const ts = 'ts-repeated-body'
+    const md = [
+      '```md',
+      '![real](/tmp/real.png)',
+      '```',
+      '',
+      '<mcwidget title="![ghost](/tmp/ghost.png)"><div>x</div></mcwidget>',
+      '',
+      '![real](/tmp/real.png)',
+    ].join('\n')
+    vi.spyOn(api, 'sandboxDocUrl').mockResolvedValue({ url: '/sandbox-doc/test/tok' })
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <MarkdownRenderer content={md} messageTs={ts} />
+        </ThemeProvider>
+      </QueryClientProvider>,
+    )
+    const real = container.querySelector('img[src*="real.png"]') as HTMLImageElement
+    expect(real).not.toBeNull()
+
+    fireEvent.error(real)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 2)}/asset`,
+      )
+    })
+    fireEvent.error(container.querySelector('img')!)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 0)}/asset`,
+      )
+    })
+  })
+
+  it('resolves an image after a same-line widget close whose title repeats it', async () => {
+    // Raw order: widget title opener (0), then the rendered image which starts
+    // mid-line right after `</mcwidget>` (1). The block's raw span begins after
+    // the tag, so the title copy counts as a raw occurrence BEFORE the block and
+    // the rendered image resolves to its exact ordinal 1; 0 is the fallback.
+    const ts = 'ts-empty-widget'
+    const md = '<mcwidget title="![real](/tmp/real.png)"></mcwidget> ![real](/tmp/real.png)'
+    vi.spyOn(api, 'sandboxDocUrl').mockResolvedValue({ url: '/sandbox-doc/test/tok' })
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <MarkdownRenderer content={md} messageTs={ts} />
+        </ThemeProvider>
+      </QueryClientProvider>,
+    )
+    const real = container.querySelector('img[src*="real.png"]') as HTMLImageElement
+    expect(real).not.toBeNull()
+
+    fireEvent.error(real)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 1)}/asset`,
+      )
+    })
+    // Exact copy missing -> the other copy of the same destination is tried…
+    fireEvent.error(container.querySelector('img')!)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 0)}/asset`,
+      )
+    })
+    // …and only then the broken-image chip.
+    fireEvent.error(container.querySelector('img')!)
+    await waitFor(() => expect(container.querySelector('img')).toBeNull())
+    expect(container.textContent).toContain('real')
+  })
+
+  it('ignores openers the renderer strips before parsing (stray protocol tags)', async () => {
+    // Raw order: ghost inside a stray <tool_use> (0), real (1). MarkdownBlock
+    // strips the tag before react-markdown sees the text, so any positional
+    // count over the rendered source would say 0.
+    const ts = 'ts-stripped-tag'
+    const md = '<tool_use>![ghost](/tmp/ghost.png)</tool_use>\n\n![real](/tmp/real.png)'
+    const { container } = render(<MarkdownRenderer content={md} messageTs={ts} />)
+    const real = container.querySelector('img[src*="real.png"]') as HTMLImageElement
+    expect(real).not.toBeNull()
+
+    fireEvent.error(real)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 1)}/asset`,
+      )
+    })
+  })
+
+  it('starts over from the original file when the message version changes under it', async () => {
+    // Variant browsing swaps messageTs without remounting the <img>. A fallback
+    // reached for the OLD variant must not carry over: the new variant's own
+    // file is tried first, and a later failure resolves the NEW ts's artifact.
+    const md = '![shot](/tmp/shot.png)'
+    const { container, rerender } = render(<MarkdownRenderer content={md} messageTs="ts-old" />)
+    fireEvent.error(container.querySelector('img')!)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug('ts-old', 0)}/asset`,
+      )
+    })
+    rerender(<MarkdownRenderer content={md} messageTs="ts-new" />)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toContain('/api/file-raw?path=')
+      expect(container.querySelector('img')?.getAttribute('src')).toContain('v=ts-new')
+    })
+    fireEvent.error(container.querySelector('img')!)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug('ts-new', 0)}/asset`,
+      )
+    })
+  })
+
+  it('names its own session on the artifact URL so a colliding slug cannot serve another chat', async () => {
+    const ts = 'ts-owner'
+    const { container } = render(
+      <MarkdownRenderer content="![shot](/tmp/shot.png)" messageTs={ts} slotKey="chat-7" />,
+    )
+    fireEvent.error(container.querySelector('img')!)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 0)}/asset?session=chat-7`,
+      )
+    })
+  })
+
+  it("never routes a reference-style image to a direct image's artifact", async () => {
+    const ts = 'ts-reference-image'
+    const md = '![ref image][shot]\n\n![direct](/tmp/direct.png)\n\n[shot]: /tmp/missing-ref.png'
+    const { container } = render(<MarkdownRenderer content={md} messageTs={ts} />)
+    const images = Array.from(container.querySelectorAll('img'))
+    expect(images).toHaveLength(2)
+
+    // The reference-style image has no registered artifact: on failure it goes
+    // straight to the broken-image chip instead of borrowing ordinal 0.
+    fireEvent.error(images[0])
+    await waitFor(() => expect(container.querySelectorAll('img')).toHaveLength(1))
+    expect(container.textContent).toContain('ref image')
+
+    // The direct image is still ordinal 0 among direct openers.
+    fireEvent.error(container.querySelector('img')!)
+    await waitFor(() => {
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(
+        `/api/artifacts/${deriveImageArtifactSlug(ts, 0)}/asset`,
+      )
+    })
+  })
+})

--- a/website/src/test/imageArtifactSlug.test.ts
+++ b/website/src/test/imageArtifactSlug.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildImageOrdinalMap,
+  imageDestinationAt,
+  imageOrdinalCandidates,
+  parseMarkdownImageDestination,
+} from '../lib/imageArtifactSlug'
+
+// Mirrors `md_destination` / `IMAGE_MD_RE` in kiro_crew/messaging/outbound_files.py
+// and the numbering in kiro_crew/image_artifacts.register_images.
+describe('parseMarkdownImageDestination', () => {
+  it('parses a plain destination and drops a title', () => {
+    expect(parseMarkdownImageDestination('/tmp/a.png)')).toBe('/tmp/a.png')
+    expect(parseMarkdownImageDestination('/tmp/a.png "shot")')).toBe('/tmp/a.png')
+  })
+
+  it('keeps balanced parens and honours markdown escapes only', () => {
+    expect(parseMarkdownImageDestination('/tmp/shot(1).png)')).toBe('/tmp/shot(1).png')
+    expect(parseMarkdownImageDestination('/tmp/a\\).png)')).toBe('/tmp/a).png')
+    // A Windows path keeps its separators: `\U` is not an escapable character.
+    expect(parseMarkdownImageDestination('C:\\Users\\me\\shot.png)')).toBe('C:\\Users\\me\\shot.png')
+  })
+
+  it('unwraps <...> so a spaced path survives whole', () => {
+    expect(parseMarkdownImageDestination('</tmp/generated images/c.png>)')).toBe('/tmp/generated images/c.png')
+    expect(parseMarkdownImageDestination('</tmp/unterminated)')).toBeNull()
+  })
+
+  it('rejects unterminated, multi-line and control-character destinations', () => {
+    expect(parseMarkdownImageDestination('/tmp/never-closes.png')).toBeNull()
+    expect(parseMarkdownImageDestination('/tmp/a\n.png)')).toBeNull()
+    expect(parseMarkdownImageDestination('/tmp/a\u0001.png)')).toBeNull()
+  })
+})
+
+describe('buildImageOrdinalMap', () => {
+  it('numbers every direct opener in raw order, including ones the renderer never shows', () => {
+    const raw = [
+      '```md',
+      '![fenced](/tmp/fenced.png)',            // 0
+      '```',
+      '<mcwidget title="![ghost](/tmp/ghost.png)"></mcwidget>',  // 1
+      '<tool_use>![stray](/tmp/stray.png)</tool_use>',           // 2
+      '![ref][r]',                              // reference-style: not an opener
+      '![real](/tmp/real.png)',                 // 3
+      '![real](/tmp/real.png)',                 // 4 -> same file, first ordinal kept
+      '![remote](https://example.com/x.png)',   // 5
+      '',
+      '[r]: /tmp/ref.png',
+    ].join('\n')
+    const map = buildImageOrdinalMap(raw)
+    expect(map.get('/tmp/fenced.png')).toEqual([0])
+    expect(map.get('/tmp/ghost.png')).toEqual([1])
+    expect(map.get('/tmp/stray.png')).toEqual([2])
+    expect(map.get('/tmp/real.png')).toEqual([3, 4])
+    expect(map.get('https://example.com/x.png')).toEqual([5])
+    expect(map.has('/tmp/ref.png')).toBe(false)
+  })
+})
+
+describe('imageOrdinalCandidates', () => {
+  const raw = '![a](/tmp/a.png)\n![b](/tmp/b.png)\n![a](/tmp/a.png)\n![a](/tmp/a.png)'
+  const map = buildImageOrdinalMap(raw)
+  const whole = { message: raw, blockStart: 0, blockEnd: raw.length }
+
+  it('resolves a unique destination without needing the raw span', () => {
+    expect(imageOrdinalCandidates(raw, raw.indexOf('![b]'), map)).toEqual([1])
+  })
+
+  it('resolves a repeated destination exactly when the raw span is known, other copies after', () => {
+    expect(imageOrdinalCandidates(raw, raw.lastIndexOf('![a]'), map, whole)).toEqual([3, 0, 2])
+    expect(imageOrdinalCandidates(raw, 0, map, whole)).toEqual([0, 2, 3])
+  })
+
+  it('never guesses: a repeated destination without a raw span gets no fallback', () => {
+    expect(imageOrdinalCandidates(raw, 0, map)).toEqual([])
+  })
+
+  it('returns nothing for a reference-style image, an unknown destination, or no map', () => {
+    const text = '![r][ref]\n![z](/tmp/z.png)'
+    expect(imageOrdinalCandidates(text, 0, map)).toEqual([])
+    expect(imageOrdinalCandidates(text, text.indexOf('![z]'), map)).toEqual([])
+    expect(imageOrdinalCandidates(raw, 0, null)).toEqual([])
+  })
+
+  it('maps a block-local occurrence onto the raw occurrences before the block', () => {
+    // Raw: a fenced copy (0), then a markdown block whose rendered text equals
+    // its raw slice: the block's only image is raw ordinal 1.
+    const message = '```\n![a](/tmp/a.png)\n```\n![a](/tmp/a.png)'
+    const block = '![a](/tmp/a.png)'
+    const blockStart = message.lastIndexOf(block)
+    const m = buildImageOrdinalMap(message)
+    expect(imageOrdinalCandidates(block, 0, m, {
+      message, blockStart, blockEnd: blockStart + block.length,
+    })).toEqual([1, 0])
+  })
+
+  it('gives no fallback when preprocessing removed a copy from the block (counts disagree)', () => {
+    // The raw block holds two openers (one inside a stray tag the renderer
+    // strips) but the rendered text holds one: the occurrence is ambiguous.
+    const rawBlock = '<tool_use>![a](/tmp/a.png)</tool_use>\n![a](/tmp/a.png)'
+    const rendered = '\n![a](/tmp/a.png)'
+    const m = buildImageOrdinalMap(rawBlock)
+    expect(imageOrdinalCandidates(rendered, 1, m, {
+      message: rawBlock, blockStart: 0, blockEnd: rawBlock.length,
+    })).toEqual([])
+  })
+})
+
+describe('imageDestinationAt', () => {
+  it('reads the destination only when a direct opener starts exactly at the offset', () => {
+    const text = 'see ![a](/tmp/a.png) and ![b][ref]'
+    expect(imageDestinationAt(text, text.indexOf('![a]'))).toBe('/tmp/a.png')
+    expect(imageDestinationAt(text, text.indexOf('![b]'))).toBeNull()
+    expect(imageDestinationAt(text, 0)).toBeNull()
+  })
+})

--- a/website/src/test/imageGrammarParity.test.ts
+++ b/website/src/test/imageGrammarParity.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { countImageOpeners, parseMarkdownImageDestination } from '../lib/imageArtifactSlug'
+
+// The backend's grammar (kiro_crew/messaging/outbound_files.py: IMAGE_MD_RE,
+// md_destination) and this port must agree byte for byte. One corpus drives
+// both test/test_image_grammar_parity.py and this file.
+interface Corpus {
+  destinations: { rest: string; expect: string | null }[]
+  openers: { text: string; count: number }[]
+}
+
+const corpus: Corpus = JSON.parse(
+  readFileSync(resolve(__dirname, '../../../test/fixtures/image_grammar_parity.json'), 'utf-8'),
+)
+
+describe('image grammar parity with the backend', () => {
+  it.each(corpus.destinations)('destination %j', ({ rest, expect: want }) => {
+    expect(parseMarkdownImageDestination(rest)).toBe(want)
+  })
+
+  it.each(corpus.openers)('opener count %j', ({ text, count }) => {
+    expect(countImageOpeners(text)).toBe(count)
+  })
+})

--- a/website/src/test/useBlockAssembler.test.ts
+++ b/website/src/test/useBlockAssembler.test.ts
@@ -5,7 +5,31 @@ describe('parseBlocks', () => {
   it('parses plain markdown', () => {
     const blocks = parseBlocks('Hello **world**', false)
     expect(blocks).toHaveLength(1)
-    expect(blocks[0]).toEqual({ type: 'markdown', content: 'Hello **world**', complete: true, startLine: 1 })
+    expect(blocks[0]).toEqual({ type: 'markdown', content: 'Hello **world**', complete: true, startLine: 1, startOffset: 0 })
+  })
+
+  it('records the exact raw offset where each markdown block begins', () => {
+    const raw = [
+      'intro',                                        // 0..5
+      '```md',                                        // 6..11
+      'fenced',                                       // 12..18
+      '```',                                          // 19..22
+      '<mcwidget title="t"></mcwidget> tail-a',       // 23..
+      'plain',
+      '<mcwidget title="t">',
+      'body',
+      '</mcwidget>tail-b',
+    ].join('\n')
+    const md = parseBlocks(raw, false).filter(b => b.type === 'markdown')
+    expect(md.map(b => b.content)).toEqual(['intro', ' tail-a\nplain', 'tail-b'])
+    for (const b of md) {
+      // The offset points at the block's own first character in the raw text,
+      // including a block that starts mid-line after a same-line close tag.
+      expect(raw.slice(b.startOffset!, b.startOffset! + b.content.length)).toBe(b.content)
+    }
+    expect(md[0].startOffset).toBe(0)
+    expect(md[1].startOffset).toBe(raw.indexOf(' tail-a'))
+    expect(md[2].startOffset).toBe(raw.lastIndexOf('tail-b'))
   })
 
   it('parses a fenced code block', () => {

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -1229,6 +1229,11 @@ export interface ContentBlock {
   complete: boolean
   /** 1-based line in the original raw source where this block starts. */
   startLine?: number
+  /** 0-based character offset in the original raw source where this block's
+   * text begins (markdown blocks only). Exact, including a block that starts
+   * mid-line after a same-line `</mcwidget>`; lets the renderer count
+   * `![…](` openers over the raw text the same way the backend does. */
+  startOffset?: number
   /** Artifact slug (widget blocks only) — when present, the widget is
    * already saved as an artifact in the user's library. The dashboard uses
    * this to render the bookmark filled, link the title to /artifacts/<slug>,


### PR DESCRIPTION
## Problem / Motivation

An agent that writes a picture into its scratch directory and shows it in chat as `![alt](/…/scratch/…/chart.png)` gets a working image — until the scratch directory is reclaimed (gateway restart, agent exit, the periodic sweep). After that the transcript shows the broken-image chip for a message that used to have a picture in it.

The backend already copies each local chat image into the artifact store when the message is finalized (`register_images`, one deterministic slug per image ordinal). It does not help today because (1) the frontend never tries that copy — a failed `/api/file-raw` load goes straight to the chip — and (2) the copies are auto-registered widgets to the store, so the rolling widget-preview sweep prunes them like any other auto widget.

## Why it matters

Pictures are how agents show their work (charts, screenshots, diagrams). A transcript that silently loses them a few hours later is not a record you can go back to. It also hits everyone who sends the dashboard to the background overnight: scratch reclamation is the normal lifecycle, not a fault.

## What changed (motivation → approach → change)

Symptom: broken chip after the scratch file is gone. Root cause: no fallback path to the durable copy, and the durable copy itself is not durable.

Approach: keep the backend's existing deterministic identity (`derive_widget_slug(f"{ts}#image", ordinal)`) and make both ends honor it, rather than inventing a second registry.

Backend (`src/kiro_crew/artifacts.py`, `src/kiro_crew/dashboard/handlers/sessions.py`):
- `_is_sweepable_auto_widget` excludes `kind == "image"`, so chat-image copies are no longer pruned by the widget-preview policy.
- New `ArtifactStore.delete_auto_images_for_sessions(keys)` removes the untouched auto-registered image copies of a set of sessions. `api_session_delete` calls it (off-loop via `asyncio.to_thread`) so the copies live exactly as long as the chat that produced them — permanent delete, not clear.

Frontend (`website/src/components/MarkdownRenderer.tsx`, new `website/src/lib/imageArtifactSlug.ts`):
- `ImgWithFallback` first loads `/api/file-raw?path=…` as before. On error it tries `/api/artifacts/<slug>/asset` for the image's durable copy, and only when every candidate fails does it show the broken chip. Its fallback state is keyed to the image identity (`src` + message ts) and resets when either changes, so a component reused for another image (variant browsing, an edited message) starts from the original file again.
- The slug needs the image's ordinal in the *raw* message as the backend counted it. That cannot be derived from positions in the rendered tree: the block assembler strips `<mcwidget …>` tags (whose title can contain an opener), `MarkdownBlock` strips stray `<tool_use>`/`<mcwidget>` markup and repairs fences, and a reference-style `![alt][ref]` renders an `<img>` the backend never registered. So the renderer builds one map over the raw message text, destination → all ordinals holding that destination, using a port of the backend's `IMAGE_MD_RE` and `md_destination` grammar (shared parity fixture `test/fixtures/image_grammar_parity.json` drives both suites; the Python regex carries a KEEP IN SYNC pointer). Each rendered image looks itself up by the destination written at its own source offset.
- Exact or nothing. A destination that appears once in the message is unambiguous. A repeated destination is resolved only when the block's exact raw span is known (the assembler records `startOffset`) and the raw slice holds the same number of that destination's openers as the rendered block — i.e. preprocessing removed nothing — so the node's in-block occurrence maps onto the raw ordinal the backend stored for that very image; other copies of the same destination are tried after it. In every other case the image gets no artifact fallback rather than a guessed one: a wrong picture is worse than the broken chip.
- Variants: `AssistantMessage` now passes the ts of the variant being shown (`variants[activeIdx].ts`, falling back to the message ts) to `MarkdownRenderer`. A regenerated reply registers its own image copies under its own ts, so browsing back to an older variant must key its images (cache-busting `&v=` and the fallback) by that variant's ts, not the active one's.

Backend lifetime, refined during review:
- Bulk clear (`DELETE /api/sessions`) reaps image copies for every session it permanently deletes, the same as the single delete; an AST test pins that every handler referencing `delete_session` also calls `_reap_session_images`.
- Forks copy messages with their ts intact and image slugs derive from ts alone, so a fork renders its source's copies. The reap snapshots fork lineage (`forked_from`) before unlinking and skips any deleted session a surviving transcript descends from, through any depth of fork-of-fork.
- The widget sweep and the image reap share one investment predicate (`_is_unclaimed_auto_artifact`), so "nobody has claimed this" cannot drift between them.
- Owner check on the asset endpoint. Image slugs are keyed by (message ts, ordinal) only, so two sessions finalizing in the same instant can collide on a slug. The transcript fallback therefore names its own session (`GET /api/artifacts/<slug>/asset?session=<slot>`) and the endpoint returns 404 unless the copy's recorded session is that session or one it descends from by fork lineage (`kiro_crew/dashboard/fork_lineage.py`, the single ancestry walker used by both the endpoint and the reap). Callers that name no session (the artifact library) are unchanged. Forks persist their full ancestry (`fork_ancestors`) so lineage stays provable after an intermediate fork is deleted; a fork of a pre-upgrade fork reconstructs the chain from the catalog at fork time.
- Registration drain on delete. Image registration is a detached task at finalize time; a permanent delete first removes the slot (killing its kiro-cli session), then waits for that session's in-flight registrations (`image_artifacts.track_registration` / `drain_registrations`, 30 s cap) before reaping, so a late copy can never outlive its transcript. If the wait times out the reap is skipped and logged.

Positional counting was the first design and was rejected during local review: every preprocessing step that removes or adds an opener shifted the ordinal onto a neighbouring image. Keying by destination and refusing to guess removes the dependency on preprocessing entirely.

## Tests

- `test/test_image_artifacts.py`: image artifacts survive the widget-preview prune; `delete_auto_images_for_sessions` removes only untouched auto images of the named sessions and leaves user-touched artifacts and other sessions alone; `api_session_delete` invokes the cleanup.
- `test/test_dashboard_sessions_clear.py`: bulk clear reaps for exactly the sessions it deleted and skips the store when nothing was deleted; every `delete_session` handler is pinned to call the reap (AST); a surviving fork (any depth) protects its ancestors' copies; the session-key spellings match what `register_images` records.
- `test/test_image_grammar_parity.py` + `website/src/test/imageGrammarParity.test.ts`: one fixture, both grammars.
- `test/test_fork_lineage.py`: the shared ancestry walker — fold, materialize, descend through forks/grandforks, survive a deleted intermediate via the recorded chain, walk legacy `forked_from`-only forks, reconstruct a legacy source chain at fork time, fail closed on unreadable metadata, terminate on cycles.
- `test/test_image_artifacts.py` (asset): owner check accepts the owner in every spelling and its forks (incl. after the intermediate is deleted), refuses unrelated sessions and unreadable lineage; registration drain waits and reports timeouts.
- `website/src/test/AssistantMessage.test.tsx`: the rendered markdown is keyed to the ts of the variant being shown.
- `website/src/test/imageArtifactSlug.test.ts`: destination parser parity with the backend (balanced parens, `_MD_ESCAPABLE`-only escapes so Windows paths survive, `<…>` unwrap, title stripping, control characters, CR/LF), ordinal numbering over raw text incl. fenced/widget-title/stray-tag openers and reference images; exact-or-nothing candidate resolution (unique destination, exact raw span, disagreeing counts → none).
- `website/src/test/MarkdownRenderer.imageArtifactFallback.test.tsx`: local → artifact → broken chip progression; per-image ordinals; openers hidden in widget titles and stray protocol tags; duplicate destinations across fences and same-line widget closes resolve to their exact ordinal with the other copies after it and never a different image; fallback state resets when the message ts changes under a live image; reference-style images never borrow a direct image's artifact.

Full gates run locally: backend lint/format/mypy/sync-io checks green; backend suite has 84 pre-existing failures that reproduce identically on a clean `origin/main` worktree (host uid / missing gh+electron binaries), none in touched files; frontend vendor/tsc/build/i18n/bundle green; full vitest 1957 files / 30,834 tests green; electron 1824 green.

## Manual verification

N/A — unit coverage exercises the load-error path directly via `fireEvent.error`; the fallback URL is a pure function of message text and message id, so a browser run adds no information the tests do not already assert.

## Screenshots / video

<!-- no-visual-delta -->
No visual delta on any surface: the change is only reached when an image's original file fails to load, and in that case it renders the same `<img>` element with a different `src`. The broken-image chip is unchanged.

## Related Issues

Fixes #9679

## Pattern harvest

Rule candidate: review-prompt
Pattern: "frontend derives an identity by counting positions in a string the renderer has preprocessed (stripped/repaired) — count over the raw source the backend saw, or key by content instead"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated: `docs/system-specs/modules/artifacts.md` — retention bullet rewritten to the shipped lifecycle, asset endpoint gains the `?session=` owner check, new "Chat image fallback" section documents the transcript consumer
- [x] No secrets, credentials, or internal references in the diff



