### PR TITLE
fix(slack): guard remaining presentation-side calls in the streaming loop

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -990,7 +990,6 @@ test/test_slack_mirror_unlink.py
 test/test_slack_options_lifecycle.py
 test/test_slack_pins_reactions.py
 test/test_slack_render_pipeline.py
-test/test_slack_renderer.py
 test/test_slack_scope_probe.py
 test/test_slack_sessions_view.py
 test/test_slack_thread_session_binding.py

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -3192,17 +3192,38 @@ async def handle_message(
     _tool_gap = False
 
     async def _rotate_stream() -> str | None:
-        """Stop the dead stream and start a fresh one. Returns new ts or None."""
+        """Stop the dead stream and start a fresh one. Returns new ts or None.
+
+        Best-effort: MUST NOT raise. The
+        real ``SlackClient`` swallows its own API errors, but a client or
+        transport that does not would send the exception up into the streaming
+        loop, where the typed ``except`` arms are all ``kiro_crew.acp.client``
+        errors — it reaches the generic ``except Exception`` catch-all, renders
+        the terminal "🔧 Something went wrong" message, and records a session
+        failure on a turn that is still live. A failed rotation is the existing,
+        handled outcome (``new_ts`` None → demote to chat.update), so map a
+        raise onto it.
+        """
         nonlocal stream_ts, use_slack_stream
         if stream_ts:
-            await slack.stop_stream(channel, stream_ts)
-        new_ts = await slack.start_stream(
-            channel,
-            reply_ts,
-            initial_text=_STREAM_CONTINUED,
-            team_id=team_id or None,
-            user_id=user_id or None,
-        )
+            try:
+                await slack.stop_stream(channel, stream_ts)
+            except Exception:
+                logger.warning(
+                    "Slack stop_stream failed during rotation — abandoning old stream",
+                    exc_info=True,
+                )
+        try:
+            new_ts = await slack.start_stream(
+                channel,
+                reply_ts,
+                initial_text=_STREAM_CONTINUED,
+                team_id=team_id or None,
+                user_id=user_id or None,
+            )
+        except Exception:
+            logger.warning("Slack start_stream failed during rotation", exc_info=True)
+            new_ts = None
         if new_ts:
             stream_ts = new_ts
             logger.info("Stream rotated: new ts=%s", new_ts)
@@ -3231,11 +3252,30 @@ async def handle_message(
             return True  # whole delta withheld (partial credential) — nothing to send yet
         if "[REDACTED" in safe:
             _stream_had_redaction = True
-        ok = await slack.append_stream(channel, stream_ts, safe)
+        # Best-effort: MUST NOT raise. A raising append is the same event as a
+        # refused append — the text is not on the stream — and the refusal path
+        # below (rotate, then retry once) already handles it. Letting it raise
+        # would escape into the generic catch-all below the loop and fake a
+        # terminal error on a live turn.
+        try:
+            ok = await slack.append_stream(channel, stream_ts, safe)
+        except Exception:
+            logger.warning("Slack append_stream failed — attempting rotation", exc_info=True)
+            ok = False
         if not ok and use_slack_stream:
             if await _rotate_stream():
                 assert stream_ts is not None
-                return await slack.append_stream(channel, stream_ts, safe)
+                try:
+                    ok = await slack.append_stream(channel, stream_ts, safe)
+                except Exception:
+                    logger.warning("Slack append_stream failed after rotation", exc_info=True)
+                    ok = False
+        # A delta that failed both the append and the post-rotation retry is
+        # not re-delivered: the real ``stop_stream`` deliberately ignores
+        # ``final_text``, and this is the same outcome the shipped client's
+        # REFUSED append produces on this path. Confirmed-delivery recovery
+        # for this class is a designed subsystem tracked as its own issue
+        # (delivery debt), deliberately not grown inside this guard sweep.
         return ok
 
     async def _append_task(task_id: str, title: str, status: str, details: str = "") -> bool:
@@ -3344,9 +3384,19 @@ async def handle_message(
                 thinking_ts = await slack.post_message(channel, _THINKING_PLACEHOLDER, reply_ts)
             except Exception:
                 logger.debug("Failed to reserve thinking slot", exc_info=True)
-        stream_ts = await slack.start_stream(
-            channel, reply_ts, team_id=team_id or None, user_id=user_id or None
-        )
+        # Best-effort: MUST NOT raise. The real ``SlackClient.start_stream``
+        # swallows its own errors and returns None, but a client or transport
+        # that raises instead would escape into the loop's generic catch-all
+        # from the first TEXT_CHUNK or TOOL_CALL event. A raise is the same
+        # event as a None return — streaming is unavailable — so map it onto
+        # the existing demotion path below.
+        try:
+            stream_ts = await slack.start_stream(
+                channel, reply_ts, team_id=team_id or None, user_id=user_id or None
+            )
+        except Exception:
+            logger.warning("Slack start_stream failed — demoting to chat.update", exc_info=True)
+            stream_ts = None
         use_slack_stream = stream_ts is not None
         if not use_slack_stream:
             # ``SlackClient.start_stream`` swallows its own errors and returns
@@ -3658,7 +3708,17 @@ async def handle_message(
                 accumulated += event.text
 
                 if _status_dirty and use_slack_stream:
-                    await slack.set_thread_status(channel, reply_ts, _STATUS_WORKING)
+                    # Best-effort: MUST NOT raise. The thread
+                    # status is decoration, and a raise here escapes into the
+                    # generic ``except Exception`` catch-all below the loop,
+                    # faking a terminal error on a live turn.
+                    try:
+                        await slack.set_thread_status(channel, reply_ts, _STATUS_WORKING)
+                    except Exception:
+                        logger.warning(
+                            "Slack set_thread_status failed — skipping status refresh",
+                            exc_info=True,
+                        )
                     _status_dirty = False
 
                 # ── Bracket hold-back: filter [OPTIONS: ...] from stream ──
@@ -3774,7 +3834,16 @@ async def handle_message(
                 tool_status = f"\n🫆 `{tool_name}`\n"
                 await _ensure_stream_started()
                 if use_slack_stream:
-                    await slack.set_thread_status(channel, reply_ts, f"is using {tool_name}")
+                    # Best-effort: MUST NOT raise. Decoration
+                    # only — a raise escapes to the catch-all and fakes a
+                    # terminal error on a live turn.
+                    try:
+                        await slack.set_thread_status(channel, reply_ts, f"is using {tool_name}")
+                    except Exception:
+                        logger.warning(
+                            "Slack set_thread_status failed — skipping tool status",
+                            exc_info=True,
+                        )
                     _status_dirty = True
                 if use_slack_stream:
                     # Flush any buffered text before the tool status
@@ -3828,7 +3897,19 @@ async def handle_message(
                         )
                         await _append_task(_active_task_id, _ct, "complete")
                         _active_task_id = ""
-                    await slack.stop_stream(channel, stream_ts)
+                    # Best-effort: MUST NOT raise. The stream is being
+                    # abandoned either way (``stream_ts`` is cleared just
+                    # below, and ``_ensure_stream_started`` opens a fresh
+                    # message after wait returns), so a raising ``stop_stream``
+                    # changes nothing except — unguarded — faking a terminal
+                    # error on a live turn via the catch-all.
+                    try:
+                        await slack.stop_stream(channel, stream_ts)
+                    except Exception:
+                        logger.warning(
+                            "Slack stop_stream failed at wait finalize — abandoning stream",
+                            exc_info=True,
+                        )
                     stream_ts = None
                     accumulated = ""
 
@@ -4315,8 +4396,8 @@ async def handle_message(
         # either per-chunk during streaming (_stream_had_redaction), inside the
         # final render (_render_redacted), or caught by the post-decorator scan
         # (exfil_warnings/cred_warnings). The security invariant requires the
-        # final visible message reflect the redacted accumulated text; all other
-        # cases leave the rich render intact.
+        # final visible message reflect the redacted accumulated text; all
+        # other cases leave the rich render intact.
         #
         # _render_redacted is the one that catches an ANSI-obfuscated credential:
         # the per-chunk StreamRedactor sees raw chunks and does not strip escapes,

--- a/src/kiro_crew/slack/renderer.py
+++ b/src/kiro_crew/slack/renderer.py
@@ -389,7 +389,11 @@ class SlackRenderer(Renderer):
         self._started = True
         self._t0 = self._now()
         self._ensure_controller()  # set_phase("queued")
-        await self.slack.set_thread_status(self.channel, self.thread_ts or "", _STATUS_WORKING)
+        # Best-effort: MUST NOT raise. Decoration only.
+        try:
+            await self.slack.set_thread_status(self.channel, self.thread_ts or "", _STATUS_WORKING)
+        except Exception:
+            logger.warning("Slack set_thread_status failed — skipping status", exc_info=True)
 
     def _ensure_controller(self) -> Any:
         """Lazily create the (reused) StatusReactionController.
@@ -412,33 +416,66 @@ class SlackRenderer(Renderer):
             ctrl.set_phase(phase)
             ctrl.on_progress()
 
-    async def _ensure_stream(self) -> str:
+    async def _ensure_stream(self) -> str | None:
         if self._stream_ts is None:
-            ts = await self.slack.start_stream(
-                self.channel, self.thread_ts or "", user_id=self._user_id or None
-            )
+            # Best-effort: MUST NOT raise. The real client swallows and
+            # returns None, but a raising client/transport would escape into
+            # the transport catch-all and post a terminal error on a live
+            # turn. A raise is the same event as a None return — streaming
+            # unavailable — so map it onto the fallback below.
+            try:
+                ts = await self.slack.start_stream(
+                    self.channel, self.thread_ts or "", user_id=self._user_id or None
+                )
+            except Exception:
+                logger.warning("Slack start_stream failed — demoting to chat.update", exc_info=True)
+                ts = None
             if ts:
                 self._stream_ts = ts
                 self._use_slack_stream = True
             else:
                 # No streaming surface — fall back to chat.update on a posted
                 # placeholder message (native ``_ensure_stream_started``).
+                # The placeholder post is best-effort too: on failure leave
+                # ``_stream_ts`` None — there is no placeholder to edit, and
+                # ``on_done`` posts the final answer directly with a fresh
+                # ``post_message`` (mirrors the native semantics; do NOT
+                # substitute a truthy sentinel).
                 self._use_slack_stream = False
-                self._stream_ts = await self.slack.post_message(
-                    self.channel, _THINKING, self.thread_ts
-                )
+                try:
+                    self._stream_ts = await self.slack.post_message(
+                        self.channel, _THINKING, self.thread_ts
+                    )
+                except Exception:
+                    logger.warning("Failed to post chat.update placeholder", exc_info=True)
+                    self._stream_ts = None
         return self._stream_ts
 
     async def _rotate_stream(self) -> str | None:
-        """Stop the dead stream and start a fresh one (native ``_rotate_stream``)."""
+        """Stop the dead stream and start a fresh one (native ``_rotate_stream``).
+
+        Best-effort: MUST NOT raise. A failed rotation is the existing,
+        handled outcome (``new_ts`` None → demote), so map a raise onto it
+        rather than letting it reach the transport catch-all.
+        """
         if self._stream_ts:
-            await self.slack.stop_stream(self.channel, self._stream_ts)
-        new_ts = await self.slack.start_stream(
-            self.channel,
-            self.thread_ts or "",
-            initial_text=_STREAM_CONTINUED,
-            user_id=self._user_id or None,
-        )
+            try:
+                await self.slack.stop_stream(self.channel, self._stream_ts)
+            except Exception:
+                logger.warning(
+                    "Slack stop_stream failed during rotation — abandoning old stream",
+                    exc_info=True,
+                )
+        try:
+            new_ts = await self.slack.start_stream(
+                self.channel,
+                self.thread_ts or "",
+                initial_text=_STREAM_CONTINUED,
+                user_id=self._user_id or None,
+            )
+        except Exception:
+            logger.warning("Slack start_stream failed during rotation", exc_info=True)
+            new_ts = None
         if new_ts:
             self._stream_ts = new_ts
         else:
@@ -453,11 +490,29 @@ class SlackRenderer(Renderer):
         # appended text on this path is FINAL (chat.stopStream does not replace
         # it), which makes an unscanned append unrecoverable.
         text = _display_safe(text)
-        ok = await self.slack.append_stream(self.channel, self._stream_ts, text)
+        # Best-effort: MUST NOT raise. A raising append is the same event as a
+        # refused append — the text is not on the stream — and the refusal
+        # path below (rotate, then retry once) already handles it. Letting it
+        # raise would reach the transport catch-all and fake a terminal error
+        # on a live turn.
+        try:
+            ok = await self.slack.append_stream(self.channel, self._stream_ts, text)
+        except Exception:
+            logger.warning("Slack append_stream failed — attempting rotation", exc_info=True)
+            ok = False
         if not ok and self._use_slack_stream:
             if await self._rotate_stream():
                 assert self._stream_ts is not None
-                ok = await self.slack.append_stream(self.channel, self._stream_ts, text)
+                try:
+                    ok = await self.slack.append_stream(self.channel, self._stream_ts, text)
+                except Exception:
+                    logger.warning("Slack append_stream failed after rotation", exc_info=True)
+                    ok = False
+        # A delta that failed both the append and the post-rotation retry is
+        # not re-delivered here: this matches the shipped client's refused-
+        # append outcome on this path. Confirmed-delivery recovery for the
+        # class is a designed subsystem tracked as its own issue (delivery
+        # debt), deliberately not grown inside this guard sweep.
         if ok:
             # Delivery ledger. This is the ONE sink every streamed assistant string
             # passes through, and it reports whether Slack accepted the append — so
@@ -699,12 +754,24 @@ class SlackRenderer(Renderer):
         only caller touching the stream — and rotating on its failure would cost
         the reader the message they are watching and split the answer in two.
         ``_append_stream`` still rotates for real text.
+
+        Best-effort: MUST NOT raise. Guarded at this single definition,
+        covering all call sites (the native handler guards its twin the same
+        way): the unguarded ``on_tool_call`` call site runs before any text
+        streams, and a propagated Slack error there reaches the transport
+        catch-all in ``transport_dispatch``, which posts a terminal "🔧
+        Something went wrong (transport path)" reply on a turn that is still
+        live.
         """
         if not self._stream_ts:
             return False
-        return await self.slack.append_task(
-            self.channel, self._stream_ts, task_id, title, status, details=details
-        )
+        try:
+            return await self.slack.append_task(
+                self.channel, self._stream_ts, task_id, title, status, details=details
+            )
+        except Exception:
+            logger.warning("Slack append_task failed — skipping progress card", exc_info=True)
+            return False
 
     def _tool_elapsed_str(self) -> str:
         """Formatted elapsed time for the active tool, or '' (native helper)."""
@@ -856,13 +923,21 @@ class SlackRenderer(Renderer):
                 # fallback ``delivered_text`` stays empty and the dispatcher's
                 # rescue is a no-op — the correct outcome, because nothing here can
                 # be shown to have reached the user.
-                await _safe_update(self.slack, self.channel, ts, frame[0] + _CURSOR)
+                # ``ts`` may be None: both the stream start and the
+                # placeholder post failed, so there is no message to edit. Skip
+                # the cursor edit — ``on_done`` posts the final answer directly.
+                if ts is not None:
+                    await _safe_update(self.slack, self.channel, ts, frame[0] + _CURSOR)
             self._last_edit = now
 
     async def on_thinking(self, text: str) -> None:
         self._set_phase("thinking")
         # Thinking is surfaced via the thread status indicator, not the stream.
-        await self.slack.set_thread_status(self.channel, self.thread_ts or "", "is_typing")
+        # Best-effort: MUST NOT raise. Decoration only.
+        try:
+            await self.slack.set_thread_status(self.channel, self.thread_ts or "", "is_typing")
+        except Exception:
+            logger.warning("Slack set_thread_status failed — skipping status", exc_info=True)
         # When enabled, accumulate the reasoning so it can be posted as a 💭
         # thread reply above the answer (honors slack.show_thinking, matching
         # native). When disabled, reasoning is never accumulated or surfaced.
@@ -887,7 +962,12 @@ class SlackRenderer(Renderer):
         # the whole 💭 reply, not its tail. Split it fence-safely so a long
         # chain of thought arrives as ordered replies instead of vanishing.
         for chunk in await self._split_for_slack(f"💭 {reasoning}"):
-            await self.slack.post_message(self.channel, chunk, self.thread_ts)
+            # Best-effort: MUST NOT raise. Reasoning is a
+            # decorative side channel — the answer is delivered separately.
+            try:
+                await self.slack.post_message(self.channel, chunk, self.thread_ts)
+            except Exception:
+                logger.warning("Failed to post thinking chunk", exc_info=True)
 
     async def on_tool_call(
         self, tool_call_id: str, title: str, tool_kind: str = "", tool_purpose: str = ""
@@ -901,9 +981,15 @@ class SlackRenderer(Renderer):
         if self._controller is not None and self._tool_to_phase is not None:
             self._controller.set_phase(self._tool_to_phase(tool_name, tool_kind))
             self._controller.on_progress()
-        await self.slack.set_thread_status(
-            self.channel, self.thread_ts or "", f"is using {tool_name}"
-        )
+        # Best-effort: MUST NOT raise. Decoration only — a raise
+        # escapes to the transport catch-all and fakes a terminal error on a
+        # live turn.
+        try:
+            await self.slack.set_thread_status(
+                self.channel, self.thread_ts or "", f"is using {tool_name}"
+            )
+        except Exception:
+            logger.warning("Slack set_thread_status failed — skipping tool status", exc_info=True)
         # Flush any buffered streamed text before the tool status, like native.
         if self._use_slack_stream:
             await self._flush_stream_buffer()
@@ -935,7 +1021,18 @@ class SlackRenderer(Renderer):
             if self._ref_hold:
                 await self._append_stream(self._ref_hold)
                 self._ref_hold = ""
-            await self.slack.stop_stream(self.channel, self._stream_ts)
+            # Best-effort: MUST NOT raise. The stream is being abandoned
+            # either way (``_stream_ts`` is cleared just below and the next
+            # chunk opens a fresh one), so a raising ``stop_stream`` changes
+            # nothing except — unguarded — faking a terminal error on a live
+            # turn via the transport catch-all.
+            try:
+                await self.slack.stop_stream(self.channel, self._stream_ts)
+            except Exception:
+                logger.warning(
+                    "Slack stop_stream failed at wait finalize — abandoning stream",
+                    exc_info=True,
+                )
             self._stream_ts = None
             self._accumulated = ""
             self._stream_buffer = ""
@@ -967,9 +1064,13 @@ class SlackRenderer(Renderer):
         )
 
     async def on_compaction(self, context_usage_pct: float) -> None:
-        await self.slack.set_thread_status(
-            self.channel, self.thread_ts or "", "compacting context…"
-        )
+        # Best-effort: MUST NOT raise. Decoration only.
+        try:
+            await self.slack.set_thread_status(
+                self.channel, self.thread_ts or "", "compacting context…"
+            )
+        except Exception:
+            logger.warning("Slack set_thread_status failed — skipping status", exc_info=True)
 
     async def on_done(self, stop_reason: str = "") -> None:
         # Surface any reasoning not already flushed by the first text chunk
@@ -1038,18 +1139,44 @@ class SlackRenderer(Renderer):
                     await self._append_stream(tail)
                 if upload_notes:
                     await self._append_stream(f"\n\n{upload_notes}")
-                await self.slack.stop_stream(self.channel, self._stream_ts, clean_text or None)
+                try:
+                    await self.slack.stop_stream(self.channel, self._stream_ts, clean_text or None)
+                except Exception:
+                    logger.warning("Slack stop_stream failed at finalize", exc_info=True)
             else:
                 # No-stream fallback: _stream_ts is a regular message ts (the
                 # _THINKING placeholder), not a stream handle — finalize it via
                 # chat.update, mirroring the on_tool_call gating.
                 await self._render_fallback(clean_text or "")
+        elif clean_text:
+            # No stream and no placeholder exists (both the stream start and
+            # the placeholder post failed) — post the final answer
+            # directly, mirroring the native handler's end-of-turn else branch.
+            # This is the answer-carrying call, not decoration: a raise
+            # propagates (the transport catch-all recording a failure is the
+            # honest outcome), with ``_finalized`` reset FIRST so the
+            # dispatcher's partial-progress rescue is not suppressed, and each
+            # confirmed part recorded in the delivery ledger so the rescue
+            # knows what was already shown.
+            try:
+                for part in await self._split_for_slack(clean_text):
+                    await self.slack.post_message(self.channel, part, self.thread_ts)
+                    self._delivered += part
+            except Exception:
+                self._finalized = False
+                raise
         if files:
             # After the text, so the answer reads first and each picture lands
             # under the sentence that introduced it.
             await self._upload_files(files)
-        # Clear thread status now that the turn is complete.
-        await self.slack.set_thread_status(self.channel, self.thread_ts or "", "")
+        # Clear thread status now that the turn is complete. Best-effort, and
+        # MUST NOT raise: the answer is already delivered above — a
+        # raising status clear must not convert a delivered turn into a
+        # recorded failure.
+        try:
+            await self.slack.set_thread_status(self.channel, self.thread_ts or "", "")
+        except Exception:
+            logger.warning("Slack set_thread_status failed — skipping status clear", exc_info=True)
         # Timing footer (always posted at turn end), mirroring native.
         turn_elapsed = (self._now() - self._t0) if self._t0 else 0.0
         footer_blocks, footer_text = build_timing_footer(turn_elapsed, None)

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -4058,3 +4058,236 @@ class TestLiveTurnPresentationFailure:
         )
         assert "Something went wrong" not in all_text, slack.actions
         assert sessions.record_failure_calls == 0
+
+
+class TestStreamingLoopPresentationGuards:
+    """Presentation-guard sweep: every remaining presentation-side Slack
+    call inside the streaming loop must be best-effort. The real ``SlackClient``
+    swallows its own API errors, but a client or transport that raises instead
+    would escape into the generic ``except Exception`` catch-all (the typed arms
+    are all ``kiro_crew.acp.client`` errors), rendering the terminal
+    "🔧 Something went wrong" message and recording a session failure on a turn
+    that is still live. Each test drives one guarded site with a raising client
+    and asserts: no failure recorded, no terminal placeholder, reply delivered.
+    """
+
+    class _TrackingSessions(FakeSessionManager):
+        def __init__(self, provider):
+            super().__init__(provider)
+            self.record_failure_calls = 0
+            self.record_success_calls = 0
+
+        async def record_failure(self, key):
+            self.record_failure_calls += 1
+            return False
+
+        def record_success(self, key):
+            self.record_success_calls += 1
+
+    @staticmethod
+    def _all_text(slack) -> str:
+        return " ".join(
+            str(a[1].get("text") or "")
+            for a in slack.actions
+            if a[0] in ("post", "update", "append_stream", "stop_stream")
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_thread_status_raise_in_tool_and_text_branches(self):
+        """``set_thread_status`` raises in the TOOL_CALL branch (tool status) and
+        again in the TEXT_CHUNK branch (the ``_status_dirty`` reset): both are
+        decoration and must be swallowed."""
+
+        class RaisingStatusSlack(MockSlackClient):
+            def __init__(self):
+                super().__init__()
+                self._stream_enabled = True
+                self.status_raises = 0
+
+            async def set_thread_status(self, *a, **kw):
+                # Out-of-scope calls for this sweep: the pre-loop base-status
+                # call (before the stream opens) and the end-of-turn/error-path
+                # status CLEARS (empty status). Raise only on the in-loop
+                # TOOL_CALL / TEXT_CHUNK branch calls this sweep guards —
+                # non-empty statuses sent after the stream opened.
+                status = a[2] if len(a) > 2 else kw.get("status", "")
+                if not status or not any(m == "start_stream" for m, _ in self.actions):
+                    return await super().set_thread_status(*a, **kw)
+                self.status_raises += 1
+                raise RuntimeError("ratelimited: assistant.threads.setStatus")
+
+        slack = RaisingStatusSlack()
+        # tool_call hits the TOOL_CALL-branch status; the following text chunk
+        # (with _status_dirty=True) hits the TEXT_CHUNK-branch reset.
+        provider = FakeProvider(
+            [
+                LLMEvent(
+                    kind="tool_call",
+                    title="Running: grep",
+                    tool_kind="execute",
+                    tool_purpose="searching the repo",
+                ),
+                LLMEvent(kind="text_chunk", text="The answer is 42"),
+            ]
+        )
+        sessions = self._TrackingSessions(provider)
+
+        await handle_message(slack, sessions, "C1", "do something slow", None, "msg1", "U1")
+
+        assert slack.status_raises >= 2, slack.actions  # both branches actually fired
+        assert sessions.record_failure_calls == 0
+        all_text = self._all_text(slack)
+        assert "Something went wrong" not in all_text, slack.actions
+        assert "The answer is 42" in all_text, slack.actions
+        assert sessions.record_success_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_wait_finalize_stop_stream_raise(self):
+        """``stop_stream`` raising at the wait-tool finalize must not fail the
+        turn: the stream is abandoned either way and the next chunk reopens a
+        fresh one. Only the finalize call (no ``final_text``) raises — the
+        end-of-turn delivery call carries the reply and stays live."""
+
+        class RaisingFinalizeSlack(MockSlackClient):
+            def __init__(self):
+                super().__init__()
+                self._stream_enabled = True
+                self.finalize_raises = 0
+
+            async def stop_stream(self, channel, ts, final_text=None):
+                if final_text is None:
+                    self.finalize_raises += 1
+                    raise RuntimeError("message_not_found: chat.stopStream")
+                return await super().stop_stream(channel, ts, final_text)
+
+        slack = RaisingFinalizeSlack()
+        provider = FakeProvider(
+            [
+                LLMEvent(
+                    kind="tool_call",
+                    title="Running: wait",
+                    tool_kind="execute",
+                    tool_purpose="waiting for CI",
+                ),
+                LLMEvent(kind="text_chunk", text="The answer is 42"),
+            ]
+        )
+        sessions = self._TrackingSessions(provider)
+
+        await handle_message(slack, sessions, "C1", "babysit the build", None, "msg1", "U1")
+
+        assert slack.finalize_raises >= 1, slack.actions  # the finalize path actually fired
+        assert sessions.record_failure_calls == 0
+        all_text = self._all_text(slack)
+        assert "Something went wrong" not in all_text, slack.actions
+        assert "The answer is 42" in all_text, slack.actions
+        assert sessions.record_success_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_append_stream_raise_with_failed_rotation(self):
+        """``append_stream`` raising (instead of returning False) must route into
+        the existing rotation path, and the rotation's own ``start_stream``
+        raising must demote to chat.update — never escape to the catch-all. The
+        reply is still delivered from ``accumulated`` at end of turn."""
+
+        class RaisingAppendSlack(MockSlackClient):
+            def __init__(self):
+                super().__init__()
+                self._stream_enabled = True
+                self._started_once = False
+                self.append_raises = 0
+
+            async def start_stream(self, *a, **kw):
+                # First open succeeds (streaming path taken); the rotation's
+                # reopen raises like a transport failure.
+                if self._started_once:
+                    raise RuntimeError("fatal_error: chat.startStream")
+                self._started_once = True
+                return await super().start_stream(*a, **kw)
+
+            async def append_stream(self, *a, **kw):
+                self.append_raises += 1
+                raise RuntimeError("ratelimited: chat.appendStream")
+
+        slack = RaisingAppendSlack()
+        provider = FakeProvider([LLMEvent(kind="text_chunk", text="The answer is 42")])
+        sessions = self._TrackingSessions(provider)
+
+        await handle_message(slack, sessions, "C1", "hello", None, "msg1", "U1")
+
+        assert slack.append_raises >= 1, slack.actions  # the guarded site actually fired
+        assert sessions.record_failure_calls == 0
+        all_text = self._all_text(slack)
+        assert "Something went wrong" not in all_text, slack.actions
+        assert "The answer is 42" in all_text, slack.actions
+        assert sessions.record_success_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_append_retry_raise_after_successful_rotation_still_delivers(self):
+        """Rotation SUCCEEDS but the retry append raises too: the raise must
+        map onto the refused-append outcome — the turn stays live, no terminal
+        error, no failure record — exactly as the shipped client's refused
+        append behaves on this path. (Re-delivering the dropped delta is the
+        delivery-debt follow-up, deliberately out of this sweep's scope.)"""
+
+        class AlwaysRaisingAppendSlack(MockSlackClient):
+            def __init__(self):
+                super().__init__()
+                self._stream_enabled = True
+                self.append_raises = 0
+
+            async def append_stream(self, *a, **kw):
+                self.append_raises += 1
+                raise RuntimeError("ratelimited: chat.appendStream")
+
+        slack = AlwaysRaisingAppendSlack()
+        provider = FakeProvider([LLMEvent(kind="text_chunk", text="The answer is 42")])
+        sessions = self._TrackingSessions(provider)
+
+        await handle_message(slack, sessions, "C1", "hello", None, "msg1", "U1")
+
+        # Both the first append and the post-rotation retry fired and raised.
+        assert slack.append_raises >= 2, slack.actions
+        assert sessions.record_failure_calls == 0
+        all_text = self._all_text(slack)
+        assert "Something went wrong" not in all_text, slack.actions
+        assert sessions.record_success_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_initial_start_stream_raise_demotes_to_fallback(self):
+        """The lazy first ``start_stream`` in ``_ensure_stream_started`` raising
+        must demote to the chat.update path exactly like a ``None`` return —
+        not escape to the catch-all from the first event."""
+
+        class RaisingStartSlack(MockSlackClient):
+            def __init__(self):
+                super().__init__()
+                self._stream_enabled = True
+                self.start_raises = 0
+
+            async def start_stream(self, *a, **kw):
+                self.start_raises += 1
+                raise RuntimeError("fatal_error: chat.startStream")
+
+        slack = RaisingStartSlack()
+        provider = FakeProvider(
+            [
+                LLMEvent(
+                    kind="tool_call",
+                    title="Running: grep",
+                    tool_kind="execute",
+                    tool_purpose="searching the repo",
+                ),
+                LLMEvent(kind="text_chunk", text="The answer is 42"),
+            ]
+        )
+        sessions = self._TrackingSessions(provider)
+
+        await handle_message(slack, sessions, "C1", "hello", None, "msg1", "U1")
+
+        assert slack.start_raises >= 1, slack.actions  # the guarded site actually fired
+        assert sessions.record_failure_calls == 0
+        all_text = self._all_text(slack)
+        assert "Something went wrong" not in all_text, slack.actions
+        assert "The answer is 42" in all_text, slack.actions
+        assert sessions.record_success_calls == 1

--- a/test/test_slack_renderer.py
+++ b/test/test_slack_renderer.py
@@ -43,15 +43,17 @@ class _RecSlack:
         return f"ts-{self._n}"
 
     async def start_stream(self, channel, thread_ts, **kw):
-        self.calls.append((
-            "start_stream",
-            {
-                "channel": channel,
-                "thread_ts": thread_ts,
-                "user_id": kw.get("user_id"),
-                "initial_text": kw.get("initial_text"),
-            },
-        ))
+        self.calls.append(
+            (
+                "start_stream",
+                {
+                    "channel": channel,
+                    "thread_ts": thread_ts,
+                    "user_id": kw.get("user_id"),
+                    "initial_text": kw.get("initial_text"),
+                },
+            )
+        )
         return self._ts()
 
     async def append_stream(self, channel, ts, text):
@@ -122,9 +124,9 @@ class TestRendererClose:
         async def scenario():
             rec = _RecSlack()
             renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-            await renderer.on_done()          # success path marks _finalized
-            await renderer.close()            # must be a no-op, not re-finalize
-            await renderer.close()            # idempotent
+            await renderer.on_done()  # success path marks _finalized
+            await renderer.close()  # must be a no-op, not re-finalize
+            await renderer.close()  # idempotent
             assert renderer._finalized is True
 
         asyncio.run(scenario())
@@ -166,9 +168,9 @@ class TestOptionsControlIsStamped:
 
             actions = self._options_block(rec)
             assert actions is not None, "the options control must still be posted"
-            assert actions.get("block_id") == "stamp-abc", (
-                "the control must carry the stamp, or its clicks cannot be judged"
-            )
+            assert (
+                actions.get("block_id") == "stamp-abc"
+            ), "the control must carry the stamp, or its clicks cannot be judged"
             assert seen, "the stamp must be taken BEFORE the control is posted"
 
         asyncio.run(scenario())
@@ -197,9 +199,9 @@ class TestOptionsControlIsStamped:
             await renderer.on_done()
 
             assert persisted, "the stamp must have been invoked"
-            assert "[OPTIONS: alpha | beta]" in persisted[0], (
-                "the persisted text must keep the trailer, or replay loses the control"
-            )
+            assert (
+                "[OPTIONS: alpha | beta]" in persisted[0]
+            ), "the persisted text must keep the trailer, or replay loses the control"
 
         asyncio.run(scenario())
 
@@ -242,16 +244,23 @@ class TestSlackRendererMapping:
     def test_text_turn_maps_to_stream(self):
         rec = _RecSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="Hello "),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="world"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="Hello "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="world"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("hi"))
         methods = [m for m, _ in rec.calls]
         assert methods == [
-            "set_thread_status", "start_stream", "append_stream", "append_stream",
-            "stop_stream", "set_thread_status", "post_blocks",
+            "set_thread_status",
+            "start_stream",
+            "append_stream",
+            "append_stream",
+            "stop_stream",
+            "set_thread_status",
+            "post_blocks",
         ]
         # stop_stream carries the clean final text
         stop = [kw for m, kw in rec.calls if m == "stop_stream"][0]
@@ -260,11 +269,13 @@ class TestSlackRendererMapping:
     def test_shared_driver_strips_split_steering_marker(self):
         rec = _RecSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="Before [STEERING steer-7e6a4a0d"),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="94314d2db: internal ack] after"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="Before [STEERING steer-7e6a4a0d"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="94314d2db: internal ack] after"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("hi"))
         visible = "".join(
             str(kw.get("text") or kw.get("final_text") or "")
@@ -281,10 +292,12 @@ class TestSlackRendererMapping:
         # no-op rather than post a second working-status update.
         rec = _RecSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
 
         async def _drive():
             await renderer.on_turn_start()  # early ack, before session spin-up
@@ -294,7 +307,8 @@ class TestSlackRendererMapping:
         # Exactly one working-status ack at the start (the driver's call no-ops),
         # plus the clearing set_thread_status at on_done.
         working = [
-            kw for m, kw in rec.calls
+            kw
+            for m, kw in rec.calls
             if m == "set_thread_status" and kw.get("status") == _STATUS_WORKING
         ]
         assert len(working) == 1
@@ -302,11 +316,13 @@ class TestSlackRendererMapping:
     def test_bracket_hold_filters_options_from_stream(self):
         rec = _RecSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="Pick one "),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="[OPTIONS: A | B]"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="Pick one "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="[OPTIONS: A | B]"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("hi"))
         streamed = "".join(kw["text"] for m, kw in rec.calls if m == "append_stream")
         # The [OPTIONS:...] markup must never hit the live stream...
@@ -321,11 +337,13 @@ class TestSlackRendererMapping:
     def test_tool_turn_maps_to_tasks(self):
         rec = _RecSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="x", title="grep", tool_final=False),
