### PR TITLE
docs(skill): pr_checks needs a non-draft PR, and an open question card slows patrol

### DIFF
--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -41,6 +41,7 @@ A candidate qualifies only if **all three** hold:
    work — CI runs the suite, and its verdict is the one that counts. If an item's
    completion genuinely cannot be stated as one of these, it is not assertable:
    say so and treat it as a needs-human item rather than inventing a condition.
+   A `pr_checks` condition names a NON-DRAFT pull request: while a pull request is a draft, a repository that gates readiness on draft state holds its checks incomplete, so the verdict stays `pending` for as long as the draft lasts and the item can never pass.
 3. **Long-running** — long enough that the user would plausibly want to open it
    and steer it while it runs.
 
@@ -131,6 +132,8 @@ For each item in the round:
    dispatch). That entry is the ONLY place the acceptance spec survives
    compaction; `next` carries the resumable intent.
 
+**A `pr_checks` seed says how the pull request is opened.** Tell the worker to open it non-draft — `gh pr create` without `--draft` — or to run `gh pr ready` before it reports done. A completion claim that arrives on a draft costs a whole verify cycle that can only answer `pending`.
+
 Send the seed BEFORE recording the ledger row as dispatched — a ledger row that
 says "running" for a session that never got its seed is the worse failure.
 
@@ -184,6 +187,10 @@ Each cycle:
    malformed spec indistinguishable from one that is merely early. Never fake
    the gap with a search-style command either — list commands exit 0 on empty
    results, so they cannot carry the verdict.
+
+   **A `human_approval` item is verified by asking, and the ask is fragile.** The evaluator answers `pending` for it forever, so put the decision to the user with `ask_question` — then `monitor_update` `interval_secs=1800`, or the largest interval the goal tolerates, until the answer arrives, and restore the interval once it does.
+
+   If the user says the card is gone, re-issue it. A report that the card vanished is not an answer.
 3. For items still running, `session_read_message` with the `since` cursor you
    stored last cycle — this answers "is it moving / did it ask a question",
    never "did it succeed". Store the returned `next_since` back into that item's
@@ -354,6 +361,7 @@ watches, and that cost grows with the loop's own history.
   auto-approved for exactly this, so the load never prompts — then repeat the
   call. `chat_folder_create` is on the same server; `monitor_start` is served by
   `kirocrew-core`, so its id is `kirocrew-core::monitor_start`.
+- **A question card can be displaced by your own later turns.** `ask_question` posts a card into the dashboard transcript, and every patrol turn you take while it is outstanding can push it out of the user's view. Slow patrol while a card is open, and treat "the card is gone" as a re-issue rather than an answer.
 - **A cron job may dispatch into the sessions it created**, so a fleet can be
   stood up and driven from a schedule instead of only from a live chat session.
   Session control is on by default: the agent config is the grant, so you do not

--- a/src/kiro_crew/builtin_skills/goal-ledger-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-ledger-conductor/SKILL.md
@@ -47,6 +47,7 @@ A candidate qualifies only if **all three** hold:
    work — CI runs the suite, and its verdict is the one that counts. If an item's
    completion genuinely cannot be stated as one of these, it is not assertable:
    say so and treat it as a needs-human item rather than inventing a condition.
+   A `pr_checks` condition names a NON-DRAFT pull request: while a pull request is a draft, a repository that gates readiness on draft state holds its checks incomplete, so the verdict stays `pending` for as long as the draft lasts and the item can never pass.
 3. **Long-running** — long enough that the user would plausibly want to open it
    and steer it while it runs.
 
@@ -129,6 +130,8 @@ For each item in the round, in **exactly this order**:
    The seed is the item's whole contract: the child session gets no other
    context from you.
 
+**A `pr_checks` seed says how the pull request is opened.** Tell the worker to open it non-draft — `gh pr create` without `--draft` — or to run `gh pr ready` before it reports done. A completion claim that arrives on a draft costs a whole verify cycle that can only answer `pending`.
+
 **Bind BEFORE you seed.** This inverts `goal-conductor`'s "seed before you
 record" rule, deliberately. That rule protects against a ledger row with no
 session behind it; this one protects against a running worker with no binding,
