### PR TITLE
fix(overview): report a usage payload without sessions, not a TypeError

### DIFF
--- a/website/src/providers/adapters/acp.ts
+++ b/website/src/providers/adapters/acp.ts
@@ -2,6 +2,7 @@ import { api } from '../../api/client'
 import modelTokensRaw from '../../model_tokens.json'
 import { markModelsDegraded } from '../modelListHealth'
 import { isPricedMultiplier } from '../modelList'
+import { i18nT } from '../../i18n/t'
 import type {
   ProviderAdapter,
   ProviderCapabilities,
@@ -254,7 +255,17 @@ export class AcpAdapter implements ProviderAdapter {
 
   async fetchUsage(): Promise<NormalizedUsage> {
     const data = await api.kiroUsage()
-    const s = data.sessions
+    const s = data?.sessions
+    // A 2xx whose body is not the route's contract at all: no `sessions` half
+    // (a proxy or a stub answering `[]`, a gateway that never had the route).
+    // Reading `s.total_sessions` off that rejects with the engine's own
+    // "Cannot read properties of undefined", and the Overview card and the
+    // Usage tab render whatever this rejects with verbatim -- an English JS
+    // TypeError in place of a message, in every locale. Say what happened
+    // instead, in the catalog's words.
+    if (!s || typeof s !== 'object' || Array.isArray(s)) {
+      throw new Error(i18nT('api.client.unexpected_server_response'))
+    }
     // The route answers 200 even when the transcript directory could not be
     // read, because billing is a separate half of the payload. `error` is the
     // server's own message for that failure, and the statistics beside it are

--- a/website/src/test/AcpAdapter.usageSessionsError.test.ts
+++ b/website/src/test/AcpAdapter.usageSessionsError.test.ts
@@ -120,3 +120,34 @@ describe('AcpAdapter.fetchUsage — an unreadable sessions directory', () => {
     expect(usage.billing?.plan).toBe('Pro')
   })
 })
+
+// `GET /api/usage/kiro` can also answer 200 with a body that is not the route's
+// contract at all -- no `sessions` half. A reverse proxy or a fixture stub that
+// answers `[]` for a route it does not map is the concrete case: the i18n
+// render gate's stub does exactly that, and reading `s.total_sessions` off it
+// turns the Overview usage card into "Cannot read properties of undefined
+// (reading 'total_sessions')" -- the engine's English, in every locale, which
+// the en-XA pseudolocale sweep counts as a latin leak as soon as the gate waits
+// for the surface to settle before scanning it (#9709).
+describe('AcpAdapter.fetchUsage — a payload with no sessions half', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it.each([
+    ['an array', []],
+    ['an empty object', {}],
+    ['a sessions half that is an array', { username: 'someone', billing: {}, sessions: [] }],
+  ])('rejects with the catalog message for %s, not a TypeError', async (_label, payload) => {
+    kiroUsage.mockResolvedValue(payload)
+    const err = await new AcpAdapter().fetchUsage().then(
+      () => null,
+      (e: unknown) => e,
+    )
+    expect(err).toBeInstanceOf(Error)
+    // The message is what the Overview card and the Usage tab print, so it has
+    // to be a catalog string: setup pins i18next to English, and the key is the
+    // one `api/client.ts` already uses for a body that is not what the route
+    // promised.
+    expect((err as Error).message).toBe('Unexpected server response')
+    expect((err as Error).message).not.toMatch(/undefined|total_sessions/)
+  })
+})


### PR DESCRIPTION
## Summary

Heals main: `ci.yml` run 34357289612 on `ab07d6e922` fails only the E2E job's **i18n render-time gate** step:

```
[i18n-render] FAIL [vs-base] -- this branch ADDS render-time i18n defects
    settings-overview.text: 6 -> 14 (+8)
  latin-leak/untranslated-text  [settings-overview · en-XA]  ×8
    "Cannot read properties of undefined (reading 'total_sessions')"
    src/components/ErrorNotice.tsx:130 via src/pages/OverviewPage.tsx:85 / :298
```