-            AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="x", tool_output="ok", tool_final=True),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="x", title="grep", tool_final=False),
+                AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="x", tool_output="ok", tool_final=True),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("hi"))
         statuses = [kw.get("status") for m, kw in rec.calls if m == "append_task"]
         # Unified on_tool_call: start task1; tool2 completes task1 + starts task2;
@@ -336,10 +354,16 @@ class TestSlackRendererMapping:
         rec = _RecSlack()
         decider = SlackApprovalDecider()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, decider=decider)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rq1", options=[{"id": "grep", "label": "grep"}]),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(
+                    kind=EVENT_PERMISSION_REQUEST,
+                    request_id="rq1",
+                    options=[{"id": "grep", "label": "grep"}],
+                ),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         driver = TurnDriver(provider, renderer, approval_mode=APPROVAL_INTERACTIVE, decider=decider)
 
         async def scenario():
@@ -356,8 +380,11 @@ class TestSlackRendererMapping:
         # Approval blocks are posted only when a decider can act on them.
         all_ids = {
             e["action_id"]
-            for kw in posted for b in kw["blocks"] if b["type"] == "actions"
-            for e in b["elements"] if "action_id" in e
+            for kw in posted
+            for b in kw["blocks"]
+            if b["type"] == "actions"
+            for e in b["elements"]
+            if "action_id" in e
         }
         assert f"{TOOL_APPROVE_ACTION_PREFIX}rq1" in all_ids
         assert provider.approved == ["rq1"]
