### PR TITLE
resolve symlinked argv[0] for pod child spawn on macos .app

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -49,7 +49,16 @@ not a preference:
   dispatching on `argv[0]` (`~/.toolbox/bin/kiro-cli` → `toolbox-exec`), a
   wrapper reading a sibling registry, or a self-updating install whose real
   payload lives beside it. The launch path is therefore the path the caller
-  resolved, **not** its realpath.
+  resolved, **not** its realpath. One exception, a pod child only: its remapped
+  `$HOME` puts the sibling nowhere, so `apply_pod_bundle_spawn` resolves a
+  symlinked `argv[0]` **onto a verified `<name>.app/Contents/MacOS/` target only** —
+  same basename, executable, with a `<basename>-` sibling beside it. Verifying the
+  whole layout, not just that the link resolves, is what keeps the exception off
+  the `argv[0]`-dispatching multiplexer above and off any wrapper that finds its
+  resources through the path it was invoked by. Crew's launcher still takes the
+  sandbox, though not for the bundle swap's reason: no shim is in this chain, and
+  delegating would skip Crew's seatbelt for an internal sandbox whose behaviour
+  under the pod's remapped `$HOME` Crew cannot verify.
 
 **Removed: the resolve-to-exec integrity snapshot.** An earlier design copied the
 resolved bytes into a private location and executed that instead — a sealed

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1107,6 +1107,46 @@ def _kiro_cli_bundle_binary(
     return None
 
 
+#: The path tail a macOS ``.app`` install puts the kiro-cli binary at. A multi-call
+#: kiro-cli locates the sibling it execs by searching for this tail in its OWN
+#: executable path, so it is the one layout where resolving a symlink is safe.
+_MACOS_APP_BUNDLE_SUFFIX = ".app"
+_MACOS_APP_BUNDLE_TAIL = ("Contents", "MacOS")
+
+
+def _kiro_cli_app_bundle_target(executable: str) -> str | None:
+    """The macOS ``.app`` kiro-cli binary *executable* symlinks to, or ``None``.
+
+    Verifies the LAYOUT, not just that the link resolves: each condition is one the
+    target must satisfy for the child's own sibling search to succeed afterwards.
+    Same basename keeps an ``argv[0]``-dispatching multiplexer out; the
+    ``<basename>-`` sibling proves this is the multi-call binary.
+    """
+    try:
+        real = os.path.realpath(executable)
+        if real == executable:
+            return None
+        name = os.path.basename(real)
+        if name != os.path.basename(executable):
+            return None
+        macos_dir = os.path.dirname(real)
+        contents_dir = os.path.dirname(macos_dir)
+        app_dir = os.path.dirname(contents_dir)
+        tail = (os.path.basename(contents_dir), os.path.basename(macos_dir))
+        if tail != _MACOS_APP_BUNDLE_TAIL:
+            return None
+        if not os.path.basename(app_dir).endswith(_MACOS_APP_BUNDLE_SUFFIX):
+            return None
+        if not os.path.isfile(real) or not os.access(real, os.X_OK):
+            return None
+        siblings = os.listdir(macos_dir)
+    except OSError:  # pragma: no cover - defensive; a spawn must not fail on this
+        return None
+    if not any(entry.startswith(f"{name}-") for entry in siblings):
+        return None
+    return real
+
+
 def apply_pod_bundle_spawn(
     argv: list[str],
     *,
@@ -1153,10 +1193,20 @@ def apply_pod_bundle_spawn(
     goes ``False`` and ``wrap_argv`` wraps the child in Crew's launcher instead.
     The substitution is per-pod-child and never reaches a host session.
 
-    If the bundle binary cannot be located the pair degrades to the status quo
-    (shim, internal sandbox) rather than spawning something unlaunchable; a pod
-    whose child cannot bootstrap is meant to be refused loudly at ``pod up``, not
-    papered over here.
+    If the bundle binary cannot be located, one further layout resolves: a symlinked
+    ``argv[0]`` whose target :func:`_kiro_cli_app_bundle_target` verifies as a macOS
+    ``.app`` binary. Its exec'd sibling shares that directory -- which is why the
+    fixed-depth candidate above misses it -- so the real name puts the sibling beside
+    the child instead of under the remapped ``HOME``.
+    ``delegate_internal_sandbox`` goes ``False``, though not for the swap's reason:
+    no shim is in this chain, and delegating would instead skip Crew's seatbelt for
+    an internal sandbox whose behaviour under the pod's remapped ``HOME`` Crew cannot
+    verify -- that remap already broke the other sandbox in this chain. Uncertainty
+    resolves toward our own layer, the direction
+    :func:`sandbox.kiro_internal_sandbox_enabled` states for itself. Failing both,
+    the pair degrades to the status quo (shim, internal sandbox) rather than spawning
+    something unlaunchable; a pod whose child cannot bootstrap is meant to be refused
+    loudly at ``pod up``, not papered over here.
     """
     delegate = backend in ACP_BACKENDS_INTERNAL_SANDBOX
     env = os.environ if environ is None else environ
@@ -1167,6 +1217,8 @@ def apply_pod_bundle_spawn(
     if not argv:  # pragma: no cover - defensive; callers always pass argv[0]
         return argv, delegate
     bundle = _kiro_cli_bundle_binary(argv[0], environ=env)
+    if bundle is None:
+        bundle = _kiro_cli_app_bundle_target(argv[0])
     if bundle is None:
         return argv, delegate
     return [bundle, *argv[1:]], False

--- a/test/test_acp_pod_bundle_spawn.py
+++ b/test/test_acp_pod_bundle_spawn.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+from conftest import requires_symlinks
 from kiro_crew.acp.client import (
     _kiro_cli_bundle_binary,
     apply_pod_bundle_spawn,
@@ -40,6 +41,25 @@ def _bundle_layout(tmp_path: Path) -> tuple[str, str]:
         path.write_text("#!/bin/sh\nexit 0\n")
         path.chmod(0o755)
     return str(shim), str(bundle)
+
+
+def _app_bundle_layout(tmp_path: Path, *, sibling: str | None = "kiro-cli-chat") -> Path:
+    macos_dir = tmp_path / "Applications" / "Kiro CLI.app" / "Contents" / "MacOS"
+    macos_dir.mkdir(parents=True)
+    names = ["kiro-cli"] + ([sibling] if sibling else [])
+    for name in names:
+        path = macos_dir / name
+        path.write_text("#!/bin/sh\nexit 0\n")
+        path.chmod(0o755)
+    return macos_dir / "kiro-cli"
+
+
+def _symlink_in_local_bin(tmp_path: Path, target: Path) -> Path:
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    link = local_bin / "kiro-cli"
+    link.symlink_to(target)
+    return link
 
 
 def _pod_env(os_home: Path) -> dict[str, str]:
@@ -101,6 +121,91 @@ def test_pod_spawn_degrades_to_status_quo_when_no_bundle_binary_exists(
         environ=_pod_env(tmp_path / "os-home"),
     )
     assert argv == [str(lone), "acp"]
+    assert delegate is (ACP_BACKEND_KIRO in ACP_BACKENDS_INTERNAL_SANDBOX)
+
+
+@requires_symlinks
+def test_pod_spawn_resolves_a_macos_app_bundle_symlink_and_takes_crew_sandbox(
+    tmp_path: Path,
+) -> None:
+    bundle = _app_bundle_layout(tmp_path)
+    link = _symlink_in_local_bin(tmp_path, bundle)
+
+    assert _kiro_cli_bundle_binary(str(link), environ={}) is None
+
+    argv, delegate = apply_pod_bundle_spawn(
+        [str(link), "acp"],
+        backend=ACP_BACKEND_KIRO,
+        environ=_pod_env(tmp_path / "os-home"),
+    )
+
+    assert argv == [str(bundle), "acp"]
+    assert delegate is False
+
+
+@requires_symlinks
+def test_pod_spawn_leaves_a_same_named_symlink_outside_an_app_bundle_unresolved(
+    tmp_path: Path,
+) -> None:
+    vendor = tmp_path / "opt" / "vendor"
+    vendor.mkdir(parents=True)
+    target = vendor / "kiro-cli"
+    target.write_text("#!/bin/sh\nexit 0\n")
+    target.chmod(0o755)
+    link = _symlink_in_local_bin(tmp_path, target)
+
+    assert _kiro_cli_bundle_binary(str(link), environ={}) is None
+
+    argv, delegate = apply_pod_bundle_spawn(
+        [str(link), "acp"],
+        backend=ACP_BACKEND_KIRO,
+        environ=_pod_env(tmp_path / "os-home"),
+    )
+
+    assert argv == [str(link), "acp"]
+    assert delegate is (ACP_BACKEND_KIRO in ACP_BACKENDS_INTERNAL_SANDBOX)
+
+
+@requires_symlinks
+def test_pod_spawn_leaves_a_bundle_shaped_target_with_no_sibling_unresolved(
+    tmp_path: Path,
+) -> None:
+    bundle = _app_bundle_layout(tmp_path, sibling=None)
+    link = _symlink_in_local_bin(tmp_path, bundle)
+
+    assert _kiro_cli_bundle_binary(str(link), environ={}) is None
+
+    argv, delegate = apply_pod_bundle_spawn(
+        [str(link), "acp"],
+        backend=ACP_BACKEND_KIRO,
+        environ=_pod_env(tmp_path / "os-home"),
+    )
+
+    assert argv == [str(link), "acp"]
+    assert delegate is (ACP_BACKEND_KIRO in ACP_BACKENDS_INTERNAL_SANDBOX)
+
+
+@requires_symlinks
+def test_pod_spawn_leaves_an_argv0_dispatching_multiplexer_symlink_unresolved(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / ".toolbox" / "bin"
+    bin_dir.mkdir(parents=True)
+    multiplexer = bin_dir / "toolbox-exec"
+    multiplexer.write_text("#!/bin/sh\nexit 0\n")
+    multiplexer.chmod(0o755)
+    link = bin_dir / "kiro-cli"
+    link.symlink_to(multiplexer)
+
+    assert _kiro_cli_bundle_binary(str(link), environ={}) is None
+
+    argv, delegate = apply_pod_bundle_spawn(
+        [str(link), "acp"],
+        backend=ACP_BACKEND_KIRO,
+        environ=_pod_env(tmp_path / "os-home"),
+    )
+
+    assert argv == [str(link), "acp"]
     assert delegate is (ACP_BACKEND_KIRO in ACP_BACKENDS_INTERNAL_SANDBOX)
 
 


### PR DESCRIPTION
## Problem / Motivation

On a stock macOS install where Kiro CLI ships as an app bundle, **every** `kirocrew pod up` is refused. The operator sees the pod never come up:

```
FATAL: the pod's kiro-cli child exited immediately (rc=1) instead of serving ACP.
stderr: error: No such file or directory (os error 2), so every agent turn in this
pod would fail while /health still answered 200. Child: /usr/bin/env with
HOME=~/.kirocrew-pods/<name>/os-home.
kirocrew-pod: exiting 0 instead of 78 so launchd does not restart into the same
refusal every 5s; recorded at ~/.kiro/crew/pods/<name>.refused
pod: <name>: gateway never became healthy on :<port> within timeout
```

The precondition is the default install layout, not an unusual one: `~/.local/bin/kiro-cli` is a symlink into `/Applications/Kiro CLI.app/Contents/MacOS/kiro-cli`.

## Why it matters

Pods are unusable on macOS `.app` installs, not degraded but refused outright, for any pod name and any worktree. That takes out the whole isolated-instance workflow (`pod up` / `pod api` / `pod exec`), which is how a change is proved against a running gateway without touching the live plane (`docs/guides/worktree-verification-recipes.md`), and it is the admission gate for `pod_required` repro work in the pipeline conductor.

Worth stating what is *not* at risk: the boot correctly **refuses** rather than serving a broken pod. `_probe_pod_child_bootstrap` returns DEAD and the refusal is recorded, so nobody gets a pod that answers `/health` 200 while every agent turn dies. The bug is that the refusal is unconditional on this layout.

## What changed (motivation → approach → change)

**Symptom.** `kiro-cli acp` dispatches by exec'ing its sibling `kiro-cli-chat`, located relative to its own executable path. A pod child is spawned with `HOME` remapped to the pod's `os-home` (`_apply_pod_home_remap`). When `argv[0]` is the `~/.local/bin/kiro-cli` symlink, that dispatch looks for the sibling under `$HOME/.local/bin`, inside the pod tree, where nothing stages it. Every dispatch therefore fails with `os error 2`.

**Root cause.** `apply_pod_bundle_spawn` already handles the shim case by swapping in the bundle binary that `_kiro_cli_bundle_binary` locates. But that helper infers the layout from a fixed depth, `dirname(dirname(realpath))/kiro-cli`, which matches the toolbox layout (`<root>/sandbox/kiro-cli` to `<root>/kiro-cli`) and *misses* the `.app` layout, where the binary and its sibling share one directory (`Contents/MacOS/`), so the computed candidate lands at `Contents/kiro-cli` and does not exist. The helper returns `None`, and the caller's `None` branch meant "no bundle to swap to, spawn what was resolved": correct for a host with no bundle, wrong for a symlink *into* one.

**Change.** On that same `None` branch, recognise the `.app` layout in a second helper, `_kiro_cli_app_bundle_target`, and spawn the target by its real name so the sibling resolves beside it regardless of `$HOME`. The helper verifies the whole LAYOUT rather than merely following the link, because a same-named symlink on its own says nothing about whether rewriting `argv[0]` is safe. Every condition is one the target must satisfy for the child's own sibling search to succeed afterwards: the `<name>.app/Contents/MacOS/` path tail kiro-cli searches for in its own executable path, the same basename (a launcher that dispatches on `argv[0]`'s name must still see the name the caller used), an executable file, and a `<basename>-` sibling proving this is the multi-call binary rather than a coincidentally-named one. So the exception covers the stock `.app` install and nothing else: not the `argv[0]`-dispatching multiplexer (`~/.toolbox/bin/kiro-cli` to `toolbox-exec`), and not a wrapper that finds its resources through the path it was invoked by.

`delegate_internal_sandbox` becomes `False` on this branch, exactly as on the bundle swap and for the same reason. The verified target is the multi-call binary itself, so the shim is out of the chain and kiro-cli's internal sandbox never runs; skipping Crew's seatbelt is only sound while that internal sandbox is actually active (`client.py:1194`). Measured on a host with `kiro_internal_sandbox_enabled()` true, `True` returns a delegated argv with no seatbelt profile at all while `False` produces one, so the flag is the whole difference between a confined pod child and an unconfined one.

Scope is unchanged too. The whole function is still gated on `KIROCREW_POD` compared exactly to `"1"`, positive membership in `ACP_BACKENDS_POD_HOME_REMAP`, and a `KIROCREW_OS_HOME` to point at. No host session and no harness outside the remap set is affected, and identity stays positive (harness-parity H6/H7).

**Doc.** `docs/system-specs/modules/acp-client.md` states the invariant *"The launch path is therefore the path the caller resolved, **not** its realpath"*, which this change carves an exception out of. The carve-out names the scope (pod child only), the exact layout it is confined to, the function to grep for, and the sandbox-ownership answer, so the spec no longer reads as forbidding what the code does. The full rationale stays in the function docstring rather than being restated.

## Tests

`test/test_acp_pod_bundle_spawn.py`, one positive case and three negative ones. Every one of them asserts `_kiro_cli_bundle_binary` returns `None` for its layout first, so each provably exercises the `bundle is None` branch and cannot silently drift onto the pre-existing swap path.

`test_pod_spawn_resolves_a_macos_app_bundle_symlink_and_takes_crew_sandbox` builds a real `.app` layout in `tmp_path` (bundle binary plus its `kiro-cli-chat` sibling) with a `~/.local/bin/kiro-cli` symlink into it, and pins both halves of the decision: `argv[0]` becomes the resolved bundle path, and `delegate` is `False`.

The three negatives are what keep the exception narrow, and each is non-vacuous by construction — every condition except the one under test holds, so a predicate missing that check does resolve the case:

1. `test_pod_spawn_leaves_a_same_named_symlink_outside_an_app_bundle_unresolved` — a same-named executable target that is not in a bundle at all, the wrapper-loses-its-resources case.
2. `test_pod_spawn_leaves_a_bundle_shaped_target_with_no_sibling_unresolved` — a lone same-named executable inside some other application's bundle, which execs nothing beside itself.
3. `test_pod_spawn_leaves_an_argv0_dispatching_multiplexer_symlink_unresolved` — a `~/.toolbox/bin/kiro-cli` link onto `toolbox-exec`, where resolving would run a different program.

Both new negatives were verified red against the un-narrowed predicate, not merely asserted to be non-vacuous.

The file's existing coverage is what keeps the change scoped, and all of it still passes: the shim swap still takes Crew's sandbox, `KIRO_CLI_PATH` still wins outright, a host with no bundle still degrades to the status quo, the non-pod path is byte-identical across four marker spellings, and a harness outside `ACP_BACKENDS_POD_HOME_REMAP` is untouched inside a pod. **14 passed** (34 with `test_pod_child_viability.py`).

## Manual verification

Reproduced and fixed on a real macOS `.app` install, as a one-variable A/B with the same pod name, the same derived port and the same checkout, only the `kirocrew` build performing the boot differing.

Deterministic, 100%, not intermittent.

The spawn decision itself, A/B'd directly against the same pod `HOME`:

```
unfixed: spawn argv ['~/.local/bin/kiro-cli', 'acp']                              <- symlink
patched: spawn argv ['/Applications/Kiro CLI.app/Contents/MacOS/kiro-cli', 'acp'] <- realpath
```

And re-run after the layout narrowing, driving the real install through `wrap_argv` under the pod's remapped `HOME` with `chat --help` (which reaches the sibling dispatch with no credentials, unlike `acp`, which exits on "not logged in" before it). 

The control arm is what proves Crew's own seatbelt does not break the `.app` child: the change of sandbox owner is not what makes the patched arm work, resolving `argv[0]` is.

Gates: black gate passed, comment-history gate passed, `flake8` clean, `mypy --platform linux src/kiro_crew` clean over 1384 files, `scripts/docs-lint.sh` all checks passed, and `scripts/check_harness_parity.py` reports *"Kiro identity tested positively in the lines added since origin/main"*.

## Related Issues

Fixes #9829

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: a helper that sniffs a layout from a fixed number of path levels returns `None` for *both* "not applicable" and "layout not recognised", and the caller's degrade-to-status-quo branch turns the second meaning into a runtime failure. When reviewing a `None`/sentinel fallback, check that the fallback is safe for **every** reason the sentinel can be produced, not just the one the author had in mind.

Recurrence worth flagging: this is the second defect in this exact seam where a pod's `HOME` remap invalidated a path resolution that was correct before the remap. The first, recorded in `apply_pod_bundle_spawn`'s docstring, was toolbox's `aim sandbox` mount plan. Any change to a pod child's spawn should be reviewed against the question "what does this child resolve relative to `$HOME` or to `argv[0]`?"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text; it will be added here once Legal provides it. -->
