### PR TITLE
fix(dashboard): regenerate the agent-facing settings registry

### DIFF
--- a/src/kiro_crew/docs/settings-registry.generated.json
+++ b/src/kiro_crew/docs/settings-registry.generated.json
@@ -481,6 +481,14 @@
       "description": "Compact is the original view. Comfortable and Full use more screen space."
     },
     {
+      "id": "chat.default-memory-mode",
+      "label": "Default Memory Mode",
+      "tab": "chat",
+      "route": "/settings/chat?highlight=key%3Adashboard.default_memory_mode",
+      "description": "Persistent uses what it knows and saves new memory. Incognito uses what it knows but saves no new memory. Temporary starts blank and saves no new memory. Every chat still appears in History. You can change the mode for any chat.",
+      "configKey": "dashboard.default_memory_mode"
+    },
+    {
       "id": "chat.default-model",
       "label": "Default Model",
       "tab": "chat",
@@ -810,6 +818,14 @@
       "description": "Inbound webhook tokens, registered contexts, and run history. The API works; the page is not finished."
     },
     {
+      "id": "display.command-completion",
+      "label": "Command completion",
+      "tab": "display",
+      "route": "/settings/display?highlight=key%3Adashboard.terminal.completion.enabled",
+      "description": "Show the completion popup while typing in the Terminal. Enter runs the line you typed; to take a suggestion, press ↑/↓ then Enter, or Tab. Off hides the popup; your shell's own Tab completion still works.",
+      "configKey": "dashboard.terminal.completion.enabled"
+    },
+    {
       "id": "display.default-for-new-sessions",
       "label": "Default for New Sessions",
       "tab": "display",
@@ -1031,6 +1047,20 @@
       "route": "/settings/privacy?highlight=key%3Atelemetry.beacon_enabled",
       "description": "Saved for future launches.",
       "configKey": "telemetry.beacon_enabled"
+    },
+    {
+      "id": "secrets.jira-api-token",
+      "label": "Jira API token",
+      "tab": "secrets",
+      "route": "/settings/secrets?highlight=secrets.jira-api-token",
+      "description": "Authenticates Jira issue lookups for the configured instance."
+    },
+    {
+      "id": "secrets.wakatime-api-key",
+      "label": "WakaTime API key",
+      "tab": "secrets",
+      "route": "/settings/secrets?highlight=secrets.wakatime-api-key",
+      "description": "Authenticates coding-activity sync when WakaTime is enabled."
     },
     {
       "id": "security.denied-commands",


### PR DESCRIPTION
## Problem

**Frontend Tests shard 3 is red on `main`, not on any one pull request.** Reproduced on a clean worktree at `origin/main` (`ef6167041`) with no local changes: 1 test file fails out of 1992, and it is `src/components/commandPalette/providers/settingsRegistry.test.ts`.

`src/kiro_crew/docs/settings-registry.generated.json` is missing four entries the extractor produces from the live settings source:

- `chat.default-memory-mode`
- `display.command-completion`
- `secrets.jira-api-token`
- `secrets.wakatime-api-key`

## Why it matters beyond the red check

`npm run gen:settings` writes **two** artifacts from one extraction pass: the UI registry the command palette imports (`website/src/components/commandPalette/settingsRegistry.gen.ts`), and this JSON, which ships inside the Python docs package and is what a deployed gateway reads to answer "where is that setting?".

Only the first was current. So those four settings exist in the dashboard while the agent-facing lookup cannot name them, and — as that test's own docstring says — nothing at runtime can tell a stale copy from a correct one; the user gets a link to a control the registry does not know about. That is why the test compares this file **byte-for-byte** rather than by shape.

## Fix

Regenerated with the extractor: 195 entries, `+30` lines, one file. No source change — the UI registry was already correct, so this only moves the second artifact onto it.

## Verification

- `settingsRegistry.test.ts`: 10 passed (was 1 failed).
- Full frontend suite on `main` before the change: `1 failed | 1991 passed` files, and the one failure is this test. After: that file is green, so the shard is the only thing that changes colour.

## Note for whoever regenerates next

`npm run gen:settings` did not run for me in this environment: it shells out to `npx vite-node`, which is not in `node_modules` and cannot be fetched from the configured registry (`E401`). I ran the extractor through `vitest` instead — same two functions from `website/scripts/settingsExtract`, so the output is what the script would have written. Worth making the script use the vitest already installed, or adding `vite-node` as a dev dependency, so the command works from a plain `npm ci` checkout. Not in this PR: it is a separate change and this one should stay a one-file regeneration.

## Pattern harvest

Rule candidate: lint
Pattern: a generator's data artifact committed stale while its compiled sibling is current

**One command writing two artifacts will eventually ship one of them stale, and the copy nobody imports is the one that rots.** Both files here come from a single `gen:settings` pass, but only one is imported by code that fails loudly when it is wrong. The JSON is read at runtime by a deployed gateway, so a stale copy produces a wrong answer rather than a broken build — which is why its test compares it byte-for-byte instead of by shape. Two lessons worth carrying:

- When a generator emits both a compiled artifact and a data artifact, the data one needs the strictest check, not the loosest. Shape assertions would have passed here.
- A generator that cannot run from a plain `npm ci` checkout (this one needs `vite-node`, which is absent and unfetchable) turns "regenerate and commit" into a step contributors skip. The staleness is downstream of that, so the durable fix is making the command runnable, not adding another reminder to a docstring.

**The check was red on `main`, not on the PR that surfaced it.** The report arrived against an unrelated backend-only pull request, which cost a round of investigation before the branch was cleared. Reproducing on a clean worktree at `origin/main` with zero local changes is the cheap first move whenever a failing shard touches no file the diff names — and worth doing before reading a single job log.
