### PR TITLE
fix(cron): label a silent run that delivered instead of "_No response._"

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -789,6 +789,30 @@ def _build_heartbeat_hooks(user_hooks: HookManager) -> HookManager:
     return HookManager(scoped)
 
 
+_NO_RESPONSE = "_No response._"
+
+
+def _bare_tool_name(title: str) -> str:
+    """``Running: @server/Tool`` / ``mcp__server__Tool`` / ``Tool`` -> ``Tool``.
+
+    Same wire forms ``_is_heartbeat_safe_tool`` unwraps; kept separate
+    because that helper answers an allowlist question and this one only
+    needs the name.
+    """
+    name = (title or "").strip()
+    for prefix in _HEARTBEAT_STATUS_PREFIXES:
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+            break
+    if name.startswith("mcp__"):
+        parts = name.split("__", 2)
+        if len(parts) == 3:
+            name = parts[2]
+    if name.startswith("@") and "/" in name:
+        name = name.rsplit("/", 1)[-1]
+    return name.strip()
+
+
 class _GateTally:
     """Tool-gate outcomes accumulated over one cron run.
 
@@ -808,14 +832,45 @@ class _GateTally:
         self.refused: list[str] = []
         self.approved = 0
         self.unresolved = 0
+        # An approved call whose bare tool name is ``send_message``. Titles
+        # arrive as ``Running: @server/send_message`` (kiro-cli) or
+        # ``mcp__server__send_message`` (ACP); ``_bare_tool_name`` strips
+        # either wrapper so the comparison is on the name alone.
+        self.delivered = False
 
     def note(self, title: str, approved: bool, security_blocked: bool) -> None:
         if approved:
             self.approved += 1
+            if _bare_tool_name(title) == "send_message":
+                self.delivered = True
         elif security_blocked:
             self.refused.append(title)
         else:
             self.unresolved += 1
+
+    def empty_reply_placeholder(self) -> str:
+        """Row text for a turn that returned no prose.
+
+        A silent cron is told to reply with nothing and deliver through
+        ``send_message``, so an empty reply is its normal shape -- but it is
+        also the shape of a turn that died before its first tool call. The
+        tally tells them apart: approved tool calls mean work happened, and a
+        ``send_message`` among them means a delivery was attempted. Attempted,
+        not confirmed: ``on_tool_gate`` fires at the permission decision and
+        never sees the tool's result, so the text does not claim the message
+        arrived.
+        """
+        if self.delivered:
+            return (
+                f"_Silent run completed -- delivery attempted via send_message"
+                f" ({self.approved} tool call{'s' if self.approved != 1 else ''} ran)._"
+            )
+        if self.approved:
+            return (
+                f"_Completed with no reply text -- {self.approved} tool call"
+                f"{'s' if self.approved != 1 else ''} ran._"
+            )
+        return _NO_RESPONSE
 
     @property
     def all_blocked(self) -> bool:
@@ -4812,7 +4867,7 @@ class GatewayOrchestrator:
                             fallback_models=configured_fallback_chain(),
                         )
                         if not result_text:
-                            result_text = "_No response._"
+                            result_text = _gate.empty_reply_placeholder()
                         result_text = _annotate_model_fallback(result_text, client)
                         logger.info("Cron '%s': agent '%s' completed", job.name, agent)
 
@@ -4952,7 +5007,7 @@ class GatewayOrchestrator:
                 )
 
                 if not result_text:
-                    result_text = "_No response._"
+                    result_text = _gate.empty_reply_placeholder()
 
                 if _model_downgraded:
                     result_text = _annotate_model_downgrade(result_text)

--- a/test/test_cron_silent_run_placeholder.py
+++ b/test/test_cron_silent_run_placeholder.py
@@ -1,0 +1,190 @@
+"""A silent cron that sent via ``send_message`` must not read as a dead run.
+
+A silent job is told to reply with nothing and deliver through ``send_message``,
+so its turn ends with empty prose by design -- the same shape as a turn that
+died before its first tool call. The gate tally counts approved tool calls and
+sees each tool's title; these tests pin that the empty-reply text reads from it,
+so a run that attempted a ``send_message`` delivery, a run that ran tools without
+one, and a run that approved no tool each render distinctly, and only the last
+reads ``_No response._``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from kiro_crew.cron import CronJob, CronSchedule
+from kiro_crew.slack.gateway import _GateTally
+
+GateScript = list[tuple[str, bool, bool]]
+
+# The two wire spellings a send_message call arrives under.
+SEND_KIRO_CLI = ("Running: @kirocrew-core/send_message", True, False)
+SEND_ACP = ("mcp__kirocrew-core__send_message", True, False)
+READ = ("Read README.md", True, False)
+BLOCKED = ("rm -rf /", False, True)
+
+
+def _run_silent_cron(gate: GateScript, reply: str = "", runs: int = 1) -> CronJob:
+    """Drive the real ``_cron_callback`` *runs* times on a silent job.
+
+    Each turn replays *gate* and returns *reply* as the model's prose -- empty
+    by default, which is the shape a silent job's turn actually has.
+    """
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    gw = GatewayOrchestrator.__new__(GatewayOrchestrator)
+    gw.sessions = MagicMock()
+    gw.sessions.get_pid = MagicMock(return_value=None)
+    gw.ctx_builder = MagicMock()
+    gw.slack = MagicMock()
+    gw.conv_log = None
+    gw.dashboard_state = None
+    gw._owner_id = "U000"
+    gw.subagent_mgr = None
+    gw._cron_injecting = {}
+    gw._no_crons = False
+    gw.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    gw.sessions.release = MagicMock()
+    gw.sessions.reset = AsyncMock()
+    gw.sessions.cancel_current = AsyncMock()
+    gw.ctx_builder.build_message = MagicMock(return_value=("msg", None))
+    gw.ctx_builder.hooks = MagicMock()
+    gw._interactive_approval = MagicMock(return_value="interactive_cb")
+
+    async def fake_stream(client, msg, **kwargs):
+        report: Callable[[str, bool, bool], None] | None = kwargs.get("on_tool_gate")
+        assert report is not None, "the cron path must observe its tool-gate decisions"
+        for title, approved, blocked in gate:
+            report(title, approved, blocked)
+        return reply
+
+    job = CronJob(
+        id="s1",
+        name="silent-digest",
+        message="go",
+        schedule=CronSchedule(kind="every", every_secs=900),
+        approval_mode="auto",
+        silent=True,
+    )
+
+    captured_cb = None
+
+    with (
+        patch("kiro_crew.slack.gateway.stream_and_collect", fake_stream),
+        patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls,
+    ):
+
+        def capture_cron(on_job=None, **kw):
+            nonlocal captured_cb
+            captured_cb = on_job
+            svc = MagicMock()
+            svc.start = AsyncMock()
+            return svc
+
+        mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+
+        async def _init_and_run():
+            await gw._init_cron()
+            assert captured_cb is not None
+            for _ in range(runs):
+                await captured_cb(job)
+
+        asyncio.run(_init_and_run())
+
+    return job
+
+
+# ── The placeholder itself ──────────────────────────────────────────────────
+
+
+def test_tally_names_a_send_message_attempt_for_kiro_cli_titles() -> None:
+    tally = _GateTally()
+    tally.note(*READ)
+    tally.note(*SEND_KIRO_CLI)
+
+    text = tally.empty_reply_placeholder()
+
+    assert "delivery attempted via send_message" in text
+    assert "2 tool calls ran" in text
+    assert text != "_No response._"
+
+
+def test_tally_names_a_send_message_attempt_for_acp_titles() -> None:
+    tally = _GateTally()
+    tally.note(*SEND_ACP)
+
+    text = tally.empty_reply_placeholder()
+
+    assert "delivery attempted via send_message" in text
+    assert "1 tool call ran" in text
+
+
+def test_tally_names_work_without_delivery() -> None:
+    """Tools ran but nothing was sent: say so, and do not claim a delivery."""
+    tally = _GateTally()
+    tally.note(*READ)
+
+    text = tally.empty_reply_placeholder()
+
+    assert "1 tool call ran" in text
+    assert "send_message" not in text
+    assert text != "_No response._"
+
+
+def test_tally_keeps_the_bare_placeholder_for_a_turn_that_did_nothing() -> None:
+    """No approved tool call is the dead-run shape -- the old text is correct there."""
+    assert _GateTally().empty_reply_placeholder() == "_No response._"
+
+    blocked_only = _GateTally()
+    blocked_only.note(*BLOCKED)
+    assert blocked_only.empty_reply_placeholder() == "_No response._"
+
+
+def test_a_refused_send_message_is_not_a_delivery() -> None:
+    tally = _GateTally()
+    tally.note("Running: @kirocrew-core/send_message", False, True)
+
+    assert tally.delivered is False
+    assert tally.empty_reply_placeholder() == "_No response._"
+
+
+def test_a_tool_whose_name_merely_ends_in_send_message_is_not_a_delivery() -> None:
+    """Match the bare tool name, not a suffix: a foreign tool must not be mistaken
+    for the delivery channel."""
+    tally = _GateTally()
+    tally.note("Running: @other-mcp/bulk_send_message", True, False)
+    tally.note("mcp__other-mcp__resend_message", True, False)
+
+    assert tally.delivered is False
+    assert "send_message" not in tally.empty_reply_placeholder()
+    assert "2 tool calls ran" in tally.empty_reply_placeholder()
+
+
+# ── Through the real cron path ──────────────────────────────────────────────
+
+
+def test_a_silent_run_that_sent_records_the_attempt() -> None:
+    job = _run_silent_cron([SEND_KIRO_CLI])
+
+    assert job.last_result is not None
+    assert "delivery attempted via send_message" in job.last_result
+    assert "_No response._" not in job.last_result
+    assert job.last_status != "error"
+
+
+def test_a_silent_run_that_died_before_any_tool_still_reads_no_response() -> None:
+    """The dead-run signature must survive: it is the only signal that shape has."""
+    job = _run_silent_cron([])
+
+    assert job.last_result == "_No response._"
+
+
+def test_model_prose_on_a_silent_job_is_left_alone() -> None:
+    """A silent job that DOES reply keeps its reply; the placeholder is for empty prose only."""
+    job = _run_silent_cron([SEND_KIRO_CLI], reply="Digest sent.")
+
+    assert job.last_result is not None
+    assert job.last_result.startswith("Digest sent.")


