### PR TITLE
fix(config): refuse symlinked breadcrumb and write atomically

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -81,8 +81,11 @@ Independently, a user who wants the data home entirely outside `~/.kiro/` can se
 **Technical hedge — recovery-pointer breadcrumb.** `config_dir()` writes a small,
 non-secret `~/.kirocrew.breadcrumb` pointer file at the top-level home
 (`RECOVERY_BREADCRUMB_NAME`), deliberately **outside** `~/.kiro/`, recording the
-data-home path (see `_write_recovery_breadcrumb`). It is idempotent (rewritten
-only when the recorded path changes), best-effort (never blocks startup), and
+data-home path (see `_write_recovery_breadcrumb`). It is idempotent where the
+platform can check safely (on POSIX the prior content is read via `O_NOFOLLOW`
+and rewritten only when the recorded path changes; where that flag is missing —
+Windows — the check is skipped and the file is atomically rewritten once per
+process), best-effort (never blocks startup), and
 written only on the default path (a `KIROCREW_HOME` override carries no `~/.kiro/`
 wipe risk). It is **not a backup** — just a durable signpost that survives a
 `~/.kiro/`-wide uninstaller wipe so a user or support script can find any

--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -2,7 +2,10 @@
 
 This is a **leaf module**: it depends only on the standard library
 (``os``, ``sys``, ``pathlib``, ``logging``) and imports nothing from
-``kiro_crew``. Modules that only need to locate ``~/.kirocrew/`` should import
+``kiro_crew`` at import time. The one exception is a lazy, in-function import
+of :mod:`kiro_crew.atomic_write` inside ``_write_recovery_breadcrumb`` (that
+helper itself imports this module lazily, so there is no cycle). Modules that
+only need to locate ``~/.kirocrew/`` should import
 from here directly::
 
     from kiro_crew.config.paths import config_dir
@@ -26,6 +29,7 @@ from __future__ import annotations
 
 import logging
 import os
+import stat
 import sys
 import tempfile
 from collections.abc import Callable, Mapping
@@ -146,14 +150,38 @@ def _write_recovery_breadcrumb(data_home: Path) -> None:
             "any surviving data or know where it had been. It is NOT a backup.\n"
         )
         # Idempotent: only (re)write when absent or the recorded path changed, so
-        # we don't churn the file on every process start.
-        if crumb.is_file():
+        # we don't churn the file on every process start. Read through a
+        # no-follow descriptor and confirm it is a regular file, so a planted
+        # symlink or FIFO can neither redirect the read nor hang or bloat
+        # startup (``read_text`` would follow it). Where O_NOFOLLOW does not
+        # exist (Windows), skip the read entirely - an open there would follow
+        # a symlink (e.g. to an unreachable UNC path, stalling startup) - and
+        # fall through to the atomic rewrite.
+        no_follow = getattr(os, "O_NOFOLLOW", 0)
+        if no_follow:
             try:
-                if str(data_home) in crumb.read_text(encoding="utf-8"):
-                    return
+                read_flags = os.O_RDONLY | no_follow | getattr(os, "O_NONBLOCK", 0)
+                crumb_fd = os.open(crumb, read_flags)
+                try:
+                    if stat.S_ISREG(os.fstat(crumb_fd).st_mode):
+                        existing = os.read(crumb_fd, 65536).decode("utf-8", errors="replace")
+                        if str(data_home) in existing:
+                            return
+                finally:
+                    os.close(crumb_fd)
             except OSError:
                 pass
-        crumb.write_text(content, encoding="utf-8")
+
+        # Write via the repo's mandated atomic-write helper: unique temp file,
+        # fchmod on the descriptor (never a path-based chmod), rename with the
+        # Windows sharing-violation retry, cleanup on failure. The rename
+        # replaces whatever directory entry sits at the breadcrumb path without
+        # following it, so a planted symlink is consumed - never written
+        # through - and its target is untouched. Imported lazily: this module
+        # stays an import-time leaf (see module docstring).
+        from kiro_crew.atomic_write import atomic_write
+
+        atomic_write(crumb, content, mode=0o600)
     except OSError:  # pragma: no cover - defensive: a breadcrumb is best-effort
         logger.debug("could not write recovery breadcrumb", exc_info=True)
 

