### PR TITLE
fix(eval): save the eval report as utf-8, not the host code page

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -2023,6 +2023,28 @@ def _policy_fetch(*, force: bool) -> None:
     raise SystemExit(1)
 
 
+def write_eval_artifacts(
+    results_dir: Path, ts: str, report: str, json_data: dict[str, object]
+) -> tuple[Path, Path]:
+    """Write the run's Markdown report and JSON summary, and return their paths.
+
+    Both are written as UTF-8 rather than the host's locale codec.
+    ``eval.runner.format_results`` puts a ✅ or ❌ on every scenario, session and
+    turn, so the report is never ASCII, and the turn snippets it embeds carry
+    whatever the agent said. Under the default codec on a Windows host — cp1252 in
+    the US and western Europe, cp950, cp932 and friends elsewhere — encoding that
+    raises ``UnicodeEncodeError``, and the raise lands AFTER the whole eval has
+    run, taking the JSON summary with it.
+    """
+
+    results_dir.mkdir(exist_ok=True)
+    report_path = results_dir / f"eval_{ts}.md"
+    report_path.write_text(report + "\n", encoding="utf-8")
+    json_path = results_dir / f"eval_{ts}.json"
+    json_path.write_text(json.dumps(json_data, indent=2) + "\n", encoding="utf-8")
+    return report_path, json_path
+
+
 async def _run_eval(args: argparse.Namespace) -> None:
     """Run multi-session evaluation scenarios."""
 
@@ -2110,13 +2132,7 @@ async def _run_eval(args: argparse.Namespace) -> None:
 
     # Save results
     results_dir = Path.cwd() / "eval_results"
-    results_dir.mkdir(exist_ok=True)
     ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-
-    report_path = results_dir / f"eval_{ts}.md"
-    report_path.write_text(report + "\n")
-
-    json_path = results_dir / f"eval_{ts}.json"
     json_data = {
         "timestamp": ts,
         "scenarios": [r.summary() for r in results],
@@ -2124,7 +2140,7 @@ async def _run_eval(args: argparse.Namespace) -> None:
         "overall_passed": overall,
         "overall_total": len(results),
     }
-    json_path.write_text(json.dumps(json_data, indent=2) + "\n")
+    report_path, json_path = write_eval_artifacts(results_dir, ts, report, json_data)
 
     print(f"\nResults saved to:\n  {report_path}\n  {json_path}")
 

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -19,6 +19,9 @@ import argparse
 import dataclasses
 import io
 import json
+import os
+import subprocess
+import sys
 import urllib.error
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -2654,6 +2657,76 @@ class TestRunEval:
         assert "smoke_test" in out
         h.runner.run_scenarios.assert_not_awaited()
         assert not (tmp_path / "eval_results").exists()
