### PR TITLE
fix(chat): make the empty-turn give-up notice cause-aware

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -155,7 +155,19 @@ send time.
      and suppressed while a Stop is active;
   3. **third empty** (the nudge also produced nothing) → terminal notice card
      asking the user to send a message; the counter resets so the next
-     genuine user turn gets a fresh budget.
+     genuine user turn gets a fresh budget. The card's wording is cause-aware,
+     mirroring rung 2's split: a productive turn is told the turn ended
+     without a closing reply and that completed steps will not re-run (never
+     "returned nothing", which is false for it and — read back by the model
+     via the transcript — invites a redo of landed side effects). For
+     non-productive turns the recovery clause appears only when the counter
+     shows budget was spent, and claims only that automatic recovery was
+     attempted — the counter counts budget, not which rungs ran (with the
+     auto-continue gate off, give-up arrives at one with no auto-continue).
+     Give-up with the counter at zero is reachable non-productive only on
+     nested depth>0 turns, where the card reports only the empty turn (the
+     gate-off zero-counter path is productive by construction and takes the
+     productive wording).
 
   **A PRODUCTIVE turn never reaches rung 1.** "Empty" at this branch means only
   that the FINAL assistant segment is empty, which is not the same as "the turn

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -11088,18 +11088,41 @@ async def _run_chat(
                 _retrying_empty = True
             else:
                 _empty_rung = EMPTY_RUNG_GIVE_UP
-                # Recoverable, usually-transient: the runner already silently
-                # self-retried once (first empty = silent re-queue). Surface a
-                # soft "notice" card (not a red "error" card) so a self-healing
-                # event doesn't read like a crash — and phrase it to reflect
-                # that the retry already happened. Single emit (see AcpProcessDied
-                # note): slot.append persists + broadcasts one chat_message via
-                # _on_message; no explicit broadcast_ws.
-                _empty_msg = (
-                    "ℹ️ The model returned nothing this turn (it was retried "
-                    "and auto-continued automatically). Just send your message "
-                    "again to continue."
-                )
+                # Recoverable, usually-transient: surface a soft "notice" card
+                # (not a red "error" card) so a self-healing event doesn't read
+                # like a crash. Single emit (see AcpProcessDied note):
+                # slot.append persists + broadcasts one chat_message via
+                # _on_message; no explicit broadcast_ws. Same rung, different
+                # words, for the same reason as the continue rung above: the
+                # card is read by the MODEL (via the transcript) and by the
+                # user. "returned nothing" is false for a productive turn and
+                # invites a redo of work whose side effects already landed,
+                # and a recovery claim is false on the paths that reach
+                # give-up with the recovery counter still at zero (nested
+                # depth>0 turns; a gate-off zero-counter give-up is only
+                # reachable productive and takes the productive wording). The
+                # counter counts budget spent, not which rungs ran (flag-off
+                # reaches give-up at one with no auto-continue; a productive
+                # turn's continuation reaches it at two with no verbatim
+                # retry), so the non-zero clause claims only that automatic
+                # recovery was attempted.
+                if _empty_activity.productive:
+                    _empty_msg = (
+                        "ℹ️ The turn ended without a closing reply. Send a "
+                        "message to continue from where it stopped — completed "
+                        "steps will not re-run."
+                    )
+                elif slot._empty_response_retries > 0:
+                    _empty_msg = (
+                        "ℹ️ The model returned nothing this turn (automatic "
+                        "recovery was attempted). Just send your message "
+                        "again to continue."
+                    )
+                else:
+                    _empty_msg = (
+                        "ℹ️ The model returned nothing this turn. Just send "
+                        "your message again to continue."
+                    )
                 slot.append("notice", _empty_msg, "msg msg-info")
             # ONE warning per empty verdict, emitted AFTER the rung is chosen so
             # the log line carries the decision rather than only the symptom. The

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -16629,6 +16629,87 @@ class TestEmptyResponseRetry:
         assert slot._empty_response_retries == 0
 
     @pytest.mark.asyncio
+    async def test_productive_giveup_notice_does_not_claim_nothing_happened(
+        self, tmp_path: Path
+    ) -> None:
+        """A PRODUCTIVE turn reaching give-up (its one continuation also ended
+        without a closing reply) must not be described as "returned nothing":
+        the card is read by the model via the transcript, and telling it the
+        completed work produced no output invites a redo of side effects that
+        already landed. Same distinction the continue rung draws one rung up."""
+        from kiro_crew.acp.types import STOP_REASON_END_TURN
+        from kiro_crew.providers.base import (
+            EVENT_COMPLETE,
+            EVENT_TOOL_CALL,
+            EVENT_TOOL_RESULT,
+            LLMEvent,
+        )
+
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        slot._empty_response_retries = 2  # the single continuation is spent
+
+        async def _stream(msg):
+            yield LLMEvent(kind=EVENT_TOOL_CALL, tool_call_id="tc-1", title="send_message")
+            yield LLMEvent(kind=EVENT_TOOL_RESULT, tool_call_id="tc-1", text="sent")
+            yield LLMEvent(kind=EVENT_COMPLETE, stop_reason=STOP_REASON_END_TURN)
+
+        client.stream = _stream
+        client.stream_command = _stream
+
+        await _run_chat(state, slot, "test message")
+        await self._cancel_background_tasks(state)
+
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert notice_msgs, "give-up produced no notice card"
+        assert not any("returned nothing" in m.get("content", "") for m in notice_msgs), (
+            "the give-up card claims the turn produced nothing, but this turn "
+            "ran a tool whose side effects already landed"
+        )
+        assert any("without a closing reply" in m.get("content", "") for m in notice_msgs)
+        # The card reassures rather than inviting a redo: completed steps stay done.
+        assert any("will not re-run" in m.get("content", "") for m in notice_msgs)
+        # Terminal rung still resets the budget for the next genuine user turn.
+        assert slot._empty_response_retries == 0
+
+    @pytest.mark.asyncio
+    async def test_giveup_without_recoveries_drops_retry_claim(self, tmp_path: Path) -> None:
+        """A give-up reached with the recovery counter still at zero (here: a
+        nested depth>0 turn) must not assert that a retry and an auto-continue
+        ran — neither did. The counter is the evidence, not the rung."""
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        self._make_empty_stream(client)
+
+        await _run_chat(state, slot, "test message", _prompt_depth=1)
+
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert any("returned nothing this turn" in m.get("content", "") for m in notice_msgs)
+        assert not any("retried" in m.get("content", "") for m in notice_msgs), (
+            "the give-up card claims a retry ran, but slot._empty_response_retries "
+            "is still 0 on this path"
+        )
+        assert not any("auto-continued" in m.get("content", "") for m in notice_msgs)
+        assert not any("recovery was attempted" in m.get("content", "") for m in notice_msgs)
+
+    @pytest.mark.asyncio
+    async def test_giveup_after_spent_recoveries_reports_recovery(self, tmp_path: Path) -> None:
+        """When the recovery budget was actually spent (counter exhausted, turn
+        not productive), the card reports that automatic recovery was
+        attempted. Phrased phase-neutrally on purpose: the counter counts
+        budget spent, not which rungs ran."""
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        slot._empty_response_retries = 2  # re-queue + nudge both spent
+        self._make_empty_stream(client)
+
+        await _run_chat(state, slot, "test message")
+
+        notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
+        assert any("automatic recovery was attempted" in m.get("content", "") for m in notice_msgs)
+        # The counter alone cannot prove WHICH rungs ran (a productive turn's
+        # continuation arrives here at 2 with no verbatim retry), so the card
+        # must not name specific recovery phases.
+        assert not any("auto-continued automatically" in m.get("content", "") for m in notice_msgs)
+
+    @pytest.mark.asyncio
     async def test_second_empty_flag_off_shows_notice(self, tmp_path: Path) -> None:
         """With session.empty_response_auto_continue disabled, the second empty
         surfaces the terminal notice immediately (pre-feature behavior)."""
@@ -16647,6 +16728,14 @@ class TestEmptyResponseRetry:
 
         notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
         assert any("returned nothing this turn" in m.get("content", "") for m in notice_msgs)
+        # Counter is 1 here: ONLY the silent verbatim re-queue ran (rung 1's
+        # guard ignores the gate); the auto-continue was forbidden by config.
+        # The card reports budget spent phase-neutrally and must not assert
+        # the auto-continue that provably did not run. This is also the
+        # boundary case for the counter gate: budget WAS spent, so the bare
+        # zero-recoveries wording would be wrong too.
+        assert any("automatic recovery was attempted" in m.get("content", "") for m in notice_msgs)
+        assert not any("auto-continued" in m.get("content", "") for m in notice_msgs)
         assert slot._empty_response_retries == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #9809

## Scope note (read first)

This closes **Problem 2 only** (the give-up notice's wording). **Problem 1 — raising the auto-continue budget / a `session.empty_response_max_continues` setting / a recovery-count display — is deliberately left to a maintainer**: it is a product decision about how many billed turns the runner may spend on the user's behalf during a provider-instability window, and it would overturn the deliberate `slot._empty_response_retries = 2` pin at the CONTINUE rung's productive branch, whose comment explains why the budget stops at one continuation. Since `Fixes #9809` closes the whole issue on merge, if you want Problem 1 tracked, please split it into its own issue before this lands (say the word and I file it).

## Symptom

The empty-turn recovery ladder's terminal "give-up" notice card was one unconditional literal:

> ℹ️ The model returned nothing this turn (it was retried and auto-continued automatically). Just send your message again to continue.

Two false claims on reachable paths:

1. **"returned nothing" on productive turns.** A `visible_partial` turn streamed text and ran tools before ending without a closing reply. The statement is false for it, and — because the card is read back by the model via the transcript — it invites re-sending a request whose tool side effects already landed. The ladder's own log line (`cause=visible_partial rung=give_up` in the issue's excerpt) already distinguishes this; the card did not.
2. **A recovery claim where no (or partial) recovery ran.** The `else` arm is reached whenever both recovery guards fail. At `_prompt_depth > 0` the counter is still `0` — no recovery ran, yet the card asserted one did. With `session.empty_response_auto_continue` off, give-up arrives at counter `1`: the silent retry ran (rung 1's guard ignores the gate) but the auto-continue provably did not — yet the card claimed both.

## Root cause

The ladder became cause-aware one rung earlier (the CONTINUE rung branches on `_empty_activity.productive` with a comment explaining that the words are read by the model as well as the user) and the give-up rung never inherited that split. This PR is a consistency fix against that in-tree precedent, not new behaviour.

## Fix

Pure wording/branching change at the give-up arm — one `slot.append("notice", …, "msg msg-info")`, single emit, soft notice; ladder control flow, rung constants, counter arithmetic and the structured warning are untouched. Three cases:

| condition | card |
|---|---|
| `_empty_activity.productive` | "The turn ended without a closing reply. Send a message to continue from where it stopped — completed steps will not re-run." |
| counter > 0 | "The model returned nothing this turn (automatic recovery was attempted). Just send your message again to continue." |
| counter == 0 | "The model returned nothing this turn. Just send your message again to continue." |

The counter>0 clause is **phase-neutral by design** (adopted from round-1 review findings by both lanes): the counter counts budget spent, not which rungs ran — flag-off reaches give-up at `1` with no auto-continue, and a productive turn's continuation reaches it at `2` with no verbatim retry. Naming specific phases from the count alone would keep lying on those paths, and tracking which rungs fired would need new state, which is out of this PR's scope (follow-up: #9818).

`docs/system-specs/modules/session.md` rung-3 bullet updated in the same commit (AGENTS.md module-spec rule).

**i18n:** the notice strings are inline backend literals; no catalog resolves this path (verified: no `website/src/i18n` hits, `NoticeCard` renders the body verbatim with no locale keying). No catalog work needed.

## Verification

- **Red before green:** the productive-case and zero-recoveries tests were written first and failed against unmodified main with exactly the targeted assertions (productive card contained "returned nothing this turn"; zero-recoveries card carried the retry claim).
- **Mutation checks, both directions** (each mutant killed by its own test, fix restored green after each):
  1. productive branch disabled (`if False and …`) → productive test red.
  2. counter gate dropped (`elif True`) → zero-recoveries test red.
  3. counter comparison inverted (`> 0` → `== 0`) → both counter tests red.
  4. boundary shift (`> 0` → `> 1`) → strengthened flag-off test red (this is the counter==1 boundary round 1 flagged as untested).
- **Gates:** black (shrink-only baseline), comment-history, flake8, mypy all green on the head; changed files are black-clean.
- **Backend zero-regression:** full suite (`pytest -q -n auto --dist loadgroup`, the gate's own invocation) run on the branch AND on a pristine `origin/main` git worktree; sorted FAILED/ERROR id sets (ANSI-stripped) diffed both directions. Branch 111 ids vs main 110 ids, sets identical except `test_browser_recording_skill.py::TestEndToEnd::test_records_a_webm` — proven a workspace-setup artifact, not a diff effect: the test is skip-gated on `website/node_modules/playwright`, which existed only in the branch tree (installed for the frontend guard); after equalizing node_modules the identical Node-16 environmental failure reproduces on origin/main. All remaining 110 ids are the repo's known environmental baseline, byte-identical both directions.
- **Frontend cross-surface guards:** all 229 gate-planned guard specs (231 test files, 6,470 tests) green via the AL2 Node 24 vitest run.
- **Review lanes (model-pinned, one spawn each):** round 1 GPT PASS + 1 advisory, Opus PASS + 2 advisories — the counter/phase-accuracy findings were adopted (phase-neutral wording + strengthened flag-off test + doc corrections). Round 2 on the adopted head: GPT PASS (no findings), Opus PASS (2 advisories, dispositioned below).

## Advisory dispositions (round 2, Opus)

1. *Productive episode ending in a non-productive continuation takes the counter>0 wording, keeping the resend clause.* Real, verified, and inherited — the pre-fix unconditional wording carried the identical clause on the identical path, so this PR does not worsen it. A truthful fix needs episode-scoped productivity state, which this PR's binding scope excludes. Filed as #9818 with the verified path and a suggested shape.
2. *`website/capture/notice-card-style.tsx` embeds the retired give-up copy.* Not CI-load-bearing (outside `tsconfig.app.json` include; referenced only by the manual screenshot runner; no vitest asserts the literal). The file's own header frames its rows as verbatim historical captures from the field report, so the literal is left as a historical record; noted in #9818's optional-cleanup section.

## Screenshot evidence

<!-- no-visual-delta -->

The change is user-visible chat copy, but the rendered delta is purely textual inside the existing `NoticeCard` component (same classes, same severity-glyph handling — only the string differs), and the give-up state is not reachable on demand in a browser: it requires a live provider to return three consecutive empty/reply-less turns. The evidence is the asserted notice text in the tests, which pin all three wordings and the boundaries between them.

## Pattern harvest

Rule candidate: when a multi-rung recovery ladder gains cause-aware wording at one rung, every terminal rung must inherit the same distinction — and a card that asserts a recovery ran must derive its claim from the recovery counter (or better, from which rungs actually fired), never from reaching the terminal rung. Corollary from review: a counter that budgets recoveries cannot name *which* recovery ran; wording driven by such a counter must stay phase-neutral. Knowingly out-of-scope sibling: the episode-vs-turn productivity distinction at the same site (#9818).