`AcpAdapter.fetchUsage` now checks that the `/api/usage/kiro` body carries a `sessions` object before reading `s.total_sessions` off it, and rejects with the catalog's existing `api.client.unexpected_server_response` when it does not -- the same channel the server's own `sessions.error` diagnostic already takes, and a string every shipped locale has. Healthy payloads and both error-carrying shapes are unchanged.

## Root cause

- The unguarded read is `website/src/providers/adapters/acp.ts` (`const s = data.sessions` … `total: s.total_sessions`), not OverviewPage itself; `OverviewPage.tsx:85` is the `ErrorNotice` that renders `error?.message` verbatim.
- The render gate's stub (`scripts/lib/stub-dashboard-api.mjs`) has no fixture for `/api/usage/kiro` and answers `[]` for it (the CI log says so: `STUB: no fixture for /api/usage/kiro — guessing []`). `[].sessions` is `undefined`, so the read throws the engine's English TypeError and the Overview usage card prints it -- in every locale.
- **Introducing merge: #9709 (`ab07d6e922`)**, which makes the gate wait for a surface to go quiet before scanning. Before it, the fixed 250 ms sleep usually landed inside react-query's 1 s retry gap (`retryPolicy` gives a non-429 error one retry) and the scan measured the loading skeleton. Now it can see the settled error state. The base and head sweeps landed on different sides of that race (base 6, head 14), so `[vs-base]` charged the +8 to a commit that only changed the scanner. The read was unguarded all along; the gate only started seeing it. The gate is not weakened here.

## Tested

- Red-first: the three new cases in `website/src/test/AcpAdapter.usageSessionsError.test.ts` (`[]`, `{}`, `{sessions: []}`) fail on the previous adapter with exactly `Cannot read properties of undefined (reading 'total_sessions')`; the file passes 7/7 with the fix.
- Reproduced the gate finding locally on pristine main with `node scripts/check-i18n-render.mjs --build --surface settings-overview --locale en-XA`, with the surface's settle floor temporarily raised past the retry gap so the scan deterministically sees the settled state: ×16 `latin-leak/untranslated-text` (both viewports) at the same site. Same run on the fixed tree: `text=6 layout=0 latent=0` -- the 6 is the surface's pre-existing `fragment/multi-unit` debt, identical to the base's 6 in the CI log. The probe edit is not part of this PR.
- `npx vitest run` on `OverviewPage.test.tsx`, `OverviewPage.suppressBuiltin.test.tsx`, `UsageTab.refusedTranscripts.test.tsx`: 16/16.
- `npx tsc --noEmit` clean; `npm run lint` clean; `I18N_BASE_REF=origin/main npm run i18n:check`: 19/19 PASS (no new key -- the message reuses an existing one).

## Not done here

- The scan timing on this surface is still a race between the quiet-wait and react-query's retry backoff; after this fix both outcomes measure the same, so it no longer changes the verdict. A digit-shaped fixture for `/api/usage/kiro` in `FIXTURE_OVERRIDES` would make the surface render its real usage card and is worth a separate follow-up.

<!-- no-visual-delta -->
**Why no screenshot:** the only rendered change is the text of an error notice on a payload the real gateway never produces (the `/api/usage/kiro` handler always returns a `sessions` object); no normal surface changes.


## Pattern harvest

Rule candidate: a provider adapter that reads a nested field off a fetched response (`data.x.y`) without first checking that `data.x` is an object should fail the render-time i18n gate deterministically rather than depending on scan timing -- either a lint rule flagging unguarded nested reads in `website/src/providers/adapters/*.ts`, or a stub-backend fixture for every `/api/usage/*` endpoint the overview reads so the stub never answers `[]` where an object is expected. The gate itself already caught this once the scan settled; the fixture gap is what let it hide.
