### PR TITLE
fix(governance): ladder review follow-ups — surrogate signature, unreadable home beneath authority

### DIFF
--- a/docs/guides/enterprise-mcp-governance.md
+++ b/docs/guides/enterprise-mcp-governance.md
@@ -243,6 +243,15 @@ the authority narrowed by it: allow-lists intersect, deny-lists union, a strictn
 level takes the stricter value. A subordinate cannot repeal by omission either — a
 scope it simply leaves out keeps the authority's value.
 
+Two values a subordinate sets are kept only when the authority left them empty:
+`updates.source` (where both name one, the authority's glob stands — two globs have no
+expressible intersection) and `channels.posture` (the authority's posture wins; a
+subordinate posture is not yet folded). A `min_version`
+floor does fold: the higher of the two wins. A
+`~/.kiro/crew/security_policy.json` that cannot be used (unreadable, not JSON, or
+a document the schema rejects) beneath a central document is skipped with one
+warning rather than refusing boot; the authority governs unchanged.
+
 ```bash
 KIROCREW_POLICY_URL=https://config.corp.example/kirocrew/security_policy.json
 KIROCREW_POLICY_HEADERS='{"Authorization":"Bearer <per-machine token>"}'

--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -151,6 +151,18 @@ meaningful when the authority actually said something:
   switching the central tier off and dropping every centrally supplied restriction.
   `compose_tier_ladder` tracks the effective value as the fold proceeds and
   re-applies it on every exit, so no path that rebuilds a ceiling can drop it.
+  An **unusable home file beneath a present authority is skipped, not raised**
+  (`_subordinate_ceiling(beneath_authority=True)`, one warning per process) --
+  unreadable, not JSON, JSON that `parse_policy` rejects, or bytes on which verifying
+  or parsing raises anything at all (the catch is total at this one boundary), one
+  path for every shape so JSON validity does not split the behaviour. The home
+  `distribution` peek that runs before the central document is known is a lookup for
+  a declared source, not a ruling on the file: a malformed block declares no source
+  and the peek moves on, leaving skip-or-fatal to `_subordinate_ceiling`, which
+  re-parses the home document only when the home tier is the one selected. The
+  authority governs unchanged, which is the fail-closed direction, whereas raising
+  -- the behaviour when the home file is the only ceiling -- would let whoever owns
+  `~/.kiro/crew` refuse boot and freeze every refresh on a fleet host.
   "Declared" is read from the **presence** of the block, not from its values
   (`PolicyDistribution.explicit`, set by `from_dict`, outside `__eq__`): a central
   document that spells out `on_unavailable: fail_closed` -- the default -- has
@@ -661,7 +673,7 @@ so there is no age left to restart.
 **A refused install does not leave the rejected bytes as the last-known-good.** The
 publish is confirmed before the install, so the new document is on disk before
 `apply_ceiling` has had its say — and that step refuses for reasons the earlier
-`validate_ceiling` cannot see (a bound profile, the trust root, or a tier-1 pin that moved
+`validate_ceiling` cannot see (a bound profile, the trust root, or a subordinate tier that moved
 between the two). `refresh_now` snapshots the prior copy and `_restore_cache` puts it back
 on any failure — **invalidating first, then writing** — carrying its original `fetched_at` so a repeatedly-failing refresh cannot
 keep resetting the staleness clock. **The rollback is itself a compare-and-swap**, on the

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -1897,7 +1897,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
         _platform_extra["KIROCREW_PROFILE"] = os.environ["KIROCREW_PROFILE"]
     for _policy_env in ("KIROCREW_SECURITY_POLICY", "KIROCREW_ADMISSION_POLICY"):
         # Forward the governance trust-root path overrides alongside the profile.
-        # These are the fleet operator's highest-priority policy sources
+        # These are the operator's local policy sources
         # (governance.load_security_policy / admission), and minimal_env() strips
         # them. Now that the backend boots the platform context itself, dropping
         # them would make the child resolve its ceiling from the on-disk /

--- a/src/kiro_crew/platform/admission.py
+++ b/src/kiro_crew/platform/admission.py
@@ -142,8 +142,17 @@ def hmac_signature(secret: str, payload: bytes) -> str:
     against a publisher/issuer public key pinned in the policy; the shape (the
     trust root holds the key, the signed document holds only the signature) is
     unchanged, which is why both call sites route through one helper.
+
+    ``surrogatepass``: the key is text parsed from a JSON trust root, and
+    ``json.loads`` accepts a lone surrogate that a strict encode raises on.  A
+    UnicodeEncodeError here is a ValueError, not a refusal, so it would escape the
+    signature check of every caller.  ``surrogatepass`` only prevents that crash:
+    the key still produces an ordinary HMAC, which verifies exactly when the signer
+    used the same key bytes and reads as UNVERIFIED otherwise.
     """
-    return hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+    return hmac.new(
+        secret.encode("utf-8", errors="surrogatepass"), payload, hashlib.sha256
+    ).hexdigest()
 
 
 def _normalize_name(name: str) -> str:

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -77,10 +77,10 @@ from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
 
-# Where the enterprise security policy is read from.  Env wins so a managed
-# fleet can point at a root-owned / read-only location without a package
-# rebuild; the home file is the standalone operator's authoring location.  The
-# companion-bundled resource (precedence step 2) is resolved separately by the
+# Where the local security policy tiers are read from.  Both sit BENEATH the
+# centrally distributed document and may only tighten it (``compose_tier_ladder``);
+# the env file is the first subordinate, the home file the standalone operator's
+# authoring location.  The companion-bundled resource is resolved separately by the
 # caller that knows the active edition (see ``load_security_policy``).
 _POLICY_ENV = "KIROCREW_SECURITY_POLICY"
 _POLICY_HOME_LEAF = "security_policy.json"
@@ -2828,7 +2828,15 @@ def _policy_signature_state(
     # fallback: a tampered policy would yield an UNGOVERNED host even with
     # ``require_policy_signature`` on, inverting the flag. Encoding both sides
     # keeps every malformed signature an ordinary UNVERIFIED verdict.
-    if hmac.compare_digest(expected.encode("utf-8"), signature.encode("utf-8")):
+    #
+    # ``surrogatepass`` for the same reason: ``json.loads`` accepts a lone surrogate
+    # (``"\udc80"``) and a strict ``encode`` raises UnicodeEncodeError -- a ValueError,
+    # not a composition error, with the same ungoverned outcome. The ladder verifies a
+    # user-owned home file BENEATH the central document on every load, so without this
+    # one byte in that file would take the fleet ceiling out of the process.
+    if hmac.compare_digest(
+        expected.encode("utf-8"), signature.encode("utf-8", errors="surrogatepass")
+    ):
         return SIGNATURE_VERIFIED, f"issuer {issuer!r}"
     return SIGNATURE_UNVERIFIED, f"signature does not match trust key for issuer {issuer!r}"
 
@@ -2981,6 +2989,11 @@ class _TierProcessState:
     this the bundled rung would drop out of the ladder at the first poll, loosening a
     ceiling an edition tightened. The packaged resource is static for the process.
 
+    ``home_unreadable_warned`` -- the one-time warning that an unusable home file
+    (unreadable, or one ``parse_policy`` rejects) beneath a present authority was
+    skipped has fired. Once, because the fold runs on
+    every refresh poll and a warning per poll would be a warning per interval.
+
     ``env_beneath_central_warned`` -- the one-time warning that
     ``KIROCREW_SECURITY_POLICY`` only tightens has fired. A runbook may still describe
     it as a rollback lever that outranks the central document; the first compose of
@@ -3006,6 +3019,7 @@ class _TierProcessState:
 
     last_bundled: Optional[Mapping[str, object]] = None
     env_beneath_central_warned: bool = False
+    home_unreadable_warned: bool = False
     tier_intersects_audited: "set[Tuple[str, str]]" = field(default_factory=set)
     last_composed: Optional["GovernanceCeiling"] = None
 
@@ -3177,6 +3191,34 @@ def _audit_policy_tier(operation: str, authority_tier: str, lower_tier: str) -> 
         logger.debug("policy tier SEL emit unavailable", exc_info=True)
 
 
+def _warn_home_unreadable_beneath_authority_once(home_path: Path, error: Exception) -> None:
+    """Say once per process that an unusable home file was skipped beneath a higher tier.
+
+    Unusable covers every shape ``_subordinate_ceiling`` skips: a read error, a JSON
+    error, and a document ``parse_policy`` rejects -- and the ``distribution`` peek in
+    :func:`load_security_policy` that moves on from a malformed home block. The
+    governing tier (central, env or bundled) is unchanged, so nothing loosened; but a
+    local operator who meant that file to tighten the ceiling, or to name where the
+    ceiling lives, must be able to see that it did not.
+
+    Only the path and the exception CLASS are logged. This line is served by
+    ``GET /api/logs``, and a ``PolicyDistribution.from_dict`` error quotes the declared
+    source URL, which :func:`_audit_policy_tier` and :func:`_audit_policy_signature`
+    deliberately keep off agent-reachable surfaces because a source URL may itself be a
+    credential. The full error still reaches the operator through the fatal path when
+    the home file is the only ceiling.
+    """
+    if _process_state.home_unreadable_warned:
+        return
+    _process_state.home_unreadable_warned = True
+    logger.warning(
+        "security policy at %s is unusable (%s); skipped, the governing tier is "
+        "unchanged. Fix or remove the file for a local tightening to apply.",
+        home_path,
+        type(error).__name__,
+    )
+
+
 def _warn_env_beneath_central_once(authority_tier: str) -> None:
     """Say once per process that the env document now only TIGHTENS the fleet ceiling.
 
@@ -3276,11 +3318,23 @@ def _subordinate_ceiling(
     home_path: Path,
     env_data: Optional[Dict[str, object]] = None,
     env_path: Optional[Path] = None,
+    *,
+    beneath_authority: bool = False,
 ) -> Optional[GovernanceCeiling]:
     """Tiers 2-4, first present wins: env -> bundled -> home.
 
     Mutually exclusive by design, and collectively the *subordinate*: whichever one
     is present may only tighten whatever authority sits above it.
+
+    *beneath_authority* says a central document is present above this fold. A home
+    file that cannot be USED -- unreadable, not JSON, JSON that ``parse_policy``
+    rejects, or bytes on which verifying or parsing raises anything at all -- is
+    then reported and treated as ABSENT rather than raised: the
+    authority still governs, which is the fail-closed direction, and a raise would
+    hand whoever owns ``~/.kiro/crew`` a lever that refuses boot and freezes every
+    refresh on a fleet host -- an availability lever, not a tightening. One path
+    for every shape of unusable, so JSON validity does not split the behaviour.
+    With no authority the home file is the only ceiling, so its error stays fatal.
 
     *env_data* / *env_path* let a caller that ALREADY read the env document hand it
     over instead of having this function read the file a second time -- which matters
@@ -3305,12 +3359,29 @@ def _subordinate_ceiling(
         bundled_state = _verify_policy_signature(bundled, source="companion-bundled resource")
         return replace(parse_policy(bundled, signature_state=bundled_state), tier=TIER_BUNDLED)
     if home_error is not None:
+        if beneath_authority:
+            _warn_home_unreadable_beneath_authority_once(home_path, home_error)
+            return None
         raise PlatformCompositionError(
             f"security policy at {home_path} is unreadable: {home_error}"
         ) from home_error
     if home_data is not None:
-        home_state = _verify_policy_signature(home_data, source=str(home_path))
-        return replace(parse_policy(home_data, signature_state=home_state), tier=TIER_HOME)
+        try:
+            home_state = _verify_policy_signature(home_data, source=str(home_path))
+            parsed = parse_policy(home_data, signature_state=home_state)
+        except Exception as exc:
+            # Valid JSON the schema refuses (a stale ``version``, an unknown key) is
+            # the same lever as an unreadable file, reached one step later -- and so
+            # is anything ELSE these two calls raise on user-owned bytes. The catch is
+            # total on purpose: this is the one boundary where a document a standard
+            # user controls meets the fleet ceiling, and an exception class nobody
+            # anticipated (the lone-surrogate UnicodeEncodeError was one) must land
+            # on the same skip-and-warn path, not escape the loader as ungoverned.
+            if beneath_authority:
+                _warn_home_unreadable_beneath_authority_once(home_path, exc)
+                return None
+            raise
+        return replace(parsed, tier=TIER_HOME)
     return None
 
 
@@ -3367,7 +3438,11 @@ def compose_installed_ceiling(central: GovernanceCeiling) -> GovernanceCeiling:
     """
     home_data, home_error, home_path = _read_home_policy()
     subordinate = _subordinate_ceiling(
-        _process_state.last_bundled, home_data, home_error, home_path
+        _process_state.last_bundled,
+        home_data,
+        home_error,
+        home_path,
+        beneath_authority=True,
     )
     # Tagged here exactly as boot tags it: ``parse_distributed_policy`` returns an
     # untiered ceiling, and an untagged authority makes ``compose_tier_ladder``'s
@@ -3422,10 +3497,15 @@ def load_security_policy(
     tracked as a follow-up issue (see the enterprise governance guide) rather than
     provided here.
 
-    A **present-but-unreadable / invalid** policy at the env or home path raises
-    ``PlatformCompositionError`` (fail-closed to strictest), mirroring
-    ``admission.load_admission_policy`` — a fleet that meant to enforce something
-    must never silently fall open.
+    A **present-but-unreadable / invalid** policy at the env path, or at the home
+    path when it is the only ceiling, raises ``PlatformCompositionError``
+    (fail-closed to strictest), mirroring ``admission.load_admission_policy`` — a
+    fleet that meant to enforce something must never silently fall open.  Beneath a
+    central document the home file is the one exception: it is skipped with a
+    once-per-process warning and the authority governs unchanged
+    (:func:`_subordinate_ceiling`), because raising there would let whoever owns
+    ``~/.kiro/crew`` refuse boot and freeze every refresh on a fleet host while the
+    ceiling itself is unaffected.
 
     **Signature verification (``identity.signature``).**  Every tier's document is
     checked as it is read, so every ``GovernanceCeiling`` carries its own verdict.
@@ -3480,11 +3560,24 @@ def load_security_policy(
     # in the chain: it is the tier directly beneath central, above bundled and home.
     # Leaving it out meant an env-declared ``distribution.source`` was silently
     # ignored and the central tier never loaded from it.
-    declared = (
-        _declared_distribution(env_data)
-        or _declared_distribution(bundled)
-        or _declared_distribution(home_data)
-    )
+    declared = _declared_distribution(env_data) or _declared_distribution(bundled)
+    # The home peek is a LOOKUP for a declared source, not a ruling on the home file:
+    # a malformed home ``distribution`` block declares no source, so the peek moves on.
+    # Whether that file is then skipped or fatal is decided once, by
+    # ``_subordinate_ceiling`` -- which re-parses the same document only if the home
+    # tier is the one selected, after the central tier is known and after env and
+    # bundled have had precedence. Ruling here as well would refuse boot on a host
+    # that env or central would have governed with the home file ignored. Moving on
+    # is not silent, though: when env or bundled then governs with no central, this
+    # is the only place the skipped block is ever seen, and a fleet that mistyped
+    # where its ceiling lives must find out from a log line, not from nothing. Same
+    # once-per-process warning as the skip in ``_subordinate_ceiling`` (it latches, so
+    # a home file that is then also skipped there warns once, not twice).
+    if declared is None:
+        try:
+            declared = _declared_distribution(home_data)
+        except PlatformCompositionError as exc:
+            _warn_home_unreadable_beneath_authority_once(home_path, exc)
     if (
         declared is not None
         or os.environ.get(_POLICY_DISTRIBUTION_URL_ENV, "").strip()
@@ -3498,7 +3591,13 @@ def load_security_policy(
 
     # Tiers 2–4 — the subordinate, first present wins.
     subordinate = _subordinate_ceiling(
-        bundled, home_data, home_error, home_path, env_data, env_path
+        bundled,
+        home_data,
+        home_error,
+        home_path,
+        env_data,
+        env_path,
+        beneath_authority=central is not None,
     )
 
     composed = compose_tier_ladder(central, subordinate)
@@ -3580,8 +3679,8 @@ def assert_policy_signature_satisfied(ceiling: Optional[GovernanceCeiling]) -> N
       ceiling whatsoever, the exact failure the flag exists to prevent.
 
     Enforcing here rather than in the loader is what makes tier precedence work.
-    ``load_security_policy`` walks env → companion bundle → operator home and runs
-    more than once per boot with different arguments (the core with no
+    ``load_security_policy`` folds the central document over env → companion bundle →
+    operator home and runs more than once per boot with different arguments (the core with no
     ``bundled_loader``, an edition with one).  A raise inside it fires on whichever
     tier that particular pass happened to reach: the core's loader-less pass falls
     through to an unsigned HOME file and would abort even when the edition's later

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -18,6 +18,7 @@ import logging
 
 import pytest
 
+from kiro_crew.platform import governance
 from kiro_crew.platform.context import PlatformCompositionError
 from kiro_crew.platform.governance import (
     CAPABILITY,
@@ -1210,6 +1211,37 @@ class TestPolicySignatureStates:
             ceiling = load_security_policy()
             assert ceiling is not None
             assert ceiling.signature_state == SIGNATURE_UNVERIFIED
+
+    def test_a_lone_surrogate_signature_is_unverified_not_a_crash(self):
+        """``json.loads`` accepts ``"\\udc80"``; a strict ``encode`` would raise.
+
+        A UnicodeEncodeError is a ValueError, not a PlatformCompositionError, so it
+        would escape the loader and the host would degrade to ungoverned. The tier
+        ladder verifies a user-owned home file beneath the central document on every
+        load, so this is one byte in that file removing the fleet ceiling. It must
+        classify like every other malformed signature instead.
+        """
+        doc = json.loads(
+            '{"version": 1, "boot": {"fail_closed": true}, '
+            '"identity": {"issuer": "corp", "signature": "\\udc80"}}'
+        )
+        state, _detail = governance._policy_signature_state(doc, {"corp": "k"})
+        assert state == SIGNATURE_UNVERIFIED
+
+    def test_a_lone_surrogate_trust_key_is_unverified_not_a_crash(self):
+        """The other text the compare depends on: the key from the JSON trust root.
+
+        ``hmac_signature`` encodes the key before hashing; a strict encode raised on a
+        lone surrogate there, one call before the compare this class fixes.
+        """
+        doc = json.loads(
+            '{"version": 1, "boot": {"fail_closed": true}, '
+            '"identity": {"issuer": "corp", "signature": "abcd"}}'
+        )
+        trust_keys = json.loads('{"corp": "\\udc80"}')
+        assert len(trust_keys["corp"]) == 1  # a real lone surrogate, not the 6-char escape
+        state, _detail = governance._policy_signature_state(doc, trust_keys)
+        assert state == SIGNATURE_UNVERIFIED
 
     def test_non_ascii_signature_fails_closed_when_required(self, monkeypatch, tmp_path):
         """...and with the opt-in ON it must ABORT, not degrade to ungoverned."""

--- a/test/test_governance_tier_ladder.py
+++ b/test/test_governance_tier_ladder.py
@@ -978,3 +978,206 @@ class TestAnExplicitDefaultDistributionIsDeclared:
             )
         )
         assert refreshed.distribution.on_unavailable == governance.UNAVAILABLE_FAIL_CLOSED
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# An unreadable home file beneath a present authority is skipped, not fatal
+# ──────────────────────────────────────────────────────────────────────────
+class TestAnUnreadableHomeFileBeneathAnAuthorityIsSkipped:
+    """An unusable home file is fatal only when that file is the sole ceiling.
+
+    The home file is folded beneath the central document on every load and on every
+    refresh poll. Raising there -- on a read error, or on valid JSON the schema
+    rejects -- would let whoever owns ``~/.kiro/crew`` refuse boot and freeze every
+    refresh on a fleet host: an availability lever, not a tightening. Beneath an
+    authority the file is skipped with one warning and the authority governs
+    unchanged, by one path whatever the shape of the damage; with no authority it is
+    the only ceiling and its error stays fatal (``test_governance_distribution.py``).
+    """
+
+    @pytest.fixture
+    def broken_home(self, monkeypatch, tmp_path):
+        home = tmp_path / "home.json"
+        home.write_text("{ not json", encoding="utf-8")
+        _point_home(monkeypatch, home)
+        return home
+
+    def test_the_authority_governs_unchanged_at_boot(self, central, broken_home):
+        central("fleet")
+        ceiling = load_security_policy()
+        assert ceiling is not None
+        assert ceiling.identity_issuer == "fleet"
+        assert ceiling.tier == TIER_CENTRAL
+
+    def test_the_skip_is_announced_once_per_process(self, central, broken_home, caplog):
+        central("fleet")
+        with caplog.at_level("WARNING", logger=governance.logger.name):
+            load_security_policy()
+            load_security_policy()
+        hits = [r for r in caplog.records if "is unusable" in r.getMessage()]
+        assert len(hits) == 1
+        assert str(broken_home) in hits[0].getMessage()
+
+    def test_a_refresh_keeps_the_authority_too(self, central, broken_home):
+        # ``compose_installed_ceiling`` re-reads the home file on every poll; a raise
+        # here would reject every refresh and let the cache age toward fail-closed.
+        central("fleet")
+        fetched = governance.parse_policy(_doc("fleet"))
+        refreshed = governance.compose_installed_ceiling(fetched)
+        assert refreshed.identity_issuer == "fleet"
+
+    def test_with_no_authority_the_error_is_still_fatal(self, broken_home):
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        with pytest.raises(PlatformCompositionError, match="is unreadable"):
+            load_security_policy()
+
+    @pytest.fixture
+    def schema_invalid_home(self, monkeypatch, tmp_path):
+        # Valid JSON that ``parse_policy`` refuses: the same lever, one step later.
+        home = tmp_path / "home.json"
+        home.write_text(json.dumps({"version": 2, "boot": {"fail_closed": True}}), encoding="utf-8")
+        _point_home(monkeypatch, home)
+        return home
+
+    def test_a_schema_invalid_home_file_is_skipped_by_the_same_path(
+        self, central, schema_invalid_home, caplog
+    ):
+        central("fleet")
+        with caplog.at_level("WARNING", logger=governance.logger.name):
+            ceiling = load_security_policy()
+        assert ceiling is not None
+        assert ceiling.identity_issuer == "fleet"
+        assert ceiling.tier == TIER_CENTRAL
+        hits = [r for r in caplog.records if "is unusable" in r.getMessage()]
+        assert len(hits) == 1
+        assert str(schema_invalid_home) in hits[0].getMessage()
+
+    def test_a_schema_invalid_home_file_does_not_reject_a_refresh(
+        self, central, schema_invalid_home
+    ):
+        central("fleet")
+        refreshed = governance.compose_installed_ceiling(governance.parse_policy(_doc("fleet")))
+        assert refreshed.identity_issuer == "fleet"
+
+    def test_with_no_authority_a_schema_error_is_still_fatal(self, schema_invalid_home):
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        with pytest.raises(PlatformCompositionError):
+            load_security_policy()
+
+    @pytest.fixture
+    def verify_raises_something_unexpected(self, monkeypatch):
+        # The catch is total: an exception class nobody anticipated must land on
+        # the same path. Stand in for the next strict operation that raises.
+        real = governance._verify_policy_signature
+
+        def boom(data, *, source):
+            if source.endswith("home.json"):
+                raise RuntimeError("unanticipated failure while verifying " + source)
+            return real(data, source=source)
+
+        monkeypatch.setattr(governance, "_verify_policy_signature", boom)
+
+    def test_an_unanticipated_exception_is_skipped_beneath_an_authority(
+        self, monkeypatch, tmp_path, central, verify_raises_something_unexpected, caplog
+    ):
+        central("fleet")
+        _point_home(monkeypatch, _write_policy(tmp_path / "home.json", "operator"))
+        with caplog.at_level("WARNING", logger=governance.logger.name):
+            ceiling = load_security_policy()
+        assert ceiling is not None
+        assert ceiling.identity_issuer == "fleet"
+        assert any("is unusable" in r.getMessage() for r in caplog.records)
+
+    def test_a_malformed_home_distribution_block_is_skipped_beneath_an_authority(
+        self, monkeypatch, tmp_path, central, caplog
+    ):
+        # The home ``distribution`` block is PEEKED before the central document is
+        # known; a malformed one must not refuse boot on a host central governs.
+        central("fleet")
+        _point_home(
+            monkeypatch,
+            _write_policy(tmp_path / "home.json", "operator", distribution="not-a-block"),
+        )
+        with caplog.at_level("WARNING", logger=governance.logger.name):
+            ceiling = load_security_policy()
+        assert ceiling is not None
+        assert ceiling.identity_issuer == "fleet"
+        assert any("is unusable" in r.getMessage() for r in caplog.records)
+
+    def test_a_malformed_home_distribution_block_with_no_authority_is_fatal(
+        self, monkeypatch, tmp_path
+    ):
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        _point_home(
+            monkeypatch,
+            _write_policy(tmp_path / "home.json", "operator", distribution="not-a-block"),
+        )
+        with pytest.raises(PlatformCompositionError, match="distribution"):
+            load_security_policy()
+
+    def test_a_malformed_home_distribution_block_does_not_abort_an_env_tier_boot(
+        self, monkeypatch, tmp_path
+    ):
+        # No central document, but the env tier outranks home: the malformed home
+        # block declares no source, and the file it sits in is never the selected
+        # ceiling, so it must not refuse a boot the env document governs.
+        monkeypatch.setenv(_POLICY_ENV, str(_write_policy(tmp_path / "env.json", "local-env")))
+        _point_home(
+            monkeypatch,
+            _write_policy(tmp_path / "home.json", "operator", distribution="not-a-block"),
+        )
+        ceiling = load_security_policy()
+        assert ceiling is not None
+        assert ceiling.identity_issuer == "local-env"
+        assert ceiling.tier == TIER_ENV
+
+    def test_a_malformed_home_distribution_block_is_announced_on_the_peek_path(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        # The env tier governs and no central document resolves, so the peek in
+        # ``load_security_policy`` is the ONLY place the skipped block is seen:
+        # ``_subordinate_ceiling`` returns at the env tier without reaching its home
+        # branch. A fleet that mistyped where its ceiling lives has to find out from a
+        # log line rather than from nothing.
+        monkeypatch.setenv(_POLICY_ENV, str(_write_policy(tmp_path / "env.json", "local-env")))
+        home = _write_policy(tmp_path / "home.json", "operator", distribution="not-a-block")
+        _point_home(monkeypatch, home)
+        with caplog.at_level("WARNING", logger=governance.logger.name):
+            load_security_policy()
+            load_security_policy()
+        hits = [r for r in caplog.records if "is unusable" in r.getMessage()]
+        assert len(hits) == 1
+        assert str(home) in hits[0].getMessage()
+
+    def test_the_skip_warning_names_the_error_class_not_its_text(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        # The warning is served by ``GET /api/logs``, and a ``distribution`` error
+        # quotes a fragment of the declared source -- here the port -- which the SEL
+        # rows for this tier deliberately keep off agent-reachable surfaces because a
+        # source URL may itself be a credential. Path and exception CLASS only.
+        monkeypatch.setenv(_POLICY_ENV, str(_write_policy(tmp_path / "env.json", "local-env")))
+        home = _write_policy(
+            tmp_path / "home.json",
+            "operator",
+            distribution={"source": "https://policy.example:sekrit-port/policy.json"},
+        )
+        _point_home(monkeypatch, home)
+        with caplog.at_level("WARNING", logger=governance.logger.name):
+            load_security_policy()
+        hits = [r for r in caplog.records if "is unusable" in r.getMessage()]
+        assert len(hits) == 1
+        message = hits[0].getMessage()
+        assert "PlatformCompositionError" in message
+        assert "sekrit-port" not in message
+        assert str(home) in message
+
+    def test_an_unanticipated_exception_with_no_authority_still_surfaces(
+        self, monkeypatch, tmp_path, verify_raises_something_unexpected
+    ):
+        _point_home(monkeypatch, _write_policy(tmp_path / "home.json", "operator"))
+        with pytest.raises(RuntimeError, match="unanticipated"):
+            load_security_policy()


### PR DESCRIPTION
## Problem / Motivation

One bad byte in a user-owned `~/.kiro/crew/security_policy.json` takes the fleet ceiling out of the process. Write `"signature": "\udc80"` (a lone surrogate, which `json.loads` accepts) with any issuer name from `trust_keys`, and `_policy_signature_state` raises `UnicodeEncodeError`. That is a `ValueError`, not a `PlatformCompositionError`. The boot handler logs it as "platform boot deferred", `safe_context_call` falls back to the default context, and the host runs ungoverned. The tier ladder verifies the home file beneath the central document on every load, so a standard user reaches this on a centrally governed host.

A second lever sits next to it. `_subordinate_ceiling` raises on a home file it cannot use — unreadable, not JSON, or valid JSON that `parse_policy` rejects (a stale `version`, an unknown key) — no matter what sits above it. Beneath a central document that refuses boot, and because `compose_installed_ceiling` re-reads the file on every poll, it also rejects every refresh: fleet tightenings stop landing, the cache ages to `max_cache_age_secs`, cache-only children fail closed. A host carrying a pre-central home file that no longer parses hits this on upgrade.

## Why it matters

Both are the class the ladder exists to refuse: a document the local user owns changing what the fleet's document does. The first removes the ceiling. The second lets one user refuse boot and freeze refresh on a fleet host. Neither needs privilege.

## What changed (motivation → approach → change)

The signature compare now encodes with `errors="surrogatepass"`, and so does the trust-key encode inside `hmac_signature` (the key is text from the JSON trust root and can carry the same surrogate). `surrogatepass` only prevents the crash: a lone-surrogate signature can never equal the hex digest, and a lone-surrogate key still produces an ordinary HMAC that verifies only when the signer used the same key bytes — either way the verdict is an ordinary `UNVERIFIED`, never an exception. `expected` is a hex digest, so its own encode never raises.

`_subordinate_ceiling` takes `beneath_authority`. With a central document above, a home file that cannot be used is skipped and the authority governs unchanged. One path covers every shape of damage — a read error, a JSON error, a `parse_policy` refusal, and any other exception verifying or parsing the home bytes raises — so JSON validity does not split the behaviour, and the catch at this one boundary is total on purpose. The home `distribution` peek that runs before the central document is known is a lookup for a declared source, not a ruling on the file: a malformed block declares no source and the peek moves on. Skip-or-fatal is decided once, in `_subordinate_ceiling`, and only when the home tier is the one selected — so a malformed home block neither refuses boot on a host the central document governs nor on one the env tier governs. Moving on is not silent: the peek emits the same once-per-process warning, which is the only place a mistyped `distribution.source` is seen when env or bundled governs and no central document resolves. That is the fail-closed direction: the home tier can only tighten, so dropping it never loosens the fleet ceiling. `_warn_home_unreadable_beneath_authority_once` says so once per process (latched in `_TierProcessState.home_unreadable_warned`), because the fold runs on every refresh poll. It logs the path and the exception class, never the error text: this line is served by `GET /api/logs`, and a `distribution` error quotes a fragment of the declared source, which the tier's SEL rows keep off agent-reachable surfaces because a source URL may itself be a credential. With no authority the home file is the only ceiling and its error stays fatal. `compose_installed_ceiling` passes `True`; `load_security_policy` passes `central is not None`.

The enterprise guide names the two subordinate values that are kept only when the authority left them empty: `updates.source` (two globs have no expressible intersection) and `channels.posture` (not yet folded, #9798). Comments and docs that still described the pre-ladder precedence (the module header in `governance.py`, the `enforce` docstring's tier walk, `apps/backend.py`, `governance.md`) say what the code does today.

## Tests

- `test_a_lone_surrogate_signature_is_unverified_not_a_crash` and `test_a_lone_surrogate_trust_key_is_unverified_not_a_crash` — `"\udc80"` as the signature, and as the trust-key value (both built through `json.loads`, so each is a real lone surrogate), each yield `SIGNATURE_UNVERIFIED`; nothing raises. Reverting the key-side encode makes the trust-key test fail with `UnicodeEncodeError`.
- `TestAnUnreadableHomeFileBeneathAnAuthorityIsSkipped` — beneath a central document a `{ not json` home file, and separately a `{"version": 2}` one the schema rejects, leave `identity_issuer == "fleet"` and `tier == TIER_CENTRAL` at boot; the warning fires once across two loads and names the path; `compose_installed_ceiling` keeps the authority on the refresh path for both shapes; with no central document `load_security_policy` still raises for both. A stand-in `RuntimeError` from the verify step is skipped beneath a central document and still surfaces without one. A `"distribution": "not-a-block"` home file is skipped beneath a central document, ignored when an env document governs (`tier == TIER_ENV`, no central), and still fatal when it is the only ceiling. Reverting the peek to raise makes the env-tier test fail with `PlatformCompositionError`.
- `test_a_malformed_home_distribution_block_is_announced_on_the_peek_path` — with the env tier governing and no central document, the skip is named in exactly one warning across two loads; making the peek swallow silently again fails it. `test_the_skip_warning_names_the_error_class_not_its_text` — a home `distribution.source` with an unusable port yields a warning carrying `PlatformCompositionError` and the path, and not the port fragment the error quotes; logging the error text again fails it.
- Existing `test_an_unreadable_home_file_still_raises_at_its_own_tier` and `test_a_bundled_policy_still_outranks_an_unreadable_home_file` are unchanged and still pass.

Governance and admission suites: 1112 passed, 3 skipped.

## Manual verification

N/A — unit coverage sufficient. Both changes are pure functions of document bytes and tier presence, and each branch (surrogate, beneath-authority, no-authority, refresh) has a test.

## Related Issues

no linked issue: the defects were raised as review items N1, N3, N4 on #7362 (head `89f6477c04`) and fixed here rather than filed. Mentions #9798 (posture folding, out of scope here) and #9826 (the plugin-manifest sibling of the signature compare, out of scope here).

## Pattern harvest

Rule candidate: review-prompt
Pattern: a `str.encode("utf-8")` on attacker-controlled text inside a loader whose caller treats only `PlatformCompositionError` as fatal — a `UnicodeEncodeError` (ValueError) is a silent fail-open. Grep for `.encode("utf-8")` on parsed-JSON strings in `platform/` and check each caller's exception contract.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
