### PR TITLE
feat(sidebar): carry search into older sessions

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -3081,6 +3081,18 @@ function ChatSidebar({
     try { return new URLSearchParams(window.location.search).get('history') === '1' }
     catch { return false }
   })
+  // The main session search is the broad entry point. Carry it into Older
+  // Sessions when that pane opens, then keep following it while both controls
+  // are visible. The history field can still be refined independently: only a
+  // later edit to the main search intentionally replaces that refinement.
+  const openHistoryPane = useCallback(() => {
+    setHistoryFilter(slotFilter)
+    setHistoryOpen(true)
+    dispatch(fetchHistory(false))
+  }, [dispatch, slotFilter])
+  useEffect(() => {
+    if (historyOpen) setHistoryFilter(slotFilter)
+  }, [historyOpen, slotFilter])
   // The toggle below fetches when it OPENS the pane, so a pane that starts open
   // has never fetched and would render its empty state over real history.
   useEffect(() => {
@@ -3417,7 +3429,7 @@ function ChatSidebar({
       <button
         type="button"
         data-testid={`older-sessions-hint-${lane}`}
-        onClick={() => { setHistoryOpen(true); dispatch(fetchHistory(false)) }}
+        onClick={openHistoryPane}
         className="mt-1 mx-1 px-2 py-1.5 text-left text-[12px] text-muted hover:text-accent hover:bg-accent-subtle rounded-md cursor-pointer bg-transparent border-none transition-colors"
       >
         {i18nT('pages.chatSidebar.show_all_older_sessions')}
@@ -7508,8 +7520,8 @@ function ChatSidebar({
       <div
         role="button"
         tabIndex={0}
-        onClick={() => { setHistoryOpen(!historyOpen); if (!historyOpen) dispatch(fetchHistory(false)) }}
-        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setHistoryOpen(!historyOpen); if (!historyOpen) dispatch(fetchHistory(false)) } }}
+        onClick={() => { if (historyOpen) setHistoryOpen(false); else openHistoryPane() }}
+        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (historyOpen) setHistoryOpen(false); else openHistoryPane() } }}
         /* pt/pb are 14px, not py-3, so this row's top border lands on the same
            baseline as the nav rail's community row ("Star us · Report issue"):
            both cards sit 8px off the shell floor, the rail spends 8+2+24+10 =

--- a/website/src/test/ChatSidebarCoverage.test.tsx
+++ b/website/src/test/ChatSidebarCoverage.test.tsx
@@ -593,6 +593,24 @@ describe('ChatSidebar — Older Sessions pane', () => {
     expect(screen.queryByText('Fresh history')).toBeNull()
   })
 
+  it('carries the main session search into Older Sessions and keeps following it', async () => {
+    renderSidebar({ history: HISTORY })
+    const sessionSearch = screen.getByPlaceholderText('Search sessions…')
+
+    fireEvent.change(sessionSearch, { target: { value: 'Week' } })
+    openHistory()
+
+    const historySearch = screen.getByPlaceholderText('Search older sessions…')
+    expect(historySearch).toHaveValue('Week')
+    expect(screen.getByText('Week history')).toBeTruthy()
+    expect(screen.queryByText('Fresh history')).toBeNull()
+
+    fireEvent.change(screen.getByPlaceholderText('Search sessions…'), { target: { value: 'Fresh' } })
+    await waitFor(() => expect(screen.getByPlaceholderText('Search older sessions…')).toHaveValue('Fresh'))
+    expect(screen.getByText('Fresh history')).toBeTruthy()
+    expect(screen.queryByText('Week history')).toBeNull()
+  })
+
   it('groups backend search results by folder and collapses a group', async () => {
     mocks.sessionsSearch.mockResolvedValue({
       sessions: [


### PR DESCRIPTION
## Problem / Motivation

Searching the main Sessions list does not carry the query into Older Sessions. Users who open the history pane after an unsuccessful live-session search must retype the same keyword into the second search field.

## Why it matters

Older Sessions is the natural continuation of the main session list. Dropping the active query at that boundary adds avoidable friction precisely when someone is already trying to recover a session they cannot find.

## What changed (motivation → approach → change)

The main session search remains the broad entry point, while the existing Older Sessions field remains available for a history-only refinement.

- Opening Older Sessions through either the footer or the in-flow hint copies the current main query into the older-session filter.
- While the pane is open, later edits to the main query continue to update the older-session filter.
- Editing the lower field remains independent until the main query changes again.
- A shared open helper keeps pointer and keyboard disclosure paths consistent.

## Tests

- Added a ChatSidebar regression covering query handoff when Older Sessions opens.
- The regression also proves later main-query edits update the visible older-session filter and results.
- Mutation proof: the new regression fails at the expected query-value assertion when only the production hunk is reverted.
- Focused ChatSidebar suites: 53 passed.
- Full website suite: 31,180 passed, 1 expected failure, 2 skipped.
- Electron suite: 1,837 passed, 1 skipped.
- TypeScript, ESLint, build, localization, duplication, documentation, contract, and bundle-size gates passed.
- Backend cross-surface floor has 73 host-policy/path-ownership failures reproduced identically on clean current origin/main (1,825 passed, 9 skipped in the compared files); this PR changes no backend code.

## Manual verification

N/A — the behavior is completely exercised through the rendered interaction test, including both visible query values and filtered row results.

## Screenshots / video

N/A — this changes state handoff between two existing controls without changing their visual appearance or layout; the interaction regression is the meaningful evidence.

## Related Issues

Fixes #9830

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no documentation surface changed)
- [x] No secrets, credentials, or internal references in the diff