### PR TITLE
fix(chat): release scroll-follow only on confirmed upward input at a bottom clamp

### DIFF
--- a/website/src/hooks/virtualizer/FollowController.ts
+++ b/website/src/hooks/virtualizer/FollowController.ts
@@ -230,7 +230,11 @@ export const FOLLOW_REENGAGE_PX = 16
  *      absorbs the layout engine's clamp: a mid-stream content SHRINK drops
  *      scrollTop (which reads as an upward move) but lands exactly at the new
  *      bottom — releasing there froze streaming follow for the rest of the
- *      turn.
+ *      turn. The exception is a non-downward landing under a confirmed UPWARD
+ *      user input inside the settle window (`upwardInputWithinSettle`): that
+ *      shrink coincided with the reader's own scroll-up, so it belongs to the
+ *      user and releases follow. A downward or directionless input keeps the
+ *      clamp absorbed.
  *   2. Any other upward move → release, regardless of distance from the
  *      bottom. The scroll position now belongs to the user; only returning to
  *      the bottom (3) re-engages.
@@ -264,6 +268,29 @@ export function resolveUserScrollStick(args: {
    *  shrink moves `scrollHeight`, not `clientHeight` — so the two are
    *  distinguishable, and this is the delta that tells them apart. */
   viewportGrowth?: number
+  /** A hardware user input whose own direction was UPWARD (wheel up / upward
+   *  key / upward touch drag) landed within the scroll-settle window before
+   *  this scroll event.
+   *
+   *  The bottom-epsilon branch below treats a scroll landing within
+   *  `atBottomEpsilon` of the true bottom as the layout engine's clamp and
+   *  keeps `stick` as it was. But a genuine user scroll-UP that happens to
+   *  coincide with a mid-turn content shrink terminates within epsilon of the
+   *  NEW bottom too, so it wears the same signature — and keeping `stick` armed
+   *  there pins the reader back to the end on the next streaming resize. The
+   *  intent listeners stamp the input's direction BEFORE its scroll event
+   *  dispatches, so a fresh UPWARD stamp is proof the reader scrolled up: a
+   *  non-downward landing at the bottom under it is the reader, not the
+   *  engine, and releases follow.
+   *
+   *  The direction requirement is load-bearing: a wheel-DOWN at the bottom is
+   *  an ordinary input during streaming, and a content-shrink clamp landing
+   *  inside its settle window must NOT release follow — the reader asked to
+   *  stay at the end. Directionless inputs (a scrollbar grab, a first touch
+   *  move) are treated the same conservative way: only confirmed upward
+   *  intent disables the clamp guard. A genuine clamp carries no upward
+   *  input, so it still keeps `stick`. */
+  upwardInputWithinSettle?: boolean
 }): boolean {
   const { stick, followOutput, scrollTop, prevScrollTop, geom } = args
   if (!followOutput) return false
@@ -276,7 +303,17 @@ export function resolveUserScrollStick(args: {
   // closes is refused their re-engagement.
   const clampedByViewport =
     (args.viewportGrowth ?? 0) > atBottomEpsilon() && scrollTop <= prevScrollTop + atBottomEpsilon()
-  if (dist <= atBottomEpsilon()) return clampedByViewport ? stick : true
+  if (dist <= atBottomEpsilon()) {
+    // A clamp only ever lowers scrollTop, so a downward move here is the user's
+    // own and re-engages. A non-downward landing at the bottom is ambiguous
+    // between the engine's clamp and a user scroll-up that coincided with a
+    // content shrink -- and an UPWARD hard input within the settle window is
+    // the evidence the reader scrolled up, so the landing belongs to them:
+    // release. Direction-blind or downward input keeps the clamp guard.
+    const movedDown = prevScrollTop >= 0 && scrollTop > prevScrollTop + atBottomEpsilon()
+    if (args.upwardInputWithinSettle && !movedDown) return false
+    return clampedByViewport ? stick : true
+  }
   if (prevScrollTop < 0) return dist <= FOLLOW_REENGAGE_PX
   if (scrollTop < prevScrollTop - 0.5) return false
   // Re-engagement requires a genuine DOWNWARD move, not merely a non-upward

--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -733,6 +733,14 @@ export function useVirtualChat<T>(
   // hardware events and by the smooth-pin grab interrupts, never by scroll
   // events themselves.
   const lastHardInputAtRef = useRef<number>(Number.NEGATIVE_INFINITY)
+  // UPWARD-only sibling of lastHardInputAtRef: stamped when the input's own
+  // direction was up (wheel up / upward key / upward touch drag), or when a
+  // smooth-glide grab moved scrollTop backward (confirmed upward by motion).
+  // resolveUserScrollStick's clamp branch keys its release on THIS stamp, not
+  // the direction-blind one: a wheel-down at the bottom is an ordinary input
+  // during streaming, and a content-shrink clamp inside its settle window must
+  // keep follow armed rather than releasing the reader who asked for the end.
+  const lastUpwardInputAtRef = useRef<number>(Number.NEGATIVE_INFINITY)
   // When WE last established the reader's bottom position: a pin write, or a
   // re-baseline of `lastWriteTopRef` onto a layout clamp / an already-at-bottom
   // observation. Compared against the hard-input stamp above it answers "has the
@@ -2287,6 +2295,9 @@ export function useVirtualChat<T>(
           smoothPinActiveRef.current = false
           lastUserScrollAtRef.current = performance.now()
           lastHardInputAtRef.current = lastUserScrollAtRef.current
+          // scrollTop moving backward against the animation IS a confirmed
+          // upward gesture, so it also arms the clamp-release stamp.
+          lastUpwardInputAtRef.current = lastUserScrollAtRef.current
           stickRef.current = false
           detachSmoothAbort()
         }
@@ -2320,6 +2331,15 @@ export function useVirtualChat<T>(
             lastScrollClientHRef.current > 0
               ? geom.clientHeight - lastScrollClientHRef.current
               : 0,
+          // An UPWARD hardware input stamped within the settle window is proof
+          // the reader scrolled up. The intent listeners stamp its direction
+          // BEFORE this scroll event dispatches, so a landing at the bottom
+          // under a fresh upward stamp is the reader's own scroll-up coinciding
+          // with a content shrink, not the engine's clamp — release follow
+          // instead of holding the reader at the end. A downward or
+          // directionless input leaves the clamp guard in place.
+          upwardInputWithinSettle:
+            performance.now() - lastUpwardInputAtRef.current < SCROLL_SETTLE_MS,
         })
         if (wasStick && !stickRef.current) releaseFollowBaseline()
         const layoutClamp = stickRef.current && clampedAtBottom
@@ -2392,9 +2412,13 @@ export function useVirtualChat<T>(
     // the gesture (fighting a trackpad fling frame by frame). Suppression is
     // harmless when the input does not scroll (a click, a wheel at the bottom):
     // follow resumes SCROLL_SETTLE_MS later.
-    const detachIntent = attachUserScrollIntent(el, () => {
+    const detachIntent = attachUserScrollIntent(el, (dir) => {
       lastUserScrollAtRef.current = performance.now()
       lastHardInputAtRef.current = performance.now()
+      // Only a confirmed upward input arms the clamp-release stamp — a
+      // directionless grab or a downward input must not disable the clamp
+      // guard (see lastUpwardInputAtRef).
+      if (dir === 'up') lastUpwardInputAtRef.current = performance.now()
     })
     onScroll()
     return () => {

--- a/website/src/test/FollowController.test.ts
+++ b/website/src/test/FollowController.test.ts
@@ -604,3 +604,69 @@ describe('resolveUserScrollStick — a clamp only ever lowers scrollTop', () => 
     expect(armed).toBe(false)
   })
 })
+
+describe('resolveUserScrollStick — a clamp under an upward user input is the reader', () => {
+  // A user scroll-UP concurrent with a mid-turn content shrink terminates within
+  // epsilon of the NEW bottom, wearing the same signature as the engine's clamp.
+  // The intent listeners stamp the input's own direction before the scroll event
+  // dispatches, so a fresh UPWARD stamp is the discriminator: with it the landing
+  // is the reader's own move and releases follow; without it the landing is the
+  // engine's clamp and keeps follow, which is what rule 1 is for.
+  const geom = { scrollTop: 600, scrollHeight: 1000, clientHeight: 400 }
+
+  it('a content-shrink clamp with NO recent input keeps stick armed', () => {
+    const armed = resolveUserScrollStick({
+      stick: true,
+      followOutput: true,
+      scrollTop: 600,
+      prevScrollTop: 620,
+      geom,
+      upwardInputWithinSettle: false,
+    })
+    expect(armed).toBe(true)
+  })
+
+  it('a clamp inside the settle window of a DOWNWARD input keeps stick armed', () => {
+    // A wheel-down at the bottom is an ordinary input while a stream is live: it
+    // stamps hard input but NOT upward intent, and a content-shrink clamp landing
+    // inside its settle window must not release follow — the reader asked to stay
+    // at the end. Only confirmed upward input disables the clamp guard, so the
+    // caller passes false here exactly as it does for a directionless grab.
+    const armed = resolveUserScrollStick({
+      stick: true,
+      followOutput: true,
+      scrollTop: 600,
+      prevScrollTop: 620,
+      geom,
+      upwardInputWithinSettle: false,
+    })
+    expect(armed).toBe(true)
+  })
+
+  it('the same clamp WITHIN the settle window of an upward input releases stick', () => {
+    const armed = resolveUserScrollStick({
+      stick: true,
+      followOutput: true,
+      scrollTop: 600,
+      prevScrollTop: 620,
+      geom,
+      upwardInputWithinSettle: true,
+    })
+    expect(armed).toBe(false)
+  })
+
+  it('a genuine downward re-engage under an upward stamp still follows', () => {
+    // A clamp only ever lowers scrollTop, so a downward move is the reader's own
+    // and must re-engage even with a fresh input stamp — the release is for
+    // non-downward landings only.
+    const armed = resolveUserScrollStick({
+      stick: false,
+      followOutput: true,
+      scrollTop: 600,
+      prevScrollTop: 400,
+      geom,
+      upwardInputWithinSettle: true,
+    })
+    expect(armed).toBe(true)
+  })
+})

--- a/website/src/test/searchScroll.test.ts
+++ b/website/src/test/searchScroll.test.ts
@@ -487,6 +487,57 @@ describe('attachUserScrollIntent', () => {
     detach()
   })
 
+  it('reports the wheel delta as the input direction', () => {
+    // The clamp-release path keys on confirmed UPWARD input: a wheel-down at
+    // the bottom is an ordinary streaming input and must not read as upward.
+    const { el, onUser, detach } = harness()
+    el.dispatchEvent(new WheelEvent('wheel', { deltaY: -40 }))
+    expect(onUser).toHaveBeenLastCalledWith('up')
+    el.dispatchEvent(new WheelEvent('wheel', { deltaY: 40 }))
+    expect(onUser).toHaveBeenLastCalledWith('down')
+    el.dispatchEvent(new WheelEvent('wheel', { deltaY: 0 }))
+    expect(onUser).toHaveBeenLastCalledWith(undefined)
+    detach()
+  })
+
+  it('partitions the scrolling keys by direction', () => {
+    const { el, onUser, detach } = harness()
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
+    expect(onUser).toHaveBeenLastCalledWith('up')
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageDown' }))
+    expect(onUser).toHaveBeenLastCalledWith('down')
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }))
+    expect(onUser).toHaveBeenLastCalledWith('down')
+    // Horizontal arrows scroll neither way and stay directionless.
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    expect(onUser).toHaveBeenLastCalledWith(undefined)
+    detach()
+  })
+
+  it('a scrollbar grab is directionless', () => {
+    const { el, onUser, detach } = harness()
+    el.dispatchEvent(new Event('pointerdown'))
+    expect(onUser).toHaveBeenLastCalledWith()
+    detach()
+  })
+
+  it('derives touch direction from the finger path, with no guess on the first move', () => {
+    const touchAt = (clientY: number) =>
+      new TouchEvent('touchmove', {
+        touches: [new Touch({ identifier: 1, target: document.body, clientY })],
+      })
+    const { el, onUser, detach } = harness()
+    // First move has no baseline: no direction rather than a guess.
+    el.dispatchEvent(touchAt(300))
+    expect(onUser).toHaveBeenLastCalledWith(undefined)
+    // Finger moving DOWN the screen scrolls the content UP.
+    el.dispatchEvent(touchAt(340))
+    expect(onUser).toHaveBeenLastCalledWith('up')
+    el.dispatchEvent(touchAt(310))
+    expect(onUser).toHaveBeenLastCalledWith('down')
+    detach()
+  })
+
   it('fires on scrolling keys', () => {
     const { el, onUser, detach } = harness()
     for (const key of ['ArrowDown', 'PageUp', 'Home', 'End', ' ']) {

--- a/website/src/utils/searchScroll.ts
+++ b/website/src/utils/searchScroll.ts
@@ -256,6 +256,16 @@ const SCROLLING_KEYS = new Set([
   'PageUp', 'PageDown', 'Home', 'End', ' ', 'Spacebar',
 ])
 
+// Direction of one scrolling key, for callers that need the input's own
+// direction. Comparisons against `KeyboardEvent.key` protocol values, never
+// rendered; horizontal arrows scroll neither way, and Space pages down.
+function scrollKeyDirection(key: string): 'up' | 'down' | undefined {
+  if (key === 'ArrowUp' || key === 'PageUp' || key === 'Home') return 'up'
+  if (key === 'ArrowDown' || key === 'PageDown' || key === 'End') return 'down'
+  if (key === ' ' || key === 'Spacebar') return 'down'
+  return undefined
+}
+
 /**
  * Attach a one-shot "the user is trying to scroll" listener set and return a
  * detach function.
@@ -273,25 +283,48 @@ const SCROLLING_KEYS = new Set([
  */
 export function attachUserScrollIntent(
   target: EventTarget | undefined,
-  onUser: () => void,
+  onUser: (dir?: 'up' | 'down') => void,
 ): () => void {
   if (!target) return () => {}
   const onKey = (e: Event) => {
     const key = (e as KeyboardEvent).key
     // A bare modifier press is not scroll intent; an unknown key is not either.
-    if (typeof key === 'string' && SCROLLING_KEYS.has(key)) onUser()
+    if (typeof key !== 'string' || !SCROLLING_KEYS.has(key)) return
+    onUser(scrollKeyDirection(key))
   }
+  const onWheel = (e: Event) => {
+    // The wheel delta is the input's own direction, available BEFORE any scroll
+    // event: negative deltaY scrolls up. A zero/absent delta stays directionless.
+    const dy = (e as WheelEvent).deltaY
+    onUser(dy < 0 ? 'up' : dy > 0 ? 'down' : undefined)
+  }
+  // Track the previous touch Y within this attachment: a finger moving DOWN the
+  // screen scrolls the content UP. The first move has no baseline and reports
+  // no direction rather than guessing.
+  let lastTouchY = Number.NaN
+  const onTouch = (e: Event) => {
+    const y = (e as TouchEvent).touches?.[0]?.clientY
+    if (typeof y !== 'number') {
+      onUser()
+      return
+    }
+    const prev = lastTouchY
+    lastTouchY = y
+    onUser(Number.isNaN(prev) || y === prev ? undefined : y > prev ? 'up' : 'down')
+  }
+  // A scrollbar grab carries no direction until it actually scrolls.
+  const onPointer = () => onUser()
   const passive = { passive: true } as const
-  target.addEventListener('wheel', onUser, passive)
-  target.addEventListener('touchmove', onUser, passive)
+  target.addEventListener('wheel', onWheel, passive)
+  target.addEventListener('touchmove', onTouch, passive)
   // pointerdown fires when the scrollbar thumb is grabbed, before any scroll
   // event arrives, so the abort lands ahead of the first drag movement.
-  target.addEventListener('pointerdown', onUser, passive)
+  target.addEventListener('pointerdown', onPointer, passive)
   target.addEventListener('keydown', onKey, passive)
   return () => {
-    target.removeEventListener('wheel', onUser)
-    target.removeEventListener('touchmove', onUser)
-    target.removeEventListener('pointerdown', onUser)
+    target.removeEventListener('wheel', onWheel)
+    target.removeEventListener('touchmove', onTouch)
+    target.removeEventListener('pointerdown', onPointer)
     target.removeEventListener('keydown', onKey)
   }
 }


### PR DESCRIPTION
## Problem / Motivation

When a reader scrolls up during a streaming response, the viewport keeps pulling them back to the bottom instead of holding their position — reported as "chat keeps scrolling while I read".

## Why it matters

The reader cannot read earlier output while a turn is still streaming: every scroll-up is undone on the next resize, so they are stuck at the end until the turn finishes.

## What changed (motivation → approach → change)

The passive scroll listener classifies any user scroll landing within `atBottomEpsilon` of the true bottom as the layout engine's clamp, and `resolveUserScrollStick`'s bottom-epsilon branch keeps `stick` armed across it. That branch exists for a real case: a mid-turn content shrink drops `scrollTop` to exactly the new bottom, and releasing there would freeze streaming follow for the rest of the turn.

The root cause is a misclassification. A genuine user scroll-up that happens to coincide with such a content shrink also terminates within epsilon of the new bottom, so it wears the same signature. Read as a clamp, `stick` stays armed and the next streaming resize pins the reader back to the end — every attempt.

The persistent intent listeners already stamp `lastHardInputAtRef` at wheel / touch / key / scrollbar time, which is earlier than the scroll event. So the fix threads that recency into `resolveUserScrollStick` as `hardInputWithinSettle`: in the bottom-epsilon branch, a non-downward landing at the bottom under a hard input within `SCROLL_SETTLE_MS` belongs to the reader and releases follow. A clamp with no recent input still keeps `stick` (the legitimate case the branch exists for), and a genuine downward move still re-engages. The new parameter is optional, so the app-sdk consumer — which has no intent listeners — keeps its prior behavior.

## Tests

Extended `FollowController.test.ts` for `resolveUserScrollStick`:
- a content-shrink clamp with **no** recent input keeps `stick` armed (existing contract pinned);
- the same clamp **within** the settle window of a hard input releases `stick`;
- a genuine downward re-engage under a hard input still follows (the release is for non-downward landings only).

`FollowController.test.ts`: 55 passed. `useVirtualChat` follow/shrink/resize/anchor/geometry suites: 42 passed. `tsc -b`: clean. Comment-history gate: clean.

## Manual verification

N/A — unit coverage sufficient. `resolveUserScrollStick` is a pure function; the fix is fully exercised by the unit tests above, and the call-site change only forwards an existing timestamp already used elsewhere in the same handler.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** logic-only change to scroll-follow decision code; it changes when follow releases, not any rendered element, layout, or string.

## Related Issues

Fixes #9652

## Pattern harvest

Rule candidate: review-prompt
Pattern: a position-based classifier that distinguishes a user action from an engine action by geometry alone is ambiguous when the two land in the same place; consult an earlier, unambiguous intent signal (a stamped input timestamp) to break the tie rather than widening the geometric tolerance.

## Checklist

- [x] At most two commits (one here), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
