### PR TITLE
docs: ledger-conductor dispatch sequence diagram

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -14,6 +14,7 @@ writing both marks, not editing the page and leaving the rule to look broken.
 | Mirror | Upstream |
 |---|---|
 | [kiro-cli/](kiro-cli/README.md) | The `kiro-cli` documentation, taken from the 2.x line. kiro-cli is Kiro Crew's required agent backend, so its ACP surface, agent-spec schema, and MCP config shape are load-bearing here. |
+| [ledger-conductor-sequence.md](ledger-conductor-sequence.md) | **Named exception — local page, no upstream.** Kiro Crew's own end-to-end sequence for the work-ledger dispatch lifecycle. Preserve it across a re-fetch. |
 
 Where Kiro Crew's own behavior differs from a mirrored page, Kiro Crew's docs win:
 this fork is KiroACP-only and does not use every capability the upstream CLI

--- a/docs/reference/ledger-conductor-sequence.md
+++ b/docs/reference/ledger-conductor-sequence.md
@@ -1,0 +1,88 @@
+# Ledger-conductor dispatch sequence
+
+**Local page, not a mirror.** This file is Kiro Crew's own documentation and has no upstream source, so a re-fetch of the `kiro-cli/` mirror must leave it alone. It is marked as a named exception in [the Reference index](README.md).
+
+This page traces one work item from the moment a conductor mints it to the moment it is closed, end to end. It extends the shorter "Binding lifecycle" diagram in [the work-ledger RFC](../request-for-change/rfc-conductor-work-ledger.md) past the first report, through acceptance promotion, evaluation, and the terminal write. Every action name and every status value below is taken from the tool surface in `src/kiro_crew/mcp_work.py` and the routes in `src/kiro_crew/dashboard/handlers/work_ledger.py`.
+
+The two halves of the surface never overlap. A conductor writes with `work_ledger_record` and reads with `work_ledger_read`; a worker reads with `work_brief` and writes with `work_report`. Which half answers a call is resolved from the caller's own session identity, so a worker has no parameter naming its item, its conductor, or itself.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as Conductor
+    participant L as WorkLedger
+    participant W as WorkerSession
+    participant E as accept_eval
+
+    U->>C: a goal
+    C->>L: work_ledger_record action=goal (goal, round)
+    C->>L: work_ledger_record action=create (title, acceptance)
+    L-->>C: item_id
+
+    C->>W: session_create (title, folder, agent)
+    W-->>C: worker session key
+    C->>L: work_ledger_record action=bind (item_id, worker_session_key)
+    C->>W: session_send (seed prompt)
+
+    W->>L: work_brief
+    L-->>W: title, acceptance, round, decision, own last status
+
+    W->>L: work_report status=progress (summary)
+    Note over W,L: progress is informational — it wakes nobody
+
+    opt the conductor's own decision is needed
+        W->>L: work_report status=question (summary)
+        C->>L: work_ledger_read
+        L-->>C: items, events, accept_batch
+        C->>L: work_ledger_record action=decide (item_id, decision)
+        W->>L: work_brief
+        L-->>W: decision
+    end
+
+    opt an external dependency stopped the work
+        W->>L: work_report status=blocked (summary)
+    end
+
+    W->>L: work_report status=done (summary, artifacts, pr)
+    Note over W,L: done is a CLAIM — nothing on the worker half writes a verdict
+
+    C->>L: work_ledger_read
+    L-->>C: the claimed pr, and accept_batch built from acceptance alone
+    C->>L: work_ledger_record action=accept (item_id, acceptance with the real pr)
+    L-->>C: the bar now names the checked pull request
+
+    C->>E: accept_eval.py over the promoted acceptance
+    E-->>C: pass / fail / pending / refused / error
+    C->>L: work_ledger_record action=verdict (item_id, verdict, fails)
+
+    alt verdict=pass
+        C->>L: work_ledger_record action=close (item_id, state=accepted, decision)
+    else verdict=fail and the work is over
+        C->>L: work_ledger_record action=close (item_id, state=rejected, decision)
+    else verdict=fail and the worker retries
+        C->>L: work_ledger_record action=decide (item_id, decision)
+        W->>L: work_brief
+    end
+
+    C->>U: the outcome
+```
+
+## Legend
+
+`work_ledger_record` takes exactly one `action` per call, and the seven are `goal`, `create`, `bind`, `decide`, `accept`, `verdict`, and `close`.
+
+`work_report` takes exactly one `status`, and the four are `progress`, `blocked`, `question`, and `done`. `blocked` and `question` differ by who must act: `blocked` names an external dependency, `question` needs the conductor's own decision.
+
+**`done` is a claim.** A worker calling `work_report status=done` says it believes the acceptance condition is met and puts its evidence in `artifacts` and `pr`. It has no parameter that writes a verdict, a state, or an acceptance condition.
+
+**`verdict` is the evaluator's answer.** It carries `accept_eval.py`'s own five values — `pass`, `fail`, `pending`, `refused`, `error` — recorded under the conductor's key after the script ran. A claim and a verdict are therefore two different facts about the same item, and both are stored.
+
+**`accept` is why a `pr` claim is not self-serving.** `accept_batch` is composed from each item's stored `acceptance` alone and deliberately ignores whatever `pr` a worker reported, so a worker cannot point the bar at someone else's green pull request. Promoting the number into the bar is a separate conductor write, made after the conductor has read and checked it, and it refuses to clear the bar rather than accepting an empty condition.
+
+**`verdict` and `state` answer different questions.** `verdict` is the evaluator's reading; `state` is the conductor's disposition, written by `close` as `accepted`, `rejected`, or `abandoned`. An item can hold `verdict: fail` and stay open while the worker retries.
+
+**The bind precedes the seed.** A worker that runs before its binding exists reads `not_bound` and cannot retry intelligently, so `action=bind` is sent before `session_send`. A bound item with no session is visible and recoverable; an unbound running worker is neither.
+
+**Every write appends exactly one event.** There is no way to change a field without also appending a line to the item's event log, which is what lets a conductor read history rather than infer it from a transcript.


### PR DESCRIPTION
## Problem / Motivation

The only picture of the conductor/worker dispatch lifecycle is the "Binding lifecycle" diagram in `docs/request-for-change/rfc-conductor-work-ledger.md`, and it stops at the worker's first `work_report`. Everything after that — the `accept` promotion, `accept_eval.py`, the `verdict` write, and the terminal `close` — exists only as prose scattered across the RFC and the two source modules, so a reader cannot see the whole handshake in one place.

## Why it matters

A conductor session, a worker session, and a maintainer all need the same mental model of who writes what and in which order. Two mix-ups are easy and expensive without one diagram: reading a worker's `done` as an acceptance, and seeding a worker before its `bind` (which makes the worker read `not_bound` with no intelligent retry).

## What changed (motivation → approach → change)

Goal: one standalone page showing the full lifecycle. Approach: extend the RFC's existing mermaid `sequenceDiagram` rather than invent a new notation, keep the same participants plus `User` and `accept_eval`, and put every claim's source in the tool surface instead of in narrative.

Added `docs/reference/ledger-conductor-sequence.md`: an intro paragraph, one `sequenceDiagram` covering `action=goal` → `create` → `session_create` → `bind` → `session_send` → `work_brief` → `work_report` (all four statuses, including the `pr` claim) → `accept` → `accept_eval.py` → `verdict` → `close`, and a legend. The legend states the two facts most easily conflated: `done` is the worker's claim and carries no verdict-writing parameter, while `verdict` is `accept_eval.py`'s five-value answer recorded under the conductor's key.

`docs/reference/` is a mirror tree whose README forbids authoring by default and provides a named-exception mechanism for local pages. Both required marks are written: a "local page, not a mirror" note in the page's own body, and a marked row in the Reference index (which also satisfies the docs-lint reachability rule).

## Tests

N/A — documentation only, no code changed. The repository's docs gate is the test that applies.

## Manual verification

- Action names verified against `WORK_TOOLS` and the `work_ledger_record` action enum in `src/kiro_crew/mcp_work.py`, and against `RECORD_ACTIONS` in `src/kiro_crew/dashboard/handlers/work_ledger.py` (`accept` is a route-level superset of the store's `CONDUCTOR_ACTIONS`).
- Status values verified against `WORKER_STATUSES`, verdicts against `VERDICTS`, and `close` states against `ITEM_STATES` in `src/kiro_crew/work_ledger.py`. Nothing in the diagram is invented.
- The `accept`-refuses-an-empty-bar and `accept_batch`-ignores-a-claimed-`pr` statements verified against `apply_acceptance_update` and `accept_batch`.
- `python3 scripts/docs_lint.py` → "All documentation checks passed".
- Diff-scoped gates run with their base refs exported at `e8747ec25c`: brand gate ✓, harness parity ✓, changelog history OK, focus cue reports only pre-existing elements (no touched element).

## Screenshots / video

N/A — `no-screenshots`: documentation only, no user-visible UI surface is added or changed.

## Related Issues

None.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — docs only)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
