### PR TITLE
fix(frontend): refetch model list when the agent backend is switched

### DIFF
--- a/website/src/pages/developer/AgentBackendTab.tsx
+++ b/website/src/pages/developer/AgentBackendTab.tsx
@@ -8,6 +8,7 @@ import ErrorNotice from '../../components/ErrorNotice'
 import { SettingsCard, SettingsButtonGroup } from '../../components/settings'
 import { useConfigSchema } from '../../components/settingRef/useConfigSchema'
 import { i18nT } from '../../i18n/t'
+import { clearCachedModels } from '../../providers/adapters/acp'
 
 /** The config field the switch owns. Also the schema path the options are gated on. */
 const CONFIG_KEY = 'agent.acp_backend'
@@ -167,6 +168,25 @@ export function AgentBackendTab() {
     onSuccess: () => {
       setSaveError('')
       qc.invalidateQueries({ queryKey: ['kirocrewConfig'] })
+      // The model list is the NEW backend's now. `/api/models` re-reads
+      // `agent.acp_backend` on every call, so the server side needs no restart;
+      // only the frontend cache did, because `['available-models']` is refetched
+      // in exactly one other place — a spawned session (`useWebSocket`'s
+      // `activity_event`) — and the global `staleTime: Infinity` plus the
+      // self-heal poll stopping after one live success mean nothing else ever
+      // re-asks. That is why the picker looked like it needed a gateway restart:
+      // the restart was just the next session spawn.
+      //
+      // `resetQueries`, not `invalidateQueries`: invalidate keeps the OLD
+      // backend's rows on screen until the refetch lands, and a cold
+      // `--list-models` spawn can take the gateway's full 10s. A pick in that
+      // window writes an id the new backend rejects. Reset drops the data to
+      // `undefined` first, so every picker shows the auto-only placeholder for
+      // those seconds, then refetches. Drop the last-good localStorage list
+      // FIRST for the same reason: a failing first fetch must degrade to
+      // auto-only, not to the old backend's ids.
+      clearCachedModels()
+      qc.resetQueries({ queryKey: ['available-models'] })
     },
     // No optimistic write and no local mirror of the value: the button group reads
     // straight from the query, so a rejected PATCH needs no revert — the cache was
@@ -482,7 +502,12 @@ export function AgentBackendTab() {
             disabled: disabledOption(value),
             describedById: statusId(value),
           }))}
