### PR TITLE
fix(agents): reclaim dead idle scratch trees over scan cap

### DIFF
--- a/src/kiro_crew/agent_scratch.py
+++ b/src/kiro_crew/agent_scratch.py
@@ -141,11 +141,6 @@ def _pgroup_alive(pid: int) -> bool:
     return platform_compat.pgroup_exists(pid)
 
 
-#: Entry cap for the tree-idle walk: a tree too big to scan cheaply reads as
-#: ACTIVE (kept) -- the sweep must stay cheap and err toward keeping.
-_TREE_IDLE_SCAN_CAP = 10_000
-
-
 def _tree_newest_mtime(root: Path, fallback: float) -> float:
     """The newest mtime anywhere in *root*'s tree (lstat, symlinks never followed).
 
@@ -153,20 +148,23 @@ def _tree_newest_mtime(root: Path, fallback: float) -> float:
     touches the top DIRECTORY's mtime, but every write refreshes the FILE's
     own mtime -- so tree-newest is the faithful idle signal on every
     platform, and the only one available on Windows (no process groups).
-    Fail-safe: an unreadable entry or a tree past the scan cap returns
-    *fallback* (reads as active, the sweep keeps the dir).
+    Fail-safe: an unreadable entry returns *fallback* (reads as active, the
+    sweep keeps the dir).
+
+    Deliberately UNCAPPED: an entry cap that bails to *fallback* turns every
+    tree larger than the cap into a permanently active-looking one, so a dead
+    agent that wrote enough entries could never be reclaimed. The walk runs
+    on a periodic sweep (not per-request), and its size is bounded by what one
+    agent wrote into its OWN scratch dir, so a full metadata walk is the
+    right trade -- same call as ``mcp_gateway.backend_tmp``.
     """
     newest = 0.0
-    seen = 0
     try:
         newest = os.lstat(root).st_mtime
         stack = [root]
         while stack:
             current = stack.pop()
             for entry in os.scandir(current):
-                seen += 1
-                if seen > _TREE_IDLE_SCAN_CAP:
-                    return fallback
                 info = os.lstat(entry.path)
                 if info.st_mtime > newest:
                     newest = info.st_mtime

--- a/test/test_agent_scratch.py
+++ b/test/test_agent_scratch.py
@@ -126,6 +126,25 @@ class TestLivenessSweep:
     def test_missing_root_returns_zero(self, scratch_root: Path) -> None:
         assert sc.sweep_dead_scratch() == 0
 
+    def test_large_dead_idle_tree_is_reclaimed(self, scratch_root: Path) -> None:
+        # Regression (issue #9508): the idle walk used to bail to "active"
+        # past 10_000 entries, so a dead tree that big could never be
+        # reclaimed no matter how idle. The walk is uncapped now.
+        path = sc.allocate_scratch("bigdead")
+        sc.record_owner(path, 2**22 - 1)  # dead owner
+        target = path / "shard"
+        target.mkdir()
+        for i in range(10_001):
+            (target / f"f{i:05d}.log").touch()
+        past = time.time() - 2 * sc._UNOWNED_GRACE_SECONDS
+        for p in (path, target, path / sc.OWNER_FILENAME):
+            os.utime(p, (past, past))
+        for f in target.iterdir():
+            os.utime(f, (past, past))
+
+        assert sc.sweep_dead_scratch() == 1
+        assert not path.exists()
+
     @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege")
     def test_symlink_child_is_never_followed(self, scratch_root: Path, tmp_path: Path) -> None:
         victim = tmp_path / "victim"


### PR DESCRIPTION
## Problem / Motivation

_dead idle_ scratch trees larger than 10,000 entries could never be reclaimed: _tree_newest_mtime bailed to the all-active fallback past _TREE_IDLE_SCAN_CAP, so sweep_dead_scratch kept them forever and repeated dead runs exhausted storage (issue #9508).

## Why it matters

Scratch dirs accumulate across agent runs; an unbounded leak on the data home defeats the sweeper's purpose.

## What changed

- Removed the entry cap from the idle walk (uncapped metadata walk, same call as mcp_gateway.backend_tmp which documents the identical failure).
- Fail-safe preserved: unreadable entries still return the fallback (reads as active, kept); symlinks still never followed; ownerless/garbled dirs still never deleted.
- Added regression test with a 10,001-entry dead idle tree.

## Tests

- test/test_agent_scratch.py::TestLivenessSweep::test_large_dead_idle_tree_is_reclaimed (new; fails on the old bail-out)
- Full test/test_agent_scratch.py run locally: 11 passed, 1 skipped (win32 symlink privilege)
- black/isort/flake8 clean on touched files; mypy left to CI (times out locally on cold cache)