### PR TITLE
fix(outbound): keep Windows extended-length path intact in strip_url_syntax

### DIFF
--- a/src/kiro_crew/messaging/outbound_files.py
+++ b/src/kiro_crew/messaging/outbound_files.py
@@ -348,12 +348,27 @@ def _literal_image_marker(text: str, offset: int, fenced: list[tuple[int, int]])
     )
 
 
+#: Windows extended-length path prefix (``\\?\``). ``os.readlink`` returns a
+#: symlink target in this form, and its ``?`` is part of the prefix, not a URL
+#: query delimiter -- so the query/fragment split below must not run on it.
+_EXTENDED_LENGTH_PREFIX = "\\\\?\\"
+
+
 def strip_url_syntax(raw_dest: str) -> str:
-    """A markdown destination with URL syntax removed, ready for the filesystem.
+    r"""A markdown destination with URL syntax removed, ready for the filesystem.
 
     Drops anything after ``?`` or ``#`` -- a local path has no query or fragment,
     so those would be taken for part of the filename -- and unwraps ``file://``.
+
+    A Windows extended-length path (``\\?\C:\...``, or the share spelling
+    ``\\?\UNC\server\share``) is returned unchanged: its ``?`` belongs to the
+    prefix, not to a query string, and such a path never carries a ``file://``
+    scheme. The full string therefore reaches the UNC gate, where the share,
+    device and object-namespace spellings are refused and a drive-local path is
+    not. Mirrors the fold in ``hooks.validate_file_path``.
     """
+    if raw_dest.startswith(_EXTENDED_LENGTH_PREFIX):
+        return raw_dest
     clean = raw_dest.split("?", 1)[0].split("#", 1)[0]
     if clean.startswith("file://"):
         clean = clean[len("file://") :]

--- a/test/test_outbound_files.py
+++ b/test/test_outbound_files.py
@@ -206,6 +206,61 @@ class TestDestinationForms:
         assert local_destination("./rel.png") is None
 
 
+class TestStripUrlSyntaxExtendedLengthPath:
+    r"""A Windows extended-length path (``\\?\...``) survives
+    ``strip_url_syntax`` intact.
+
+    ``os.readlink`` returns a symlink target in this form. Its ``?`` belongs to
+    the ``\\?\`` prefix, not to a query string, so the query/fragment split does
+    not run on it and the full path reaches the UNC gate. See
+    ``hooks.validate_file_path`` for the same fold.
+    """
+
+    _LOCAL = "\\\\?\\C:\\Users\\me\\pic.png"  # \\?\C:\Users\me\pic.png
+    _LOCAL_LOWER = "\\\\?\\c:\\users\\me\\pic.png"  # \\?\c:\users\me\pic.png
+    _SHARE = "\\\\?\\UNC\\server\\share\\x.png"  # \\?\UNC\server\share\x.png
+    _DEVICE = "\\\\.\\PhysicalDrive0"  # \\.\PhysicalDrive0
+    _OBJNS = "\\\\?\\GLOBALROOT\\Device\\HarddiskVolume1\\x.png"
+
+    def test_query_and_fragment_stripping_still_works(self) -> None:
+        """The load-bearing behaviour is preserved: a URL-shaped destination
+        still loses its query and fragment (this is why the split exists)."""
+        assert strip_url_syntax("file:///tmp/a.png?v=2#top") == "/tmp/a.png"
+        assert strip_url_syntax("/tmp/a.png#frag") == "/tmp/a.png"
+        assert strip_url_syntax("C:/x/y.png?a=1") == "C:/x/y.png"
+
+    def test_extended_length_local_path_survives_the_strip(self) -> None:
+        """An extended-length local path is returned whole, not split at ``?``."""
+        assert strip_url_syntax(self._LOCAL) == self._LOCAL
+        assert strip_url_syntax(self._LOCAL_LOWER) == self._LOCAL_LOWER
+
+    def test_extended_length_share_form_survives_and_stays_refused(self) -> None:
+        r"""SECURITY: the ``\\?\UNC\...`` share form and the other extended
+        namespaces are returned whole AND remain UNC-shaped, so the UNC gate
+        refuses them. Asserted directly, because a strip that mangled them into a
+        non-share shape would let a share reach the filesystem.
+        """
+        from kiro_crew.hooks import is_unc_shape
+
+        for raw in (self._SHARE, self._DEVICE, self._OBJNS):
+            assert strip_url_syntax(raw) == raw, f"strip mangled {raw!r}"
+            assert is_unc_shape(strip_url_syntax(raw)) is True, f"share form slipped: {raw!r}"
+
+    def test_local_destination_refuses_the_share_form_end_to_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end on a simulated Windows host: the surviving share form is
+        refused by ``local_destination`` (no ``Path`` is constructed for it)."""
+        from kiro_crew.messaging import outbound_files as module
+
+        monkeypatch.setattr(module, "os", type("OS", (), {"name": "nt"})(), raising=False)
+        monkeypatch.setattr(module, "unc_probe_allowed", lambda raw: False, raising=False)
+        monkeypatch.setattr(
+            module, "Path", lambda raw: pytest.fail(f"path constructed for share: {raw}")
+        )
+        assert module.local_destination(self._SHARE) is None
+
+
 class TestOutboundSecurity:
     def test_untrusted_windows_unc_is_rejected_before_path_construction(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## What is the problem?

`strip_url_syntax` in `src/kiro_crew/messaging/outbound_files.py` splits its input on `?`, which destroys a Windows extended-length path before the UNC gate ever sees it.

`os.readlink` returns a symlink target in extended-length form, `\\?\C:\Users\...`. The `?`-split cuts it at the `?`:

```
strip_url_syntax(r"\\?\C:\Users\me\pic.png")  ==  "\\"
```

`\\` is two leading separators, so `is_unc_shape("\\")` is `True` and `local_destination` refuses it as a network share. `local_destination` is the shared normalizer for `outbound_files` (markdown upload extraction) and `image_artifacts` (markdown image finalize).

## Why this issue matters to the user

A legitimate LOCAL file named by an extended-length path is refused from outbound uploads and image finalize on Windows. It is the same class of false-positive as #9754, but it lives in a different place and survives the #9754 predicate fix untouched: the path is already mangled to `\\` before the predicate runs, so widening `is_unc_shape` changes nothing here. It fails CLOSED -- nothing is exposed; the cost is a usable local destination becoming unusable.

## How our fix solves it

Chain from symptom to root cause: the false refusal surfaces at the predicate (`is_unc_shape`), but for this caller the predicate never gets a fair input because the `?`-split truncates `\\?\...` to `\\` first. The share form `\\?\UNC\server\share` collapsed to the same `\\`, so it was refused for the WRONG reason -- the `\\` coincidence, not a real share verdict.

The `?`-split is load-bearing: it drops a URL query string from a URL-shaped destination (`strip_url_syntax("file:///tmp/a.png?v=2#top") == "/tmp/a.png"`), which must keep working. A Windows extended-length prefix `\\?\` is not a query string and never carries a `file://` scheme, so the fix recognises the prefix BEFORE the split and returns the string unchanged. The full string then reaches the UNC gate, where:

- `\\?\UNC\server\share`, `\\.\` device paths and `\\?\GLOBALROOT\...` stay UNC-shaped and are refused ON PURPOSE, and
- `\\?\C:\...` is admitted as a local path once #9754's predicate fix lands.

This mirrors the precedent already in `hooks.validate_file_path`, which folds `\\?\UNC\` to `\\` and strips `\\?\` only when the remainder is drive-absolute. The predicate must answer the same way in every module; this change feeds it the same shape `validate_file_path` already does, so a second reader finds the existing answer instead of deriving a third one.

## What tests we did

New `TestStripUrlSyntaxExtendedLengthPath` in `test/test_outbound_files.py`:

- query/fragment stripping on URL-shaped destinations still works (the load-bearing behaviour);
- an extended-length local `\\?\C:\...` (upper and lower drive) survives the strip intact (was `\\`);
- SECURITY, written first and asserted directly rather than assumed: the `\\?\UNC\`, `\\.\` and `\\?\GLOBALROOT\` forms survive the strip AND stay UNC-shaped, so `is_unc_shape` still refuses them -- this is the one way the change could make a destination less safe;
- end-to-end on a simulated Windows host, `local_destination` refuses the surviving share form (no `Path` is constructed).

Ran green locally: `test_outbound_files.py` (88), `test_image_artifacts.py`, `test_acp_prompt_blocks.py`, `test_dashboard_themes_coverage.py`, `test_memory_markdown_read.py`, `test_memory_read_counters.py` (373 passed / 1 skipped together), and `test_hooks_coverage.py` (246). `black` clean; branch ASCII-clean.

## Pattern harvest

Rule candidate: a string sanitizer that strips URL syntax (query/fragment, scheme) must exempt a Windows extended-length prefix first, because its literal '?' is path syntax, not a query delimiter -- otherwise the sanitizer mangles the path before any security gate downstream sees a faithful copy, and a coincidental collapse can make the gate pass or fail for the wrong reason.

## Any other suggestions on the work

On `main` this change does NOT admit a drive-local extended-length path: `is_unc_shape(r"\\?\C:\...")` still returns True there, so `local_destination` still refuses it after the fix -- now at the UNC gate rather than via the truncation to `\\`. Admission is a separate concern tracked in #9754, and Opus found that widening the predicate would open a credential-path hole, so admission will come from normalising the path in `hooks.validate_file_path` (stripping the prefix before the walk), not from a predicate change. The tests here deliberately assert only survival of the string, never admission, so this PR stays uncoupled from that work.

Independent of, and complementary to, #9754. This PR lets the extended-length string REACH the predicate; #9754 makes the predicate return the right answer for `\\?\C:`. The two are separate bugs and land as separate PRs; neither blocks the other for its own scope. Fixes #9761.


