### PR TITLE
feat(session): make the empty-turn auto-continue budget configurable

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1045,6 +1045,7 @@
       "defaultValue": {
         "timeout_secs": 3600,
         "empty_response_auto_continue": true,
+        "empty_response_max_continues": 1,
         "autocompact_pct": 70.0,
         "pool_size": 0,
         "pool_agent": "",
@@ -1077,10 +1078,24 @@
       "sensitive": false,
       "tags": [],
       "label": "Auto-Continue on Empty Response",
-      "help": "After the model returns an empty response twice in a row, automatically send one 'continue' nudge on the same session (transcript-visible, bounded to once per user message).",
+      "help": "After the model returns an empty response twice in a row, automatically send a 'continue' nudge on the same session (transcript-visible, bounded by Max Auto-Continues on Empty Response).",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": true
+    },
+    {
+      "path": "session.empty_response_max_continues",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Max Auto-Continues on Empty Response",
+      "help": "How many 'continue' nudges may run back to back before the runner gives up and asks for a message (1-10). Above 1 the recovery notice shows progress ('recovery 2 of 3'). Useful during provider-instability windows where each continuation makes real progress before failing the same way. Only applies while Auto-Continue on Empty Response is enabled.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 1
     },
     {
       "path": "session.autocompact_pct",

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -981,7 +981,8 @@ class AgentConfig:
 @dataclass
 class SessionConfig:
     timeout_secs: int = 3600       # 60 min idle timeout (DEFAULT_SESSION_TIMEOUT)
-    empty_response_auto_continue: bool = True  # after TWO consecutive empty model responses, auto-send ONE synthetic "continue" nudge on the same live session (transcript-visible notice; bounded to once per user message; the config gate fails OPEN to the default so a config-load hiccup cannot disable self-healing). See session.md "Empty-response recovery ladder".
+    empty_response_auto_continue: bool = True  # after TWO consecutive empty model responses, auto-send synthetic "continue" nudges on the same live session (transcript-visible notice; count bounded by empty_response_max_continues; the config gate fails OPEN to the default so a config-load hiccup cannot disable self-healing). See session.md "Empty-response recovery ladder".
+    empty_response_max_continues: int = 1  # how many continue nudges may run back to back before the give-up card (EMPTY_RESPONSE_MAX_CONTINUES_MIN/MAX; load-time clamped to [1, 10] so a hand-edited 0 cannot disable recovery and a large value cannot arm an unbounded ladder). Default 1 keeps the pre-knob behavior byte-identical; above 1 the notice numbers each recovery ("recovery 2 of 3").
     autocompact_pct: float = 70.0  # context usage % at which auto-compaction triggers (DEFAULT_AUTOCOMPACT_PCT). Load-time clamped to [5.0, 90.0] (one constant pair shared with the dashboard write gate)
     pool_size: int = 0             # pre-warmed kiro-cli processes kept ready for instant session start; 0 (the default) disables. Single source of truth: DEFAULT_POOL_SIZE, read by both the field default and load()'s file-parse fallback. Load-time clamped to [0, 10]
     watchdog_rss_max_mb: int = 0   # recycle a session when its process tree RSS exceeds this many MiB; 0 disables (default). Busy sessions (turn in flight) are never recycled.

--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -183,14 +183,17 @@ send time.
   1. **first empty** → the ORIGINAL message is silently re-queued at the
      front of the slot queue (no visible card). Reached ONLY by a turn with no
      activity — see the productive-turn exclusion below;
-  2. **second empty** (the same-message retry also produced nothing) → ONE
+  2. **later empties** (the same-message retry also produced nothing) → a
      synthetic continue nudge (`_EMPTY_AUTO_CONTINUE_MSG` — a DIFFERENT
      message, since re-sending the identical prompt tends to reproduce the
      identical empty generation) is queued on the SAME live session, with a
-     transcript-visible notice card ("auto-continuing once"). Gated by
+     transcript-visible notice card. The budget is
+     `session.empty_response_max_continues` (default 1 — one nudge, notice
+     "auto-continuing once"; above 1 consecutive failures keep continuing and
+     the notice shows "recovery N of M"). Gated by
      `session.empty_response_auto_continue` (default ON; the gate fails open),
      and suppressed while a Stop is active;
-  3. **third empty** (the nudge also produced nothing) → terminal notice card
+  3. **budget exhausted** (the nudges also produced nothing) → terminal notice card
      asking the user to send a message; the counter resets so the next
      genuine user turn gets a fresh budget. The card's wording is cause-aware,
      mirroring rung 2's split: a productive turn is told the turn ended

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3168,6 +3168,20 @@ class KiroCrewConfig:
                 empty_response_auto_continue=bool(
                     session_data.get("empty_response_auto_continue", True)
                 ),
+                # RANGE-clamped like the other session ints: a hand-edited 0
+                # or 999 must load as a sane budget, never disable recovery or
+                # arm an unbounded ladder. Type handling is owned by
+                # `_validate_config_data` upstream of section extraction. The
+                # bounds are referenced via the module handle rather than
+                # imported: this module's top-level names are a FROZEN
+                # compatibility facade (test_loader_reexports_historical
+                # _snapshot_by_identity), so a new re-export may not be added.
+                empty_response_max_continues=_safe_int(
+                    session_data.get("empty_response_max_continues", 1),
+                    1,
+                    _sections.EMPTY_RESPONSE_MAX_CONTINUES_MIN,
+                    _sections.EMPTY_RESPONSE_MAX_CONTINUES_MAX,
+                ),
                 autocompact_pct=_safe_float(
                     session_data.get("autocompact_pct", DEFAULT_AUTOCOMPACT_PCT),
                     DEFAULT_AUTOCOMPACT_PCT,

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -1434,8 +1434,21 @@ class SessionConfig:
         metadata=_meta(
             "Auto-Continue on Empty Response",
             "After the model returns an empty response twice in a row, "
-            "automatically send one 'continue' nudge on the same session "
-            "(transcript-visible, bounded to once per user message).",
+            "automatically send a 'continue' nudge on the same session "
+            "(transcript-visible, bounded by Max Auto-Continues on Empty "
+            "Response).",
+        ),
+    )
+    empty_response_max_continues: int = field(
+        default=1,
+        metadata=_meta(
+            "Max Auto-Continues on Empty Response",
+            "How many 'continue' nudges may run back to back before the "
+            "runner gives up and asks for a message (1-10). Above 1 the "
+            "recovery notice shows progress ('recovery 2 of 3'). Useful "
+            "during provider-instability windows where each continuation "
+            "makes real progress before failing the same way. Only applies "
+            "while Auto-Continue on Empty Response is enabled.",
         ),
     )
     autocompact_pct: float = field(
@@ -3820,6 +3833,12 @@ SOFT_STOP_BUDGET_MIN = 0.5
 SOFT_STOP_BUDGET_MAX = 60.0
 EXTRACTION_POOL_SIZE_MIN = 1
 EXTRACTION_POOL_SIZE_MAX = 10
+# Load-only bounds. Unlike the parity block above these are NOT consumed by
+# `_EDITABLE_CONFIG` — the field is config-file-only (no dashboard write path),
+# so the only clamp site is the loader. Kept out of the shared block so its
+# "every bound is shared with the write gate" claim stays true.
+EMPTY_RESPONSE_MAX_CONTINUES_MIN = 1
+EMPTY_RESPONSE_MAX_CONTINUES_MAX = 10
 # knowledge.* budgets. These share a floor of 0, but 0 is MEANINGFUL for several
 # of them (a zero budget disables that sweep), so the floor is deliberately not
 # enforced by clamping a negative up to 0 -- see `_safe_nonnegative_int`, which

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -334,13 +334,30 @@ from kiro_crew.dashboard.chat_utils import (  # noqa: E402
 
 def _empty_auto_continue_enabled() -> bool:
     """Config gate for the empty-response auto-continue rung (default ON —
-    the recovery is bounded to one nudge per user message and always
-    transcript-visible). Fail-open to the default: a config-load hiccup must
-    not disable self-healing mid-incident."""
+    the recovery is bounded by :func:`_empty_max_auto_continues` nudges per
+    user message and always transcript-visible). Fail-open to the default: a
+    config-load hiccup must not disable self-healing mid-incident."""
     try:
         return bool(KiroCrewConfig.load().session.empty_response_auto_continue)
     except Exception:  # pragma: no cover — config load must not break recovery
         return True
+
+
+def _empty_max_auto_continues() -> int:
+    """How many synthetic continue nudges the ladder may queue for one user
+    message before the give-up rung (``session.empty_response_max_continues``).
+
+    Default 1 — exactly the pre-knob behavior. Raising it helps during a
+    provider-instability window where each continuation makes real forward
+    progress before dying the same way: one continuation abandons a
+    task that three finish. The loader clamps the persisted value to a sane
+    range; fail-open to the default here for the same reason as the gate
+    above — a config-load hiccup must not disable self-healing mid-incident.
+    """
+    try:
+        return int(KiroCrewConfig.load().session.empty_response_max_continues)
+    except Exception:  # pragma: no cover — config load must not break recovery
+        return 1
 
 
 # Consumption contract carried inside every pending-context frame, between the
@@ -11086,7 +11103,7 @@ async def _run_chat(
                 _retrying_empty = True
             elif (
                 _prompt_depth == 0
-                and slot._empty_response_retries < 2
+                and slot._empty_response_retries < 1 + _empty_max_auto_continues()
                 and not _should_suppress_requeue(slot)
                 and _empty_auto_continue_enabled()
             ):
@@ -11095,21 +11112,32 @@ async def _run_chat(
                 # to reproduce the identical empty generation, but a DIFFERENT
                 # message reliably recovers (observed repeatedly in the field —
                 # the user typing "continue" broke the pattern every time). So
-                # auto-send ONE synthetic continue nudge on the same live
+                # auto-send a synthetic continue nudge on the same live
                 # session, with a transcript-visible notice so the recovery is
-                # never invisible. Third empty falls through to the give-up
-                # notice below — bounded, no loop.
-                # A productive turn skipped the verbatim-replay rung entirely.
-                # Its ONE continuation consumes the remaining recovery budget:
-                # if that continuation is itself empty, the next turn must give
-                # up rather than enqueue a second continuation. Leaving the
-                # counter at 1 here would run `_EMPTY_AUTO_CONTINUE_MSG` next,
+                # never invisible. The budget is
+                # session.empty_response_max_continues (default 1 — one nudge,
+                # the original behavior); when it is spent, the give-up notice
+                # below fires — bounded, no loop.
+                # A productive turn skipped the verbatim-replay rung entirely,
+                # so its counter jumps past the replay slot (0 → 2) on its
+                # first continuation and counts normally from there. That
+                # keeps the give-up arithmetic uniform across both paths —
+                # replay-or-jump plus the continue budget — and at the default
+                # budget it is exactly the old jump-to-2: the single
+                # continuation consumes the remaining budget, so a counter
+                # left at 1 would run `_EMPTY_AUTO_CONTINUE_MSG` next,
                 # contradicting both the notice ("continuing once") and the
                 # side-effect boundary this branch protects.
+                _max_continues = _empty_max_auto_continues()
                 if _empty_activity.productive:
-                    slot._empty_response_retries = 2
+                    slot._empty_response_retries = max(slot._empty_response_retries + 1, 2)
                 else:
                     slot._empty_response_retries += 1
+                # Ordinal of THIS continuation (1-based): the counter minus the
+                # replay slot. Shown in the notice when the budget exceeds one,
+                # so a user watching repeated recoveries sees the ladder
+                # advancing, not looping.
+                _continue_no = max(slot._empty_response_retries - 1, 1)
                 _empty_rung = EMPTY_RUNG_CONTINUE
                 if _empty_activity.productive:
                     # Same rung, different words, because the words are read by
@@ -11120,15 +11148,26 @@ async def _run_chat(
                     # path exists to avoid.
                     slot.append(
                         "notice",
-                        "ℹ️ The turn ended without a closing reply — continuing "
-                        "once from what already ran.",
+                        (
+                            "ℹ️ The turn ended without a closing reply — continuing "
+                            "once from what already ran."
+                            if _max_continues == 1
+                            else "ℹ️ The turn ended without a closing reply — "
+                            "continuing from what already ran "
+                            f"(recovery {_continue_no} of {_max_continues})."
+                        ),
                         "msg msg-info",
                     )
                     _empty_continue_msg = _ACTIVITY_NO_REPLY_CONTINUE_MSG
                 else:
                     slot.append(
                         "notice",
-                        "ℹ️ The model returned nothing twice — auto-continuing once.",
+                        (
+                            "ℹ️ The model returned nothing twice — auto-continuing once."
+                            if _max_continues == 1
+                            else "ℹ️ The model returned nothing — auto-continuing "
+                            f"(recovery {_continue_no} of {_max_continues})."
+                        ),
                         "msg msg-info",
                     )
                     _empty_continue_msg = _EMPTY_AUTO_CONTINUE_MSG

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -238,7 +238,8 @@ Set via `kirocrew config set agent.acp_backend kas`.
 | Key | Description | Default |
 |-----|-------------|---------|
 | `session.timeout_secs` | Idle session timeout in seconds (0 disables the idle sweep) | `3600` (60 min) |
-| `session.empty_response_auto_continue` | After two consecutive empty model responses, send one transcript-visible `continue` nudge per user message | `true` |
+| `session.empty_response_auto_continue` | After two consecutive empty model responses, send transcript-visible `continue` nudges on the same session | `true` |
+| `session.empty_response_max_continues` | How many `continue` nudges may run back to back before the give-up card (clamped 1-10; above 1 the notice shows "recovery N of M") | `1` |
 | `session.autocompact_pct` | Context usage percentage at which auto-compaction triggers (5-90). Lower compacts sooner and keeps per-turn cost down; higher retains more conversation before rewriting it. Applies to new installs: an existing `config.json` keeps its stored value | `70.0` |
 | `session.pool_size` | Number of pre-spawned kiro-cli processes kept ready for instant session start. 0 disables | `0` |
 | `session.pool_agent` | Agent for warm-pool processes. Empty uses `agent.default_agent` | `""` |

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -4723,6 +4723,28 @@ class TestEmptyResponseAutoContinueWiring:
         assert cfg.session.empty_response_auto_continue is True
 
 
+class TestEmptyResponseMaxContinuesWiring:
+    """session.empty_response_max_continues: wired, defaulted, and RANGE-clamped
+    — a hand-edited 0 must not disable recovery and a 999 must not arm an
+    unbounded ladder (the ladder's give-up arithmetic trusts this clamp)."""
+
+    def test_persisted_value_survives_load(self) -> None:
+        cfg = _load_from_dict({"session": {"empty_response_max_continues": 3}})
+        assert cfg.session.empty_response_max_continues == 3
+
+    def test_default_is_one(self) -> None:
+        cfg = _load_from_dict({})
+        assert cfg.session.empty_response_max_continues == 1
+
+    def test_below_range_clamps_to_min(self) -> None:
+        cfg = _load_from_dict({"session": {"empty_response_max_continues": 0}})
+        assert cfg.session.empty_response_max_continues == 1
+
+    def test_above_range_clamps_to_max(self) -> None:
+        cfg = _load_from_dict({"session": {"empty_response_max_continues": 999}})
+        assert cfg.session.empty_response_max_continues == 10
+
+
 class TestGitLabHostAllowlist:
     """dashboard.gitlab_hosts authorizes self-managed GitLab instances for the
     Changes panel, so it must fail closed and never sanitize a malformed entry

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -16832,6 +16832,58 @@ class TestEmptyResponseRetry:
         assert slot._empty_response_retries == 0
 
     @pytest.mark.asyncio
+    async def test_max_continues_config_extends_the_ladder(self, tmp_path: Path) -> None:
+        """With session.empty_response_max_continues=3, the second consecutive
+        continuation failure keeps continuing — numbered so the transcript
+        reads as advancing, not looping — instead of giving up after one.
+        Exercises the REAL config path like the flag-off test above, so a
+        loader that drops the field fails this test too."""
+        from kiro_crew.dashboard.chat_runner import _EMPTY_AUTO_CONTINUE_MSG
+
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        slot._empty_response_retries = 2  # replay + first continue spent
+        self._make_empty_stream(client)
+
+        calls = []
+        orig = _ChatSlot.queue_insert
+
+        def spy(self_slot, *a, **kw):
+            calls.append(a)
+            return orig(self_slot, *a, **kw)
+
+        cfg_file = tmp_path / "max-continues-config.json"
+        cfg_file.write_text('{"session": {"empty_response_max_continues": 3}}')
+        with (
+            patch("kiro_crew.config.loader.config_path", return_value=cfg_file),
+            patch.object(_ChatSlot, "queue_insert", spy),
+        ):
+            await _run_chat(state, slot, "test message")
+            await self._cancel_background_tasks(state)
+
+        assert (0, _EMPTY_AUTO_CONTINUE_MSG) in calls
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert any("(recovery 2 of 3)" in m.get("content", "") for m in notice_msgs)
+        assert slot._empty_response_retries == 3
+
+    @pytest.mark.asyncio
+    async def test_max_continues_budget_still_terminates(self, tmp_path: Path) -> None:
+        """The raised budget is still a budget: with max=3 and the replay plus
+        all three continues spent, the give-up card fires and the counter
+        resets for the next independent user turn."""
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        slot._empty_response_retries = 4  # replay + 3 continues spent
+        self._make_empty_stream(client)
+
+        cfg_file = tmp_path / "max-continues-config.json"
+        cfg_file.write_text('{"session": {"empty_response_max_continues": 3}}')
+        with patch("kiro_crew.config.loader.config_path", return_value=cfg_file):
+            await _run_chat(state, slot, "test message")
+
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert any("returned nothing this turn" in m.get("content", "") for m in notice_msgs)
+        assert slot._empty_response_retries == 0
+
+    @pytest.mark.asyncio
     async def test_successful_response_resets_counter(self, tmp_path: Path) -> None:
         """A successful (non-empty) response resets the retry counter."""
         from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

The empty-turn recovery ladder gives up after one auto-continue. During a provider-instability window the model keeps ending turns right after a tool result: text streamed, tools ran, the turn was billed — and then no closing reply. The one continuation dies the same way. The session parks on the give-up card, and the user has to type "continue" by hand, over and over. Field data in #9809: three manual continues in one hour on a task that was moving forward the whole time.

There is no setting to raise the budget. `session.empty_response_auto_continue` is only an on/off switch. The count lives in code.

## Why it matters

A long-running task dies mid-flight for no code reason. Each failed round still bills a turn. The operator who knows their provider is having a bad night has no knob to turn — their only tool is babysitting the session.

## What changed (motivation → approach → change)

The goal is a budget the operator can raise, without changing anything for everyone else. Default behavior must stay byte-identical: issue #9809's triage flagged the budget as a policy call about billed-turn spend, so this PR makes it an opt-in setting instead of ruling on a new default. The alternative — just raising the hardcoded count — would decide that policy for every install.

The change adds `session.empty_response_max_continues` (int, default 1, clamped 1–10 by the loader). The continue rung's gate becomes `retries < 1 + max_continues`. The productive-turn jump keeps its shape: `max(retries + 1, 2)` skips past the replay slot on the first continuation and counts normally after, so at the default it is exactly the old assignment `= 2`, and at any budget both the replay path and the jump path get the same number of continuations.

At the default the notice strings are unchanged. Above 1, the notice numbers each recovery — "recovery 2 of 3" — so a transcript with several recoveries reads as advancing, not looping. The give-up rung is untouched: the ladder still terminates, only the budget before it is configurable.

The setting's mirrors move with it: the settings schema snapshot (`config-baseline.json`, regenerated by its own script) and the `SessionConfig` doc mirror (`docs/system-specs/modules/config.md`). The bounds constants live in a load-only stanza in `sections.py` — the field has no dashboard write path, so they deliberately sit outside the load/write parity block — and the loader reads them through its module handle to keep its frozen re-export facade unchanged. The comment-history baseline records one reworded narration line in `test_config_loader.py` (the gate's ratchet requires touchers to pay down drift).

```mermaid
flowchart LR
  subgraph Before
    A1[empty turn]:::ctx --> B1[silent replay]:::ctx --> C1[1 continue]:::ctx --> D1[give-up card]:::ctx
  end
  subgraph After
    A2[empty turn]:::ctx --> B2[silent replay]:::ctx --> C2[continue xN, default 1]:::changed --> D2[give-up card]:::ctx
    C2 -->|"recovery N of M notice"| C2
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The ladder keeps its three rungs; only how many times the continue rung may repeat is now a setting.*

## Tests

- `test_config_loader.py::TestEmptyResponseMaxContinuesWiring` — four tests: a persisted 3 survives load, the default is 1, 0 clamps to 1 (a hand-edit cannot disable recovery), 999 clamps to 10 (cannot arm an unbounded ladder).
- `test_dashboard_chat.py::test_max_continues_config_extends_the_ladder` — with the real config path carrying `max_continues=3`, a second consecutive continuation failure keeps continuing, the nudge is queued, the notice says "recovery 2 of 3", and the counter advances.
- `test_dashboard_chat.py::test_max_continues_budget_still_terminates` — with the budget spent, the give-up card fires and the counter resets for the next user turn.
- All existing ladder tests pass unchanged — that is the proof the default is byte-identical, including the exact notice strings.

## Manual verification

N/A — unit coverage sufficient: the ladder tests drive the real `_run_chat` path with a scripted provider stream, and the config tests exercise the real loader.

## Related Issues

Addresses Problem 1 of #9809 (the configurable budget). Problem 2 (the give-up card's wording) is claimed and in flight separately, so this PR deliberately carries no closing keyword.

no linked issue: #9809 must stay open for its in-flight Problem-2 fix; this PR resolves only Problem 1.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
