### PR TITLE
fix(i18n): wait for a surface to go quiet before scanning it

### DIFF
--- a/website/scripts/check-i18n-render.mjs
+++ b/website/scripts/check-i18n-render.mjs
@@ -78,6 +78,11 @@ import { stubDashboardApi, logPageProblems, json } from './lib/stub-dashboard-ap
 import { SURFACES, LOCALES, VIEWPORTS, FIXTURE_DETAIL_APP } from './lib/i18n-surfaces.mjs'
 import { browserBundle } from './lib/render-scan.mjs'
 import {
+  SETTLE_POLL_MS,
+  SETTLE_TIMEOUT_MS,
+  createSettleTracker,
+} from './lib/render-settle.mjs'
+import {
   BUCKETS,
   BUCKET_MEANING,
   LEDGER_COMMENT,
@@ -900,6 +905,14 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
         // (exit 2) rather than as findings.
         const pageErrors = []
         page.on('pageerror', err => pageErrors.push(String(err.message || err)))
+        // Cumulative counters, deliberately never reset per surface. A request that
+        // outlives the surface that started it still settles, so the difference
+        // stays honest across the loop; resetting would strand those stragglers and
+        // leave the count permanently short.
+        const net = { started: 0, settled: 0, get inflight() { return this.started - this.settled } }
+        page.on('request', () => { net.started += 1 })
+        page.on('requestfinished', () => { net.settled += 1 })
+        page.on('requestfailed', () => { net.settled += 1 })
         await stubDashboardApi(page, {
           theme: 'dark',
           extra: (path, route) => FIXTURE_OVERRIDES(locale.code, path, route),
@@ -933,9 +946,15 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
               + 'the wrong shape for this surface (see lib/boot-api.mjs for the two shapes that '
               + 'error-boundary the whole shell). Re-run with --verbose to see the page errors.')
           }
-          // Panels that fetch after mount need a beat more; a half-rendered surface
-          // under-reports rather than failing loudly.
-          await page.waitForTimeout(surface.settle || 250)
+          // Panels that fetch after mount need a beat more. `settle` stays as the
+          // FLOOR for that beat, but it is no longer the whole of it: a fixed sleep
+          // made the wait a race whose loss was silent, so the surface now has to
+          // actually go quiet before it is scanned (lib/render-settle.mjs has the
+          // two conditions and the `app-detail` regression that came from checking
+          // neither). The floor and the quiet window OVERLAP rather than stack, so a
+          // surface that was already settled during its old sleep waits no longer
+          // than it did before.
+          await waitForSurfaceQuiet(page, net, surface, label)
           // Every width this gate reports is a text measurement, and text measures
           // differently in the fallback face than in the real one. Scanning before
           // the webfonts land made the layout bucket differ by 2 between identical
@@ -995,6 +1014,47 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
   // required a real locale precisely so this assertion could not go quiet; that
   // requirement now belongs to that script, which the i18n runner fails closed on.
   return { all, unresolved }
+}
+
+/**
+ * Hold until the surface stops changing, or fail saying it never did.
+ *
+ * The old wait was `surface.settle` milliseconds and nothing else, which made every
+ * post-mount fetch a race the gate could lose without saying so -- the scan just
+ * measured the loading skeleton and charged the surface a smaller number. `[vs-base]`
+ * then read one lost race on the base sweep as findings the branch had added.
+ *
+ * `settle` survives as a MINIMUM, because a page that has not dispatched its fetch
+ * yet is indistinguishable from one that never will. It runs CONCURRENTLY with the
+ * quiet window rather than ahead of it: sampling starts immediately, so a surface
+ * that settles inside its old sleep returns at the same moment it always did, and
+ * only a surface that needed longer costs longer.
+ *
+ * Reaching the cap is INFRASTRUCTURE broken, in the same sense as a surface that
+ * never painted: a page that keeps mutating cannot be measured twice and compared,
+ * so the run must say which surface it was rather than quietly scan it mid-flight.
+ */
+async function waitForSurfaceQuiet(page, net, surface, label) {
+  const tracker = createSettleTracker()
+  const started = Date.now()
+  const floor = started + (surface.settle || 250)
+  const deadline = started + SETTLE_TIMEOUT_MS
+  for (;;) {
+    const shot = await page.evaluate(() => ({
+      chars: document.body.innerText.trim().length,
+      nodes: document.querySelectorAll('*').length,
+    }))
+    const quiet = tracker.observe({ ...shot, inflight: net.inflight })
+    if (quiet && Date.now() >= floor) return
+    if (Date.now() >= deadline) break
+    await page.waitForTimeout(SETTLE_POLL_MS)
+  }
+  const seen = tracker.last || { chars: 0, nodes: 0 }
+  die(`[${label}] ${surface.url} never went quiet in ${SETTLE_TIMEOUT_MS}ms `
+    + `(${net.inflight} request(s) in flight, ${seen.chars} chars, ${seen.nodes} nodes). `
+    + 'A surface that keeps changing cannot be compared against a second sweep. Give it a '
+    + 'deterministic fixture in FIXTURE_OVERRIDES, or drop it from lib/i18n-surfaces.mjs '
+    + 'with a comment saying why.')
 }
 
 /**

--- a/website/scripts/lib/render-settle.mjs
+++ b/website/scripts/lib/render-settle.mjs
@@ -1,0 +1,108 @@
+/**
+ * When a captured surface is DONE rendering.
+ *
+ * The gate used to answer that with a fixed sleep: paint the shell, sleep
+ * `surface.settle` milliseconds, scan. Every panel that fetches AFTER mount was
+ * then a race, and losing it was silent -- the page still rendered, just its
+ * loading skeleton, so the surface reported a SMALLER number instead of failing.
+ *
+ * `[vs-base]` subtracts two of those captures, so one lost race on the base sweep
+ * is reported as findings the branch ADDED. That is how a documentation-only pull
+ * request drew `app-detail.text: 44 -> 70 (+26)`: the head sweep measured the
+ * populated detail body (70, which is also the number `render-baseline.json`
+ * records), the base sweep measured the skeleton (44), and the difference was
+ * charged to a diff with no rendering changes in it.
+ *
+ * So the capture waits for two conditions instead of a clock, and both have to
+ * hold at the same time before a sample counts as quiet:
+ *
+ *   - NOTHING IN FLIGHT. A post-mount fetch that has not answered yet is exactly
+ *     the skeleton case, and no amount of DOM stillness distinguishes it from a
+ *     finished page.
+ *   - THE DOM HOLDS STILL. The response has to be rendered, not merely received.
+ *     Measured as text volume plus node count, which is locale-agnostic on
+ *     purpose: the same predicate has to work under the pseudolocale and under
+ *     zh-CN, so it cannot look for any particular string.
+ *
+ * The tracker is a pure state machine over samples for the reason
+ * `renderVerdict.test.ts` gives for its own subject: reaching this logic through
+ * two vite builds and a browser is a ten-minute round trip, which is what kept the
+ * old behaviour untested while it mis-blamed pull requests.
+ *
+ * The per-surface `settle` value is NOT gone. It survives in the caller as a
+ * minimum elapsed time, because a page that has not dispatched its fetch yet looks
+ * exactly like one that never will. It runs alongside the quiet window instead of
+ * before it, so a surface that was already settled during its old sleep is scanned
+ * at the same moment it always was.
+ */
+
+/** Milliseconds between samples. */
+export const SETTLE_POLL_MS = 100
+
+/**
+ * Consecutive QUIET samples required. Three matches spans ~300ms of no network and
+ * no mutation, which is longer than the gap between a stubbed response and the React
+ * commit that renders it. Measured cost of the whole change at this setting: a full
+ * sweep of 114 captures (57 surfaces x 2 viewports) went from 113s to 158s, with an
+ * identical census, so a `[vs-base]` job pays it twice.
+ */
+export const SETTLE_STABLE_SAMPLES = 3
+
+/**
+ * Cap on the whole wait. Reaching it means the surface never went quiet, which the
+ * caller must report rather than absorb: a page that mutates forever cannot be
+ * measured reproducibly, and scanning it anyway is the silent understatement this
+ * module exists to remove.
+ */
+export const SETTLE_TIMEOUT_MS = 10000
+
+/**
+ * True when two samples describe the same rendered page.
+ *
+ * Node count is carried alongside text length because a swap can preserve length
+ * -- a skeleton row replaced by a real row of the same width is a different page
+ * with the same character count.
+ */
+export function sameRender(a, b) {
+  if (!a || !b) return false
+  return a.chars === b.chars && a.nodes === b.nodes
+}
+
+/**
+ * A sample is quiet when the page owes nothing to the network. `inflight` is a
+ * started-minus-settled difference, so a straggler from the previously captured
+ * surface can drive it negative; treat that as idle rather than as a request that
+ * has yet to be made.
+ */
+export function sampleIsQuiet(sample) {
+  return Boolean(sample) && sample.inflight <= 0
+}
+
+/**
+ * Accumulates samples until the surface has held still long enough.
+ *
+ * `observe` returns true the moment the run is settled, and never returns to false
+ * afterwards for the same tracker -- one tracker per capture, meaning one per
+ * surface per viewport per locale.
+ */
+export function createSettleTracker({ stableSamples = SETTLE_STABLE_SAMPLES } = {}) {
+  let previous = null
+  let stable = 0
+  let settled = false
+
+  return {
+    observe(sample) {
+      if (settled) return true
+      // A sample only extends the run when the page is idle AND unchanged. Either
+      // one alone is the failure mode: idle-but-changing is React still
+      // committing, unchanged-but-busy is the skeleton waiting on its fetch.
+      stable = sampleIsQuiet(sample) && sameRender(previous, sample) ? stable + 1 : 0
+      previous = sample
+      settled = stable >= stableSamples
+      return settled
+    },
+    get settled() { return settled },
+    get stable() { return stable },
+    get last() { return previous },
+  }
+}

