### PR TITLE
fix(ci): diff base to working tree for added lines in merge-ref ratchets

### DIFF
--- a/scripts/ratchet_scope.py
+++ b/scripts/ratchet_scope.py
@@ -165,16 +165,35 @@ def added_lines(scope_label: str) -> dict[str, set[int]] | None:
     """Repo-relative path -> line numbers this change ADDED, or None.
 
     Uses the diff endpoints named by ``changed_paths``' label, so the added set
-    and the changed-file set always describe the same diff. An unknown label (or
-    a failing git) degrades to None -- the added-line rule is then skipped
+    and the changed-file set describe the same base. An unknown label (or a
+    failing git) degrades to None -- the added-line rule is then skipped
     rather than guessed, and a caller's count rules still apply.
+
+    The consuming ratchets scan violations from the WORKING TREE, so the line
+    numbers here must describe the same file state. For the ``<base>...HEAD``
+    label -- the local-run shape -- the diff therefore runs from
+    ``merge-base(<base>, HEAD)`` to the working tree (a single-commit
+    ``git diff``), matching :func:`added_lines_at`. Diffing to HEAD instead
+    would number lines by HEAD's copy of each file: on a tree with uncommitted
+    edits, a pre-existing violation can then sit on a line number the HEAD diff
+    counts as added, and the gate reports it as new even though committing the
+    identical bytes makes it pass. On a clean tree the two diffs are equal, so
+    CI -- which checks out clean -- is unaffected. The merge-base (not the base
+    TIP) keeps three-dot semantics: a tip diff would count the reversal of the
+    base branch's own later commits as this change's added lines. The two merge
+    labels are CI checkout shapes with a clean tree and keep their committed
+    endpoints; ``merge parents`` has no working-tree form at all.
     """
     if scope_label == "merge HEAD^1..HEAD":
         args = ["diff", "--unified=0", "HEAD^1", "HEAD"]
     elif scope_label == "merge parents":
         args = ["diff", "--unified=0", "HEAD^1", "HEAD^2"]
     elif scope_label.endswith("...HEAD"):
-        args = ["diff", "--unified=0", scope_label]
+        base = scope_label[: -len("...HEAD")]
+        code, out = _git("merge-base", base, "HEAD")
+        if code != 0 or not out.strip():
+            return None
+        args = ["diff", "--unified=0", out.strip()]
     else:
         return None
     proc = subprocess.run(

--- a/test/test_check_comment_history.py
+++ b/test/test_check_comment_history.py
@@ -387,3 +387,98 @@ class TestCommittedBaseline:
     def test_committed_baseline_only_lists_scanned_trees(self) -> None:
         for rel in gate._read_baseline(BASELINE):
             assert rel.startswith(gate.DEFAULT_TARGETS), f"{rel} is outside the scanned trees"
+
+
+class TestDirtyTreeScope:
+    """The gate's added-line rule on a tree with uncommitted edits.
+
+    The gate scans violations from the working tree, and ``ratchet_scope``
+    provides the added-line set for the same diff. On a dirty tree those two
+    descriptions must be of the same file state: a baselined marker shifted by
+    an uncommitted insert must not be judged as newly added just because its
+    working-tree line number falls inside the committed diff's added range,
+    while a marker the uncommitted edit genuinely writes must still fail. Each
+    test builds a synthetic repo, computes scope and added lines through a
+    fresh ``ratchet_scope`` pointed at it, scans the working-tree bytes with
+    the gate's real detector, and reads the verdict from ``_verdicts`` -- the
+    same pipeline ``run_gate`` wires together.
+    """
+
+    BASE_SOURCE = "# hotfix\nvalue = 1\n"
+    COMMITTED_SOURCE = "# hotfix\nvalue = 1\nextra_a = 2\nextra_b = 3\nextra_c = 4\n"
+
+    @pytest.fixture()
+    def dirty_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        import subprocess
+
+        from test_ratchet_scope import _fixture_git_env
+
+        from kiro_crew.platform.update_governance import _GIT_LOCATION_VARS
+
+        # The module under test runs git with the ambient environment; an
+        # exported GIT_DIR would answer for the wrong repository.
+        for var in _GIT_LOCATION_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*args: str) -> None:
+            subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+                env=_fixture_git_env(),
+            )
+
+        git("init", "-b", "main", ".")
+        (repo / "pkg.py").write_text(self.BASE_SOURCE, encoding="utf-8")
+        git("add", "pkg.py")
+        git("commit", "-m", "base file with one recorded marker")
+        git("update-ref", "refs/remotes/origin/main", "HEAD")
+        git("checkout", "-b", "topic")
+        (repo / "pkg.py").write_text(self.COMMITTED_SOURCE, encoding="utf-8")
+        git("add", "pkg.py")
+        git("commit", "-m", "append clean lines below the marker")
+
+        spec = importlib.util.spec_from_file_location(
+            "ratchet_scope_dirty_tree", ROOT / "scripts" / "ratchet_scope.py"
+        )
+        assert spec and spec.loader
+        rs = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(rs)
+        monkeypatch.setattr(rs, "ROOT", repo)
+        return repo, rs
+
+    def _verdict(self, repo: Path, rs, worktree_source: str):
+        (repo / "pkg.py").write_text(worktree_source, encoding="utf-8")
+        changed, label = rs.changed_paths()
+        assert label == "origin/main...HEAD"
+        added = rs.added_lines(label)
+        assert added is not None
+        violations = {"pkg.py": gate.violations_in_source(worktree_source)}
+        return gate._verdicts(violations, {"pkg.py": 1}, changed, added)
+
+    def test_a_shifted_baselined_marker_is_not_flagged(self, dirty_repo) -> None:
+        # Uncommitted insert above the marker: it moves to working-tree line 3,
+        # a number inside the committed diff's added range {3, 4, 5}. The gate
+        # must read it as the pre-existing line it is; committing these exact
+        # bytes produces the same verdict.
+        repo, rs = dirty_repo
+        new, grown, on_added, shrunk = self._verdict(
+            repo, rs, "wip_a = 0\nwip_b = 0\n" + self.COMMITTED_SOURCE
+        )
+        assert not new and not grown and not on_added and not shrunk
+
+    def test_a_marker_written_by_the_uncommitted_edit_still_fails(self, dirty_repo) -> None:
+        # Swap: the uncommitted edit deletes the recorded marker and writes a
+        # fresh one at the end. The count stays level, so only the added-line
+        # rule can catch it -- and it must.
+        repo, rs = dirty_repo
+        source = self.COMMITTED_SOURCE.replace("# hotfix\n", "") + "# hotfix\n"
+        new, grown, on_added, shrunk = self._verdict(repo, rs, source)
+        assert on_added == {"pkg.py": gate.violations_in_source(source)}
+        assert not new and not grown and not shrunk

