### PR TITLE
fix(acp): treat an idle AcpClient as turn-done so model switch is not refused

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -3507,6 +3507,11 @@ class AcpClient:
         self._stderr_task: asyncio.Task | None = None  # type: ignore[type-arg]
         self._last_activity: float = time.monotonic()
         self._turn_done: asyncio.Event = asyncio.Event()
+        # Idle reads as "turn done": has_active_turn() must be False on a spawned
+        # but never-prompted client, or the model/agent switch endpoints refuse
+        # with turn_in_flight against a turn that never ran. Every prompt entry
+        # point clear()s this before running, so a real turn still reads active.
+        self._turn_done.set()
         # Serializes whole read turns on this client's single stdout StreamReader.
         # An asyncio StreamReader permits exactly ONE waiting reader; the shared
         # `_bg` session is streamed by ~8 callers and the per-session Semaphore(1)
@@ -6007,7 +6012,19 @@ class AcpClient:
         self._cancel_ts = 0.0
         self._cancel_grace_secs = _CANCEL_GRACE_SECS
         self._resumed = False
-        self._turn_done = asyncio.Event()
+        # Keep the existing _turn_done OBJECT across a respawn — do not replace
+        # it. A wait_turn_done() waiter captures self._turn_done.wait() on the
+        # object live at that moment; swapping in a fresh Event would strand that
+        # waiter on an object nothing sets, so the cooperative-stop ack times out
+        # and hard-kills the respawned turn. Reusing the object also carries the
+        # turn state for free: a mid-turn respawn's event stays cleared (reads
+        # active, so a concurrent cancel is not dropped), and an idle client's
+        # stays set (the idle == "turn done" invariant, so a later model switch
+        # is not refused with turn_in_flight). Synthesize one only when absent —
+        # test clients built without __init__ — defaulting to idle.
+        if getattr(self, "_turn_done", None) is None:
+            self._turn_done = asyncio.Event()
+            self._turn_done.set()
         self._last_stop_reason = ""
         self._pending_oauth_requests.clear()
         self._oauth_emitted_servers.clear()

--- a/test/test_acp_client_more_coverage.py
+++ b/test/test_acp_client_more_coverage.py
@@ -410,6 +410,10 @@ class TestClientAccessors:
         client._process = _live_process()
         assert client.is_process_alive() is True
         assert client.exit_code is None
+        # A never-prompted client is idle: _turn_done is set at construction, so
+        # there is no unfinished turn even with a live process.
+        assert client.has_unfinished_turn() is False
+        client._turn_done.clear()  # a turn is now in flight
         assert client.has_unfinished_turn() is True  # turn not done + process alive
 
         client._process.returncode = 3

