### PR TITLE
fix(test): patch the server class workflows main() actually constructs

### DIFF
--- a/test/test_workflows_app.py
+++ b/test/test_workflows_app.py
@@ -269,7 +269,10 @@ def test_main_boots_platform_before_binding_server(monkeypatch) -> None:
 
     monkeypatch.setattr(server, "boot_platform", _boot)
     monkeypatch.setattr(server.KiroCrewConfig, "load", classmethod(lambda cls: SimpleNamespace()))
-    monkeypatch.setattr(server, "ThreadingHTTPServer", _FakeServer)
+    # `main()` constructs the module's `_Server` subclass, not the imported
+    # `ThreadingHTTPServer` name; patching the latter would bind a real socket
+    # on PORT and block in serve_forever() for the rest of the run.
+    monkeypatch.setattr(server, "_Server", _FakeServer)
 
     assert server.main() is None
     assert calls == ["boot", "bind", "serve"]
@@ -287,7 +290,7 @@ def test_main_fails_closed_when_platform_cannot_compose(monkeypatch) -> None:
     monkeypatch.setattr(server, "boot_platform", _boom)
     monkeypatch.setattr(
         server,
-        "ThreadingHTTPServer",
+        "_Server",
         lambda *args, **kwargs: served.append("bind"),
     )
 


### PR DESCRIPTION
## Summary

Main has been red on **Backend Tests (3.12, 4)** and **Backend Tests (Windows) (4)** since #9066 landed (`ebf9ffb55`, "fix(workflows): bootstrap the platform context"): main's own run on `67716d722` fails the same two shards plus Coverage Gate, and so does every PR rebased onto it (e.g. #8947).

The culprit is a test that patches the wrong name. `test_main_boots_platform_before_binding_server` does

```python
monkeypatch.setattr(server, "ThreadingHTTPServer", _FakeServer)
```

but `server.main()` instantiates the module's own subclass:

```python
class _Server(ThreadingHTTPServer): ...
server = _Server(("127.0.0.1", PORT), _Handler)
server.serve_forever()
```

`_Server` is bound at import time, so replacing the imported `ThreadingHTTPServer` name changes nothing — the test binds a real socket on `PORT` and `serve_forever()` never returns. On Linux that is `Failed: Timeout >120.0s`; on Windows the xdist worker (`gw3`) crashes.

## Fix

Patch `server._Server` in both tests. The fail-closed sibling (`test_main_fails_closed_when_platform_cannot_compose`) had the same wrong target and only passed because `boot_platform` raises before the server line; it is corrected too so it keeps guarding the right thing.

Test-only change; no production code touched.

## Evidence

- main `67716d722` run 34328282177: `Backend Tests (Windows) (4)`, `Backend Tests (3.12, 4)`, `Coverage Gate` failed.
- #8947 head `ebf99636b` run 34328983606: identical failures, `test_main_boots_platform_before_binding_server` — Linux `Timeout >120.0s`, Windows `worker 'gw3' crashed`.
- `git log 02921dfc1..67716d722 -- test/test_workflows_app.py` → only `ebf9ffb55` (#9066).

## Local gates

`ruff check test/test_workflows_app.py` clean. Tests not run locally (CI is the gate).

## Pattern harvest

- **Pattern:** a test monkeypatches the *imported* base-class name (`server.ThreadingHTTPServer`) while the code under test instantiates a module-level *subclass* (`_Server`) that captured the base at import time. The patch is silently inert; the test then does the real thing (bind a socket, block in `serve_forever()`), which shows up as a 120 s timeout on Linux and an xdist worker crash on Windows rather than an assertion failure — so it reads like flakiness, not a wrong patch target.
- **Detection gap:** the failure mode (hang) hid the cause; the test passed locally for the author only if `PORT` happened to be free *and* nobody waited 120 s. CI ran it in a sharded job where a single hang takes the whole shard.
- **Guard going forward:** when patching what `main()` builds, patch the name `main()` reads (`_Server`), not what that name was built from. A cheap tripwire for this family: any test that stubs a server/loop should assert the stub was *called* (`calls == [...]` here does that — it just never got to run).

Rule candidate: a test that monkeypatches a class the code under test *inherits from* (rather than the name it *instantiates*) is a dead patch — flag `monkeypatch.setattr(<module>, "<BaseClass>", …)` where `<module>` defines a subclass of `<BaseClass>` that the tested entrypoint constructs. Reviewers/AutoSDE: require the patched name to appear in the entrypoint's body.

- **Sibling swept:** `test_main_fails_closed_when_platform_cannot_compose` had the identical wrong target and only passed because `boot_platform` raised first; fixed in the same commit so it keeps guarding the right thing.
