### PR TITLE
fix(meetings): match a dictionary alias that starts or ends with punctuation

### DIFF
--- a/docs/system-specs/modules/meetings.md
+++ b/docs/system-specs/modules/meetings.md
@@ -159,6 +159,14 @@ never overwrites, so user edits survive every restart. A second `on_startup`
 hook launches the calendar poller (below); its `on_cleanup` partner runs before
 the session teardown hook, so no poll tick can pre-create a meeting mid-shutdown.
 
+An alias matches a standalone occurrence, case-insensitively, longest alias first.
+"Standalone" is asserted per edge: `\b` where the alias's own edge character is a
+word character, and a lookaround for a neighbouring word character where it is
+not. `\b` alone cannot express the second case — it asserts a word character on
+exactly one side, so `\b\.net\b` demands one before the dot, skipping the
+standalone ".net" and firing inside "asp.net" instead. Aliases like `c++`, `c#`
+and `.net` are ordinary dictionary entries and have to match what was said.
+
 Dictionary terms and aliases round-trip through UTF-8 TOML, including supplementary
 Unicode characters. Quotes, backslashes, and control characters remain escaped;
 the serializer does not emit JSON surrogate-pair escapes that TOML rejects.

--- a/src/kiro_crew/apps/builtins/meetings/backend/domain/dictionary.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/domain/dictionary.py
@@ -10,8 +10,9 @@ File format (``<data>/dictionary.toml``)::
     correct = "DynamoDB"
     aliases = ["dynamo db", "dynamo d.b."]
 
-Matching is case-insensitive with word boundaries; the longest alias wins so a
-multi-word alias is not shadowed by one of its own prefixes.
+Matching is case-insensitive and bounded to a standalone occurrence (see
+:func:`_bounded_pattern`); the longest alias wins so a multi-word alias is not
+shadowed by one of its own prefixes.
 
 The parse is deliberately paranoid: this file is user-editable AND writable by
 the agent's own file tools, so a malformed or hostile document must degrade to
@@ -46,8 +47,8 @@ from kiro_crew.atomic_write import atomic_write
 
 logger = logging.getLogger("kirocrew.app.meetings")
 
-# An alias is matched with \b…\b, so a regex-special alias must be escaped (it
-# is) and an absurdly long one must be refused (a 10k-char alias compiled 500
+# An alias is matched as a bounded regex, so a regex-special alias must be escaped
+# (it is) and an absurdly long one must be refused (a 10k-char alias compiled 500
 # times is a cheap CPU sink for something the user never intended).
 _MAX_ALIAS_LEN = 120
 _MAX_CORRECT_LEN = 120
@@ -63,6 +64,7 @@ _DICTIONARY_HEADER = "# Domain dictionary for meetings speech-to-text correction
 # `save` can never write, so the corrections applied to live transcripts and the
 # document on disk would disagree until the next reload.
 _SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+_WORD_CHAR_RE = re.compile(r"\w")
 
 
 def _literal_replacement(value: str) -> Callable[[re.Match[str]], str]:
