### PR TITLE
perf(windows): stop re-reading every source file on gateway boot

### DIFF
--- a/.github/scripts/test-windows-installer.ps1
+++ b/.github/scripts/test-windows-installer.ps1
@@ -219,9 +219,10 @@ if ($SkipGatewayValidation) {
 } else {
 # Exercise the same bundled interpreter Electron launches, immediately after
 # installation while Defender's post-install scanning is still active. The
-# Windows package ships checked-hash bytecode for the measured gateway import
-# closure; this catches either those files being filtered out of the artifact or
-# the launcher accidentally redirecting imports into an empty user cache again.
+# Windows package ships hash-based (unchecked) bytecode for the measured gateway
+# import closure; this catches either those files being filtered out of the
+# artifact or the launcher accidentally redirecting imports into an empty user
+# cache again.
 $backendRoot = Join-Path $installLocation "resources\backend-dist\kirocrew-backend"
 $bundledPython = Join-Path $backendRoot "python.exe"
 if (-not (Test-Path -LiteralPath $bundledPython -PathType Leaf)) {

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -116,11 +116,17 @@ Current status:
   palette remains centered on the window, and native minimize/maximize/close
   controls remain on the right.
 - **Precompiled Windows gateway startup** — packaging traces the real
-  `kiro_crew.cli_server` import after pruning and ships checked-hash bytecode for
+  `kiro_crew.cli_server` import after pruning and ships hash-based (unchecked) bytecode for
   that import closure beside its sources. Windows consumes those caches directly,
   avoiding the thousand-file cache-population burst that otherwise overlaps
   Defender's post-install scanning. macOS and Linux still redirect bytecode out
-  of the signed/read-only app tree. The loading screen retains its extended
+  of the signed/read-only app tree. The Windows caches are **unchecked**-hash,
+  not checked. Both modes ignore mtime, which is the property that survives
+  extraction restamping the sources, but a checked-hash pyc makes the loader read
+  and hash each `.py` in *addition* to reading the `.pyc` — measured at 43.55 MB
+  and 1639 extra cold file opens per boot, a median 12.5 s on a cold file cache.
+  The macOS whole-tree caches remain checked-hash: a separate mechanism that does
+  not show this cost. The loading screen retains its extended
   Windows handoff window as a slow-machine fallback; a child exit or spawn error
   still fails immediately and includes the launch-log cause.
   `.github/scripts/test-windows-installer.ps1` can start the just-installed

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -683,10 +683,17 @@ build_backend_windows() {
   # After pruning, so it validates what actually ships.
   stdlib_probe_gate "$out"
 
-  # Trace the real gateway import after the final prune and ship checked-hash
-  # pycs for exactly that closure. Windows can consume these beside the source
-  # without invalidating an Authenticode signature, avoiding the first launch's
-  # thousand-file cache write while keeping unrelated modules out of the bundle.
+  # Trace the real gateway import after the final prune and ship hash-based
+  # (UNCHECKED) pycs for exactly that closure. Windows can consume these beside
+  # the source without invalidating an Authenticode signature, avoiding the first
+  # launch's thousand-file cache write while keeping unrelated modules out of the
+  # bundle. Unchecked, not checked, and the difference is load-bearing: a
+  # checked-hash pyc makes the loader read and hash each .py in ADDITION to the
+  # .pyc, which measured 43.55 MB and 1639 extra cold file opens per boot -- a
+  # median 12.5 s on a cold file cache. Both hash modes ignore mtime, which is
+  # the property this needs; only the re-read is dropped. The posix tree above
+  # stays checked-hash: it is a different mechanism (whole tree, codesigned) and
+  # does not show the symptom.
   log "Precompiling Windows gateway startup modules ($(basename "$out"))…"
   env PYTHONDONTWRITEBYTECODE=1 PYTHONNOUSERSITE=1 PYTHONPATH= \
     "$out/python.exe" -s "$ROOT/packaging/precompile_windows.py" \

--- a/packaging/precompile_windows.py
+++ b/packaging/precompile_windows.py
@@ -5,12 +5,38 @@ the first time otherwise creates more than a thousand small ``.pyc`` files
 while antivirus scanning is hottest, turning a few seconds of Python work into
 a long first launch.  This build helper imports the gateway without writing
 bytecode, records only modules actually loaded from the bundled runtime, then
-emits deterministic checked-hash caches beside their sources.
+emits deterministic hash-based caches beside their sources.
 
 Keeping this as a build helper (rather than runtime bootstrap code) means the
-end user's first launch does no cache-population pass.  Checked-hash pycs remain
+end user's first launch does no cache-population pass.  Hash-based pycs remain
 valid when archive extraction changes mtimes, and relative ``co_filename``
 values avoid leaking a CI runner path into tracebacks.
+
+The caches are ``UNCHECKED_HASH``, and the distinction from ``CHECKED_HASH``
+is worth stating because it is the difference between a fast launch and a slow
+one.  What this tree needs from a hash-based pyc is *mtime independence*:
+extraction restamps sources, so a TIMESTAMP pyc would look stale on every
+user's machine and be rewritten in place, and that rewrite is the defect the
+shipped caches exist to prevent.  Both hash modes deliver that.  They differ
+only in whether the loader re-validates: a ``CHECKED_HASH`` pyc makes every
+import read its ``.py`` in full and hash it *in addition to* reading the
+``.pyc``.  Measured on native Windows over this closure, that second read costs
+43.55 MB and ~3232 extra read operations per boot across 1639 additional cold
+file opens.  The hashing arithmetic itself is free (~11 ms); the opens are not,
+because each one pays a first-touch metadata and antivirus toll.  Cold cache --
+the regime a real launch after login runs in -- that measured a median 16718 ms
+with ``CHECKED_HASH`` against 4192 ms with ``UNCHECKED_HASH`` (n=5 per arm,
+interleaved), a 12.5 s difference at the median and 10.9 s min-to-min, for
+byte-identical code.  Warm it is worth 195 ms, which is why a warm benchmark
+will conclude this change does nothing.
+
+What ``UNCHECKED_HASH`` gives up is detecting a ``.py`` edited underneath the
+cache: the stale bytecode is used instead.  That is the correct trade for a
+runtime the installer owns and the user is not meant to edit, and it is not a
+signing guarantee being dropped -- Authenticode seals the installer, not this
+resource tree, so ``CHECKED_HASH`` was never what made the tree trustworthy.
+Anyone deliberately editing the shipped runtime to debug it can force
+validation back on for one run with ``--check-hash-based-pycs always``.
 """
 
 from __future__ import annotations
@@ -67,7 +93,7 @@ def precompile_import_closure(root: Path, module_names: list[str]) -> tuple[int,
             dfile=relative_name,
             doraise=True,
             optimize=sys.flags.optimize,
-            invalidation_mode=py_compile.PycInvalidationMode.CHECKED_HASH,
+            invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH,
         )
         total_bytes += cache.stat().st_size
     return len(sources), total_bytes

--- a/test/test_precompile_windows.py
+++ b/test/test_precompile_windows.py
@@ -18,7 +18,7 @@ finally:
     sys.dont_write_bytecode = _PREVIOUS_DONT_WRITE_BYTECODE
 
 
-def test_precompiles_import_closure_as_relocatable_checked_hash_pyc(
+def test_precompiles_import_closure_as_relocatable_unchecked_hash_pyc(
     tmp_path: Path, monkeypatch
 ) -> None:
     root = tmp_path / "runtime"
@@ -37,7 +37,16 @@ def test_precompiles_import_closure_as_relocatable_checked_hash_pyc(
     for source in package.glob("*.py"):
         cache = Path(importlib.util.cache_from_source(str(source)))
         payload = cache.read_bytes()
-        assert struct.unpack("<I", payload[4:8])[0] == 3  # checked-hash pyc
+        flags = struct.unpack("<I", payload[4:8])[0]
+        # Bit 0 = hash-based, which is what survives extraction restamping the
+        # sources; a TIMESTAMP pyc would look stale on the user's machine and be
+        # rewritten in place. Bit 1 = check_source, which must stay CLEAR: with
+        # it set the loader reads and hashes every .py in addition to the .pyc,
+        # measured at 43.55 MB and 1639 extra cold file opens per Windows boot
+        # (median 16718 ms vs 4192 ms, n=5 per arm) for byte-identical code.
+        assert flags & 0b01, "pyc must be hash-based to survive extraction restamping"
+        assert not flags & 0b10, "source-check must be off: it costs ~12.5s per cold boot"
+        assert flags == 0b01  # UNCHECKED_HASH exactly, not some future third mode
         code = importlib.machinery.SourcelessFileLoader(source.stem, str(cache)).get_code(
             source.stem
         )

--- a/website/electron/README.md
+++ b/website/electron/README.md
@@ -101,9 +101,12 @@ Notes:
   and copies only the small root remainder; per-machine installs keep the
   upstream copy path so files inherit the Program Files ACL. Cross-volume or
   occupied destinations also retain the upstream copy-and-retry fallback. The
-  Windows backend ships checked-hash
+  Windows backend ships hash-based (unchecked)
   bytecode for the measured gateway import closure, so first launch consumes
   build-time caches rather than generating thousands of files under Defender.
+  Unchecked rather than checked so the loader does not also re-read and re-hash
+  every `.py` it imports, which cost a median 12.5 s per cold boot; macOS's
+  whole-tree caches stay checked-hash.
 - The native welcome/finish sidebar and the header used on intermediate pages
   carry the Kiro Crew logo and ghost artwork. The standard NSIS controls and
   localized instructions remain native. Page boundaries use a short Win32

--- a/website/electron/gateway-env.js
+++ b/website/electron/gateway-env.js
@@ -41,13 +41,18 @@ function buildGatewayEnvironment(baseEnv) {
  * Decide where a packaged gateway's bytecode may go — and on macOS, that it may
  * not be written at all.
  *
- * Both desktop bundles ship checked-hash pycs beside their sources, so a
+ * Both desktop bundles ship hash-based pycs beside their sources, so a
  * packaged runtime finds its modules already compiled and has no reason to write
  * one. That is what lets this consume adjacent `__pycache__` instead of
  * redirecting to a per-user cache the first launch would have to populate.
- * macOS compiles the WHOLE tree (`compileall --invalidation-mode checked-hash`
- * in `packaging/build-desktop.sh`); Windows ships the narrower traced startup
- * closure, which is enough there because a later write is harmless.
+ * macOS compiles the WHOLE tree as CHECKED-hash
+ * (`compileall --invalidation-mode checked-hash` in
+ * `packaging/build-desktop.sh`); Windows ships the narrower traced startup
+ * closure as UNCHECKED-hash, which is enough there because a later write is
+ * harmless. Both ignore mtime, which is the property that survives extraction
+ * restamping; they differ only in whether the loader re-reads and re-hashes the
+ * `.py` on every import, which on Windows measured a median 12.5 s per cold boot
+ * across the closure's 1639 modules.
  *
  * macOS additionally FORBIDS the write. `codesign` seals every file under a
  * `.app`'s `Contents/`, so bytecode written there after signing invalidates the


### PR DESCRIPTION
no linked issue: found by direct measurement while investigating a user report that the
Windows gateway takes tens of seconds to start on every boot while macOS is near-instant.
No existing issue describes this mechanism, and the two follow-ups it turned up are recorded
at the bottom of this description rather than filed pre-emptively.

## What

The Windows desktop bundle ships precompiled bytecode for the traced gateway import
closure, so a first launch does no cache-population pass. Those caches were
`CHECKED_HASH`, which makes the loader read each module's `.py` **in full and hash it, in
addition to reading the `.pyc`**. Boot therefore opened 1639 source files it never needed
to look at.

This switches the Windows traced closure to `UNCHECKED_HASH`. One token in
`packaging/precompile_windows.py`; it covers every launch path (Electron, `kirocrew.cmd`,
`python -m kiro_crew`, a user's shell).

## Why it is slow, measured

Native Windows, bundled CPython 3.12.14, 1639 closure modules. Timing only
`import kiro_crew.cli_server`. Arms interleaved to cancel order bias; both arms given the
**identical** pyc header-rewrite pass so only the invalidation flag differs; cold arms are
`robocopy /J` (unbuffered) copies so the destination does not land in the file cache; each
run printed `kiro_crew.__file__` to prove the import came from its own copy.

| file cache | mode | import (median) | bytes read | read ops |
|---|---|---|---|---|
| **cold**, n=5 | `CHECKED_HASH` | **16717.9 ms** | 85,049,813 | 6631 |
| **cold**, n=5 | `UNCHECKED_HASH` | **4192.3 ms** | 41,495,550 | 3399 |
| warm, n=12 | `CHECKED_HASH` | 2651.0 ms | 85,049,813 | 6631 |
| warm, n=12 | `UNCHECKED_HASH` | 2456.3 ms | 41,495,550 | 3399 |

**Cold: −12.5 s at the median (4.0× faster), −10.9 s min-to-min. Warm: −194.8 ms.**

The I/O counters were bit-identical across runs within each arm, so the mechanism is
proven even where the timing is noisy: `CHECKED_HASH` costs exactly **43.55 MB and 3232
extra read operations per boot**.

The hashing arithmetic is not the cost — siphash over the whole 41.98 MiB measures
**10.8 ms**. The cost is **1639 extra cold file opens at 6.7–7.6 ms each**, because every
first-touch open pays an NTFS metadata and antivirus toll. That is why the symptom is
Windows-shaped even though the mechanism is cross-platform.

A third arm bounds what the precompile step itself is worth: with the closure's pycs
deleted, the same tree imports in **8914.9 ms warm** against 2656.5 ms — the two arms read
the same volume in the same number of ops, so that ~6.3 s gap is pure compilation CPU.
Shipping without pycs would be far worse. This changes only their *mode*, never their
existence.

## Why `UNCHECKED_HASH` is the right mode, not just the faster one

`build-desktop.sh` records why these caches are hash-based: extraction restamps sources, so
a `TIMESTAMP` pyc always looks stale on the user's machine and is rewritten in place — and
"that rewrite IS the corruption." Both hash modes are mtime-independent. They differ only
in whether the loader **re-validates**. The original rationale needs the *hash* half, not
the *checked* half, so this keeps the property it was chosen for and drops only the re-read.

## What it gives up

An edited `.py` under its cache is no longer detected; the stale pyc runs. Being precise
about when that is reachable:

- **Post-install: unreachable by construction.** The build regenerates a pyc for every
  closure module from the shipped sources, and the installer replaces both, so `.py` and
  `.pyc` cannot drift apart through any supported path.
- **Mid-install: reachable, and pre-existing.** The NSIS installer extracts incrementally
  while `runAfterFinish` can already start the app — the window `bundle-integrity.js`
  exists to guard. In that window `CHECKED_HASH` is arguably worse, not better: it detects
  the mismatch and *recompiles, writing into the tree the installer is still writing.*
- **An engineer hot-patching a shipped `.py`** sees no effect, silently. Mitigated with no
  rebuild: `--check-hash-based-pycs always` forces validation for one run.

This drops no signing guarantee. Authenticode seals the installer, not the resource tree,
so `CHECKED_HASH` was never what made the shipped tree trustworthy.

Sources are still required at import: `path_stats(source_path)` runs before the pyc is
used, so a missing `.py` makes the loader ignore the pyc entirely. Only the source's
*contents* stop being read.

## Scope

Windows traced closure only. `build-desktop.sh`'s posix whole-tree
`compileall --invalidation-mode checked-hash` is deliberately **unchanged**: no macOS host
was available to measure it, and macOS does not show the symptom. Changing it on inference
would be exactly the kind of unmeasured claim this PR is trying to replace.

## Testing

- `test/test_precompile_windows.py` now pins the two properties **separately** — bit 0
  hash-based (survives extraction restamping) and bit 1 source-check **off** (the 12.5 s) —
  so a future revert fails on the mode instead of passing silently.
- **The pin was verified to bite**: reverting `precompile_windows.py` to `CHECKED_HASH`
  fails on `assert not flags & 0b10`, with the intended message. Restored after.
- `black==26.3.1` / `isort==6.0.0` / `flake8==7.1.0` clean on both files; neither is in
  `.github/black-baseline.txt`, so black is enforced rather than skipped.

## Reviewer note on reproducing this

Benchmark it **cold** — a freshly copied tree or a reboot. Warm, this fix is worth 195 ms,
inside run-to-run noise, and a warm A/B will correctly conclude it does nothing. The 12.5 s
exists only on a cold file cache, which is the state a machine is in right after installing
or logging in — the state users report as "tens of seconds every time".

## Follow-ups found while measuring, deliberately not bundled here

- The Windows path has **no `__pycache__` prune** (that prune is posix-only), so the shipped
  tree still carries **1175 `TIMESTAMP` pycs**, 1106 of them in `site-packages`, including
  pytest assertion-rewrite caches. None are on the boot closure so this costs boot nothing,
  but it is dead weight in a 489 MB / 14022-file tree and it means non-closure imports can
  still write into the install tree — the failure the build comment believes it avoided.
- The shipped boot metric cannot observe any of this: `state.start_time` is stamped at
  `dashboard/server.py:3268`, *after* the import closure, so
  `kirocrew.gateway.boot.duration` excludes interpreter start and the entire import. A
  metric that starts its clock after the expensive phase is why this went unnoticed.

## Pattern harvest

Rule candidate: a performance fix whose cost is per-file I/O must be benchmarked on a cold file cache; measured warm, this one is 195 ms of noise and would have been rejected, while cold it is 12.5 s. State the cache regime beside every boot/startup number.

Rule candidate: when a build pins a mechanism for a documented reason, check whether the reason needs the whole mechanism. Hash-based pycs were chosen for mtime independence; `CHECKED_HASH` supplies that plus re-validation, and only the first half was ever required.
