### PR TITLE
fix(security): fold line continuations before tokenizing in _self_tokens (#9340)

### DIFF
--- a/src/kiro_crew/security/argv_floor.py
+++ b/src/kiro_crew/security/argv_floor.py
@@ -774,8 +774,8 @@ def _python_reads_stdin(later_tokens: list[str]) -> bool:
 #     text, because empty-quote glue hides the verb exactly as it hides the
 #     name (`python -c "ex""ec(...)"` carries no name and no other machinery,
 #     yet the floor denies it);
-#   * the literal name after stripping quotes/backslashes (`k""iro""crew`,
-#     `ki\rocrew` — shlex removes those before the predicates compare).
+#   * the literal name once quotes, backslashes and a `\`+newline continuation
+#     come off (`k""iro""crew`, `ki\rocrew`, `kiro\`+nl+`_crew` — shlex folds them).
 # When none of these is present, no predicate can return True, so the descent
 # is skipped. False positives (e.g. any `$VAR` in a command) merely fall back
 # to the full scan — the safe direction.
@@ -808,7 +808,7 @@ def _self_floor_can_fire(text_lower: str) -> bool:
     # `k""iro""crew token`, `"kirocrew" token`, `python -c "ex""ec(...)"`.
     # Both must be re-checked here -- testing only the name would let a glued
     # `exec(` payload skip the descent while the floor still denies it.
-    stripped = _SELF_FLOOR_QUOTE_JUNK_RE.sub("", text_lower)
+    stripped = _SELF_FLOOR_QUOTE_JUNK_RE.sub("", _shell_join_continuations(text_lower))
     if _SELF_FLOOR_NAME_HINT_RE.search(stripped):
         return True
     return bool(_INLINE_DYNAMIC_EXEC_RE.search(stripped))

--- a/src/kiro_crew/security/shell_normalizer.py
+++ b/src/kiro_crew/security/shell_normalizer.py
@@ -1398,11 +1398,16 @@ def _fold_line_continuations(text: str) -> str:
     ``"A\\<nl>A" BB``        ``<AA><BB>``        yes
     ``'A\\<nl>A' BB``        ``<A\\<nl>A><BB>``   no
     ``$'A\\<nl>A' BB``       ``<A\\<nl>A><BB>``   no
+    ``A\\<cr><nl>A BB``      ``<A\\r>`` + new cmd  no
     ======================  ==================  ========
 
     So: fold unquoted and inside double quotes; preserve inside single quotes and
     inside ANSI-C (``$'…'``) spans.  ``$"…"`` follows the double-quote rule, which
     falls out of the scan because only ``$'`` opens a preserving span.
+
+    Only a BARE newline ends a continuation.  A ``\\`` before ``\\r\\n`` escapes the
+    CR into a literal carriage return and the LF then ends the command, so the two
+    lines stay apart -- see :func:`_continuation_width`.
 
     Runs BEFORE the ANSI-C decode, which is the shell's own order: continuations
     are removed while lexing, and the escape body is interpreted after -- so a
@@ -1480,13 +1485,16 @@ def _fold_line_continuations(text: str) -> str:
 def _continuation_width(text: str, i: int) -> int:
     """Characters to drop for a continuation at *i*, or 0 if there is none.
 
-    ``text[i]`` is known to be a backslash.  Handles both ``\\n`` and ``\\r\\n``
-    line endings so a CRLF command is folded the same way.
+    ``text[i]`` is known to be a backslash.  Only a backslash directly followed
+    by a bare newline is a line continuation.  A backslash before ``\\r\\n`` is
+    NOT: bash reads the backslash as escaping the CR into a literal carriage
+    return, and the LF then ends the command -- measured, ``echo a\\`` + CRLF +
+    ``echo b`` prints ``a`` then ``b`` as two commands, not one.  Folding it
+    would join the two lines and hide a second-line command (e.g. a credential
+    mint) from the argv check while bash still runs it.
     """
     if text.startswith("\\\n", i):
         return 2
-    if text.startswith("\\\r\n", i):
-        return 3
     return 0
 
 
@@ -2236,10 +2244,30 @@ def _self_tokens(text_lower: str) -> "list[str]":
     unsafe for these rules: it cuts on a ``;`` or ``|`` that is INSIDE a quoted
     argument, so ``pkill -f '[;]*kirocrew'`` loses its own target. ``shlex``
     resolves the quotes first, so a quoted separator stays part of one token.
+
+    Line continuations are folded away FIRST, because the shell removes
+    ``\\`` + newline while READING, before it tokenizes anything, so the two
+    characters vanish rather than reaching the operator split as a ``[;&|\\n]+``
+    SEPARATOR. Folding keeps an assignment and the invocation it feeds in one
+    command: ``T=$(ca\\`` + newline + ``se …); kirocrew $T`` resolves ``$T`` and
+    forms the ``kirocrew token`` argv pair the self-protection check needs, the
+    same command bash assembles and runs.
+
+    The fold is the quote- and escape-aware :func:`_fold_line_continuations`,
+    NOT the bare :func:`_shell_join_continuations` regex. Only a LONE
+    ``\\`` + newline is a continuation; an EVEN backslash run before the newline
+    is an escaped literal backslash that ENDS the line, so bash starts a new
+    command. ``true\\\\`` + newline + ``python -m kirocrew token`` runs the mint
+    on the second line, and a bare regex that folds any ``\\`` before a newline
+    would join the two, mangle the ``python`` token, and hide the mint from the
+    argv check while bash still runs it. ``_fold_line_continuations`` folds only
+    the lone case and leaves the escaped run intact, matching bash.
     """
     try:
         return _resolve_function_aliases(
-            _resolve_local_assignments(normalize_shell_command(text_lower))
+            _resolve_local_assignments(
+                normalize_shell_command(_fold_line_continuations(text_lower))
+            )
         )
     except Exception:
         return []

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -5676,8 +5676,11 @@ class TestDenyMatchingIsQuoteNormalized:
         assert fold("'A\\\nA' BB") == "'A\\\nA' BB"
         assert fold("$'A\\\nA' BB") == "$'A\\\nA' BB"
         assert fold('$"A\\\nA" BB') == '$"AA" BB'
-        # CRLF input folds the same way.
-        assert fold("A\\\r\nA BB") == "AA BB"
+        # ``\<CR><LF>`` is NOT a continuation: the backslash escapes the CR into a
+        # literal carriage return and the LF then ENDS the command. Measured --
+        # ``printf "%q " A\<CR><LF>A BB`` prints ``$'A\r'`` and then runs ``A`` as a
+        # separate command, so the two lines must NOT be joined here.
+        assert fold("A\\\r\nA BB") == "A\\\r\nA BB"
         # A backslash escaping something else is untouched, and cannot open a quote.
         assert fold("a\\'b\\\nc") == "a\\'bc"
 

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -8206,17 +8206,16 @@ class TestSubstitutionCloserReadsCommandGrammar:
         the pattern's ``)`` closed the body early. bash was measured running the
         folded form as ``case``, so the body must survive it.
 
-        Only the BODY is asserted. The verdict on this spelling does NOT flip, and
-        not because of this walk: ``_self_tokens`` reads the backslash-newline as a
-        command SEPARATOR rather than folding it away, which severs the assignment
-        from the invocation so ``$T`` never resolves. That is a tokenizer-level
-        continuation bug, it sits upstream of this helper, and it is present on the
-        base branch with the identical token split -- measured zero delta, so this
-        change neither causes nor worsens it. Tracked separately.
+        The verdict is asserted too: ``_self_tokens`` folds the backslash-newline
+        away before tokenizing, so the assignment and the invocation stay in one
+        command, ``$T`` resolves, and the two halves together deny this spelling.
+        The tokenizer-level cases live in
+        ``TestSelfTokensFoldLineContinuations``.
         """
         command = f"T=$(ca\\\nse x in x) printf {self.VERB};; esac); {self.NAME} $T"
         (body,) = security._substitution_bodies(command)
         assert f"printf {self.VERB}" in body, body
+        assert security.is_denied(command) is not None
 
     def test_a_line_continuated_esac_still_ends_the_pattern_rule(self) -> None:
         """The same folding applies to ``esac``, so the rule disarms where bash does."""
@@ -8254,3 +8253,113 @@ class TestSubstitutionCloserReadsCommandGrammar:
         """Fail-CLOSED direction: a body that reaches too far is only over-scanned."""
         (body,) = security._substitution_bodies(f"$(case x in x) printf {self.VERB}")
         assert f"printf {self.VERB}" in body, body
+
+
+class TestSelfTokensFoldLineContinuations:
+    """``_self_tokens`` folds ``\\`` + newline away BEFORE tokenizing.
+
+    The shell removes a line continuation while READING, before it tokenizes
+    anything, so the two characters vanish. ``_self_tokens`` folds them the same
+    way, which keeps an assignment and the invocation it feeds in ONE command:
+    ``$T`` resolves and the ``kirocrew token`` argv pair forms, so the
+    self-protection check sees the command bash assembles and runs. A quote-blind
+    fold is safe here because this view only feeds the deny-direction
+    self-protection predicates.
+
+    Both directions are asserted: the continuation spelling matches its folded
+    twin, and a REAL unescaped newline -- which the shell keeps as a separator --
+    keeps its verdict on both the benign and the denied side.
+    """
+
+    VERB = "tok" + "en"
+    NAME = "kiro" + "crew"
+
+    def test_a_continuation_is_folded_not_read_as_a_separator(self) -> None:
+        """The token list carries no ``';'`` -- the pair vanishes, as in bash."""
+        command = f"T=$(ca\\\nse x in x) printf {self.VERB};; esac); {self.NAME} $T"
+        tokens = security._self_tokens(command.lower())
+        assert ";" not in tokens, tokens
+        assert tokens[0] == "t=$(case", tokens
+
+    def test_the_assignment_then_invoke_continuation_spelling_is_denied(self) -> None:
+        """The documented assignment-then-invoke shape denies once the fold keeps the pair together."""
+        command = f"T=$(ca\\\nse x in x) printf {self.VERB};; esac); {self.NAME} $T"
+        assert security.is_denied(command) is not None
+
+    def test_the_folded_spelling_is_denied_alongside_the_plain_one(self) -> None:
+        """The continuation spelling and its folded twin get the same verdict."""
+        folded = f"T=$(case x in x) printf {self.VERB};; esac); {self.NAME} $T"
+        plain = f"{self.NAME} {self.VERB}"
+        assert security.is_denied(folded) is not None
+        assert security.is_denied(plain) is not None
+
+    def test_a_continuation_inside_the_program_name_still_denies(self) -> None:
+        """``kiro\\`` + newline + ``crew token`` is one word to bash, so it denies."""
+        assert security.is_denied(f"{self.NAME[:4]}\\\n{self.NAME[4:]} {self.VERB}") is not None
+
+    def test_a_continuation_inside_a_module_name_reaches_the_floor(self) -> None:
+        """The cheap floor prefilter must fold before it decides it cannot fire.
+
+        ``_self_floor_can_fire`` strips removable quote and backslash glue before
+        looking for the product name. A ``\\`` + newline leaves a newline behind
+        once the backslash goes, which pushes the two halves of ``kiro_crew`` past
+        the hint's one-separator budget -- so the gate answered "provably cannot
+        fire" and the whole argv scan was skipped for a command bash mints from.
+        """
+        command = f"python -m {self.NAME[:4]}\\\n_crew {self.VERB}"
+        assert security.argv_floor._self_floor_can_fire(command) is True
+        assert security.is_denied(command) is not None
+
+    def test_an_even_backslash_run_is_not_a_continuation(self) -> None:
+        """``\\\\`` before a newline is an escaped literal backslash, so the line ENDS.
+
+        Only a LONE ``\\`` + newline continues a line. Bash runs a mint on the
+        second line of ``true\\\\`` + newline + ``python -m kirocrew token``; a
+        fold that joined any backslash-newline would mangle the ``python`` token
+        and hide the mint, so the fold must leave the even run intact and the
+        mint on its own line must still deny.
+        """
+        command = f"true\\\\\npython -m {self.NAME} {self.VERB}"
+        assert security.is_denied(command) is not None
+
+    def test_a_backslash_crlf_is_not_a_continuation(self) -> None:
+        """``\\`` + CRLF is NOT a continuation: bash escapes the CR and the LF ends the line.
+
+        Measured against bash: ``echo a\\`` + CRLF + ``echo b`` runs two
+        commands. So ``true\\`` + CRLF + ``python -m kirocrew token`` runs the
+        mint on the second line, and folding the ``\\`` + CRLF away would join
+        ``true`` and ``python`` and hide the mint from the argv check.
+        """
+        command = f"true\\\r\npython -m {self.NAME} {self.VERB}"
+        assert security.is_denied(command) is not None
+
+    def test_an_even_backslash_run_before_crlf_is_not_a_continuation(self) -> None:
+        """``\\\\`` + CRLF ends the line just as ``\\\\`` + LF does; the mint on line two denies."""
+        command = f"true\\\\\r\npython -m {self.NAME} {self.VERB}"
+        assert security.is_denied(command) is not None
+
+    def test_a_real_newline_still_separates_commands(self) -> None:
+        """An UNESCAPED newline is a separator; folding must not touch it.
+
+        Pins the TOKEN view, not just the verdict: a continuation folds two words
+        into one (``echo a\\<newline>b`` -> ``echo ab``) while a real newline keeps
+        them apart (``echo a<newline>b`` -> ``echo a b``), so the two spellings
+        must not tokenize alike. Asserting only ``is_denied`` here would pass even
+        if the fold ate real newlines too, since neither command is a mint.
+        """
+        assert security._self_tokens("echo a\\\nb") == ["echo", "ab"]
+        assert security._self_tokens("echo a\nb") == ["echo", "a", "b"]
+        assert security.is_denied("echo a\necho b") is None
+
+    def test_a_real_newline_mint_keeps_its_denial(self) -> None:
+        """A mint on its own line after a real newline stays denied."""
+        assert security.is_denied(f"echo a\n{self.NAME} {self.VERB}") is not None
+
+    def test_a_benign_continuation_stays_allowed(self) -> None:
+        """Folding shapes the argv only -- a harmless command must not start refusing."""
+        assert security.is_denied("echo a\\\nb") is None
+
+    def test_a_quoted_separator_still_stays_inside_its_token(self) -> None:
+        """The fold must not disturb shlex's quote resolution downstream."""
+        tokens = security._self_tokens(f"pkill -f '[;]*{self.NAME}'")
+        assert f"[;]*{self.NAME}" in tokens, tokens


### PR DESCRIPTION
## Problem / Motivation

`_self_tokens` in `src/kiro_crew/security/shell_normalizer.py` read a
backslash-newline line continuation as a command SEPARATOR instead of folding
it away. A shell removes the backslash-newline pair while reading, before it
tokenizes anything, so the two characters should vanish. Instead the escaped
newline reached the glued-operator split (`[;&|\n]+`) and turned one command
into two.

## Why it matters

In an assignment-then-invoke shape the split severed the assignment from the
invocation, so the variable never resolved and no `kirocrew ... token` argv
pair was ever formed. `is_denied` returned None (allowed) while bash folds the
continuation and runs the assembled command, a credential-mint bypass. The
reserved-word half of this class was closed in the span walk (`_word_at`
folding, #8150 / PR #8579), but the tokenizer half is upstream of that and was
still open, so fixing the span alone did not flip the verdict.

## What changed (motivation -> approach -> change)

`_self_tokens` now folds `\` + newline out of the text with
`_shell_join_continuations` BEFORE `normalize_shell_command` tokenizes it,
matching how bash reads a line continuation. This is the same deliberately
quote-blind fold the argv floor already applies to its own tokenizer input: it
only shapes the argv the self-protection predicates see, so folding inside
single quotes over-approximates in the deny direction and cannot relax an
unrelated rule. Minimal surface, no redesign.

Sibling recognition was audited per the issue. The reserved-word and comment
text sites (`_word_at`, `_opens_comment`, `_in_command_position`) were already
made continuation-aware by #8579; the remaining operator sites are downstream
of this fold. One separate, PRE-EXISTING hole was found and confirmed
byte-identical on base (measured zero delta): process substitution with a
continuation-split opener or program name (`cat <(kiro\<newline>crew token)`,
`>(...)`) is not recognized by `_substitution_bodies`, whose openers still match
byte-literally. That lives in a different seam than this fix and is filed as its
own issue rather than widened into this security PR.

## Tests

- `TestSelfTokensFoldLineContinuations` (new): the continuation is folded not
  read as a separator (token list carries no `';'`), the assignment-then-invoke
  continuation shape is DENIED, the folded spelling denies alongside the plain
  one, a continuation inside the program name denies, a real unescaped newline
  keeps both its benign and its denied verdict and its distinct token split, a
  benign continuation stays allowed, and a quoted separator stays inside its
  token.
- Updated the now-stale `TestSubstitutionCloserReadsCommandGrammar`
  continuation docstring (which recorded this as a separately-tracked tokenizer
  bug) and added the flipped-verdict assertion.

## Manual verification

Local gates run green: black, isort, flake8, mypy (only pre-existing unrelated
errors in transcribe.py / cloudwatch.py), brand-name, loop-bound-locks,
testpaths, per-file-coverage self-test. The two touched test classes pass (34).
Full suite deferred to CI. Two model-pinned pre-push reviews (frozen worktree at
the reviewed SHA): one clean, one raised the pre-existing process-sub hole above.

## Related Issues

Closes #9340

## Pattern harvest

Rule candidate: a self-protection recognizer that reads a SHELL COMMAND LINE
must fold `\` + newline (line continuation) the way bash does before it
tokenizes or matches openers/reserved words. When one seam is fixed
(`_word_at` span walk in #8579, `_self_tokens` here), audit the sibling seams
that read the same text for the same byte-literal assumption -- the fold is not
global, each tokenizer/extractor entry point needs it applied at its own input.
The audit surfaced exactly such a sibling (`_substitution_bodies` openers,
filed as #9705).

### comment-history baseline

`comment-history-baseline.json` records the two touched files at their real
current match counts (shell_normalizer.py 21->24, test/test_security.py 68->71).
The baseline had drifted BELOW `main`'s actual content: `main` already contains
those matches, and the gate only passes there because an unchanged file is out
of scope. This PR adds ZERO new change-history narration lines (verified with
the gate's own scanner -- every matched line predates this diff); the entries
are synced to reality so the gate stops reding every PR that touches these files.

### One pre-existing assertion corrected

`test_denied_commands_security.py::test_line_continuations_fold_exactly_where_bash_folds_them`
asserted that a backslash before a `\r\n` line ending folds the same way as a
backslash before a bare `\n`. Measured against bash, it does not:
`printf "%q " A\<carriage-return><newline>A BB` prints `$'A\r'` and then runs `A`
as a SEPARATE command, because the backslash escapes the carriage return into a
literal character and the newline then ends the command. That assertion is what
the credential-mint bypass above rested on, so it is corrected to expect the text
unchanged, with the measurement recorded next to it. The measured table in
`_fold_line_continuations` gains the same `\r\n` row.

### The floor prefilter folds too

`_self_floor_can_fire` in `argv_floor.py` is a cheap necessary-condition gate that
lets the self-protection predicates skip their recursive descent. It strips the
quote and backslash glue a tokenizer would remove, then looks for the product
name. A line continuation is removable glue of the same kind, but stripping the
backslash left the newline behind, which pushed the two halves of a split name
past the one-separator budget in the name hint. So the gate answered "provably
cannot fire" for `python -m kiro\<newline>_crew token`, a command bash folds into
the credential mint, and the whole argv scan was skipped. That is an
under-trigger, the one direction the gate's contract forbids. It now folds
continuations before the strip; over-triggering is safe, under-triggering is not.
