### PR TITLE
feat(gui-user-test): feature + user_story per scenario, reports grouped by feature

### DIFF
--- a/.github/workflows/gui-user-test.yml
+++ b/.github/workflows/gui-user-test.yml
@@ -243,6 +243,23 @@ jobs:
         if: always()
         run: bash scripts/gui-user-test/teardown.sh
 
+      # features.md is the "what does the product do, and is it healthy"
+      # catalog: every scenario's feature + user story, joined with this run's
+      # verdicts. Built from the repo-authored YAML, so it renders even when
+      # the target never booted (the verdict column then reads "not run").
+      - name: Render the feature catalog
+        if: always()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          mkdir -p "$GUI_OUT/results"
+          summary="$GUI_OUT/results/summary.json"
+          summary_args=()
+          [ -f "$summary" ] && summary_args=(--summary "$summary")
+          python test/gui_user/report.py --format features --run-url "$RUN_URL" "${summary_args[@]}" \
+            > "$GUI_OUT/results/features.md"
+
       - name: Upload screenshots, steps and verdict
         id: artifact
         if: always()
@@ -275,6 +292,16 @@ jobs:
           else
             verdict="ERROR"
             echo "## GUI user test — ERROR (no summary.json: the target did not boot or the harness crashed)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f "$GUI_OUT/results/features.md" ]; then
