### PR TITLE
feat: session-context and automation-plumbing fixes

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -849,7 +849,6 @@ test/test_options_click_validation.py
 test/test_options_submit.py
 test/test_orphaned_approval_card.py
 test/test_outbox_binary.py
-test/test_outbox_notify_broadcast.py
 test/test_override_expiry_notice.py
 test/test_papyrus_gitops.py
 test/test_papyrus_latex.py

--- a/docs/system-specs/modules/taskrunner.md
+++ b/docs/system-specs/modules/taskrunner.md
@@ -225,6 +225,34 @@ dashboard_sources = {"text", "spec", "file", "chat", "dashboard", "mcp", "yaml"}
 | `plan()` API | `"text"`, `"spec"`, `"file"` | ✅ |
 | Cron job | must pass `source="cron"` | ❌ (filtered out) |
 
+### Decomposer Selection
+
+`run()` picks the decomposer from the spec's suffix, not from the caller. A spec whose
+path ends in `.yaml`/`.yml` is decomposed deterministically by `decompose_yaml` for
+every `source`, so a cron- or MCP-started workflow spec produces the same task DAG as
+the same file started from the dashboard. Inline YAML submitted with `source="yaml"` is
+likewise decomposed deterministically. Any other spec is decomposed by the LLM.
+
+Deny-by-default governs the invalid case, and it is keyed on whether anyone is
+watching. When an **unattended** run's `.yaml`/`.yml` spec is not workflow-shaped —
+`source` in `_UNATTENDED_SOURCES` = `{"cron", "mcp"}` — the run fails and is never
+retried through the LLM decomposer. **Attended** sources (`chat`, `dashboard`, and
+unsourced CLI runs) fall back to the LLM decomposer, because an operator is present to
+read the plan and both of those surfaces always supply a source, so a truthiness gate
+would have removed a path that worked before the rule. The SEL `decompose_yaml` `error`
+event is recorded either way.
+
+"Not workflow-shaped" includes a document YAML cannot parse at all. `decompose_yaml`
+raises `ValueError` for every rejected spec, its own shape checks and a `yaml.YAMLError`
+out of `safe_load` alike, and this gate selects on that one class — so a syntax error,
+the most ordinary way a hand-written spec is wrong, takes the same branch as a semantic
+one instead of failing an attended run that would otherwise have been given the LLM
+fallback.
+
+Every `decompose_yaml` audit event carries the run's provenance — `source` and
+`spec_name` in its metadata, and the source as its caller identity (`dashboard` for
+unsourced runs), so a denial is attributed to the surface that started the run.
+
 ### Data Types
 
 Named `TaskStatus`/`Task`/`Project` in `task_models.py`; `StepStatus`/`Step`/`TaskRun`

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -6106,7 +6106,93 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
                     cached_project_agent_names(slot.project or None) or frozenset()
                 )
                 if not is_project_agent:
-                    new_project = default_project_dir(workspace)
+                    # A slot filed into a project-linked folder keeps that
+                    # folder's directory rather than the new agent's workspace
+                    # default: the link is an explicit choice about where this
+                    # chat's tools run, and `api_chat_slot_create` already
+                    # prefers it over the workspace default — an agent pick must
+                    # not silently undo it. Resolved through the SAME helper as
+                    # the create path, which walks the parent_id chain (so a
+                    # project inherited from an ancestor folder counts too) and
+                    # RE-VALIDATES the stored path instead of trusting
+                    # folders.json: a directory recorded there can since have
+                    # been moved, or become sensitive, and this value becomes
+                    # the agent subprocess's cwd. Off the loop, as the helper's
+                    # docstring requires (realpath/isdir priming).
+                    folder_project = ""
+                    if slot.folder_id:
+                        try:
+                            # REVALIDATED against the id the snapshot was taken
+                            # for. `read_folders` and the off-loop resolve are two
+                            # awaits, and a concurrent assignment can file this
+                            # slot into a folder CREATED after the snapshot -- whose
+                            # id is then absent from it, resolving to nothing and
+                            # committing the workspace default as this chat's
+                            # directory. One retry is enough for an assignment that
+                            # has already landed; a slot being reassigned faster
+                            # than that has no stable answer to commit, so it keeps
+                            # the documented fall-through.
+                            folder_error: str | None = ""
+                            for _ in range(2):
+                                folder_id_at_read = slot.folder_id
+                                if not folder_id_at_read:
+                                    break
+                                folder_snapshot = await state.read_folders(
+                                    lambda folders: [dict(folder) for folder in folders]
+                                )
+                                folder_project, folder_error = await asyncio.to_thread(
+                                    _resolve_folder_project_dir,
+                                    folder_snapshot,
+                                    folder_id_at_read,
+                                )
+                                if slot.folder_id == folder_id_at_read:
+                                    break
+                                # Reassigned mid-resolve: what came back describes a
+                                # folder other than the one this slot now holds, so
+                                # it is discarded rather than committed.
+                                folder_project, folder_error = "", ""
+                            if folder_error:
+                                # Deliberately NOT the create path's 400: that
+                                # validator also rejects a directory that no
+                                # longer exists, so failing the request here
+                                # would make the agent permanently unswitchable
+                                # for any folder whose project was moved or
+                                # deleted. Fall through to the workspace default.
+                                logger.warning(
+                                    "Slot %s folder project unusable (%s); "
+                                    "falling back to the workspace default",
+                                    name,
+                                    folder_error,
+                                )
+                                folder_project = ""
+                        except Exception:
+                            # Same fall-through for an unreadable or corrupt
+                            # folder store: letting it reach the outer handler
+                            # would leave the workspace advanced with the
+                            # project stale — a half-applied switch.
+                            logger.warning(
+                                "Failed to resolve folder project for slot %s", name, exc_info=True
+                            )
+                            folder_project = ""
+                    if folder_project:
+                        new_project = folder_project
+                    elif ws_name not in ("default", cfg.default_workspace):
+                        # Only a workspace the agent RESOLVED TO DELIBERATELY may
+                        # retarget the project. Two names fail that test and both
+                        # have to be excluded:
+                        #
+                        # * the literal "default" — `_workspace_name_for_dir`
+                        #   answers it both for an agent bound to no workspace and
+                        #   for one naming a workspace absent from the config;
+                        # * `cfg.default_workspace` — on an install that renames
+                        #   its default, the resolver falls back to that NAME, so
+                        #   the same "no deliberate choice" case arrives spelled
+                        #   differently and a literal-only gate lets it through.
+                        #
+                        # Either way the agent expressed no workspace preference,
+                        # and retargeting on a fallback discards the directory the
+                        # user chose and runs the next turn's tools elsewhere.
+                        new_project = default_project_dir(workspace)
         except Exception:
             logger.warning("Failed to resolve agent bindings for %r", agent_name, exc_info=True)
 

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -46,6 +46,7 @@ from kiro_crew.config.loader import (
     update_config_locked,
 )
 from kiro_crew.dashboard import part_stream, upload_destination
