### PR TITLE
feat(monitoring): add github_workflow_run kind as data

### DIFF
--- a/src/kiro_crew/monitoring/github_workflow_run.py
+++ b/src/kiro_crew/monitoring/github_workflow_run.py
@@ -1,0 +1,438 @@
+"""Typed public-GitHub Actions workflow-run observations for structured monitors.
+
+This module is the second monitored kind, and it exists to test one claim the
+monitoring substrate makes: that a genuinely different subject can be added as a
+probe plus a registry entry, without editing the shared decision engine, the
+shared result type, or the shared probe protocol.
+
+A workflow run is a different subject from a pull request, deliberately. It shares
+the credential and the CLI, so there is no authentication work here to distract
+from that question. What differs is the substance: a run's terminal states are
+``success`` / ``failure`` / ``cancelled`` / ``timed_out`` rather than merged or
+closed, its objective is that the run REACHED a conclusion rather than that a human
+may review it, and it cannot be inferred from a message by URL the way a pull
+request can. The last property is why the kind is registered as not publicly
+armable: it has to speak the registry's vocabulary by construction.
+
+The engine reads only what :class:`MonitorProbeResult` declares. Everything a
+workflow run knows that a pull request does not -- the run's conclusion, the
+workflow name -- stays on this module's own response type and its own probe-result
+subclass, never on the shared type. That is the line every kind draws for itself.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import re
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+from kiro_crew.github_runner import SetupError, resolve_gh, run_gh
+from kiro_crew.monitoring.models import (
+    MonitorObservation,
+    MonitorObservationStatus,
+    MonitorProbeResult,
+    ProviderErrorKind,
+)
+
+_GITHUB_HOST = "github.com"
+_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_RAW_URL_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f\u2028\u2029]")
+_HTTP_STATUS_RE = re.compile(r"\bhttp\s+(\d{3})\b", re.IGNORECASE)
+_HEAD_REVISION_RE = re.compile(r"^[0-9a-fA-F]{1,128}$")
+_PROBE_TIMEOUT_SECS = 30.0
+_RUN_FIELDS = "databaseId,status,conclusion,headSha,workflowName,event"
+_MAX_WORKFLOW_RUN_ID = 9_223_372_036_854_775_807
+
+GitHubResolver = Callable[[], str]
+GitHubRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+#: Actions statuses that are not yet a conclusion. Any status outside this set that
+#: is also not ``completed`` is treated as pending too, so a status vocabulary the
+#: CLI adds later degrades to "still running" rather than to a wrong verdict.
+_IN_PROGRESS_STATUSES = frozenset({"queued", "in_progress", "waiting", "requested", "pending"})
+
+#: A run's conclusion mapped to this kind's OWN terminal vocabulary. Not merged or
+#: closed: those are pull-request words. A run either reached a good end, a bad end,
+#: or was stopped. ``neutral`` / ``skipped`` / ``stale`` are non-failing ends and
+#: read as success, matching how the pull-request check normalizer treats the same
+#: conclusions on an individual check.
+_SUCCESS_CONCLUSIONS = frozenset({"success", "neutral", "skipped", "stale"})
+_CANCELLED_CONCLUSIONS = frozenset({"cancelled"})
+_FAILURE_CONCLUSIONS = frozenset({"failure", "timed_out", "action_required", "startup_failure"})
+
+
+@dataclass(frozen=True)
+class GitHubWorkflowRunTarget:
+    """Validated identity of one public GitHub Actions workflow run."""
+
+    host: str
+    owner: str
+    repo: str
+    run_id: int
+
+    def __post_init__(self) -> None:
+        if self.host != _GITHUB_HOST:
+            raise ValueError("target must be a public GitHub workflow run")
+        if any(
+            segment in {".", ".."} or _SEGMENT_RE.fullmatch(segment) is None
+            for segment in (self.owner, self.repo)
+        ):
+            raise ValueError("target must be a public GitHub workflow run")
+        if isinstance(self.run_id, bool) or not isinstance(self.run_id, int) or self.run_id <= 0:
+            raise ValueError("target must be a public GitHub workflow run")
+
+    @property
+    def identity(self) -> str:
+        return f"{self.host}/{self.owner}/{self.repo}/actions/runs/{self.run_id}"
+
+    @property
+    def repo_slug(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+    @property
+    def url(self) -> str:
+        return f"https://{self.host}/{self.owner}/{self.repo}/actions/runs/{self.run_id}"
+
+
+@dataclass(frozen=True)
+class GitHubWorkflowRunResponse:
+    """Allowlisted provider facts with no raw response attached."""
+
+    target: GitHubWorkflowRunTarget
+    status: str
+    conclusion: str
+    head_revision: str
+    workflow_name: str
+    event: str
+
+
+@dataclass(frozen=True)
+class GitHubWorkflowRunProbeResult(MonitorProbeResult):
+    """One run's canonical facts, plus the typed response behind them.
+
+    The engine reads only what :class:`MonitorProbeResult` declares. ``response``
+    is this kind's own detail and stays here rather than on the shared type -- the
+    same line the pull-request kind draws with its own subclass.
+    """
+
+    response: GitHubWorkflowRunResponse | None
+
+
+class GitHubWorkflowRunProvider:
+    """Read public workflow-run state through the authenticated hardened gh runner."""
+
+    def __init__(
+        self,
+        *,
+        resolver: GitHubResolver = resolve_gh,
+        runner: GitHubRunner = run_gh,
+    ) -> None:
+        self._resolver = resolver
+        self._runner = runner
+
+    def probe(
+        self,
+        subjects: Sequence[str],
+        *,
+        previous_observations: Mapping[str, Mapping[str, object]] | None = None,
+    ) -> Mapping[str, GitHubWorkflowRunProbeResult]:
+        """Return one canonical run-completion observation per subject.
+
+        The GitHub CLI answers for one run per call, so this loops. The loop is an
+        implementation detail of this kind: the boundary is plural so a host that
+        answers for many subjects at once needs no signature change, and keyed by
+        the subject string as passed so a caller can look up what it asked for.
+
+        ``previous_observations`` is accepted to satisfy the shared boundary; a
+        workflow run has no head-change semantics, so it is unused here.
+        """
+        return {subject: self._probe_one(subject) for subject in subjects}
+
+    def _probe_one(self, raw_target: str) -> GitHubWorkflowRunProbeResult:
+        """Return one canonical run-completion observation."""
+        try:
+            target = parse_github_workflow_run_target(raw_target)
+            gh = self._resolver()
+            proc = self._runner(
+                [
+                    gh,
+                    "run",
+                    "view",
+                    str(target.run_id),
+                    "--repo",
+                    target.repo_slug,
+                    "--json",
+                    _RUN_FIELDS,
+                ],
+                timeout=_PROBE_TIMEOUT_SECS,
+                audit_caller="core:monitor",
+                pin_host=_GITHUB_HOST,
+            )
+            failure = _process_failure(proc)
+            if failure is not None:
+                return failure
+            response = _normalize_response(target, _json_object(proc.stdout))
+        except (SetupError, FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            return _provider_exception_error(exc)
+        except (TypeError, ValueError, KeyError):
+            return _provider_error(ProviderErrorKind.TRANSIENT, "provider_malformed_response")
+        canonical = _canonical_response(response)
+        status, reason_code = _classify_response(response)
+        return GitHubWorkflowRunProbeResult(
+            response=response,
+            canonical=canonical,
+            observation=MonitorObservation(
+                _fingerprint(canonical),
+                status,
+                reason_code=reason_code,
+            ),
+        )
+
+
+def parse_github_workflow_run_target(raw: str) -> GitHubWorkflowRunTarget:
+    """Parse one exact public GitHub Actions run URL into a typed identity.
+
+    A workflow run URL is ``/owner/repo/actions/runs/<id>``. An attempt-scoped URL
+    ``.../actions/runs/<id>/attempts/<n>`` and the job-scoped ``/job/<id>`` form are
+    both refused: the run id is the durable identity a probe watches, and admitting
+    a sub-view would make two URLs for one subject key the same watch differently.
+    """
+    if not isinstance(raw, str) or not raw or _RAW_URL_CONTROL_RE.search(raw):
+        raise ValueError("target must be a GitHub workflow run URL")
+    parsed = urlparse(raw)
+    try:
+        host = (parsed.hostname or "").lower()
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("target must be a public GitHub workflow run URL") from exc
+    if (
+        parsed.scheme != "https"
+        or host not in {_GITHUB_HOST, f"www.{_GITHUB_HOST}"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("target must be a public GitHub workflow run URL")
+    parts = PurePosixPath(parsed.path).parts
+    if len(parts) != 6 or parts[0] != "/" or parts[3] != "actions" or parts[4] != "runs":
+        raise ValueError("target must be a GitHub workflow run URL")
+    owner, repo, raw_id = parts[1], parts[2], parts[5]
+    if parsed.path != f"/{owner}/{repo}/actions/runs/{raw_id}":
+        raise ValueError("target must be a canonical GitHub workflow run URL")
+    if (
+        not raw_id.isascii()
+        or not raw_id.isdecimal()
+        or raw_id.startswith("0")
+        or int(raw_id, 10) > _MAX_WORKFLOW_RUN_ID
+    ):
+        raise ValueError("target must be a GitHub workflow run with a positive id")
+    try:
+        return GitHubWorkflowRunTarget(_GITHUB_HOST, owner, repo, int(raw_id, 10))
+    except ValueError as exc:
+        raise ValueError("target must be a valid GitHub workflow run") from exc
+
+
+def _json_object(raw: str | None) -> dict[str, Any]:
+    if not isinstance(raw, str):
+        raise ValueError("GitHub response is malformed")
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError("GitHub response is malformed") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub response is malformed")
+    return payload
+
+
+def _normalize_response(
+    target: GitHubWorkflowRunTarget,
+    raw: Mapping[str, Any],
+) -> GitHubWorkflowRunResponse:
+    required = {"databaseId", "status", "conclusion", "headSha", "workflowName", "event"}
+    if not required.issubset(raw):
+        raise ValueError("GitHub workflow run response is malformed")
+    run_id = raw["databaseId"]
+    if isinstance(run_id, bool) or not isinstance(run_id, int) or run_id != target.run_id:
+        raise ValueError("GitHub workflow run response is malformed")
+    status = raw["status"]
+    if not isinstance(status, str) or not status:
+        raise ValueError("GitHub workflow run response is malformed")
+    conclusion = raw["conclusion"]
+    # A run that has not concluded reports an empty-string or null conclusion.
+    if conclusion is None:
+        conclusion = ""
+    if not isinstance(conclusion, str):
+        raise ValueError("GitHub workflow run response is malformed")
+    head_revision = raw["headSha"]
+    if not isinstance(head_revision, str) or (
+        head_revision and _HEAD_REVISION_RE.fullmatch(head_revision) is None
+    ):
+        raise ValueError("GitHub workflow run response is malformed")
+    workflow_name = raw["workflowName"]
+    event = raw["event"]
+    if not isinstance(workflow_name, str) or not isinstance(event, str):
+        raise ValueError("GitHub workflow run response is malformed")
+    return GitHubWorkflowRunResponse(
+        target=target,
+        status=status.lower(),
+        conclusion=conclusion.lower(),
+        head_revision=head_revision,
+        workflow_name=workflow_name,
+        event=event,
+    )
+
+
+def _canonical_response(response: GitHubWorkflowRunResponse) -> dict[str, object]:
+    return {
+        "conclusion": response.conclusion,
+        "event": response.event,
+        "head_revision": response.head_revision,
+        "kind": "github_workflow_run",
+        "status": response.status,
+        "target": response.target.identity,
+        "workflow_name": response.workflow_name,
+    }
+
+
+def _fingerprint(canonical: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        canonical,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _classify_response(
+    response: GitHubWorkflowRunResponse,
+) -> tuple[MonitorObservationStatus, str]:
+    """Map a run to the engine's generic status plus this kind's own reason code.
+
+    The objective is ``run_complete``: a run is done when it reaches a conclusion.
+    A completed run's conclusion decides success or blocked; anything not completed
+    is pending. This is the terminal-state mapping the acceptance test pins.
+    """
+    if response.status in _IN_PROGRESS_STATUSES or response.status != "completed":
+        return MonitorObservationStatus.PENDING, "run_in_progress"
+    if response.conclusion in _SUCCESS_CONCLUSIONS:
+        return MonitorObservationStatus.SUCCESS, "run_succeeded"
+    if response.conclusion in _CANCELLED_CONCLUSIONS:
+        return MonitorObservationStatus.BLOCKED, "run_cancelled"
+    if response.conclusion in _FAILURE_CONCLUSIONS:
+        return MonitorObservationStatus.BLOCKED, "run_failed"
+    # Completed with a conclusion this kind does not recognize. Treated as blocked
+    # rather than pending: a completed run is terminal, and calling an unrecognized
+    # terminal conclusion "still running" would keep a finished watch alive forever.
+    return MonitorObservationStatus.BLOCKED, "run_conclusion_unknown"
+
+
+def _process_failure(
+    proc: subprocess.CompletedProcess[str],
+) -> GitHubWorkflowRunProbeResult | None:
+    if proc.returncode == 0:
+        return None
+    kind = _classify_cli_error(proc.stderr if isinstance(proc.stderr, str) else "")
+    reasons = {
+        ProviderErrorKind.RATE_LIMITED: "provider_rate_limited",
+        ProviderErrorKind.AUTHENTICATION: "provider_authentication",
+        ProviderErrorKind.AUTHORIZATION: "provider_authorization",
+        ProviderErrorKind.NOT_FOUND: "provider_not_found",
+        ProviderErrorKind.TRANSIENT: "provider_transient",
+    }
+    return _provider_error(kind, reasons[kind])
+
+
+def _classify_cli_error(raw: str) -> ProviderErrorKind:
+    lowered = raw.lower()
+    if any(marker in lowered for marker in ("rate limit", "abuse detection", "too many requests")):
+        return ProviderErrorKind.RATE_LIMITED
+    status_match = _HTTP_STATUS_RE.search(raw)
+    if status_match is not None:
+        status = int(status_match.group(1), 10)
+        if status == 429:
+            return ProviderErrorKind.RATE_LIMITED
+        if status == 401:
+            return ProviderErrorKind.AUTHENTICATION
+        if status == 403:
+            return ProviderErrorKind.AUTHORIZATION
+        if status == 404:
+            return ProviderErrorKind.NOT_FOUND
+        if status >= 500:
+            return ProviderErrorKind.TRANSIENT
+    if "could not resolve host" in lowered:
+        return ProviderErrorKind.TRANSIENT
+    if "http 429" in lowered:
+        return ProviderErrorKind.RATE_LIMITED
+    if any(
+        marker in lowered
+        for marker in ("bad credentials", "authentication", "not logged into", "gh auth login")
+    ):
+        return ProviderErrorKind.AUTHENTICATION
+    if any(
+        marker in lowered for marker in ("not found", "could not resolve to a", "no runs found")
+    ):
+        return ProviderErrorKind.NOT_FOUND
+    if any(
+        marker in lowered
+        for marker in ("forbidden", "permission", "resource not accessible", "saml")
+    ):
+        return ProviderErrorKind.AUTHORIZATION
+    return ProviderErrorKind.TRANSIENT
+
+
+def _transient_os_error(error: BaseException | None) -> bool:
+    """Classify bounded host-pressure and connection failures as retryable."""
+    return isinstance(error, OSError) and error.errno in {
+        errno.EAGAIN,
+        errno.EMFILE,
+        errno.ENFILE,
+        errno.ENOMEM,
+        errno.ECONNRESET,
+        errno.ETIMEDOUT,
+    }
+
+
+def _provider_exception_kind(error: BaseException) -> ProviderErrorKind:
+    if isinstance(error, subprocess.TimeoutExpired):
+        return ProviderErrorKind.TRANSIENT
+    if isinstance(error, FileNotFoundError):
+        return ProviderErrorKind.SETUP
+    if isinstance(error, SetupError):
+        return (
+            ProviderErrorKind.TRANSIENT
+            if _transient_os_error(error.__cause__)
+            else ProviderErrorKind.SETUP
+        )
+    if isinstance(error, OSError) and _transient_os_error(error):
+        return ProviderErrorKind.TRANSIENT
+    return ProviderErrorKind.SETUP
+
+
+def _provider_exception_error(error: BaseException) -> GitHubWorkflowRunProbeResult:
+    kind = _provider_exception_kind(error)
+    reason = "provider_transient" if kind is ProviderErrorKind.TRANSIENT else "provider_setup"
+    return _provider_error(kind, reason)
+
+
+def _provider_error(kind: ProviderErrorKind, reason_code: str) -> GitHubWorkflowRunProbeResult:
+    return GitHubWorkflowRunProbeResult(
+        response=None,
+        canonical={},
+        observation=MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=kind,
+            reason_code=reason_code,
+        ),
+    )

--- a/src/kiro_crew/monitoring/registry.py
+++ b/src/kiro_crew/monitoring/registry.py
@@ -49,7 +49,21 @@ GITHUB_PULL_REQUEST = "github_pull_request"
 #: the two spellings agree, so a drift fails loudly instead of silently.
 GH_PR = "gh-pr"
 
+#: A public GitHub Actions workflow run. A genuinely different subject from a pull
+#: request: its terminal states are success / failure / cancelled / timed_out, not
+#: merged or closed. Registered but NOT publicly armable, because a workflow run
+#: cannot be inferred from a message by URL the way a pull request can, so a caller
+#: has no way to name one -- see the note on ``publicly_armable`` below for whether
+#: that is a property of the subject or a limit still to lift.
+GITHUB_WORKFLOW_RUN = "github_workflow_run"
+
 REVIEW_READY = "review_ready"
+
+#: What a workflow run's completion IS. Declared by the workflow-run kind alone, not
+#: drawn from a shared vocabulary: ``review_ready`` means "a human can look at this
+#: pull request now", which is not a sentence about a run. A run's objective is that
+#: it REACHED a conclusion, whatever that conclusion turns out to be.
+RUN_COMPLETE = "run_complete"
 
 
 @dataclass(frozen=True)
@@ -78,6 +92,12 @@ _KINDS: dict[str, MonitorKind] = {
         objectives=frozenset({REVIEW_READY}),
         publicly_armable=False,
         supports_shadow=False,
+    ),
+    GITHUB_WORKFLOW_RUN: MonitorKind(
+        name=GITHUB_WORKFLOW_RUN,
+        objectives=frozenset({RUN_COMPLETE}),
+        publicly_armable=False,
+        supports_shadow=True,
     ),
 }
 

--- a/test/test_github_workflow_run_monitor.py
+++ b/test/test_github_workflow_run_monitor.py
@@ -1,0 +1,309 @@
+"""Contract for the GitHub Actions workflow-run monitored kind.
+
+This kind is the acceptance test for the monitoring substrate: a second, genuinely
+different subject added as a probe plus a registry entry. These tests pin the
+subject-specific behaviour -- the terminal-state mapping and the URL identity --
+and drive the kind end to end through the SHARED persistence-only path
+(``run_shadow_probe``) to show the shared engine carries it with no change.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from kiro_crew.monitoring.github_workflow_run import (
+    GitHubWorkflowRunProvider,
+    parse_github_workflow_run_target,
+)
+from kiro_crew.monitoring.models import (
+    MonitorObservationStatus,
+    MonitorProbeResult,
+    ProviderErrorKind,
+)
+
+_URL = "https://github.com/owner/repo/actions/runs/123456"
+
+
+def _completed(fake_runner_stdout: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=0, stdout=json.dumps(fake_runner_stdout), stderr=""
+    )
+
+
+def _run_json(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "databaseId": 123456,
+        "status": "completed",
+        "conclusion": "success",
+        "headSha": "a" * 40,
+        "workflowName": "CI",
+        "event": "push",
+    }
+    payload.update(changes)
+    return payload
+
+
+def _probe_once(fake_runner_stdout: dict[str, object]) -> MonitorProbeResult:
+    def runner(argv: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return _completed(fake_runner_stdout)
+
+    provider = GitHubWorkflowRunProvider(resolver=lambda: "/usr/bin/gh", runner=runner)
+    results = provider.probe((_URL,))
+    return results[_URL]
+
+
+class TestTheRunUrlIsTypedIdentity:
+    def test_a_canonical_run_url_parses(self) -> None:
+        target = parse_github_workflow_run_target(_URL)
+        assert target.owner == "owner"
+        assert target.repo == "repo"
+        assert target.run_id == 123456
+        assert target.repo_slug == "owner/repo"
+        assert target.identity == "github.com/owner/repo/actions/runs/123456"
+
+    def test_www_host_is_accepted(self) -> None:
+        target = parse_github_workflow_run_target(
+            "https://www.github.com/owner/repo/actions/runs/9"
+        )
+        assert target.run_id == 9
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "https://github.com/owner/repo/pull/5",
+            "https://github.com/owner/repo/actions/runs/123456/attempts/2",
+            "https://github.com/owner/repo/actions/runs/123456/job/9",
+            "https://github.com/owner/repo/actions/runs/0",
+            "https://github.com/owner/repo/actions/runs/007",
+            "http://github.com/owner/repo/actions/runs/1",
+            "https://gitlab.com/owner/repo/actions/runs/1",
+            "https://github.com/owner/repo/actions/runs/1?x=1",
+            "https://github.com/owner/repo/actions/runs/notanumber",
+            "",
+        ],
+    )
+    def test_non_canonical_or_foreign_urls_are_refused(self, bad: str) -> None:
+        with pytest.raises(ValueError):
+            parse_github_workflow_run_target(bad)
+
+
+class TestTheTerminalStateMapping:
+    """A run's own vocabulary -- success / failure / cancelled / timed_out -- mapped
+    to the engine's generic status. This is the mapping the acceptance test pins."""
+
+    @pytest.mark.parametrize(
+        ("status", "conclusion", "expected_status", "expected_reason"),
+        [
+            ("completed", "success", MonitorObservationStatus.SUCCESS, "run_succeeded"),
+            ("completed", "neutral", MonitorObservationStatus.SUCCESS, "run_succeeded"),
+            ("completed", "skipped", MonitorObservationStatus.SUCCESS, "run_succeeded"),
+            ("completed", "stale", MonitorObservationStatus.SUCCESS, "run_succeeded"),
+            ("completed", "failure", MonitorObservationStatus.BLOCKED, "run_failed"),
+            ("completed", "timed_out", MonitorObservationStatus.BLOCKED, "run_failed"),
+            ("completed", "startup_failure", MonitorObservationStatus.BLOCKED, "run_failed"),
+            ("completed", "action_required", MonitorObservationStatus.BLOCKED, "run_failed"),
+            ("completed", "cancelled", MonitorObservationStatus.BLOCKED, "run_cancelled"),
+            (
+                "completed",
+                "some_new_conclusion",
+                MonitorObservationStatus.BLOCKED,
+                "run_conclusion_unknown",
+            ),
+            ("queued", "", MonitorObservationStatus.PENDING, "run_in_progress"),
+            ("in_progress", "", MonitorObservationStatus.PENDING, "run_in_progress"),
+            ("waiting", "", MonitorObservationStatus.PENDING, "run_in_progress"),
+            ("requested", "", MonitorObservationStatus.PENDING, "run_in_progress"),
+            ("some_new_status", "", MonitorObservationStatus.PENDING, "run_in_progress"),
+        ],
+    )
+    def test_a_conclusion_maps_to_the_engine_status_and_this_kinds_reason(
+        self,
+        status: str,
+        conclusion: str,
+        expected_status: MonitorObservationStatus,
+        expected_reason: str,
+    ) -> None:
+        result = _probe_once(_run_json(status=status, conclusion=conclusion))
+        assert result.observation.status is expected_status
+        assert result.observation.reason_code == expected_reason
+
+    def test_the_conclusion_is_uppercased_by_gh_and_still_maps(self) -> None:
+        result = _probe_once(_run_json(status="COMPLETED", conclusion="SUCCESS"))
+        assert result.observation.status is MonitorObservationStatus.SUCCESS
+
+    def test_a_null_conclusion_on_a_running_run_is_pending(self) -> None:
+        result = _probe_once(_run_json(status="in_progress", conclusion=None))
+        assert result.observation.status is MonitorObservationStatus.PENDING
+
+    def test_the_canonical_names_this_kind_and_carries_no_pull_request_words(self) -> None:
+        result = _probe_once(_run_json())
+        assert result.canonical["kind"] == "github_workflow_run"
+        assert result.canonical["conclusion"] == "success"
+        assert result.canonical["status"] == "completed"
+        assert result.canonical["workflow_name"] == "CI"
+        assert "mergeability" not in result.canonical
+        assert "review_decision" not in result.canonical
+
+
+class TestProviderErrors:
+    def test_a_404_is_not_found(self) -> None:
+        def runner(argv: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="HTTP 404: Not Found"
+            )
+
+        provider = GitHubWorkflowRunProvider(resolver=lambda: "/usr/bin/gh", runner=runner)
+        result = provider.probe((_URL,))[_URL]
+        assert result.observation.status is MonitorObservationStatus.PROVIDER_ERROR
+        assert result.observation.provider_error is ProviderErrorKind.NOT_FOUND
+
+    def test_a_rate_limit_is_retryable(self) -> None:
+        def runner(argv: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="API rate limit exceeded"
+            )
+
+        provider = GitHubWorkflowRunProvider(resolver=lambda: "/usr/bin/gh", runner=runner)
+        result = provider.probe((_URL,))[_URL]
+        assert result.observation.provider_error is ProviderErrorKind.RATE_LIMITED
+
+    def test_a_timeout_is_transient(self) -> None:
+        def runner(argv: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=30.0)
+
+        provider = GitHubWorkflowRunProvider(resolver=lambda: "/usr/bin/gh", runner=runner)
+        result = provider.probe((_URL,))[_URL]
+        assert result.observation.provider_error is ProviderErrorKind.TRANSIENT
+
+    def test_a_malformed_response_is_transient(self) -> None:
+        result = _probe_once({"databaseId": 123456, "status": "completed"})  # missing fields
+        assert result.observation.provider_error is ProviderErrorKind.TRANSIENT
+        assert result.observation.reason_code == "provider_malformed_response"
+
+    def test_a_databaseid_mismatch_is_rejected(self) -> None:
+        result = _probe_once(_run_json(databaseId=999))
+        assert result.observation.status is MonitorObservationStatus.PROVIDER_ERROR
+
+
+class TestTheKindIsRegisteredAsData:
+    def test_the_registry_knows_the_kind_and_its_objective(self) -> None:
+        from kiro_crew.monitoring.registry import (
+            GITHUB_WORKFLOW_RUN,
+            RUN_COMPLETE,
+            kind_supports_objective,
+            kind_supports_shadow,
+            monitor_kind,
+        )
+
+        entry = monitor_kind(GITHUB_WORKFLOW_RUN)
+        assert entry is not None
+        assert entry.objectives == frozenset({RUN_COMPLETE})
+        assert kind_supports_objective(GITHUB_WORKFLOW_RUN, RUN_COMPLETE)
+        assert kind_supports_shadow(GITHUB_WORKFLOW_RUN)
+
+    def test_the_objective_is_this_kinds_own_not_review_ready(self) -> None:
+        from kiro_crew.monitoring.registry import (
+            GITHUB_WORKFLOW_RUN,
+            REVIEW_READY,
+            RUN_COMPLETE,
+            kind_supports_objective,
+        )
+
+        assert not kind_supports_objective(GITHUB_WORKFLOW_RUN, REVIEW_READY)
+        from kiro_crew.monitoring.registry import GITHUB_PULL_REQUEST
+
+        assert not kind_supports_objective(GITHUB_PULL_REQUEST, RUN_COMPLETE)
+
+    def test_the_kind_is_not_publicly_armable(self) -> None:
+        """A workflow run cannot be inferred from a message by URL, so it is not
+        namable by a caller. This also keeps the public armable sets pinned, which
+        is what lets the existing engine tests pass unchanged."""
+        from kiro_crew.monitoring.registry import (
+            GITHUB_WORKFLOW_RUN,
+            publicly_armable_kinds,
+            publicly_armable_objectives,
+        )
+
+        assert GITHUB_WORKFLOW_RUN not in publicly_armable_kinds()
+        assert "run_complete" not in publicly_armable_objectives()
+
+
+@pytest.mark.asyncio
+async def test_the_shared_shadow_path_drives_the_kind_to_a_terminal_outcome() -> None:
+    """End to end through the SHARED engine: a failed run stops the monitor blocked,
+    a successful run stops it success -- with the workflow-run provider injected and
+    no change to decision.py, models.py, or the probe protocol."""
+    from kiro_crew.monitoring.models import (
+        MonitorDecision,
+        MonitorOutcome,
+        MonitorState,
+    )
+    from kiro_crew.monitoring.registry import GITHUB_WORKFLOW_RUN, RUN_COMPLETE
+    from kiro_crew.monitoring.shadow import run_shadow_probe
+
+    persisted: list[MonitorState] = []
+
+    async def persist(updated: MonitorState) -> None:
+        persisted.append(updated)
+
+    def failing_runner(argv: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return _completed(_run_json(conclusion="failure"))
+
+    provider = GitHubWorkflowRunProvider(resolver=lambda: "/usr/bin/gh", runner=failing_runner)
+    state = MonitorState(
+        kind=GITHUB_WORKFLOW_RUN,
+        target=_URL,
+        objective=RUN_COMPLETE,
+        created_ts=1_000.0,
+    )
+    verdict = await run_shadow_probe(state, provider, persist, now=1_100.0)
+    assert verdict.decision is MonitorDecision.STOP_BLOCKED
+    assert state.outcome is MonitorOutcome.BLOCKED
+    assert state.stopped_reason == "run_failed"
+    assert persisted and persisted[-1].outcome is MonitorOutcome.BLOCKED
+
+    def succeeding_runner(argv: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return _completed(_run_json(conclusion="success"))
+
+    ok_provider = GitHubWorkflowRunProvider(
+        resolver=lambda: "/usr/bin/gh", runner=succeeding_runner
+    )
+    ok_state = MonitorState(
+        kind=GITHUB_WORKFLOW_RUN,
+        target=_URL,
+        objective=RUN_COMPLETE,
+        created_ts=1_000.0,
+    )
+    ok_verdict = await run_shadow_probe(ok_state, ok_provider, persist, now=1_100.0)
+    assert ok_verdict.decision is MonitorDecision.STOP_SUCCESS
+    assert ok_state.outcome is MonitorOutcome.SUCCESS
+    assert ok_state.stopped_reason == "run_succeeded"
+
+
+@pytest.mark.asyncio
+async def test_a_running_run_records_and_reschedules_without_stopping() -> None:
+    from kiro_crew.monitoring.models import MonitorDecision, MonitorState
+    from kiro_crew.monitoring.registry import GITHUB_WORKFLOW_RUN, RUN_COMPLETE
+    from kiro_crew.monitoring.shadow import run_shadow_probe
+
+    async def persist(updated: MonitorState) -> None:
+        return None
+
+    def running_runner(argv: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return _completed(_run_json(status="in_progress", conclusion=None))
+
+    provider = GitHubWorkflowRunProvider(resolver=lambda: "/usr/bin/gh", runner=running_runner)
+    state = MonitorState(
+        kind=GITHUB_WORKFLOW_RUN,
+        target=_URL,
+        objective=RUN_COMPLETE,
+        created_ts=1_000.0,
+        cadence_secs=300,
+    )
+    verdict = await run_shadow_probe(state, provider, persist, now=1_100.0)
+    assert verdict.decision is MonitorDecision.RECORD_ONLY
+    assert state.outcome is None
+    assert state.next_probe_at == 1_400.0


### PR DESCRIPTION
## Problem / Motivation

The result first, because it is a split, not a pass: a genuinely different monitored
subject can be REGISTERED and PROBED as pure data, and it CANNOT yet be DELIVERED.
The registry made it free to gate a new kind; it did not make it free to deliver one.

The monitoring substrate claims a new subject is added as data -- a registry entry
plus a probe module -- without editing the shared decision engine, the shared result
type, or the shared probe protocol. That claim was untested: both kinds in the
registry before this change (`github_pull_request` and the internal `gh-pr`) are two
spellings of the SAME subject, so nothing exercised a genuinely different one. This
change adds a GitHub Actions workflow run as the first genuinely different subject and
reports what that attempt proves.

## Why it matters

A substrate whose extension point has never carried a second, different subject is a
substrate whose extension point is unproven. If adding a real new kind required a
branch inside a shared layer, every loop built on the substrate would inherit that
special case, and the cost would surface only when a second kind was attempted --
which is when it is most expensive to discover. Proving the gate half works AND
finding the delivery half does not is worth more than a clean pass, which would have
hidden the second fact.

## What changed (motivation, approach, change)

Goal: test whether a genuinely different monitored subject is pure data. Approach:
add a GitHub Actions workflow run, chosen because it is genuinely different from a
pull request -- its terminal states are `success` / `failure` / `cancelled` /
`timed_out` rather than merged or closed, its objective is that the run REACHED a
conclusion rather than that a human may review it, and it cannot be inferred from a
message by URL the way a pull request can. It shares the credential and CLI with pull
requests, so no authentication work distracts from the real question. What was built:

- `registry.py` gains two constants (`GITHUB_WORKFLOW_RUN`, `RUN_COMPLETE`) and one
  `_KINDS` entry. Additive data only, no logic touched (the diff stat is +767 / -0).
  The objective `run_complete` is declared BY the kind, not drawn from a shared
  vocabulary: `review_ready` means "a human can look at this pull request now", which
  is not a sentence about a run.
- A new probe module `github_workflow_run.py` reads run state through the same
  hardened `run_gh` / `resolve_gh` path the pull-request provider uses, maps a run to
  the engine's generic status with this kind's own reason codes, and returns the
  shared `MonitorProbeResult`. Its run-specific detail (`GitHubWorkflowRunResponse`)
  lives on its own probe-result subclass `GitHubWorkflowRunProbeResult`, never on the
  shared type -- the same line the pull-request kind draws.

The gate half holds: `MonitorProbeResult` gained no field, no Protocol changed, and
the decision engine was not edited.

The kind is registered NOT publicly armable. That is correct on its own merits -- a
workflow run cannot be inferred from a message by URL, so a caller has no way to name
one today -- and it is stated plainly because the passing result partly rests on it:
the registry's public-set contract is pinned by exact-equality in
`test_the_publicly_armable_kind_set_is_the_one_the_schema_hardcoded`, so a publicly
armable second kind would force an edit to that engine test. Making a kind publicly
armable is therefore a separate change, out of scope here.

### The delivery boundary this PR deliberately does NOT cross

A second kind can be registered and probed, and cannot yet be delivered. Two shared
sites assume a single kind and have no per-kind routing:

- `MonitorController.__init__` holds one provider
  (`self._provider = provider or GitHubPullRequestProvider()`), so a live workflow-run
  monitor would be probed by the pull-request provider against an Actions URL.
- `format_monitor_wake` composes a pull-request-shaped wake envelope and reads
  pull-request-shaped canonical fields.

These are left untouched on purpose, and the reason is the point of the finding, not
an oversight: the experiment ran under a stop-the-line rule that forbade changing any
shared decision code, result type, protocol, or controller to make the kind fit.
Adding kind-to-provider routing to the controller is exactly that forbidden change.
Because the rule forbade the branch, the boundary got NAMED here instead of being
papered over by a special case inside `MonitorController`. A change that made a live
workflow-run monitor fit by editing the controller would have looked like success and
hidden the boundary; refusing it is what surfaces that the live path is not yet
extensible. Making the controller and `format_monitor_wake` kind-aware is the natural
next design step and belongs in its own change.

## Tests

- New `test_github_workflow_run_monitor.py`: run-URL parsing (canonical form accepted;
  attempt-scoped, job-scoped, foreign-host, and non-canonical forms refused), the
  terminal-state mapping table (every conclusion to its engine status and reason
  code), provider-error classification (404 not-found, rate-limit retryable, timeout
  transient, malformed and id-mismatch responses), the registry entry, and end-to-end
  drives through the shared `run_shadow_probe` (a failing run stops blocked with
  reason `run_failed`; a succeeding run stops success with `run_succeeded`; a running
  run records and reschedules without stopping).
- The existing monitoring engine tests ran UNCHANGED and passed:
  `test_monitor_decision.py`, `test_monitor_kind_registry.py`,
  `test_monitor_persistence.py`, `test_monitor_controller.py`,
  `test_monitor_behaviour_golden.py`. That they pass with zero edits is a large part
  of what this change certifies.
- The falsifiable evidence is the diff stat: three files, +767 / -0. Zero deletions
  means adding a kind removed nothing from any shared file, checkable from the stat
  alone. `git diff --name-only` shows no `decision.py`, `models.py`, `controller.py`,
  `shadow.py`, or any Protocol.

## Manual verification

N/A -- unit coverage sufficient. The behaviour is a pure probe-and-decide path with no
UI and no live external call; the end-to-end drives through `run_shadow_probe` with an
injected fake runner cover the full observe-classify-decide-persist loop.

## Related Issues

None.
