### PR TITLE
fix(issue-radar): send Content-Type with glab api bodies

### DIFF
--- a/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_transport.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_transport.py
@@ -194,7 +194,9 @@ def glab_api(
             argv += ["--method", method]
         input_text = None
         if body is not None:
-            argv += ["--input", "-"]
+            # Strict GitLab instances reject a body without an explicit
+            # Content-Type as HTTP 415; glab does not set one for stdin input.
+            argv += ["--header", "Content-Type: application/json", "--input", "-"]
             input_text = json.dumps(body)
 
         proc = run(argv, host=host, timeout=timeout, input_text=input_text)

--- a/test/test_gitlab_client_coverage.py
+++ b/test/test_gitlab_client_coverage.py
@@ -460,8 +460,22 @@ def test_glab_api_sends_a_body_on_stdin_with_a_method(route):
         "projects/g%2Fp/issues/7", host="gitlab.com", method="PUT", body={"state_event": "close"}
     )
     call = router.calls[0]
-    assert call["argv"][3:] == ["--method", "PUT", "--input", "-"]
+    assert call["argv"][3:] == [
+        "--method",
+        "PUT",
+        "--header",
+        "Content-Type: application/json",
+        "--input",
+        "-",
+    ]
     assert json.loads(call["input"]) == {"state_event": "close"}
+
+
+def test_glab_api_sends_no_content_type_header_without_a_body(route):
+    router = route([("user", {"username": "u"})])
+    gl._glab_api("user", host="gitlab.com")
+    argv = router.calls[0]["argv"]
+    assert "--header" not in argv and "--input" not in argv
 
 
 def test_glab_api_rejects_unparseable_output(route):


### PR DESCRIPTION
## Problem / Motivation

Issue Radar's GitLab write operations fail with HTTP 415 Unsupported Media Type on some strict self-hosted GitLab instances. Adding a label to an issue is the reported case. The write path sends a JSON body to `glab api` over stdin with `--input -` but sets no Content-Type header, and those instances reject a body with no `Content-Type: application/json`.

## Why it matters

Anyone running Issue Radar against a strict self-hosted GitLab cannot perform any write: label add/remove and state changes all fail. The reporter verified locally that adding the header makes the writes succeed (glab 1.117.0 supports `--header`).

## What changed (motivation -> approach -> change)

The symptom is HTTP 415 on writes. The root cause is in `glab_api` in `src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_transport.py`: it builds the glab argv with `--input -` for a body but never names the body's media type, so the server has to guess and a strict one refuses. The fix adds `--header "Content-Type: application/json"` to the argv whenever a body is present. The header value is a constant and the body is always `json.dumps(dict)`, so the declared type is always correct. Read paths without a body are unchanged, and the GitHub transport is untouched.

## Tests

`test/test_gitlab_client_coverage.py`:
- `test_glab_api_sends_a_body_on_stdin_with_a_method` now asserts the exact argv includes `--header "Content-Type: application/json"` before `--input -` when a body is present.
- `test_glab_api_sends_no_content_type_header_without_a_body` (new) asserts a body-less GET carries neither `--header` nor `--input`.

## Manual verification

N/A -- unit coverage sufficient: the change is pure argv assembly, pinned both ways (header present with a body, absent without one), and the reporter already verified the header fixes the 415 against a real strict instance.

## Related Issues

Closes #9723

## Pattern harvest

Rule candidate: review-prompt
Pattern: CLI wrapper pipes a request body over stdin without declaring its media type; strict servers reject the untyped body.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