+            {
+              echo
+              echo "<details><summary>Feature catalog (what the scenarios cover)</summary>"
+              echo
+              cat "$GUI_OUT/results/features.md"
+              echo
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
 

--- a/docs/build/gui-user-test.md
+++ b/docs/build/gui-user-test.md
@@ -27,8 +27,8 @@ while the code holding credentials is not. `pr-readiness.yml` does not read this
 | `scripts/gui-user-test/teardown.sh` | Kills the three process groups and removes the scratch home and browser profile. |
 | `test/gui_user/harness.py` | The screenshot -> Bedrock Messages API -> action loop with the step, time and budget gates. |
 | `test/gui_user/x11.py` | Screenshots (Pillow `ImageGrab`) and input (`xdotool`); coordinate scaling, key aliases and argv building are pure and unit-tested. |
-| `test/gui_user/scenarios.py` + `scenarios/*.yaml` | The scenario DSL and the shipped scenarios. |
-| `test/gui_user/report.py` | Renders `summary.json` into `verdict.md`, the PR comment and the nightly issue. |
+| `test/gui_user/scenarios.py` + `scenarios/*.yaml` | The scenario DSL (including the `FEATURES` registry) and the shipped scenarios. |
+| `test/gui_user/report.py` | Renders `summary.json` into `verdict.md`, the PR comment and the nightly issue, all grouped by feature; renders `features.md` from the scenario directory. |
 
 The unit tests under `test/gui_user/` run in the ordinary Backend Tests shards; they
 need no display and never call Bedrock.
@@ -58,7 +58,8 @@ need no display and never call Bedrock.
    hard stops.
 5. Everything lands in the `gui-user-test-<run id>` artifact: `results/<scenario>/attempt-N/NN-<action>.png`,
    `steps.jsonl` (every action with parameters and the screenshot it produced),
-   `summary.json`, `verdict.md`, plus `gateway.log` / `gateway.err` / `chrome.log` /
+   `summary.json`, `verdict.md`, `features.md` (the feature catalog joined with this
+   run's verdicts), plus `gateway.log` / `gateway.err` / `chrome.log` /
    `xvfb.log` with the one-time token scrubbed.
 
 ### The model and the tool shape
@@ -88,6 +89,11 @@ Create `test/gui_user/scenarios/<name>.yaml`; the file stem must equal `name`:
 ```yaml
 name: settings-theme-toggle
 tier: smoke                 # smoke = runs on PRs and nightly; nightly = nightly only
+feature: settings           # product area -- a key of scenarios.FEATURES (see below)
+user_story: >-              # one sentence a person can read: who wants what, and why
+  As a user, I want to switch the dashboard theme in Settings, so that the app
+  matches my environment and the change is visible at once.
+docs_url: docs/system-specs/modules/themes.md   # optional: where the feature is specified
 summary: Switch the dashboard theme in Settings and confirm the colours change
 preconditions:
   seed: rich                # KIROCREW_HOME fixture (kirocrew gateway --seed NAME)
@@ -107,6 +113,47 @@ click -- and `expectations` as things that are true or false on the final screen
 a scenario to one flow; the cheapest scenario is the one that needs the fewest
 screenshots. `test_scenarios_and_report.py` loads every shipped file, so a malformed
 scenario fails the unit tests before it costs a model call.
+
+### `feature` and `user_story`: the scenario directory is also the feature catalog
+
+`feature` and `user_story` are required and are never shown to the model. They exist
+for the readers of the report: the verdict table, the step summary and the nightly
+issue are grouped by feature, each row carries the user story, and
+`report.py --format features` renders **`features.md`** -- one section per feature
+listing its user stories with the latest verdict, followed by the features that have no
+scenario yet. The workflow uploads `results/features.md` with the artifact and appends
+it to the run's step summary, so "what does the product do, and is it healthy" is
+answered from any run page without opening the YAML.
+
+- `feature` is a slug from the closed registry `scenarios.FEATURES` (`chat`, `sidebar`,
+  `members`, `settings`, `apps`, `schedule`, `knowledge`, `artifacts`, `files`,
+  `browser-panel`, `voice`, `notifications`, `onboarding`, `search`, `developer`). A closed
+  list, not a free-form slug, so a typo cannot split one feature into two report groups.
+  To add a product area, add `slug: "Human title"` to `FEATURES` in the order you want
+  it reported and mention it in the list above; a scenario naming an unknown feature
+  is rejected at load time.
+- `user_story` is one sentence of at most 300 characters, in the user's voice: `As a
+  <who>, I want <what>, so that <why>`, or a plain use case when the persona adds
+  nothing. Say what the user is trying to achieve, not which control they press --
+  that is what `steps` are for. The shipped scenarios all start with `As a`, and the
+  unit tests hold them to it.
+- `docs_url` is optional: an `https://` URL or a repo path under `docs/` ending in
+  `.md` (an anchor is allowed). It becomes the **Docs** link in `features.md`.
+
+Scenario names should start with the feature they belong to where that reads
+naturally (`settings-theme-toggle`, `members-dm-hello`) so the artifact directory
+sorts the same way the report groups.
+
+### Keeping a scenario true as the product moves
+
+A step that names a control by its exact label goes stale when the label changes.
+When a surface is mid-transition, describe it by what does not change: the Feature
+Previews card for Crew Members was relabelled from "Crew Members and Crew Mode" to
+"Crew Members" as Crew Mode retired (#9519), so `members-dm-hello` asks for the card
+"whose title starts with `Crew Members`" and names both readings, and finds the page by
+its rail label, which was the same on both sides of the change. When a scenario does
+need to move with the product, change the YAML in the same PR as the UI and re-run it
+on demand (below) before merging.
 
 `boot.sh` seeds one home per run from `GUI_SEED` (default `rich`) with `GUI_MEMBERS`
 (default `nova-sky`); a scenario's `preconditions.seed` / `members` document what it

--- a/test/gui_user/harness.py
+++ b/test/gui_user/harness.py
@@ -337,6 +337,21 @@ class ScenarioResult:
     summary: str
     status: str  # PASS | FAIL | ERROR | SKIPPED
     attempts: list[AttemptResult] = field(default_factory=list)
+    # Carried through to summary.json so report.py can group by product area
+    # without re-reading the scenario files.
+    feature: str = ""
+    user_story: str = ""
+
+    @classmethod
+    def for_scenario(cls, sc: Scenario, status: str) -> "ScenarioResult":
+        return cls(
+            name=sc.name,
+            tier=sc.tier,
+            summary=sc.summary,
+            status=status,
+            feature=sc.feature,
+            user_story=sc.user_story,
+        )
 
     @property
     def usd(self) -> float:
@@ -532,7 +547,7 @@ class Runner:
         results: list[ScenarioResult] = []
         budget_hit = False
         for sc in scenarios:
-            res = ScenarioResult(name=sc.name, tier=sc.tier, summary=sc.summary, status="SKIPPED")
+            res = ScenarioResult.for_scenario(sc, "SKIPPED")
             results.append(res)
             if budget_hit:
                 continue
@@ -633,26 +648,20 @@ def main(argv: Optional[list[str]] = None) -> int:
             time.sleep(3.0)
             _, path = display.screenshot("dry-run")
             log.write("screenshot", label="dry-run", file=path.name)
-            results.append(
-                ScenarioResult(
-                    sc.name,
-                    sc.tier,
-                    sc.summary,
-                    "SKIPPED",
-                    [
-                        AttemptResult(
-                            "DRY_RUN",
-                            0,
-                            0.0,
-                            0,
-                            0,
-                            0.0,
-                            "",
-                            shots_dir=str(shots.relative_to(args.out)),
-                        )
-                    ],
+            dry = ScenarioResult.for_scenario(sc, "SKIPPED")
+            dry.attempts.append(
+                AttemptResult(
+                    "DRY_RUN",
+                    0,
+                    0.0,
+                    0,
+                    0,
+                    0.0,
+                    "",
+                    shots_dir=str(shots.relative_to(args.out)),
                 )
             )
+            results.append(dry)
         mode = "dry-run"
         usage = Usage()
     else:

--- a/test/gui_user/report.py
+++ b/test/gui_user/report.py
@@ -1,8 +1,14 @@
-"""Render ``summary.json`` for humans: ``verdict.md``, the PR comment, the nightly issue.
+"""Render ``summary.json`` for humans: ``verdict.md``, the PR comment, the nightly issue, ``features.md``.
 
 Kept free of harness imports so the workflow can call it after the harness has
 already exited (``python test/gui_user/report.py --summary ... --format comment``)
-and so its formatting is unit-testable from a dict.
+and so its formatting is unit-testable from a dict. It does read the scenario
+DSL (``scenarios.py``, pure YAML) for the feature titles and for the
+``features`` format, which is a catalog of the scenario directory itself.
+
+Every table is grouped by ``feature``: the nightly report reads as "which
+product areas are healthy", and each row carries the scenario's ``user_story``
+so a reader who has never opened the YAML knows what the user was trying to do.
 """
 
 from __future__ import annotations
@@ -11,13 +17,30 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
+
+if __package__ in (None, ""):  # ``python test/gui_user/report.py`` -- make ``gui_user`` importable
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gui_user.scenarios import (  # noqa: E402
+    FEATURES,
+    Scenario,
+    ScenarioError,
+    by_feature,
+    load_all,
+)
 
 COMMENT_MARKER = "<!-- gui-user-test -->"
 REVIEWED_MARKER = "[GUI-USER-TESTED]"
 
+#: The shipped scenario directory the ``features`` format catalogs.
+SCENARIOS_DIR = Path(__file__).resolve().parent / "scenarios"
+
 #: Longest model-authored excerpt a comment carries.
 MAX_MODEL_TEXT = 1200
+
+#: Group heading for summary.json entries written before ``feature`` existed.
+UNCLASSIFIED = "unclassified"
 
 _BADGE = {
     "PASS": "✅ PASS",
@@ -25,6 +48,7 @@ _BADGE = {
     "ERROR": "⚠️ ERROR",
     "SKIPPED": "⏭️ SKIPPED",
 }
+_NOT_RUN = "▫️ not run"
 
 
 def overall(summary: dict[str, Any]) -> str:
@@ -45,8 +69,13 @@ def _last_attempt(sc: dict[str, Any]) -> dict[str, Any]:
     return attempts[-1] if attempts else {}
 
 
+def _cell(text: Any, *, max_chars: int = 300) -> str:
+    """Repo-authored text (slugs, user stories) as a table cell: no pipes, no newlines."""
+    return neutralize(str(text or ""), max_chars=max_chars).replace("|", "/").replace("\n", " ")
+
+
 def scenario_line(sc: dict[str, Any]) -> str:
-    """One table row per scenario: status, name, steps, seconds, attempts, cost."""
+    """One table row per scenario: status, name, user story, steps, seconds, attempts, cost."""
     last = _last_attempt(sc)
     attempts = len(sc.get("attempts") or [])
     steps = last.get("steps", 0)
@@ -56,8 +85,47 @@ def scenario_line(sc: dict[str, Any]) -> str:
     if last.get("error"):
         detail = f"{detail}: {neutralize(str(last['error']), max_chars=80).replace('|', '/')}"
     return (
-        f"| {_BADGE.get(sc.get('status', ''), sc.get('status', ''))} | `{sc.get('name')}` | {sc.get('tier')} "
+        f"| {_BADGE.get(sc.get('status', ''), sc.get('status', ''))} | `{sc.get('name')}` "
+        f"| {_cell(sc.get('user_story'))} | {sc.get('tier')} "
         f"| {steps} | {secs}s | {attempts} | ${usd:.2f} | {detail} |"
+    )
+
+
+_TABLE_HEADER = (
+    "| | Scenario | User story | Tier | Steps | Time | Attempts | Cost | Detail |",
+    "|---|---|---|---|---|---|---|---|---|",
+)
+
+
+def feature_title(slug: str) -> str:
+    return FEATURES.get(slug, "Unclassified" if slug == UNCLASSIFIED else slug)
+
+
+def group_by_feature(scenarios: Iterable[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """summary.json entries by ``feature`` in :data:`FEATURES` order; unknown/missing last."""
+    groups: dict[str, list[dict[str, Any]]] = {slug: [] for slug in FEATURES}
+    extra: dict[str, list[dict[str, Any]]] = {}
+    for sc in scenarios:
+        slug = sc.get("feature") or UNCLASSIFIED
+        if slug in groups:
+            groups[slug].append(sc)
+        else:
+            extra.setdefault(slug, []).append(sc)
+    out = {slug: g for slug, g in groups.items() if g}
+    out.update(extra)
+    return out
+
+
+def group_verdict(scenarios: list[dict[str, Any]]) -> str:
+    return overall({"scenarios": scenarios})
+
+
+def _group_heading(slug: str, scenarios: list[dict[str, Any]]) -> str:
+    passed = sum(1 for sc in scenarios if sc.get("status") == "PASS")
+    verdict = group_verdict(scenarios)
+    return (
+        f"### {_cell(feature_title(slug), max_chars=80)} (`{_cell(slug, max_chars=64)}`) — "
+        f"{_BADGE.get(verdict, verdict)} {passed}/{len(scenarios)}"
     )
 
 
@@ -125,12 +193,17 @@ def _final_text_blocks(summary: dict[str, Any]) -> list[str]:
 def render_markdown(
     summary: dict[str, Any], *, artifact_url: Optional[str] = None, run_url: Optional[str] = None
 ) -> str:
-    """``verdict.md`` body (no marker, no header badge line)."""
-    lines = [
-        "| | Scenario | Tier | Steps | Time | Attempts | Cost | Detail |",
-        "|---|---|---|---|---|---|---|---|",
-    ]
-    lines += [scenario_line(sc) for sc in summary.get("scenarios", [])]
+    """``verdict.md`` body (no marker, no header badge line): one table per feature."""
+    lines: list[str] = []
+    for slug, group in group_by_feature(summary.get("scenarios", [])).items():
+        if lines:
+            lines.append("")
+        lines.append(_group_heading(slug, group))
+        lines.append("")
+        lines += list(_TABLE_HEADER)
+        lines += [scenario_line(sc) for sc in group]
+    if not lines:
+        lines += list(_TABLE_HEADER)
     usage = summary.get("usage") or {}
     lines += [
         "",
@@ -154,18 +227,69 @@ def render_markdown(
 
 def render_console(summary: dict[str, Any]) -> str:
     rows = []
-    for sc in summary.get("scenarios", []):
-        last = _last_attempt(sc)
-        rows.append(
-            f"  {sc.get('status', ''):7} {sc.get('name'):28} steps={last.get('steps', 0)} "
-            f"t={last.get('seconds', 0)}s attempts={len(sc.get('attempts') or [])}"
-        )
+    for slug, group in group_by_feature(summary.get("scenarios", [])).items():
+        rows.append(f"  [{slug}] {feature_title(slug)}: {group_verdict(group)}")
+        for sc in group:
+            last = _last_attempt(sc)
+            rows.append(
+                f"    {sc.get('status', ''):7} {sc.get('name'):28} steps={last.get('steps', 0)} "
+                f"t={last.get('seconds', 0)}s attempts={len(sc.get('attempts') or [])}"
+            )
     return "\n".join(
         [
             f"GUI user test: {overall(summary)}  (${float(summary.get('usd', 0)):.2f}, mode {summary.get('tool_mode')})"
         ]
         + rows
     )
+
+
+def render_features(
+    catalog: list[Scenario],
+    summary: Optional[dict[str, Any]] = None,
+    *,
+    run_url: Optional[str] = None,
+) -> str:
+    """``features.md``: what the product does, as the scenario directory describes it.
+
+    One section per feature in :data:`FEATURES` order, each listing its user
+    stories with the latest verdict when a ``summary.json`` is attached (a
+    scenario the run did not select shows as *not run*). Features that have no
+    scenario yet are listed at the end so the catalog doubles as the coverage
+    backlog. The ``catalog`` is repo-authored YAML, never model output, so the
+    only defanging needed is table-cell hygiene.
+    """
+    latest: dict[str, dict[str, Any]] = {
+        str(sc.get("name")): sc for sc in (summary or {}).get("scenarios", [])
+    }
+    groups = by_feature(catalog)
+    smoke = sum(1 for s in catalog if s.tier == "smoke")
+    lines = [
+        "# GUI user-test feature catalog",
+        "",
+        f"_{len(groups)} of {len(FEATURES)} features covered · "
+        f"{len(catalog)} scenarios ({smoke} smoke / {len(catalog) - smoke} nightly)._",
+    ]
+    if summary is not None:
+        where = f" ([workflow run]({run_url}))" if run_url else ""
+        lines.append(
+            f"_Latest verdict: **{overall(summary)}** on tier `{summary.get('tier')}` "
+            f"with `{summary.get('model')}`{where}._"
+        )
+    else:
+        lines.append("_No run attached: verdict column shows the catalog only._")
+    for slug, group in groups.items():
+        lines += ["", f"## {FEATURES[slug]} (`{slug}`)", ""]
+        lines += ["| | User story | Scenario | Tier | Docs |", "|---|---|---|---|---|"]
+        for s in group:
+            res = latest.get(s.name)
+            badge = _BADGE.get(res.get("status", ""), res.get("status", "")) if res else _NOT_RUN
+            docs = f"[docs]({s.docs_url})" if s.docs_url else ""
+            lines.append(f"| {badge} | {_cell(s.user_story)} | `{s.name}` | {s.tier} | {docs} |")
+    missing = [f"`{slug}` {title}" for slug, title in FEATURES.items() if slug not in groups]
+    if missing:
+        lines += ["", "## Not yet covered", ""]
+        lines += [f"- {m}" for m in missing]
+    return "\n".join(lines) + "\n"
 
 
 def render_comment(
@@ -215,20 +339,36 @@ def render_issue(
 
 def main(argv: Optional[list[str]] = None) -> int:
     p = argparse.ArgumentParser(description="render a GUI user-test summary.json")
-    p.add_argument("--summary", type=Path, required=True)
+    p.add_argument("--summary", type=Path, help="summary.json (optional for --format features)")
     p.add_argument(
         "--format",
-        choices=("markdown", "comment", "issue-title", "issue-body", "verdict"),
+        choices=("markdown", "comment", "issue-title", "issue-body", "verdict", "features"),
         default="markdown",
     )
     p.add_argument("--head-sha", default="")
     p.add_argument("--run-url", default="")
     p.add_argument("--artifact-url", default="")
     args = p.parse_args(argv)
-    try:
-        summary = json.loads(args.summary.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        print(f"could not read {args.summary}: {exc}", file=sys.stderr)
+
+    summary: Optional[dict[str, Any]] = None
+    if args.summary is not None:
+        try:
+            summary = json.loads(args.summary.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"could not read {args.summary}: {exc}", file=sys.stderr)
+            return 2
+
+    if args.format == "features":
+        try:
+            catalog = load_all(SCENARIOS_DIR)
+        except ScenarioError as exc:
+            print(f"could not load scenarios: {exc}", file=sys.stderr)
+            return 2
+        print(render_features(catalog, summary, run_url=args.run_url or None), end="")
+        return 0
+
+    if summary is None:
+        print("--summary is required for this format", file=sys.stderr)
         return 2
     if args.format == "verdict":
         print(overall(summary))

--- a/test/gui_user/scenarios.py
+++ b/test/gui_user/scenarios.py
@@ -4,6 +4,10 @@
 
     name: settings-theme-toggle          # slug, also the artifact sub-directory
     tier: smoke                          # smoke (PR + nightly) | nightly (nightly only)
+    feature: settings                    # product area, a key of FEATURES (groups the report)
+    user_story: >-                       # one user-readable sentence: what the user wants and why
+      As a user, I want to switch the dashboard theme so that it matches my desk.
+    docs_url: docs/build/gui-user-test.md   # optional: where the feature is documented
     summary: one line for the report table
     preconditions:
       seed: rich                         # KIROCREW_HOME fixture the target boots from
@@ -20,6 +24,12 @@ The harness turns ``steps`` + ``expectations`` into the task prompt and asks the
 model for a ``VERDICT`` block; the workflow only ever sees the resulting
 ``summary.json``. Everything here is data: the loader validates shape and
 bounds, it never interprets the natural language.
+
+``feature`` and ``user_story`` are not read by the harness at all: they exist so
+the report can be read as "which product areas are healthy" and so the scenario
+directory doubles as a catalog of what the product does (``report.py --format
+features``). A scenario without them is rejected, because a catalog with
+unclassified entries is not a catalog.
 """
 
 from __future__ import annotations
@@ -33,6 +43,42 @@ import yaml
 
 TIERS: tuple[str, ...] = ("smoke", "nightly")
 _SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+
+#: Product areas a scenario may claim, slug -> human title. A closed list rather
+#: than a free-form slug so a typo cannot split one feature into two report
+#: groups; adding an area is a one-line data change here plus a row in
+#: ``docs/build/gui-user-test.md``. Order is the order the report groups appear in.
+FEATURES: dict[str, str] = {
+    "chat": "Chat sessions",
+    "sidebar": "Sessions sidebar & folders",
+    "members": "Crew Members",
+    "settings": "Settings",
+    "apps": "Apps & App Store",
+    "schedule": "Schedule (cron jobs)",
+    "knowledge": "Knowledge library",
+    "artifacts": "Artifacts",
+    "files": "File viewer & project files",
+    "browser-panel": "Browser panel",
+    "voice": "Voice",
+    "notifications": "Notifications",
+    "onboarding": "Onboarding & login",
+    "search": "Search everywhere & command palette",
+    "developer": "Developer tools",
+}
+
+#: A user story is one sentence a product manager could read aloud; the bound is
+#: generous enough for "As a …, I want …, so that …" and tight enough to refuse a
+#: pasted paragraph.
+USER_STORY_MAX = 300
+
+#: An ``https://`` URL, or a repo path under ``docs/`` ending in ``.md`` (optional
+#: anchor). Path segments are letters, digits, ``.``, ``_`` and ``-`` and never
+#: start with ``.``, so ``docs/../x.md`` and hidden files are refused.
+_DOCS_URL_RE = re.compile(
+    r"^(https://[^\s]+"
+    r"|docs/(?:[A-Za-z0-9_-][A-Za-z0-9._-]*/)*[A-Za-z0-9_-][A-Za-z0-9._-]*\.md"
+    r"(#[A-Za-z0-9._-]+)?)$"
+)
 
 #: Hard ceilings, independent of what a scenario asks for. A scenario that
 #: wants more is a design smell (split it), and the ceiling is what bounds the
@@ -49,11 +95,14 @@ class ScenarioError(ValueError):
 class Scenario:
     name: str
     tier: str
+    feature: str
+    user_story: str
     summary: str
     steps: tuple[str, ...]
     expectations: tuple[str, ...]
     max_steps: int
     max_seconds: int
+    docs_url: str = ""
     seed: str = "rich"
     members: tuple[str, ...] = ()
     start_url: str = "/"
@@ -104,6 +153,9 @@ def parse_scenario(doc: Any, path: Path) -> Scenario:
     unknown = set(doc) - {
         "name",
         "tier",
+        "feature",
+        "user_story",
+        "docs_url",
         "summary",
         "preconditions",
         "steps",
@@ -123,6 +175,30 @@ def parse_scenario(doc: Any, path: Path) -> Scenario:
     tier = doc.get("tier", "nightly")
     if tier not in TIERS:
         raise ScenarioError(f"{path}: 'tier' must be one of {TIERS}")
+
+    feature = doc.get("feature")
+    if not isinstance(feature, str) or feature not in FEATURES:
+        raise ScenarioError(
+            f"{path}: 'feature' is required and must be one of {sorted(FEATURES)} "
+            "(add a new product area to scenarios.FEATURES first)"
+        )
+
+    user_story = doc.get("user_story")
+    if (
+        not isinstance(user_story, str)
+        or not user_story.strip()
+        or len(user_story.strip()) > USER_STORY_MAX
+    ):
+        raise ScenarioError(
+            f"{path}: 'user_story' is required: one sentence of at most {USER_STORY_MAX} chars "
+            "('As a …, I want …, so that …' or a use case)"
+        )
+
+    docs_url = doc.get("docs_url", "")
+    if not isinstance(docs_url, str) or (docs_url and not _DOCS_URL_RE.match(docs_url)):
+        raise ScenarioError(
+            f"{path}: 'docs_url' must be an https:// URL or a repo path under docs/ ending in .md"
+        )
 
     summary = doc.get("summary")
     if not isinstance(summary, str) or not summary.strip() or len(summary) > 200:
@@ -154,6 +230,8 @@ def parse_scenario(doc: Any, path: Path) -> Scenario:
     return Scenario(
         name=name,
         tier=tier,
+        feature=feature,
+        user_story=user_story.strip(),
         summary=summary.strip(),
         steps=_str_list(doc.get("steps"), "steps", path),
         expectations=_str_list(doc.get("expectations"), "expectations", path),
@@ -161,6 +239,7 @@ def parse_scenario(doc: Any, path: Path) -> Scenario:
         max_seconds=_bounded_int(
             doc.get("max_seconds", 300), "max_seconds", MAX_SECONDS_CEILING, path
         ),
+        docs_url=docs_url,
         seed=seed,
         members=tuple(members),
         start_url=start_url,
@@ -204,3 +283,11 @@ def select(
     if missing:
         raise ScenarioError(f"unknown scenario name(s): {sorted(missing)}")
     return out
+
+
+def by_feature(scenarios: Iterable[Scenario]) -> dict[str, list[Scenario]]:
+    """Group scenarios by ``feature`` in :data:`FEATURES` order (empty groups omitted)."""
+    groups: dict[str, list[Scenario]] = {slug: [] for slug in FEATURES}
+    for s in scenarios:
+        groups[s.feature].append(s)
+    return {slug: group for slug, group in groups.items() if group}

--- a/test/gui_user/scenarios/members-dm-hello.yaml
+++ b/test/gui_user/scenarios/members-dm-hello.yaml
@@ -1,9 +1,21 @@
 # Nightly: the PoC scenario from the research report -- find a crew member and
 # send them a DM. The Crew Members page sits behind a feature-preview switch
 # (per-device localStorage), so the tester turns it on through the GUI first,
-# exactly as a user would. Nightly-only because it is the longest scenario.
+# exactly as a user would.
+#
+# The Feature Previews card for this page is titled "Crew Members"; older
+# builds titled it "Crew Members and Crew Mode". The steps describe the card by
+# what both titles share (a title that STARTS with "Crew Members") and the page
+# by its rail label, "Crew Members", so the scenario reads the same on either
+# build. Nightly-only because it is the longest scenario.
 name: members-dm-hello
 tier: nightly
+feature: members
+user_story: >-
+  As a user with several agents, I want to open one of my crew members and
+  message it directly, so that each agent has its own standing conversation
+  instead of a pile of one-off sessions.
+docs_url: docs/system-specs/modules/crew-mode.md
 summary: Enable the Crew Members preview, open a member and send "hello" in the DM
 preconditions:
   seed: rich
@@ -11,8 +23,8 @@ preconditions:
   start_url: /settings
 steps:
   - You are on the Settings page. Open the Developer section and find the Feature Previews list.
-  - Turn on the preview named "Crew Members and Crew Mode".
-  - Open the Crew Members page (a new item appears in the left rail after the preview is on).
+  - Turn on the preview whose title starts with "Crew Members" (it may read "Crew Members" or "Crew Members and Crew Mode"; either is the right one). Ignore the Webhooks preview.
+  - Open the Crew Members page. After the preview is on, a "Crew Members" item appears in the left rail, directly under Sessions; click it.
   - Click the first member card (a member named Nova Sky is expected) to open a direct-message conversation with it.
   - Type exactly "hello" in the message box and send it with Enter.
   - Wait about two seconds.

--- a/test/gui_user/scenarios/sessions-new-chat.yaml
+++ b/test/gui_user/scenarios/sessions-new-chat.yaml
@@ -4,6 +4,11 @@
 # from the seeded ones on screen.
 name: sessions-new-chat
 tier: smoke
+feature: chat
+user_story: >-
+  As a user, I want to start a new chat from the sidebar and get a reply, so
+  that I can begin a piece of work without leaving what I was doing.
+docs_url: docs/system-specs/modules/session.md
 summary: Create a new chat from the sidebar and confirm it appears in the session list
 preconditions:
   seed: rich

--- a/test/gui_user/scenarios/settings-theme-toggle.yaml
+++ b/test/gui_user/scenarios/settings-theme-toggle.yaml
@@ -4,6 +4,12 @@
 # flipped a class name.
 name: settings-theme-toggle
 tier: smoke
+feature: settings
+user_story: >-
+  As a user, I want to switch the dashboard between light and dark themes in
+  Settings, so that the app matches my environment and the change is visible
+  at once.
+docs_url: docs/system-specs/modules/themes.md
 summary: Switch the dashboard theme in Settings and confirm the colours change
 preconditions:
   seed: rich

--- a/test/gui_user/test_scenarios_and_report.py
+++ b/test/gui_user/test_scenarios_and_report.py
@@ -51,6 +51,38 @@ class TestShippedScenarios:
         for exp in sc.expectations:
             assert exp in prompt
         assert f"at most {sc.max_steps} actions" in prompt
+        # The catalog fields describe the scenario to people, not to the model.
+        assert sc.user_story not in prompt
+
+    def test_every_shipped_scenario_is_classified(self) -> None:
+        for sc in scenarios.load_all(SCENARIOS_DIR):
+            assert sc.feature in scenarios.FEATURES
+            assert sc.user_story.startswith("As a "), sc.name
+            assert sc.docs_url.startswith("docs/") or sc.docs_url.startswith("https://")
+            if sc.docs_url.startswith("docs/"):
+                assert (Path(__file__).parents[2] / sc.docs_url.split("#")[0]).is_file(), sc.name
+
+    def test_shipped_scenarios_group_by_feature(self) -> None:
+        groups = scenarios.by_feature(scenarios.load_all(SCENARIOS_DIR))
+        assert {slug: [s.name for s in g] for slug, g in groups.items()} == {
+            "chat": ["sessions-new-chat"],
+            "members": ["members-dm-hello"],
+            "settings": ["settings-theme-toggle"],
+        }
+        # FEATURES order, not alphabetical: chat is the product's primary surface.
+        assert list(groups) == ["chat", "members", "settings"]
+
+    def test_members_scenario_holds_across_the_crew_mode_retirement(self) -> None:
+        """The Feature Previews card carries two titles across the Crew Mode retirement; the steps name both."""
+        sc = scenarios.load_scenario(SCENARIOS_DIR / "members-dm-hello.yaml")
+        preview_step = next(
+            s for s in sc.steps if "preview" in s.lower() and "turn on" in s.lower()
+        )
+        assert 'starts with "Crew Members"' in preview_step
+        assert (
+            "Crew Members and Crew Mode" in preview_step
+        )  # the longer title is still a valid reading
+        assert any('"Crew Members" item appears in the left rail' in s for s in sc.steps)
 
 
 def _write(tmp_path: Path, name: str, doc: dict) -> Path:
@@ -63,6 +95,8 @@ def _valid(name: str = "demo") -> dict:
     return {
         "name": name,
         "tier": "smoke",
+        "feature": "settings",
+        "user_story": "As a user, I want to do a thing, so that the thing is done.",
         "summary": "do a thing",
         "preconditions": {"seed": "rich", "members": ["nova-sky"], "start_url": "/settings"},
         "steps": ["click the thing"],
@@ -76,6 +110,18 @@ class TestScenarioValidation:
     def test_valid_document_round_trips(self, tmp_path: Path) -> None:
         sc = scenarios.load_scenario(_write(tmp_path, "demo", _valid()))
         assert sc.members == ("nova-sky",) and sc.start_url == "/settings" and sc.seed == "rich"
+        assert sc.feature == "settings" and sc.user_story.startswith("As a user")
+        assert sc.docs_url == ""
+
+    def test_docs_url_accepts_https_and_repo_docs_paths(self, tmp_path: Path) -> None:
+        for url in (
+            "https://github.com/kirodotdev/KiroCrew/issues/9578",
+            "docs/system-specs/modules/themes.md",
+            "docs/build/gui-user-test.md#adding-a-scenario",
+        ):
+            doc = _valid()
+            doc["docs_url"] = url
+            assert scenarios.load_scenario(_write(tmp_path, "demo", doc)).docs_url == url
 
     def test_defaults(self, tmp_path: Path) -> None:
         doc = _valid()
@@ -97,6 +143,16 @@ class TestScenarioValidation:
             (lambda d: d.update(name="Demo"), "lowercase slug"),
             (lambda d: d.update(name="other"), "file stem"),
             (lambda d: d.update(tier="weekly"), "tier"),
+            (lambda d: d.pop("feature"), "'feature' is required"),
+            (lambda d: d.update(feature="Settings"), "'feature' is required"),
+            (lambda d: d.update(feature="not-a-feature"), "'feature' is required"),
+            (lambda d: d.pop("user_story"), "'user_story' is required"),
+            (lambda d: d.update(user_story="   "), "'user_story' is required"),
+            (lambda d: d.update(user_story="x" * (scenarios.USER_STORY_MAX + 1)), "user_story"),
+            (lambda d: d.update(docs_url="http://insecure.example"), "docs_url"),
+            (lambda d: d.update(docs_url="docs/../secret.md"), "docs_url"),
+            (lambda d: d.update(docs_url="README.md"), "docs_url"),
+            (lambda d: d.update(docs_url=7), "docs_url"),
             (lambda d: d.update(summary=""), "summary"),
             (lambda d: d.update(steps=[]), "steps"),
             (lambda d: d.update(expectations=[""]), "expectations"),
@@ -251,6 +307,8 @@ def _summary() -> dict:
             {
                 "name": "settings-theme-toggle",
                 "tier": "smoke",
+                "feature": "settings",
+                "user_story": "As a user, I want to switch theme | quickly.",
                 "summary": "s",
                 "status": "PASS",
                 "attempts": [
@@ -270,6 +328,8 @@ def _summary() -> dict:
             {
                 "name": "sessions-new-chat",
                 "tier": "smoke",
+                "feature": "chat",
+                "user_story": "As a user, I want a new chat.",
                 "summary": "s",
                 "status": "FAIL",
                 "attempts": [
@@ -317,13 +377,74 @@ class TestReport:
         )
         assert md.count("| `settings-theme-toggle` |") == 1
         assert (
-            "| ❌ FAIL | `sessions-new-chat` | smoke | 14 | 90.0s | 2 | $0.12 | MAX_STEPS |" in md
+            "| ❌ FAIL | `sessions-new-chat` | As a user, I want a new chat. | smoke "
+            "| 14 | 90.0s | 2 | $0.12 | MAX_STEPS |" in md
         )
         assert "≈ $0.17 of $3.00 budget" in md
         assert "[screenshots + steps.jsonl](https://x/artifact)" in md
         # A failing scenario's final report is shown; a passing one only if it flagged UI issues.
         assert "no new row" in md
         assert "VERDICT: PASS" not in md
+
+    def test_markdown_is_grouped_by_feature_in_registry_order(self) -> None:
+        md = report.render_markdown(_summary())
+        chat = md.index("### Chat sessions (`chat`) — ❌ FAIL 0/1")
+        settings = md.index("### Settings (`settings`) — ✅ PASS 1/1")
+        assert chat < settings  # FEATURES order, even though the fixture lists settings first
+        assert md.count("| | Scenario | User story | Tier |") == 2
+        # A pipe inside a repo-authored user story cannot break the table.
+        assert "switch theme / quickly." in md and "theme | quickly" not in md
+
+    def test_pre_feature_summaries_still_render(self) -> None:
+        s = _summary()
+        for sc in s["scenarios"]:
+            sc.pop("feature")
+            sc.pop("user_story")
+        md = report.render_markdown(s)
+        assert "### Unclassified (`unclassified`) — ❌ FAIL 1/2" in md
+        assert md.count("| `") == 2
+        assert report.group_by_feature([]) == {}
+
+    def test_console_groups_too(self) -> None:
+        out = report.render_console(_summary())
+        assert out.splitlines()[0].startswith("GUI user test: FAIL")
+        assert "  [chat] Chat sessions: FAIL" in out
+        assert "  [settings] Settings: PASS" in out
+
+    def test_features_catalog_lists_stories_verdicts_and_gaps(self) -> None:
+        catalog = scenarios.load_all(SCENARIOS_DIR)
+        md = report.render_features(catalog, _summary(), run_url="https://x/run")
+        assert md.startswith("# GUI user-test feature catalog\n")
+        assert (
+            f"_3 of {len(scenarios.FEATURES)} features covered · 3 scenarios (2 smoke / 1 nightly)._"
+            in md
+        )
+        assert (
+            "_Latest verdict: **FAIL** on tier `smoke` with `test-model` ([workflow run](https://x/run))._"
+            in md
+        )
+        # Sections in FEATURES order, each with its stories; the nightly-only member
+        # scenario was not selected by this smoke run and says so.
+        assert (
+            md.index("## Chat sessions (`chat`)")
+            < md.index("## Crew Members (`members`)")
+            < md.index("## Settings (`settings`)")
+        )
+        assert "| ❌ FAIL | As a user, I want to start a new chat" in md
+        assert "| ▫️ not run | As a user with several agents" in md
+        assert (
+            "| `settings-theme-toggle` | smoke | [docs](docs/system-specs/modules/themes.md) |"
+            in md
+        )
+        # Uncovered features are the backlog.
+        assert "## Not yet covered" in md
+        assert "- `knowledge` Knowledge library" in md
+        assert "- `chat` Chat sessions" not in md
+
+    def test_features_catalog_without_a_run(self) -> None:
+        md = report.render_features(scenarios.load_all(SCENARIOS_DIR))
+        assert "_No run attached" in md
+        assert md.count("▫️ not run") == 3 and "✅" not in md and "❌" not in md
 
     def test_neutralize_defangs_fences_mentions_and_control_chars(self) -> None:
         raw = "ok\n```\n@maintainer see <img src=x onerror=1>\x07\r~~~\n" + "z" * 50
@@ -372,3 +493,32 @@ class TestReport:
         )
         assert report.COMMENT_MARKER in capsys.readouterr().out
         assert report.main(["--summary", str(tmp_path / "missing.json")]) == 2
+        capsys.readouterr()
+        # Every non-catalog format needs a summary.
+        assert report.main(["--format", "verdict"]) == 2
+        assert "--summary is required" in capsys.readouterr().err
+
+    def test_cli_features_with_and_without_summary(
+        self, tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        p = tmp_path / "summary.json"
+        p.write_text(json.dumps(_summary()), encoding="utf-8")
+        assert report.main(["--format", "features", "--summary", str(p)]) == 0
+        out = capsys.readouterr().out
+        assert "# GUI user-test feature catalog" in out and "Latest verdict: **FAIL**" in out
+        assert report.main(["--format", "features"]) == 0
+        assert "_No run attached" in capsys.readouterr().out
+        # A malformed shipped scenario is a hard error, not a half catalog.
+        (tmp_path / "bad.yaml").write_text("name: bad\n", encoding="utf-8")
+        monkeypatch.setattr(report, "SCENARIOS_DIR", tmp_path)
+        assert report.main(["--format", "features"]) == 2
+        assert "could not load scenarios" in capsys.readouterr().err
+
+
+class TestScenarioResultCarriesTheCatalogFields:
+    def test_for_scenario_copies_feature_and_story(self) -> None:
+        sc = scenarios.load_scenario(SCENARIOS_DIR / "members-dm-hello.yaml")
+        res = harness.ScenarioResult.for_scenario(sc, "SKIPPED")
+        assert (res.name, res.tier, res.status) == ("members-dm-hello", "nightly", "SKIPPED")
+        assert res.feature == "members" and res.user_story == sc.user_story
+        assert res.attempts == []


### PR DESCRIPTION
Closes #9962 · part of #9578

## Summary

The GUI user-test scenario directory becomes a **feature catalog**, not just a list of drives. Every scenario YAML now says which product area it exercises and what the user is trying to do, and every report is grouped by that.

| Piece | Change |
|---|---|
| `test/gui_user/scenarios.py` | New required fields **`feature`** (a key of the new closed `FEATURES` registry — 15 product areas, in report order) and **`user_story`** (one sentence, ≤ 300 chars, "As a …, I want …, so that …"), optional **`docs_url`** (`https://` or `docs/**/*.md`). `parse_scenario` validates all three; `load_all` therefore refuses an unclassified scenario. `by_feature()` groups in registry order. |
| `test/gui_user/harness.py` | `ScenarioResult` carries `feature` + `user_story` into `summary.json` (`ScenarioResult.for_scenario` replaces the two hand-built constructors). |
| `test/gui_user/report.py` | `verdict.md`, the PR comment, the nightly issue and console output are **grouped by feature** — one table per feature with a *User story* column and a per-group `N/M PASS` heading. Summaries written before this change render under *Unclassified*. New **`--format features`** renders `features.md`: feature → user stories → latest verdict (or *not run*), then the features with no scenario yet — from the scenario directory, with or without a `summary.json`. |
| `.github/workflows/gui-user-test.yml` | Renders `results/features.md` before the artifact upload (also when the target never booted) and appends it to `GITHUB_STEP_SUMMARY` in a `<details>`. |
| `scenarios/members-dm-hello.yaml` | The Feature Previews step named the card **"Crew Members and Crew Mode"**; #9533 retired Crew Mode and #9519 relabels the card to **"Crew Members"**. The step now asks for the card *whose title starts with "Crew Members"* (naming both readings) and finds the page by its rail label, which is `Crew Members` on both sides of #9519. |
| `scenarios/*.yaml` | All three shipped scenarios gain `feature` / `user_story` / `docs_url`. |
| `docs/build/gui-user-test.md` | The new fields, the `FEATURES` convention, and "keeping a scenario true as the product moves". |
| `test/gui_user/test_scenarios_and_report.py` | Schema validation for the new fields (missing / unknown feature, blank / oversized story, bad `docs_url`), grouping order, pipe-safe cells, the catalog with and without a run, CLI paths, and a guard that `members-dm-hello` holds across #9519. |

## User request (verbatim)

> 让那个 session 开一个 dynamic workflow，让这个 test 覆盖我们的所有功能。我希望 yaml 里面也能有一个 user story 或者 use case 的描述，这样我们可以分类或者告诉用户我们有什么功能。

This PR is the schema + reporting half. The feature inventory (`test/gui_user/FEATURES.md`) and the scenario batches follow in separate PRs under #9578.

## What `features.md` looks like today

```
# GUI user-test feature catalog

_3 of 15 features covered · 3 scenarios (2 smoke / 1 nightly)._

## Chat sessions (`chat`)
| | User story | Scenario | Tier | Docs |
| ▫️ not run | As a user, I want to start a new chat from the sidebar and get a reply, so that … | `sessions-new-chat` | smoke | [docs](docs/system-specs/modules/session.md) |

## Crew Members (`members`)
| ▫️ not run | As a user with several agents, I want to open one of my crew members and message it directly, so that … | `members-dm-hello` | nightly | … |

## Settings (`settings`)
| ▫️ not run | As a user, I want to switch the dashboard between light and dark themes in Settings, so that … | `settings-theme-toggle` | smoke | … |

## Not yet covered
- `sidebar` Sessions sidebar & folders
- `apps` Apps & App Store
- …
```

## Decisions

- **Closed `FEATURES` registry, not a free-form slug.** A typo would silently split one product area into two report groups; adding an area is a one-line data change plus a doc row, and an unknown slug fails at load time before it costs a model call.
- **`user_story` is for people, not the model.** It is deliberately left out of `task_prompt()` — the model is briefed by `steps` / `expectations` only, so the catalog text cannot change what the tester does.
- **`features.md` renders without a run.** Built from the YAML, joined with the run's verdicts when there are any, so the step summary still answers "what do we cover" on a night the target failed to boot.
- **`members-dm-hello` describes the card by its invariant prefix** instead of picking one label, so it does not need a follow-up PR when #9519 merges.

## Verification

- Local: `black`, `isort`, `flake8` clean on `test/gui_user/`; `scripts/check_black_formatting.py` passes; workflow YAML parses; `python test/gui_user/report.py --format features` renders the catalog above. No tests run locally (CI runs them).
- CI: Backend Tests run `test/gui_user/test_scenarios_and_report.py`.
- CI RUN https://github.com/kirodotdev/KiroCrew/actions/runs/34529453890 — `workflow_dispatch` of the lane on this branch (`tier=smoke scenario=members-dm-hello`). Verdict: **NOT RUN (credential step)**. Boot (Xvfb → seeded gateway → Chromium) succeeded, then `configure-aws-credentials` failed with `Not authorized to perform sts:AssumeRoleWithWebIdentity`: the shared fallback Bedrock role trusts `main` only, exactly as `docs/build/gui-user-test.md` § Running it warns for branch dispatches. The new **Render the feature catalog** step did run on that failed job and produced `results/features.md` from the YAML alone (the "no run attached" shape), which is the fallback this PR adds. The rewritten `members-dm-hello` therefore gets its first real drive on the first nightly after merge (`20 9 * * *` UTC), or on a maintainer `gh workflow run gui-user-test.yml --ref main -f tier=nightly -f scenario=members-dm-hello`. Pre-merge branch verification of scenarios needs a lane-scoped `GUI_TEST_BEDROCK_ROLE_ARN` whose trust policy covers `refs/heads/*` — flagged on #9578.

No user-visible UI change — CI lane, Python, YAML and docs only.