@@ -372,18 +399,18 @@ class TestSlackRendererMapping:
         rec = _RecSlack()
         decider = SlackApprovalDecider()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, decider=decider)
-        provider = _Provider([
-            AcpEvent(
-                kind=EVENT_PERMISSION_REQUEST,
-                request_id="rq1",
-                title="execute_bash",
-                options=[{"id": "allow", "label": "Allow"}],
-            ),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
-        driver = TurnDriver(
-            provider, renderer, approval_mode=APPROVAL_INTERACTIVE, decider=decider
+        provider = _Provider(
+            [
+                AcpEvent(
+                    kind=EVENT_PERMISSION_REQUEST,
+                    request_id="rq1",
+                    title="execute_bash",
+                    options=[{"id": "allow", "label": "Allow"}],
+                ),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
         )
+        driver = TurnDriver(provider, renderer, approval_mode=APPROVAL_INTERACTIVE, decider=decider)
 
         async def scenario():
             task = asyncio.create_task(driver.run("hi"))
@@ -397,8 +424,10 @@ class TestSlackRendererMapping:
         asyncio.run(scenario())
         sections = [
             b["text"]["text"]
-            for m, kw in rec.calls if m == "post_blocks"
-            for b in kw["blocks"] if b.get("type") == "section"
+            for m, kw in rec.calls
+            if m == "post_blocks"
+            for b in kw["blocks"]
+            if b.get("type") == "section"
         ]
         assert any("execute_bash" in t for t in sections), sections
         assert not any("*Allow*" in t for t in sections), sections
@@ -407,16 +436,25 @@ class TestSlackRendererMapping:
         # Deny-by-default (no decider): no dead approve/deny buttons are posted.
         rec = _RecSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rq1", options=[{"id": "grep", "label": "grep"}]),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(
+                    kind=EVENT_PERMISSION_REQUEST,
+                    request_id="rq1",
+                    options=[{"id": "grep", "label": "grep"}],
+                ),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode=APPROVAL_INTERACTIVE).run("hi"))
         posted = [kw for m, kw in rec.calls if m == "post_blocks"]
         all_ids = {
             e["action_id"]
-            for kw in posted for b in kw["blocks"] if b["type"] == "actions"
-            for e in b["elements"] if "action_id" in e
+            for kw in posted
+            for b in kw["blocks"]
+            if b["type"] == "actions"
+            for e in b["elements"]
+            if "action_id" in e
         }
         assert f"{TOOL_APPROVE_ACTION_PREFIX}rq1" not in all_ids
         # No decider to resolve -> deny by default.
@@ -428,10 +466,12 @@ class TestApprovalDecider:
         rec = _RecSlack()
         decider = SlackApprovalDecider()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, decider=decider)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rq1", options=[{"id": "grep"}]),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rq1", options=[{"id": "grep"}]),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         driver = TurnDriver(provider, renderer, approval_mode=APPROVAL_INTERACTIVE, decider=decider)
 
         async def scenario():