@@ -199,8 +202,10 @@ Each cycle:
    ```
 
    **The filter is yours to apply, and it is not optional.** `accept_batch` is
-   composed from every open item that has a concrete acceptance, whatever its
-   status — it is the two-phase promotion seam, not a verdict gate. The evaluator
+   composed from every open item whose acceptance is concrete, whatever its
+   status — it is the two-phase promotion seam, not a verdict gate. Each entry
+   carries that item's `status` beside its condition, and that field is the one
+   you filter on; the server does not filter by it. The evaluator
    answers a world-state question ("does this file exist", "are this PR's checks
    green"), and a worker that is still `progress` can have made that true early:
    a stub written before the real content, a PR that is green before the last
@@ -241,12 +246,17 @@ Each cycle:
    `pr_checks` is the common case. Store the condition with the value marked TBD
    at `create`, tell the child in its seed to report the number through
    `work_report`'s `pr`, and `accept_batch` will leave that item OUT of the batch
-   until the stored `acceptance` is concrete. **The worker's claimed `pr` is
+   until the stored `acceptance` is concrete — the item's `acceptance_concrete`
+   flag is what says whether its bar is real yet. **The worker's claimed `pr` is
    never read as the bar.** Promote it yourself with `work_ledger_record`
    `action=accept` once you have looked at it, and verify on the next cycle. A
    worker that could fill in its own acceptance could point it at anybody's
    already-green pull request, which is exactly why the claim and the condition
    are separate fields.
+
+   **A `human_approval` item is verified by asking, and the ask is fragile.** The evaluator answers `pending` for it forever, so put the decision to the user with `ask_question` — then `monitor_update` `interval_secs=1800`, or the largest interval the goal tolerates, until the answer arrives, and restore the interval once it does.
+
+   If the user says the card is gone, re-issue it. A report that the card vanished is not an answer.
 4. `work_ledger_record` `action=close` with the item's `state` when an item is
    finally done with — that is what ends it. `action=decide` records an
    instruction you want the worker to read out of `work_brief`; it is the ONE
@@ -388,6 +398,7 @@ what the composer renders:
   arm that instead and the quiet cycles stop costing a turn. Until then, size
   the interval for the report cadence you expect rather than for the latency you
   want.
+- **A question card can be displaced by your own later turns.** `ask_question` posts a card into the dashboard transcript, and every patrol turn you take while it is outstanding can push it out of the user's view. Slow patrol while a card is open, and treat "the card is gone" as a re-issue rather than an answer.
 - **The session and ledger tools may not be in your tool list yet.** With MCP
   Tool Search active their specs are deferred, so a first `session_create` fails
   with `A tool with the name 'session_create' does not exist`. That means


### PR DESCRIPTION
## Problem / Motivation

Three defects observed in a live conductor run today, all in the two conductor skills' text rather than in code.

1. Both skills tell a conductor to accept work with `pr_checks` and say nothing about draft pull requests. On a repository that gates readiness on draft state, a draft PR holds its checks incomplete, `gh pr checks` never exits 0, and the acceptance verdict stays `pending` forever. Today's conductor lost about an hour before a worker raised it as a question.
2. For a `human_approval` item the conductor posts an `ask_question` card and keeps patrolling on its normal interval. Each later patrol turn can push that card out of the user's view; a user who switched sessions and came back could not find it. Nothing in either skill told the conductor to slow patrol while a card is outstanding, or that "the card is gone" is a re-issue rather than an answer.
3. The ledger skill's `accept_batch` paragraph describes the two-phase TBD omission without naming the fields a conductor should actually read.

## Why it matters

A conductor following the skill as written could set an acceptance condition that can never pass, and could burn a human's attention on a card that is no longer visible. Both are silent: the item just sits.

## What changed

`goal-ledger-conductor/SKILL.md` and `goal-conductor/SKILL.md`:

- The `pr_checks` kind definition now says the condition names a NON-DRAFT pull request, and states the consequence (verdict stays `pending` while the draft lasts).
- The dispatch section now says what the seed must carry: open non-draft (`gh pr create` without `--draft`), or `gh pr ready` before reporting done.
- Patrol's verification step now carries the `human_approval` rule: `ask_question`, then `monitor_update` `interval_secs=1800` (or the largest interval the goal tolerates) until the answer arrives, then restore. If the user says the card vanished, re-issue it — that report is not an answer.
- Known limits gains one bullet naming the card-displacement behaviour.

`goal-ledger-conductor/SKILL.md` only:

- The `accept_batch` wording now names the per-entry `status` field as the thing the conductor filters on, and `acceptance_concrete` as what says whether an item's bar is real yet. **The "filter to `done` yourself" rule is unchanged and still load-bearing** — the server does not filter by status.

Two corrections to the reported defect, both verified against the code:

- The evaluator does **not** return `refused` on a draft PR. `accept_eval.py` builds `gh pr checks <n>`; `gh` exits 8 while checks are incomplete, which `_GH_PENDING_EXIT` maps to `pending`. The text says `pending`, not `refused`.
- The draft-holds-readiness behaviour is written as conditional on the repository ("a repository that gates readiness on draft state"), not as universal. These skills ship to every install, so naming this repository's own readiness check would be a dead reference for everyone else — the builtin-skill scope gate exists for exactly that class.

## Ordering note

The `acceptance_concrete` and per-entry `status` fields are added by a sibling PR in the same round. On `main` today `accept_batch` includes TBD items and carries no `status` (verified in `work_ledger.py`). If this PR lands first, those two field names read ahead of the server for as long as that gap lasts; the rule the conductor acts on — filter to `done` yourself — is correct either way.

No code, no agent-prompt change. `agent.py`'s ledger-conductor prompt does not embed any sentence edited here; its own claim that the batch leaves a placeholder item out stays true once the sibling lands.

## Tests

- `test/test_ledger_conductor_agent.py`, `test/test_conductor_agent.py`, `test/test_work_ledger_tools.py`, `test/test_work_ledger.py`, `test/test_conductor_ledger_entry.py` — 288 passed. These are the tests that pin SKILL.md content (whitespace-normalized phrase assertions, prompt/skill agreement, and the "goal-conductor is untouched by the ledger flow" guard, which still holds: no `work_ledger` or `kirocrew-work` string was added there).
- Builtin Skill Scope Gate: self-test 19/19, gate clean — no repository markers added.
- Brand Name, Comment History, Focus Cue, Feature Map, Changelog History, Harness Parity gates: run with their `*_BASE_REF` exported to `git merge-base HEAD origin/main`, all pass.
- `scripts/docs-lint.sh`: all documentation checks pass.
