### PR TITLE
fix(dashboard): back up sound, interface mode, and reading width across origins

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -470,7 +470,31 @@ Contract:
   files) is excluded, as are the settings `config.json` already owns (theme
   mode/colour, language, onboarding flags) and keys a migration deliberately
   deletes (`mc-zoom`, `mc-font-scale`), so no setting has two homes and nothing
-  resurrects a key a migration removed.
+  resurrects a key a migration removed. The per-surface prefs that used to
+  silently reset across origins -- notification sound (`mc-notification-sound`),
+  interface mode (`mc-ui`), reading width (`mc-reading-width`) -- are durable.
+- GROWING the durable set is guarded by a reconcile pass (growth-gap issue
+  9491). A warm profile never runs the cold restore, so a key added to the
+  allowlist by an upgrade would otherwise be flushed at its local DEFAULT --
+  often written by a hook on mount (`mc-ui` is the live example) -- overwriting
+  the value another origin backed up. Before the first flush after an upgrade
+  that added keys, the client reads the host copy once for the keys this
+  profile has never synced: a key absent locally adopts the host value (with
+  the same reload-if-restored rule as the cold path), a key present locally is
+  baselined so the first flush does not upload it (it goes up when the user
+  next changes it), and a key the host does not hold is seeded from local. The
+  reconciled roster is recorded as a reserved entry inside `mc-ui-prefs-synced`
+  -- deliberately not its own key, so a downgraded (pre-roster) build's next
+  fingerprint rewrite sheds it and a re-upgrade reconciles again instead of
+  trusting a stale roster -- making the pass one GET per allowlist growth, not
+  per boot. A profile with no roster predates the mechanism and is baselined
+  against the frozen pre-mechanism allowlist, so only genuinely new keys are
+  reconciled: a key the profile merely never held is NOT bulk-imported from
+  another origin. A failed reconcile suppresses
+  the sync for the session -- flushing unreconciled keys is the exact clobber
+  the pass exists to prevent -- and the next boot retries; the failed-restore
+  marker applies as on the cold path, so a default written by a settings-less
+  render between the failure and the retry loses to the host.
 - Also excluded: any value that GATES A SAFETY CONFIRMATION. `mc-yolo-ack` is the
   instance — its presence makes the approval-mode picker skip the confirmation
   and enable full auto-approval — and the reason is that this file sits in the

--- a/website/src/lib/uiPrefs.ts
+++ b/website/src/lib/uiPrefs.ts
@@ -47,12 +47,17 @@ import { safeGetItem, safeSetItem } from '../utils/safeStorage'
  * it out: a missing backup degrades to today's behaviour, while backing up
  * session-scoped state resurrects stale UI on an unrelated profile.
  *