@@ -457,10 +497,12 @@ class TestApprovalDecider:
         rec = _RecSlack()
         decider = SlackApprovalDecider(session_key="thread-42")
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, decider=decider)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rqS", options=[{"id": "grep"}]),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rqS", options=[{"id": "grep"}]),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         driver = TurnDriver(provider, renderer, approval_mode=APPROVAL_INTERACTIVE, decider=decider)
 
         async def scenario():
@@ -483,10 +525,12 @@ class TestApprovalDecider:
         rec = _RecSlack()
         decider = SlackApprovalDecider()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, decider=decider)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rqG", options=[{"id": "grep"}]),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rqG", options=[{"id": "grep"}]),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         driver = TurnDriver(provider, renderer, approval_mode=APPROVAL_INTERACTIVE, decider=decider)
 
         async def scenario():
@@ -511,10 +555,12 @@ class TestApprovalDecider:
         rec = _RecSlack()
         decider = SlackApprovalDecider()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, decider=decider)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rqD", options=[{"id": "grep"}]),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rqD", options=[{"id": "grep"}]),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         driver = TurnDriver(provider, renderer, approval_mode=APPROVAL_INTERACTIVE, decider=decider)
 
         async def scenario():
@@ -538,11 +584,17 @@ class TestApprovalDecider:
         rec = _RecSlack()
         decider = SlackApprovalDecider()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, decider=decider)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rqT", options=[{"id": "grep"}]),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