--- a/website/src/test/renderSettle.test.ts
+++ b/website/src/test/renderSettle.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SETTLE_STABLE_SAMPLES,
+  createSettleTracker,
+  sameRender,
+  sampleIsQuiet,
+} from '../../scripts/lib/render-settle.mjs'
+
+/**
+ * When the render gate decides a surface is done.
+ *
+ * The property under test is the one the fixed sleep got wrong: a page still
+ * waiting on a post-mount fetch must NEVER be declared settled, because scanning it
+ * yields a smaller number rather than an error, and `[vs-base]` reports that
+ * shortfall as findings the branch introduced.
+ *
+ * Tested as a pure state machine for the reason `renderVerdict.test.ts` gives for
+ * its own subject: reaching this logic through two vite builds and a browser is a
+ * ten-minute round trip, which is what kept the old behaviour untested while it
+ * mis-blamed pull requests.
+ */
+
+const quiet = (chars = 500, nodes = 300) => ({ chars, nodes, inflight: 0 })
+const busy = (chars = 500, nodes = 300) => ({ chars, nodes, inflight: 1 })
+
+/** Feed a sequence and report the 1-based sample that settled it, or null. */
+function settledAt(samples) {
+  const tracker = createSettleTracker()
+  for (let i = 0; i < samples.length; i += 1) {
+    if (tracker.observe(samples[i])) return i + 1
+  }
+  return null
+}
+
+describe('sameRender', () => {
+  it('compares text volume and node count together', () => {
+    expect(sameRender({ chars: 10, nodes: 5 }, { chars: 10, nodes: 5 })).toBe(true)
+    expect(sameRender({ chars: 10, nodes: 5 }, { chars: 11, nodes: 5 })).toBe(false)
+  })
+
+  it('separates a same-length swap, which is a different page', () => {
+    expect(sameRender({ chars: 42, nodes: 20 }, { chars: 42, nodes: 31 })).toBe(false)
+  })
+
+  it('has no opinion without two samples', () => {
+    expect(sameRender(null, { chars: 1, nodes: 1 })).toBe(false)
+  })
+})
+
+describe('sampleIsQuiet', () => {
+  it('is quiet only when the page owes the network nothing', () => {
+    expect(sampleIsQuiet({ chars: 1, nodes: 1, inflight: 0 })).toBe(true)
+    expect(sampleIsQuiet({ chars: 1, nodes: 1, inflight: 1 })).toBe(false)
+  })
+
+  it('reads a straggler from an earlier surface as idle, not as a pending fetch', () => {
+    expect(sampleIsQuiet({ chars: 1, nodes: 1, inflight: -2 })).toBe(true)
+  })
+})
+
+describe('createSettleTracker', () => {
+  it('needs the configured run of matching quiet samples', () => {
+    expect(settledAt(Array(SETTLE_STABLE_SAMPLES).fill(quiet()))).toBe(null)
+    expect(settledAt(Array(SETTLE_STABLE_SAMPLES + 1).fill(quiet())))
+      .toBe(SETTLE_STABLE_SAMPLES + 1)
+  })
+
+  it('never settles a page that is still fetching, however still its DOM is', () => {
+    // The `app-detail` skeleton: nothing moves, because the answer has not arrived.
+    expect(settledAt(Array(20).fill(busy()))).toBe(null)
+  })
+
+  it('never settles a page that is still mutating, however idle the network is', () => {
+    const growing = Array.from({ length: 20 }, (_, i) => quiet(100 + i * 10, 50 + i))
+    expect(settledAt(growing)).toBe(null)
+  })
+
+  it('restarts the run when the awaited body finally lands', () => {
+    // Skeleton held still while busy, then the real body arrives and holds.
+    const samples = [
+      busy(120, 40), busy(120, 40), busy(120, 40),
+      quiet(900, 260), quiet(900, 260), quiet(900, 260), quiet(900, 260),
+    ]
+    // Settles on the 4th consecutive quiet, unchanged sample -- not on the
+    // skeleton's stillness that preceded it.
+    expect(settledAt(samples)).toBe(7)
+  })
+
+  it('restarts the run on a late mutation instead of settling early', () => {
+    const samples = [
+      quiet(900, 260), quiet(900, 260), quiet(900, 260),
+      quiet(950, 265),
+      quiet(950, 265), quiet(950, 265), quiet(950, 265),
+    ]
+    expect(settledAt(samples)).toBe(7)
+  })
+
+  it('stays settled once settled, and keeps the last sample for the failure text', () => {
+    const tracker = createSettleTracker()
+    for (const s of Array(SETTLE_STABLE_SAMPLES + 1).fill(quiet(400, 111))) tracker.observe(s)
+    expect(tracker.settled).toBe(true)
+    expect(tracker.observe(busy(1, 1))).toBe(true)
+    expect(tracker.last).toEqual({ chars: 400, nodes: 111, inflight: 0 })
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The render gate decided a surface was done rendering by sleeping
`surface.settle` milliseconds after first paint, then scanning. Every panel that
fetches AFTER mount was therefore a race, and losing it was silent: the page still
rendered, just its loading skeleton, so the surface reported a SMALLER number
instead of failing.

`[vs-base]` subtracts two of those captures, so one lost race on the base sweep
reads as findings the branch ADDED.

That is how PR #9435 was blocked. Its diff is documentation, five skill markdown
files and one model-facing prompt module, and it drew:

```
[i18n-render] FAIL [vs-base] - this branch ADDS render-time i18n defects
    app-detail.text: 44 -> 70 (+26)                (base -> head)
```

All 26 findings were fixture copy the gate itself supplies, rendered by
`AppDetailPage.tsx`, which that pull request never touched. `render-baseline.json`
records `app-detail: { text: 70 }`, so the head sweep's 70 was the correct
measurement and the base sweep's 44 was the anomaly. Re-running the same job on the
same head SHA, with no push and no code change, turned it green.

## Why it matters

The step belongs to a required E2E job, so this is a hard red with no honest way
out for the author: there is nothing in their diff to fix, the gate's message tells
them to extract fixture strings they do not own, and `/ai-review override` does not
apply because this is a test job rather than a review lane. On #9435 it was a first
pull request, and the author's reasonable read was that the check was broken.

Any pull request whose diff changes the website build can draw it.

## What changed

The capture waits for the surface to go quiet instead of for a clock. Both
conditions must hold in the same sample:

- **Nothing in flight.** A post-mount fetch that has not answered yet IS the
  skeleton case, and no amount of DOM stillness tells the two apart.
- **The DOM holds still.** Measured as text volume plus node count, so the
  predicate stays locale-agnostic and reads the same under the pseudolocale as
  under a real catalog.

`settle` survives as a minimum elapsed time, because a page that has not
dispatched its fetch yet looks exactly like one that never will. It runs ALONGSIDE
the quiet window rather than ahead of it, so a surface that already settled during
its old sleep is scanned at the same moment it was before.

A surface that never goes quiet now fails by name. Reaching that cap means the page
cannot be measured twice and compared, and scanning it anyway is the silent
understatement this change exists to remove.

The decision logic is a pure state machine in a new `scripts/lib/render-settle.mjs`
for the reason `renderVerdict.test.ts` gives for its own subject: reaching it
through two vite builds and a browser is a ten-minute round trip, which is what
kept the old behaviour untested while it mis-blamed pull requests.

## Tests

`website/src/test/renderSettle.test.ts`, 11 cases. The ones that carry the bug:
a page that is still fetching never settles however still its DOM is; a page that
is still mutating never settles however idle the network is; the run restarts when
the awaited body finally lands, so the skeleton's stillness cannot settle it.

Behavioural A/B on the real gate, delaying the fixture's per-app response past the
400ms settle window to force the lost race deterministically
(`--surface app-detail --locale en-XA`):

| response delay | old wait | this change |
| --- | --- | --- |
| 0ms | text=70 | text=70 |
| 1500ms | **text=0**, exit 0 | text=70 |
| 3000ms | **text=0**, exit 0 | text=70 |

The old wait reports zero findings on a surface whose record says 70 and exits
successfully. That is the failure mode, in the form it reaches other authors.

Full sweeps agree on the census, so nothing about a settled tree is remeasured:
both report `text=684 layout=2 latent=10` and exit 0, with no surface hitting the
never-went-quiet cap across all 57.

Cost, measured on the same host: a full sweep of 114 captures (57 surfaces x 2
viewports) went from 113s to 158s, so a `[vs-base]` job pays about 90s more. That
the average capture pays 0.4s of it is itself the finding: most surfaces were still
mutating when the old sleep ended, so the numbers they reported were partly luck.
`SETTLE_POLL_MS` is the knob if that trade is judged wrong.

Local gates: `eslint` clean on all three files, `tsc --noEmit` clean,
`I18N_BASE_REF=origin/main npm run i18n:check` exit 0, brand-name gate clean,
`renderVerdict` and `renderScan` suites still pass (109 cases together).

## Pattern harvest

Rule candidate: agents-md
Pattern: a fixed sleep standing in for a readiness signal in a script that MEASURES
the page, where losing the race lowers the number instead of failing.

This is the third instance of that class in this one file. The
`/api/knowledge/stats` fixture exists because a truthy `[]` fallback made a stats
row "appear in only one of the HEAD and base sweeps and create a false diff", and
the paint predicate above the sleep exists because a fixed sleep "raced the first
render and made the gate report zero findings on a surface it never saw". Both were
fixed by removing the timing dependence at that one site, which is why the third
instance was still there to find. The rule worth writing down is the invariant, not
the site: anything that produces a number two sweeps will be SUBTRACTED must fail
when it cannot measure, because an under-measurement is indistinguishable from a
real improvement and gets charged to whoever is standing nearby.

A narrower mechanical form is possible -- flag a `page.waitForTimeout` that is the
last wait before a scan or screenshot under `website/scripts/` -- but a capture
script also sleeps legitimately for animations, so a semgrep rule of that shape
needs a real look at the false-positive rate before it earns a gate.

## Any other suggestions on the work

`render-baseline.json` is stale on 4 of 55 surfaces on main today
(`knowledge.text 2 -> 0`, `file-explorer.latent 2 -> 0`,
`capabilities-prompts.text 6 -> 2`, `developer-config.text 38 -> 36`). Left alone
here: a refresh is a separate change, and folding it in would mix a record update
into a capture fix.

Fixes #9702