### PR DESCRIPTION
## Problem / Motivation

A cron with `silent: true` is told to reply with nothing and deliver its result through `send_message`. When it does exactly that, its transcript row, `last_result`, and run history all read `_No response._`. That is the same text a run that died before its first tool call produces. Looking at the row, you cannot tell a delivered digest from a dead run.

## Why it matters

Silent digest and poller jobs are the normal shape for scheduled work. Every healthy run of one looks like a failure. An operator either learns to ignore `_No response._` (and then misses a real dead run) or investigates a job that did its work. Both waste attention on the one row meant to save it.

## What changed (motivation → approach → change)

The cron callback substituted `_No response._` for any empty reply. It did not ask whether the turn had done anything. `_GateTally` already counts approved tool calls for the same run and sees each tool's title, so the run knows the answer; the placeholder just never read it.

Now `_GateTally` records whether an approved call's bare tool name was `send_message` (`_bare_tool_name` unwraps the `Running: @server/Tool` and `mcp__server__Tool` wire forms). Its new `empty_reply_placeholder()` produces the row text for an empty reply: `_Silent run completed -- delivery attempted via send_message (N tool calls ran)._` when it was, `_Completed with no reply text -- N tool calls ran._` when tools ran but nothing was sent, and the bare `_No response._` only when no tool call was approved.

