### PR TITLE
fix(auto-improvement): provider-runner credential gate reads agent.sandbox, not top-level .sandbox

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
@@ -199,7 +199,9 @@ def _credentials_are_unconfined() -> str:
     try:
         from kiro_crew.config import KiroCrewConfig
 
-        mode = str(getattr(KiroCrewConfig.load(), "sandbox", "") or "").strip().lower()
+        # The sandbox tier is on the agent section, not the config top level.
+        _agent = getattr(KiroCrewConfig.load(), "agent", None)
+        mode = str(getattr(_agent, "sandbox", "") or "").strip().lower()
     except Exception as exc:  # noqa: BLE001 — an unverifiable sandbox is an unconfined one
         return f"the gateway sandbox setting could not be read ({type(exc).__name__})"
     # The provider path runs repository-controlled text through an agent with

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
@@ -2846,6 +2846,62 @@ class TestTheLoopRunnerRefusesWithoutCredentialConfinement:
             "the provider-backed agent"
         )
 
+    def test_a_credential_hiding_agent_sandbox_passes_the_gate(self, monkeypatch) -> None:
+        """A credential-hiding ``agent.sandbox`` (``strict``/``cc``) passes the gate."""
+        from kiro_crew.apps.builtins.auto_improvement.backend import runner as R
+        import kiro_crew.config as cfgmod
+
+        monkeypatch.setattr(R, "_unsandboxed_agent_accepted", lambda: False)
+
+        class _Agent:
+            sandbox = "strict"
+
+        class _Cfg:
+            agent = _Agent()
+
+            @staticmethod
+            def load():
+                return _Cfg()
+
+        monkeypatch.setattr(cfgmod, "KiroCrewConfig", _Cfg)
+        assert R._credentials_are_unconfined() == "", (
+            "agent.sandbox='strict' hides credential stores, so the gate must allow the run"
+        )
+
+        class _AgentCC:
+            sandbox = "cc"
+
+        class _CfgCC:
+            agent = _AgentCC()
+
+            @staticmethod
+            def load():
+                return _CfgCC()
+
+        monkeypatch.setattr(cfgmod, "KiroCrewConfig", _CfgCC)
+        assert R._credentials_are_unconfined() == "", "agent.sandbox='cc' must also pass"
+
+    def test_a_non_hiding_agent_sandbox_still_refuses(self, monkeypatch) -> None:
+        """``agent.sandbox='auto'`` still refuses and names the value, not ``'unset'``."""
+        from kiro_crew.apps.builtins.auto_improvement.backend import runner as R
+        import kiro_crew.config as cfgmod
+
+        monkeypatch.setattr(R, "_unsandboxed_agent_accepted", lambda: False)
+
+        class _Agent:
+            sandbox = "auto"
+
+        class _Cfg:
+            agent = _Agent()
+
+            @staticmethod
+            def load():
+                return _Cfg()
+
+        monkeypatch.setattr(cfgmod, "KiroCrewConfig", _Cfg)
+        reason = R._credentials_are_unconfined()
+        assert reason and "auto" in reason, "a non-hiding sandbox must refuse and name the value"
+
 
 class TestAgentRegistrationFailsClosed:
     """A failed agent registration must NOT fall through to the default agent.


### PR DESCRIPTION
## Problem / Motivation

Starting an auto-improvement run fails instantly with:

```
AgentRunnerOffline: the run did no work because the provider-backed agent runner was refused because the gateway sandbox is 'unset' -- the auto-improvement provider path requires 'cc' or 'strict' (credential-hiding profiles) or the explicit acceptUnsandboxedAgentRisk opt-in
```

This happens even when the operator has set a credential-hiding sandbox (`agent.sandbox = "strict"`) and the running gateway is demonstrably spawning strict sandboxes (`KIROCREW_SANDBOX_LEVEL=strict` in spawned children). The word in the message is `'unset'`, not the configured value.

## Why it matters

The provider-backed auto-improvement path is unreachable for **every** operator: no value of `agent.sandbox` can satisfy the gate, so the only way to run it is the `acceptUnsandboxedAgentRisk` opt-in — which runs a repo-controlled agent with credential stores exposed, the exact risk `strict`/`cc` exist to remove. Operators who did the secure thing (set `strict`) are still refused, and are nudged toward the less-safe escape hatch.

## What changed (motivation → approach → change)

- **Symptom:** gate reports the sandbox as `'unset'` regardless of configuration.
- **Root cause:** `_credentials_are_unconfined()` in `src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py` read the tier as `getattr(KiroCrewConfig.load(), "sandbox", "")`. The sandbox tier is a field on the **agent** section (`agent.sandbox`), not a top-level attribute, so `getattr` always returned the default `""` → the gate saw `mode = ""` → `'unset'` → refuse. The gateway's own `sandbox.configured_sandbox_mode()` reads `agent.sandbox`; the two readers disagreed.
- **Change:** read `config.agent.sandbox`, matching `configured_sandbox_mode()`:

  ```python
  _agent = getattr(KiroCrewConfig.load(), "agent", None)
  mode = str(getattr(_agent, "sandbox", "") or "").strip().lower()
  ```

  The fail-closed behavior on an unreadable config, the `{"cc","strict"}` allowlist, and the `acceptUnsandboxedAgentRisk` opt-in are all unchanged.

## Tests

Added two regression tests to `test_dogfood_learnings.py` in the existing gate suite:

- `test_a_credential_hiding_agent_sandbox_passes_the_gate` — a stubbed config whose `agent.sandbox` is `strict` (and `cc`) makes `_credentials_are_unconfined()` return `""` (allow). This is the case that had **no** coverage: the prior tests only stubbed the app config (`store.read_json`) and asserted the refuse path, so none exercised a real `agent.sandbox` value — which is why the bug shipped.
- `test_a_non_hiding_agent_sandbox_still_refuses` — `agent.sandbox = "auto"` still refuses and names the value (not `'unset'`).

All 11 tests in the gate suite pass locally.

## Manual verification

Applied to a live gateway (Linux/AL2023, `agent.sandbox = "strict"`): before the fix a fresh auto-improvement run failed instantly with the `'unset'` error; after the fix + gateway restart, a run starts and executes a cycle. `configured_sandbox_mode()` and the spawned children already reported `strict`, confirming only the gate's read was wrong.

## Screenshots / video

N/A — no user-visible UI change (backend gate logic only).

## Related Issues

<!-- none filed; happy to open a tracking issue if maintainers prefer -->
N/A

## Pattern harvest

Rule candidate: review-prompt / agents-md
Pattern: reading a config value with `getattr(config, "<field>")` for a field that lives on a sub-section (e.g. `config.agent.<field>`) silently returns the getattr default instead of raising — a config-read that targets the wrong nesting level fails open/closed silently. Two readers of the same setting (`configured_sandbox_mode()` vs this gate) diverged because one went through the agent section and the other did not. Candidate guard: flag `getattr(KiroCrewConfig.load(), X)` / `cfg.<X>` where `<X>` is a known agent-section field, and prefer a single shared accessor for a security-relevant setting rather than each call site re-deriving it.

## Checklist

- [x] At most two commits (one here), with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changed (the gate was never meant to reject a configured `strict`)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- CLA text to be supplied by the project; acknowledged. -->

---

_Disclosure: this change was prepared with the assistance of an AI coding agent (Kiro Crew). The submitting human is the author of record and has reviewed the diff._