+
+    #: Imports the helper and writes a report holding the formatter's own glyph.
+    _WRITE_CHILD = """
+import locale, sys
+from pathlib import Path
+from kiro_crew.cli_commands import write_eval_artifacts
+
+print("encoding=" + locale.getencoding())
+report_path, json_path = write_eval_artifacts(
+    Path(sys.argv[1]), "20260101_000000", "## \\u2705 ok", {"overall_passed": 1}
+)
+print("wrote=" + report_path.name + "," + json_path.name)
+"""
+
+    def test_the_artifacts_survive_a_non_utf8_default_codec(self, tmp_path: Path) -> None:
+        """The report is written as UTF-8, not the host's locale codec.
+
+        Run in a CHILD PROCESS on purpose, against this file's usual convention:
+        the default codec ``open()`` picks is fixed when the interpreter starts,
+        so it cannot be substituted in-process — patching ``locale`` does not
+        reach the C-level lookup ``io`` actually performs.
+
+        Without ``encoding="utf-8"`` the write raises ``UnicodeEncodeError`` under
+        cp1252/cp950/cp932, and it raises after the eval has already run, so both
+        artifacts are lost.
+        """
+        env = dict(os.environ)
+        # PEP 540 off, PEP 538 coercion off, C locale: a non-UTF-8 default on
+        # every platform -- the Windows ANSI code page, or ASCII on POSIX.
+        env["PYTHONUTF8"] = "0"
+        env["PYTHONCOERCECLOCALE"] = "0"
+        env["LC_ALL"] = "C"
+        env["LANG"] = "C"
+        env.pop("PYTHONIOENCODING", None)
+        # The child is anchored outside the checkout, so hand it this
+        # interpreter's own import path rather than relying on an installed copy.
+        env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
+        env["KIROCREW_HOME"] = str(tmp_path / "home")
+        out_dir = tmp_path / "eval_results"
+        proc = subprocess.run(
+            [sys.executable, "-c", self._WRITE_CHILD, str(out_dir)],
+            env=env,
+            capture_output=True,
+            text=True,
+            # This process's own capture is UTF-8 regardless of the codec the
+            # CHILD was forced onto; only the child's file write is under test.
+            encoding="utf-8",
+            errors="replace",
+            # The child imports the installed package; anchor it outside the
+            # checkout so nothing it writes relatively lands in the repo.
+            cwd=tmp_path,
+        )
+        encoding = next(
+            (
+                line.split("=", 1)[1].strip()
+                for line in proc.stdout.splitlines()
+                if line.startswith("encoding=")
+            ),
+            "",
+        )
+        if not encoding:
+            pytest.fail(f"the child never started:\n{proc.stdout}\n{proc.stderr}")
+        if encoding.lower().replace("-", "") in {"utf8", "utf8mb4"}:
+            pytest.skip(f"this host's default codec stayed UTF-8 ({encoding}); nothing to prove")
+
+        assert proc.returncode == 0, f"the save died under {encoding}:\n{proc.stderr}"
+        report = next(p for p in out_dir.iterdir() if p.suffix == ".md")
+        # Decode strictly: the bytes on disk have to BE UTF-8, whatever the host
+        # codec was. (Line endings are the text layer's, so compare by line.)
+        assert report.read_bytes().decode("utf-8").splitlines() == ["## ✅ ok"]
 
     @pytest.mark.asyncio
     async def test_dimension_summary_marks_pass_and_fail_rates(

--- a/test/test_eval_harness.py
+++ b/test/test_eval_harness.py
@@ -621,6 +621,31 @@ class TestReporting:
         assert "# Eval Results" in report
         assert "test" in report
 
+    def test_the_report_is_never_ascii(self):
+        """Every result carries a ✅ or ❌, so the report cannot be saved as ASCII.
+
+        This is the premise the artifact writer rests on: `_run_eval` hands this
+        string straight to `write_eval_artifacts`, and the coverage tests around
+        that call all patch this function out for a plain ASCII stub, so nothing
+        else pins what the writer is really given.
+        """
+        for ok in (True, False):
+            result = ScenarioResult(
+                name="test",
+                sessions=[SessionResult(name="s1", turns=[
+                    TurnResult(
+                        user_message="q",
+                        agent_response="r",
+                        assertion_results=[
+                            (Assertion(type=AssertionType.CONTAINS, value="r"), ok),
+                        ],
+                    ),
+                ])],
+            )
+            assert result.passed is ok
+            with pytest.raises(UnicodeEncodeError):
+                format_results([result]).encode("ascii")
+
     def test_format_results_with_dimensions(self):
         result = ScenarioResult(
             name="test",


### PR DESCRIPTION
## Problem / Motivation

`kirocrew eval` runs its scenarios, prints the report, and then dies saving it on
any host whose default codec is not UTF-8:

```
UnicodeEncodeError: 'cp950' codec can't encode character '✅'
    in position 3: illegal multibyte sequence
```

Measured on this Windows host (default codec cp950); cp1252 — the Windows default
across the US and western Europe — fails on the same character.

Neither artifact is written. The `.md` write raises, and the `.json` write is the
statement after it, so it never runs. The eval is the expensive part (real
provider sessions, optionally an LLM judge); what survives is terminal
scrollback.

## Why it matters

This is not a rare-input path. `eval/runner.format_results` puts a `✅` or `❌` on
**every** scenario, session, turn and assertion, so the report is non-ASCII for
any run that produced a single result — the failure is deterministic per host,
not data-dependent. `kirocrew eval` is a documented command
(`docs/system-specs/modules/cli.md`), and `eval_results/` is where a user is told
their results are.

The report also embeds `tr.agent_response[:200]` and scenario names, so even
without the glyphs an agent reply containing a non-Latin-1 character would take
the same path.

## What changed (motivation → approach → change)

**Symptom → cause.** `_run_eval` saved with `Path.write_text(report + "\n")` and
no `encoding=`. With `encoding=None`, Python encodes with `locale.getencoding()`
— the host code page on Windows — and the first `✅` is unencodable there.

**The change.** Both writes pass `encoding="utf-8"`, which is what the reader on
the other side already assumes (Markdown and JSON are both UTF-8 by their own
specs, and the JSON in particular is re-read by tooling).

**Why the two lines moved into `write_eval_artifacts`.** The default codec
`open()` picks is fixed when the interpreter starts and is resolved at C level,
so it cannot be substituted in-process: patching `locale` does not reach it, and
`PYTHONIOENCODING` governs the standard streams, not `open()`. Proving the fix
therefore needs a child process with a forced non-UTF-8 default calling the real
writer — which needs the writer to be callable. That is the whole reason for the
extraction; it is otherwise the same two statements, in the same order, with the
same `mkdir`. `_run_eval` keeps building the JSON payload.

No user-visible behaviour is documented differently, so no spec change: the
command already claimed to save both files, and now it does.

## Tests

- `test/test_eval_harness.py::TestReporting::test_the_report_is_never_ascii` —
  the premise, asserted at the formatter: a `ScenarioResult` in either state
  produces a report that `.encode("ascii")` rejects. This exists because every
  test around the save patches `format_results` out for the ASCII stub
  `"## Report"`, which is exactly why the existing coverage never saw this.
- `test/test_cli_commands_coverage.py::TestRunEval::test_the_artifacts_survive_a_non_utf8_default_codec`
  — a child process with `PYTHONUTF8=0`, `PYTHONCOERCECLOCALE=0`, `LC_ALL=C`
  calls `write_eval_artifacts` with a report holding `✅`, and the test decodes
  the bytes on disk as strict UTF-8. It runs in a child against this file's usual
  convention, for the reason above; the docstring says so. If the forced locale
  did not take (a host that stays UTF-8), it **skips with the encoding named**
  rather than passing vacuously.

**Red-before**, with only the two `encoding="utf-8"` kwargs removed from the
committed tree:

```
FAILED TestRunEval::test_the_artifacts_survive_a_non_utf8_default_codec
  - AssertionError: the save died under cp950:
    UnicodeEncodeError: 'cp950' codec can't encode character '✅'
```

12 passed, 1 failed. The premise test passes on both sides, as a guard-the-guard
must.

**Green-after:** `TestRunEval` + `TestReporting` → **13 passed**.

Gates on the changed files: flake8 clean, isort clean, `mypy --platform linux`
clean, `check_black_formatting.py`, `check_comment_history.py`,
`check_subprocess_encoding.py` and `git diff --check` all pass.

## Manual verification

N/A — unit coverage sufficient: the child-process test exercises the real writer
under a real non-UTF-8 default codec, which is the entire failing condition; the
surrounding `_run_eval` behaviour is unchanged and already covered.

## Related Issues

None — found by scanning text writes for a missing `encoding=` whose writer
actually emits non-ASCII.

## Pattern harvest

Rule candidate: semgrep

Pattern: a text write with no `encoding=` whose content comes from a formatter
that unconditionally emits non-ASCII. The general "missing `encoding=`" shape is
mostly latent in this repo — `json.dumps` defaults to `ensure_ascii=True`, so
most JSON writes are pure ASCII by construction. What makes an instance live is a
writer that is *guaranteed* non-ASCII: a status glyph, an arrow, an em dash, or
embedded user/agent text. A rule that pairs "no `encoding=`" with "the written
expression reaches a function containing a non-ASCII literal" separates the live
ones from the latent ones.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