- * Adding a member is NOT a safe no-op. A warm profile never hydrates
- * (`needsHydrate` is false once `SYNCED_KEYS_KEY` exists), so a newly added
- * key's local DEFAULT is flushed to the host before the host's own value is
- * ever read, overwriting a value another origin saved. The list reads like an
- * ordinary allowlist, but growing it safely needs the sync path to hydrate a
- * newly added key before its first flush — see the growth-gap issue 9491.
+ * Growing this list is safe ONLY because of the reconcile pass. A warm profile
+ * never cold-hydrates (`needsHydrate` is false once `SYNCED_KEYS_KEY` exists),
+ * so without it a newly added key's local DEFAULT -- often written by a hook on
+ * mount -- would be flushed to the host before the host's own value was ever
+ * read, overwriting a value another origin saved (growth-gap issue 9491).
+ * `reconcileNewDurableKeys` runs before the first flush and reads the host copy
+ * for keys this profile has never synced: an absent local key adopts the host
+ * value, a present one is baselined so the first flush does not upload it. A
+ * key counts as "new" when it is in neither the synced fingerprints nor the
+ * reconciled roster (see `ROSTER_ENTRY`), so the pass costs one GET per
+ * allowlist growth, not per boot.
  */
 export const DURABLE_PREF_KEYS: readonly string[] = [
   // Chat preferences — one JSON blob holding ~16 settings (send-key mode,
@@ -67,8 +72,15 @@ export const DURABLE_PREF_KEYS: readonly string[] = [
   // factor and then DELETES them, so backing them up would restore them on the
   // next cold profile and re-run the migration forever.
   'mc-font-family',
+  // Chat reading width (md | full) -- hooks/useReadingWidth.ts.
+  'mc-reading-width',
   // Navigation and shell layout the user arranged by hand.
   'mc-nav',
+  // Interface paradigm (chat | cli) -- hooks/useUIMode.tsx. Its provider
+  // persists the current mode on MOUNT, so on a warm origin this key is always
+  // present locally; the reconcile pass below is what keeps that mount-written
+  // default from overwriting another origin's backup.
+  'mc-ui',
   'mc-app-nav-order',
   'mc-apps-expanded',
   'mc-bottom-terminal',
@@ -103,6 +115,9 @@ export const DURABLE_PREF_KEYS: readonly string[] = [
   'mc-dev-mode',
   'mc-agent-scene',
   'mc-kb-graph-physics',
+  // Notification sound settings (enabled/volume/per-category presets) --
+  // hooks/useNotificationSound.ts. JSON blob, written only on an explicit save.
+  'mc-notification-sound',
   'mc:notif:activeKinds:v2',
   'kirocrew:account-email-hidden',
   'kirocrew:comment-hint-dismissed',
@@ -111,6 +126,73 @@ export const DURABLE_PREF_KEYS: readonly string[] = [
   'mc-cloud-region',
   'mc-cloud-size',
   // Per-app preferences.
+  'kc-cron-folders-collapsed',
+  'kc:file-explorer:state:v2',
+  'kc:issue-radar:ui-state',
+  'telemetry:tab',
+  'telemetry:spend-group',
+  'mdnb-view',
+  'mdnb-sort',
+  'mdnb-list-view',
+  'mdnb-full-width',
+  'mdnb-panel-width',
+  'mdnb-panel-open',
+  'mdnb-auto-commit',
+  'mdnb-auto-sync',
+  'mdnb-auto-sync-mins',
+  'mdnb-sync-shortcut',
+  'ste_rail_w',
+]
+
+/**
+ * The allowlist as it stood BEFORE the reconcile mechanism shipped, frozen
+ * forever -- never append to this list; new keys go in `DURABLE_PREF_KEYS`
+ * only.
+ *
+ * This is the reconcile baseline for a profile that carries no roster entry: a
+ * legacy profile predates the roster, and every key its builds ever knew is in
+ * this list, so "durable now but not in here" is exactly "added after this
+ * profile could have known it". Without the frozen baseline, "no fingerprint"
+ * had to stand in for "newly added", and the two are not the same: a key the
+ * profile simply NEVER HELD (most of them, for most users) has no fingerprint
+ * either, and reconciling those would bulk-import another origin's layout onto
+ * a warm profile -- the cross-origin sync that design decision 1 above rules
+ * out.
+ */
+const PRE_ROSTER_KEYS: readonly string[] = [
+  'mc-chat-config',
+  'mc-busy-send-mode',
+  'mc-font-family',
+  'mc-nav',
+  'mc-app-nav-order',
+  'mc-apps-expanded',
+  'mc-bottom-terminal',
+  'mc-files-rail-open',
+  'mc-crews-view',
+  'mc-crew-switcher-pinned',
+  'mc-crew-switcher-stable-order',
+  'mc-filter-folders-shelved',
+  'mc-flat-hidden-folders',
+  'mc-input-height',
+  'mc-diff-plain',
+  'mc-diff-split',
+  'mc-file-linenums',
+  'mc-file-wordwrap',
+  'mc-file-collapse-unchanged',
+  'mc-artifacts-view',
+  'mc-artifacts-sort',
+  'mc-artifacts-pinned-only',
+  'mc-artifacts-session-docs-collapsed',
+  'mc-artifact-folders-expanded',
+  'mc-dev-mode',
+  'mc-agent-scene',
+  'mc-kb-graph-physics',
+  'mc:notif:activeKinds:v2',
+  'kirocrew:account-email-hidden',
+  'kirocrew:comment-hint-dismissed',
+  'mc-cloud-profile',
+  'mc-cloud-region',
+  'mc-cloud-size',
   'kc-cron-folders-collapsed',
   'kc:file-explorer:state:v2',
   'kc:issue-radar:ui-state',
@@ -181,6 +263,29 @@ const SYNCED_KEYS_KEY = 'mc-ui-prefs-synced'
  * its first GET finds an empty host, succeeds, and there is nothing to override.
  */
 const HYDRATE_PENDING_KEY = 'mc-ui-prefs-hydrate-pending'
+/**
+ * Reserved entry INSIDE the `SYNCED_KEYS_KEY` document holding the durable-key
+ * roster this profile last reconciled, as a JSON string array. It can never be
+ * mistaken for a fingerprint: `readSyncedPrints` only admits keys in
+ * `DURABLE_PREF_KEYS`, and the allowlist test pins this name out of that list.
+ *
+ * A key in `DURABLE_PREF_KEYS` but in neither this roster nor the synced
+ * fingerprints was added to the allowlist AFTER this profile last talked to
+ * the host, and `reconcileNewDurableKeys` must read the host's copy of it
+ * before the first flush may run (see the allowlist doc). A profile with no
+ * roster predates the mechanism, so its baseline is the frozen
+ * `PRE_ROSTER_KEYS` -- every key its builds could have known.
+ *
+ * Living inside the synced document is what makes a DOWNGRADE shed it: a
+ * pre-roster build's `readSyncedPrints` ignores the entry and its next
+ * `commitSent` rewrites the document without it, so after a re-upgrade the
+ * key is reconciled AGAIN instead of trusted from a stale roster -- the old
+ * build also dropped the key's fingerprint, and roster-without-fingerprint
+ * would upload the stale local value over a backup another origin refreshed
+ * meanwhile. A separate localStorage key could not have this property: no
+ * shipped build would ever rewrite or delete it.
+ */
+const ROSTER_ENTRY = 'mc:ui-prefs:roster'
 
 /** Keys the profile held when its first restore failed, or null if it never failed. */
 function ownedAtFailure(): Set<string> | null {
@@ -198,6 +303,185 @@ function markHydrateFailed(): void {
   if (safeGetItem(HYDRATE_PENDING_KEY) !== null) return
   const owned = DURABLE_PREF_KEYS.filter((k) => safeGetItem(k) !== null)
   safeSetItem(HYDRATE_PENDING_KEY, JSON.stringify(owned))
+}
+
+/** The raw roster entry in the synced document, or null when absent/unreadable. */
+function currentRosterEntry(): string | null {
+  const raw = safeGetItem(SYNCED_KEYS_KEY)
+  if (raw === null) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    const entry = (parsed as Record<string, unknown>)[ROSTER_ENTRY]
+    return typeof entry === 'string' ? entry : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The roster this profile last reconciled, or null when it predates the
+ * mechanism (or the entry is unreadable) -- the caller then falls back to the
+ * frozen `PRE_ROSTER_KEYS`, which can only ever treat MORE keys as new, never
+ * import ones the profile might have chosen not to sync.
+ */
+function readRoster(): Set<string> | null {
+  const entry = currentRosterEntry()
+  if (entry === null) return null
+  try {
+    const list: unknown = JSON.parse(entry)
+    if (!Array.isArray(list)) return null
+    return new Set(list.filter((k): k is string => typeof k === 'string'))
+  } catch {
+    return null
+  }
+}
+
+/** Record the CURRENT build's roster inside the synced document. */
+function markReconciled(): void {
+  const out: Record<string, string> = { [ROSTER_ENTRY]: JSON.stringify(DURABLE_PREF_KEYS) }
+  for (const [k, v] of readSyncedPrints()) out[k] = v
+  safeSetItem(SYNCED_KEYS_KEY, JSON.stringify(out))
+}
+
+/**
+ * Durable keys this profile has neither synced nor reconciled -- the ones a
+ * build upgrade just added to the allowlist. In the synced fingerprints means
+ * the profile has exchanged the key with the host; in the roster means a
+ * reconcile already read the host's copy and decided. Either clears it. NOT
+ * "no fingerprint" alone: a key the profile simply never held has no
+ * fingerprint either, and treating those as new would bulk-import another
+ * origin's values onto a warm profile (the cross-origin sync design decision 1
+ * rules out).
+ */
+function unreconciledKeys(): string[] {
+  const prints = readSyncedPrints()
+  const known = readRoster() ?? new Set(PRE_ROSTER_KEYS)
+  return DURABLE_PREF_KEYS.filter((k) => !prints.has(k) && !known.has(k))
+}
+
+/**
+ * True when this WARM profile must reconcile newly added durable keys with the
+ * host before the sync may start. Synchronous, so the usual boot (nothing new)
+ * pays one localStorage read. Meaningless on a cold profile -- the full hydrate
+ * covers it there.
+ */
+export function hasUnreconciledKeys(): boolean {
+  return unreconciledKeys().length > 0
+}
+
+/**
+ * Hydrate-before-flush for keys added to `DURABLE_PREF_KEYS` after this
+ * profile last talked to the host (growth-gap issue 9491).
+ *
+ * A warm profile never runs the cold hydrate, so without this pass a newly
+ * added key's local value -- typically a DEFAULT a hook persisted on mount --
+ * would read as "changed" on the first flush and overwrite the value another
+ * origin already backed up. The rules mirror `hydrateUiPrefs`, applied only to
+ * the new keys:
+ *
+ *   * host has a value, local absent: adopt the host value (this origin never
+ *     chose one). Counts as restored, so the caller reloads for the same
+ *     module-scope-reader reason as the cold path.
+ *   * host has a value, local present: keep local IN USE here but baseline it,
+ *     so the first flush does not upload it; it goes up when the user changes
+ *     it. Exception: after a FAILED reconcile, a key the profile did not hold
+ *     at the failure was written by a settings-less render, so the HOST wins
+ *     (the shared `HYDRATE_PENDING_KEY` contract -- a warm profile can only
+ *     carry that marker from a failed reconcile, since a failed cold hydrate
+ *     leaves the profile cold).
+ *   * host has no value, local present: left out of the baseline on purpose,
+ *     so the first flush uploads it and seeds the backup.
+ *
+ * Returns the number of keys written locally; rejects never (a failure returns
+ * -1 so the caller can decline to start the sync, exactly like a failed cold
+ * hydrate -- flushing without the reconcile is the clobber this exists to
+ * prevent). Success writes the roster, so the pass costs one GET per
+ * allowlist growth, not per boot.
+ */
+export async function reconcileNewDurableKeys(): Promise<number> {
+  const fresh = unreconciledKeys()
+  if (fresh.length === 0) {
+    markReconciled()
+    return 0
+  }
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), HYDRATE_TIMEOUT_MS)
+  const owned = ownedAtFailure()
+  try {
+    const res = await fetch(ENDPOINT, { signal: controller.signal })
+    if (!res.ok) {
+      markHydrateFailed()
+      return -1
+    }
+    const body: unknown = await res.json()
+    const prefs = (body as { prefs?: unknown } | null)?.prefs
+    if (!prefs || typeof prefs !== 'object' || Array.isArray(prefs)) {
+      // A 200 whose body is not a backup is NOT an empty backup. Recording the
+      // roster here would start the sync and flush the unreconciled keys'
+      // local defaults over whatever the host really holds -- fail instead,
+      // and the next boot retries against a healthy gateway. Like every other
+      // failure path, record the ownership snapshot: without it the retry
+      // would read ownedAtFailure() as null and trust a default a hook mounts
+      // AFTER this failure, keeping it over the host's real value forever.
+      markHydrateFailed()
+      return -1
+    }
+    const hostValues = prefs as Record<string, unknown>
+    const updates = new Map<string, string>()
+    let restored = 0
+    for (const key of fresh) {
+      const value = hostValues[key]
+      if (typeof value !== 'string') continue // host has nothing: local (if any) seeds it
+      const local = safeGetItem(key)
+      const keepLocal = local !== null && (owned === null || owned.has(key))
+      if (keepLocal) {
+        updates.set(key, local)
+        continue
+      }
+      if (local === value) {
+        updates.set(key, local)
+        continue
+      }
+      if (safeSetItem(key, value)) {
+        updates.set(key, value)
+        restored += 1
+      }
+      // Dropped by quota: NOT baselined, or the first flush would read the
+      // missing key as a deletion and null out a good host backup.
+    }
+    // Commit baselines and roster in ONE verified write. Two separate writes
+    // opened a real clobber: the baseline write could be dropped by quota while
+    // the roster write landed, and a roster without baselines starts the sync
+    // whose first flush uploads the unreconciled keys' local values over the
+    // host backup. One write cannot half-land, and a dropped write fails the
+    // reconcile below, so the sync never starts on an uncommitted baseline.
+    const prints = readSyncedPrints()
+    for (const [k, v] of updates) prints.set(k, fingerprint(v))
+    const doc: Record<string, string> = { [ROSTER_ENTRY]: JSON.stringify(DURABLE_PREF_KEYS) }
+    for (const [k, v] of prints) doc[k] = v
+    if (!safeSetItem(SYNCED_KEYS_KEY, JSON.stringify(doc))) {
+      // The keys already restored above stay in localStorage: the next boot's
+      // retry finds them present, keeps them, and baselines them then. Record
+      // the ownership snapshot like every failure path (the restored keys hold
+      // host values, so trusting them on retry is correct), or a default a
+      // hook mounts after this point would be kept over the host's value.
+      markHydrateFailed()
+      return -1
+    }
+    try {
+      localStorage.removeItem(HYDRATE_PENDING_KEY)
+    } catch {
+      /* best-effort */
+    }
+    if (restored > 0) window.dispatchEvent(new Event('mc-config-changed'))
+    return restored
+  } catch {
+    markHydrateFailed()
+    return -1
+  } finally {
+    clearTimeout(timer)
+  }
 }
 /** Debounce for a change-triggered flush. Long enough that dragging a splitter
  *  produces one PUT, short enough that closing the window right after a click
@@ -276,6 +560,10 @@ function readSyncedPrints(): Map<string, string> {
 
 function writeSyncedPrints(values: Map<string, string>): void {
   const prints: Record<string, string> = {}
+  // Carry the roster through: this build's reconcile state must survive every
+  // prints rewrite (a pre-roster build dropping it here is the DESIRED shed).
+  const roster = currentRosterEntry()
+  if (roster !== null) prints[ROSTER_ENTRY] = roster
   for (const [k, v] of values) prints[k] = fingerprint(v)
   safeSetItem(SYNCED_KEYS_KEY, JSON.stringify(prints))
 }
@@ -296,6 +584,8 @@ function mergeSyncedPrints(updates: Map<string, string | null>): void {
     else prints.set(k, fingerprint(v))
   }
   const out: Record<string, string> = {}
+  const roster = currentRosterEntry()
+  if (roster !== null) out[ROSTER_ENTRY] = roster
   for (const [k, v] of prints) out[k] = v
   safeSetItem(SYNCED_KEYS_KEY, JSON.stringify(out))
 }
@@ -326,7 +616,19 @@ export function needsHydrate(): boolean {
 function buildPatch(current: Map<string, string>): Record<string, string | null> {
   const patch: Record<string, string | null> = {}
   const prints = lastSent ? null : readSyncedPrints()
+  // Enforced at every flush, not only at boot: a key whose reconcile state is
+  // uncommitted NEVER goes up. The boot-time reconcile alone left a producible
+  // race -- in a mixed-version multi-tab session (a build upgrade with an old
+  // tab still open), the OLD build's own baseline rewrite sheds the roster
+  // entry mid-session, and this tab's next debounced flush would then read the
+  // new keys as changed and upload their local defaults over the host backup.
+  // Reading the unreconciled set on the flush path closes the whole class:
+  // whoever drops the roster, the affected keys just stop flushing until a
+  // boot reconciles them again. Steady-state cost is one localStorage read
+  // per flush; the set is empty on every profile whose roster is intact.
+  const withheld = new Set(unreconciledKeys())
   for (const [key, value] of current) {
+    if (withheld.has(key)) continue
     const unchanged = lastSent
       ? lastSent.get(key) === value
       : prints!.get(key) === fingerprint(value)
@@ -334,6 +636,7 @@ function buildPatch(current: Map<string, string>): Record<string, string | null>
   }
   const previousKeys = lastSent ? new Set(lastSent.keys()) : new Set(prints!.keys())
   for (const key of previousKeys) {
+    if (withheld.has(key)) continue
     if (!current.has(key)) patch[key] = null
   }
   return patch
@@ -457,7 +760,18 @@ export async function hydrateUiPrefs(): Promise<number> {
       const local = safeGetItem(key)
       if (local !== null) syncedNow.set(key, local)
     }
-    writeSyncedPrints(syncedNow)
+    // One write for baselines AND roster (the hydrate has, by definition,
+    // reconciled every key this build knows, so the next boot must not pay the
+    // growth-gap reconcile GET). Split writes could leave a roster without
+    // baselines when quota drops the first write: the profile would then look
+    // warm and reconciled, and the first flush would upload local values over
+    // the backup. If this single write is dropped, the synced marker stays
+    // absent and the next boot simply hydrates again -- today's behaviour.
+    const hydratedDoc: Record<string, string> = {
+      [ROSTER_ENTRY]: JSON.stringify(DURABLE_PREF_KEYS),
+    }
+    for (const [k, v] of syncedNow) hydratedDoc[k] = fingerprint(v)
+    safeSetItem(SYNCED_KEYS_KEY, JSON.stringify(hydratedDoc))
     // Cleared AFTER the synced marker is written, so a crash between the two
     // leaves the profile still pending rather than synced-with-untrusted-locals.
     try {

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -30,7 +30,13 @@ import ErrorBoundary from './components/ErrorBoundary'
 import DashboardBootstrap from './components/DashboardBootstrap'
 import { installPageZoomSuppression } from './utils/pageZoom'
 import { installStaleShellHeal } from './lib/staleShellHeal'
-import { hydrateUiPrefs, needsHydrate, startUiPrefsSync } from './lib/uiPrefs'
+import {
+  hasUnreconciledKeys,
+  hydrateUiPrefs,
+  needsHydrate,
+  reconcileNewDurableKeys,
+  startUiPrefsSync,
+} from './lib/uiPrefs'
 import 'katex/dist/katex.min.css'
 import './index.css'
 import './styles/cli-mode.css'
@@ -247,6 +253,22 @@ if (needsHydrate()) {
     (restored) => {
       if (restored > 0) window.location.reload()
       else boot(!needsHydrate())
+    },
+    () => boot(false),
+  )
+} else if (hasUnreconciledKeys()) {
+  // A WARM profile whose build upgrade added keys to DURABLE_PREF_KEYS: read
+  // the host's copy of the new keys before the first flush may run, or a
+  // default a hook persists on mount would overwrite the value another origin
+  // backed up (growth-gap issue 9491). Same shape as the cold path above --
+  // reload when something was written locally (module-scope readers already
+  // captured the pre-restore value), and do NOT sync after a failure (the
+  // next boot retries; flushing unreconciled keys is the clobber itself).
+  // Runs once per allowlist growth, not per boot: success records the roster.
+  void reconcileNewDurableKeys().then(
+    (restored) => {
+      if (restored > 0) window.location.reload()
+      else boot(restored === 0)
     },
     () => boot(false),
   )

--- a/website/src/pages/apps/LibraryPage.tsx
+++ b/website/src/pages/apps/LibraryPage.tsx
@@ -49,10 +49,11 @@ export default function LibraryPage() {
   const navigate = useNavigate()
   // The reader's view control. Persisted in THIS origin's localStorage and
   // live-synced across tabs by `usePersistedBool`; it does NOT follow the reader
-  // to a new origin. Adding it to `DURABLE_PREF_KEYS` would let a warm profile's
-  // default flush over another origin's saved value, because a warm profile
-  // never hydrates — a gap in the ui-prefs sync mechanism, tracked in issue
-  // 9491, that the durable view toggles like `mc-diff-split` predate. Off by
+  // to a new origin. The growth-gap that once made adding keys to
+  // `DURABLE_PREF_KEYS` unsafe is closed (issue 9491's reconcile pass in
+  // lib/uiPrefs.ts), so keeping this origin-local is now purely a product
+  // decision -- a per-machine browsing-view toggle, not a preference the reader
+  // would expect to follow them. Off by
   // default so a fresh visit shows the apps the reader enabled, not the ~20
   // default-off builtins the wheel ships.
   const [showAll, setShowAll] = usePersistedBool('mc-apps-library-show-all', false)

--- a/website/src/test/uiPrefs.test.ts
+++ b/website/src/test/uiPrefs.test.ts
@@ -5,10 +5,21 @@ import {
   needsHydrate,
   flushUiPrefs,
   startUiPrefsSync,
+  hasUnreconciledKeys,
+  reconcileNewDurableKeys,
   __resetUiPrefsSyncForTests,
 } from '../lib/uiPrefs'
 
 const SYNCED_KEYS_KEY = 'mc-ui-prefs-synced'
+const ROSTER_ENTRY = 'mc:ui-prefs:roster'
+
+/** The reconciled roster stored inside the synced document, or null. */
+function storedRoster(): string[] | null {
+  const raw = localStorage.getItem(SYNCED_KEYS_KEY)
+  if (raw === null) return null
+  const entry = (JSON.parse(raw) as Record<string, string>)[ROSTER_ENTRY]
+  return typeof entry === 'string' ? (JSON.parse(entry) as string[]) : null
+}
 
 function mockFetch(impl: (url: string, init?: RequestInit) => unknown) {
   const spy = vi.fn((url: string, init?: RequestInit) => Promise.resolve(impl(url, init)))
@@ -46,12 +57,11 @@ describe('uiPrefs', () => {
     })
 
     it('excludes the Apps Library view toggle, which is origin-local by decision', () => {
-      // Adding a key to this list is not safe for a WARM profile: it never
-      // hydrates (needsHydrate is false once SYNCED_KEYS_KEY exists), so the
-      // key's local default flushes over another origin's saved value. The
-      // Library show-all toggle is therefore kept out until the mechanism can
-      // hydrate a newly added key before the first flush (growth-gap issue 9491).
-      // A re-add without that fix fails here.
+      // The growth-gap mechanism (reconcileNewDurableKeys, issue 9491) now
+      // hydrates a newly added key before its first flush, so re-adding this
+      // key is mechanically safe -- but whether the Library show-all toggle
+      // SHOULD follow the user across origins is a product decision that has
+      // not been made. A re-add without that decision fails here.
       expect(DURABLE_PREF_KEYS).not.toContain('mc-apps-library-show-all')
     })
 
@@ -104,6 +114,15 @@ describe('uiPrefs', () => {
     it('excludes its own sync bookkeeping keys', () => {
       expect(DURABLE_PREF_KEYS).not.toContain(SYNCED_KEYS_KEY)
       expect(DURABLE_PREF_KEYS).not.toContain('mc-ui-prefs-hydrate-pending')
+      expect(DURABLE_PREF_KEYS).not.toContain(ROSTER_ENTRY)
+    })
+
+    it('holds the three per-surface prefs that used to reset across origins', () => {
+      // Issue 9875: sound, interface mode, and reading width were localStorage
+      // only, so they silently reverted to defaults on every fresh origin.
+      for (const key of ['mc-notification-sound', 'mc-ui', 'mc-reading-width']) {
+        expect(DURABLE_PREF_KEYS).toContain(key)
+      }
     })
   })
 
@@ -280,9 +299,10 @@ describe('uiPrefs', () => {
       vi.restoreAllMocks()
 
       expect(localStorage.getItem('mc-dev-mode')).toBeNull()
-      expect(Object.keys(JSON.parse(localStorage.getItem(SYNCED_KEYS_KEY)!))).toEqual([
-        'mc-crews-view',
-      ])
+      const printKeys = Object.keys(JSON.parse(localStorage.getItem(SYNCED_KEYS_KEY)!)).filter(
+        (k) => k !== ROSTER_ENTRY, // reconcile bookkeeping, not a fingerprint
+      )
+      expect(printKeys).toEqual(['mc-crews-view'])
 
       // The follow-up flush must not delete the host's copy of the key it failed
       // to store locally.
@@ -607,6 +627,330 @@ describe('uiPrefs', () => {
       window.dispatchEvent(new Event('storage'))
       await vi.advanceTimersByTimeAsync(2000)
       expect(lastPatch(spy)).toEqual({ 'mc-dev-mode': 'true' })
+    })
+  })
+
+  describe('reconcileNewDurableKeys (growth-gap, issue 9491)', () => {
+    /** Build the state of a profile from BEFORE a key joined the allowlist:
+     *  warm (has synced fingerprints for an old key), no reconciled roster. */
+    async function warmLegacyProfile() {
+      localStorage.setItem('mc-crews-view', 'list')
+      mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      __resetUiPrefsSyncForTests() // reload into the upgraded build
+      expect(storedRoster()).toBeNull()
+    }
+
+    it('a cold origin restores the three keys through the ordinary hydrate', async () => {
+      mockFetch(() =>
+        okJson({
+          prefs: {
+            'mc-notification-sound': '{"enabled":false,"volume":0.2,"perCategory":{"all":"ding"}}',
+            'mc-ui': 'cli',
+            'mc-reading-width': 'full',
+          },
+        }),
+      )
+      expect(await hydrateUiPrefs()).toBe(3)
+      expect(localStorage.getItem('mc-ui')).toBe('cli')
+      expect(localStorage.getItem('mc-reading-width')).toBe('full')
+      expect(hasUnreconciledKeys()).toBe(false) // hydrate also records the roster
+    })
+
+    it('a warm origin does NOT flush a mount-written default over the host value', async () => {
+      await warmLegacyProfile()
+      // UIModeProvider persists the current mode on mount, so by the time the
+      // upgraded build reconciles, the key exists locally holding the default.
+      localStorage.setItem('mc-ui', 'chat')
+      mockFetch(() => okJson({ prefs: { 'mc-ui': 'cli' } }))
+      expect(await reconcileNewDurableKeys()).toBe(0)
+
+      // Local stays in use here (the backup is not a live sync channel)...
+      expect(localStorage.getItem('mc-ui')).toBe('chat')
+      // ...and the first flush does not upload it over the host's copy.
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+
+      // The moment the user changes it HERE, it is theirs and goes up.
+      localStorage.setItem('mc-ui', 'cli')
+      const spy2 = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy2)).toEqual({ 'mc-ui': 'cli' })
+    })
+
+    it('a warm origin adopts the host value for a new key it never held', async () => {
+      await warmLegacyProfile()
+      mockFetch(() => okJson({ prefs: { 'mc-reading-width': 'full' } }))
+      expect(await reconcileNewDurableKeys()).toBe(1) // caller reloads on > 0
+      expect(localStorage.getItem('mc-reading-width')).toBe('full')
+
+      // Adopted, so baselined: nothing to flush.
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('a warm origin seeds the backup for a new key the host does not hold', async () => {
+      await warmLegacyProfile()
+      localStorage.setItem('mc-notification-sound', '{"enabled":false}')
+      mockFetch(() => okJson({ prefs: {} }))
+      expect(await reconcileNewDurableKeys()).toBe(0)
+
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy)).toEqual({ 'mc-notification-sound': '{"enabled":false}' })
+    })
+
+    it('records the roster, so the pass runs once per allowlist growth, not per boot', async () => {
+      await warmLegacyProfile()
+      expect(hasUnreconciledKeys()).toBe(true)
+      mockFetch(() => okJson({ prefs: {} }))
+      await reconcileNewDurableKeys()
+      expect(hasUnreconciledKeys()).toBe(false)
+      expect(storedRoster()).toEqual([...DURABLE_PREF_KEYS])
+    })
+
+    it('does NOT bulk-import old keys a legacy profile merely never held', async () => {
+      // Only keys added AFTER the profile's baseline are reconciled. mc-nav is
+      // a pre-mechanism key with no fingerprint here (never held); adopting it
+      // would be the cross-origin sync design decision 1 forbids.
+      await warmLegacyProfile()
+      mockFetch(() => okJson({ prefs: { 'mc-nav': 'ORIGIN-A-LAYOUT' } }))
+      expect(await reconcileNewDurableKeys()).toBe(0)
+      expect(localStorage.getItem('mc-nav')).toBeNull()
+
+      // And it is not baselined, so a local deletion can never null the host copy.
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('a downgrade sheds the roster, so a re-upgrade reconciles again', async () => {
+      await warmLegacyProfile()
+      mockFetch(() => okJson({ prefs: {} }))
+      await reconcileNewDurableKeys()
+      expect(hasUnreconciledKeys()).toBe(false)
+
+      // A pre-roster build rewrites the synced document from its own prints
+      // and drops both the roster entry and the new keys' fingerprints.
+      const doc = JSON.parse(localStorage.getItem(SYNCED_KEYS_KEY)!) as Record<string, string>
+      delete doc[ROSTER_ENTRY]
+      for (const k of ['mc-notification-sound', 'mc-ui', 'mc-reading-width']) delete doc[k]
+      localStorage.setItem(SYNCED_KEYS_KEY, JSON.stringify(doc))
+
+      // Back on this build: the keys must count as new again -- trusting the
+      // stale roster would upload a stale local value over the host backup.
+      expect(hasUnreconciledKeys()).toBe(true)
+    })
+
+    it('withholds an unreconciled key from every flush, not only at boot', async () => {
+      // Mixed-version multi-tab race: this (new-build) tab reconciled at boot,
+      // then an OLD tab's baseline rewrite sheds the roster and the new keys'
+      // fingerprints mid-session. This tab's next debounced flush must NOT
+      // read the new keys as changed and upload their local values over the
+      // host backup -- they stop flushing until a boot reconciles them again.
+      await warmLegacyProfile()
+      localStorage.setItem('mc-ui', 'chat')
+      mockFetch(() => okJson({ prefs: { 'mc-ui': 'cli' } }))
+      await reconcileNewDurableKeys()
+
+      // The old tab's commitSent, as a pre-roster build performs it.
+      const doc = JSON.parse(localStorage.getItem(SYNCED_KEYS_KEY)!) as Record<string, string>
+      delete doc[ROSTER_ENTRY]
+      for (const k of ['mc-notification-sound', 'mc-ui', 'mc-reading-width']) delete doc[k]
+      localStorage.setItem(SYNCED_KEYS_KEY, JSON.stringify(doc))
+
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled() // mc-ui withheld, nothing else changed
+
+      // An old (reconciled-baseline) key still flushes normally.
+      localStorage.setItem('mc-crews-view', 'grid')
+      const spy2 = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy2)).toEqual({ 'mc-crews-view': 'grid' })
+    })
+
+    it('the roster survives an ordinary flush baseline rewrite', async () => {
+      await warmLegacyProfile()
+      mockFetch(() => okJson({ prefs: {} }))
+      await reconcileNewDurableKeys()
+
+      localStorage.setItem('mc-dev-mode', 'true')
+      mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs() // commitSent rewrites the whole document
+      expect(storedRoster()).toEqual([...DURABLE_PREF_KEYS])
+    })
+
+    it('reports failure on a non-2xx response too, and writes no roster', async () => {
+      await warmLegacyProfile()
+      mockFetch(() => ({ ok: false, status: 503, json: () => Promise.resolve({}) }))
+      expect(await reconcileNewDurableKeys()).toBe(-1)
+      expect(storedRoster()).toBeNull()
+      expect(hasUnreconciledKeys()).toBe(true)
+    })
+
+    it('treats a 200 with a malformed body as a failure, not as an empty backup', async () => {
+      // Recording completion here would start the sync and flush local
+      // defaults over whatever the host really holds.
+      await warmLegacyProfile()
+      localStorage.setItem('mc-ui', 'chat')
+      mockFetch(() => okJson({ prefs: 'nope' }))
+      expect(await reconcileNewDurableKeys()).toBe(-1)
+      expect(storedRoster()).toBeNull()
+      expect(hasUnreconciledKeys()).toBe(true)
+    })
+
+    it('a malformed-body failure still records the ownership snapshot for the retry', async () => {
+      // Without the snapshot, ownedAtFailure() is null on retry, keepLocal is
+      // true for the default a hook mounted AFTER the failure, and the host
+      // value would be silently lost forever.
+      await warmLegacyProfile()
+      mockFetch(() => okJson({ prefs: 'nope' }))
+      expect(await reconcileNewDurableKeys()).toBe(-1)
+      localStorage.setItem('mc-ui', 'chat') // mounted default, written post-failure
+
+      mockFetch(() => okJson({ prefs: { 'mc-ui': 'cli' } }))
+      expect(await reconcileNewDurableKeys()).toBe(1)
+      expect(localStorage.getItem('mc-ui')).toBe('cli') // host wins
+    })
+
+    it('a dropped-commit failure records the snapshot; restored keys stay, later defaults lose', async () => {
+      await warmLegacyProfile()
+      const realSet = Storage.prototype.setItem
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+        this: Storage,
+        k: string,
+        v: string,
+      ) {
+        if (k === SYNCED_KEYS_KEY) throw new DOMException('full', 'QuotaExceededError')
+        realSet.call(this, k, v)
+      })
+      mockFetch(() => okJson({ prefs: { 'mc-reading-width': 'full' } }))
+      expect(await reconcileNewDurableKeys()).toBe(-1)
+      vi.restoreAllMocks()
+      // The adoption landed before the commit failed; it holds the HOST value,
+      // so the snapshot treats it as owned and the retry keeps it.
+      expect(localStorage.getItem('mc-reading-width')).toBe('full')
+      localStorage.setItem('mc-ui', 'chat') // mounted default, written post-failure
+
+      mockFetch(() => okJson({ prefs: { 'mc-reading-width': 'full', 'mc-ui': 'cli' } }))
+      expect(await reconcileNewDurableKeys()).toBe(1)
+      expect(localStorage.getItem('mc-reading-width')).toBe('full') // kept
+      expect(localStorage.getItem('mc-ui')).toBe('cli') // host wins
+
+      // Both baselined: nothing to flush.
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('does not baseline an adopted value the quota-safe writer had to drop', async () => {
+      await warmLegacyProfile()
+      const realSet = Storage.prototype.setItem
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+        this: Storage,
+        k: string,
+        v: string,
+      ) {
+        if (k === 'mc-reading-width') throw new DOMException('full', 'QuotaExceededError')
+        realSet.call(this, k, v)
+      })
+      mockFetch(() => okJson({ prefs: { 'mc-reading-width': 'full' } }))
+      expect(await reconcileNewDurableKeys()).toBe(0)
+      vi.restoreAllMocks()
+
+      // Not stored locally, and NOT baselined: a baseline for a missing key
+      // would make the first flush null out the good host backup.
+      expect(localStorage.getItem('mc-reading-width')).toBeNull()
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('fails the whole reconcile when the baseline+roster commit write is dropped', async () => {
+      // A roster recorded without its baselines would start the sync and let
+      // the first flush upload unreconciled local values over the host backup.
+      // The commit is one write, and a dropped write is a failed reconcile.
+      await warmLegacyProfile()
+      localStorage.setItem('mc-ui', 'chat')
+      const realSet = Storage.prototype.setItem
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+        this: Storage,
+        k: string,
+        v: string,
+      ) {
+        if (k === SYNCED_KEYS_KEY) throw new DOMException('full', 'QuotaExceededError')
+        realSet.call(this, k, v)
+      })
+      mockFetch(() => okJson({ prefs: { 'mc-ui': 'cli' } }))
+      expect(await reconcileNewDurableKeys()).toBe(-1)
+      vi.restoreAllMocks()
+      expect(storedRoster()).toBeNull()
+      expect(hasUnreconciledKeys()).toBe(true) // retried next boot
+    })
+
+    it('a hydrate whose marker write is dropped leaves the profile cold, never roster-only', async () => {
+      // Baselines and roster land in ONE write: a profile must never look warm
+      // and reconciled while holding no fingerprints.
+      const realSet = Storage.prototype.setItem
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+        this: Storage,
+        k: string,
+        v: string,
+      ) {
+        if (k === SYNCED_KEYS_KEY) throw new DOMException('full', 'QuotaExceededError')
+        realSet.call(this, k, v)
+      })
+      mockFetch(() => okJson({ prefs: { 'mc-ui': 'cli' } }))
+      await hydrateUiPrefs()
+      vi.restoreAllMocks()
+      expect(needsHydrate()).toBe(true) // next boot hydrates again
+      expect(storedRoster()).toBeNull()
+    })
+
+    it('reports failure so the caller can decline to start the sync, and the next boot retries', async () => {
+      await warmLegacyProfile()
+      vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('ECONNREFUSED'))))
+      expect(await reconcileNewDurableKeys()).toBe(-1)
+      expect(hasUnreconciledKeys()).toBe(true) // roster not written: retried next boot
+    })
+
+    it('after a FAILED reconcile, the host wins for a new key written by a settings-less render', async () => {
+      await warmLegacyProfile()
+      vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('ECONNREFUSED'))))
+      await reconcileNewDurableKeys()
+      // The page rendered without its settings; the mount hook wrote a default.
+      localStorage.setItem('mc-ui', 'chat')
+
+      mockFetch(() => okJson({ prefs: { 'mc-ui': 'cli' } }))
+      expect(await reconcileNewDurableKeys()).toBe(1)
+      expect(localStorage.getItem('mc-ui')).toBe('cli')
+      expect(localStorage.getItem('mc-ui-prefs-hydrate-pending')).toBeNull()
+    })
+
+    it('a reconciled key still propagates a later local deletion', async () => {
+      await warmLegacyProfile()
+      localStorage.setItem('mc-reading-width', 'full')
+      mockFetch(() => okJson({ prefs: { 'mc-reading-width': 'full' } }))
+      await reconcileNewDurableKeys()
+
+      localStorage.removeItem('mc-reading-width')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy)).toEqual({ 'mc-reading-width': null })
+    })
+
+    it('leaves every previously synced fingerprint intact', async () => {
+      await warmLegacyProfile()
+      mockFetch(() => okJson({ prefs: { 'mc-ui': 'cli' } }))
+      await reconcileNewDurableKeys()
+      // The old key's fingerprint survived the merge: nothing is re-uploaded.
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+      expect(localStorage.getItem('mc-crews-view')).toBe('list')
     })
   })
 })