-        asyncio.run(TurnDriver(provider, renderer, approval_mode=APPROVAL_INTERACTIVE, decider=decider).run("hi"))
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rqT", options=[{"id": "grep"}]),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
+        asyncio.run(
+            TurnDriver(provider, renderer, approval_mode=APPROVAL_INTERACTIVE, decider=decider).run(
+                "hi"
+            )
+        )
         assert provider.rejected == ["rqT"]
         assert provider.approved == []
         assert "rqT" not in SlackApprovalDecider._REGISTRY
@@ -569,11 +621,11 @@ class TestApprovalDecider:
             assert SlackApprovalDecider._REGISTRY.get("thread-B:1") is dec_b
             # Approve ONLY thread B via its namespaced token.
             assert SlackApprovalDecider.resolve_global("thread-B:1", True) is True
-            assert (await task_b) is True          # B approved
+            assert (await task_b) is True  # B approved
             # A is untouched and still pending — deny it to finish the test.
             assert not task_a.done()
             assert SlackApprovalDecider.resolve_global("thread-A:1", False) is True
-            assert (await task_a) is False         # A independently denied
+            assert (await task_a) is False  # A independently denied
 
         _asyncio.run(scenario())
 
@@ -646,12 +698,14 @@ class TestTaskCardNeverAbandonsTheStream:
         lands in the message that was already open."""
         rec = _FlakyTaskSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="looking "),
-            AcpEvent(kind=EVENT_TOOL_CALL, title="Bash", tool_name="Bash"),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="done "),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="looking "),
+                AcpEvent(kind=EVENT_TOOL_CALL, title="Bash", tool_name="Bash"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="done "),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
         opens = [kw for m, kw in rec.calls if m == "start_stream"]
         assert len(opens) == 1, rec.calls
@@ -663,10 +717,12 @@ class TestTaskCardNeverAbandonsTheStream:
         one answer rather than as a failure plus a mystery reply."""
         rec = _FlakyAppendSlack()  # first append_stream fails => one rotation
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi "),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi "),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
         opens = [kw for m, kw in rec.calls if m == "start_stream"]
         assert len(opens) == 2, rec.calls