+from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
 from kiro_crew.dashboard.chat_utils import (
     dashboard_slot_key,
     drained_to_thread,
@@ -53,6 +54,7 @@ from kiro_crew.dashboard.chat_utils import (
 )
 from kiro_crew.dashboard.file_index import _SKIP_DIRS as _WALK_SKIP_DIRS
 from kiro_crew.dashboard.handlers._shared import _probe_persisted_session, read_bounded_json
+from kiro_crew.dashboard.handlers.messaging import _resolve_session_target
 from kiro_crew.dashboard.origin import is_direct_local_request
 from kiro_crew.dashboard.state import (
     VALID_MEMORY_MODES,
@@ -99,8 +101,71 @@ mimetypes.add_type(
 
 _INLINE_DISPOSITION_PREFIXES = frozenset({"audio/", "video/", "image/", "application/pdf"})
 
+#: Session-key namespace of a sub-agent run. A sub-agent has no tab of its own, so
+#: its file card belongs to the PARENT's tab — the surface every other sub-agent
+#: output already routes to (``subagent_manager.monitoring``'s completion
+#: injection, ``chat_utils.subagent_event_slot``'s WS frames).
+_SUBAGENT_SESSION_PREFIX = "subagent:"
+
 
 logger = logging.getLogger(__name__)
+
+
+def _subagent_parent_session_key(state: DashboardState, session_key: str) -> str:
+    """The parent session key of the sub-agent running under *session_key*, or ``""``.
+
+    Matches on BOTH spellings a run can be keyed by — its ``conversation_key`` (a
+    continuable run) and ``subagent:<id>`` — the same comparison
+    ``subagent_manager.continuation`` makes, because a continuable run's key is not
+    derivable from its id. Returns ``""`` when the manager is absent or the run is
+    unknown, so the caller SUPPRESSES the card rather than guessing a tab.
+    """
+    manager = getattr(state, "subagents", None)
+    if manager is None:
+        return ""
+    try:
+        # A PROPERTY, not a method (``subagent.py`` ``@property all_agents``).
+        # Calling it invoked the returned LIST, so every lookup raised TypeError,
+        # the except below swallowed it, and the card was suppressed for every
+        # sub-agent -- the routing this function exists to do never happened once.
+        agents = list(manager.all_agents)
+    except Exception:
+        logger.warning("outbox notify: sub-agent roster unavailable", exc_info=True)
+        return ""
+    matches = [
+        info
+        for info in agents
+        if (getattr(info, "conversation_key", "") or f"{_SUBAGENT_SESSION_PREFIX}{info.id}")
+        == session_key
+    ]
+    if not matches:
+        return ""
+    # More than one record can carry ONE key: a continuation is minted as a new run
+    # whose ``conversation_key`` is the original's ``subagent:<id>``, and the
+    # original (spawned with an empty conversation_key) resolves to that same
+    # string. Their parents differ whenever a DIFFERENT session continued the
+    # conversation -- so taking the first match routes the card to whichever chat
+    # happens to sit earlier in the roster, which is the PREVIOUS owner's tab.
+    #
+    # Newest ACTIVE run wins: a live run is the one the card belongs to, and among
+    # equals the most recently started. Ranked rather than filtered so a roster of
+    # only-finished records still answers with the latest instead of nothing.
+
+    def _rank(info: object) -> tuple[int, float]:
+        # Defensive reads: a stubbed manager can hand back non-bool/non-number here,
+        # and a comparison against those raises inside the sort rather than routing.
+        done = getattr(info, "done", False)
+        started = getattr(info, "started", 0.0)
+        return (
+            0 if (done is True) else 1,
+            float(started) if isinstance(started, (int, float)) else 0.0,
+        )
+
+    best = max(matches, key=_rank)
+    parent = getattr(best, "parent_session_key", "")
+    # isinstance, not truthiness: a stubbed manager can hand back a
+    # non-str here and dashboard_slot_key would treat it as a key.
+    return parent if isinstance(parent, str) else ""
 
 
 def _sel():
@@ -335,40 +400,98 @@ async def api_outbox_notify(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": f"Binary file type not allowed: {guessed_type or 'unknown'}"}, status=400
             )
-    # Inject into the caller's chat slot so the card persists in the correct session
-    if state._slots:
-        # Prefer the caller's own slot via X-Session-Key header
-        session_key = request.headers.get("X-Session-Key", "").strip()
-        active = None
-        if session_key.startswith("cron:"):
-            # A cron slot is named cron-<id>, which is not the session key folded.
-            active = state.get_slot(f"cron-{session_key.removeprefix('cron:')}")
-        else:
-            # A channel-born conversation keeps its channel key (slack:<ts>)
-            # while its tab is open, so the slot name comes from the surface
-            # lookup — stripping a "dashboard:" prefix would miss it and drop the
-            # card into whichever tab happened to be active last.
-            slot_key = dashboard_slot_key(session_key)
-            if slot_key:
-                active = state.get_slot(slot_key)
-        # An explicitly header-targeted slot receives the file even when empty
-        header_targeted = active is not None
-        # Fallback: most recently active slot
-        if not active:
-            active = max(
-                state._slots.values(),
-                key=lambda s: s.messages[-1]["ts"] if s.messages else "",
-            )
-        if active and (active.messages or header_targeted):
-            # Route through the context-aware redact() so a loaded companion's
-            # extra credential regexes scrub the broadcast file JSON too — the
-            # same overlay-aware pass the filename/path/description gates use.
-            redacted_file_json = redact(json.dumps(file_data))
-            # append_and_surface = the same conditional-broadcast pattern this
-            # site pioneered, now also stamping ``ts`` + ``meta.mid`` on the
-            # reader-suppressed frame so a client seeing the row through two
-            # doors recognises it instead of rendering a duplicate card.
-            append_and_surface(state, active, "file", redacted_file_json)
+    # Inject the file card into the caller's chat slot so it persists in the
+    # correct session. This runs even when ``state._slots`` is empty: a headless
+    # script cron typically has no dashboard tab open at all, and its origin slot
+    # is rehydrated from history below — gating the whole block on
+    # ``if state._slots`` skipped exactly that case.
+    # Prefer the caller's own slot via X-Session-Key header
+    session_key = request.headers.get("X-Session-Key", "").strip()
+    active = None
+    if session_key.startswith("cron:"):
+        # A cron slot is named cron-<job-id>, which is not the session key folded.
+        # Only the JOB ID: a cron turn's key can carry a further segment
+        # (`cron:<job>:<run>` for a per-run session, `cron:<job>:<agent>` for a
+        # multi-agent one), and folding the whole tail asks for a `cron-<job>:<run>`
+        # slot that never exists — so every suffixed turn missed its own open tab
+        # and fell through to origin resolution or suppression.
+        job_id = session_key.removeprefix("cron:").split(":", 1)[0]
+        active = state.get_slot(f"cron-{job_id}")
+        if active is None:
+            # A headless script cron has no live "cron-<id>" slot. Rather than
+            # leak the card into whichever tab happens to be focused, route it to
+            # the cron's ORIGIN dashboard session — the chat that created the cron
+            # — through the same resolver ``send_message(session="origin")`` uses,
+            # so both delivery paths agree on where a cron's output belongs.
+            origin_slot_key, _origin_job = _resolve_session_target(state, "origin", session_key)
+            if origin_slot_key:
+                # get_slot is the hot path (O(1)); on a miss the origin session
+                # exists on disk but has no tab open, so rehydrate it — with the
+                # transcript read off the loop, the shape the sibling origin path
+                # established, because a large store would otherwise stall the
+                # gateway. A truly-gone session (never persisted, deleted, or
+                # closed) returns None and falls through to suppression below; no
+                # phantom empty tab is ever created.
+                active = state.get_slot(origin_slot_key)
+                if active is None:
+                    active = await rehydrate_slot_from_history_async(state, origin_slot_key)
+    elif session_key.startswith(_SUBAGENT_SESSION_PREFIX):
+        # A sub-agent has no tab of its own, so route its card to the PARENT slot
+        # — the same destination its completion injection and its ``subagent_*`` WS
+        # frames already use. Only the dedicated-process arm arrives here: a
+        # shared-runtime sub-agent's MCP stub carries the parent's own key and is
+        # resolved by the branch below. An unknown run or a parent with no open tab
+        # yields "" and falls through to suppression — never into an unrelated
+        # conversation.
+        parent_key = _subagent_parent_session_key(state, session_key)
+        parent_slot_key = dashboard_slot_key(parent_key) if parent_key else ""
+        if parent_slot_key:
+            active = state.get_slot(parent_slot_key)
+    else:
+        # A channel-born conversation keeps its channel key (slack:<ts>)
+        # while its tab is open, so the slot name comes from the surface
+        # lookup — stripping a "dashboard:" prefix would miss it and drop the
+        # card into whichever tab happened to be active last.
+        slot_key = dashboard_slot_key(session_key)
+        if slot_key:
+            active = state.get_slot(slot_key)
+    # An explicitly header-targeted slot receives the file even when empty
+    header_targeted = active is not None
+    # Fallback: most recently active slot — ONLY for a legacy headerless caller,
+    # the best-effort case it was written for. A key that IS present but resolves
+    # to nothing names a session we could not reach (a cron with no originating
+    # chat, an unknown job, a sub-agent whose parent has no tab, a task-runner or
+    # webhook session that owns no chat, a closed tab); suppress the card rather
+    # than surface it in an unrelated conversation.
+    if not active and not session_key and state._slots:
+        active = max(
+            state._slots.values(),
+            key=lambda s: s.messages[-1]["ts"] if s.messages else "",
+        )
+    delivered = False
+    if active is not None and (active.messages or header_targeted):
+        delivered = True
+        # Route through the context-aware redact() so a loaded companion's
+        # extra credential regexes scrub the broadcast file JSON too — the
+        # same overlay-aware pass the filename/path/description gates use.
+        redacted_file_json = redact(json.dumps(file_data))
+        # append_and_surface = the same conditional-broadcast pattern this
+        # site pioneered, now also stamping ``ts`` + ``meta.mid`` on the
+        # reader-suppressed frame so a client seeing the row through two
+        # doors recognises it instead of rendering a duplicate card.
+        append_and_surface(state, active, "file", redacted_file_json)
+    else:
+        # Suppression is the RIGHT outcome — better nowhere than in an unrelated
+        # conversation — but it is silent, and a caller that reads `ok: true` has
+        # no way to tell a delivered card from a vanished one. So say so once, at
+        # the only point that knows both that a key was supplied and that it
+        # resolved to no destination. The key is logged because it is the whole
+        # diagnosis (which namespace, which id); the file is already named in the
+        # audit event below.
+        logger.info(
+            "outbox notify: no destination for session key %r; file card suppressed",
+            session_key or "<none>",
+        )
 
     _sel().log_tool_invocation(
         session_key="api",
@@ -376,7 +499,11 @@ async def api_outbox_notify(request: web.Request) -> web.Response:
         tool_name="file_send",
         tool_kind="notify",
         outcome="completed",
-        resources=f"filename={file_data['filename']}",
+        # `delivered` distinguishes the two outcomes this endpoint folds into one
+        # 200: the card reached a session, or it was suppressed for want of a
+        # destination. Carried here rather than as a separate SEL outcome so the
+        # existing "completed" consumers keep working.
+        resources=f"filename={file_data['filename']} delivered={int(delivered)}",
     )
     return web.json_response({"ok": True})
 

--- a/src/kiro_crew/task_planner.py
+++ b/src/kiro_crew/task_planner.py
@@ -533,6 +533,14 @@ def decompose_yaml(yaml_content: str) -> list[Task]:
     """Parse a YAML workflow definition directly into Task objects.
 
     Bypasses the LLM decomposer entirely — depends_on is enforced as-is.
+
+    Every "this is not a valid workflow spec" outcome leaves here as
+    ``ValueError``, INCLUDING an unparseable document. Callers distinguish a
+    rejected spec from a broken runtime by that class alone (``taskrunner``
+    decides between the LLM fallback and a hard failure on it), so leaking
+    ``yaml``'s own exception hierarchy through would make a syntax error — the
+    most ordinary way for a hand-written spec to be wrong — take the runtime
+    path instead.
     """
     if len(yaml_content) > _MAX_YAML_SIZE:
         raise ValueError(f"YAML too large ({len(yaml_content)} bytes, max {_MAX_YAML_SIZE})")
@@ -542,7 +550,10 @@ def decompose_yaml(yaml_content: str) -> list[Task]:
         raise ImportError(
             "PyYAML is required for YAML workflow decomposition: pip install PyYAML"
         ) from exc
-    wf = _yaml.safe_load(yaml_content)
+    try:
+        wf = _yaml.safe_load(yaml_content)
+    except _yaml.YAMLError as exc:
+        raise ValueError(f"YAML is not parseable: {exc}") from exc
     if not wf or not isinstance(wf, dict) or "agents" not in wf:
         raise ValueError("YAML must have an 'agents' key with agent definitions")
 

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -98,6 +98,10 @@ _HEARTBEAT_INTERVAL = 30  # watchdog checks process liveness every 30s
 _DEAD_THRESHOLD = 2  # consecutive dead checks before fail-fast reset
 _RESULT_MEM_CAP = 4000  # truncate task.result in memory after step completes
 _WORKFLOW_RESULT_SUMMARY_CAP = 120
+# Sources with no operator watching the run: an invalid workflow spec must fail
+# with the SEL denial rather than degrade to the LLM decomposer. Attended sources
+# (chat, dashboard, CLI/unsourced) keep the fallback.
+_UNATTENDED_SOURCES = frozenset({"cron", "mcp"})
 
 
 class WorkflowRunPublisher(Protocol):
@@ -220,25 +224,42 @@ def _read_spec_prefix(path: str, max_chars: int) -> str:
         return spec_file.read(max_chars).strip()
 
 
-def _decompose_yaml_with_audit(yaml_content: str, task_id: str) -> list[Task]:
-    """Decompose YAML with SEL audit logging."""
+def _decompose_yaml_with_audit(
+    yaml_content: str,
+    task_id: str,
+    source: str = "",
+    spec_name: str = "",
+) -> list[Task]:
+    """Decompose YAML with SEL audit logging.
+
+    ``source``/``spec_name`` carry the run's provenance. Without them a
+    cron/MCP-sourced denial is recorded against ``dashboard`` — the one surface
+    that did not start the run — which makes the audit trail unusable for
+    exactly the unattended callers it exists to record.
+    """
+    metadata: dict[str, Any] = {"task_id": task_id}
+    if source:
+        metadata["source"] = source
+    if spec_name:
+        metadata["spec_name"] = spec_name
+    caller = source or "dashboard"
     try:
         tasks = decompose_yaml(yaml_content)
         sel().log_tool_invocation(
-            session_key="dashboard",
+            session_key=caller,
             source="taskrunner",
             tool_name="decompose_yaml",
             outcome="ok",
-            metadata={"task_id": task_id, "task_count": len(tasks)},
+            metadata={**metadata, "task_count": len(tasks)},
         )
         return tasks
     except Exception as exc:
         sel().log_tool_invocation(
-            session_key="dashboard",
+            session_key=caller,
             source="taskrunner",
             tool_name="decompose_yaml",
             outcome="error",
-            metadata={"task_id": task_id, "error": str(exc)},
+            metadata={**metadata, "error": str(exc)},
         )
         raise
 
@@ -672,7 +693,12 @@ class TaskRunner:
                 self._ctx, session_key, f"{_SESSION_PREFIX}:{task_id}:runtime"
             )
             if source == "yaml":
-                run.tasks = _decompose_yaml_with_audit(decompose_input, task_id)
+                run.tasks = _decompose_yaml_with_audit(
+                    decompose_input,
+                    task_id,
+                    source=source,
+                    spec_name=Path(spec_path).name if spec_path else "",
+                )
             else:
                 try:
                     run.tasks = await asyncio.wait_for(
@@ -1027,11 +1053,25 @@ class TaskRunner:
             await self._apersist_runs()  # persist immediately so crash recovery works
             await self._notify("\U0001f680 Task started", f"Spec: `{spec_path.name}`", run=run)
             if source == "yaml":
-                run.tasks = _decompose_yaml_with_audit(spec_content, task_id)
-            elif not source and spec_path.suffix in (".yaml", ".yml"):
+                run.tasks = _decompose_yaml_with_audit(
+                    spec_content, task_id, source=source, spec_name=spec_path.name
+                )
+            elif spec_path.suffix in (".yaml", ".yml"):
+                # The suffix decides the decomposer, not the caller: a cron- or
+                # MCP-sourced workflow spec must decompose deterministically too.
                 try:
-                    run.tasks = _decompose_yaml_with_audit(spec_content, task_id)
+                    run.tasks = _decompose_yaml_with_audit(
+                        spec_content, task_id, source=source, spec_name=spec_path.name
+                    )
                 except (ValueError, KeyError):
+                    # Deny by default for UNATTENDED callers (cron/MCP): nobody is
+                    # watching, so an invalid spec fails with the audit trail above
+                    # rather than degrading to the unaudited LLM decomposer.
+                    # Attended callers (chat, dashboard, CLI) keep the fallback —
+                    # an operator is present to see the plan, and `/task run
+                    # <file>.yaml` on a non-workflow YAML worked before the gate.
+                    if source in _UNATTENDED_SOURCES:
+                        raise
                     logger.warning(
                         "YAML spec %s is not in workflow format; falling back to LLM decomposition",
                         spec_path.name,

--- a/test/test_chat_slot_agent_project_scope.py
+++ b/test/test_chat_slot_agent_project_scope.py
@@ -1,0 +1,208 @@
+"""Project-scope rules for the dashboard agent-switch handler.
+
+``api_chat_slot_agent`` re-derives ``slot.project`` from the newly selected
+agent's bindings, and that value becomes the next turn's subprocess cwd. Two
+carve-outs keep the derivation from discarding a directory the user deliberately
+chose:
+
+* a slot filed into a project-linked sidebar folder keeps that folder's
+  directory, so file search and tools stay in the folder's repo;
+* an agent that resolves to the DEFAULT workspace (bound to none, or naming one
+  absent from the config) leaves ``slot.project`` alone, so such a pick does not
+  silently move the chat to the default workspace root.
+
+These tests pin both carve-outs, plus the cases that must keep resetting.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app_with_agent_routes, _make_state
+
+MOD = "kiro_crew.dashboard.chat_handlers"
+
+_WORKSPACE_DEFAULT_DIR = "/workspace/default"
+_WORKSPACE_DEV_DIR = "/workspace/dev"
+
+
+def _stub_agent_resolution(
+    monkeypatch, *, ws_name: str, workspace_dir: str, default_workspace: str = "default"
+) -> None:
+    """Make the switch resolve ``dev`` as a config alias bound to *ws_name*.
+
+    *default_workspace* is set explicitly rather than left to the MagicMock: the
+    handler compares ``ws_name`` against it, and an auto-attribute is never equal
+    to anything, so a test would pass whether or not that comparison exists.
+    """
+    mock_cfg = MagicMock()
+    # A config alias, so the project-scope carve-out above does not apply.
+    mock_cfg.agents = {"dev": MagicMock(workspace=ws_name)}
+    mock_cfg.default_workspace = default_workspace
+
+    mock_bindings = MagicMock()
+    mock_bindings.workspace_dir = Path(workspace_dir)
+    mock_bindings.requested_resolved = True
+
+    monkeypatch.setattr(f"{MOD}.KiroCrewConfig.load", lambda: mock_cfg)
+    monkeypatch.setattr(
+        f"{MOD}.resolve_agent_bindings", lambda cfg, name, project_dir=None: mock_bindings
+    )
+    monkeypatch.setattr(f"{MOD}._workspace_name_for_dir", lambda cfg, ws_dir: ws_name)
+    monkeypatch.setattr(f"{MOD}.warm_project_agent_names", AsyncMock())
+    monkeypatch.setattr(f"{MOD}.cached_project_agent_names", lambda project_dir: frozenset())
+    monkeypatch.setattr(f"{MOD}.default_project_dir", lambda ws: workspace_dir)
+
+
+class TestChatSlotAgentProjectScope:
+    @pytest.mark.asyncio
+    async def test_agent_switch_preserves_folder_project_dir(self, tmp_path, monkeypatch):
+        """A slot in a project-linked folder keeps that folder's directory.
+
+        Without this the agent pick retargets the slot at the new agent's
+        workspace default, and the folder's repo silently stops being the cwd.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        folder_dir = tmp_path / "folder-repo"
+        folder_dir.mkdir()
+        state = _make_state(tmp_path)
+        state._folders = [{"id": "f1", "name": "Repo", "project_dir": str(folder_dir)}]
+        slot = state.get_or_create_slot("s1")
+        slot.folder_id = "f1"
+        slot.project = str(folder_dir)
+        state.sessions.reset = AsyncMock()
+        _stub_agent_resolution(monkeypatch, ws_name="dev-ws", workspace_dir=_WORKSPACE_DEV_DIR)
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "dev"})
+            assert resp.status == 200
+            assert slot.project == str(
+                folder_dir
+            ), f"agent switch clobbered the folder project: {slot.project!r}"
+
+    @pytest.mark.asyncio
+    async def test_agent_switch_inherits_ancestor_folder_project_dir(self, tmp_path, monkeypatch):
+        """The folder project is inherited from the nearest configured ancestor."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        folder_dir = tmp_path / "parent-repo"
+        folder_dir.mkdir()
+        state = _make_state(tmp_path)
+        state._folders = [
+            {"id": "parent", "name": "Parent", "project_dir": str(folder_dir)},
+            {"id": "child", "name": "Child", "parent_id": "parent"},
+        ]
+        slot = state.get_or_create_slot("s1")
+        slot.folder_id = "child"
+        slot.project = str(folder_dir)
+        state.sessions.reset = AsyncMock()
+        _stub_agent_resolution(monkeypatch, ws_name="dev-ws", workspace_dir=_WORKSPACE_DEV_DIR)
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "dev"})
+            assert resp.status == 200
+            assert slot.project == str(folder_dir)
+
+    @pytest.mark.asyncio
+    async def test_agent_switch_preserves_project_when_agent_resolves_to_default(
+        self, tmp_path, monkeypatch
+    ):
+        """An agent resolving to the DEFAULT workspace leaves the project alone.
+
+        ``_workspace_name_for_dir`` answers the literal "default" for an agent
+        bound to no workspace and for one naming a workspace absent from the
+        config, so without the gate every such pick discards the user's choice.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        picked = tmp_path / "picked"
+        picked.mkdir()
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.project = str(picked)
+        state.sessions.reset = AsyncMock()
+        _stub_agent_resolution(monkeypatch, ws_name="default", workspace_dir=_WORKSPACE_DEFAULT_DIR)
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "dev"})
+            assert resp.status == 200
+            assert slot.project == str(
+                picked
+            ), f"default-resolving agent clobbered the project: {slot.project!r}"
+
+    @pytest.mark.asyncio
+    async def test_agent_switch_preserves_project_on_a_RENAMED_default_workspace(
+        self, tmp_path, monkeypatch
+    ):
+        """The same fallback, spelled differently.
+
+        On an install that renames its default workspace, the resolver falls back
+        to that NAME rather than the literal "default", so a literal-only gate lets
+        the fallback through and the project is clobbered on exactly the installs
+        that configured a default.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        picked = tmp_path / "picked"
+        picked.mkdir()
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.project = str(picked)
+        state.sessions.reset = AsyncMock()
+        _stub_agent_resolution(
+            monkeypatch,
+            ws_name="house-default",
+            workspace_dir=_WORKSPACE_DEFAULT_DIR,
+            default_workspace="house-default",
+        )
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "dev"})
+            assert resp.status == 200
+            assert slot.project == str(
+                picked
+            ), f"renamed-default agent clobbered the project: {slot.project!r}"
+
+    @pytest.mark.asyncio
+    async def test_agent_switch_retargets_project_for_named_workspace(self, tmp_path, monkeypatch):
+        """A folder-less slot still follows a NAMED workspace (control).
+
+        The reset is deliberate for this case — file search must not stay scoped
+        to the previous workspace — so the two carve-outs above must not widen
+        into an unconditional preserve.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.project = "/old/project"
+        state.sessions.reset = AsyncMock()
+        _stub_agent_resolution(monkeypatch, ws_name="dev-ws", workspace_dir=_WORKSPACE_DEV_DIR)
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "dev"})
+            assert resp.status == 200
+            assert slot.project == _WORKSPACE_DEV_DIR
+
+    @pytest.mark.asyncio
+    async def test_agent_switch_survives_unusable_folder_project(self, tmp_path, monkeypatch):
+        """A folder whose project directory is gone must not block the switch.
+
+        The create path answers 400 for an invalid folder project; doing that
+        here would make the agent permanently unswitchable for any folder whose
+        directory was moved or deleted, so the switch falls through instead.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state._folders = [
+            {"id": "f1", "name": "Gone", "project_dir": str(tmp_path / "deleted-repo")}
+        ]
+        slot = state.get_or_create_slot("s1")
+        slot.folder_id = "f1"
+        slot.project = "/old/project"
+        state.sessions.reset = AsyncMock()
+        _stub_agent_resolution(monkeypatch, ws_name="dev-ws", workspace_dir=_WORKSPACE_DEV_DIR)
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "dev"})
+            assert resp.status == 200
+            assert slot.project == _WORKSPACE_DEV_DIR

--- a/test/test_decompose_yaml.py
+++ b/test/test_decompose_yaml.py
@@ -174,6 +174,28 @@ def test_empty_agents():
         decompose_yaml("agents: {}")
 
 
+@pytest.mark.parametrize(
+    "body",
+    [
+        "agents:\n  first: [unterminated\n",  # flow sequence never closed
+        "agents:\n\tfirst: {}\n",  # tab indentation
+        'agents: "unterminated\n',  # quoted scalar never closed
+    ],
+)
+def test_unparseable_yaml_is_a_value_error(body):
+    """A document YAML cannot parse is a REJECTED SPEC, same class as a bad shape.
+
+    ``safe_load`` raises out of its own hierarchy (``yaml.YAMLError``), and
+    callers select behaviour on the class: ``taskrunner`` gives an attended
+    caller the LLM fallback for a ``ValueError`` and fails the run for anything
+    else. Leaking the parser class would put the single most common authoring
+    mistake — a syntax error — on the failure path while every semantic mistake
+    took the fallback.
+    """
+    with pytest.raises(ValueError, match="not parseable"):
+        decompose_yaml(body)
+
+
 # ── Size limits ──
 
 

--- a/test/test_outbox_notify_broadcast.py
+++ b/test/test_outbox_notify_broadcast.py
@@ -3,11 +3,12 @@
 Verifies that api_outbox_notify broadcasts a chat_message event (not file_ready)
 so the frontend receives the file card in real-time via the existing WebSocket handler.
 """
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -87,6 +88,11 @@ def _make_state_with_two_slots():
     state = MagicMock()
     state._slots = {"chat-1": slot_1, "chat-2": slot_2}
     state.get_slot = MagicMock(side_effect=lambda slot_name: state._slots.get(slot_name))