### PR DESCRIPTION
# Problem / Motivation

Three dashboard preferences live only in the renderer's per-origin localStorage: notification sound (`mc-notification-sound`), interface mode (`mc-ui`), and reading width (`mc-reading-width`). localStorage is keyed by origin, so a moved port, a relocated Electron userData directory, a stable/nightly switch, or a storage eviction silently resets all three to defaults -- and two surfaces on one host can hold different values forever. They were absent from `DURABLE_PREF_KEYS`, the allowlist mirrored to the gateway's `ui-prefs.json` backup.

Adding them was deliberately unsafe until now: the growth gap (#9491). A warm profile never runs the cold restore, and `UIModeProvider` persists `mc-ui` on MOUNT, so a newly added key's local default would be flushed over the value another origin had backed up -- the upgrade itself would corrupt the user's backup.

## Why it matters

"I upgraded and my settings reset" is the exact complaint the ui-prefs backup exists to remove, and these three are user-visible on every session: sound on/off, chat vs CLI mode, reading width. Without the growth-gap fix, the allowlist could never grow safely, so every future preference would face the same trap.

## What changed

- `website/src/lib/uiPrefs.ts`: the three keys join `DURABLE_PREF_KEYS`. New pre-render reconcile pass (`reconcileNewDurableKeys` + `hasUnreconciledKeys`) closes the growth gap: on a warm profile, keys added since the profile last talked to the host are read from the backup BEFORE the first flush -- an absent local key adopts the host value (reload-if-restored, same as the cold path), a present one is baselined so its mount-written default is never uploaded, and a key the host lacks is seeded from local. Failure suppresses sync for the session (flushing unreconciled keys is the exact clobber) and retries next boot, reusing the cold path's failed-restore marker semantics.
- Reconcile state: the roster of reconciled keys is a reserved entry INSIDE `mc-ui-prefs-synced`, so a downgraded pre-roster build's own fingerprint rewrite sheds it and a re-upgrade reconciles again (a stale roster would trust a stale local value). A profile with no roster is baselined against the frozen pre-mechanism allowlist (`PRE_ROSTER_KEYS`), so only genuinely new keys reconcile -- old keys a profile merely never held are NOT bulk-imported across origins. A 200 with a malformed body counts as failure, not as an empty backup.
- `website/src/main.tsx`: boot gains the warm-profile reconcile branch beside the cold hydrate.
- `docs/system-specs/modules/config.md`: spec of record updated (durable keys + reconcile contract).
- `website/src/pages/apps/LibraryPage.tsx`: stale comment citing 9491 as an open blocker updated (keeping that toggle origin-local is now a product decision).

Two pre-push review dispositions, accepted as designed: a non-2xx reconcile GET (including 401/403) suppresses sync for that session rather than retrying inline -- identical to the cold path's failed-hydrate asymmetry (losing one session's backup is recoverable, overwriting the host copy is not); and after a failed reconcile the host wins for a new key first written after the failure, which cannot distinguish a deliberate user change in that window -- the same documented trade-off the cold path's pending marker makes ("a login screen counts").

