### PR TITLE
chore(apps): strip history narration from comments

### DIFF
--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -2915,7 +2915,7 @@ def _health_check_loop(ap: AppProcess, health_path: str) -> AppProcess | None:
     probed. Deriving both from the record leaves nothing to disagree.
 
     Returns the record if this call promoted it to healthy, else None (never answered, or
-    no longer the tracked entry).
+    not the tracked entry).
     """
     app_name = ap.app_name
     port = ap.port
@@ -3009,7 +3009,7 @@ def _watch_backend_health(ap: AppProcess, health_path: str) -> None:
             )
             with _lock:
                 if _processes.get(ap.app_name) is not ap:
-                    return  # no longer tracked — nothing left to watch
+                    return  # not the tracked record — nothing left to watch
 
 
 def _watch_backend_health_sweeps(ap: AppProcess, health_path: str) -> None:
@@ -3031,9 +3031,9 @@ def _watch_backend_health_sweeps(ap: AppProcess, health_path: str) -> None:
     and stays REVERSIBLE — the watch keeps running and re-promotes on the next success,
     which is what lets an app that wedged briefly heal without operator action.
 
-    Exits when the record is no longer the tracked one for its app: ``stop_app_backend``
+    Exits when the record stops being the tracked one for its app: ``stop_app_backend``
     pops it and a restart replaces it, so this needs no separate teardown — the same
-    "no longer tracked" guard the startup poll already uses.
+    "not the tracked record" guard the startup poll uses.
     """
     consecutive_failures = 0
     while True:
@@ -3220,7 +3220,7 @@ def _set_backend_health(ap: AppProcess, *, healthy: bool) -> bool:
     """
     with _health_reconcile_lock:
         # IDENTITY FIRST. The undo below deregisters by app NAME, so running it for a
-        # record that is no longer the tracked one would delete the SUCCESSOR's
+        # record that is not the tracked one would delete the SUCCESSOR's
         # resources — and an unreadable enabled state is exactly the case that would
         # send a retired watcher down that path.
         with _lock:
@@ -3370,7 +3370,7 @@ def _pidfile_path() -> Path:
 def _proc_start_time(pid: int) -> str | None:
     """Stable per-process start time, or None if unavailable.
 
-    PID-reuse guard: a recorded pid whose live start_time no longer matches has
+    PID-reuse guard: a recorded pid whose live start_time does not match has
     been recycled to an unrelated process and MUST NOT be killed. The value must
     be stable across gateway restarts (the reap compares a string recorded by a
     prior generation against one read now), so it cannot use ``hash()`` — that

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -74,8 +74,8 @@ logger = logging.getLogger(__name__)
 # Resolved per call, never captured at import: an import-time binding freezes
 # the data home and defeats pod isolation, the lazy legacy-home migration and
 # test isolation. The name below is an opt-in override (None = live home) so
-# existing monkeypatch call sites keep working. See config.md "Data Home" and
-# issue #874; dashboard/handlers/usage.py is the reference implementation.
+# existing monkeypatch call sites keep working. See config.md "Data Home";
+# dashboard/handlers/usage.py is the reference implementation.
 KIRO_AGENTS_DIR: Path | None = None
 
 
@@ -432,7 +432,7 @@ def _apply_agent_mcp_policy(
             continue
         merged = {**base, **spec}
         merged.pop("neutralized", None)
-        merged.pop("disabled", None)  # a grant un-disables a previously denied server
+        merged.pop("disabled", None)  # a grant un-disables a denied server
         # `mountOnly` (set by a policy for a built-in grant) means: mount the
         # server so the tool is visible, but keep it OFF allowedTools no matter
         # what the ceiling says, so every call routes through the approval gate
@@ -934,7 +934,7 @@ def _register_agents(
     dispatchable: set[str] = set()
     # Held across the whole materialization, not just the writes: each agent COPIES the
     # ambient server spec, so a read taken before a health scrub and a write landing
-    # after it would leave the agent naming a server that no longer exists. The read and
+    # after it would leave the agent naming a server that does not exist. The read and
     # the write have to be inside the same critical section as the transition they race.
     #
     # Kept INLINE rather than delegated to a helper: the governed-auto-approve strip
@@ -1081,14 +1081,13 @@ def _register_agents(
             # would be answered by the wrong agent.
             publish_materialized_agents(dispatchable)
         # Reconcile the whole directory UNCONDITIONALLY, even when this call wrote
-        # nothing: a re-registration whose manifest no longer declares an agent (or
+        # nothing: a re-registration whose manifest does not declare an agent (or
         # that follows a prune) leaves the removed name in the snapshot, and only a
         # rescan drops it. A name that is dispatchable in memory but gone from disk is
-        # the same invisible mismatch as the bug this change fixes — kiro-cli cannot
-        # load it and falls back to its own default. `_register_agents` runs ON the
-        # loop for the dashboard enable/update handlers (see the prune note in
-        # `register_app`), so the scan goes to an executor rather than walking every
-        # agent file inline.
+        # an invisible mismatch — kiro-cli cannot load it and falls back to its own
+        # default. `_register_agents` runs ON the loop for the dashboard enable/update
+        # handlers (see the prune note in `register_app`), so the scan goes to an
+        # executor rather than walking every agent file inline.
         schedule_materialized_agents_refresh()
 
         return registered
@@ -1232,12 +1231,11 @@ def _deregister_skills(app_name: str) -> int:
     Removes **only what registration created** — the symlinks, and the directory
     itself once it holds nothing else. It must NOT ``rmtree`` unconditionally: when a
     PACKAGED builtin skill shares the app's name, ``skills/<app_name>/`` is that
-    skill's real directory, not an app-owned link farm. Blowing it away deleted a
+    skill's real directory, not an app-owned link farm. Blowing it away deletes a
     shipped skill and every SOP under it, leaving the app's cron prompts pointing at
-    files that no longer existed — silently, since a missing skill file is not an
-    error anywhere. Hit for real by ops-mission-control, whose skill ships under
-    ``builtin_skills/`` because a builtin app's own directory is never copied into
-    the data home.
+    missing files — silently, since a missing skill file is not an error anywhere.
+    Real case: ops-mission-control, whose skill ships under ``builtin_skills/``
+    because a builtin app's own directory is never copied into the data home.
     """
     skills_root = _skills_dir()
     app_skills_dir = skills_root / app_name
@@ -1343,7 +1341,7 @@ def reconcile_app_skills(app_name: str) -> list[str]:
     # _register_skills is already idempotent (overwrites existing symlinks)
     registered = _register_skills(app_name, manifest, app_root)
 
-    # Clean stale links: skills present as symlinks but no longer in manifest
+    # Clean stale links: skills present as symlinks but absent from the manifest
     skills_root = _skills_dir()
     app_skills_dir = skills_root / app_name
     if app_skills_dir.is_dir():
@@ -3210,11 +3208,11 @@ def refresh_app_agents(app_name: str, io_failures: list[str] | None = None) -> l
 def reconcile_enabled_app_resources() -> dict[str, int]:
     """Re-register resources for every ENABLED gateway-managed app.
 
-    Called once at gateway startup.  Registration used to happen ONLY in the
-    enable path, so an app that gained agents/skills in a later version never
-    registered them for a user who had already enabled it — silently, because a
-    missing resource only logs a warning.  Reconciling at boot makes the on-disk
-    state a function of the current manifests instead of of install history.
+    Called once at gateway startup.  Registering ONLY in the enable path would
+    leave an app that gains agents/skills in a later version unregistered for a
+    user who has already enabled it — silently, because a missing resource only
+    logs a warning.  Reconciling at boot makes the on-disk state a function of
+    the current manifests rather than of install history.
 
     Idempotent: agent configs are rewritten from their template, skills/crons/MCP
     registration already overwrite in place.  Apps with ``resources="app"`` are

--- a/src/kiro_crew/apps/builtins/__init__.py
+++ b/src/kiro_crew/apps/builtins/__init__.py
@@ -24,7 +24,7 @@ BUILTIN_NAMES: list[str] = [
 _MIGRATED_BUILTINS: list[str] = [
     "deploy-web",
     "deploy_web",
-    # The auto-triage pipeline is no longer an app: it is one of Issue Radar's
+    # The auto-triage pipeline is not an app: it is one of Issue Radar's
     # dashboards. Dropping it from BUILTIN_NAMES stops it being REGISTERED, but an
     # install that already has it keeps the directory and its installed.json
     # entry -- leaving an App Store card for an app with no manifest behind it,

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
@@ -191,13 +191,12 @@ def _origin_urls(repo: Path, *, push: bool) -> list[str] | None:
     executed, identified by the launcher's own stderr signature. This module
     spawns git directly, so no launcher exists in this probe's chain on a
     stock install — the signature appears only on deployments that route the
-    gateway's subprocesses through the sandbox (the issue #8151 host, where
-    every ``git remote get-url`` probe carried the launcher's traceback), and
-    the classification is inert everywhere else because the structural
-    matching in :func:`_launcher_failure_detail` cannot be satisfied by git's
-    own output. Collapsing that crash into the fail-closed path reported
-    "push is not disabled" for a clone whose remotes were never read — the
-    misleading 409 in issue #8151.
+    gateway's subprocesses through the sandbox, where every ``git remote
+    get-url`` probe carries the launcher's traceback, and the classification is
+    inert everywhere else because the structural matching in
+    :func:`_launcher_failure_detail` cannot be satisfied by git's own output.
+    Collapsing that crash into the fail-closed path would report "push is not
+    disabled" for a clone whose remotes were never read — a misleading 409.
     """
     key = "remote.origin.pushurl" if push else "remote.origin.url"
     try:
@@ -240,7 +239,7 @@ def _repository_is_safe(repo: Path) -> bool:
     unsafe-keys probe's sandbox launcher died before git executed — a crashed
     launcher exits 1, indistinguishable from git's own "no unsafe keys", so
     reading the exit code alone would report an unscanned config as safe (the
-    one probe in the isolation chain that failed OPEN, issue #8493).
+    one probe in the isolation chain that would otherwise fail OPEN).
     """
     git_dir = repo / ".git"
     if first_linked_ancestor(git_dir) or is_link_or_junction(git_dir):
@@ -326,11 +325,11 @@ def _repository_is_safe(repo: Path) -> bool:
         # Exit 1 means "no unsafe keys" only when git itself ran. A sandbox
         # launcher that dies before git executes also exits 1, so reading the
         # exit code alone makes this the one probe in the isolation chain that
-        # fails OPEN during a launcher outage (issue #8493): metadata unsafety
+        # fails OPEN during a launcher outage: metadata unsafety
         # becomes invisible exactly when the host cannot run the probes. Same
         # classifier as :func:`_origin_urls` — the structural stderr match is
         # what keeps git's own output unable to satisfy it, and the raise says
-        # "the probe could not run" instead of an isolation verdict (#8151).
+        # "the probe could not run" instead of an isolation verdict.
         detail = _launcher_failure_detail(proc.stderr or "")
         if detail is not None:
             raise IsolationProbeError(detail)
@@ -588,7 +587,7 @@ def _repository_is_isolated(repo: Path) -> bool:
     Fails CLOSED (``False``) for ambiguous git errors, but raises
     :class:`IsolationProbeError` when the probe's sandbox launcher crashed
     before git executed — that exit is not evidence about the remotes, and
-    reporting it as "push is not disabled" hid the real failure (#8151). Both
+    reporting it as "push is not disabled" would hide the real failure. Both
     outcomes refuse to start; only the surfaced reason differs.
     """
     return _repository_is_safe(repo) and _push_disabled(repo)
@@ -999,15 +998,12 @@ def resolve_origin_url(config: dict) -> str:
     Returns ``""`` when it does not validate, and every caller treats ``""`` as "no push
     target" — fail closed.
 
-    ``origin_url`` used to be returned VERBATIM while only the legacy fallback validated,
-    which made the docstring's own promise false for the preferred path. Measured:
-    ``{"origin_url": "https://attacker.example.com/exfil.git"}`` was returned unchanged and
-    became the push destination, while the identical string under ``target_url`` was
-    correctly refused ("Only github.com URLs are supported"). This is the one place the push
-    destination is resolved for the draft-PR push, the F10 direct push and one-click commit,
-    so an unvalidated value here redirects all three. Raised by the GPT review of this branch;
-    the security guidance on untrusted URL destinations asks for exactly this — allowlist the
-    destination rather than trusting persisted input.
+    ``origin_url`` must be validated on this path too, not returned VERBATIM: an
+    ``{"origin_url": "https://attacker.example.com/exfil.git"}`` that is passed through
+    unchanged becomes the push destination. This is the one place the push destination is
+    resolved for the draft-PR push, the F10 direct push and one-click commit, so an
+    unvalidated value here redirects all three — allowlist the destination rather than
+    trusting persisted input.
     """
     direct = str((config or {}).get("origin_url") or "").strip()
     if direct:
@@ -1202,7 +1198,7 @@ def checkout_branch(clone: Path, branch: str, *, timeout_s: int = 120) -> tuple[
         if co.returncode == 0:
             return True, f"checked out {bare} @ {remote_ref} (no fetch — origin is disabled)"
 
-    # Then a local branch, so a previously-fetched branch still runs offline.
+    # Then a local branch, so an already-fetched branch still runs offline.
     local = _run("rev-parse", "--verify", "--quiet", bare, tmo=30)
     if local.returncode == 0:
         co = _run("checkout", bare)

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/commit.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/commit.py
@@ -138,7 +138,7 @@ def materialize_queued_diff(
                 # Redact BEFORE the bound: git echoes the authenticated remote URL —
                 # userinfo and all — on an auth failure, and a slice can cut the
                 # credential mid-match into a fragment the downstream serving route's
-                # redaction pass no longer recognises.
+                # redaction pass does not recognise.
                 "error": (
                     f"could not fetch {branch}: " f"{redact_via_context(fetch.stderr or '')[:160]}"
                 ),
@@ -266,7 +266,7 @@ def _commit_finding_locked(fp: str) -> dict[str, object]:
             return {"ok": False, "error": "repository isolation check failed — re-run setup"}
     except IsolationProbeError as exc:
         # A crashed probe is a sandbox failure, not an isolation verdict — re-running
-        # setup cannot fix it, so surface the real reason instead (#8151).
+        # setup cannot fix it, so surface the real reason instead.
         return {"ok": False, "error": str(exc)}
 
     diff_text = diff_path.read_text(encoding="utf-8")
@@ -328,9 +328,8 @@ def _commit_finding_locked(fp: str) -> dict[str, object]:
     # rather than to an unguarded push.
 
     # Resolved from the SAME source `materialize_queued_diff` fetched through, so the base
-    # this commit sits on and the url it is pushed to cannot disagree. (It used to be one
-    # local variable shared by both steps; the fetch moved into the helper, so recompute it
-    # here from `config` rather than threading it back out.)
+    # this commit sits on and the url it is pushed to cannot disagree. (The fetch lives in
+    # that helper, so this is recomputed here from `config` rather than threaded back out.)
     configured_url = resolve_origin_url(config)
     remote_url = _prefer_authenticated_remote(configured_url) if configured_url else ""
     url = remote_url or _resolve_push_url(clone, _prefer_authenticated_remote)

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/ledger_admin.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/ledger_admin.py
@@ -12,11 +12,11 @@ These three operations are the escape hatch, and all three work by APPENDING a
 
     forget(fp)      the locus becomes re-discoverable; artifacts are left alone
     purge(fp)       same, and the fingerprint-addressed artifacts are deleted
-    purge_dead()    sweep every record that can no longer make progress
+    purge_dead()    sweep every record that cannot make progress
 
 WHY ``purged`` and not a delete: ``Ledger.known()`` returns False for
 :data:`STATUS_PURGED` (see ``spine/ledger.py``), so appending one event is exactly
-"the dedup layer no longer knows this locus" — the retry falls out of the existing
+"the dedup layer does not know this locus" — the retry falls out of the existing
 status machine instead of needing a second mechanism. Rewriting or truncating the
 file would also destroy the audit trail, which is the ledger's other job: the
 timeline view shows ``seen → failed_gate → purged`` and a reader can see that a
@@ -28,7 +28,7 @@ an event; an append cannot. The lock serializes read → decide → append here 
 requests cannot both conclude "no prior event" for one fingerprint. Readers tolerate
 a torn final line (a crash mid-append), so one bad tail never hides earlier entries.
 
-The on-disk field carrying the pull-request reference is historically named ``cr``.
+The on-disk field carrying the pull-request reference is named ``cr``.
 Both spellings are READ; the ledger event written here keeps ``cr`` because
 ``spine.ledger.LedgerEntry`` is a fixed-field dataclass that rejects an unknown key
 outright — an event written with ``pr`` is dropped by ``Ledger._load()``, which would
@@ -48,7 +48,7 @@ from typing import Any
 # The ONE process-wide lock that serializes read → decide → append against the ledger
 # file, SHARED with the loop's own filing writer: :meth:`spine.ledger.Ledger.record`
 # acquires the SAME object, so an operator forget / purge / manual-filed / commit here
-# cannot interleave with the loop's `record()` on the same file (#6716). It lives in the
+# cannot interleave with the loop's `record()` on the same file. It lives in the
 # stdlib-only leaf :mod:`spine.ledger_lock` precisely so both layers share one object
 # without this module pulling the spine engine (the driver / agent runner / PR pipeline).
 # Aliased to the historical name so the four `with _LEDGER_LOCK:` sites read unchanged.
@@ -407,7 +407,7 @@ def purge(fp: str, *, remove_artifacts: bool = True) -> dict[str, Any]:
 
 
 def purge_dead(*, remove_artifacts: bool = False) -> dict[str, Any]:
-    """Sweep every record that can no longer make progress.
+    """Sweep every record that cannot make progress.
 
     Housekeeping for the findings list: a run interrupted between "filed" and the
     reference being recorded leaves records that claim a pull request nobody can

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/mcp_server.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/mcp_server.py
@@ -323,12 +323,11 @@ def handle(request: dict[str, Any]) -> dict[str, Any] | None:
             return _error(req_id, _INVALID_PARAMS, f"invalid arguments: {_redact_error(str(exc))}")
         fn = entry[0]
         # Audit the DISPATCH before running the handler, so the record of "this tool was
-        # invoked" cannot be lost by whatever the handler does. Previously only the
-        # outcome was audited, all of it after `fn(args)` returned — so a handler that
-        # died hard (a killed process, an interpreter-level failure, anything that does
-        # not surface as an exception here) executed with no audit trail at all. The
-        # outcome events below still fire; this one makes the invocation itself
-        # unconditional. Raised by the GPT review of this branch.
+        # invoked" cannot be lost by whatever the handler does. Auditing only the outcome,
+        # after `fn(args)` returns, leaves a handler that dies hard (a killed process, an
+        # interpreter-level failure, anything that does not surface as an exception here)
+        # with no audit trail at all. The outcome events below still fire; this one makes
+        # the invocation itself unconditional.
         # AUDIT-OR-DENY. `critical=True` writes synchronously and re-raises on a
         # filesystem failure, so a call that cannot be recorded is REFUSED instead of
         # served untraced. No human is in this loop and the result goes to an LLM, so this
@@ -367,12 +366,11 @@ def handle(request: dict[str, Any]) -> dict[str, Any] | None:
         # finding's signature/hypothesis/note come from the model's own prose) and it is
         # handed to an LLM. This is the same class of text `routes._redact_for_display`
         # scans for the browser and `runner._redact_activity` scans for the feed; the MCP
-        # surface was the remaining reader. Measured before fixing: a credential in a
-        # ledger note came back verbatim in `list_findings`. Raised by review of this
-        # branch.
+        # surface is a reader of the same text, so without this pass a credential in a
+        # ledger note comes back verbatim in `list_findings`.
         #
         # Order matters — truncating first could split a credential across the cut and
-        # leave a fragment the scanner no longer recognizes.
+        # leave a fragment the scanner does not recognize.
         text = _redact_result(json.dumps(payload, default=str))[:_MAX_RESULT_CHARS]
         return _result(req_id, {"content": [{"type": "text", "text": text}]})
     return _error(req_id, _METHOD_NOT_FOUND, f"unknown method: {method}")

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/pr_checks.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/pr_checks.py
@@ -11,10 +11,9 @@ allowlist. This module is a thin, app-specific *interpreter* on top of it.
 
 What it adds over the raw provider payload is the single question the watcher
 loop needs answered: **is this PR done, does it need work, or is it blocked?**
-That verdict was previously parsed out of an LLM's free-text reply, which made
-the loop's control flow depend on prose. Here it is computed from structured
-provider fields instead, and the agent is only asked to *act*, never to report
-state.
+That verdict is computed from structured provider fields rather than parsed out
+of an LLM's free-text reply, so the loop's control flow does not depend on prose,
+and the agent is only asked to *act*, never to report state.
 
 Mergeability vocabulary (GitHub, via the provider's own normalization):
   ``mergeable``   — no conflicts; ``conflicting`` — needs a rebase;

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/pr_watchers.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/pr_watchers.py
@@ -1387,7 +1387,7 @@ def _delete_clone_if_unowned(reg: PRWatcherRegistry, child: Path) -> bool:
 
 
 def sweep_orphan_clones(*, clones_root: str | None = None) -> int:
-    """Delete per-PR watcher clones whose watcher is no longer live. Returns the count.
+    """Delete per-PR watcher clones whose watcher is not live. Returns the count.
 
     A watcher removes its own clone on a clean exit, but a crash, a SIGKILL, or a gateway
     restart mid-run leaves it behind — and each is a full repo checkout, so they
@@ -1471,12 +1471,11 @@ def _work_items(status: dict[str, Any]) -> list[str]:
 def _redact(text: str) -> str:
     """Credential/exfiltration redaction for a watcher log line. FAIL-CLOSED.
 
-    This used to fail OPEN so "redaction must never be the reason a watcher stops logging".
-    The concern was right but the remedy leaked: `GET /watchers/{fp}/log` serves these lines
-    straight to the browser with NO second redaction pass, so this is the only scan standing
-    between agent/CI output and the operator's screen — the same boundary
-    `routes._redact_for_display` fails closed on. Fixed alongside the identical gap in
-    `runner._redact_activity`, which the GPT review of this branch raised.
+    Failing OPEN would honour "redaction must never be the reason a watcher stops logging",
+    but it leaks: `GET /watchers/{fp}/log` serves these lines straight to the browser with NO
+    second redaction pass, so this is the only scan standing between agent/CI output and the
+    operator's screen — the same boundary `routes._redact_for_display` fails closed on.
+    `runner._redact_activity` guards the identical surface for the activity feed.
 
     Failing closed still does not stop the watcher logging: the LINE is replaced by a fixed
     placeholder, so the log keeps advancing and the operator sees activity, just not

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/progress.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/progress.py
@@ -46,7 +46,7 @@ def _coerce_float(value: Any) -> float | None:
 
     Load-bearing: a ``primary_delta`` of ``"n/a"``, ``"-"``, ``""`` or any other
     non-numeric string must read as *missing*, not raise. An unguarded ``float()``
-    here previously crashed the whole progress read on one bad row.
+    here crashes the whole progress read on one bad row.
     """
     try:
         return float(str(value).strip())
@@ -122,7 +122,7 @@ def _archive_rows() -> list[dict[str, Any]]:
 def read_findings() -> list[dict[str, Any]]:
     """Ledger entries, newest first, with the PR reference normalized.
 
-    The on-disk field is historically named ``cr``; both keys are read and the
+    The on-disk field is named ``cr``; both keys are read and the
     result always carries ``pr`` so every consumer speaks one vocabulary.
     """
     path = store.ledger_path()

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
@@ -359,12 +359,12 @@ async def _handle_setup_clone(request: web.Request) -> web.StreamResponse:
     def _clone() -> tuple[dict, str]:
         return clone_setup.setup_safe_clone(url, store.scratch_path())
 
-    # `result` is a PARAMETER, not a closure read. It used to be a free variable of this
-    # handler, which broke the moment clone+persist moved inside `_clone_and_persist` to take
-    # the lock: that inner function binds its own local `result`, so the outer cell stayed
-    # empty and every successful setup raised `NameError` (a 500, with the clone on disk and
-    # config.json never written — the app could not be set up at all). Passing it explicitly
-    # makes the dependency visible instead of scope-dependent. Raised by the Opus 5 review.
+    # `result` is a PARAMETER, not a closure read. clone+persist live inside
+    # `_clone_and_persist` so they hold the lock, and that inner function binds its own local
+    # `result` — read as a free variable of this handler, the outer cell stays empty and every
+    # successful setup raises `NameError` (a 500, with the clone on disk and config.json never
+    # written, so the app cannot be set up at all). Passing it explicitly makes the dependency
+    # visible instead of scope-dependent.
     def _persist(result: dict) -> dict[str, Any]:
         current = store.read_json(store.config_path(), {}) or {}
         retargeted = str(current.get("target_url") or "") != url
@@ -634,7 +634,7 @@ async def _handle_finding_detail(request: web.Request) -> web.StreamResponse:
             "status": latest.get("status") or "",
             "note": latest.get("note") or "",
             "ts": latest.get("ts"),
-            # The ledger's field is historically named ``cr``; expose it as ``pr``
+            # The ledger's field is named ``cr``; expose it as ``pr``
             # so the UI speaks one vocabulary, and keep the raw key readable.
             "pr": latest.get("pr") or latest.get("cr") or "",
             "history": history,
@@ -801,7 +801,7 @@ async def _handle_draft_pr(request: web.Request) -> web.StreamResponse:
         try:
             isolated = clone_setup._repository_is_isolated(Path(clone))
         except clone_setup.IsolationProbeError as exc:
-            # Sandbox failure, not an isolation verdict — name it (#8151).
+            # Sandbox failure, not an isolation verdict — name it as such.
             return {"ok": False, "error": str(exc)}
         if not isolated:
             return {"ok": False, "error": "repository isolation check failed — re-run setup"}
@@ -1390,7 +1390,7 @@ async def _handle_run_start(_request: web.Request) -> web.StreamResponse:
         # Before the generic clause: this subclasses RuntimeError, but it is a
         # sandbox-launcher failure, not a config/state conflict — a distinct
         # `code` so a UI branching on it does not render the misleading
-        # push-isolation guidance (#8151). The message is the actionable part.
+        # push-isolation guidance. The message is the actionable part.
         return web.json_response(
             {"code": "sandbox_launcher_failed", "error": str(exc)}, status=409
         )

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
@@ -152,7 +152,7 @@ class RunState:
     #:
     #: Carried per-run rather than on the supervisor because it decides this run's TERMINAL
     #: STATUS: an offline run's discovery early-returns an empty candidate list, so the loop
-    #: quiesces and ``driver.run()`` returns cleanly, and a clean return used to be reported
+    #: quiesces and ``driver.run()`` returns cleanly — a clean return with no reason set reads
     #: as ``done``. Set from :meth:`RunSupervisor._build_runner` via :meth:`RunSupervisor.start`.
     offline_reason: str = ""
     #: Where THIS run's terminal record belongs, bound when the run started.
@@ -485,21 +485,17 @@ class RunSupervisor:
             # Register the tool-restricted discovery agent so kiro-cli resolves it by name.
             # FAIL CLOSED on the returned bool: an unknown agent name does not error, it
             # silently activates the DEFAULT agent — which carries the full kirocrew-core
-            # toolset including `spawn_sub_agents`. Ignoring this result meant an
-            # unwritable agent dir quietly widened an unattended agent's tool scope to
-            # everything, which is the opposite of what registering it is for. Raised by
-            # review of this branch.
+            # toolset including `spawn_sub_agents`. Ignoring this result lets an unwritable
+            # agent dir quietly widen an unattended agent's tool scope to everything, which
+            # is the opposite of what registering it is for.
             if not runner.ensure_agent_registered():
-                # OFFLINE, not the subprocess fallback. This used to fall through, which
-                # meant a configured provider whose agent registration failed silently
-                # downgraded to `claude -p` — bypassing the provider's own permission
-                # gate even though a provider EXISTED. Measured: with `available()` True
-                # and `ensure_agent_registered()` False, `_build_runner` returned
-                # `AgentRunner`. That is the substance of the review's long-standing
-                # "fallback bypasses the ACP gate" objection, and it is a real hole
-                # rather than the impossible case it looked like: the fallback is only
-                # defensible when there is NO provider to route through. Raised by the
-                # GPT review of this branch.
+                # OFFLINE, not the subprocess fallback. Falling through here lets a
+                # configured provider whose agent registration failed downgrade silently
+                # to `claude -p` — bypassing the provider's own permission gate even
+                # though a provider EXISTS. The hole is reachable, not theoretical:
+                # `available()` True with `ensure_agent_registered()` False is a state
+                # `_build_runner` sees here. The fallback is only defensible when there
+                # is NO provider to route through.
                 logger.warning(
                     "%s: could not register the tool-restricted agent — running OFFLINE "
                     "rather than falling back to the subprocess agent, because a provider "
@@ -514,10 +510,9 @@ class RunSupervisor:
                 return None
             self._offline_reason = ""
             return runner
-        # NO subprocess fallback. Review asked for this removal on every head, and after the
-        # two fall-through holes were closed the remaining objection turned out to be right on
-        # the facts: the fallback's stated purpose — "the only path that authors fixes when no
-        # in-process provider is configured" — describes a state that cannot occur.
+        # NO subprocess fallback. The fallback's stated purpose — "the only path that authors
+        # fixes when no in-process provider is configured" — describes a state that cannot
+        # occur.
         # `SessionAgentRunner.available()` is `cfg.create_provider_factory() is not None`, and
         # `create_provider_factory` has exactly two returns (`AcpProvider(...)` and `_acp`) and
         # NEVER returns None — verified by inspecting its source. So `available()` is False only
@@ -527,7 +522,7 @@ class RunSupervisor:
         # agent outside the provider's permission gate precisely when the platform is unhealthy.
         # Running OFFLINE (no fabricated fixes) is the honest outcome. Removing the selection
         # rather than the class keeps `AgentRunner` available for a future caller that can route
-        # it properly. Raised by the GPT review of this branch.
+        # it properly.
         logger.warning(
             "%s: no provider-backed agent runner available — running offline (the subprocess "
             "fallback is deliberately not used: it would bypass the provider permission gate)",
@@ -831,7 +826,7 @@ class RunSupervisor:
         UI reporting ``calibrating`` forever."""
         with self._lock:
             # The thread is RUNNING now, so `is_alive()` can carry the answer from here and the
-            # reservation is no longer needed. Released first so an early return or raise below
+            # reservation is not needed. Released first so an early return or raise below
             # cannot leave the supervisor permanently busy.
             self._reserved = False
         try:
@@ -922,15 +917,15 @@ class RunSupervisor:
                 self._note("running the canary (a known win must clear the band)")
                 canary = profile.ruler.measure_canary(base_src=clone)
                 observed = float(getattr(canary, "primary_delta", 0.0) or 0.0)
-                # Reuse the SPINE's predicate rather than re-deriving it. This used to be
-                # `abs(observed) > band`, which ignored both `canary.ok` and the ruler's improving
-                # DIRECTION — so `POST /calibrate` wrote `status="calibrated"` for two cases that
-                # prove the opposite. Measured against the spine's rule at band=10: a REGRESSION of
-                # +25 (minimize) passed, and a measurement with `ok=False` passed. A canary is the
+                # Reuse the SPINE's predicate rather than re-deriving it. A local
+                # `abs(observed) > band` ignores both `canary.ok` and the ruler's improving
+                # DIRECTION — so `POST /calibrate` writes `status="calibrated"` for two cases that
+                # prove the opposite: against the spine's rule at band=10, a REGRESSION of +25
+                # (minimize) clears, and so does a measurement with `ok=False`. A canary is the
                 # one measurement whose sign we know a priori, so direction-blindness here defeats
                 # the whole point of proving the ruler. `_canary_clears_band` already handles ok /
                 # None / direction and is what Phase-1 preflight uses; a second copy is exactly how
-                # these two drifted apart. Raised by the GPT review of this branch.
+                # the two drift apart.
                 from ..spine.preflight import _canary_clears_band
 
                 cleared = _canary_clears_band(
@@ -1134,7 +1129,7 @@ class RunSupervisor:
         kill the thread silently and leave the UI reporting ``running`` forever."""
         with self._lock:
             # The thread is RUNNING now, so `is_alive()` can carry the answer from here and the
-            # reservation is no longer needed. Released first so an early return or raise below
+            # reservation is not needed. Released first so an early return or raise below
             # cannot leave the supervisor permanently busy.
             self._reserved = False
         try:

--- a/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/pr_recipe.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/pr_recipe.py
@@ -101,15 +101,13 @@ def _redact_prose(text: str) -> str:
     rewritten, whereas redacting a code diff would corrupt the fix the gate proved
     (that content is DETECTED and refused instead — see ``_scan_pushable_content``).
 
-    FAILS CLOSED by raising :class:`ProseRedactionUnavailable`. This was previously
-    best-effort — it returned the text unscanned — on the reasoning that the diff beside
-    it had passed a fail-closed scan and the PR is only a draft. That reasoning does not
-    hold: the prose is a SEPARATE artifact from the diff, it is the part the agent wrote
-    most freely, and `gh pr create` publishes it to GitHub where a description cannot be
-    un-published (it persists in the API's edit history even after an edit). Every other
-    egress path in this app already fails closed for exactly this reason
-    (`mcp_server._redact_result`, `routes._redact_for_display`); this was the one that
-    did not. Raised by the GPT review of this branch.
+    FAILS CLOSED by raising :class:`ProseRedactionUnavailable`. Best-effort — returning
+    the text unscanned because the diff beside it passed a fail-closed scan and the PR is
+    only a draft — does not hold: the prose is a SEPARATE artifact from the diff, it is
+    the part the agent wrote most freely, and `gh pr create` publishes it to GitHub where
+    a description cannot be un-published (it persists in the API's edit history even
+    after an edit). Every other egress path in this app fails closed for exactly this
+    reason (`mcp_server._redact_result`, `routes._redact_for_display`).
 
     The caller degrades to the durable queue, so a verified fix is never lost — it waits
     on disk for a human instead of being published unscanned.
@@ -392,7 +390,7 @@ class GitHubPRRecipe:
             isolated = _repository_is_isolated(self.clone_path)
         except IsolationProbeError as exc:
             # Sandbox failure, not an isolation verdict — the note must not
-            # read as if the repository changed under review (#8151).
+            # read as if the repository changed under review.
             return False, str(exc)
         if not isolated:
             return False, "repository isolation changed after review"

--- a/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
@@ -211,7 +211,7 @@ _ADDABLE_TEST_GLOBS = (
 # ── shared helpers ───────────────────────────────────────────────────────────
 
 
-#: Directory names that hold a pytest suite. Used to locate the RUN ROOT, which is
+#: Directory names that hold a pytest suite. They locate the RUN ROOT, which is
 #: not always the directory the spine hands us — see :func:`_repo_root`.
 _TEST_DIRS = ("tests", "test")
 
@@ -468,7 +468,7 @@ def _xdist_argv() -> tuple[str, ...]:
 _XDIST_ARGV: tuple[str, ...] = _xdist_argv()
 
 #: Substrings that mean xdist itself failed to run, as opposed to tests failing.
-#: Used to retry the suite serially so the gate still gets a real verdict.
+#: They trigger a serial retry of the suite so the gate still gets a real verdict.
 _XDIST_FAILURE_MARKERS = (
     "unrecognized arguments: -n",
     "error: unrecognized arguments",
@@ -698,7 +698,7 @@ class SuiteRuler:
             "runner": self.benchmark_cmd or "python -m pytest -q",
             "timer": "time.perf_counter around the subprocess",
         }
-        #: Baseline medians captured during calibration, used to DERIVE the guardrail
+        #: Baseline medians captured during calibration; they DERIVE the guardrail
         #: tolerance the driver adopts (see :meth:`guardrail_tolerances`).
         self._baseline_median: float | None = None
         #: Duck-typed by the driver so a Stop click interrupts the calibration loop
@@ -1306,12 +1306,12 @@ class RepoEditAllowlist:
         # denylist — the BUG track's one carve-out, and only for additions. Modifying an
         # existing test always falls through to off_limits.
         #
-        # Gated on the track, which it previously was not: the class docstring promised "the
-        # perf track may not touch tests/** AT ALL" while the code granted the carve-out to
-        # both. That is the gaming the fence exists to stop — the RH guard compares collected
-        # test COUNTS, so adding one cheap test while an expensive one stops being collected
-        # keeps the count equal while measured suite time drops, and a purely artifactual
-        # "win" gets drafted as a real perf PR. Raised by the GPT review.
+        # Gated on the track: the class docstring promises "the perf track may not touch
+        # tests/** AT ALL", so granting the carve-out to both tracks is the gaming the
+        # fence exists to stop — the RH guard compares collected test COUNTS, so adding one
+        # cheap test while an expensive one stops being collected keeps the count equal
+        # while measured suite time drops, and a purely artifactual "win" gets drafted as a
+        # real perf PR.
         if added and self.track == TRACK_BUG and self._is_addable_test(path):
             return False
         if self._matches(path, self.off_limits):
@@ -1385,15 +1385,15 @@ class RepoIsolation:
         BOTH urls, not just the push url: a live FETCH url is a live push target
         (``git push "$(git remote get-url origin)" HEAD`` ignores the push url entirely
         and writes to the fetch url — see ``clone_setup._disable_push``). Checking only
-        the push url reported "disabled" for a clone that could still write to the remote;
-        `_ok` checks both, and this drifted from it. Raised by the GPT review of this branch.
+        the push url reports "disabled" for a clone that can still write to the remote;
+        `_ok` checks both, and this predicate must not drift from it.
 
         One nonzero probe exit is NOT read as a live remote: when the probe's own
         sandbox launcher crashed before git executed, this propagates
         ``clone_setup.IsolationProbeError`` instead of returning ``False``. The run
         still refuses to start either way — the exception exists so the surfaced
         reason names the sandbox failure rather than the misleading
-        "push is not disabled" (#8151).
+        "push is not disabled".
         """
 
         from ...backend.clone_setup import _repository_is_isolated
@@ -1493,26 +1493,25 @@ class GitHubRepoProfile(ProfileFieldAliases):
         #: narrowed to the change set this branch introduced.
         self.scope_base = (scope_base or "").strip()
         self._scope = scope_util.scoped_relpaths(self.clone_path, self.scope_base)
-        # `scoped_relpaths` used to return None for THREE different situations — a blank ref, a
-        # git FAILURE (bad/unresolvable ref), and a valid-but-EMPTY diff (base == HEAD) — and
-        # the caller could not tell them apart. Treating all three as "no scope" means a
-        # misconfigured `scopeDiffBase` silently widens the edit fence from "what this branch
-        # changed" to the WHOLE REPOSITORY, the opposite of what setting a scope is for.
+        # `scoped_relpaths` separates THREE situations a bare None would conflate — a blank
+        # ref, a git FAILURE (bad/unresolvable ref), and a valid-but-EMPTY diff
+        # (base == HEAD). Treating all three as "no scope" means a misconfigured
+        # `scopeDiffBase` silently widens the edit fence from "what this branch changed" to
+        # the WHOLE REPOSITORY, the opposite of what setting a scope is for.
         #
-        # Two fixes, in two review rounds. First: an unresolvable ref REFUSES here rather than
-        # running unscoped. Then the remaining hole — `scopeDiffBase=HEAD` RESOLVES fine and
-        # yields an empty diff, so it still fell through to unscoped. `scoped_relpaths` now
-        # returns `set()` for a successful-but-empty diff (None only for blank/error), and the
-        # allowlist checks `scope is not None`, so an empty scope enforces "no file may be
-        # edited" — a run that keeps nothing beats a run that may edit anything.
+        # So an unresolvable ref REFUSES here rather than running unscoped, and
+        # `scopeDiffBase=HEAD` — which RESOLVES fine and yields an empty diff — must not
+        # fall through to unscoped either: `scoped_relpaths` returns `set()` for a
+        # successful-but-empty diff (None only for blank/error), and the allowlist checks
+        # `scope is not None`, so an empty scope enforces "no file may be edited" — a run
+        # that keeps nothing beats a run that may edit anything.
         # The condition is simply "a scope was configured but could not be computed". The
-        # REASON is deliberately not consulted: this guard was previously gated on
-        # a ref-resolvability check, which only covered a base that does not exist. A base
-        # that RESOLVES but whose diff fails left `_scope is None` and nothing refused —
-        # reproduced with two unrelated histories, where `rev-parse --verify` succeeds while
-        # `diff <ref>...HEAD` exits 128 "no merge base". Third variant of one bug on this
-        # branch (unresolvable ref, empty diff, git error), so the guard now keys on the
-        # CONSEQUENCE rather than enumerating causes. Raised by the GPT review.
+        # REASON is deliberately not consulted: a ref-resolvability check covers only a base
+        # that does not exist, while a base that RESOLVES but whose diff FAILS leaves
+        # `_scope is None` with nothing refusing — two unrelated histories make
+        # `rev-parse --verify` succeed while `diff <ref>...HEAD` exits 128 "no merge base".
+        # Keying on the CONSEQUENCE covers all three causes (unresolvable ref, empty diff,
+        # git error) instead of enumerating them.
         if self.scope_base and self._scope is None:
             raise ValueError(
                 f"scopeDiffBase {self.scope_base!r} could not be resolved to a file set in "

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_discovery.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_discovery.py
@@ -36,7 +36,7 @@ When the run is diff-scoped (``scopeDiffBase`` set — e.g. dogfooding the app o
 feature branch), the agent is handed the CHANGED-FILE LIST plus each file's DEPENDENTS
 (callers), NOT a unified diff, and told to READ the files itself (it has Read/Grep/Glob).
 
-WHY NOT A DIFF (operator directive 2026-06-15 — "agent should not receive diff … it should
+WHY NOT A DIFF (operator directive — "agent should not receive diff … it should
 receive file list from diff and all dependencies which are using new functionality"): a
 branch that introduces a whole new subsystem produces a huge diff dominated by new-file
 boilerplate (``__init__`` headers, config) that, truncated to fit context, never reaches
@@ -139,9 +139,9 @@ def changed_py_files(clone: Path, base_ref: str) -> list[str]:
     huge diff dominated by new-file boilerplate (``__init__`` headers, config) that, once
     truncated to fit context, never reaches the logic-bearing modules — so the agent reads
     setup.cfg and finds nothing. Handing it the file list and letting it READ the actual
-    modules (and their callers) is what surfaces real defects (operator directive
-    2026-06-15: "agent should not receive diff — it should receive file list from diff and
-    all dependencies which are using new functionality")."""
+    modules (and their callers) is what surfaces real defects (operator directive:
+    "agent should not receive diff — it should receive file list from diff and all
+    dependencies which are using new functionality")."""
     if not base_ref:
         return []
     out = _git(["diff", "--name-only", f"{base_ref}...HEAD"], clone, timeout=120.0)
@@ -180,14 +180,14 @@ def allowlisted_py_files(clone: Path, globs: list[str]) -> list[str]:
 def prioritize_focus(files: list[str], *, cap: int | None = None, rotate: int = 0) -> list[str]:
     """ORDER changed files by testable-logic VALUE — high-value logic modules (spine engine,
     gate, ledger, parsing, calibration…) first, boilerplate/wiring (__init__, config, routes,
-    app/server) last — and return ALL of them (operator directive 2026-06-18: "do NOT limit
-    the search space; if anything, randomize before any cut — I do not like cutting").
+    app/server) last — and return ALL of them (operator directive: "do NOT limit the
+    search space; if anything, randomize before any cut — I do not like cutting").
 
-    The earlier ``cap=12`` permanently BLINDED discovery to ~69 of 81 changed files: within
-    the high-value tier, paths sort alphabetically, so ``profiles/*`` + ``harness/*`` filled
-    all 12 slots and the engine (``spine/driver.py``, ``backend/cr_watchers.py``, ``gate.py``,
-    ``keeper.py``, …) was dropped EVERY cycle → "mined out" was an artifact of the cap, not an
-    absence of bugs. So: no truncation by default (``cap=None`` returns the full ordered list).
+    A small ``cap`` BLINDS discovery to most of the changed files: within the high-value
+    tier, paths sort alphabetically, so ``profiles/*`` + ``harness/*`` fill every slot and
+    the engine (``spine/driver.py``, ``backend/cr_watchers.py``, ``gate.py``, ``keeper.py``,
+    …) is dropped EVERY cycle → "mined out" becomes an artifact of the cap, not an absence
+    of bugs. So: no truncation by default (``cap=None`` returns the full ordered list).
 
     Within each value tier, ``rotate`` (e.g. the cycle index) deterministically ROTATES the
     order so a per-cycle read budget lands on a DIFFERENT slice of the tier each cycle —
@@ -325,7 +325,7 @@ def _has_json_array(text: str) -> bool:
     Position/form decides, not value shape: scalar prose fragments (``[12]``),
     instruction-echo (``Use [] when none``), and object-wrapped replies all read
     as unanswered, so the tool-side forcing re-emit fires and demands the bare
-    array (GPT review rounds 1-3, #4974)."""
+    array."""
     if not text:
         return False
     if _whole_reply_array(text) is not None:
@@ -389,10 +389,10 @@ def _normalize_surface(
 
 # How many files form THIS cycle's PRIORITY SLICE — the bounded set the agent is told to
 # actually read this cycle so it converges within the turn budget. The FULL changed-file list
-# stays VISIBLE below it (operator 2026-06-18: do not limit the search space) — nothing is
+# stays VISIBLE below it (operator directive: do not limit the search space) — nothing is
 # hidden; the slice just rotates each cycle (upstream rotate=), so over the loop's cycles the
-# read budget sweeps the ENTIRE surface. This replaces the old hard cap=12 that PERMANENTLY
-# dropped 69 files: here all 82 are listed, only the per-cycle *reading focus* is bounded.
+# read budget sweeps the ENTIRE surface. A hard cap would instead drop most of the surface
+# permanently: every changed file is listed, only the per-cycle *reading focus* is bounded.
 DEFAULT_PRIORITY_SLICE = 12
 
 
@@ -440,9 +440,9 @@ def _build_prompt(
 ) -> str:
     """The discovery prompt. Read-only investigation; STRICT JSON-array output.
 
-    KEY DESIGN (operator directive 2026-06-15): the agent is NOT handed a unified diff — a
-    raw diff pollutes context (new-subsystem branches are dominated by boilerplate that
-    truncates before the logic) and led to discovered=0. Instead it gets the CHANGED-FILE
+    KEY DESIGN (operator directive): the agent is NOT handed a unified diff — a raw diff
+    pollutes context (new-subsystem branches are dominated by boilerplate that truncates
+    before the logic) and yields discovered=0. Instead it gets the CHANGED-FILE
     LIST plus each file's DEPENDENTS (callers), and is told to READ the files itself (it has
     Read/Grep/Glob) — open the changed modules AND their callers, and judge whether the code
     is correct and whether it honors the contract its callers rely on. This is how a human
@@ -555,7 +555,7 @@ def _diag_log(log_dir: Path | None, payload: dict) -> None:
     """Append one JSON diagnostic record to ``<log_dir>/agent_discovery.log`` (best-effort,
     never raises). This is the durable visibility into WHY discovery returned what it did —
     the full prompt, the raw agent reply, every dropped surface + its reason, and the final
-    count. Without it, a ``discovered=0`` is opaque (operator directive 2026-06-15:
+    count. Without it, a ``discovered=0`` is opaque (operator directive:
     "make sure sufficient logs are produced for further diagnostics")."""
     if log_dir is None:
         return
@@ -588,8 +588,8 @@ def discover_surfaces_via_agent(
 
     ``rotate`` (e.g. the cycle index) rotates the focus ordering WITHIN each value tier so a
     per-cycle read budget samples a different slice of the FULL changed-file surface each
-    cycle — coverage rotates across all files over the loop's cycles (operator directive
-    2026-06-18: do not limit the search space; rotate rather than cut).
+    cycle — coverage rotates across all files over the loop's cycles (operator directive:
+    do not limit the search space; rotate rather than cut).
 
     Same return shape as ``build_gate.discover_defect_surfaces`` so the caller treats both
     sources identically: ``{target, rule, message, file, line, symbol, hypothesis}``.
@@ -626,7 +626,7 @@ def discover_surfaces_via_agent(
         return []
     scoped = bool(scope_base)
     # FOCUS LIST instead of a diff body: the changed product files + their callers. The agent
-    # READS the files itself (operator directive 2026-06-15). If a scope was requested but
+    # READS the files itself (operator directive). If a scope was requested but
     # produced no changed files (blank base / git failure / empty change set), fall back to a
     # whole-tree read so the agent still has something to do — mirrors how _diff_scope degrades
     # to unscoped rather than narrowing to zero.
@@ -645,8 +645,8 @@ def discover_surfaces_via_agent(
             allowlist_focus = True
     # ORDER the FULL set high-value-logic-first, then ROTATE within each tier by the cycle
     # index so the read budget samples a different slice each cycle (operator directive
-    # 2026-06-18: do NOT limit the search space — the old cap=12 permanently hid the engine
-    # modules behind alphabetically-earlier profiles/ files). NO truncation: the agent sees
+    # do NOT limit the search space — a cap hides the engine modules behind
+    # alphabetically-earlier profiles/ files). NO truncation: the agent sees
     # every focus file (rendered compactly as a priority slice + the rest).
     changed = prioritize_focus(all_changed, rotate=rotate)
     dependents = dependents_of(Path(clone), changed) if changed else {}
@@ -672,25 +672,24 @@ def discover_surfaces_via_agent(
         res = run(
             prompt,
             cwd=str(clone),
-            # NO shell. The comment here used to read "read-only investigation" while granting
-            # `Bash`, which is write-capable — and this agent runs in the SHARED clone, the
+            # NO shell: `Bash` is write-capable, and this agent runs in the SHARED clone, the
             # tree the loop later stages and commits from. Discovery's whole job is to READ
             # the target repository's source, which is untrusted content, so an injection
-            # there could have edited that tree and a later `git add -A` would publish an edit
-            # no measurement gated. `allowed_tools` also AUTO-APPROVES, so such a call never
+            # there could edit that tree and a later `git add -A` would publish an edit no
+            # measurement gated. `allowed_tools` also AUTO-APPROVES, so such a call never
             # reaches the platform governance chokepoint. Read/Grep/Glob cover everything the
-            # prompt actually asks for. Raised by the GPT review.
+            # prompt actually asks for.
             allowed_tools=["Read", "Grep", "Glob"],
-            # HARD turn cap — the convergence lever (validated 2026-06-16). A thinking/opus
-            # agent has NO terminal commitment, so the cap must MATCH the reading surface: the
-            # full 82-file list with a 12-turn cap was exhausted by reading before the agent
-            # emitted → runner_error=max_turns, raw_items=0 EVERY cycle. The fix keeps the FULL
-            # list VISIBLE (operator 2026-06-18: do not limit the search space) but bounds the
-            # per-cycle READING to a rotated PRIORITY SLICE (~12 files, _render_focus_list), so
-            # the agent only needs to investigate the slice — which fits a modest turn budget.
-            # 16 turns: ~12-slice + a few emit/think turns, with margin over the old 12. The
-            # runner returns accumulated text on the limit so a late JSON array survives;
-            # tool-side forcing drops Read/Grep on the final turns as the backstop.
+            # HARD turn cap — the convergence lever. A thinking/opus agent has NO terminal
+            # commitment, so the cap must MATCH the reading surface: an 80+-file list under a
+            # 12-turn cap is exhausted by reading before the agent emits → runner_error=
+            # max_turns, raw_items=0 every cycle. The FULL list stays VISIBLE (operator
+            # directive: do not limit the search space) while the per-cycle READING is bounded
+            # to a rotated PRIORITY SLICE (~12 files, _render_focus_list), so the agent only
+            # needs to investigate the slice — which fits a modest turn budget. 16 turns:
+            # ~12-slice + a few emit/think turns, with margin. The runner returns accumulated
+            # text on the limit so a late JSON array survives; tool-side forcing drops
+            # Read/Grep on the final turns as the backstop.
             max_turns=16,
             timeout_s=timeout_s,
         )
@@ -711,14 +710,14 @@ def discover_surfaces_via_agent(
     ok = getattr(res, "ok", None)
     err = getattr(res, "error", "") or ""
     raw_items = _extract_json_array(text)
-    # TOOL-SIDE FORCING FALLBACK (validated 2026-06-16 — the most robust convergence fix):
+    # TOOL-SIDE FORCING FALLBACK (the most robust convergence lever):
     # if the investigation pass produced NO parseable JSON (the agent over-investigated and
     # got cut off mid-reading — runner not-ok, or ok but no array), make ONE more call with
     # NO tools, handing back the agent's own reasoning and demanding ONLY the JSON array.
     # With no Read/Grep available, the only possible action is to answer — converting a
     # "read until timeout" run into the findings it already reasoned about. This is the
-    # harness forcing function the subagent comparison identified: prompt wording alone
-    # doesn't beat a thinking agent's investigation momentum; removing the tools does.
+    # harness forcing function: prompt wording alone does not beat a thinking agent's
+    # investigation momentum; removing the tools does.
     forced = False
     # Trigger the re-emit ONLY when the agent produced NO json array at all (over-investigated
     # and got cut off) — NOT when it answered with a valid empty array `[]` (a legitimate

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_runner.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_runner.py
@@ -303,10 +303,9 @@ _COMMAND_WRAPPERS: dict[str, int] = {
     "script": 0,
     # SHELL BUILTIN wrappers. These are not on PATH, so they only appear inside a shell —
     # but a nested `sh -c "..."` argument is re-analyzed from the top by this same table, so
-    # omitting them left a hole. Measured before adding them: bare `git push` was REFUSED
-    # while `command git push` and `exec git push` were both ALLOWED. `command` was raised by
-    # the GPT review of this branch; `exec` and `builtin` are the same class and were found
-    # by testing the neighbours rather than waiting for the next review round.
+    # omitting them leaves a hole: bare `git push` is REFUSED while `command git push` and
+    # `exec git push` would both be ALLOWED. `exec` and `builtin` are the same class as
+    # `command`, so all three are listed.
     "command": 0,
     "exec": 0,
     "builtin": 0,
@@ -419,9 +418,9 @@ def _refusal(text: str, *, depth: int) -> str:
                 opt = wrapped[0]
                 # A short option without `=` is assumed to take a value (`nice -n 5`); a long
                 # option takes one only if it is a KNOWN value-taking wrapper option
-                # (`env --unset FOO`). Long options were previously all treated as valueless,
-                # which let `env --unset FOO curl …` leave `FOO` as the command and pass the
-                # `curl` behind it — the bypass this branch now closes. An inline `--opt=value`
+                # (`env --unset FOO`). Treating every long option as valueless would let
+                # `env --unset FOO curl …` leave `FOO` as the command and pass the `curl`
+                # behind it — the bypass this table closes. An inline `--opt=value`
                 # carries its own value, so it consumes nothing extra.
                 if "=" in opt:
                     takes_value = 0
@@ -697,10 +696,9 @@ class AgentRunner:
         This agent runs with ``--dangerously-skip-permissions``, so its Bash tool is
         unattended: the worktree stays VISIBLE (there would be nothing to edit otherwise)
         while the operator's credential directories are hidden and the environment is
-        scrubbed. Review of this branch asked for the fallback to be DELETED; sandboxing
-        addresses the same concern — a malicious repository prompt can no longer reach
-        credentials outside the worktree — without removing the only path that works when
-        no in-process provider is configured.
+        scrubbed. Sandboxing is what makes keeping this fallback safe — a malicious
+        repository prompt cannot reach credentials outside the worktree — so the only
+        path that works when no in-process provider is configured stays available.
         """
         root = str(Path(cwd).resolve()) if cwd else None
         # STRICT mode, not the default "standard": "standard" deliberately leaves ~/.aws
@@ -859,7 +857,7 @@ class AgentRunner:
             )
 
         # `sandboxed_spawn_argv` may write a launcher script the caller owns; its contract
-        # is that the caller unlinks it once the child no longer needs it. The streaming
+        # is that the caller unlinks it once the child is done with it. The streaming
         # path has many exits, so this is a finally rather than a call per return.
         try:
             if streaming:
@@ -1198,7 +1196,7 @@ class SessionAgentRunner:
             # construction raised", and without this line it can never say WHAT raised.
             # The realistic cause is the acp → client → session → config.loader circular
             # import the loader documents, which resolves only when ``acp`` is imported
-            # first, and it was previously invisible in every log.
+            # first.
             logger.warning(
                 "SessionAgentRunner.available(): provider factory could not be built, "
                 "reporting the agent runner as unavailable",
@@ -1389,10 +1387,10 @@ class SessionAgentRunner:
             announced_tool_detail: dict[str, str] = {}
             deadline = t0 + timeout_s
             full_prompt = (append_system + "\n\n" + prompt) if append_system else prompt
-            # HARD WALL-CLOCK WATCHDOG (operator directive 2026-06-15): the old `async for`
-            # only checked the deadline BETWEEN events, so a long in-turn await (the agent
-            # thinking/reading for minutes inside one stream step) could blow past timeout_s
-            # unbounded — the runaway 10-min discovery run. We instead drive the stream as an
+            # HARD WALL-CLOCK WATCHDOG (operator directive): a plain `async for` only checks
+            # the deadline BETWEEN events, so a long in-turn await (the agent
+            # thinking/reading for minutes inside one stream step) can blow past timeout_s
+            # unbounded — a runaway multi-minute discovery run. Drive the stream as an
             # explicit async iterator and bound EACH event fetch with asyncio.wait_for on the
             # REMAINING budget. A stall is force-cancelled and we return the accumulated text
             # (so any findings already streamed survive). Falls back to the plain async-for if
@@ -1461,14 +1459,12 @@ class SessionAgentRunner:
                     # and never forwarded here, so every request was granted whatever it
                     # asked for. That matters most for a WATCHER: it reads PR comments
                     # through `gh`, so a malicious comment could ask for a shell and get it,
-                    # against an authenticated GitHub session. Raised by review of this
-                    # branch. Deny-by-default only when a caller supplied a list — an
-                    # absent list keeps the previous behavior for callers that never set one.
+                    # against an authenticated GitHub session. Deny-by-default applies only
+                    # when a caller supplied a list — an absent list imposes no allowlist.
                     # FIRST gate: the platform governance chokepoint (`hooks.on_tool_call`)
                     # — the enterprise ceiling, builtin denied rules, and sensitive-path
                     # (~/.aws/~/.ssh) blocks that the dashboard/Slack paths honor. This
-                    # unattended runner previously skipped it and relied only on the
-                    # app-local checks below. Raised by the Arbiter's review of this branch.
+                    # unattended runner must not rely only on the app-local checks below.
                     gov = _governance_denial(ev, session_key=session_key, agent=self.agent_name)
                     if gov:
                         logger.warning("refusing tool %r — governance: %s", tool, gov)
@@ -1519,8 +1515,8 @@ class SessionAgentRunner:
                     # ENFORCE max_turns on the ACP/session path. Unlike the subprocess runner
                     # (which passes --max-turns to claude), the streaming provider has no turn
                     # limit of its own — so a thinking agent with no terminal commitment reads
-                    # tools until the wall-clock (the discovered=0 over-investigation, validated
-                    # 2026-06-16). Counting tool calls and stopping at the cap is the real
+                    # tools until the wall-clock (the discovered=0 over-investigation).
+                    # Counting tool calls and stopping at the cap is the real
                     # convergence lever: it ends the stream and returns the accumulated text
                     # (a late JSON answer survives). max_turns<=0 disables the cap.
                     tool_calls += 1
@@ -1638,7 +1634,7 @@ class SessionAgentRunner:
             # allowlist/denylist check AND the `critical=True` audit-or-deny write. The
             # unattended loop is exactly the caller that must not buy a blanket exemption
             # with its first approval; re-deciding per call is the whole point of routing
-            # through here. Raised by the GPT review of this branch.
+            # through here.
             await provider.approve_tool(rid)
         except Exception:  # noqa: BLE001
             pass
@@ -1647,13 +1643,12 @@ class SessionAgentRunner:
 def _repro_test_dir(worktree: Path) -> str:
     """The directory this repo actually keeps tests in — ``tests`` or ``test``.
 
-    The prompt used to hard-code ``test/``, but a repo using ``tests/`` (plural) then got
-    a reproducing test written into a directory that does not exist, so T2 could never
-    collect it and EVERY candidate failed ``test_invalid`` regardless of fix quality.
-    Found by running docs/system-specs/modules/auto-improvement.md against Zedmor/chess_test, which uses ``tests/``.
+    Hard-coding ``test/`` in the prompt breaks a repo that keeps its tests in ``tests/``
+    (plural): the reproducing test lands in a directory that does not exist, so T2 cannot
+    collect it and EVERY candidate fails ``test_invalid`` regardless of fix quality.
 
-    The edit fence already permits both (``_ADDABLE_TEST_GLOBS``), so only the
-    instruction was wrong. Prefers an EXISTING directory; falls back to ``test``.
+    The edit fence permits both (``_ADDABLE_TEST_GLOBS``), so the directory only has to be
+    named correctly here. Prefers an EXISTING directory; falls back to ``test``.
     """
     counts = {
         name: len(list((Path(worktree) / name).glob("test_*.py")))

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/bug_gate.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/bug_gate.py
@@ -235,7 +235,7 @@ class BugGate:
 
             # ── STAYGREEN (§2.2 step 3) ─────────────────────────────────────
             # Run the full suite (or documented smoke subset — Profile choice) with
-            # the full fix applied. Any PREVIOUSLY-PASSING test now failing →
+            # the full fix applied. Any test that fails under the fix but passes on base →
             # the fix regressed something → discard.
             suite_ok, failing = runner.run_suite(src=cand_src)
             if not suite_ok:

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
@@ -480,15 +480,15 @@ class Driver:
             # The probe could not RUN — its sandbox launcher died before git
             # executed, which says nothing about the clone. Do NOT retire:
             # retiring renames away a clone whose remotes were never read,
-            # destroying good state over an unrelated sandbox failure (#8151).
-            # The tightened signature match in `_launcher_failure_detail` is
+            # destroying good state over an unrelated sandbox failure.
+            # The tight signature match in `_launcher_failure_detail` is
             # what keeps this branch unreachable for ambiguous or
-            # repository-influenced errors — those still return False below
-            # and retire as before. Re-raise after recording: swallowing here
-            # let `driver.run()` return normally, so the supervisor recorded
-            # STATUS_DONE for a run aborted by a safety-probe failure (raised
-            # by the GPT review of this branch); the run-loop's catch-all
-            # records STATUS_ERROR with this message instead.
+            # repository-influenced errors — those return False below and
+            # retire. Re-raise after recording: swallowing here would let
+            # `driver.run()` return normally, so the supervisor would record
+            # STATUS_DONE for a run aborted by a safety-probe failure; the
+            # run-loop's catch-all records STATUS_ERROR with this message
+            # instead.
             self._stop = True
             self._probe_failure = exc
             self.log.error("isolation probe could not run after %s: %s", stage, exc)
@@ -595,8 +595,8 @@ class Driver:
         self.log.info("preflight: proving the ruler before Phase 2 (03_metric §0/§11)…")
         boot = self.boot_callable if self._explicit_boot else self._resolve_measurement_boot()
         # Duck-wire a stop_check onto the ruler so a clean-stop request can interrupt
-        # the ~30-boot calibration loop between reps (previously a Stop click had to
-        # wait out the entire preflight — the "stuck in phase2_perf" symptom). The
+        # the ~30-boot calibration loop between reps (without it a Stop click waits out
+        # the entire preflight — the "stuck in phase2_perf" symptom). The
         # ruler treats it as optional; partial samples surface as CalibrationError.
         try:
             self.profile.ruler.stop_check = lambda: self._stop  # type: ignore[attr-defined]
@@ -754,7 +754,7 @@ class Driver:
             )
             # The cycle index rotates agent-discovery's focus ordering WITHIN each value tier
             # so a per-cycle read budget samples a different slice of the FULL changed-file
-            # surface each cycle (operator directive 2026-06-18: do not limit the search space
+            # surface each cycle (operator directive: do not limit the search space
             # — rotate coverage across all files instead of capping to the same top-N).
             self.profile._discovery_rotate = cycle  # type: ignore[attr-defined]
         except Exception:  # noqa: BLE001 — skip-list is a cost optimization, never fatal
@@ -1831,7 +1831,7 @@ class Driver:
         ``base_ref...HEAD`` in the clone, via this driver's agent runner. The agent emits a
         final ``REVIEW: clean`` / ``REVIEW: <N> open`` / ``REVIEW: unavailable`` line.
 
-        AUTHORIZATION (operator directive 2026-06-15): the push is allowed when the fix has
+        AUTHORIZATION (operator directive): the push is allowed when the fix has
         a clean POSITIVE signal — a clean review verdict OR (when the review is INCONCLUSIVE)
         a clean full build/test (``_build_test_pre_push_clean``). CONCRETE review open
         findings still BLOCK (a green build does not excuse a real review finding).
@@ -1904,9 +1904,9 @@ class Driver:
             # otherwise provably safe — fall back to a clean POSITIVE build/test signal
             # (a fresh full `bb release` / pytest suite green on the committed fix). The push
             # is authorized iff the review is clean OR the build/test is clean; it stays
-            # fail-closed only when BOTH are inconclusive (06_*.md F6/F10; operator directive
-            # 2026-06-15: "clean prepush_review + bb release or other clean autotest should allow
-            # push to the remote").
+            # fail-closed only when BOTH are inconclusive (06_*.md F6/F10; operator
+            # directive: "clean prepush_review + bb release or other clean autotest
+            # should allow push to the remote").
             reason = (
                 "prepush_review unavailable"
                 if "unavailable" in low
@@ -2730,7 +2730,7 @@ class Driver:
         # landed, a clone-sync moved HEAD, or the agent touched an artifact like uv.lock
         # that already exists here). A plain ``git apply`` fails outright on any context
         # mismatch or "already exists in working directory" — the observed committed=0
-        # cause (2026-06-17: "bug fix diff did not apply: error: uv.lock: already exists").
+        # cause ("bug fix diff did not apply: error: uv.lock: already exists").
         # --3way falls back to a blob-level 3-way merge, which reconciles drift and
         # absorbs an already-present file instead of aborting. We retry plain-apply first
         # (cheapest, no index churn) and only fall back to 3-way so behavior is unchanged

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/ledger.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/ledger.py
@@ -75,8 +75,8 @@ VALID_STATUSES = frozenset(
 # error, or a fix ATTEMPT that didn't verify must NOT permanently poison the ledger (the
 # bug bringing this in: 3 speculative seeds recorded as ``error`` blocked the loop forever,
 # so it idled with "0 fresh"; and a real defect whose FIRST fix attempt failed verification
-# was never retried even though a different fix might pass — observed 2026-06-17: a scoped
-# run re-discovered 5 real surfaces, all deduped as terminal, kept=0 filed=0).
+# was never retried even though a different fix might pass — a scoped run re-discovers 5
+# real surfaces, all deduped as terminal, kept=0 filed=0).
 #   * ``error`` / ``no_defect`` — transient miss; retry after cooldown.
 #   * ``failed_verify`` — the reproducing test was written but THIS fix attempt didn't make
 #     it pass; that's "this attempt didn't work", NOT "there's no bug here", so a later
@@ -285,9 +285,9 @@ class Ledger:
         # file is written by the operator's forget / purge / manual-filed / commit
         # paths in `backend.ledger_admin`, which hold `LEDGER_WRITE_LOCK` across their
         # read → decide → append. Sharing one lock makes this append atomic against a
-        # concurrent `forget`'s read → decide → `purged`, so a just-filed row can no
-        # longer be superseded by a stale purge (#6716). `self._lock` still guards the
-        # in-memory `_seen` map for readers on this instance.
+        # concurrent `forget`'s read → decide → `purged`, so a stale purge cannot
+        # supersede a just-filed row. `self._lock` still guards the in-memory
+        # `_seen` map for readers on this instance.
         with LEDGER_WRITE_LOCK, self._lock:
             self._seen[entry.fp] = entry
             with self.path.open("a", encoding="utf-8") as f:

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/ledger_lock.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/ledger_lock.py
@@ -16,7 +16,7 @@ of those paths hold DIFFERENT locks, their read → decide → append sequences
 interleave: a ``forget`` that read a ``QUEUED`` placeholder can append ``purged``
 AFTER a concurrent path appended the real ``filed(<pr-url>)`` row, so ``purged``
 wins, the pull request is hidden, and the loop drafts a second PR for a change
-already up for review (#6716). One lock shared by all three writers makes each
+already up for review. One lock shared by all three writers makes each
 sequence atomic against the others and removes the interleaving.
 
 WHY A DEDICATED LEAF MODULE, not a lock defined in ``spine.ledger`` or

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/profile.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/profile.py
@@ -257,8 +257,8 @@ class BugRunner(Protocol):
     def run_suite(self, *, src: Path) -> tuple[bool, list[str]]:
         """STAYGREEN: run the full suite (or the documented smoke subset — a
         Target-Profile choice, §8) against ``src``. Returns ``(all_green, failing)``
-        where ``failing`` lists any previously-passing test now failing (exact pytest
-        nodeids when available, so the gate can re-check them on base).
+        where ``failing`` lists every failing test (exact pytest nodeids when
+        available, so the gate can re-check them on base).
 
         OPTIONAL companion (NOT part of this structural protocol so a minimal runner
         still satisfies ``isinstance``): ``run_named_tests(*, src, test_ids) -> set[str]``

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/proposer.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/proposer.py
@@ -113,7 +113,7 @@ class Proposer:
         # worktree (e.g. ``uv.lock`` from a ``uv`` invocation, ``.venv``, caches). They are
         # NEVER part of a legitimate code fix, and including them breaks the downstream
         # ``git apply`` onto the clone ("uv.lock: already exists in working directory" — the
-        # observed committed=0 / failed-CR cause, 2026-06-17). Pathspec exclusions keep the
+        # observed committed=0 / failed-CR cause). Pathspec exclusions keep the
         # diff to real source changes (the fix + its reproducing test).
         return subprocess.run(
             [
@@ -132,7 +132,7 @@ class Proposer:
                 ":(exclude)**/__pycache__/**",
                 ":(exclude)*.pyc",
                 # Agent-tooling settings the session writes into its own worktree.
-                # Observed live (2026-07-31): the first filed PR carried a spurious
+                # Without this a filed PR carries a spurious
                 # ``.kiro/settings/cli.json`` hunk, which is noise in a reviewer's
                 # diff and can collide on ``git apply`` onto a clone that has its own.
                 ":(exclude).kiro/**",
@@ -187,13 +187,12 @@ class Proposer:
                 bug_runner = getattr(profile, "bug_runner", None)
                 hint_fn = getattr(bug_runner, "agent_test_hint", None)
                 test_cmd_hint = hint_fn(wt) if callable(hint_fn) else None
-                # Dispatch by TRACK. The perf branch used to be missing entirely, which
-                # dead-ended the whole track: a profile with no mechanical seed returns
-                # False from propose(), and with no agent escalation a perf candidate
-                # produced no diff and was recorded no_defect — so the loop could never
-                # keep or file a perf win. Both tracks now author through the model and
-                # are judged by their own deterministic gate (RED→GREEN for a bug, A/B
-                # against the noise band for perf).
+                # Dispatch by TRACK. BOTH tracks author through the model and are judged
+                # by their own deterministic gate (RED→GREEN for a bug, A/B against the
+                # noise band for perf). A track without agent escalation dead-ends: a
+                # profile with no mechanical seed returns False from propose(), so the
+                # candidate produces no diff and is recorded no_defect, and the loop can
+                # never keep or file a win on that track.
                 author = author_bug_fix if candidate.kind == TRACK_BUG else author_perf_fix
                 produced = author(
                     self.agent_runner,
@@ -274,11 +273,11 @@ class Proposer:
         proposals: list[Proposal] = []
         wide_cands = candidates[: self.wide]
         # DISJOINT from wide, per this method's own contract ("reserve the strongest
-        # top-K candidate(s) for deep"). Both slices previously started at index 0, so
-        # with wide=1/deep=1 the two proposers authored THE SAME candidate: two full
+        # top-K candidate(s) for deep"). Were both slices to start at index 0, then at
+        # wide=1/deep=1 the two proposers would author THE SAME candidate: two full
         # agent passes, two worktrees and two gate ladders spent to answer one question,
-        # and the second was then discarded as a same-cycle duplicate. Observed live —
-        # every `c<N>_wide_*` had a matching `c<N>_deep_*` on the identical locus.
+        # with the second discarded as a same-cycle duplicate, and every `c<N>_wide_*`
+        # carrying a matching `c<N>_deep_*` on the identical locus.
         deep_cands = candidates[self.wide : self.wide + self.deep]
         for c in wide_cands:
             if stop_check is not None and stop_check():

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/push_policy.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/push_policy.py
@@ -51,8 +51,8 @@ PROTECTED_BRANCH_NAMES = frozenset(
     }
 )
 
-# Release/integration line prefixes — ``release/*``, ``releases/*``, ``hotfix/*``, etc.
-# These are conventionally protected integration lines, never a personal feature branch.
+# Release/integration line prefixes. These are conventionally protected integration
+# lines, never a personal feature branch.
 PROTECTED_BRANCH_PREFIXES = (
     "release/",
     "releases/",
@@ -226,9 +226,9 @@ def scan_content_for_secrets(text: str) -> tuple[bool, str]:
 
 
 #: Credential-shaped env names to drop before untrusted code runs. Matched by NAME, never
-#: by value. ONE definition: this used to be copied into both the gate and the agent
-#: spawn, and a duplicated security decision is how the empty-allowlist inversion survived
-#: in one copy after being fixed in the other.
+#: by value. ONE definition shared by the gate and the agent spawn: a duplicated security
+#: decision can be fixed in one copy and left inverted in the other, which is how the
+#: empty-allowlist inversion survives.
 #:
 #: Needed because the shared `kiro_crew.sandbox` scrub does not cover every family —
 #: measured on the author's host, `GITHUB_TOKEN` survives `scrub_env` (its list has

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
@@ -33,7 +33,7 @@ that escaped a temporary directory would be obvious in a log.
 against. ``write_json_atomic`` REPLACES the document rather than merging, so the live
 ``target_url``/``target_display`` are dropped and ``clone`` is left naming a pytest temporary
 directory that is reaped when the session ends. The app's page then renders with no repository,
-and calibration refuses because the configured clone no longer exists.
+and calibration refuses because the configured clone does not exist.
 
 Nothing in the suite fails when that happens — the damage lands outside the assertions — so the
 redirect is ``autouse``: a per-file opt-in fixture only protects the files that remember to ask

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_agent_discovery_focus.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_agent_discovery_focus.py
@@ -1,7 +1,7 @@
 """Discovery reading FOCUS — the unscoped, edit-allowlist-narrowed case.
 
 When a run is UNSCOPED (no ``scopeDiffBase``) but the operator narrowed the edit
-allowlist to a subtree (the blast-radius control used to dogfood the app on its
+allowlist to a subtree (the blast-radius control for dogfooding the app on its
 own repo), discovery must read only that subtree. Reading the whole tree while
 the fence confines fixes to one subdir makes the agent spend its budget on files
 it cannot touch, so it finds nothing fixable and returns ``[]`` every cycle —

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_backend_deps_cov80.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_backend_deps_cov80.py
@@ -251,7 +251,7 @@ class TestInstallDeps:
     ) -> None:
         """Redact-before-bound invariant: the credential is laid out so the
         200-char bound falls INSIDE the token. Bound-before-redact would keep
-        an unredacted token prefix that no longer matches the credential regex
+        an unredacted token prefix that does not match the credential regex
         — the exact fragment shape the serving route's own redaction pass
         cannot recognise — so this test goes red if the redact and the bound
         are ever reordered.

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_clone_setup_idempotent.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_clone_setup_idempotent.py
@@ -1,4 +1,4 @@
-"""Offline regressions for idempotent push-disabled clone setup."""
+"""Offline tests pinning idempotent, push-disabled clone setup."""
 
 from __future__ import annotations
 

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
@@ -1660,8 +1660,7 @@ class TestCheckoutPrecedesProfileBuild:
         remote-tracking ref AND a local ref, so a False means the configured branch exists
         NOWHERE — starting an edit-and-push loop against whatever HEAD the clone holds would
         operate on the wrong revision. A scopeDiffBase makes it worse (mis-scoped fence) but
-        the base case is already unsafe. Tightened per the GPT review of this branch (was
-        best-effort: unscoped runs used to continue on the wrong HEAD)."""
+        the base case is already unsafe."""
         from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
         from kiro_crew.apps.builtins.auto_improvement.backend.runner import RunSupervisor
 
@@ -2248,7 +2247,7 @@ class TestTheStoredPushDestinationIsValidated:
         whose ``_host_is_blocked`` SSRF check does a LIVE ``socket.getaddrinfo`` resolve
         and fails CLOSED on any resolver error. On a transient runner DNS hiccup
         ``github.com`` read as blocked and a legitimate remote resolved to ``""``,
-        flaking the legitimate-remote cases in CI (#5229); the foreign-remote cases
+        flaking the legitimate-remote cases in CI; the foreign-remote cases
         short-circuit on the allowlist before DNS and cannot flake, but the pin covers
         the whole class so no case here ever reaches a resolver. These tests are about
         URL/identity validation, not address screening — the address decision has its
@@ -2317,9 +2316,10 @@ class TestTheStoredPushDestinationIsValidated:
 class TestTheAddressDecisionItself:
     """The SSRF screen the class above stubs out gets its own direct coverage.
 
-    ``TestTheStoredPushDestinationIsValidated`` pins ``getaddrinfo`` so it no longer
-    exercises ``_host_is_blocked`` incidentally (#5229) — which was the helper's ONLY
-    coverage in the repo. Losing the pinned-away coverage without an equivalent is how
+    ``TestTheStoredPushDestinationIsValidated`` pins ``getaddrinfo``, so it does not
+    exercise ``_host_is_blocked`` incidentally — and that incidental exercise is the
+    helper's ONLY other coverage in the repo. Losing the pinned-away coverage without an
+    equivalent is how
     a later edit to the screen (say, dropping the ``is_private`` predicate, or turning
     the fail-closed ``except`` into fail-open) would land silently. Same split as the
     ``public_dns`` precedent in ``test/test_meetings_providers.py``: the scheme tests
@@ -2360,9 +2360,9 @@ class TestTheAddressDecisionItself:
     def test_a_resolver_error_fails_closed(self, monkeypatch) -> None:
         """The contract the fixture above leans on: a DNS error means BLOCKED.
 
-        This is exactly the behaviour that made #5229 a test-hermeticity defect and
-        not a production one — pin it so the fail-closed ``except`` cannot quietly
-        become fail-open.
+        This is what makes a resolver hiccup a test-hermeticity problem and not a
+        production one — pin it so the fail-closed ``except`` cannot quietly become
+        fail-open.
         """
         self._pin(monkeypatch, OSError("resolver down"))
         assert clone_setup._host_is_blocked("github.com") is True
@@ -2554,18 +2554,12 @@ class TestFallbackAgentCannotSeeCredentials:
 class TestTheFallbackNeverBypassesAConfiguredProvider:
     """A configured provider whose agent registration fails must go OFFLINE, not subprocess.
 
-    `_build_runner` used to fall through: `SessionAgentRunner.available()` True but
-    `ensure_agent_registered()` False landed on `AgentRunner`, i.e. `claude -p` — bypassing
-    the provider's own permission gate even though a provider EXISTED. Measured before the
-    fix: that combination returned `AgentRunner`.
-
-    This is the substance of the review's long-standing "the fallback bypasses the ACP gate"
-    objection. Earlier rounds declined it as self-contradictory ("the fallback only runs when
-    no provider is configured") — that was true of the `available()` branch and NOT of the
-    registration-failure branch, which is a real hole. The fallback is only defensible when
-    there is genuinely no provider to route through, which is now what the code does.
-
-    Raised by the GPT review of this branch.
+    `_build_runner` must not fall through when `SessionAgentRunner.available()` is True but
+    `ensure_agent_registered()` is False: landing on `AgentRunner`, i.e. `claude -p`, bypasses
+    the provider's own permission gate even though a provider EXISTS. "The fallback only runs
+    when no provider is configured" holds for the `available()` branch and NOT for the
+    registration-failure branch, which is the hole this closes — the fallback is only
+    defensible when there is genuinely no provider to route through.
     """
 
     @staticmethod
@@ -3019,7 +3013,7 @@ class TestProvisionalCommitFailsClosed:
         ).stdout.strip()
 
         # Force ONLY the `git commit` to fail, letting real staging/reset run. A pre-commit
-        # hook can no longer do this: D-120 hardens every host-side git with
+        # hook cannot do this: D-120 hardens every host-side git with
         # `-c core.hooksPath=<devnull>` so a repo-controlled hook never executes host-side, and
         # making `.git/objects` read-only would also break the `git add` that must succeed
         # first. Wrapping the real `_git` and failing the `commit` subcommand is the
@@ -3084,7 +3078,7 @@ class TestProvisionalCommitFailsClosed:
         )
         # Fail ONLY `git commit`, letting the real `apply`/`add -A`/`reset --hard` run so the
         # staged-diff cleanup this test is about is genuinely exercised. A pre-commit hook can
-        # no longer force this: D-120 hardens host-side git with `-c core.hooksPath=<devnull>`,
+        # force this: D-120 hardens host-side git with `-c core.hooksPath=<devnull>`,
         # so a repo hook is inert. Wrapping `_git` to reject the `commit` subcommand is the
         # hook-independent equivalent.
         real_git = drv_mod._git
@@ -3208,10 +3202,9 @@ class TestWinnerIsInTheTreeBeforeDrafting:
         """`self.branch` is the CONFIG form (``origin/main``), and ``git checkout
         origin/main`` DETACHES HEAD onto the remote-tracking ref — so a commit made in one
         cycle is orphaned and the next cycle's checkout throws it away. Measured against a
-        bare repo: after a second checkout the prior winner was no longer an ancestor of
-        HEAD. The stage step now checks out ``normalize_branch(self.branch)`` (the local
-        branch ``runner`` already created), so cycle N+1 builds ON cycle N. Raised by the
-        GPT review of this branch.
+        bare repo: after a second checkout the prior winner is not an ancestor of HEAD.
+        The stage step checks out ``normalize_branch(self.branch)`` (the local branch
+        ``runner`` already created), so cycle N+1 builds ON cycle N.
         """
         import subprocess
 
@@ -3415,10 +3408,10 @@ class TestToolRequestsAreGated:
     def test_the_platform_governance_gate_is_consulted_before_approval(self) -> None:
         """The unattended runner's approval must route through the SAME `hooks.on_tool_call`
         chokepoint the dashboard/Slack paths use, so the enterprise ceiling, builtin denied
-        rules, and the shell gate's IMDS / env-credential tiers apply here too. It previously had
-        only an app-local gate and skipped the platform one — so an injected instruction in
-        outsider-writable PR-comment text could drive an auto-approved call the central gate
-        would deny. Raised by the Arbiter's long-term review of this branch."""
+        rules, and the shell gate's IMDS / env-credential tiers apply here too. An app-local
+        gate alone is not enough: skipping the platform one lets an injected instruction in
+        outsider-writable PR-comment text drive an auto-approved call the central gate would
+        deny."""
         from kiro_crew.apps.builtins.auto_improvement.spine.agent_runner import (
             _governance_denial,
         )
@@ -3647,10 +3640,7 @@ class TestToolRequestsAreGated:
         can only over-refuse — the safe direction for a denylist.
 
         `--exec-path` is deliberately excluded from that table because its value is OPTIONAL,
-        so listing it reintroduced the same swallow (`git --exec-path push`). Found by writing
-        this matrix rather than by the next review round.
-
-        Raised by the GPT review of this branch.
+        so listing it would reintroduce the same swallow (`git --exec-path push`).
         """
         from kiro_crew.apps.builtins.auto_improvement.spine.agent_runner import (
             shell_command_refusal,
@@ -4471,7 +4461,7 @@ class TestOneClickCommitWorksInAPushDisabledClone:
         # FORCE the interleaving instead of hoping the scheduler produces it. A plain
         # two-thread race reproduced the bug only ~1 run in 3 (measured with the lock
         # removed), which is too flaky to be a regression test. `A` parks *after* staging its
-        # diff — the exact window where B's `checkout -B` used to carry A's change into B's
+        # diff — the exact window where B's `checkout -B` can carry A's change into B's
         # commit.
         #
         # A's park ends when B has PROVED the clone lock is contended, not when B
@@ -5292,7 +5282,7 @@ class TestASuccessfulManualDraftLeavesNoCommitBehind:
         # The reset moved into `finally` (D-91), which is STRICTER than the original
         # success-arm placement this test was written against: it now also survives a raising
         # ledger append. Assert on the `finally`, since scanning up to an `else:` would look
-        # for a branch that no longer exists.
+        # for a branch that does not exist.
         success_arm = after_record[: after_record.index("return {")]
         assert "finally:" in success_arm, "the reset is no longer unconditional"
         assert "_rollback()" in success_arm, (
@@ -6544,15 +6534,11 @@ class TestDiscoveryHasNoShell:
             assert any(tool in ln for ln in grants), f"discovery lost {tool}"
 
     def test_the_prompt_does_not_advertise_a_shell_it_lacks(self) -> None:
-        """The prompt USED to offer "read-only Bash: `sed -n`, `grep`, `git grep`" — which was
-        the honest reason the tool was granted, and also the reason the grant was unsafe: that
-        instruction is GUIDANCE, and the grant permits writes regardless. (My first version of
-        this test asserted the prompt never mentioned a shell at all; it did, so the claim was
-        wrong and is corrected here.)
-
-        Now the prompt must not offer shell COMMANDS the agent cannot run — otherwise it burns
-        turns on refused calls. Saying "there is NO shell" is fine and desirable; naming
-        `sed`/`git grep` as available is not.
+        """The prompt must not offer shell COMMANDS the agent cannot run — otherwise it
+        burns turns on refused calls. Advertising "read-only Bash: `sed -n`, `grep`,
+        `git grep`" is both dishonest and unsafe: that instruction is GUIDANCE, and the
+        grant behind it permits writes regardless. Saying "there is NO shell" is fine and
+        desirable; naming `sed`/`git grep` as available is not.
         """
         import inspect
         import re
@@ -6790,7 +6776,7 @@ class TestTheGovernanceGateGetsBothDenyInputs:
 
     def test_the_two_config_builders_really_differ(self, tmp_path, monkeypatch) -> None:
         """The premise, measured rather than asserted — if these ever converge, the first test
-        above is testing a distinction that no longer exists."""
+        above is testing a distinction that does not exist."""
         import json
 
         monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
@@ -6913,12 +6899,11 @@ class TestSetupCannotRetargetARunThatStartedMeanwhile:
     section. A setup request that passes the status check and then blocks on `clone_lock` can
     have a run start while it waits; when it finally gets the lock it clones and persists a NEW
     target, and the active run's artifacts are stranded in the old workspace under a
-    `workspace_key` the dashboard no longer displays.
+    `workspace_key` the dashboard does not display.
 
-    D-77 made setup and run-startup mutually exclusive, which was necessary but not
-    sufficient: mutual exclusion decides WHO goes first, it does not re-validate the
-    precondition after waiting. The status must be re-checked INSIDE the lock, immediately
-    before the clone. Raised by the GPT review.
+    D-77's mutual exclusion between setup and run-startup is necessary but not sufficient:
+    mutual exclusion decides WHO goes first, it does not re-validate the precondition after
+    waiting. The status must be re-checked INSIDE the lock, immediately before the clone.
     """
 
     def test_the_status_is_rechecked_inside_the_lock(self) -> None:

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_finding_detail.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_finding_detail.py
@@ -106,7 +106,7 @@ class TestFindingDetail:
 
     @pytest.mark.asyncio
     async def test_cr_field_is_exposed_as_pr(self, data_home: Path) -> None:
-        """The spine's ledger field is historically ``cr``. The API must surface it
+        """The spine's ledger field is named ``cr``. The API must surface it
         as ``pr`` or the UI never renders a pull-request link."""
         _write_ledger(
             data_home,
@@ -466,8 +466,6 @@ class TestCommitButton:
             src = inspect.getsource(getattr(routes, name))
             # The gate is now ONE shared helper (`_refuse_while_running`) rather than four
             # inline copies — a hand-rolled fourth copy is how the guarded status set drifts.
-            # This test previously grepped for the inline `run_in_progress` literal, and the
-            # refactor tripped it, which is the guard working.
             assert "_refuse_while_running(" in src, f"{name} can act mid-run"
 
         # And the helper itself must still consult the supervisor and refuse with 409.

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py
@@ -674,11 +674,8 @@ class TestToolingArtifactsIgnored:
 class TestMeasureEnvDoesNotUndoTheSandboxScrub:
     """`_run` layers `_measure_env` ON TOP of the sandbox's credential-scrubbed
     environment, so anything `_measure_env` inherits is put back after the sandbox removed
-    it. It used to be `dict(os.environ)`.
-
-    Measured before fixing: an `AWS_SECRET_ACCESS_KEY` that the sandbox had scrubbed
-    reappeared in the child env once this dict was applied — handing the operator's
-    credentials to agent-authored test code. Raised by review of this branch.
+    it. A `dict(os.environ)` here therefore restores an `AWS_SECRET_ACCESS_KEY` the sandbox
+    scrubbed, handing the operator's credentials to agent-authored test code.
     """
 
     def test_measure_env_carries_no_credentials(self, tmp_path, monkeypatch) -> None:

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_isolation_probe_crash.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_isolation_probe_crash.py
@@ -1,10 +1,10 @@
 """A crashed isolation probe must surface as a sandbox failure, never as
 "push is not disabled".
 
-Issue #8151: on a host whose LSM kills the namespace-sandbox launcher (AppArmor
+On a host whose LSM kills the namespace-sandbox launcher (AppArmor
 unprivileged-userns restriction), the ``git remote``/``config`` probe exits
-nonzero with the launcher's traceback on stderr. ``_push_disabled`` fail-closed
-that exit into ``False`` and the run-start route reported the 409
+nonzero with the launcher's traceback on stderr. Folding that exit into a
+fail-closed ``False`` makes the run-start route answer 409
 "the clone's push is not disabled — re-run repository setup" for a clone whose
 remotes were never read. These tests pin the distinction:
 
@@ -12,15 +12,14 @@ remotes were never read. These tests pin the distinction:
   :class:`IsolationProbeError` naming the sandbox failure (still refuses to
   start — the surfaced REASON is what changes);
 * the same classification applies to ``_repository_is_safe``'s unsafe-keys
-  probe (issue #8493): its ``returncode == 1`` tail meant "no unsafe keys"
-  and a crashed launcher also exits 1, so this was the one probe in the
-  isolation chain that failed OPEN during a launcher outage;
+  probe: its ``returncode == 1`` tail reads as "no unsafe keys" and a crashed
+  launcher also exits 1, so it is the one probe in the isolation chain that can
+  fail OPEN during a launcher outage;
 * every other nonzero exit keeps its existing fail-closed meaning — git's own
   exit 1 for an absent config key, a launcher WARNING that coexists with a
-  genuine git exit code, an ambiguous fatal, and (the Opus finding on this
-  branch) a git fatal that merely ECHOES a clone path containing the launcher
-  filename substring, which a repository named ``kirocrew_sandbox_x`` can put
-  there legally;
+  genuine git exit code, an ambiguous fatal, and a git fatal that merely ECHOES
+  a clone path containing the launcher filename substring, which a repository
+  named ``kirocrew_sandbox_x`` can put there legally;
 * tuple-returning entry points (``setup_safe_clone``, ``list_clone_branches``,
   ``checkout_branch``) convert the raise into their error string instead of
   letting it escape a worker thread as a 500.
@@ -38,7 +37,7 @@ from kiro_crew.apps.builtins.auto_improvement.profiles.github_repo.profile impor
     RepoIsolation,
 )
 
-#: The reported crash verbatim (issue #8151): a real Python traceback naming the
+#: The crash verbatim: a real Python traceback naming the
 #: launcher's own script file — the frame line plus the banner are what the
 #: structural matcher requires.
 _LAUNCHER_TRACEBACK = (
@@ -163,7 +162,7 @@ class TestProbeCrashShape:
 
 class TestRepositoryIsSafeCrashShape:
     """The unsafe-keys probe must classify a crashed launcher, not read it as
-    "no unsafe keys" (issue #8493 — the one probe that failed OPEN)."""
+    "no unsafe keys" — it is the one probe in the chain that can fail OPEN."""
 
     def test_launcher_traceback_raises_probe_error(
         self, probe_result: dict, tmp_path: Path
@@ -268,7 +267,7 @@ class TestTupleEntryPointsStaySoft:
     def test_list_clone_branches_converts_metadata_probe_crash(
         self, probe_result: dict, tmp_path: Path
     ) -> None:
-        """The raise from ``_repository_is_safe`` itself (issue #8493) is
+        """The raise from ``_repository_is_safe`` itself is
         converted, not leaked — the safety probe runs FIRST, so on a crashed
         launcher it is the one that surfaces."""
         clone = _metadata_safe_clone(tmp_path)

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_ledger_admin.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_ledger_admin.py
@@ -120,8 +120,8 @@ class TestIsDeadRecord:
             assert la.is_dead_record(_row("f", "filed", cr=ref)) is True
 
     def test_both_key_spellings_are_read(self) -> None:
-        """The on-disk field is historically ``cr``; newer writers use ``pr``. Reading
-        only one spelling would judge half the ledger dead."""
+        """Both spellings appear on disk: ``cr`` in older records, ``pr`` in newer
+        ones. Reading only one spelling would judge half the ledger dead."""
         assert la.pr_reference({"cr": REAL_PR}) == REAL_PR
         assert la.pr_reference({"pr": REAL_PR}) == REAL_PR
         assert la.pr_reference({"cr": "", "pr": REAL_PR}) == REAL_PR
@@ -409,7 +409,7 @@ class TestPurgeDead:
 
     def test_is_idempotent(self, data_home: Path) -> None:
         """A second sweep must find nothing: the purged event supersedes ``filed``, so
-        the record is no longer dead."""
+        the record does not count as dead."""
         _write_ledger(data_home, [_row("dead1", "filed", cr="")])
         assert la.purge_dead()["count"] == 1
         assert la.purge_dead() == {"ok": True, "purged": [], "count": 0}

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_perf_track_propose.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_perf_track_propose.py
@@ -160,7 +160,7 @@ class TestProposerDispatch:
         from kiro_crew.apps.builtins.auto_improvement.spine import proposer as P
 
         src = Path(P.__file__).read_text(encoding="utf-8")
-        # The dispatch is by track, and no longer gated on TRACK_BUG alone.
+        # The dispatch is by track, not gated on TRACK_BUG alone.
         assert "author_bug_fix if candidate.kind == TRACK_BUG else author_perf_fix" in src
         assert "if not produced and candidate.kind == TRACK_BUG" not in src
 

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_checks.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_checks.py
@@ -139,8 +139,8 @@ class TestCountUnresolved:
     def test_counts_only_explicit_false(self) -> None:
         """Uses the keys the PROVIDER really writes (`resolvable` + `resolved`).
 
-        This fixture previously used `isResolved`, which `source_providers.py` never emits — so
-        it passed while the production counter returned 0 for every real payload, leaving both
+        A fixture keyed on `isResolved`, which `source_providers.py` never emits, passes
+        while the production counter returns 0 for every real payload, leaving both
         open-thread guards dead. A fixture that invents its own key shape tests nothing but
         itself. `resolvable` is required because a plain issue comment is not a thread.
         """

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
@@ -456,11 +456,11 @@ class TestPushedContentIsScanned:
     def test_a_scanner_that_cannot_run_refuses_rather_than_returning_the_text(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Fail CLOSED. This used to return the prose unscanned, on the reasoning that the
-        diff beside it had passed a fail-closed scan and the PR is only a draft — but the
+        """Fail CLOSED. Returning the prose unscanned is not defensible on the grounds
+        that the diff beside it passed a fail-closed scan and the PR is only a draft: the
         prose is a separate artifact, it is the part the agent wrote most freely, and a
         published PR description cannot be un-published. Every other egress path in this
-        app already fails closed. Raised by the GPT review of this branch."""
+        app fails closed."""
         import kiro_crew.security as security_mod
         from kiro_crew.apps.builtins.auto_improvement.profiles.github_repo.pr_recipe import (
             ProseRedactionUnavailable,
@@ -1097,9 +1097,9 @@ class TestTrustedPublisherStillWorksAfterNeutralizing:
 
 @pytest.mark.usefixtures("_public_dns")
 class TestOriginUrlMigratesOldConfigs:
-    """Neutralizing BOTH clone urls means the trusted publishers can no longer read the
-    remote out of git — they take it from config's ``origin_url``. A config written before
-    that change has no such key, and its clone still has a live fetch url.
+    """Neutralizing BOTH clone urls means the trusted publishers cannot read the
+    remote out of git — they take it from config's ``origin_url``. An older config has no
+    such key, and its clone still has a live fetch url.
 
     Found by inspecting the live dogfood configs on this host: both had ``clone`` set and
     no ``origin_url``. Without a migration they would silently degrade to queue-only after
@@ -1129,8 +1129,8 @@ class TestOriginUrlMigratesOldConfigs:
         # `origin_url` is preferred over the legacy `target_url` — but only when the two name
         # the SAME repository. Host-allowlisting alone let an injected config keep
         # `github.com` and swap the path, redirecting the push to another owner's repo, so the
-        # identity is pinned now. (This case previously used mismatched repos, which is
-        # precisely the attack it must refuse — see the mismatch assertion below.)
+        # identity is pinned too. Mismatched repos are precisely the attack it must
+        # refuse — see the mismatch assertion below.
         cfg = {"origin_url": "https://github.com/o/r.git", "target_url": "https://github.com/o/r"}
         assert resolve_origin_url(cfg) == "https://github.com/o/r.git"
 

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py
@@ -154,7 +154,7 @@ def _await_status(
 
 
 def _await_gone(path: Path, timeout: float = WAIT_S) -> None:
-    """Poll until ``path`` no longer exists. Fails the test on timeout."""
+    """Poll until ``path`` is gone. Fails the test on timeout."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if not path.exists():
@@ -588,9 +588,9 @@ class TestGitOutputDecoding:
     `git diff` prints the CONTENT of changed files, and repositories legitimately contain
     binary (a PNG fixture) or non-UTF-8 text (a latin-1 source). Under a strict decode the
     UnicodeDecodeError is raised inside ``subprocess.communicate``, so it is NOT something
-    callers can read off ``returncode`` as data: it propagated out of `_export_is_durable`,
-    past `_run_agent_pass`, and killed the whole watcher with STATUS_ERROR — every PR in a
-    repo containing one binary file. Regression for the strict-decode default.
+    callers can read off ``returncode`` as data: it propagates out of `_export_is_durable`,
+    past `_run_agent_pass`, and kills the whole watcher with STATUS_ERROR — every PR in a
+    repo containing one binary file. These pin the lenient decode that avoids it.
     """
 
     def _repo_with_binary(self, tmp_path: Path) -> Path:

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_progress_and_deps.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_progress_and_deps.py
@@ -392,7 +392,7 @@ class TestMcpResultsAreRedacted:
 
     def test_redaction_runs_before_truncation(self) -> None:
         """Truncating first could split a credential across the cut and leave a fragment
-        the scanner no longer matches."""
+        the scanner does not match."""
         import inspect
 
         from kiro_crew.apps.builtins.auto_improvement.backend import mcp_server
@@ -451,10 +451,10 @@ class TestMcpArgumentsAreValidated:
         assert out["error"]["code"] == mcp_server._INVALID_PARAMS
 
     def test_a_non_dict_arguments_payload_is_rejected_not_coerced(self, data_home: Path) -> None:
-        """`"arguments": [1,2]` or a bare string must return INVALID_PARAMS. The handler
-        used to coerce any non-dict to `{}`, so a malformed call SUCCEEDED with `result`
-        for a no-required-arg tool instead of being refused — the schema validator only
-        ever saw the emptied dict. Raised by the GPT review of this branch."""
+        """`"arguments": [1,2]` or a bare string must return INVALID_PARAMS. Coercing any
+        non-dict to `{}` makes a malformed call SUCCEED with `result` for a
+        no-required-arg tool instead of being refused, because the schema validator then
+        only ever sees the emptied dict."""
         for bad in ([1, 2, 3], "garbage", 5, True):
             out = self._call("get_status", bad)
             assert "error" in out, f"non-dict arguments {bad!r} was accepted"

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
@@ -60,7 +60,7 @@ def _tiny_repo(root: Path, *, push_disabled: bool = True) -> Path:
     _git("remote", "add", "origin", "https://example.invalid/owner/repo.git", cwd=root)
     if push_disabled:
         # Neutralize BOTH urls, exactly as `clone_setup._disable_push` does in production.
-        # A push-only disable no longer satisfies the runtime `push_disabled()` gate: a
+        # A push-only disable does not satisfy the runtime `push_disabled()` gate: a
         # live FETCH url is a live push target, so both must be sentinelled.
         _git("remote", "set-url", "--push", "origin", "DISABLED_NO_PUSH", cwd=root)
         _git("remote", "set-url", "origin", "DISABLED_NO_PUSH", cwd=root)
@@ -318,8 +318,8 @@ class TestOfflineRunIsNotReportedAsDone:
 
     With ``agent_runner=None`` the profile's discovery early-returns an empty candidate
     list, so every cycle finds nothing, the budget's quiescence break fires, and
-    ``driver.run()`` returns its stats CLEANLY. The supervisor used to take that as success
-    and report ``done`` with an empty ``error`` -- a state indistinguishable from a run that
+    ``driver.run()`` returns its stats CLEANLY. Taking that as success and reporting
+    ``done`` with an empty ``error`` is a state indistinguishable from a run that
     genuinely searched and found nothing.
 
     ``_build_driver`` is patched, which is exactly how the sibling tests in this file drive
@@ -710,12 +710,11 @@ def _join_calibration(supervisor: R.RunSupervisor, *, timeout: float = 30.0) -> 
 
 
 class TestCalibrationWritesToTheLaunchedWorkspace:
-    """`_calibrate_loop` runs on a background thread and used to write the ruler via
-    `store.ruler_dir()`, which re-reads the LIVE `config.json`. If the operator retargeted
-    (or started another repo's calibration) while this one measured, the ruler landed in a
-    DIFFERENT workspace, overwriting a ruler calibrated on unrelated code. The write now
-    derives its path from the CAPTURED config the worker was launched with. Raised by the
-    GPT review of this branch.
+    """`_calibrate_loop` runs on a background thread, so it must NOT write the ruler via
+    `store.ruler_dir()`, which re-reads the LIVE `config.json`. If the operator retargets
+    (or starts another repo's calibration) while this one measures, that path lands the
+    ruler in a DIFFERENT workspace, overwriting a ruler calibrated on unrelated code. The
+    write derives its path from the CAPTURED config the worker was launched with.
     """
 
     def test_a_retarget_mid_calibration_does_not_move_the_ruler(
@@ -1010,7 +1009,7 @@ class TestCalibrationRespondsToStop:
     def test_stopping_a_recalibration_preserves_the_prior_ruler(
         self, supervisor: R.RunSupervisor, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Stopping a RECALIBRATION must leave a previously-proven ruler intact.
+        """Stopping a RECALIBRATION must leave an already-proven ruler intact.
 
         A stop is as often "this is taking too long" as "supersede this", so the
         abort lever must not destroy prior work the operator would have to re-pay a

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_stderr_redact_before_bound.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_stderr_redact_before_bound.py
@@ -5,7 +5,7 @@ character count. ``commit.py`` reaches git with an AUTHENTICATED remote URL
 (``materialize_queued_diff`` passes ``_prefer_authenticated_remote``'s result as
 argv), and on an auth failure git echoes that URL — userinfo and all — to
 stderr. Bounding BEFORE redaction can cut the credential mid-match, leaving a
-prefix that no longer matches any credential regex, so the downstream serving
+prefix that matches no credential regex, so the downstream serving
 route's own redaction pass (``routes.py``'s ``_redact_for_display``) cannot
 recognise it either. The fix is redact-then-bound through the companion-aware
 context shims (``redact_via_context`` for payloads, ``redact_log_via_context``
@@ -122,7 +122,7 @@ class TestNoRawBoundedStderrSliceAnywhereInTheApp:
     bound must redact-then-bound through a redactor shim instead.
     """
 
-    # The shapes redaction can no longer see through once the slice has run:
+    # The shapes redaction cannot see through once the slice has run:
     # - a stderr expression head-sliced to a bound, with or without an interposed
     #   `or ''` default or `.strip()`  -> stderr...[:N]
     # - a stderr expression (or a var named like one) TAIL-sliced to a bound

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_suite_scope.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_suite_scope.py
@@ -141,10 +141,10 @@ class TestUnresolvableScopeRefuses:
         from kiro_crew.apps.builtins.auto_improvement.profiles.github_repo import profile as gp
 
         clone = self._repo(tmp_path / "clone")
-        # Matches on the CONSEQUENCE, not the cause: the guard deliberately no longer
-        # distinguishes "does not resolve" from "resolves but cannot be diffed" (both widen
-        # the fence identically), so asserting the old cause-specific wording would pin a
-        # distinction the code dropped on purpose.
+        # Matches on the CONSEQUENCE, not the cause: the guard deliberately does not
+        # distinguish "does not resolve" from "resolves but cannot be diffed" (both widen
+        # the fence identically), so asserting cause-specific wording would pin a
+        # distinction the code does not make.
         with pytest.raises(ValueError, match="could not be resolved to a file set"):
             gp.GitHubRepoProfile(
                 clone_path=clone,

--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -205,8 +205,8 @@ def _safe_campaign_dir(campaign_id: str) -> Path | None:
 
 
 # The campaigns DB carries a 30s busy timeout, so one on-loop lock wait can
-# outlast the 25s loop-stall watchdog budget and kill the gateway. #7039
-# offloaded all six call sites and added this guard; it now uses the shared
+# outlast the 25s loop-stall watchdog budget and kill the gateway. All six call
+# sites are offloaded behind this guard, which delegates to the shared
 # implementation in ``kiro_crew.on_loop_db``. Defaults are deliberate: this
 # surface IS fully offloaded, so it stays on the shared
 # ``KIROCREW_STRICT_ON_LOOP_PERSIST`` switch (which the e2e harness exports) and
@@ -1117,7 +1117,7 @@ async def _expire_trust(cid: str, observed_started_at: float | None) -> None:
     Transition FIRST, then write the synthetic question only if it persisted:
     a refused transition (a user Stop committed during the hop) must not leave
     a stale question file behind — it would drag a later Resume straight back
-    into NEEDS_INPUT with an expiry prompt that no longer applies.
+    into NEEDS_INPUT with an expiry prompt that does not apply.
     ``observed_started_at`` fences the write to the run generation whose age
     was actually measured — a Pause→Resume replacement run must not be parked
     by the previous run's expiry verdict.
@@ -1309,9 +1309,9 @@ def _stalled_campaign_verdict(
     The watchdog only marks COMPLETE when a NEW cycle file arrives carrying
     ``verification.passed=true`` (or the cycle cap is hit). A worker that ends
     its run deliberately via ``autonudge_stop`` — goal met, nothing more to
-    write — produces no further findings, so the campaign used to sit silent
-    until the unresponsive deadline and get stamped FAILED ("research stalled")
-    despite a finished report on disk. Distinguish the cases from durable
+    write — produces no further findings, so silence up to the unresponsive
+    deadline is not evidence of a stall: stamping FAILED ("research stalled")
+    would contradict a finished report on disk. Distinguish the cases from durable
     evidence:
 
     - Latest finding has ``verification.passed=true`` → COMPLETE. Also heals a
@@ -2654,7 +2654,7 @@ async def _handle_validate(request: web.Request) -> web.Response:
 #   { id, parent|null, kind: "root"|"clarifier"|"research", text,
 #     recommended (clarifier only), answer (clarifier only),
 #     origin: "grill"|"emergent" (research only), status }
-_MAX_GRILL_DEPTH = 4  # a node at this depth can no longer be expanded
+_MAX_GRILL_DEPTH = 4  # a node at this depth cannot be expanded
 _GRILL_CHILD_CAP = 5  # max children returned per expand
 
 
@@ -2728,8 +2728,8 @@ def _parse_grill_nodes(raw: str) -> list[dict]:
     """Extract child node dicts {kind, text, recommended?} from an LLM reply.
 
     Extraction delegates to the shared ``llm_helpers._extract_json_of_type``
-    scanner, so a stray bracket in surrounding prose no longer corrupts the
-    span the way the old outermost ``find('[') .. rfind(']')`` slice did.
+    scanner, so a stray bracket in surrounding prose cannot corrupt the span
+    the way an outermost ``find('[') .. rfind(']')`` slice would.
     Returns [] on any parse failure, or when two DIFFERENT node-shaped arrays
     make the choice ambiguous (the shared contract refuses to guess)."""
     try:
@@ -2739,8 +2739,6 @@ def _parse_grill_nodes(raw: str) -> list[dict]:
         # the untrusted reply overflows long before any structural bound. This
         # parser's callers are outside any exception envelope (the grill-expand
         # handler would surface it as HTTP 500), so degrade to no-nodes here.
-        # PR #5066 makes the shared scanner fail closed on this centrally;
-        # this guard becomes redundant-but-harmless once that lands.
         return []
     if not isinstance(items, list):
         return []
@@ -3428,9 +3426,9 @@ async def _handle_to_knowledge(request: web.Request) -> web.Response:
 
     # The store hands out one connection per thread, so all statement work for
     # this request runs off-loop in a single worker: a lock wait on the store's
-    # busy timeout must stall a thread, never the event loop (issue #7020's
-    # loop-stall class). ``add_source`` rides in the same closure because the
-    # status UPDATE needs its ``sid`` on the same per-thread connection.
+    # busy timeout must stall a thread, never the event loop. ``add_source`` rides
+    # in the same closure because the status UPDATE needs its ``sid`` on the same
+    # per-thread connection.
     def _add_source_marked_syncing() -> str:
         new_sid = store.add_source(name=name, source_type="local_file", uri=uri, properties={})
         store.db.execute("UPDATE sources SET sync_status = 'syncing' WHERE id = ?", (new_sid,))

--- a/src/kiro_crew/apps/builtins/aws_control/backend/accounts.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/accounts.py
@@ -48,7 +48,7 @@ _PROBE_TTL_SECS = 300.0
 #: once.
 _PROBE_CONCURRENCY = 4
 
-#: ``aws configure get`` reads used to classify a profile's auth mechanism.
+#: ``aws configure get`` reads that classify a profile's auth mechanism.
 #: Values are setting names passed to the CLI — the CLI parses the config
 #: files itself, so the names-only invariant holds.
 _KIND_SSO_SESSION = "sso_session"
@@ -61,7 +61,7 @@ KIND_CREDENTIAL_PROCESS = "credential-process"
 KIND_OTHER = "other"
 
 #: LoopBoundLock, not asyncio.Lock: a module-global asyncio primitive binds
-#: to the import-time loop and raises when acquired from another (#4800).
+#: to the import-time loop and raises when acquired from another.
 _snapshot_lock = LoopBoundLock()
 _snapshot: dict[str, Any] | None = None
 _snapshot_at: float = 0.0
@@ -470,7 +470,7 @@ def resolve_account_profile_cached(account: str) -> tuple[str, str] | None:
     runners, which are plain ``def`` by the SDK's contract. The async twin cannot
     be reached from there — ``asyncio.run`` in a worker thread builds a second
     event loop, and a module-global asyncio primitive binds to the loop that
-    imported it and raises when acquired from another (#4800, which is why
+    imported it and raises when acquired from another (which is why
     ``_snapshot_lock`` is a :class:`LoopBoundLock` at all). So this reads the
     snapshot the loop already built rather than building one of its own.
 

--- a/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
@@ -838,7 +838,7 @@ def make_job_runner(sdk: Any, kind: str) -> Any:
     Every resolution step is therefore sync. ``accounts.resolve_account_profile``
     and ``aws_consent.authorize`` are coroutines and are NOT reachable from a
     worker thread -- ``asyncio.run`` would build a second event loop, which is
-    the #4800 failure this package already carries a ``LoopBoundLock`` to avoid
+    the failure this package already carries a ``LoopBoundLock`` to avoid
     -- so this uses the sync cached resolver and lets the sync
     :func:`_authorize_upload` gate inside each runner make the paid-service
     decision. That gate is the real one: it re-checks the LIVE account against
@@ -921,7 +921,7 @@ def restore_download(
 
     The staging dir is agent-writable, so the download never writes through the
     final name: a link planted at that path would have the S3 bytes land on its
-    target. Two separate checks are needed, and round 17 only had the second:
+    target. Two separate checks are needed:
 
     * The staging DIRECTORY itself, and every component of it under the app data
       dir, must be a real directory. A linked ``restore/`` puts both the

--- a/src/kiro_crew/apps/builtins/aws_control/backend/library.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/library.py
@@ -124,7 +124,7 @@ def _read_ledger_for_update() -> dict[str, Any]:
     offers a re-push (a duplicate billable upload) and leaves the real cloud
     copies with no record to remove them by.
 
-    Corruption propagates too (#7805, mirroring #7794): "cannot merge into" is
+    Corruption propagates too: "cannot merge into" is
     not "safe to destroy". A truncated ledger still holds most of its records
     verbatim, and replacing it discards the operator's only chance to recover
     them by hand. Two shapes that never reach ``json.loads``'s own raise are
@@ -139,8 +139,7 @@ def _read_ledger_for_update() -> dict[str, Any]:
     The per-ACCOUNT tolerance in :func:`_update_ledger` (a corrupted scalar
     entry for the account being written is reset) is deliberately untouched:
     it replaces one account's unusable entry while carrying every other row
-    forward verbatim, not the whole document. The sidecar-preserve alternative
-    for even that case is tracked in #7789.
+    forward verbatim, not the whole document.
     """
     try:
         data = json.loads(_ledger_path().read_text(encoding="utf-8"))

--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -136,7 +136,7 @@ Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
 #: an out-of-band delete + hostile re-creation of the same name. Numbers can
 #: be stale; the identity of the bucket we write to cannot.
 #: Serializes drive creation (see _handle_drive_bootstrap). LoopBoundLock so
-#: the module global never binds an import-time loop (#4800).
+#: the module global never binds an import-time loop.
 #: How long the RENDER path waits for the Library lock before giving up on the
 #: reconcile. The lock is also held across a push, whose upload allows up to 600s,
 #: so waiting on it unbounded would let one large push hang every Library page
@@ -162,7 +162,7 @@ _bootstrap_lock = LoopBoundLock()
 #: surface where a human clicks buttons, so the contention is theoretical, and a
 #: per-slug map would need eviction to stay bounded. LoopBoundLock for the same
 #: reason ``_bootstrap_lock`` uses it: a module global must not bind an
-#: import-time loop (#4800).
+#: import-time loop.
 _library_lock = LoopBoundLock()
 
 #: Per-object-key write locks for the drive surface. A move promises "never
@@ -238,7 +238,7 @@ class _SectionRWLock:
 
     Writer-preferent: a waiting sweep blocks NEW shared holders, so a steady
     stream of uploads cannot starve a folder delete forever. State lives in
-    a per-loop map for the same reason ``LoopBoundLock`` exists (#4800): a
+    a per-loop map for the same reason ``LoopBoundLock`` exists: a
     module-global asyncio primitive must not bind an import-time loop.
     """
 
@@ -395,8 +395,8 @@ def _ledger_corrupt(code: str) -> web.Response:
     """Map a ledger reader's corruption refusal to a coded response.
 
     The share and library ledger update readers refuse a corrupt document
-    rather than replacing it (#7805), so mutation handlers can see a
-    ``json.JSONDecodeError`` that previously could not happen. Letting it
+    rather than replacing it, so mutation handlers can see a
+    ``json.JSONDecodeError`` at all. Letting it
     escape gives aiohttp's bare 500 -- no ``code`` for the UI to branch on --
     and letting a handler's ``except ValueError`` arm claim it (it IS a
     ``ValueError``) reports corruption as a client mistake. 500 rather than
@@ -1102,7 +1102,7 @@ async def _handle_drive_download(request: web.Request) -> web.Response:
     if isinstance(section, web.Response):
         return section
     if section == "backup":
-        # Backups stay owner-only by construction: no share (round 8) and no
+        # Backups stay owner-only by construction: no share and no
         # download presign either — a bearer URL to raw gateway state is the
         # same exposure class regardless of which route mints it. Recovery
         # goes through the restore endpoint, which downloads server-side.
@@ -1113,9 +1113,9 @@ async def _handle_drive_download(request: web.Request) -> web.Response:
         return _bad_request(err, "invalid_key")
     try:
         # Presigning is LOCAL signing - S3 is never consulted - so a stale or
-        # typo'd key mints a URL that looks fine and 404s when opened. Share has
-        # required this head-object since round 3; download mints the same kind
-        # of bearer URL and needs the same precondition. The same HEAD carries
+        # typo'd key mints a URL that looks fine and 404s when opened. Share
+        # requires this head-object; download mints the same kind of bearer URL
+        # and needs the same precondition. The same HEAD carries
         # the stored Content-Type, returned so the preview can tell a real PDF
         # from a `.pdf`-named object served as octet-stream (uploaded before
         # content types were set), which a sandboxed iframe shows as blank.
@@ -1381,7 +1381,7 @@ async def _handle_drive_upload(request: web.Request) -> web.Response:
             # Same per-key lock the move handler holds across its probe+copy:
             # an upload put inside the lock either finishes before a move's
             # destination probe (the probe then answers 409) or starts after
-            # the move released — it can no longer land inside the move's
+            # the move released — it cannot land inside the move's
             # probe-to-copy window and be silently overwritten. Only the
             # re-authorization and the put are inside the lock; the spool
             # transfer above must not hold it.
@@ -1675,8 +1675,8 @@ async def _handle_drive_share(request: web.Request) -> web.Response:
     note = str(body.get("note", ""))
     try:
         # The mint joins the coordination net: holding the KEY for the whole
-        # exists-check -> presign -> ledger-record sequence means a share can
-        # no longer land on a file mid-move (the race: move checks the share
+        # exists-check -> presign -> ledger-record sequence means a share cannot
+        # land on a file mid-move (the race: move checks the share
         # ledger, THEN this mints a share for the source, THEN the move
         # deletes it — a broken URL the ledger reports live until expiry).
         # With the lock, the mint either completes before the move's ledger
@@ -1757,7 +1757,7 @@ async def _drive_object_keys(request: web.Request, account: str) -> tuple[set[st
         # failing: the profile became unavailable or now names another account.
         # `_guarded`'s rule is that such a decision reaches SEL, and degrading
         # quietly would drop the one event an incident review asks about.
-        # `_audit` routes the SEL write off the loop itself (issue #8139).
+        # `_audit` routes the SEL write off the loop itself.
         await _audit("shares_list", request.path, "denied", error="account_unavailable")
         return None, "no working connection for this account"
     _account, profile, region = target
@@ -1886,7 +1886,7 @@ async def _reauthorize_in_lock(
     can be disabled, the profile can be repointed at another account, consent
     can be withdrawn, publish governance can start denying, or the drive tags
     can move to a different bucket -- and the call would then run on an
-    authorization that no longer holds.
+    authorization that does not hold.
 
     The order is deliberate: app, then IDENTITY, then consent. Consent is asked
     ABOUT a profile and region, so verifying it against a stale pair proves
@@ -2020,7 +2020,7 @@ async def _reconciled_remote_slugs(request: web.Request) -> tuple[set[str] | Non
         try:
             await asyncio.to_thread(library_mod.reconcile, account, slugs, observed_at=observed_at)
         except json.JSONDecodeError:
-            # The strict update reader refused a corrupt ledger (#7805). Same
+            # The strict update reader refuses a corrupt ledger. Same
             # degradation as the OSError arm below -- this route is best-effort by
             # contract and the LIST must keep rendering (its rows come from the
             # lenient display read) -- but the reason differs on the axis the
@@ -2161,7 +2161,7 @@ async def _handle_library_push(request: web.Request) -> web.Response:
         return _not_found("unknown artifact", "unknown_artifact")
     except json.JSONDecodeError:
         # MUST precede the ``ValueError`` arm below: ``JSONDecodeError`` subclasses
-        # ``ValueError``, so without this the ledger's corruption refusal (#7805)
+        # ``ValueError``, so without this the ledger's corruption refusal
         # would be reported as ``not_pushable`` -- a 400 blaming the artifact for a
         # store the operator has to repair. The objects may already be in the
         # bucket (upload precedes the ledger write); the honest answer is that the
@@ -2315,15 +2315,15 @@ async def _handle_backup_run(request: web.Request) -> web.Response:
     ``_jobs`` surface, which withholds ``dedupe_key`` and so cannot answer
     "is a backup running for THIS account".
 
-    The pre-flight below stays, but its job has changed. It is no longer the
-    authorization gate -- ``backup._authorize_upload`` is, inside the worker,
+    The pre-flight below is not the authorization gate --
+    ``backup._authorize_upload`` is, inside the worker,
     immediately before the upload, and it holds for a run started through the
     generic ``_jobs`` surface too. What the pre-flight buys is a FAST, specific
     refusal: an unreconnected account, unconfirmed S3, or a missing drive answers
     409 with a code the UI can localise, instead of accepting the run and
     reporting the same thing thirty seconds later as a failed record.
 
-    The terminal record is no longer in this response, because there is no
+    There is no terminal record in this response, because there is no
     terminal record yet. It reaches the client through ``GET /backup/{account}``,
     whose ``runs`` ledger the worker writes on success -- unchanged, and still
     the app's own record of what a backup PRODUCED (key, size, when). The Job SDK

--- a/src/kiro_crew/apps/builtins/aws_control/backend/shares.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/shares.py
@@ -102,7 +102,7 @@ def _load_for_update() -> list[dict[str, Any]]:
     truncated ledger under-reports access that is still working. The error
     propagates and the mutation is abandoned instead.
 
-    Corruption propagates too (#7805, mirroring #7794): a document that failed
+    Corruption propagates too: a document that failed
     to parse carries nothing to merge into, but "cannot merge into" is not
     "safe to destroy". A truncated file still holds most of its records
     verbatim, and replacing it discards the operator's only chance to recover

--- a/src/kiro_crew/apps/builtins/aws_control/backend/storage.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/storage.py
@@ -723,7 +723,7 @@ def get_object_head_bytes(
     # tree -- a pinned directory can be neither renamed nor deleted, and
     # neither can anything above it. So by the time the destination is created
     # below, every component of the path the CLI will write through is held
-    # in place: a watcher can no longer rename the directory away and plant a
+    # in place: a watcher cannot rename the directory away and plant a
     # junction at its name between our create and the CLI's open.
     root_fd = platform_compat.pin_directory(staging_parent)
     dir_fd = -1
@@ -1011,7 +1011,7 @@ def create_folder(
     shape the listing filters on cannot be spoofed into some other form.
 
     Owner-pinned like every other write: ``--expected-bucket-owner`` makes S3
-    itself reject the put if the globally-unique bucket name is no longer this
+    itself reject the put if the globally-unique bucket name is not this
     account's, the same reason :func:`put_file` cannot use ``s3 cp``. A body is
     deliberately omitted so the object is zero bytes.
     """

--- a/src/kiro_crew/apps/builtins/aws_control/hooks.py
+++ b/src/kiro_crew/apps/builtins/aws_control/hooks.py
@@ -210,7 +210,7 @@ async def on_shutdown(ctx: Any) -> None:  # noqa: ARG001 — kept for the hook A
     The residual is one in-flight object: an ``aws s3 cp`` already mid-stream
     finishes, into the owner's own bucket, and the SEL record above says it did.
     Revoking that would mean tracking and terminating the CLI subprocess itself,
-    which is the same containment work tracked in #5430.
+    which this hook does not do.
     """
     global _task
     backup_mod.signal_stop()

--- a/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
@@ -159,10 +159,8 @@ def _write_runs(payload: str) -> None:
     """
     f = _runs_file()
     f.parent.mkdir(parents=True, exist_ok=True)
-    # The shared helper already does everything this write needs, and does one
-    # thing the hand-rolled version did not: it replaces through
-    # ``replace_with_retry``, so a transient Windows sharing violation does not
-    # silently lose the save (the defect class tracked in #4701 / #4898). It also
+    # The shared helper replaces through ``replace_with_retry``, so a transient
+    # Windows sharing violation does not silently lose the save. It also
     # picks a random mkstemp name, applies the owner-only lockdown to the temp
     # BEFORE the payload lands, and refuses to follow a planted parent link --
     # the three properties the review worker's writable tree requires, since it
@@ -513,14 +511,14 @@ async def _run_review_bg(run: dict, changes: list[str]) -> None:
                 run["status"] = "error"
             elif attempted > 0 and (recorded == 0 or deep == 0):
                 # run_review returns ok=True for any run with >=1 change, so a run
-                # whose every change failed used to report "done" with an empty
-                # report. Nothing was reviewed; say so rather than letting the UI
-                # claim success and then show an empty report.
+                # whose every change failed would otherwise report "done" with an
+                # empty report. Nothing was reviewed; say so rather than letting the
+                # UI claim success and then show an empty report.
                 #
                 # `deep == 0` is checked as well as `recorded == 0`: a change can
-                # persist a record and still never be deep-reviewed, which cleared the
-                # record count while leaving the report with no findings in it. Both
-                # are the same "claimed success, delivered nothing" failure.
+                # persist a record and still never be deep-reviewed, which leaves a
+                # non-zero record count with no findings in the report. Both are the
+                # same "claimed success, delivered nothing" failure.
                 run["status"] = "error"
                 run["error"] = _first_change_error(summary) or (
                     "the reviewer produced no result record")
@@ -1556,8 +1554,8 @@ async def _handle_repos(request: web.Request) -> web.Response:
         repos = await asyncio.to_thread(discovery.remove_repo, owner, name)
     out: dict[str, Any] = {"ok": True, "repos": repos}
     if request.method == "POST":
-        # Which repo was just added. The caller previously guessed at repos[0],
-        # which is only right if the store happens to prepend.
+        # Name the added repo explicitly: repos[0] is only it if the store
+        # happens to prepend.
         out["added"] = {"owner": owner, "repo": name}
     if request.method == "POST" and pr is not None:
         # The caller uses this to open the pasted pull request instead of leaving

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/followup.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/followup.py
@@ -73,7 +73,7 @@ logger = logging.getLogger(__name__)
 #: outside the run.
 ERR_LINKED_DIR = "chat_transcript_dir_unsafe"
 
-#: The run this follow-up belongs to no longer exists.
+#: The run this follow-up belongs to does not exist.
 ERR_RUN_GONE = "chat_run_deleted"
 
 #: No descriptor was recorded for this review (it predates the feature, or its

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/learning.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/learning.py
@@ -398,9 +398,9 @@ def clear_candidate(root: Path | None = None, namespace: str | None = None,
     cf = candidate_file(root, namespace)
     if not cf.exists():
         return False
-    # Both branches run under the lock. The full unlink used to sit outside it,
-    # so a `stage_learning` append could complete between the exists() check and
-    # the unlink and be deleted without ever being read — the same read-modify-
+    # Both branches run under the lock. With the full unlink outside it, a
+    # `stage_learning` append can complete between the exists() check and the
+    # unlink and be deleted without ever being read — the same read-modify-
     # write race the selective branch takes the lock for.
     with _candidate_lock(root, namespace):
         if not cf.exists():          # a concurrent clear got there first

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/pipeline.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/pipeline.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Optional KiroCrew redaction — used to scrub LLM-generated text before it is
+# Optional Kiro Crew redaction — scrubs LLM-generated text before it is
 # posted to an external surface. Imported at module top (absent only when run
 # fully standalone outside the KiroCrew runtime).
 try:
@@ -428,13 +428,13 @@ def review_payload_units(payload: dict) -> int:
     """How many deliverable units a GitHub review payload actually contains.
 
     The poster is instructed to write ``posted_comments = len(comments) + 1 when
-    body is non-empty``, so delivery evidence is counted in PAYLOAD UNITS. Callers
-    used to compare that against the number of FINDINGS instead, which is a
-    different quantity: a finding with no usable ``{path, line}`` anchor is folded
-    into the review body rather than becoming its own inline comment (see
-    ``build_github_review_payload``). One unanchored finding therefore made a
-    complete delivery look short, and the caller then re-posted comments already on
-    the pull request.
+    body is non-empty``, so delivery evidence is counted in PAYLOAD UNITS. The
+    number of FINDINGS is a different quantity and must not be compared against
+    it: a finding with no usable ``{path, line}`` anchor is folded into the review
+    body rather than becoming its own inline comment (see
+    ``build_github_review_payload``). One unanchored finding would make a complete
+    delivery look short, and the caller would re-post comments already on the pull
+    request.
 
     This is the single place that number is derived, so the comparison in
     ``post_recorded`` and the durable ``posting_expected`` cannot drift apart.

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
@@ -124,20 +124,19 @@ def _redact_deep_map(d: dict, skip: frozenset[str] = frozenset(), *,
 def _redact_finding(f: dict) -> dict:
     """Scrub every model-written string in a finding, at any depth.
 
-    Enumerating the prose fields missed `file`, which the reviewer also writes and
+    Enumerating the prose fields misses `file`, which the reviewer also writes and
     which reaches report.json and the dashboard. Redacting every string value
-    instead of a named subset closed the set of KEYS; `_redact_deep` then closed
-    the set of VALUES, so a nested dict or list can no longer carry an injected
-    secret through.
+    instead of a named subset closes the set of KEYS; `_redact_deep` closes the
+    set of VALUES, so a nested dict or list cannot carry an injected secret
+    through.
 
-    There is NO skip set. `line` used to be exempt "because it is numeric", but
-    nothing enforced that: the boundary validator accepts any scalar, so a
-    reviewer writing a credential into `line` as a string sailed past the
-    exemption and reached the dashboard unredacted. `validate_result` now requires
-    `line` to be a real number, which makes the exemption unnecessary — a number
-    is not a string, so `_redact_deep` leaves it alone anyway. An exemption whose
-    premise is not enforced is just a hole, so the premise is enforced and the
-    exemption is gone.
+    There is NO skip set. Exempting `line` "because it is numeric" needs that
+    premise enforced: a boundary validator accepting any scalar lets a reviewer
+    write a credential into `line` as a string and sail past the exemption to the
+    dashboard unredacted. `validate_result` requires `line` to be a real number,
+    which makes an exemption unnecessary — a number is not a string, so
+    `_redact_deep` leaves it alone anyway. An exemption whose premise is not
+    enforced is just a hole, so the premise is enforced and there is no exemption.
     A finding's KEY NAMES are model-written too -- the boundary validator requires
     the fields it needs but does not forbid extras, so a worker can name a field
     anything, including a credential. `redact_keys=True` scrubs this level's names;
@@ -226,18 +225,18 @@ def classify(record: dict, config: dict | None = None) -> dict:
 # and `band_override` is already constrained to them, so this is a vocabulary for
 # screening the UNTRUSTED read path, not a constraint on our own output.
 #
-# It replaces a redaction exemption. `band` used to be the one row field skipped by
-# `_redact_row`, on the argument that `bands[row["band"]]` here and
-# `BAND_DOT[row.band]` in ReportView index on its exact value. The concern was real
-# but the protection was wrong: redaction is shape-based, so red/yellow/green come
-# back byte-identical and the indexing was never at risk — while the exemption made
-# `band` the single field in the row that reached the dashboard verbatim, so a
-# planted "red <credential>" leaked where the prose beside it was scrubbed.
+# It stands in for a redaction exemption, which no row field gets. Exempting
+# `band` from `_redact_row` because `bands[row["band"]]` here and
+# `BAND_DOT[row.band]` in ReportView index on its exact value is unnecessary:
+# redaction is shape-based, so red/yellow/green come back byte-identical and the
+# indexing is never at risk — while an exemption makes `band` the single field in
+# the row that reaches the dashboard verbatim, so a planted "red <credential>"
+# leaks where the prose beside it is scrubbed.
 #
-# An earlier version of that set also exempted `change_id`, `platform`,
-# `gate_verdict`, `blast` and `design_risk` on the claim that they are "validated
-# against fixed vocabularies". That was wrong for the same reason: `validate_result`
-# enforces a vocabulary for `gate_verdict` alone. Nothing in a row is exempt now.
+# The same holds for `change_id`, `platform`, `gate_verdict`, `blast` and
+# `design_risk`: "validated against fixed vocabularies" is not true of them —
+# `validate_result` enforces a vocabulary for `gate_verdict` alone. Nothing in a
+# row is exempt.
 _VALID_BANDS = frozenset({"red", "yellow", "green"})
 
 
@@ -650,7 +649,7 @@ def write_outputs(report: dict, html_body: str, root: Path | None = None,
     # Full report for the in-app report view (all bands + findings).
     full_path = rd / "report.json"
     _atomic_write(full_path, json.dumps(report, indent=2))
-    # Preserve a previously-set artifact slug when regenerating without one, so
+    # Preserve an already-recorded artifact slug when regenerating without one, so
     # "Open full report" keeps working across re-reviews (the driver calls
     # generate() with slug=None on every run).
     if slug is None:
@@ -817,10 +816,10 @@ def read_within_reports(path: Path, root: Path | None = None,
 
     The counterpart to `_atomic_write`, and for the same reason: the reports dir
     is reachable by the review worker, so any of these names can be a planted
-    symlink. Round 21 stopped the WRITES from following a plant, which left the
-    reads — a link at `focus-report.html` or `index.json` pointing at a
-    credential file was still followed, and its contents flowed onward into a
-    dashboard artifact or a rendered report. `hooks.safe_read_file_bytes_nolink`
+    symlink. The WRITES not following a plant is not enough on its own: an
+    unguarded read of a link at `focus-report.html` or `index.json` pointing at a
+    credential file follows it, and its contents flow onward into a dashboard
+    artifact or a rendered report. `hooks.safe_read_file_bytes_nolink`
     opens with O_NOFOLLOW and validates the inode it actually read, and pinning
     `within_root` to the reports dir also rejects a path that escapes it.
     Returns None when the file is missing, planted, or not valid UTF-8; every

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
@@ -131,9 +131,9 @@ def validate_result(record: dict) -> list[str]:
         # text (gate_verdict, design_risk, criticality, design_headline, problem,
         # why_it_matters, solution_assessment), and the readers consume them as
         # text: `.strip()` in classify, `html.escape()` in the renderer. Accepting
-        # a number here let both crash on a record this function had approved --
-        # and it also skipped the verdict-vocabulary check below, because that
-        # check used to be guarded by an isinstance() test that a number failed.
+        # a number here would let both crash on a record this function approved --
+        # and it would also skip the verdict-vocabulary check below, which is
+        # guarded by an isinstance() test that a number fails.
         # Refusing the record is the fail-closed direction: a numeric phase1 value
         # is malformed per the contract, and a rejected record is re-reviewed
         # rather than rendered half-broken.
@@ -147,9 +147,9 @@ def validate_result(record: dict) -> list[str]:
         # so execution reaches this line with the bad value still in hand, and
         # `not in VALID_VERDICTS` tests a SET — an unhashable list/dict would raise
         # TypeError inside the validator whose whole job is to report malformed
-        # records. It is no longer a hole the way it was under the "any scalar" rule:
-        # every non-string value now fails the string check above, so the guard only
-        # suppresses a duplicate complaint, never the only one.
+        # records. It is not a hole, because every non-string value fails the string
+        # check above, so the guard only suppresses a duplicate complaint, never the
+        # only one.
         if isinstance(p1.get("gate_verdict"), (str, type(None))) \
                 and p1.get("gate_verdict") not in VALID_VERDICTS:
             errs.append(f"phase1.gate_verdict must be one of {sorted(VALID_VERDICTS)}")
@@ -188,8 +188,8 @@ def validate_result(record: dict) -> list[str]:
             # `line` is checked in the loop above rather than here, so a missing key
             # and a wrong-typed one produce one message each, not two for the latter.
             # The renderer and every consumer treat it as a line number, and the
-            # report redactor no longer exempts it -- a credential written into it as
-            # a string used to ride that exemption to the dashboard.
+            # report redactor does not exempt it -- a credential written into it as a
+            # string would ride such an exemption to the dashboard.
     # `counts` and `blast_radius` are read with `.get()` in pipeline.py,
     # report.py and review_driver.py. A worker that wrote either as a list or a
     # scalar passed validation, was adopted, and then aborted the run with an
@@ -408,12 +408,12 @@ def adopt_from_shared(change_id: str, root: Path | None = None,
             str(src), str(shared), max_bytes=_RECORD_MAX_BYTES)
     if raw is None:
         return False
-    # Validate BEFORE touching the destination. Round 13 replaced an atomic
-    # os.replace with an O_TRUNC write to close a symlink hole, and in doing so
-    # gave up all-or-nothing semantics: a malformed payload truncated whatever
-    # valid record was already there, and read_result then raised on the wreckage
-    # so no retry could recover it. Parse first, and only a record that is really
-    # for THIS change is allowed to land.
+    # Validate BEFORE touching the destination. The publish is an O_TRUNC write
+    # rather than an atomic os.replace, to close a symlink hole, so it has no
+    # all-or-nothing semantics: a malformed payload truncates whatever valid record
+    # is already there, and read_result then raises on the wreckage so no retry can
+    # recover it. Parse first, and only a record that is really for THIS change is
+    # allowed to land.
     try:
         parsed = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, ValueError):

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -523,7 +523,7 @@ def build_post_task(change_link: str) -> str:
     )
     # FAIL CLOSED on host resolution — the host decides which GitHub instance
     # every `gh api` call in this prompt targets. `_confirmed_host` raises when
-    # the link names a host that no longer revalidates (a GHE host removed from
+    # the link names a host that does not revalidate (a GHE host removed from
     # `github_hosts` mid-run, an unreadable config); producing a prompt then
     # would let every call default to PUBLIC github.com and post an internal
     # enterprise draft onto a public same-slug PR. The raise is converted to a
@@ -825,7 +825,7 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
         return {"post_ok": False, "post_error": staged, "posted_comments": 0,
                 "design_comment_posted": False, "pending": len(pending),
                 "expected_units": 0, "posted_keys": list(already)}
-    # The prompt builder FAILS CLOSED when the link's host no longer revalidates
+    # The prompt builder FAILS CLOSED when the link's host does not revalidate
     # (see build_post_task): a prompt built with an unconfirmed host would let
     # its `gh api` calls default to public github.com and land this draft on a
     # public same-slug PR. Surface that as a per-change post failure — the
@@ -915,8 +915,8 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
             spawn.get("error", "")
             or ("" if confirmed else
                 "the posted draft could not be confirmed on the pull request")),
-        # Authoritative once confirmed: `after["posted_comments"]` was replaced with
-        # the payload's own unit count above, so this no longer echoes the poster.
+        # Authoritative once confirmed: `after["posted_comments"]` holds the payload's
+        # own unit count from above, so this does not echo the poster.
         "posted_comments": int(after.get("posted_comments", 0) or 0),
         "design_comment_posted": bool(after.get("design_comment_posted")),
         "pending": len(pending),
@@ -1042,7 +1042,7 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
     Phase-2 deep-review task for every usable verdict (PASS / CONCERNS / BLOCK).
     Each task is dispatched to the reusable worker pool (``dispatch``) and the
     call returns when that task's session finishes its turn. The driver reads
-    the gate verdict; a BLOCK no longer skips Phase 2 (it only informs the ship
+    the gate verdict; a BLOCK does not skip Phase 2 (it only informs the ship
     decision), then builds the Focus Report. Returns a deterministic summary.
 
     ``dispatch`` is an injected ``(task, timeout) -> {ok, output, error}`` callable
@@ -1205,7 +1205,7 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
         # someone else's findings on this pull request. If the slot cannot be cleared, skip
         # adoption rather than trust it.
         # Build the prompt BEFORE staking the shared slot: the builder FAILS
-        # CLOSED (raises) when the link's host no longer revalidates against
+        # CLOSED (raises) when the link's host does not revalidate against
         # `allowed_hosts()`, and a fetch instruction with an unconfirmed host
         # would route the worker at public github.com — reviewing (and later
         # posting about) a same-slug public PR instead of the intended one.
@@ -1406,7 +1406,7 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
         #
         # The report is written to the run's own dir FIRST and kept there
         # regardless of whether the artifact archive succeeds — the in-app report
-        # view reads that file, so a failed archive no longer means "no report".
+        # view reads that file, so a failed archive does not mean "no report".
         try:
             rep = report.generate(root, run_id=run_id)
             summary["report"] = rep["index"]

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
@@ -448,10 +448,10 @@ def data_dir(root: Path | None = None) -> Path:
 
 # --- Per-run scratch ---------------------------------------------------------
 # Every review run owns a private subtree, ``data/runs/<run-id>/``, holding its
-# result records and its report. Runs used to share one ``data/results`` dir and
-# one ``data/reports`` index, which forced the backend to serialize whole runs
-# (an overlapping run would clear the records the other was still writing) and
-# left only the newest report readable. Per-run isolation is what lets several
+# result records and its report. Sharing one ``data/results`` dir and one
+# ``data/reports`` index across runs forces the backend to serialize whole runs
+# (an overlapping run clears the records the other is still writing) and leaves
+# only the newest report readable. Per-run isolation is what lets several
 # reviews run at once AND keeps each finished report retrievable by run id.
 #
 # What stays GLOBAL (deliberately, do not move under a run): ``config.json``,
@@ -526,7 +526,7 @@ def remove_run_dir(run_id: str, root: Path | None = None) -> bool:
 
 
 def list_run_ids(root: Path | None = None) -> list[str]:
-    """Run ids that currently have an on-disk subtree (used to reap orphans)."""
+    """Run ids that currently have an on-disk subtree (the input for orphan reaping)."""
     rr = runs_root(root)
     if not rr.is_dir():
         return []

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/fixtures.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/fixtures.py
@@ -70,7 +70,7 @@ SENSITIVE_TINY_FILES = [{
 
 # A GitHub PR payload as the worker assembles it from `gh api`: the pulls/{n}
 # object merged with a `files` array (each carrying its per-file `patch`) and
-# a `comments` list. Mirrors the private kiro-team/kiro-cli PR #3361 shape.
+# a `comments` list. Mirrors the shape of a private kiro-team/kiro-cli pull request.
 GITHUB_PAYLOAD = {
     "number": 3361,
     "title": "Fix set_mode deadlock in SwapAgent handler",

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_adapters.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_adapters.py
@@ -215,7 +215,7 @@ class TestGithubParse(unittest.TestCase):
     def test_metadata(self):
         self.assertEqual(self.t.author, "zejiangg")
         self.assertEqual(self.t.target_branch, "main")
-        # head SHA is the commit_id used to anchor draft comments.
+        # head SHA is the commit_id that anchors draft comments.
         self.assertEqual(self.t.revision, "fb58081a1c0ffee0000000000000000000000000")
         self.assertTrue(self.t.is_fix)
         self.assertEqual(self.t.linked_issue, "#3250")

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
@@ -177,7 +177,7 @@ class TestRunsPersistence(unittest.TestCase):
 
 
 class TestRecordReviewedDelivery(unittest.TestCase):
-    """Regression for the reviewed-index write path:
+    """The reviewed-index write path:
       * a PR is indexed as reviewed ONLY when the poster
         actually delivered (posted_comments >= posting_expected), not merely when
         the poster turn completed (post_ok). A failed gh post must not strand it.
@@ -230,7 +230,7 @@ class TestRecordReviewedDelivery(unittest.TestCase):
 
 
 class TestUnderLockRededup(unittest.TestCase):
-    """Regression for the TOCTOU + double-review guards: a run re-checks the
+    """The TOCTOU + double-review guards: a run re-checks the
     reviewed index AND the in-flight claim registry before it owns a change, so a
     PR another run just recorded (or is reviewing right now) is not re-reviewed."""
 
@@ -640,8 +640,8 @@ if __name__ == "__main__":
 
 
 # ---------------------------------------------------------------------------
-# Round 11: worker-authored merge content reached learned-patterns.md unredacted,
-# and a half-failed auto-post still deleted the records the retry needs.
+# Worker-authored merge content must reach learned-patterns.md redacted, and a
+# half-failed auto-post must keep the records the retry needs.
 # ---------------------------------------------------------------------------
 
 
@@ -756,8 +756,8 @@ class TestAdoptionRefusesAPlantedLink:
     """The reviewer worker owns the shared dir and has file tools.
 
     ``is_file()`` follows symlinks, and ``os.replace`` moves the LINK, so a link
-    planted where a record belongs used to land in the run dir intact — and
-    ``read_result`` dereferences it with a plain read. Adoption must never carry a
+    planted where a record belongs lands in the run dir intact unless refused —
+    and ``read_result`` dereferences it with a plain read. Adoption must never carry a
     link across, and must not leave one behind to retry.
     """
 
@@ -883,10 +883,10 @@ class TestRetentionKeepsActiveRuns(unittest.IsolatedAsyncioTestCase):
 class TestAdoptionValidatesBeforeItWrites:
     """Adoption must be all-or-nothing.
 
-    Round 13 traded ``os.replace`` for an ``O_TRUNC`` write to close a symlink
-    hole, and that gave up atomicity: a malformed payload truncated whatever valid
-    record was already filed, and ``read_result`` then raised on the wreckage, so
-    no retry could recover it. Validate first, write via rename.
+    The ``O_TRUNC`` write that closes the symlink hole is not atomic: a malformed
+    payload truncates whatever valid record is already filed, and ``read_result``
+    then raises on the wreckage, so no retry can recover it. Validate first, write
+    via rename.
     """
 
     def _stage(self, tmp_path, change_id, body):
@@ -1069,7 +1069,7 @@ class TestRestartClearsAStrandedPostingFlag(unittest.TestCase):
         self.assertIn("restart", (run.get("post_error") or "").lower())
         # Delivery evidence survives, so re-posting sends only the remainder.
         self.assertEqual(run["posted_keys"], {"c1": ["k1"]})
-        # And the run is no longer considered live, so retention can reclaim it.
+        # And the run does not count as live, so retention can reclaim it.
         self.assertFalse(self.routes._is_live(run))
 
     def test_a_run_that_was_not_posting_is_untouched(self):
@@ -1093,11 +1093,11 @@ class TestGroupedPostAppliesKeysPerChange(unittest.TestCase):
     """A multi-change selection is one request, and each group keeps its own keys.
 
     `posting` is a per-run flag that only the poster clears, while the POST handler
-    returns as soon as it dispatches the poster -- so one request per change had
+    returns as soon as it dispatches the poster -- so one request per change gets
     every change after the first refused with `already_posting`. The grouped form
     is what makes the deliberate multi-select actually publish; the per-change key
-    scoping (round 8) has to survive inside it, or a selection made on one pull
-    request would be applied to another.
+    scoping has to survive inside it, or a selection made on one pull request would
+    be applied to another.
     """
 
     def setUp(self):
@@ -1455,10 +1455,10 @@ class TestCountValuesMustBeNumeric:
 
 
 class TestReportsDirReadsDoNotFollowAPlant:
-    """Round 21 made the reports-dir WRITES not follow a plant; the READS did.
+    """The reports-dir READS must not follow a plant, just as the WRITES do not.
 
-    The dir is reachable by the review worker, so a symlink at `index.json` or
-    `focus-report.html` was followed on read and its contents flowed onward —
+    The dir is reachable by the review worker, so an unguarded read of a symlink at
+    `index.json` or `focus-report.html` follows it and its contents flow onward —
     into a rendered report, or into a shareable dashboard artifact.
     """
 
@@ -1772,7 +1772,7 @@ class TestNoFindingFieldIsExemptFromRedaction:
 
 
 class TestFindingLineMustBeANumber:
-    """The boundary enforces what the redactor used to assume."""
+    """The boundary enforces `line` as a number, so no exemption rests on it."""
 
     def _record(self, line):
         return {
@@ -1912,11 +1912,11 @@ class TestNestedStringFieldsMustBeScalars:
 class TestRetryRepairsTheReviewedIndex(unittest.TestCase):
     """A retry that succeeds after a failed post must leave the PR indexed.
 
-    `_record_reviewed` reads ONLY `summary.per_change`. The explicit-retry path
-    used to write just the run-level counters, so a record still showing the
-    original failure kept the PR out of the dedup index -- and the next repo
-    review reviewed and posted it a second time. Both the first attempt and the
-    retry now write those fields through `review_driver.apply_post_outcome`.
+    `_record_reviewed` reads ONLY `summary.per_change`. A retry writing just the
+    run-level counters leaves a record still showing the original failure, which
+    keeps the PR out of the dedup index -- and the next repo review reviews and
+    posts it a second time. Both the first attempt and the retry write those fields
+    through `review_driver.apply_post_outcome`.
     """
 
     def setUp(self):
@@ -2242,11 +2242,11 @@ class TestPhase1ValuesMustBeStrings(unittest.TestCase):
         self.assertTrue(any("must be a string" in e for e in errs), errs)
 
     def test_numeric_gate_verdict_is_refused(self):
-        """This used to validate cleanly.
+        """A numeric gate_verdict must not validate cleanly.
 
-        The vocabulary check sat behind an isinstance() guard, so a numeric
-        gate_verdict was neither rejected as a shape nor checked against
-        VALID_VERDICTS — it reached `html.escape()` in the renderer, which raises.
+        Behind an isinstance() guard alone, a numeric gate_verdict is neither
+        rejected as a shape nor checked against VALID_VERDICTS — it reaches
+        `html.escape()` in the renderer, which raises.
         """
         from sage_lib import results
 
@@ -2345,12 +2345,12 @@ class TestPersistedReportIsRedactedOnRead(unittest.TestCase):
 class TestPlantedReportMetadataCannotBreakTheEndpoint(unittest.TestCase):
     """The remaining worker-writable fields in the read_report payload.
 
-    Round 40 redacted the rows and coerced the tallies but left two gaps in its
-    own hardening: `bands` was screened for truthiness rather than for being a
-    MAPPING, and `report_slug` was passed through untouched.
+    Redacting the rows and coercing the tallies is not enough on its own: `bands`
+    screened for truthiness rather than for being a MAPPING, and `report_slug`
+    passed through untouched, are two gaps.
 
-    `[] or {}` yields `{}`, so an empty list looked handled -- but a truthy
-    non-dict (a non-empty list, a string, a number) reached `.get` and raised
+    `[] or {}` yields `{}`, so an empty list looks handled -- but a truthy
+    non-dict (a non-empty list, a string, a number) reaches `.get` and raises
     AttributeError, turning a planted file into an HTTP 500 on the report
     endpoint. The slug names an artifact the dashboard turns into a share link, so
     it is screened against the artifact store's own grammar rather than redacted:

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_paste_pr_link.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_paste_pr_link.py
@@ -2,10 +2,10 @@
 """Pasting a PULL REQUEST link into the add-repo field.
 
 That field is the only place in the app you can type, so a URL from the clipboard
-lands there whatever it points at. It used to reject a PR link and tell the user to
-use the paste-PR box — which only exists once a repo is already picked, i.e. the
-thing they were trying to do. Now the PR's repo is pinned and the PR is reported
-back so the caller can open it.
+lands there whatever it points at. A PR link pins that PR's repo and reports the
+PR back so the caller can open it, rather than being refused in favour of the
+paste-PR box — which only exists once a repo is already picked, i.e. the thing the
+user is trying to do.
 """
 from __future__ import annotations
 
@@ -102,8 +102,8 @@ class TestRepoEndpointWithPullRequest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("pull_request", _text(resp))
 
     async def test_reports_which_repo_was_added(self):
-        # The caller previously guessed repos[0], which is only right if the store
-        # happens to prepend.
+        # repos[0] is only the added repo if the store happens to prepend, so the
+        # response names it.
         await routes._handle_repos(_FakeRequest(  # type: ignore[arg-type]
             {"repo": "https://github.com/first/one"}))
         resp = await routes._handle_repos(_FakeRequest(  # type: ignore[arg-type]

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_pipeline.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_pipeline.py
@@ -29,8 +29,8 @@ class TestBatchParse(unittest.TestCase):
 
     def test_a_malformed_link_does_not_sink_the_batch(self):
         # "https://[::1" makes urlparse raise ValueError. The user-facing failure
-        # this guards: one malformed entry in a pasted batch used to crash the
-        # whole request (HTTP 500), discarding every valid link with it.
+        # this guards: one malformed entry in a pasted batch crashing the whole
+        # request (HTTP 500) and discarding every valid link with it.
         out = P.parse_batch("https://github.com/o/r/pull/3\n"
                             "https://[::1\n"
                             "https://github.com/o/r/pull/4")
@@ -52,9 +52,9 @@ class TestBatchParse(unittest.TestCase):
 
     def test_prefixed_tokens_yield_their_embedded_url(self):
         # Bulleted/markdown lists are the normal clipboard shape from Slack or
-        # an issue. The user-facing failure this guards: every prefixed link
-        # used to be dropped silently, so the batch under-reviewed with no
-        # error. Each shape must yield its embedded PR URL.
+        # an issue. The user-facing failure this guards: a prefixed link dropped
+        # silently, so the batch under-reviews with no error. Each shape must yield
+        # its embedded PR URL.
         text = ("- https://github.com/o/r/pull/1\n"
                 "* https://github.com/o/r/pull/2\n"
                 "[PR](https://github.com/o/r/pull/3)\n"

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_post_comments.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_post_comments.py
@@ -139,7 +139,7 @@ class TestPostRecorded(_Base):
         self.assertEqual(out["posted_comments"], 0)
 
     async def test_an_unresolvable_host_aborts_the_post_fail_closed(self):
-        """A link whose host is no longer in `allowed_hosts()` (the GHE host was
+        """A link whose host is absent from `allowed_hosts()` (the GHE host
         removed from `github_hosts` between run start and posting) must abort
         BEFORE any poster runs. A prompt built anyway would carry no
         `--hostname`, every `gh api` call in it would default to PUBLIC

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """The worker writes ``data/results/<id>.json``; the run reads its own dir.
 
-Regression for a real failure: per-run isolation moved the READ path to
-``data/runs/<run_id>/results/`` but the reviewing worker's prompt (and the
-`sage-review` skill) still name the shared ``data/results/<id>.json``. The run
-dir stayed empty, so a review that had genuinely completed reported
-``result_records: 0`` and the UI showed an empty report while claiming "done".
+Per-run isolation puts the READ path at ``data/runs/<run_id>/results/`` while the
+reviewing worker's prompt (and the `sage-review` skill) name the shared
+``data/results/<id>.json``. Without adoption the run dir stays empty, so a review
+that genuinely completed reports ``result_records: 0`` and the UI shows an empty
+report while claiming "done".
 
 The driver owns run scoping, so it adopts the worker's record after each turn.
 """

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_report.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_report.py
@@ -78,11 +78,11 @@ class TestLlmRedaction(unittest.TestCase):
         # exfiltration link there and the report view renders it as a link. The
         # structural fields the app keys on are the ones held back.
         self.assertTrue(row["url"].startswith("[R]"), "url not redacted")
-        # `band` is redacted like every other worker-written string. It used to be
-        # the one exemption, on the argument that `bands[]` and `BAND_DOT[]` index
-        # on its exact value — but that made it the single field in a row that
-        # reached the dashboard verbatim, so a planted "red <credential>" leaked
-        # while the prose beside it was scrubbed. Keying is protected instead by
+        # `band` is redacted like every other worker-written string. Exempting it
+        # because `bands[]` and `BAND_DOT[]` index on its exact value would make it
+        # the single field in a row reaching the dashboard verbatim, so a planted
+        # "red <credential>" leaks while the prose beside it is scrubbed. Keying is
+        # protected instead by
         # admitting only the three known bands on the untrusted read path, and by
         # the fact that the REAL redactor leaves those three byte-identical (see
         # test_a_legitimate_band_survives_redaction_unchanged). Under this test's

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
@@ -57,8 +57,8 @@ class TestHostQualifiedIdentity(unittest.TestCase):
         self.assertNotIn("--hostname", D.build_review_task("CR-1"))
 
     def test_prompt_builders_fail_closed_on_an_unresolvable_host(self):
-        """The leak guard: when the link's host no longer revalidates (e.g. the
-        GHE host was removed from `github_hosts` between run start and this
+        """The leak guard: when the link's host does not revalidate (e.g. the
+        GHE host removed from `github_hosts` between run start and this
         build), every prompt builder must REFUSE — a prompt whose `gh api`
         calls silently default to public github.com would fetch from, or post
         an internal enterprise draft onto, a public same-slug PR."""
@@ -394,8 +394,8 @@ class TestReviewDriver(unittest.TestCase):
             self.assertEqual(rec["skipped_reason"], entries[cid].get("reason"))
 
     def test_progress_entry_names_a_refused_host_as_review_failed(self):
-        # `build_review_task` fails CLOSED when the link's host no longer
-        # revalidates. Patched rather than reached through a crafted URL so the
+        # `build_review_task` fails CLOSED when the link's host does not
+        # revalidate. Patched rather than reached through a crafted URL so the
         # test pins THIS site's payload, not the host-allowlist rules.
         def refuse(link):
             raise D.pipeline.adapters.AdapterError("host is not allowed")
@@ -603,8 +603,8 @@ class TestWorkerPromptInterpreter(unittest.TestCase):
     def test_no_prompt_names_a_bare_interpreter(self):
         # Both needles are anchored on the opening backtick of an inline code
         # span: python_command() legitimately embeds the absolute
-        # sys.executable, which can itself end in "python3" (issue #8205), so
-        # an unanchored needle would fire on the correct path. Unbackticked
+        # sys.executable, which can itself end in "python3", so an unanchored
+        # needle would fire on the correct path. Unbackticked
         # prose is covered only by the span test below
         # (test_every_script_command_carries_the_resolved_interpreter).
         for p in self._prompts():

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_run_scoping.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_run_scoping.py
@@ -130,10 +130,10 @@ class TestSafeRunId(_RootTest):
                              f"{raw!r} escaped runs_root")
 
     def test_run_dir_dotdot_is_contained(self):
-        # Regression: the _UNSAFE_RUN_ID character filter treats '.' as SAFE, so a
-        # run id of exactly '..' used to pass through unchanged and run_dir('..')
-        # resolved to the parent data/ dir — escaping runs_root entirely. The
-        # all-dots rejection in safe_run_id is what closes that.
+        # The _UNSAFE_RUN_ID character filter treats '.' as SAFE, so a run id of
+        # exactly '..' passes through it unchanged and run_dir('..') resolves to the
+        # parent data/ dir — escaping runs_root entirely. The all-dots rejection in
+        # safe_run_id is what closes that.
         rr = store.runs_root(self.root).resolve()
         for raw in ("..", ".", "...", "./.."):
             self.assertEqual(store.run_dir(raw, self.root).resolve().parent, rr,

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_store_selfheal.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_store_selfheal.py
@@ -20,10 +20,10 @@ from kiro_crew.apps.builtins.code_review_sage.tests.fixtures import SYMLINKS_OK
 class TestPinnedAtomicWrite(unittest.TestCase):
     """``atomic_write_locked`` resolves the parent directory ONCE.
 
-    The staging temp and the rename that publishes it used to resolve the parent
-    by NAME three times over (``mkstemp(dir=...)`` plus both halves of
-    ``os.replace``). The review worker runs prompt-injected model output and has
-    a shell inside its own run tree, so it could swap a directory for a symlink
+    Resolving the parent by NAME for the staging temp and again for the rename
+    that publishes it (``mkstemp(dir=...)`` plus both halves of ``os.replace``) is
+    three resolutions. The review worker runs prompt-injected model output and has
+    a shell inside its own run tree, so it can swap a directory for a symlink
     between those resolutions and steer the write out of the sandbox.
     """
 

--- a/src/kiro_crew/apps/builtins/crew_companion/__init__.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/__init__.py
@@ -22,18 +22,17 @@ Architecture — three parts, no separate application:
   main-process APIs, so they live in Kiro Crew's existing shell rather than
   shipping a second Electron runtime.
 
-WHAT THIS REPLACED, AND WHY IT MATTERS
---------------------------------------
-The companion used to be a SEPARATE macOS application. This builtin was a
-connector to it: the manifest declared ``mcpServers.crew-companion.url =
-http://127.0.0.1:7778/mcp`` and ran ``open "$HOME/Applications/Crew
-Companion.app"`` as an ``onEnable`` script. Because the enable path rolls back
-when that script fails, and because the app was never shipped, downloadable or in
-any registry, **the tile could not be enabled by anyone but its author** — on
-whose machine the app happened to exist from a local build.
+NO SEPARATE PROCESS, AND WHY IT MATTERS
+---------------------------------------
+The companion is not a SEPARATE macOS application and this builtin is not a
+connector to one: the manifest declares no ``mcpServers.crew-companion.url``
+pointing at a loopback port, and no ``open "$HOME/Applications/Crew
+Companion.app"`` ``onEnable`` script. Because the enable path rolls back when
+such a script fails, a launch step would make **the tile impossible to enable
+for anyone without that app already on disk**.
 
 Nothing here launches anything, so there is nothing to fail and nothing to roll
-back. Enabling the app and the app working are now the same state.
+back. Enabling the app and the app working are the same state.
 """
 
 # Required re-export: dashboard/server.py's startup route registration imports

--- a/src/kiro_crew/apps/builtins/crew_companion/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/backend/routes.py
@@ -87,11 +87,11 @@ def _require_enabled(handler: Handler) -> Handler:
 
     The write-failure translation lives here, in the one wrapper every route
     already goes through, rather than in each of the seven handlers that mutate
-    the store. The store used to log an OSError and return ``{"ok": True}``, so a
-    full or read-only data home produced a 200: the panel cleared the input and
-    the reminder was gone after a restart. Now the store raises, and a raise that
-    reached aiohttp would be a bare 500 with no machine-readable ``code`` — which
-    is what ``test/test_error_code_contract.py`` exists to prevent. Putting it
+    the store. The store RAISES on a failed write: logging the OSError and
+    returning ``{"ok": True}`` would turn a full or read-only data home into a
+    200, clearing the panel's input for a reminder that is gone after a restart.
+    A raise that reached aiohttp would be a bare 500 with no machine-readable
+    ``code`` — which is what ``test/test_error_code_contract.py`` prevents. Putting it
     here also means a route added later cannot forget it.
     """
 
@@ -279,7 +279,7 @@ async def _handle_appearance_detail(request: web.Request) -> web.StreamResponse:
     pack_id = request.query.get("id", "")
     detail = await asyncio.to_thread(get_appearances().pack_detail, pack_id)
     if detail is None:
-        # Not found rather than a 400: an id that no longer resolves is the normal
+        # Not found rather than a 400: an id that does not resolve is the normal
         # outcome of a pack the user just deleted, not a malformed request.
         return _bad_request("no such appearance pack", "pack_not_found")
     return web.json_response(detail)

--- a/src/kiro_crew/apps/builtins/crew_companion/store.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/store.py
@@ -560,17 +560,11 @@ class CompanionStore:
             # Re-arm ONLY when the interval itself changed, so a shortened interval
             # takes effect now rather than after the old, longer one elapses.
             #
-            # This used to re-arm on EVERY patch, which quietly broke break nudges
-            # altogether: the overlay saves the companion's position through this same
-            # config endpoint, and the companion moves ITSELF (the idle fidget). So
-            # each little hop reset the break countdown, and a companion left alone
-            # postponed its own breaks indefinitely. Measured live: 22 seconds before
-            # a nudge was due, a position write pushed it back out to 269 seconds.
-            #
-            # The app this was ported from never had the bug — it re-arms only on
-            # start, on return from away, and after firing, and reads the interval
-            # lazily at arm time. Gating on a real change keeps the prompt behaviour
-            # that comment wanted without inventing the regression.
+            # Re-arming on EVERY patch breaks break nudges altogether: the overlay
+            # saves the companion's position through this same config endpoint, and
+            # the companion moves ITSELF (the idle fidget), so each little hop would
+            # reset the break countdown and a companion left alone would postpone its
+            # own breaks indefinitely.
             if cfg.break_reminder_mins != before_mins:
                 self._next_break_at = 0.0
         self._last_stats_flush = 0.0

--- a/src/kiro_crew/apps/builtins/crew_companion/tests/test_manifest.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/tests/test_manifest.py
@@ -146,16 +146,15 @@ def test_no_absolute_user_path_in_builtin_dir() -> None:
 
 
 def test_declares_no_separate_process_backend() -> None:
-    """The inverse of the assertion this replaced, and the point of the migration.
+    """No loopback backend URL may appear in this manifest.
 
-    This manifest used to declare ``mcpServers.crew-companion.url =
-    http://127.0.0.1:7778/mcp`` — a SEPARATE macOS app the gateway proxied to.
-    That single field is what made the whole class of defects reachable: the
-    ``.app_secret`` the proxy signs with, the malformed-port crash that could
-    stop gateway startup, and the hole where a never-enabled app still had an
-    authenticated route to its backend.
+    An ``mcpServers.crew-companion.url = http://127.0.0.1:7778/mcp`` field means a
+    SEPARATE macOS app the gateway proxies to, and that single field is what makes
+    a whole class of defects reachable: the ``.app_secret`` the proxy signs with, a
+    malformed-port crash that can stop gateway startup, and the hole where a
+    never-enabled app still has an authenticated route to its backend.
 
-    There is no second process now, so there must be no loopback backend URL to
+    The backend runs in-process, so there must be no loopback backend URL to
     resolve. Asserting the absence is what stops someone reintroducing it.
     """
     servers = _raw().get("mcpServers", {})
@@ -170,12 +169,11 @@ def test_declares_no_separate_process_backend() -> None:
 def test_does_not_launch_anything_on_enable() -> None:
     """Enabling must not run a command that can fail.
 
-    ``setup.onEnable`` used to be ``open "$HOME/Applications/Crew Companion.app"``,
-    and ``handle_app_api_proxy`` rolls an enable BACK when that script fails. On
-    every machine without that app already present — which is every machine but
-    the author's — the tile therefore could not be switched on at all. Nothing
-    here may reintroduce a launch step: the window follows the enabled state
-    instead, so there is nothing to fail and nothing to roll back.
+    ``handle_app_api_proxy`` rolls an enable BACK when a ``setup.onEnable`` script
+    fails, so a launch step such as ``open "$HOME/Applications/Crew
+    Companion.app"`` makes the tile impossible to switch on for anyone without
+    that app already present. The window follows the enabled state instead, so
+    there is nothing to fail and nothing to roll back.
     """
     raw = _raw()
     assert "onEnable" not in raw.get("setup", {}), (

--- a/src/kiro_crew/apps/builtins/crew_companion/tests/test_store.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/tests/test_store.py
@@ -471,10 +471,10 @@ class TestPendingSurvivesRestart:
 
     The window this pins: a due reminder is consumed from `reminders` the moment
     the tick queues it, so between that tick and the overlay's poll the fire
-    exists ONLY in `_pending`. A restart in that window used to lose it — the
-    reminder row was already gone, the queue was memory-only, and the client's
-    refetch-from-zero restart recovery found nothing to refetch. The user's
-    promise silently evaporated. `seq` persists with it so a restart cannot
+    exists ONLY in `_pending`. A restart in that window loses it unless the queue
+    is persisted — the reminder row is already gone, and the client's
+    refetch-from-zero restart recovery finds nothing to refetch, so the user's
+    promise evaporates silently. `seq` persists with it so a restart cannot
     reissue numbers below a client's stored cursor.
     """
 

--- a/src/kiro_crew/apps/builtins/crew_companion/tests/test_write_failures.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/tests/test_write_failures.py
@@ -1,14 +1,14 @@
 """A write that did not happen must not be reported as success.
 
-Two endpoints used to answer `{"ok": True}` for work they had not done:
+Two endpoints must not answer `{"ok": True}` for work they have not done:
 
-  * `patch_config` accepted `customPresets` and `kiro.accessory` and dropped both,
-    so a saved colour preset or a chosen dress-up prop vanished on the next load —
-    while the UI showed it applied, because the renderer had already set its own
+  * `patch_config` must persist `customPresets` and `kiro.accessory`; dropping
+    either loses a saved colour preset or a chosen dress-up prop on the next load —
+    while the UI shows it applied, because the renderer has already set its own
     state.
-  * `_save_locked` logged an OSError and returned, so a full or read-only data
-    home produced an HTTP 200: the panel cleared its input and the reminder was
-    gone after a restart.
+  * `_save_locked` must raise rather than log an OSError and return, so a full or
+    read-only data home cannot produce an HTTP 200: the panel would clear its input
+    and the reminder would be gone after a restart.
 
 The second is the more dangerous shape, and its test asserts the part that is easy
 to get wrong — that memory is rolled back to what is actually on disk, so the

--- a/src/kiro_crew/apps/builtins/design_critique/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/design_critique/backend/routes.py
@@ -7,8 +7,8 @@ Registered at gateway startup by the ``BUILTIN_NAMES`` loop in
 These endpoints do every step that needs a shell or the filesystem — cloning a
 repo, discovering its routes, and rendering screens to PNGs — server-side, so the
 LLM agent never has to. The agent is then only ever asked to reason over finished
-images with no tools, which is why it can no longer stall on a tool-approval
-prompt that the app panel has nowhere to show.
+images with no tools, so it cannot stall on a tool-approval prompt that the app
+panel has nowhere to show.
 
 Routes (browser-facing, same-origin authed):
 
@@ -94,11 +94,10 @@ _CLONE_TTL_SEC = 60 * 60
 
 # ── background job registry ──
 #
-# discover/render used to run inline in the request, so a browser navigating away
-# mid-scan cancelled the fetch and the scan with it. Now the heavy work runs in a
-# DETACHED asyncio task keyed by a job id: the request returns the id immediately
-# and the client polls a GET for the result, so a disconnect can no longer stop
-# the scan. Records live in memory only (a critique is transient) and are swept on
+# The heavy discover/render work runs in a DETACHED asyncio task keyed by a job
+# id: the request returns the id immediately and the client polls a GET for the
+# result, so a browser navigating away mid-scan cancels only the fetch, never the
+# scan. Records live in memory only (a critique is transient) and are swept on
 # the same ~1h TTL the clone dirs use.
 _JOBS: dict[str, dict[str, Any]] = {}
 _JOBS_LOCK = threading.Lock()
@@ -469,7 +468,7 @@ def _sweep_clones() -> None:
     with _PROBE_CACHE_LOCK:
         # A retained probe dir (dc-probe-*) is swept above on the same TTL, but its
         # _PROBE_CACHE entry would otherwise outlive the dir and hand /render a
-        # route->png path for a directory that no longer exists. Purge any cache entry
+        # route->png path for a directory that does not exist. Purge any cache entry
         # whose retained dir was just removed, so the cache never serves a missing PNG.
         if removed:
             stale_handles = [
@@ -788,9 +787,9 @@ def _group_for(path: str) -> str:
 
 
 async def _handle_method(request: web.Request) -> web.Response:
-    # The critique rubric used to be fetched by the agent with fs_read (a tool
-    # call that stalls in the panel). Serve the checklist here so the frontend
-    # can inline it into the tool-free prompt instead.
+    # Serve the critique rubric here so the frontend can inline it into the
+    # tool-free prompt: an agent fetching it with fs_read is a tool call, and a
+    # tool call stalls in the panel.
     def _read() -> dict[str, str]:
         checklist = (_SKILL_DIR / "frameworks/main-checklist.md").read_text(encoding="utf-8")
         return {"checklist": checklist}
@@ -1459,7 +1458,7 @@ async def _handle_render(request: web.Request) -> web.Response:
         if cached is not None:
             token = await asyncio.to_thread(_served_signature, Path(cached["build_dir"]))
             # A missing token means "unknown", not "unchanged", so it must not satisfy
-            # the match: a build output that no longer stats is no evidence it stands
+            # the match: a build output that does not stat is no evidence it stands
             # still. Only the digest is compared — newest_mtime_ns is a discover-time
             # concern. The stored side is never None: _probe_put is only reached with a
             # real digest.

--- a/src/kiro_crew/apps/builtins/design_critique/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/design_critique/tests/test_backend_routes.py
@@ -1220,7 +1220,7 @@ def test_sweep_purges_probe_cache_entry_when_dir_swept(monkeypatch, tmp_path) ->
     probe_dir.mkdir()
     os.utime(probe_dir, (aged, aged))
     # A cache entry pointing at the soon-to-be-swept dir must be purged too, so the
-    # cache never hands /render a path for a directory that no longer exists.
+    # cache never hands /render a path for a directory that does not exist.
     routes._probe_put(
         "clone-old",
         routes._probe_claim("clone-old"),

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/http_api.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/http_api.py
@@ -593,7 +593,7 @@ class Handler(BaseHTTPRequestHandler):
                     row["previewUrl"] = static_url
                     row["previewMode"] = "static"
             elif row.get("previewUrl"):
-                # Never return a persisted value that no longer proves loopback.
+                # Never return a persisted value that does not prove loopback.
                 row["previewUrl"] = ""
             projects.append(row)
         return self._json(

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
@@ -218,7 +218,7 @@ MAX_DRAFT_COMMENTS = 200
 MAX_THREAD_ENTRIES = 500
 # On-disk ceiling for ONE queue record. The SAME number gates the write and the
 # read deliberately: a record the writer accepts but the reader refuses is a
-# draft the user can no longer see, and silently losing queued work is worse than
+# draft the user cannot see, and silently losing queued work is worse than
 # refusing the append that would have caused it. Kept distinct from
 # `MAX_BODY_BYTES` (which bounds ONE inbound payload) because a record
 # accumulates many payloads over its life — they are equal today, and conflating

--- a/src/kiro_crew/apps/builtins/dev_fleet/fleet_state.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/fleet_state.py
@@ -214,7 +214,7 @@ async def _pr_status_cached(branch: str, head_oid: str | None = None) -> dict | 
             # Invalidate a MERGED entry when the caller supplies a head OID
             # that differs from the one recorded at cache-write time.  A changed
             # head means the branch was reused for new work; the old MERGED
-            # verdict no longer describes the current commits.
+            # verdict does not describe the current commits.
             cached_head = ent.get("cached_head")
             if head_oid and cached_head != head_oid:
                 # Head changed (or entry was written without a head OID) —
@@ -525,7 +525,7 @@ def _fleet_forget(name: str) -> None:
     ``_fleet_cached`` is stale-while-revalidate: once past the TTL it serves the
     PREVIOUS snapshot and only schedules a rebuild behind it. Without this hook a
     just-removed worktree keeps rendering for the length of a full rebuild, so
-    the UI shows rows that no longer exist and refreshing does not help. Evicting
+    the UI shows rows for worktrees that are gone and refreshing does not help. Evicting
     the row makes the very next response truthful at zero rebuild latency, and
     zeroing the timestamp schedules the rebuild that refreshes the rest.
     """
@@ -823,16 +823,16 @@ def _pod_resources_sync(cfg: Any, running_names: list[str]) -> dict[str, dict]:
             # sync probe. Absent until then, never a fabricated 0.
             "home_bytes": None,
         }
-    # Drop CPU samples for pods no longer running so a stopped-then-restarted
+    # Drop CPU samples for pods that are not running so a stopped-then-restarted
     # pod starts fresh (null on its first new observation) and the dict cannot
     # grow without bound across a long-lived gateway.
     for stale in set(_POD_CPU_SAMPLES) - set(units):
         _POD_CPU_SAMPLES.pop(stale, None)
-    # Same for the home-size cache, which was previously left to expire on its
-    # TTL. A worktree evicted mid-TTL kept a cached size that went on being
-    # summed into the fleet total, so the header reported disk for a pod that no
-    # longer existed -- and the dict grew unbounded besides. Dropping it here
-    # ties both to the same liveness signal.
+    # Same for the home-size cache. Letting it expire on its own TTL instead
+    # leaves a worktree evicted mid-TTL holding a cached size that keeps being
+    # summed into the fleet total, so the header reports disk for a pod that is
+    # gone -- and the dict grows unbounded besides. Dropping it here ties both
+    # to the same liveness signal.
     for stale in set(_POD_HOME_SIZE_CACHE) - set(units):
         _POD_HOME_SIZE_CACHE.pop(stale, None)
     return out
@@ -1092,7 +1092,7 @@ async def _build_fleet() -> dict:
         # ``static/dist`` directory present) and is therefore knowable on EVERY
         # platform — report it even where pods cannot run, so the Fleet view
         # still tells the truth about which worktrees are built. That includes
-        # the MAIN checkout (#8058): during a cutover the panel is exactly the
+        # the MAIN checkout: during a cutover the panel is exactly the
         # surface a human checks, and reporting main as unprovisioned reads as
         # "the cutover failed". The ``not is_main`` restriction belongs to the
         # POD-state check below (pods never run on main), not to these probes.
@@ -1302,10 +1302,10 @@ async def _build_fleet() -> dict:
         # controls stay clickable and keep succeeding, so nothing else on screen
         # would ever reveal that the managed code is not the running code.
         "serving_install_reason": await _serving_install_reason(worktrees),
-        # Whether pods can run on THIS host, and if not, why. Previously
-        # _POD_ERROR was computed and then never read by anything, so a
-        # non-Linux user saw pod controls that silently failed with no
-        # explanation. The UI uses these to disable those controls and say why.
+        # Whether pods can run on THIS host, and if not, why. _POD_ERROR has to
+        # reach the UI: without it a non-Linux user sees pod controls that
+        # silently fail with no explanation. The UI uses these to disable those
+        # controls and say why.
         "pods_available": runtime._POD_AVAILABLE,
         "fleet_totals": fleet_totals,
         "pods_unavailable_reason": runtime._POD_ERROR or None,

--- a/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
@@ -150,15 +150,15 @@ def atomic_write_text(path: Path, content: str) -> None:
 
     Thin delegate to :func:`kiro_crew.atomic_write.atomic_write`, kept as a
     named function because it is the seam Dev Fleet's tests drive the staging
-    failure path through. The shared helper carries the same
-    ``mkstemp``-plus-rename shape this used to hand-roll, plus the Windows
+    failure path through. The shared helper carries the
+    ``mkstemp``-plus-rename shape this needs, plus the Windows
     sharing-violation rename retry and the ``except BaseException`` temp
-    cleanup that the local ``finally`` provided.
+    cleanup a hand-rolled ``finally`` would have to provide.
 
-    ``fsync`` stays off and no explicit *mode* is passed, so the drop-in lands
-    at the umask default exactly as ``Path.write_text`` left it. Encoding is
-    now pinned to UTF-8 rather than following the locale, which is what the
-    generated unit text (systemd reads it as UTF-8) always needed.
+    ``fsync`` stays off and no explicit *mode* is passed, so the write lands
+    at the umask default exactly as ``Path.write_text`` does. Encoding is
+    pinned to UTF-8 rather than following the locale, which is what the
+    generated unit text (systemd reads it as UTF-8) requires.
     """
     atomic_write(path, content)
 
@@ -690,9 +690,10 @@ class ForegroundBackend:
 
     On a host where neither systemd nor launchd can be driven (see
     :data:`FOREGROUND_ELIGIBLE`) the gateway is just a foreground/detached
-    process, and Make Live used to stage the live-target pointer and stop —
-    telling the operator to run ``kirocrew restart`` themselves. This backend
-    performs exactly that command FOR them, detached so it survives the death
+    process, with no manager to ask for a bounce: the fallback is for Make Live
+    to stage the live-target pointer and stop, telling the operator to run
+    ``kirocrew restart`` themselves. This backend performs exactly that command
+    FOR them, detached so it survives the death
     of the gateway it bounces, and otherwise reuses the CLI's whole
     kill-and-respawn path (lsof+SIGTERM the incumbent, wait, spawn a detached
     replacement that reads the staged pointer, poll ``/api/ready``) rather than
@@ -872,7 +873,7 @@ def backend(run_cmd: RunCmd, *, unit: Callable[[], str],
     globals, which keeps the existing test seams working: the dev_fleet tests
     drive platform detection by patching ``live.sys`` / ``live.shutil``, and
     a direct read here would silently escape those patches — the Linux paths
-    would then be "passing" tests that no longer exercise them.
+    would then be "passing" tests that do not exercise them.
 
     ``None`` is NOT "everything is fine, just hide the buttons" — callers must
     surface it as an explicit, reasoned unavailability (see

--- a/src/kiro_crew/apps/builtins/dev_fleet/live.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/live.py
@@ -790,7 +790,7 @@ async def _make_live(path: str, dry_run: bool = False, expected_staged: str | No
     refusing with ``stage_changed`` otherwise — without both bindings, a
     cancel confirmed against one stage/live pair could silently discard a
     different stage, or fall through to the cutover path and restart the
-    gateway into a checkout that is no longer live.
+    gateway into a checkout that is not the live one.
 
     Validation order (all enforced for ``dry_run`` too): the path is a known,
     existing worktree (``unknown_path`` / ``missing_path``); NOT inside a pod,
@@ -908,7 +908,7 @@ async def _make_live(path: str, dry_run: bool = False, expected_staged: str | No
         # A request carrying expected_staged is a CANCEL: it re-pins the
         # checkout the operator saw as live. If the live checkout moved since
         # the dialog (a cutover landed and re-staged in between), the request
-        # names a checkout that is no longer running — falling through to the
+        # names a checkout that is not the running one — falling through to the
         # cutover path below would restart the gateway into it, the
         # destructive opposite of a cancel. Refuse instead.
         live_name = Path(live).name if live else "an unknown checkout"
@@ -989,7 +989,7 @@ async def _make_live(path: str, dry_run: bool = False, expected_staged: str | No
                 }
             # Re-read under the lock: the awaits above mean the stage may have
             # been completed or re-pointed since the entry check, and cancelling
-            # a stage that no longer exists would delete a pointer someone else
+            # a stage that is already gone would delete a pointer someone else
             # just wrote.
             pending_now = _staged_target()
             if pending_now is None:

--- a/src/kiro_crew/apps/builtins/dev_fleet/npm_preflight.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/npm_preflight.py
@@ -36,7 +36,7 @@ retrieval at all: against a lockfile pinning a tarball that 404s, measured,
 while the same command without ``--dry-run`` exits 1 on the missing tarball. A
 dry run would therefore pass exactly the case this module exists to catch, so
 the probe has to fetch. That install is cheap next to the emptied
-``node_modules`` it prevents -- and it is no longer paid on every sync:
+``node_modules`` it prevents -- and it is not paid on every sync:
 :func:`_install_already_proven` skips it when the incoming ref touches nothing
 under ``website/`` and a populated tree is already there to answer for it.
 
@@ -296,7 +296,7 @@ def _install_already_proven(git: str, repo: str, ref: str) -> str | None:
       ``.npmrc`` was not enough, and the gap is worth stating because it is
       subtle: with those three identical but frontend SOURCE changed, a skipped
       probe lets the merge land, and a failing ``npm ci`` afterwards leaves the
-      checkout with new source and the previously-built bundle. Requiring the
+      checkout with new source and a bundle built from the old source. Requiring the
       entire subtree to be identical makes that unreachable -- with no frontend
       change there is no new bundle to be missing, so a failed sync leaves the
       frontend byte-for-byte as it was.
@@ -314,12 +314,11 @@ def _install_already_proven(git: str, repo: str, ref: str) -> str | None:
       dead-registry residual does: the skip decides only whether this sync PAYS
       for a rehearsal, so a refusal lands one step later instead of never, and
       the transaction keeps the checkout consistent either way. The evidence test
-      tracked in #7132 should cover this scenario and not only the interrupted
-      one.
+      should cover this scenario and not only the interrupted one.
 
     What makes skipping SAFE rather than merely cheap is where a failure lands.
     The probe exists because ``npm ci`` deletes ``node_modules`` first, so a
-    refusal after the merge used to leave new source beside an emptied tree.
+    refusal after the merge would leave new source beside an emptied tree.
     Under this condition that outcome is not reachable: the runner's transaction
     moves the tree aside and puts it back on any non-zero step, the lockfile did
     not change, and neither did the source the bundle was built from.
@@ -443,7 +442,7 @@ def _frontend_build_already_current(git: str, npm: str, repo: str, ref: str) -> 
     partial-``node_modules`` gap), and that the staged bundle was built from the
     source the sync will end up with (the fingerprint below).
 
-    The extra proof closes the concrete hole (#7132): a prior FRONTEND sync can
+    The extra proof closes a concrete hole: a prior FRONTEND sync can
     merge new ``website/`` source and then have its ``npm ci`` fail, at which
     point the runner's transaction restores the OLD ``node_modules``. From then
     on the subtree stops changing, so ``_install_already_proven`` would skip --
@@ -465,13 +464,13 @@ def _frontend_build_already_current(git: str, npm: str, repo: str, ref: str) -> 
     # to be clean INCLUDING untracked files before skipping, mirroring the
     # stamp-time guard in frontend._write_build_source_fingerprint: the two
     # together mean a skip implies the tree that produced the bundle and the tree
-    # now on disk are the same, tracked and untracked alike (#7132).
+    # now on disk are the same, tracked and untracked alike.
     if not _frontend_worktree_clean(git, repo):
         return None
     # The install-proven check only requires node_modules to be NON-EMPTY. A
     # partial tree (an interrupted install) passes that, so verify completeness
     # against the lockfile before skipping the real npm ci -- otherwise the sync
-    # could succeed on incomplete dependencies (#7132).
+    # could succeed on incomplete dependencies.
     if not _frontend_tree_complete(npm, repo):
         return None
     fingerprint_path = Path(repo).joinpath(*_STATIC_DIST) / _BUILD_SOURCE_FINGERPRINT
@@ -608,7 +607,7 @@ def main(argv: list[str] | None = None) -> int:
     # outside, and a worktree-run step exiting 48 is demoted to a plain failure.
     # This is the same window the probe uses (after fetch pinned --ref, before
     # merge), which is the only point where "does the incoming ref touch the
-    # frontend?" has a correct answer (#7132).
+    # frontend?" has a correct answer.
     ap.add_argument("--emit-frontend-skip", action="store_true")
     # --subdir and --timeout were CLI flags no caller passed. The subdir is now
     # _FRONTEND_SUBDIR and the timeout is probe()'s own default, so the surface

--- a/src/kiro_crew/apps/builtins/dev_fleet/repository.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/repository.py
@@ -598,12 +598,12 @@ async def _discover_worktrees() -> list[dict]:
             # git never ran: the HOST has no git the resolver is willing to
             # execute. Checked before the .git probe because the probe's
             # outcome is irrelevant here — wrapping this in "worktree
-            # discovery failed in <repo>" (the old behavior) sent users to
-            # debug a healthy checkout (#2530). The trusted-PATH detail is
+            # discovery failed in <repo>" would send users to debug a healthy
+            # checkout. The trusted-PATH detail is
             # operator-diagnostic, so it goes to the log, not the banner.
             runtime.logger.warning("dev-fleet: %s", raw)
             raise RepoUnreadable(runtime._unresolved_tool_message("git"))
-        # Every other git failure was previously swallowed into a silent [] —
+        # Every other git failure must NOT be swallowed into a silent [] —
         # which the UI renders as the "No worktrees found / Nothing under the
         # worktrees root yet" empty state. When MAIN_REPO is wrong that empty
         # state is a lie: the fleet is not empty, it is unreadable. Reaching here

--- a/src/kiro_crew/apps/builtins/dev_fleet/runtime.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/runtime.py
@@ -60,7 +60,7 @@ _RUN_DEADLINE_S = 1800
 #                    ``prov.has_dist``, both plain filesystem checks) may be
 #                    called. True on every platform unless the import failed.
 #   _POD_AVAILABLE — pods can actually RUN here, i.e. Linux with ``systemctl``.
-# Conflating the two used to report every worktree as "not built" off Linux,
+# Conflating the two reports every worktree as "not built" off Linux,
 # even though the build state is knowable everywhere.
 _POD_IMPORTED = False
 _POD_AVAILABLE = False
@@ -330,10 +330,10 @@ def _bin_override_var(name: str) -> str:
 def _unresolved_tool_message(name: str) -> str:
     """User-facing message for an unresolved trusted tool.
 
-    Blames the HOST toolchain, not the checkout (issue #2530: the previous
-    wording folded this failure into "git worktree discovery failed in
-    <repo>", sending users to debug a healthy repository), and names the
-    operator remedy in the same voice as the missing-checkout branch. The
+    Blames the HOST toolchain, not the checkout (folding this failure into
+    "git worktree discovery failed in <repo>" sends users to debug a healthy
+    repository), and names the operator remedy in the same voice as the
+    missing-checkout branch. The
     trusted-PATH detail stays in the log line, not here: it is unactionable
     noise in a UI banner.
     """
@@ -590,8 +590,8 @@ def _kill_tree_sync(pid: int) -> None:
         try:
             platform_compat.kill_process_tree(child)
         except (ProcessLookupError, OSError, ValueError):
-            # Already reaped by the group kill, or a pid we may no longer
-            # signal — the primary kill has happened either way.
+            # Already reaped by the group kill, or a pid we may not be able
+            # to signal — the primary kill has happened either way.
             continue
 
 
@@ -616,7 +616,7 @@ _ACTIVE_RUNS: dict[str, tuple[asyncio.Task, Any]] = {}
 # there is no risk of asyncio lock contention or done-callback deadlocks.
 # LoopBoundLock (not a bare asyncio.Lock) because a module-global primitive
 # binds to the import-time loop and raises RuntimeError from any other loop
-# (Python 3.10+, see #4800) — this module is imported once but serves
+# (Python 3.10+) — this module is imported once but serves
 # whichever loop the gateway runs.
 _SHUTDOWN_ADMISSION_LOCK = LoopBoundLock()
 _SHUTDOWN_IN_PROGRESS = False

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/_pathcheck.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/_pathcheck.py
@@ -289,8 +289,8 @@ def safe_open_output(path, workdir=None, mode="w", replace=False):
         # cannot be pinned against a link swap. A pathname-based fallback was
         # tried and is worse than nothing: it looks like the same guarantee while
         # a concurrent swap can still redirect the write. Refusing keeps the
-        # contract honest AND is still a clean, explained exit rather than the
-        # AttributeError this used to raise.
+        # contract honest AND is still a clean, explained exit rather than an
+        # opaque AttributeError.
         _fail(
             "this platform has no directory-descriptor support, so an output "
             "cannot be pinned against a link swap -- run the pipeline on a POSIX host"

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/compose.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/compose.py
@@ -204,8 +204,8 @@ def main() -> int:
     # The gate cannot hand a descriptor across a process boundary: the browser and
     # ffmpeg open these during `npm run render`, long after this script exits. So the
     # check is on the RESOLVED path (realpath, sensitive-path refused) and the HTML
-    # references that resolved file -- a symlink re-pointed afterwards no longer
-    # decides what gets baked into the film.
+    # references that resolved file -- a symlink re-pointed afterwards does not
+    # decide what gets baked into the film.
     footage_real = safe_input_path(args.footage)
     footage_src = os.path.relpath(footage_real, out_dir).replace(os.sep, "/")
     audio_real = safe_input_path(narr_dir / "narration.mp3")

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/deps.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/deps.py
@@ -61,7 +61,7 @@ def _ffmpeg_dirs() -> list[pathlib.Path]:
     """Resolved per call, not at import.
 
     A module-level list holding a home-derived path is still an import-time data
-    home resolution, which the repo's isolation floor rejects (issue #874): a test
+    home resolution, which the repo's isolation floor rejects: a test
     that imports this module would bind the operator's real home.
     """
     return [_home() / ".local/bin"]

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/narrate.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/narrate.py
@@ -373,7 +373,7 @@ def main() -> int:
         raise SystemExit(f"unknown role(s): {sorted(str(r) for r in unknown)}")
 
     # Resolved, because the concat step runs with cwd set to this directory: a
-    # relative --out-dir would then no longer point at the list file.
+    # relative --out-dir would then not point at the list file.
     aud = pathlib.Path(safe_output_path(args.out_dir))
     aud.mkdir(parents=True, exist_ok=True)
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-playwright.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-playwright.py
@@ -121,7 +121,7 @@ def _bounded(label: str, seconds: float, fn) -> bool:
 
     SIGALRM is the mechanism because the sync Playwright API is greenlet-based
     and must be driven from the thread that created it — a worker thread cannot
-    be used to bound a blocking call like context.close().
+    impose a bound on a blocking call like context.close().
     """
     if not hasattr(signal, "setitimer") or seconds <= 0:
         if seconds > 0:                          # pragma: no cover - env guard

--- a/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
@@ -1,12 +1,12 @@
 """The Pull+Build sync runner, as a real module instead of a string literal.
 
-This is the program that :func:`server._sync_start_locked` used to assemble from
-Python source and hand to ``[sys.executable, "-c", <string>]``. That form had one
-defect the code itself was blameless for: no linter parsed it, and its only tests
-string-matched the source. So the transaction that moves ``node_modules`` aside
-and puts it back on failure -- the part whose whole point is not to lose a
-dependency tree -- was unreachable by an executing test. Extracting it here makes
-every branch a real function a test can drive against a real directory tree.
+The alternative shape -- assembling this program from Python source and handing
+it to ``[sys.executable, "-c", <string>]`` -- has one defect the code itself is
+blameless for: no linter parses it, and tests can only string-match the source.
+So the transaction that moves ``node_modules`` aside and puts it back on failure
+-- the part whose whole point is not to lose a dependency tree -- is unreachable
+by an executing test. A module makes every branch a real function a test can
+drive against a real directory tree.
 
 It mirrors :mod:`npm_preflight`'s discipline exactly, and for the same reasons:
 
@@ -269,7 +269,7 @@ def run_steps(
     come ONLY from the preflight: a worktree-run step (a pip lifecycle script)
     exiting the same code is demoted to a plain failure by
     :func:`demote_reserved`, so an untrusted step cannot forge a "skip the
-    build" verdict and ship stale assets (#7132).
+    build" verdict and ship stale assets.
     """
     skip_frontend = False
     for i, st in enumerate(steps):

--- a/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
@@ -759,10 +759,10 @@ async def _worktree_remove_locked(
     # about working-tree edits. `git worktree remove --force` bypasses git's
     # own dirty check and would irrecoverably destroy uncommitted edits.
     # Contract: NO path from this gate ever passes --force to git:
-    #   - dirty is not False → refuse outright (round 5)
+    #   - dirty is not False → refuse outright
     #   - dirty is False → drop --force so git's own dirty check is the
     #     atomic last line against edits arriving in the check-to-removal
-    #     window (round 6, mirrors the unmerged-clean TOCTOU pattern)
+    #     window (mirrors the unmerged-clean TOCTOU pattern)
     if force and fleet_state._is_pr_merged(pr) and branch:
         dirty = await _dirty_now()
         if dirty is not False:
@@ -1433,7 +1433,7 @@ def _frontend_build_steps(
     correct answer. Deciding it here at assembly time would read the per-PID sync
     ref before fetch wrote it, so on a long-lived gateway's second sync it would
     compare against the PRIOR tip and skip a rebuild an incoming frontend change
-    genuinely needed (#7132).
+    genuinely needed.
 
     The two steps suppress together because the runner keys on their labels off
     one preflight verdict, and they must: ``npm ci`` reifies the incoming
@@ -1797,7 +1797,7 @@ async def _sync_start_locked() -> dict:
                     # runner suppresses the later npm ci and build+stage steps.
                     # A flag, not a value -- the verdict travels as this step's
                     # exit code and lives in runner state, never a file another
-                    # same-UID step could forge (#7132).
+                    # same-UID step could forge.
                     "--emit-frontend-skip",
                 ],
                 "strict",
@@ -1878,7 +1878,7 @@ async def _sync_start_locked() -> dict:
         # before reinstalling from an unchanged lockfile) and a full vite build
         # that reproduces a byte-identical bundle. The decision is made
         # post-fetch, carried by the preflight's trusted exit code rather than
-        # in-process here where the ref is not yet fetched (#7132).
+        # in-process here where the ref is not yet fetched.
         raw_steps += _frontend_build_steps(npm_bin=npm_bin, git_bin=git_bin, repo=str(repo))
     cleanups: list[str] = []
     # The preflight's snapshot is removed with the run's other temporaries. It is
@@ -2047,7 +2047,7 @@ async def _rebase_locked(target: dict) -> dict:
     if st is None:
         return {"ok": False, "error": "cannot verify worktree state (git status failed)"}
     if st:
-        # Same fileless refusal the removal path used to give. Name the dirt so
+        # Same fileless refusal the removal path gives. Name the dirt so
         # the user can act on it. The GATE is deliberately unchanged: an
         # untracked file cannot conflict semantically, but it can still block
         # the rebase's checkout when it collides with a path a replayed commit

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
@@ -1952,7 +1952,7 @@ def set_issue_assignees(
     hazard is not the same: a tag edit is a read-modify-write of a delimited
     string shared with every other tag, while this field is replaced wholesale.
     The lost-update guard for a wholesale replace lives one level up, where
-    ``routes._replace_assignees_checked`` refuses when the forge no longer holds
+    ``routes._replace_assignees_checked`` refuses when the forge does not hold
     the set the editor was rendered from.
     """
     org, project = _split_owner(owner)
@@ -2172,7 +2172,7 @@ def _list_pulls(
 
     ``searchCriteria.status`` is passed EXPLICITLY on every call: Azure defaults it
     to ``active`` server-side, so an omitted status would silently return only
-    open PRs on the closed tab. The app's "closed" means "no longer open", which
+    open PRs on the closed tab. The app's "closed" means "not open", which
     covers both ``completed`` and ``abandoned`` -- two separate Azure statuses --
     so the closed listing asks for ``all`` and filters, rather than hiding every
     abandoned PR (or every merged one).
@@ -2475,8 +2475,8 @@ def list_pr_checks(
     """Check-run-shaped rows for commit ``sha``: its builds plus its PR's policies.
 
     Keyed on the head SHA to match the other two clients, and because that is the
-    correct semantics: a run against an older commit describes code that no longer
-    exists. Azure needs one extra step for the policy half -- evaluations are
+    correct semantics: a run against an older commit describes code that does not
+    exist. Azure needs one extra step for the policy half -- evaluations are
     addressed by pull request, so the PR whose head is ``sha`` is resolved first;
     if no PR matches (a commit on a branch with no open PR), the builds are still
     returned rather than nothing.
@@ -3014,8 +3014,8 @@ def merge_pull_request(
     which surfaces as an error.
 
     ``head_sha`` is REQUIRED and rides as ``lastMergeSourceCommit``, which Azure
-    treats as a real precondition: it refuses the completion when that is no longer
-    the PR's last source commit, so a push landing between the review and the click
+    treats as a real precondition: it refuses the completion when that is not the
+    PR's last source commit, so a push landing between the review and the click
     cannot merge unreviewed code. It is a positional parameter with an empty default
     only so the three module signatures stay identical; an empty value is refused
     here, never defaulted.

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/crew_runtime.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/crew_runtime.py
@@ -227,8 +227,8 @@ def never_block(labels: Sequence[str] = (), terms: Mapping[str, str] | None = No
     ``crew:``-prefixed label — one left behind on an issue, or one a differently
     configured install writes — does carry it and is still not this crew's to write.
 
-    The CI clause names NO PATH. It used to say ``.github/``, which is wrong on
-    GitLab and names a directory that does not exist on an Azure DevOps repo — and
+    The CI clause names NO PATH. ``.github/`` is wrong on GitLab and names a
+    directory that does not exist on an Azure DevOps repo — and
     a per-provider path would be no better, because the prohibition is not about a
     location: a GitHub repo can be gated by a CircleCI or Jenkins config outside
     ``.github/``, and an Azure pipeline definition can live anywhere under any
@@ -324,8 +324,8 @@ def compose_nudge(snapshot: dict[str, Any]) -> str:
     vocab = vocabulary(provider.RepoKey(provider=str(snapshot.get("provider") or "")))
     # An empty label list means EVERY open tracked item, not none. The editor
     # defaults a new crew to no labels and does not require any, so the opposite
-    # reading — which this line used to give — told every default-configured crew to
-    # pick up nothing, and it would idle for its whole life without an error
+    # reading would tell every default-configured crew to pick up nothing, and such
+    # a crew would idle for its whole life without an error
     # anywhere. No backend code filters on this list; it is advisory text the crew
     # self-applies from the brief, so the wording here IS the contract, and the
     # brief's filter step is conditioned to match.
@@ -1027,7 +1027,7 @@ def _slot_key(crew: dict[str, Any]) -> str:
 
 
 async def _rehydrate(state: Any, slot_key: str) -> Any:
-    """Rebuild a slot the gateway no longer holds in memory (tab closed, restart).
+    """Rebuild a slot the gateway does not hold in memory (tab closed, restart).
 
     ``autonudge`` cannot do this for us: arming and firing both gate on the slot
     being resident, so a crew whose slot left ``_slots`` is unreachable by nudge
@@ -1305,7 +1305,7 @@ async def watchdog_cycle(
       (:func:`sync_trust`), so an unattended crew silently loses it on restart, and
       on a watchdog that stopped — which is the point — and the next tool call parks
       it in an approval prompt nobody is watching. Trust needs a slot to hold the
-      scope key, so a crew whose slot the gateway no longer holds is rehydrated
+      scope key, so a crew whose slot the gateway does not hold is rehydrated
       first — an armed loop fires against the slot key regardless, and it must land
       on a trusted session.
     * **The loop.** A crew whose autonudge loop is missing or deactivated has no
@@ -1315,7 +1315,7 @@ async def watchdog_cycle(
       resident keeps its trust until something takes it away. The BACKSTOP, not the
       first line: pause and retire revoke inline before they answer, and this cycle
       catches what they cannot — a record edited directly, and a restart that
-      re-armed a loop for a crew that is no longer live.
+      re-arms a loop for a crew that is not live.
     * **Both hooks.** The dismissal hook and the app-disable hook are process
       memory, so a restart empties them. Re-registering here is what keeps a ✕ and
       an app disable from going quiet for the rest of a process's life.
@@ -1895,7 +1895,7 @@ async def sweep_repo(app: Any, key: provider.RepoKey, root: Path | None = None) 
             if _is_due(item, entry if isinstance(entry, dict) else None, now):
                 due.append((crew, item))
 
-    # A mark for an item that is no longer open is dead weight — a crew that works
+    # A mark for an item that is not open is dead weight — a crew that works
     # for a month would otherwise carry every issue it ever finished in a file it
     # rewrites every minute. Dropping it also makes a REOPENED item re-seed, which
     # is right: its old fingerprint describes a different state of the world.

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/crew_store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/crew_store.py
@@ -252,7 +252,7 @@ def _finite_int(value: Any) -> int | None:
     Returning ``None`` for "not a number" is :func:`_validated_text_setting`'s
     convention — the caller decides whether that means the default, ``None`` on the
     record, or a refusal. A FRACTIONAL float reads as "not a number" too: ``int()``
-    truncates, so ``47.9`` used to store as ``47`` — a value the operator never
+    truncates, so ``47.9`` would store as ``47`` — a value the operator never
     asked for, silently, with the form reporting success. Truncation is the same
     silent substitution the frontend's ``Number.isInteger`` guard refuses one layer
     up; refusing here as well means neither layer can invent a value on its own.
@@ -823,7 +823,7 @@ def open_slot_count(
 ) -> int:
     """Work items occupying a slot: every unfinished one.
 
-    No exemption, because there is no longer a phase in which the crew is not the
+    No exemption, because there is no phase in which the crew is not the
     actor: an item it cannot progress without a human is recorded as a pass and its
     claim released, so anything still open is work this crew owes.
     """
@@ -1405,7 +1405,7 @@ def record_skip(
     ``_records_lock_path``. Every crew writes this one file whole, so a per-crew
     lock would let two of them drop each other's decisions.
 
-    THE FLAG IS TRUE AT THE MOMENT OF THE WRITE AND NO LONGER. It says this call
+    THE FLAG IS TRUE AT THE MOMENT OF THE WRITE AND NOT AFTER IT. It says this call
     inserted the entry; it cannot say the entry is still this caller's to remove,
     because this function's lock is released before it returns. A caller that will
     later COMPENSATE the write — un-index the entry if a subsequent write of its own
@@ -1598,7 +1598,7 @@ def commit_work_progress(
                         # rolled back like any other step. The item is already
                         # written by this point, so an exception here — the lock
                         # file is one more open descriptor, and fd exhaustion or a
-                        # permission fault raises — used to escape past the rollback
+                        # permission fault raises — would escape past the rollback
                         # and leave the item changed with neither its skip-index
                         # entry nor its ledger event: the one outcome this
                         # transaction exists to prevent.
@@ -1829,7 +1829,7 @@ def _fold_one_item(
     Three things a naive fold gets wrong, each pinned by a test:
 
     * **The live phase is the record's, authoritative — never the max timeline
-      index.** A review round-trip (``awaiting-ci -> addressing-review ->
+      index.** A round-trip through review (``awaiting-ci -> addressing-review ->
       awaiting-ci``) ends LEFT of where it has been, so keying the head off the
       furthest column reached puts the item in a phase it already left. This
       function reads ``phase`` straight off the record and returns it as its own
@@ -1865,10 +1865,10 @@ def _fold_one_item(
         if ph in seen_spine and exit_entry is not None:
             # Came back to a phase already visited, AND an exit was standing — this
             # is a genuine reopen (the store cleared the terminal fields to make it
-            # one), not a review round-trip within the spine.
+            # one), not a round-trip through review within the spine.
             reopens += 1
         if exit_entry is not None:
-            # Reopened: the exit no longer holds, whatever it was.
+            # Reopened: the exit does not hold, whatever it was.
             exit_entry = None
         seen_spine.add(ph)
         timeline.append({"phase": ph, "at": at})

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/github_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/github_client.py
@@ -778,7 +778,7 @@ def list_pr_timeline(
 # ── dependency edges (blocked-by / blocking graph) ───────────────────────────
 #
 # Two sources feed the graph, tagged by provenance:
-#   • NATIVE — GitHub's issue-dependencies API (GA 2025-08-21). One call per open
+#   • NATIVE — GitHub's issue-dependencies API. One call per open
 #     issue reads its blocked_by set; a blocker of issue N is an edge
 #     ``{blocked: N, blocker: B}``. The endpoint is young, so a repo/token/GHES
 #     that has not enabled it answers 404/410 — handled as ZERO native edges for
@@ -2095,7 +2095,7 @@ def submit_pr_review(
 
     **``commit_id`` is ATTRIBUTION, not a rejecting precondition** — unlike the
     ``sha`` parameter on :func:`merge_pull_request`, which GitHub really does check
-    and 409s. GitHub accepts a review naming a commit that is no longer the head; it
+    and 409s. GitHub accepts a review naming a commit that is not the head; it
     just records the review against that commit, and whether the stale approval still
     counts toward branch protection depends on the repo's
     "dismiss stale pull request approvals" setting. So the pin makes the verdict
@@ -2526,10 +2526,11 @@ _CREW_CLAIM_FIELD_RE = github_normalization.CREW_CLAIM_FIELD_RE
 #
 # Deliberately stricter than ``_parse_gh_timestamp`` / ``datetime.fromisoformat``,
 # which also accept a space separator and an absent or offset timezone. Those forms
-# are hazardous here rather than merely lax: ``2026-08-08 20:44:12`` parses to a
-# NAIVE datetime, and comparing that against the aware ``now`` a freshness check
-# uses raises TypeError — so a malformed stamp would crash the claim reader instead
-# of reading as stale. Refusing it up front makes "unparseable" mean "not fresh",
+# are hazardous here rather than merely lax: a space-separated, zoneless stamp
+# parses to a NAIVE datetime, and comparing that against the aware ``now`` a
+# freshness check uses raises TypeError — so a malformed stamp crashes the claim
+# reader instead of reading as stale. Refusing it up front makes "unparseable"
+# mean "not fresh",
 # which is the safe direction: a claim that cannot prove it is alive must not be
 # treated as alive.
 _CREW_CLAIM_ISO_Z_RE = github_normalization.CREW_CLAIM_ISO_Z_RE

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/gitlab_client.py
@@ -446,8 +446,8 @@ def _list_issues(
 ) -> list[dict]:
     """List issues of ``state``, most-recently-updated first.
 
-    ``scope=all`` is REQUIRED: GitLab's project-issues endpoint historically
-    defaults to issues created by the caller, which on someone else's project
+    ``scope=all`` is REQUIRED: GitLab's project-issues endpoint defaults to
+    issues created by the caller, which on someone else's project
     silently returns almost nothing — the exact failure mode that would make the
     triage view look empty rather than broken.
     """
@@ -1081,7 +1081,7 @@ def _norm_pull(raw: dict) -> dict:
 
 def _list_pulls(owner: str, repo: str, state: str, *, host: str, timeout: float, paginate: bool) -> list[dict]:
     # "closed" on GitLab excludes merged MRs, but the app's closed tab means
-    # "no longer open" — so a closed listing asks for all and filters, rather
+    # "not open" — so a closed listing asks for all and filters, rather
     # than silently hiding every merged MR.
     gl_state = "opened" if state == "open" else "all"
     # Full page on the single-page path, for the same reason as the issue list:
@@ -1223,7 +1223,7 @@ def list_pr_checks(
     Keyed on the head SHA (not the MR iid) to match
     ``github_client.list_pr_checks``, and because that is the correct semantics:
     an MR accumulates one pipeline per pushed commit, and a pipeline for an
-    older commit describes code that no longer exists. Asking GitLab for the
+    older commit describes code that does not exist. Asking GitLab for the
     pipelines of a specific SHA gets the run that matches what the user is
     looking at.
 

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/pipeline_fold.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/pipeline_fold.py
@@ -145,7 +145,7 @@ def _printable(raw: Any, limit: int = 160) -> str:
     Truncation happens LAST, and after redaction specifically: cutting first could
     split a credential so that only its tail survives to be matched, leaving the
     head in the output. Cutting last also keeps a multi-character sequence from
-    being bisected into a fragment the filter no longer recognises.
+    being bisected into a fragment the filter does not recognise.
     """
     if raw is None:
         return ""
@@ -334,8 +334,8 @@ def _extract_pr(record: dict[str, Any]) -> int | None:
     all three and every caller applies it to every event.
 
     Free prose is deliberately NOT parsed. Some records spell the number only in a
-    sentence ("PR 5327 head abc1234"), but the same prose also says things like
-    "rebased over PR 5191" -- so a text pattern yields a confidently WRONG link,
+    sentence ("PR <n> head <sha>"), but the same prose also says things like
+    "rebased over PR <other>" -- so a text pattern yields a confidently WRONG link,
     and an operator who clicks it acts on the wrong pull request. A missing link is
     the safer failure.
     """
@@ -394,7 +394,7 @@ class StepSpec:
     done: frozenset[str]
     skipped: frozenset[str]
     #: Events that are PROGRESS INSIDE the step, neither an entry nor an exit:
-    #: a gate run, a review round, a push answering one. Kept distinct from
+    #: a gate run, a review pass, a push answering one. Kept distinct from
     #: ``skipped`` because "78 gate runs" and "78 items declined" are opposite
     #: facts and a view that conflates them misreports a working step as a
     #: rejecting one.
@@ -911,12 +911,11 @@ class ItemRow:
     """One issue as it appears in a step's table.
 
     Carries the item's identity, its timing and its latest event NAME -- not its
-    whole trail. The trail used to ship here for an expanded-row phase strip that
-    was removed: a strip of the pipeline's internal event names answers a question
-    this level does not ask, and it pushed the cost table below the fold. Shipping
-    a field with no renderer is not free either -- up to 200 events per item across
-    up to 2000 items -- so the field went out with the view that wanted it. Item
-    relationships belong to a dependency view, which Issue Radar already owns.
+    whole trail. The trail does NOT belong here: a strip of the pipeline's internal
+    event names answers a question this level does not ask, and it pushes the cost
+    table below the fold. Shipping a field with no renderer is not free either --
+    up to 200 events per item across up to 2000 items. Item relationships belong to
+    a dependency view, which Issue Radar already owns.
     """
 
     number: int

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/provider.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/provider.py
@@ -121,7 +121,7 @@ def normalize_host(raw: object, provider: str) -> str:
 
     A provider in ``_PINNED_HOSTS`` has its host replaced by that constant
     regardless of what the client sent -- otherwise a crafted host would become
-    part of a cache path and of the identity used to look a repo up. GitHub
+    part of a cache path and of the identity a repo is looked up by. GitHub
     Enterprise and on-premises Azure DevOps Server are both out of scope, so both
     providers are pinned to their public host. Azure's legacy
     ``{org}.visualstudio.com`` form is accepted when PARSING a pasted URL and

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
@@ -1611,11 +1611,11 @@ class _DepsScopeUnavailable(GhCliError):
 
     A dedicated type rather than a message pattern: the route maps this to the
     ``deps_issue_scope_unavailable`` code and a plain :class:`GhCliError` to
-    ``deps_fetch_failed``. Both failures used to be told apart by which of two
-    ``try`` blocks caught them; now that one helper owns the whole build, the
-    distinction has to travel with the exception, and sniffing the message text
-    would silently reclassify every scope failure whose wording does not happen
-    to mention issues (``gh api ... failed`` mentions neither).
+    ``deps_fetch_failed``. One helper owns the whole build, so the distinction
+    has to travel with the exception rather than with which ``try`` block caught
+    it, and sniffing the message text would silently reclassify every scope
+    failure whose wording does not happen to mention issues
+    (``gh api ... failed`` mentions neither).
     """
 
 
@@ -2850,7 +2850,7 @@ async def _handle_labels_apply(request: web.Request) -> web.Response:
     # The cache was patched inside the locked step above. Pruning the Tagging queue
     # is a SEPARATE try: sharing one with the patch meant a failed patch skipped the
     # prune, leaving a successfully labelled issue sitting in the queue.
-    # The issue is no longer untagged, so its Tagging-queue proposal is spent —
+    # The issue is tagged, so its Tagging-queue proposal is spent —
     # drop it here too (not just on the bulk path) so accepting a suggestion from
     # the detail pane also clears it from the dashboard.
     if final_labels:
@@ -3885,9 +3885,9 @@ async def _handle_get_tagging(request: web.Request) -> web.Response:
     which the queue's reload needs: labels get added on GitHub itself, and a
     cache-first read would keep reporting those issues as untagged.
 
-    Returns the issues as ROWS, not just numbers. The frontend used to resolve
-    numbers against the shared issue list, which follows the user's open/closed
-    filter — so entering Tagging from a Closed filter showed an empty queue."""
+    Returns the issues as ROWS, not just numbers. Resolving numbers in the
+    frontend against the shared issue list would follow the user's open/closed
+    filter, so entering Tagging from a Closed filter would show an empty queue."""
     key = _key_from_request(request)
     owner, repo = key.owner, key.repo
     if not owner or not repo:
@@ -3960,7 +3960,7 @@ async def _handle_get_tagging(request: web.Request) -> web.Response:
 
     # Only report suggestions for issues that are STILL untagged: a label applied
     # elsewhere (GitHub, the detail pane) makes a cached proposal moot, and
-    # showing it would offer to re-label an issue that no longer needs it.
+    # showing it would offer to re-label an issue that does not need it.
     live = {str(n) for n in untagged}
     return web.json_response(
         {
@@ -4899,7 +4899,7 @@ async def _refuse_if_head_moved(
 
     The check neither provider will do for us on a review. GitLab's ``/approve`` takes a
     real ``sha`` precondition, but GitHub's ``commit_id`` only ATTRIBUTES the review to a
-    commit — it accepts one that is no longer the head, and whether the resulting stale
+    commit — it accepts one that is not the head, and whether the resulting stale
     approval still counts toward branch protection is a per-repo setting ("dismiss stale
     pull request approvals"). Where that is off, an unchecked approval satisfies
     protection on code nobody read. So the app reads the head itself, exactly as
@@ -5109,9 +5109,9 @@ async def _handle_pull_auto_merge(request: web.Request) -> web.Response:
 #                blocking discussions and required pipelines all satisfied
 #
 # `unstable` is deliberately EXCLUDED. It is usually described as "only non-required
-# checks are failing", and that reading is what an earlier revision allowed — but the
-# state does not actually distinguish a failing REQUIRED check from a failing optional
-# one, so it cannot be used to conclude the protections are satisfied. For an ordinary
+# checks are failing", but the state does not actually distinguish a failing REQUIRED
+# check from a failing optional one, so it cannot prove the protections are satisfied.
+# For an ordinary
 # user the provider would refuse anyway; for the admin this gate exists to protect
 # against, allowing it would land code over a red required check. A gate that cannot
 # tell must refuse: the PR is still one click from `auto_merge`, which lets the provider

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
@@ -1531,9 +1531,9 @@ DEPS_CACHE_SCHEMA = 1
 # This constant has TWO consumers with DIFFERENT needs, which is why it stays at
 # ten minutes even though the /deps route alone would be happy with hours:
 #
-#   * the /deps route, which since serve-stale-revalidate-behind no longer blocks
-#     a request on an expired cache (it returns the stale graph and refreshes in
-#     the background), so for the route this TTL governs how often a BACKGROUND
+#   * the /deps route, which does not block a request on an expired cache (it
+#     serves the stale graph and revalidates behind, refreshing in the
+#     background), so for the route this TTL governs how often a BACKGROUND
 #     rebuild fires and a long value would be harmless;
 #   * crew_runtime._read_or_refresh_deps, the sweep that feeds SIG_DEP_UNBLOCKED.
 #     For the sweep this TTL IS the freshness horizon on which a crew waiting for
@@ -1788,7 +1788,7 @@ def apply_state_change_to_caches(
     *, root: Path | None = None,
 ) -> None:
     """Patch an issue's state in the detail cache and drop it from the list
-    cache it no longer belongs to (the open list on close, the closed list on
+    cache it does not belong in (the open list on close, the closed list on
     reopen). The issue reappears in the correct list on the next refresh."""
     dpath = issue_detail_cache_path(owner, repo, number, root)
     if dpath.is_file():

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_azure_actions.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_azure_actions.py
@@ -180,7 +180,7 @@ class TestMergePullRequest(unittest.TestCase):
             out = azure_client.merge_pull_request(OWNER, REPO, 7, "SQUASH", SHA, host=HOST)
         body = az.writes()[0]["body"]
         self.assertEqual(body["status"], "completed")
-        # Azure refuses the completion when this is no longer the PR's last source
+        # Azure refuses the completion when this is not the PR's last source
         # commit, which is what stops a push landing mid-review from being merged.
         self.assertEqual(body["lastMergeSourceCommit"], {"commitId": SHA})
         self.assertEqual(out, {"merged": True, "sha": "c" * 40, "message": ""})

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_azure_pulls.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_azure_pulls.py
@@ -227,7 +227,7 @@ class TestNormPull(unittest.TestCase):
 
     def test_a_deactivated_label_is_dropped(self):
         # Azure keeps a removed PR label as a row with ``active: false``. Rendering
-        # it would show a tag the PR no longer carries.
+        # it would show a tag the PR does not carry.
         row = azure_client._norm_pull(
             _pr_payload(
                 labels=[
@@ -1034,7 +1034,7 @@ class TestPrChecks(unittest.TestCase):
 
     def test_a_build_for_another_commit_is_not_reported(self):
         # Azure's build list has no commit filter, so the match happens locally.
-        # A run against an older commit describes code that no longer exists.
+        # A run against an older commit describes code that is not in the head.
         az = self._az(
             builds=[
                 {

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_gitlab.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_gitlab.py
@@ -765,9 +765,10 @@ class TestMrTimelineNotesFetch(unittest.TestCase):
     """The MR timeline reads the notes endpoint ONCE.
 
     GitLab keeps inline (diff) comments in the same notes stream, so the MR
-    timeline both assembles the notes AND promotes the positioned ones. It used to
-    fetch ``{base}/notes`` twice per PR-detail load; ``_assemble_timeline`` now
-    returns the notes it fetched so the promotion reuses that one read."""
+    timeline both assembles the notes AND promotes the positioned ones.
+    ``_assemble_timeline`` returns the notes it fetched so the promotion reuses
+    that one read instead of fetching ``{base}/notes`` a second time per
+    PR-detail load."""
 
     def test_notes_endpoint_is_hit_once(self):
         note = {
@@ -1131,7 +1132,7 @@ class TestClientParity(unittest.TestCase):
     # signatures, so a disagreement is always the OTHER client drifting. Comparing
     # each module against GitHub (not pairwise against each other) also means a
     # failure names the provider that drifted, instead of only reporting that the
-    # three no longer agree.
+    # three disagree.
     REFERENCE = "github"
     CLIENTS = {
         "github": github_client,

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_lock_no_truncate.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_lock_no_truncate.py
@@ -1,25 +1,24 @@
 """issue_radar lock sidecars must be opened WRITABLE but WITHOUT truncation.
 
-Regression for #9263 (part of the #9248 sweep). Every lock context manager in
-``store.py`` and ``crew_store.py`` used ``open(lock_path, "w")`` and then handed
-the descriptor to ``platform_compat.file_lock(..., exclusive=True)``. ``"w"``
-truncates at open, BEFORE the lock is held. ``msvcrt.locking`` needs a writable
-handle, so ``"r"`` is not an option either; but on Windows a truncating open of a
-lock file whose first byte another holder already locked raises a sharing
-violation instead of waiting, so the second contending acquirer crashes before it
-ever reaches ``file_lock`` and the critical section is never mutually excluded.
-POSIX ``flock`` tolerates the truncate, which is why the defect is Windows-only.
+Every lock context manager in ``store.py`` and ``crew_store.py`` opens the lock
+file and hands the descriptor to ``platform_compat.file_lock(..., exclusive=True)``.
+``open(path, "w")`` truncates at open, BEFORE the lock is held. ``msvcrt.locking``
+needs a writable handle, so ``"r"`` is not an option either; but on Windows a
+truncating open of a lock file whose first byte another holder already locked
+raises a sharing violation instead of waiting, so the second contending acquirer
+crashes before it ever reaches ``file_lock`` and the critical section is never
+mutually excluded. POSIX ``flock`` tolerates the truncate, which is why the
+defect is Windows-only.
 
-Truncation is the direct, platform-independent observable, exactly as the
-work_ledger regression (#9237) pins it: seed the lock file with bytes, acquire
-and release the lock, and assert the bytes survived. Under the old
-``open(path, "w")`` these fail on every platform (the file is emptied); under the
-``touch`` + ``"r+"`` open they pass, and the same non-truncating open is what
-stops the Windows sharing violation.
+Truncation is the direct, platform-independent observable, and the work_ledger
+suite pins it the same way: seed the lock file with bytes, acquire and release the
+lock, and assert the bytes survived. A truncating ``open(path, "w")`` fails these
+on every platform (the file is emptied); the ``touch`` + ``"r+"`` open passes, and
+that same non-truncating open is what stops the Windows sharing violation.
 
-The cases below cover both modules and all three path expressions the sweep
-touched: a bound ``lock_path`` variable, a ``.with_suffix(".json.lock")`` cache
-sidecar, and a per-item ``.lock`` name.
+The cases below cover both modules and all three path expressions in use: a bound
+``lock_path`` variable, a ``.with_suffix(".json.lock")`` cache sidecar, and a
+per-item ``.lock`` name.
 """
 
 import shutil

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_pr_actions.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_pr_actions.py
@@ -943,7 +943,7 @@ class TestReviewRoutePinning(unittest.TestCase):
 
         GitLab's ``/approve`` takes a real ``sha`` precondition, but GitHub's
         ``commit_id`` is only ATTRIBUTION — GitHub accepts a review naming a commit that
-        is no longer the head and records it there, and whether that stale approval still
+        is not the head and records it there, and whether that stale approval still
         counts toward branch protection is a per-repo setting. Where "dismiss stale
         approvals" is off, an unchecked approval satisfies protection on code nobody
         read. So the app reads the head itself, exactly as the merge route does.

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_pulls.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_pulls.py
@@ -689,7 +689,7 @@ class TestPrListMergeReadiness(unittest.TestCase):
         self.assertEqual(out[1]["pr_merged_at"], "2026-08-03T06:45:33Z")
 
     def test_enrichment_corrects_a_stale_cached_row(self):
-        # The #1265 case: the row was cached while the PR was open, the user armed
+        # The row was cached while the PR was open, the user armed
         # auto-merge from it, and GitHub answered "already merged".
         pulls = [{"number": 1265, "state": "open", "merged_at": None}]
         summaries = {1265: {"additions": 1, "deletions": 0, "changed_files": 1,
@@ -964,7 +964,7 @@ class TestPrAiSummary(unittest.TestCase):
     def test_fingerprint_catches_an_edit_that_changes_no_metadata(self):
         # Editing a comment changes neither its created_at nor the comment count,
         # so a metadata-only digest would keep serving a summary written from text
-        # that no longer exists. The body is hashed, so it cannot.
+        # that is gone. The body is hashed, so it cannot.
         base = routes._pr_ai_fingerprint(self.detail, self.timeline, self.checks)
         edited = list(self.timeline)
         edited[0] = {**edited[0], "body": "Actually this is fine."}

--- a/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
@@ -721,8 +721,8 @@ async def status(dir_: str, subfolder: Optional[str] = None) -> list[FileChange]
     # transaction. Everything else is filesystem content and stays visible.
     #
     # The consequence is deliberate: an orphan left behind when a cleanup unlink
-    # lost the race becomes VISIBLE once its transaction ends and ownership can
-    # no longer be evidenced. That is the safe direction to fail. Reaping an
+    # lost the race becomes VISIBLE once its transaction ends and nothing can
+    # evidence ownership. That is the safe direction to fail. Reaping an
     # aged orphan is a lifecycle problem with its own answer; a permanent
     # filename-shape exclusion is not that answer, because it cannot tell an
     # orphan from a file the user put there.
@@ -1041,7 +1041,7 @@ async def sync(
         elif not origin_urls:
             raise GitError(f"No remote.origin.url configured for {dir_}")
 
-        # Refuse to sync if the vault's git remote no longer matches the URL it
+        # Refuse to sync if the vault's git remote does not match the URL it
         # was created/attached with. A vault's `.git/config` is agent-writable,
         # so a prompt-injected agent could repoint `remote.origin.url` (or
         # `pushurl`) at an attacker and have auto-sync upload the note history

--- a/src/kiro_crew/apps/builtins/md_notebook/notes.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/notes.py
@@ -62,7 +62,7 @@ def _json_safe(value: Any, _seen: Optional[set[int]] = None) -> Any:
     """Coerce YAML-parsed values that JSON cannot serialize into safe forms.
 
     ``yaml.safe_load`` resolves the YAML core schema, so an unquoted frontmatter
-    date (``date: 2026-08-01`` — routine in Obsidian) becomes a ``datetime.date``,
+    date (``date:`` with a bare ISO day — routine in Obsidian) becomes a ``datetime.date``,
     a ``!!binary`` becomes ``bytes``, a ``!!set`` becomes ``set`` and ``.nan`` /
     ``.inf`` become non-finite floats — none of which round-trips as valid JSON,
     so the note read would 500 (or emit bare ``NaN``, which the browser's

--- a/src/kiro_crew/apps/builtins/md_notebook/server.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/server.py
@@ -60,11 +60,11 @@ APP_NAME = os.environ.get("KIROCREW_APP_NAME", "md-notebook")
 _STAGING_LEAF = "md-notebook-staging"
 
 
-# Data-home paths are resolved LAZILY, never at import time (issue #874): the
+# Data-home paths are resolved LAZILY, never at import time: the
 # active KiroCrew home depends on KIROCREW_HOME, which a pod, the legacy-home
 # migration, or the test-isolation fixture can change AFTER this module is
 # imported. `_HOME` is the override hook (None = live-resolve); tests do
-# `monkeypatch.setattr(server, "_HOME", tmp)`. See config/paths.py / issue #874.
+# `monkeypatch.setattr(server, "_HOME", tmp)`. See config/paths.py.
 _HOME: Optional[Path] = None
 
 
@@ -915,7 +915,7 @@ async def trash_dir_path(vault: dict[str, Any]) -> Path:
     So any symlink is refused, escaping or not. `lstat` via `is_symlink()` is the
     only test that can see it — `exists()` and `is_dir()` both follow the link.
     On Windows the same redirection is possible via a directory JUNCTION, which
-    `is_symlink()` does NOT report, so `is_link_or_junction` is used to catch both.
+    `is_symlink()` does NOT report, so `is_link_or_junction` catches both.
     """
     trash_dir = await vault_mutation_path(vault, git_ops.TRASH_DIR)
     if await asyncio.to_thread(platform_compat.is_link_or_junction, trash_dir):
@@ -1084,8 +1084,8 @@ async def read_note_text(path: Path) -> Optional[str]:
     not enough on its own. `safe_read_file_bytes` canonicalizes via realpath,
     refuses a sensitive resolved target and opens with O_NOFOLLOW.
 
-    Centralized deliberately: this gate was previously applied per call site and
-    each new read path was a fresh hole.
+    Centralized deliberately: applied per call site instead, every new read path
+    is a fresh hole.
     """
     try:
         data = await asyncio.to_thread(hooks.safe_read_file_bytes, str(path))
@@ -1369,7 +1369,7 @@ async def api_vault_clone(request: web.Request) -> web.Response:
         raise ApiError("url is required", 400, code="url_required")
     # Use a submitted token TRANSIENTLY for this clone; persist it only after the
     # clone succeeds. Writing it up front would let a failed clone (bad URL or
-    # bad token) overwrite a previously-valid stored PAT and break every existing
+    # bad token) overwrite a valid stored PAT and break every existing
     # vault's auth.
     submitted_pat = str(body["pat"]) if body.get("pat") else None
     pat = submitted_pat or await resolve_auth()
@@ -2040,7 +2040,7 @@ async def api_note_delete(request: web.Request) -> web.Response:
     mark_self_write(trash_dir / trashed)
     # Rebuild rather than drop one index entry: the deleted note's own
     # [[wikilinks]] disappear with it, so every note it pointed at keeps a
-    # backlink to a note that no longer exists until the next rebuild.
+    # backlink to a missing note until the next rebuild.
     await rebuild_cache(vault)
     return web.json_response({"ok": True, "trashed": f"{git_ops.TRASH_DIR}/{trashed}"})
 

--- a/src/kiro_crew/apps/builtins/md_notebook/syncer.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/syncer.py
@@ -5,13 +5,13 @@ and cancelled on ``app.on_cleanup``. Every :data:`TICK_SEC` seconds it re-reads
 ``settings.json`` and, when the configured interval has elapsed, commits, merges
 and pushes every writable vault exactly as ``POST /api/sync`` does.
 
-WHY IT LIVES HERE rather than in the page. Auto-sync used to be a
-``window.setInterval`` inside the Notes React page, so closing the tab — or
-navigating to another app — stopped syncing entirely, silently and with no
-indication that notes had stopped reaching the remote. A backup that only runs
-while you are looking at it is the one case where the user believes they are
-covered and are not. Living in the app's own backend means the interval is
-honoured while the gateway runs, with no dashboard tab open.
+WHY IT LIVES HERE rather than in the page. A ``window.setInterval`` inside the
+Notes React page stops syncing entirely when the tab closes — or the user
+navigates to another app — silently and with no indication that notes have
+stopped reaching the remote. A backup that only runs while you are looking at it
+is the one case where the user believes they are covered and are not. Living in
+the app's own backend means the interval is honoured while the gateway runs,
+with no dashboard tab open.
 
 It is NOT a cron job: it runs inside this backend process only, and stops when the
 process does.

--- a/src/kiro_crew/apps/builtins/meetings/backend/constants.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/constants.py
@@ -34,7 +34,7 @@ MAX_BATCH_CHARS = 60_000  # per flushed agent batch
 #: about, and each is already capped at ``MAX_TRANSCRIPT_CHARS``.
 #:
 #: The window is the agent-initialization span, measured at ~46s on a real
-#: meeting (issue #4610). Speech finals arrive every few seconds, so a real
+#: meeting. Speech finals arrive every few seconds, so a real
 #: opening lands 15-25 lines here; 200 leaves an order of magnitude of headroom
 #: while bounding the hold at ``200 * MAX_TRANSCRIPT_CHARS`` (~800 KB) for the
 #: one meeting ``MAX_CONCURRENT_MEETINGS`` permits.
@@ -50,7 +50,7 @@ MAX_TITLE_LEN = 300
 MAX_ICS_BYTES = 4 * 1024 * 1024  # refuse absurd .ics payloads
 ICS_FETCH_TIMEOUT_SECS = 20
 #: Redirects are followed MANUALLY so each hop is SSRF-validated, so the chain
-#: needs its own bound (aiohttp's own `max_redirects` no longer applies).
+#: needs its own bound (aiohttp's own `max_redirects` does not apply).
 ICS_MAX_REDIRECTS = 5
 CALENDAR_SYNC_DAYS = 7
 

--- a/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
@@ -422,7 +422,7 @@ class MeetingSession:
     #: Lives on the session, not on the holder, so it is bound to the identity
     #: whose initialization it covers: a session that is replaced or torn down
     #: takes its hold with it, and a later session can never inherit and replay
-    #: lines that were spoken into a meeting that no longer exists.
+    #: lines that were spoken into a meeting that does not exist.
     #:
     #: The recipient set is stored rather than recomputed at drain because the
     #: hold must change WHEN a line is delivered, never WHO it was addressed to.
@@ -432,7 +432,7 @@ class MeetingSession:
     #:
     #: NAMES, not queue objects: an agent disabled mid-initialization has its
     #: queue removed from ``agents``, and holding a reference would enqueue into
-    #: a queue nothing flushes. A name that no longer resolves is simply skipped.
+    #: a queue nothing flushes. A name that does not resolve is simply skipped.
     init_buffer: list[tuple[str, frozenset[str]]] = field(default_factory=list)
     #: How many of the OLDEST held lines the cap displaced. Read at drain time
     #: to size the marker, so a drop is announced once with an exact count
@@ -558,7 +558,7 @@ class MeetingSession:
 
         The agents cannot receive anything yet — they do not know which file they
         own until ``init_agents`` has run — but the speaker is already talking, and
-        refusing the line is what lost the opening of every meeting (issue #4610).
+        refusing the line loses the opening of the meeting.
 
         Normalized and filtered HERE, at arrival, and stored with the recipients of
         this moment: both halves of "what happens to this line" are decided when a

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/_common.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/_common.py
@@ -58,9 +58,9 @@ class _ActiveMeeting:
         #:
         #: ``accepting_dispatches`` alone cannot answer "should this line be
         #: refused?", because it is false for two opposite reasons: the meeting is
-        #: stopping/reviewing/expired (the line has nowhere to go — refuse it, which
-        #: is the gate issue #1981 added) or the meeting is STARTING and its agents
-        #: are not ready yet (the line is wanted — hold it). Conflating them is what
+        #: stopping/reviewing/expired (the line has nowhere to go — refuse it) or
+        #: the meeting is STARTING and its agents are not ready yet (the line is
+        #: wanted — hold it). Conflating them is what
         #: made a meeting refuse its own opening speech for ~46s.
         #:
         #: Stored as the SESSION rather than a bool so the state cannot outlive the
@@ -482,7 +482,7 @@ class Admission(NamedTuple):
     ingress is open (fan out normally); True is a session still INITIALIZING its
     agents, admitted only because the producer opted into the hold — the line is
     wanted, so it is appended to the transcript and buffered for the drain instead
-    of refused (issue #4610).
+    of refused.
     """
 
     session: MeetingSession

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/agents.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/agents.py
@@ -329,7 +329,7 @@ async def handle_dispatch_text(request: web.Request) -> web.Response:
     # and the expiry side effects) is shared with the audio-import producer — see
     # `_common.dispatch_line`. Only THIS producer opts into the initialization
     # hold: a line of live speech arriving while the agents are still starting is
-    # wanted and is buffered (issue #4610), whereas a file import has no business
+    # wanted and is buffered, whereas a file import has no business
     # trickling into a hold buffer — it is refused whole and retried.
     source = k.TRANSCRIPT_SOURCE_TYPED if is_chat else k.TRANSCRIPT_SOURCE_SPEECH
     segment, accepted, line = await dispatch_line(

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/audio_import.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/audio_import.py
@@ -216,7 +216,7 @@ def _snapshot_recording(
     step's ceiling judged the original name, and a swap could have replaced it
     with something the memory ceiling exists to refuse. Returns the snapshot
     path, or None when the source was refused (swapped for a link, ancestor
-    directory swapped for a link, no longer a regular file, vanished before the
+    directory swapped for a link, not a regular file, vanished before the
     copy) or grew past the ceiling. BLOCKING.
     """
     # Windows first: ``O_NOFOLLOW`` does not exist there, so the pinned open

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/meeting_lifecycle.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/meeting_lifecycle.py
@@ -159,7 +159,7 @@ async def handle_get_meeting(request: web.Request) -> web.Response:
         # snapshot and may change by the next poll, which is exactly what a poll is
         # for.
         live_payload["accepting_dispatches"] = ACTIVE.accepting_dispatches
-        # And whether it would be HELD rather than refused (issue #4610). The
+        # And whether it would be HELD rather than refused. The
         # frontend polls this endpoint to decide when to open the microphone, and
         # "would speech land?" is now these two ORed: during initialization the
         # answer is yes-by-holding. Reported separately rather than folded into the
@@ -340,7 +340,7 @@ async def handle_start_meeting(request: web.Request) -> web.Response:
             # fan-out closed until every enabled agent knows its output contract —
             # but HOLD what is said meanwhile instead of refusing it.
             #
-            # Refusing was measured at ~46s of a real meeting (issue #4610): the
+            # Refusing costs a measured ~46s of a real meeting: the
             # speaker opens with the agenda, every line 409s, and the notes and
             # tasks begin partway through the first topic with nothing to show a
             # turn was lost. The hold is bounded and drains in arrival order right
@@ -360,14 +360,13 @@ async def handle_start_meeting(request: web.Request) -> web.Response:
 
         # ALWAYS initialize, restart or not, THEN send the restart notice.
         #
-        # The restart branch used to skip `init_agents` entirely, on the assumption
-        # that a restarted meeting's agents still remember their instructions. They
-        # may not: the slots are ordinary kiro sessions and can have been reclaimed
-        # (session cleanup, a gateway restart, an idle sweep) between stop and
-        # restart. A fresh session then received only "continue appending to your
-        # output" — an instruction that names no output — so it had no `OUTPUT_FILE`
-        # and the notes and tasks silently stopped updating for the rest of the
-        # meeting.
+        # A restarted meeting's agents cannot be assumed to remember their
+        # instructions: the slots are ordinary kiro sessions and can have been
+        # reclaimed (session cleanup, a gateway restart, an idle sweep) between stop
+        # and restart. Skipping `init_agents` on the restart branch leaves a fresh
+        # session with only "continue appending to your output" — an instruction that
+        # names no output — so it has no `OUTPUT_FILE` and the notes and tasks
+        # silently stop updating for the rest of the meeting.
         #
         # Re-initializing a session that DOES remember is harmless: the init message
         # is idempotent by construction (it re-states the path and says "the file
@@ -376,12 +375,12 @@ async def handle_start_meeting(request: web.Request) -> web.Response:
         # "disregard the previous 'Meeting ended' message" arrives after the
         # instructions it qualifies.
         #
-        # INSIDE `START_LOCK`, which now also covers `handle_stop_meeting`. Agent
-        # initialization is a long sequence of awaited dispatches, and it ran
-        # unlocked: a stale Close in another tab could tear the session down midway,
-        # so the remaining agents were initialized into a session no longer installed
-        # while this request still answered `active` — a meeting the UI showed as
-        # running, with no live session and an `ended` status on disk.
+        # INSIDE `START_LOCK`, which also covers `handle_stop_meeting`. Agent
+        # initialization is a long sequence of awaited dispatches, so unlocked a
+        # stale Close in another tab tears the session down part-way through: the
+        # agents are initialized into a session that is not installed while this
+        # request still answers `active` — a meeting the UI shows as running, with no
+        # live session and an `ended` status on disk.
         #
         # The lock is what makes stop WAIT for a start to finish rather than
         # interleave with it. The cost is that a stop arriving during initialization
@@ -518,9 +517,10 @@ async def handle_stop_meeting(request: web.Request) -> web.Response:
     """End a meeting: flush every agent, send the finalize notice, mark ended.
 
     Takes ``START_LOCK``, so a stop cannot interleave with a start. Without it, a
-    stale Close in one tab tore down a session another tab was still initializing:
-    the remaining agents were initialized into a session no longer installed, and the
-    start still answered `active` for a meeting with `ended` on disk and nothing live.
+    stale Close in one tab tears down a session another tab is still initializing:
+    the remaining agents are initialized into a session that is not installed, and
+    the start still answers `active` for a meeting with `ended` on disk and nothing
+    live.
 
     Both directions matter, which is why the lock is shared rather than a second one:
     a stop landing mid-start waits for the agents to be ready (the finalize notice

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/tasks.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/tasks.py
@@ -77,7 +77,7 @@ def task_mutation_transaction() -> "threading.Lock":
 
     Hold it only from a worker thread. Meeting deletion takes the same lock so
     an in-flight mutation either finishes before the directory is removed or
-    observes that the meeting no longer exists.
+    observes that the meeting does not exist.
     """
     return _TASKS_LOCK
 
@@ -164,7 +164,7 @@ def _normalize_task(raw: Any) -> dict[str, Any] | None:
         # which is exactly how a credential-shaped id would have crossed the
         # boundary while `description` beside it was scrubbed. Redact BEFORE the
         # truncation, so a marker cannot be sliced in half into something the
-        # scanner no longer recognises.
+        # scanner does not recognise.
         "id": redact(str(raw.get("id") or f"t{uuid.uuid4().hex[:8]}"))[:64],
         "description": description[:_MAX_DESCRIPTION],
         "assignee": redact(str(raw.get("assignee") or "").strip())[:200],

--- a/src/kiro_crew/apps/builtins/meetings/backend/store.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/store.py
@@ -689,7 +689,7 @@ def append_translation(
     both be writing, and ``atomic_write`` makes the WRITE atomic, not the
     read-modify-write around it.
 
-    Returns ``None`` without writing when the meeting no longer exists: the
+    Returns ``None`` without writing when the meeting does not exist: the
     worker's persistence runs on a thread and can lose a race with
     ``delete_meeting`` — without this guard, ``_write_json``'s ``mkdir`` would
     silently recreate the deleted meeting's directory. Both sides take

--- a/src/kiro_crew/apps/builtins/mochi/agent_policy.py
+++ b/src/kiro_crew/apps/builtins/mochi/agent_policy.py
@@ -186,7 +186,7 @@ def build_policy(settings: dict[str, Any], data_dir: Path | None = None) -> dict
     # never overwrites an explicit choice, it only fills the floor.
     #
     # `mountOnly` marks these built-in grants so the bridge mounts the server
-    # (the tool becomes visible, no longer stranded) but does NOT add it to
+    # (the tool becomes visible rather than stranded) but does NOT add it to
     # `allowedTools`. allowedTools is kiro-cli's auto-approve list, the one path
     # that never reaches hooks.on_tool_call — writing spawn_run/cron_add there
     # would let prompt-injected content (the pet web_fetches watch targets)
@@ -265,11 +265,11 @@ def apply_policy(data_dir: Path, settings: dict[str, Any]) -> dict[str, Any]:
     startup reconcile picks up, so persisting it is useful even when this
     materialization fails.
 
-    Raises :class:`PolicyNotMaterialized` when the refresh does not land. This
-    used to be swallowed with a warning — including the case where
-    ``refresh_app_agents`` returned an EMPTY list, which was logged as "applied to
-    0 agent config(s)" and read as success. Both left the caller believing the
-    deny policy was in force when it was not.
+    Raises :class:`PolicyNotMaterialized` when the refresh does not land,
+    including the case where ``refresh_app_agents`` returns an EMPTY list — a
+    warning there ("applied to 0 agent config(s)") reads as success. Swallowing
+    either one leaves the caller believing the deny policy is in force when it
+    is not.
 
     Not raised when the app has NO registered agent configs: there is then nothing
     for kiro-cli to load either, so nothing holds ambient reach.

--- a/src/kiro_crew/apps/builtins/mochi/appearance_store.py
+++ b/src/kiro_crew/apps/builtins/mochi/appearance_store.py
@@ -116,8 +116,8 @@ def _pack_dir(data_dir: Path, pack_id: str) -> Path:
     if target != root and root not in target.parents:
         raise PackError(f"pack id escapes the appearances directory: {pack_id!r}")
     # Return the CHECKED path, not a second join of the same parts. Re-joining
-    # produced a path expression that no longer carried the barrier, so every
-    # caller that appended a filename to it was flagged again — the guard has to
+    # produces a path expression that does not carry the barrier, so every
+    # caller that appends a filename to it is flagged again — the guard has to
     # be on the value that actually escapes this function.
     return target
 
@@ -186,9 +186,9 @@ def save_sprite_pack(data_dir: Path, payload: dict[str, Any]) -> str:
     pack_id = str(overwrite_id) if overwrite_id else str(uuid.uuid4())
     pack_dir = _pack_dir(data_dir, pack_id)
 
-    # Decode EVERYTHING before touching the existing pack. An overwrite used to
-    # rmtree first and decode after, so one malformed data URI destroyed the
-    # pack it was replacing — validation failed, but the deletion had already
+    # Decode EVERYTHING before touching the existing pack. An overwrite that
+    # rmtrees first and decodes after lets one malformed data URI destroy the
+    # pack it is replacing — validation fails, but the deletion has already
     # happened. Decode errors must leave the existing pack untouched.
     decoded_slots: dict[str, bytes] = {}
     for slot, data_uri in assignments.items():
@@ -455,9 +455,10 @@ def import_bundle(data_dir: Path, blob: bytes) -> dict[str, Any]:
                 + ", ".join(missing_files)
             )
 
-        # Staged like every other pack write: a CRC-corrupt entry partway through
-        # the archive used to leave the pack it was replacing half-overwritten,
-        # with a manifest naming files that were never extracted.
+        # Staged like every other pack write: extracting in place lets a
+        # CRC-corrupt entry partway through the archive leave the pack it is
+        # replacing half-overwritten, with a manifest naming files that were
+        # never extracted.
         with _staged_pack(target) as staging:
             for entry in entries:
                 if entry.filename == MANIFEST_FILE:
@@ -555,8 +556,8 @@ def save_pack(
     }
     manifest = {"meta": full_meta, "states": state_map, "moods": mood_map}
 
-    # One staged swap, like the other two writers. It also subsumes the prune step
-    # upstream did by hand (deleting files the new manifest no longer references):
+    # One staged swap, like the other two writers. It also subsumes a by-hand
+    # prune step upstream (deleting files the new manifest does not reference):
     # the staging directory only ever contains the files just written, so a re-save
     # that drops a slot leaves nothing behind to prune.
     with _staged_pack(pack_dir) as staging:

--- a/src/kiro_crew/apps/builtins/mochi/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/mochi/backend/routes.py
@@ -294,9 +294,8 @@ async def _handle_bg_usage(request: web.Request) -> web.Response:
 def _pins_corrupt() -> web.Response:
     """Map the pin store's corruption refusal to a coded response.
 
-    The update reader refuses a corrupt pin list rather than replacing it
-    (#8088, mirroring #7805), so these handlers can now see a
-    ``PinsCorruptError`` that previously could not happen. Letting it escape
+    The update reader refuses a corrupt pin list rather than replacing it, so
+    these handlers can see a ``PinsCorruptError``. Letting it escape
     gives aiohttp's bare 500 with no ``code`` for the UI to branch on, and
     reporting ``{"ok": false}`` instead would be read as "no such pin" -- for
     mark-seen, as outright success. 500 rather than 503: corruption does not
@@ -922,7 +921,7 @@ async def _handle_pack_delete(request: web.Request) -> web.Response:
     except PackError as exc:
         return web.json_response({"error": str(exc), "code": "invalid_pack_delete"}, status=400)
     # Deleting the ACTIVE pack must also clear the pointer, or the pet keeps
-    # trying to render a pack that no longer exists.
+    # trying to render a pack that is gone.
     active = (await asyncio.to_thread(load_settings, _rt().data_dir)).get("activeAppearance")
     if removed and active == pack_id:
         updated = await asyncio.to_thread(save_settings, _rt().data_dir, {"activeAppearance": ""})
@@ -1153,8 +1152,8 @@ async def _handle_displays(request: web.Request) -> web.Response:
 
 def _write_displays_cache(data_dir: Any, displays: list[Any], active_id: Any) -> None:
 
-    # Keep the GEOMETRY, not just the size. This projection used to reduce each
-    # monitor to {id, width, height}, which left the pet unable to answer the one
+    # Keep the GEOMETRY, not just the size. Reducing each monitor to
+    # {id, width, height} leaves the pet unable to answer the one
     # question the cache exists for: which screen am I on, and where is it. With
     # no ordinal, no primary flag and no origin, an agent asked "which display?"
     # has nothing to reason from and guesses — usually "display 1". `index` is

--- a/src/kiro_crew/apps/builtins/mochi/hooks.py
+++ b/src/kiro_crew/apps/builtins/mochi/hooks.py
@@ -709,9 +709,9 @@ class MochiRuntime:
         # browser — summary/chatMessage via the mochi:notify broadcast and the chat
         # push, mood via the state manager and the /pet-state + /stats reads. Scrub
         # credentials/exfiltration URLs ONCE up front so EVERY sink below consumes
-        # the redacted copy. A mood-only notify (no summary) previously skipped the
-        # redaction that lived inside the has_summary block and leaked the raw mood
-        # to /pet-state and /stats — hoisting it closes that path.
+        # the redacted copy. Redacting inside the has_summary block instead would
+        # let a mood-only notify (no summary) skip it and leak the raw mood to
+        # /pet-state and /stats, so it is hoisted above the branch.
         action = redact_tree(action)
         summary = action.get("summary")
         if has_summary:
@@ -760,7 +760,7 @@ class MochiRuntime:
 
         The active flag is bounded by ``_CHAT_TURN_MAX_MS``: past that age a
         turn whose terminal event never arrived (panel closed / socket dropped)
-        no longer counts as busy, so the drain can release its backlog rather
+        does not count as busy, so the drain can release its backlog rather
         than deferring forever."""
         if self._chat_turn_active and now_ms - self._last_user_input_ms < self._CHAT_TURN_MAX_MS:
             return True

--- a/src/kiro_crew/apps/builtins/mochi/mcp_server.py
+++ b/src/kiro_crew/apps/builtins/mochi/mcp_server.py
@@ -609,7 +609,7 @@ def _tool_pin_file(args: dict[str, Any]) -> str:
     with pins_mutation(str(pins_path)):
         # read_pins_for_update, not the lenient _read_json with an empty default:
         # the write below replaces the WHOLE file, so a corrupt store read as
-        # `{"pins": []}` would be ZEROED here (#8088). That is strictly worse than
+        # `{"pins": []}` would be ZEROED here. That is strictly worse than
         # the gateway service's version of the same bug, which at least wrote its
         # live in-memory list back. Both writers share the one reader so refusing
         # in the service cannot be undone by the next pin_file from this process.

--- a/src/kiro_crew/apps/builtins/mochi/pinned_files_service.py
+++ b/src/kiro_crew/apps/builtins/mochi/pinned_files_service.py
@@ -96,7 +96,7 @@ class PinsCorruptError(Exception):
     first one just refused to touch.
 
     Modelled on ops-mission-control's ``CorruptDocumentError`` rather than the
-    bare ``json.JSONDecodeError`` the aws-control readers raise (#7805): that
+    bare ``json.JSONDecodeError`` the aws-control readers raise: that
     app reached for the plain type only because the named one lived in another
     app, which does not apply to a type declared in the module both writers
     already import.
@@ -137,12 +137,11 @@ def read_pins_for_update(file_path: str) -> list[Any] | None:
     it becomes U+FFFD, ``json.loads`` SUCCEEDS, and the whole-file rewrite then
     persists the mangled text. That is the same irreversible loss as the three
     refusals above, reached without any parse failure to catch it, so an
-    undecodable byte is a fourth refusal rather than a repair. Found in review
-    (GPT 5.6).
+    undecodable byte is a fourth refusal rather than a repair.
 
     ``load`` keeps the lenient decode: it does not write, and a corrupt file it
     accepts is preserved as a ``.bak.<now_ms>`` sidecar first. A mangled label
-    read at startup can therefore reach memory, but it can no longer reach DISK,
+    read at startup can therefore reach memory, but it cannot reach DISK,
     because every write path first re-reads through this reader and refuses.
     """
     try:

--- a/src/kiro_crew/apps/builtins/mochi/queue_file.py
+++ b/src/kiro_crew/apps/builtins/mochi/queue_file.py
@@ -45,10 +45,9 @@ from kiro_crew.platform_compat import chmod_safe, file_lock
 logger = logging.getLogger(__name__)
 
 #: The queue file's name, owned HERE because this module owns queue file
-#: operations. It used to be defined independently in both ``hooks`` and
-#: ``mcp_server`` — two copies of one literal, which meant renaming the file in
-#: one place left the other reading a path nothing writes, with no error to see.
-#: Every reader now takes it from this single definition.
+#: operations. Every reader takes it from this single definition: with a second
+#: copy of the literal in ``hooks`` or ``mcp_server``, renaming the file in one
+#: place leaves the other reading a path nothing writes, with no error to see.
 QUEUE_FILE = "mochi-queue.json"
 
 # Default TTL for done-task cleanup: 2 hours.

--- a/src/kiro_crew/apps/builtins/mochi/stats_service.py
+++ b/src/kiro_crew/apps/builtins/mochi/stats_service.py
@@ -270,7 +270,7 @@ class StatsService:
 
         Dispatched off the event loop (``asyncio.to_thread``) and held under
         ``self._lock`` so it is mutually exclusive with tick()/flush(): a due
-        flush running in another worker thread can no longer rewrite a stale
+        flush running in another worker thread cannot rewrite a stale
         in-memory snapshot back over the wipe. The dirty flag, the pending flush
         deadline, and the session counter are cleared first so a tick right after
         the lock is released cannot resurrect pre-reset state. Returns True if a

--- a/src/kiro_crew/apps/builtins/mochi/watchlist_file.py
+++ b/src/kiro_crew/apps/builtins/mochi/watchlist_file.py
@@ -8,8 +8,8 @@ This is a MECHANICAL port. The six primitives the migration plan calls out
 (due-time recomputation after every check, priority dispatch, the timestamp
 lock, fail-degradation with cooldown, at-least-once delivery, lifecycle and
 archiving) live partly here and partly in ``watchlistService``; nothing about
-them is redesigned in passing. Upgrading this into a core scheduler is
-KiroCrew issue #721's business, with THIS file as the baseline.
+them is redesigned in passing. Upgrading this into a core scheduler is separate
+work, with THIS file as the baseline.
 
 PORTING NOTES
 -------------
@@ -353,16 +353,16 @@ def _reject_malformed_ops(params: dict[str, Any]) -> None:
 
     Nothing upstream type-checks these. The HTTP route forwards a decoded JSON
     body and the MCP tool forwards agent-authored arguments; both only assert
-    that at least one operation KEY is present. A wrong TYPE therefore used to
-    reach the per-item code, where it read as a server fault rather than a bad
+    that at least one operation KEY is present. Without this check a wrong TYPE
+    reaches the per-item code, where it reads as a server fault rather than a bad
     request:
 
-    - ``{"add": "x"}`` sliced the STRING, then called ``create_watch_item`` on
+    - ``{"add": "x"}`` slices the STRING, then calls ``create_watch_item`` on
       each character -> ``AttributeError`` -> HTTP 500.
     - ``{"add": [{"checkIntervalMins": "abc"}]}`` -> ``TypeError`` in
       ``_clamp_interval`` -> HTTP 500.
-    - ``{"remove": "abc"}`` built a set of CHARACTERS and deleted every item
-      whose id was one of them: silent data loss with no error at all.
+    - ``{"remove": "abc"}`` builds a set of CHARACTERS and deletes every item
+      whose id is one of them: silent data loss with no error at all.
 
     ``ValueError`` is what both callers already treat as the client's mistake
     (the route maps it to 400), so validating here — rather than in the route —

--- a/src/kiro_crew/apps/builtins/mochi/watchlist_service.py
+++ b/src/kiro_crew/apps/builtins/mochi/watchlist_service.py
@@ -66,7 +66,7 @@ GUARD_INTERVAL_MS = 5 * 60_000
 REMINDER_INTERVAL_MS = 60_000
 
 # Spawn lock auto-release (AGENT_SPAWN_TIMEOUT_MS in the original's shared
-# constants): a spawn older than this no longer blocks the next one.
+# constants): a spawn older than this does not block the next one.
 SPAWN_TIMEOUT_MS = 5 * 60_000
 
 # Consecutive failures before degraded mode.
@@ -202,11 +202,10 @@ class WatchlistService:
     async def _drain_queue(self) -> None:
         """Run queued writes one at a time, each on a worker thread.
 
-        `await to_thread(fn)`, not `fn()`: every one of these callables now takes
-        the cross-process watchlist lock, so it can block for as long as the MCP
-        server process holds it. Running that on the event loop froze chat and the
-        heartbeat for the duration — the lock made a previously-cheap synchronous
-        call genuinely blocking, so the drain had to move off the loop with it.
+        `await to_thread(fn)`, not `fn()`: every one of these callables takes the
+        cross-process watchlist lock, so it can block for as long as the MCP
+        server process holds it. Running that on the event loop freezes chat and
+        the heartbeat for the duration, so the drain stays off the loop.
 
         `self._writing` still serializes: only one write is in flight at a time,
         which is the invariant the archive/active write ORDER depends on.

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/dispatch.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/dispatch.py
@@ -174,7 +174,7 @@ class CycleResult:
         speak on exactly the signals an operator asked to stop hearing about.
 
         ``verifications`` counts only where the verdict is ``still_firing``. That verdict
-        means the app previously reported an action as applied and the alarm is still
+        means the app reported an action as applied and the alarm is still
         going — a claim it made that turned out not to be true, which is the single most
         newsworthy thing this cycle can discover. ``cleared`` is the expected outcome and
         announcing it would make the heartbeat congratulate itself, and ``unknown`` is
@@ -1044,10 +1044,10 @@ def investigation_brief(claimed: ClaimedIncident) -> str:
             lines.append(f"  • [{entry.confidence}/{entry.trust}] {entry.pattern}")
             lines.append(f"      fix: {entry.fix}")
 
-    # The no-credentials statement is UNCONDITIONAL, and deliberately so. It used to
-    # live only inside the ``if claimed.evidence`` branch below, which meant the one
-    # case that most needs it — no evidence gathered — was the one case that never got
-    # it. An agent handed an AWS incident and no explanation reasonably assumes it
+    # The no-credentials statement is UNCONDITIONAL, and deliberately so. Scoping it to
+    # the ``if claimed.evidence`` branch below would leave the one case that most needs
+    # it — no evidence gathered — as the one case that never gets it. An agent handed
+    # an AWS incident and no explanation reasonably assumes it
     # should go look itself, and then spends its whole turn re-running
     # ``aws … --profile …`` against a credential chain it cannot reach (observed on
     # INV-1/INV-2: repeated NoCredentials, no diagnosis). Saying it once, always, costs

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/handover.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/handover.py
@@ -88,8 +88,8 @@ def recurring_patterns() -> list[dict[str, Any]]:
             # someone to apply the wrong fix confidently.
             #
             # Delegated to the ledger's own predicate rather than restating
-            # "verified/high" — which is exactly what this line used to do, and it went
-            # stale the moment the bar gained a use-count floor and a miss ceiling. A
+            # "verified/high" here, which goes stale the moment the bar gains a use-count
+            # floor or a miss ceiling. A
             # digest that disagrees with the engine about what counts as proven tells a
             # responder to trust an entry the agent itself would not.
             "proven": ledger.entry_unlocks_fast_path(e),
@@ -136,7 +136,7 @@ def open_work() -> dict[str, Any]:
     incidents = store.open_incidents()
     waiting = [i for i in incidents if i.blocked_reason]
     # Escalated is a TERMINAL status, so it is deliberately absent from
-    # ``open_incidents`` — the app no longer owns that work. It still belongs in a
+    # ``open_incidents`` — the app does not own that work. It still belongs in a
     # handover though: "we passed this to another owner" is exactly the kind of thing
     # that gets lost at shift change, and the incoming responder may be the one who
     # has to chase it. Read from the index rather than the open set, and keep it out

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger.py
@@ -379,7 +379,7 @@ def match(
     provider_key: str = "",
     limit: int = MAX_MATCHES_PER_SIGNAL,
 ) -> list[LedgerEntry]:
-    """Entries that have previously matched this failure.
+    """Entries that match this failure.
 
     Two keys, tried in order of how much they can be trusted:
 
@@ -481,7 +481,7 @@ def record_use(entry_id: str, fingerprint: str = "", provider_key: str = "") -> 
     differently-worded alarm gets attached to the entry that already knows the
     fix. Binding the ``provider_key`` is what turns the FIRST fuzzy match into an
     exact one for every later occurrence — the entry learns the provider's own identity
-    for the failure, so the next recurrence no longer depends on the shape hash.
+    for the failure, so the next recurrence does not depend on the shape hash.
 
     Locked read-modify-write: a bare ``read_entries``/``_write_all`` here would clobber a
     concurrent ``upsert`` or hygiene rewrite. See ``_LedgerLock``.
@@ -640,8 +640,8 @@ def hygiene(*, now: datetime | None = None) -> dict[str, int]:
     - ``decayed`` — nobody needed this for ``DECAY_AFTER_DAYS``. Says nothing about
       whether the fix works; the estate moved on.
     - ``demoted`` — the fix was cited and the failure came back (``miss_count``). This is
-      evidence AGAINST the entry, which is the movement the ledger previously had no
-      mechanism for at all.
+      evidence AGAINST the entry: the one downward movement that says the entry is
+      wrong rather than merely unused.
 
     Collapsing them into one number would let "your ledger is going stale" and "your
     ledger is wrong" arrive as the same sentence.
@@ -777,14 +777,14 @@ def stats() -> dict[str, int]:
         "verified": sum(1 for e in entries if e.trust == TRUST_VERIFIED),
         "high_confidence": sum(1 for e in entries if e.confidence == CONFIDENCE_HIGH),
         "total_uses": sum(e.use_count for e in entries),
-        # ``verified`` and ``high_confidence`` are each one HALF of the old fast-path bar,
-        # so neither answers "how much of this ledger would an agent actually propose
-        # without checking". This does, and it now includes the track-record floor — which
-        # is why it can be strictly smaller than either of the two above and why showing
-        # them alone overstated the ledger's authority.
+        # ``verified`` and ``high_confidence`` are each one HALF of the fast-path bar, so
+        # neither answers "how much of this ledger would an agent actually propose
+        # without checking". This does, and it includes the track-record floor — which
+        # is why it can be strictly smaller than either of the two above, and why showing
+        # them alone overstates the ledger's authority.
         "proven": sum(1 for e in entries if entry_unlocks_fast_path(e)),
         # Entries carrying evidence their fix did not hold. The number an operator most
-        # needs and the one the app could not previously produce at all.
+        # needs, and the one no other field in this dict can express.
         "demoted": sum(1 for e in entries if is_demoted(e)),
         "total_misses": sum(e.miss_count for e in entries),
     }

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger_index.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger_index.py
@@ -86,7 +86,7 @@ def _read_cursor() -> set[str]:
     data-loss bug (see ``aws_control/backend/backup._read_state_for_update`` and
     its precedents), because the rewrite publishes the empty base over state it
     never read. Here the write is a UNION — ``_write_cursor(cursor | newly)`` —
-    so an empty base drops previously recorded ids from the cursor while
+    so an empty base drops already-recorded ids from the cursor while
     deleting nothing the cursor points at: the next import re-checks the
     dropped ids and the store's case-insensitive 80-char-prefix dedupe
     (:meth:`write_episodic`'s text-hash check, strictly broader than exact

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger_sync.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger_sync.py
@@ -388,8 +388,8 @@ async def _git(*args: str) -> tuple[int, str, str]:
     in the child, ``Popen._execute_child`` then blocks the event loop in an unbounded
     ``os.read`` with no await point for a timeout to reach, and the orphan keeps a duplicate
     of every inherited fd — the dashboard's listening socket included. The shim applies the
-    same limits after ``exec`` instead. Caught by ``test/test_spawn_preexec_guard.py``
-    (issue #935), a core gate this app had not been run against.
+    same limits after ``exec`` instead. Caught by ``test/test_spawn_preexec_guard.py``,
+    a core gate every spawn in this app must pass.
     """
     # Identity on the ARGV, not in the repo's config: `-c` beats config, so it holds
     # even against a repo-local `user.email` an agent could have written, and it needs

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/models.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/models.py
@@ -85,9 +85,8 @@ class CorruptDocumentError(json.JSONDecodeError):
     corruption arm comes first.
 
     The subclass exists so the raises are greppable and their intent explicit instead of a
-    parser exception carrying a meaning the parser never assigned it. Suggested in review
-    (Design Review) and worth having before #7805 replicates this idiom across the four
-    merged siblings.
+    parser exception carrying a meaning the parser never assigned it. The idiom is shared
+    across the four merged siblings, so one named type keeps them all readable.
     """
 
 
@@ -157,7 +156,7 @@ LEGAL_TRANSITIONS: dict[str, frozenset[str]] = {
     # whole job is to resolve incidents whose signal stopped firing, and without
     # this edge it has NO legal move for that case: the incident sticks at
     # ``dispatched`` until the stale sweep hours later, so the board claims work is
-    # in progress on a problem that no longer exists. Found by exercising the
+    # in progress on a problem that does not exist. Found by exercising the
     # reconcile SOP against a real cleared GitHub signal.
     STATUS_DISPATCHED: frozenset(
         {STATUS_INVESTIGATING, STATUS_NEEDS_HUMAN, STATUS_RESOLVED, STATUS_STALE}
@@ -292,7 +291,7 @@ VERIFIABLE_ACTIONS: frozenset[str] = frozenset({ACTION_RESOLVE, ACTION_SILENCE})
 #: ``""`` (the default) means no action was ever executed — NOT "verified fine". Every
 #: incident written before this existed reads as that, which is correct.
 VERIFY_PENDING = "pending"
-#: The recheck ran against a SUCCESSFUL poll and the signal is no longer firing.
+#: The recheck ran against a SUCCESSFUL poll and the signal is not firing.
 VERIFY_CLEARED = "cleared"
 #: The recheck ran against a successful poll and the signal is STILL firing — the 2xx
 #: did not mean what the board reported it meant.
@@ -624,7 +623,7 @@ class Signal:
             labels=dict(labels or {}),
             fingerprint=compute_fingerprint(source, resource, title),
             # Namespaced by source so two providers cannot collide on a bare numeric
-            # id — Sentry issue 12345 and a Zabbix trigger 12345 are unrelated.
+            # id — a Sentry issue id and a Zabbix trigger id can be the same number.
             provider_key=f"{source}:{provider_key}" if provider_key else "",
             # NOT namespaced by source, unlike provider_key: this is display text for a
             # human, not a match key, so prefixing it would only make the board read
@@ -779,7 +778,7 @@ class LedgerEntry:
     #: what it does not, and silently treats a row it only partly understands as fully
     #: understood. Review named this the nearest thing in the app to a one-way door.
     #:
-    #: Deliberately NOT used to reject anything today — there is exactly one version, so a
+    #: Deliberately rejects nothing today — there is exactly one version, so a
     #: gate would be dead code. It exists so the NEXT format change has somewhere to say so.
     #:
     #: The default is the LITERAL 1, not ``LEDGER_RECORD_V1``. A dataclass field default is

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
@@ -191,9 +191,10 @@ def _read_for_update() -> dict[str, Any]:
     arriving by accident instead of by attack. The error propagates and the
     write is abandoned instead.
 
-    Corruption propagates too (#7805, mirroring #7794): "cannot merge into" is
-    not "safe to destroy", and for THIS file silent replacement re-opens the
-    exact bypass the keystone floor exists to prevent -- a truncated document
+    Corruption propagates too, on the same reasoning as the sibling stores:
+    "cannot merge into" is not "safe to destroy", and for THIS file silent
+    replacement re-opens the exact bypass the keystone floor exists to prevent
+    -- a truncated document
     rewritten from empty reverts every fenced key to a value the constrained
     party can influence. Every corruption door raises the one named type,
     :class:`CorruptDocumentError`: a parse failure, a byte stream that is not
@@ -265,9 +266,9 @@ def _write(data: dict[str, Any]) -> None:
     payload = json.dumps(data, indent=2, sort_keys=True)
     # Fail-loud lockdown BEFORE any content lands, same as the secret store:
     # ``restrict_to_owner=True`` applies the owner-only DACL to the temp file
-    # before the payload reaches it (a post-rename lockdown left the ceiling
-    # readable under the inherited DACL on Windows for the write window, issue
-    # #5285) and implies the owner-only POSIX mode. The default
+    # before the payload reaches it (a post-rename lockdown leaves the ceiling
+    # readable under the inherited DACL on Windows for the write window) and
+    # implies the owner-only POSIX mode. The default
     # ``restrict_on_error="raise"`` refuses to publish a ceiling it cannot
     # protect.
     #
@@ -349,7 +350,7 @@ def get(key: str, default: Any = None) -> Any:
     from the agent-writable config: promoting a value found there onto the fenced floor would
     let the constrained party set its own ceiling — an agent shell writes ``config.json``,
     the next read lifts it to the keystone, and ``act`` is authoritative. See the module
-    docstring; the migration this used to call was removed for exactly that.
+    docstring; that is why there is no migration call here.
     """
     if key not in OPERATOR_ONLY_KEYS:  # pragma: no cover — programming error, not input
         raise KeyError(f"{key!r} is not an operator-only key; use config.json for it")
@@ -365,8 +366,7 @@ def read_authority(key: str, default: Any = None) -> Any:
     except one. ``PRIMARY_KEY`` defaults to TRUE (``rotation.is_primary``), so the lenient
     read turns a truncated policy file into GRANTED ledger-prune authority: the corrupt
     file becomes the key that unlocks destroying shared knowledge, which is the exact
-    corruption-enables-destruction failure #7805 exists to remove. Found in review
-    (GPT 5.6), which correctly rejected scoping this out as pre-existing.
+    corruption-enables-destruction failure this strict reader exists to remove.
 
     Reuses :func:`_read_for_update`'s read, deliberately: one strict reader, one set of
     corruption doors (parse failure, non-UTF-8, non-object root), no second copy to

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/github_issues.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/github_issues.py
@@ -86,7 +86,7 @@ async def _run_gh(args: list[str]) -> tuple[int, str, str]:
         # ASYNC spawn a preexec_fn forces a plain fork() of the threaded gateway and runs
         # Python in the child before exec, which can wedge the event loop and leak every
         # inherited fd. The shim applies the same limits post-exec. See
-        # `test/test_spawn_preexec_guard.py` (issue #935) and the fuller note on
+        # `test/test_spawn_preexec_guard.py` and the fuller note on
         # `ledger_sync._git`.
         proc = await create_subprocess_limited(
             *argv,

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/schedule_file.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/schedule_file.py
@@ -35,11 +35,11 @@ Schedule format (``rotation.yaml`` at the repo root)::
     leader: octocat                   # optional; runs nightly ledger hygiene ALONE
     timezone: America/Los_Angeles     # optional; UTC when absent
     shifts:
-      - from: 2026-08-01
-        to: 2026-08-08
+      - from: YYYY-MM-DD              # a date-only ``to`` covers that whole day
+        to: YYYY-MM-DD
         who: octocat                  # a GitHub login
-      - from: 2026-08-08T09:00
-        to: 2026-08-15T09:00
+      - from: YYYY-MM-DDTHH:MM        # or a wall-clock time in ``timezone`` above
+        to: YYYY-MM-DDTHH:MM
         who: [octocat, hubot]         # co-primary is allowed
 
 See ``docs/system-specs/modules/ops-mission-control.md`` § Rotation.
@@ -162,9 +162,10 @@ def _parse_moment(raw: Any, tz: Any, *, end: bool) -> datetime | None:
     """Parse a ``from``/``to`` value into an aware datetime.
 
     Accepts ``YYYY-MM-DD`` and ``YYYY-MM-DDTHH:MM``. A DATE-only ``to`` is treated as
-    the END of that day, not midnight at its start: a human writing ``to: 2026-08-08``
-    means "through the 8th", and reading it as 00:00 would silently drop the last day of
-    every shift written that way. That off-by-one-day is the single most likely way this
+    the END of that day, not midnight at its start: a human writing a date-only ``to``
+    means "through that whole day", and reading it as 00:00 would silently drop the last
+    day of every shift written that way. That off-by-one-day is the single most likely
+    way this
     file gets misread, so it is handled here rather than left to the operator.
     """
     if isinstance(raw, datetime):

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/webhook.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/webhook.py
@@ -209,18 +209,18 @@ def _suppression_attribution(status: dict[str, Any]) -> tuple[str, str]:
 def _alert_status(raw: dict[str, Any]) -> tuple[str, str, str]:
     """Read one alert's status as ``(state_text, suppressed_by, suppressed_reason)``.
 
-    Two real shapes, and only one of them used to work:
+    Two real shapes, and a scalar-only read handles only one:
 
     - **v4 webhook envelope** — ``status`` is the scalar ``"firing"``/``"resolved"``.
     - **v2 ``gettableAlert``** — ``status`` is the OBJECT
       ``{"state": "suppressed", "silencedBy": [...], "inhibitedBy": [...]}``, which is
       what anything relaying ``GET /api/v2/alerts`` forwards.
 
-    The previous scalar-only read (``str(raw.get("status") or ...)``) stringified that
-    object, so it normalized to ``unknown`` — the suppression became "we could not parse
-    the state" and ``silencedBy`` was dropped on the floor entirely. The caller then had
-    a signal indistinguishable from a garbage one from a sender that was being perfectly
-    explicit about a human having parked the alert.
+    A scalar-only read (``str(raw.get("status") or ...)``) stringifies that object, so it
+    normalizes to ``unknown`` — the suppression reads as "we could not parse the state"
+    and ``silencedBy`` is dropped on the floor entirely, leaving the caller a signal
+    indistinguishable from a garbage one from a sender that is being perfectly explicit
+    about a human having parked the alert.
     """
     status = raw.get("status")
     if isinstance(status, dict):

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/registry.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/registry.py
@@ -199,12 +199,12 @@ class OpsProviderRegistry:
         the heartbeat or suppress the others, so each source gets its own timeout
         and its failure is reported rather than raised.
 
-        Two things happen around each poll, both of which exist because a failed poll
-        used to be indistinguishable from a quiet one:
+        Two things happen around each poll, both of which exist because otherwise a
+        failed poll is indistinguishable from a quiet one:
 
-        1. **A source in backoff is skipped**, and says so in ``errors``. A provider
-           that returned 429 was previously re-polled at full rate on the very next
-           heartbeat, which is how a rate limit becomes a ban.
+        1. **A source in backoff is skipped**, and says so in ``errors``. Re-polling a
+           provider that returned 429 at full rate on the very next heartbeat is how a
+           rate limit becomes a ban.
         2. **The outcome is recorded in ``poll_health``.** Absence of a signal only
            means "it cleared" if the poll that would have reported it actually
            succeeded; callers that resolve work on absence MUST consult this.

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/rotation.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/rotation.py
@@ -55,11 +55,10 @@ TIER_PRIMARY = "primary"
 #: Cron names per tier, as the SCHEDULER knows them.
 #:
 #: These MUST match what app registration actually creates. A manifest cron named
-#: ``dispatch`` is registered namespaced as ``ops-mission-control/dispatch`` — so the
-#: bare ``omc-*`` names this table used to carry matched no job at all, and every
-#: pause/resume the rotation tier emitted silently targeted nothing. The whole tier
-#: mechanism was inert. Found by exercising the rotation-check SOP against the real
-#: scheduler; pinned by ``test_tier_cron_names_match_the_manifest``.
+#: ``dispatch`` is registered namespaced as ``ops-mission-control/dispatch`` — a bare
+#: ``omc-*`` name here matches no job at all, and every pause/resume the rotation
+#: tier emits then silently targets nothing, leaving the whole tier mechanism inert.
+#: Pinned by ``test_tier_cron_names_match_the_manifest``.
 _CRON_PREFIX = "ops-mission-control"
 
 TIER_CRONS: dict[str, tuple[str, ...]] = {
@@ -339,14 +338,14 @@ def resolve_mode(signal: Signal) -> str:
     With no matching rule the app mode applies. A matching rule can only NARROW
     it, so a rule cannot escalate an instance the operator pinned to ``observe``.
 
-    When SEVERAL rules match, the TIGHTEST one wins. This used to take the most
-    permissive (``max``), which broke the one thing rules are for: adding a narrow
-    ``observe`` rule to carve an exception out of a broad ``act`` grant did nothing,
-    because the broad grant still won and the write was authorized. Carving out the
-    exception is the whole reason to write the second rule, so the narrower rule has
-    to be the one that decides. ``min`` also matches the algebra the rest of the
-    module already uses -- ``effective_mode`` is ``min``, the governance ceiling is
-    ``min`` -- so overlap now resolves the same direction everywhere. Found in review.
+    When SEVERAL rules match, the TIGHTEST one wins. Taking the most permissive
+    (``max``) would break the one thing rules are for: adding a narrow ``observe``
+    rule to carve an exception out of a broad ``act`` grant would do nothing, because
+    the broad grant would still win and the write would be authorized. Carving out
+    the exception is the whole reason to write the second rule, so the narrower rule
+    has to be the one that decides. ``min`` also matches the algebra the rest of the
+    module uses -- ``effective_mode`` is ``min``, the governance ceiling is ``min``
+    -- so overlap resolves the same direction everywhere.
     """
     base = app_mode()
     matching = [r for r in load_rules() if r.matches(signal)]
@@ -417,12 +416,10 @@ def _definitely_off_shift() -> bool:
                 # PagerDuty with no `schedule_ids`, a missing secret (the request raises and
                 # lands in the `except` below). Genuine indeterminacy still permits the action
                 # — that is the documented design, so a broken rotation cannot lock an operator
-                # out — but the agent can no longer MANUFACTURE indeterminacy from config.
+                # out — but the agent cannot MANUFACTURE indeterminacy from config.
                 #
-                # Fourth instance of one class this round: a security refusal must not depend
-                # on an input the constrained party can write. The other three were the
-                # rotation login, strict gating, and `config_fields` still advertising the
-                # login to the generic provider-config route.
+                # One instance of a general class: a security refusal must not depend on an
+                # input the constrained party can write.
                 status = _shift_sync(src)
             except Exception:  # noqa: BLE001 — one bad source must not decide the vote
                 logger.warning(
@@ -660,8 +657,8 @@ def is_primary() -> bool:
         return bool(me) and me.lower() == leader.lower()
     # The STRICT read, not `get`: this flag defaults to True, so the lenient read
     # turns an unreadable or corrupt policy file into granted prune authority --
-    # the corrupt file becoming the key that unlocks destroying shared knowledge
-    # (#7805). Refuse for the same reason the no-login case above answers False:
+    # the corrupt file becoming the key that unlocks destroying shared knowledge.
+    # Refuse for the same reason the no-login case above answers False:
     # a skipped hygiene pass is recoverable, a wrong prune is not.
     try:
         flag = policy_store.read_authority(policy_store.PRIMARY_KEY, True)
@@ -734,14 +731,12 @@ def tier_states(shift: ShiftStatus) -> dict[str, bool]:
     **``on_shift`` alone decides.** ``unknown`` is an explanation for the UI, never an
     arming input.
 
-    This used to read ``shift.on_shift or shift.unknown``, which silently defeated strict
-    gating for exactly the case it was written for: a schedule that cannot say whether this
-    operator is on call returns ``on_shift=False, unknown=True``, and the ``or`` re-armed
-    it anyway. Verified before fixing — an instance with no resolvable login reported
-    ``on_shift=False`` and ``dispatch armed=True``, so every teammate would still pick up
-    the same alarm.
+    Reading ``shift.on_shift or shift.unknown`` here would silently defeat strict gating
+    for exactly the case it exists for: a schedule that cannot say whether this operator
+    is on call returns ``on_shift=False, unknown=True``, and the ``or`` re-arms it
+    anyway, so every teammate picks up the same alarm.
 
-    The fail-open intent is still available and now lives where it belongs: each
+    The fail-open intent lives where it belongs instead: each
     ``RotationSource`` decides what "cannot tell" means for it. A rotation *API* returns
     ``on_shift=True, unknown=True`` (a network fault must not disable response); the
     committed schedule returns ``on_shift=False, unknown=True`` under ``strict_gating``.
@@ -772,19 +767,19 @@ async def apply_tiers(shift: ShiftStatus, cron_service: Any) -> dict[str, Any]:
 
     Why this exists rather than the agent issuing ``cron_pause``/``cron_resume``:
 
-    tier arming used to be entirely the ``rotation-check`` agent's job, and the ONLY thing
-    stopping it pausing ``rotation-check`` itself — the sole always-tier job, and so the only
-    job that can ever re-arm a gated instance — was one sentence of SOP prose telling it not
-    to. A single misfollowed turn silently ends incident response until a human notices,
-    which is precisely the quiet-versus-broken conflation this app refuses everywhere else
+    left to the ``rotation-check`` agent, the ONLY thing stopping it pausing
+    ``rotation-check`` itself — the sole always-tier job, and so the only job that can ever
+    re-arm a gated instance — is one sentence of SOP prose telling it not to. A single
+    misfollowed turn silently ends incident response until a human notices, which is
+    precisely the quiet-versus-broken conflation this app refuses everywhere else
     ("a source that failed is shown as failed, never as quiet"). Prose is not an enforcement
-    mechanism. Found in design review.
+    mechanism.
 
     So the whole arming decision moves here, into deterministic code the model does not
     mediate: the caller is a route, the tier map is computed from the shift, and
     ``protected_cron_names()`` is skipped unconditionally — this function cannot pause an
     always-tier job even if the tier map somehow said to. The agent's remaining role is to
-    POST, which is why the SOP no longer needs it to hold ``cron_pause`` at all.
+    POST, which is why the SOP does not need it to hold ``cron_pause`` at all.
 
     ``cron_service`` is duck-typed (``list_jobs_async`` + ``raise_if_store_unreadable``
     + ``enable_job_async``) so tests pass a fake. Returns a summary of what changed, so
@@ -926,10 +921,11 @@ def describe(shift: ShiftStatus) -> dict[str, Any]:
         "sweep": sweep_windows(),
         # The two FENCED rotation identities, so Settings can render and edit them.
         #
-        # They have to be reported here rather than through `GET /providers`: both moved off
-        # `config_fields` onto the keystone floor (they are inputs to the off-shift refusal, and
-        # provider config is agent-writable), so the provider catalog no longer carries them and
-        # the generic field renderer cannot see them. Reporting the VALUE is fine — an identity
+        # They have to be reported here rather than through `GET /providers`: both live on the
+        # keystone floor rather than in `config_fields` (they are inputs to the off-shift
+        # refusal, and provider config is agent-writable), so the provider catalog does not
+        # carry them and the generic field renderer cannot see them. Reporting the VALUE is
+        # fine — an identity
         # is not a credential, `roster.me` already publishes the resolved login, and an operator
         # who cannot see which identity is stored cannot tell a wrong one from an unset one.
         "identities": {

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
@@ -191,17 +191,16 @@ def _audit(op: str, target: str, outcome: str, *, error: str = "") -> None:
 def _store_read_refusal(exc: Exception, *, code: str) -> web.Response:
     """Map a strict reader's refusal to a coded response.
 
-    The store and config readers now refuse rather than publishing a mutation over a
-    read they could not make, so every handler that mutates them can see two failures
-    that previously could not happen. They get DIFFERENT statuses because the operator's
+    The store and config readers refuse rather than publishing a mutation over a read
+    they could not make, so every handler that mutates them can see two distinct
+    failures. They get DIFFERENT statuses because the operator's
     next move differs: an unreadable file is transient, so 503 correctly says "retry",
     while a corrupt one needs a person to repair it, so 503 would send them at something
     that cannot succeed and 500 is the honest answer.
 
-    Centralized because four handlers need the identical pair, and three review lanes
-    independently flagged that translating it at some of them and not others is worse
-    than not translating it anywhere -- an operator cannot tell a route that reports the
-    condition from one that swallows it.
+    Centralized because four handlers need the identical pair, and translating it at
+    some of them and not others is worse than not translating it anywhere -- an
+    operator cannot tell a route that reports the condition from one that swallows it.
 
     ``JSONDecodeError`` MUST be matched before any ``ValueError`` arm at the call site.
     It is a `ValueError` subclass, so an existing arm for a domain error will otherwise
@@ -292,14 +291,14 @@ def _slot_state(request: web.Request, slot_key: str) -> dict[str, Any] | None:
         return None
 
     # `to_dict()` is the slot's PUBLIC serializer and it already derives `pending_approval`
-    # from the approval futures (state.py). This used to read `slot._approval_futures`
-    # directly — review flagged it, correctly: a private attribute is not a contract, so a
-    # core refactor that renamed it would silently turn "waiting on you" into "progressing"
-    # on this board, with nothing failing anywhere. Asking the owner is the fix.
+    # from the approval futures (state.py). Reading `slot._approval_futures` directly is
+    # wrong: a private attribute is not a contract, so a core refactor that renamed it
+    # would silently turn "waiting on you" into "progressing" on this board, with nothing
+    # failing anywhere. Asking the owner is the fix.
     #
     # Falls back to the public attribute if `to_dict` is absent or raises: this read paints
-    # the whole board, so it degrades rather than 500s. The fallback is deliberately NOT the
-    # old private reach-in — a narrower truth beats a fragile one.
+    # the whole board, so it degrades rather than 500s. The fallback is deliberately NOT a
+    # private reach-in — a narrower truth beats a fragile one.
     pending = bool(getattr(slot, "pending_approval", False))
     to_dict = getattr(slot, "to_dict", None)
     if callable(to_dict):
@@ -484,8 +483,8 @@ async def _handle_handover(request: web.Request) -> web.StreamResponse:
 
 #: Incidents returned by ``/incidents`` in one response. The board shows recent work; a
 #: responder scrolling to incident 900 is not a workflow this app has. Bounded because
-#: the endpoint used to serialize the ENTIRE index — fine at 3 incidents, a growing
-#: payload on every dashboard poll once a flapping alarm has minted hundreds.
+#: serializing the ENTIRE index is fine at 3 incidents and a growing payload on every
+#: dashboard poll once a flapping alarm has minted hundreds.
 MAX_INCIDENTS_RESPONSE = 200
 
 
@@ -755,10 +754,9 @@ async def _handle_claim(request: web.Request) -> web.StreamResponse:
 
     # Acknowledge the push spool here too. `dispatch.run_cycle` acks what IT claims, and this
     # route is the second place a claim becomes durable — so without this a hand-claimed
-    # webhook signal stayed spooled forever, and on a full (200-entry) spool the next signed
-    # delivery evicted the OLDEST unclaimed entry to make room for it: a real alert lost to a
-    # duplicate nobody needed. A direct consequence of moving consumption off `poll()`;
-    # `drain()` used to cover this path by accident. Found in review.
+    # webhook signal stays spooled forever, and on a full (200-entry) spool the next signed
+    # delivery evicts the OLDEST unclaimed entry to make room for it: a real alert lost to a
+    # duplicate nobody needed. `poll()` does not consume, so nothing else on this path acks.
     #
     # Cheap and unconditional: `ack` on an id that is not spooled removes nothing, so no
     # source check is needed and a future push provider gets the same treatment for free.
@@ -883,11 +881,11 @@ async def _handle_action(request: web.Request) -> web.StreamResponse:
     #
     # `authorize_action` gates on `incident.signal`, and `AutonomyRule.matches` keys on
     # `signal.source` — so a rule only ever grants authority over the provider that
-    # RAISED the signal. `sink_id` used to be honoured verbatim, which let a grant on one
-    # provider execute against another: a webhook signal carrying `dd_monitor_id`, a
-    # webhook-scoped act-rule, and `sink="datadog"` passed the webhook check and then
-    # silenced an unrelated Datadog monitor. The gate was correct; the code just did not
-    # act on the thing the gate had approved.
+    # RAISED the signal. Honouring `sink_id` verbatim would let a grant on one provider
+    # execute against another: a webhook signal carrying `dd_monitor_id`, a webhook-scoped
+    # act-rule, and `sink="datadog"` would pass the webhook check and then silence an
+    # unrelated Datadog monitor. The gate is correct, and the write has to land on the
+    # thing the gate approved.
     #
     # Rejected rather than silently ignored. A caller that names the wrong sink has a
     # wrong model of what it is authorized to do, and quietly redirecting the write to the
@@ -964,9 +962,10 @@ async def _handle_action(request: web.Request) -> web.StreamResponse:
             # Echoed so a caller can see the window actually applied, which may be
             # smaller than the one it asked for.
             "duration_secs": payload.get("duration_secs"),
-            # What a 2xx from the provider now DOES and does not mean, reported in the
-            # same response that used to imply "applied". ``pending`` says a recheck is
-            # scheduled; ``not_checkable`` says this app cannot observe this verb's
+            # What a 2xx from the provider DOES and does not mean, in the same response
+            # as the result — a 2xx alone never means "applied". ``pending`` says a
+            # recheck is scheduled; ``not_checkable`` says this app cannot observe this
+            # verb's
             # outcome; ``""`` says the call failed so nothing was scheduled.
             "verification": verification,
             "verify_after": verify_after,
@@ -1031,15 +1030,14 @@ def _schedule_verification(incident_id: str, action: str, duration_secs: Any) ->
         # ALREADY performed the real external write by the time this runs (`result.ok and
         # not result.simulated`), so raising turns a successful action into a 500 and invites
         # the operator to retry it -- in `act` mode that is a second real write against their
-        # production tooling. Found in review: Design Review caught that corruption was
-        # silently swallowed by the clause below (`JSONDecodeError` subclasses `ValueError`),
-        # and GPT 5.6 then caught that re-raising misreports a completed action. Neither
-        # remedy alone is right.
+        # production tooling. Swallowing it in the clause below (`JSONDecodeError`
+        # subclasses `ValueError`) hides it, and re-raising misreports a completed action.
+        # Neither remedy alone is right.
         #
         # So it is REPORTED rather than either swallowed or raised: its own clause, an
         # exception log, and a SEL audit entry recording that the action ran with no
-        # verification scheduled. That is the same choice #7788 made for a partial ceiling
-        # apply in this file -- the audit log is the durable reader, and unlike a new
+        # verification scheduled. That is the same choice a partial ceiling apply in this
+        # file makes -- the audit log is the durable reader, and unlike a new
         # `verification` value it needs no vocabulary the dashboard cannot render. The
         # persistence argument still holds (corruption never self-heals), which is why it is
         # audited as a failure rather than folded into the tolerant arm.
@@ -1432,10 +1430,10 @@ async def _handle_decide_proposal(request: web.Request) -> web.StreamResponse:
             {"error": "unknown incident", "code": "unknown_incident"}, status=404
         )
     except (json.JSONDecodeError, OSError) as exc:
-        # `decide_proposal` is a locked read-modify-write that now refuses rather than
-        # publishing over a failed read. Previously this could only answer a coded 404, so
-        # both new failures became a bare 500. The request is a human's approval of a
-        # production action, so "did my approval land?" must not be ambiguous.
+        # `decide_proposal` is a locked read-modify-write that refuses rather than
+        # publishing over a failed read, so its refusals need coded answers of their own
+        # instead of a bare 500. The request is a human's approval of a production action,
+        # so "did my approval land?" must not be ambiguous.
         logger.warning("ops-mission-control: proposal decision refused for %s", incident_id)
         _audit("incident_proposal_decide", incident_id, "failure", error="index unreadable")
         return _store_read_refusal(exc, code="dispatch_index")
@@ -1504,11 +1502,10 @@ async def _handle_signals(request: web.Request) -> web.StreamResponse:
     """Current provider state: what is firing, what is unclaimed, and what we could not read.
 
     ``firing`` is the list a caller should reason about, and it is filtered the same way
-    ``dispatch.run_cycle`` filters — previously this route returned every signal
-    regardless of state under the key ``signals``, while dispatch claimed only firing
-    ones. That was harmless while no adapter could emit ``ok``; once one can, an
-    already-cleared signal would appear in the very list the reconcile SOP reads as
-    "what is still firing", and in ``unclaimed`` as apparent work.
+    ``dispatch.run_cycle`` filters. Returning every signal regardless of state would put
+    an already-cleared one in the very list the reconcile SOP reads as "what is still
+    firing", and in ``unclaimed`` as apparent work — the two must agree on what firing
+    means.
 
     ``poll_health`` is the other half of that contract: absence from ``firing`` only
     means "it cleared" for a source whose poll actually SUCCEEDED. Resolving an incident
@@ -1864,11 +1861,10 @@ async def _handle_put_settings(request: web.Request) -> web.StreamResponse:
     # branch name are not credentials (auth is the operator's own git/ssh/gh
     # config), so they belong in plain app config like the Slack channel above.
     #
-    # These were previously settable ONLY by hand-editing ``data/config.json``:
-    # ``ledger_sync.set_settings`` existed and worked, but nothing outside the
-    # tests ever called it, so the app's headline team feature had no way in. An
-    # operator looking for "where do I point this at my team repo?" correctly
-    # found nothing.
+    # Settable here rather than only by hand-editing ``data/config.json``:
+    # ``ledger_sync.set_settings`` needs a caller, or the app's headline team
+    # feature has no way in and an operator looking for "where do I point this
+    # at my team repo?" finds nothing.
     wants_sync = (
         "ledger_sync_remote" in body
         or "ledger_sync_branch" in body
@@ -2175,9 +2171,9 @@ async def _handle_put_secret(request: web.Request) -> web.StreamResponse:
     try:
         await asyncio.to_thread(put_secret, provider_id, field_name, value)
     except json.JSONDecodeError as exc:
-        # The store's update reader now refuses a corrupt document rather than
-        # replacing it (#7805), so this handler can see a failure that previously
-        # could not happen. Same shared mapper as the settings writes, for the same
+        # The store's update reader refuses a corrupt document rather than
+        # replacing it, so this handler can see that refusal. Same shared mapper
+        # as the settings writes, for the same
         # reason: translating it at some handlers and not others is worse than not
         # translating it anywhere. 500-with-code rather than the OSError arm's 503:
         # corruption does not clear on retry, it needs a person to repair the file.
@@ -2237,7 +2233,7 @@ async def _handle_rotation(request: web.Request) -> web.StreamResponse:
 async def _handle_rotation_arm(request: web.Request) -> web.StreamResponse:
     """Arm/disarm this app's crons to match the tier map — server-side, not agent-driven.
 
-    The whole point is that the agent no longer decides WHICH crons to pause. It POSTs here;
+    The whole point is that the agent does not decide WHICH crons to pause. It POSTs here;
     ``rotation.apply_tiers`` computes the tier map and refuses to pause an always-tier job
     unconditionally. See that function for why prose in the SOP was not sufficient.
     """
@@ -2288,7 +2284,7 @@ async def _handle_ledger_contradictions(request: web.Request) -> web.StreamRespo
     """Entry pairs claiming different fixes for the same fingerprint.
 
     A read-only diagnostic for the hygiene SOP, which is told to "resolve contradictions"
-    and previously had to find them by eye across the whole ledger. Detection is
+    and cannot find them by eye across the whole ledger. Detection is
     deterministic and cheap; the resolution (split the two patterns so each names its own
     cause) needs the model, so this endpoint deliberately changes nothing.
     """
@@ -2633,11 +2629,11 @@ async def _read_capped(request: web.Request, cap: int) -> bytes | None:
 def _webhook_reject_status(detail: str) -> int:
     """Map a rejection reason to its HTTP status.
 
-    Everything used to return 401, including "malformed JSON" and "payload has no
-    title" — which are *authenticated* requests with a bad body. A sender debugging
-    a payload was told "Unauthorized" and would go re-check credentials that were
-    fine, while a real signature failure looked identical to a typo. Payload faults
-    are 400; only the trust checks are 401. Defaults to 401 for an unrecognized
+    "malformed JSON" and "payload has no title" are *authenticated* requests with a
+    bad body. Answering 401 for them tells a sender debugging a payload to go
+    re-check credentials that are fine, and makes a real signature failure look
+    identical to a typo. Payload faults are 400; only the trust checks are 401.
+    Defaults to 401 for an unrecognized
     reason, so a newly-added rejection is treated as auth-ish rather than
     accidentally advertised as "your request was fine".
     """

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
@@ -292,8 +292,8 @@ class KeystoneFileBackend:
         PagerDuty and Datadog, and every poll fails closed until they do. The
         error propagates and the mutation is abandoned instead.
 
-        Corruption propagates too (#7805, mirroring #7794's decision for the
-        incident index): "cannot merge into" is not "safe to destroy". A
+        Corruption propagates too, on the same reasoning as the incident
+        index: "cannot merge into" is not "safe to destroy". A
         truncated store still holds most of its tokens verbatim -- readable
         right up to the moment a rewrite replaces them -- and a refusal costs
         one skipped mutation and a visible error. Every corruption door raises
@@ -345,9 +345,9 @@ class KeystoneFileBackend:
         payload = json.dumps(data, indent=2, sort_keys=True)
         # Fail-loud lockdown BEFORE any content lands: ``restrict_to_owner=True``
         # applies the owner-only DACL to the temp file before the payload
-        # reaches it (a post-rename lockdown left every stored provider token
-        # readable under the inherited DACL on Windows for the write window,
-        # issue #5285) and implies the owner-only POSIX mode. The default
+        # reaches it (a post-rename lockdown leaves every stored provider token
+        # readable under the inherited DACL on Windows for the write window)
+        # and implies the owner-only POSIX mode. The default
         # ``restrict_on_error="raise"`` refuses to publish a token file it
         # cannot protect.
         #

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/store.py
@@ -82,13 +82,12 @@ _DIR_MODE = 0o700
 #: not progressing holds its signal unworked, and the failure is silent — so every
 #: pre-terminal state is sweepable, including ``needs_human``.
 #:
-#: ``needs_human`` was previously excluded, which made the app's quietest failure:
+#: Excluding ``needs_human`` makes the app's quietest failure:
 #: ``LEGAL_TRANSITIONS`` legalises ``needs_human -> stale`` *specifically* so "an
 #: incident nobody ever answers must not pin a signal as claimed forever"
 #: (``models.py``), and ``dispatch.py`` counts every non-stale non-terminal incident
-#: as owning its signal — so an unanswered question meant the alarm was never
-#: re-claimed, on machinery that looked deliberate. The edge existed, was unit-tested
-#: as a legal move, and was never traversed.
+#: as owning its signal — so an unanswered question means the alarm is never
+#: re-claimed, on machinery that looks deliberate.
 _SWEEPABLE_STATUSES: frozenset[str] = frozenset(
     {STATUS_DISPATCHED, STATUS_INVESTIGATING, STATUS_NEEDS_HUMAN}
 )
@@ -349,18 +348,15 @@ def _read_index_for_update() -> dict[str, Incident]:
     each one -- and in ``act`` mode a duplicate investigation is a second real
     write against the operator's production paging. The per-incident markdown
     logs survive on disk but nothing indexes them any more, and an open incident
-    that is no longer listed is never swept, resolved, or answered.
+    that is not listed is never swept, resolved, or answered.
 
-    Corruption propagates too, which began as a DELIBERATE divergence from the four
-    merged siblings of this idiom (``library.py``, ``shares.py``, ``secrets.py``,
-    ``policy_store.py``), which then read an unparseable document as empty.
-    Their justification was real -- a document that failed to parse carries nothing
-    to merge into -- but "cannot merge into" is not "safe to destroy". A truncated
+    Corruption propagates too, the same way it does in the four merged siblings of
+    this idiom (``library.py``, ``shares.py``, ``secrets.py``, ``policy_store.py``).
+    "A document that failed to parse carries nothing to merge into" is a real
+    observation, but "cannot merge into" is not "safe to destroy". A truncated
     index still holds most of its records verbatim, and replacing it discards the
     operator's only chance to recover them by hand. Refusing costs one skipped
-    mutation and a visible error; overwriting costs the records, silently. Found in
-    review (GPT 5.6). The siblings received the same treatment in #7805, so the
-    divergence is closed and this paragraph is its record, not its tracker.
+    mutation and a visible error; overwriting costs the records, silently.
     """
     try:
         raw = json.loads(index_path().read_text(encoding="utf-8"))
@@ -705,9 +701,9 @@ def counts_by_status() -> dict[str, int]:
 #: Closed incidents kept in the dispatch index. Open ones are NEVER pruned regardless
 #: of this cap — live work must not vanish because history is long.
 #:
-#: This exists because making a resolved alarm re-claimable (see ``claim``) removed the
-#: accidental ceiling that "one incident per alarm, forever" used to provide. A genuinely
-#: flapping alarm on the 2-minute dispatch cadence now mints a new incident per flap, and
+#: This exists because a resolved alarm is re-claimable (see ``claim``), so there is no
+#: accidental ceiling from "one incident per alarm, forever". A genuinely flapping alarm
+#: on the 2-minute dispatch cadence mints a new incident per flap, and
 #: every claim re-reads and re-writes the WHOLE index — measured superlinear: 50 entries
 #: → 6ms/claim, 450 → 53ms. Left unbounded, a month of one flapping alarm projects to
 #: ~21,600 incidents, and `/incidents` returns every one of them to the dashboard.
@@ -941,14 +937,14 @@ def decide_proposal(incident_id: str, *, approve: bool, digest: str = "") -> dic
     through the normal ``authorize_action`` gate so approving cannot bypass autonomy.
 
     **The whole read-check-write runs under ``_IndexLock``, so exactly one caller can move a
-    proposal out of ``pending``.** It previously read through ``get_incident``, tested the
-    state, and wrote through ``update_fields`` — three separate index accesses with no lock
+    proposal out of ``pending``.** Reading through ``get_incident``, testing the state, and
+    writing through ``update_fields`` would be three separate index accesses with no lock
     held across them, so two approvals arriving together (a double-click, a retried request,
-    two operators, Slack plus the dashboard) both observed ``pending``, both were told "ok",
-    and the caller executed the provider action TWICE. Acking twice is untidy; resolving or
-    silencing twice is a duplicated write on someone else's production tooling, and a second
-    ``silence`` re-arms a suppression window the first one had already bounded. Found in
-    review.
+    two operators, Slack plus the dashboard) would both observe ``pending``, both be told
+    "ok", and the caller would execute the provider action TWICE. Acking twice is untidy;
+    resolving or silencing twice is a duplicated write on someone else's production
+    tooling, and a second ``silence`` re-arms a suppression window the first one had
+    already bounded.
 
     This is the same compare-and-set ``claim`` already uses for the same reason — a claim
     and an approval are both "exactly one winner" decisions on shared JSON.
@@ -1043,13 +1039,13 @@ def expire_stale_proposals(*, now: str = "") -> list[str]:
     decorative; auto-rejecting would quietly drop work the operator may still want. So
     the proposal stops ASKING and says so, and the agent is free to re-propose.
 
-    **The whole sweep runs under ``_IndexLock``** — the same fix, and the same reasoning, as
-    ``decide_proposal`` one function up. It previously read the index, tested each proposal's
-    state, and wrote through ``update_fields``: separate index accesses with no lock held
-    across them. So the heartbeat could read an expired draft, a concurrent
-    ``/incident/proposal`` request revise or decide it, and this stale write then stamp
-    ``expired`` over the newer state — silently reverting an operator's decision, or replacing
-    a re-proposed draft with a dead one the agent had already superseded. Found in review.
+    **The whole sweep runs under ``_IndexLock``** — the same reasoning as ``decide_proposal``
+    one function up. Unlocked, this would read the index, test each proposal's state, and
+    write through ``update_fields`` as separate accesses: the heartbeat could read an
+    expired draft, a concurrent ``/incident/proposal`` request revise or decide it, and this
+    stale write then stamp ``expired`` over the newer state — silently reverting an
+    operator's decision, or replacing a re-proposed draft with a dead one the agent had
+    superseded.
 
     Mutating under the lock also means the recheck is authoritative: each proposal is re-read
     from the locked index rather than from the pre-lock snapshot, so only a proposal that is

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_agent_api_tool.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_agent_api_tool.py
@@ -153,8 +153,8 @@ class TestGatewayAdmission(unittest.TestCase):
     def test_sensitive_routes_are_not_admitted(self):
         """The routes that must stay dashboard-only (cookie/token auth).
 
-        This is the property PR #1066 named when it chose full paths over the
-        app prefix: prefix-matching would admit provider secret writes and the
+        This is the property that makes the allowlist use full paths rather than
+        the app prefix: prefix-matching would admit provider secret writes and the
         human proposal-decision route to anything holding the internal secret.
         """
         mixed = self._mixed()

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_config_routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_config_routes.py
@@ -299,8 +299,8 @@ class TestSettingsRoute(_HomeIsolatedAsync):
     async def test_the_failure_fallback_has_the_same_shape_as_a_real_status(self):
         """One shape, so the UI can read every field instead of guarding each one.
 
-        The fallback used to carry two keys out of six. A panel reading it therefore had to
-        guard each field individually, and forgetting one renders ``undefined`` as the team's
+        A fallback carrying two keys out of six makes a panel guard each field
+        individually, and forgetting one renders ``undefined`` as the team's
         remote — which reads as a repo called "undefined" rather than as "we could not tell".
         """
         from kiro_crew.apps.builtins.ops_mission_control.backend import ledger_sync

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_dispatch.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_dispatch.py
@@ -108,11 +108,11 @@ class TestCycleSilence(_HomeIsolated):
     async def test_a_resolved_alarm_refiring_is_claimed_through_run_cycle(self):
         """The recurrence fix, asserted through the FULL cycle rather than `store.claim`.
 
-        `store.claim` learned that a terminal incident no longer owns its signal, and 408
-        unit tests passed — but `run_cycle` has its own cheap pre-filter that computed
-        `owned` from every non-stale incident, so it discarded the recurrence *before*
-        `claim` ever saw it. The app still permanently stopped responding to any failure it
-        had already handled once, and the compounding-memory fast path stayed unreachable.
+        `store.claim` knows a terminal incident does not own its signal, but `run_cycle`
+        has its own cheap pre-filter: computing `owned` from every non-stale incident
+        discards the recurrence *before* `claim` ever sees it, so the app permanently stops
+        responding to any failure it has already handled once and the compounding-memory
+        fast path is unreachable.
 
         Caught only by driving a real gateway: inject → resolve → re-inject reported
         `polled=1, claimed=0`. Two places encoded the same ownership rule and fixing one
@@ -579,15 +579,15 @@ class TestBrief(_HomeIsolated):
     async def test_brief_always_states_it_has_no_credentials(self):
         """The no-evidence brief is the case that MOST needs the warning.
 
-        Regression test for an observed live failure. The statement used to live only
-        inside the ``if claimed.evidence`` branch, so an incident with nothing gathered
-        — an unconfigured evidence source, a provider outage, a source that returned
-        empty — handed the agent an AWS alarm and no explanation. Two real sessions
-        (INV-1, INV-2) then spent their entire turn re-running ``aws … --profile …``,
-        collecting NoCredentials each time, and produced no diagnosis.
+        The statement belongs outside the ``if claimed.evidence`` branch: an incident with
+        nothing gathered — an unconfigured evidence source, a provider outage, a source
+        that returned empty — otherwise gets an AWS alarm and no explanation, and real
+        sessions (INV-1, INV-2) then spend their entire turn re-running
+        ``aws … --profile …``, collecting NoCredentials each time, and produce no
+        diagnosis.
 
-        Asserted with evidence EMPTY on purpose: with evidence present the old code
-        passed too, which is exactly why the gap survived.
+        Asserted with evidence EMPTY on purpose: a branch-scoped statement passes with
+        evidence present, which is exactly how the gap hides.
         """
         from kiro_crew.apps.builtins.ops_mission_control.backend import dispatch
 
@@ -659,7 +659,7 @@ class TestBrief(_HomeIsolated):
                 trust=TRUST_VERIFIED,
             )
         )
-        # Verified and high is no longer sufficient on its own: the entry needs a track
+        # Verified and high is not sufficient on its own: the entry needs a track
         # record too. The claim under test supplies the last use itself.
         for _ in range(ledger.MIN_USES_FOR_FAST_PATH - 1):
             ledger.record_use(entry.entry_id)
@@ -958,8 +958,8 @@ class TestPostActionVerification(_HomeIsolated):
         """`changed` gates the cron's silence, so what counts as news is load-bearing.
 
         A confirmed action is the expected outcome and announcing it would make the
-        heartbeat congratulate itself. A still-firing one means the app previously
-        reported something as applied that was not — the most newsworthy thing a cycle
+        heartbeat congratulate itself. A still-firing one means the app reported
+        something as applied that was not — the most newsworthy thing a cycle
         can find.
         """
         from kiro_crew.apps.builtins.ops_mission_control.backend.dispatch import CycleResult
@@ -1082,13 +1082,13 @@ if __name__ == "__main__":
 
 
 class TestEveryInstancePullsTheSchedule(_HomeIsolated):
-    """`rotation.yaml` travels in the ledger repo, and only the primary used to fetch it.
+    """`rotation.yaml` travels in the ledger repo, so EVERY instance has to fetch it.
 
     `sync_safely`'s only other caller is the daily hygiene pass, which is gated to the
-    primary instance. So a NON-primary instance had no code path that ever fetched the
-    schedule: it kept arming (or not) off whatever it last saw. That is the double-claim
-    the single-owner model exists to prevent, reintroduced by the transport rather than
-    by the model.
+    primary instance. Without a fetch of its own, a NON-primary instance has no code path
+    that ever reads the schedule: it keeps arming (or not) off whatever it last saw. That
+    is the double-claim the single-owner model exists to prevent, arriving through the
+    transport rather than the model.
     """
 
     async def test_the_cycle_pulls_before_it_reads_the_shift(self):
@@ -1392,9 +1392,9 @@ class TestAMaintenancePassCannotCostTheCycle(_HomeIsolated):
     claim", and the notification bus runs after both "so a bus fault can cost
     neither".
 
-    The strict for-update index read made ``expire_stale_proposals`` and
-    ``sweep_stale`` RAISE on an unreadable index, where they previously degraded to
-    a silent no-op. Both are maintenance passes that rerun on every heartbeat, and
+    The strict for-update index read makes ``expire_stale_proposals`` and
+    ``sweep_stale`` RAISE on an unreadable index rather than degrade to a silent
+    no-op. Both are maintenance passes that rerun on every heartbeat, and
     both abandon their write before touching the file — so the durable state is
     already safe and the cycle must log and carry on. Letting them escape would
     make one transient EACCES cost this cycle's claims, the Slack mirror, the

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_models.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_models.py
@@ -146,7 +146,7 @@ class TestProviderSideSuppressionIsReadable(unittest.TestCase):
     """
 
     def test_every_providers_word_for_parked_reads_as_suppressed(self):
-        """The vocabularies differ per provider; all of them used to land in `unknown`."""
+        """The vocabularies differ per provider; a naive read lands them all in `unknown`."""
         for raw in (
             "suppressed",  # Alertmanager status.state
             "silenced",
@@ -290,7 +290,7 @@ class TestTransitionGrammar(unittest.TestCase):
         A signal can clear between the claim and the agent's first turn (a flapping
         alarm; a GitHub issue closed a minute later). Without this edge the
         incident sticks at ``dispatched`` until the stale sweep hours later, so the
-        board asserts work is in progress on a problem that no longer exists.
+        board asserts work is in progress on a problem that does not exist.
         Found by exercising the reconcile SOP against a real cleared signal.
         """
         self.assertIn(

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
@@ -656,13 +656,12 @@ class TestConcurrentWritesCannotRestoreAStaleCeiling(unittest.TestCase):
 class TestPolicyLockdownOrdering(_HomeIsolated):
     """The ceiling's write must never publish a file it has not protected.
 
-    Ports the previous-store-survival recipe from
+    Ports the prior-store-survival recipe from
     ``test/test_aws_consent.py::TestGrantIsOnTheKeystoneFloor``: every failure
     inside ``atomic_write`` happens BEFORE the rename, so a transient lockdown
-    or write failure can no longer reach — let alone delete — the previous,
-    healthy ceiling (the old post-publish ``restrict_to_owner`` + unlink-on-
-    OSError shape silently reset the operator's autonomy policy on one lockdown
-    failure).
+    or write failure cannot reach — let alone delete — the healthy ceiling
+    already on disk (a post-publish ``restrict_to_owner`` plus unlink-on-OSError
+    silently resets the operator's autonomy policy on one lockdown failure).
     """
 
     def test_write_lockdown_precedes_content(self):
@@ -850,10 +849,10 @@ class TestTheCeilingIsNeverPublishedOverAFailedRead(_HomeIsolated):
         self.assertEqual(policy_store.read_mode("observe"), "act")
 
     def test_a_corrupt_ceiling_refuses_the_write_and_is_left_intact(self):
-        """#7805: a corrupt policy file is refused, never rewritten.
+        """A corrupt policy file is refused, never rewritten.
 
-        The old tolerance read an unparseable document as empty and let the
-        write publish over it -- and for THIS file a rewrite-from-empty reverts
+        Reading an unparseable document as empty and letting the write publish
+        over it is worse here than anywhere -- a rewrite-from-empty reverts
         every fenced key to a value the constrained party can influence, which
         is the exact bypass the keystone floor exists to prevent. A truncated
         document still holds the operator's keys verbatim; refusing keeps them
@@ -916,13 +915,11 @@ class TestTheCeilingIsNeverPublishedOverAFailedRead(_HomeIsolated):
         """A corrupt policy file must never GRANT prune authority.
 
         ``PRIMARY_KEY`` is the one operator-only key whose default is
-        permissive (True), so the lenient gate read turned a truncated policy
+        permissive (True), so a lenient gate read turns a truncated policy
         file into granted ledger-prune authority -- the corrupt file becoming
-        the key that unlocks destroying shared knowledge, the exact
-        corruption-enables-destruction failure #7805 removes. Found in review
-        (GPT 5.6), two rounds. Authority decisions now go through the STRICT
-        :func:`policy_store.read_authority`, and ``rotation.is_primary``
-        answers False when it cannot read its input.
+        the key that unlocks destroying shared knowledge. Authority decisions
+        go through the STRICT :func:`policy_store.read_authority`, and
+        ``rotation.is_primary`` answers False when it cannot read its input.
         """
         from kiro_crew.apps.builtins.ops_mission_control.backend import (
             policy_store,

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers.py
@@ -926,10 +926,10 @@ class TestSuppressionIsAlwaysBounded(unittest.IsolatedAsyncioTestCase):
     """A suppression with no expiry hides a live fault until a human remembers it.
 
     This is the property that makes ``act`` a bounded bet rather than an
-    all-or-nothing one: a WRONG silence expires by itself. The shipped Datadog sink
-    used to POST ``/mute`` with ``body={}``, and Datadog reads a missing ``end`` as
-    "mute forever" — so the board showed the incident resolved while the metric stayed
-    bad, with no way back but a human noticing.
+    all-or-nothing one: a WRONG silence expires by itself. POSTing ``/mute`` with
+    ``body={}`` leaves Datadog reading the missing ``end`` as "mute forever" — the
+    board shows the incident resolved while the metric stays bad, with no way back
+    but a human noticing.
     """
 
     def test_a_requested_window_is_clamped_not_honoured_blindly(self):
@@ -1935,7 +1935,7 @@ class TestRunGhTimeoutReapsChild(unittest.IsolatedAsyncioTestCase):
 
     After ``wait_for`` cancels ``communicate()``, a killed child blocked
     writing into a full stderr pipe makes a bare ``wait()`` hang the polling
-    task forever (#5989) — the reap must be a SECOND ``communicate()``.
+    task forever — the reap must be a SECOND ``communicate()``.
     """
 
     async def test_timeout_reaps_child_via_communicate_not_wait(self):
@@ -2117,7 +2117,7 @@ class TestTheAppConfigIsNeverPublishedOverAFailedRead(unittest.TestCase):
         self.assertTrue(providers.provider_enabled("pagerduty"))
 
     def test_a_corrupt_config_refuses_the_merge_instead_of_replacing_it(self):
-        """Inverted deliberately: this used to assert repair-on-write.
+        """Refusal, not repair-on-write.
 
         A half-written or hand-broken config still names every provider the operator
         enabled. Replacing it discards that and leaves them re-entering settings they

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
@@ -196,11 +196,11 @@ class TestSecretsAreWriteOnly(unittest.IsolatedAsyncioTestCase):
 
 
 class TestIncidentsPayloadIsBounded(unittest.IsolatedAsyncioTestCase):
-    """`/incidents` used to serialize the ENTIRE index on every dashboard poll.
+    """`/incidents` must not serialize the ENTIRE index on every dashboard poll.
 
-    Fine at three incidents. Once a flapping alarm has minted hundreds — which became
-    possible when resolved alarms were made re-claimable — it is an ever-growing payload
-    on a polled endpoint.
+    Fine at three incidents. Once a flapping alarm has minted hundreds — which a
+    re-claimable resolved alarm allows — it is an ever-growing payload on a polled
+    endpoint.
     """
 
     def setUp(self):
@@ -883,12 +883,12 @@ class TestStateReportsTheNotificationChannel(unittest.IsolatedAsyncioTestCase):
 
 
 class TestAnActionSchedulesItsOwnVerification(unittest.IsolatedAsyncioTestCase):
-    """A 2xx from a provider is no longer the end of the story.
+    """A 2xx from a provider is not the end of the story.
 
-    `_handle_action` used to await `sink.execute`, audit, and return — so the response's
-    `ok` meant only "transmitted". Checkmk documents exactly that gap for its Livestatus
-    command dispatch; Nagios's command pipe returns nothing at all. The route now records
-    what was done and when to look again, and says which of the two it is doing.
+    Awaiting `sink.execute`, auditing and returning would make the response's `ok` mean
+    only "transmitted". Checkmk documents exactly that gap for its Livestatus command
+    dispatch; Nagios's command pipe returns nothing at all. The route records what was
+    done and when to look again, and says which of the two it is doing.
     """
 
     def setUp(self):
@@ -1471,12 +1471,11 @@ class TestHygieneIsPrimaryOnly(unittest.IsolatedAsyncioTestCase):
 
 
 class TestProposeLoop(unittest.IsolatedAsyncioTestCase):
-    """`propose` mode used to be behaviourally identical to `observe`.
+    """`propose` mode must not be behaviourally identical to `observe`.
 
-    `authorize_action` refuses anything below `act`, `proposed_action` was declared and
-    never assigned, and there was no store, no approve endpoint and no timeout. So the
-    mode most operators will live in — "tell me what you would do" — was prose in a chat
-    transcript with nothing to approve.
+    `authorize_action` refuses anything below `act`, so without a stored draft, an
+    approve endpoint and a timeout, the mode most operators live in — "tell me what you
+    would do" — is prose in a chat transcript with nothing to approve.
 
     The load-bearing property is that **the drafted text is the contract**: an approval
     binds to the exact terms shown, and executes those, not whatever the request supplies.
@@ -1936,7 +1935,7 @@ class TestBlockedStateReadsThePublicSlotContract(unittest.IsolatedAsyncioTestCas
     ``_ChatSlot.to_dict()`` is the owner's public serializer and already derives the same
     fact. These tests pin BOTH that we ask it, and that our answer agrees with the core's
     across the states that matter -- against the real class, not a stand-in, because a mock
-    would happily agree with a contract that no longer exists.
+    would happily agree with a contract that does not exist.
     """
 
     def test_no_private_slot_attribute_is_read(self):
@@ -2316,7 +2315,7 @@ class TestOutboundNotesAreRedacted(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(token, seen[0].get("note", ""), "a token must never leave in a note")
 
     def test_redaction_happens_before_the_length_clip(self):
-        """Clipping first could sever a token so the pattern no longer matches."""
+        """Clipping first could sever a token so the pattern does not match."""
         import inspect
 
         source = inspect.getsource(routes._handle_action)
@@ -3051,12 +3050,12 @@ class TestTheSlotKeyIsDerivedNotTrusted(unittest.TestCase):
 
 
 class TestManualClaimRequiresAFiringSignal(unittest.IsolatedAsyncioTestCase):
-    """`POST /incident/claim` must refuse a signal that is no longer firing.
+    """`POST /incident/claim` must refuse a signal that is not firing.
 
-    `poll_all` returns EVERY state — firing, ok and suppressed — and this handler matched on
-    id alone. The local was even named `firing`, which is what hid it: a signal that recovered
-    between the board's poll and this one came back as `ok`, matched, and minted an incident
-    for a fault that had already cleared. The two other `poll_all` consumers
+    `poll_all` returns EVERY state — firing, ok and suppressed — so matching on id alone is
+    wrong, and a local named `firing` is what hides it: a signal that recovered between the
+    board's poll and this one comes back as `ok`, matches, and mints an incident for a
+    fault that has already cleared. The two other `poll_all` consumers
     (`dispatch.run_cycle`, `GET /signals`) both filter explicitly. Found in review.
     """
 
@@ -3385,10 +3384,10 @@ class TestAStoreThatRefusesToWriteIsReportedNotCrashed(unittest.IsolatedAsyncioT
     async def test_a_corrupt_secret_store_is_a_coded_500_on_save(self):
         """Corruption is not retryable, so it must not be advertised as a 503.
 
-        The store's update reader now refuses a corrupt document rather than
-        replacing it (#7805), and this handler caught only ``OSError`` -- so the
+        The store's update reader refuses a corrupt document rather than
+        replacing it, so a handler catching only ``OSError`` would surface the
         refusal protecting the operator's only copy of every provider token
-        would have surfaced as aiohttp's bare uncoded 500.
+        as aiohttp's bare uncoded 500.
         """
         token = "u+ThisIsTheActualTokenValue"
         corrupt = json.JSONDecodeError("Expecting value", "{ not json", 2)

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py
@@ -12,7 +12,7 @@ of what would hurt most if broken:
    file every instance reads, "cannot tell" means the schedule is wrong, and arming would
    make the whole team pick up the same alarm. Only ``on_shift`` gates work; ``unknown``
    survives so the UI can say WHY.
-3. **A date-only ``to`` includes that day.** ``to: 2026-08-08`` means "through the 8th".
+3. **A date-only ``to`` includes that day.** It means "through that whole day".
    Reading it as midnight would silently drop the last day of every shift.
 4. **The file is untrusted input.** It arrives by ``git pull`` from a shared repo, so it
    must be size-capped and parsed with ``safe_load``.
@@ -102,7 +102,7 @@ class TestOnShiftResolution(_Env):
         self.assertTrue(schedule_file.resolve_now(self._at("2026-08-03T12:00")).on_shift)
 
     def test_date_only_end_includes_the_final_day(self) -> None:
-        """`to: 2026-08-08` means through the 8th, not midnight at its start.
+        """A date-only `to` means through that whole day, not midnight at its start.
 
         Read as 00:00 this drops the last day of every shift written date-only — the
         single most likely misreading of this file format.
@@ -301,7 +301,7 @@ class TestLoginResolution(_Env):
 
             def _counting_run(argv, *a, **kw):
                 # Match the whole argv, not argv[0]: sandboxed_spawn_argv PREPENDS a
-                # wrapper, so `gh` is no longer element 0 and an argv[0] check silently
+                # wrapper, so `gh` is not element 0 and an argv[0] check silently
                 # lets the real `gh` run (observed: it returned the developer's login).
                 if "api" in argv and "user" in argv:
                     gh_calls.append(argv)
@@ -337,7 +337,7 @@ class TestLoginResolution(_Env):
 
             def _counting_run(argv, *a, **kw):
                 # Match the whole argv, not argv[0]: sandboxed_spawn_argv PREPENDS a
-                # wrapper, so `gh` is no longer element 0 and an argv[0] check silently
+                # wrapper, so `gh` is not element 0 and an argv[0] check silently
                 # lets the real `gh` run (observed: it returned the developer's login).
                 if "api" in argv and "user" in argv:
                     gh_calls.append(argv)
@@ -615,9 +615,9 @@ class TestOffShiftCannotWrite(_Env):
     not pass through it.
     """
 
-    #: A window covering any plausible test clock. An earlier version of this fixture used
-    #: 2026-08-01..08 and silently tested the INDETERMINATE path instead, because the real
-    #: clock fell outside it — the guard correctly did not fire and it read as a failure.
+    #: A window covering any plausible test clock. A narrow one silently tests the
+    #: INDETERMINATE path instead, because the real clock falls outside it — the guard
+    #: correctly does not fire and it reads as a failure.
     WIDE = "timezone: UTC\nshifts:\n  - from: 2026-01-01\n    to: 2027-12-31\n    who: alice\n"
 
     def _grant_act(self, login: str) -> None:
@@ -788,11 +788,11 @@ class TestOffShiftCannotWrite(_Env):
     def test_the_off_shift_vote_does_not_consult_provider_enabled(self) -> None:
         """Instance 4 of the same class, pinned structurally.
 
-        `_definitely_off_shift` used to skip any source where `configured()` was false, and
+        Skipping any source where `configured()` is false would be fatal here:
         `configured()` reads `providers.<id>.enabled` from `config.json` for every adapter but
-        this one. One flag flip therefore made a source abstain, nothing answered, and the
-        refusal stopped firing. The vote now asks every non-fallback source and lets each
-        report its own inability to answer as `unknown`.
+        this one, so one flag flip makes a source abstain, nothing answers, and the refusal
+        stops firing. The vote asks every non-fallback source and lets each report its own
+        inability to answer as `unknown`.
         """
         import ast
         import inspect

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
@@ -290,8 +290,8 @@ class TestSecretBackend(unittest.TestCase):
         self.assertEqual(self.backend.get("pagerduty", "api_token"), "")
 
     def test_non_utf8_file_degrades_to_empty(self):
-        # New with #7805: UnicodeDecodeError previously escaped the lookup read
-        # (a ValueError, not a JSONDecodeError). The lenient read must treat a
+        # UnicodeDecodeError escapes a JSONDecodeError-only clause here (it is a
+        # ValueError, not a JSONDecodeError). The lenient read must treat a
         # corrupt byte stream as one condition regardless of which decoder
         # noticed it -- failing a render would wedge the Settings UI on a file
         # only a person can repair.
@@ -302,12 +302,12 @@ class TestSecretBackend(unittest.TestCase):
 class TestSecretStoreLockdownOrdering(unittest.TestCase):
     """The store's write must never publish a token file it has not protected.
 
-    Ports the previous-store-survival recipe from
+    Ports the prior-store-survival recipe from
     ``test/test_aws_consent.py::TestGrantIsOnTheKeystoneFloor``: every failure
     inside ``atomic_write`` happens BEFORE the rename, so a transient lockdown
-    or write failure can no longer reach — let alone delete — the previous,
-    healthy store (the old post-publish ``restrict_to_owner`` + unlink-on-
-    OSError shape destroyed every stored provider token on one lockdown failure).
+    or write failure cannot reach — let alone delete — the healthy store already
+    on disk (a post-publish ``restrict_to_owner`` plus unlink-on-OSError destroys
+    every stored provider token on one lockdown failure).
     """
 
     def setUp(self):
@@ -489,10 +489,10 @@ class TestSecretStoreNeverPublishesOverAFailedRead(unittest.TestCase):
         self.assertEqual(self.backend.get("pagerduty", "api_token"), "u+thefirsttoken")
 
     def test_a_corrupt_store_refuses_the_save_and_is_left_intact(self):
-        """#7805: a corrupt store is refused, never rewritten.
+        """A corrupt store is refused, never rewritten.
 
-        The old tolerance read an unparseable document as empty and let ``put``
-        publish over it -- destroying tokens a truncated JSON still held
+        Reading an unparseable document as empty and letting ``put``
+        publish over it destroys tokens a truncated JSON still holds
         verbatim, silently, when this file is the only copy of every provider
         credential on the box. Byte-for-byte intactness is the half a raise
         alone does not prove.

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_and_gate.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_and_gate.py
@@ -278,9 +278,9 @@ class TestTransition(_HomeIsolated):
         # Back to unclaimed is not legal: an incident that exists has been claimed by
         # definition, and "release it" is `stale`, not a rewind.
         #
-        # This used to assert dispatched -> resolved, which is now a REQUIRED edge —
-        # reconcile must close an incident whose signal cleared before the agent's
-        # first turn. Note same-status is deliberately a no-op update (see
+        # ``dispatched -> resolved`` is NOT a usable example here: it is a REQUIRED edge,
+        # because reconcile must close an incident whose signal cleared before the
+        # agent's first turn. Same-status is deliberately a no-op update (see
         # store.transition), so it is not a usable example of illegality either.
         with self.assertRaises(ValueError):
             store.transition(inc.incident_id, models.STATUS_UNCLAIMED)
@@ -659,11 +659,11 @@ class TestAutonomyGate(_HomeIsolated):
     def _write_config(self, payload: dict) -> None:
         """Seed the ceiling on the KEYSTONE floor, the way the dashboard PUT does.
 
-        These tests used to write `mode`/`autonomy_rules` into `data/config.json` and rely on
-        the read path picking them up. That path is gone on purpose: `config.json` is
-        agent-writable, so honouring a ceiling found there let the constrained party set its
-        own ceiling (see `policy_store` — the migration that did this was deleted). Seeding via
-        `policy_store` keeps these tests exercising the gate rather than the hole.
+        Writing `mode`/`autonomy_rules` into `data/config.json` and relying on the read path
+        to pick them up does not work, on purpose: `config.json` is agent-writable, so
+        honouring a ceiling found there would let the constrained party set its own ceiling
+        (see `policy_store`). Seeding via `policy_store` keeps these tests exercising the
+        gate rather than the hole.
 
         Non-ceiling keys still go to `config.json`, which is where the app legitimately reads
         them, so a test that mixes both still lands each value in its real home.
@@ -865,14 +865,13 @@ class TestTierArming(_HomeIsolated):
     def test_a_failing_rotation_api_still_arms_the_tier(self):
         """Fail-open is preserved — but the SOURCE decides it, not the gate.
 
-        This test used to construct ``on_shift=False, unknown=True`` and assert the tier
-        armed anyway, which encoded ``on_shift or unknown`` into the gate. That silently
-        defeated strict gating: a committed schedule that cannot say whether this operator
-        is on call returns exactly that shape, and the ``or`` re-armed every teammate —
-        verified before the fix (``on_shift=False`` yet ``dispatch armed=True``).
+        Asserting that ``on_shift=False, unknown=True`` arms the tier would encode
+        ``on_shift or unknown`` into the gate, which silently defeats strict gating: a
+        committed schedule that cannot say whether this operator is on call returns exactly
+        that shape, and the ``or`` re-arms every teammate.
 
-        The intent was always "an unreachable API must not disable response", and that is
-        still true: ``pagerduty.on_shift`` returns ``on_shift=True, unknown=True`` on any
+        The intent is "an unreachable API must not disable response", and it holds:
+        ``pagerduty.on_shift`` returns ``on_shift=True, unknown=True`` on any
         failure, which is the shape asserted here. Two sources, two policies for "cannot
         tell", one gate that just reads ``on_shift``.
         """
@@ -946,12 +945,12 @@ class TestTierArming(_HomeIsolated):
     def test_arming_is_server_side_not_agent_held(self):
         """The app must not hold `cron_pause`/`cron_resume`.
 
-        Tier arming used to be the agent's job, and the only thing stopping it pausing
+        With tier arming as the agent's job, the only thing stopping it pausing
         `rotation-check` — the sole always-tier job, so the only one that can re-arm a
-        gated instance — was a sentence of SOP prose. Prose is not enforcement, and
+        gated instance — is a sentence of SOP prose. Prose is not enforcement, and
         `mcpTools` is declarative only (nothing calls `check_tool_permission` at runtime),
-        so the manifest entry was never a gate either. Arming moved into
-        `rotation.apply_tiers`; the capability must be gone from the manifest with it, or
+        so the manifest entry is not a gate either. Arming lives in
+        `rotation.apply_tiers`; the capability must be absent from the manifest, or
         a future SOP edit can quietly hand the loaded gun back.
         """
         import json
@@ -1301,7 +1300,7 @@ class TestLedgerGitMerge(_HomeIsolated):
         """Two people hit the same failure on different resources.
 
         Losing one branch's fingerprint means that recurrence stops matching — the
-        ledger keeps working while silently no longer recognizing half its own history.
+        ledger keeps working while silently failing to recognize half its own history.
         """
         import json
 
@@ -2712,12 +2711,11 @@ class TestTheWriteGateConsultsEveryRotation(_HomeIsolated):
     def test_no_configured_rotation_allows_the_write(self):
         """A solo install has no rotation to be off.
 
-        Expressed as `unknown`, NOT as `configured=False`. This test used to install a source
-        that reported `on_shift=False, configured=False` and assert the write was allowed — it
-        was asserting that the gate SKIPS an unconfigured source, which turned out to be the
-        hole below rather than the property. A source that cannot answer says so with
-        `unknown=True`; that is the contract every shipped source already implements, and it is
-        the one the gate reads now.
+        Expressed as `unknown`, NOT as `configured=False`. A source reporting
+        `on_shift=False, configured=False` with the write allowed would assert that the gate
+        SKIPS an unconfigured source, which is the hole below rather than the property. A
+        source that cannot answer says so with `unknown=True`; that is the contract every
+        shipped source implements, and the one the gate reads.
         """
         from kiro_crew.apps.builtins.ops_mission_control.backend import rotation
 
@@ -2729,17 +2727,16 @@ class TestTheWriteGateConsultsEveryRotation(_HomeIsolated):
 
         `configured()` reads `providers.<id>.enabled` from `data/config.json` for every adapter
         except the schedule file — and that file is agent-writable and served unauthenticated.
-        The gate used to skip any source where `configured()` was false, so ONE flag flip made
-        a rotation source abstain, no real source answered, and the off-shift refusal stopped
-        firing without anything changing about who was actually on call.
+        A gate that skips any source where `configured()` is false lets ONE flag flip make a
+        rotation source abstain, so no real source answers and the off-shift refusal stops
+        firing without anything changing about who is actually on call.
 
-        Reproduced end to end before fixing: PagerDuty reporting `on_shift=False` refused the
-        write; with `enabled: false` the same signal returned "granted by rule on cloudwatch".
+        Reproduced end to end: PagerDuty reporting `on_shift=False` refuses the write; with
+        `enabled: false` the same signal returns "granted by rule on cloudwatch".
 
-        Fourth instance of one class in a single review round — the rotation login, strict
-        gating, `config_fields` still advertising the login to the generic provider route, and
-        this. The gate now asks EVERY non-fallback source and lets each report its own
-        inability to answer as `unknown`, which is both safer and simpler.
+        One instance of a general class — a security refusal must not read an input the
+        constrained party can write. The gate asks EVERY non-fallback source and lets each
+        report its own inability to answer as `unknown`, which is both safer and simpler.
         """
         from kiro_crew.apps.builtins.ops_mission_control.backend import rotation
 
@@ -3241,7 +3238,7 @@ class TestTheIndexIsNeverPublishedOverAFailedRead(_HomeIsolated):
     investigation of each — and in ``act`` mode a duplicate investigation is a
     second real write against the operator's production paging. The per-incident
     markdown logs survive on disk with nothing indexing them, and an open incident
-    that is no longer listed is never swept, resolved, or answered.
+    that is not listed is never swept, resolved, or answered.
     """
 
     def _unreadable_index(self):
@@ -3330,16 +3327,16 @@ class TestTheIndexIsNeverPublishedOverAFailedRead(_HomeIsolated):
         self.assertIn(inc.incident_id, store.read_index())
 
     def test_a_corrupt_index_refuses_the_mutation_instead_of_replacing_it(self):
-        """Inverted deliberately: this used to assert repair-on-write.
+        """Refusal, not repair-on-write.
 
         The four merged siblings of this idiom (`library.py`, `shares.py`,
-        `secrets.py`, `policy_store.py`) used to read an unparseable document as
-        empty (their reasoning was real -- nothing parsed, so there is nothing to
-        merge into), until #7805 gave them this same refusal. "Cannot merge into"
-        is not "safe to destroy": a truncated index still holds most of its records
+        `secrets.py`, `policy_store.py`) answer corruption the same way. Reading an
+        unparseable document as empty has a real argument behind it -- nothing
+        parsed, so there is nothing to merge into -- but "cannot merge into" is not
+        "safe to destroy": a truncated index still holds most of its records
         verbatim, and the mutation would replace the file and take them with it.
-        Refusing costs one skipped mutation and a visible error; the old behaviour
-        cost the records, silently. Found in review (GPT 5.6).
+        Refusing costs one skipped mutation and a visible error; replacing costs
+        the records, silently.
 
         The fixture writes malformed JSON to the real index path, so the corruption
         is reached by the update reader itself rather than simulated -- and `claim`

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_webhook.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_webhook.py
@@ -232,10 +232,10 @@ class TestPayloadValidation(_Env):
     def test_peek_does_not_consume_the_queue(self) -> None:
         """A READ must not destroy delivered signals.
 
-        This test used to assert the opposite (`drain` emptying the spool), which is the
-        bug: `poll_all` is called by the Signals-tab read and by the claim-authorization
-        check as well as by the heartbeat, so a "Poll now" click permanently destroyed
-        every queued alert — signature-verified, delivered, and then silently nothing.
+        `drain` emptying the spool on a read is the bug: `poll_all` is called by the
+        Signals-tab read and by the claim-authorization check as well as by the
+        heartbeat, so a "Poll now" click would permanently destroy every queued alert —
+        signature-verified, delivered, and then silently nothing.
         """
         self._send(_body(id="a"))
         self._send(_body(id="b"))
@@ -275,10 +275,10 @@ class TestPayloadValidation(_Env):
 class TestAlertmanagerEnvelope(_Env):
     """The v4 ``{status, alerts:[...]}`` body — the most common machine-readable alert.
 
-    Previously rejected outright: a raw Alertmanager body carries no top-level
-    ``title``/``summary``, so ``signal_from_payload`` returned None and the ingress
-    answered 400 "payload has no title" — while this module's own docstring named
-    Alertmanager as a supported sender.
+    Accepted rather than rejected outright: a raw Alertmanager body carries no top-level
+    ``title``/``summary``, so a title-only read returns None and the ingress answers
+    400 "payload has no title" — for the sender this module's own docstring names as
+    supported.
     """
 
     def setUp(self) -> None:
@@ -442,14 +442,14 @@ class TestAlertmanagerEnvelope(_Env):
 
 
 class TestProviderSideSuppressionIsHonoured(_Env):
-    """Alertmanager publishes suppression two ways, and only one shape used to parse.
+    """Alertmanager publishes suppression two ways, and both shapes must parse.
 
     The v4 webhook envelope sends a scalar ``status``. Anything relaying
     ``GET /api/v2/alerts`` sends the ``gettableAlert`` OBJECT
-    ``{"state": "suppressed", "silencedBy": [...]}``, which the previous scalar-only read
-    stringified — so it normalized to ``unknown`` and ``silencedBy`` was dropped entirely.
-    A sender being perfectly explicit about a human having parked the alert produced a
-    signal indistinguishable from garbage.
+    ``{"state": "suppressed", "silencedBy": [...]}``, which a scalar-only read
+    stringifies — normalizing it to ``unknown`` and dropping ``silencedBy`` entirely.
+    A sender being perfectly explicit about a human having parked the alert then
+    produces a signal indistinguishable from garbage.
     """
 
     def setUp(self) -> None:
@@ -612,9 +612,9 @@ class TestProviderSideSuppressionIsHonoured(_Env):
 class TestRejectStatusMapping(unittest.TestCase):
     """A payload fault is not an auth failure.
 
-    Everything used to return 401, so a sender debugging a bad body was told
-    "Unauthorized" and would re-check credentials that were fine — while a genuine
-    signature failure looked identical to a typo.
+    Answering 401 for everything tells a sender debugging a bad body
+    "Unauthorized", so it re-checks credentials that are fine — and a genuine
+    signature failure looks identical to a typo.
     """
 
     def test_trust_failures_are_401(self) -> None:

--- a/src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
@@ -435,9 +435,9 @@ async def _git(
     except SandboxUnavailableError as exc:
         # Translated, not bypassed. See `GitSandboxUnavailable` — the wrap is what
         # keeps an agent-written repo config from reaching a shell on the one path
-        # that deliberately keeps `~/.ssh` visible. Previously this escaped as an
-        # unhandled 500, so on a Windows host (no sandbox backend exists there)
-        # every clone/commit/push/pull reported "internal error" and named no fix.
+        # that deliberately keeps `~/.ssh` visible. Unhandled, this escapes as a 500,
+        # so on a Windows host (no sandbox backend exists there) every
+        # clone/commit/push/pull reports "internal error" and names no fix.
         _audit(args[0] if args else "run", str(cwd), "denied", error="sandbox unavailable")
         raise GitSandboxUnavailable(str(exc)) from exc
     # A push/pull must never block on an interactive credential prompt: the

--- a/src/kiro_crew/apps/builtins/papyrus/backend/latex.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/latex.py
@@ -562,10 +562,10 @@ def _symlinked_artifacts(project: Path) -> tuple[list[str], bool]:
     the question the compiler actually poses is "is the file I am about to open a link?",
     and **the document chooses that filename**. ``\\openout\\ch=chapter1`` writes
     ``chapter1.tex``; ``\\jobname`` can be redirected; ``.bbl``/``.idx`` tool chains write
-    names no suffix list predicts. Enumerating names loses that race by construction, so
-    each round closed one instance and left the class open.
+    names no suffix list predicts. Enumerating names loses that race by construction:
+    closing one instance leaves the class open.
 
-    Refusing on ANY link inverts it: the guard no longer has to predict what the compiler
+    Refusing on ANY link inverts it: the guard does not have to predict what the compiler
     will write, because nothing beneath the project is a link at all. That is also the
     stance ``store.list_files`` already takes ("a link is not a file the editor should
     follow — and following one is how a tree walk escapes containment"), so a symlinked
@@ -743,11 +743,11 @@ async def compile_project(project: Path, main_file: str) -> CompileResult:
                 timeout=BIBTEX_TIMEOUT_SEC,
                 operation="bibtex",
             )
-            # A bibtex failure is REPORTED, not swallowed. Its result used to be
-            # discarded, so a missing `.bst` or an unparseable `.bib` produced no `.bbl`,
-            # the two later pdflatex passes still exited 0, and the compile was reported
-            # SUCCESSFUL while the PDF carried `[?]` for every citation and an empty
-            # bibliography. The user saw a green compile and a silently wrong paper.
+            # A bibtex failure is REPORTED, not swallowed. Discarding its result means a
+            # missing `.bst` or an unparseable `.bib` produces no `.bbl`, the two later
+            # pdflatex passes still exit 0, and the compile is reported SUCCESSFUL while
+            # the PDF carries `[?]` for every citation and an empty bibliography — a
+            # green compile on a silently wrong paper.
             #
             # The bar is deliberately NOT "any non-zero exit". bibtex exits 1 for
             # WARNINGS, which are routine on a healthy document (an undefined cross
@@ -785,12 +785,11 @@ async def compile_project(project: Path, main_file: str) -> CompileResult:
     # `None` when the emitted name is not contained (a symlinked `main.pdf` in a
     # cloned repo), which is reported as a failed compile rather than served.
     #
-    # OFF the loop. `pdf_path` used to be pure path arithmetic, so calling it inline was
-    # free — adding the containment check gave it a `Path.resolve()` and a
-    # sensitive-path probe, i.e. real syscalls, and on a project under a stalled network
-    # mount (`KIROCREW_HOME` on NFS/SMB) those block for as long as the mount takes to
-    # answer. The `is_file()` beside it was already offloaded for exactly this reason;
-    # the security fix quietly put a second syscall in front of it.
+    # OFF the loop. `pdf_path` is not pure path arithmetic: the containment check gives
+    # it a `Path.resolve()` and a sensitive-path probe, i.e. real syscalls, and on a
+    # project under a stalled network mount (`KIROCREW_HOME` on NFS/SMB) those block for
+    # as long as the mount takes to answer. The `is_file()` beside it is offloaded for
+    # exactly this reason.
     pdf = await asyncio.to_thread(store.pdf_path, project, main_file)
     ok = code == 0 and pdf is not None and await asyncio.to_thread(pdf.is_file)
     return CompileResult(

--- a/src/kiro_crew/apps/builtins/papyrus/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/routes.py
@@ -379,8 +379,8 @@ async def _handle_create_project(request: web.Request) -> web.StreamResponse:
             # authoritative answer to "did someone else take this name", and it is the
             # only one free of a check/use window. `_project_for_create`'s `exists()`
             # probe above narrows the window but cannot close it — two worker threads
-            # can both pass it — so the loser used to raise an unhandled
-            # FileExistsError and the request 500'd on what is really a 409.
+            # can both pass it — so the loser's FileExistsError is caught here rather
+            # than 500ing the request on what is really a 409.
             #
             # Same conflict, same status, as the probe reports; the user sees "project
             # already exists" either way rather than a server error for a name clash

--- a/src/kiro_crew/apps/builtins/papyrus/backend/store.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/store.py
@@ -603,7 +603,7 @@ def create_file(project: Path, relative: str, content: str = "") -> None:
         raise ValueError("content too large")
     target.parent.mkdir(parents=True, exist_ok=True)
     # `x` is `O_CREAT | O_EXCL`: it raises FileExistsError itself, which is exactly the
-    # error the probe used to raise, so callers are unchanged. `newline=""` matches
+    # error the probe raises, so callers need no second case. `newline=""` matches
     # `write_file` so a round-tripped document does not accumulate carriage returns.
     with open(target, "x", encoding="utf-8", newline="") as handle:
         handle.write(content)

--- a/src/kiro_crew/apps/builtins/papyrus/backend/tectonic.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/tectonic.py
@@ -680,9 +680,10 @@ def _download_to(asset: TectonicAsset, staging: Path) -> tuple[bool, str]:
         _set_progress(downloaded, downloaded)
     # `http.client.HTTPException` is in the tuple deliberately: it is NOT an
     # `OSError`, a `URLError` or a `ValueError`, so `InvalidURL` (a malformed mirror
-    # override — the credentialed case) used to pass through this handler entirely
-    # and be reported by the outer catch-all as "provisioning crashed". Handling it
-    # here turns an unexplained crash into the accurate "download failed", and keeps
+    # override — the credentialed case) would otherwise pass through this handler
+    # entirely and be reported by the outer catch-all as "provisioning crashed".
+    # Handling it here turns an unexplained crash into the accurate "download failed",
+    # and keeps
     # the redaction and the retry loop that go with it.
     except (
         urllib.error.URLError,

--- a/src/kiro_crew/apps/builtins/personal_shopper/backend/store.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/backend/store.py
@@ -407,7 +407,7 @@ class PreferenceStore:
         with that id to the second group.
 
         Same-name adds still return the original group instead of creating a
-        duplicate, which is the idempotency the slug used to provide for free.
+        duplicate, which is the idempotency a slug provides for free.
         Matching is case-insensitive on the trimmed name.
         """
         clean = name.strip()
@@ -451,7 +451,7 @@ class PreferenceStore:
                 if group_id in tags:
                     # Strip EVERY occurrence. list.remove drops only the first,
                     # so a preference tagged twice kept a tag pointing at a group
-                    # that no longer exists -- it then belongs to no visible group
+                    # that does not exist -- it then belongs to no visible group
                     # and is not "ungrouped" either, so it vanishes from the UI
                     # while still sitting in the database.
                     tags = [t for t in tags if t != group_id]

--- a/src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py
@@ -1,9 +1,9 @@
 """Tests for the Personal Shopper HTTP routes.
 
 The load-bearing ones here pin the boundary between a CLIENT error and a SERVER
-error. Every field these handlers read used to go straight into a string or int
-operation, so a wrong TYPE — not a wrong value — raised inside the handler and
-surfaced as a 500. A 500 tells a caller "the server is broken" and is what gets
+error. A field these handlers read must not go straight into a string or int
+operation: a wrong TYPE — not a wrong value — then raises inside the handler and
+surfaces as a 500. A 500 tells a caller "the server is broken" and is what gets
 paged on; the correct answer to ``{"text": 1}`` is a 400 naming the offending
 field, which is what these assert.
 
@@ -135,8 +135,8 @@ class TestJsonObjectCatchWidth(unittest.IsolatedAsyncioTestCase):
 
     async def test_an_unknown_charset_codec_is_a_400_not_a_500(self) -> None:
         # An unknown ``charset=`` on the request makes aiohttp's decode step raise
-        # LookupError (not a ValueError), which used to escape ``_json_object`` as
-        # a 500. It is a client-input mistake and must answer 400.
+        # LookupError (not a ValueError), which escapes ``_json_object`` as a 500
+        # unless it is caught. It is a client-input mistake and must answer 400.
         body, err = await routes_mod._json_object(
             _req_raising(LookupError("unknown encoding: bogus-codec"))
         )

--- a/src/kiro_crew/apps/builtins/personal_shopper/tests/test_store.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/tests/test_store.py
@@ -235,7 +235,7 @@ class TestVectorStaleness(PreferenceStoreTestCase):
 
 class TestFtsIndexSync(PreferenceStoreTestCase):
     def test_update_replaces_the_indexed_text(self) -> None:
-        """After an edit the OLD wording must no longer be findable."""
+        """After an edit the OLD wording must not be findable."""
         with _no_embedder():
             store = self._store()
             entry_id = store.add("prefers wool coats")

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/engine_source.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/engine_source.py
@@ -57,7 +57,7 @@ logger = logging.getLogger("kirocrew.app.pptx-maker")
 
 # ── the pin ─────────────────────────────────────────────────────────────────
 
-#: The public engine repository. Only ever used to build the archive URL.
+#: The public engine repository. Its only role is building the archive URL.
 ENGINE_REPO = "https://github.com/aws-samples/sample-spec-driven-presentation-maker"
 
 #: The upstream release the pinned tree corresponds to. DISPLAY ONLY — it is
@@ -274,8 +274,8 @@ def download_archive(staging: Path) -> tuple[bool, str]:
                     digest.update(chunk)
                     downloaded += len(chunk)
     # `http.client.HTTPException` is in the tuple deliberately: `InvalidURL` derives
-    # from it, NOT from `OSError`/`URLError`/`ValueError`, so a malformed mirror URL
-    # used to pass straight through this handler and be reported by an outer catch-all.
+    # from it, NOT from `OSError`/`URLError`/`ValueError`, so without it a malformed
+    # mirror URL passes straight through this handler to an outer catch-all.
     except (
         urllib.error.URLError,
         http.client.HTTPException,

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/library.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/library.py
@@ -43,7 +43,7 @@ TEMPLATE_SUFFIX = ".pptx"
 
 # Upload ceilings. A style is a single HTML document and a template is one
 # .pptx; these are an order of magnitude above any real one, and they exist so a
-# request body cannot be used to fill the disk.
+# request body cannot fill the disk.
 MAX_STYLE_BYTES = 4 * 1024 * 1024
 MAX_TEMPLATE_BYTES = 64 * 1024 * 1024
 
@@ -279,9 +279,9 @@ def _save_state_or_undo_rename(
     Returns ``None`` on success, or the caller's error response.
 
     The rename has ALREADY committed by the time state is written, so a failing
-    write left the file under its new name while ``state.json`` still referred to
-    the old one — a pin or a template's metadata pointing at a name that no longer
-    exists, with the request reporting 500 as though nothing had happened. Undoing
+    write leaves the file under its new name while ``state.json`` still refers to
+    the old one — a pin or a template's metadata pointing at a name that does not
+    exist, with the request reporting 500 as though nothing had happened. Undoing
     the rename is the only outcome that keeps the two consistent: the operation
     fails cleanly and the user can retry.
 
@@ -472,9 +472,9 @@ def rename_style(name: str, new_name: str) -> tuple[int, dict]:
         return 404, {"error": "style not found", "code": "style_not_found"}
     # The MOVE and the state update are ONE critical section.
     #
-    # Splitting them let a concurrent delete of `new_name` interleave between the link
-    # and the state write: both verbs returned 200 while `state.json` referenced a file
-    # that no longer existed. The move is what makes the state stale, so the lock has
+    # Splitting them lets a concurrent delete of `new_name` interleave between the link
+    # and the state write: both verbs return 200 while `state.json` references a file
+    # that does not exist. The move is what makes the state stale, so the lock has
     # to span both — the same rule `delete_style` above already follows, and the same
     # lost-update shape as the template-metadata fix. `_load_state`/`_save_state` do
     # not acquire the lock themselves, so this cannot self-deadlock on a plain Lock.
@@ -671,9 +671,9 @@ def rename_template(name: str, new_name: str) -> tuple[int, dict]:
     if not source.is_file():
         return 404, {"error": "template not found", "code": "template_not_found"}
     # The MOVE and the state update are ONE critical section — see `rename_style`.
-    # Splitting them let a concurrent delete of `new_name` interleave between the link
-    # and the state write, leaving `state.json` naming a file that no longer exists
-    # while both verbs answered 200.
+    # Splitting them lets a concurrent delete of `new_name` interleave between the link
+    # and the state write, leaving `state.json` naming a file that does not exist
+    # while both verbs answer 200.
     with _STATE_LOCK:
         # `os.link` + `unlink`, not `rename`. `Path.rename` REPLACES an existing target
         # on POSIX, so `exists()` then `rename` is check-then-act: two tabs renaming

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/provision.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/provision.py
@@ -9,7 +9,7 @@ absolute paths.
 **Nothing has to be installed by hand.** ``pip install kirocrew`` is the only
 prerequisite: ``uv`` is a declared Python dependency and is resolved through the
 installed package (:func:`resolve_uv`) rather than assumed to be on ``PATH``, and
-the engine arrives over plain HTTPS, so ``git`` is no longer required at all.
+the engine arrives over plain HTTPS, so ``git`` is not required at all.
 
 Why this is a Python job and not a ``setup.onInstall`` shell script: a BUILTIN
 app's source lives read-only inside the installed Python package, and the
@@ -567,7 +567,7 @@ def provision() -> ProvisionOutcome:
 
     # `uv` ships as a declared Python dependency, so this only fails on a
     # genuinely broken install. Reported precisely (and only about uv — `git` is
-    # no longer used) so the message is actionable rather than a guess.
+    # not used) so the message is actionable rather than a guess.
     uv_bin = resolve_uv()
     if uv_bin is None:
         log.append(

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
@@ -181,7 +181,7 @@ _INLINE_BITMAP_RE = re.compile(
 # and stays O(1) per blob: a genuine raster always carries its signature, and a
 # smuggled secret essentially never decodes into one. The shared sniffer also
 # checks WebP's form tag at offset 8, so a bare `RIFF` container (e.g. a WAVE
-# audio file) no longer counts as a bitmap here.
+# audio file) does not count as a bitmap here.
 
 # AVIF/HEIF put a 4-byte box length BEFORE the `ftyp` brand, so the signature is
 # at an offset rather than at byte 0.
@@ -193,7 +193,7 @@ _BITMAP_FTYP_MAGIC = b"ftyp"
 # An AWS key id is a fixed 4-char prefix plus exactly 16 upper/digit chars — all of it
 # base64 alphabet — so it can be smuggled as body text and reproduced by the re-encode.
 # Chance collision is negligible (~1.6e-7 per 20 KB raster) because the 16-char body is
-# required; matching a BARE 4-char prefix instead is what used to blank real pictures at
+# required; matching a BARE 4-char prefix instead blanks real pictures at
 # 0.88% per 20 KB and 4.7% per 100 KB.
 #
 # Every other provider marker (`xox…`, `sk-ant…`, `gh[pousr]_…`, `pypi-`, `glpat-`, a
@@ -489,7 +489,7 @@ async def _json_body(request: web.Request) -> tuple[dict | None, web.Response | 
     ``styles/import`` endpoint instead, not this JSON path.
 
     The catch spans the client-input failure set: ``LookupError`` (an unknown
-    ``charset=`` codec) previously escaped as a 500 and is now a 400, and
+    ``charset=`` codec) answers 400 rather than escaping as a 500, and
     ``RecursionError`` (a deeply nested body) is caught for the same reason.
     ``UnicodeDecodeError`` is a ``ValueError`` subclass, so ``ValueError`` alone
     already covers undecodable bytes; it is dropped from the tuple as redundant.
@@ -685,7 +685,7 @@ async def _handle_deps(request: web.Request) -> web.Response:
     which is a privileged host mutation driven by an unauthenticated-to-the-OS
     caller — the dashboard shows the command and the user runs it.
 
-    ``pdftoppm`` is no longer in that category: it is provided by an app-private
+    ``pdftoppm`` is not in that category: it is provided by an app-private
     launcher over the engine venv's own ``pypdfium2`` (see :mod:`.preview_tools`),
     installed as part of ``POST /engine/provision``. Nothing is elevated and
     nothing is written outside this app's data dir, so there is still no
@@ -975,7 +975,7 @@ async def _handle_put_config(request: web.Request) -> web.Response:
     """PUT /config {"deckRoot": "<path>"} — set the deck output directory.
 
     ``deckRoot`` is the ONLY writable key: the body is checked for exact key
-    equality rather than merged, so this endpoint cannot be used to set an
+    equality rather than merged, so this endpoint cannot set an
     arbitrary engine option.
     """
     body, error = await _json_body(request)

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/decisions.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/decisions.py
@@ -273,7 +273,7 @@ def _apply_recorded_answers(
     ``locked``, whatever the state file says about it -- including a pending
     re-emission of the same id. Decisions the agent has dropped from its state
     file are NOT resurrected: there is no card to lock, and synthesising one
-    would put a title on screen that no longer exists anywhere.
+    would put a title on screen that appears nowhere in that state.
     """
     if not recorded or not isinstance(spec_state, dict):
         return spec_state
@@ -379,7 +379,7 @@ def _claim_decision_locked(
                 return _CLAIM_ALIAS_CONFLICT, ""
             # The directory must still verify as ITSELF before anything is recorded
             # under its key. This is the half that keeps the alias-by-spelling hole
-            # closed now that _decision_key no longer resolves: an entry whose spec_dir
+            # closed given that _decision_key does not resolve: an entry whose spec_dir
             # disagrees with realpath is either a directory swapped after indexing or a
             # hand-written index entry spelling one directory two ways, and either way
             # recording under it would mint a second record for documents that already

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/handlers.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/handlers.py
@@ -157,7 +157,7 @@ def _collect_spec_documents(spec_dir: Path) -> tuple[str, dict, dict | None, dic
     scoping that consumes it, so a delete-and-re-import in that window handed the
     replacement's slot a stale ``meta`` -- and the agent's next turn ran in the old
     project directory. The ledger is scoped by ``spec_dir``, and the fresh index
-    read refuses outright when that no longer matches, so reading it here is either
+    read refuses outright when that does not match, so reading it here is either
     consistent with the response or the whole request is refused.
     """
     phase = _derive_phase(spec_dir)
@@ -475,7 +475,7 @@ async def _handle_create(request: web.Request) -> web.Response:
     safe_wd = await asyncio.to_thread(_safe_dir, working_dir)
     if safe_wd is None:
         # Covers "missing", "not a directory" and "sensitive location" with one
-        # response so the endpoint can't be used to probe the filesystem.
+        # response so the endpoint cannot serve as a filesystem probe.
         return web.json_response(
             {
                 "code": "working_dir_not_a_directory",
@@ -824,7 +824,7 @@ async def _handle_create(request: web.Request) -> web.Response:
         # conversation. Only already-indexed specs may adopt a closed transcript.
         slot = await _ensure_worker_slot(state, name, entry, adopt_closed=False)
         if slot is None:
-            # Another app owns this slot key, or the working dir no longer validates.
+            # Another app owns this slot key, or the working dir does not validate.
             await _unwind_create()
             return web.json_response(
                 {
@@ -1010,7 +1010,7 @@ async def _handle_get(request: web.Request) -> web.Response:
             "running": bool(getattr(slot, "running", False)) if slot is not None else False,
             "phase": phase,
             "files": files,
-            # Per-document raw hash, used to bind approval to the exact stored
+            # Per-document raw hash, which binds approval to the exact stored
             # revision even when the rendered text required redaction.
             "docs": doc_meta["docs"],
             # tasks.md's checklist, enumerated and individually addressable, plus
@@ -1128,8 +1128,8 @@ async def _handle_message(request: web.Request) -> web.Response:
     # index we just read: comparing the index to itself always matches, so the
     # check was vacuous. The SPA sends the spec_dir it rendered (from the detail
     # payload), which is what makes a stale tab detectable -- if the spec was
-    # deleted and recreated elsewhere under the same name, that value no longer
-    # matches and the instruction must not reach the replacement's agent. A caller
+    # deleted and recreated elsewhere under the same name, that value does not
+    # match and the instruction must not reach the replacement's agent. A caller
     # that sends no spec_dir cannot be pinned; it is then treated as unpinned
     # rather than refused, so an older client keeps working.
     # The slot key rides along because a directory does NOT identify a creation:
@@ -1939,9 +1939,9 @@ async def _handle_handoff(request: web.Request) -> web.Response:
         # spec the delete had already removed.
         # Arming awaits too, so re-verify the creation once more. A DELETE landing in
         # that window tears down the slot and the loops it can see BY NAME -- ours
-        # arrives after, and would be left nudging a spec that no longer exists. The
-        # old arm-then-commit order caught this at the commit; the reorder above has to
-        # catch it here instead.
+        # arrives after, and would be left nudging a spec the delete removed.
+        # Committing before arming would catch this at the commit; arming last means
+        # it has to be caught here.
         refreshed = await _touch_spec(
             name,
             expect_spec_dir=str(spec_dir),
@@ -2041,7 +2041,7 @@ async def _handle_handoff(request: web.Request) -> web.Response:
     return web.json_response({"ok": True, "status": "executing"})
 
 
-#: Returned when the client's rendered spec identity no longer matches the index.
+#: Returned when the client's rendered spec identity does not match the index.
 _STALE_CLIENT_ERROR = "spec was deleted or recreated; reload and retry"
 
 
@@ -2378,7 +2378,7 @@ async def _handle_run_task(request: web.Request) -> web.Response:
                 status=409,
             )
         # Slot setup and status reconciliation both await. The IDE can edit
-        # tasks.md during either window, so the earlier snapshot is no longer safe
+        # tasks.md during either window, so the earlier snapshot is not safe
         # to dispatch. Execute and Delete cannot cross this final awaited reread,
         # and _dispatch_turn publishes slot.task synchronously before the lock is
         # released.
@@ -2994,7 +2994,7 @@ async def _handle_stop_execution(request: web.Request) -> web.Response:
             # Kept alongside the slot-key check because it answers a different question:
             # the index is agent-writable, so an entry can be repointed at another
             # directory WITHOUT a recreate, leaving the slot key intact while the lock
-            # held is no longer the one guarding these documents.
+            # held is not the one guarding these documents.
             # now would serialize against nothing that matters and could cancel the
             # replacement's run. Refuse and let the client retry against what exists.
             return web.json_response(

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/parsers.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/parsers.py
@@ -78,7 +78,7 @@ def _redact_and_truncate(text: str, max_chars: int) -> str:
     """Scrub like ``_redact``, then truncate — never ``_redact(x[:n])``.
 
     Truncating first can cut a credential at the boundary, leaving a fragment
-    the redaction regexes no longer match, so the raw remainder would leak.
+    the redaction regexes do not match, so the raw remainder would leak.
     Fails CLOSED exactly like ``_redact``: with no security module there is no
     way to scrub, so withhold the text rather than serving a bounded raw slice.
     """
@@ -96,8 +96,8 @@ def _usable_name(name: str) -> bool:
     same grammar `create` enforces, because it becomes a slot key and a session
     filename downstream. And it must survive `_redact` unchanged: index.json is
     agent-writable, so a credential can be parked in the KEY, and `GET /specs`
-    returns the key as `"name"`. Scrubbing it would produce a name that no longer
-    matches the directory the entry points at, so the entry goes instead.
+    returns the key as `"name"`. Scrubbing it would produce a name that does not
+    match the directory the entry points at, so the entry goes instead.
     """
     return _valid_name(name) and _redact(name) == name
 

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/repository.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/repository.py
@@ -358,7 +358,7 @@ def _refresh_slot_keys(index: dict) -> None:
     _INDEXED_SPEC_IDENTITIES = indexed_identities
     # Never forget a per-creation identity during this process. If an agent later
     # removes its persisted key, the ordinary resolver must stop using it because the
-    # index no longer authenticates that mapping, but legacy migration must also not
+    # index does not authenticate that mapping, but legacy migration must also not
     # reinterpret the same entry as a genuine pre-key spec and mint a second slot.
     for name, slot_key in _SLOT_KEYS.items():
         legacy_key = f"spec-builder-{name}"
@@ -672,7 +672,7 @@ async def _touch_spec(
     """Stamp ``fields`` + ``updated_at`` on a spec, re-reading the index first.
 
     Returns the updated entry (a copy, safe to read after the hop) or ``None``
-    if the spec no longer exists -- which the caller MUST treat as "deleted
+    if the spec is gone -- which the caller MUST treat as "deleted
     while this request was in flight" and abort, not as a reason to recreate it.
 
     ``expect_spec_dir`` additionally pins the spec's IDENTITY. A name is not an
@@ -884,7 +884,7 @@ def _observed_slot_keys_for_dir(dir_key: str) -> set[str]:
 
 
 def _unindexed_observed_slot_keys() -> set[str]:
-    """Authenticated creation keys no longer represented anywhere in the index."""
+    """Authenticated creation keys that no index row represents."""
     # The resolver retains an authenticated K1 for a surviving name even when
     # the agent removes or corrupts the raw slot_key.  Such a name remains a
     # valid Stop/Delete endpoint, so it is not a global orphan merely because
@@ -1413,7 +1413,7 @@ def _clear_duplicate_stage_documents_at(dir_fd: int, token: str, documents: obje
 
     The marker proves ownership of the directory, while the manifest digest
     proves ownership of each document. Recovery must preserve the reservation
-    if a present document no longer matches; a project writer may have moved an
+    if a present document does not match; a project writer may have moved an
     unrelated file into an abandoned stage before recovery runs.
 
     The marker remains until the matching index transition is durably saved.
@@ -1642,7 +1642,7 @@ def _recover_abandoned_copy(name: str, meta: dict) -> tuple[str, Path | None]:
                 pass
             finally:
                 os.close(stage_fd)
-        # The recorded transaction inode is no longer reachable at either name.
+        # The recorded transaction inode is unreachable at either name.
         # Keep the reservation hidden: clearing it would adopt the unrelated
         # target after a crash in the post-rename identity-check window.
         return _DUPLICATE_RECOVERY_RETRY, None
@@ -1898,8 +1898,8 @@ def _write_stop_sentinel(spec_dir: Path) -> bool:
 def _clear_stop_sentinel(spec_dir: Path) -> None:
     """Remove a stale STOP sentinel belonging to THIS spec.
 
-    Refuses a spec_dir that no longer resolves to itself (see
-    ``_verified_spec_dir``). Verification alone was not enough: between the check
+    Refuses a spec_dir that does not resolve to itself (see
+    ``_verified_spec_dir``). Verification alone is not enough: between the check
     and the ``unlink`` the agent this app runs can replace the verified directory
     with a symlink, and a path-based unlink then resolves through the replacement
     and deletes a STOP file outside the spec. The directory is therefore PINNED
@@ -1990,7 +1990,7 @@ def _prepare_handoff(spec_dir: Path, name: str = "", expect_slot_key: str = "") 
     With *name* and *expect_slot_key*, the identity is re-checked under the index
     lock and the sentinel is armed WITHIN THE SAME critical section, and a
     mismatch refuses. Arming is destructive -- it removes the STOP that a Pause
-    wrote -- so it must not happen for a spec this request no longer refers to: a
+    wrote -- so it must not happen for a spec this request does not refer to: a
     stale same-name, same-path execute would otherwise clear a REPLACEMENT's stop
     and let the persisted loop resume after a restart. Gating the act itself is
     what covers a request carrying no client claim, which no claim comparison can
@@ -2046,7 +2046,7 @@ def _read_spec_files(spec_dir: Path) -> tuple[dict, dict, list[dict]]:
     """Read the documents once, returning ``(files, docs, tasks)``.
 
     ``files`` is what the browser renders: the text with credentials REDACTED.
-    ``docs`` carries the ON-DISK hash used to bind approvals to the version that
+    ``docs`` carries the ON-DISK hash that binds approvals to the version that
     was reviewed. ``tasks`` carries redacted labels but raw-text identity hashes.
     Documents remain read-only here because the agent and IDE write the same files
     without participating in a dashboard lock; no portable compare-and-swap can
@@ -2087,7 +2087,7 @@ def _prepare_git_spawn(argv: list[str]) -> tuple[list[str], Any, str | None]:
     BLOCKING -- call via ``asyncio.to_thread``. Returns
     ``(argv, env, cleanup_path)``. Still its own thread hop because
     ``sandboxed_spawn_argv`` probes the sandbox host and writes the scrubbed-env
-    temp file; the resource limits are no longer built here, because
+    temp file; the resource limits are not built here, because
     ``create_subprocess_limited`` applies them after exec.
     """
     sandbox_argv, env, cleanup = sandboxed_spawn_argv(argv)
@@ -2245,7 +2245,7 @@ async def _rollback_worktree_if_ours(
     discard the REPLACEMENT spec's uncommitted work and hard-delete its branch.
 
     ``was_ours`` is the identity-pinned index pop's own answer. A False pop means
-    the name no longer refers to our create, and the worktree path is derived
+    the name does not refer to our create, and the worktree path is derived
     from the name (``<repo>-wt-<name>``), so it is not ours to remove either.
     Leaving it is the safe failure: an orphaned worktree is recoverable by hand,
     deleted work is not.

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/runtime.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/runtime.py
@@ -73,7 +73,7 @@ except Exception:  # pragma: no cover - autonudge always present in prod
 
 logger = logging.getLogger("kirocrew.app.spec-builder")
 # The autonomous nudge loop is capped rather than infinite. There is no trust
-# TTL any more because this app no longer grants trust — see the create handler.
+# TTL because this app does not grant trust — see the create handler.
 _EXEC_MAX_CYCLES = 60
 
 # Bound recovery on a fire callback whose history storage or provider ignores
@@ -500,7 +500,7 @@ async def _restore_worker_transcript(state: Any, name: str, *, adopt_closed: boo
     belongs to the spec, and idle-slot cleanup marks it closed on idleness alone.
     For a spec being CREATED it must be False -- a delete leaves the archived
     transcript on disk under a key derived from the name, so creating a new spec
-    with a previously used name would hand the fresh agent the deleted spec's
+    with an already-used name would hand the fresh agent the deleted spec's
     conversation.
 
     Best-effort by design. A missing, malformed or foreign transcript must leave
@@ -520,7 +520,7 @@ async def _restore_worker_transcript(state: Any, name: str, *, adopt_closed: boo
 
 
 def _slot_identity_moved(name: str, slot_key: str) -> bool:
-    """True when ``name`` no longer resolves to the key this request captured.
+    """True when ``name`` does not resolve to the key this request captured.
 
     ``_slot_key`` reads the module-global ``_SLOT_KEYS``, which a delete +
     same-name recreate rewrites to a fresh per-creation key. Any resolution taken
@@ -615,8 +615,8 @@ async def _ensure_worker_slot(
     # index entry would become the worker's cwd on the next message, and relative
     # reads from a credential directory would sidestep every per-path check this
     # app makes. Re-validate through the same chokepoint every caller-supplied
-    # directory passes, off the event loop, and REFUSE the slot if it no longer
-    # holds: a spec whose working dir is unusable must not run at all.
+    # directory passes, off the event loop, and REFUSE the slot if it does not
+    # hold: a spec whose working dir is unusable must not run at all.
     #
     # ABSENT counts as unusable, which is why this is not gated on `wd` being
     # truthy. `create` rejects an empty or relative working_dir with a 400 and
@@ -1116,7 +1116,7 @@ def _alias_slots_locked(
 
     ``None`` is an alias whose persisted slot identity is not ownership-valid.
     Such an alias is occupied: its worker may still be running under the
-    per-creation key that the agent-writable index no longer reveals.
+    per-creation key that the agent-writable index does not reveal.
 
     BLOCKING -- call via ``asyncio.to_thread`` (``_alias_slots`` is the only caller). It
     reads the index and resolves each entry's directory, both filesystem work, which is
@@ -1452,7 +1452,7 @@ async def _halt_execution(
 ) -> None:
     """Stop an autonomous run: sentinel the loop, then remove it.
 
-    Deliberately does NOT touch ``slot._trust``. This app no longer grants
+    Deliberately does NOT touch ``slot._trust``. This app does not grant
     trust, so there is nothing of ours to revoke — and if the USER trusted the
     session from the approval card, Stop must not silently undo their decision.
     """

--- a/src/kiro_crew/apps/builtins/spec_builder/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/tests/conftest.py
@@ -63,13 +63,10 @@ _POSIX_PATH_SHAPE = {
     "test_safe_dir_still_accepts_absolute_and_tilde",
 }
 
-#: Process-control timing previously listed ``test_cancelled_git_is_killed_...``
-#: here. Its root cause was not Windows at all: the sandbox-preparation thread
-#: hop sat inside the window its wait bounds, so it timed out on any heavily
-#: parallel shard (it went red on Linux 3.10 too). The hop is stubbed in the test
-#: now, so the entry is gone rather than carried as a reason that no longer
-#: applies. If Windows reds on it again it is a genuinely different failure and
-#: belongs back here with that reason stated.
+#: An entry belongs here only when Windows itself is the cause. A process-control
+#: timeout whose sandbox-preparation thread hop sits inside the window its wait
+#: bounds goes red on any heavily parallel shard, Linux included, and the fix is
+#: stubbing that hop in the test rather than listing the test here.
 
 _WINDOWS_GAPS = _POSIX_SENTINEL_PINNING | _POSIX_PATH_SHAPE
 

--- a/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
@@ -130,7 +130,7 @@ def _live_state_snapshot() -> dict[str, int]:
     is always un-redirected), but it must NOT happen at import time -- a
     module-level ``routes._state_dir()`` freezes whichever ``KIROCREW_HOME``
     is active at collection, defeating pod isolation and the per-test home
-    isolation (the issue #874 class the lazy-paths ratchet enforces).
+    isolation (the class of leak the lazy-paths ratchet enforces against).
     """
     global _REAL_STATE_DIR
     if _REAL_STATE_DIR is None:
@@ -566,7 +566,7 @@ async def test_settings_rejects_sensitive_base_path(tmp_path, monkeypatch):
         assert resp.status == 400
 
 
-# ── GPT round-1 HIGHs (#518) ─────────────────────────────────────────────────
+# ── symlink containment, state normalization, create pre-checks ──────────────
 #
 # One test group per finding, so a regression names the finding it re-opens.
 
@@ -698,7 +698,7 @@ def test_contained_accepts_the_worktree_itself(tmp_path):
     assert routes._contained(spec_dir, worktree) is True
 
 
-# ── GPT round-3 findings (#518) ───────────────────────────────────────────────
+# ── browse scan offloading and symlink skipping ──────────────────────────────
 
 
 # (1) planning-phase auto-approval never expired
@@ -752,7 +752,7 @@ def test_security_helper_is_imported_at_module_scope():
     assert callable(routes.is_sensitive_path)
 
 
-# ── GPT round-4 findings (#518) ───────────────────────────────────────────────
+# ── descriptor-pinned spec reads; this app grants no worker trust ────────────
 
 
 # (1) spec reads must be descriptor-pinned, not check-then-read
@@ -803,15 +803,13 @@ def test_spec_read_is_size_capped():
 
 
 def test_app_never_grants_worker_trust():
-    """The load-bearing invariant of round 4.
+    """The load-bearing invariant: this app never stamps worker trust.
 
-    This app used to stamp ``slot._trust = True`` on create/message/execute
-    because a permission prompt was invisible in the embedded chat. That premise
-    is gone — the embed now renders working Approve/Trust/Reject controls — and a
-    backend grant could not be bounded honestly: the wall-clock TTL was enforced
-    on the UI's status poll, so closing the page stopped all enforcement while
-    the grant survived. The decision belongs to the user, via core's own trust
-    mechanism, where it is auditable as their choice.
+    The embed renders working Approve/Trust/Reject controls, so the permission
+    prompt is visible where the user is, and a backend grant cannot be bounded
+    honestly: a wall-clock TTL enforced on the UI's status poll stops enforcing the
+    moment the page closes, while the grant survives. The decision belongs to the
+    user, via core's own trust mechanism, where it is auditable as their choice.
     """
 
     src = routes_source()
@@ -851,7 +849,7 @@ async def test_halt_execution_leaves_user_trust_alone(tmp_path):
     assert slot._trust is True  # user's choice preserved
 
 
-# ── GPT round-5 findings (#518) ───────────────────────────────────────────────
+# ── handlers offload filesystem work; delete tears down the slot ─────────────
 
 
 # (1) polled handlers must not do filesystem work on the event loop
@@ -2132,7 +2130,7 @@ def test_prepare_handoff_refuses_a_tasks_file_with_no_open_task(tmp_path):
     assert routes._prepare_handoff(spec_dir)[0] is True
 
 
-# ── GPT round-7 findings (#518) ──────────────────────────────────────────────
+# ── index transactions serialize; phases derive off the loop ─────────────────
 
 
 @pytest.mark.asyncio
@@ -2229,7 +2227,7 @@ def test_gateway_helpers_are_imported_at_module_scope():
         assert hasattr(routes, name), f"{name} is not bound at module scope"
 
 
-# ── GPT round-8 findings (#518) ──────────────────────────────────────────────
+# ── atomic state writes and git auditing ─────────────────────────────────────
 
 
 def test_state_files_are_written_atomically(tmp_path, monkeypatch):
@@ -2366,7 +2364,7 @@ async def test_detail_payload_reports_live_running_state(tmp_path, monkeypatch):
     assert body["duplicate_supported"] is False
 
 
-# ── GPT round-9 findings (#518) ──────────────────────────────────────────────
+# ── sentinel isolation; the index is arbitrated before the slot ──────────────
 
 
 def test_symlinked_spec_dir_cannot_touch_another_specs_sentinel(tmp_path):
@@ -2426,7 +2424,7 @@ def test_create_arbitrates_the_index_before_touching_the_shared_slot():
     assert "_ensure_worker_slot(" in src[arbitration:]
 
 
-# ── GPT round-10 findings (#518) ─────────────────────────────────────────────
+# ── handoff authorization, pause, and stop ───────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -2591,7 +2589,7 @@ def test_stop_handler_halts_the_running_turn():
     assert "_halt_active_turn(" in inspect.getsource(routes._halt_execution)
 
 
-# ── GPT round-11 findings (#518) ─────────────────────────────────────────────
+# ── path validation off the loop; the slot-scoping chokepoint ────────────────
 
 
 def test_no_handler_validates_paths_on_the_event_loop():
@@ -2708,7 +2706,7 @@ def test_every_slot_acquisition_goes_through_the_scoping_chokepoint():
         ), f"{handler.__name__} does not scope the slot it uses"
 
 
-# ── GPT round-12 findings (#518) ─────────────────────────────────────────────
+# ── index reads stay off the event loop ──────────────────────────────────────
 
 
 def test_no_handler_reads_the_index_on_the_event_loop():
@@ -2799,7 +2797,7 @@ async def test_aload_index_returns_the_persisted_index(tmp_path, monkeypatch):
     assert await routes._aload_index() == routes._load_index()
 
 
-# ── GPT round-13 findings (#518) ─────────────────────────────────────────────
+# ── recents and settings IO off the loop; missing git degrades ───────────────
 
 
 def test_recents_and_settings_io_stay_off_the_event_loop():
@@ -2867,7 +2865,7 @@ async def test_git_reports_unavailable_when_the_sandbox_refuses(tmp_path, monkey
     assert "unavailable" in err
 
 
-# ── GPT round-14 findings (#518) ─────────────────────────────────────────────
+# ── repo info and handoff validate through the chokepoint ────────────────────
 
 
 def test_repo_info_validates_through_the_chokepoint_off_loop():
@@ -2932,7 +2930,7 @@ def test_handoff_refuses_a_symlinked_tasks_file(tmp_path):
     assert routes._prepare_handoff(spec_dir)[0] is True
 
 
-# ── GPT round-15 findings (#518) ─────────────────────────────────────────────
+# ── persisted transcripts are read off the loop and redacted ─────────────────
 
 
 @pytest.mark.asyncio
@@ -2986,7 +2984,7 @@ async def test_persisted_transcript_is_served_and_redacted():
     assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(out), "credential not redacted"
 
 
-# ── GPT round-16 findings (#518) ─────────────────────────────────────────────
+# ── redaction fails closed ───────────────────────────────────────────────────
 
 
 def test_redaction_fails_closed_without_the_security_module(monkeypatch):
@@ -3010,7 +3008,7 @@ def test_redaction_fails_closed_without_the_security_module(monkeypatch):
     assert routes._redact("") == ""
 
 
-# ── GPT round-17 findings (#518) ─────────────────────────────────────────────
+# ── slot ownership and default-model stamping ────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -3047,12 +3045,11 @@ async def test_foreign_slot_is_not_silently_re_owned(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_only_our_own_slot_is_adopted_and_a_missing_one_is_created(monkeypatch):
-    """Round 22 tightened this: an UNSCOPED slot under our key is somebody else's
-    conversation (a main-chat session that happens to be named
-    `spec-builder-<x>`), and adopting it rewrote its ownership, repointed its
-    project and pulled its transcript into this app. Only a slot already owned by
-    this app is adopted; a MISSING slot is still created and scoped, which is what
-    keeps the discovered-spec fix working."""
+    """An UNSCOPED slot under our key is somebody else's conversation (a main-chat
+    session that happens to be named `spec-builder-<x>`), and adopting it would
+    rewrite its ownership, repoint its project and pull its transcript into this
+    app. Only a slot already owned by this app is adopted; a MISSING slot is still
+    created and scoped, which is what keeps a discovered spec usable."""
     # The indexed working_dir now goes through _safe_dir; these fixtures use
     # synthetic paths, so accept them (the validation itself is covered
     # separately by test_indexed_working_dir_is_revalidated).
@@ -3285,7 +3282,7 @@ def test_dispatching_handlers_refuse_a_foreign_slot():
         assert "status=409" in src[claim:], f"{handler.__name__} does not report the conflict"
 
 
-# ── GPT round-18 findings (#518) ─────────────────────────────────────────────
+# ── no async function touches the filesystem inline ──────────────────────────
 
 
 def test_no_async_function_touches_the_filesystem_inline():
@@ -3350,7 +3347,7 @@ async def _async_value(v):
     return v
 
 
-# ── GPT round-19 findings (#518) ─────────────────────────────────────────────
+# ── spec_dir revalidation and identity pinning ───────────────────────────────
 
 
 def test_resolved_spec_dir_is_revalidated_for_sensitivity(tmp_path, monkeypatch):
@@ -3386,9 +3383,9 @@ def test_ordinary_destination_is_still_created(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_detail_refuses_when_the_spec_is_recreated_mid_request(tmp_path, monkeypatch):
-    """The reported race, refined by round 20: the detail handler read the index,
-    awaited the document collection, then used that PRE-AWAIT snapshot. A spec
-    deleted and recreated elsewhere under the SAME NAME is a different spec, so
+    """The detail handler reads the index, awaits the document collection, and must
+    not then trust that PRE-AWAIT snapshot. A spec deleted and recreated elsewhere
+    under the SAME NAME is a different spec, so
     continuing would pair documents read from the old directory with the new
     metadata and point the new worker at the old project. The request must refuse
     and let the client retry."""
@@ -3509,14 +3506,13 @@ def test_identity_pinned_sites_pass_expect_spec_dir():
     assert 'spec_dir", "")) != str(spec_dir)' in detail_src
 
 
-# ── GPT round-21 findings (#518) ─────────────────────────────────────────────
+# ── abort cleanup spares replacements; status is served reconciled ───────────
 
 
 @pytest.mark.asyncio
 async def test_abort_cleanup_spares_a_replacement_slot():
-    """The reported defect, introduced by round 20's abort path: both cleanups look
-    the slot up BY NAME, so unwinding a refused handoff destroyed the slot of the
-    same-name spec that had replaced ours."""
+    """Both cleanups look the slot up BY NAME, so unwinding a refused handoff must
+    not destroy the slot of a same-name spec that has replaced ours."""
 
     class _Slot:
         def __init__(self, tag):
@@ -3660,7 +3656,7 @@ def test_status_is_served_reconciled_not_raw():
         assert 'meta.get("status", "planning")' not in src
 
 
-# ── GPT round-22 findings (#518) ─────────────────────────────────────────────
+# ── handoff confirms identity before acquiring the slot ──────────────────────
 
 
 @pytest.mark.asyncio
@@ -3725,7 +3721,7 @@ def test_handoff_checks_identity_before_slot_acquisition():
     assert check < acquire, "handoff acquires the slot before confirming identity"
 
 
-# ── GPT round-23 findings (#518) ─────────────────────────────────────────────
+# ── name-only operations are identity-pinned ─────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -3850,7 +3846,7 @@ def test_name_only_operations_are_identity_pinned():
         assert src.index(cap) < src.index(acts_on), f"{handler.__name__} captures too late"
 
 
-# ── GPT round-24 findings (#518) ─────────────────────────────────────────────
+# ── sandbox setup and loop removal stay off the event loop ───────────────────
 
 
 def test_sandbox_setup_is_offloaded():
@@ -3921,7 +3917,7 @@ async def test_nudge_loop_removal_keeps_the_fsync_off_the_loop(tmp_path, monkeyp
     assert writes == []
 
 
-# ── GPT round-25 findings (#518) ─────────────────────────────────────────────
+# ── foreign-slot refusal; the seed prompt is self-contained ──────────────────
 
 
 @pytest.mark.asyncio
@@ -3987,8 +3983,8 @@ def test_seed_prompt_is_self_contained_and_type_aware():
     bug = routes._seed_prompt("bug", "thing", spec_dir, "/w", "")
     assert "root cause" in bug.lower()
 
-    # The state-file contract must be stated inline (it used to be "as the
-    # skill's 'Structured state' section specifies").
+    # The state-file contract must be stated inline, not deferred to the skill's
+    # 'Structured state' section.
     for token in ('"decisions"', '"blocking"', '"context"', ".spec-state.json"):
         assert token in quick, f"seed no longer states {token}"
     # ...and stay plumbing, never a chat topic or a deliverable.
@@ -4000,7 +3996,7 @@ def test_seed_prompt_is_self_contained_and_type_aware():
     )
 
 
-# ── GPT round-26 findings (#518) ─────────────────────────────────────────────
+# ── cancelled persistence cannot be overtaken ────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -4045,7 +4041,7 @@ async def test_cancelled_persistence_cannot_be_overtaken(tmp_path):
     assert remover.cancelled() or remover.done()
 
 
-# ── GPT round-27 findings (#518) ─────────────────────────────────────────────
+# ── handoff unwinds when the index commit raises ─────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -4140,7 +4136,7 @@ async def test_handoff_unwinds_when_the_index_commit_raises(tmp_path, monkeypatc
     assert routes._load_index()["boom"].get("status") != "executing"
 
 
-# ── GPT round-28 findings (#518) ─────────────────────────────────────────────
+# ── every ownership check is exact ───────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -4206,7 +4202,7 @@ def test_every_ownership_check_is_exact():
         assert "not in (None" not in stripped, f"lax ownership check: {stripped}"
 
 
-# ── GPT round-30 findings (#518) ─────────────────────────────────────────────
+# ── delete ordering and handoff-unwind gating ────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -4368,7 +4364,7 @@ def test_handoff_unwind_is_gated_on_having_created_the_slot():
     ), "unwind tears down a slot it may not have created"
 
 
-# ── GPT round-31 findings (#518) ─────────────────────────────────────────────
+# ── transcript ownership; registration touches no filesystem ─────────────────
 
 
 @pytest.mark.asyncio
@@ -4420,7 +4416,7 @@ def test_route_registration_touches_no_filesystem():
 
 def test_registration_works_with_an_uncreatable_state_dir(tmp_path, monkeypatch):
     """Non-vacuous: registration must succeed even when STATE_DIR cannot be made,
-    which is what proves it no longer touches it."""
+    which is what proves it does not touch it."""
     monkeypatch.setattr(routes, "_STATE_DIR", tmp_path / "nope" / "deeper")
 
     def _explode(*_a, **_k):
@@ -4432,7 +4428,7 @@ def test_registration_works_with_an_uncreatable_state_dir(tmp_path, monkeypatch)
     assert any("/api/apps/spec-builder" in str(r.resource) for r in app.router.routes())
 
 
-# ── GPT round-32 findings (#518) ─────────────────────────────────────────────
+# ── the indexed working dir is revalidated, off the loop ─────────────────────
 
 
 @pytest.mark.asyncio
@@ -4491,15 +4487,14 @@ def test_working_dir_validation_is_offloaded():
     assert "slot.project = wd" not in src, "the raw indexed value is still assigned"
 
 
-# ── GPT round-33 findings (#518) ─────────────────────────────────────────────
+# ── create refuses, and unwinds, when the spec is replaced ───────────────────
 
 
 @pytest.mark.asyncio
 async def test_create_refuses_when_the_spec_is_replaced_during_slot_setup(tmp_path, monkeypatch):
-    """The window round 32 opened: making the working-dir chokepoint async means slot
-    setup now AWAITS, so a delete-and-recreate can land between the index insert and
-    the dispatch. The seed prompt names OUR spec_dir, so dispatching would drive the
-    replacement spec's agent with our plan."""
+    """The working-dir chokepoint is async, so slot setup AWAITS and a delete-and-recreate
+    can land between the index insert and the dispatch. The seed prompt names OUR
+    spec_dir, so dispatching would drive the replacement spec's agent with our plan."""
     client = _make_client(monkeypatch, tmp_path)
     wd = Path(os.path.realpath(tmp_path)) / "wd"
     wd.mkdir()
@@ -4562,7 +4557,7 @@ def test_create_unwind_is_identity_pinned():
     assert recheck < src.index("_dispatch_turn("), "create dispatches before rechecking identity"
 
 
-# ── GPT round-34 findings (#518) ─────────────────────────────────────────────
+# ── persisted shapes are validated; identity comes from the client ───────────
 
 
 def test_persisted_shapes_are_validated(tmp_path, monkeypatch):
@@ -4655,7 +4650,7 @@ async def test_message_identity_comes_from_the_client(tmp_path, monkeypatch):
     assert dispatched == []
 
 
-# ── GPT round-35 findings (#518) ─────────────────────────────────────────────
+# ── discovery validates each root; controls reject a stale identity ──────────
 
 
 def test_discovery_validates_each_indexed_root(tmp_path, monkeypatch):
@@ -4858,7 +4853,7 @@ def test_transcript_restore_runs_before_slot_creation():
     ), "the empty slot is created before the transcript is restored"
 
 
-# ── GPT round-37 findings + scrub/CodeQL fallout (#518) ──────────────────────
+# ── settings shapes, slot-name grammar, and the browse skip list ─────────────
 
 
 def test_settings_reader_normalizes_a_non_string_base_path(tmp_path, monkeypatch):
@@ -4941,7 +4936,7 @@ def test_browse_skip_list_carries_no_hidden_paths():
     ), "the hidden-entry skip that makes the dotted names redundant is gone"
 
 
-# ── GPT round-38 findings (#518) ──────────────────────────────────────────────
+# ── the body is parsed first; sentinel clear is directory-pinned ─────────────
 
 
 @pytest.mark.asyncio
@@ -5037,7 +5032,7 @@ def test_slack_ts_regex_is_bounded():
     assert not link_mod.is_legacy_slack_key("dashboard:spec-builder-x")
 
 
-# ── GPT round-39 findings (#518) ───────────────────────────────────────────────
+# ── failures are reported, never swallowed ───────────────────────────────────
 
 
 def test_index_entries_missing_identity_fields_are_dropped(tmp_path, monkeypatch):
@@ -5144,15 +5139,15 @@ def test_loop_removal_does_not_swallow_failures():
     assert "status=503" in delete_src and "_remove_nudge_loop" in delete_src
 
 
-# ── GPT round-40 findings (#518) ───────────────────────────────────────────────
+# ── create never inherits a deleted spec's conversation ──────────────────────
 
 
 @pytest.mark.asyncio
 async def test_create_does_not_inherit_a_deleted_specs_conversation(tmp_path, monkeypatch):
-    """The reported leak: round 36 restored transcripts with adopt_closed=True at
-    the chokepoint, and a delete leaves the archived conversation on disk under a
-    key derived from the NAME -- so creating a new spec with a previously used
-    name handed the fresh agent the deleted spec's chat."""
+    """Transcript restore at the chokepoint passes adopt_closed=True, and a delete
+    leaves the archived conversation on disk under a key derived from the NAME -- so
+    creating a new spec with an already-used name would hand the fresh agent the
+    deleted spec's chat."""
     _redirect_state(monkeypatch, tmp_path)
     seen: list[bool] = []
 
@@ -5242,7 +5237,7 @@ async def test_delete_restores_the_spec_when_archiving_fails(tmp_path, monkeypat
     assert state.get_slot(routes._slot_key("keepme")) is slot
 
 
-# ── GPT round-41 findings (#518) ───────────────────────────────────────────────
+# ── tombstones, and slot keys that are per-creation ──────────────────────────
 
 
 def test_deleted_specs_are_not_rediscovered(tmp_path, monkeypatch):
@@ -5338,15 +5333,15 @@ def test_slot_key_resolution_has_a_single_source():
     assert "_SLOT_KEYS = {" in src
 
 
-# ── GPT round-42 findings (#518) ───────────────────────────────────────────────
+# ── a minted slot key survives the commit; git needs its audit ───────────────
 
 
 def test_a_freshly_minted_slot_key_survives_the_commit(tmp_path, monkeypatch):
-    """The reported break in round 41's own fix: create minted a unique key, then
-    committed through _mutate_index -- whose internal RE-READ rebuilt the resolver
-    map from the pre-insert snapshot and discarded it. Everything afterwards (seed
-    turn, embedded chat, teardown) fell back to the legacy name-derived key while
-    the index held the unique one, splitting one spec across two slots."""
+    """Create mints a unique key, then commits through _mutate_index -- whose internal
+    RE-READ rebuilds the resolver map, and that rebuild must follow the WRITE. Rebuilt
+    from the pre-insert snapshot it discards the minted key, and everything afterwards
+    (seed turn, embedded chat, teardown) falls back to the legacy name-derived key
+    while the index holds the unique one, splitting one spec across two slots."""
     _redirect_state(monkeypatch, tmp_path)
     minted = routes._new_slot_key("fresh")
 
@@ -5440,18 +5435,15 @@ async def test_git_refuses_to_run_when_the_invocation_cannot_be_audited(tmp_path
     assert src.count('_audit_tool("error"') >= 1
 
 
-# ── GPT round-43 findings (#518) ───────────────────────────────────────────────
-
-
-# ── GPT round-44 finding (#518) ────────────────────────────────────────────────
+# ── sentinel writes are pinned to the verified directory ─────────────────────
 
 
 def test_sentinel_write_is_pinned_to_the_verified_directory(tmp_path, monkeypatch):
-    """The reported traversal, and the half of round 38 I left open: the sentinel
-    CLEAR was pinned to a directory descriptor but the WRITE still worked through
-    paths. An agent that swaps its verified directory for a symlink between the
-    check and the open redirects both the temp create and the rename, so ANOTHER
-    active spec receives the STOP file and halts."""
+    """Pinning the sentinel CLEAR to a directory descriptor is only half the fence: a
+    WRITE that works through paths keeps the traversal open. An agent that swaps its
+    verified directory for a symlink between the check and the open redirects both the
+    temp create and the rename, so ANOTHER active spec receives the STOP file and
+    halts."""
     real = Path(os.path.realpath(tmp_path))
     mine = real / "wd" / ".kiro" / "specs" / "mine"
     mine.mkdir(parents=True)
@@ -5507,7 +5499,7 @@ def test_both_sentinel_helpers_pin_the_directory():
         assert op in probe, f"{op} is not covered by the pin capability probe"
 
 
-# ── GPT round-45 findings (#518) ───────────────────────────────────────────────
+# ── the state guard covers every path the app writes ─────────────────────────
 
 
 def test_redirect_state_covers_every_path_the_app_writes():
@@ -5530,8 +5522,8 @@ def test_redirect_state_covers_every_path_the_app_writes():
 
 
 def test_state_guard_watches_the_whole_directory():
-    """The guard used to assert one known filename, which is why the second leak
-    got through. It now compares the directory listing."""
+    """The guard compares the whole directory listing: asserting one known filename
+    lets a write to any other file through."""
     src = inspect.getsource(_never_touch_the_real_state)
     assert "_live_state_snapshot()" in src
     assert "_REAL_STATE_DIR" in inspect.getsource(_live_state_snapshot)
@@ -5540,8 +5532,8 @@ def test_state_guard_watches_the_whole_directory():
 def test_state_guard_compares_the_real_dir_not_the_redirect():
     """The captured dir must survive the autouse redirect active right now.
 
-    _REAL_STATE_DIR is captured on first use rather than at import (banned by
-    issue #874). The property that makes the guard work is that it holds the
+    _REAL_STATE_DIR is captured on first use rather than at import (which the
+    lazy-paths ratchet bans). The property that makes the guard work is that it holds the
     un-redirected dir even while routes._STATE_DIR points at a tmp dir -- the
     guard re-reads it AFTER its yield, with the redirect still applied. If the
     memoization were ever dropped so it re-resolved live, before == after would
@@ -5555,7 +5547,7 @@ def test_state_guard_compares_the_real_dir_not_the_redirect():
     )
 
 
-# ── GPT round-46 findings (#518) ───────────────────────────────────────────────
+# ── slot_key is the deciding identity; handoff refuses early ─────────────────
 
 
 def test_slot_key_is_the_deciding_identity(tmp_path, monkeypatch):
@@ -5709,7 +5701,7 @@ def test_handoff_refuses_before_any_side_effect():
     assert guard < src.index("_dispatch_turn("), "the turn is dispatched before the refusal"
 
 
-# ── GPT round-47 findings (#518) ───────────────────────────────────────────────
+# ── mutations pin the creation; failures revert armed state ──────────────────
 
 
 @pytest.mark.asyncio
@@ -5924,7 +5916,7 @@ async def test_deletion_during_authorization_removes_the_armed_loop(tmp_path, mo
     assert slot.key not in slots, "the worker slot was left behind"
 
 
-# ── GPT round-48 findings (#518) ───────────────────────────────────────────────
+# ── the arming window survives polling ───────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -5966,7 +5958,7 @@ async def test_polling_does_not_reconcile_away_the_arming_window(tmp_path, monke
 
 def test_handoff_stamps_and_clears_the_arming_marker():
     """Source guard: the marker is set by the pre-arm commit and cleared once the
-    loop exists, so the exemption lasts for the arming window and no longer."""
+    loop exists, so the exemption lasts for the arming window and not past it."""
     # The stamp is part of the atomic claim; the clear is in the handler, after the
     # loop exists.
     assert 'meta["exec_arming_at"] = now' in inspect.getsource(
@@ -5979,7 +5971,7 @@ def test_handoff_stamps_and_clears_the_arming_marker():
     assert claim < arm < clear, "the marker does not bracket the arm"
 
 
-# ── GPT round-49 findings (#518) ───────────────────────────────────────────────
+# ── claims serialize; delete tombstones before it drops the entry ────────────
 
 
 @pytest.mark.asyncio
@@ -6127,7 +6119,7 @@ def test_delete_orders_the_tombstone_before_the_pop():
     assert src.count("_forget_deleted") >= 2, "a non-deleting arm leaves the tombstone behind"
 
 
-# ── GPT round-50 findings (#518) ───────────────────────────────────────────────
+# ── tombstone writes hold the lock; errors carry a code ──────────────────────
 
 
 def test_concurrent_tombstone_writes_do_not_lose_deletions(tmp_path, monkeypatch):
@@ -6217,7 +6209,7 @@ def test_every_error_response_carries_a_machine_readable_code():
     assert not bad, f"codes must be lower_snake identifiers: {bad}"
 
 
-# ── GPT round-51 findings (#518) ───────────────────────────────────────────────
+# ── a create abort spares a replacement spec ─────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -6310,7 +6302,7 @@ def test_create_identity_checks_pin_the_creation():
     ), "the post-slot-setup check compares the directory alone"
 
 
-# ── GPT round-52 findings (#518) ───────────────────────────────────────────────
+# ── index-derived strings are redacted on egress ─────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -6324,7 +6316,7 @@ async def test_index_derived_strings_are_redacted_on_egress(tmp_path, monkeypatc
     spec_dir = tmp_path / "wd" / ".kiro" / "specs" / "leaky"
     spec_dir.mkdir(parents=True)
     # Scrub only path-shaped values: a stub that also rewrote the NAME would make
-    # _usable_name drop the entry at load (round 57), testing nothing about egress.
+    # _usable_name drop the entry at load, testing nothing about egress.
     monkeypatch.setattr(
         routes, "_redact", lambda text: "[SCRUBBED]" if text and "/" in str(text) else text
     )
@@ -6391,7 +6383,7 @@ async def test_malformed_timestamps_do_not_break_the_listing(tmp_path, monkeypat
     assert names[0] == "missing" and names[1] == "numeric", names
 
 
-# ── GPT round-53 findings (#518) ───────────────────────────────────────────────
+# ── sentinel helpers fail closed without directory pinning ───────────────────
 
 
 def test_sentinel_helpers_fail_closed_without_directory_pinning(tmp_path, monkeypatch):
@@ -6468,16 +6460,16 @@ async def test_halt_still_stops_the_run_without_a_sentinel(tmp_path, monkeypatch
     assert halted == ["quiet"], "the in-flight turn was not cancelled"
 
 
-# ── GPT round-54 findings (#518) ───────────────────────────────────────────────
+# ── git refuses when its invocation cannot be audited ────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_git_refuses_when_only_the_durable_audit_write_fails(tmp_path, monkeypatch):
-    """The reported gap in round 42's gate: the default log path ENQUEUES the event
-    and a background writer flushes it, so `_audit_tool` returning True proved only
-    that the enqueue did not raise -- the record could still be dropped when the log
-    was unwritable, and git ran unaudited. The invocation event is now written with
-    `critical=True`, which raises on a filesystem failure.
+    """The default log path ENQUEUES the event and a background writer flushes it, so
+    `_audit_tool` returning True proves only that the enqueue did not raise -- the
+    record can still be dropped when the log is unwritable, leaving git unaudited. The
+    invocation event is written with `critical=True`, which raises on a filesystem
+    failure.
 
     The stub models exactly that asymmetry: a queued (non-critical) call succeeds, a
     critical one raises. A gate that never asked for durability would pass."""
@@ -6526,7 +6518,7 @@ def test_audit_helper_defaults_to_queued():
     assert sig.parameters["critical"].default is False
 
 
-# ── GPT round-55 findings (#518) ───────────────────────────────────────────────
+# ── slot-key ownership, and timestamps validated on egress ───────────────────
 
 
 def test_a_spec_cannot_claim_another_specs_slot_key(tmp_path, monkeypatch):
@@ -6572,9 +6564,9 @@ def test_slot_key_ownership_rules():
 
 @pytest.mark.asyncio
 async def test_timestamps_are_validated_on_egress(tmp_path, monkeypatch):
-    """The reported leak: round 52 redacted the index's STRING fields but left
-    created_at/updated_at as whatever the agent-writable index held, so a credential
-    parked in a timestamp reached the dashboard verbatim."""
+    """Redacting the index's STRING fields is not enough on its own:
+    created_at/updated_at are whatever the agent-writable index holds, so a credential
+    parked in a timestamp would reach the dashboard verbatim."""
     client = _make_client(monkeypatch, tmp_path)
     base = tmp_path / "wd" / ".kiro" / "specs"
     (base / "stamped").mkdir(parents=True)
@@ -6605,17 +6597,17 @@ async def test_timestamps_are_validated_on_egress(tmp_path, monkeypatch):
     assert routes._numeric("1700000000") == 1700000000.0
 
 
-# ── GPT round-56 findings (#518) ───────────────────────────────────────────────
+# ── a failed archive restores the name; a reserved name holds ────────────────
 
 
 @pytest.mark.asyncio
 async def test_failed_archive_restores_the_original_name_and_key(tmp_path, monkeypatch):
-    """The reported severance: round 43 popped the entry and, if the name had been
-    taken while archival ran, restored it as `<name>-2`. Round 55 then bound slot keys
-    to their entry's own name, so the renamed entry could no longer own its
-    per-creation key -- `_slot_key` fell back to the name-derived form and the original
-    conversation became unreachable. The name is now RESERVED for the whole teardown,
-    so a failure puts the spec back exactly as it was."""
+    """A teardown that pops the entry and restores it as `<name>-2` when the name was
+    taken mid-archival severs the conversation: slot keys are bound to their entry's own
+    name, so a renamed entry cannot own its per-creation key -- `_slot_key` falls back
+    to the name-derived form and the original conversation is unreachable. The name is
+    RESERVED for the whole teardown, so a failure puts the spec back exactly as it
+    was."""
     client = _make_client(monkeypatch, tmp_path)
     spec_dir = tmp_path / "wd" / ".kiro" / "specs" / "keeper"
     spec_dir.mkdir(parents=True)
@@ -6740,14 +6732,14 @@ async def test_removal_failure_keeps_the_spec_hidden_for_a_retry(tmp_path, monke
     assert restarted.get(routes._DELETING), "restart exposed the torn-down spec"
 
 
-# ── GPT round-57 findings (#518) ───────────────────────────────────────────────
+# ── unusable index keys are dropped; status is allowlisted ───────────────────
 
 
 def test_index_keys_that_cannot_be_served_are_dropped_at_load(tmp_path, monkeypatch):
     """The reported egress path: a spec NAME is an index key, index.json is
     agent-writable, and `GET /specs` returns the key as `"name"` -- so a credential
     parked in the key reached the dashboard verbatim. Such an entry is dropped at load
-    rather than scrubbed: a scrubbed name would no longer match the directory the
+    rather than scrubbed: a scrubbed name would not match the directory the
     entry points at."""
     _redirect_state(monkeypatch, tmp_path)
     # A real AWS-key shape satisfies the name grammar, which is why the grammar alone
@@ -6829,7 +6821,7 @@ async def test_list_serves_only_allowlisted_statuses(tmp_path, monkeypatch):
     assert [s["status"] for s in body["specs"]] == ["planning"], body["specs"]
 
 
-# ── GPT round-58 findings (#518) ───────────────────────────────────────────────
+# ── non-finite timestamps; git is killed on every exceptional exit ───────────
 
 
 @pytest.mark.asyncio
@@ -7011,7 +7003,7 @@ def test_git_kills_the_process_on_every_exceptional_exit():
         )
 
 
-# ── GPT round-59 findings (#518) ───────────────────────────────────────────────
+# ── an index entry without a working dir is refused a slot ───────────────────
 
 
 def _slot_stub():
@@ -7110,7 +7102,7 @@ def test_slot_scoping_never_gates_its_working_dir_check_on_presence():
     )
 
 
-# ── GPT round-60 findings (#518) ───────────────────────────────────────────────
+# ── a delete reservation blocks dispatch ─────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -7270,15 +7262,15 @@ async def test_failed_loop_removal_releases_both_tombstone_and_reservation(tmp_p
     assert await routes._touch_spec("keeper", expect_spec_dir=sd) is not None
 
 
-# ── GPT round-62 findings (#518) ───────────────────────────────────────────────
+# ── the pre-dispatch re-pin uses the captured entry ──────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_predispatch_repin_uses_captured_key_when_client_sends_none(tmp_path, monkeypatch):
-    """The reported hole in round 60's re-pin: slot_key is OPTIONAL on the wire, so a
-    client that sends none left the pre-dispatch check with no creation pin. A delete
-    plus a same-path recreate then passed it -- spec_dir still matched -- and the
-    stale slot wrote into the REPLACEMENT's files.
+    """slot_key is OPTIONAL on the wire, so a client that sends none must not leave the
+    pre-dispatch check with no creation pin. A delete plus a same-path recreate passes a
+    spec_dir-only check -- spec_dir still matches -- and the stale slot then writes into
+    the REPLACEMENT's files.
 
     Simulates the window by swapping the index for a same-name, same-path spec with a
     NEW slot_key while _ensure_worker_slot is awaiting, then asserts the turn is
@@ -7319,7 +7311,7 @@ async def test_predispatch_repin_uses_captured_key_when_client_sends_none(tmp_pa
     await client.start_server()
     try:
         client.app["state"] = state
-        # NO slot_key in the body -- the older-client shape the pin used to trust.
+        # NO slot_key in the body -- the older-client shape the pin must not trust.
         resp = await client.post(f"{_BASE}/specs/s/message", json={"text": "edit files"})
         body = await resp.json()
     finally:
@@ -7350,7 +7342,7 @@ def test_predispatch_repin_pins_both_halves_from_the_captured_entry():
     )
 
 
-# ── Pause / Delete must not relaunch queued work (round 66) ──────────────────
+# ── Pause / Delete must not relaunch queued work ─────────────────────────────
 
 
 # The spec name these two use. Deliberately not a name any other test creates:
@@ -7509,7 +7501,7 @@ def test_run_chat_still_relaunches_from_these_three_fields():
     assert re.search(r"except asyncio\.CancelledError:", src)
 
 
-# ── A stale create-unwind must not delete a replacement's worktree (round 67) ─
+# ── A stale create-unwind must not delete a replacement's worktree ───────────
 
 
 def _removal_probe(monkeypatch):
@@ -7617,7 +7609,7 @@ def test_only_the_post_insert_unwind_needs_the_gate():
     assert "was_ours" not in early, "an early rollback should not need the gate"
 
 
-# ── Slot identity must survive both awaits in _ensure_worker_slot (round 68) ──
+# ── Slot identity must survive both awaits in _ensure_worker_slot ────────────
 
 _IDENTITY_SPEC = "identity-probe"
 
@@ -7813,9 +7805,9 @@ def test_handoff_captures_its_identity_before_the_await_and_pins_on_both():
     """Source guard on the ORDER and the ARGUMENTS.
 
     The capture must precede the _prepare_handoff await, and the reread must
-    compare BOTH spec_dir and the captured slot_key. The slot_key check that
-    already existed validates only the CLIENT's claim, so a request carrying no
-    claim previously had no identity check at all.
+    compare BOTH spec_dir and the captured slot_key. A slot_key check validates only
+    the CLIENT's claim, so on its own it leaves a request carrying no claim with no
+    identity check at all.
     """
     src = inspect.getsource(routes._handle_handoff)
     capture = src.index('started_slot_key = str(meta.get("slot_key", ""))')
@@ -8402,8 +8394,8 @@ def test_duplicate_doc_create_retries_short_writes(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_approve_records_the_version_and_the_user(tmp_path, monkeypatch):
-    """Approval used to be nothing but a chat message: the server never knew a
-    phase had been signed off, by whom, or against which text."""
+    """Approval is recorded, not merely said in chat: the server must know that a
+    phase was signed off, by whom, and against which text."""
     client = _make_client(monkeypatch, tmp_path)
     _seed_spec(tmp_path, files={"requirements.md": "# reviewed"})
     digest = routes._sha256_text("# reviewed")
@@ -9159,8 +9151,8 @@ async def test_title_relabels_without_touching_the_identity(tmp_path, monkeypatc
 @pytest.mark.asyncio
 async def test_archive_marks_the_spec_without_deleting_it(tmp_path, monkeypatch):
     """The non-destructive counterpart to delete: documents, transcript and index
-    entry all stay. Delete used to be the only way out of the rail, so tidying up
-    and destroying the work were the same action."""
+    entry all stay. Without it the only way out of the rail is delete, which makes
+    tidying up and destroying the work the same action."""
     client = _make_client(monkeypatch, tmp_path)
     spec_dir, _ = _seed_spec(tmp_path, files={"requirements.md": "# keep me"})
 
@@ -11853,8 +11845,8 @@ async def test_the_ledger_key_matches_the_id_the_detail_read_serves(tmp_path, mo
     """The overlay matches the ledger KEY against the id from the state file, so
     the two must be normalized identically.
 
-    An id carrying whitespace (or longer than a tighter cap) used to be stripped
-    on the wire but not in the state projection. The mismatch is silent in the
+    Stripping an id that carries whitespace (or exceeds a tighter cap) on the wire
+    but not in the state projection leaves a mismatch. It is silent in the
     worst way: the answer IS recorded, no card is ever locked, and the decision
     stays re-answerable forever."""
     client = _make_client(monkeypatch, tmp_path)
@@ -11988,9 +11980,9 @@ async def test_the_card_shows_the_option_not_the_whole_prompt(tmp_path, monkeypa
 async def test_a_delete_that_lands_after_the_repin_strands_no_claim(tmp_path, monkeypatch):
     """The window the in-claim reservation check does NOT cover, closed by ordering.
 
-    A DELETE reserving after the pre-dispatch re-pin used to reach a claim that had
-    already committed: the dispatch was refused, and when the delete rolled back the
-    spec came back with a decision locked to an answer the agent never received.
+    A DELETE reserving after the pre-dispatch re-pin would otherwise reach a claim that
+    has already committed: the dispatch is refused, and when the delete rolls back the
+    spec returns with a decision locked to an answer the agent never received.
     With the claim as the last await, the same delete makes the CLAIM refuse, so
     nothing is recorded and the user can answer again."""
     client = _make_client(monkeypatch, tmp_path)
@@ -12487,10 +12479,9 @@ def test_every_turn_start_takes_the_turn_lock():
 
 @pytest.mark.asyncio
 async def test_deleting_a_spec_retains_its_turn_lock(tmp_path, monkeypatch):
-    """This test asserted the OPPOSITE until round 24, as housekeeping: a deleted
-    spec's lock was dropped rather than accumulating for the process lifetime.
+    """A deleted spec's turn lock is RETAINED, not dropped as housekeeping.
 
-    That was unsafe at any reference count. A handler that called `_turn_lock()`
+    Eviction is unsafe at any reference count. A handler that called `_turn_lock()`
     before the eviction is already waiting on the OLD object, so the next arrival is
     handed a brand-new lock and the two serialize against nothing -- concurrent turns
     over the same documents, which is the hole the directory-keyed lock exists to
@@ -12848,7 +12839,7 @@ async def test_a_delete_whose_cleanup_fails_still_deletes(tmp_path, monkeypatch)
 @pytest.mark.asyncio
 async def test_a_delete_clears_the_record_after_the_index_entry(tmp_path, monkeypatch):
     """...and on the happy path the entry IS cleared, so the ledger does not accumulate
-    answers for specs that no longer exist."""
+    answers for specs that have been deleted."""
     client = _make_client(monkeypatch, tmp_path)
     spec_dir, slot_key = _decision_spec(tmp_path)
     assert (
@@ -12928,10 +12919,10 @@ def test_a_recorded_answer_round_trips_non_ascii(tmp_path, monkeypatch):
 async def test_an_alias_name_for_the_same_folder_cannot_re_answer(tmp_path, monkeypatch):
     """A name is a label the agent can mint more of; the directory is the spec.
 
-    Adding a second index entry pointing at the SAME spec directory used to give the
-    alias its own empty record, so its cards rendered answerable and a click dispatched
-    a conflicting answer over the same documents. Keyed on the directory, both names
-    resolve to one record.
+    A record keyed on the NAME gives a second index entry pointing at the SAME spec
+    directory its own empty record, so its cards render answerable and a click
+    dispatches a conflicting answer over the same documents. Keyed on the directory,
+    both names resolve to one record.
     """
     client = _make_client(monkeypatch, tmp_path)
     spec_dir, slot_key = _decision_spec(tmp_path)
@@ -13244,14 +13235,14 @@ async def test_a_renamed_spec_keeps_its_recorded_answers(tmp_path, monkeypatch):
 
 
 def test_a_symlinked_spelling_cannot_record_a_second_answer(tmp_path, monkeypatch):
-    """Until round 28 this asserted the KEY collapsed a symlinked spelling.
+    """The KEY does not collapse a symlinked spelling; the WRITE end refuses it.
 
-    It did, via resolve() -- and that bought a worse hole, because the spec directory
-    belongs to the agent: swapping the directory for a symlink moved the key while the
-    index identity still matched, so a settled record went missing and the card
-    re-opened. A key derived from mutable filesystem state is a key the agent can move.
+    Collapsing it via resolve() buys a worse hole, because the spec directory belongs
+    to the agent: swapping the directory for a symlink moves the key while the index
+    identity still matches, so a settled record goes missing and the card re-opens. A
+    key derived from mutable filesystem state is a key the agent can move.
 
-    The alias-by-spelling guarantee therefore moved to the WRITE end. The key is now
+    The alias-by-spelling guarantee therefore lives at the WRITE end. The key is
     lexical (two spellings ARE two keys), and `_claim_decision_locked` refuses a
     spec_dir that does not verify as itself -- so the aliased spelling cannot record
     anything, which is what the collapse existed to prevent.
@@ -13262,7 +13253,7 @@ def test_a_symlinked_spelling_cannot_record_a_second_answer(tmp_path, monkeypatc
     link = tmp_path / "link-spec"
     link.symlink_to(real, target_is_directory=True)
 
-    # Lexical now, so the spellings no longer share a key...
+    # Lexical, so the spellings do not share a key...
     assert routes._decision_key(str(link)) != routes._decision_key(str(real))
     # ...and that is safe because the aliased spelling is refused at the write gate.
     assert (
@@ -15458,12 +15449,10 @@ async def test_an_alias_mid_turn_blocks_a_handoff(tmp_path, monkeypatch):
     """...and a handoff, which starts an autonomous build -- the most expensive way to
     end up with two agents in one spec directory.
 
-    Until round 27 this asserted that the refusal RELEASES the loop it had already
-    armed, because arming happened before the turn lock: a bare 409 left an active
-    timer that later dispatched the very build the refusal denied. Round 27 moved
-    arming inside the lock and AFTER this check, so no loop is armed on this path at
-    all. The assertion is therefore stronger now -- authorization is never reached,
-    so there is nothing to leak and no release to get right.
+    Arming lives inside the turn lock and AFTER this check, so no loop is armed on
+    this path at all: authorization is never reached, which leaves nothing to leak and
+    no release to get right. Arming ahead of the lock instead leaves a bare 409 holding
+    an active timer that dispatches the very build the refusal denied.
     """
     client = _make_client(monkeypatch, tmp_path)
     spec_dir, _slot_key = _decision_spec(tmp_path, state={"phase": "tasks"})
@@ -15564,7 +15553,7 @@ async def test_a_completed_alias_turn_during_authorization_blocks_a_handoff(tmp_
 async def test_handoff_refuses_when_its_own_slot_starts_during_authorization(tmp_path, monkeypatch):
     """Authorization awaits while channel traffic can start the same slot.
 
-    The pre-arm snapshot is no longer authoritative after that await. Dispatching the
+    The pre-arm snapshot is not authoritative after that await. Dispatching the
     build would queue it behind the new turn, and Pause deliberately clears that queue,
     despite this endpoint reporting that execution started.
     """
@@ -15654,10 +15643,10 @@ async def test_handoff_refuses_when_its_own_slot_starts_during_the_final_repin(
 def test_the_busy_refusal_cannot_leak_an_armed_loop():
     """Source guard: the busy check must precede the arm.
 
-    Round 18 fixed a leaked timer by releasing it in the refusal; round 27 removed
-    the leak instead by arming after the check. Ordering is the property worth
-    pinning -- a future edit that moves arming back above the check reintroduces a
-    hazard that only shows up as a build firing minutes after a 409.
+    Arming after the check removes the leak outright, where releasing the timer inside
+    the refusal only patches it. Ordering is the property worth pinning -- an edit that
+    moves arming above the check reintroduces a hazard that only shows up as a build
+    firing minutes after a 409.
     """
     src = inspect.getsource(routes._handle_handoff)
     lock = src.index("async with _turn_lock(handoff_dir_key):")
@@ -15799,12 +15788,11 @@ def test_the_busy_check_reads_no_filesystem():
     """Source guard: `_busy_alias` runs ON the event loop, so it must ask the nudge
     registry by SLOT KEY and derive nothing itself.
 
-    Round 19 justified this with a claim that was wrong: `_slot_key` reads the
-    module-global `_SLOT_KEYS`, not the index, so calling it is not a filesystem hop.
-    The guard stands for the reason that survived round 21 -- key derivation belongs
-    in ONE off-loop place (`_alias_slots_locked`), because that is what makes every
-    alias key ownership-validated instead of trusted raw from an agent-writable file.
-    Re-deriving per call here would also invite an unvalidated shortcut back in.
+    Not because `_slot_key` is itself a filesystem hop -- it reads the module-global
+    `_SLOT_KEYS`, not the index. The reason is that key derivation belongs in ONE
+    off-loop place (`_alias_slots_locked`), because that is what makes every alias key
+    ownership-validated instead of trusted raw from an agent-writable file. Re-deriving
+    per call here would also invite an unvalidated shortcut back in.
     """
     src = inspect.getsource(routes._busy_alias)
     assert "_exec_loop_active_for_slot(" in src, "the busy check ignores an armed loop"
@@ -16072,17 +16060,17 @@ async def test_create_refuses_when_a_stale_record_survives_the_clear(tmp_path, m
 
 @pytest.mark.asyncio
 async def test_create_refuses_when_the_ledger_is_unreadable(tmp_path, monkeypatch):
-    """This test asserted the OPPOSITE until round 26.
+    """Create refuses rather than proceeding when the ledger clear cannot be read.
 
-    Round 21 let a create proceed when the clear failed only because the store was
-    unusable, reasoning that nothing can read a stale answer out of a store nothing
-    can read. That is wrong, and the error is worth keeping visible: unreadability
-    is a property of ONE READ, not of the store. A transient failure -- a partial
-    write, a momentary IO error -- leaves the old record intact on disk, so the
-    probe returned empty, the create proceeded, and the record became readable
-    again afterwards and overlaid its answers onto the brand-new spec.
+    Letting a create proceed because the store was unusable rests on the reasoning
+    that nothing can read a stale answer out of a store nothing can read. That is
+    wrong, and the error is worth keeping visible: unreadability is a property of ONE
+    READ, not of the store. A transient failure -- a partial write, a momentary IO
+    error -- leaves the old record intact on disk, so the probe returns empty, the
+    create proceeds, and the record becomes readable again afterwards and overlays its
+    answers onto the brand-new spec.
 
-    So the refusal is back on the clear's own result, which is the only signal that
+    So the refusal rests on the clear's own result, which is the only signal that
     actually reports whether the ledger is clean. The cost is that a corrupt
     decisions store blocks new spec creation -- loud, and the correct direction to
     fail for a trust root.
@@ -16150,11 +16138,11 @@ def _two_names_one_dir(tmp_path, *, alias_key):
 
 @pytest.mark.asyncio
 async def test_an_alias_with_no_slot_key_is_still_seen(tmp_path, monkeypatch):
-    """Deleting the field used to drop the alias from the scan entirely.
+    """An alias whose ``slot_key`` field is deleted is still seen by the scan.
 
-    The old code skipped an entry with no key, so an agent could delete its own
-    ``slot_key`` and become invisible to every busy check -- then both names ran a
-    turn over the same documents.
+    Skipping an entry with no key lets an agent delete its own ``slot_key`` and become
+    invisible to every busy check -- then both names run a turn over the same
+    documents.
     """
     _redirect_state(monkeypatch, tmp_path)
     spec_dir = _two_names_one_dir(tmp_path, alias_key="")
@@ -16208,10 +16196,10 @@ async def test_an_invalid_identity_cannot_claim_the_own_slot_exemption(tmp_path,
 
 @pytest.mark.asyncio
 async def test_an_alias_that_copies_our_key_is_still_seen(tmp_path, monkeypatch):
-    """Copying the caller's key used to make the alias read as "our own slot".
+    """Copying the caller's key must not make the alias read as "our own slot".
 
     Own-slot exclusion exists so a same-session message can queue rather than be
-    refused. Keyed on a field the agent writes, it became a way to borrow the
+    refused. Keyed on a field the agent writes, it would be a way to borrow that
     exemption -- ownership validation rejects a key that does not encode the
     alias's own name, so the copy cannot be claimed.
     """
@@ -16262,13 +16250,13 @@ async def test_our_own_name_is_still_excluded(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_stop_waits_for_an_in_flight_decision_answer(tmp_path, monkeypatch):
-    """The race: Stop used to cancel a turn a decision answer was mid-dispatch.
+    """The race: Stop must not cancel a turn a decision answer is mid-dispatch.
 
     The answer path records the answer and dispatches it while holding the
-    directory turn lock. Stop took no lock, so it could land BETWEEN those two
-    steps -- the turn it cancelled was the one carrying the answer, and because the
-    record is never rewritten the card stayed locked to an answer the agent never
-    received. Stop now takes the same lock, so it cannot observe that midpoint.
+    directory turn lock. A lockless Stop lands BETWEEN those two steps -- the turn
+    it cancels is the one carrying the answer, and because the record is never
+    rewritten the card stays locked to an answer the agent never received. Stop
+    takes the same lock, so it cannot observe that midpoint.
 
     Timing is deliberate: the halt sets an Event, and the assertion is that it does
     not fire within a REAL timeout while the lock is held. An earlier version of
@@ -16343,9 +16331,9 @@ def test_stop_rechecks_the_spec_after_waiting_for_the_lock():
 async def test_stop_refuses_a_spec_recreated_at_the_same_path(tmp_path, monkeypatch):
     """The directory cannot detect a delete + recreate; the slot key can.
 
-    Round 23 rechecked the canonical directory after waiting for the lock, but a
+    Rechecking the canonical directory after waiting for the lock is not enough: a
     recreate at the SAME path resolves to the same directory -- so the recheck
-    passed and Stop cancelled the replacement's run. Slot keys are minted per
+    passes and Stop cancels the replacement's run. Slot keys are minted per
     creation, so the replacement necessarily carries a different one.
     """
     client = _make_client(monkeypatch, tmp_path)
@@ -16453,12 +16441,11 @@ async def test_create_waits_for_the_directory_turn_lock(tmp_path, monkeypatch):
 
 
 def test_every_handler_that_starts_work_holds_the_turn_lock():
-    """The invariant, widened after round 27 found the axis it was missing.
+    """The invariant covers every way a handler can cause work to start.
 
-    Round 25 stated this as "every handler that mutates the index holds the lock",
-    which is why a handler that ARMED A TIMER outside the lock was found by a
-    reviewer instead of by this test: the timer dispatched on its own while the
-    handler still waited for the lock. Causing work to start has three shapes, not
+    Stated as "every handler that mutates the index holds the lock", it misses a
+    handler that ARMS A TIMER outside the lock: the timer dispatches on its own while
+    the handler still waits for the lock. Causing work to start has three shapes, not
     one -- register/remove an index entry, arm a nudge loop, or dispatch a turn --
     and all three must be serialized on the directory.
 
@@ -16496,9 +16483,9 @@ def _effect_calls_outside_turn_lock(fn) -> list[str]:
     _turn_lock(...)` block.
 
     On the AST rather than on text, because "is the lock present in this function"
-    is the question that let round 28 through: create held the lock around its index
-    insert and dispatched its seed ~190 lines after the block closed. Containment is
-    the property; presence is not.
+    is the wrong question: create can hold the lock around its index insert and
+    dispatch its seed ~190 lines after the block closed. Containment is the property;
+    presence is not.
     """
     tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
 
@@ -16535,13 +16522,12 @@ def _effect_calls_outside_turn_lock(fn) -> list[str]:
 
 
 def test_every_serialized_effect_is_inside_the_lock_not_merely_near_it():
-    """The invariant, made positional after round 28.
+    """The invariant is positional: per-path and presence-anywhere are both weaker.
 
-    Rounds 23-27 each fixed one handler that started work outside the directory turn
-    lock, and each time the guard I wrote was weaker than the rule it stood for:
-    first per-path, then presence-anywhere-in-the-handler. This checks CONTAINMENT on
-    the AST, for every handler and every effect, which is the form that would have
-    caught create dispatching its seed after the block closed.
+    A guard that checks one path, or only that the lock appears somewhere in the
+    handler, is weaker than the rule it stands for. This checks CONTAINMENT on
+    the AST, for every handler and every effect, which is the form that catches
+    create dispatching its seed after the block closed.
     """
     offenders: dict[str, list[str]] = {}
     checked: list[str] = []
@@ -16583,10 +16569,10 @@ def test_every_serialized_effect_is_inside_the_lock_not_merely_near_it():
 async def test_create_dispatches_its_seed_before_anything_else_can_run(tmp_path, monkeypatch):
     """A registered spec whose seed has not been dispatched must accept nothing else.
 
-    The lock used to close at the index insert, so a list poll could expose the spec
-    while create was still awaiting slot setup; a concurrent message then took the
-    lock and started the FIRST turn, leaving the seed queued second and the persisted
-    conversation beginning with something other than the prompt that defines the spec.
+    A lock closing at the index insert lets a list poll expose the spec while create
+    is still awaiting slot setup; a concurrent message then takes the lock and starts
+    the FIRST turn, leaving the seed queued second and the persisted conversation
+    beginning with something other than the prompt that defines the spec.
     """
     project = tmp_path / "proj"
     project.mkdir()
@@ -16848,11 +16834,10 @@ async def test_a_decision_absent_from_state_is_refused(tmp_path, monkeypatch):
 async def test_two_spellings_of_one_directory_share_the_turn_lock(monkeypatch):
     """A raw path and a normalized key must resolve to the SAME lock object.
 
-    Round 28 made the ledger key lexical via `normcase`, which lowercases on Windows.
-    Call sites passing a raw path then hashed to a different dictionary entry than
-    those passing `_decision_key(...)` -- two locks for one directory, so two turns
-    could run on the same documents. That is the exact hole the directory-keyed lock
-    exists to close, reintroduced by the fix for a different one.
+    The ledger key is lexical via `normcase`, which lowercases on Windows. A call site
+    passing a raw path would hash to a different dictionary entry than one passing
+    `_decision_key(...)` -- two locks for one directory, so two turns could run on the
+    same documents, which is the exact hole the directory-keyed lock exists to close.
 
     `normcase` is the identity on Linux, so this simulates Windows explicitly. Without
     the patch the assertion holds trivially and proves nothing.

--- a/src/kiro_crew/apps/dependency_ledger.py
+++ b/src/kiro_crew/apps/dependency_ledger.py
@@ -2,7 +2,7 @@
 
 Tracks which apps installed which external dependencies (capability-manager
 MCP servers, skills, agents) so that uninstall can safely clean up dependencies
-that are no longer referenced by any app.
+that no app references any more.
 
 All reads/writes use ``fcntl.flock()`` for concurrency safety, consistent
 with KiroCrew's existing file locking patterns.  Read-modify-write cycles

--- a/src/kiro_crew/apps/dev_mode.py
+++ b/src/kiro_crew/apps/dev_mode.py
@@ -9,9 +9,9 @@ When an installed app has ``dev: true`` in its ``installed.json``:
   and broadcasts an ``app_reload`` WebSocket event whenever any file changes.
   The dashboard's AppHost reloads so edits appear without a manual refresh.
 
-Link the whole ``ui/`` DIRECTORY, never individual files inside it: since
-#6809 the UI route opens the final name with ``O_NOFOLLOW`` (the swap-resistant
-open that closed the check-then-reopen window), so a per-file symlink like
+Link the whole ``ui/`` DIRECTORY, never individual files inside it: the UI route
+opens the final name with ``O_NOFOLLOW`` (the swap-resistant open that closes
+the check-then-reopen window), so a per-file symlink like
 ``ln -s ~/src/app/dist/index.mjs ui/index.mjs`` answers 404 — indistinguishable
 from "not built yet". The directory link keeps working because the route
 resolves the ui root before validating against it.
@@ -77,11 +77,11 @@ _DEV_SENTINEL = ".dev-apps.json"
 #: :func:`_reconcile_sentinel_from_installed` rebuilds from each app's own
 #: (app-writable) ``installed.json``, so a sentinel entry can be laundered by
 #: an app that writes ``dev: true`` to its own metadata and waits for a
-#: restart. This record is the AUTHORIZATION half the UI route requires
-#: (#6809). Binding the grant to the SPECIFIC resolved root (not a bare name)
+#: restart. This record is the AUTHORIZATION half the UI route requires.
+#: Binding the grant to the SPECIFIC resolved root (not a bare name)
 #: is load-bearing: it makes the grant self-invalidating — repointing ``ui``
 #: after the toggle (an app update, a swapped link, a reinstall under the same
-#: name) yields a root that no longer equals the granted one, so any grant
+#: name) yields a root that does not equal the granted one, so any grant
 #: left behind by a crash mid-revoke or an uninstall race authorizes at most
 #: the exact tree the operator approved, never a new target. The two files
 #: stay separate on purpose — merging them would either re-open the
@@ -198,7 +198,7 @@ def _write_dev_grants(grants: dict[str, str]) -> None:
 def _grant_record_unwritable() -> str | None:
     """Reason the grant record cannot be written from THIS process, or ``None``.
 
-    The STRUCTURAL half of the operator-vs-agent runtime check (#6907): the
+    The STRUCTURAL half of the operator-vs-agent runtime check: the
     grant record is sealed read-only against agent-sandboxed processes at the
     OS level (``sandbox._CREW_READONLY_LEAVES``), so opening it for write
     succeeds only outside that confinement. Unlike the environment marker,
@@ -309,7 +309,7 @@ def _reconcile_sentinel_from_installed() -> set[str]:
         # preserved data while the app itself — its ``installed.json`` — is
         # gone. Never ADD a grant from ``installed.json`` — that is
         # app-writable metadata, and deriving the grant from it is exactly
-        # the laundering path #6809 closes.
+        # the laundering path a separate grant record closes.
         grants = _read_dev_grants()
         live: dict[str, str] = {}
         for gname, groot in grants.items():
@@ -333,7 +333,7 @@ def _reconcile_sentinel_from_installed() -> set[str]:
             # creatable from inside an agent sandbox until the first operator
             # toggle. Seatbelt denies by path pattern and does not need this,
             # but the record's existence also keeps the operator-attestation
-            # write probe (#6907) exercising the same open() the seal governs.
+            # write probe exercising the same open() the seal governs.
             _write_dev_grants(live)
         _set_dev_cache(installed)
     return installed
@@ -395,7 +395,7 @@ def set_dev_mode(
         out_of_install_confirmed = False
         # VALIDATE BEFORE ANY WRITE: every enable (and any disable of a granted
         # app) mutates the grant record, and that record is sealed read-only
-        # against agent-sandboxed processes at the OS level (#6907 — see
+        # against agent-sandboxed processes at the OS level (see
         # ``sandbox._CREW_READONLY_LEAVES``). Probing writability up front
         # keeps the refusal atomic: without it, an enable would write
         # installed.json and the sentinel and then fail at the (deliberately
@@ -438,8 +438,7 @@ def set_dev_mode(
             # re-pointing to re-bind). A root escaping the install dir into a
             # SENSITIVE location (credential stores, key material) is refused
             # outright — no dev workflow legitimately serves those, and the
-            # unauthenticated UI route must never be grantable onto them
-            # (#6809).
+            # unauthenticated UI route must never be grantable onto them.
             granted_root = os.path.realpath(apps_dir() / name / "ui")
             try:
                 # Anchor = resolved apps ROOT + literal name (same rule as the
@@ -516,7 +515,7 @@ def set_dev_mode(
                         ),
                         "code": "dev_mode_out_of_install_confirmation_required",
                     }
-                # RUNTIME human-vs-agent check (#6907): the flag is operator
+                # RUNTIME human-vs-agent check: the flag is operator
                 # ATTESTATION, so it is honoured only from a process showing
                 # no evidence of agent-shell confinement. The deny-list tiers
                 # above stop an agent SPELLING the flag; this stops an agent
@@ -647,9 +646,9 @@ def dev_mode_granted_root(name: str) -> str | None:
     the apps ROOT written only by :func:`set_dev_mode` — never created by the
     startup reconcile) AND the app's ``installed.json`` ``dev`` flag.
     ``installed.json`` alone is the app's own writable metadata — an app that
-    edits it to ``dev: true`` must not thereby authorize itself (#6809: the UI
-    route relaxes root containment only under this grant, and a self-granted
-    app could point its ui root at a credential directory). The watch
+    edits it to ``dev: true`` must not thereby authorize itself: the UI route
+    relaxes root containment only under this grant, and a self-granted app
+    could point its ui root at a credential directory. The watch
     sentinel is deliberately NOT consulted: the reconcile rebuilds it from
     app-writable metadata at every startup, so it proves watching, not
     authorization.

--- a/src/kiro_crew/apps/discovery.py
+++ b/src/kiro_crew/apps/discovery.py
@@ -87,11 +87,11 @@ def _manifest_to_builtin_dict(manifest: AppManifest) -> dict[str, Any]:
         d["publishProvider"] = pp_d
 
     # The REMAINING declarative fields, same reasoning as the agents/skills block
-    # above (#1076): this dict is what register_builtin_apps() persists as the
+    # above: this dict is what register_builtin_apps() persists as the
     # app.json snapshot, and register_app() reads that snapshot rather than the
     # packaged manifest — so any typed field not copied here is silently dropped
-    # for every builtin. agents/skills was the instance that shipped; these are
-    # the rest of the same class, and the round-trip guard covers all of them.
+    # for every builtin. agents/skills is one instance of that class; these are
+    # the rest of it, and the round-trip guard covers all of them.
     if manifest.sops:
         d["sops"] = list(manifest.sops)
     if manifest.jobFamilies:

--- a/src/kiro_crew/apps/hook_reconcile.py
+++ b/src/kiro_crew/apps/hook_reconcile.py
@@ -247,7 +247,7 @@ async def _reconcile_app(name: str, snapshot_info: dict[str, Any] | None) -> Non
 
     ``snapshot_info`` is what the tick's ``list_apps`` read for this app (or
     ``None`` if it was absent then). It only decides that this app is WORTH
-    examining; the authoritative state used to act is re-read here under
+    examining; the authoritative state acted on is re-read here under
     ``app_lifecycle_lock(name)`` via ``get_app``, because a dashboard
     enable/disable/uninstall or a trust withdrawal may have run between the
     snapshot and now. Holding the lock is what closes the revive-during-
@@ -308,7 +308,7 @@ async def _reconcile_app(name: str, snapshot_info: dict[str, Any] | None) -> Non
                 # as a closure over a store the uninstall deleted, and
                 # notify_slot_closed reporting its failure is what
                 # api_chat_slot_delete turns into a tab the user cannot dismiss
-                # for an app that no longer exists.
+                # for an app that does not exist.
                 if gone:
                     forget_app_hooks(name)
             return

--- a/src/kiro_crew/apps/hooks_integration.py
+++ b/src/kiro_crew/apps/hooks_integration.py
@@ -155,7 +155,7 @@ async def record_loaded_hook_signature(app_name: str, app_info: dict[str, Any]) 
 
     Also retains the loaded app's ``manifest`` (the hooks half is what matters):
     if the app is later UNINSTALLED between reconciler ticks, its files are gone
-    and its ``on_shutdown`` can no longer be resolved from disk -- yet a
+    and its ``on_shutdown`` cannot be resolved from disk -- yet a
     background task its ``on_startup`` spawned is still live in the gateway after
     uninstall removed execution trust. The reconciler uses this retained manifest
     to run ``on_shutdown`` against the code that was ACTUALLY loaded, so that
@@ -640,7 +640,7 @@ async def on_app_disable(
 
     # A startup hook may have been detached after its readiness deadline. It is
     # still third-party code with a live AppContext, so disable/revocation must
-    # stop it even if the current manifest no longer declares hooks. A resistant
+    # stop it even if the current manifest does not declare hooks. A resistant
     # task becomes a hard teardown failure; callers keep trust in place rather
     # than falsely claiming all app code stopped.
     if startup_stopped is None:
@@ -677,7 +677,7 @@ async def on_app_disable(
         _route_registry.deregister_app_routes(app_name)
 
     # A disabled app has no live hooks, so a recorded failure would linger as a
-    # stale claim about an app that is no longer wired up at all.
+    # stale claim about an app that is not wired up at all.
     clear_hook_health(app_name)
 
     # Shared source of truth: the app's hooks are now torn down, so drop its

--- a/src/kiro_crew/apps/job_sdk.py
+++ b/src/kiro_crew/apps/job_sdk.py
@@ -40,10 +40,10 @@ so the runner unwinds AT that point. The second is the stronger form -- the
 ``cancelled`` record then names an observed stop rather than a set flag -- but
 neither reaches work the runner spawned onto a thread the SDK does not own. For
 that work there is exactly one instant where a stop is possible: if the runner
-hands the work back -- the reported #7814 case returns an unwaited
+hands the work back -- a runner that submits to a pool returns an unwaited
 ``concurrent.futures.Future`` -- then ``_stop_returned_work`` asks it not to run,
 and the record states which of the two things happened. If nothing comes back,
-nothing can be asked; that residue is #7814's execution-ownership half, which needs
+nothing can be asked; that residue is the execution-ownership half, which needs
 the spawn to register itself and is out of scope here.
 
 **One writer per run file.** There is no lock helper beside ``atomic_write`` and
@@ -119,7 +119,7 @@ from kiro_crew.sel import sel
 logger = logging.getLogger(__name__)
 
 #: Identity of THIS gateway process. A run record carrying a different origin
-#: belongs to a process that no longer exists, which is what makes staleness
+#: belongs to a process that is gone, which is what makes staleness
 #: decidable without trusting a pid (pids are reused, and the reconciling
 #: process could hold the very pid a stale record names).
 _ORIGIN = uuid.uuid4().hex
@@ -354,9 +354,8 @@ _SUSPENDABLE_KINDS: tuple[tuple[str, Any], ...] = (
 )
 
 
-#: The wording for an unsettled future this SDK could NOT stop. Kept verbatim from
-#: the string #7737 shipped, because for this branch every clause of it is still
-#: true and a consumer matching the old text must still find it.
+#: The wording for an unsettled future this SDK could NOT stop. Every clause of it
+#: is true for this branch, and consumers match on the text, so it stays verbatim.
 _UNSETTLED_NOT_STOPPED = (
     "a future that is not settled, so the runner returned before its work "
     "finished; that work may still be running somewhere this SDK does not "
@@ -376,9 +375,9 @@ _UNSETTLED_STOPPED = (
 def _stop_returned_work(result: Any) -> bool:
     """Ask work a runner handed back to not run. ``True`` ONLY when it is stopped.
 
-    This is the reachability half of #7814. The SDK cannot stop work a runner
-    spawned onto a thread it does not own -- unless the runner hands the work back,
-    which the reported case does: it submits to a pool and returns the unwaited
+    This is the reachability half of the ownership problem. The SDK cannot stop work
+    a runner spawned onto a thread it does not own -- unless the runner hands the
+    work back, which a runner submitting to a pool does: it returns the unwaited
     ``concurrent.futures.Future``. At that instant this process holds the only
     reference to that work, so this is the one moment a stop is even possible.
 
@@ -487,10 +486,9 @@ def _undriven_result(result: Any) -> str:
     discards return values by design, so returning a suspendable cannot serve a runner
     even in principle.
 
-    An async generator needs no separate case now. It used to have one because its
-    state was not portably readable (``inspect.getasyncgenstate`` is 3.12+ while this
-    module supports 3.10) -- and no state is read any more, so the special case that
-    existed to avoid a version-dependent record dissolves into the general rule.
+    An async generator needs no separate case: no state is read, and reading it would
+    not be portable anyway (``inspect.getasyncgenstate`` is 3.12+ while this module
+    supports 3.10), so it falls under the general rule.
 
     **Futures, four verdicts, and deliberately NOT flattened.** Unlike a suspendable, a
     future does answer the question, so the distinctions it draws are kept. ``done()``
@@ -591,9 +589,9 @@ def _close_quietly(result: Any) -> None:
     async generator's ``aclose`` is itself a coroutine needing a loop, so it is
     left to the interpreter rather than driven from this thread.
 
-    This ``cancel`` is HYGIENE, and it used to be the only one. Stopping the work a
-    future stands for is now :func:`_stop_returned_work`'s job, which runs earlier
-    and reads what the stop returned. The two are not duplicates: that one answers
+    This ``cancel`` is HYGIENE only. Stopping the work a future stands for is
+    :func:`_stop_returned_work`'s job, which runs earlier and reads what the stop
+    returned. The two are not duplicates: that one answers
     a question the record needs, this one silences a warning, and by the time this
     runs on a future the earlier call has usually already settled it -- a second
     ``cancel`` on a cancelled or running future returns ``False`` and invokes no
@@ -770,14 +768,14 @@ class JobHandle:
     remains cooperative either way.
 
     ``checkpoint`` is the P1 progress channel, and it is deliberately the SAME
-    call that carries cancellation -- the pairing #7804 and #7814 asked to be
-    designed together. A runner that reports it reached a checkpoint necessarily
+    call that carries cancellation -- progress and cancellation are one design,
+    not two. A runner that reports it reached a checkpoint necessarily
     observes the cancel signal AT that checkpoint, because ``checkpoint`` raises
     ``JobCancelled`` before it returns when a cancel is pending. There is no way
     to spell "report progress but ignore cancellation": the channel that answers
     "did work happen" is the channel that answers "should it stop", so a progress
-    report that left cancellation unobservable -- the half-capability the issues
-    warned about -- is not a state this API can represent.
+    report that left cancellation unobservable -- a half-capability -- is not a
+    state this API can represent.
 
     It writes NOTHING to disk. The observed fact lives on the handle and is read
     ONCE by ``_execute`` at the terminal write, so the record keeps its single
@@ -824,8 +822,8 @@ class JobHandle:
         if a cancel is pending.
 
         Call this at each unit of work a runner completes. Two things happen, and
-        they are one act on purpose -- the pairing #7804 and #7814 asked to be
-        designed together:
+        they are one act on purpose -- progress and cancellation are one design,
+        not two:
 
         * The handle records that a checkpoint was reached -- an OBSERVED fact the
           terminal write reads, so ``done`` rests on "this runner did work" rather
@@ -1073,17 +1071,16 @@ class JobSDK:
     ) -> bool:
         """Write a run's record. The ONLY path that writes one.
 
-        Three callers used to write directly -- start, the worker's terminal
-        write, and reconcile (a fourth, a persisting progress write, never
-        existed; ``handle.checkpoint`` reports progress WITHOUT touching disk, so
-        it adds no writer) -- and each had to remember the same three rules. Two
-        review rounds found a different one missed each time, so the rules live here
-        instead:
+        Three callers reach it -- start, the worker's terminal write, and reconcile
+        (there is no persisting progress write; ``handle.checkpoint`` reports
+        progress WITHOUT touching disk, so it adds no writer) -- and the same three
+        rules hold for every one of them, so they live here rather than in each
+        caller:
 
         * the discard check and the write happen under ONE lock acquisition, the
-          same lock ``remove_all_async`` sets ``discarded`` with, so cleanup can
-          no longer land between a caller's check and its write and have the
-          record recreated;
+          same lock ``remove_all_async`` sets ``discarded`` with, so cleanup cannot
+          land between a caller's check and its write and have the record
+          recreated;
         * a serialization or I/O failure returns ``False`` instead of raising, so
           a caller's bookkeeping (the live table, the dedupe claim) can never be
           skipped by an exception escaping mid-cleanup;
@@ -1148,11 +1145,11 @@ class JobSDK:
         and three shapes return a lazy object instead of doing the work: a
         coroutine function, an async generator function, and a plain generator
         function. For each, the object is dropped and no line of the runner's body
-        ever runs. Such a run USED to be recorded ``done`` -- a run reporting
-        success having executed nothing, and silent, since an un-awaited coroutine
-        warning goes to the gateway log at most. That is now caught at execution by
-        ``_undriven_result`` and recorded ``failed``, so refusing here is the early
-        friendly error and not the thing that makes the record honest. The check
+        ever runs. Recording such a run ``done`` would report success having executed
+        nothing, and silently, since an un-awaited coroutine warning goes to the
+        gateway log at most. ``_undriven_result`` catches it at execution and records
+        ``failed``, so refusing here is the early friendly error and not the thing
+        that makes the record honest. The check
         goes through ``__call__`` as well as the object itself, so a callable
         instance with an ``async def __call__`` is caught too.
 
@@ -1381,15 +1378,15 @@ class JobSDK:
         run.status = RUNNING
         try:
             # The transition is a PRECONDITION for running the body, not a
-            # notification alongside it. This return used to be discarded, so a
-            # failed write left the record at `starting` while the runner went on
-            # to commit real work -- and if the process then died before the
-            # terminal write, `reconcile` read that record and stated the run had
+            # notification alongside it. Discarding this return would let a failed
+            # write leave the record at `starting` while the runner went on to
+            # commit real work -- and if the process then died before the terminal
+            # write, `reconcile` would read that record and state the run had
             # never begun. There is no way to correct that claim after the fact,
             # because the knowledge that the write failed dies with the process.
             # So the run does not begin unless the record can say it began.
             #
-            # The cost is deliberate: a transient store error now fails a run that
+            # The cost is deliberate: a transient store error fails a run that
             # might have succeeded. For an SDK whose product is a durable record,
             # a run that is not recorded is worse than a run not attempted.
             if not self._persist(run, handle):
@@ -1618,7 +1615,7 @@ class JobSDK:
         committed side effects, one interrupted from ``queued`` or ``starting``
         provably has not, and only the cause says whether offering a retry makes
         sense. ``error`` is composed from both by :func:`_interrupt_error`, which
-        is why the pass no longer has to choose one of two strings from the runner
+        is why the pass does not have to choose one of two strings from the runner
         table alone. This runs only after every app has registered, so a missing
         runner means the kind is gone rather than not yet loaded.
 
@@ -1726,17 +1723,17 @@ class JobSDK:
         """
         with self._lock:
             # Set BEFORE the snapshot, under the lock ``start``'s claim section
-            # takes. Marking and snapshotting were previously the whole of this
-            # section, so a start that had already read the runner table could
-            # still claim afterwards and spawn a worker this cleanup would never
-            # see -- a disabled app doing real work with its records deleted.
+            # takes. Marking after the snapshot would let a start that had already
+            # read the runner table claim afterwards and spawn a worker this
+            # cleanup would never see -- a disabled app doing real work with its
+            # records deleted.
             # Disable is terminal for this instance; a re-enable builds a new one.
             self._closed = True
             live = list(self._live.values())
             # Marked and cleared under the SAME lock the guarded writer takes,
             # so a worker cannot slip a write in between this and the delete.
             # The dedupe index goes too, or a key would stay owned by a run
-            # whose record no longer exists and the next start would adopt a
+            # whose record does not exist and the next start would adopt a
             # ghost.
             for entry in live:
                 entry.handle.discarded.set()

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -529,8 +529,8 @@ def _copy_app_tree(source: Path, dest: Path) -> None:
 # destroy preserved user data.  Different apps proceed in parallel.
 _LIFECYCLE_LOCKS: dict[str, LoopBoundLock] = {}
 
-# Registry installs historically call ``install_app(source)`` / ``update_app(source)``
-# with one positional argument. Keep that internal callable contract (tests and
+# Registry installs call ``install_app(source)`` / ``update_app(source)`` with one
+# positional argument. Keep that internal callable contract (tests and
 # downstream integrations replace these functions), while carrying the server-
 # resolved repository through ``asyncio.to_thread`` without putting it in the
 # app-controlled manifest. Context variables are copied into to_thread workers
@@ -560,7 +560,7 @@ def _effective_source_repository(explicit: str) -> str:
 
 
 def app_lifecycle_lock(name: str) -> LoopBoundLock:
-    """Return the per-app lock guarding install/update/uninstall (loop-bound, #4800).
+    """Return the per-app lock guarding install/update/uninstall (loop-bound).
 
     Must be called from (and the lock used on) the event loop thread; the
     guarded blocking work itself runs off-loop via executor/``to_thread``.
@@ -2062,7 +2062,7 @@ def app_enabled_state(name: str) -> bool | None:
         data = json.loads(meta_path.read_text(encoding="utf-8"))
         return bool(InstalledApp.from_dict(data).enabled)
     # No `json.JSONDecodeError` member: it subclasses ValueError, so pairing the two is
-    # redundant and the repo ratchets against it (see #5287).
+    # redundant and the repo ratchets against it.
     except (OSError, ValueError, TypeError, KeyError) as exc:
         logger.warning("Could not determine enabled state from %s: %s", meta_path, exc)
         return None
@@ -2768,8 +2768,7 @@ def _builtin_owns_install(existing: InstalledApp) -> bool:
     False means a USER installed an app under this name, and the builtin must not
     touch it. That distinction cannot be recovered once lost: registration would
     overwrite ``origin`` and set ``lifecycle="locked"``, so afterwards nothing on
-    disk shows the install was ever user-owned, and the user can no longer
-    uninstall it.
+    disk shows the install was ever user-owned, and the user cannot uninstall it.
 
     ``source`` is the discriminator: this function is the only writer of
     ``source="builtin"``, while ``install_app()`` records the install path or
@@ -3131,7 +3130,7 @@ def register_builtin_apps() -> int:
 
                 write_app_secret(name, generate_app_secret())
             # Invalidate the proxy secret cache so the newly-written (or
-            # previously existing) secret is picked up on the next request.
+            # pre-existing) secret is picked up on the next request.
             try:
                 # circular import: routes → manager
                 # kiro_crew.apps.routes imports from kiro_crew.apps.manager

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -216,8 +216,8 @@ def _path_escapes_app_root(rel_path: str, app_root: Path | None) -> bool:
     return False
 
 
-# Expected JSON type per CronEntry field that from_dict type-gates, used to turn
-# a recorded parse-time violation into a message an app author can act on.
+# Expected JSON type per CronEntry field that from_dict type-gates; turns a
+# recorded parse-time violation into a message an app author can act on.
 _CRON_FIELD_JSON_TYPES = {
     "every": "a number of seconds",
     "agent_sequence": "an array of agent names",
@@ -276,8 +276,8 @@ class CronEntry:
     # non-null but of the wrong JSON type. Parsing degrades them to the field's
     # empty value so /api/apps/register cannot 500, and validate() reports each
     # one -- erasing a wrong-typed value SILENTLY would be its own bug: an
-    # author who wrote "skip_dates": "2026-12-25" (a string, not an array) asked
-    # for a skip, and dropping it without a word lets the job fire on the
+    # author who wrote ``skip_dates`` as one date string instead of an array
+    # asked for a skip, and dropping it without a word lets the job fire on the
     # excluded date. Same shape as enabled_type_invalid; never serialized.
     type_invalid_fields: list[str] = field(default_factory=list)
 
@@ -557,9 +557,9 @@ def _normalize_status_path(raw: Any) -> str:
 class SessionControlContribution:
     """A compact control an app contributes to the session (composer) bar.
 
-    The slot exists because per-session app configuration previously had nowhere
-    to live: an app could contribute a sidebar page and nothing else, so a
-    setting scoped to "this chat" had to be set on a separate page against an
+    The slot exists because per-session app configuration has nowhere else to
+    live: without it an app contributes a sidebar page and nothing else, so a
+    setting scoped to "this chat" has to be set on a separate page against an
     opaque session key the app cannot even discover.
 
     Rendered by the dashboard as a lazily-imported ESM module, exactly like a
@@ -2111,8 +2111,9 @@ class Contributes:
     #: Outermost case of the same shape. Not serialized.
     bad_block: bool = False
     #: How many ENTRIES of a well-formed ``commands`` array were not objects. The array
-    #: being a list is not enough: a single bad element used to be filtered out here, so
-    #: an app declaring five commands with one typo installed with four and no warning.
+    #: being a list is not enough: silently filtering out a single bad element would
+    #: let an app declaring five commands with one typo install with four and no
+    #: warning.
     #: Counted rather than flagged so the error can say how many vanished. Not
     #: serialized.
     dropped_commands: int = 0

--- a/src/kiro_crew/apps/module_loader.py
+++ b/src/kiro_crew/apps/module_loader.py
@@ -41,8 +41,8 @@ _shutdown_callables: dict[str, tuple[int, Callable[..., Any]]] = {}
 #: disable, or the gateway teardown sweep), so a shutdown callable captured under
 #: one generation can be told apart from the code loaded by a LATER enable. A
 #: cached callable is only honoured while its generation is still current: after
-#: an unload+re-enable, the stale v1 callable is ignored rather than used to tear
-#: down the freshly loaded v2 worker (it would leave v2 running).
+#: an unload+re-enable, the stale v1 callable is ignored rather than applied to
+#: tear down the freshly loaded v2 worker (it would leave v2 running).
 _app_load_generation: dict[str, int] = {}
 
 

--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -164,10 +164,10 @@ def _open_catalog(req: urllib.request.Request) -> Any:
 
     A named function rather than an inline `urlopen`, because tests must be able
     to intercept the network at a place that cannot drift: patching
-    `urllib.request.urlopen` used to work here, and when this function started
-    using an opener instead, those tests silently stopped intercepting anything
-    and began making real requests to the live CDN. A seam that belongs to this
-    module cannot be bypassed by changing how this module calls out.
+    `urllib.request.urlopen` does not survive this module switching to an opener:
+    such tests silently stop intercepting anything and make real requests to the
+    live CDN. A seam that belongs to this module cannot be bypassed by changing
+    how this module calls out.
 
     The opener is built per call: an opener is mutable shared state, and one
     built at import time is something any other import can reach in and
@@ -335,8 +335,8 @@ def _curated_str(value: Any) -> str:
 
     Every field below arrives from a document fetched over the network, so its
     TYPE is as untrusted as its content. A wrong type is not hypothetical
-    tidiness: ``{"tags": 5}`` used to reach ``list(5)`` and turn one malformed
-    entry into an HTTP 500 for the whole store, and a non-string
+    tidiness: unguarded, ``{"tags": 5}`` reaches ``list(5)`` and turns one
+    malformed entry into an HTTP 500 for the whole store, and a non-string
     ``displayName`` reaches the browser to be sorted and lowercased there.
     Returning ``""`` collapses both into the falsy case the callers already
     handle, so a bad field degrades that field and nothing else.
@@ -449,8 +449,8 @@ def inventory(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
     This is what makes the catalog the SHELF rather than a decoration on one:
     :func:`annotate` can only change a row that already exists, so an app the
-    catalog lists but the bundled seed does not was previously unlistable and
-    therefore uninstallable -- adding one required shipping a release.
+    catalog lists but the bundled seed does not would otherwise be unlistable and
+    therefore uninstallable -- adding one would require shipping a release.
 
     ``builtin`` entries produce nothing here on purpose. Their code ships in the
     wheel and is discovered from disk; a row for code this client does not have

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -1420,8 +1420,7 @@ async def _fetch_app_manifest(
         # was placed, never what it now holds. This manifest is what the admission and
         # platform gates read, so a local edit bypasses `installMode`/`os`
         # restrictions and gets the tree built server-side. It is the same reason a
-        # pinned install never reuses an existing checkout; the rule belongs here too,
-        # and previously stopped one caller short of this one.
+        # pinned install never reuses an existing checkout; the rule belongs here too.
         #
         # The cost is a shallow single-commit fetch per pinned listing, which the
         # pinned branch below already performs.
@@ -3513,8 +3512,8 @@ async def list_registry() -> list[dict[str, Any]]:
 
     # Probe the seed/catalog rows, then append external registries at the single
     # shared merge site. Reserving every seed/catalog name means an external row
-    # can only ADD a name none of them claim — the precedence the inline dedup
-    # here used to enforce.
+    # can only ADD a name none of them claim, which is the precedence this merge
+    # site enforces.
     detected = await _detect_installed_probe(entries, installed_map)
     entries, external_detected = await _append_external_registry_apps(
         entries, {e.get("name") for e in entries}, installed_map
@@ -3537,8 +3536,8 @@ async def list_registry() -> list[dict[str, Any]]:
     #
     # Annotate from the SAME fresh entries the inventory came from, never the cache.
     #
-    # Round 11 stopped the agent-writable cache from INTRODUCING a row; this stops it
-    # from REWRITING one. `annotate` overlays `displayName` and `description`, which
+    # Blocking the agent-writable cache from INTRODUCING a row is not enough; this
+    # stops it from REWRITING one. `annotate` overlays `displayName` and `description`, which
     # are exactly what the consent modal renders, and it only skips rows carrying
     # `_registry` -- so a poisoned cache entry could re-label a freshly fetched
     # first-party row and the name-scoped grant would then execute the real app under
@@ -5231,7 +5230,7 @@ async def _git_clone_or_pull(
                         "manually and retry the install."
                     ),
                 }
-            # Fall through: `dest` no longer exists, so the pinned fetch below
+            # Fall through: `dest` is gone, so the pinned fetch below
             # creates it fresh inside the try/finally that owns restoration.
         else:
             # Already cloned from the verified origin AND branch (or the branch
@@ -5744,8 +5743,8 @@ async def _unpoison_rejected_checkout(
         # is best-effort and must never mask the refusal it follows.
         logger.debug("post-rejection rollback failed for %s: %s", app_name, exc)
     if _contained_join(pkg_dir, manifest_relpath) is None:
-        # manifest_relpath (the FULL path, e.g. "sub/app.json") no longer
-        # resolves inside pkg_dir RIGHT NOW — some callers reach this point
+        # manifest_relpath (the FULL path, e.g. "sub/app.json") does not
+        # resolve inside pkg_dir RIGHT NOW — some callers reach this point
         # after a build step or onInstall script ran with write access to the
         # checkout, so a containment check the caller made earlier cannot be
         # trusted here. Checking only `subdirectory` (the directory, and only
@@ -5956,14 +5955,13 @@ async def _clone_build_app_locked(
 
     # Build in the directory that actually HOLDS the package, not the clone root.
     #
-    # A monorepo registry entry declares `subdirectory`, and historically it was
-    # joined only AFTER this build ran — so `_run_app_build` looked for
-    # pyproject.toml/package.json at the clone root, found none, logged "No build
-    # step detected — using source as-is", and returned ok=True having installed
-    # nothing. The app's own pyproject.toml was never seen. A silent success is
-    # the worst shape for this: `setup.onInstall` does get `cwd=app_source`, so
-    # an app could paper over it with a script, which is exactly how a bug like
-    # this stays hidden.
+    # A monorepo registry entry declares `subdirectory`, and joining it only AFTER
+    # this build ran would leave `_run_app_build` looking for
+    # pyproject.toml/package.json at the clone root, finding none, logging "No build
+    # step detected — using source as-is", and returning ok=True having installed
+    # nothing — the app's own pyproject.toml never seen. A silent success is the
+    # worst shape for this: `setup.onInstall` does get `cwd=app_source`, so an app
+    # could paper over it with a script, which is how such a break stays hidden.
     #
     # `app_source` is already the containment-checked join of `subdirectory`
     # under the clone root (the identity gate above fails closed on an escaping
@@ -6036,7 +6034,7 @@ async def _clone_build_app_locked(
                         f"{stale_path}"
                     )
         # Drop the checkouts actually put back from the caller-owned pending
-        # list: a restored checkout is no longer a retained `.stale-*` sibling,
+        # list: a restored checkout is not a retained `.stale-*` sibling,
         # so `_clone_build_app`'s single-exit stamp must not carry it and the
         # caller's `_report_retained_stale_checkouts` must not name it. A rename
         # that FAILED above stays in the list so it is still reported stranded.
@@ -6226,14 +6224,13 @@ def _report_retained_stale_checkouts(
       exception path is still named instead of being silently swept.
 
     Both routes funnel the wording through here precisely so they can never
-    drift: the reporter used to be hand-replicated across every exit with a
+    drift: hand-replicating the reporter across every exit, with a
     ``filter_restorable`` flag manually mirrored to ``durable_success`` at each
-    one, which is the scattered-per-exit stranding class the caller's
-    move-aside bookkeeping exists to avoid — a new exit could forget the call
-    or pass the wrong flag and silently strand or double-report a checkout.
-    Every normal exit now reaches the single ``finally`` call and derives the
-    flag once; the only other caller is the exception path that no ``finally``
-    return can cover.
+    one, is the scattered-per-exit stranding class the caller's move-aside
+    bookkeeping exists to avoid — a new exit could forget the call or pass the
+    wrong flag and silently strand or double-report a checkout. Every normal
+    exit reaches the single ``finally`` call and derives the flag once; the only
+    other caller is the exception path that no ``finally`` return can cover.
 
     ``_pending_stale_cleanup`` collects every move-aside regardless of
     reason, but ``_restorable_stale`` (a subset) is put back by the
@@ -6571,7 +6568,7 @@ async def install_from_registry(
 
     # NOTE: the provenance signer is computed LATER, from the identity-checked
     # CLONED manifest — not from this pre-clone prefetch. An update can pull a
-    # commit whose manifest is no longer signed (or signed by someone else);
+    # commit whose manifest is not signed (or is signed by someone else);
     # provenance must record the artifact actually installed, not the preview.
 
     # Platform compatibility check — if the app requires a specific OS and
@@ -6830,8 +6827,8 @@ async def install_from_registry(
 
         # ADMISSION GATE, third pass — the post-build manifest is what
         # install_app/update_app will actually register, and a build step can
-        # rewrite app.json; a manifest that no longer satisfies the admission
-        # policy (e.g. signature required and now absent) must not install.
+        # rewrite app.json; a manifest that does not satisfy the admission
+        # policy (e.g. signature required but absent) must not install.
         denied = app_admission_denied(
             name,
             manifest=AppManifest.from_dict(manifest_data),
@@ -7310,7 +7307,7 @@ async def install_from_registry(
             # never off `outcome`), so removing them here deprives no consumer.
             # Two of them -- `_pending_stale_cleanup` and `_restorable_stale` --
             # are `list[Path]`, which is not JSON-serializable, so a build
-            # refusal that spreads `{**build_result}` into `outcome` used to make
+            # refusal that spreads `{**build_result}` into `outcome` would make
             # the API/SSE layer raise `TypeError` when it serialized the refusal.
             # Scrubbing the CLASS (every `_`-prefixed key) rather than those two
             # names closes it at the single seam: `_checkout_preexisted`,

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -833,7 +833,7 @@ async def handle_update_app(request: web.Request) -> web.Response:
 
         # Stop the backend, then deregister old resources — same order as uninstall and
         # the disable rollback. Stopping pops the tracking record, so the health watch
-        # can no longer re-register the OLD manifest's MCP servers after the scrub
+        # cannot re-register the OLD manifest's MCP servers after the scrub
         # (see app-kit-platform §17).
         await asyncio.get_running_loop().run_in_executor(
             subprocess_executor(), stop_app_backend, name
@@ -2515,7 +2515,7 @@ async def handle_app_config(request: web.Request) -> web.Response:
 
 
 #: Ceiling on one UI-bundle file this route will serve. With streaming (see
-#: :func:`handle_app_ui_file`) the ceiling no longer bounds gateway memory —
+#: :func:`handle_app_ui_file`) the ceiling does not bound gateway memory —
 #: per-request memory is one :data:`_UI_STREAM_CHUNK` regardless of file size —
 #: it bounds the WORK one unauthenticated request can command (bytes read and
 #: sent per request; the route bypasses token auth). Measured reality: the
@@ -2555,7 +2555,7 @@ def _open_ui_file(name: str, file_path: str) -> tuple[int, os.stat_result] | str
     ``"not_found"`` (-> 404). On the tuple path the CALLER owns closing the fd.
 
     Handing back the descriptor rather than a path is the security-relevant
-    part, and it is the same fix :func:`_read_declared_art` carries (#6794):
+    part, and it is the same fix :func:`_read_declared_art` carries:
     validating a path and then handing it to ``FileResponse`` opens it a SECOND
     time, so the app that owns this directory can swap a validated name for a
     symlink between the check and that open and have the gateway read the
@@ -2716,8 +2716,8 @@ async def handle_app_ui_file(request: web.Request) -> web.StreamResponse:
 
     Serves bytes STREAMED from a pinned descriptor (see :func:`_open_ui_file`)
     rather than handing a validated path to ``FileResponse``, which re-opens it
-    and re-introduces the check-then-reopen window #6794 closed on the art
-    route. Streaming rather than buffering is itself load-bearing: this route
+    and re-introduces the check-then-reopen window the art route also closes.
+    Streaming rather than buffering is itself load-bearing: this route
     is UNAUTHENTICATED (the ``/apps/{name}/ui/`` token-auth bypass), so a
     buffered body would let N outstanding requests each pin a whole file in
     gateway memory — with streaming, per-request memory is one chunk
@@ -3081,8 +3081,8 @@ async def _fetch_git_blob(
     second registry-row resolution would open without retaining credentials in
     the row itself.
 
-    ``owner_designated`` extends the same-repo credential carve-out (PR 918) to
-    this third clone chokepoint.  It is ``True`` only when the caller has
+    ``owner_designated`` extends the same-repo credential carve-out to this third
+    clone chokepoint.  It is ``True`` only when the caller has
     confirmed — via the merged :func:`_owner_designated_repo_target` predicate,
     evaluated against the SAME entry ``git_url`` was resolved from — that the
     entry's clone URL is byte-identical to the owner-typed
@@ -3329,7 +3329,7 @@ async def handle_blob_proxy(request: web.Request) -> web.Response:
     # repo's cache directory — a crafted ``ref`` would then yield a cache hit that
     # returns another repo's cached (possibly private) bytes without
     # authorization.  Reject any ``..`` segment or leading ``/`` in ``ref``
-    # BEFORE it is used to build or read the cache path, mirroring the
+    # BEFORE the cache path is built or read from it, mirroring the
     # ``file_path`` guard above, so a ``ref`` can only ever name a flat branch
     # subtree under its own ``repo_key``.
     if ".." in ref or ref.startswith("/"):
@@ -3415,7 +3415,7 @@ async def handle_blob_proxy(request: web.Request) -> web.Response:
     cache_path.parent.mkdir(parents=True, exist_ok=True)
 
     if not cache_path.is_file():
-        # Same-repo credential carve-out (PR 918, extended to the blob chokepoint):
+        # Same-repo credential carve-out, extended to the blob chokepoint:
         # only when the entry's clone URL is byte-identical to the owner-typed
         # registry repo does the clone get owner credentials.  Reuse the merged
         # predicate verbatim — no host normalization, no index-supplied URL trust;
@@ -3812,8 +3812,8 @@ async def handle_registries(request: web.Request) -> web.Response:
         # Edition-pinned registries are reported SEPARATELY and read-only. They
         # are not part of ``registries`` because PUT replaces that list verbatim:
         # a GET→edit→PUT round-trip would persist an edition default into the
-        # operator's config.json, where a later edition change could no longer
-        # move it. The client renders these as non-editable rows.
+        # operator's config.json, where a later edition change cannot move it.
+        # The client renders these as non-editable rows.
         pinned = [
             {
                 "name": r.name,

--- a/src/kiro_crew/apps/spawn_sdk.py
+++ b/src/kiro_crew/apps/spawn_sdk.py
@@ -214,7 +214,7 @@ def build_spawn_impl(subagents: object) -> SpawnImpl:
 def build_done_probe(subagents: object) -> DoneProbe:
     """Adapt a live ``SubagentManager`` to :data:`DoneProbe`.
 
-    An id the manager no longer tracks reads as done: the reaper prunes
+    An id the manager does not track reads as done: the reaper prunes
     records, and "gone" must never hold a caller's serial lock open.
     """
 

--- a/src/kiro_crew/apps/teardown.py
+++ b/src/kiro_crew/apps/teardown.py
@@ -173,16 +173,15 @@ async def teardown_app_runtime(
     # before the backend process is stopped, because the script may need its own
     # backend alive to shut down cleanly.
     #
-    # This step used to live only in the disable HANDLER, which made trust
-    # revocation strictly WEAKER than an ordinary off-switch: `onEnable` can start
-    # something the gateway never tracked (a detached helper, a daemon it spawned),
-    # and `onDisable` is the only thing that knows how to stop it. Revoking trust
-    # stopped the tracked backend and hooks, returned 200, and left that helper
+    # Running this step only in the disable HANDLER would make trust revocation
+    # strictly WEAKER than an ordinary off-switch: `onEnable` can start something
+    # the gateway never tracked (a detached helper, a daemon it spawned), and
+    # `onDisable` is the only thing that knows how to stop it. Revoking trust would
+    # then stop the tracked backend and hooks, return 200, and leave that helper
     # running — third-party code still executing after its permission to execute was
     # withdrawn. An inversion, since revoke is the security operation and disable is
-    # merely lifecycle. Moving it into the ONE shared teardown is what the disable
-    # handler's own comment already asked for: a second copy is how the revoke path
-    # came to miss steps in the first place.
+    # merely lifecycle. It lives in the ONE shared teardown instead: a second copy
+    # is how a revoke path comes to miss steps.
     #
     # Classified as a WARNING, never a failure, for both callers — the same call as
     # ``hooks_shutdown`` below and for a sharper reason: this script is the app's own
@@ -551,7 +550,7 @@ def forget_app_hooks(app: str) -> None:
     a false return. A slot belonging to an uninstalled app therefore becomes
     undismissable: the stale hook raises, the close is refused with
     ``app_close_hook_failed``, and the user is left with a tab they cannot get rid
-    of for an app that no longer exists. Dropping the entry restores the
+    of for an app that does not exist. Dropping the entry restores the
     no-hook-registered path, which returns True and lets the close proceed.
 
     DISABLE deliberately does not call this, and the asymmetry with the


### PR DESCRIPTION
## Problem / Motivation

Comments and docstrings under `src/kiro_crew/apps/` narrate how the code got
here instead of what it does. They name pull requests, issue numbers, review
rounds and dates, and they say "previously", "used to", "no longer", "we now".

`docs/system-specs/common/code-style.md`, section "Comments explain the WHY",
forbids all of that. This directory carried 786 such markers across 186 files.

## Why it matters

A comment that narrates a change goes stale the moment the next change lands. A
reader cannot tell whether it describes the code in front of them or the code it
replaced. A ticket number is worse: it sends the reader to a tracker to learn
something the comment should have said outright.

`scripts/check_comment_history.py` now judges only the lines a change ADDS, so
these 786 markers are no longer machine-checked at all. They stay until someone
reads them, and every one of them is an example a contributor can copy.

## What changed (motivation → approach → change)

The markers were found with the gate's own matcher, then each comment was read on
its own.

Every comment was rewritten to say what the code does now, in present tense, and
why. The history came out. The reason stayed in. Where a comment said "X used to
be Y, which broke Z", the new comment says "X is W because Y breaks Z" — the
reason is the part worth keeping.

A comment that had nothing left once the history was stripped was deleted. Every
invariant, edge case, unit, threat-model note and "why this surprising choice is
correct" was kept.

Scope: `src/kiro_crew/apps/` only, all `.py` files, including the app test
suites. Comments and docstrings only — no executable code changed, no identifier
renamed, no log or user-facing string touched, no test renamed.

Marker count for this directory: **786 → 0**, in 186 files.

## Tests

N/A — no behaviour changed, so no test can pin this. The proof is mechanical
instead:

- A token-stream verifier compares each of the 186 files against `origin/main`:
  it parses both revisions, blanks every docstring literal, drops `COMMENT` and
  non-logical `NL` tokens, and requires both the `ast.dump` and the remaining
  token sequence to be identical. All 186 files pass, so the diff cannot contain
  a code change.
- `COMMENT_HISTORY_BASE_REF=origin/main python3 scripts/check_comment_history.py`
  exits 0, and a whole-tree run reports zero markers left under
  `src/kiro_crew/apps/`.
- `python3 scripts/check_black_formatting.py` exits 0, run on the pinned
  `black==26.3.1`.
- `python3 scripts/check_subprocess_encoding.py` exits 0.
- `isort==6.0.0 --check-only` and `flake8==7.1.0` on all 186 files: clean.
- `BRAND_BASE_REF=origin/main python3 scripts/check_brand_name.py` exits 0.
- No added line carries an internal hostname or domain.
- No added line exceeds 100 characters.

## Manual verification

Every rewritten comment was read against the code it sits on, to check the
rewrite still states the same constraint. Spot-checked in each app that the
surviving text names the invariant rather than the change that introduced it.

## Related Issues

N/A — part of the repo-wide comment audit; this PR covers `src/kiro_crew/apps/`.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — comment-only)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
