### PR TITLE
fix(acp): idle AcpClient must not read as a turn in flight

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -3506,7 +3506,13 @@ class AcpClient:
         self._jsonl_pos: int = 0  # track read position in session JSONL for tool results
         self._stderr_task: asyncio.Task | None = None  # type: ignore[type-arg]
         self._last_activity: float = time.monotonic()
+        # Idle == done. An idle client (spawned, no prompt sent yet) must read
+        # as NOT in a turn: has_active_turn() is the 409 turn_in_flight gate
+        # on set-model / set-agent, so an unset Event on a live warm process
+        # blocks the user until a real turn's finally runs. Every prompt
+        # entry clear()s this before sending, so a real turn still reads active.
         self._turn_done: asyncio.Event = asyncio.Event()
+        self._turn_done.set()
         # Serializes whole read turns on this client's single stdout StreamReader.
         # An asyncio StreamReader permits exactly ONE waiting reader; the shared
         # `_bg` session is streamed by ~8 callers and the per-session Semaphore(1)
@@ -6007,7 +6013,14 @@ class AcpClient:
         self._cancel_ts = 0.0
         self._cancel_grace_secs = _CANCEL_GRACE_SECS
         self._resumed = False
-        self._turn_done = asyncio.Event()
+        # _turn_done is deliberately NOT rebuilt here. Its state is the truth
+        # about the TURN, not the process: the prompt entries clear() it before
+        # ensure_ready(), and ensure_ready() reaches this reset on the
+        # dead-process respawn branch -- rebuilding the Event there (set OR
+        # unset) would misreport the whole respawned turn. Cleared stays
+        # cleared (turn in flight, the shutdown drain must wait for it); set
+        # stays set (idle, see __init__). Waiters on the old object also keep
+        # their Event instead of being orphaned.
         self._last_stop_reason = ""
         self._pending_oauth_requests.clear()
         self._oauth_emitted_servers.clear()

--- a/test/test_acp_client_more_coverage.py
+++ b/test/test_acp_client_more_coverage.py
@@ -410,6 +410,11 @@ class TestClientAccessors:
         client._process = _live_process()
         assert client.is_process_alive() is True
         assert client.exit_code is None
+        # Idle == done: a live process with no prompt sent is NOT an unfinished
+        # turn (see test_acp_turn_done_idle_init). A turn begins when the prompt
+        # entry clear()s the Event.
+        assert client.has_unfinished_turn() is False
+        client._turn_done.clear()
         assert client.has_unfinished_turn() is True  # turn not done + process alive
 
         client._process.returncode = 3