+    # ``_resolve_session_target`` iterates ``state.crons.list_jobs(...)``; a bare
+    # MagicMock is not iterable, so cron-key tests need a real list here. Tests
+    # that want an origin override it with their own job.
+    state.crons = MagicMock()
+    state.crons.list_jobs = MagicMock(return_value=[])
     return state, slot_1, slot_2
 
 
@@ -98,7 +104,9 @@ def _make_state_with_cron_and_chat_slots():
     """
     cron_slot = MagicMock()
     cron_slot.key = "cron-daily-digest"
-    cron_slot.messages = [{"role": "assistant", "content": "digest", "ts": "2026-05-27T20:00:00+00:00"}]
+    cron_slot.messages = [
+        {"role": "assistant", "content": "digest", "ts": "2026-05-27T20:00:00+00:00"}
+    ]
 
     def fake_append_cron(role, content, cls="", **kwargs):
         msg = {
@@ -114,7 +122,9 @@ def _make_state_with_cron_and_chat_slots():
 
     chat_slot = MagicMock()
     chat_slot.key = "chat-2"
-    chat_slot.messages = [{"role": "assistant", "content": "newer", "ts": "2026-05-27T21:00:00+00:00"}]
+    chat_slot.messages = [
+        {"role": "assistant", "content": "newer", "ts": "2026-05-27T21:00:00+00:00"}
+    ]
 
     def fake_append_chat(role, content, cls="", **kwargs):
         msg = {
@@ -131,6 +141,10 @@ def _make_state_with_cron_and_chat_slots():
     state = MagicMock()
     state._slots = {"cron-daily-digest": cron_slot, "chat-2": chat_slot}
     state.get_slot = MagicMock(side_effect=lambda slot_name: state._slots.get(slot_name))
+    # See _make_state_with_two_slots: keep ``list_jobs`` iterable so a cron key
+    # that misses its live slot reaches origin resolution instead of a TypeError.
+    state.crons = MagicMock()
+    state.crons.list_jobs = MagicMock(return_value=[])
     return state, cron_slot, chat_slot
 
 
@@ -199,12 +213,15 @@ class TestOutboxNotifyBroadcast:
         wav.write_bytes(b"\x00" * 100)
         state, slot = _make_state_with_slot()
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post("/api/outbox/notify", json={
-                "path": str(wav),
-                "filename": "test.wav",
-                "description": "audio clip",
-                "size": 100,
-            })
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(wav),
+                    "filename": "test.wav",
+                    "description": "audio clip",
+                    "size": 100,
+                },
+            )
             assert resp.status == 200
             state.broadcast_ws.assert_called_once()
             call_args = state.broadcast_ws.call_args
@@ -221,12 +238,15 @@ class TestOutboxNotifyBroadcast:
         wav.write_bytes(b"\x00" * 50)
         state, slot = _make_state_with_slot()
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post("/api/outbox/notify", json={
-                "path": str(wav),
-                "filename": "clip.wav",
-                "description": "test",
-                "size": 50,
-            })
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(wav),
+                    "filename": "clip.wav",
+                    "description": "test",
+                    "size": 50,
+                },
+            )
             assert resp.status == 200
             broadcast_ts = state.broadcast_ws.call_args[0][1]["ts"]
             persisted_ts = slot.messages[-1]["ts"]
@@ -239,12 +259,15 @@ class TestOutboxNotifyBroadcast:
         wav.write_bytes(b"\x00" * 50)
         state = MagicMock(_slots={})
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post("/api/outbox/notify", json={
-                "path": str(wav),
-                "filename": "orphan.wav",
-                "description": "no slot",
-                "size": 50,
-            })
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(wav),
+                    "filename": "orphan.wav",
+                    "description": "no slot",
+                    "size": 50,
+                },
+            )
             assert resp.status == 200
             state.broadcast_ws.assert_not_called()
 
@@ -255,12 +278,15 @@ class TestOutboxNotifyBroadcast:
         mp3.write_bytes(b"\xff\xfb\x90\x00" + b"\x00" * 50)
         state, slot = _make_state_with_slot()
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post("/api/outbox/notify", json={
-                "path": str(mp3),
-                "filename": "track.mp3",
-                "description": "music",
-                "size": 54,
-            })
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(mp3),
+                    "filename": "track.mp3",
+                    "description": "music",
+                    "size": 54,
+                },
+            )
             assert resp.status == 200
             slot.append.assert_called_once()
             call_args = slot.append.call_args
@@ -277,12 +303,15 @@ class TestOutboxNotifyBroadcast:
         wav.write_bytes(b"\x00" * 50)
         state, slot = _make_state_with_slot(has_reader=False)
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post("/api/outbox/notify", json={
-                "path": str(wav),
-                "filename": "no_dup.wav",
-                "description": "dedup test",
-                "size": 50,
-            })
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(wav),
+                    "filename": "no_dup.wav",
+                    "description": "dedup test",
+                    "size": 50,
+                },
+            )
             assert resp.status == 200
             state.broadcast_ws.assert_not_called()
 
@@ -301,7 +330,12 @@ class TestOutboxNotifySlotTargeting:
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
                 "/api/outbox/notify",
-                json={"path": str(wav), "filename": "voice.wav", "description": "test", "size": 100},
+                json={
+                    "path": str(wav),
+                    "filename": "voice.wav",
+                    "description": "test",
+                    "size": 100,
+                },
                 headers={"X-Session-Key": "dashboard:chat-1"},
             )
             assert resp.status == 200
@@ -319,7 +353,12 @@ class TestOutboxNotifySlotTargeting:
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
                 "/api/outbox/notify",
-                json={"path": str(wav), "filename": "fallback.wav", "description": "test", "size": 100},
+                json={
+                    "path": str(wav),
+                    "filename": "fallback.wav",
+                    "description": "test",
+                    "size": 100,
+                },
             )
             assert resp.status == 200
             # slot_2 has newer ts — max heuristic picks it
@@ -329,21 +368,90 @@ class TestOutboxNotifySlotTargeting:
             assert broadcast_payload["slot"] == "chat-2"
 
     @pytest.mark.asyncio
-    async def test_notify_falls_back_when_session_key_slot_not_found(self, outbox, mock_sel):
-        """B3: Header present but slot doesn't exist → graceful fallback to max heuristic."""
+    async def test_notify_suppresses_card_when_session_key_slot_not_found(self, outbox, mock_sel):
+        """B3: Header present but slot doesn't exist → card is SUPPRESSED, not
+        leaked to an unrelated slot. A present-but-unresolved X-Session-Key
+        denotes a session with no live slot; falling back to the
+        most-recently-active slot would surface the card in whatever session the
+        user happens to have focused (the file_send card-leak bug)."""
         wav = outbox / "stale.wav"
         wav.write_bytes(b"\x00" * 100)
         state, slot_1, slot_2 = _make_state_with_two_slots()
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
                 "/api/outbox/notify",