@@ -81,6 +83,27 @@ def _literal_replacement(value: str) -> Callable[[re.Match[str]], str]:
     lambda``), and this reads as what it is.
     """
     return lambda _match: value
+
+
+def _bounded_pattern(alias: str) -> str:
+    """Build the standalone-occurrence pattern for *alias*.
+
+    ``\\b`` asserts that a word character sits on exactly ONE side of the position,
+    so it delimits an alias only where the alias's own edge is itself a word
+    character. On an alias that begins or ends with punctuation it asserts the
+    opposite of what the term means: ``\\b\\.net\\b`` requires a word character
+    before the dot, so it skips the standalone ".net" the speaker said and fires
+    inside "asp.net" instead.
+
+    Each edge therefore takes ``\\b`` only when the alias's own character there is a
+    word character, and a lookaround for a neighbouring word character otherwise.
+    On a word-character edge the two spellings are equivalent, so an alias that is
+    entirely alphanumeric keeps exactly the pattern it had.
+    """
+
+    prefix = r"\b" if _WORD_CHAR_RE.match(alias[:1]) else r"(?<!\w)"
+    suffix = r"\b" if _WORD_CHAR_RE.match(alias[-1:]) else r"(?!\w)"
+    return f"{prefix}{re.escape(alias)}{suffix}"
 
 
 class DomainDictionary:
@@ -145,7 +168,9 @@ class DomainDictionary:
         ]
         replacements.sort(key=lambda pair: len(pair[0]), reverse=True)
         for alias, correct in replacements:
-            self._compiled.append((correct, re.compile(rf"\b{re.escape(alias)}\b", re.IGNORECASE)))
+            self._compiled.append(
+                (correct, re.compile(_bounded_pattern(alias), re.IGNORECASE))
+            )
 
     # -- applying --
 

--- a/test/test_meetings_dictionary.py
+++ b/test/test_meetings_dictionary.py
@@ -83,6 +83,58 @@ class TestMatching:
     def test_empty_text_untouched(self, dictionary):
         assert dictionary.correct("") == ""
 
+    @pytest.mark.parametrize(
+        ("alias", "correct", "said", "expected"),
+        [
+            ("c++", "C++", "we used c++ today", "we used C++ today"),
+            ("c#", "C#", "the c# team shipped", "the C# team shipped"),
+            (".net", ".NET", "migrated to .net core", "migrated to .NET core"),
+            ("++x", "++X", "the ++x trick", "the ++X trick"),
+        ],
+    )
+    def test_an_alias_edged_with_punctuation_matches(
+        self, alias: str, correct: str, said: str, expected: str
+    ):
+        """An alias whose first or last character is not a word character.
+
+        `\\b` asserts a word character on exactly one side, so wrapping such an
+        alias in it demanded a word character OUTSIDE the punctuation: "c++",
+        "c#" and ".net" were accepted by the dictionary editor, listed as active
+        terms, and then silently never corrected anything.
+        """
+        d = DomainDictionary()
+        d.load_terms([{"correct": correct, "aliases": [alias]}])
+        assert d.correct(said) == expected
+
+    @pytest.mark.parametrize(
+        ("alias", "said"),
+        [
+            (".net", "asp.net rocks"),
+            ("c#", "objc#tag"),
+            ("c++", "c++11 shipped"),
+        ],
+    )
+    def test_a_punctuation_edged_alias_does_not_match_inside_a_token(
+        self, alias: str, said: str
+    ):
+        """The same `\\b` fired where the term did NOT apply.
+
+        `\\b\\.net\\b` requires a word character before the dot, which is exactly
+        the "asp.net" case, so the standalone term was skipped and the substring
+        was rewritten instead. Both directions have to hold.
+        """
+        d = DomainDictionary()
+        d.load_terms([{"correct": "REPLACED", "aliases": [alias]}])
+        assert d.correct(said) == said
+
+    def test_an_alphanumeric_alias_keeps_its_boundaries(self):
+        """The word-character edges are unchanged: still no match inside a word."""
+        d = DomainDictionary()
+        d.load_terms([{"correct": "AWS", "aliases": ["aws"]}])
+        assert d.correct("aws bill") == "AWS bill"
+        assert d.correct("awsome sauce") == "awsome sauce"
+        assert d.correct("beclaws") == "beclaws"
+
     def test_regex_special_alias_is_literal(self):
         d = DomainDictionary()
         d.load_terms([{"correct": "C++", "aliases": ["c plus plus"]}])


### PR DESCRIPTION
## Problem / Motivation

A Meetings pronunciation-dictionary alias whose first or last character is not a
word character never corrects anything, and corrects text it does not name.

Add the term `.NET` with alias `.net` (or `C++`/`c++`, `C#`/`c#`) and the editor
accepts it, `dictionary.toml` stores it, and the Dictionary page lists it as an
active term. Measured on `origin/main` `ab07d6e92`:

```
'we used c++ today'     -> 'we used c++ today'      # alias never fires
'the c# team shipped'   -> 'the c# team shipped'    # alias never fires
'migrated to .net core' -> 'migrated to .net core'  # alias never fires
'asp.net rocks'         -> 'asp.NET rocks'          # fires where it must not
'we use dot.net here'   -> 'we use dot.NET here'    # fires where it must not
```

Both directions are wrong from the same cause, and both are silent.

## Why it matters

`DomainDictionary.correct()` runs on every finalized transcription line before it
reaches the meeting's agents, so the dictionary is the one place a user can fix a
mangled project noun. `c++`, `c#`, `.net`, `f#` are exactly the nouns speech
recognition mangles, and there is no feedback anywhere that such a term is inert:
the API returns 200, the term persists, the list shows it. The user watches the
transcript stay wrong with a rule on screen that says it should be right.

The second direction is worse than a no-op: "asp.net" becomes "asp.NET" in the
stored transcript and in everything downstream of it (notes, action items,
diagram), for a term the speaker never used.

## What changed (motivation → approach → change)

**Symptom → cause.** `_compile()` built every pattern as `rf"\b{re.escape(alias)}\b"`.
`\b` is an assertion about the position, not about the alias: it holds where a
word character sits on exactly ONE side. That delimits an alias whose own edge is
a word character, and asserts the opposite on one whose edge is punctuation —
`\b\.net\b` requires a word character *before* the dot. So the standalone `.net`
(preceded by a space or the start of the line) fails the assertion, and `asp.net`
passes it.

**The change.** Choose each edge's assertion from the alias's own character at
that edge:

```python
prefix = r"\b" if _WORD_CHAR_RE.match(alias[:1]) else r"(?<!\w)"
suffix = r"\b" if _WORD_CHAR_RE.match(alias[-1:]) else r"(?!\w)"
```

On a word-character edge `\b` and the lookaround are equivalent, so `\b` is kept
there and an alias that is entirely alphanumeric compiles to exactly the pattern
it had — the existing `test_word_boundaries_respected` and `test_longest_alias_wins`
are untouched. Only the punctuation edges change, and they change to the
assertion `\b` was already trying to express: no word character glued to the
alias on that side.

Scope is one helper plus its call site. Alias escaping, ordering (longest first),
case-insensitivity, the length caps and the surrogate refusal are all unchanged.

`docs/system-specs/modules/meetings.md` gains the matching rule in the same
commit; the module docstring and the `_MAX_ALIAS_LEN` comment stop naming `\b…\b`
as the pattern shape.

## Tests

`test/test_meetings_dictionary.py`, all in `TestMatching`:

- `test_an_alias_edged_with_punctuation_matches` — 4 cases (`c++`, `c#`, `.net`,
  and `++x` for a leading-punctuation alias) each assert the correction is
  applied to a sentence containing the standalone alias.
- `test_a_punctuation_edged_alias_does_not_match_inside_a_token` — 3 cases assert
  the alias does NOT fire inside a larger token (`asp.net`, `objc#tag`, `c++11`),
  pinning the inverted direction so a future widening cannot trade one bug for
  the other.
- `test_an_alphanumeric_alias_keeps_its_boundaries` — the guard-the-guard: an
  ordinary alias still matches standalone and still does not match inside
  `awsome` / `beclaws`.

**Red-before**, production file reverted to `origin/main` `ab07d6e92` with the
new tests in place: **6 failed, 48 passed** — the 4 never-fires cases and the 2
fires-wrongly cases (`c++11 shipped` → `REPLACED11 shipped`, `asp.net rocks` →
`aspREPLACED rocks`). The alphanumeric guard-the-guard passes on both sides, as
it must.

**Green-after:** `test/test_meetings_dictionary.py` **54 passed**.

Wider: `test_meetings_dictionary.py test_meetings_routes.py` → **253 passed, 1
skipped, 1 failed**. The failure is
`TestAgentRoutes::test_the_server_and_client_transition_tables_agree`, a
pre-existing host issue on this box — it reads a TypeScript file with the
cp950 host code page and raises `UnicodeDecodeError` before reaching any changed
code.

Gates on the changed files: flake8 clean, isort clean, `mypy --platform linux`
clean, `scripts/check_black_formatting.py` passed (both changed Python files are
in `.github/black-baseline.txt`, so they are deliberately not reformatted),
`scripts/check_comment_history.py` passed, `git diff --check` clean.

## Manual verification

N/A — unit coverage sufficient: the defect is entirely inside the pure
`alias → compiled pattern → corrected string` function the tests call directly,
with no I/O, no route and no UI state between the input and the observable.

## Related Issues

None — found by inspection of the alias compilation.

## Pattern harvest

Rule candidate: review-prompt

Pattern: `\b` used to mean "standalone occurrence" around user-supplied text
whose own edges may not be word characters. `\b` is an assertion about the
neighbouring character, so on a punctuation edge it inverts: it refuses the
standalone occurrence and accepts the embedded one. Any place that wraps
arbitrary user input in `\b…\b` — a mention matcher, a highlight, a redaction
term — has the same defect for any term starting or ending in punctuation.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