--- a/test/test_acp_turn_done_idle_init.py
+++ b/test/test_acp_turn_done_idle_init.py
@@ -1,0 +1,85 @@
+"""An idle AcpClient must not read as "a turn is running".
+
+``has_active_turn()`` is the 409 ``turn_in_flight`` gate on set-model /
+set-agent. It reads ``not _turn_done.is_set() and _is_process_alive()``. An
+``asyncio.Event`` starts UNSET, so a client whose process is alive but that
+has never been prompted (eager spawn on a fresh chat) reported a turn in
+flight and the user could not switch model until a real turn's ``finally``
+set the flag. Idle must read as done; every prompt entry ``clear()``s the
+Event before sending, so a real turn still reads active.
+
+``_reset_state()`` must leave the Event alone. The prompt entries clear it
+BEFORE ``ensure_ready()``, and ``ensure_ready()`` reaches ``_reset_state()`` on
+the dead-process respawn branch. Rebuilding the Event there would mark the
+whole respawned turn as done, and the shutdown drain (``has_unfinished_turn``)
+would then kill the replacement process mid-turn.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from kiro_crew.acp.client import AcpClient
+
+
+def _live_process() -> MagicMock:
+    proc = MagicMock()
+    proc.pid = 12345
+    proc.returncode = None  # _is_process_alive() -> True
+    return proc
+
+
+def _dead_process() -> MagicMock:
+    proc = MagicMock()
+    proc.pid = 12345
+    proc.returncode = 1
+    return proc
+
+
+def test_fresh_client_reads_idle_even_with_live_process() -> None:
+    client = AcpClient()
+    client._process = _live_process()
+
+    assert client._turn_done.is_set()
+    assert client.has_active_turn() is False
+    assert client.has_unfinished_turn() is False
+
+
+def test_prompt_start_still_reads_active() -> None:
+    # The prompt entries clear() the Event before sending; the idle default
+    # must not mask that.
+    client = AcpClient()
+    client._process = _live_process()
+
+    client._turn_done.clear()
+
+    assert client.has_active_turn() is True
+
+
+def test_reset_state_keeps_idle_when_idle() -> None:
+    client = AcpClient()
+    client._process = _dead_process()
+
+    client._reset_state()  # e.g. a failed startup outside any turn
+    client._process = _live_process()  # re-spawn
+
+    assert client._turn_done.is_set()
+    assert client.has_active_turn() is False
+
+
+def test_reset_state_keeps_turn_in_flight_across_respawn() -> None:
+    # send_message()/stream_events(): clear() -> ensure_ready(). With the
+    # previous process dead, ensure_ready() runs _reset_state() and re-spawns.
+    # The turn is still in flight after that, so the shutdown drain must still
+    # see it.
+    client = AcpClient()
+    client._process = _dead_process()
+    client._turn_done.clear()  # prompt entry, turn begins
+    event_before = client._turn_done
+
+    client._reset_state()  # respawn branch inside ensure_ready()
+    client._process = _live_process()
+
+    assert client._turn_done is event_before  # waiters are not orphaned
+    assert client.has_active_turn() is True
+    assert client.has_unfinished_turn() is True


### PR DESCRIPTION
## Problem / Motivation

On a fresh chat with the Claude Code backend, picking a model sometimes fails with "A turn is running" (HTTP 409 `turn_in_flight`). Nothing is running. The message never goes away on its own. The user has to send a real message and wait for it to finish before the model picker works.

## Why it matters

Anyone on the Claude Code backend can hit this on any new chat. There is no timeout, so it looks like a hang. The only way out is to start a turn you did not want.

## What changed (motivation → approach → change)

The 409 gate is `AcpClient.has_active_turn()`. It says a turn is running when the `_turn_done` Event is not set and the process is alive.

`_turn_done` is an `asyncio.Event`, and an Event starts unset. Nothing sets it when the process starts. Only the end of a real prompt sets it. So a client that was spawned early (eager spawn on a new chat) but never prompted looks like it is mid-turn.

Two changes, one rule: the Event's state is the truth about the turn, not the process. In `__init__` the Event is set right after it is created (idle means done). In `_reset_state()` the Event is no longer rebuilt. The prompt entries `clear()` it before `ensure_ready()`, and `ensure_ready()` reaches `_reset_state()` on the dead-process respawn branch, so rebuilding it there would mark the whole respawned turn as done and the shutdown drain would kill the replacement process mid-turn. Cleared stays cleared; set stays set.

Only the Claude Code backend takes this path. It runs one `AcpClient` per session. kiro-cli and KAS run on `AcpRuntime` + `AcpSessionHandle`, and that handle already set its `_turn_done` at construction (`session_handle.py`).

## Tests

- `test/test_acp_turn_done_idle_init.py` (new):
  - a fresh client with a live process reads `has_active_turn() is False` and `has_unfinished_turn() is False`
  - after `_turn_done.clear()` (what every prompt entry does) it reads active again
  - `_reset_state()` on an idle client keeps it idle
  - `_reset_state()` during a turn (dead process, Event cleared) keeps the turn in flight and keeps the same Event object, so `has_unfinished_turn()` still holds for the shutdown drain
- `test/test_acp_client_more_coverage.py::TestClientAccessors::test_process_state_accessors`: it had pinned the bug (live process + no prompt == unfinished turn). It now asserts idle first, then `clear()`s to model a started turn.

Mutation-checked: without the `__init__` set, two idle assertions fail; with the Event rebuilt in `_reset_state()`, the respawn test fails. The full `_turn_done` / `has_active_turn` / `wait_turn_done` consumer set (44 test files, ~4.9K tests) passes locally, as does the full backend suite minus 79 host-environment failures that fail identically on clean `main`.

## Manual verification

N/A — unit coverage sufficient. The gate is a pure read of the Event and process state, and the tests drive exactly that read, including the respawn branch.

## Related Issues

no linked issue: the bug was found in chat, not filed. Follow-up for a shared-process host for non-kiro backends is tracked in #9976 (not fixed here).

## Pattern harvest

Rule candidate: review-prompt
Pattern: an `asyncio.Event` that means "not busy" is created unset, so the idle state reads as busy until the first busy→idle edge; and a reset path that rebuilds such an Event erases in-flight state

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc describes this flag
- [x] No secrets, credentials, or internal references in the diff