-                json={"path": str(wav), "filename": "stale.wav", "description": "test", "size": 100},
+                json={
+                    "path": str(wav),
+                    "filename": "stale.wav",
+                    "description": "test",
+                    "size": 100,
+                },
                 headers={"X-Session-Key": "dashboard:nonexistent-slot"},
             )
             assert resp.status == 200
-            # Slot not found → fallback picks slot_2 (newer ts)
-            slot_2.append.assert_called_once()
+            # Present-but-unresolved key → no slot receives the card
             slot_1.append.assert_not_called()
+            slot_2.append.assert_not_called()
+            state.broadcast_ws.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_suppressed_card_is_distinguishable_in_the_audit(self, outbox, mock_sel):
+        """Suppression is right, but it must not read as delivery.
+
+        The endpoint answers 200 either way and records one ``completed`` event
+        either way, so without a marker the vanished card and the delivered one
+        are the same event and there is nothing to diagnose from.
+        """
+        wav = outbox / "vanished.wav"
+        wav.write_bytes(b"\x00" * 100)
+        state, slot_1, slot_2 = _make_state_with_two_slots()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(wav),
+                    "filename": "vanished.wav",
+                    "description": "test",
+                    "size": 100,
+                },
+                headers={"X-Session-Key": "dashboard:nonexistent-slot"},
+            )
+            assert resp.status == 200
+        notified = [
+            call.kwargs
+            for call in mock_sel.log_tool_invocation.call_args_list
+            if call.kwargs.get("tool_kind") == "notify"
+        ]
+        assert len(notified) == 1
+        assert notified[0]["outcome"] == "completed"
+        assert "delivered=0" in notified[0]["resources"]
+
+    @pytest.mark.asyncio
+    async def test_a_delivered_card_says_so_in_the_same_field(self, outbox, mock_sel):
+        """The marker's other value, so the pair is what distinguishes them."""
+        wav = outbox / "landed.wav"
+        wav.write_bytes(b"\x00" * 100)
+        state, slot_1, slot_2 = _make_state_with_two_slots()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(wav),
+                    "filename": "landed.wav",
+                    "description": "test",
+                    "size": 100,
+                },
+                headers={"X-Session-Key": "dashboard:chat-1"},
+            )
+            assert resp.status == 200
+        slot_1.append.assert_called_once()
+        notified = [
+            call.kwargs
+            for call in mock_sel.log_tool_invocation.call_args_list
+            if call.kwargs.get("tool_kind") == "notify"
+        ]
+        assert len(notified) == 1
+        assert "delivered=1" in notified[0]["resources"]
 
     @pytest.mark.asyncio
     async def test_notify_targets_cron_slot_from_cron_session_key(self, outbox, mock_sel):
