### PR TITLE
chore: reword history comments to clear the lint gate on main

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
@@ -1295,7 +1295,7 @@ def decide(
        belongs here for the same reason the marker conditions do: mid-round a
        fresh CONCERNS with no ruling yet is expected, not a defect -- the
        author has not been shown it. It gates only once the round has settled,
-       which is exactly the state that used to return 0 and arm auto-merge
+       which is exactly the state that would otherwise return 0 and arm auto-merge
        past an unanswered whole-design review. LOCAL ONLY: --disposition-gate
        never reaches this function, so the repository's required status keeps
        treating CONCERNS as advisory.

--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -116,7 +116,7 @@ SUBAGENT_TIMEOUT_MAX = 86400
 # body is unambiguous (linear) while still capturing an inner ``[`` inside an
 # option ("Fix [x] logging", "a[1]"). A CLOSER is admitted CONDITIONALLY, not
 # freely: only where an earlier ``[`` in the same label matches it or the label
-# list continues after it (#9284 — see :data:`_MARKER_LABEL_CONTINUES` for why
+# list continues after it (see :data:`_MARKER_LABEL_CONTINUES` for why
 # an unconditional ``]`` made the body run past the marker and delete prose).
 # This parser runs over untrusted LLM/relayed text before Slack, the dashboard,
 # Discord, Telegram, and WeCom render it.
@@ -201,7 +201,7 @@ MARKER_WRAPPERS = "`*_"
 _MARKER_WRAP_CLASS = "[" + re.escape(MARKER_WRAPPERS) + "]"
 
 #: A closer may stay INSIDE a label only where it CONTINUES the label list
-#: (#9284). A label may legitimately carry a closer -- ``[OPTIONS: Alpha ] |
+#: A label may legitimately carry a closer -- ``[OPTIONS: Alpha ] |
 #: Bravo ]]`` is a supported shape -- so the body has to admit one. Admitting it
 #: UNCONDITIONALLY (the old ``[^[\n]``, which includes ``]``) made the body run to
 #: the LAST closer in range instead of the first plausible one, so an ordinary
@@ -482,7 +482,7 @@ def strip_control_comments(text: str) -> str:
 #: that body, and the one place the "spelled once" rule in
 #: :data:`_MARKER_BODY_LINE` does not apply. It has to be: a prefix of a legal
 #: body need not itself be a legal body. ``[OPTIONS: A ]`` mid-stream holds a
-#: closer that satisfies neither half of the #9284 rule YET, and becomes legal
+#: closer that satisfies neither half of the closer rule YET, and becomes legal
 #: the moment ``| B]`` arrives, so a probe spelled as the real body would call
 #: that tail dead and publish the marker as raw text. Widening this to the
 #: grammar is what ``test_options_marker_closers.py``'s

--- a/src/kiro_crew/git_coord.py
+++ b/src/kiro_crew/git_coord.py
@@ -249,7 +249,7 @@ async def _branch_history_intact(git_cwd: str, run: Project) -> bool:
     are absent. With no recorded commits there is nothing to verify -- that is
     a run which never committed a step, not a rewritten branch.
 
-    Fails closed: a recorded commit that no longer resolves (rewritten then
+    Fails closed: a recorded commit that does not resolve (rewritten then
     garbage-collected) and any git error both answer False.
     """
     if not run.commit_hashes:
@@ -464,7 +464,7 @@ async def _leftover_dir_is_ours(run: Project, path: str | None = None) -> bool:
     can proceed); nothing in recovery deletes a leftover tree.
 
     *path* defaults to ``run.worktree_path``. Pass it explicitly to judge a
-    tree that has been renamed aside, where the saved path no longer names
+    tree that has been renamed aside, where the saved path differs from
     the directory in question.
     """
     path = path or run.worktree_path
@@ -555,7 +555,7 @@ async def reinit_workspace_for_retry(run: Project) -> bool:
         # the LAST operation to resolve the saved path, and everything
         # afterwards addresses ``doomed`` -- a private name carrying a random
         # token, which nothing else can be holding. A later swap onto the
-        # saved path can no longer redirect anything; it merely loses the race
+        # saved path redirects nothing; it merely loses the race
         # to the ``worktree add`` below, which then fails and returns False
         # rather than clobbering whatever arrived.
         #
@@ -717,7 +717,7 @@ async def _is_git_repo(path: str) -> bool:
         # Something in the invocation is NOT THERE, which is genuinely
         # answerable as "no git repo here": either no ``git`` binary on the
         # host (the task runner is git-optional, so such a host simply has no
-        # git repos), or *path* itself no longer exists -- exactly the
+        # git repos), or *path* itself is absent -- exactly the
         # lost-worktree state the retry path probes for. The platforms spell
         # the missing-cwd case differently: POSIX raises ``FileNotFoundError``
         # from the spawn, Windows raises ``NotADirectoryError`` (WinError 267)

--- a/src/kiro_crew/messaging/inbound_spool.py
+++ b/src/kiro_crew/messaging/inbound_spool.py
@@ -25,7 +25,7 @@ already has exactly one authorization seam in this codebase:
 ``MessagingTransport.may_send_to``. Scoping replay to the notice puts the whole
 feature behind a gate that already exists and is already owned, instead of
 introducing a parallel one. Re-dispatch, if wanted, is a separate design owned
-by the channel dispatch wiring -- issue #9144.
+by the channel dispatch wiring.
 
 Why the spool is written at the refusal point and nowhere else
 --------------------------------------------------------------
@@ -44,7 +44,7 @@ carries the group's private operating rules, and the notice quotes the entry
 only where ``may_send_to`` can express
 revocation for it**: Discord answers threads from ``_allowed_threads``; WhatsApp's
 answers from ``dm_policy`` alone and knows nothing of the group roster, so
-WhatsApp spools DMs only and leaves group routes to #9144.
+WhatsApp spools DMs only; group routes belong to that re-dispatch design.
 
 Bounding, in one primitive
 --------------------------
@@ -72,7 +72,7 @@ at most one duplicate notice and never the entries queued behind it. An entry
 whose channel is not connected THIS run is never noticed: it stays on disk for a
 start where the channel is back, and the age horizon bounds it.
 
-Attachments are NOT spooled (issue #2217's fifth question, still open): an
+Attachments are NOT spooled: an
 ingested attachment lives in a turn-owned temp path that is gone after a
 restart. The entry records how many were dropped and the notice says so.
 
@@ -210,7 +210,7 @@ class SpooledInbound:
     Every field is plain JSON: the entry survives a process boundary, so it may
     hold no live object (no renderer, no socket, no temp path). Exactly the
     fields the notice needs and nothing recorded "for later": a field nothing
-    reads is a field nothing tests, and a re-dispatch design (#9144) would own
+    reads is a field nothing tests, and a re-dispatch design would own
     its own record.
     """
 
@@ -251,7 +251,7 @@ class SpooledInbound:
         Distinct from :attr:`dedupe_key`, which is a correctness identity and is
         deliberately empty for an entry the platform gave no id: a log line still
         needs something to name. Two identical bodies can share a trace id, which
-        is acceptable for a diagnostic and is exactly why it must not be used to
+        is acceptable for a diagnostic and is exactly why it must never
         decide whether one of them is a duplicate.
         """
         tail = self.message_id or hashlib.sha256(self.text.encode("utf-8")).hexdigest()[:8]
@@ -764,7 +764,7 @@ def _quote(entry: SpooledInbound, transport: Any) -> str:
     defang runs on the QUOTE before it is sized, because it inserts characters.
 
     Sized to ``capabilities.max_message_chars``, because the notice PREFIXES the
-    quote: a message that fit the platform's cap on the way in no longer fits
+    quote: a message that fit the platform's cap on the way in overflows the cap
     with the prefix and the ``> `` markers added, and a transport's ``send_message``
     that slices to its cap and returns an id would confirm a notice whose tail
     was silently cut. The quote is truncated here, VISIBLY, before the send, so

--- a/src/kiro_crew/security/redaction.py
+++ b/src/kiro_crew/security/redaction.py
@@ -889,7 +889,7 @@ _REDACTED_ENCODED_CREDENTIAL_TAG = "[REDACTED: encoded credential]"
 #: :data:`kiro_crew.security.exfil.EXFILTRATION_REDACTION_TAG_PREFIX` (beside
 #: the rewriter itself), and a consumer that needs the full "was this text
 #: rewritten" answer must check that constant by prefix ALONGSIDE this tuple --
-#: the dashboard chat notice does exactly that (issues #6189 and #8132).
+#: the dashboard chat notice does exactly that.
 #:
 #: This tuple exists because the enumeration used to live at the call site, where
 #: it silently missed the encoded tag and under-reported redactions on the

--- a/src/kiro_crew/security/shell_normalizer.py
+++ b/src/kiro_crew/security/shell_normalizer.py
@@ -1052,7 +1052,7 @@ def _substitution_bodies(text: str) -> "list[str]":
 
     Quoting was not the whole of it. That span helper counted a ``)`` that shell
     COMMAND GRAMMAR also puts there as an ordinary character, and two such
-    spellings were measured allowing a payload this module still refuses (#8150):
+    spellings were measured allowing a payload this module still refuses:
     a ``#`` comment (``$(: # )`` closes on a later line) and a ``case`` pattern
     (``$(case x in x) printf token;; esac)``). Both truncated the body before the
     verb, so the value assembled from it was never recognised. The closer for the
@@ -1624,7 +1624,7 @@ def _opens_comment(text: str, index: int) -> bool:
 def _in_command_position(text: str, index: int) -> bool:
     """True if a command could START at *index* -- the previous real character separates.
 
-    Used to tell the reserved word ``esac`` from the ordinary string ``esac``, which
+    Tells the reserved word ``esac`` from the ordinary string ``esac``, which
     a command may pass as an argument.
 
     A backslash-newline is a line CONTINUATION, not a separator: ``echo \\`` then a
@@ -1662,7 +1662,7 @@ def _matching_close_paren(text: str, open_end: int) -> "tuple[int, bool]":
 
     Quoting is not the only way a ``)`` reaches this walk as an ordinary
     character. Two COMMAND-GRAMMAR constructs put one there too, and each was
-    measured allowing a payload this module still refuses (#8150):
+    measured allowing a payload this module still refuses:
 
     * a ``#`` COMMENT runs to the end of its line, so the ``)`` in
       ``$(: # )`` is commented out and the substitution closes on a LATER line.

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -1596,7 +1596,7 @@ class TaskRunner:
                     # remove` deregisters and deletes in separate steps, so
                     # an interrupted finalize() (or the worktree being
                     # removed out from under the run some other way) can
-                    # leave the directory present but no longer a registered
+                    # leave the directory present but not registered as a
                     # git worktree -- resuming against it would silently
                     # dispatch every remaining step against a non-git
                     # directory while still reporting them completed.

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -1835,9 +1835,9 @@ def provider_splits_oversized(stt_config) -> bool:  # type: ignore[no-untyped-de
     under (``sandbox.py``), so a segment WAV handed to the helper by name is
     unreadable and every over-cap Apple import would 502. AWS Transcribe has no
     silent ceiling at all (``batch_duration_cap_secs`` is None for it). So the
-    split is local-only, which is also what issue #8272 intends: "segmentation
+    split is local-only, by design: segmentation
     only ever triggers where the ceiling exists (AWS/Apple providers fail loudly
-    and need no split)". Takes the caller's config snapshot as a REQUIRED
+    and need no split). Takes the caller's config snapshot as a REQUIRED
     argument (the one production caller always has it in hand, from the same
     snapshot the readiness/cap/transcribe calls share); it never reads config
     itself, so there is no window for the three answers to describe different

--- a/src/kiro_crew/weixin/transport_dispatch.py
+++ b/src/kiro_crew/weixin/transport_dispatch.py
@@ -185,10 +185,10 @@ class WeixinDispatcher:
         attachment_temp_paths: list[str] = []
         # Captured BEFORE ingestion, which clears ``inbound.attachments`` and
         # inlines the temp paths into the text. The durable inbound spool needs
-        # both originals (issue #2217): the count is what tells the restart
+        # both originals: the count is what tells the restart
         # notice this turn carried media that was not carried over, and the
         # pre-ingestion text is what the notice quotes -- the ingested form
-        # holds paths to files that no longer exist.
+        # holds paths to temp files that are gone after a restart.
         original_text = text
         original_attachments = len(inbound.attachments or ())
         if inbound.attachments:
@@ -272,9 +272,9 @@ class WeixinDispatcher:
         """Session acquisition + turn dispatch for one already-ingested message.
 
         ``original_text`` / ``original_attachments`` are the pre-ingestion values,
-        which this frame can no longer recover: ingestion clears
+        which this frame cannot recover: ingestion clears
         ``inbound.attachments`` and rewrites the text with temp paths that are gone
-        after a restart. They exist for the durable inbound spool (issue #2217).
+        after a restart. They exist for the durable inbound spool.
         """
         assert self.client is not None
         # ── Mid-turn concurrency: check the CURRENT-generation key for an
@@ -312,7 +312,7 @@ class WeixinDispatcher:
             ChannelTurn(
                 channel_type="weixin",
                 session_key=session_key,
-                # Durable inbound spool (issue #2217): the peer id IS the reply
+                # Durable inbound spool: the peer id IS the reply
                 # target on this DM-only channel, and the reply's context_token
                 # is already persisted off-loop, so the restart notice can land.
                 # ``original_text`` with NO fallback to the ingested ``text``: the

--- a/src/kiro_crew/whatsapp/transport.py
+++ b/src/kiro_crew/whatsapp/transport.py
@@ -176,9 +176,9 @@ class WhatsAppTransport(MessagingTransport):
         self.pending_message_id: dict[int, str] = {}
         #: ``(text as the user sent it, media count)`` captured BEFORE ingestion
         #: rewrites ``msg.text`` with attachment context and temp paths. The
-        #: durable inbound spool (issue #2217) quotes the spooled text back to the
+        #: durable inbound spool quotes the spooled text back to the
         #: user in a restart notice, and the ingested form would quote on-disk
-        #: paths to files that no longer exist. Same keying and lifetime as the
+        #: paths to files that do not survive the restart. Same keying and lifetime as the
         #: three tables above.
         self.pending_original: dict[int, tuple[str, int]] = {}
         client.on_message = self.receive

--- a/src/kiro_crew/whatsapp/transport_dispatch.py
+++ b/src/kiro_crew/whatsapp/transport_dispatch.py
@@ -358,14 +358,14 @@ class WhatsAppDispatcher:
                 channel_type="whatsapp",
                 session_key=session_key,
                 conversation_id=f"whatsapp:{scope}",
-                # Durable inbound spool (issue #2217): DMs ONLY. The replay is a
+                # Durable inbound spool: DMs ONLY. The replay is a
                 # restart notice gated on ``may_send_to``, and this transport's
                 # ``may_send_to`` answers from ``dm_policy`` alone -- it knows
                 # nothing of the group roster, so a group removed or set to ``off``
                 # while the gateway was down would still receive the notice.
                 # Rather than teach the egress gate a roster it was never asked to
                 # hold, group routes are not declared and a refused group message
-                # degrades exactly as before this seam (tracked in #9144).
+                # degrades as any un-spooled refusal does: lost, with no restart notice.
                 #
                 # The text is the PRE-INGESTION original the transport captured,
                 # not ``inbound.text`` (by now rewritten with attachment context

--- a/test/test_autonudge_member_self_arm.py
+++ b/test/test_autonudge_member_self_arm.py
@@ -2,7 +2,7 @@
 
 The defect these pin: ``autonudge_authz`` refused every arm on a crew- or
 member-mode slot with "<mode>-mode sessions do not accept direct automation
-turns". The intent (PR #5184) was to keep a cron, another session or an app
+turns". The intent of that refusal is to keep a cron, another session or an app
 from injecting automation turns into a member's own thread. The side effect
 was that a member's OWN ``monitor_start`` was refused too, and the MCP tool
 had already answered "requested" over its own pipe, so nothing told anyone:
@@ -778,7 +778,7 @@ async def test_refused_monitor_start_carries_the_status_code() -> None:
     assert result.endswith("[status 409]")
 
 
-# ── round 2: hardening the persisted bit + provenance ratchet ───────────────
+# ── Persisted-bit hardening + provenance ratchet ───────────────
 
 
 def test_load_normalises_a_non_boolean_self_armed_to_false(tmp_path: Path) -> None:
@@ -877,7 +877,7 @@ def test_only_the_session_directive_consumer_passes_initiator_slot_key() -> None
     )
 
 
-# ── round 2: injected turns carry no provenance; trust record is required ────
+# ── Injected turns carry no provenance; trust record is required ────
 
 
 @pytest.mark.asyncio
@@ -1382,9 +1382,9 @@ class TestSelfArmTrustRecord:
     def test_record_is_an_upsert_that_preserves_sibling_entries(self) -> None:
         """Two members arming back to back (crew boot) must both stay recorded.
 
-        The write used to prune against a caller-supplied live-id snapshot taken
-        outside the lock; an arm whose snapshot predated a sibling's ``svc.add``
-        but committed last pruned the sibling's entry, refusing that loop at
+        The write must not prune against a caller-supplied live-id snapshot taken
+        outside the lock; an arm whose snapshot predates a sibling's ``svc.add``
+        but commits last would prune the sibling's entry, refusing that loop at
         every fire. Only revocation removes entries now.
         """
         from kiro_crew import autonudge_selfarm as sa
@@ -1441,7 +1441,7 @@ class TestFireTimeGuardRequiresTheTrustRecord(TestFireTimeModeRecheck):
         assert await self._authorize(mode=mode, self_armed=True) is False
 
 
-# ── round 3: prompt loops gated too; revocation on removal ──────────────────
+# ── Prompt loops gated too; revocation on removal ──────────────────
 
 
 class TestPromptLoopsAreGatedAtFireTime:

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -348,7 +348,7 @@ def test_slack_home_tab_sessions_per_kind_parsed_and_round_trips():
 
 
 class TestMemberDispatchLoad:
-    """agent.member_dispatch load-time coercion (issue #8073).
+    """agent.member_dispatch load-time coercion.
 
     The operator ceiling on the member session-control bypass. A MISSING key
     defaults to true (today's behaviour), but a PRESENT-but-malformed value —

--- a/test/test_inbound_spool.py
+++ b/test/test_inbound_spool.py
@@ -1,6 +1,6 @@
 """Durable inbound spool: the loss it closes, and the bounds that keep it safe.
 
-Issue #2217. Gateway shutdown gathers channel teardown and
+Gateway shutdown gathers channel teardown and
 ``SessionManager.close_all()`` concurrently, so a message the platform has
 already accepted can be refused by the ``_closing`` gate before its turn ever
 opens. Nothing retries it: the payload was discarded and the user was answered
@@ -216,7 +216,7 @@ def test_a_refused_turn_is_spooled_with_its_routing(monkeypatch, spool_home: Pat
 
     RED-BEFORE: with no spool wired into ``drive_turn``'s
     ``except SessionClosingError`` branch, the refusal leaves nothing on disk and
-    the user's text is gone for good — which is the whole of issue #2217.
+    the user's text is gone for good — the loss this spool exists to close.
     """
     _patch_pipeline(monkeypatch)
     sessions = _Sessions(closing=True)
@@ -767,7 +767,7 @@ def test_a_revoked_discord_thread_gets_no_notice_even_from_an_allowed_sender(
 
     RED-BEFORE: with ``principal=entry.user_id`` passed for the thread route, the
     still-allowed sender authorizes via the DM arm and the notice lands in a
-    thread that is no longer on the roster.
+    thread that is off the roster.
     """
     from kiro_crew.discord.transport import DiscordTransport
 
@@ -1103,8 +1103,8 @@ def test_the_default_spool_path_lives_under_the_data_home(spool_home: Path) -> N
 def test_an_entry_records_only_what_the_notice_reads() -> None:
     """No field ridden along "for later": every persisted key is consumed by the pass.
 
-    ``session_key`` and ``chat_type`` were recorded for a re-dispatch design that
-    was removed (#9144). A field nothing reads is a field nothing tests.
+    No ``session_key`` or ``chat_type``: a re-dispatch design would own its own
+    record, and a field nothing reads is a field nothing tests.
     """
     keys = set(SpooledInbound(channel_type="t", conversation_id="c", text="x").to_dict())
     assert keys == {

--- a/test/test_llm_helpers_edit_gate.py
+++ b/test/test_llm_helpers_edit_gate.py
@@ -1,11 +1,11 @@
-"""A file EDIT's tool_input is a document, and its gate is the target path (#8812).
+"""A file EDIT's tool_input is a document, and its gate is the target path.
 
 ``_dispatch.derive_edit_diff`` renders an edit's new content as a unified diff and
 that text is what ``event.tool_input`` carries. Feeding it to the shell-command
 scan refused writing a Markdown page that says ``git push origin main`` or a
 docstring naming the gateway-restart command (both live ``is_denied`` regex
-rules) -- and any body over the command-line size cap, for its length. (Before
-#9183 a sentence naming ``~/.ssh`` was refused too; that producer is gone.) These tests pin the
+rules) -- and any body over the command-line size cap, for its length. A body
+sentence naming ``~/.ssh`` is not refused either: there is no text-path fence. These tests pin the
 replacement: an edit is judged by where it writes (``is_sensitive_write_path`` over
 every accepted path spelling), the title tier still runs, and a non-edit tool
 keeps the document scan byte for byte.
@@ -170,9 +170,9 @@ class TestEditTargetIsTheGate:
 
     @pytest.mark.asyncio
     async def test_title_tier_still_runs_first(self) -> None:
-        # The title is a shell command the env-credential tier refuses (#9183
-        # removed the text path fence, so a credential PATH in a title is no
-        # longer the producer -- an env-credential read still is).
+        # The title is a shell command the env-credential tier refuses. A credential
+        # PATH in a title is not the producer (there is no text-path fence); an
+        # env-credential read is.
         ev = _edit_event("/tmp/proj/a.md")
         ev.title = "env | grep AWS_SECRET_ACCESS_KEY"
         approved, _p, rows = await _resolve(ev)

--- a/test/test_member_session_control.py
+++ b/test/test_member_session_control.py
@@ -266,7 +266,7 @@ class TestMemberDispatchCeiling:
             assert sc.member_dispatch_enabled() is True
 
     def test_member_falls_back_under_switch_when_ceiling_off(self):
-        # Switch off AND ceiling off: the member is no longer exempt, so it hits
+        # Switch off AND ceiling off: the member's exemption does not apply, so it hits
         # the same session_control_disabled refusal an ordinary caller gets.
         member = DM_SLOT_KEY_PREFIX + "radar"
         worker = _slot("chat-1-w1", created_by=member)

--- a/test/test_options_marker_closers.py
+++ b/test/test_options_marker_closers.py
@@ -75,7 +75,7 @@ class TestClosersNotOverlyBroad:
         # reachable through closers that are MATCHED by an earlier ``[`` or that
         # CONTINUE the label list -- here the ``]`` after ``a`` is followed by ``|``,
         # so it stays inside the label. An UNMATCHED closer followed by ordinary
-        # words ends the block instead (#9284); see
+        # words ends the block instead; see
         # ``test_options_marker_label_closers.py``.
         match = OPTIONS_RE_LINE.search("[OPTIONS: a] | b\u3011")
         assert match is not None

--- a/test/test_options_marker_label_closers.py
+++ b/test/test_options_marker_label_closers.py
@@ -1,4 +1,4 @@
-"""Tests for #9284: a closer stays in an ``[OPTIONS:]`` label only where it is
+"""A closer stays in an ``[OPTIONS:]`` label only where it is
 MATCHED by an earlier ``[``, or where it CONTINUES the label list.
 
 A label may legitimately carry a closer -- ``[OPTIONS: Alpha ] | Bravo ]]`` is a
@@ -36,8 +36,8 @@ one step further down, to ``split_options_trailer``, because narrowing the gramm
 is what made that function's partial-cut gate load-bearing: a marker the grammar
 declines must not be silently deleted by the consumer instead.
 
-Measured against ``origin/main`` at 56f67aa43 (post-#9174): every case in
-``OVERREACH`` and ``TRAILER_OVERREACH`` matches there and deletes the prose shown.
+Under an unconditional closer, every case in
+``OVERREACH`` and ``TRAILER_OVERREACH`` matches whole and deletes the prose shown.
 """
 
 from __future__ import annotations
@@ -59,12 +59,12 @@ OVERREACH = [
     "Pick [OPTIONS: A | B] and the type is dict[str, Any]",
     "All set [OPTIONS: Ship | Hold] before you diff src/app[0]",
     "Ready [OPTIONS: Yes | No] see the note in docs[2]",
-    # The wrapped forms of the same shape, on #9174's leading-wrapper path.
+    # The wrapped forms of the same shape, on the leading-wrapper (``lwrap``) path.
     "`[OPTIONS: A | B] then check arr[0]`",
     "**[OPTIONS: Merge | Wait] then read CHANGELOG[1]**",
 ]
 
-#: End-of-buffer shapes for the DOTALL grammar, where the body used to cross blank
+#: End-of-buffer shapes for the DOTALL grammar, where an unconditional closer lets the body cross blank
 #: lines and take the whole closing paragraph.
 TRAILER_OVERREACH = [
     "[OPTIONS: A | B]\n\nAnd then a whole closing paragraph about arr[0]",
@@ -242,7 +242,7 @@ class TestAcceptedCosts:
 
 
 class TestTheWideningIsNotOverlyNarrow:
-    """Everything #9174 and the closer widening added must still parse."""
+    """Everything the wrapper tolerance and the closer widening admit must still parse."""
 
     def test_the_plain_marker_still_parses_on_both_grammars(self):
         for text in ("Done.\n\n[OPTIONS: Merge | Wait]", "Done. [OPTIONS: Merge | Wait]"):
@@ -262,8 +262,8 @@ class TestTheWideningIsNotOverlyNarrow:
             assert match.group("lwrap") == wrap, text
 
     def test_a_wrapped_marker_with_a_continuing_closer_still_parses(self):
-        # The two rules compose: the wrapper is #9174's, the mid-label closer is
-        # this one's, and a marker carrying both is still a marker.
+        # The two rules compose: wrapper tolerance and the mid-label closer are independent,
+        # and a marker carrying both is still a marker.
         match = OPTIONS_RE_LINE.search("`[OPTIONS: Alpha ] | Bravo]`")
         assert match is not None
         assert match.group("lwrap") == "`"

--- a/test/test_prepare_pr_findings.py
+++ b/test/test_prepare_pr_findings.py
@@ -1038,7 +1038,7 @@ class TestDispositionViolations:
 # ---------------------------------------------------------------------------
 # Whole-design lanes reach the drill-in with span ids of their own. FINDING_RE
 # reads the `BLOCKING -- path:line` shape only GPT and Opus emit, so a Design
-# or First Principles Watch item used to be invisible to the loop even though
+# or First Principles Watch item is invisible to FINDING_RE alone even though
 # SKILL.md ranks those lanes ABOVE the line-level ones in triage.
 # ---------------------------------------------------------------------------
 
@@ -1237,7 +1237,7 @@ class TestWholeDesignItems:
 
     def test_the_not_justified_section_is_an_item_section(self) -> None:
         """The section the prompts gained for the premise gate. Its items are
-        exactly the ones a PASS used to bury, so they must reach the loop with
+        exactly the ones a PASS verdict would otherwise bury, so they must reach the loop with
         span ids like any other."""
         module = _load_script()
         comment = {

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -3321,7 +3321,7 @@ class TestRedactExfiltrationUrls:
     def test_substitution_is_built_from_the_exported_prefix(self) -> None:
         """The URL tag must start with ``EXFILTRATION_REDACTION_TAG_PREFIX``.
 
-        The dashboard chat notice (issue #8132) prefix-counts that constant in
+        The dashboard chat notice prefix-counts that constant in
         the persisted text to tell the user a URL was rewritten -- the tag
         interpolates the domain, so unlike the constant credential tags it
         cannot be equality-compared. Driving the REAL redactor here pins the
@@ -8115,7 +8115,7 @@ class TestTrustedIssueLinkChannel:
 
 
 class TestSubstitutionCloserReadsCommandGrammar:
-    """A ``)`` that shell COMMAND GRAMMAR makes ordinary must not end a body (#8150).
+    """A ``)`` that shell COMMAND GRAMMAR makes ordinary must not end a body.
 
     ``_substitution_bodies`` is the shared answer to "what text does this command
     run as a shell", so a body that stops early is not one pass's problem: every
@@ -8128,7 +8128,7 @@ class TestSubstitutionCloserReadsCommandGrammar:
     would mask what these cases are actually testing.
 
     Both directions are asserted. The scan may not stop early (the anchors), and
-    it may not start refusing shapes it used to allow -- a scanner made stricter
+    it may not start refusing shapes it allows today -- a scanner made stricter
     in the wrong place is how a gate becomes unusable.
     """
 

--- a/test/test_taskrunner.py
+++ b/test/test_taskrunner.py
@@ -3541,7 +3541,7 @@ class TestGitCoord:
 
     @pytest.mark.asyncio
     async def test_reinit_recovers_an_orphaned_worktree(self, tmp_path: Path) -> None:
-        """#3792: reproduce the reported state precisely -- the worktree
+        """Reproduce the reported state precisely -- the worktree
         directory still exists on disk, but its registration under the main
         repo's ``.git/worktrees/`` was removed out from under it (what an
         interrupted ``git worktree remove`` leaves behind: deregistration and
@@ -3596,7 +3596,7 @@ class TestGitCoord:
     async def test_reinit_fails_closed_when_the_original_repo_is_also_gone(
         self, tmp_path: Path
     ) -> None:
-        """If even run.repo_root can no longer be recovered from, reinit must
+        """If even run.repo_root cannot be recovered from, reinit must
         report failure rather than silently disabling git."""
         from kiro_crew import git_coord
 
@@ -3678,7 +3678,7 @@ class TestGitCoord:
         read as valid.
 
         Matching paths are not identity: something else can create a repo
-        exactly where the lost worktree used to be, and then
+        exactly where the lost worktree stood, and then
         ``rev-parse --show-toplevel`` answers with that path -- the expected
         one. Resuming on that would commit the run's remaining steps into a
         repository that is not the run's own. A linked worktree shares its main
@@ -3780,7 +3780,7 @@ class TestGitCoord:
     async def test_git_probe_fails_closed_when_the_directory_itself_is_gone(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Probing a directory that no longer exists must read as "not a git
+        """Probing a directory that does not exist must read as "not a git
         repo", never raise.
 
         The two platforms disagree on how the spawn fails: POSIX reports a
@@ -3838,7 +3838,7 @@ class TestGitCoord:
         await git_coord.init_workspace(run)
         worktree_dir = Path(run.worktree_path)
 
-        # The #3792 state: deregistered, checkout still on disk, so the first
+        # The orphaned state: deregistered, checkout still on disk, so the first
         # proof legitimately passes and recovery proceeds to capture.
         admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_dir.name
         assert admin_dir.exists()
@@ -3905,7 +3905,7 @@ class TestGitCoord:
         await git_coord.init_workspace(run)
         worktree_dir = Path(run.worktree_path)
 
-        # The #3792 state: deregistered, but the checkout survives on disk, so
+        # The orphaned state: deregistered, but the checkout survives on disk, so
         # the ownership proof passes and recovery proceeds to delete.
         admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_dir.name
         assert admin_dir.exists()
@@ -3971,7 +3971,7 @@ class TestGitCoord:
         worktree_dir = Path(run.worktree_path)
         (worktree_dir / "scratch.txt").write_text("uncommitted scratch")
 
-        # The #3792 orphaned state: deregistered, directory intact.
+        # The orphaned state: deregistered, directory intact.
         import shutil
 
         admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_dir.name
@@ -4225,7 +4225,7 @@ class TestGitCoord:
         # Replace the worktree with an unrelated directory carrying a FORGED
         # pointer: a regular ``.git`` file naming a nonexistent entry under
         # the real repository's ``worktrees`` directory. The ownership checks
-        # accept it as a stale checkout, which used to authorize deletion.
+        # accept it as a stale checkout, which on its own would authorize deletion.
         await git_coord.finalize(run)
         worktree_dir.mkdir(parents=True)
         forged_target = Path(run.repo_root) / ".git" / "worktrees" / "no-such-entry"
@@ -4375,7 +4375,7 @@ class TestGitCoord:
         step = Step(index=1, title="Add step.py", description="d")
         assert await git_coord.commit_step(run, step) != ""
 
-        # The #3792 orphaned state: checkout on disk, admin entry gone. The
+        # The orphaned state: checkout on disk, admin entry gone. The
         # branch is still intact here, so every PRE-add check passes.
         admin_dir = Path(run.repo_root) / ".git" / "worktrees" / worktree_dir.name
         assert admin_dir.exists()

--- a/test/test_taskrunner_coverage.py
+++ b/test/test_taskrunner_coverage.py
@@ -918,7 +918,7 @@ class TestRetryFromTask:
         detected by the same workspace_is_valid() check -- _is_git_repo()
         against a nonexistent directory is False too -- and recovery is
         attempted via reinit_workspace_for_retry(), not init_workspace()
-        directly (see #3792: a second init_workspace() call would check the
+        directly (a second init_workspace() call would check the
         DEAD worktree path rather than the original repo)."""
         runner = _runner(tmp_path)
         run = _seed_run(runner, tmp_path, status="failed")
@@ -940,8 +940,8 @@ class TestRetryFromTask:
     async def test_retry_fails_the_run_when_the_workspace_cannot_be_restored(
         self, tmp_path: Path
     ) -> None:
-        """#3792: the original bug -- a retry whose worktree was deregistered
-        (directory present, no longer a registered git repo) must not
+        """A retry whose worktree was deregistered
+        (directory present, not a registered git repo) must not
         silently dispatch the remaining steps against it. If recovery fails,
         the run is failed terminally instead of continuing."""
         runner = _runner(tmp_path)

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -2744,7 +2744,7 @@ class TestDispatcher:
     def test_a_shutdown_refusal_is_spooled_for_a_persistent_session(
         self, tmp_path, monkeypatch
     ) -> None:
-        """The durable inbound spool (#2217) receives the refused message."""
+        """The durable inbound spool receives the refused message."""
         from kiro_crew.messaging import inbound_spool as S
 
         monkeypatch.setattr(S, "data_home", lambda: tmp_path)

--- a/test/test_whatsapp_dispatch.py
+++ b/test/test_whatsapp_dispatch.py
@@ -644,7 +644,7 @@ def _captured_turn(monkeypatch, dispatcher, inbound):
     return seen.get("turn")
 
 
-# ── durable inbound spool route (#2217) ──────────────────────────────────────
+# ── durable inbound spool route ──────────────────────────────────────────────
 
 
 def test_dm_route_spools_the_pre_ingestion_original_not_the_prompt(monkeypatch):
@@ -678,7 +678,7 @@ def test_dm_route_is_not_declared_without_a_captured_original(monkeypatch):
 
 
 def test_group_route_is_never_declared(monkeypatch):
-    """``may_send_to`` knows nothing of the group roster, so groups are not spooled (#9144)."""
+    """``may_send_to`` knows nothing of the group roster, so groups are not spooled."""
     d, _client, _sessions, transport = _make()
     inbound = _msg("hi group", conv=_GROUP)
     transport.pending_original[id(inbound)] = ("hi group", 0)

--- a/test/test_whatsapp_transport.py
+++ b/test/test_whatsapp_transport.py
@@ -529,12 +529,12 @@ class TestOwnOutgoingMessages:
 
 @pytest.mark.asyncio
 class TestPreIngestionOriginalIsCapturedForTheSpool:
-    """The durable inbound spool (#2217) quotes the spooled text back to the user.
+    """The durable inbound spool quotes the spooled text back to the user.
 
     ``receive`` rewrites ``msg.text`` with attachment context and temp paths
     before dispatch, so a route built from ``inbound.text`` at the dispatch site
     would spool -- and the restart notice would quote -- on-disk paths to files
-    that no longer exist. The original caption and media count are captured
+    that do not survive the restart. The original caption and media count are captured
     BEFORE ingestion in a side table keyed like the others.
     """
 


### PR DESCRIPTION
## Problem / Motivation

Main is above its history-narration baseline in 25 files. A PR that touches one of those files gets a red `Backend Lint & Type Check (3.12)` result even when it adds no matching comment.

## Why it matters

Unrelated PRs are blocked by comments already on `main`. Fixing the same inherited lines in each PR would repeat work and hide the real cause.

## What changed (motivation → approach → change)

The 73 excess markers state what the code does in present tense. The recorded baseline does not move. No executable code changes.

## Tests

The comment-history gate passes for the PR diff and the whole tree.

- `python3 scripts/check_comment_history.py --test`
- `python3 scripts/check_comment_history.py`
- `RATCHET_SCOPE_WHOLE_TREE=1 python3 scripts/check_comment_history.py`
- Black, isort, and flake8 on every changed file
- `pytest -n0` on every touched test path: 2,710 passed, 5 skipped

## Manual verification

N/A — the whole-tree gate proves every count is at or below its recorded baseline.

<!-- no-visual-delta -->
**Why no screenshot:** Only comments and docstrings change. No rendered surface changes.

## Related Issues

no linked issue: this repairs inherited lint failures seen by open PRs.

## Pattern harvest

Rule candidate: lint
Pattern: Ratchet checks on protected-base pushes must inspect the integrated whole tree, not an empty base-to-HEAD diff.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
