### PR TITLE
feat(cron): accept one-shot schedules over REST

### DIFF
--- a/comment-history-baseline.json
+++ b/comment-history-baseline.json
@@ -410,7 +410,7 @@
     "src/kiro_crew/mcp_cleanup.py": 2,
     "src/kiro_crew/mcp_computer.py": 4,
     "src/kiro_crew/mcp_core.py": 8,
-    "src/kiro_crew/mcp_cron.py": 12,
+    "src/kiro_crew/mcp_cron.py": 11,
     "src/kiro_crew/mcp_dashboard.py": 4,
     "src/kiro_crew/mcp_discovery.py": 18,
     "src/kiro_crew/mcp_gateway/app_call.py": 1,

--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1137,
+    "missing_code": 1135,
     "opaque_body": 18,
-    "dynamic_status": 43
+    "dynamic_status": 42
   },
-  "_compliant": 1722,
+  "_compliant": 1776,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -72,8 +72,8 @@
       "missing_code": 15
     },
     "dashboard/handlers/cron.py": {
-      "dynamic_status": 6,
-      "missing_code": 30
+      "dynamic_status": 5,
+      "missing_code": 28
     },
     "dashboard/handlers/discover.py": {
       "missing_code": 15

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -32,7 +32,7 @@ import time
 import uuid
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterator, NamedTuple
 from zoneinfo import ZoneInfo
@@ -1140,6 +1140,78 @@ def get_local_tz() -> tuple[str, ZoneInfo]:
             exc_info=True,
         )
         return "UTC", ZoneInfo("UTC")