@@ -355,7 +463,12 @@ class TestOutboxNotifySlotTargeting:
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
                 "/api/outbox/notify",
-                json={"path": str(wav), "filename": "digest.wav", "description": "test", "size": 100},
+                json={
+                    "path": str(wav),
+                    "filename": "digest.wav",
+                    "description": "test",
+                    "size": 100,
+                },
                 headers={"X-Session-Key": "cron:daily-digest"},
             )
             assert resp.status == 200
@@ -363,12 +476,49 @@ class TestOutboxNotifySlotTargeting:
             chat_slot.append.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_notify_falls_back_when_cron_slot_not_found(self, outbox, mock_sel):
-        """B5: cron:{id} key with NO matching cron-{id} slot → graceful fallback
-        to the max-heuristic (this state has no cron-daily-digest slot)."""
+    @pytest.mark.parametrize("suffix", [":run-42", ":team-alpha"])
+    async def test_a_suffixed_cron_key_still_finds_its_own_tab(self, outbox, mock_sel, suffix):
+        """A cron turn's key can carry a further segment.
+
+        `cron:<job>:<run>` for a per-run session and `cron:<job>:<agent>` for a
+        multi-agent one are both real shapes, and the slot is named for the JOB
+        alone. Folding the whole tail asks for a `cron-<job>:<run>` slot that never
+        exists, so every suffixed turn missed its own open tab and fell through to
+        origin resolution or suppression.
+        """
+        wav = outbox / "digest.wav"
+        wav.write_bytes(b"\x00" * 100)
+        state, cron_slot, chat_slot = _make_state_with_cron_and_chat_slots()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(wav),
+                    "filename": "digest.wav",
+                    "description": "test",
+                    "size": 100,
+                },
+                headers={"X-Session-Key": f"cron:daily-digest{suffix}"},
+            )
+            assert resp.status == 200
+            cron_slot.append.assert_called_once()
+            chat_slot.append.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_routes_to_cron_origin_when_no_live_slot(self, outbox, mock_sel):
+        """B5: cron:{id} key with NO matching cron-{id} slot (a headless script
+        cron with no live dashboard slot) routes the card to the cron's ORIGIN
+        dashboard session — the chat that created the cron — mirroring
+        send_message(session="origin"). It must NOT leak into the
+        most-recently-active dashboard slot."""
         wav = outbox / "cron.wav"
         wav.write_bytes(b"\x00" * 100)
         state, slot_1, slot_2 = _make_state_with_two_slots()
