### PR TITLE
fix(mcp-gateway): stop the stub's degrade path from exiting on Windows

### DIFF
--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -4,8 +4,10 @@ The stub is the shim kiro-cli execs in place of the real MCP binary. It
 connects to gatewayd over a unix socket, Registers with a full
 :class:`PoolKey` payload, then bridges kiro-cli stdio ↔ gateway until
 either side closes. On handshake failure it logs a structured fallback
-record to ``$KIROCREW_HOME/logs/stub_fallback.jsonl`` and ``execvpe``\u200bs
-the real MCP backend in place, preserving per-session correctness.
+record to ``$KIROCREW_HOME/logs/stub_fallback.jsonl`` and hands the session
+to the real MCP backend, preserving per-session correctness: ``execvpe`` in
+place on POSIX, and on Windows -- which has no in-place exec -- a child
+inheriting this process's stdio (see :func:`_fallback_spawn_child`).
 
 Register fields match :meth:`PoolKey.from_register`; hashes use SHA-256
 (stdlib). Bridge phase is NOT wrapped in a timeout (learned correction
@@ -26,6 +28,7 @@ import os
 import queue
 import shutil
 import signal
+import subprocess
 import sys
 import threading
 import time
@@ -1603,10 +1606,112 @@ async def alog_fallback(
     )
 
 
+def _inherited_std_fd(stream: Any, default: int) -> int:
+    """The fd to hand a child for one of our own standard streams.
+
+    ``sys.stdin`` and friends can be replaced or detached (pytest's capture, a
+    ``pythonw`` host), in which case ``fileno()`` raises rather than answering.
+    Fall back to the well-known number: this runs in a process kiro-cli spawned
+    with real pipes on 0/1/2, so the constant is right whenever the object is
+    not.
+    """
+    try:
+        fd = stream.fileno()
+    except (AttributeError, OSError, ValueError):
+        return default
+    return fd if isinstance(fd, int) and fd >= 0 else default
+
+
+def _child_exit_status(rc: object) -> int:
+    """The status to exit with after relaying a Windows child's own.
+
+    Windows reports an exit code as an unsigned ``DWORD``, and a crash lands far
+    above ``INT_MAX``: an access violation is ``0xC0000005``, i.e. 3221225477.
+    ``os._exit`` parses its argument as a C ``int``, so handing that straight
+    over raises ``OverflowError`` -- the stub would die on an exception instead
+    of relaying the status, which is the one thing this function exists to do,
+    and it would do so on the ordinary signature of a crashing backend rather
+    than in some corner.
+
+    Reinterpret such a value as signed 32-bit instead of clamping it. The OS
+    reads the low 32 bits back out, so the code kiro-cli observes is the exact
+    ``DWORD`` the backend exited with -- a clamp would silently rewrite a crash
+    into some unrelated status. Anything still outside a C ``int``, or not an
+    int at all, becomes 1: unrepresentable, so report plain failure.
+    """
+    if not isinstance(rc, int):
+        return 1
+    if rc > 0x7FFFFFFF:
+        rc -= 0x100000000
+    return rc if -0x80000000 <= rc <= 0x7FFFFFFF else 1
+
+
+def _fallback_spawn_child(argv: list[str], exec_env: dict[str, str]) -> NoReturn:
+    """Stand in for ``execvpe`` on Windows, which has no in-place exec.
+
+    CPython documents the replacement as in-place *"On Unix"*, where the image
+    is loaded into this process and keeps its pid. Windows has no such call, so
+    the ``exec*`` family is emulated as spawn-then-exit: the backend comes up
+    under a NEW pid and THIS process dies. kiro-cli owns this process's stdio
+    pipe and waits on the pid it spawned, so that exit reads to it as the server
+    hanging up -- it reports ``connection closed: initialize response`` and the
+    server's whole tool surface is missing from the session. The degrade path was
+    fatal on the one platform it existed to rescue, and every stubbed server
+    failed while every directly-launched one worked.
+
+    Run the backend as a CHILD and stay alive as its parent instead. Its stdin,
+    stdout and stderr are this process's own fds, duplicated into it explicitly
+    (``close_fds`` blocks handle inheritance on Windows, so passing the numbers
+    is what guarantees the child gets the real pipe rather than a fresh
+    console). kiro-cli therefore talks to the real backend over the pipe it
+    already holds, and the pid it waits on lives for the session. Every
+    ``fallback_exec`` call site is reached with kiro-cli's ``initialize`` still
+    unread -- the stub's own "clean per-session exec" invariant, asserted by the
+    comments at each of those sites -- so the hand-off loses no buffered request.
+
+    Resolve the command against the CHILD's ``PATH``, because that is what
+    ``execvpe`` searches; Windows ``CreateProcess`` would search this process's
+    instead, so a relative command could otherwise resolve differently on the
+    two platforms. An unresolvable name is passed through unchanged so the
+    resulting ``FileNotFoundError`` still surfaces, matching ``execvpe``.
+
+    Exit through ``os._exit``: this stands in for a process replacement, which
+    runs no cleanup handlers and flushes nothing, and a ``SystemExit`` raised
+    here would have to survive the teardown of the stub's own event loop.
+    """
+    resolved = shutil.which(argv[0], path=exec_env.get("PATH")) or argv[0]
+    # Our own buffers, not the child's: it inherits the same fds, so anything
+    # still queued here would interleave into the middle of its JSON-RPC stream.
+    for stream in (sys.stdout, sys.stderr):
+        with contextlib.suppress(AttributeError, OSError, ValueError):
+            stream.flush()
+    proc = subprocess.Popen(  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
+        [resolved, *argv[1:]],
+        env=exec_env,
+        stdin=_inherited_std_fd(sys.stdin, 0),
+        stdout=_inherited_std_fd(sys.stdout, 1),
+        stderr=_inherited_std_fd(sys.stderr, 2),
+    )
+    try:
+        rc = proc.wait()
+    except BaseException:
+        # Do not leave the backend holding kiro-cli's pipe with nobody waiting on
+        # it. A hard ``TerminateProcess`` on us cannot be intercepted at all, and
+        # the child survives that; what saves the session there is the pipe
+        # itself -- kiro-cli's exit closes fd 0 and an MCP server exits on stdin
+        # EOF, exactly as a directly-launched one would.
+        with contextlib.suppress(OSError):
+            proc.terminate()
+        raise
+    os._exit(_child_exit_status(rc))
+
+
 def fallback_exec(args: argparse.Namespace) -> None:
     """Replace the current process with the real MCP backend. ``execvpe``
     never returns on success; a return raises so the caller surfaces a
-    diagnostic."""
+    diagnostic. Windows has no in-place exec, so there the backend runs as a
+    child inheriting this process's stdio -- see :func:`_fallback_spawn_child`
+    for why the emulated ``exec*`` would kill the session outright."""
     target_args = _split_target_args(args.target_args, args.target_args_sep)
     argv = [args.target_command, *target_args]
     # Restore the server's declared env. The rewriter moves declared env
@@ -1616,6 +1721,8 @@ def fallback_exec(args: argparse.Namespace) -> None:
     # the non-pooled baseline — the daemon's own environment lacks it.
     exec_env = dict(os.environ)
     exec_env.update(_parse_env_file(getattr(args, "env_file", "") or ""))
+    if platform_compat.IS_WINDOWS:
+        _fallback_spawn_child(argv, exec_env)
     # exec IS this fallback stub's whole purpose: when the gateway is
     # unavailable, replace this process with the operator's real MCP backend.
     # argv (target_command / target_args) and exec_env (the server's declared

--- a/test/test_mcp_gateway_stub_windows_degrade.py
+++ b/test/test_mcp_gateway_stub_windows_degrade.py
@@ -1,0 +1,264 @@
+"""The stub's degrade path must not end this process on Windows.
+
+When the broker is unreachable the stub hands the session to the real MCP
+backend instead of failing. On POSIX that is ``execvpe``: the image is replaced
+in place, the pid is kept, and kiro-cli -- which spawned this process, holds its
+stdio pipe and waits on its pid -- never notices the swap.
+
+Windows has no in-place exec. CPython documents the replacement as in-place
+*"On Unix"* only; on Windows the ``exec*`` family is emulated as
+spawn-then-exit, so the backend comes up under a NEW pid and this process dies.
+kiro-cli reads that as the server hanging up and reports
+``connection closed: initialize response``, with the server's whole tool surface
+missing from the session. Reported from the field on 0.6.0.16: every stubbed
+server (``kirocrew-core``, ``kirocrew-cron``) failed exactly that way while every
+directly-launched one in the same session was fine, and the real servers all
+answered ``initialize`` correctly when started by hand -- the middle hop was the
+only broken thing.
+
+Both branches are asserted on every platform (``IS_WINDOWS`` is monkeypatched
+either way) rather than skipping one, because the bug was precisely that the
+untested platform took a path nobody had exercised.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.mcp_gateway import stub
+
+
+class _FakeProc:
+    """Stands in for the spawned backend. ``wait`` is the only call the code makes."""
+
+    def __init__(self, rc: int = 0, raise_on_wait: BaseException | None = None) -> None:
+        self._rc = rc
+        self._raise = raise_on_wait
+        self.terminated = False
+
+    def wait(self) -> int:
+        if self._raise is not None:
+            raise self._raise
+        return self._rc
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+
+def _args(command: str = "backend-bin", env_file: str = "") -> argparse.Namespace:
+    return argparse.Namespace(
+        target_command=command,
+        target_args="--serve|--stdio",
+        target_args_sep="|",
+        env_file=env_file,
+    )
+
+
+@pytest.fixture
+def degrade(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Instrument every exit the degrade path can take, and let none of them run.
+
+    ``os._exit`` really would end the test session, and ``execvpe`` really would
+    replace it, so both are recorded instead. ``shutil.which`` is stubbed to a
+    fixed answer so a machine without the fake binary still exercises the
+    resolution call.
+    """
+    seen: dict[str, Any] = {"exec": [], "popen": [], "exit": [], "which": []}
+
+    def _fake_exec(path: str, argv: list[str], env: dict[str, str]) -> None:
+        seen["exec"].append((path, list(argv), dict(env)))
+        raise AssertionError("execvpe would have replaced the test process")
+
+    def _fake_which(cmd: str, path: str | None = None) -> str | None:
+        seen["which"].append((cmd, path))
+        return f"/resolved/{cmd}"
+
+    def _fake_exit(rc: int) -> None:
+        seen["exit"].append(rc)
+        raise SystemExit(rc)
+
+    monkeypatch.setattr(stub.os, "execvpe", _fake_exec)
+    monkeypatch.setattr(stub.shutil, "which", _fake_which)
+    monkeypatch.setattr(stub.os, "_exit", _fake_exit)
+    return seen
+
+
+def _install_popen(monkeypatch: pytest.MonkeyPatch, seen: dict[str, Any], proc: _FakeProc) -> None:
+    def _fake_popen(argv: list[str], **kwargs: Any) -> _FakeProc:
+        seen["popen"].append((list(argv), kwargs))
+        return proc
+
+    monkeypatch.setattr(stub.subprocess, "Popen", _fake_popen)
+
+
+def test_the_windows_degrade_runs_the_backend_as_a_child_of_this_process(
+    monkeypatch: pytest.MonkeyPatch, degrade: dict[str, Any]
+) -> None:
+    """The pid kiro-cli waits on must survive the hand-off.
+
+    This is the whole fix. An ``exec`` here ends this process, and its death --
+    not any fault in the backend -- is what kiro-cli reports as a closed
+    connection.
+    """
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    proc = _FakeProc(rc=0)
+    _install_popen(monkeypatch, degrade, proc)
+
+    with pytest.raises(SystemExit):
+        stub.fallback_exec(_args())
+
+    assert degrade["exec"] == [], "the backend was exec'd, which kills the session"
+    assert len(degrade["popen"]) == 1, "the backend was not started as a child"
+    argv, kwargs = degrade["popen"][0]
+    assert argv == ["/resolved/backend-bin", "--serve", "--stdio"]
+    assert kwargs["stdin"] == stub._inherited_std_fd(sys.stdin, 0)
+    assert kwargs["stdout"] == stub._inherited_std_fd(sys.stdout, 1)
+    assert kwargs["stderr"] == stub._inherited_std_fd(sys.stderr, 2)
+
+
+def test_the_posix_degrade_still_replaces_this_process_in_place(
+    monkeypatch: pytest.MonkeyPatch, degrade: dict[str, Any]
+) -> None:
+    """POSIX keeps ``execvpe``: same pid, same fds, and no child to reap."""
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+    _install_popen(monkeypatch, degrade, _FakeProc())
+
+    with pytest.raises(AssertionError, match="execvpe would have replaced"):
+        stub.fallback_exec(_args())
+
+    assert degrade["popen"] == [], "POSIX must not gain a child process"
+    path, argv, _env = degrade["exec"][0]
+    assert path == "backend-bin"
+    assert argv == ["backend-bin", "--serve", "--stdio"]
+
+
+def test_the_windows_degrade_carries_the_declared_env_to_the_child(
+    monkeypatch: pytest.MonkeyPatch, degrade: dict[str, Any], tmp_path: Path
+) -> None:
+    """The sidecar env is why the degrade is correct at all.
+
+    The rewriter moves the server's declared env (routinely tokens) out of the
+    spec into a 0600 sidecar, so a child started without it is a server missing
+    the credential it needs -- the POSIX path restores it and the Windows path
+    has to as well.
+    """
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    sidecar = tmp_path / "env.json"
+    sidecar.write_text('{"BACKEND_TOKEN": "declared-value"}', encoding="utf-8")
+    _install_popen(monkeypatch, degrade, _FakeProc())
+
+    with pytest.raises(SystemExit):
+        stub.fallback_exec(_args(env_file=str(sidecar)))
+
+    _argv, kwargs = degrade["popen"][0]
+    assert kwargs["env"]["BACKEND_TOKEN"] == "declared-value"
+    assert "PATH" in kwargs["env"], "the child lost the inherited environment"
+
+
+def test_the_windows_degrade_resolves_the_command_on_the_childs_path(
+    monkeypatch: pytest.MonkeyPatch, degrade: dict[str, Any], tmp_path: Path
+) -> None:
+    """Resolution must follow ``execvpe``'s rule, not ``CreateProcess``'s.
+
+    ``execvpe`` searches the PATH it is handed; Windows ``CreateProcess`` searches
+    the CALLING process's, so a relative command would otherwise resolve
+    differently on the two platforms.
+    """
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    sidecar = tmp_path / "env.json"
+    sidecar.write_text('{"PATH": "C:\\\\declared\\\\bin"}', encoding="utf-8")
+    _install_popen(monkeypatch, degrade, _FakeProc())
+
+    with pytest.raises(SystemExit):
+        stub.fallback_exec(_args(env_file=str(sidecar)))
+
+    assert degrade["which"] == [("backend-bin", "C:\\declared\\bin")]
+
+
+def test_the_windows_degrade_exits_with_the_backends_own_status(
+    monkeypatch: pytest.MonkeyPatch, degrade: dict[str, Any]
+) -> None:
+    """Stand in for a replaced image: this process's status is the backend's."""
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    _install_popen(monkeypatch, degrade, _FakeProc(rc=3))
+
+    with pytest.raises(SystemExit):
+        stub.fallback_exec(_args())
+
+    assert degrade["exit"] == [3]
+
+
+def test_the_windows_degrade_relays_a_crash_status_without_overflowing(
+    monkeypatch: pytest.MonkeyPatch, degrade: dict[str, Any]
+) -> None:
+    """A crashing backend is the common case, not a corner.
+
+    Windows reports an exit code as an unsigned DWORD and an access violation is
+    ``0xC0000005`` (3221225477). ``os._exit`` parses a C ``int``, so relaying that
+    raw would raise ``OverflowError`` and the stub would die on an exception
+    instead of reporting the status. Signed-32-bit reinterpretation is what keeps
+    the code kiro-cli reads identical to the one the backend exited with.
+    """
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    _install_popen(monkeypatch, degrade, _FakeProc(rc=0xC0000005))
+
+    with pytest.raises(SystemExit):
+        stub.fallback_exec(_args())
+
+    assert degrade["exit"] == [-0x3FFFFFFB]
+    # The OS reads the low 32 bits back, so what a caller sees is the original.
+    assert degrade["exit"][0] & 0xFFFFFFFF == 0xC0000005
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0, 0),
+        (3, 3),
+        (0x7FFFFFFF, 0x7FFFFFFF),
+        (0xC0000005, -0x3FFFFFFB),  # Windows access violation
+        (0xFFFFFFFF, -1),
+        (0x1FFFFFFFF, 1),  # wider than a DWORD: unrepresentable
+        (None, 1),
+        (-1, -1),  # already signed (a POSIX-shaped status)
+    ],
+)
+def test_the_relayed_status_always_fits_a_c_int(raw: object, expected: int) -> None:
+    """Total over what ``wait`` can answer, so no status can crash the relay."""
+    assert stub._child_exit_status(raw) == expected
+
+
+def test_the_windows_degrade_does_not_orphan_the_backend_when_interrupted(
+    monkeypatch: pytest.MonkeyPatch, degrade: dict[str, Any]
+) -> None:
+    """A backend left holding kiro-cli's pipe with nobody waiting is worse than none."""
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    proc = _FakeProc(raise_on_wait=KeyboardInterrupt())
+    _install_popen(monkeypatch, degrade, proc)
+
+    with pytest.raises(KeyboardInterrupt):
+        stub.fallback_exec(_args())
+
+    assert proc.terminated, "the child was left running with no parent waiting on it"
+    assert degrade["exit"] == [], "an interrupted wait must not report a clean status"
+
+
+def test_the_module_still_exposes_the_real_subprocess_and_exit_calls() -> None:
+    """Guard the monkeypatch targets above against a rename or a lost import.
+
+    Every test in this file patches ``stub.subprocess.Popen`` / ``stub.os._exit``;
+    if the module stopped importing ``subprocess``, or the code switched to a
+    different spawn call, those patches would silence themselves and the suite
+    would go green while asserting nothing.
+    """
+    assert stub.subprocess is subprocess
+    assert stub.os is os
+    assert "subprocess.Popen(" in Path(stub.__file__).read_text(encoding="utf-8")

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -1191,6 +1191,21 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "mcp_gateway/gatewayd.py::main",
         "mcp_gateway/manager.py::_spawn_once",
         "mcp_gateway/stub.py::main",
+        # The Windows arm of the stub's degrade path. Same spawn as
+        # ``stub.py::main`` and the same argv: the target command and args the
+        # rewriter resolved out of the operator's own ``~/.kiro/agents/*.json``,
+        # plus the env from the 0600 sidecar it wrote beside them -- an MCP
+        # backend on the trusted side of the sandbox boundary, like every other
+        # ``mcp_gateway`` entry above. Nothing on this path is agent-supplied;
+        # the stub receives it all as its own argv from the overlay.
+        #
+        # It is a spawn only because Windows has no in-place exec: the POSIX
+        # sibling of this call is ``os.execvpe``, which is not a spawn at all and
+        # so needed no entry. Sandboxing it would be strictly wrong rather than
+        # merely pointless -- the child must inherit THIS process's stdio fds to
+        # keep serving kiro-cli's existing pipe, which is the whole fix, and a
+        # scrubbed env would drop the credentials the sidecar exists to restore.
+        "mcp_gateway/stub.py::_fallback_spawn_child",
         # The update seam's one read-only git chokepoint: `git config` (the
         # `updates.source` pin's remote, the repo-driver probe, and which remote a
         # branch tracks) and `git ls-remote --get-url`. Fixed list-argv (no


### PR DESCRIPTION
## 1. What is the problem?

On Windows, every MCP server routed through the gateway stub loses its whole
tool surface in a chat session. kiro-cli reports, once per stubbed server:

```
failed to launch MCP server name="kirocrew-core"  err=Custom("connection closed: initialize response")
failed to launch MCP server name="kirocrew-cron"  err=Custom("connection closed: initialize response")
```

Directly-launched servers in the same session at the same moment are fine, and
the real backends answer `initialize` correctly when started by hand. The middle
hop is the only broken thing.

## 2. Why this issue matters to the user

`kirocrew-core` carries `learn_add`, `spawn_run`, `monitor_*`, `artifact_*` and
`tool_search`. When it fails there is nothing left to recover it with, so the
agent loses its own control plane for the life of the session.

The stub's central promise is that it can always step aside: when the broker is
unreachable it hands the session to the real backend, so pooling is lost and
nothing else is. Five call sites degrade that way, each commented as safe
because kiro-cli's `initialize` is still unread. On Windows that degrade was the
thing killing the session, which made the failure reachable from any cause -- a
connect timeout, a busy daemon, an open breaker, a daemon that does not know the
server's name -- and fatal in every one of them.

It is also close to undiagnosable from the obvious place. The stub logs to
stderr, which kiro-cli swallows, plus a record in `stub_fallback.jsonl`; the
daemon logs to its own `mcp-gatewayd.stdout`. Neither writes to the gateway log,
so grepping it for the server name returns nothing and reads as "never
attempted".

## 3. How our fix solves it

Symptom: kiro-cli says the connection closed before the `initialize` response.

It closed because the process kiro-cli spawned exited. `fallback_exec` ends in
`os.execvpe`, and CPython documents the replacement as in-place *"On Unix"*
only -- the image is loaded into the current process and keeps its pid. Windows
has no such call, so the `exec*` family is emulated as spawn-then-exit: the
backend comes up under a NEW pid and the caller dies. kiro-cli holds that
process's stdio pipe and waits on that pid, so its exit is indistinguishable
from the server hanging up.

POSIX keeps `execvpe` unchanged: same pid, same fds, proven. On Windows the
backend now runs as a child of the stub, which stays alive as its parent. Five
details make that a faithful stand-in for a replacement:

* the child's stdin/stdout/stderr are this process's own fds, passed explicitly
  because `close_fds` blocks handle inheritance on Windows -- so kiro-cli talks
  to the real backend over the pipe it already holds;
* the command is resolved against the CHILD's `PATH`, which is what `execvpe`
  searches, rather than letting `CreateProcess` search the parent's;
* the child is terminated if the wait is interrupted, so a backend is never left
  holding kiro-cli's pipe with nobody waiting on it;
* the exit goes through `os._exit` with the backend's own status, matching a
  replacement (no cleanup handlers, no flush) and avoiding a `SystemExit` that
  would have to survive the stub's event-loop teardown;
* that status is reinterpreted as signed 32-bit first. Windows reports an exit
  code as an unsigned DWORD and a crash lands above `INT_MAX` (an access
  violation is `0xC0000005`), which `os._exit` cannot parse as a C `int`.
  Relaying it raw would raise `OverflowError` and kill the stub on an exception
  instead of reporting the status -- on the ordinary signature of a crashing
  backend, not in a corner. Reinterpreting rather than clamping keeps the code
  kiro-cli reads identical to the one the backend exited with.

No buffered request is lost in the hand-off: every `fallback_exec` call site is
reached with kiro-cli's `initialize` still unread, which is the stub's own
documented invariant.

## 4. What tests we did

New `test/test_mcp_gateway_stub_windows_degrade.py`, 9 tests. Both branches are
asserted on every platform (`IS_WINDOWS` is monkeypatched either way) instead of
skipping one, because the bug was precisely that the untested platform took a
path nobody had exercised:

* the backend runs as a child, `execvpe` is never reached, and the child gets
  this process's own stdio fds;
* POSIX still replaces in place and gains no child process;
* the 0600 sidecar env reaches the child (without it the backend is missing the
  credential it needs);
* resolution consults the child's `PATH`;
* the exit status is the backend's;
* a Windows access-violation DWORD is relayed without overflowing, and the low
  32 bits still read back as the original code;
* the status conversion is total over what `wait` can answer (8 parametrized
  cases: in-range, `0x7FFFFFFF`, `0xC0000005`, `0xFFFFFFFF`, wider than a DWORD,
  non-int, already-signed);
* an interrupted wait terminates the child and reports no clean status;
* a guard asserting the monkeypatch targets still exist, so a rename or a lost
  import cannot silence the whole file.

Mutation-verified: removing the two-line Windows branch fails 5 of the original
7 (the POSIX test and the target guard correctly still pass). Regression: the
existing `test_mcp_gateway_stub_admission_fallback.py` and
`test_stub_bridge_liveness.py` pass alongside them, 26 total. flake8 clean, mypy
clean, black clean on the new file.

Not end-to-end tested on Windows: I have no Windows host. The platform-specific
behaviour is pinned by the monkeypatched tests above and by CPython's own
documented `exec*` semantics, and the Windows CI shard runs the whole suite, so
these tests execute there natively.

## 5. Any other suggestions on the work

Three follow-ups, deliberately not in this PR:

* An operator can hit this without any broker fault at all, because a daemon
  that does not recognise a server name sends a fallback-eligible rejection.
  #6432 already repaired the adopted-daemon stale target map; worth re-checking
  whether any path still leaves a live daemon's map behind the roster.
* The MCP Servers panel shows servers as online with a tool count before any
  handshake happens, so a fresh chat looks healthy until the first message. That
  is what made this take a day to pin down. Filed as #9903.
* `api_mcp_gateway_set_stub`'s docstring still says the roster "takes effect
  when the gateway is enabled". That predates #2810, which made the stub its own
  per-server decision; the stale sentence directly misled the reporter into
  thinking a disabled gateway meant nothing was stubbed.

## Pattern harvest

Rule candidate: audit ratchet, same family as `test/test_windows_kill_probe_audit.py`

Pattern: a POSIX-only process primitive on a code path a non-POSIX platform can
reach, where the difference is silent rather than an error. `os.exec*` is the
instance here: it exists on Windows, it does not raise, and it even appears to
work -- the backend really does start. What changes is the pid and the fact that
the caller dies, which only matters because another process holds this one's
stdio and waits on its pid. Nothing in the type system or the linter can see
that; the docstring said "in place" and the platform quietly disagreed.

Concrete form: flag `os.exec*` under `src/kiro_crew/**` that is not inside an
`IS_WINDOWS`-style guard. Not implemented in this diff because the repo has four
other `os.exec*` sites (`apps/deps_boot.py`, `safety_override.py`,
`dashboard/handlers/updates.py`, `platform_compat.reexec_python_module`) and each
needs its own triage first: they are self-restart paths where no peer holds the
pid, so the same call may well be correct there. A ratchet that baselines all
four without deciding is worse than none.

Second, narrower candidate: `os._exit` given a value that came from
`Popen.wait()`. That is a C `int` sink fed an unsigned DWORD source, which is
representable-looking and wrong only above `INT_MAX` -- exactly the range a
Windows crash lands in.

Closes #9901