-          onChange={v => patchMut.mutate(v)}
+          // `SettingsButtonGroup` fires for the pressed option too, and a PATCH
+          // that writes the value already stored still resolves successfully —
+          // which would run `onSuccess` and reset the model list, blanking every
+          // picker and spawning `--list-models` for a backend that did not
+          // change. Only a real change is a save.
+          onChange={v => { if (v !== current) patchMut.mutate(v) }}
         />
         {/* One line per agent the panel offers — the reader is choosing BETWEEN them,
             so showing only the selected one's status would hide the very comparison

--- a/website/src/providers/adapters/acp.ts
+++ b/website/src/providers/adapters/acp.ts
@@ -97,6 +97,22 @@ function readCachedModels(): ModelInfo[] | null {
  *  it. */
 for (const m of readCachedModels() ?? []) learnWindow(m.name, m.contextWindow ?? 0)
 
+/** Drop the last-good list. Called when `agent.acp_backend` changes: the cache
+ *  is keyed by nothing but time, so after a switch it still holds the PREVIOUS
+ *  backend's ids. If the new backend's first `/api/models` then fails (a cold
+ *  `--list-models` spawn past the gateway timeout is the common case), the
+ *  degraded path would serve that list and the picker would offer ids the new
+ *  backend rejects. Dropping it makes the degraded answer auto-only, which every
+ *  backend accepts, until the first live success rewrites the cache. */
+export function clearCachedModels(): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    localStorage.removeItem(MODELS_CACHE_KEY)
+  } catch {
+    /* storage disabled — nothing to drop */
+  }
+}
+
 /** Persist a live model list with a timestamp. Best-effort — storage errors
  *  (quota, disabled, SSR) are swallowed so caching never breaks the picker. */
 function writeCachedModels(models: ModelInfo[]): void {

--- a/website/src/test/AcpAdapter.models.test.ts
+++ b/website/src/test/AcpAdapter.models.test.ts
@@ -9,7 +9,7 @@ vi.mock('../api/client', () => ({
 }))
 
 import { api } from '../api/client'
-import { AcpAdapter } from '../providers/adapters/acp'
+import { AcpAdapter, clearCachedModels } from '../providers/adapters/acp'
 import {
   markModelsDegraded,
   modelsDegraded,
@@ -108,6 +108,24 @@ describe('AcpAdapter.fetchAvailableModels', () => {
   it('falls back to auto-only when the API throws and there is no cache', async () => {
     ;(api.models as ModelsMock).mockRejectedValue(new Error('503'))
     const models = await new AcpAdapter().fetchAvailableModels()
+    expect(models).toHaveLength(1)
+    expect(models[0].name).toBe('auto')
+  })
+
+  it('clearCachedModels drops the last-good list so a failing fetch degrades to auto-only', async () => {
+    // A backend switch: the cache holds the OLD backend's ids. After the drop,
+    // a failing first fetch on the new backend must not resurrect them.
+    ;(api.models as ModelsMock).mockResolvedValueOnce([
+      { model_name: 'auto', description: 'a' },
+      { model_name: 'claude-opus-4.8', description: 'b' },
+    ])
+    const adapter = new AcpAdapter()
+    await adapter.fetchAvailableModels()
+    expect(localStorage.getItem('kc.acp.models.v1')).not.toBeNull()
+    clearCachedModels()
+    expect(localStorage.getItem('kc.acp.models.v1')).toBeNull()
+    ;(api.models as ModelsMock).mockRejectedValue(new Error('503'))
+    const models = await adapter.fetchAvailableModels()
     expect(models).toHaveLength(1)
     expect(models[0].name).toBe('auto')
   })

--- a/website/src/test/AgentBackendTab.test.tsx
+++ b/website/src/test/AgentBackendTab.test.tsx
@@ -68,18 +68,24 @@ function probeRow(
   }
 }
 
-function wrap() {
+function wrapWithClient() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={qc}>
       <AgentBackendTab />
     </QueryClientProvider>,
   )
+  return { qc }
+}
+
+function wrap() {
+  wrapWithClient()
 }
 
 const button = (name: string) => screen.getByRole('button', { name })
 
 beforeEach(() => {
+  localStorage.clear()
   patchConfigMock.mockClear()
   patchConfigMock.mockResolvedValue({})
   kirocrewConfigMock.mockClear()
@@ -144,6 +150,57 @@ describe('AgentBackendTab', () => {
     wrap()
     fireEvent.click(await screen.findByRole('button', { name: 'KAS (kiro-agent)' }))
     await waitFor(() => expect(patchConfigMock).toHaveBeenCalledWith('agent.acp_backend', 'kas'))
+  })
+
+  it('re-clicking the already-selected backend saves nothing and leaves the model list alone', async () => {
+    // The chip group fires onChange for the pressed option as well, and a PATCH
+    // writing the current value would still succeed -- which would reset the
+    // model list and spawn `--list-models` for a backend that never changed.
+    localStorage.setItem('kc.acp.models.v1', JSON.stringify({ ts: Date.now(), models: [{ name: 'auto', description: '' }] }))
+    const { qc } = wrapWithClient()
+    qc.setQueryData(['available-models', 'acp'], [{ name: 'auto' }, { name: 'kiro-model' }])
+    const reset = vi.spyOn(qc, 'resetQueries')
+    fireEvent.click(await screen.findByRole('button', { name: 'Kiro CLI' }))
+    await waitFor(() => expect(button('Kiro CLI')).toHaveAttribute('aria-pressed', 'true'))
+    expect(patchConfigMock).not.toHaveBeenCalled()
+    expect(reset).not.toHaveBeenCalled()
+    expect(qc.getQueryData(['available-models', 'acp'])).toHaveLength(2)
+    expect(localStorage.getItem('kc.acp.models.v1')).not.toBeNull()
+  })
+
+  it('resets the model list and drops its localStorage cache after a switch', async () => {
+    // The picker's list belongs to the OLD backend until something re-asks
+    // `/api/models`, and nothing but a session spawn does -- so without this the
+    // list only changed after a gateway restart. RESET, not invalidate: the old
+    // rows must leave the screen before the refetch lands, or a pick during a
+    // slow `--list-models` spawn writes an id the new backend rejects. The cache
+    // drop keeps a failing first fetch from serving the old backend's ids.
+    localStorage.setItem('kc.acp.models.v1', JSON.stringify({ ts: Date.now(), models: [{ name: 'auto', description: '' }] }))
+    const { qc } = wrapWithClient()
+    qc.setQueryData(['available-models', 'acp'], [{ name: 'auto' }, { name: 'old-backend-model' }])
+    const reset = vi.spyOn(qc, 'resetQueries')
+    fireEvent.click(await screen.findByRole('button', { name: 'KAS (kiro-agent)' }))
+    await waitFor(() => expect(patchConfigMock).toHaveBeenCalledWith('agent.acp_backend', 'kas'))
+    await waitFor(() => expect(reset).toHaveBeenCalledWith({ queryKey: ['available-models'] }))
+    // The old rows are gone the moment the switch saves, not after a refetch.
+    expect(qc.getQueryData(['available-models', 'acp'])).toBeUndefined()
+    expect(localStorage.getItem('kc.acp.models.v1')).toBeNull()
+  })
+
+  it('leaves the model list alone when the save is rejected', async () => {
+    // A refused PATCH means the backend did NOT change; refetching would spawn
+    // `--list-models` for nothing, and dropping the cache would throw away a
+    // list that is still correct.
+    patchConfigMock.mockRejectedValueOnce(new Error('403'))
+    localStorage.setItem('kc.acp.models.v1', JSON.stringify({ ts: Date.now(), models: [{ name: 'auto', description: '' }] }))
+    const { qc } = wrapWithClient()
+    qc.setQueryData(['available-models', 'acp'], [{ name: 'auto' }, { name: 'still-valid-model' }])
+    const reset = vi.spyOn(qc, 'resetQueries')
+    fireEvent.click(await screen.findByRole('button', { name: 'KAS (kiro-agent)' }))
+    await screen.findByText('Could not save the agent backend.')
+    expect(reset).not.toHaveBeenCalled()
+    expect(qc.getQueryData(['available-models', 'acp'])).toHaveLength(2)
+    expect(localStorage.getItem('kc.acp.models.v1')).not.toBeNull()
   })
 
   it('hides a backend the deployment may not select, rather than dimming it', async () => {


### PR DESCRIPTION
## Problem / Motivation

Switch the agent backend in Developer > Agent Backend. Every model picker keeps showing the old backend's models. Only a gateway restart made them change.

## Why it matters

The picker offers models the new backend does not serve. A pick fails the next turn with a model-not-available error. The user learns the wrong lesson: "you must restart after switching". The server never needed the restart.

## What changed (motivation → approach → change)

`GET /api/models` reads `agent.acp_backend` fresh on every call, so the stale part is the frontend cache. The `['available-models']` query is refetched in exactly one other place: a spawned session (`useWebSocket`'s `activity_event` with `spawned: true`). The app's global `staleTime: Infinity` and the self-heal poll that stops after one live success mean nothing else ever asks again. A restart spawns a new session. That is the whole reason it looked required.

A real change to `agent.acp_backend` now resets the shared query. `AgentBackendTab` calls `resetQueries({ queryKey: ['available-models'] })` after the save lands, so every picker drops the old rows at once and refetches. Reset rather than invalidate: invalidate keeps the old rows on screen until the refetch returns, and a cold `--list-models` spawn can take the gateway's full 10s — a pick in that window writes an id the new backend rejects. Two clicks do nothing at all: re-clicking the pressed chip is not a save, and a rejected PATCH leaves the list alone, because in both cases the backend did not change and `/api/models` spawns `kiro chat --list-models`.

`clearCachedModels()` runs first, dropping the adapter's `kc.acp.models.v1` entry. That last-good list is keyed by time alone, so after a switch it still holds the old backend's ids, and the adapter serves it whenever a fetch fails. With it gone the degraded answer is auto-only, which every backend accepts, until the first live success rewrites it.

```mermaid
flowchart LR
  subgraph Before
    S1[save backend]:::ctx --> C1[config query invalidated]:::ctx
    S1 -.-> X1[model list untouched]:::removed --> R1[stale until session spawn]:::removed
  end
  subgraph After
    S2[save backend]:::ctx --> C2[config query invalidated]:::ctx
    S2 --> D2[drop localStorage list]:::added --> Q2[reset model query]:::added --> F2[refetch for new backend]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 1,2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 4,5,6 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟥 removed · 🟦 unchanged

*Saving a backend now clears the model list and asks the new backend for its own, instead of leaving the old one on screen.*

## Tests

- `AgentBackendTab.test.tsx`: a real switch resets the query and drops the localStorage entry, with the old rows gone before any refetch; a rejected save does neither; re-clicking the already-selected chip sends no PATCH at all.
- `AcpAdapter.models.test.ts`: `clearCachedModels` makes a failing fetch degrade to auto-only rather than to the stale list.

Each new assertion was mutation-checked: restoring `invalidateQueries`, dropping the cache clear, or removing the `v !== current` guard each fails its own test.

## Manual verification

N/A — unit coverage sufficient. Every observable effect (query reset, cache key removed, PATCH suppressed) is asserted directly against the query client, localStorage, and the API mock.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no pixel changes. The Agent Backend tab renders identically; what changed is which data the model pickers hold after a save.

## Related Issues

no linked issue: found while switching backends by hand, not tracked.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a mutation invalidates its own query key but not the dependent endpoint's, under a global `staleTime: Infinity`

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