+        # The "daily-digest" cron was created from dashboard chat-1 (the older
+        # slot). slot_2 is newer, so the old max-heuristic would have leaked the
+        # card there — origin resolution must override that.
+        job = MagicMock(id="daily-digest", session_key="dashboard:chat-1")
+        state.crons.list_jobs = MagicMock(return_value=[job])
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
                 "/api/outbox/notify",
@@ -376,9 +526,222 @@ class TestOutboxNotifySlotTargeting:
                 headers={"X-Session-Key": "cron:daily-digest"},
             )
             assert resp.status == 200
-            # No cron-daily-digest slot → fallback picks slot_2 (newer ts)
+            # Origin is chat-1 → slot_1 receives the card, not the newer slot_2
+            slot_1.append.assert_called_once()
+            slot_2.append.assert_not_called()
+            broadcast_payload = state.broadcast_ws.call_args[0][1]
+            assert broadcast_payload["slot"] == "chat-1"
+
+    @pytest.mark.asyncio
+    async def test_notify_suppresses_card_when_cron_origin_unresolvable(self, outbox, mock_sel):
+        """B5b: cron:{id} key with NO live cron-{id} slot AND no resolvable origin
+        (a cron created from the dashboard UI with no originating chat, or an
+        unknown job) → card SUPPRESSED, not leaked into the most-recently-active
+        dashboard slot."""
+        wav = outbox / "orphan_cron.wav"
+        wav.write_bytes(b"\x00" * 100)
+        state, slot_1, slot_2 = _make_state_with_two_slots()
+        # No job matches the cron id → origin unresolvable
+        state.crons.list_jobs = MagicMock(return_value=[])
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(wav),
+                    "filename": "orphan_cron.wav",
+                    "description": "test",
+                    "size": 100,
+                },
+                headers={"X-Session-Key": "cron:unknown-job"},
+            )
+            assert resp.status == 200
+            slot_1.append.assert_not_called()
+            slot_2.append.assert_not_called()
+            state.broadcast_ws.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_rehydrates_cron_origin_slot_on_get_slot_miss(self, outbox, mock_sel):
+        """B5c: the COMMON headless case — a script cron running with NO dashboard
+        tab open, so state._slots is EMPTY. The origin slot is not loaded, so on
+        the get_slot miss the handler rehydrates it from history (off the loop,
+        mirroring send_message(session="origin")) and delivers the card there. A
+        cold-rehydrated slot has no live reader, so delivery goes through append's
+        own _on_message callback, not an explicit broadcast."""
+        wav = outbox / "cold.wav"
+        wav.write_bytes(b"\x00" * 100)
+        # No dashboard tabs open at all → state._slots is empty
+        state = MagicMock()
+        state._slots = {}
+        state.get_slot = MagicMock(return_value=None)
+        job = MagicMock(id="daily-digest", session_key="dashboard:chat-cold")
+        state.crons = MagicMock()
+        state.crons.list_jobs = MagicMock(return_value=[job])
+        # The origin session exists on disk; rehydration returns a COLD slot
+        # (no live reader — faithful to a session with no open tab).
+        cold = MagicMock()
+        cold.key = "chat-cold"
+        cold._has_reader = False
+        cold.messages = [
+            {"role": "assistant", "content": "prev", "ts": "2026-05-27T19:00:00+00:00"}
+        ]
+
+        def fake_append_cold(role, content, cls="", **kwargs):
+            msg = {
+                "role": role,
+                "content": content,
+                "ts": "2026-05-27T22:00:00+00:00",
+                "meta": {**(kwargs.get("meta") or {}), "mid": f"m-cold-{len(cold.messages)}"},
+            }
+            cold.messages.append(msg)
+            return msg
+
+        cold.append = MagicMock(side_effect=fake_append_cold)
+        with patch(
+            "kiro_crew.dashboard.handlers.files.rehydrate_slot_from_history_async",
+            new_callable=AsyncMock,
+            return_value=cold,
+        ) as mock_rehydrate:
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.post(
+                    "/api/outbox/notify",
+                    json={
+                        "path": str(wav),
+                        "filename": "cold.wav",
+                        "description": "test",
+                        "size": 100,
+                    },
+                    headers={"X-Session-Key": "cron:daily-digest"},
+                )
+                assert resp.status == 200
+                # get_slot("chat-cold") missed → rehydrated from history
+                mock_rehydrate.assert_awaited_once_with(state, "chat-cold")
+                cold.append.assert_called_once()
+                content = json.loads(cold.append.call_args[0][1])
+                assert content["filename"] == "cold.wav"
+                state.broadcast_ws.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_suppresses_when_cron_origin_slot_gone(self, outbox, mock_sel):
+        """B5d: origin resolves to a slot key, but the session is truly gone
+        (never persisted, deleted, or closed) so rehydration also returns None →
+        card SUPPRESSED. Two live slots are seeded to prove the card is not leaked
+        into a focused slot either."""
+        wav = outbox / "gone_cron.wav"
+        wav.write_bytes(b"\x00" * 100)
+        state, slot_1, slot_2 = _make_state_with_two_slots()
+        job = MagicMock(id="daily-digest", session_key="dashboard:chat-gone")
+        state.crons.list_jobs = MagicMock(return_value=[job])
+        with patch(
+            "kiro_crew.dashboard.handlers.files.rehydrate_slot_from_history_async",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_rehydrate:
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.post(
+                    "/api/outbox/notify",
+                    json={
+                        "path": str(wav),
+                        "filename": "gone_cron.wav",
+                        "description": "test",
+                        "size": 100,
+                    },
+                    headers={"X-Session-Key": "cron:daily-digest"},
+                )
+                assert resp.status == 200
+                mock_rehydrate.assert_awaited_once_with(state, "chat-gone")
+                slot_1.append.assert_not_called()
+                slot_2.append.assert_not_called()
+                state.broadcast_ws.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_routes_a_subagent_card_to_its_parent_slot(self, outbox, mock_sel):
+        """B7: a dedicated-process sub-agent has no tab of its own, so its card
+        belongs to the PARENT's tab — the surface its completion injection and its
+        ``subagent_*`` WS frames already route to. Suppressing it instead would let
+        ``file_send`` answer "File sent" with nothing on screen anywhere."""
+        wav = outbox / "sub.wav"
+        wav.write_bytes(b"\x00" * 100)
+        state, slot_1, slot_2 = _make_state_with_two_slots()
+        # A PLAIN LIST, because the real ``all_agents`` is a @property. Doubling it
+        # as a callable is what let the production `manager.all_agents()` bug pass:
+        # the double accepted the call, the real object raised TypeError, and the
+        # card was suppressed for every sub-agent.
+        state.subagents.all_agents = [
+            MagicMock(id="a1", conversation_key="", parent_session_key="dashboard:chat-1")
+        ]
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={"path": str(wav), "filename": "sub.wav", "description": "t", "size": 100},
+                headers={"X-Session-Key": "subagent:a1"},
+            )
+            assert resp.status == 200
+            slot_1.append.assert_called_once()
+            slot_2.append.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_routes_a_continuation_to_its_own_parent(self, outbox, mock_sel):
+        """Two records can carry ONE key, and the card belongs to the LIVE one.
+
+        A continuation is minted as a new run whose ``conversation_key`` is the
+        original's ``subagent:<id>``, and the original resolves to that same string.
+        When a DIFFERENT session continued the conversation the two parents differ,
+        so taking the first match routes the card to the PREVIOUS owner's chat --
+        another user's tab. The newest active run is the right answer.
+        """
+        wav = outbox / "cont.wav"
+        wav.write_bytes(b"\x00" * 100)
+        state, slot_1, slot_2 = _make_state_with_two_slots()
+        # Roster order puts the ORIGINAL first, so a first-match scan picks it.
+        state.subagents.all_agents = [
+            MagicMock(
+                id="orig",
+                conversation_key="",
+                parent_session_key="dashboard:chat-1",
+                done=True,
+                started=100.0,
+            ),
+            MagicMock(
+                id="cont",
+                conversation_key="subagent:orig",
+                parent_session_key="dashboard:chat-2",
+                done=False,
+                started=200.0,
+            ),
+        ]
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={"path": str(wav), "filename": "cont.wav", "description": "t", "size": 100},
+                headers={"X-Session-Key": "subagent:orig"},
+            )
+            assert resp.status == 200
             slot_2.append.assert_called_once()
             slot_1.append.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_suppresses_an_unknown_subagents_card(self, outbox, mock_sel):
+        """B7b: an unknown run (reaped, or a manager that cannot answer) yields no
+        parent, so the card is suppressed rather than guessed into a focused tab."""
+        wav = outbox / "sub_unknown.wav"
+        wav.write_bytes(b"\x00" * 100)
+        state, slot_1, slot_2 = _make_state_with_two_slots()
+        state.subagents.all_agents = []
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/outbox/notify",
+                json={
+                    "path": str(wav),
+                    "filename": "sub_unknown.wav",
+                    "description": "t",
+                    "size": 100,
+                },
+                headers={"X-Session-Key": "subagent:gone"},
+            )
+            assert resp.status == 200
+            slot_1.append.assert_not_called()
+            slot_2.append.assert_not_called()
+            state.broadcast_ws.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_notify_appends_to_empty_header_targeted_slot(self, outbox, mock_sel):
@@ -390,7 +753,12 @@ class TestOutboxNotifySlotTargeting:
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
                 "/api/outbox/notify",