@@ -695,12 +751,14 @@ class TestStreamMachinery:
         # redactor holdback.
         clock = _FakeClock([1000.0, 1000.0, 1000.2, 1000.4, 1000.4])
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, now=clock)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="A "),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="B "),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="C "),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="A "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="B "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="C "),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("hi"))
         streamed = [kw["text"] for m, kw in rec.calls if m == "append_stream"]
         assert streamed == ["A ", "B C "], streamed
@@ -710,11 +768,13 @@ class TestStreamMachinery:
         clock = _FakeClock([1000.0, 1000.0, 1002.0, 1003.0])  # B is 2s after A
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, now=clock)
         # Trailing space so StreamRedactor commits each chunk immediately.
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="A "),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="B "),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="A "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="B "),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("hi"))
         streamed = [kw["text"] for m, kw in rec.calls if m == "append_stream"]
         assert streamed == ["A ", "B "], streamed
@@ -722,10 +782,12 @@ class TestStreamMachinery:
     def test_append_failure_triggers_one_rotation(self):
         rec = _FlakyAppendSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
         methods = [m for m, _ in rec.calls]
         # Initial open + one rotation = 2 start_streams; the failed append is
@@ -737,10 +799,12 @@ class TestStreamMachinery:
     def test_no_stream_falls_back_to_chat_update(self):
         rec = _NoStreamSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="hello"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="hello"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
         methods = [m for m, _ in rec.calls]
         # No streaming surface -> a placeholder is posted and edits go via
