### PR TITLE
fix(dashboard): decline clicks on closed-session links instead of dead-navigating

### DIFF
--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -864,9 +864,22 @@ function MdAnchor({ node, href, children }: React.AnchorHTMLAttributes<HTMLAncho
       sessionCandidate = decodeURIComponent(href)
     } catch { /* keep it a normal link */ }
   }
+  // Whether this href NAMES a same-origin chat session at all, independent of
+  // whether that session is currently reachable (open). A closed/unknown key is
+  // still a chat-session href — it just does not resolve in the open-tabs roster.
+  const sessionHrefKey = sessionCandidate ? sessionKeyFromChatHref(sessionCandidate) : null
+  // Whether this renderer is wired to route sessions at all — the SAME predicate
+  // `resolveSessionChip` guards on (`onSessionOpen` AND `sessions`), so the link
+  // affordance and the click handler can never disagree. Both must be present:
+  // `ChatPage` keeps `onSessionOpen` wired but WITHHOLDS `sessions` while offline
+  // (`sessions={connected ? sessionTitles : undefined}`), and a no-controller
+  // render (e.g. an SDK `user` message row) has neither. In either case there is
+  // nothing that could switch sessions, so a `?sid=` link must stay an ordinary
+  // navigating link rather than be swallowed.
+  const sessionRouting = !!(sessionActions.onSessionOpen && sessionActions.sessions)
   // Same gate as the inline chip, so a link and a bare key naming one session
   // cannot disagree about whether it is reachable.
-  const sessionLink = sessionCandidate ? resolveSessionChip(sessionKeyFromChatHref(sessionCandidate) ?? '', sessionActions) : null
+  const sessionLink = sessionHrefKey ? resolveSessionChip(sessionHrefKey, sessionActions) : null
   // The attribute carries the canonical key: a modified click goes to the browser,
   // and an authored `dashboard_…` sid would open a session `?sid=` cannot resolve.
   const sessionHref = sessionLink && sessionCandidate ? canonicalChatHref(sessionCandidate, sessionLink.key) : null