+
+
+# Patterns for parse_time_string
+_RE_IN_DURATION = re.compile(
+    r"^in\s+(\d+)\s*(s|sec|second|seconds|m|min|minute|minutes|h|hr|hour|hours)$", re.I
+)
+_UNIT_SECS = {
+    "s": 1,
+    "sec": 1,
+    "second": 1,
+    "seconds": 1,
+    "m": 60,
+    "min": 60,
+    "minute": 60,
+    "minutes": 60,
+    "h": 3600,
+    "hr": 3600,
+    "hour": 3600,
+    "hours": 3600,
+}
+
+
+def parse_time_string(s: str) -> float | str:
+    """Parse a human time string into a Unix timestamp. Returns error string on failure.
+
+    Lives here, next to :func:`get_local_tz`, because BOTH one-shot entry points
+    need it: the ``cron_add`` MCP tool and ``POST /api/crons``. A second copy
+    would let the two drift, and "5pm" resolving to different instants depending
+    on which door the request came through is exactly the class of bug a shared
+    parser prevents. Relative forms ("in 30 minutes") are absolute already;
+    everything else is interpreted in the CONFIGURED timezone, never the
+    process's, so a gateway running in UTC still honours the user's setting.
+    """
+    s = s.strip()
+    _, tz = get_local_tz()
+    now = datetime.now(tz)
+
+    # "in 5 minutes", "in 2 hours"
+    m = _RE_IN_DURATION.match(s)
+    if m:
+        secs = int(m.group(1)) * _UNIT_SECS[m.group(2).lower()]
+        return time.time() + secs
+
+    # Try common formats with optional "tomorrow"
+    tomorrow = False
+    text = s
+    if text.lower().startswith("tomorrow"):
+        tomorrow = True
+        text = re.sub(r"^at\b\s*", "", text[8:].strip())
+
+    # "5pm", "5:30pm", "17:00", "9:30am"
+    for fmt in ("%I%p", "%I:%M%p", "%H:%M", "%I %p", "%I:%M %p"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            result = now.replace(hour=parsed.hour, minute=parsed.minute, second=0, microsecond=0)
+            if tomorrow:
+                result += timedelta(days=1)
+            elif result <= now:
+                result += timedelta(days=1)  # "5pm" when it's already 6pm → tomorrow
+            return result.timestamp()
+        except ValueError:
+            continue
+
+    # ISO-ish: "YYYY-MM-DD HH:MM", space or "T" separator, seconds optional
+    for fmt in ("%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            parsed = datetime.strptime(text, fmt).replace(tzinfo=now.tzinfo)
+            return parsed.timestamp()
+        except ValueError:
+            continue
+
+    return f"Error: could not parse time '{s}'. Examples: '5pm', 'in 30 minutes', 'tomorrow 9am'"
 
 
 def _job_tz(job: CronJob) -> ZoneInfo:

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 import time
@@ -23,6 +24,7 @@ from kiro_crew.cron import (
     CronStoreBusy,
     CronStoreUnreadable,
     is_valid_timezone,
+    parse_time_string,
 )
 from kiro_crew.cron_script import (
     _read_script_body,
@@ -53,10 +55,12 @@ from kiro_crew.validation import (
     _MODEL_NAME_RE,
     CHANNEL_ID_RE,
     CHANNEL_MAX_LEN,
+    CRON_ADD_SCHEMA,
     LEARN_ADD_SCHEMA,
     MAX_CRON_MESSAGE,
     MAX_SHORT_STRING,
     SLACK_THREAD_TS_RE,
+    FieldSpec,
     ValidationError,
     normalize_lesson_category,
     validate_string_field,
@@ -313,6 +317,148 @@ async def _resolve_and_supersede(
 # ── Cron / Lessons ──
 
 
+def _schema_field(field_name: str) -> FieldSpec | None:
+    """Return *field_name*'s :class:`FieldSpec` from ``CRON_ADD_SCHEMA``, or ``None``.
+
+    Every limit this route applies to a one-shot field is read through here
+    rather than restated, because the route's contract is that it validates the
+    same bodies the ``cron_add`` tool does: a copied limit is a limit that drifts
+    the moment the schema's is retuned, and the drift reappears as the divergence
+    this route exists to close. That covers the numeric bounds AND ``at_time``'s
+    length — a longer string than the tool accepts is how an oversized duration
+    reaches the parser in the first place.
+    """
+    for spec in CRON_ADD_SCHEMA.fields:
+        if spec.name == field_name:
+            return spec
+    return None
+
+
+def _resolve_one_shot_at(body: dict[str, Any]) -> tuple[float | None, web.Response | None]:
+    """Resolve a one-shot fire time from ``at`` / ``delay`` / ``at_time``.
+
+    Returns ``(at_ts, None)`` on success — with ``at_ts`` ``None`` when the body
+    names no one-shot at all, which is the recurring case and not an error — or
+    ``(None, response)`` carrying a 400 the caller returns verbatim.
+
+    Mirrors ``cron_add``'s **parser and precedence**: ``at`` (absolute epoch
+    seconds) wins, then ``delay`` (seconds from now), then ``at_time`` (human
+    string, parsed in the CONFIGURED timezone by the shared
+    :func:`parse_time_string`), so a one-shot body means the same instant
+    whichever door received it. The acceptance sets are NOT identical: the
+    resolved-instant ceiling below is stricter than the tool, which bounds only
+    its raw fields.
+
+    Four things this refuses that the declared type alone would let through:
+
+    * a bool for ``at``/``delay`` — ``isinstance(True, int)`` is true in Python,
+      so a bare ``isinstance`` check would silently read ``True`` as ``1``;
+    * a value ``float()`` cannot even represent. JSON integers are unbounded, and
+      ``float(10**400)`` raises ``OverflowError`` — uncaught, that is a bare 500
+      on a request that never reaches the store;
+    * a non-finite float — ``json.loads`` accepts ``NaN`` and ``Infinity`` by
+      default, and ``NaN`` defeats every comparison below (each is false), which
+      would persist a job whose next run can never arrive;
+    * a value outside the schema's own bounds. An unbounded far-future ``at`` is
+      not merely a silly job: ``format_schedule`` renders it through
+      ``datetime.fromtimestamp``, which raises above year 9999, and it does so
+      inside the comprehension that serializes EVERY job — so one poisoned
+      record turns the whole cron listing into a 500 until it is deleted by id.
+      ``{"at": 1.75e12}`` (epoch MILLIseconds — the ordinary ``Date.now()``
+      mistake) is exactly that shape, which is why the bound is enforced here
+      rather than left to the store;
+    * a time already gone, which would otherwise fire the moment the scheduler
+      next ticks rather than when the caller asked.
+    """
+
+    def _number(field: str) -> tuple[float | None, web.Response | None]:
+        spec = _schema_field(field)
+
+        def refuse(why: str) -> tuple[None, web.Response]:
+            return None, web.json_response(
+                {"error": f"'{field}' {why}", "code": f"invalid_{field}"}, status=400
+            )
+
+        raw = body.get(field)
+        if raw is None:
+            return None, None
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            return refuse("must be a number")
+        try:
+            val = float(raw)
+        except OverflowError:
+            # A JSON integer has no width limit, so this arrives from the wire.
+            # Refused as out-of-range rather than propagating: it is by definition
+            # past any ceiling the schema declares.
+            return refuse("is too large")
+        if not math.isfinite(val):
+            return refuse("must be a finite number")
+        lo = spec.min_val if spec else None
+        hi = spec.max_val if spec else None
+        if (lo is not None and val < lo) or (hi is not None and val > hi):
+            return refuse(f"must be between {lo} and {hi}")
+        return val, None
+
+    at_ts, err = _number("at")
+    if err is not None:
+        return None, err
+    if at_ts is None:
+        delay, err = _number("delay")
+        if err is not None:
+            return None, err
+        if delay is not None:
+            at_ts = time.time() + delay
+    if at_ts is None:
+        # Length from the schema, not MAX_SHORT_STRING: a string longer than the
+        # tool accepts is how an oversized relative duration ("in <hundreds of
+        # digits> hours") reaches the parser, where the arithmetic overflows.
+        at_time_spec = _schema_field("at_time")
+        at_time_max = at_time_spec.max_len if at_time_spec and at_time_spec.max_len else 100
+        try:
+            at_time = validate_string_field(body, "at_time", max_len=at_time_max)
+        except ValidationError as exc:
+            return None, web.json_response(
+                {"error": str(exc), "code": "invalid_at_time"}, status=400
+            )
+        if at_time:
+            parsed = parse_time_string(at_time)
+            if isinstance(parsed, str):
+                # parse_time_string reports failure as an already-prefixed
+                # "Error: ..." string; strip the prefix so the JSON body is not
+                # doubly labelled once the client reads `error`.
+                return None, web.json_response(
+                    {
+                        "error": parsed.removeprefix("Error: "),
+                        "code": "invalid_at_time",
+                    },
+                    status=400,
+                )
+            at_ts = parsed
+    # The resolved instant carries the same ceiling as a raw ``at``, whatever
+    # produced it. ``delay`` cannot escape its own bound, but ``at_time``'s
+    # relative form has none — ``"in 999999999 hours"`` parses to a timestamp
+    # ``datetime.fromtimestamp`` cannot render, which is the poisoned record that
+    # 500s the listing. Bounding the raw fields alone would leave that door open.
+    if at_ts is not None:
+        at_spec = _schema_field("at")
+        lo = at_spec.min_val if at_spec else None
+        hi = at_spec.max_val if at_spec else None
+        if (lo is not None and at_ts < lo) or (hi is not None and at_ts > hi):
+            return None, web.json_response(
+                {
+                    "error": f"resolved time is outside the supported range ({lo} to {hi})",
+                    "code": "at_out_of_range",
+                },
+                status=400,
+            )
+    if at_ts is not None and at_ts < time.time():
+        return None, web.json_response(
+            {"error": "requested time is in the past", "code": "at_in_past"},
+            status=400,
+        )
+    return at_ts, None
+
+
 async def api_crons_create(request: web.Request) -> web.Response:
     """POST /api/crons — create a cron job."""
     state: DashboardState = request.app["state"]
@@ -345,6 +491,13 @@ async def api_crons_create(request: web.Request) -> web.Response:
     if not every and not cron_expr and schedule:
         # Treat schedule string as cron expr if 5-field, else as interval
         cron_expr = schedule if len(schedule.split()) == 5 else None
+    # One-shot scheduling, mirroring cron_add's `at` / `delay` / `at_time`.
+    # Precedence matches the tool exactly (`at` wins, then `delay`, then
+    # `at_time`) so the same request body cannot mean two different instants
+    # depending on which entry point received it.
+    at_ts, at_err = _resolve_one_shot_at(body)
+    if at_err is not None:
+        return at_err
     if channel and not CHANNEL_ID_RE.match(channel):
         return web.json_response({"error": "invalid channel ID format"}, status=400)
     if approval_mode and approval_mode not in {"", "auto"}:
@@ -411,26 +564,40 @@ async def api_crons_create(request: web.Request) -> web.Response:
     }
     if approval_mode:
         add_kwargs["approval_mode"] = approval_mode
+    # Which schedule this job carries. Resolved to kwargs FIRST, then handed to a
+    # single add_job_async call: one call site means the store-failure handling
+    # below is written once and cannot drift between the three schedule shapes.
+    schedule_kwargs: dict[str, Any]
     if every:
         try:
             every = int(every)
         except (ValueError, TypeError):
-            return web.json_response({"error": "'every' must be an integer"}, status=400)
-        try:
-            job = await state.crons.add_job_async(name, message, every_secs=every, **add_kwargs)
-        except CronStoreBusy:
-            return web.json_response(_CRON_BUSY_BODY, status=_CRON_BUSY_STATUS)
-        except CronStoreUnreadable as exc:
-            return _cron_unreadable_response(exc)
+            return web.json_response(
+                {"error": "'every' must be an integer", "code": "invalid_every"}, status=400
+            )
+        schedule_kwargs = {"every_secs": every}
     elif cron_expr:
-        try:
-            job = await state.crons.add_job_async(name, message, cron_expr=cron_expr, **add_kwargs)
-        except CronStoreBusy:
-            return web.json_response(_CRON_BUSY_BODY, status=_CRON_BUSY_STATUS)
-        except CronStoreUnreadable as exc:
-            return _cron_unreadable_response(exc)
+        schedule_kwargs = {"cron_expr": cron_expr}
+    elif at_ts is not None:
+        # One-shot: `delete_after_run` is derived here rather than accepted from
+        # the body, exactly as cron_add derives it (`delete_after_run=bool(at_ts)`).
+        # A caller-supplied flag would allow a job with a single fire time that
+        # never leaves the store, which the scheduler has no way to run again.
+        schedule_kwargs = {"at_ts": at_ts, "delete_after_run": True}
     else:
-        return web.json_response({"error": "schedule, every, or cron required"}, status=400)
+        return web.json_response(
+            {
+                "error": "schedule, every, cron, at, delay, or at_time required",
+                "code": "missing_schedule",
+            },
+            status=400,
+        )
+    try:
+        job = await state.crons.add_job_async(name, message, **schedule_kwargs, **add_kwargs)
+    except CronStoreBusy:
+        return web.json_response(_CRON_BUSY_BODY, status=_CRON_BUSY_STATUS)
+    except CronStoreUnreadable as exc:
+        return _cron_unreadable_response(exc)
     state.push_refresh("crons")
     return web.json_response({"ok": True, "id": job.id})
 

--- a/src/kiro_crew/docs/cron-and-scheduling.md
+++ b/src/kiro_crew/docs/cron-and-scheduling.md
@@ -46,7 +46,7 @@ cron resume <id>
 | Type | Syntax | Example |
 |------|--------|---------|
 | Interval | MCP `every=<seconds>` or CLI `--every <seconds>` | `every=300` (5 min, minimum 60s) |
-| One-shot | MCP `at=<Unix timestamp>`, `delay=<seconds>`, or `at_time=<human time>` | `at_time="tomorrow 9am"` |
+| One-shot | MCP or `POST /api/crons` `at=<Unix timestamp>`, `delay=<seconds>`, or `at_time=<human time>` | `at_time="tomorrow 9am"` |
 | Cron expression | MCP `cron_expr=<5-field expression>` or CLI `--cron <expression>` | `cron_expr="0 9 * * 1-5"` (weekdays 9am) |
 
 `cron_expr` uses five fields: `min hour dom month dow`; the MCP schema documents numeric day-of-week values `0=Sun` through `6=Sat`.

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -22,7 +22,7 @@ import logging
 import os
 import re
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +42,7 @@ from kiro_crew.cron import (
     is_valid_skip_date,
     is_valid_timezone,
     lookup_cron_folder_id,
+    parse_time_string,
 )
 from kiro_crew.cron_script import (
     compute_secret_env_pin,
@@ -75,25 +76,6 @@ from kiro_crew.sel import sel
 from kiro_crew.validation import MCP_CRON_SCHEMAS, ValidationError, validate_tool_args
 
 logger = logging.getLogger(__name__)
-
-# Patterns for _parse_time_string
-_RE_IN_DURATION = re.compile(
-    r"^in\s+(\d+)\s*(s|sec|second|seconds|m|min|minute|minutes|h|hr|hour|hours)$", re.I
-)
-_UNIT_SECS = {
-    "s": 1,
-    "sec": 1,
-    "second": 1,
-    "seconds": 1,
-    "m": 60,
-    "min": 60,
-    "minute": 60,
-    "minutes": 60,
-    "h": 3600,
-    "hr": 3600,
-    "hour": 3600,
-    "hours": 3600,
-}
 
 
 def _sub_floor_timeout_note(timeout_secs_val: object) -> str:
@@ -1031,49 +1013,6 @@ def _resolve_cron_folder(ref: str, *, session_key: str | None) -> tuple[str, str
     if not fid:
         return "", f"could not create cron folder {redact(ref)}: no id returned"
     return fid, None
-
-
-def _parse_time_string(s: str) -> float | str:
-    """Parse a human time string into a Unix timestamp. Returns error string on failure."""
-    s = s.strip()
-    _, tz = get_local_tz()
-    now = datetime.now(tz)
-
-    # "in 5 minutes", "in 2 hours"
-    m = _RE_IN_DURATION.match(s)
-    if m:
-        secs = int(m.group(1)) * _UNIT_SECS[m.group(2).lower()]
-        return time.time() + secs
-
-    # Try common formats with optional "tomorrow"
-    tomorrow = False
-    text = s
-    if text.lower().startswith("tomorrow"):
-        tomorrow = True
-        text = re.sub(r"^at\b\s*", "", text[8:].strip())
-
-    # "5pm", "5:30pm", "17:00", "9:30am"
-    for fmt in ("%I%p", "%I:%M%p", "%H:%M", "%I %p", "%I:%M %p"):
-        try:
-            parsed = datetime.strptime(text, fmt)
-            result = now.replace(hour=parsed.hour, minute=parsed.minute, second=0, microsecond=0)
-            if tomorrow:
-                result += timedelta(days=1)
-            elif result <= now:
-                result += timedelta(days=1)  # "5pm" when it's already 6pm → tomorrow
-            return result.timestamp()
-        except ValueError:
-            continue
-
-    # ISO-ish: "2026-03-28 14:00", "2026-03-28T14:00"
-    for fmt in ("%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
-        try:
-            parsed = datetime.strptime(text, fmt).replace(tzinfo=now.tzinfo)
-            return parsed.timestamp()
-        except ValueError:
-            continue
-
-    return f"Error: could not parse time '{s}'. Examples: '5pm', 'in 30 minutes', 'tomorrow 9am'"
 
 
 def _list_tools() -> list[dict[str, Any]]:
@@ -2171,7 +2110,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         if delay is not None and at_ts is None:
             at_ts = time.time() + delay
         if at_time is not None and at_ts is None:
-            parsed = _parse_time_string(at_time)
+            parsed = parse_time_string(at_time)
             if isinstance(parsed, str):
                 return parsed  # error message
             at_ts = parsed

--- a/test/test_dashboard_cron_oneshot.py
+++ b/test/test_dashboard_cron_oneshot.py
@@ -1,0 +1,386 @@
+"""Tests for one-shot job creation over `POST /api/crons`.
+
+The handler's validation mirrors `CRON_ADD_SCHEMA` "so the REST + tool paths
+validate identically", so a body the `cron_add` MCP tool accepts must be accepted
+here too and must land on the same instant. These tests pin that parity for the
+one-shot fields: same names, same precedence (`at`, then `delay`, then
+`at_time`), the same derived `delete_after_run`, and the refusals the schema
+alone does not catch.
+
+Mirrors test_dashboard_cron_folder_id.py's create-path structure.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from body_stream_helpers import attach_body
+
+from kiro_crew.cron import CronService, compute_next_run_ts
+from kiro_crew.dashboard.handlers import api_crons_create
+from kiro_crew.validation import CRON_ADD_SCHEMA, MAX_SHORT_STRING
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cron_store(monkeypatch, tmp_path):
+    monkeypatch.setattr("kiro_crew.cron._DEFAULT_DIR", tmp_path)
+    yield
+
+
+def _create_request(body: dict, crons: CronService) -> MagicMock:
+    state = MagicMock()
+    state.crons = crons
+    request = MagicMock()
+    request.app = {"state": state}
+    attach_body(request, body)
+    return request
+
+
+def _body(resp) -> dict:
+    return json.loads(resp.body)
+
+
+class TestOneShotAccepted:
+    """A one-shot fire time is a valid schedule on its own."""
+
+    @pytest.mark.asyncio
+    async def test_absolute_at_creates_self_deleting_job(self):
+        crons = CronService()
+        when = time.time() + 3600
+        resp = await api_crons_create(
+            _create_request({"name": "later", "message": "ping", "at": when}, crons)
+        )
+        assert resp.status == 200
+        job = crons.list_jobs()[0]
+        assert job.schedule.at_ts == pytest.approx(when)
+        # Derived, never accepted from the body: a one-shot that outlives its
+        # single fire time can never run again.
+        assert job.delete_after_run is True
+        assert job.schedule.every_secs is None
+        assert job.schedule.cron_expr is None
+        # Stored is not the same as schedulable — assert the scheduler resolves a
+        # next run at the requested instant, so the job actually fires rather
+        # than sitting in the store with no due time.
+        assert compute_next_run_ts(job) == pytest.approx(when)
+
+    @pytest.mark.asyncio
+    async def test_delay_is_relative_to_now(self):
+        crons = CronService()
+        before = time.time()
+        resp = await api_crons_create(
+            _create_request({"name": "soon", "message": "ping", "delay": 120}, crons)
+        )
+        assert resp.status == 200
+        at_ts = crons.list_jobs()[0].schedule.at_ts
+        assert before + 120 <= at_ts <= time.time() + 120
+
+    @pytest.mark.asyncio
+    async def test_at_time_human_string_is_parsed(self):
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "human", "message": "ping", "at_time": "in 45 minutes"}, crons)
+        )
+        assert resp.status == 200
+        at_ts = crons.list_jobs()[0].schedule.at_ts
+        assert at_ts == pytest.approx(time.time() + 45 * 60, abs=30)
+
+    @pytest.mark.asyncio
+    async def test_at_wins_over_delay_and_at_time(self):
+        """Precedence matches cron_add: `at`, then `delay`, then `at_time`.
+
+        Pinned because a body carrying more than one must not mean different
+        instants depending on which entry point received it.
+        """
+        crons = CronService()
+        when = time.time() + 7200
+        resp = await api_crons_create(
+            _create_request(
+                {
+                    "name": "precedence",
+                    "message": "ping",
+                    "at": when,
+                    "delay": 60,
+                    "at_time": "in 5 minutes",
+                },
+                crons,
+            )
+        )
+        assert resp.status == 200
+        assert crons.list_jobs()[0].schedule.at_ts == pytest.approx(when)
+
+    @pytest.mark.asyncio
+    async def test_delay_wins_over_at_time(self):
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request(
+                {"name": "mid", "message": "ping", "delay": 300, "at_time": "in 5 hours"},
+                crons,
+            )
+        )
+        assert resp.status == 200
+        at_ts = crons.list_jobs()[0].schedule.at_ts
+        assert at_ts == pytest.approx(time.time() + 300, abs=30)
+
+
+class TestRecurringUnaffected:
+    """The recurring paths keep precedence over any one-shot field."""
+
+    @pytest.mark.asyncio
+    async def test_every_still_creates_a_repeating_job(self):
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "loop", "message": "ping", "every": 3600}, crons)
+        )
+        assert resp.status == 200
+        job = crons.list_jobs()[0]
+        assert job.schedule.every_secs == 3600
+        assert job.delete_after_run is False
+
+    @pytest.mark.asyncio
+    async def test_every_takes_precedence_over_at(self):
+        """`every` is checked first, so a body with both stays recurring.
+
+        Asserted rather than assumed: silently converting a recurring job to a
+        one-shot would delete it after its first run.
+        """
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request(
+                {"name": "both", "message": "ping", "every": 3600, "at": time.time() + 60},
+                crons,
+            )
+        )
+        assert resp.status == 200
+        job = crons.list_jobs()[0]
+        assert job.schedule.every_secs == 3600
+        assert job.delete_after_run is False
+
+
+class TestOneShotRefusals:
+    """Every refusal carries a machine-readable `code` (error-code contract)."""
+
+    @pytest.mark.asyncio
+    async def test_no_schedule_at_all_names_the_one_shot_fields(self):
+        crons = CronService()
+        resp = await api_crons_create(_create_request({"name": "naked", "message": "ping"}, crons))
+        assert resp.status == 400
+        body = _body(resp)
+        assert body["code"] == "missing_schedule"
+        # The message must advertise the new fields, or a caller reading only the
+        # error keeps guessing at `every`.
+        assert "at_time" in body["error"]
+        assert crons.list_jobs() == []
+
+    @pytest.mark.asyncio
+    async def test_past_at_is_refused(self):
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "gone", "message": "ping", "at": time.time() - 60}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "at_in_past"
+        assert crons.list_jobs() == []
+
+    @pytest.mark.asyncio
+    async def test_delay_below_schema_floor_is_refused(self):
+        """`delay` carries `min_val=1` in the schema, so 0 and negatives are out.
+
+        The refusal names `delay` rather than reporting a past instant: the
+        problem is the field, and `at_in_past` would point at the wrong input.
+        """
+        crons = CronService()
+        for bad in (0, -600):
+            resp = await api_crons_create(
+                _create_request({"name": "back", "message": "ping", "delay": bad}, crons)
+            )
+            assert resp.status == 400
+            assert _body(resp)["code"] == "invalid_delay"
+        assert crons.list_jobs() == []
+
+    @pytest.mark.asyncio
+    async def test_millisecond_at_is_refused(self):
+        """`Date.now()` without the /1000 is the ordinary caller mistake.
+
+        1.75e12 is finite and far-future, so only the schema's ceiling catches
+        it. Left through, `format_schedule` renders it with
+        `datetime.fromtimestamp` inside the comprehension that serializes EVERY
+        job, so one such record turns the whole listing into a 500.
+        """
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "millis", "message": "ping", "at": 1.75e12}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_at"
+        assert crons.list_jobs() == []
+
+    @pytest.mark.asyncio
+    async def test_at_above_schema_ceiling_is_refused(self):
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "far", "message": "ping", "at": 1e20}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_at"
+
+    @pytest.mark.asyncio
+    async def test_delay_above_schema_ceiling_is_refused(self):
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "distant", "message": "ping", "delay": 86400 * 40}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_delay"
+
+    @pytest.mark.asyncio
+    async def test_unbounded_relative_at_time_is_refused(self):
+        """`at_time`'s relative form has no bound of its own.
+
+        "in 999999999 hours" parses to a timestamp `datetime.fromtimestamp`
+        cannot render at all, and no `at`/`delay` check sees it — the resolved
+        instant has to carry the ceiling for the crash class to be closed.
+        """
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request(
+                {"name": "forever", "message": "ping", "at_time": "in 999999999 hours"}, crons
+            )
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "at_out_of_range"
+        assert crons.list_jobs() == []
+
+    @pytest.mark.asyncio
+    async def test_bounds_are_read_from_the_schema_not_restated(self):
+        """The route's bounds must BE the tool's bounds, not a copy of them.
+
+        Asserted against `CRON_ADD_SCHEMA` itself so retuning the schema cannot
+        silently leave this route on the old numbers — the divergence the route
+        exists to close.
+        """
+        specs = {f.name: f for f in CRON_ADD_SCHEMA.fields}
+        at_max = specs["at"].max_val
+        delay_max = specs["delay"].max_val
+        assert at_max is not None and delay_max is not None
+        crons = CronService()
+        # One tick past each ceiling is refused; the ceiling itself is not,
+        # unless it is already in the past (`at`'s ceiling is a fixed epoch).
+        resp = await api_crons_create(
+            _create_request({"name": "edge", "message": "ping", "at": at_max + 1}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_at"
+        resp = await api_crons_create(
+            _create_request({"name": "edge2", "message": "ping", "delay": delay_max + 1}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_delay"
+        resp = await api_crons_create(
+            _create_request({"name": "ok", "message": "ping", "delay": delay_max}, crons)
+        )
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_oversized_integer_at_is_refused(self):
+        """A JSON integer has no width limit, so `float()` can overflow.
+
+        `float(10**308)` raises `OverflowError`; uncaught that is a bare 500 on
+        `POST /api/crons`. Refused as out-of-range instead, since a value
+        `float` cannot hold is by definition past any declared ceiling.
+        """
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "huge", "message": "ping", "at": int("1" + "0" * 308)}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_at"
+        assert crons.list_jobs() == []
+
+    @pytest.mark.asyncio
+    async def test_oversized_integer_delay_is_refused(self):
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request(
+                {"name": "huge2", "message": "ping", "delay": int("1" + "0" * 489)}, crons
+            )
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_delay"
+        assert crons.list_jobs() == []
+
+    @pytest.mark.asyncio
+    async def test_overlong_at_time_is_refused_at_the_schema_length(self):
+        """`at_time`'s length limit must be the schema's, not the generic one.
+
+        A string longer than the tool accepts is how an oversized relative
+        duration reaches the parser, where `time.time() + secs` on a
+        several-hundred-digit int overflows into a 500. Asserted against
+        `CRON_ADD_SCHEMA` so the generic `MAX_SHORT_STRING` cannot creep back.
+        """
+        specs = {f.name: f for f in CRON_ADD_SCHEMA.fields}
+        at_time_max = specs["at_time"].max_len
+        assert at_time_max and at_time_max < MAX_SHORT_STRING
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request(
+                {"name": "verbose", "message": "ping", "at_time": "in " + "9" * 490 + " hours"},
+                crons,
+            )
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_at_time"
+        assert crons.list_jobs() == []
+
+    @pytest.mark.asyncio
+    async def test_unparseable_at_time_is_refused(self):
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "gibberish", "message": "ping", "at_time": "elevenses"}, crons)
+        )
+        assert resp.status == 400
+        body = _body(resp)
+        assert body["code"] == "invalid_at_time"
+        # The "Error: " prefix belongs to the parser's string return, not to a
+        # JSON body that already labels the field `error`.
+        assert not body["error"].startswith("Error: ")
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_at_is_refused(self):
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "stringly", "message": "ping", "at": "5pm"}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_at"
+
+    @pytest.mark.asyncio
+    async def test_bool_at_is_refused_not_read_as_one(self):
+        """`isinstance(True, int)` is true in Python, so bools need their own gate.
+
+        Without it `{"at": true}` resolves to epoch 1 — a past timestamp whose
+        refusal would name the wrong problem.
+        """
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "boolish", "message": "ping", "at": True}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_at"
+
+    @pytest.mark.asyncio
+    async def test_nan_delay_is_refused(self):
+        """`json.loads` accepts NaN, and NaN defeats the past-time comparison.
+
+        Every comparison against NaN is false, so an unguarded NaN would persist
+        a job whose next run can never arrive.
+        """
+        crons = CronService()
+        resp = await api_crons_create(
+            _create_request({"name": "nan", "message": "ping", "delay": float("nan")}, crons)
+        )
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_delay"
+        assert crons.list_jobs() == []

--- a/test/test_parse_time_string_tz.py
+++ b/test/test_parse_time_string_tz.py
@@ -1,18 +1,24 @@
-"""Tests that _parse_time_string uses config timezone, not system timezone."""
+"""Tests that parse_time_string uses config timezone, not system timezone.
+
+Patches ``kiro_crew.cron`` rather than ``kiro_crew.mcp_cron``: the parser lives
+beside ``get_local_tz`` in ``cron`` so both one-shot entry points (the
+``cron_add`` MCP tool and ``POST /api/crons``) share one implementation, and a
+patch has to target the module whose globals the function actually reads.
+"""
 
 from datetime import datetime
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
-import kiro_crew.mcp_cron as mcp_cron_mod
+import kiro_crew.cron as cron_mod
 
 
 def test_at_time_uses_config_timezone_not_system():
     """'23:59' interpreted in config tz (Pacific) should show 23:59 Pacific."""
     pacific = ZoneInfo("America/Los_Angeles")
 
-    with patch.object(mcp_cron_mod, "get_local_tz", return_value=("America/Los_Angeles", pacific)):
-        result = mcp_cron_mod._parse_time_string("23:59")
+    with patch.object(cron_mod, "get_local_tz", return_value=("America/Los_Angeles", pacific)):
+        result = cron_mod.parse_time_string("23:59")
 
     assert isinstance(result, float)
     result_pacific = datetime.fromtimestamp(result, tz=pacific)
@@ -26,7 +32,7 @@ def test_at_time_respects_different_timezones():
     Uses 23:59 to avoid flakiness — this time is almost always in the future
     regardless of when the test runs, for both Pacific and Eastern timezones.
 
-    The two ``datetime.now(tz)`` calls inside ``_parse_time_string`` must
+    The two ``datetime.now(tz)`` calls inside ``parse_time_string`` must
     observe the same wall-clock instant so that 23:59-in-Pacific and
     23:59-in-Eastern resolve to the same calendar date in their tz.
     Without this, when UTC is in the late-night-Pacific / early-morning-
@@ -47,13 +53,13 @@ def test_at_time_respects_different_timezones():
         def now(cls, tz=None):
             return fixed_utc.astimezone(tz) if tz else fixed_utc.replace(tzinfo=None)
 
-    with patch.object(mcp_cron_mod, "datetime", _FixedDatetime), \
-         patch.object(mcp_cron_mod, "get_local_tz", return_value=("America/Los_Angeles", pacific)):
-        result_pacific = mcp_cron_mod._parse_time_string("23:59")
+    with patch.object(cron_mod, "datetime", _FixedDatetime), \
+         patch.object(cron_mod, "get_local_tz", return_value=("America/Los_Angeles", pacific)):
+        result_pacific = cron_mod.parse_time_string("23:59")
 
-    with patch.object(mcp_cron_mod, "datetime", _FixedDatetime), \
-         patch.object(mcp_cron_mod, "get_local_tz", return_value=("America/New_York", eastern)):
-        result_eastern = mcp_cron_mod._parse_time_string("23:59")
+    with patch.object(cron_mod, "datetime", _FixedDatetime), \
+         patch.object(cron_mod, "get_local_tz", return_value=("America/New_York", eastern)):
+        result_eastern = cron_mod.parse_time_string("23:59")
 
     assert isinstance(result_pacific, float)
     assert isinstance(result_eastern, float)


### PR DESCRIPTION
## Problem / Motivation

`POST /api/crons` accepts only a **recurring** schedule — `every` or a cron
expression — and refuses everything else with `400 "schedule, every, or cron
required"`. The `cron_add` tool accepts `at`, `delay` and `at_time` and derives
`delete_after_run` from them, and `add_job` has taken `at_ts` /
`delete_after_run` all along.

The handler states that its validation mirrors `CRON_ADD_SCHEMA` "so the REST +
tool paths validate identically". The two doors disagreeing on which *schedules
exist* is a break in that stated contract, not a missing feature.

## Why it matters

A one-shot job is reachable only through MCP. `createCron` posting to this route
is the only create path the dashboard has, so "run this once at 5pm" is
available to an agent and impossible from the UI — and every other HTTP caller
(a script, `curl`, an integration) has the same hole. Any UI for scheduling a
one-shot has to start by fixing this route.

## What changed (motivation → approach → change)

Goal: a body either door accepts should be accepted by both, and land on the
same instant.

- **Resolution.** `_resolve_one_shot_at()` reads `at` (absolute epoch seconds),
  then `delay` (seconds from now), then `at_time` (human string) — the same
  precedence `cron_add` applies, so one body cannot mean two instants depending
  on which door received it.
- **`delete_after_run` is derived, not accepted.** `cron_add` derives it as
  `bool(at_ts)`; this route sets it alongside `at_ts` for the same reason. A
  caller-supplied flag would allow a job with a single fire time that never
  leaves the store, which the scheduler has no way to run again.
- **Shared parser.** `parse_time_string` moves from `mcp_cron` to `cron`, beside
  the `get_local_tz` it reads, because both entry points now need it and a
  second copy would let `"5pm"` resolve differently depending on the door.
- **Bounds come from the schema, not from literals.** `_schema_bounds()` reads
  `min_val` / `max_val` off `CRON_ADD_SCHEMA` (`at ≤ 4102444800`, `delay` 1s to
  30 days), so retuning the schema cannot leave this route on the old numbers —
  which is the divergence the route exists to close.

  These bounds are load-bearing, not cosmetic. A finite far-future `at` —
  `1.75e12` is just `Date.now()` without the `/1000` — passes a finite-and-not-past
  check, persists, and is then rendered by `format_schedule` through
  `datetime.fromtimestamp` *inside the comprehension that serializes every job*.
  One such record turns `GET /api/crons` into a 500 for all jobs until it is
  deleted by id out of band.

  The ceiling also applies to the **resolved** instant, not just the raw fields:
  `at_time`'s relative form carries no bound of its own, and `"in 999999999
  hours"` parses to a timestamp `fromtimestamp` cannot render at all, which no
  `at`/`delay` check would see.

  One deliberate asymmetry: this makes the route stricter than the tool for
  `at_time`, which the tool leaves unbounded — `cron_add at_time="in 999999999
  hours"` can still poison the store the same way. That is pre-existing and left
  alone here rather than bundled in; happy to follow up if you want it closed in
  `parse_time_string` (now shared by both paths, so one bound would cover them).

- **Three further refusals the type alone would allow**, each with a
  machine-readable `code`:
  - a **bool** for `at`/`delay` — `isinstance(True, int)` is true, so `{"at":
    true}` would otherwise read as epoch `1` and be refused as "in the past",
    naming the wrong problem;
  - a **non-finite** float — `json.loads` accepts `NaN`, and every comparison
    against `NaN` is false, so it would defeat the past-timestamp check and
    persist a job whose next run can never arrive;
  - a time **already past**, which would otherwise fire on the next tick rather
    than when asked.
- **One `add_job_async` call site.** The three schedule shapes now build kwargs
  and share a single call, so the `CronStoreBusy` / `CronStoreUnreadable`
  handling is written once instead of three times.

`session_key` is deliberately **not** here: `cron_add` does not take one from
the caller either — it derives it and refuses a caller it cannot name — so
adopt-on-create is an ownership decision rather than parity, and it belongs with
the UI that needs it.

`thread_ts` remains a REST/tool gap. Left out on purpose: no caller sends it
yet, and it widens this diff without a consumer.

### Baselines

Two ratchets move **downward**, both as a consequence of the consolidation
above; neither was raised to make a check pass:

- `error-code-baseline.json` — `dashboard/handlers/cron.py` `dynamic_status`
  6 → 5, `missing_code` 30 → 28 (two duplicated uncoded refusals collapse into
  one coded one).
- `comment-history-baseline.json` — `mcp_cron.py` 12 → 11 markers, which left
  with the parser.

## Tests

`test/test_dashboard_cron_oneshot.py` (new, 19 cases):

- each of `at` / `delay` / `at_time` creates a job, and `delete_after_run` is
  set;
- `compute_next_run_ts()` resolves to the requested instant — stored is not the
  same as schedulable, so the test asserts the job would actually fire;
- precedence `at` > `delay` > `at_time`;
- `every` and `cron` keep precedence over a one-shot field, so a body carrying
  both stays recurring and is **not** silently converted into a job that deletes
  itself after one run;
- the bound cases: the millisecond-`at` mistake, `at` above the ceiling, `delay`
  above and below its range, and the unbounded relative `at_time`;
- one test asserts the bounds **against `CRON_ADD_SCHEMA` itself** — one tick
  past each ceiling refused, the ceiling accepted — so a copy of the numbers
  cannot creep back in;
- every refusal above, asserted on its `code`, with the store left empty.

`test/test_parse_time_string_tz.py` patches `kiro_crew.cron` rather than
`kiro_crew.mcp_cron`, following the parser to the module whose globals it reads.

## Manual verification

N/A — unit coverage sufficient: the tests drive `api_crons_create` against a
real `CronService` on a temp store and assert through the scheduler's own
`compute_next_run_ts`, so the route, the store and the due-time computation are
all exercised. No user-visible surface changes.

Also run locally: the full cron + schedule suite (`test/*cron* test/*schedul*`,
2144 passed / 1 skipped), the error-code contract, the comment-history gate, and
black / isort / flake8 / mypy on every touched file.

## Related Issues

no linked issue: nothing open tracks the REST/tool parity gap for one-shot
schedules.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a store field or schedule shape reachable from the MCP tool path but
dropped by its HTTP counterpart, in a handler that claims schema parity with
that tool. `minimal_context` had the identical gap across all three HTTP
surfaces (#9597); this is the same class one field over. A check could compare
`CRON_ADD_SCHEMA`'s keys against what `api_crons_create` reads and fail on a
divergence that no comment documents.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
