### PR TITLE
fix(build): raise all-chunk budget after #9810/#9812

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -57,7 +57,17 @@ export const CHUNK_BUDGETS = {
   // takeover, 13 catalogs x 52 lines, ~55 KB). Same recurrence as the `t` and
   // `App` entries below: a ceiling that drifted to <1% headroom fails on
   // routine string growth rather than on the new library it exists to catch.
-  all: 10975 * KB, // measured 10450 KB on main 2026-09-06 (~5% headroom)
+  // Re-measured 2026-09-10: main @ b165ba1be alone builds the chunk at
+  // 11,302,007 B (11037 KB) against the 10975 KB ceiling -- 62 KB OVER, so
+  // main's own gate is red and every PR rebased onto it inherits the failure.
+  // Attribution is measured, not assumed: the two feature PRs merged back to
+  // back at 17:53-17:54 (#9810 browser element annotations, +423 catalog lines
+  // across 13 languages; #9812 file-viewer type-first annotator, +107 lines)
+  // ship only translated product copy into this chunk -- it still holds the
+  // same 14 modules (13 catalogs plus the entry), no library reached it, and
+  // no lazy import() boundary can move a catalog string out of `all`. Same
+  // recurrence, same remedy: back to the 5% convention.
+  all: 11590 * KB, // measured 11037 KB on main 2026-09-10 (~5% headroom)
 
   // The i18n RUNTIME — the i18next singleton, `initI18n`, the English catalog —
   // named after `src/i18n/t.ts`. Held separately from `all` above because


### PR DESCRIPTION
## Root cause

`main` has been failing its own **Bundle Size Gate** since `b165ba1be` (2026-09-10 18:14 UTC):

```
FAIL assets/all-*.js: 10.78 MB exceeds its 10.72 MB budget by 62.1 KB (chunk 'all')
```

The `all` chunk is the eager i18n catalog bundle (`src/i18n/all.ts`, 13 catalogs plus the entry -- 14 modules, unchanged). Two feature PRs merged back to back at 17:53-17:54 UTC and together pushed it past the `CHUNK_BUDGETS.all` ceiling:

| PR | Merge | Catalog lines added (`website/src/i18n/`) |
|---|---|---|
| #9810 feat(browser): select page elements and type annotations | `70d567f6c` | +423 / -12 across 13 languages |
| #9812 feat(file-viewer): type-first annotator | `e518d7646` | +107 / -1 across 13 languages |

Measured on a pristine `origin/main` @ `b165ba1be` worktree (`npx vite build --mode analyze` -> `node scripts/check-bundle-size.mjs`): `all-AVRQIvsv.js` = **11,302,007 B (11037 KB)** against the **10975 KB** ceiling -- 62 KB over, reproducing CI byte-for-byte. No PR code involved; every branch rebased onto current `main` inherits the red on its merge ref.

## Fix

One line in `website/scripts/check-bundle-size.mjs`: `all: 10975 * KB` -> `all: 11590 * KB` (~5% headroom over the measured 11037 KB), plus the attribution comment the entry's own convention asks for.

Why not a lazy `import()` / `codeSplitting` group instead: the growth is translated product copy inside the catalog files themselves. The chunk still holds exactly the same 14 modules -- no library or new surface reached it -- so there is no JS module to move out of `all`; a lazy boundary around the Electron overlay/walker or the file-viewer annotator would not shrink this chunk by a byte. The gate's own header documents this exact recurrence (`t` on 09-04/09-08, `App` on 09-04/09-08, `all` on 09-06) and its remedy: restore the 5% convention so routine string growth does not re-trip the ceiling for a library-class regression it exists to catch.

## Affected PRs (inherit the red today)

#9793, #9519, #8599, #9934 -- and any other PR whose merge ref includes `b165ba1be`.

## Verification

From `website/` on this branch (built, not tested -- no vitest/pytest/playwright run):

```
npx vite build --mode analyze
node scripts/check-bundle-size.mjs
# bundle-size gate: 689 chunks within budget (default 500.0 KB, 14 allowlisted).  exit 0
```

Before the change the same build fails with the CI line above (exit 1). `npx eslint scripts/check-bundle-size.mjs` and `npx tsc --noEmit` both clean.

## Pattern harvest

Rule candidate: bundle-size gate headroom warning
Pattern: a `CHUNK_BUDGETS` ceiling that drifts under ~2% headroom on `main` fails on the next routine catalog/first-party growth instead of on the library-class regression it exists to catch (fourth recurrence: `t` 09-04, `App` 09-04/09-08, `all` 09-06, `all` again here). `scripts/check-bundle-size.mjs` already knows every chunk's measured size and budget; emitting a WARN line (not a failure) when headroom < 2% would let the feature PR that consumes the margin raise the ceiling in-PR, so `main` never goes red on its own gate.