Both cron paths (single-agent and agent-sequence) call it in place of the literal. A turn that approved nothing keeps the old text on purpose: that is the dead-run shape, and the text is right there. Nothing else in the tree keys on the literal string (checked backend and dashboard; the only other mentions are a preset comment and an unrelated Slack handler constant).

## Tests

`test/test_cron_silent_run_placeholder.py` (new, 9 tests):

- `_GateTally` names a `send_message` attempt under both wire forms, with the right tool-call count and plural. "Attempted", not "delivered": `on_tool_gate` fires at the permission decision and never sees the tool result, so the text does not claim the message arrived.
- Tools ran but no `send_message`: the text says work happened and does not claim a delivery.
- No approved tool, or only a security-blocked one: the text stays `_No response._`.
- A refused `send_message` is not a delivery.
- A tool whose name merely ends in `send_message` (`bulk_send_message`, `resend_message`) is not a delivery -- the match is on the bare name.
- Through the real `_cron_callback` on a silent job: a run that called `send_message` records the attempt text and no error; a run with no tool calls still records `_No response._`; a silent job that does reply keeps its reply.

Mutation check: with `src/kiro_crew/slack/gateway.py` reverted to `main` and the tests kept, 7 of 9 fail; the 2 that pass are the two "unchanged behaviour" cases above.

## Manual verification

N/A — unit coverage sufficient. The change is a pure text substitution driven by state the tests set directly, and the real callback path is exercised by the through-the-callback tests.

## Related Issues

Fixes #9736

## Pattern harvest

Not generalizable: the defect is one placeholder that did not consult run state already in hand; the other `_No response._` sites (heartbeat, subagent result) have no tally to read.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe the placeholder
- [x] No secrets, credentials, or internal references in the diff
