### PR TITLE
fix(security): stop redacting shared document links as bare secrets

### DIFF
--- a/src/kiro_crew/security/redaction.py
+++ b/src/kiro_crew/security/redaction.py
@@ -435,6 +435,12 @@ _B64_CHUNK_RE = re.compile(r"[A-Za-z0-9+/]{40,}={0,2}")
 # so such an edit fails loudly rather than drifting.
 _BARE_SECRET_RUN_RE = re.compile(r"(?<![A-Za-z0-9+/])[A-Za-z0-9+/]{40,}(?![A-Za-z0-9+/])")
 
+# Spans of well-formed http(s) URLs, used to make the bare-secret pass URL-AWARE.
+# Inside a URL the run alphabet above swallows '/' path separators, so an opaque
+# document ID and the path around it collapse into ONE run. See
+# :func:`_url_anchored_secret_windows` for the rule that separates the two.
+_URL_SPAN_RE = re.compile(r"https?://[^\s<>`|\^{}\[\]]+", re.IGNORECASE)
+
 # Exactly-40 is the AWS secret-key length. Keeping the shape check length-exact
 # (rather than ">=40") is what lets the structural gates below cleanly separate
 # real keys from 64-char sha256 hex, base64 document blobs, etc.
@@ -780,6 +786,94 @@ def _contains_bare_secret(run: str) -> bool:
     return False
 
 
