### PR TITLE
cron: translate an invalid cron expression on the create paths

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1316,27 +1316,31 @@ def _cron_dispatch(args: argparse.Namespace) -> None:
                 f"Error: invalid channel ID format (expected {CHANNEL_ID_RE.pattern.strip('^$')})"
             )
             return
-        if cron_expr:
-            job = svc.add_job(
-                name=args.name,
-                message=args.message,
-                cron_expr=cron_expr,
-                channel=channel,
-                approval_mode=approval_mode,
-                folder_id=folder_id,
-            )
-        elif every:
-            job = svc.add_job(
-                name=args.name,
-                message=args.message,
-                every_secs=every,
-                channel=channel,
-                approval_mode=approval_mode,
-                folder_id=folder_id,
-            )
-        else:
-            print("Provide --every or --cron")
-            return
+        try:
+            if cron_expr:
+                job = svc.add_job(
+                    name=args.name,
+                    message=args.message,
+                    cron_expr=cron_expr,
+                    channel=channel,
+                    approval_mode=approval_mode,
+                    folder_id=folder_id,
+                )
+            elif every:
+                job = svc.add_job(
+                    name=args.name,
+                    message=args.message,
+                    every_secs=every,
+                    channel=channel,
+                    approval_mode=approval_mode,
+                    folder_id=folder_id,
+                )
+            else:
+                print("Provide --every or --cron")
+                return
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
         # agent_id and silent are CronJob fields but not add_job kwargs;
         # mirror the MCP cron_add post-create mutation pattern so they
         # are persisted with the job.

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -598,6 +598,8 @@ async def api_crons_create(request: web.Request) -> web.Response:
         return web.json_response(_CRON_BUSY_BODY, status=_CRON_BUSY_STATUS)
     except CronStoreUnreadable as exc:
         return _cron_unreadable_response(exc)
+    except ValueError as e:
+        return web.json_response({"error": str(e), "code": "invalid_cron"}, status=400)
     state.push_refresh("crons")
     return web.json_response({"ok": True, "id": job.id})
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -680,6 +680,39 @@ class TestCronCli:
                 folder_id="",
             )
 
