### PR TITLE
fix(members): hold the driving-sessions order across slots frames too

### DIFF
--- a/website/src/pages/members/MembersPage.test.tsx
+++ b/website/src/pages/members/MembersPage.test.tsx
@@ -784,6 +784,50 @@ describe('MembersPage drawer — driving sessions', () => {
     expect(navigateSpy).toHaveBeenCalledWith('/chat?sid=chat-1-w')
   })
 
+  it('a slots frame never reorders the list; a change to the driven set re-sorts it', async () => {
+    // Each row navigates, so a row that moves between aim and click sends the
+    // reader into a DIFFERENT session — and `lastActivityEpoch` advances on
+    // every frame from a worker that is merely working.
+    const { store } = await openDrawer([
+      worker('chat-1-a', { last_turn_ts: '2026-09-04T12:00:00Z' }),
+      worker('chat-1-b', { last_turn_ts: '2026-09-04T11:00:00Z' }),
+    ])
+    // `textContent` concatenates the title with the status words, so read the
+    // key off the row's title attribute ("Worker <key>" + separator + label).
+    const keys = () =>
+      screen
+        .getAllByTestId('member-driving-row')
+        .map((r) => r.getAttribute('title')?.split(' ')[1])
+    expect(keys()).toEqual(['chat-1-a', 'chat-1-b'])
+    // b becomes the most recently active AND starts running: the status dot must
+    // update in place while the row stays where the reader last saw it.
+    act(() => {
+      store.dispatch(
+        sseSlots([
+          worker('chat-1-a', { last_turn_ts: '2026-09-04T12:00:00Z' }),
+          worker('chat-1-b', { running: true, last_turn_ts: '2026-09-04T13:30:00Z' }),
+        ] as never),
+      )
+    })
+    await waitFor(() =>
+      expect(screen.getAllByTestId('member-driving-row')[1]).toHaveAttribute('data-status', 'running'),
+    )
+    expect(keys()).toEqual(['chat-1-a', 'chat-1-b'])
+    // A new worker opens — the driven set changed, so the whole list re-sorts by
+    // recency at once rather than appending out of order.
+    act(() => {
+      store.dispatch(
+        sseSlots([
+          worker('chat-1-a', { last_turn_ts: '2026-09-04T12:00:00Z' }),
+          worker('chat-1-b', { running: true, last_turn_ts: '2026-09-04T13:30:00Z' }),
+          worker('chat-1-c', { last_turn_ts: '2026-09-04T13:00:00Z' }),
+        ] as never),
+      )
+    })
+    await waitFor(() => expect(screen.getAllByTestId('member-driving-row')).toHaveLength(3))
+    expect(keys()).toEqual(['chat-1-b', 'chat-1-c', 'chat-1-a'])
+  })
+
   it('folds past five rows behind a Show-all toggle that expands and collapses', async () => {
     await openDrawer(Array.from({ length: 7 }, (_, i) => worker(`chat-1-w${i}`)))
     expect(screen.getAllByTestId('member-driving-row')).toHaveLength(5)

--- a/website/src/pages/members/MembersPage.tsx
+++ b/website/src/pages/members/MembersPage.tsx
@@ -532,11 +532,31 @@ export default function MembersPage() {
   // live slots and therefore this list, which is the honest reading of
   // "driving right now".
   const activeMemberKey = activeSlot || active?.slot_key || ''
+  // The ORDER is committed per DRIVEN SET, not per frame. `liveSlots` refreshes
+  // on every WS slots frame and `lastActivityEpoch` advances whenever a worker
+  // does anything, so sorting per render moves rows under the cursor mid-click —
+  // and each row is a jump into a session, so a shifted row navigates into the
+  // WRONG one. It also decides which rows sit behind the DRIVING_VISIBLE fold,
+  // so a live re-sort can pull a row out from under the pointer entirely.
+  // Row CONTENT still updates from every frame (status dot, title, timestamp);
+  // only the positions hold, until the driven set changes (a worker opens or
+  // closes) or the member does, either of which re-sorts from scratch by
+  // recency. Same rule as the roster order above, and the same reason.
+  const committedDrivingRef = useRef<{ member: string; keys: string[] }>({ member: '', keys: [] })
   const drivingSessions = useMemo(() => {
     if (!activeMemberKey) return []
-    return liveSlots
-      .filter((s) => !!s.created_by && s.created_by === activeMemberKey)
-      .sort((a, b) => lastActivityEpoch(b) - lastActivityEpoch(a))
+    const mine = liveSlots.filter((s) => !!s.created_by && s.created_by === activeMemberKey)
+    const byKey = new Map(mine.map((s) => [s.key, s]))
+    const prev = committedDrivingRef.current
+    const sameSet =
+      prev.member === activeMemberKey &&
+      prev.keys.length === byKey.size &&
+      prev.keys.every((k) => byKey.has(k))
+    const keys = sameSet
+      ? prev.keys
+      : [...mine].sort((a, b) => lastActivityEpoch(b) - lastActivityEpoch(a)).map((s) => s.key)
+    committedDrivingRef.current = { member: activeMemberKey, keys }
+    return keys.map((k) => byKey.get(k)).filter((s): s is (typeof mine)[number] => !!s)
   }, [liveSlots, activeMemberKey])
   // Collapsed past DRIVING_VISIBLE rows. Keyed to the member: the fold is a
   // reading position in ONE member's list, so switching members starts the


### PR DESCRIPTION
## Problem / Motivation

Follow-up to the review of #9537, which counted this sibling in the same file:
`drivingSessions` in `website/src/pages/members/MembersPage.tsx` sorted the live
WebSocket `liveSlots` by `lastActivityEpoch` on every render.

That list refreshes on every slots frame, and the sort key advances whenever a
worker does anything, so a frame landing between the reader aiming at a row and
clicking it moves the row. Each row is a `navigate()` into that session, so a
shifted row opens a DIFFERENT session than the one that was under the pointer.
The order also decides which rows sit behind the `DRIVING_VISIBLE` fold, so a
live re-sort can remove the aimed-at row from the visible list entirely.

## Why it matters

Same class and same consequence as the roster defect #9537 fixed -- a click that
lands somewhere the reader did not choose -- and it needs no unusual conditions:
one active worker session is enough, because a working member emits frames
continuously. #9537 fixed the roster one panel over and left this one, which the
First Principles lane flagged as the counted unfixed sibling.

## What changed (motivation -> approach -> change)

Root cause: the display order was a function of frame timing rather than of the
list's contents.

The order is now committed per DRIVEN SET, keyed by member: it re-sorts from
scratch when the set of driven slot keys changes (a worker opens or closes) or
when the active member changes, and otherwise maps the committed key order over
the fresh slots. Row CONTENT still updates from every frame -- status dot, title,
timestamp -- so nothing about liveness is lost; only positions hold.

Keying by member as well as by key-set matters: the list is per active member and
the fold is keyed to the member, so a bare key-set comparison would try to map
one member's committed order onto another member's slots on a switch.

Deliberately the same idiom as the roster fix rather than a new mechanism, so the
two sit side by side in one file and read as one rule.

## Tests

`a slots frame never reorders the list; a change to the driven set re-sorts it`
in `website/src/pages/members/MembersPage.test.tsx`: a frame that makes the lower
row both the most recently active AND running must update its status dot in place
while the order holds, and a newly opened worker must re-sort the whole list by
recency. The existing `newest activity first` case still passes, so the first
frame's ordering is unchanged.

Mutation-proven: with the previous per-render sort restored, the new test fails
(1 failed / 81 passed); with the fix, 82 passed.

`npx eslint` on both changed files exits 0. `npx tsc -b` reports the same 30
errors before and after my change (0 new) -- all in `PasteTokenNode.tsx`, from an
incomplete local install: `npm ci` fails `E401` against the package registry
configured on this machine, so the lexical packages are absent. Nothing in that
set touches the members page.

## Manual verification

N/A -- the defect is a race between a WebSocket frame and a click, which the test
reproduces deterministically by dispatching a frame between assertions.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** there is no visual delta. No styling, layout, markup or
component change -- the same rows render with the same classes, and the first
paint is byte-identical because the first frame still sorts by recency. What
changes is purely temporal: whether a later frame may reorder them. A still of
before and after is identical, and the regression test is what demonstrates the
behaviour.

## Related Issues

Refs #9524
Follows up the First Principles review on #9537

## Pattern harvest

Rule candidate: review-prompt
Pattern: an activity-keyed sort over live-refreshing data, feeding rows that are
click targets. The sort key advancing is indistinguishable from the list
changing, so ordering becomes a function of refresh timing -- and when each row
navigates, that turns a background refresh into a misroute. Worth asking wherever
a live list is sorted by a timestamp that the live data itself moves.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
