### PR TITLE
fix(apps): declare each built-in's platforms once instead of twice

### DIFF
--- a/src/kiro_crew/apps/builtins/crew_companion/app.json
+++ b/src/kiro_crew/apps/builtins/crew_companion/app.json
@@ -21,9 +21,6 @@
     "routes": "backend.routes:register_routes"
   },
   "platform": {
-    "requiresDesktopApp": true
-  },
-  "platform": {
     "os": [
       "macos",
       "linux",

--- a/src/kiro_crew/apps/builtins/design_tweak/app.json
+++ b/src/kiro_crew/apps/builtins/design_tweak/app.json
@@ -42,12 +42,6 @@
   "platform": {
     "os": [
       "macos",
-      "linux"
-    ]
-  },
-  "platform": {
-    "os": [
-      "macos",
       "linux",
       "windows"
     ]

--- a/src/kiro_crew/apps/builtins/meetings/app.json
+++ b/src/kiro_crew/apps/builtins/meetings/app.json
@@ -23,12 +23,6 @@
   "platform": {
     "os": [
       "macos",
-      "linux"
-    ]
-  },
-  "platform": {
-    "os": [
-      "macos",
       "linux",
       "windows"
     ]

--- a/src/kiro_crew/apps/builtins/mochi/app.json
+++ b/src/kiro_crew/apps/builtins/mochi/app.json
@@ -26,9 +26,6 @@
   "iconUrl": "/app-assets/mochi/icon.png",
   "defaultEnabled": false,
   "platform": {
-    "requiresDesktopApp": true
-  },
-  "platform": {
     "os": [
       "macos",
       "linux",

--- a/src/kiro_crew/apps/builtins/pptx_maker/app.json
+++ b/src/kiro_crew/apps/builtins/pptx_maker/app.json
@@ -78,12 +78,6 @@
   "platform": {
     "os": [
       "macos",
-      "linux"
-    ]
-  },
-  "platform": {
-    "os": [
-      "macos",
       "linux",
       "windows"
     ]

--- a/test/test_app_manifest.py
+++ b/test/test_app_manifest.py
@@ -1891,3 +1891,63 @@ class TestContributesPanelTabs:
         tabs = [_panel_tab(id=f"t{i}") for i in range(_MAX_PANEL_TABS_PER_APP + 1)]
         m = AppManifest.from_dict(_valid_manifest(contributes={"panelTabs": tabs}))
         assert any("exceeds the limit of" in e for e in m.validate())
+
+
+class TestShippedManifestsAreWellFormedJson:
+    """Every shipped ``app.json`` must be JSON no reader can disagree about.
+
+    A duplicate key is not a parse error in Python or in JavaScript -- both keep the LAST
+    occurrence -- so a manifest carrying two ``"platform"`` blocks loads, validates, and
+    behaves, while saying two different things to anyone reading it. That is how five
+    built-in manifests came to declare ``"os": ["macos", "linux"]`` immediately above
+    ``"os": ["macos", "linux", "windows"]``: an edit appended a second block instead of
+    changing the first, and last-wins hid it.
+
+    Two reasons that is worth a test rather than a one-time cleanup. A stricter reader
+    rejects the file outright -- ``jq`` flags it, JSON Schema validators flag it, and Rust
+    and Go parsers error by default -- so the manifests are one tool away from being
+    unreadable. And an editor who later deletes "the" ``platform`` block has even odds of
+    deleting the live one, silently dropping a platform with nothing failing.
+    """
+
+    def _builtin_manifests(self) -> list[Path]:
+        paths = sorted((_REPO_ROOT / "src/kiro_crew/apps/builtins").glob("*/app.json"))
+        assert paths, "no built-in manifests found -- the glob or the layout moved"
+        return paths
+
+    def test_no_shipped_manifest_has_a_duplicate_key(self):
+        """Recursively: a duplicate anywhere, at any nesting depth, fails here."""
+        offenders: list[str] = []
+
+        def _reject_duplicates(pairs: list[tuple[str, object]]) -> dict:
+            seen: set[str] = set()
+            for key, _value in pairs:
+                if key in seen:
+                    offenders.append(key)
+                seen.add(key)
+            return dict(pairs)
+
+        for manifest in self._builtin_manifests():
+            offenders.clear()
+            json.loads(manifest.read_text(encoding="utf-8"), object_pairs_hook=_reject_duplicates)
+            assert not offenders, (
+                f"{manifest.parent.name}/app.json declares {sorted(set(offenders))!r} "
+                "more than once. Both copies load and the LAST one wins, so the file "
+                "reads as two different manifests -- edit the existing block instead of "
+                "appending a second one."
+            )
+
+    def test_every_builtin_declares_its_platforms_exactly_once(self):
+        """The specific shape that went wrong, asserted on the shipped files.
+
+        Complements the general check: this one names ``platform`` so a regression here
+        reports the field a reader cares about rather than a generic duplicate.
+        """
+        for manifest in self._builtin_manifests():
+            raw = manifest.read_text(encoding="utf-8")
+            count = raw.count('"platform"')
+            assert count <= 1, (
+                f"{manifest.parent.name}/app.json contains {count} \"platform\" keys; "
+                "the effective value is whichever comes last, which is not what the "
+                "file appears to say."
+            )


### PR DESCRIPTION
Five shipped `app.json` manifests carry TWO `"platform"` blocks — `crew_companion`,
`design_tweak`, `meetings`, `mochi` and `pptx_maker`. In each, the first says the app
runs on macOS and Linux and the second says macOS, Linux and Windows:

```json
  "platform": { "os": ["macos", "linux"] },
  "platform": { "os": ["macos", "linux", "windows"] },
```

A duplicate key is not a parse error in either language that reads these files. Python's
`json.loads` and JavaScript's `JSON.parse` both keep the LAST occurrence, so every one of
these apps is already Windows-eligible at runtime and nothing is visibly broken. The file
simply says two different things, and the one a human reads first is the wrong one.

## Why this is a defect rather than untidiness

**The manifests are one tool away from being unreadable.** A duplicate key is rejected,
not resolved, by `jq`, by JSON Schema validators, and by Rust and Go decoders in their
default configuration. Any future manifest validation, packaging step, or third-party
consumer that is stricter than `json.loads` fails on five built-ins at once.

**The next edit has even odds of dropping a platform silently.** Someone updating "the"
platform block sees two, changes one, and cannot tell from any test or any runtime
behaviour whether they changed the live one. Deleting the second block reverts Windows
support with no failure anywhere.

## The fix is a no-op at runtime, by construction

In all five files the second block is a superset of the first, so the first is deleted and
the second kept. `crew_companion` and `mochi` are the ones worth checking by hand: their
FIRST block carried `"requiresDesktopApp": true` and no `os`, while the second carried
both — verified still present after the edit. The effective `platform.os` is unchanged for
all 24 built-ins and still contains `windows` everywhere, because last-wins was already
selecting the block this commit keeps.

## Verification

- All 24 built-in manifests parse; effective `platform.os` before and after is identical.
- `requiresDesktopApp` still true for `crew_companion` and `mochi`.
- The two new tests fail on the pre-fix manifests (checked by stashing only the manifest
  edits) and pass after, so they pin the fix rather than merely accompanying it.

## Pattern harvest

**The pattern.** A configuration format whose duplicate keys are silently last-wins lets
an edit APPEND a contradiction instead of resolving one, and every layer downstream keeps
working. The failure is invisible from the direction people look: the app behaves, the
tests pass, and the file's first answer is the stale one. It was found by parsing the
manifests with `object_pairs_hook` while investigating something else — a substring grep
for `windows`, which is the obvious check, reports all 24 manifests as correct.

Rule candidate: lint. A duplicate-key check over every shipped JSON manifest is
mechanical and belongs in the same lane as the repo's other deterministic gates; this
commit adds it as a test over `src/kiro_crew/apps/builtins/*/app.json`, which is the
narrow version. The general version — every JSON asset the repo ships, not only app
manifests — is worth a `scripts/` gate if a second instance of this ever appears.

**What generalises.** When a merged change adds a value to a structured file, assert the
value is where it should be, not merely that it is present. `"windows" in raw_text` was
true for all five broken files.
