### PR TITLE
fix(chat): dismiss the folder-suggestion tip in all windows once the session is filed

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -399,6 +399,40 @@ const evictSlotState = (state: ChatState, slotKey: string): void => {
   if (state.slotSwitchOrigin && spellings.includes(state.slotSwitchOrigin.key)) state.slotSwitchOrigin = null
 }
 
+/** Retire folder-suggestion cards for slots an authoritative list reports as
+ *  already filed.
+ *
+ *  The card is per-window Redux state, but the question it asks — "file this
+ *  unfiled session?" — is answered globally the moment ANY window files the
+ *  session: accepting the card, the sidebar row menu, and drag-to-folder all
+ *  land in PATCH /api/chat/slots/{slot}/folder, whose push_slots_update
+ *  broadcasts the new folder_id to every connected client. Without this pass
+ *  every OTHER window keeps offering a move that already happened, and
+ *  accepting there re-issues it. Deliberately unconditional on the card's
+ *  `ts`: the backend offers at most one card per slot and never re-offers
+ *  after filing, so any card for a filed slot is moot regardless of
+ *  generation. That holds only for a list that is CURRENT — a session key can
+ *  be reused after close, and a stale list then reports the PREVIOUS tenant's
+ *  folder_id against the replacement's card — so each caller must ensure its
+ *  payload is not stale relative to the suggestion stream: WS frames are
+ *  ordered with the suggestion frames on one socket, and the fetch reply is
+ *  only trusted before the first live snapshot (see its call site). Declining,
+ *  by contrast, writes nothing server-side, so a decline stays window-local
+ *  and other windows age their copy out (FOLDER_SUGGESTION_MAX_TURNS) — the
+ *  offer is still answerable there. */
+const clearFiledFolderSuggestions = (
+  state: ChatState,
+  payload: readonly { key: string; folder_id?: string }[],
+): void => {
+  if (!state.folderSuggestions) return
+  for (const s of payload) {
+    if (!s.folder_id) continue
+    // Both spellings, same as evictSlotState: some writers key through safeKey().
+    delete state.folderSuggestions[s.key]
+    delete state.folderSuggestions[safeKey(s.key)]
+  }
+}
+
 /** Read one slot's pending question card, or null.
  *
  *  A bare `map[slot]` lookup is not safe even with guarded writes: for
@@ -5494,6 +5528,7 @@ const chatSlice = createSlice({
         // even when it is empty.
         if (action.payload.length === 0 && !seenSnapshot) return
         reconcileSlotResidue(state, action.payload)
+        clearFiledFolderSuggestions(state, action.payload)
       })
       /** The other authoritative slot-list writer. A request's reply is
        *  authoritative even when empty — nothing to disambiguate — so this is
@@ -5505,6 +5540,16 @@ const chatSlice = createSlice({
       .addCase(fetchSlots.fulfilled, (state, action) => {
         if (state.slotsSnapshotSeen === true) return
         reconcileSlotResidue(state, action.payload)
+        // Gated behind the snapshot bit like the residue reconcile above, and
+        // for the same staleness reason: an HTTP reply can be OLDER than the WS
+        // stream. A filed slot's key can be reused by a fresh session that has
+        // already received its own suggestion card; a pre-reuse reply still
+        // names the key with folder_id set, and clearing on it would delete the
+        // replacement's one-shot card — which the backend never re-offers. The
+        // WS path has no such window (suggestion frames and slots frames arrive
+        // in order on one socket), so after the first live snapshot the frames
+        // own this cleanup exclusively.
+        clearFiledFolderSuggestions(state, action.payload)
       })
       .addCase(fetchHistory.fulfilled, (state, action) => {
         const { sessions, hasMore, offset, append } = action.payload

--- a/website/src/test/ChatSliceCoverage.test.tsx
+++ b/website/src/test/ChatSliceCoverage.test.tsx
@@ -87,7 +87,7 @@ const goalLoop = (
   kind: 'legacy_goal_loop', id: `loop-${slotKey}`, slotKey, message: '', idleSecs: 60,
   maxCycles, cycleCount, active, lastFireAt: 0, stoppedReason: '',
 })
-import dashboardReducer, { sseSlots } from '../store/dashboardSlice'
+import dashboardReducer, { fetchSlots, sseSlots } from '../store/dashboardSlice'
 import notificationsReducer from '../store/notificationsSlice'
 import instancesReducer from '../store/instancesSlice'
 import type { ChatMessage, ChatSlot } from '../types'
@@ -1004,6 +1004,45 @@ describe('chatSlice slot reconcile from the authoritative slots list', () => {
     expect(chat(store).slotMessages.gone).toBeUndefined()
     expect(chat(store).followups.gone).toBeUndefined()
     expect(chat(store).slotContextPct.gone).toBeUndefined()
+  })
+
+  it('retires a folder-suggestion card once any client files the session', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('front'))
+    store.dispatch(setFolderSuggestion({ slot: 'front', folderId: 'f1', folderName: 'Work', breadcrumb: 'Work' }))
+    store.dispatch(setFolderSuggestion({ slot: 'back', folderId: 'f1', folderName: 'Work', breadcrumb: 'Work' }))
+
+    // A frame that still shows both sessions unfiled leaves both cards alone.
+    store.dispatch(sseSlots([slotRow('front'), slotRow('back')]))
+    expect(chat(store).folderSuggestions.front).toBeDefined()
+    expect(chat(store).folderSuggestions.back).toBeDefined()
+
+    // Another window accepted the card (or dragged the session into a folder):
+    // the broadcast snapshot now carries folder_id, and the card must go —
+    // including for the ACTIVE slot, which the residue reconcile never touches.
+    store.dispatch(sseSlots([slotRow('front', { folder_id: 'f1' }), slotRow('back')]))
+    expect(chat(store).folderSuggestions.front).toBeUndefined()
+    expect(chat(store).folderSuggestions.back).toBeDefined()
+  })
+
+  it('trusts a fetch reply for card retirement only before the first live snapshot', async () => {
+    // Before any live frame: the reply is the only authority, so it retires.
+    apiMock.chatSlots.mockResolvedValueOnce([slotRow('s1', { folder_id: 'f1' })])
+    const cold = makeStore()
+    cold.dispatch(setFolderSuggestion({ slot: 's1', folderId: 'f1', folderName: 'Work', breadcrumb: 'Work' }))
+    await cold.dispatch(fetchSlots())
+    expect(chat(cold).folderSuggestions.s1).toBeUndefined()
+
+    // After a live frame: a reply can be STALE — a filed session's key reused
+    // by a fresh session would still carry the old tenant's folder_id, and
+    // clearing on it would delete the replacement's one-shot card (never
+    // re-offered). Live frames own the cleanup once seen.
+    apiMock.chatSlots.mockResolvedValueOnce([slotRow('s1', { folder_id: 'f1' })])
+    const warm = makeStore()
+    warm.dispatch(sseSlots([slotRow('s1')]))
+    warm.dispatch(setFolderSuggestion({ slot: 's1', folderId: 'f2', folderName: 'Later', breadcrumb: 'Later' }))
+    await warm.dispatch(fetchSlots())
+    expect(chat(warm).folderSuggestions.s1).toBeDefined()
   })
 })
 


### PR DESCRIPTION
## Summary

The "file this session in _folder_?" card (`FolderSuggestionCard`) is per-window Redux state. The backend broadcasts `slot_folder_suggestion` to every connected client, but answering the card only dispatched a window-local `clearFolderSuggestion` — so with several dashboard windows open, accepting the move in one window left every other window still offering a move that had already happened, and accepting there re-issued it.

## Fix

Ride the broadcast that already exists rather than adding a new frame or endpoint. Every filing path — card accept, sidebar row menu, drag-to-folder — lands in `PATCH /api/chat/slots/{slot}/folder`, whose `push_slots_update` pushes an authoritative `slots` snapshot (carrying `folder_id`, see `slot_projection.py`) to all clients. `chatSlice` now retires any pending suggestion for a slot that snapshot reports as filed:

- New `clearFiledFolderSuggestions` pass, wired into both authoritative slot-list writers: `sseSlots` (live frames) and `fetchSlots.fulfilled` (reconnect snapshots).
- In `fetchSlots.fulfilled` it is gated behind `slotsSnapshotSeen`, exactly like the residue reconcile and for the same reason: an HTTP reply can be older than the WS stream. A filed session’s key can be reused by a fresh session that already holds its own card; a pre-reuse reply still reports `folder_id` for that key, and clearing on it would delete the replacement’s one-shot card (never re-offered). WS frames carry no such window — suggestion and slots frames arrive in order on one socket — so after the first live snapshot the frames own the cleanup. (Found by the GPT review lane on the first revision; fixed in the second.)
- Deliberately unconditional on the card's `ts` generation, for the same one-shot reason.
- Both key spellings are deleted (`key` and `safeKey(key)`), matching `evictSlotState`.

### Deliberate non-changes

- **Declining stays window-local.** It writes nothing server-side, so other windows age their copy out via `FOLDER_SUGGESTION_MAX_TURNS` as before; syncing it would need a new endpoint for no real harm avoided (a declined offer is still answerable elsewhere).
- **No optimistic clear on the local move dispatch** (`updateSlotFolder`): a failed move rolls back, and the card must survive it. The WS echo clears only durable moves; the accepting window already clears its own card immediately, so it sees no delay.

## Testing

- 2 new store-level tests: a `slots` frame carrying `folder_id` retires the card (including for the ACTIVE slot, which the residue reconcile deliberately never touches) while unfiled slots keep theirs; and a `fetchSlots` reply retires it only before the first live snapshot — after one, a potentially stale reply is ignored and the card survives.
- `vitest run` on the four surrounding suites (ChatSliceCoverage, ChatSliceCoverageSecondPass, FolderSuggestionCard, chatSlice.slotPrune): 230 tests green on this branch.
- `tsc --noEmit` and `eslint` clean on the touched files.

No visual delta — the change is when an existing card disappears (cross-window dismissal propagation), store logic only.

no linked issue: reported directly by the maintainer in a Kiro Crew session (multi-window dashboard: tip persisted in other windows after moving the session in one)


## Pattern harvest

Not generalizable: no mechanical rule can catch this class — the defect is "a UI offer delivered by server broadcast, but retired only by window-local state" — semgrep cannot see that a Redux clear lacks a cross-client echo. Class-level review done instead: of the three composer-band cards, the question card already resolves through the server (the answer is a message), and the follow-up card's actions are inherently window-local (they pre-fill this window's composer, no durable server effect). The folder-suggestion card was the only one whose accept has a durable server-side effect (the folder move) with an existing broadcast echo left unconsumed — that echo is what this PR wires up.


