### PR TITLE
chore(settings): regenerate settings-registry.generated.json (unblock Frontend Tests)

### DIFF
--- a/src/kiro_crew/docs/settings-registry.generated.json
+++ b/src/kiro_crew/docs/settings-registry.generated.json
@@ -481,6 +481,14 @@
       "description": "Compact is the original view. Comfortable and Full use more screen space."
     },
     {
+      "id": "chat.default-memory-mode",
+      "label": "Default Memory Mode",
+      "tab": "chat",
+      "route": "/settings/chat?highlight=key%3Adashboard.default_memory_mode",
+      "description": "Persistent uses what it knows and saves new memory. Incognito uses what it knows but saves no new memory. Temporary starts blank and saves no new memory. Every chat still appears in History. You can change the mode for any chat.",
+      "configKey": "dashboard.default_memory_mode"
+    },
+    {
       "id": "chat.default-model",
       "label": "Default Model",
       "tab": "chat",
@@ -810,6 +818,14 @@
       "description": "Inbound webhook tokens, registered contexts, and run history. The API works; the page is not finished."
     },
     {
+      "id": "display.command-completion",
+      "label": "Command completion",
+      "tab": "display",
+      "route": "/settings/display?highlight=key%3Adashboard.terminal.completion.enabled",
+      "description": "Show the completion popup while typing in the Terminal. Enter runs the line you typed; to take a suggestion, press ↑/↓ then Enter, or Tab. Off hides the popup; your shell's own Tab completion still works.",
+      "configKey": "dashboard.terminal.completion.enabled"
+    },
+    {
       "id": "display.default-for-new-sessions",
       "label": "Default for New Sessions",
       "tab": "display",
@@ -1031,6 +1047,20 @@
       "route": "/settings/privacy?highlight=key%3Atelemetry.beacon_enabled",
       "description": "Saved for future launches.",
       "configKey": "telemetry.beacon_enabled"
+    },
+    {
+      "id": "secrets.jira-api-token",
+      "label": "Jira API token",
+      "tab": "secrets",
+      "route": "/settings/secrets?highlight=secrets.jira-api-token",
+      "description": "Authenticates Jira issue lookups for the configured instance."
+    },
+    {
+      "id": "secrets.wakatime-api-key",
+      "label": "WakaTime API key",
+      "tab": "secrets",
+      "route": "/settings/secrets?highlight=secrets.wakatime-api-key",
+      "description": "Authenticates coding-activity sync when WakaTime is enabled."
     },
     {
       "id": "security.denied-commands",


### PR DESCRIPTION
## What

Checked-in `src/kiro_crew/docs/settings-registry.generated.json` regenerated with `npm run gen:settings`. Output only — no hand edits.

## Why

`website/src/components/commandPalette/providers/settingsRegistry.test.ts` ("checked-in JSON matches live extraction") fails on **current `main`**: a pristine `origin/main` worktree (`ef6167041`) regenerates a 30-line diff — five entries the JSON lacks (`chat.default-memory-mode`, `display.command-completion`, …) that landed via recent settings PRs without a regen. Main's own CI runs are being cancelled by rapid merges so it does not show there, but every PR rebased onto main reds `Frontend Tests (3)` (seen on #9793 head `1e4d3abe5`).

Cross-merge unblocker, kept separate from the affected feature PR on purpose.

## Pattern harvest

Rule candidate: CI gate — run `npm run gen:settings` in the frontend lint job and fail on a dirty `settings-registry.generated.json`, so a settings PR cannot merge with a stale checked-in registry. (The existing test catches it only at the next PR's merge ref.)

<!-- no-visual-delta -->
**Why no screenshot:** generated data file only; no rendered change.