### PR TITLE
fix(apps): soft-skip Python build when the gateway has no pip

### DIFF
--- a/docs/app-kit/publishing-guide.md
+++ b/docs/app-kit/publishing-guide.md
@@ -490,7 +490,8 @@ The store's Install button (`POST /api/apps/registry/install`, or the SSE varian
    app; 60s timeout) and run a detected build: `npm install` plus `npm run build`
    when `package.json` declares a build script, or `pip install .` /
    `pip install -r requirements.txt` for a Python source tree. A missing
-   `npm` is a logged skip; the pip step runs on the gateway's own interpreter
+   `npm` is a logged skip, and so is a gateway interpreter with no `pip`
+   module; when pip is present the step runs on the gateway's own interpreter
    and a failed run fails the install. **An official-catalog entry does
    not clone a branch**: it fetches exactly the commit the published catalog
    pins and hard-fails on any mismatch, never reuses a pre-existing checkout

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -27,6 +27,7 @@ minimal environment that excludes process secrets.
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import json
 import logging
 import os
@@ -6130,13 +6131,25 @@ async def _run_app_build(
                     "signed application bundle and cannot install packages"
                 ),
             }
-        pip_cmd = [sys.executable, "-m", "pip"]
-        if (build_dir / "requirements.txt").is_file() and not (
-            (build_dir / "pyproject.toml").is_file() or (build_dir / "setup.py").is_file()
-        ):
-            build_cmds.append([*pip_cmd, "install", "-r", "requirements.txt"])
+        # A missing `pip` module is a soft skip, exactly like a missing npm
+        # (see the docstring). `sys.executable` is the gateway interpreter, and a
+        # venv created with `--without-pip` — or any minimal runtime — has no `pip`
+        # module: running `-m pip` against it exits non-zero and would abort the
+        # whole registry install. Probe with `find_spec` on THIS interpreter (no
+        # subprocess: it is the interpreter that would run the build) and skip when
+        # pip is absent, so an app that needs no Python build still installs cleanly.
+        if importlib.util.find_spec("pip") is None:
+            log_lines.append(
+                "pip not available in the gateway interpreter — skipping Python build step"
+            )
         else:
-            build_cmds.append([*pip_cmd, "install", "."])
+            pip_cmd = [sys.executable, "-m", "pip"]
+            if (build_dir / "requirements.txt").is_file() and not (
+                (build_dir / "pyproject.toml").is_file() or (build_dir / "setup.py").is_file()
+            ):
+                build_cmds.append([*pip_cmd, "install", "-r", "requirements.txt"])
+            else:
+                build_cmds.append([*pip_cmd, "install", "."])
 
     if not build_cmds:
         log_lines.append("No build step detected — using source as-is")

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -23,6 +23,7 @@ This file lives in ``test/`` (not ``tests/``) so the ``setup.cfg``
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import json
 import os
 import shutil
@@ -3208,6 +3209,48 @@ async def test_python_build_uses_the_running_interpreter_not_path_pip(tmp_path, 
     argv = captured[0]
     assert argv[0] == sys.executable, f"build must use the running interpreter, got {argv[0]!r}"
     assert argv[1:3] == ["-m", "pip"], f"expected `-m pip`, got {argv[1:3]!r}"
+
+
+@pytest.mark.asyncio
+async def test_python_build_soft_skips_when_the_interpreter_has_no_pip(tmp_path, monkeypatch):
+    """A gateway interpreter without a ``pip`` module must skip the Python build,
+    not abort the whole registry install.
+
+    The docstring promises "no npm / no pip" is a soft skip, and the npm branch
+    honours it. Planning ``[sys.executable, "-m", "pip", "install", "."]`` without
+    checking availability breaks that contract: a venv created with
+    ``--without-pip`` (or any minimal runtime) has no ``pip`` module, so ``-m pip``
+    exits non-zero and the install fails with ``build failed (exit N)``.
+    ``importlib.util.find_spec("pip")`` checks the gateway interpreter and lets the
+    build soft-skip with a logged warning when pip is absent, mirroring npm.
+    """
+    log_lines: list[str] = []
+    captured: list[list[str]] = []
+
+    async def _fake_exec(*argv, **_kwargs):  # pragma: no cover - must NOT run
+        captured.append(list(argv))
+        raise AssertionError("no build command may be planned when pip is unavailable")
+
+    monkeypatch.setattr(registry, "create_subprocess_limited", _fake_exec)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\nversion='0'\n", encoding="utf-8")
+
+    # This interpreter has no importable `pip` — exactly a `--without-pip` venv.
+    real_find_spec = importlib.util.find_spec
+
+    def _no_pip(name, *args, **kwargs):
+        if name == "pip":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(registry.importlib.util, "find_spec", _no_pip)
+
+    result = await registry._run_app_build(tmp_path, "x", log_lines)
+
+    assert result == {"ok": True}, f"a pip-less interpreter must soft-skip, got {result}"
+    assert captured == [], f"no build command may be planned, got {captured}"
+    assert any(
+        "pip not available" in line for line in log_lines
+    ), f"the skip must be logged, log was {log_lines}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

Installing a Python-source app from the registry fails outright when the gateway's
interpreter has no `pip` module — the install aborts with `build failed (exit N)`.
The docstring on `_run_app_build`, and `docs/app-kit/publishing-guide.md`, both
promise that a missing build toolchain (no npm / no pip) is a *soft* skip. The npm
branch keeps that promise; the pip branch did not.

## Why it matters

Any gateway running on a minimal interpreter — a venv built `--without-pip`, or a
trimmed runtime — cannot install a Python app from the registry at all, even one
whose build step it could safely skip. The docs tell authors it will skip; the code
hard-fails instead.

## What changed (motivation → approach → change)

- Symptom: a registry install of a Python-source app aborts with `build failed`.
- Root cause: the pip branch built `[sys.executable, "-m", "pip", "install", "."]`
  unconditionally, with no availability probe — unlike the npm branch, which guards
  on `shutil.which("npm")`. On an interpreter with no `pip` module, `-m pip` exits
  non-zero and `_run_app_build` returns `ok=False`, aborting the whole install.
- Change: probe `importlib.util.find_spec("pip")` on the gateway interpreter (the
  one that would run the build — no subprocess needed) and, when pip is absent,
  soft-skip with a logged warning, mirroring the npm branch exactly. No behavior
  change beyond the probe. The publishing-guide wording is updated to state the
  symmetric skip.

## Tests

- `test_python_build_soft_skips_when_the_interpreter_has_no_pip`: forces
  `find_spec("pip")` to `None`, drives `_run_app_build` on a lone `pyproject.toml`,
  and asserts it returns `{"ok": True}`, plans no build command, and logs the skip.
  Hermetic: no host side effects, no real pip invocation.

## Manual verification

Reproduced in an isolated pod's worktree environment:
- Pre-fix mechanism — a real `--without-pip` interpreter running the original
  unconditional command `python -m pip install .` exits 1 ("No module named pip"),
  which is exactly the `build failed (exit 1)` the pre-fix `_run_app_build` returned.
- Post-fix — the real `_run_app_build` on this branch soft-skips: log line
  `pip not available in the gateway interpreter — skipping Python build step`, then
  `No build step detected — using source as-is`, result `{"ok": True}`.

## Related Issues

Fixes #9770

## Pattern harvest

Rule candidate: review-prompt
Pattern: one branch of a paired "detect toolchain, else soft-skip" block probes
availability (`shutil.which`) while its sibling builds the command unconditionally,
silently breaking the soft-skip the shared docstring promises.