--- a/test/test_ratchet_scope.py
+++ b/test/test_ratchet_scope.py
@@ -304,6 +304,85 @@ class TestWholeTreeOverride:
         )
 
 
+class TestDirtyTree:
+    """``added_lines`` must describe the file state the consuming gates scan.
+
+    The merge-ref ratchets read violations from the WORKING TREE. On a tree
+    with uncommitted edits, an added set numbered by HEAD's copy of a file and
+    a violation numbered by the working-tree copy can collide: a pre-existing
+    line shifted by an uncommitted insert lands on a line number the HEAD diff
+    counts as added, and the gate fails on bytes that pass once committed.
+    These tests pin the three-dot label's diff to base-to-working-tree, and pin
+    that the base stays the MERGE-BASE rather than the base tip.
+    """
+
+    def test_uncommitted_edits_are_in_the_added_set(self, repo: Path) -> None:
+        _git(repo, "checkout", "feature")
+        _set_origin_main(repo)
+        (repo / "feature.py").write_text("feature.py\nuncommitted\n", encoding="utf-8")
+
+        added = scope.added_lines("origin/main...HEAD")
+
+        assert added is not None
+        assert 2 in added["feature.py"]
+
+    def test_a_shifted_preexisting_line_is_not_counted_as_added(self, repo: Path) -> None:
+        # The reproduction from the comment-history gate: `victim.py` exists on
+        # the base with a line the baseline already records, the branch appends
+        # committed lines below it, and an uncommitted insert ABOVE it shifts
+        # the recorded line onto a number the base..HEAD diff counts as added.
+        # The added set must describe the working tree, where that line is old.
+        (repo / "victim.py").write_text("recorded = 1\n", encoding="utf-8")
+        _git(repo, "add", "victim.py")
+        _git(repo, "commit", "-m", "base file with a recorded line")
+        _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+        _git(repo, "checkout", "-b", "topic")
+        (repo / "victim.py").write_text(
+            "recorded = 1\nadded_a = 2\nadded_b = 3\n", encoding="utf-8"
+        )
+        _git(repo, "add", "victim.py")
+        _git(repo, "commit", "-m", "append two lines below the recorded one")
+        # Uncommitted: insert two lines above. The recorded line now sits at
+        # working-tree line 3, a number inside HEAD's added range {2, 3}.
+        (repo / "victim.py").write_text(
+            "wip_a = 0\nwip_b = 0\nrecorded = 1\nadded_a = 2\nadded_b = 3\n", encoding="utf-8"
+        )
+
+        added = scope.added_lines("origin/main...HEAD")
+
+        assert added is not None
+        assert 3 not in added["victim.py"]
+        assert {1, 2}.issubset(added["victim.py"])
+
+    def test_the_base_is_the_merge_base_not_the_base_tip(self, repo: Path) -> None:
+        # main rewrites base.txt AFTER the branch point. A diff against the
+        # base TIP would count the working tree's older copy of base.txt as
+        # this change's added lines; the merge-base diff sees no edit there.
+        _git(repo, "checkout", "main")
+        (repo / "base.txt").write_text("rewritten on main\n", encoding="utf-8")
+        _git(repo, "add", "base.txt")
+        _git(repo, "commit", "-m", "rewrite base.txt on main after the branch point")
+        _set_origin_main(repo)
+        _git(repo, "checkout", "feature")
+        (repo / "feature.py").write_text("feature.py\nuncommitted\n", encoding="utf-8")
+
+        added = scope.added_lines("origin/main...HEAD")
+
+        assert added is not None
+        assert "base.txt" not in added
+        assert 2 in added["feature.py"]
+
+    def test_a_clean_tree_matches_the_head_diff(self, repo: Path) -> None:
+        # CI checks out a clean tree; the working-tree diff must be identical
+        # to the committed one there, so this change is invisible to CI.
+        _git(repo, "checkout", "feature")
+        _set_origin_main(repo)
+
+        added = scope.added_lines("origin/main...HEAD")
+
+        assert added == {"feature.py": {1}}
+
+
 class TestExplicitBase:
     """The env-base family's entry points: an EXPLICIT ref in, shared parsing out.
 


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

`scripts/check_comment_history.py` fails locally on a working tree with uncommitted edits, reporting "markers on added lines" for comment lines the baseline already records. The gate scans violations from the working tree, but its added-line numbers came from `git diff <base>...HEAD`, which cannot see uncommitted edits. An uncommitted insert above a baselined marker shifts that marker onto a line number the committed diff counts as added, and the gate flags it. Committing the identical bytes makes the same tree pass.

## Why it matters

Anyone running the gate on a dirty tree gets a false red that names a pre-existing comment as new. The failure points at code the contributor never wrote, and the "fix" (commit first, then re-run) is undiscoverable from the error text. CI never shows this, so a local red that CI later contradicts erodes trust in the gate.

## What changed (motivation -> approach -> change)

The gate's two inputs described two different file states: violations came from the working-tree bytes, added lines from the base-to-HEAD diff. On a clean tree the two are equal; on a dirty tree they are not, and the line numbers collide.

`ratchet_scope.added_lines()` now diffs from `merge-base(<base>, HEAD)` to the working tree for the `<base>...HEAD` scope label, so the added set describes the same file state the gates scan. This is the same endpoint choice the sibling `added_lines_at()` already makes, and the merge-base (not the base tip) preserves the three-dot semantics, so the base branch's own later commits never count as this change's added lines. The two merge-shape labels are CI checkout shapes with a clean tree and keep their committed endpoints. All four consumers of `added_lines()` (comment-history, subprocess-encoding, sync-io-in-async, agent-sdk-boundary) scan the working tree, so the one shared fix keeps them consistent.

```mermaid
flowchart LR
  subgraph Before
    A1[gate scans WORKING TREE]:::ctx --> C1[verdict]:::ctx
    B1[added lines from base...HEAD]:::removed --> C1
  end
  subgraph After
    A2[gate scans WORKING TREE]:::ctx --> C2[verdict]:::ctx
    B2[added lines from merge-base to WORKING TREE]:::added --> C2
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 3 stroke:#16A34A,stroke-width:2px
```

Legend: green = added, red = removed, blue = unchanged

*Both inputs to the verdict now describe the same copy of each file.*

## Tests

- `test_ratchet_scope.py::TestDirtyTree` -- four tests: uncommitted added lines appear in the set; a pre-existing line shifted by an uncommitted insert is not counted as added (the reproduction); the diff base is the merge-base, not the base tip; a clean tree yields exactly the HEAD diff (CI parity).
- `test_check_comment_history.py::TestDirtyTreeScope` -- end-to-end through the gate's own scanner and `_verdicts`: a baselined marker shifted onto a HEAD-added line number is not flagged, and a marker genuinely written by the uncommitted edit still is.
- Reverting the production hunk makes 4 of the new tests fail, so they pin the fix.

## Manual verification

Reproduced live in this branch's own checkout: inserted 200 uncommitted padding lines above the one baselined marker in `test/test_ratchet_scope.py`, pushing it into this branch's committed added range. The gate at the old code exits 1 with "markers on added lines"; at the new code, exit 0 on the identical dirty tree. All four consumer gate scripts plus the comment-history `--test` self-test run green.

## Related Issues

Closes #9719

## Pattern harvest

Rule candidate: review-prompt
Pattern: "two inputs to one verdict computed from different snapshots of the same file (committed vs working tree)"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