@@ -757,15 +821,16 @@ class TestToolTimerAndWait:
         # completes tool1), on_done. Tool1 ran 2s -> "⏱ 2.0s" in its title.
         clock = _FakeClock([1000.0, 1000.0, 1002.0, 1002.0])
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, now=clock)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="a", title="grep", tool_final=False),
-            AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="b", title="cat", tool_final=False),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="a", title="grep", tool_final=False),
+                AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="b", title="cat", tool_final=False),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
         completes = [
-            kw["title"] for m, kw in rec.calls
-            if m == "append_task" and kw["status"] == "complete"
+            kw["title"] for m, kw in rec.calls if m == "append_task" and kw["status"] == "complete"
         ]
         assert any("⏱" in t for t in completes), completes
         assert renderer._tool_timer_task is None  # timer cancelled on done
@@ -773,11 +838,13 @@ class TestToolTimerAndWait:
     def test_wait_tool_finalizes_stream(self):
         rec = _RecSlack()
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="w", title="wait", tool_final=False),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="back"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TOOL_CALL, tool_call_id="w", title="wait", tool_final=False),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="back"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
         methods = [m for m, _ in rec.calls]
         # The wait tool finalizes (stop_stream) then a fresh stream opens for
@@ -805,15 +872,15 @@ class TestNoStreamOptionsFiltering:
 
     def test_options_markup_not_leaked_in_no_stream_updates(self):
         rec = _NoStreamSlack()
-        renderer = SlackRenderer(
-            rec, "C1", "t1", reactions_enabled=False, now=_StepClock(step=2.0)
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, now=_StepClock(step=2.0))
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="Pick one: "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="A or B "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="[OPTIONS: A | B]"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
         )
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="Pick one: "),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="A or B "),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="[OPTIONS: A | B]"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("hi"))
 
         updates = [kw["text"] for m, kw in rec.calls if m == "update_message"]
@@ -827,15 +894,15 @@ class TestNoStreamOptionsFiltering:
 
     def test_thinking_tags_not_leaked_in_no_stream_updates(self):
         rec = _NoStreamSlack()
-        renderer = SlackRenderer(
-            rec, "C1", "t1", reactions_enabled=False, now=_StepClock(step=2.0)
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, now=_StepClock(step=2.0))
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="Answer: "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="<thinking>secret</thinking>"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="42"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
         )
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="Answer: "),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="<thinking>secret</thinking>"),
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="42"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("hi"))
 
         updates = [kw["text"] for m, kw in rec.calls if m == "update_message"]
@@ -884,7 +951,9 @@ class TestShowThinking:
             AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
         ]
         asyncio.run(TurnDriver(_Provider(events), renderer, approval_mode="auto").run("hi"))
-        thinking = [kw["text"] for m, kw in rec.calls if m == "post_message" and kw["text"].startswith("💭")]
+        thinking = [
+            kw["text"] for m, kw in rec.calls if m == "post_message" and kw["text"].startswith("💭")
+        ]
         assert thinking, rec.calls
         assert "AKIA1234567890ABCDEX" not in thinking[0]
         assert "[REDACTED: credential]" in thinking[0]
@@ -958,10 +1027,12 @@ class TestStreamRecipientRouting:
         """Whole-turn coverage: the initial open and the rotation both carry it."""
         rec = _FlakyAppendSlack()  # first append fails => one rotation
         renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, user_id="U123")
-        provider = _Provider([
-            AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi"),
-            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
-        ])
+        provider = _Provider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
         asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
         opens = [kw for m, kw in rec.calls if m == "start_stream"]
         assert len(opens) == 2, rec.calls
@@ -1092,3 +1163,192 @@ class TestDeliveryLedger:
             assert renderer.delivered_text.startswith(before)
 
         asyncio.run(scenario())
+
+
+class TestAppendTaskRaiseIsSwallowed:
+    """``SlackRenderer._append_task`` forwards to ``slack.append_task``,
+    which the real client swallows internally — but a client or transport that
+    raises would propagate out of ``on_tool_call`` (before any text streams)
+    into the transport catch-all, which posts a terminal "Something went wrong
+    (transport path)" reply on a live turn. The guard at ``_append_task``'s
+    single definition (mirroring the native handler's guard) must swallow
+    the raise at every call site and let the turn deliver."""
+
+    def test_raising_append_task_does_not_escape_the_turn(self):
+        class RaisingTaskSlack(_RecSlack):
+            def __init__(self):
+                super().__init__()
+                self.task_raises = 0
+
+            async def append_task(self, *a, **kw):
+                self.task_raises += 1
+                raise RuntimeError("ratelimited: chat.appendStream")
+
+        rec = RaisingTaskSlack()
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
+        provider = _Provider(
+            [
+                AcpEvent(
+                    kind=EVENT_TOOL_CALL, tool_call_id="x", title="Running: grep", tool_final=False
+                ),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="The answer is 42"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ]
+        )
+        # Must not raise out of the turn — a raise here is what reaches the
+        # transport catch-all and posts the terminal error.
+        asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("hi"))
+
+        assert rec.task_raises >= 1, rec.calls  # the guarded site actually fired
+        # The reply still reached the user via the normal delivery path.
+        final_texts = [
+            str(kw.get("final_text") or kw.get("text") or "")
+            for m, kw in rec.calls
+            if m in ("stop_stream", "post_message", "update_message", "append_stream")
+        ]
+        joined = " ".join(final_texts)
+        assert "The answer is 42" in joined, rec.calls
+        assert "Something went wrong" not in joined, rec.calls
+
+
+class TestRendererPresentationGuards:
+    """Renderer presentation-guard sweep: the transport path (``use_transport`` defaults True)
+    drives ``SlackRenderer`` whose presentation calls, on a raising client,
+    would escape into the transport catch-all and post a terminal error on a
+    live turn — same class as the native handler sites. Each test drives one
+    guarded site and asserts the turn completes and the reply is delivered."""
+
+    @staticmethod
+    def _events():
+        return [
+            AcpEvent(
+                kind=EVENT_TOOL_CALL, tool_call_id="x", title="Running: grep", tool_final=False
+            ),
+            AcpEvent(kind=EVENT_TEXT_CHUNK, text="The answer is 42"),
+            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+        ]
+
+    @staticmethod
+    def _joined(rec):
+        return " ".join(
+            str(kw.get("final_text") or kw.get("text") or "")
+            for m, kw in rec.calls
+            if m in ("stop_stream", "post_message", "update_message", "append_stream")
+        )
+
+    def test_raising_set_thread_status_does_not_escape(self):
+        class RaisingStatusSlack(_RecSlack):
+            def __init__(self):
+                super().__init__()
+                self.status_raises = 0
+
+            async def set_thread_status(self, channel, thread_ts, status):
+                if status.startswith("is using"):
+                    self.status_raises += 1
+                    raise RuntimeError("ratelimited: assistant.threads.setStatus")
+                return await super().set_thread_status(channel, thread_ts, status)
+
+        rec = RaisingStatusSlack()
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
+        asyncio.run(TurnDriver(_Provider(self._events()), renderer, approval_mode="auto").run("hi"))
+        assert rec.status_raises >= 1, rec.calls
+        joined = self._joined(rec)
+        assert "The answer is 42" in joined, rec.calls
+        assert "Something went wrong" not in joined, rec.calls
+
+    def test_raising_wait_finalize_stop_stream_does_not_escape(self):
+        class RaisingFinalizeSlack(_RecSlack):
+            def __init__(self):
+                super().__init__()
+                self.finalize_raises = 0
+
+            async def stop_stream(self, channel, ts, final_text=None):
+                if final_text is None:
+                    self.finalize_raises += 1
+                    raise RuntimeError("message_not_found: chat.stopStream")
+                return await super().stop_stream(channel, ts, final_text)
+
+        rec = RaisingFinalizeSlack()
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
+        events = [
+            AcpEvent(
+                kind=EVENT_TOOL_CALL, tool_call_id="x", title="Running: wait", tool_final=False
+            ),
+            AcpEvent(kind=EVENT_TEXT_CHUNK, text="The answer is 42"),
+            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+        ]
+        asyncio.run(TurnDriver(_Provider(events), renderer, approval_mode="auto").run("hi"))
+        assert rec.finalize_raises >= 1, rec.calls
+        joined = self._joined(rec)
+        assert "The answer is 42" in joined, rec.calls
+        assert "Something went wrong" not in joined, rec.calls
+
+    def test_raising_append_stream_recovers_full_text(self):
+        """Append raises, rotation succeeds, retry raises: the raise must map
+        onto the refused-append outcome — the turn completes without a
+        terminal error, matching the shipped client's refused append on this
+        path. (Re-delivering the dropped delta is the delivery-debt
+        follow-up, deliberately out of this sweep's scope.)"""
+
+        class RaisingAppendSlack(_RecSlack):
+            def __init__(self):
+                super().__init__()
+                self.append_raises = 0
+
+            async def append_stream(self, channel, ts, text):
+                self.append_raises += 1
+                raise RuntimeError("ratelimited: chat.appendStream")
+
+        rec = RaisingAppendSlack()
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
+        asyncio.run(TurnDriver(_Provider(self._events()), renderer, approval_mode="auto").run("hi"))
+        assert rec.append_raises >= 2, rec.calls  # first append + post-rotation retry
+        assert "Something went wrong" not in self._joined(rec), rec.calls
+
+    def test_raising_start_stream_and_placeholder_still_delivers(self):
+        """Both the stream start AND the placeholder post raise: no message
+        exists at all — ``on_done`` must post the final answer directly."""
+
+        class RaisingStartSlack(_RecSlack):
+            def __init__(self):
+                super().__init__()
+                self.start_raises = 0
+
+            async def start_stream(self, channel, thread_ts, **kw):
+                self.start_raises += 1
+                raise RuntimeError("fatal_error: chat.startStream")
+
+            async def post_message(self, channel, text, thread_ts=None, **kw):
+                if "Thinking" in text:
+                    raise RuntimeError("channel_not_found: chat.postMessage")
+                return await super().post_message(channel, text, thread_ts=thread_ts, **kw)
+
+        rec = RaisingStartSlack()
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
+        asyncio.run(TurnDriver(_Provider(self._events()), renderer, approval_mode="auto").run("hi"))
+        assert rec.start_raises >= 1, rec.calls
+        posts = [str(kw.get("text") or "") for m, kw in rec.calls if m == "post_message"]
+        assert any("The answer is 42" in p for p in posts), rec.calls
+        assert "Something went wrong" not in self._joined(rec), rec.calls
+
+    def test_total_delivery_failure_propagates(self):
+        """Stream start, placeholder post AND the final direct post all raise:
+        nothing was delivered, so the raise must PROPAGATE — the transport
+        catch-all recording a failure is the honest outcome. Swallowing here
+        would convert total delivery failure into recorded success (a
+        review finding)."""
+        import pytest
+
+        class TotalFailureSlack(_RecSlack):
+            async def start_stream(self, channel, thread_ts, **kw):
+                raise RuntimeError("fatal_error: chat.startStream")
+
+            async def post_message(self, channel, text, thread_ts=None, **kw):
+                raise RuntimeError("channel_not_found: chat.postMessage")
+
+        rec = TotalFailureSlack()
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False)
+        with pytest.raises(RuntimeError):
+            asyncio.run(
+                TurnDriver(_Provider(self._events()), renderer, approval_mode="auto").run("hi")
+            )