-                json={"path": str(wav), "filename": "first.wav", "description": "test", "size": 100},
+                json={
+                    "path": str(wav),
+                    "filename": "first.wav",
+                    "description": "test",
+                    "size": 100,
+                },
                 headers={"X-Session-Key": "dashboard:chat-1"},
             )
             assert resp.status == 200
@@ -415,12 +783,15 @@ class TestOutboxNotifyRedaction:
             side_effect=lambda s: s.replace("http://evil.com", "[REDACTED_URL]"),
         ) as mock_redact:
             async with TestClient(TestServer(_make_app(state))) as client:
-                resp = await client.post("/api/outbox/notify", json={
-                    "path": str(wav),
-                    "filename": "test.wav",
-                    "description": "exfil http://evil.com payload",
-                    "size": 100,
-                })
+                resp = await client.post(
+                    "/api/outbox/notify",
+                    json={
+                        "path": str(wav),
+                        "filename": "test.wav",
+                        "description": "exfil http://evil.com payload",
+                        "size": 100,
+                    },
+                )
                 assert resp.status == 200
                 assert mock_redact.called
                 # Both append and broadcast must receive redacted content

--- a/test/test_taskrunner_coverage.py
+++ b/test/test_taskrunner_coverage.py
@@ -179,6 +179,216 @@ class TestDecomposeYamlWithAudit:
         assert kwargs["outcome"] == "error"
         assert kwargs["metadata"]["task_id"] == "plan_2"
 