--- a/test/test_acp_turn_done_idle_init.py
+++ b/test/test_acp_turn_done_idle_init.py
@@ -1,0 +1,70 @@
+"""has_active_turn() must read False on a spawned but never-prompted client.
+
+`_turn_done` is an asyncio.Event whose CLEARED state means "a turn is in
+flight". It is cleared at every prompt entry point and set again in the prompt
+loop's finally. If it is left in its default (cleared) state at construction,
+a client whose process is alive but which has never run a prompt reports
+has_active_turn() == True — a false positive. The model/agent-switch endpoints
+gate on has_active_turn(), so that false positive refuses a model switch on a
+brand-new session with `turn_in_flight` (409) and never clears, because no real
+turn exists to reach the finally that would set the event.
+
+These are RED before the fix (event constructed cleared) and GREEN after
+(event constructed set).
+"""
+
+from unittest.mock import MagicMock
+
+from kiro_crew.acp.client import AcpClient
+
+
+def _alive_never_prompted(tmp_path):
+    """An AcpClient with a live process that has never run a prompt."""
+    client = AcpClient(work_dir=tmp_path)
+    proc = MagicMock()
+    proc.returncode = None  # _is_process_alive() -> True
+    client._process = proc
+    return client
+
+
+def test_idle_spawned_client_has_no_active_turn(tmp_path):
+    """A spawned, never-prompted client is idle, not mid-turn."""
+    client = _alive_never_prompted(tmp_path)
+    assert client.has_active_turn() is False
+
+
+def test_cleared_turn_done_still_reads_active(tmp_path):
+    """The fix must not mask a real turn: once _turn_done is cleared (as every
+    prompt entry point does before running), the client reads as active."""
+    client = _alive_never_prompted(tmp_path)
+    client._turn_done.clear()
+    assert client.has_active_turn() is True
+
+
+def _rearm_live_process(client):
+    """_reset_state closes the process; give it a fresh live one so the assert
+    turns on the event state, not on liveness."""
+    proc = MagicMock()
+    proc.returncode = None  # _is_process_alive() -> True after re-spawn
+    client._process = proc
+
+
+def test_reset_of_idle_client_stays_idle(tmp_path):
+    """Resetting an IDLE client (event set) leaves it idle after re-spawn, so a
+    later model switch is not refused with turn_in_flight."""
+    client = _alive_never_prompted(tmp_path)  # _turn_done set from __init__
+    client._reset_state()
+    _rearm_live_process(client)
+    assert client.has_active_turn() is False
+
+
+def test_reset_midturn_stays_active(tmp_path):
+    """Resetting on the respawn path runs mid-turn: a prompt entry point already
+    cleared _turn_done, and the turn keeps running after the respawn, so the
+    reset must preserve the cleared (active) state — not force it to idle, which
+    would drop a concurrent cancel and mis-gate the live turn as switchable."""
+    client = _alive_never_prompted(tmp_path)
+    client._turn_done.clear()  # a turn is in flight when the reset fires
+    client._reset_state()
+    _rearm_live_process(client)
+    assert client.has_active_turn() is True


### PR DESCRIPTION
## Problem / Motivation

On the Claude Code backend, picking a model on a brand-new chat sometimes fails with "A turn is running — try again when it finishes." No turn was running. The chat was empty and idle.

## Why it matters

The user cannot switch the model or agent on that session. Nothing clears the error on its own: there is no real turn to finish, so it stays until the session is torn down. It only shows on Claude Code, so it looks like a backend outage when it is not.

## What changed (motivation → approach → change)

`AcpClient._turn_done` is an event. Cleared means "a turn is in flight". It was built cleared, so a client whose process was already spawned but had never run a prompt read as mid-turn — `has_active_turn()` returned True. The model and agent switch endpoints refuse with a 409 `turn_in_flight` when `has_active_turn()` is True, so an idle session refused a switch for a turn that never ran.

Only Claude Code hits this. It runs one process per session directly on `AcpClient`, so the live idle client's event is what gates the switch. KAS and kiro-cli run on the shared `AcpRuntime`, whose `AcpSessionHandle` already builds `_turn_done` set.

The fix builds `_turn_done` set at construction. On respawn (`_reset_state`) it carries the state instead of forcing it: a reset that fires mid-turn (a prompt entry point cleared the event, then `ensure_ready()` found the process dead and respawned) stays active, so a concurrent cancel is not dropped and the switch gates do not treat the live turn as idle; a reset of an idle client reads done. Every prompt entry point clears the event before running, so a real turn always reads active. `has_unfinished_turn()` reads the same event, so the shutdown drain no longer waits on an idle never-prompted client — it has no turn to drain.

## Tests

`test/test_acp_turn_done_idle_init.py`:
- a spawned, never-prompted client reports no active turn;
- clearing `_turn_done` (what every prompt start does) still reads active, so the fix cannot mask a real turn;
- resetting an idle client leaves it idle;
- resetting mid-turn leaves it active, so a respawn-driven turn is not mis-read as idle.

## Manual verification

N/A — unit coverage sufficient. The change is a pure state predicate (`has_active_turn()` / `has_unfinished_turn()`), which the tests exercise directly.

## Pattern harvest

Pattern: an `asyncio.Event` whose cleared state encodes "busy" must be set at construction, or an object that has never run reads as busy; and a helper that re-creates such an event must carry the old state, not force one.
Rule candidate: review-prompt — flag an Event used as a done/idle latch that is not `.set()` at construction, or re-created without preserving its prior state.

## Related Issues

no linked issue: reported by a user in chat; no tracking issue filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