@@ -874,9 +887,28 @@ function MdAnchor({ node, href, children }: React.AnchorHTMLAttributes<HTMLAncho
     // Only the PLAIN click is reinterpreted; the href stays real so Cmd+click
     // still opens the session in its own tab.
     const plainPrimaryClick = e.button === 0 && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey
-    if (!sessionLink || !plainPrimaryClick) return
-    e.preventDefault()
-    sessionActions.onSessionOpen!(sessionLink.key)
+    if (!plainPrimaryClick) return
+    // A resolvable session opens in place. A chat-session href that does NOT
+    // resolve is swallowed rather than left to the browser. `resolveSessionChip`
+    // returns null in two cases, both correctly declined here:
+    //   - a closed / unknown key — its raw `?sid=` would navigate to a session
+    //     the controller cannot load, landing on a dead/blank view (#9914);
+    //   - the ACTIVE session's own key (`resolveSessionChip` rejects
+    //     `key === activeSession`) — a plain click is a no-op on the session you
+    //     are already in, matching the backtick chip, which renders the active
+    //     key as inert. Cmd/Ctrl/middle-click still opens the real href for
+    //     anyone who actually wants a duplicate tab.
+    //
+    // Both branches require `sessionRouting` — the renderer must actually be
+    // able to route sessions. When it cannot (offline: `sessions` withheld; or a
+    // no-controller render: neither wired), a `?sid=` link is an ordinary
+    // external link and keeps navigating as before, never a dead no-op.
+    if (sessionLink) {
+      e.preventDefault()
+      sessionActions.onSessionOpen!(sessionLink.key)
+    } else if (sessionHrefKey && sessionRouting) {
+      e.preventDefault()
+    }
   }
   const pathResolution = usePathResolution(
     localHref ?? '',
@@ -972,7 +1004,11 @@ function MdAnchor({ node, href, children }: React.AnchorHTMLAttributes<HTMLAncho
       {...sp(node)}
       href={sessionHref ?? href}
       // A `/chat?sid=` href is never a path, so the session branch wins outright.
-      onClick={sessionLink ? onSessionClick : (pathResolution.candidate ? onPathClick : undefined)}
+      // `sessionHrefKey` (not `sessionLink`) gates the handler so a session link
+      // that does not resolve — a closed/unknown key, or the active session's own
+      // key — is still intercepted and declined rather than left to navigate the
+      // browser to a dead `?sid=` view (#9914) or a duplicate tab.
+      onClick={sessionHrefKey ? onSessionClick : (pathResolution.candidate ? onPathClick : undefined)}
       title={sessionLink
         ? `${sessionLink.title}\n${i18nT('components.markdownRenderer.click_to_switch_to_this_session')}`
         : undefined}

--- a/website/src/test/renderUserContent.sessionLink.test.tsx
+++ b/website/src/test/renderUserContent.sessionLink.test.tsx
@@ -54,10 +54,13 @@ describe('a /chat?sid= link in a user message (#8253)', () => {
     expect(onSessionOpen).toHaveBeenCalledWith(THERE)
   })
 
-  it('leaves a link to the ACTIVE session inert with its existing behaviour', () => {
-    // Negative control: resolveSessionChip refuses the active key (a click
-    // would be a visible no-op), so the anchor keeps the pre-existing
-    // external-branch shape — identical to what assistant rows render today.
+  it('declines a plain click to the ACTIVE session, matching the chip (#9927)', () => {
+    // resolveSessionChip refuses the active key, so `sessionLink` is null — but
+    // the renderer CAN route sessions, so the plain click is declined
+    // (preventDefault, no navigation, no switch): a no-op on the session you are
+    // already in, exactly as the backtick chip renders the active key inert.
+    // The href stays real (target=_blank) so a modified click still opens a
+    // duplicate tab for anyone who wants one.
     const onSessionOpen = vi.fn()
     const { container } = render(
       <>{renderUserContent({ content: `see [here](/chat?sid=${HERE})`, meta: undefined, ...triple(onSessionOpen) })}</>,
@@ -65,17 +68,29 @@ describe('a /chat?sid= link in a user message (#8253)', () => {
     const anchor = container.querySelector('a')!
     expect(anchor).toHaveAttribute('target', '_blank')
     expect(anchor.getAttribute('title')).toBeNull()
+    const notCancelled = fireEvent.click(anchor)
+    expect(notCancelled).toBe(false)
     expect(onSessionOpen).not.toHaveBeenCalled()
   })
 
-  it('leaves a link whose key names no open session as an ordinary link', () => {
+  it('declines a plain click to a closed/unknown session instead of navigating (#9914)', () => {
+    // A `?sid=` link whose key names no OPEN session used to fall through to
+    // native navigation on a plain click, landing on a dead/blank `?sid=` view.
+    // It must now be intercepted and declined (preventDefault, no navigation),
+    // matching the backtick chip's existing behaviour for a closed key.
     const onSessionOpen = vi.fn()
     const { container } = render(
       <>{renderUserContent({ content: `see [gone](/chat?sid=${UNKNOWN})`, meta: undefined, ...triple(onSessionOpen) })}</>,
     )
     const anchor = container.querySelector('a')!
-    expect(anchor).toHaveAttribute('target', '_blank')
+    // Unresolvable: no switch tooltip, and it does not open in place.
     expect(anchor.getAttribute('title')).toBeNull()
+    expect(onSessionOpen).not.toHaveBeenCalled()
+    // The plain primary click is cancelled — the browser does not follow the
+    // raw href to an unresolvable sid. fireEvent.click returns false when a
+    // handler called preventDefault().
+    const notCancelled = fireEvent.click(anchor)
+    expect(notCancelled).toBe(false)
     expect(onSessionOpen).not.toHaveBeenCalled()
   })
 
@@ -96,7 +111,7 @@ describe('a /chat?sid= link in a user message (#8253)', () => {
     expect(onSessionOpen).toHaveBeenCalledWith(THERE)
   })
 
-  it('offers no chip when the triple is absent (most call sites)', () => {
+  it('offers no chip when the triple is absent, and still navigates (most call sites)', () => {
     // `sessions` ABSENT is deliberately not the same as an empty map — a
     // caller that never wired the roster gets the pre-#8253 behaviour.
     const { container } = render(
@@ -104,5 +119,28 @@ describe('a /chat?sid= link in a user message (#8253)', () => {
     )
     const anchor = container.querySelector('a')!
     expect(anchor).toHaveAttribute('target', '_blank')
+    // No session controller is wired, so there is nothing that could switch
+    // sessions: the link is an ordinary external link and a plain click must
+    // still navigate (NOT be swallowed). Gating the #9914 decline on the
+    // controller — not on the href shape alone — is what preserves this.
+    const notCancelled = fireEvent.click(anchor)
+    expect(notCancelled).toBe(true)
+  })
+
+  it('still navigates when offline: onSessionOpen wired but sessions withheld (#9927)', () => {
+    // ChatPage keeps `onSessionOpen` wired while disconnected but withholds the
+    // roster: `sessions={connected ? sessionTitles : undefined}`. The #9914
+    // decline must match resolveSessionChip's full guard (onSessionOpen AND
+    // sessions), or an offline `?sid=` link becomes a dead no-op instead of a
+    // normal navigating link.
+    const onSessionOpen = vi.fn()
+    const { container } = render(
+      <>{renderUserContent({ content: `see [next](/chat?sid=${THERE})`, meta: undefined, onFileOpen: noop, onSessionOpen, activeSession: HERE })}</>,
+    )
+    const anchor = container.querySelector('a')!
+    expect(anchor).toHaveAttribute('target', '_blank')
+    const notCancelled = fireEvent.click(anchor)
+    expect(notCancelled).toBe(true)
+    expect(onSessionOpen).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Problem / Motivation

A `/chat?sid=<key>` markdown link to a chat session that is not currently an open tab navigates to a dead/blank view on a plain click. The user clicks a session link and lands on an empty `?sid=` page instead of either switching to the session or having the click do nothing.

A backticked `chat-N-<ts>` key to the same closed session already renders as inert plain text (it declines cleanly), so the two affordances for the same key disagree: the backtick declines, the link breaks.

## Why it matters

Any agent-emitted link to a session that is not an open tab is a trap: clicking it throws the user onto a dead page in the current chat. As agents increasingly hand out cross-session links, this is hit often, and the failure is silent — nothing tells the user the link was unresolvable.

## What changed (motivation → approach → change)

The symptom is a dead-window navigation. The root cause is in `MdAnchor` (`website/src/components/MarkdownRenderer.tsx`): the click handler bailed on `!sessionLink` *without* `preventDefault()`, and the handler was only attached to the anchor when the session resolved. So for a closed/unknown key the click was never intercepted — it fell through to the anchor's native `href` and the browser navigated to a `?sid=` the session controller cannot resolve.

The fix distinguishes "this href names a chat session" from "that session resolved in the open-tabs roster". A new `sessionHrefKey` captures the former, independent of resolution. The handler is now attached whenever the href is a chat-session link, and a plain primary click: opens a resolvable session in place (unchanged); declines with `preventDefault()` and no navigation for a chat-session href that does not resolve (the fix); falls through to normal navigation only for a non-session link (unchanged). Modified clicks (Cmd/Ctrl/middle) still open the real href in a new tab, unchanged.

The decline covers every session key that does not resolve to an *open, non-active* session: a closed/unknown key (the #9914 dead-window case) and the *active* session's own key. `resolveSessionChip` already rejects the active key, and the backtick chip renders it inert, so a plain click on a link to the session you are already in is a no-op — parity with the chip. Cmd/Ctrl/middle-click still opens the real href in a new tab in every case. The decline only applies where the renderer can actually route sessions (`onSessionOpen` and `sessions` both wired); offline (roster withheld) and no-controller renders fall through to normal navigation unchanged.

This brings the `?sid=` link into parity with the backtick chip, which already declines a non-resolving key cleanly. It is intentionally a decline, not a resume: making closed sessions actually navigable is tracked separately in #9915.

## Tests

Updated `website/src/test/renderUserContent.sessionLink.test.tsx`. The existing case that asserted a closed-key link stays an ordinary navigating link (the buggy behaviour) is rewritten to assert the new contract: a plain primary click on an unresolvable `?sid=` link is cancelled (`fireEvent.click` returns `false`, i.e. `preventDefault()` was called), does not navigate, and does not call `onSessionOpen`. The existing open-session and active-session cases are unchanged and still pass.

## Manual verification

N/A — unit coverage sufficient. The change is confined to click-handler branching in `MdAnchor`; the decline path is asserted directly via the cancelled-click test, and the open-session / modified-click paths are unchanged and covered by the existing tests in the same file.

<!-- no-visual-delta -->
**Why no screenshot:** click-handling change only — the link/anchor renders identically (same text, same `href`, same `target`); only what a plain click *does* changes, which a still image cannot show.

## Related Issues

Fixes #9914

## Pattern harvest

Rule candidate: review-prompt
Pattern: an event handler early-returns without `preventDefault()` on the "not handled by me" branch, letting a claimed element fall through to native navigation/submission — when an affordance intercepts some cases, the un-intercepted case must be an explicit decline, not a silent fall-through.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no docs affected
- [x] No secrets, credentials, or internal references in the diff