+    def test_provenance_is_recorded_when_supplied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A sourced denial is attributed to its origin, not to the dashboard."""
+        audit = MagicMock()
+        monkeypatch.setattr(tr, "sel", lambda: audit)
+        with pytest.raises(ValueError):
+            tr._decompose_yaml_with_audit(
+                "not: a workflow\n", "plan_3", source="cron", spec_name="wf.yaml"
+            )
+        kwargs = audit.log_tool_invocation.call_args.kwargs
+        assert kwargs["session_key"] == "cron"
+        assert kwargs["metadata"]["source"] == "cron"
+        assert kwargs["metadata"]["spec_name"] == "wf.yaml"
+
+
+# ── YAML spec routing in run() ──
+
+
+class TestYamlSpecDecomposeRouting:
+    """A ``.yaml``/``.yml`` spec decomposes deterministically for every source."""
+
+    @staticmethod
+    def _write(tmp_path: Path, body: str, name: str = "wf.yaml") -> Path:
+        spec = tmp_path / name
+        spec.write_text(body, encoding="utf-8", newline="\n")
+        return spec
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("source", ["cron", "mcp"])
+    async def test_sourced_workflow_spec_bypasses_llm(self, tmp_path: Path, source: str) -> None:
+        spec = self._write(tmp_path, _YAML_SPEC)
+        runner = _runner(tmp_path)
+        with (
+            patch.object(TaskRunner, "_decompose", AsyncMock()) as dec,
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
+            run = await runner.run(spec, task_id="yaml_1", source=source)
+        dec.assert_not_awaited()
+        assert [t.index for t in run.tasks] == [1, 2]
+        assert run.tasks[1].depends_on == [1]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("source", ["cron", "mcp"])
+    async def test_sourced_invalid_spec_denies_llm_fallback(
+        self, tmp_path: Path, source: str
+    ) -> None:
+        spec = self._write(tmp_path, "not: a workflow\n")
+        runner = _runner(tmp_path)
+        with (
+            patch.object(TaskRunner, "_decompose", AsyncMock()) as dec,
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
+            run = await runner.run(spec, task_id="yaml_2", source=source)
+        dec.assert_not_awaited()
+        assert run.status == "failed"
+        assert run.tasks == []
+
+    @pytest.mark.asyncio
+    async def test_sourced_denial_audit_carries_provenance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        audit = MagicMock()
+        monkeypatch.setattr(tr, "sel", lambda: audit)
+        spec = self._write(tmp_path, "not: a workflow\n")
+        runner = _runner(tmp_path)
+        with (
+            patch.object(TaskRunner, "_decompose", AsyncMock()),
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
+            run = await runner.run(spec, task_id="yaml_3", source="cron")
+        assert run.status == "failed"
+        denials = [
+            call.kwargs
+            for call in audit.log_tool_invocation.call_args_list
+            if call.kwargs.get("tool_name") == "decompose_yaml"
+            and call.kwargs.get("outcome") == "error"
+        ]
+        assert len(denials) == 1
+        assert denials[0]["session_key"] == "cron"
+        assert denials[0]["metadata"]["source"] == "cron"
+        assert denials[0]["metadata"]["spec_name"] == "wf.yaml"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("source", ["chat", "dashboard"])
+    async def test_attended_invalid_spec_still_falls_back_to_llm(
+        self, tmp_path: Path, source: str
+    ) -> None:
+        """Attended surfaces keep the LLM fallback for a non-workflow ``.yaml``.
+
+        ``/task run <file>.yaml`` (``source="chat"``) and the dashboard both always
+        supply a source, so a truthiness gate would have killed a path that worked
+        before the deny-by-default rule — with an operator right there to read the
+        plan the LLM produces.
+        """
+        spec = self._write(tmp_path, "not: a workflow\n")
+        runner = _runner(tmp_path)
+        with (
+            patch.object(
+                TaskRunner,
+                "_decompose",
+                AsyncMock(return_value=[Task(index=1, title="T", description="d")]),
+            ) as dec,
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
+            run = await runner.run(spec, task_id=f"yaml_att_{source}", source=source)
+        dec.assert_awaited_once()
+        assert [t.title for t in run.tasks] == ["T"]
+
+    #: A spec that YAML itself cannot parse — an unterminated flow sequence, so
+    #: ``safe_load`` raises out of the scanner rather than returning a mapping
+    #: the shape checks then reject. This is the ORDINARY way a hand-written
+    #: spec is wrong, and it takes a different code path from a parseable
+    #: non-workflow document: the shape checks raise ``ValueError``, the parser
+    #: raises ``yaml.YAMLError``, and only one of those two classes is what the
+    #: routing gate below decides on.
+    _UNPARSEABLE = "agents:\n  first: [unterminated\n"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("source", ["chat", "dashboard"])
+    async def test_attended_unparseable_spec_still_falls_back_to_llm(
+        self, tmp_path: Path, source: str
+    ) -> None:
+        """A syntax error is a rejected spec, not a broken runtime.
+
+        The attended fallback is selected on the exception class, so a spec that
+        fails in the scanner has to arrive as the same class as one that fails a
+        shape check. Otherwise the most common authoring mistake is the one case
+        the fallback does not cover, and an operator watching a plan get built
+        instead sees the run fail.
+        """
+        spec = self._write(tmp_path, self._UNPARSEABLE)
+        runner = _runner(tmp_path)
+        with (
+            patch.object(
+                TaskRunner,
+                "_decompose",
+                AsyncMock(return_value=[Task(index=1, title="T", description="d")]),
+            ) as dec,
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
+            run = await runner.run(spec, task_id=f"yaml_unp_{source}", source=source)
+        dec.assert_awaited_once()
+        assert [t.title for t in run.tasks] == ["T"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("source", ["cron", "mcp"])
+    async def test_sourced_unparseable_spec_is_still_denied(
+        self, tmp_path: Path, source: str
+    ) -> None:
+        """Normalizing the parser error must not open the unattended path."""
+        spec = self._write(tmp_path, self._UNPARSEABLE)
+        runner = _runner(tmp_path)
+        with (
+            patch.object(TaskRunner, "_decompose", AsyncMock()) as dec,
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
+            run = await runner.run(spec, task_id=f"yaml_unp_deny_{source}", source=source)
+        dec.assert_not_awaited()
+        assert run.status == "failed"
+        assert run.tasks == []
+
+    @pytest.mark.asyncio
+    async def test_local_invalid_spec_still_falls_back_to_llm(self, tmp_path: Path) -> None:
+        """Unsourced (local) runs keep the pre-existing LLM fallback."""
+        spec = self._write(tmp_path, "not: a workflow\n")
+        runner = _runner(tmp_path)
+        with (
+            patch.object(
+                TaskRunner,
+                "_decompose",
+                AsyncMock(return_value=[Task(index=1, title="T", description="d")]),
+            ) as dec,
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
+            run = await runner.run(spec, task_id="yaml_4")
+        dec.assert_awaited_once()
+        assert [t.title for t in run.tasks] == ["T"]
+
+    @pytest.mark.asyncio
+    async def test_sourced_markdown_spec_still_uses_llm(self, tmp_path: Path) -> None:
+        """Widening the suffix gate must not divert non-YAML specs."""
+        spec = self._write(tmp_path, _YAML_SPEC, name="TASK.md")
+        runner = _runner(tmp_path)
+        with (
+            patch.object(
+                TaskRunner,
+                "_decompose",
+                AsyncMock(return_value=[Task(index=1, title="T", description="d")]),
+            ) as dec,
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "init_workspace", AsyncMock()),
+        ):
+            run = await runner.run(spec, task_id="yaml_5", source="cron")
+        dec.assert_awaited_once()
+        assert [t.title for t in run.tasks] == ["T"]
+
 
 # ── current_run ──
 


### PR DESCRIPTION
## Problem / Motivation

Four session-context and automation-plumbing fixes ported by content from open code
reviews on the retiring predecessor product, which shares no git history with this
repo. Each is hand-written against the current design and carries a test that fails
on the pre-image. The changes are independent — grouped by subsystem, not
dependency — so this can be split if a reviewer would rather take it in pieces.

1. **Switching a session's agent moved it off its folder's project and workspace.** `api_chat_slot_agent` recomputed the project from the workspace default and never consulted the slot's folder.
2. **A headless cron's `file_send` card was broadcast** rather than routed to the cron's origin session; a card whose session cannot be resolved landed in whichever tab was focused.
3. **A sub-agent's `file_send` card had no destination.** A sub-agent has no tab of its own, so its card took the suppression path.
4. **A `.yaml` workflow spec only decomposed deterministically under interactive source**, an invalid unattended spec degraded silently to the LLM decomposer, and an UNPARSEABLE spec failed outright on every source because the parser's exception class was not the one the fallback gate selects on.

**Nothing here touches an agent or tool-scope surface.** `task_run`'s `agent`
parameter — the fifth item earlier revisions carried — is split out; see below.

## Why it matters

Item 1 is a wrong-context bug: a session quietly leaves its folder's project with
nothing on screen saying so, and the next turn's tools run in another repository.
Items 2 and 3 lose user-visible output outright — the card lands in an unrelated
conversation, or nowhere. Item 4 removes an unaudited LLM decomposition from the
unattended path, where nobody is watching to notice it happened, and stops a plain
YAML syntax error from being the one authoring mistake the attended fallback does
not cover.

## What changed (motivation → approach → change)

**Item 1.** One precedence ladder (project-scope agent → folder project → workspace
default) feeding the existing commit-token CAS, rather than a second recomputation
that could disagree with the folder. The ladder also declines to move the project
when the chosen agent resolves to the *default* workspace — under either spelling,
the literal `"default"` or a renamed `cfg.default_workspace`, because on an install
that renames its default the resolver falls back to that name and a literal-only
gate would clobber the project on exactly the installs that configured one.

**Items 2 and 3.** One resolver per origin shape: a cron routes to the session that
created it (through the same resolver `send_message(session="origin")` uses), a
sub-agent routes to its parent slot (the destination its completion injection and
`subagent_*` frames already use, ranked newest-active so a re-run does not resolve a
previous owner's tab), and anything that resolves to no destination is **suppressed**
rather than surfaced in an unrelated conversation. Suppression is the right outcome
but it was silent — the endpoint answers `ok: true` either way — so the audit event
carries `delivered=0|1` and the suppression is logged with the key that failed to
resolve. The cron slot lookup takes the JOB ID only: a cron turn's key can carry a
further segment (`cron:<job>:<run>`, `cron:<job>:<agent>`), and folding the whole
tail asked for a slot that never exists, so every suffixed turn missed its own tab.

**Item 4.** Deny-by-default for unattended callers. This is a behaviour change for a
pre-existing cron whose `.yaml` is not workflow-shaped: it now fails rather than
degrading. The failure is user-visible — the raise reaches `run()`'s outer handler,
which emits a `❌ Task error` notification and a failed run, not a silent SEL-only
event. Every `decompose_yaml` audit event also carries the run's provenance, so a
denial is attributed to the surface that started the run rather than to `dashboard`.
Separately, `decompose_yaml` normalizes a `yaml.YAMLError` out of `safe_load` to
`ValueError`, so *every* rejected spec leaves it as one class: the gate selects the
attended fallback on that class, and leaking the parser's class put a syntax error on
the failure path while every semantic mistake took the fallback.

## Withdrawn and split out

Three pieces earlier revisions carried have left this PR. All three for the same
reason — they are not fixes this PR is titled for, and each carries an open question
of its own that should not hold four verified fixes.

- **`learn_add` from automation sessions** (with the run-origin provenance it needs).
  Admitting `taskrunner:` / `subagent:` / `hook:` / `cron:` sessions to the durable
  memory-write path means each must inherit the spawning conversation's
  incognito/temporary ban, on identity that cannot be forged, for every automation
  key shape. Five review rounds each found a further real gap: a cross-run agent
  fallback; an origin that did not survive a restart; an origin dropped by `run()`'s
  rebuild; extraction bound to whichever run cold-started the shared background
  session; provenance resolved through a forgeable `/proc` walk; an uncovered `cron:`
  namespace; `taskrunner:{id}:decompose` unstripped, so the phase that runs for
  *every* task run resolved to a nonexistent id and failed open; and continuation
  keys resolving a previous owner's record. Each fix was correct; the set was not
  converging, because the fragile part is inferring authorization from the *shape* of
  a session key. It returns with an explicit unforgeable origin recorded where the
  run is created, one resolver every namespace routes through, and a tri-state origin
  (verified / unknown / restricted) so an unverifiable identity fails **closed**.

- **The `[AVAILABLE AGENTS]` roster** → `feat/agent-roster-context`. A feature
  addition riding a fixes PR, carrying a finding about materializing agent
  descriptions ahead of its own row cap.

- **The `_iter` skill-walk single-flight** → `perf/skills-iter-single-flight`. A
  redundant-work optimization whose lock wait blocks the gateway event loop on a
  cache miss, because `_iter` is called on the loop. Closing that means offloading
  the enumeration at those callers — shared infrastructure and its callers.

- **`task_run`'s `agent` parameter and the per-run agent field** →
  `feat/task-run-agent-scope`. The largest, and the reason is worth stating: **eight
  review rounds each found a real defect, and every one was the same root cause in a
  new place** — a tool-scope decision derived from state that is not trustworthy. An
  unresolved name; an unresolvable type; a spec file stranded on the refusal path; a
  selection recoverable from an agent-writable file; a resolution scope the callee
  discards; a capacity rejection that still committed the selection; a retry that
  skipped the reauthorization; and finally a marker whose *cleared* value is not the
  safe direction I claimed — for a run that asked to be restricted, resuming under
  the configured default is a widening, reachable by editing one boolean in a file
  the agent can write. Closing that needs the selection in gateway-protected state
  agents cannot reach: a persistence mechanism with its own migration and review, not
  a patch on a fixes PR. Seven of the eight are fixed on that branch, which carries
  all of them as its design brief.

## Tests

Pytest against a real install, with clean flake8, isort, the black gate, the
comment-history gate, the feature-map gate, docs lint, the sync-io gate, and `mypy`
over 1413 files: `test_chat_slot_agent_project_scope.py`,
`test_outbox_notify_broadcast.py`, `test_taskrunner_coverage.py`,
`test_decompose_yaml.py` and every suite touching the task runner, cron, or the
outbox — **7351 passed, 8 skipped**.

Every new assertion was checked against the pre-image. Reverting the ladder's
renamed-default arm, the cron job-id extraction, the `decompose_yaml` normalization
and the delivery marker each fails its own tests and nothing else.

## Manual verification

Worth a maintainer's own check on an install whose `default_workspace` is renamed:
pick a folder-linked chat, switch its agent to one bound to no workspace, and confirm
the chat stays in its folder's project.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend and spec-only change — no `website/src` surface is
touched, so nothing rendered differs.

## Related Issues

None filed — these originate from code reviews on the predecessor product.

## Pattern harvest

Rule candidate: `review-prompt` — **a new parameter that selects an execution
identity (agent, profile, role, credential) is not a parameter, it is an
authorization input.** It needs a single trusted origin decided before any resource
is acquired, not validation added at each call site; and if its value must survive a
restart, the store has to be one the subject of the authorization cannot write. Eight
rounds on the split-out `agent` parameter were eight views of that one omission.

Second candidate: **a guard that tests a sentinel VALUE rather than the condition it
stands for.** `ws_name != "default"` and `removeprefix("cron:")` are the same mistake
twice in this diff — one identity has more than one spelling (a renamed default
workspace; a suffixed cron key), so a check written against the canonical spelling
passes for the others. Worth flagging any comparison against a literal that a config
field can also supply.

Third, from the withdrawal: **a security gate keyed on string shape.** When
authorization is derived by parsing an identifier rather than read from a recorded,
unforgeable fact, each new producer of that identifier is a new bypass, and review
finds them one at a time.

## Checklist

- [x] At most two commits, with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; description matches the diff exactly
- [x] Documentation updated in the same commit — spec prose describes only shipped code
- [x] No secrets, credentials, or internal references in the diff

## Note for the reviewer: the `.github/**` touch

`Fork workflow-change guard` is red on this PR, and the only `.github/**` file in
the diff is `.github/black-baseline.txt` — one line removed. That edit is **required
by another gate**, not incidental: the black gate is a shrinking ratchet, so a file
this diff made black-clean (`test/test_outbox_notify_broadcast.py`) must be dropped
from the baseline or the gate fails closed. There is no way to satisfy that ratchet
without touching `.github/**`, and therefore no way to keep this guard green from a
fork.

No workflow logic, no CODEOWNERS and no gate configuration is changed — the diff
under `.github/` is a single baseline-list removal, which a reviewer can confirm at a
glance. Per the guard's own header it is advisory (not in any
`required_status_checks`); clearing it needs the `allow-fork-workflow-change` label
from a maintainer, which I cannot apply.


<!-- readiness re-evaluated after all lanes completed -->
