### PR TITLE
fix(accept-eval): refuse a PENDING draft PR, and print usage instead of blocking on stdin

### DIFF
--- a/src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py
+++ b/src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py
@@ -7,6 +7,11 @@ exit code and a JSON document, not a model's impression of a transcript.
 
 Usage:
     python3 accept_eval.py < items.json
+    python3 accept_eval.py --help      # this block, on stderr, exit 2
+
+The input arrives on STDIN. Invoked with nothing piped in (a terminal) or with
+``-h``/``--help``, this script prints this block and exits 2 instead of
+blocking on a read that would look like a hang.
 
 stdin (JSON):
     {"items": [
@@ -67,6 +72,15 @@ Other properties:
 - Evidence is tail-capped so a chatty check cannot flood the conductor's turn.
 - A ``refused`` verdict is one the conductor must surface to the user, never
   retry around.
+- ``pr_checks`` that comes back PENDING on a DRAFT pull request is ``refused``,
+  not waited on. A draft is the author's own statement that the PR is not ready
+  for review, so an unfinished check run on one is a person's turn, not a
+  machine's. This deliberately covers a draft whose checks are merely still
+  running: the evaluator holds no state across cycles and cannot tell that apart
+  from a readiness check gated on the draft flag, which never resolves - and the
+  remedy is the same either way, and one the author owes anyway. A draft whose
+  checks have RESOLVED is judged on them like any other PR (a green draft
+  passes).
 
 Stdlib-only, Python 3.8+.
 """
@@ -78,8 +92,10 @@ from pathlib import Path
 
 #: Binaries this script itself invokes, from argv it builds. NOT a spec-facing
 #: allowlist - nothing in a spec can name a command at all. This exists so a
-#: handler that ever passes spec input into `_run` fails closed instead of
+#: handler that ever passes spec input into `_exec` fails closed instead of
 #: executing it, which is the regression the `cmd` kind's removal prevents.
+#: Both invocations here are `gh` (`pr checks` and the `pr view` draft probe),
+#: so a second entry would widen the surface for nothing.
 _SELF_BUILT_COMMANDS = {"gh"}
 
 TIMEOUT_SECS = 300
@@ -94,20 +110,27 @@ def _tail(text: str) -> str:
     return text[-EVIDENCE_TAIL_CHARS:] if len(text) > EVIDENCE_TAIL_CHARS else text
 
 
-def _run(argv, cwd=None):
-    """Run one SCRIPT-BUILT check without a shell; return (verdict, evidence).
+def _exec(argv, cwd=None):
+    """Run one SCRIPT-BUILT argv without a shell; return ``(problem, proc)``.
+
+    Exactly one half is not ``None``. ``problem`` is a ready
+    ``(verdict, evidence)`` pair for the cases where no process ran at all.
 
     Every caller must pass an argv it constructed itself. The guard below is an
     internal invariant, not a spec gate: reaching it with something outside
     ``_SELF_BUILT_COMMANDS`` means a handler leaked spec input into an exec path,
-    so it refuses rather than runs.
+    so it refuses rather than runs. It lives HERE, in the one exec seam, which
+    is why adding a second invocation did not add a second way past it.
     """
     raw = str(argv[0])
     if raw not in _SELF_BUILT_COMMANDS:
         return (
-            "refused",
-            f"evaluator bug: {raw!r} is not a command this script builds; "
-            "no spec field may name a command",
+            (
+                "refused",
+                f"evaluator bug: {raw!r} is not a command this script builds; "
+                "no spec field may name a command",
+            ),
+            None,
         )
     try:
         proc = subprocess.run(  # noqa: S603 - argv array, no shell, script-built
@@ -125,17 +148,47 @@ def _run(argv, cwd=None):
             timeout=TIMEOUT_SECS,
         )
     except subprocess.TimeoutExpired:
-        return ("error", f"timed out after {TIMEOUT_SECS}s")
+        return (("error", f"timed out after {TIMEOUT_SECS}s"), None)
     except FileNotFoundError:
-        return ("error", f"{raw!r} not found on PATH")
+        return (("error", f"{raw!r} not found on PATH"), None)
     except OSError as exc:
-        return ("error", f"could not run: {exc}")
+        return (("error", f"could not run: {exc}"), None)
+    return (None, proc)
+
+
+def _run(argv, cwd=None):
+    """Run one SCRIPT-BUILT check and map its exit into a verdict."""
+    raw = str(argv[0])
+    problem, proc = _exec(argv, cwd)
+    if proc is None:
+        return problem or ("error", "could not run")
     output = _tail(proc.stdout + "\n" + proc.stderr)
     if proc.returncode == 0:
         return ("pass", output or "exit 0")
     if raw == "gh" and proc.returncode == _GH_PENDING_EXIT:
         return ("pending", output or "checks still running")
     return ("fail", f"exit {proc.returncode}: {output}")
+
+
+def _pr_is_draft(pr, repo=None):
+    """Is this pull request still a draft? ``True`` only on an unambiguous yes.
+
+    Asked ONLY to explain a check run that came back pending - see the
+    ``pr_checks`` handler for why the order matters.
+
+    The probe is deliberately one-sided. Anything other than a clean ``true`` -
+    gh absent, no such PR, an auth failure, a forge without the field - returns
+    ``False``, and the pending verdict then stands exactly as it did before, so
+    a probe that cannot answer never invents a refusal.
+    """
+    argv = ["gh", "pr", "view", str(pr)]
+    if repo:
+        argv += ["--repo", str(repo)]
+    argv += ["--json", "isDraft", "-q", ".isDraft"]
+    problem, proc = _exec(argv)
+    if problem is not None or proc is None or proc.returncode != 0:
+        return False
+    return proc.stdout.strip().lower() == "true"
 
 
 def _evaluate(item):
@@ -147,11 +200,40 @@ def _evaluate(item):
         # checks True`; reject it with the same message as any other non-int.
         if not isinstance(pr, int) or isinstance(pr, bool):
             return ("error", "pr_checks spec needs an integer pr")
-        argv = ["gh", "pr", "checks", str(pr)]
         repo = accept.get("repo")
+        argv = ["gh", "pr", "checks", str(pr)]
         if repo:
             argv += ["--repo", str(repo)]
-        return _run(argv)
+        verdict, evidence = _run(argv)
+        # The draft probe runs HERE, behind a pending verdict, and nowhere else.
+        #
+        # A draft PR is not unconditionally unsatisfiable, so the probe must not
+        # pre-empt the check: where a repo has no aggregate check gated on the
+        # draft flag, a draft's checks resolve and `gh pr checks` exits 0 - a
+        # `pass` this script keeps returning, since this skill ships to
+        # arbitrary repos. Probing only a pending run also costs nothing on the
+        # pass and fail paths, which is every cycle that was never going to
+        # loop.
+        #
+        # A PENDING draft is refused on the spec, not on a prediction about CI.
+        # The two ways a draft's checks stay pending - a readiness check gated
+        # on the draft flag, which never resolves, and ordinary checks still
+        # running, which do - are indistinguishable to a stateless evaluator,
+        # and this returns the same answer for both ON PURPOSE. A draft is the
+        # author's own "not ready for review", so an unfinished check run on one
+        # is a person's turn; "mark it ready for review" is a step they owe
+        # regardless, and it is bounded. Waiting instead is not: guessing wrong
+        # in that direction is the reported defect, an hour of polling a
+        # condition no cycle could change.
+        if verdict == "pending" and _pr_is_draft(pr, repo):
+            return (
+                "refused",
+                f"PR #{pr} is a draft and its checks have not finished; a draft "
+                "is not a review-ready PR, and where readiness is gated on the "
+                "draft flag no further polling resolves it -- mark it ready for "
+                "review or change the acceptance kind",
+            )
+        return (verdict, evidence)
     if kind == "file":
         path = accept.get("path")
         if not isinstance(path, str) or not path:
@@ -182,7 +264,39 @@ def _evaluate(item):
     return ("error", f"unknown accept kind {kind!r}")
 
 
+def _usage_text() -> str:
+    """The Usage..exit-code part of the module docstring, verbatim.
+
+    Sliced out of ``__doc__`` instead of duplicated, so help a caller reads can
+    never drift from the contract documented above it. ``python -OO`` strips
+    docstrings, hence the one-line fallback.
+    """
+    doc = __doc__ or ""
+    start = doc.find("Usage:")
+    end = doc.find("THE SECURITY INVARIANT")
+    if start < 0 or end <= start:
+        return "Usage: python3 accept_eval.py < items.json"
+    return doc[start:end].rstrip()
+
+
+def _stdin_is_a_tty() -> bool:
+    """Is stdin a terminal? A closed or detached stdin counts as not one."""
+    try:
+        return bool(sys.stdin is not None and sys.stdin.isatty())
+    except (AttributeError, ValueError, OSError):
+        return False
+
+
 def main() -> int:
+    args = sys.argv[1:]
+    if "-h" in args or "--help" in args or _stdin_is_a_tty():
+        # Run with nothing piped in, the json.load below blocks on a read that
+        # never completes: from a caller's side that is a tool timeout, an
+        # approval spent, and no output - not "you forgot the input". Say what
+        # the input is and stop. Exit 2 is the code malformed input already
+        # uses, so nothing that pipes real input sees a new outcome.
+        print(_usage_text(), file=sys.stderr)
+        return 2
     try:
         payload = json.load(sys.stdin)
         items = payload["items"]

--- a/src/kiro_crew/builtin_skills/goal-conductor/scripts/ledger_entry.py
+++ b/src/kiro_crew/builtin_skills/goal-conductor/scripts/ledger_entry.py
@@ -337,6 +337,14 @@ _MODES = {
 }
 
 
+def _stdin_is_a_tty() -> bool:
+    """Is stdin a terminal? A closed or detached stdin counts as not one."""
+    try:
+        return bool(sys.stdin is not None and sys.stdin.isatty())
+    except (AttributeError, ValueError, OSError):
+        return False
+
+
 def main() -> int:
     if len(sys.argv) != 2 or sys.argv[1] not in _MODES:
         # stdout, like the malformed-stdin error below and accept_eval.py: the
@@ -345,6 +353,21 @@ def main() -> int:
         print(
             json.dumps(
                 {"error": f"usage: ledger_entry.py {{{'|'.join(sorted(_MODES))}}} < input.json"}
+            )
+        )
+        return 2
+    if _stdin_is_a_tty():
+        # A VALID mode with nothing piped in still blocked on the read below
+        # until the caller's tool timeout: an approval spent, no output, and
+        # nothing saying the input goes on stdin. The argv guard above never saw
+        # it, because the invocation was well-formed. Same exit 2, so no caller
+        # that pipes real input sees a new outcome.
+        print(
+            json.dumps(
+                {
+                    "error": "stdin is a terminal; "
+                    f"usage: ledger_entry.py {{{'|'.join(sorted(_MODES))}}} < input.json"
+                }
             )
         )
         return 2

--- a/src/kiro_crew/builtin_skills/goal-ledger-conductor/scripts/accept_eval.py
+++ b/src/kiro_crew/builtin_skills/goal-ledger-conductor/scripts/accept_eval.py
@@ -7,6 +7,11 @@ exit code and a JSON document, not a model's impression of a transcript.
 
 Usage:
     python3 accept_eval.py < items.json
+    python3 accept_eval.py --help      # this block, on stderr, exit 2
+
+The input arrives on STDIN. Invoked with nothing piped in (a terminal) or with
+``-h``/``--help``, this script prints this block and exits 2 instead of
+blocking on a read that would look like a hang.
 
 stdin (JSON):
     {"items": [
@@ -67,6 +72,15 @@ Other properties:
 - Evidence is tail-capped so a chatty check cannot flood the conductor's turn.
 - A ``refused`` verdict is one the conductor must surface to the user, never
   retry around.
+- ``pr_checks`` that comes back PENDING on a DRAFT pull request is ``refused``,
+  not waited on. A draft is the author's own statement that the PR is not ready
+  for review, so an unfinished check run on one is a person's turn, not a
+  machine's. This deliberately covers a draft whose checks are merely still
+  running: the evaluator holds no state across cycles and cannot tell that apart
+  from a readiness check gated on the draft flag, which never resolves - and the
+  remedy is the same either way, and one the author owes anyway. A draft whose
+  checks have RESOLVED is judged on them like any other PR (a green draft
+  passes).
 
 Stdlib-only, Python 3.8+.
 """
@@ -78,8 +92,10 @@ from pathlib import Path
 
 #: Binaries this script itself invokes, from argv it builds. NOT a spec-facing
 #: allowlist - nothing in a spec can name a command at all. This exists so a
-#: handler that ever passes spec input into `_run` fails closed instead of
+#: handler that ever passes spec input into `_exec` fails closed instead of
 #: executing it, which is the regression the `cmd` kind's removal prevents.
+#: Both invocations here are `gh` (`pr checks` and the `pr view` draft probe),
+#: so a second entry would widen the surface for nothing.
 _SELF_BUILT_COMMANDS = {"gh"}
 
 TIMEOUT_SECS = 300
@@ -94,20 +110,27 @@ def _tail(text: str) -> str:
     return text[-EVIDENCE_TAIL_CHARS:] if len(text) > EVIDENCE_TAIL_CHARS else text
 
 
-def _run(argv, cwd=None):
-    """Run one SCRIPT-BUILT check without a shell; return (verdict, evidence).
+def _exec(argv, cwd=None):
+    """Run one SCRIPT-BUILT argv without a shell; return ``(problem, proc)``.
+
+    Exactly one half is not ``None``. ``problem`` is a ready
+    ``(verdict, evidence)`` pair for the cases where no process ran at all.
 
     Every caller must pass an argv it constructed itself. The guard below is an
     internal invariant, not a spec gate: reaching it with something outside
     ``_SELF_BUILT_COMMANDS`` means a handler leaked spec input into an exec path,
-    so it refuses rather than runs.
+    so it refuses rather than runs. It lives HERE, in the one exec seam, which
+    is why adding a second invocation did not add a second way past it.
     """
     raw = str(argv[0])
     if raw not in _SELF_BUILT_COMMANDS:
         return (
-            "refused",
-            f"evaluator bug: {raw!r} is not a command this script builds; "
-            "no spec field may name a command",
+            (
+                "refused",
+                f"evaluator bug: {raw!r} is not a command this script builds; "
+                "no spec field may name a command",
+            ),
+            None,
         )
     try:
         proc = subprocess.run(  # noqa: S603 - argv array, no shell, script-built
@@ -125,17 +148,47 @@ def _run(argv, cwd=None):
             timeout=TIMEOUT_SECS,
         )
     except subprocess.TimeoutExpired:
-        return ("error", f"timed out after {TIMEOUT_SECS}s")
+        return (("error", f"timed out after {TIMEOUT_SECS}s"), None)
     except FileNotFoundError:
-        return ("error", f"{raw!r} not found on PATH")
+        return (("error", f"{raw!r} not found on PATH"), None)
     except OSError as exc:
-        return ("error", f"could not run: {exc}")
+        return (("error", f"could not run: {exc}"), None)
+    return (None, proc)
+
+
+def _run(argv, cwd=None):
+    """Run one SCRIPT-BUILT check and map its exit into a verdict."""
+    raw = str(argv[0])
+    problem, proc = _exec(argv, cwd)
+    if proc is None:
+        return problem or ("error", "could not run")
     output = _tail(proc.stdout + "\n" + proc.stderr)
     if proc.returncode == 0:
         return ("pass", output or "exit 0")
     if raw == "gh" and proc.returncode == _GH_PENDING_EXIT:
         return ("pending", output or "checks still running")
     return ("fail", f"exit {proc.returncode}: {output}")
+
+
+def _pr_is_draft(pr, repo=None):
+    """Is this pull request still a draft? ``True`` only on an unambiguous yes.
+
+    Asked ONLY to explain a check run that came back pending - see the
+    ``pr_checks`` handler for why the order matters.
+
+    The probe is deliberately one-sided. Anything other than a clean ``true`` -
+    gh absent, no such PR, an auth failure, a forge without the field - returns
+    ``False``, and the pending verdict then stands exactly as it did before, so
+    a probe that cannot answer never invents a refusal.
+    """
+    argv = ["gh", "pr", "view", str(pr)]
+    if repo:
+        argv += ["--repo", str(repo)]
+    argv += ["--json", "isDraft", "-q", ".isDraft"]
+    problem, proc = _exec(argv)
+    if problem is not None or proc is None or proc.returncode != 0:
+        return False
+    return proc.stdout.strip().lower() == "true"
 
 
 def _evaluate(item):
@@ -147,11 +200,40 @@ def _evaluate(item):
         # checks True`; reject it with the same message as any other non-int.
         if not isinstance(pr, int) or isinstance(pr, bool):
             return ("error", "pr_checks spec needs an integer pr")
-        argv = ["gh", "pr", "checks", str(pr)]
         repo = accept.get("repo")
+        argv = ["gh", "pr", "checks", str(pr)]
         if repo:
             argv += ["--repo", str(repo)]
-        return _run(argv)
+        verdict, evidence = _run(argv)
+        # The draft probe runs HERE, behind a pending verdict, and nowhere else.
+        #
+        # A draft PR is not unconditionally unsatisfiable, so the probe must not
+        # pre-empt the check: where a repo has no aggregate check gated on the
+        # draft flag, a draft's checks resolve and `gh pr checks` exits 0 - a
+        # `pass` this script keeps returning, since this skill ships to
+        # arbitrary repos. Probing only a pending run also costs nothing on the
+        # pass and fail paths, which is every cycle that was never going to
+        # loop.
+        #
+        # A PENDING draft is refused on the spec, not on a prediction about CI.
+        # The two ways a draft's checks stay pending - a readiness check gated
+        # on the draft flag, which never resolves, and ordinary checks still
+        # running, which do - are indistinguishable to a stateless evaluator,
+        # and this returns the same answer for both ON PURPOSE. A draft is the
+        # author's own "not ready for review", so an unfinished check run on one
+        # is a person's turn; "mark it ready for review" is a step they owe
+        # regardless, and it is bounded. Waiting instead is not: guessing wrong
+        # in that direction is the reported defect, an hour of polling a
+        # condition no cycle could change.
+        if verdict == "pending" and _pr_is_draft(pr, repo):
+            return (
+                "refused",
+                f"PR #{pr} is a draft and its checks have not finished; a draft "
+                "is not a review-ready PR, and where readiness is gated on the "
+                "draft flag no further polling resolves it -- mark it ready for "
+                "review or change the acceptance kind",
+            )
+        return (verdict, evidence)
     if kind == "file":
         path = accept.get("path")
         if not isinstance(path, str) or not path:
@@ -182,7 +264,39 @@ def _evaluate(item):
     return ("error", f"unknown accept kind {kind!r}")
 
 
+def _usage_text() -> str:
+    """The Usage..exit-code part of the module docstring, verbatim.
+
+    Sliced out of ``__doc__`` instead of duplicated, so help a caller reads can
+    never drift from the contract documented above it. ``python -OO`` strips
+    docstrings, hence the one-line fallback.
+    """
+    doc = __doc__ or ""
+    start = doc.find("Usage:")
+    end = doc.find("THE SECURITY INVARIANT")
+    if start < 0 or end <= start:
+        return "Usage: python3 accept_eval.py < items.json"
+    return doc[start:end].rstrip()
+
+
+def _stdin_is_a_tty() -> bool:
+    """Is stdin a terminal? A closed or detached stdin counts as not one."""
+    try:
+        return bool(sys.stdin is not None and sys.stdin.isatty())
+    except (AttributeError, ValueError, OSError):
+        return False
+
+
 def main() -> int:
+    args = sys.argv[1:]
+    if "-h" in args or "--help" in args or _stdin_is_a_tty():
+        # Run with nothing piped in, the json.load below blocks on a read that
+        # never completes: from a caller's side that is a tool timeout, an
+        # approval spent, and no output - not "you forgot the input". Say what
+        # the input is and stop. Exit 2 is the code malformed input already
+        # uses, so nothing that pipes real input sees a new outcome.
+        print(_usage_text(), file=sys.stderr)
+        return 2
     try:
         payload = json.load(sys.stdin)
         items = payload["items"]

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -11,6 +11,7 @@ bare interpreters are NOT on the evaluator's allowlist (a spec could otherwise
 name ``python -c <payload>``), and pinning that is one of the tests below.
 """
 
+import inspect
 import json
 import subprocess
 import sys
@@ -689,6 +690,19 @@ class TestConductorInstaller:
         assert "1. `chat_folder_create`" not in text, "no folder-precreation dispatch step"
 
 
+class _proc:
+    """Minimal ``CompletedProcess`` stand-in for the exec seam's two callers.
+
+    The real thing needs an argv and encoding to construct; these three fields
+    are the whole surface ``_run`` and ``_pr_is_draft`` read.
+    """
+
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
 def _load_evaluator():
     """Load accept_eval.py by file location, via the shared no-bytecode helper.
 
@@ -715,12 +729,46 @@ class TestAcceptEvaluatorInvariant:
         """The only exec path constructs argv from narrowly-typed fields."""
         mod = _load_evaluator()
         seen = []
+        mod._pr_is_draft = lambda pr, repo=None: False
         mod._run = lambda argv, cwd=None: (seen.append((argv, cwd)), ("pass", "ok"))[1]
         verdict, _ = mod._evaluate(
             {"accept": {"kind": "pr_checks", "pr": 123, "repo": "owner/name"}}
         )
         assert verdict == "pass"
         assert seen == [(["gh", "pr", "checks", "123", "--repo", "owner/name"], None)]
+
+    def test_the_draft_probe_builds_its_own_argv_too(self):
+        """The second invocation is built here as well, from the same fields.
+
+        Both go through ``_exec``, whose ``_SELF_BUILT_COMMANDS`` guard is the
+        one seam: a new invocation must not arrive with a new way past it.
+        """
+        mod = _load_evaluator()
+        seen = []
+
+        def _fake_exec(argv, cwd=None):
+            seen.append((argv, cwd))
+            return (None, _proc(stdout="false"))
+
+        mod._exec = _fake_exec
+        assert mod._pr_is_draft(123, "owner/name") is False
+        assert seen == [
+            (
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    "123",
+                    "--repo",
+                    "owner/name",
+                    "--json",
+                    "isDraft",
+                    "-q",
+                    ".isDraft",
+                ],
+                None,
+            )
+        ]
 
     def test_run_refuses_a_command_it_did_not_build(self):
         """The internal guard fails closed if a handler ever leaks spec input."""
@@ -729,6 +777,14 @@ class TestAcceptEvaluatorInvariant:
         assert verdict == "refused"
         assert "not a command this script builds" in evidence
         assert mod._SELF_BUILT_COMMANDS == {"gh"}
+
+    def test_the_draft_probe_refuses_a_command_it_did_not_build(self):
+        """Same guard, reached through the probe's own seam."""
+        mod = _load_evaluator()
+        problem, proc = mod._exec(["git", "--version"])
+        assert proc is None
+        assert problem[0] == "refused"
+        assert "not a command this script builds" in problem[1]
 
     def test_no_spec_field_can_name_a_command(self):
         """Source ratchet: no handler may read an argv/command/shell spec field.
@@ -869,3 +925,260 @@ class TestAcceptEvaluator:
             timeout=30,
         )
         assert proc.returncode == 2
+
+
+class TestDraftPullRequest:
+    """A draft PR whose checks stay PENDING is ``refused``, and only then.
+
+    Two halves, and the order between them is the whole design. A draft is not
+    unconditionally unsatisfiable: without an aggregate check gated on the draft
+    flag, a draft's checks resolve and ``gh pr checks`` exits 0. What cannot
+    resolve is pending BECAUSE the PR is a draft - so the probe explains a
+    pending verdict rather than pre-empting the check, which also keeps the pass
+    and fail paths free of it.
+    """
+
+    def _wire(self, mod, monkeypatch, script):
+        """Feed ``_exec`` scripted results, newest call last; record the argvs."""
+        seen = []
+
+        def _fake_run(argv, **kwargs):
+            seen.append(list(argv))
+            return _proc(*script[len(seen) - 1])
+
+        monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+        return seen
+
+    def test_a_pending_draft_is_refused(self, monkeypatch):
+        mod = _load_evaluator()
+        seen = self._wire(mod, monkeypatch, [(8, "3 checks still running", ""), (0, "true\n", "")])
+        verdict, evidence = mod._evaluate(
+            {"accept": {"kind": "pr_checks", "pr": 123, "repo": "owner/name"}}
+        )
+        assert verdict == "refused"
+        assert "PR #123 is a draft" in evidence
+        assert "have not finished" in evidence
+        assert "mark it ready for review" in evidence
+        # The check ran first; the probe only explained its pending.
+        assert seen[0] == ["gh", "pr", "checks", "123", "--repo", "owner/name"]
+        assert seen[1][:4] == ["gh", "pr", "view", "123"]
+
+    def test_a_draft_whose_checks_are_still_running_is_refused_too(self, monkeypatch):
+        """The deliberate scope, pinned so it reads as a decision.
+
+        A stateless evaluator cannot tell "pending because a readiness check is
+        gated on the draft flag" (never resolves) from "pending because CI is
+        still running" (resolves), and this returns the same ``refused`` for
+        both. The ground is the spec, not a prediction about CI: a draft is the
+        author's own "not ready for review", so an unfinished check run on one
+        is a person's turn. "Mark it ready for review" is bounded and owed
+        anyway; waiting is the reported defect.
+        """
+        mod = _load_evaluator()
+        seen = self._wire(
+            mod,
+            monkeypatch,
+            [(8, "Backend Tests (1)\tpending\t0s\nE2E\tpending\t0s", ""), (0, "true", "")],
+        )
+        verdict, evidence = mod._evaluate({"accept": {"kind": "pr_checks", "pr": 55}})
+        assert verdict == "refused"
+        assert "have not finished" in evidence
+        assert "not a review-ready PR" in evidence
+        assert len(seen) == 2
+
+    def test_the_refusal_does_not_predict_what_ci_will_do(self):
+        """Source ratchet on the evidence a human reads.
+
+        Two earlier wordings claimed more than this script can know - that a
+        draft "cannot pass", and that its checks are "still pending" as though
+        the evaluator had established they would stay that way. The shipped
+        sentence must rest on the draft flag, which is observed.
+        """
+        src = SCRIPT.read_text(encoding="utf-8")
+        assert "cannot pass while draft" not in src
+        assert "is not a review-ready PR" in src
+
+    def test_a_green_draft_still_passes_and_is_never_probed(self, monkeypatch):
+        """The regression an unconditional probe would ship.
+
+        This script is a builtin skill pointed at whatever repo a work item
+        names. On a repo with no draft-gated aggregate check, a draft's checks
+        complete and exit 0 - the acceptance is genuinely met, and refusing it
+        would escalate a satisfied condition to a human. Only the pending loop
+        was ever the defect.
+        """
+        mod = _load_evaluator()
+        seen = self._wire(mod, monkeypatch, [(0, "all checks pass", "")])
+        verdict, evidence = mod._evaluate({"accept": {"kind": "pr_checks", "pr": 123}})
+        assert verdict == "pass"
+        assert "all checks pass" in evidence
+        assert len(seen) == 1, "a passing check must cost no draft probe"
+
+    def test_a_failing_check_is_never_probed_either(self, monkeypatch):
+        """``fail`` is already terminal; the draft flag cannot change it."""
+        mod = _load_evaluator()
+        seen = self._wire(mod, monkeypatch, [(1, "2 checks failing", "")])
+        verdict, evidence = mod._evaluate({"accept": {"kind": "pr_checks", "pr": 123}})
+        assert verdict == "fail"
+        assert "2 checks failing" in evidence
+        assert len(seen) == 1
+
+    def test_a_non_draft_pr_runs_the_check_unchanged(self, monkeypatch):
+        mod = _load_evaluator()
+        seen = self._wire(mod, monkeypatch, [(0, "all checks pass", "")])
+        verdict, evidence = mod._evaluate(
+            {"accept": {"kind": "pr_checks", "pr": 123, "repo": "owner/name"}}
+        )
+        assert verdict == "pass"
+        assert "all checks pass" in evidence
+        assert seen[0] == ["gh", "pr", "checks", "123", "--repo", "owner/name"]
+
+    def test_a_non_draft_pr_still_reports_pending_while_checks_run(self, monkeypatch):
+        """The wait contract for a ready-for-review PR is untouched."""
+        mod = _load_evaluator()
+        self._wire(mod, monkeypatch, [(8, "still running", ""), (0, "false", "")])
+        verdict, evidence = mod._evaluate({"accept": {"kind": "pr_checks", "pr": 7}})
+        assert verdict == "pending"
+        assert "still running" in evidence
+
+    def test_a_probe_that_cannot_answer_leaves_the_pending_standing(self, monkeypatch):
+        """gh missing, no such PR, an auth error: the verdict stays ``pending``.
+
+        One-sided on purpose. A probe that fails for any reason other than a
+        clean ``true`` must not turn a wait into a ``refused`` the conductor has
+        to escalate to a human.
+        """
+        mod = _load_evaluator()
+        for probe in [(1, "", "no pull requests found"), (0, "", ""), (0, "null", "")]:
+            self._wire(mod, monkeypatch, [(8, "still running", ""), probe])
+            verdict, evidence = mod._evaluate({"accept": {"kind": "pr_checks", "pr": 9}})
+            assert verdict == "pending", probe
+            assert "still running" in evidence, probe
+
+    def test_the_probe_omits_repo_when_the_spec_does_not_name_one(self, monkeypatch):
+        mod = _load_evaluator()
+        seen = self._wire(mod, monkeypatch, [(8, "still running", ""), (0, "false", "")])
+        mod._evaluate({"accept": {"kind": "pr_checks", "pr": 9}})
+        assert seen[1] == ["gh", "pr", "view", "9", "--json", "isDraft", "-q", ".isDraft"]
+
+    def test_a_malformed_pr_is_rejected_before_any_subprocess(self, monkeypatch):
+        """The integer guard still runs first; a bad spec spends no subprocess."""
+        mod = _load_evaluator()
+        seen = self._wire(mod, monkeypatch, [(0, "true", "")])
+        verdict, evidence = mod._evaluate({"accept": {"kind": "pr_checks", "pr": "123"}})
+        assert verdict == "error"
+        assert "integer pr" in evidence
+        assert seen == []
+
+
+class TestUsageInsteadOfBlockingOnStdin:
+    """No input means print usage and exit 2, never a read that hangs.
+
+    Run on a terminal or with ``--help``, the ``json.load(sys.stdin)`` below
+    blocks until the caller's tool timeout: an approval spent, no output, and
+    nothing that says the input goes on stdin.
+    """
+
+    def test_help_exits_2_with_usage_on_stderr(self):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--help"],
+            input="",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+        assert proc.returncode == 2
+        assert proc.stdout == ""
+        assert "Usage:" in proc.stderr
+        assert "accept_eval.py < items.json" in proc.stderr
+        # Usage, not the module's security essay.
+        assert "THE SECURITY INVARIANT" not in proc.stderr
+
+    def test_help_runs_no_subprocess_and_reads_no_stdin(self, monkeypatch):
+        mod = _load_evaluator()
+
+        def _forbidden(*args, **kwargs):
+            raise AssertionError("--help must not run a subprocess")
+
+        monkeypatch.setattr(mod.subprocess, "run", _forbidden)
+        stdin = _RefusingStdin()
+        monkeypatch.setattr(mod.sys, "stdin", stdin)
+        for flag in ("-h", "--help"):
+            monkeypatch.setattr(mod.sys, "argv", ["accept_eval.py", flag])
+            assert mod.main() == 2
+        assert stdin.read_calls == 0
+
+    def test_a_tty_stdin_prints_usage_instead_of_reading(self, monkeypatch):
+        mod = _load_evaluator()
+        stdin = _RefusingStdin(tty=True)
+        monkeypatch.setattr(mod.sys, "stdin", stdin)
+        monkeypatch.setattr(mod.sys, "argv", ["accept_eval.py"])
+        assert mod.main() == 2
+        assert stdin.read_calls == 0
+
+    def test_a_stdin_that_cannot_answer_isatty_is_not_treated_as_a_tty(self, monkeypatch):
+        """Piped input must keep working when ``isatty`` raises (closed stdin)."""
+        mod = _load_evaluator()
+
+        class _Broken:
+            def isatty(self):
+                raise ValueError("I/O operation on closed file")
+
+        monkeypatch.setattr(mod.sys, "stdin", _Broken())
+        assert mod._stdin_is_a_tty() is False
+
+    def test_piped_input_keeps_its_exit_codes(self):
+        """The contract for real input is unchanged: 0 evaluated, 2 malformed."""
+        for payload, expected in (('{"items": []}', 0), ("not json", 2)):
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                input=payload,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=30,
+            )
+            assert proc.returncode == expected, payload
+
+    def test_main_takes_no_injected_argv(self):
+        """``main`` reads ``sys.argv`` like the entry point that calls it.
+
+        An ``argv`` parameter had zero non-test consumers - the tests were its
+        only caller, and a parameter that exists to be passed by its own tests
+        is a seam the shipped script does not have.
+        """
+        mod = _load_evaluator()
+        assert list(inspect.signature(mod.main).parameters) == []
+
+    def test_usage_is_sliced_from_the_docstring_not_duplicated(self):
+        """One source for the contract, so help cannot drift from the module."""
+        mod = _load_evaluator()
+        usage = mod._usage_text()
+        assert usage in (mod.__doc__ or "")
+        # The anchors the slice depends on must both stay present, and the
+        # opening one must stay unique inside the docstring or the slice moves.
+        doc = mod.__doc__ or ""
+        assert doc.count("Usage:") == 1
+        assert "THE SECURITY INVARIANT" in doc
+
+
+class _RefusingStdin:
+    """A stdin that counts reads. ``isatty`` is configurable.
+
+    It returns "" rather than raising, because ``main`` catches every
+    ``Exception`` around ``json.load`` and would convert a raise into the same
+    exit 2 the usage path returns - hiding a gate that stopped working. The
+    count is what the assertion reads.
+    """
+
+    def __init__(self, tty=False):
+        self._tty = tty
+        self.read_calls = 0
+
+    def isatty(self):
+        return self._tty
+
+    def read(self, *args, **kwargs):
+        self.read_calls += 1
+        return ""

--- a/test/test_conductor_ledger_entry.py
+++ b/test/test_conductor_ledger_entry.py
@@ -400,6 +400,53 @@ class TestCli:
         # matching the malformed-stdin error and accept_eval.py.
         assert "usage" in proc.stdout
 
+    def test_a_valid_mode_with_a_terminal_stdin_does_not_block(self):
+        """The sibling of ``accept_eval.py``'s hang, in this script.
+
+        ``ledger_entry.py encode`` with nothing piped in is a WELL-FORMED
+        invocation, so the argv guard above never sees it, and the read then
+        blocks until the caller's tool timeout: an approval spent, no output,
+        and nothing saying the input goes on stdin. Exit 2 is the code a bad
+        invocation already returns, so no caller that pipes input is affected.
+        """
+        mod = _mod()
+
+        class _RefusingStdin:
+            def __init__(self):
+                self.read_calls = 0
+
+            def isatty(self):
+                return True
+
+            def read(self, *args, **kwargs):
+                self.read_calls += 1
+                return ""
+
+        stdin = _RefusingStdin()
+        argv = [str(SCRIPT), "encode"]
+        original_stdin, original_argv = mod.sys.stdin, mod.sys.argv
+        try:
+            mod.sys.stdin, mod.sys.argv = stdin, argv
+            assert mod.main() == 2
+        finally:
+            mod.sys.stdin, mod.sys.argv = original_stdin, original_argv
+        assert stdin.read_calls == 0, "the usage path must not read stdin"
+
+    def test_a_stdin_that_cannot_answer_isatty_is_not_treated_as_a_tty(self):
+        """Piped input must keep working when ``isatty`` raises (closed stdin)."""
+        mod = _mod()
+
+        class _Broken:
+            def isatty(self):
+                raise ValueError("I/O operation on closed file")
+
+        original = mod.sys.stdin
+        try:
+            mod.sys.stdin = _Broken()
+            assert mod._stdin_is_a_tty() is False
+        finally:
+            mod.sys.stdin = original
+
     def test_json_array_stdin_exits_2_without_traceback(self):
         """A JSON array parses fine but is not an object; the contract is a
         structured exit-2, never a crash inside a mode handler."""


### PR DESCRIPTION
## Problem / Motivation

Two ways the conductor's acceptance evaluator turned a person-shaped problem into an unbounded machine wait.

1. **A `pr_checks` acceptance on a DRAFT pull request polled for an hour.** This repo's aggregate "PR Readiness" check stays pending on the draft flag by itself, so `gh pr checks` kept exiting `8`. The evaluator maps exit 8 to `pending`, the conductor waited and polled again, and nothing in any verdict ever said the PR was a draft.
2. **`accept_eval.py --help`, or a run with nothing piped in, hangs.** `json.load(sys.stdin)` blocks on a read that never completes. From the caller's side that is a tool timeout, one approval spent, and no output — not "you forgot the input". The sibling `ledger_entry.py` had the same hang and is fixed with it.

## Why it matters

The conductor cannot judge acceptance itself; it only reads this script's verdicts. `pending` is an instruction to wait, so a wait nothing can end becomes a poll that burns a model turn per cycle and never reaches the person who could clear it in one click. `refused` is the vocabulary that already exists for "surface this to the user, do not retry around it".

## What changed (motivation → approach → change)

### The pending draft

Root cause: exit 8 means "checks still running", and a draft-gated readiness check produces exit 8 forever, so the mapping was right but the situation was invisible from the exit code alone. `pr_checks` now probes the draft flag **to explain a pending verdict**:

```
gh pr checks <pr> [--repo <repo>]                             # first, unchanged
gh pr view <pr> [--repo <repo>] --json isDraft -q .isDraft    # only if that came back pending
```

A clean `true` returns `refused` with evidence `PR #<n> is a draft and its checks have not finished; a draft is not a review-ready PR, and where readiness is gated on the draft flag no further polling resolves it -- mark it ready for review or change the acceptance kind`.

**The order is the design.** A draft is not unconditionally unsatisfiable: on a repo with no draft-gated aggregate check, a draft's checks resolve and `gh pr checks` exits 0. That `pass` is genuinely met and is still returned — this script is a builtin skill pointed at whatever repo a work item names. Probing only behind the pending branch also leaves the pass and fail paths, every cycle that was never going to loop, without an extra subprocess.

**The refusal rests on the spec, not on a prediction about CI.** The two ways a draft's checks stay pending — a readiness check gated on the draft flag (never resolves) and ordinary checks still running (they do) — are indistinguishable to a stateless evaluator, and both return `refused` on purpose. A draft is the author's own "not ready for review", so an unfinished check run on one is a person's turn. The two error directions are not symmetric: refusing a mid-flight draft costs one escalation whose remedy is bounded and owed before merge anyway, while waiting on a draft-gated check costs the unbounded poll this PR exists to remove. The only discriminator that would separate the two cases is matching the repo's own readiness check by name, which a skill shipping to arbitrary repos cannot carry.

The probe is **one-sided**: gh absent, no such PR, an auth failure, an empty answer — anything other than a clean `true` leaves the pending verdict standing exactly as before, so a probe that cannot answer never invents a refusal.

### The stdin hang

`-h`/`--help` in argv, or a stdin that is a TTY, prints the module docstring's `Usage`…exit-code block to stderr and exits `2`. The text is *sliced out of* `__doc__` rather than duplicated, so the help a caller reads cannot drift from the contract above it. Exit 2 is the code malformed input already returns, so nothing that pipes real input sees a new outcome. A stdin whose `isatty()` raises (closed, detached) counts as not a TTY.

`ledger_entry.py` carried the identical defect one file over: its existing guard only rejects a wrong argv *shape*, so a well-formed `ledger_entry.py encode` with no stdin never reached it and blocked on the read. It gets the same TTY check, returning the same exit 2 with the cause on stdout as its sibling errors do.

### The security invariant is intact

No model-authored argv reaches subprocess:

- The probe's argv is built here, from the same narrowly-typed spec fields the existing handler uses. No spec field names a command; the source ratchet on `accept.get("argv"|"command"|"shell")` still holds.
- The `_SELF_BUILT_COMMANDS` fail-closed guard **moved into a single `_exec` seam** both invocations share, rather than being duplicated. A second invocation therefore added no second place to bypass it, and a test reaches the guard through the new path.
- `_SELF_BUILT_COMMANDS` itself is **unchanged** (`{"gh"}`): both calls are `gh`, so widening the set would have widened the surface for nothing.
- The integer-`pr` guard still runs first, so a malformed spec spends no subprocess at all.

Both `accept_eval.py` copies (`goal-conductor/`, `goal-ledger-conductor/`) are updated byte-identically — the scope gate refuses a symlink, and the existing pin test in `test_ledger_conductor_agent.py` enforces it. The `pyproject.toml` mypy exclusion on the copy is untouched. `ledger_entry.py` has one copy. No `SKILL.md` text was changed.

## Tests

`test/test_conductor_agent.py` and `test/test_conductor_ledger_entry.py`:

- Pending + draft → `refused`; evidence names the PR and the way out; the argvs assert the check ran **first** and the probe only explained it.
- **A draft whose checks are genuinely still running → `refused` too**, pinned as a decision rather than left as an oversight, with the reasoning in the test's own docstring.
- **A green draft → `pass`, and never probed** — the regression an unconditional probe would ship.
- A failing check → `fail`, never probed; the draft flag cannot change a terminal verdict.
- Non-draft pending → still `pending` (the wait contract for a ready-for-review PR is untouched).
- A probe that cannot answer (exit 1, empty stdout, `null`) → the `pending` verdict stands.
- The probe omits `--repo` when the spec does not name one; a non-integer `pr` is rejected before any subprocess.
- Source ratchet: the shipped evidence may not claim `cannot pass while draft`, and must rest on the observed draft flag.
- The probe builds its own argv, asserted element by element; the `_SELF_BUILT_COMMANDS` guard is reachable and fails closed through the new `_exec` seam.
- `--help` → exit 2, usage on **stderr**, empty stdout, and not the module's security essay.
- `-h`/`--help` and a TTY stdin, in-process → exit 2 with **zero subprocess calls and zero stdin reads** (asserted by a counting stdin, not by a raise — `main` catches `Exception` and would have converted a raise into the same exit 2, hiding a gate that stopped working).
- `main()` takes no injected argv, asserted on the signature.
- Piped input keeps its exit codes: `0` evaluated, `2` malformed. The usage text is a substring of `__doc__`, and both slice anchors stay present and unique.
- `ledger_entry.py`: a valid mode with a terminal stdin exits 2 without reading stdin, and a stdin whose `isatty()` raises is not treated as a terminal.

**Revert-verify** (seven independent mutations, each restored):

| Mutation | Result |
| --- | --- |
| drop the draft refusal | 3 failed |
| probe unconditionally instead of behind pending | 3 failed |
| probe answers "draft" for anything (one-sidedness removed) | 3 failed |
| refusal predicts CI again | 3 failed |
| drop the usage/TTY gate | 3 failed |
| `main` takes an injected argv again | 1 failed |
| drop the sibling TTY gate in `ledger_entry.py` | 1 failed |
| restored | 104 passed |

## Manual verification

N/A — both scripts are stdin/stdout CLIs and every new path is covered, one through a real subprocess (`--help`) and the rest through a mocked `subprocess.run` (the check-then-probe sequence) or an injected stdin.

Local gates from the resolved profile: `black --target-version py310`, `isort`, `flake8` clean; `mypy src/kiro_crew/` clean over 1391 files; all 30 Python diff-scoped gates green (brand name, harness parity, feature map, loop-bound locks, builtin skill scope, testpaths coverage, changelog history, focus cue, docs lint, comment history, subprocess encoding, agent SDK boundary, sync-IO-in-async, lockdown-before-publish, per-file coverage), each run with its `*_BASE_REF` exported. The two copies `cmp` byte-identical. 309 tests pass across the five conductor/ledger test modules.

The local full backend suite reports 112 unrelated reds (`test_source_providers`, `test_symbols_manifest_contract`, `test_taskrunner*`, `spec_builder/test_routes`). Those same files run **1 failed / 1494 passed on pristine `origin/main`** in a fresh worktree, and CI's Backend Tests shards were green on this branch's previous head — they are local full-suite parallelism artifacts, not diff-caused.

Local review lanes on this head, briefed from the extracted CI contracts: **GPT 5.6 (`gpt-5.6-sol`) — no findings. Opus 4.8 (`claude-opus-4.8`) — no findings.**

## Related Issues

no linked issue: reported from a live conductor run rather than filed as an issue. The Design lane's Suggestion to bound stuck-pending in general is deferred to its own issue (a conductor-side poll budget needs durable per-item state, which a stateless evaluator does not have).

## Pattern harvest

Pattern: a retryable "not yet" verdict returned for a state that can never become true without human action, turning a bounded wait into an unbounded poll. Any poller mapping an upstream "in progress" signal must ask whether a *permanent* condition also produces it — and, when the two are indistinguishable, decide which error direction is bounded rather than guessing which state it is in. A secondary pattern: a stdin-only CLI whose argv guard checks only the argv *shape* leaves a well-formed invocation with no input hanging on the read; both scripts in this skill had it.

Rule candidate: review-prompt — when a handler maps an exit code or status to "pending"/"retry", ask what permanent state produces the same signal, whether that state is distinguishable at all, and which way the ambiguity should fail.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — both module docstrings document the new behaviour; `SKILL.md` is deliberately untouched (owned by a sibling change)
- [x] No secrets, credentials, or internal references in the diff
