### PR TITLE
fix: patch _Server in workflows entrypoint tests (#9675)

### DIFF
--- a/test/test_workflows_app.py
+++ b/test/test_workflows_app.py
@@ -249,6 +249,25 @@ def test_handler_send_redacts_before_writing_to_the_wire() -> None:
 # --------------------------------------------------------------------------- #
 
 
+def _forbid_real_bind(monkeypatch) -> None:
+    """Name-independent anti-hang guard for the entrypoint tests.
+
+    Patching ``server._Server`` intercepts what ``main()`` constructs *today*; a
+    patch on any name ``main()`` does not construct (an inlined
+    ``ThreadingHTTPServer(...)``, a ``_make_server()`` factory) still succeeds
+    but goes unused, and the test then binds a real socket and hangs the CI
+    shard. Failing at the bind itself turns that silent hang into a loud,
+    diagnosable failure whatever ``main()`` happens to name.
+    """
+    import socketserver
+
+    monkeypatch.setattr(
+        socketserver.TCPServer,
+        "server_bind",
+        lambda self: pytest.fail("main() bound a real socket"),
+    )
+
+
 def test_main_boots_platform_before_binding_server(monkeypatch) -> None:
     """The app process must compose security before accepting workflow requests."""
     from types import SimpleNamespace
@@ -269,7 +288,12 @@ def test_main_boots_platform_before_binding_server(monkeypatch) -> None:
 
     monkeypatch.setattr(server, "boot_platform", _boot)
     monkeypatch.setattr(server.KiroCrewConfig, "load", classmethod(lambda cls: SimpleNamespace()))
-    monkeypatch.setattr(server, "ThreadingHTTPServer", _FakeServer)
+    # Patch _Server, the class main() actually constructs: its ThreadingHTTPServer
+    # base was bound at class-definition time, so patching the base name never
+    # engages and the test would bind a REAL listener and block in serve_forever().
+    # setattr raises on a missing attribute, so a rename of _Server fails fast here.
+    monkeypatch.setattr(server, "_Server", _FakeServer)
+    _forbid_real_bind(monkeypatch)
 
     assert server.main() is None
     assert calls == ["boot", "bind", "serve"]
@@ -284,12 +308,25 @@ def test_main_fails_closed_when_platform_cannot_compose(monkeypatch) -> None:
         raise PlatformCompositionError("companion missing")
 
     served: list[str] = []
+
+    # Class-shaped fake (not a bare lambda): if the boot/bind ordering ever
+    # regresses, main() goes on to call .serve_forever() on the constructed
+    # object, and a lambda returning None would surface an unrelated
+    # AttributeError instead of the ordering assertion below.
+    class _FakeServer:
+        def __init__(self, *args, **kwargs) -> None:
+            served.append("bind")
+
+        def serve_forever(self) -> None:
+            served.append("serve")
+
     monkeypatch.setattr(server, "boot_platform", _boom)
-    monkeypatch.setattr(
-        server,
-        "ThreadingHTTPServer",
-        lambda *args, **kwargs: served.append("bind"),
-    )
+    # Same substitution as the boot-ordering test: main() constructs _Server, so a
+    # patch on the ThreadingHTTPServer base name is dead — masked here only because
+    # the boot stub raises before the bind, and it would bind a real socket the
+    # moment that ordering changed.
+    monkeypatch.setattr(server, "_Server", _FakeServer)
+    _forbid_real_bind(monkeypatch)
 
     with pytest.raises(PlatformCompositionError):
         server.main()


### PR DESCRIPTION
## Problem / Motivation

**URGENT — every PR based on current main is red.** Backend Tests shard 4 hangs on `test/test_workflows_app.py::test_main_boots_platform_before_binding_server`: a 120s pytest timeout on Linux 3.12, an xdist worker crash on Windows, and the Coverage Gate cascades red because the shard never uploads. The test monkeypatches `server.ThreadingHTTPServer`, but `main()` constructs `server._Server` — a subclass whose base was bound at class-definition time — so the patch never engages and the test boots a real listener on the real `PORT`, then blocks forever in `serve_forever()`.

## Why it matters

The whole repository is blocked: no PR can go green until this lands, and the failure shape is the worst kind — a silent hang with no test output to diagnose from. It was a semantic merge collision: #9066 added the test, #9413 introduced `_Server`, each PR's CI ran on a merge ref predating the other, so both were green alone and red combined.

## What changed (motivation → approach → change)

The test hung because it patched a name `main()` no longer reads. The fix (test-only — the production code is correct) patches `server._Server`, the class `main()` actually constructs, in both `test_main_boots_platform_before_binding_server` and `test_main_fails_closed_when_platform_cannot_compose`, whose identical patch was dead but masked by its raising boot stub. `monkeypatch.setattr` raises on a missing attribute, so a rename of `_Server` fails fast.

A named patch alone cannot survive the exact vector that caused this incident — `main()` constructing the listener under a name the test does not patch. Both tests therefore also arm a name-independent guard: `socketserver.TCPServer.server_bind` is patched to `pytest.fail`, so any unsubstituted construction path fails loudly at the bind instead of hanging the shard. The fail-closed test's fake is class-shaped (with `serve_forever`) so an ordering regression reports the ordering assertion, not an unrelated `AttributeError` on `None`.

## Tests

- `test_main_boots_platform_before_binding_server` — the boot→bind→serve ordering assertion is unchanged; the patch now engages. Red-before-green demonstrated locally: on unpatched main the test hangs until pytest-timeout kills the xdist worker (the exact CI signature); with the fix, the file's 34 tests pass in ~6s.
- `test_main_fails_closed_when_platform_cannot_compose` — same substitution; its previously-dead patch is now live, and `served == []` still locks the fail-closed invariant.
- The `server_bind` guard was mutation-verified: re-introducing the dead `ThreadingHTTPServer` patch with the guard armed fails immediately with "main() bound a real socket" instead of hanging.
- Full `test/test_workflows_app.py` plus `src/kiro_crew/apps/builtins/workflows/tests` green on Python 3.12.

## Manual verification

N/A — unit coverage sufficient: the defect and fix are both fully contained in the two entrypoint tests, and the red-before-green run reproduced the CI hang signature locally.

## Related Issues

Closes #9675

## Pattern harvest

Rule candidate: review-prompt
Pattern: monkeypatching a base-class name never intercepts a subclass bound at class-definition time — patch the name the code under test actually constructs, and back socket-touching entrypoint tests with a bind-level tripwire.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