## Tests

<!-- no-visual-delta -->
**Why no screenshot:** No pixel changes -- the diff is boot-sequence logic, a storage allowlist, bookkeeping in `localStorage`, a spec document, and two comment updates; every touched surface renders exactly as before.

`npx tsc -b` clean; `npx vitest run src/test/uiPrefs.test.ts` 67/67 (21 new); eslint and the i18n strict scripts clean on all touched files. New coverage: the three keys are durable; cold-origin restore; warm origin does not flush a mount-written default over the host value; warm origin adopts host values for never-held new keys; backup seeding when the host lacks a key; roster recorded once per allowlist growth and surviving flush rewrites; downgrade sheds the roster; no bulk-import of never-held pre-mechanism keys; non-2xx and malformed-200 failures write no roster; failed-reconcile host-wins semantics; quota-dropped adoptions are not baselined; a dropped baseline+roster commit fails the reconcile whole (and the hydrate equivalent leaves the profile cold, never roster-only); reconciled keys still propagate deletions.

Pre-push review: two model-pinned lanes on a frozen worktree. Both High findings (stale roster surviving a downgrade/re-upgrade cycle; legacy profiles mass-importing never-held keys) and the Medium (malformed 200 recorded as reconciled) were fixed before the PR opened. The server-side GPT lane's round-1 blocking finding (a quota-dropped baseline write could leave a roster without baselines and let the first flush clobber the backup) is fixed in the current head: baselines and roster land in ONE verified write on both the reconcile and hydrate paths, and a dropped write fails the pass.

## Pattern harvest

Rule candidate: semgrep
Pattern: two sequential writes where the second records completion of the first (marker/roster written by a separate call from the state it certifies) against a best-effort writer whose failure is a return value -- completion markers must land in the same atomic write as the state they certify, or the failure path fabricates a completed state.

## Anything else

Non-goal, unchanged: live cross-surface sync of a mid-session change between two open surfaces -- the backup stays a backup (design decision 1 in `uiPrefs.ts`). Re-adding `mc-apps-library-show-all` is now mechanically safe but remains a product decision; its exclusion test stands.

Fixes #9875
Refs #9491