### PR DESCRIPTION
## Problem / Motivation

The Slack streaming loop makes presentation-side Slack calls (thread status, task cards, stream appends/rotations/finalizes) that are safe today only because the real `SlackClient` swallows its own API errors internally. A client or transport path that raises instead sends the exception into a turn-fatal catch-all: the streaming loop's generic `except Exception` in `handler.py` (its typed arms only cover `kiro_crew.acp.client` errors), or the transport catch-all in `transport_dispatch.py` on the default `use_transport` path. The prior hardening covered only the two pre-first-chunk calls and explicitly tracked the rest as this issue. Latent, not live.

## Why it matters

When a decorative side channel raises, the user watches their in-progress reply flip to a terminal "Something went wrong" while the agent is still working and will finish with the correct answer -- and the session records a failure for a turn that never died. The same class on the transport path (the default) posts a terminal error before any text has streamed.

## What changed

Every still-unguarded presentation call now follows the established guard shape (swallow + log WARNING; a raise maps onto the call's existing refused/None outcome, so no new error contract), on BOTH delivery paths:

- `handler.py`: `set_thread_status` (TEXT_CHUNK + TOOL_CALL branches), `stop_stream` (wait-tool finalize), the initial `start_stream` in `_ensure_stream_started`, and the forwards inside `_append_stream` / `_rotate_stream` (a raise maps onto the existing refused-append / failed-rotation handling).
- `renderer.py` (transport twin): `_append_task` at its single definition (covering the unguarded `on_tool_call` site that reaches the transport catch-all), `on_tool_call`'s `set_thread_status` and wait-finalize `stop_stream`, the `_ensure_stream` / `_rotate_stream` / `_append_stream` forwards, plus `on_turn_start` / `on_thinking` / thinking posts / `on_compaction` / the `on_done` status clear.
- When no message could be created at all (stream start AND placeholder post both failed), the renderer's `on_done` posts the final answer directly -- unguarded, with `_finalized` reset before a raise propagates, and confirmed parts recorded in the delivery ledger -- so total delivery failure is an honest failure, never a silent success.

Deliberately descoped after review iteration: an in-place recovery mechanism for deltas dropped by a double append failure grew through five review rounds (segment scoping, display-safe rendering, delivery confirmation, debt carry, ledger reconciliation) with each round surfacing a real next-layer requirement. That is a designed subsystem, not an incremental patch: it is now specified in #10242 (delivery debt) with its sibling #10050 (turn-accounting ordering). This PR maps a RAISING append onto the exact outcome the shipped client's REFUSED append already produces on this path -- behavior parity with main, no new loss class.

## Tests

- `TestStreamingLoopPresentationGuards` (handler) and `TestAppendTaskRaiseIsSwallowed` + `TestRendererPresentationGuards` (renderer): every guarded site driven with a raising client, asserting no failure record, no terminal placeholder, and reply delivery; the double-append-failure tests pin refused-append parity; the total-failure test pins the propagating direct-post path.
- All failure-injection tests verified red on unfixed source. Scoped regression: `test_slack_handler.py` + `test_slack_renderer.py` + `test_slack_transport_dispatch.py` = 290 passed; black / isort / flake8 / mypy / comment-history gates clean locally.

## Pattern harvest

Rule candidate: the "presentation calls never raise" invariant lives only inside `SlackClient` while `handler.py` and `renderer.py` consume it as a contract -- any new presentation-side call site (or alternate client/transport implementation) can silently reopen this class. A raise-to-neutral-return guarantee stated at the `SlackClientOps` boundary (docstring + a conformance test any implementation must pass) would cover all sites at once instead of per-site guards; this sweep is the second round of site patches, which is the signal the invariant belongs at the interface.

Fixes #9878
Refs #10242
Refs #10050
