### PR TITLE
docs(app-kit): state that hooks apps self-provision Python deps

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -642,6 +642,43 @@ symlinked sibling resolves wherever it points. Do not use a bare
 shipping a `config.py` would end up sharing one module. `from kiro_crew...`
 absolute imports are for built-in apps only.
 
+**Python dependencies.** Runtime `requirements.txt` provisioning — the
+`data/.kirocrew-deps/` tree described in the stdio `command`-resolution passage
+above (see #7878 / #7901 for the mechanism) — runs only where app code executes
+as its own process: the `backend.entryPoint` spawn path (a real file entry
+point in the app's own tree) and stdio MCP server registration. Hook code gets
+nothing from it: the tree reaches processes **spawned on the app's behalf** —
+through a `site`-processing launch shim for Python commands, on `PYTHONPATH`
+for ABI-matched others — and is never placed on the Gateway's own import path,
+because hooks run inside the Gateway process, where an app-controlled tree
+ahead of the trusted modules could shadow the Gateway's own code. That is the
+same rule that keeps `-m kiro_crew...` servers off the app deps, and it binds
+your hook code too: do not push your own tree onto `sys.path` ahead of the
+Gateway's modules from inside a hook.
+
+What serves hooks instead is the **install-time build step**: a registry
+install (which clones the app's git source) runs `pip install .` (or
+`pip install -r requirements.txt` when there is no `pyproject.toml`/`setup.py`)
+into the Gateway's own interpreter — the one that imports your hooks (see the
+publishing guide's install flow) — but only when the app's source directory
+(the `subdirectory` when one is declared) has no `package.json`, which takes
+precedence and routes the build to npm instead. Two caveats: the desktop app's
+bundled interpreter fails the build step outright, and a failed `pip` run —
+including a Gateway interpreter that has no `pip` module — fails the install
+rather than skipping the build. An app installed by other means, one whose
+`package.json` routed the build to npm, or one declaring no
+`requirements.txt`/`pyproject.toml`/`setup.py` at all, imports only the stdlib
+plus whatever the Gateway's environment already provides.
+
+If you create a directory to hold your own dependencies, do **not** name it
+`.venv`. Interpreter resolution (`resolve_app_python`) runs only for spawned
+surfaces — a backend entry point or a stdio MCP server — so a purely
+hooks-only app never triggers it; but the moment your app also declares one of
+those (now or in a later version), a real, probe-usable virtual environment at
+`<app>/.venv` becomes the interpreter for anything spawned on the app's
+behalf whenever no provisioned deps tree is active, even when it holds no
+packages at all.
+
 ## Permissions
 
 ### `permissions` — Declared Capabilities

--- a/docs/app-kit/publishing-guide.md
+++ b/docs/app-kit/publishing-guide.md
@@ -490,7 +490,8 @@ The store's Install button (`POST /api/apps/registry/install`, or the SSE varian
    app; 60s timeout) and run a detected build: `npm install` plus `npm run build`
    when `package.json` declares a build script, or `pip install .` /
    `pip install -r requirements.txt` for a Python source tree. A missing
-   toolchain is a logged skip, not a failure. **An official-catalog entry does
+   `npm` is a logged skip; the pip step runs on the gateway's own interpreter
+   and a failed run fails the install. **An official-catalog entry does
    not clone a branch**: it fetches exactly the commit the published catalog
    pins and hard-fails on any mismatch, never reuses a pre-existing checkout
    (the old one is set aside and restored if the install fails), and clones


### PR DESCRIPTION
Fixes #7879

## Symptom

An app that declares only `backend.hooks` gets no `requirements.txt` provisioning, and `docs/app-kit/manifest-reference.md`'s `backend.hooks` section said nothing about Python dependencies — an author had no way to learn the limitation, the one mechanism that does serve hooks, or the `.venv` naming trap.

## Root cause

Documentation gap. Hooks are imported into the Gateway process; runtime provisioning is deliberately reachable only from spawned surfaces, and front-placing an app-controlled tree on the Gateway's import path is forbidden by the trust rule in `_provision_app_deps_locked`'s docstring (`src/kiro_crew/apps/backend.py:1264-1277`) and the `-m kiro_crew...` carve-out (`docs/app-kit/manifest-reference.md:57-59`). Per the issue's own framing, a documented statement resolves it; the mechanism half is a platform design ruling and is out of scope here.

## Fix (documentation only — no behaviour change)

- `docs/app-kit/manifest-reference.md`: a "Python dependencies" note at the end of the `backend.hooks` section stating (1) runtime provisioning runs only on the backend-spawn and stdio-MCP paths, and hook code gets nothing from it; (2) the provisioned tree reaches spawned children via the `deps_boot` shim / `PYTHONPATH` and is never on the Gateway's import path, with the shadowing rule made binding on hook authors; (3) the install-time build step is what serves hooks, with its real gates (registry installs only, `package.json` precedence, pip failure fails the install, desktop bundled interpreter fails outright); (4) the `.venv` naming hazard, scoped to the shapes that can actually trigger it.
- `docs/app-kit/publishing-guide.md:492-494`: the pre-existing "missing toolchain is a logged skip" sentence narrowed to npm — the pip step hard-fails — because the new note cross-references this flow and the sentence was wrong for pip (code docstring staleness tracked in #9770).

## Corrections to the issue as filed

- The provisioning directory is `data/.kirocrew-deps/` (`src/kiro_crew/apps/interpreter.py:54,73`), beneath `data/` so `update_app` keeps the last good install — not the issue's hand-rolled `<app>/.python-deps`.
- The `.venv` preference is probe-narrowed since #7901: `resolve_app_python` (`interpreter.py:253-286`) prefers `<app>/.venv` only on positive evidence from an executed probe (`_venv_is_usable`, `interpreter.py:151`) and only when no provisioned tree is active. The surviving hazard — a runnable same-ABI venv holding no packages still displaces the gateway interpreter — is what the note documents.
- The issue's one-caller framing is stale: since #7901 there are two `provision_app_deps` callers (below). Companion issue #7878 is closed as completed by #7901.

## Verification (every doc claim anchored to source at the verified SHA)

- Two `provision_app_deps` callers: backend spawn `src/kiro_crew/apps/backend.py:1842` (gated on a real file entry point, `backend.py:1831-1842`) and stdio MCP registration `src/kiro_crew/apps/bridges.py:2694`. Neither is the hooks path.
- `start_app_backend` early-returns when `entryPoint` is unset: `backend.py:764-765`.
- `src/kiro_crew/apps/hooks_integration.py`: zero occurrences of `requirements`, `deps_dir`, `app_deps`, or `sys.path`.
- Transport is Shim-XOR-PYTHONPATH (`backend.py:2117-2177`): `deps_boot` (`site.addsitedir`) for Python commands, `PYTHONPATH` only on a positive ABI match; `deps_boot.py` is a launch shim for spawned app processes only — the Gateway never adds an app deps tree to its own `sys.path`.
- Install-time build: `registry.py::_run_app_build` (`registry.py:6047-6184`) runs `pip install .` / `-r requirements.txt` on `sys.executable` in the `subdirectory`-joined `app_source` (`registry.py:5970`); `package.json` takes precedence (`if`/`elif`, `registry.py:6070/6085`); npm-only soft skip (`registry.py:6081-6084`); nonzero pip fails the install (`registry.py:6177-6184`); desktop bundled interpreter fails outright (`registry.py:6123-6132`).
- Gates: full backend suite failing-id sets byte-identical BOTH directions vs an `origin/main` worktree (108 = 108 pre-existing environmental ids, identical invocation `pytest -q -n auto --dist loadgroup`). Frontend cross-surface guards: 230 files / 6,418 tests passed. `check_comment_history.py`, `docs_lint.py`, `check_black_formatting.py` all pass; no narration phrases or non-inclusive terms in the diff.
- Review: two model-pinned lanes (gpt-5.6-sol, claude-opus-5), five rounds each, converged PASS/PASS on the final prose. Adopted along the way: shim-vs-PYTHONPATH transport, the install-time-build path serving hooks, pip hard-fail vs the stale soft-skip claim, `package.json` precedence, `subdirectory` precision, `.venv` hazard scoped to spawned surfaces. Declined with evidence: bare `#NNNN` refs (precedent at `docs/app-kit/api-reference.md:210`).

<!-- no-visual-delta -->
No frontend change; the diff is documentation prose, so there is no visual delta a screenshot could evidence.

## Pattern harvest

Rule candidate: when documenting a capability gap, anchor every sentence to a source line and enumerate the reachable states exhaustively — the review rounds here showed each unanchored generalization ("via PYTHONPATH", "a missing pip is a logged skip", "always the case for a hooks-only app") concealed a real behavioural fork (`if`/`elif` precedence, npm-vs-pip asymmetry, call-site gating) that would have misled the exact audience the note targets. Knowingly out-of-scope sibling: the stale soft-skip wording in `registry.py:6062-6066`'s docstring (#9770).
