### PR TITLE
fix(knowledge): cite agent-added documents by their own source_uri (#9929)

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -275,7 +275,15 @@ capped, stored and hashed, and never opened, resolved, stat-ed or fetched. It is
 the RAW uri while only the redacted form is stored or audited — redaction is lossy, so two
 uris differing only in a same-length credential-shaped segment reduce to the same string,
 and hashing that would merge two documents into one group. A caller needing the bytes at
-that location reads them itself and passes `content`.
+that location reads them itself and passes `content`. The redacted form is persisted in
+`agent_item_state.source_uri` on every state write, and citation enrichment attaches it
+to the document's search hits (§4), so a reader can see where the adding agent said the
+document came from — the value is writer-supplied and never resolved, so it is a stated
+origin, not a verified one — while `agent://` stays the aggregate row's control uri
+only. Rows written before the column existed carry NULL and fall back to the aggregate
+uri; a later add of the same document backfills them, including the unchanged-content
+duplicate shortcut, which writes no state row and therefore repairs the locator
+in place.
 
 This replaces the never-built server-side doc-link scanner. Rather than Kiro Crew
 regex-matching links in chat and fetching them unattended, the agent reads the document
@@ -434,7 +442,7 @@ Vectors are comparable only to vectors from the same model at the same width. Th
 
 **Re-embed scheduling class.** `rebuild_embeddings(..., priority=)` sets the class every embed in the loop runs at on the one shared inference slot, and **attendance** decides it, not corpus size — the same rule vector memory's paced sweep applies. The watcher's unattended self-heal (`_run_reembed_job`) passes `PRIORITY_BULK`, so a multi-hour rebuild yields to interactive embeds and to memory's paced sweeps and gets the reduced `memory.embedding_bulk_threads` pool. The dashboard-triggered rebuild (`_rebuild_embeddings_job`) passes `PRIORITY_NORMAL` explicitly: a user clicked it and is polling the job row, so it keeps the full pool. `InProcessEmbedder.embed` / `embed_for_item` forward the value to the backend; both default to `PRIORITY_NORMAL`, so a caller that forgets is impolite rather than throttled.
 
-**Citation enrichment** — `_attach_source_locations` batch-fetches `source_locations` (adds `section_title`, `chunk_range`, `anchor`); `_attach_citation_sources` adds `source_type`/`source_name`/`source_uri` plus the most specific per-document locator: `file_path` for folder/vault sources (from `folder_file_state`), `artifact_slug`/`artifact_name` for the aggregate artifact source (deep-links `/artifacts/<slug>`). Missing/unmapped sources degrade cleanly (extra keys simply absent).
+**Citation enrichment** — `_attach_source_locations` batch-fetches `source_locations` (adds `section_title`, `chunk_range`, `anchor`); `_attach_citation_sources` adds `source_type`/`source_name`/`source_uri` plus the most specific per-document locator: `file_path` for folder/vault sources (from `folder_file_state`), `artifact_slug`/`artifact_name` for the aggregate artifact source (deep-links `/artifacts/<slug>`), and for the aggregate agent source the hit's `source_uri` is replaced with the document's own stored locator (from `agent_item_state.source_uri`) — the aggregate's `agent://` is a control uri, not a citation, and stands only for legacy rows whose column is NULL. Missing/unmapped sources degrade cleanly (extra keys simply absent).
 
 The retrieval benchmark builds a disposable corpus with one embedding callable
 for both ingestion and queries. It explicitly uses `ANY_EMBEDDING_SPACE` because

--- a/src/kiro_crew/knowledge/agent_source.py
+++ b/src/kiro_crew/knowledge/agent_source.py
@@ -149,7 +149,8 @@ def get_state(store: KnowledgeStore, source_id: str, slug: str) -> tuple[str | N
 
 
 def _record_deduped_state(store: KnowledgeStore, source_id: str, slug: str,
-                          content_hash: str, name: str) -> None:
+                          content_hash: str, name: str,
+                          *, source_uri: str) -> None:
     """Terminal write for a document the pre-ingest gate refused.
 
     Invoked BY the gate as its ``on_duplicate`` finalizer, from inside the gate's
@@ -170,34 +171,47 @@ def _record_deduped_state(store: KnowledgeStore, source_id: str, slug: str,
     """
     adopted = store.surviving_group_in_txn("agent_item_state", source_id, slug)
     _write_state_row(store, source_id, slug, content_hash, adopted, name,
-                     status="active" if adopted else "deduped")
+                     status="active" if adopted else "deduped",
+                     source_uri=source_uri)
 
 
 def set_state(store: KnowledgeStore, source_id: str, slug: str, content_hash: str,
-              item_ids: list[str], name: str, status: str = "active") -> None:
+              item_ids: list[str], name: str, status: str = "active",
+              *, source_uri: str) -> None:
     """Record one document's hash, item group, display name and status.
 
     ``status`` is written explicitly on every call: the statement is an
     ``INSERT OR REPLACE``, so omitting it would silently reset a ``deduped``
     marker back to the column default and the document would be re-ingested and
-    re-collapsed on every pass.
+    re-collapsed on every pass. ``source_uri`` (the redacted locator) rides the
+    same rule, and is required so no caller can erase it by accident.
     """
     _write_state_row(store, source_id, slug, content_hash, item_ids, name,
-                     status=status)
+                     status=status, source_uri=source_uri)
     store.db.commit()
 
 
 def _write_state_row(store: KnowledgeStore, source_id: str, slug: str,
                      content_hash: str, item_ids: list[str], name: str,
-                     status: str = "active") -> None:
+                     status: str = "active", *, source_uri: str) -> None:
     """The row write alone, with no transaction control, so a caller already
-    holding one can include it."""
+    holding one can include it.
+
+    ``source_uri`` is the document's REDACTED locator (see
+    ``add_agent_document``); it is stored so a search hit can cite the document
+    itself rather than the aggregate's ``agent://``. It is required and
+    keyword-only for the same reason ``status`` is written explicitly on every
+    call: the statement is an ``INSERT OR REPLACE``, so a caller allowed to
+    omit it would silently erase the locator a previous add recorded. A caller
+    with genuinely no locator states ``source_uri=""``, stored as NULL.
+    """
     store.db.execute(
         "INSERT OR REPLACE INTO agent_item_state "
-        "(source_id, slug, content_hash, item_ids, updated_at, name, status) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "(source_id, slug, content_hash, item_ids, updated_at, name, status, "
+        "source_uri) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         (source_id, slug, content_hash, json.dumps(item_ids),
-         datetime.now().isoformat(), name, status),
+         datetime.now().isoformat(), name, status, source_uri or None),
     )
 
 
@@ -260,7 +274,9 @@ async def add_agent_document(
     ``source_uri`` is where the document came from -- a path, URL or any stable
     handle -- and is a stored identity label: redacted, capped, hashed into the
     document's key (see ``document_slug``), and never opened, resolved, stat-ed or
-    fetched. Keep it that way; a caller that needs the bytes at that location reads
+    fetched. The redacted form is persisted on the document's state row so search
+    hits cite the document's own locator rather than the aggregate ``agent://``.
+    Keep it that way; a caller that needs the bytes at that location reads
     them itself and passes ``content``.
 
     It is REQUIRED, because the title alone does not identify a document.
@@ -322,6 +338,20 @@ async def _add_agent_document(
     # leaving the document permanently unsearchable. An empty group therefore
     # falls through and re-attempts the write.
     if prev_hash == content_hash and old_item_ids:
+        # The shortcut writes no state row, and an unchanged document takes it
+        # on EVERY re-add -- so it must repair the one thing a legacy row can
+        # lack: a NULL locator from before the column existed. Without this,
+        # "re-add to backfill" never works for a document whose content did not
+        # change, and its citations say ``agent://`` forever.
+        def _backfill_uri() -> None:
+            cur = store.db.execute(
+                "UPDATE agent_item_state SET source_uri = ? "
+                "WHERE source_id = ? AND slug = ? "
+                "AND (source_uri IS NULL OR source_uri = '')",
+                (source_uri, source_id, slug))
+            if cur.rowcount:
+                store.db.commit()
+        await asyncio.to_thread(_backfill_uri)
         return {"status": "duplicate", "reason": "unchanged since last add",
                 "slug": slug, "source_id": source_id}
 
@@ -350,7 +380,8 @@ async def _add_agent_document(
 
     def _record_ownership(new_ids: list[str]) -> None:
         recorded_ids[:] = new_ids
-        set_state(store, source_id, slug, content_hash, new_ids, title)
+        set_state(store, source_id, slug, content_hash, new_ids, title,
+                  source_uri=source_uri)
 
     tmp_path: str | None = None
     try:
@@ -375,7 +406,8 @@ async def _add_agent_document(
             # hop for the same reason: the gate has already committed the delete
             # and the location claim by the time it reports back.
             on_duplicate=lambda _text_hash: _record_deduped_state(
-                store, source_id, slug, content_hash, title),
+                store, source_id, slug, content_hash, title,
+                source_uri=source_uri),
         )
     except ImportChunkBudgetError as exc:
         # The cross-file import budget refused this add. Surface WHY to the agent

--- a/src/kiro_crew/knowledge/retrieval.py
+++ b/src/kiro_crew/knowledge/retrieval.py
@@ -295,6 +295,11 @@ class HybridRetriever:
         - the aggregate artifact source -> ``artifact_slug`` + ``artifact_name``
           (from ``artifact_item_state``), so a citation can name the artifact
           and deep-link to ``/artifacts/<slug>``.
+        - the aggregate agent source -> ``source_uri`` is REPLACED with the
+          document's own stored locator (from ``agent_item_state``), since the
+          aggregate row's ``agent://`` is a control uri, not a citation. Rows
+          written before the locator was stored carry NULL and keep the
+          aggregate uri.
         - every other source type -> nothing extra; ``source_uri`` is already the
           document locator (uploads, quip, etc.).
 
@@ -323,6 +328,8 @@ class HybridRetriever:
                        and meta[sid]["source_type"] in ("local_folder", "obsidian_vault")]
         artifact_sids = [sid for sid in sid_list if sid in meta
                          and meta[sid]["source_type"] == "artifact"]
+        agent_sids = [sid for sid in sid_list if sid in meta
+                      and meta[sid]["source_type"] == "agent"]
 
         item_to_file: dict[str, str] = {}
         for sid in folder_sids:
@@ -342,6 +349,17 @@ class HybridRetriever:
                 for item_id in _stored_item_ids(row["item_ids"]):
                     item_to_artifact[item_id] = (row["slug"], row["name"])
 
+        item_to_agent_uri: dict[str, str] = {}
+        for sid in agent_sids:
+            for row in self.store.db.execute(
+                "SELECT source_uri, item_ids FROM agent_item_state WHERE source_id = ?",
+                (sid,),
+            ).fetchall():
+                if not row["source_uri"]:
+                    continue  # legacy row: the aggregate uri stands
+                for item_id in _stored_item_ids(row["item_ids"]):
+                    item_to_agent_uri[item_id] = row["source_uri"]
+
         for result in results:
             sid = result.get("source")
             row = meta.get(sid) if isinstance(sid, str) else None
@@ -355,6 +373,9 @@ class HybridRetriever:
             artifact = item_to_artifact.get(result["id"])
             if artifact:
                 result["artifact_slug"], result["artifact_name"] = artifact
+            agent_uri = item_to_agent_uri.get(result["id"])
+            if agent_uri:
+                result["source_uri"] = agent_uri
 
     def _keyword_search(
         self,

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -816,7 +816,10 @@ class KnowledgeStore:
             -- Same shape and role as artifact_item_state: it is what lets one
             -- aggregate source hold many independently-replaceable documents,
             -- and what gives de-duplication a per-document unit to act on
-            -- instead of the whole source.
+            -- instead of the whole source. source_uri is the document's own
+            -- REDACTED locator, kept so a search hit can cite the document it
+            -- came from rather than the aggregate's control uri (agent://);
+            -- NULL on rows written before the column existed.
             CREATE TABLE IF NOT EXISTS agent_item_state (
                 source_id TEXT NOT NULL REFERENCES sources(id),
                 slug TEXT NOT NULL,
@@ -826,6 +829,7 @@ class KnowledgeStore:
                 name TEXT,
                 status TEXT DEFAULT 'active',
                 merged_into_source_id TEXT,
+                source_uri TEXT,
                 PRIMARY KEY (source_id, slug)
             );
 
@@ -1037,6 +1041,14 @@ class KnowledgeStore:
         if "merged_into_source_id" not in agent_cols:
             self.db.execute(
                 "ALTER TABLE agent_item_state ADD COLUMN merged_into_source_id TEXT")
+        # The document's own REDACTED locator, attached to agent-source search
+        # hits so a citation names where the document came from instead of the
+        # aggregate's control uri. Legacy rows carry NULL, which citation
+        # enrichment treats as "unknown" and falls back to agent://; the next
+        # add of that document backfills it.
+        if "source_uri" not in agent_cols:
+            self.db.execute(
+                "ALTER TABLE agent_item_state ADD COLUMN source_uri TEXT")
         # The orphan sweep is NOT here any more -- see `reclaim_orphans`. The
         # constructor runs on the event loop before the socket binds, and the
         # sweep is data-scaled and writer-locked, so on a large store it

--- a/test/test_knowledge_agent_source.py
+++ b/test/test_knowledge_agent_source.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -27,6 +28,7 @@ from kiro_crew.knowledge.agent_source import (
 from kiro_crew.knowledge.folder_watcher import FolderWatcher
 from kiro_crew.knowledge.ingestion import DUPLICATE_JOB_STATUS, IngestionPipeline
 from kiro_crew.knowledge.readers import FileReader
+from kiro_crew.knowledge.retrieval import HybridRetriever
 from kiro_crew.knowledge.store import KnowledgeStore
 
 
@@ -89,7 +91,7 @@ class TestAggregateSource:
         # aggregate must be exempt via its item-state table or the very first
         # document lands in a source that was reaped at boot.
         sid, _ = ensure_agent_source(kstore)
-        set_state(kstore, sid, "slug1", "H1", [], "Doc")
+        set_state(kstore, sid, "slug1", "H1", [], "Doc", source_uri="")
         kstore.close()
         reopened = KnowledgeStore(str(tmp_path / "knowledge.db"))
         try:
@@ -113,7 +115,7 @@ class TestSlug:
 class TestState:
     def test_roundtrip(self, kstore):
         sid, _ = ensure_agent_source(kstore)
-        set_state(kstore, sid, "s", "H1", ["i1", "i2"], "Doc")
+        set_state(kstore, sid, "s", "H1", ["i1", "i2"], "Doc", source_uri="")
         assert get_state(kstore, sid, "s") == ("H1", ["i1", "i2"])
 
     def test_missing_is_empty(self, kstore):
@@ -125,7 +127,8 @@ class TestState:
         # column default, and the document would be re-ingested and re-collapsed
         # on every pass.
         sid, _ = ensure_agent_source(kstore)
-        set_state(kstore, sid, "s", "H1", ["i1"], "Doc", status="deduped")
+        set_state(kstore, sid, "s", "H1", ["i1"], "Doc", status="deduped",
+                  source_uri="")
         assert kstore.db.execute(
             "SELECT status FROM agent_item_state WHERE slug = 's'").fetchone()[0] == "deduped"
 
@@ -133,14 +136,14 @@ class TestState:
         sid, _ = ensure_agent_source(kstore)
         iid = kstore.add_item(title="t", content="c", item_type="document",
                               source_id=sid, content_hash="H1")
-        set_state(kstore, sid, "s", "H1", [iid], "Doc")
+        set_state(kstore, sid, "s", "H1", [iid], "Doc", source_uri="")
         assert remove_document(kstore, sid, "s") == 1
         assert get_state(kstore, sid, "s") == (None, [])
         assert _items(kstore, sid) == []
 
     def test_cascade_clears_agent_state(self, kstore):
         sid, _ = ensure_agent_source(kstore)
-        set_state(kstore, sid, "s", "H1", ["i1"], "Doc")
+        set_state(kstore, sid, "s", "H1", ["i1"], "Doc", source_uri="")
         kstore.delete_source_cascade(sid)
         assert kstore.db.execute(
             "SELECT COUNT(*) FROM agent_item_state").fetchone()[0] == 0
@@ -528,8 +531,8 @@ class TestAgentSourceIsDeduped:
                             source_id=sid, content_hash="H1")
         b = kstore.add_item(title="b", content="b", item_type="document",
                             source_id=sid, content_hash="H2")
-        set_state(kstore, sid, "sa", "H1", [a], "Doc A")
-        set_state(kstore, sid, "sb", "H2", [b], "Doc B")
+        set_state(kstore, sid, "sa", "H1", [a], "Doc A", source_uri="")
+        set_state(kstore, sid, "sb", "H2", [b], "Doc B", source_uri="")
         docs = enumerate_docs(kstore)
         agent_docs = [d for d in docs if d.source_id == sid]
         assert len(agent_docs) == 2
@@ -541,7 +544,7 @@ class TestAgentSourceIsDeduped:
 
     def test_state_item_ids_are_json_lists(self, kstore):
         sid, _ = ensure_agent_source(kstore)
-        set_state(kstore, sid, "s", "H1", ["i1"], "Doc")
+        set_state(kstore, sid, "s", "H1", ["i1"], "Doc", source_uri="")
         raw = kstore.db.execute(
             "SELECT item_ids FROM agent_item_state WHERE slug = 's'").fetchone()[0]
         assert json.loads(raw) == ["i1"]
@@ -821,3 +824,110 @@ def test_removing_a_deduped_agent_document_releases_its_claim(tmp_path):
         assert store.get_item(iid) is None
     finally:
         store.db.close()
+
+
+class TestCitationSourceUri:
+    """A search hit cites the document's own locator, never the aggregate's.
+
+    The aggregate source row's uri is fixed to ``agent://`` -- a control handle,
+    not a citation. The redacted per-document ``source_uri`` is persisted in
+    ``agent_item_state`` and attached to the hit by item id, so a reader can
+    open and verify the original document.
+    """
+
+    def _hit(self, kstore, source_id, query):
+        results = HybridRetriever(kstore).search(query, source_id=source_id)
+        assert results, "expected the document to be found"
+        return results[0]
+
+    @pytest.mark.asyncio
+    async def test_search_hit_cites_the_documents_own_uri(self, pipeline, kstore):
+        uri = "https://wiki.example.com/design/frobnicator"
+        res = await add_agent_document(pipeline, title="Frobnicator design",
+                                       content="the frobnicator design body",
+                                       source_uri=uri)
+        assert res["status"] == "added"
+        hit = self._hit(kstore, res["source_id"], "frobnicator design")
+        assert hit["source_type"] == AGENT_SOURCE_TYPE
+        assert hit["source_uri"] == uri
+        assert hit["source_uri"] != AGENT_SOURCE_URI
+
+    @pytest.mark.asyncio
+    async def test_cited_uri_is_the_redacted_form(self, pipeline, kstore):
+        # The raw uri may carry a credential the agent never inspected; only the
+        # redacted form may be stored, so only the redacted form can be cited.
+        res = await add_agent_document(
+            pipeline, title="Runbook", content="the deploy runbook body",
+            source_uri="https://wiki.example.com/doc?key=AKIAIOSFODNN7EXAMPLE")
+        assert res["status"] == "added"
+        hit = self._hit(kstore, res["source_id"], "deploy runbook")
+        assert "AKIA" not in hit["source_uri"]
+        assert "REDACTED" in hit["source_uri"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_row_falls_back_to_the_aggregate_uri(self, pipeline, kstore):
+        res = await add_agent_document(pipeline, title="Old doc",
+                                       content="the legacy document body",
+                                       source_uri="test://old-doc")
+        assert res["status"] == "added"
+        # A row written before the column existed carries NULL.
+        kstore.db.execute("UPDATE agent_item_state SET source_uri = NULL")
+        kstore.db.commit()
+        hit = self._hit(kstore, res["source_id"], "legacy document")
+        assert hit["source_uri"] == AGENT_SOURCE_URI
+
+    @pytest.mark.asyncio
+    async def test_re_adding_unchanged_content_backfills_a_legacy_row(
+            self, pipeline, kstore):
+        # An unchanged document takes the duplicate shortcut, which writes no
+        # state row -- so the shortcut itself must repair a NULL locator, or
+        # "re-add to backfill" never works for documents that did not change.
+        uri = "test://legacy-backfill"
+        res = await add_agent_document(pipeline, title="Old doc",
+                                       content="the stable legacy body",
+                                       source_uri=uri)
+        assert res["status"] == "added"
+        kstore.db.execute("UPDATE agent_item_state SET source_uri = NULL")
+        kstore.db.commit()
+        again = await add_agent_document(pipeline, title="Old doc",
+                                         content="the stable legacy body",
+                                         source_uri=uri)
+        assert again["status"] == "duplicate"
+        hit = self._hit(kstore, res["source_id"], "stable legacy")
+        assert hit["source_uri"] == uri
+
+    @pytest.mark.asyncio
+    async def test_locator_survives_an_edited_re_add(self, pipeline, kstore):
+        # The state write is INSERT OR REPLACE: replacing the group for edited
+        # content must carry the locator, not reset it to NULL.
+        uri = "test://edited-doc"
+        res = await add_agent_document(pipeline, title="Doc",
+                                       content="the first draft body",
+                                       source_uri=uri)
+        assert res["status"] == "added"
+        second = await add_agent_document(pipeline, title="Doc",
+                                          content="the second draft body",
+                                          source_uri=uri)
+        assert second["status"] == "added"
+        hit = self._hit(kstore, res["source_id"], "second draft")
+        assert hit["source_uri"] == uri
+
+    def test_migration_adds_the_column_idempotently(self, tmp_path):
+        db_path = str(tmp_path / "legacy.db")
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE agent_item_state ("
+            "source_id TEXT NOT NULL, slug TEXT NOT NULL, content_hash TEXT, "
+            "item_ids TEXT DEFAULT '[]', updated_at TEXT NOT NULL, name TEXT, "
+            "status TEXT DEFAULT 'active', merged_into_source_id TEXT, "
+            "PRIMARY KEY (source_id, slug))")
+        conn.commit()
+        conn.close()
+        for _ in range(2):  # the second open must not re-run the ALTER
+            store = KnowledgeStore(db_path)
+            try:
+                cols = {r[1] for r in store.db.execute(
+                    "PRAGMA table_info(agent_item_state)").fetchall()}
+                assert "source_uri" in cols
+            finally:
+                store.close()

--- a/test/test_knowledge_delete_off_loop.py
+++ b/test/test_knowledge_delete_off_loop.py
@@ -822,7 +822,8 @@ def test_agent_deduped_state_write_keeps_a_late_adoption(tmp_path):
             "VALUES (?, 'doc', ?, ?, '2026-01-01T00:00:00', 'Doc', 'active')",
             (source_id, text_hash, json.dumps([item])))
 
-        _record_deduped_state(store, source_id, "doc", text_hash, "Doc")
+        _record_deduped_state(store, source_id, "doc", text_hash, "Doc",
+                              source_uri="")
 
         row = store.db.execute(
             "SELECT item_ids, status FROM agent_item_state "
@@ -856,7 +857,7 @@ def test_aggregate_deduped_state_write_records_an_empty_group_when_nothing_adopt
             "VALUES (?, 'doc', 'h', ?, '2026-01-01T00:00:00', 'Doc', 'active')",
             (source_id, json.dumps([gone])))
 
-        _record_deduped_state(store, source_id, "doc", "h", "Doc")
+        _record_deduped_state(store, source_id, "doc", "h", "Doc", source_uri="")
 
         row = store.db.execute(
             "SELECT item_ids, status FROM agent_item_state "


### PR DESCRIPTION
## Problem / Motivation

Every document the agent adds to the Knowledge Library cites the wrong place. `knowledge_add_document` demands a `source_uri` and returns it in the result, but a later `local_knowledge_search` hit shows the aggregate source's control uri `agent://` instead — the submitted locator was hashed into the document's key and then thrown away.

## Why it matters

A citation that says `agent://` names nothing a reader can open. All agent-added documents appear to share one provenance, so nobody can check where a stored document actually came from, while the docs promise every search result cites its source.

## What changed (motivation → approach → change)

The store kept per-document state for agent documents (`agent_item_state`) but had no column for the locator, and citation enrichment read the uri off the shared source row. Folder and artifact sources already solve this with per-document reverse maps at enrichment time, so the fix reuses that shape rather than inventing a new path.

`agent_item_state` gains a `source_uri` column (same PRAGMA `table_info` migration pattern as its `status` and `merged_into_source_id` columns). Every state writer persists the redacted, capped locator, and the parameter is required keyword-only so a caller cannot omit it and silently erase a stored locator through the row's `INSERT OR REPLACE`. `_attach_citation_sources` builds an item-id → locator map for agent sources — exactly the way it builds the folder `file_path` and `artifact_slug` maps — and replaces the hit's `source_uri` with the document's own.

Rows written before the column existed carry NULL and keep the `agent://` fallback. Any later add of the same document repairs them: the unchanged-content duplicate shortcut writes no state row, so that branch backfills a NULL locator in place (parameterized update, off the event loop) before returning. The stored value is a stated origin, not a verified one — it is writer-supplied, redacted, and never resolved or fetched; the spec says so in the same words.

## Tests

- `test_search_hit_cites_the_documents_own_uri` — a document added through the production path is cited by its submitted uri, not `agent://`.
- `test_cited_uri_is_the_redacted_form` — a credential-bearing uri is cited only in redacted form.
- `test_legacy_row_falls_back_to_the_aggregate_uri` — a NULL column (pre-fix row) degrades to `agent://`.
- `test_re_adding_unchanged_content_backfills_a_legacy_row` — the duplicate shortcut repairs a NULL locator.
- `test_locator_survives_an_edited_re_add` — replacing a document's group keeps its locator.
- `test_migration_adds_the_column_idempotently` — a legacy schema gains the column once, across two opens.

## Manual verification

N/A — unit coverage exercises the production add path, the retriever, and the migration end to end on a real store.

## Related Issues

Closes #9929

## Pattern harvest

Rule candidate: review-prompt
Pattern: an aggregate source's per-document state table stores a value at write time that read-side enrichment never attaches — check both halves when a "required" input is accepted but unobservable in output.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