+    @pytest.mark.parametrize(
+        "name, cron_expr, every, expected",
+        [
+            ("bad dow", "0 9 * * 8", None, "Error: Invalid cron expression: 0 9 * * 8"),
+            ("n" * 501, None, 60, "Error: name exceeds max length 500"),
+        ],
+        ids=["cron_expr branch", "every branch"],
+    )
+    def test_cron_add_refuses_invalid_input(
+        self, name, cron_expr, every, expected, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        args = argparse.Namespace(
+            cron_action="add",
+            name=name,
+            message="m",
+            every=every,
+            cron_expr=cron_expr,
+            channel=None,
+            approval_mode="",
+            agent="",
+            silent=False,
+            folder="",
+        )
+
+        with pytest.raises(SystemExit) as exit_info:
+            _cron(args)
+
+        err = capsys.readouterr().err
+        assert exit_info.value.code == 1
+        assert err.splitlines()[-1] == expected
+        assert "Traceback" not in err
+
     def test_cron_add_with_approval_mode(self, tmp_path):
         with (
             patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,

--- a/test/test_cron_handler_json_contract.py
+++ b/test/test_cron_handler_json_contract.py
@@ -28,10 +28,12 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from kiro_crew.cron import CronService
 from kiro_crew.dashboard.handlers.cron import (
     api_cron_ack,
     api_cron_enable,
     api_cron_update,
+    api_crons_create,
     api_lessons_delete,
 )
 
@@ -86,6 +88,21 @@ async def test_cron_update_keeps_the_object_path() -> None:
     assert response.status == 200
     update.assert_awaited_once()
     assert update.await_args.kwargs["name"] == "renamed"
+
+
+async def test_cron_create_refuses_an_invalid_cron_expression(tmp_path) -> None:
+    svc = CronService(base_dir=tmp_path)
+    app = _cron_app(api_crons_create, "/api/crons", add_job_async=svc.add_job_async)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/api/crons", json={"name": "bad dow", "message": "m", "cron": "0 9 * * 8"}
+        )
+        body = await response.json()
+
+    assert response.status == 400
+    assert body == {"error": "Invalid cron expression: 0 9 * * 8", "code": "invalid_cron"}
+    assert svc.list_jobs(include_disabled=True) == []
 
 
 @pytest.mark.parametrize("payload", NON_OBJECT_BODIES)


### PR DESCRIPTION
## Problem / Motivation

`CronService._build_job` owns a cron's calendar fields and rejects an unparseable expression with a bare `ValueError`. Three of the five write paths translate that into their surface's ordinary refusal. The two **create** paths did not catch it at all, and no middleware in the dashboard chain maps handler exceptions, so it escaped to the top:

| path | with an invalid expression `0 9 * * 8` | before |
|---|---|---|
| `PATCH /api/crons/{job_id}` | `400 {"error": "Invalid cron expression: …"}` | already correct |
| `kirocrew cron update --cron` | `Error: Invalid cron expression: …`, rc 1 | already correct |
| MCP `cron_add` | `Error: Invalid cron expression: …` | already correct |
| `POST /api/crons` | aiohttp's default **500** `text/plain` page | ✗ |
| `kirocrew cron add --cron` | a Python traceback naming `kiro_crew` internals | ✗ |

The message the user needs already existed — it is the byte-identical string the PATCH path returns for the same value. On the create paths it was simply never delivered.

## Why it matters

The dashboard's Add-job form is the primary cron-creation surface, and its only client-side check is the field **count**. A well-shaped but invalid expression (`0 9 * * 8` — day-of-week 8 is out of range) is therefore submitted verbatim and comes back as a generic server error that never names the field at fault, while editing an existing job with the very same value gives a precise message.

Nothing is persisted either way — validation precedes the single locked `_save()` — so this was never data loss; it was an unactionable failure on the two surfaces a user actually creates a job from, plus an `ERROR aiohttp.server` traceback in the gateway log for what is ordinary bad input.

## What changed (motivation → approach → change)

**Motivation.** Make the create paths refuse the way their own update counterparts already do, without giving the rule a second home.

**Approach.** Translate at the caller, not at the validator. `_build_job` stays the single owner of calendar validity; each caller converts the owner's `ValueError` into its surface's normal refusal. Deliberately *not* done: no `validate_cron_expr` pre-check in the handler (that duplicates the owner's rule and lets the two drift); no catch at the `_cron` dispatch wrapper, which would swallow an unrelated `ValueError` from any of its six verbs rather than the one the create path raises; no new middleware, no new helper or module; and no change to the validator, since it was already right.

**Change** — two source files, `+27/−21` between them, and no new comments in either:

- `dashboard/handlers/cron.py` — 2 lines added to `api_crons_create`, mirroring the PATCH handler's clause and carrying the machine-readable `code` the repo's error-code ratchet (`test/test_error_code_contract.py`) requires of any *new* non-2xx JSON body. `invalid_cron` is specific rather than generic because the handler already pre-validates name, message, cron length, channel, approval mode, timezone, agent, folder, model, `every` and `at_ts` before it calls `add_job_async` — an unparseable expression is the only `ValueError` that can still reach this clause — and it sits alongside the same block's existing `invalid_every` / `invalid_at_time` / `missing_schedule`:

  ```python
  except ValueError as e:
      return web.json_response({"error": str(e), "code": "invalid_cron"}, status=400)
  ```

  This is the one place create and PATCH now differ: the ratchet governs only *newly added* error responses, so PATCH's long-shipped un-coded body is left exactly as it is rather than changed underneath its consumers. The `error` string is still byte-identical between the two, and `code` is additive for the dashboard — `friendlyErrText` (`website/src/api/apiError.ts`) unwraps `parsed?.error` and ignores sibling keys, so nothing rendered changes.

- `cli_commands.py` — the `add_job` call in the `cron add` dispatch wrapped in the `try` the `cron update` branch already uses verbatim, so the two verbs print the identical line. The `try` covers **both** schedule branches, not just `cron_expr`: `_build_job` validates the string-field caps before it reaches the schedule branch at all, so `--every` with an over-cap `--name` raises the same bare `ValueError` and printed the same traceback. `git diff` reads `+25/−21` here, but 21 of those 25 are the two original calls re-indented into the `try` — `git diff -w` shows the real change as 4 added lines.

## Tests

2 new pins, one per changed source file, added to the existing suites that already own these surfaces rather than to a new file:

- **`test/test_cron_handler_json_contract.py`** — this file's whole subject is already "a cron mutation handler raises, aiohttp answers 500, and the caller learns nothing it can act on." `POST /api/crons` with an invalid expression is a new instance of exactly that, and the file's `_cron_app` helper takes the real service's bound methods as-is, so no new harness was needed. Asserts the 400, the exact body including its `code`, and that the store stayed empty.
- **`test/test_cli.py::TestCronCli`** — the class that already covers `cron add --cron`. Asserts exit 1, the single `Error: …` line as the last line of stderr, and that no `Traceback` reaches the user. Parametrized over both schedule branches — an invalid expression through `--cron`, and an over-cap `--name` through `--every` — so the widened `try` is pinned on each: 3 test ids in total.

Both drive a real `CronService` rather than a mock, so each covers both halves — that the validator rejects the value *and* that the caller translates it.

```
$ git log --oneline -1
53b4d930f fix(cron): translate an invalid cron expression on the create paths

$ python3 -m pytest test/test_cron_handler_json_contract.py::test_cron_create_refuses_an_invalid_cron_expression test/test_cli.py::TestCronCli::test_cron_add_refuses_invalid_input -v
test/test_cron_handler_json_contract.py::test_cron_create_refuses_an_invalid_cron_expression PASSED [ 33%]
test/test_cli.py::TestCronCli::test_cron_add_refuses_invalid_input[cron_expr branch] PASSED [ 66%]
test/test_cli.py::TestCronCli::test_cron_add_refuses_invalid_input[every branch] PASSED [100%]
======================== 3 passed, 2 warnings in 0.37s =========================
```

The error-code ratchet, which is what a create-path 400 with no `code` fails:

```
$ python3 -m pytest test/test_error_code_contract.py -v
test/test_error_code_contract.py::test_baseline_file_is_parseable_and_shaped PASSED [ 16%]
test/test_error_code_contract.py::test_no_new_error_response_without_a_code PASSED [ 33%]
test/test_error_code_contract.py::test_baseline_is_not_stale PASSED      [ 50%]
test/test_error_code_contract.py::test_baseline_totals_match_the_per_file_map PASSED [ 66%]
test/test_error_code_contract.py::test_every_error_code_is_a_machine_readable_identifier PASSED [ 83%]
test/test_error_code_contract.py::test_the_scan_actually_reaches_the_backend PASSED [100%]
========================= 6 passed, 1 warning in 0.92s =========================
```

`error-code-baseline.json` is untouched: the fix adds a coded response, so no count moves and there is nothing to re-snapshot.

**Mutation check** — the same 2 pins against **unfixed** `origin/main` source (only the two test files copied over, `src/` untouched). All three ids must fail, which is what proves each pin is load-bearing on the source line it covers rather than tautological:

```
$ git log --oneline -1
160343495 fix(hooks): let a user's identity-keyed grant cover a verified child MCP call (#9635)
$ git status --porcelain
 M test/test_cli.py
 M test/test_cron_handler_json_contract.py
$ git diff --stat            # src/ carries no change at all
 test/test_cli.py                        | 33 +++++++++++++++++++++++++++++++++
 test/test_cron_handler_json_contract.py | 17 +++++++++++++++++
 2 files changed, 50 insertions(+)

$ python3 -m pytest test/test_cron_handler_json_contract.py::test_cron_create_refuses_an_invalid_cron_expression test/test_cli.py::TestCronCli::test_cron_add_refuses_invalid_input -v
test/test_cron_handler_json_contract.py::test_cron_create_refuses_an_invalid_cron_expression FAILED [ 33%]
test/test_cli.py::TestCronCli::test_cron_add_refuses_invalid_input[cron_expr branch] FAILED [ 66%]
test/test_cli.py::TestCronCli::test_cron_add_refuses_invalid_input[every branch] FAILED [100%]
FAILED ...json_contract.py::...invalid_cron_expression - aiohttp.client_exceptions.ContentTypeError: 500, message='Attempt to decode JSON with unexpected mimetype: text/plain; charset=utf-8'
FAILED ...test_cli.py::...invalid_input[cron_expr branch] - ValueError: Invalid cron expression: 0 9 * * 8
FAILED ...test_cli.py::...invalid_input[every branch] - ValueError: name exceeds max length 500
======================== 3 failed, 2 warnings in 0.81s =========================
```

Each failure names the untranslated cause rather than a mismatched assertion: the 500's `text/plain` body on the handler, and the bare `ValueError` escaping the CLI on each schedule branch.

Both host suites in full, plus the surrounding cron and API-validation suites, to show the added `except` narrows nothing:

```
$ python3 -m pytest test/test_cli.py test/test_cron_handler_json_contract.py test/test_cron.py \
    test/test_cron_name_cap.py test/test_cron_folder_on_create.py test/test_cron_minimal_context_api.py \
    test/test_cron_cancel.py test/test_cron_message_cap.py test/test_api_input_validation.py \
    test/test_cron_store_unreadable_boundaries.py test/test_cron_patch_name_validation.py \
    test/test_error_code_contract.py -q
643 passed, 7 skipped, 47 warnings in 12.55s
```

Gates: `black --target-version py310` on the touched files only, `isort`, `flake8` (rc 0), and `mypy --platform linux src/kiro_crew` — the one error mypy reports (`cli.py:420 Module has no attribute "PidfdChildWatcher"`, a Python 3.14 stdlib change) is byte-identical on a pristine mainline worktree, so it is pre-existing and unrelated.

## Manual verification


### Arm 1 - mainline, unfixed (broken)

```
$ git log --oneline -1
160343495 fix(hooks): let a user's identity-keyed grant cover a verified child MCP call (#9635)
$ git status --porcelain                          # nothing uncommitted
$ git diff --stat origin/main..HEAD               # empty => identical to mainline
$ python3 -c 'import kiro_crew, pathlib; print(pathlib.Path(kiro_crew.__file__).parent)'
/Users/avgvi/code/kc-cron500-main/src/kiro_crew

# A. CLI CREATE
$ kirocrew cron add 'bad dow' 'ping me' --cron '0 9 * * 8'
Traceback (most recent call last):
  ...
  File ".../src/kiro_crew/cli_commands.py", line 1320, in _cron_dispatch
    job = svc.add_job(
  File ".../src/kiro_crew/cron.py", line 2348, in _build_job
    raise ValueError(f"Invalid cron expression: {cron_expr}")
ValueError: Invalid cron expression: 0 9 * * 8
[exit=1]

# C. HTTP CREATE
$ curl -s -i -b jar -X POST http://localhost:8930/api/crons -H 'Content-Type: application/json' -d '{"name":"bad dow","message":"ping me","cron":"0 9 * * 8"}'
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
Content-Length: 55

500 Internal Server Error

Server got itself in trouble
[exit=0]

# H. Did the gateway log a traceback for that POST?
$ grep -c '^Traceback' gateway.log
1
$ grep -n 'ValueError: Invalid cron expression' gateway.log
59:ValueError: Invalid cron expression: 0 9 * * 8
```

### Arm 2 - this branch (fixed)

```
$ git branch --show-current
fix/cron-create-invalid-cron-expr-500
$ git log --oneline -2
53b4d930f fix(cron): translate an invalid cron expression on the create paths
160343495 fix(hooks): let a user's identity-keyed grant cover a verified child MCP call (#9635)
$ git status --porcelain                          # nothing uncommitted
$ git diff --stat origin/main..HEAD
 src/kiro_crew/cli_commands.py            | 46 +++++++++++++++++---------------
 src/kiro_crew/dashboard/handlers/cron.py |  2 ++
 test/test_cli.py                         | 33 +++++++++++++++++++++++
 test/test_cron_handler_json_contract.py  | 17 ++++++++++++
 4 files changed, 77 insertions(+), 21 deletions(-)
$ python3 -c 'import kiro_crew, pathlib; print(pathlib.Path(kiro_crew.__file__).parent)'
/Users/avgvi/code/kc-cron500-fix/src/kiro_crew

# A. CLI CREATE — now refuses like the update verb, no traceback
$ kirocrew cron add 'bad dow' 'ping me' --cron '0 9 * * 8'
Error: Invalid cron expression: 0 9 * * 8
[exit=1]

# B. CLI CONTROL — the update verb, unchanged, byte-identical line
$ kirocrew cron update ebb5f52e --cron '0 9 * * 8'
Error: Invalid cron expression: 0 9 * * 8
[exit=1]

# C. HTTP CREATE — now a 400 carrying the message and a code
$ curl -s -i -b jar -X POST http://localhost:8951/api/crons -H 'Content-Type: application/json' -d '{"name":"bad dow","message":"ping me","cron":"0 9 * * 8"}'
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=utf-8
...
Content-Length: 71

{"error": "Invalid cron expression: 0 9 * * 8", "code": "invalid_cron"}
[exit=0]

# D. HTTP CONTROL — PATCH, unchanged, byte-identical `error` string
$ curl -s -i -b jar -X PATCH http://localhost:8951/api/crons/ebb5f52e -H 'Content-Type: application/json' -d '{"cron":"0 9 * * 8"}'
HTTP/1.1 400 Bad Request
Content-Length: 47

{"error": "Invalid cron expression: 0 9 * * 8"}
[exit=0]

# E. HTTP CONTROL — a different bad field on the same handler, unchanged
$ curl -s -i -b jar -X POST http://localhost:8951/api/crons -H 'Content-Type: application/json' -d '{"name":"bad tz","message":"m","cron":"0 9 * * 1","timezone":"Mars/Olympus"}'
HTTP/1.1 400 Bad Request
{"error": "invalid timezone: 'Mars/Olympus'"}
[exit=0]

# F. A VALID expression still creates — this refuses, it does not block
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' -b jar -X POST http://localhost:8951/api/crons -H 'Content-Type: application/json' -d '{"name":"still works","message":"ping me","cron":"30 7 * * 5"}'
HTTP 200
[exit=0]

# G. What persisted — the two valid jobs and the valid create, nothing else
$ kirocrew cron list
  ✅ 7ce8920e  good job     (At 09:00 AM, only on Monday)   ping me
  ✅ ebb5f52e  control job  (At 09:00 AM, only on Tuesday)  ping me
  ✅ d7e2c205  still works  (At 07:30 AM, only on Friday)   ping me
[exit=0]

# H. Did the gateway log a traceback for that POST?
$ grep -c '^Traceback' gateway.log
0
$ grep -n 'ValueError: Invalid cron expression' gateway.log
(no output)
```



## Related Issues

Fixes https://github.com/kirodotdev/KiroCrew/issues/9849

## Pattern harvest

Rule candidate: review-prompt

Pattern: a sole-owner validator raising a bare `ValueError` is only as good as its least careful caller — enumerate the call sites and name the ones with no catch.

The generalizable shape is that this bug was invisible from either end alone. Reading `_build_job` shows a correct validator; reading `api_crons_create` shows a handler with a plausible `except` list. Only the call graph shows that three of five callers translate and two do not.

Worth a review prompt over a lint, because "is this exception translated somewhere up the stack" is not decidable syntactically — and the pins that belong with such a fix are *parity* pins (create answers what update answers), since an equality assertion between two surfaces cannot rot the way two independently-written expectations can.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. Do not invent CLA text — it will be added here once Legal provides it. -->