--- a/test/test_lazy_data_home_paths.py
+++ b/test/test_lazy_data_home_paths.py
@@ -34,12 +34,16 @@ Keeping the module-level name means existing ``monkeypatch.setattr(mod,
 from __future__ import annotations
 
 import ast
+import os
+import stat
 from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+from conftest import requires_symlinks
 
 # One xdist worker for the whole module: every test here derives from ONE module-cached
 # scan of src/ (rglob + ast.parse, ~30s). Under `--dist loadgroup` an unmarked module is
@@ -682,3 +686,116 @@ class TestConfigDirMemoIsNotServedAfterTheHomeIsCleared:
 
         assert first == second == tmp_path / "home" / ".kiro" / "crew"
         assert calls == [1], f"memo did not serve the second call: {calls}"
+
+
+class TestRecoveryBreadcrumb:
+    @requires_symlinks
+    def test_symlinked_breadcrumb_is_replaced_and_its_target_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """A planted symlink can never redirect the write onto its target.
+
+        The atomic rename replaces the directory entry at the breadcrumb path
+        without following it: the symlink is consumed (a regular breadcrumb
+        takes its place) and the file it pointed at keeps its exact content.
+        """
+        from kiro_crew.config import paths
+
+        data_home = tmp_path / "data-home"
+        crumb = tmp_path / paths.RECOVERY_BREADCRUMB_NAME
+        target = tmp_path / "target"
+        target.write_text("leave this untouched", encoding="utf-8")
+        os.symlink(target, crumb)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            paths._write_recovery_breadcrumb(data_home)
+
+        assert target.read_text(encoding="utf-8") == "leave this untouched"
+        assert crumb.is_file() and not crumb.is_symlink()
+        assert str(data_home) in crumb.read_text(encoding="utf-8")
+
+    def test_normal_breadcrumb_write_is_private_and_contains_the_data_home(
+        self, tmp_path: Path
+    ) -> None:
+        from kiro_crew.config import paths
+
+        data_home = tmp_path / "data-home"
+        crumb = tmp_path / paths.RECOVERY_BREADCRUMB_NAME
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            paths._write_recovery_breadcrumb(data_home)
+
+        assert str(data_home) in crumb.read_text(encoding="utf-8")
+        if os.name == "posix":
+            # Windows has no POSIX permission bits; st_mode reads 0o666 there.
+            assert stat.S_IMODE(crumb.stat().st_mode) == 0o600
+
+    def test_existing_breadcrumb_that_contains_the_data_home_is_unchanged(
+        self, tmp_path: Path
+    ) -> None:
+        """Up-to-date breadcrumbs are not churned - where the safe read exists.
+
+        The idempotence read is gated on ``O_NOFOLLOW``: platforms that have it
+        (POSIX) skip the rewrite when the recorded path is current; platforms
+        that lack it (Windows) deliberately rewrite every start, so there the
+        assertion is that the rewrite lands a valid breadcrumb.
+        """
+        from kiro_crew.config import paths
+
+        data_home = tmp_path / "data-home"
+        crumb = tmp_path / paths.RECOVERY_BREADCRUMB_NAME
+        existing_content = f"existing pointer: {data_home}\n"
+        crumb.write_text(existing_content, encoding="utf-8")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            paths._write_recovery_breadcrumb(data_home)
+
+        if hasattr(os, "O_NOFOLLOW"):
+            assert crumb.read_text(encoding="utf-8") == existing_content
+        else:
+            assert str(data_home) in crumb.read_text(encoding="utf-8")
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="needs os.mkfifo")
+    def test_fifo_at_breadcrumb_path_neither_hangs_nor_survives(self, tmp_path: Path) -> None:
+        """A non-regular file at the breadcrumb path must not stall startup.
+
+        The old idempotence check called ``read_text`` after a ``is_symlink``
+        re-check; a FIFO (or a symlink swapped in after the check) would make
+        that read block forever or follow the swap. The read now goes through a
+        no-follow, non-blocking descriptor gated on ``S_ISREG``, so a FIFO is
+        skipped and atomically replaced by the real breadcrumb.
+        """
+        from kiro_crew.config import paths
+
+        data_home = tmp_path / "data-home"
+        crumb = tmp_path / paths.RECOVERY_BREADCRUMB_NAME
+        os.mkfifo(crumb)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            paths._write_recovery_breadcrumb(data_home)
+
+        assert crumb.is_file() and not crumb.is_symlink()
+        assert str(data_home) in crumb.read_text(encoding="utf-8")
+
+    def test_without_o_nofollow_the_read_is_skipped_and_write_still_lands(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Platforms lacking O_NOFOLLOW (Windows) must skip the idempotence read.
+
+        An open without O_NOFOLLOW would follow a raced symlink (e.g. to an
+        unreachable UNC path, stalling startup), so the function goes straight
+        to the atomic rewrite there. Startup must not crash and the breadcrumb
+        must still land correctly.
+        """
+        from kiro_crew.config import paths
+
+        data_home = tmp_path / "data-home"
+        crumb = tmp_path / paths.RECOVERY_BREADCRUMB_NAME
+        crumb.write_text(f"already points at {data_home}\n", encoding="utf-8")
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            paths._write_recovery_breadcrumb(data_home)
+
+        assert crumb.is_file() and not crumb.is_symlink()
+        assert str(data_home) in crumb.read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem / Motivation

At startup, KiroCrew writes a recovery breadcrumb to `~/.kirocrew.breadcrumb`. The old code called `crumb.write_text(...)` on that path. `write_text` follows symlinks. If a symlink sits at that path, the write lands on the symlink's target instead of the breadcrumb. The idempotence check just before the write had the same problem: it called `crumb.read_text(...)` after a check-then-read gap, so a non-regular file (a FIFO, or a symlink swapped in after the check) could hang the read or make it follow the swap.

## Why it matters

The breadcrumb write runs on every process start, before anything else. A write through a planted symlink silently overwrites whatever file the link points at. A read of a FIFO with no writer blocks forever, so the CLI or gateway never finishes starting. Both break the file's own contract, stated in the surrounding comment: a breadcrumb is best-effort and must never block or damage startup.

## What changed (motivation → approach → change)

The symptom is a startup write that can be redirected and a startup read that can stall. The root cause is path-based file I/O on a path outside the protected data home: `write_text` and `read_text` both trust whatever inode the path resolves to at call time.

The fix makes both halves inode-safe. The write goes through the repo's mandated helper, `kiro_crew.atomic_write.atomic_write(crumb, content, mode=0o600)` (imported lazily so `paths.py` stays an import-time leaf): a unique temp file, mode set by `fchmod` on the descriptor, and an atomic rename with the Windows sharing-violation retry. The rename replaces whatever directory entry sits at the breadcrumb path without following it, so a planted symlink is consumed - never written through - and its target is untouched. The read runs only where `os.O_NOFOLLOW` exists; platforms without it (Windows) skip the read and go straight to the atomic rewrite, so no open there can follow a raced symlink. Where it runs, the read opens with `O_NOFOLLOW | O_NONBLOCK`, checks `stat.S_ISREG` on the open descriptor, and reads at most 64 KiB. A swapped-in symlink fails the open with `ELOOP`; a FIFO fails the regular-file check without blocking. Every new failure mode raises `OSError`, which the function's existing best-effort handler already catches, so startup is never blocked.

The module spec (`docs/system-specs/modules/config.md`) is updated to match: the breadcrumb is idempotent where the platform can check safely (POSIX, `O_NOFOLLOW` read) and atomically rewritten once per process where it cannot (Windows).

## Tests

Five tests in `test/test_lazy_data_home_paths.py` (four new in this PR plus one updated), all patching `Path.home()` to a tmp dir:

- `test_symlinked_breadcrumb_is_replaced_and_its_target_untouched` — a planted symlink is consumed by the atomic rename (a regular breadcrumb takes its place) and its target keeps its exact content.
- `test_normal_breadcrumb_write_is_private_and_contains_the_data_home` — the normal write records the data home and lands with mode `0o600` (mode asserted on POSIX only; Windows has no POSIX permission bits).
- `test_existing_breadcrumb_that_contains_the_data_home_is_unchanged` — platform-branched: where `O_NOFOLLOW` exists an up-to-date breadcrumb is byte-identical after the call; where it does not (Windows) the deliberate rewrite lands a valid breadcrumb.
- `test_fifo_at_breadcrumb_path_neither_hangs_nor_survives` — a FIFO at the path neither blocks the read nor survives; it is atomically replaced by a regular breadcrumb (skipped where `os.mkfifo` is absent).
- `test_without_o_nofollow_the_read_is_skipped_and_write_still_lands` — where `O_NOFOLLOW` is absent (Windows) the idempotence read is skipped and the atomic rewrite still lands the correct content.

## Manual verification

Verified by a proof-of-concept run against both trees, using a throwaway `$HOME` (the real home is never touched). The script plants `victim.txt` (stand-in for a file like `~/.zshrc`), symlinks the breadcrumb path to it, and calls `_write_recovery_breadcrumb`:

```python
import os, tempfile
from pathlib import Path
from unittest.mock import patch
from kiro_crew.config import paths

home = Path(tempfile.mkdtemp())          # fake home
victim = home / "victim.txt"             # stand-in for ~/.zshrc
victim.write_text("precious data")
crumb = home / paths.RECOVERY_BREADCRUMB_NAME
os.symlink(victim, crumb)                # attacker: breadcrumb -> victim

with patch("pathlib.Path.home", return_value=home):
    paths._write_recovery_breadcrumb(home / "data-home")

print("A intact:        ", victim.read_text() == "precious data")
print("B still symlink: ", crumb.is_symlink())
```

On unpatched `main`: `A intact: False` — the startup write follows the symlink and overwrites the victim file. On this branch: `A intact: True`, `B still symlink: False` — the target keeps its content, and the planted link is consumed by the atomic rename (a regular breadcrumb takes its place).

## Related Issues

no linked issue: found by a code audit of `_write_recovery_breadcrumb`; no tracking issue exists.

## Pattern harvest

Rule candidate: review-prompt
Pattern: path-based write/read (`write_text`/`read_text`) on a path outside the app's protected directory — use symlink refusal + temp-file + `os.replace` for writes, `O_NOFOLLOW` fd + `S_ISREG` for reads.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- retrigger-nonce 1788999942 -->
