### PR TITLE
refactor(apps): drop a shadow import and correct backend.py's comments

### DIFF
--- a/comment-history-baseline.json
+++ b/comment-history-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Comments and docstrings that narrate change history, per file, as a match COUNT. The rule they break is in docs/system-specs/common/code-style.md (\"Comments explain the WHY\"); it predates any enforcement, so the tree is recorded here rather than rewritten in one pass. The gate requires every OTHER file to be clean and none of these counts to grow, so this list can only shrink. Do NOT add or raise an entry to make a red gate green: a new offender means the comment should state CURRENT behavior in present tense. Lower and prune with `python3 scripts/check_comment_history.py --write-baseline`, which never adds or raises one.",
-  "_total": 6971,
+  "_total": 6970,
   "files": {
     "src/kiro_crew/__main__.py": 1,
     "src/kiro_crew/acp/_dispatch.py": 8,
@@ -24,7 +24,7 @@
     "src/kiro_crew/agents_janitor.py": 3,
     "src/kiro_crew/appearance_packs/store.py": 1,
     "src/kiro_crew/apple_speech/__init__.py": 2,
-    "src/kiro_crew/apps/backend.py": 7,
+    "src/kiro_crew/apps/backend.py": 6,
     "src/kiro_crew/apps/bridges.py": 7,
     "src/kiro_crew/apps/builtins/__init__.py": 1,
     "src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py": 8,

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -108,18 +108,15 @@ _health_reconcile_lock = threading.RLock()
 
 # Spawn survival check: poll the freshly-spawned child over a short grace window to
 # confirm it survived its initial bind (an immediate exit -> EADDRINUSE crash-loop must
-# be caught, see _start_app_backend_body). The loop breaks as soon as the process exits,
-# so a healthy backend only ever pays the full window on a machine where the child is
-# still starting up. Exposed as module constants so the test harness can widen the
-# window: under heavy pytest-xdist parallelism (-n auto, ~32 workers) a sandboxed child
-# can take longer than the default window just to reach its exit, which would otherwise
-# make the immediate-exit detection test flaky.
+# be caught, see _start_app_backend_body). The loop returns early on either outcome -
+# the child exiting, or our own child owning the listener - so a healthy backend pays
+# the full window only where ownership cannot be proven (no port to observe, or no
+# port->PID tool on the host); see _survived_spawn. Exposed as module constants so the
+# test harness can widen the window: under heavy pytest-xdist parallelism (-n auto, ~32
+# workers) a sandboxed child can take longer than the default window just to reach its
+# exit, which would otherwise make the immediate-exit detection test flaky.
 _SPAWN_SURVIVAL_CHECKS = 8
 _SPAWN_SURVIVAL_INTERVAL = 0.2
-# Consecutive alive polls that confirm a child cleared its bind. An immediate
-# failure (EADDRINUSE) exits within the first poll or two, so this is enough to
-# distinguish "survived" from "about to die" without burning the full budget on
-# every healthy app — see _survived_spawn.
 _PID_ANCESTRY_MAX_DEPTH = 8  # bound the parent walk when proving listener ownership
 _PORT_PROBE_TIMEOUT = 0.15  # cheap loopback gate before the costly port->PID lookup
 # Ceiling on parallel boot spawns. Each one forks a sandboxed interpreter, so an
@@ -170,9 +167,9 @@ def _survived_spawn(proc: Any, port: int | None = None) -> bool:
 
     Detects the failure this guards against — an immediate exit, e.g. EADDRINUSE
     from a port collision — while NOT paying the full grace window when the child
-    is healthy. The old loop slept its entire ~1.6s budget on the happy path and
-    broke only on death, so every app added ~1.6s of pure boot latency; with
-    concurrent boot that was the single largest startup cost.
+    is healthy. Sleeping the whole ~1.6s budget on the happy path would add that
+    much pure boot latency per app, which under concurrent boot is the single
+    largest startup cost.
 
     The early exit is driven by POSITIVE evidence: once OUR OWN child owns the
     listening socket on *port*, it has completed the very bind whose failure this
@@ -191,12 +188,12 @@ def _survived_spawn(proc: Any, port: int | None = None) -> bool:
     Ownership accepts our pid OR any descendant of it, because the sandbox
     launcher execs the real server as a child. When ownership cannot be
     established at all (no port to observe, or no port->PID tool on the host), it
-    degrades to polling the full budget exactly as before.
+    degrades to polling the full budget.
 
     The ownership probe shells out to lsof (~150ms), so it is gated behind a cheap
     loopback connect and is not run on every poll: the deadline below stays honest
     about wall-clock rather than adding the probe's cost to each interval, which
-    would otherwise make the failure path take LONGER than the original budget.
+    would otherwise make the failure path take LONGER than that budget.
     """
 
     can_check_owner = port is not None and platform_compat.listening_pid_tool_available()
@@ -335,12 +332,11 @@ def _reserve_free_port(app_name: str) -> int:
     """Atomically pick a free port and record it against *app_name*.
 
     Boot starts app backends CONCURRENTLY, so selection and reservation must be
-    one critical section. Probing without reserving (the previous behavior, safe
-    only while spawns were serialized) lets two apps be handed the same port —
-    both children then bind it and the loser dies with EADDRINUSE, which is the
-    crash-loop the post-spawn survival check exists to catch. The reservation is
-    overwritten with the real port on success and cleared on failure by the
-    existing spawn bookkeeping.
+    one critical section. Probing without reserving lets two apps be handed the
+    same port — both children then bind it and the loser dies with EADDRINUSE,
+    which is the crash-loop the post-spawn survival check exists to catch. The
+    reservation is overwritten with the real port on success and cleared on
+    failure by the existing spawn bookkeeping.
     """
     with _lock:
         port = _find_free_port()
@@ -877,18 +873,19 @@ def _await_inflight_spawn(app_name: str, timeout: float = 20.0) -> AppProcess | 
         owner_gone = False  # cannot prove the owner is gone: do not clear
     with _lock:
         cur = _processes.get(app_name)
-        if cur is not None and not getattr(cur, "starting", False):
+        if cur is None:
+            return None
+        if not getattr(cur, "starting", False):
             return cur  # resolved to a real process at the deadline
-        if cur is not None and getattr(cur, "starting", False):
-            if not owner_gone:
-                logger.info(
-                    "App %s backend spawn still in flight past the wait window "
-                    "(provisioning?) - leaving the placeholder in place",
-                    app_name,
-                )
-                return None
-            _processes.pop(app_name, None)
-            logger.warning("App %s backend spawn timed out — cleared stale placeholder", app_name)
+        if not owner_gone:
+            logger.info(
+                "App %s backend spawn still in flight past the wait window "
+                "(provisioning?) - leaving the placeholder in place",
+                app_name,
+            )
+            return None
+        _processes.pop(app_name, None)
+        logger.warning("App %s backend spawn timed out — cleared stale placeholder", app_name)
         return None
 
 
@@ -1112,8 +1109,6 @@ def _capped_spill(spill, hard_cap_bytes: int, poll_secs: float = 0.5):
     diagnostic, not a transcript). No child pid needed, so this composes
     with a mocked run_limited that spawns nothing.
     """
-    import threading
-
     stop = threading.Event()
     tripped = threading.Event()
 
@@ -1991,7 +1986,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     entry_str = str(entry) if entry else entry_point
 
     # Prefer explicit backend type from manifest over content sniffing
-    backend_type = manifest.backend.type if manifest.backend else ""
+    backend_type = manifest.backend.type
 
     # --- Node.js backend ---
     # Note: module-style entry points (entry is None) are always Python
@@ -2222,7 +2217,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     if is_builtin_app(app_root=execution_path, app_name=app_name):
         _visible = app_backend_visible_targets(app_name)
     if _cache_visible:
-        # SECURITY (#8795): refuse rather than carve when the cache sits beneath an
+        # SECURITY: refuse rather than carve when the cache sits beneath an
         # independently masked directory (a data home relocated under a credential
         # tree). ``extra_visible_dirs`` cancels any hidden mask entry that CONTAINS
         # a visible path, so carving the cache out would unmask that whole foreign
@@ -2366,12 +2361,12 @@ def _wait_for_pids(pids: list[int], timeout: float = 2.0) -> None:
     timeout duration when processes exit quickly.
 
     Uses pid_liveness (tri-state), NOT pid_exists (which collapses EPERM to
-    True): an adopted app-backend PID can be recycled between kill_pid(SIGTERM)
-    and this poll to a different user's process. pid_exists would keep it in
+    True): an adopted app-backend PID can be recycled between
+    kill_pid_pinned(SIGTERM) and this poll to a different user's process. pid_exists would keep it in
     still_alive for the whole 2.0s deadline; pid_liveness returns UNSIGNALABLE
-    for the not-ours case and we treat that as done, restoring the fast-return
-    behavior the old ``os.kill(pid, 0) except OSError`` had. Never raw
-    ``os.kill(pid, 0)`` — that TERMINATES the target on Windows.
+    for the not-ours case and we treat that as done, so a recycled PID returns
+    fast instead of holding the deadline. Never raw ``os.kill(pid, 0)`` — that
+    TERMINATES the target on Windows.
     """
     deadline = time.monotonic() + timeout
     remaining = list(pids)
@@ -3709,8 +3704,8 @@ def start_enabled_app_backends() -> list[str]:
 
     # Vet first, then spawn the admitted set CONCURRENTLY. Vetting is cheap and
     # order-dependent bookkeeping; spawning is the slow part (each child is polled
-    # for a grace window), so serializing it made boot latency scale linearly with
-    # the number of installed apps.
+    # for a grace window), so serializing it would make boot latency scale linearly
+    # with the number of installed apps.
     admitted: list[str] = []
     for app_info in apps:
         if not app_info.get("enabled"):
@@ -3800,9 +3795,10 @@ def _start_backends_concurrently(names: list[str]) -> list[str]:
     """Spawn the given app backends in parallel; return those that started.
 
     Each app's spawn blocks on a survival grace window, so starting them one at a
-    time made boot cost roughly N x that window. They are independent (ports are
-    reserved atomically — see ``_reserve_free_port``), so they run concurrently and
-    boot costs about ONE window regardless of app count.
+    time would cost roughly N x that window. They are independent (ports are
+    reserved atomically — see ``_reserve_free_port``), so they run concurrently,
+    ``_BOOT_SPAWN_MAX_WORKERS`` at a time: boot costs about one window per wave
+    rather than one per app.
 
     Declared FIXED ports are reserved up front, before any spawn is submitted.
     A fixed port is a requirement, not a preference, so it must not be lost to an
@@ -3810,9 +3806,9 @@ def _start_backends_concurrently(names: list[str]) -> list[str]:
     that race entirely, leaving `PortUnavailableError` to signal only a genuine
     conflict (two apps declaring the same port, or a foreign holder).
 
-    Failure isolation matches the previous serial loop exactly: one app's spawn
-    raising or returning None must never take down the gateway (Slack + dashboard
-    + every session) or affect the other apps.
+    Failure isolation is per app: one app's spawn raising or returning None must
+    never take down the gateway (Slack + dashboard + every session) or affect the
+    other apps.
     """
 
     if not names:


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/apps/backend.py` carried a dead import and a set of comments that
no longer matched the code under them.

The import: `_capped_spill` began with `import threading`, but the module already
imports `threading` at the top. The inner line rebinds the same module object, so
it does nothing — while telling a reader this function needs its own import.

The comments were worse, because a wrong comment is read as true. A block sitting
above `_PID_ANCESTRY_MAX_DEPTH` described "consecutive alive polls" — a thing no
constant in the file holds and `_survived_spawn` does not count. The block above
the survival constants said a healthy backend pays the full grace window "only on
a machine where the child is still starting up"; it also pays the full window on
any host with no `lsof`. `_wait_for_pids` named `kill_pid` where its caller uses
`kill_pid_pinned`. `_start_backends_concurrently` said boot costs about one grace
window "regardless of app count", which ignores the eight-worker cap. Five more
passages narrated code that has been deleted ("The old loop", "exactly as
before", "matches the previous serial loop").

## Why it matters

This file is on the gateway boot path: `dashboard/server.py` calls
`start_enabled_app_backends` before the socket binds. Anyone tuning boot latency
reads these comments first. Two of them give a wrong answer about when the
grace window is paid — the exact number that dominates boot cost. A reader who
trusts them looks in the wrong place.

Nothing here changes what the code does.

## What changed (motivation → approach → change)

The module already imports `threading` at line 24, unconditionally. So the copy
inside `_capped_spill` is a strict no-op and it is gone.

Two conditionals said something the surrounding code already proved.
`_await_inflight_spawn` asked `cur is not None` twice and re-read `.starting` to
learn what the arm above it had just ruled out; it now returns early on
`cur is None` and each later test reads once. `_start_app_backend_body` guarded
`manifest.backend` against `None` while computing `backend_type` — 326 lines
after that same function dereferenced `manifest.backend.entryPoint` with no
guard at all. The guard's `else` arm cannot run.

Everything else is comment text. Each rewritten comment was checked against the
lines it sits on, because a stale comment flipped to confident present tense
misleads worse than the stale one did.

```mermaid
flowchart LR
  subgraph Before
    A1[cur is not None<br/>and not starting]:::changed --> B1[cur is not None<br/>and starting]:::changed --> C1[return None]:::ctx
  end
  subgraph After
    A2[cur is None<br/>-> return None]:::added --> B2[not starting<br/>-> return cur]:::added --> C2[owner_gone?]:::ctx
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#D97706,stroke-width:2px
  linkStyle 2,3 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟦 unchanged

*`_await_inflight_spawn` now rules out the empty case once, up front, instead of re-asking it in every arm.*

### Equivalence, per code change

**`import threading`.** Module-scope `import threading` is at line 24, in the
plain stdlib block — no `TYPE_CHECKING`, no platform `if`, no
`try/except ImportError`. The module already depends on that binding at import
time (`_health_reconcile_lock = threading.RLock()`, line 107). Nothing rebinds
or deletes the global. The name does move from function-local to module-global,
so a test patching `backend.threading` would newly be observed — there is no
such test. Every `.threading` patch site in the suite sets an attribute *on* the
shared `threading` module (`bmod.threading` then `"Thread"`), which resolves to
the same singleton either way and is unaffected. This is the file's only
in-function plain `import`; all 13 in-function `from X import Y` statements are
untouched, as they must be.

**`_await_inflight_spawn`.** All eight combinations of
`(cur, starting, owner_gone)` return the same value and emit the same log
sequence. `cur is None` is the exact negation of `cur is not None`, and both
revisions test the attribute with the identical
`not getattr(cur, "starting", False)` predicate, so a falsy non-`False`
`starting` behaves the same. `.starting` is a plain `bool` dataclass field with
no write anywhere in `src/` outside the `AppProcess(..., starting=True)`
construction, and both old reads were inside one uninterrupted `_lock` hold —
so collapsing two reads into one cannot change the answer. The `with _lock:`
line is unchanged context; the flock probe and its `finally: os.close` are
outside the hunk. `_processes.pop` still fires under exactly
`cur is not None and starting and owner_gone`.

**`backend_type`.** `AppManifest.backend` is
`field(default_factory=BackendConfig)` — non-Optional. `BackendConfig` is a
plain dataclass; `manifest.py` defines no `__bool__` or `__len__`, so every
instance is truthy and `if manifest.backend` was always `True`. A hostile
manifest cannot reach the `else` either: `from_dict` builds
`BackendConfig.from_dict(raw) if isinstance(raw, dict) else BackendConfig()`, so
`"backend": null` still yields a real config. And the sole caller already
dereferences `manifest.backend.entryPoint` unguarded at line 762, so a `None`
would have raised there. Branch selection is not a sandbox boundary: the
Node/exec/ASGI/Python chain only builds `cmd`, and there is one `wrap_argv`
after it converges.

### The ratchet the diff had to move

Removing an issue number from a comment retires a `comment-history` marker, and
`scripts/check_comment_history.py` is a *downward* ratchet — it fails a diff that
retires one without lowering the baseline. `--write-baseline` takes
`src/kiro_crew/apps/backend.py` from 7 to 6. The six that remain are present-tense
statements about runtime state ("a record that is no longer the tracked one"), not
change history, so they stay listed rather than being rewritten to satisfy a regex.

## Tests

No new tests. This change adds no behaviour to lock in, and the campaign's rule
is that a behaviour-preserving refactor which needs a new test is not
behaviour-preserving. The existing suites already cover every touched path:
`test_apps_backend_coverage.py` calls `_capped_spill` for real and asserts the
watchdog truncates a flooding child; five tests reach `_await_inflight_spawn`
with real `AppProcess` instances; seven reach `_start_app_backend_body` through
`get_app_manifest`. Two `inspect.getsource` assertions in
`test_sandbox_governance_mask.py` pin strings inside the edited hunk's context —
both still hold. `test_check_comment_history.py` covers the baseline gate.

Ran green: 1,971 passed, 18 skipped across `test_app_backend.py`,
`test_app_backend_stale_reap.py`, `test_apps_backend_coverage.py`,
`test_app_bridges.py`, `test_sandbox_governance_mask.py`,
`test_dev_fleet_app.py`, `test_app_manager.py`, `test_app_e2e.py`,
`test_app_execution.py`, `test_app_hook_health.py`,
`test_apps_routes_coverage.py`, `test_check_comment_history.py`.

Gates, all exit 0 on this commit, on a Python 3.12 CI-parity venv: `flake8`,
`isort --check-only`, `mypy` (1,381 files), `check_black_formatting.py`,
`check_comment_history.py`, `check_subprocess_encoding.py`,
`check_brand_name.py`, `check_harness_parity.py`, `docs_lint.py --test`,
`docs-lint.sh`, `check_per_file_coverage.py --test`, `check_feature_map.py`,
`check_changelog_history.py`, `check_sync_io_in_async.py`,
`verify_vendor_manifest.py`. Re-run after the rebase onto current `main`.

## Manual verification

N/A — no runtime behaviour changes, and the equivalence of each of the three
code edits is proved above rather than sampled.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only — one Python file plus a gate baseline, no
frontend path touched, so nothing rendered changes.

## Related Issues

no linked issue: routine module-level readability sweep, not a reported defect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

---

### What the pre-PR review fleet found, and what was dropped

Five read-only subagents reviewed this diff before it opened, one per lens
(AUTOSDE blocking rules, behaviour preservation, import semantics, security
keystone, comment accuracy). Each finding was then checked against the code
before being acted on.

**Acted on (4).** The AUTOSDE lens caught the `comment-history` ratchet, which
was genuinely red — reproduced at exit 1 (`7 -> 6`) and fixed by lowering the
baseline. The comment-accuracy lens caught that deleting the orphaned block
*promoted* a neighbouring false sentence to being the sole documentation of the
grace window; that sentence is now corrected and the `see _survived_spawn`
pointer the deletion removed is restored. It also caught the `kill_pid` /
`kill_pid_pinned` mismatch and the "one window regardless of app count" claim
that ignores `_BOOT_SPAWN_MAX_WORKERS`.

**Dropped or deliberately left (3).**

- An `else:` after a `if healthy:` arm that returns on every path, in
  `_start_app_backend_body`, would dedent cleanly. Left alone: the block it
  wraps contains a `sel()` audit emit, so the edit is a 14-line whitespace diff
  that forces a reviewer to prove a no-op on an audit path in exchange for one
  nesting level. Wrong trade in a behaviour-preservation PR.
- Annotating `_start_app_backend_body(manifest: AppManifest)` would let mypy
  enforce the invariant the `backend_type` change now relies on. Correct, and out
  of scope — it is a typing change, not a simplification.
- `src/kiro_crew/sandbox.py:444` carries the same `(#8795)` marker. Left for a
  separate PR: `sandbox.py` is a keystone file in another module, and this
  campaign is one module per PR.

One reported finding did not survive checking: a claim of four new `flake8` hits
in this file. All four pre-exist in the base at the same offsets and none sits in
a diff hunk; `flake8` exits 0 on the CI-parity venv.