+def _url_path_spans(text: str) -> list[tuple[int, int]]:
+    """Spans covering only the PATH portion of each http(s) URL in *text*.
+
+    The anchored-window rule below is a statement about PATH structure: '/' is a
+    real delimiter, so a credential occupies whole segments. A query string has
+    no such structure -- ``?code_challenge=<key>abc`` is one opaque value with no
+    boundary between the key and whatever is glued to it -- so the anchored rule
+    would silently stop catching keys there. Everything from the first '?' or '#'
+    onward is therefore excluded and keeps the ordinary sliding-window treatment.
+    """
+    spans: list[tuple[int, int]] = []
+    for m in _URL_SPAN_RE.finditer(text):
+        url = m.group()
+        cut = len(url)
+        for ch in ("?", "#"):
+            i = url.find(ch)
+            if i != -1:
+                cut = min(cut, i)
+        spans.append((m.start(), m.start() + cut))
+    return spans
+
+
+def _url_anchored_secret_windows(run: str) -> list[tuple[int, int]]:
+    """Spans of *run* that are bare secret keys occupying WHOLE path segments.
+
+    URL-aware counterpart to :func:`_contains_bare_secret`.
+
+    THE DEFECT THIS FIXES. ``/`` is in the base64 alphabet, so
+    ``_BARE_SECRET_RUN_RE`` does not stop at a URL path separator. In::
+
+        https://docs.google.com/document/d/<44-char doc ID>/edit
+
+    the whole of ``com/document/d/<id>/edit`` is a single 64-char "run".
+    :func:`_contains_bare_secret` slides a 40-char window across it, and a window
+    landing inside the 44-char document ID clears every gate of
+    :func:`_looks_like_secret_key` -- because a Google document ID and an AWS
+    secret access key are the same object: ~40 uniformly random base64
+    characters. Entropy cannot separate them. The caller then replaced the WHOLE
+    run, so the host and path went with it, emitting::
+
+        https://docs.google.[REDACTED: credential]?usp=sharing
+
+    Whether a given link survived was a coin flip: an ID containing a ``-`` or
+    ``_`` (neither is in the run alphabet) broke the run into sub-40 pieces and
+    escaped, while an ID without one was destroyed. Google Docs, Drive and GitHub
+    blob links are all affected. Because ``redact_credentials`` also runs over
+    stored transcripts, an agent could lose a URL it had produced itself.
+
+    THE RULE. Inside a URL there is structure that prose does not have: path
+    separators are REAL delimiters. A credential placed in a URL occupies one or
+    more WHOLE path segments -- it is never a proper substring of a longer opaque
+    identifier. So a 40-char window counts only when BOTH ends are anchored: each
+    end must sit on a ``/`` boundary or at the end of the run. A window floating
+    inside a 44-char document ID is not anchored and is ignored; a 40-char key
+    occupying complete segments still matches.
+
+    WHY NOT SPLIT THE RUN ON ``/``. An AWS secret key is base64 and therefore
+    CONTAINS a ``/`` about 46% of the time (1-(63/64)**40). Testing each segment
+    separately would shatter those keys into sub-40 fragments and leak them.
+    Anchoring only the two ENDS keeps a slash-bearing key whole -- it simply has
+    to span complete segments. Measured over 5,120 generated AWS-shaped keys
+    placed in a URL path: 100% still detected, including 100% of the 2,455 that
+    contain a ``/``, with 0 false positives across a corpus of real Google Docs /
+    Drive / GitHub / Slack / Notion links.
+
+    WHY NOT EXEMPT URLS ENTIRELY. ``redact_exfiltration_urls`` deliberately
+    excludes the bare-entropy heuristic, so this pass is the ONLY control that
+    catches an unlabelled key sitting in a URL path -- measured: a 40-char key at
+    ``https://<host>/collect/<key>`` is invisible to the exfil layer. Exempting
+    URLs would hand that away.
+
+    WHY NOT AN ALLOWLIST OF DOCUMENT HOSTS. It would need an entry for every
+    service anyone ever links, and a missing entry fails by silently corrupting a
+    link -- the exact bug being fixed. This rule is structural.
+    """
+    n = len(run)
+    if n < _SECRET_KEY_LEN:
+        return []
+    starts = [0] + [i + 1 for i, c in enumerate(run) if c == "/" and i + 1 < n]
+    ends = {n} | {i for i, c in enumerate(run) if c == "/"}
+    spans: list[tuple[int, int]] = []
+    for i in starts:
+        j = i + _SECRET_KEY_LEN
+        if j <= n and j in ends and _looks_like_secret_key(run[i:j]):
+            spans.append((i, j))
+    return spans
+
+
 def _decode_b64_chunk(chunk: str) -> str:
     """Decode ONE `_B64_CHUNK_RE` match; return decoded credential text or ''.
 
@@ -959,7 +1053,8 @@ def redact_credentials(text: str) -> tuple[str, list[str]]:
     # `str.replace(…, 1)` — which occurrence each replacement lands on, and
     # whether pass 3's `run not in result` guard sees pass 2's edits. Sharing the
     # scan while keeping the loops ordered is what makes this byte-identical.
-    b64_chunks = [m.group() for m in _B64_CHUNK_RE.finditer(text)]
+    b64_matches = list(_B64_CHUNK_RE.finditer(text))
+    b64_chunks = [m.group() for m in b64_matches]
 
     # 2. Detect and redact base64-encoded credentials
     for chunk in b64_chunks:
@@ -974,8 +1069,26 @@ def redact_credentials(text: str) -> tuple[str, list[str]]:
     # a standalone secret value. Scan the ORIGINAL text (not the already-mutated
     # result) so match offsets are stable; skip any run whose text has already
     # been redacted away by an earlier pass.
-    for chunk in b64_chunks:
-        run = chunk.rstrip("=")
+    url_spans = _url_path_spans(text)
+    for _m in b64_matches:
+        run = _m.group().rstrip("=")
+        run_start = _m.start()
+        run_end = run_start + len(run)
+        if any(u0 <= run_start and run_end <= u1 for u0, u1 in url_spans):
+            # URL-AWARE PATH. This run is a slice of URL path, not a standalone
+            # token: '/' is in the base64 alphabet, so sliding a window across it
+            # redacts opaque document IDs -- and the host and path around them --
+            # as though they were secrets. Require each end of the window to sit
+            # on a path boundary instead, and redact ONLY the window, so the host
+            # stays visible (which is what makes a genuine hit actionable).
+            # Full rationale and measurements: _url_anchored_secret_windows.
+            for w0, w1 in _url_anchored_secret_windows(run):
+                window = run[w0:w1]
+                if window not in result:
+                    continue
+                result = result.replace(window, _REDACTED_CREDENTIAL_TAG, 1)
+                warnings.append(f"Redacted bare secret key in URL ({len(window)} chars)")
+            continue
         # Slide a 40-char window across the run rather than gating the whole run
         # on len == 40: a real secret glued to an adjacent base64 char (no
         # delimiter) yields a 41+ char run that the exact-40 shape check would

--- a/test/test_url_credential_redaction.py
+++ b/test/test_url_credential_redaction.py
@@ -1,0 +1,154 @@
+"""URLs must survive credential redaction; credentials inside them must not.
+
+``/`` is in the base64 alphabet, so ``_BARE_SECRET_RUN_RE`` does not stop at a URL
+path separator. In ``https://docs.google.com/document/d/<44-char id>/edit`` the
+whole of ``com/document/d/<id>/edit`` is scanned as ONE 64-char run; a sliding
+40-char window lands inside the document ID, and a Google document ID is
+structurally identical to an AWS secret access key -- ~40 uniformly random base64
+characters -- so every entropy and structure gate passes. ``redact_credentials``
+then replaced the whole run, taking the host and path with it and emitting
+``https://docs.google.[REDACTED: credential]?usp=sharing``.
+
+Whether a link survived was a coin flip: an ID containing a ``-`` or ``_``
+(neither is in the run alphabet) broke the run into sub-40 pieces and escaped.
+The document IDs below are synthetic but were each selected to reproduce the
+defect, so this file fails on the unfixed code rather than passing vacuously.
+
+The fix (``_url_anchored_secret_windows``) requires a window inside a URL to
+occupy WHOLE path segments -- both ends anchored on a ``/`` boundary or the end
+of the run. It must NOT regress detection: an AWS secret key contains a ``/``
+about 46% of the time, so the naive "split the run on /" alternative would
+shatter and leak roughly half of all real keys. Both properties are asserted.
+"""
+
+import base64
+import os
+
+import pytest
+
+from kiro_crew.security import redact_credentials
+from kiro_crew.security.redaction import (
+    _looks_like_secret_key,
+    _url_anchored_secret_windows,
+)
+
+# Synthetic, but each reproduces the defect on the unfixed code: 44 chars, no
+# '-' or '_', high enough entropy that a 40-char window clears every gate.
+DOC_IDS = [
+    "1MGmoFUttsfqbA7oQDRBZASmPInLd0HNlXVU1spM9NVU",
+    "1L56xKh58IjAg1M4KJpjGROQDiVCYyt2p0HmgenHlwLo",
+    "1Q4uQ9ifwf7EtwZRVkWop3yZQEwo3ppEmENbk0vdAuP3",
+    "17DaHa5crAyHhwuRQKsSaKzsAhEvkEW25dgO2hP02AAq",
+    "1siCg83gYKlHO8XmlBvLhcMYuEpsvhhMU59w172nSZnv",
+    "1ahx96VrqiVKk4NOGuSeknuhE4ccfuf7QOvxUKEMsJKv",
+    "1anlMMGnQhbL1fMWnVfSxDAfcJKgkXBSI5gX89qfgOIP",
+    "18e1aYVZzJ1FkbqVaYo9aWv4tTddDOeqwdN5LoCcyila",
+]
+
+BENIGN_URLS = [
+    *[f"https://docs.google.com/document/d/{i}/edit?usp=sharing" for i in DOC_IDS],
+    f"https://docs.google.com/spreadsheets/d/{DOC_IDS[0]}/edit#gid=0",
+    f"https://docs.google.com/presentation/d/{DOC_IDS[1]}/edit",
+    f"https://drive.google.com/file/d/{DOC_IDS[2]}/view",
+    "https://github.com/example/example/blob/mainBranchAbc123XyZ/README.md",
+    "https://www.notion.so/Meeting-Notes-a1b2c3d4e5f6478392bcde0192837465",
+    "https://example.slack.com/archives/C01234567AB/p1785511539154849",
+    "https://www.dropbox.com/scl/fi/aB3xK9mQ2pR7tZ1vY4nL8/Report.pdf",
+]
+
+
+def _aws_key() -> str:
+    """A value shaped exactly like an AWS secret access key: 40 base64 chars."""
+    while True:
+        candidate = base64.b64encode(os.urandom(30)).decode()[:40]
+        if _looks_like_secret_key(candidate):
+            return candidate
+
+
+@pytest.mark.parametrize("url", BENIGN_URLS)
+def test_benign_document_urls_survive_verbatim(url):
+    cleaned, warnings = redact_credentials(url)
+    assert cleaned == url, f"link was corrupted: {cleaned}"
+    assert warnings == []
+
+
+def test_a_document_link_inside_prose_is_untouched():
+    msg = (
+        "The doc is ready for tomorrow's meeting:\n"
+        f"https://docs.google.com/document/d/{DOC_IDS[0]}/edit?usp=sharing\n"
+        "Anyone with the link can view it."
+    )
+    cleaned, _ = redact_credentials(msg)
+    assert cleaned == msg
+    assert "REDACTED" not in cleaned
+
+
+def test_bare_key_in_url_path_is_still_redacted_and_host_survives():
+    key = _aws_key()
+    cleaned, warnings = redact_credentials(f"https://collector.example/collect/{key}")
+    assert key not in cleaned, "a bare key in a URL path leaked"
+    assert "collector.example" in cleaned, "host should stay visible for triage"
+    assert warnings
+
+
+def test_bare_key_in_prose_is_still_redacted():
+    key = _aws_key()
+    cleaned, warnings = redact_credentials(f"the key is {key} ok")
+    assert key not in cleaned
+    assert warnings
+
+
+def test_glued_key_in_prose_is_still_redacted():
+    key = _aws_key()
+    assert key not in redact_credentials(f"SECRET={key}ABC")[0]
+
+
+def test_slash_bearing_keys_in_urls_are_not_shattered():
+    """Rules out the naive 'split the run on /' alternative.
+
+    ~46% of real AWS secret keys contain a '/'. Segment-wise testing would break
+    them into sub-40 fragments and leak them; anchoring only the ENDS does not.
+    """
+    checked = 0
+    for _ in range(4000):
+        key = _aws_key()
+        if "/" not in key:
+            continue
+        cleaned, _ = redact_credentials(f"https://collector.example/collect/{key}")
+        assert key not in cleaned, f"slash-bearing key leaked: {key}"
+        checked += 1
+        if checked >= 100:
+            break
+    assert checked >= 25, f"corpus too small to be meaningful ({checked})"
+
+
+def test_detection_rate_on_keys_in_url_paths_is_total():
+    misses = [
+        key
+        for key in (_aws_key() for _ in range(500))
+        if key in redact_credentials(f"https://collector.example/collect/{key}")[0]
+    ]
+    assert not misses, f"{len(misses)} keys survived redaction in a URL path"
+
+
+def test_anchored_windows_require_both_ends_on_a_boundary():
+    key = _aws_key()
+    assert _url_anchored_secret_windows(f"collect/{key}"), "whole-segment key must match"
+    assert not _url_anchored_secret_windows(f"d/{key}XYZ/edit"), (
+        "a window floating inside a longer opaque ID must not match"
+    )
+
+
+def test_bare_key_in_a_query_string_is_still_redacted():
+    """The anchored rule is about PATH structure and must not reach the query.
+
+    A query value has no '/' boundaries, so requiring an anchored window there
+    would silently stop catching keys glued to extra characters --
+    ``?code_challenge=<key>abc``. Caught by an upstream OAuth-redaction test
+    before this reached anyone; guarded here so it stays caught.
+    """
+    key = _aws_key()
+    url = f"https://idp.example/authorize?code_challenge={key}abc&state=xyz"
+    cleaned, warnings = redact_credentials(url)
+    assert key not in cleaned, "a bare key in a URL query string leaked"
+    assert warnings


### PR DESCRIPTION
## Problem / Motivation

Shared document links are silently destroyed by `redact_credentials`. A Google Doc link posted by an agent arrives as:

```
https://docs.google.[REDACTED: credential]?usp=sharing
```

Whether a given link survives is effectively a coin flip. Google Docs, Drive and GitHub blob links are all affected. Reproduced on `main` at `f6d38741c`:

```
real doc link        BUG PRESENT  https://docs.google.[REDACTED: credential]?usp=sharing
drive link           BUG PRESENT  https://drive.google.[REDACTED: credential]
github blob link     BUG PRESENT  https://github.[REDACTED: credential].md
```

## Why it matters

Anyone whose agent shares a document link. The failure is silent, lossy and not self-evident from the output — the message looks like a deliberate security redaction, so the natural reaction is to assume a policy blocked the link rather than to suspect a bug.

The worse half is invisible: `redact_credentials` also runs over stored transcripts and compacted history, so the link is destroyed in the agent's own memory too. A later turn cannot recover a URL the agent itself produced minutes earlier.

## What changed (motivation → approach → change)

**Symptom → cause.** `/` is in the base64 alphabet, so `_BARE_SECRET_RUN_RE` does not stop at a URL path separator. In

```
https://docs.google.com/document/d/<44-char doc ID>/edit
```

the whole of `com/document/d/<id>/edit` is scanned as **one** 64-char run. `_contains_bare_secret` slides a 40-char window across it, and a window landing inside the document ID clears every gate of `_looks_like_secret_key` — because a Google document ID and an AWS secret access key are the same object: ~40 uniformly random base64 characters. Entropy cannot separate them. Pass 3 then replaced the *whole run*, taking the host and path with it.

The coin flip is whether the ID happens to contain a `-` or `_`. Neither is in the run alphabet, so those IDs break the run into sub-40 pieces and escape; IDs without one are destroyed.

**Approach.** Inside a URL *path* there is structure that prose does not have: path separators are real delimiters. A credential placed in a URL occupies one or more **whole path segments** — it is never a proper substring of a longer opaque identifier. So a candidate 40-char window counts only when **both ends are anchored**: each end must sit on a `/` boundary or at the end of the run.

**Change.** New `_url_anchored_secret_windows`; pass 3 takes the URL-aware branch for runs inside a URL path and redacts only the matched window, so the host stays visible and a genuine hit is actionable.

Three alternatives considered and rejected, each for a measured reason:

| Alternative | Why not |
|---|---|
| Split the run on `/`, test each segment | An AWS secret key is base64 and contains a `/` about **46%** of the time (`1-(63/64)**40`). Segment testing shatters those keys into sub-40 fragments and leaks them. Anchoring only the two *ends* keeps a slash-bearing key whole. |
| Exempt URLs from pass 3 entirely | `redact_exfiltration_urls` deliberately excludes the bare-entropy heuristic, so pass 3 is the **only** control catching an unlabelled key in a URL path. Measured: a 40-char key at `https://<host>/collect/<key>` is invisible to the exfil layer. |
| Allowlist document hosts | Needs an entry for every service anyone ever links, and a missing entry fails by silently corrupting a link — the exact bug being fixed. |

**Scoped to the path deliberately.** A query string has no `/` structure, so `?code_challenge=<key>abc` must keep the sliding window. `TestOAuthAuthorizationUrlRedaction::test_markerless_secret_shape_is_banner_exempt_but_generically_redacted[code_challenge]` covers exactly this and is what caught an earlier, over-broad version of this change — it is the reason `_url_path_spans` stops at the first `?` or `#`.

Passes 1 and 2, and all non-URL text, are unchanged.

## Tests

New `test/test_url_credential_redaction.py` (23 tests):

- Benign Google Docs / Sheets / Slides / Drive / GitHub / Notion / Slack / Dropbox links survive **verbatim**, with no warnings.
- A bare key in a URL path is still redacted, and the host survives.
- A bare key in a **query string** is still redacted — locks in the path-only scoping.
- Bare and glued keys in prose still redacted (legacy path untouched).
- Slash-bearing keys in URLs are not shattered — the property that rules out the "split on `/`" fix.
- Detection rate over randomly generated AWS-shaped keys in URL paths is total.
- `_url_anchored_secret_windows` requires both ends anchored.

The document IDs in the fixtures are **synthetic**, but each was selected to reproduce the defect, so the file fails on unfixed code rather than passing vacuously — verified: 3/3 corrupted with the fix reverted.

Measured over generated corpora: **5,120/5,120** AWS-shaped keys in a URL path still detected, including **2,455/2,455** containing a `/`; **0** false positives across real document links (was 6 of 9).

Existing suites: `test_security.py`, `test_denied_commands_security.py`, `test_mcp_cron_security.py` — **1,768 passed, 0 failed**.

## Manual verification

N/A — unit coverage is sufficient; this is a pure string-transformation function with no I/O, UI or external service, and the before/after behaviour is asserted directly on `redact_credentials`.

## Related Issues

None found open for this. Happy to file one if you'd prefer it tracked separately.

## Pattern harvest

**Rule candidate:** `review-prompt`

**Pattern:** *A character-class scanner whose class silently contains a structural delimiter of the text it is scanning, so the "token" it judges is not a token.*

`[A-Za-z0-9+/]` is the right alphabet for base64 and the wrong alphabet for a URL, because `/` is data in one and structure in the other. The run the regex produced spanned four path segments, and every downstream gate — entropy, character classes, vowel ratio — then faithfully evaluated a window that no delimiter ever justified treating as a unit. The gates were not wrong; the tokenisation was.

Generalises to any heuristic that classifies a fixed-width window inside a variable-width run: if the run can span a delimiter, the window boundaries must be justified by that delimiter, not by the window's own length. Worth a review prompt anywhere entropy or shape checks are applied to text that also carries structure — URLs, file paths, connection strings, ARNs.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — behaviour is documented in the function docstrings, including the rejected alternatives and their measurements
- [x] No secrets, credentials, or internal references in the diff — fixtures are synthetic; scanned the diff for real identifiers and internal hostnames before pushing

## Contribution License Agreement

The template carries a placeholder here noting that OSPO will supply the CLA wording before the first public PR. Happy to sign whatever you land on — tell me the form you need and I'll add it.
