### PR TITLE
fix(slack): keep progress-card refusals from faking a terminal error (#9730)

### DIFF
--- a/comment-history-baseline.json
+++ b/comment-history-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Comments and docstrings that narrate change history, per file, as a match COUNT. The rule they break is in docs/system-specs/common/code-style.md (\"Comments explain the WHY\"); it predates any enforcement, so the tree is recorded here rather than rewritten in one pass. The gate requires every OTHER file to be clean and none of these counts to grow, so this list can only shrink. Do NOT add or raise an entry to make a red gate green: a new offender means the comment should state CURRENT behavior in present tense. Lower and prune with `python3 scripts/check_comment_history.py --write-baseline`, which never adds or raises one.",
-  "_total": 6636,
+  "_total": 6634,
   "files": {
     "src/kiro_crew/__main__.py": 1,
     "src/kiro_crew/acp/_dispatch.py": 2,
@@ -1451,7 +1451,7 @@
     "test/test_slack_gateway.py": 15,
     "test/test_slack_gateway_coverage.py": 1,
     "test/test_slack_gateway_cron_exec_coverage.py": 3,
-    "test/test_slack_handler.py": 7,
+    "test/test_slack_handler.py": 6,
     "test/test_slack_handler_coverage.py": 1,
     "test/test_slack_handler_more_coverage.py": 6,
     "test/test_slack_home_tab.py": 2,

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -3134,7 +3134,23 @@ async def handle_message(
             return False
         if channel_activation == ACTIVATION_REVIEW:
             return True  # Suppress task cards in review mode
-        return await slack.append_task(channel, stream_ts, task_id, title, status, details=details)
+        # Best-effort, and it MUST NOT raise. ``SlackClient.append_task`` swallows
+        # its own API errors and returns False, but a client that does not (or a
+        # transport that raises before that guard) would send the exception up
+        # into the streaming loop, where nothing catches a non-ACP error: the
+        # typed ``except`` arms below the loop are all ``kiro_crew.acp.client``
+        # errors, so it reaches the generic ``except Exception`` catch-all, which
+        # renders the terminal "🔧 Something went wrong" message and records a
+        # session failure — on a turn that is still live and will finish. The
+        # card is decorative (no answer text is withheld), so swallow the failure
+        # here, logging the traceback at WARNING for diagnosis.
+        try:
+            return await slack.append_task(
+                channel, stream_ts, task_id, title, status, details=details
+            )
+        except Exception:
+            logger.warning("Slack append_task failed — skipping progress card", exc_info=True)
+            return False
 
     async def _tool_elapsed_updater() -> None:
         """Periodically update the active task card with elapsed time (every 30s)."""
@@ -3209,8 +3225,27 @@ async def handle_message(
         )
         use_slack_stream = stream_ts is not None
         if not use_slack_stream:
-            stream_ts = await slack.post_message(channel, _THINKING, reply_ts)
-        assert stream_ts is not None
+            # ``SlackClient.start_stream`` swallows its own errors and returns
+            # None, but the ``chat.update`` fallback below goes through the base
+            # ``post_message``, which raises (``resp["ts"]``) on a Slack refusal.
+            # A raise here escapes the streaming loop while the ACP turn is still
+            # live and reaches the generic ``except Exception`` catch-all below
+            # the loop (the typed arms are all ``kiro_crew.acp.client`` errors),
+            # rendering the terminal "🔧 Something went wrong" message on a run
+            # that is still succeeding. Keep it best-effort. On failure leave
+            # ``stream_ts`` as ``None``: there is no placeholder to update, and
+            # every downstream reader treats falsy as "no placeholder"
+            # (``_append_stream`` returns early; the end-of-turn delivery takes
+            # its ``else`` branch and posts the final answer with a fresh
+            # ``post_message`` rather than editing a ts that does not exist). Do
+            # NOT substitute a truthy sentinel here — that routes end of turn into
+            # the placeholder-edit branch against a non-existent message and loses
+            # a single-part reply silently.
+            try:
+                stream_ts = await slack.post_message(channel, _THINKING, reply_ts)
+            except Exception:
+                logger.warning("Failed to post chat.update placeholder", exc_info=True)
+                stream_ts = None
 
     task = Task(id=msg_ts)
     _acquired = False
@@ -3496,8 +3531,11 @@ async def handle_message(
                             await _append_stream(stream_buffer)
                             stream_buffer = ""
                     else:
-                        assert stream_ts is not None
-                        if channel_activation != ACTIVATION_REVIEW:
+                        # ``stream_ts`` may be None: the chat.update fallback in
+                        # ``_ensure_stream_started`` failed, so there is no
+                        # placeholder to edit. Skip the cursor edit — the final
+                        # answer is posted at end of turn from ``accumulated``.
+                        if stream_ts and channel_activation != ACTIVATION_REVIEW:
                             await _safe_update(
                                 slack, channel, stream_ts, redact(accumulated) + _CURSOR
                             )
@@ -3616,8 +3654,12 @@ async def handle_message(
                     _start_tool_timer()
                 else:
                     accumulated += tool_status
-                    assert stream_ts is not None
-                    if channel_activation != ACTIVATION_REVIEW:
+                    # ``stream_ts`` may be None here: ``_ensure_stream_started``
+                    # demoted (``use_slack_stream`` False) AND its chat.update
+                    # fallback post failed, so there is no placeholder to edit.
+                    # Skip the cursor edit — the final answer is posted by the
+                    # end-of-turn ``else`` branch with a fresh ``post_message``.
+                    if stream_ts and channel_activation != ACTIVATION_REVIEW:
                         await _safe_update(slack, channel, stream_ts, redact(accumulated) + _CURSOR)
                 last_edit = time.monotonic()
 

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -13,6 +13,7 @@ from kiro_crew.hooks import AutoReplyHook, HookManager, HooksConfig
 from kiro_crew.providers.base import LLMEvent
 from kiro_crew.slack.format import CONTINUATION, SLACK_MSG_LIMIT, split_message
 from kiro_crew.slack.handler import (
+    _THINKING,
     _THINKING_PLACEHOLDER,
     _build_phase_emojis,
     _condense_thinking,
@@ -215,9 +216,9 @@ class TestHandleMessage:
 
     @pytest.mark.asyncio
     async def test_channels_deny_drops_slack_inbound(self, tmp_path, monkeypatch):
-        # HIGH (GPT round-7 pass 2, user-directed): Slack is a GOVERNED transport.
-        # A channels policy that allows only non-slack members must drop a Slack
-        # inbound message before any turn runs — no reply posted.
+        # Slack is a GOVERNED transport: a channels policy that allows only
+        # non-slack members must drop a Slack inbound message before any turn
+        # runs — no reply posted.
         import json
 
         from kiro_crew.platform import governance_profiles as gp
@@ -3772,3 +3773,180 @@ class TestPerSessionTrust:
     def test_add_trusted_session_empty_key_is_noop(self):
         add_trusted_session("")
         assert "" not in _trusted_sessions
+
+
+class TestLiveTurnPresentationFailure:
+    """A presentation-side Slack call that raises mid-run must not flip the
+    placeholder to the terminal "🔧 Something went wrong" message nor record a
+    session failure while the ACP turn is still live and will finish with the
+    correct, complete reply.
+
+    The exposed calls run on the first ``tool_call`` event, before any text has
+    streamed, so ``accumulated`` is empty. A non-ACP raise there is not caught by
+    the typed ``except`` arms (all ``kiro_crew.acp.client`` errors) and would
+    reach the generic ``except Exception`` catch-all, which renders the terminal
+    error and records a failure. These tests assert the raise is swallowed and
+    the turn still delivers.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _ensure_reactions_enabled(self, monkeypatch):
+        import dataclasses
+
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        _real_load = KiroCrewConfig.load
+
+        def _patched_load():
+            cfg = _real_load()
+            return dataclasses.replace(
+                cfg, slack=dataclasses.replace(cfg.slack, reactions_enabled=True)
+            )
+
+        monkeypatch.setattr(KiroCrewConfig, "load", _patched_load)
+
+    @pytest.mark.asyncio
+    async def test_progress_card_raise_does_not_render_terminal_error(self):
+        # A slack client whose progress-card call raises like a real Slack API
+        # refusal / rate limit — NOT swallowed internally, so it propagates into
+        # the handler's loop exactly as a non-swallowing client would.
+        class RaisingCardSlack(MockSlackClient):
+            def __init__(self):
+                super().__init__()
+                self._stream_enabled = True  # take the Slack streaming path
+
+            async def append_task(self, *a, **kw):
+                raise RuntimeError("ratelimited: chat.appendStream")
+
+        # A FakeSessionManager that records whether the turn was marked failed.
+        class TrackingSessions(FakeSessionManager):
+            def __init__(self, provider):
+                super().__init__(provider)
+                self.record_failure_calls = 0
+                self.record_success_calls = 0
+
+            async def record_failure(self, key):
+                self.record_failure_calls += 1
+                return False
+
+            def record_success(self, key):
+                self.record_success_calls += 1
+
+        slack = RaisingCardSlack()
+        # tool_call FIRST (accumulated empty at the raise), then the real reply.
+        provider = FakeProvider(
+            [
+                LLMEvent(
+                    kind="tool_call",
+                    title="Running: grep",
+                    tool_kind="execute",
+                    tool_purpose="searching the repo",
+                ),
+                LLMEvent(kind="text_chunk", text="The answer is 42"),
+            ]
+        )
+        sessions = TrackingSessions(provider)
+
+        await handle_message(slack, sessions, "C1", "do something slow", None, "msg1", "U1")
+
+        # 1. The turn was NOT recorded as a failure — a cosmetic card refusal is
+        #    not the turn dying.
+        assert sessions.record_failure_calls == 0
+        # 2. The terminal error string was never sent to Slack on any surface.
+        all_text = " ".join(
+            str(a[1].get("text") or "")
+            for a in slack.actions
+            if a[0] in ("post", "update", "append_stream", "stop_stream")
+        )
+        assert "Something went wrong" not in all_text, slack.actions
+        # 3. The real reply still reached the user.
+        assert "The answer is 42" in all_text, slack.actions
+        # 4. The turn completed successfully.
+        assert sessions.record_success_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_start_and_fallback_both_fail_still_posts_reply(self):
+        """The one sub-path the card test does not reach: streaming is on, but
+        ``start_stream`` demotes (returns None) AND the ``chat.update`` fallback
+        ``post_message`` raises. ``_ensure_stream_started`` must leave
+        ``stream_ts`` falsy so end of turn posts the accumulated reply directly —
+        NOT route through the placeholder-edit branch against a ts that does not
+        exist (which loses a single-part reply silently while recording success).
+        """
+
+        class DemotedThenRaisingSlack(MockSlackClient):
+            def __init__(self):
+                super().__init__()
+                self._stream_enabled = True
+                self._real_ts: set[str] = set()
+
+            async def start_stream(self, *a, **kw):
+                # Demote: chat.startStream unavailable → non-streaming fallback.
+                return None
+
+            async def post_message(self, channel, text, thread_ts=None, **kw):
+                # The ``chat.update`` placeholder fallback goes through the base
+                # ``post_message`` and raises on a Slack refusal. The FINAL answer
+                # post is a separate call with the real reply text and must still
+                # go through, so only the placeholder text is refused.
+                if text == _THINKING:
+                    raise RuntimeError("channel_not_found: chat.postMessage")
+                ts = await super().post_message(channel, text, thread_ts=thread_ts, **kw)
+                self._real_ts.add(ts)
+                return ts
+
+            async def update_message(self, channel, ts, text):
+                # Editing a message that was never posted fails, exactly as the
+                # Slack API rejects chat.update against a non-existent ts. The
+                # handler swallows that at debug, so a reply routed here instead
+                # of to a fresh post_message is lost silently — which is the
+                # data-loss defect the buggy truthy sentinel introduced.
+                if ts not in self._real_ts:
+                    raise RuntimeError(f"message_not_found: chat.update ts={ts}")
+                return await super().update_message(channel, ts, text)
+
+        class TrackingSessions(FakeSessionManager):
+            def __init__(self, provider):
+                super().__init__(provider)
+                self.record_failure_calls = 0
+                self.record_success_calls = 0
+
+            async def record_failure(self, key):
+                self.record_failure_calls += 1
+                return False
+
+            def record_success(self, key):
+                self.record_success_calls += 1
+
+        slack = DemotedThenRaisingSlack()
+        # tool_call FIRST so _ensure_stream_started runs with accumulated empty,
+        # then a single-part reply — the part that must not be lost.
+        provider = FakeProvider(
+            [
+                LLMEvent(
+                    kind="tool_call",
+                    title="Running: grep",
+                    tool_kind="execute",
+                    tool_purpose="searching the repo",
+                ),
+                LLMEvent(kind="text_chunk", text="The answer is 42"),
+            ]
+        )
+        sessions = TrackingSessions(provider)
+
+        await handle_message(slack, sessions, "C1", "do something slow", None, "msg1", "U1")
+
+        # The reply must arrive via a real ``post`` (the end-of-turn else branch),
+        # NOT an ``update`` against a bogus placeholder ts — an update there is
+        # swallowed and the single-part reply is lost. Asserting specifically on
+        # ``post`` is what makes the truthy-sentinel regression fail this test.
+        reply_posts = [str(a[1].get("text") or "") for a in slack.actions if a[0] == "post"]
+        assert any("The answer is 42" in p for p in reply_posts), slack.actions
+        # No terminal error, and the turn is not falsely failed.
+        all_text = " ".join(
+            str(a[1].get("text") or "")
+            for a in slack.actions
+            if a[0] in ("post", "update", "stop_stream")
+        )
+        assert "Something went wrong" not in all_text, slack.actions
+        assert sessions.record_failure_calls == 0


### PR DESCRIPTION
## Problem / Motivation

On Slack, the in-progress placeholder flips to a terminal `Something went wrong. Please try again.` mid-run. The agent keeps working and posts the correct, complete reply minutes later. The result is fine; the placeholder reports a failure that did not happen. Retested on 0.6.0.16. Follow-up to #8511, which was auto-closed one second after #9260 merged with no verification comment -- and #9260 fixed a *different* failure (a refused progress card splitting the reply), so that closure did not cover this.

Read against `main` at `ef6167041f18d03f5fcd74082e04acca1ceb43bd`. The native catch-all is now `src/kiro_crew/slack/handler.py:3910-3915` and the transport sibling is `src/kiro_crew/slack/transport_dispatch.py:982` (both moved from the line numbers in the issue).

## Why it matters

The error state reads as a hard failure, so the user stops waiting, retries, or re-asks -- burning a second agent run -- even though the first run succeeded. Slack stays unreliable for exactly the long-running, tool-heavy work the agent is most useful for. It compounds now that #8511 is closed: the live symptom is invisible to triage.

## What changed (motivation -> approach -> change)

**Mechanism.** The whole `async for event in client.stream(...)` loop is wrapped in one big `try`. The four typed `except` arms below it (`AcpTimeoutError`, `AcpProcessDied`, `AcpPromptBusy`, `AcpError`) are all `kiro_crew.acp.client` errors and each renders *different* text. Anything else -- a Slack API refusal, a rate limit, a socket or JSON error -- lands in the generic `except Exception`, which sets `accumulated = accumulated or "Something went wrong. Please try again."`, calls `task.fail("unexpected")`, and `record_failure`. The `accumulated or` guard is the discriminator the operators found: the generic string only wins when **nothing had streamed yet**, i.e. the raise happened before the first text chunk. That is the tool-first path, where the loop makes presentation-side Slack calls (the progress card) while `accumulated` is still empty.

The ACP turn itself never died -- a decorative side channel did -- so the run keeps going and delivers the whole, correct reply moments later, contradicting the error the user was just shown. `logger.exception("Unexpected error handling message")` writes the traceback; in a real deployment it is in the gateway process log (stderr / the unit's journal), at the point the placeholder flipped.

Two presentation calls can raise into the loop *before any text streams*, and both go through non-swallowing paths (the real `SlackClient` methods swallow their own API errors, but a client/transport that does not -- or the base `post_message`, which raises on `resp["ts"]` -- does not):

- `_append_task` (the progress-card path -- by the code's own comment "by far the likeliest call to meet a rate limit or a stream Slack has already closed").
- The `chat.update` fallback in `_ensure_stream_started` when `start_stream` demotes.

**Fix (the error semantics, per the narrow shape).** Make exactly those two calls best-effort: swallow and log at WARNING (traceback preserved) instead of propagating. A cosmetic card/stream-start refusal stays cosmetic -- the loop continues, the turn finishes, and the reply is delivered once. This distinguishes "the turn died" (still surfaced by the typed arms and the genuine catch-all) from "a side channel failed while the turn continued" (no longer a terminal failure). `_append_task` is hardened at its single definition, so every call site (tool start, tool complete, wait-finalize, permission-reject, post-loop finalize) is covered without touching each one.

**Declared narrowness.** This does not sweep the whole error surface, and the leftovers below are tracked in #9878, not widened here. Nothing touching access, permissions, credentials or redaction was changed.

- Other unguarded presentation calls in the SAME handler loop -- `slack.set_thread_status`, `slack.stop_stream`, `_append_stream`/`_rotate_stream` -- safe today only because the real `SlackClient` swallows internally; a non-swallowing client would reach the same catch-all through them.
- The TRANSPORT path's twin of the exact call fixed here: `SlackRenderer._append_task` (`src/kiro_crew/slack/renderer.py` ~693-707) propagates and is called unguarded from `on_tool_call` (`src/kiro_crew/slack/renderer.py:918`) before any text streams, landing in the transport catch-all that posts a terminal error at `src/kiro_crew/slack/transport_dispatch.py:982`. It is a separate SURFACE, not another call site of the helper hardened here: its own renderer method, its own catch-all, its own transport-path message -- so it needs its own fix and test.

## Tests

Reproduction is not available: Slack is excluded from the pipeline's pod environment by construction (`build_pod_env` scrubs the Slack variables). The evidence is a unit test that drives `handle_message` with a tool-first event stream and a Slack client whose `append_task` raises like a rate limit, and asserts the placeholder is **not** replaced with a terminal error while the turn is live.

New test `test/test_slack_handler.py::TestLiveTurnPresentationFailure::test_progress_card_raise_does_not_render_terminal_error` asserts: no `record_failure`, the "Something went wrong" string is never posted on any surface, the real reply (`The answer is 42`) still reaches the user, and the turn records success.

Verified it fails before the change and passes after (stashed only the handler edit, kept the test):

```
timeout 900 python3 -m pytest -n0 test/test_slack_handler.py::TestLiveTurnPresentationFailure -x -q   # FAILS on unfixed handler, PASSES with fix
timeout 900 python3 -m pytest -n0 test/test_slack_handler.py -q                                       # 189 passed
timeout 900 python3 -m pytest -n0 test/test_slack_handler_coverage.py -q                              # 232 passed
```


One rider in the diff beyond the fix: a comment rewrite in the unrelated channels-policy test `test_channels_deny_drops_slack_inbound` and a one-line decrement in `comment-history-baseline.json`, both required by the repo's comment-history gate, which rejects change-history narration in comments and ratchets the baseline down when narration is removed.

## Manual verification

Not possible -- Slack credentials are scrubbed from the pod environment, so the live symptom cannot be exercised here. Broad coverage comes from CI.

## Pattern harvest

Rule candidate: a per-turn streaming loop that decorates a reply with cosmetic side-channel calls (progress cards, thread status, stream frames) must not let those calls reach a turn-fatal catch-all. Harden them at a single best-effort chokepoint (swallow + log), and when a lazily-created placeholder can now legitimately be absent, represent that as a falsy value the existing downstream guards already handle -- never a truthy sentinel borrowed from another mode, which routes an edit at a message that does not exist and loses the reply silently. Drop the assert instead of feeding it a magic value.

## Related Issues

Fixes #9730

Refs #9878


