### PR TITLE
fix: accept xwiki and text chat uploads

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -1000,6 +1000,8 @@ _SEARCH_LIMIT_CEILING = 60
 _ALLOWED_IMAGE_EXT = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
 _ALLOWED_TEXT_EXT = {
     ".txt",
+    ".text",
+    ".xwiki",
     ".md",
     ".json",
     # Excalidraw scene JSON — the composer's sketch pad attaches one per

--- a/test/test_handlers_files_upload.py
+++ b/test/test_handlers_files_upload.py
@@ -327,6 +327,30 @@ async def test_upload_har_is_accepted_as_plain_text(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("extension", [".text", ".xwiki"])
+async def test_upload_plain_text_alias_is_accepted(
+    upload_dir: Path,
+    mock_sel,
+    extension: str,
+) -> None:
+    payload = "Plain UTF-8 text\nUnicode: café 日本語\n".encode()
+    form = aiohttp.FormData()
+    form.add_field(
+        "file",
+        payload,
+        filename=f"notes{extension}",
+        content_type="text/plain",
+    )
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post("/api/upload/file", data=form)
+        assert resp.status == 200, await resp.text()
+        body = await resp.json()
+    saved = Path(body["paths"][0])
+    assert saved.name.endswith(f"_notes{extension}")
+    assert saved.read_bytes() == payload
+
+
+@pytest.mark.asyncio
 async def test_upload_unrelated_extension_still_rejected(
     upload_dir: Path,
     mock_sel,

--- a/test/test_handlers_files_video_upload.py
+++ b/test/test_handlers_files_video_upload.py
@@ -355,6 +355,18 @@ def test_accept_list_covers_every_accepted_extension() -> None:
     assert set(files_mod._ALLOWED_VIDEO_EXT) == {".mp4", ".m4v", ".mov", ".webm"}
 
 
+def test_file_picker_covers_every_text_and_document_extension() -> None:
+    """The browser picker exposes every text/document type the server accepts."""
+    match = re.search(
+        r"const FILE_ACCEPT = IMAGE_ACCEPT \+ ',' \+ VIDEO_ACCEPT \+ '([^']+)'",
+        _website_source("components/ChatInput.tsx"),
+    )
+    assert match, "FILE_ACCEPT not found in ChatInput.tsx"
+    offered = {value for value in match.group(1).split(",") if value}
+    required = files_mod._ALLOWED_TEXT_EXT | files_mod._ALLOWED_DOC_EXT
+    assert offered == required, (offered - required, required - offered)
+
+
 def test_video_ceiling_stays_above_the_document_cap() -> None:
     """``_MAX_VIDEO_UPLOAD_BYTES`` exceeds ``_MAX_UPLOAD_BYTES``.
 

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -111,7 +111,7 @@ const IMAGE_ACCEPT = 'image/png,image/jpeg,image/gif,image/webp,image/bmp,image/
 // test_accept_list_covers_every_accepted_extension pins this set against the
 // server's, from the Python side, since a vitest cannot read the Python constant.
 const VIDEO_ACCEPT = 'video/mp4,video/x-m4v,video/quicktime,video/webm'
-const FILE_ACCEPT = IMAGE_ACCEPT + ',' + VIDEO_ACCEPT + ',.txt,.md,.json,.excalidraw,.har,.yaml,.yml,.xml,.csv,.log,.py,.js,.ts,.tsx,.jsx,.html,.css,.sh,.bash,.rb,.go,.rs,.java,.c,.cpp,.h,.hpp,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.rtf,.zip,.tar,.gz'
+const FILE_ACCEPT = IMAGE_ACCEPT + ',' + VIDEO_ACCEPT + ',.txt,.text,.xwiki,.md,.json,.excalidraw,.har,.yaml,.yml,.xml,.csv,.log,.py,.js,.ts,.tsx,.jsx,.html,.css,.sh,.bash,.rb,.go,.rs,.java,.c,.cpp,.h,.hpp,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.rtf,.zip,.tar,.gz'
 
 import ApprovalModePicker, { APPROVAL_MODE_ADJUSTED_LS_KEY } from './ApprovalModePicker'
 // Effort vocabulary lives in lib/effort.ts (mirrors backend effort.py).


### PR DESCRIPTION
## Problem / Motivation

The chat attachment endpoint validates the filename suffix before reading file bytes. Plain-text `.xwiki` and `.text` files therefore fail with `unsupported_file_type`, even though their UTF-8 content is valid and Kiro Crew's MCP `file_send` path accepts text based on decoding.

The browser picker independently omits both suffixes, so users cannot select these files through the standard attachment flow.

## Why it matters

XWiki exports and files using the conventional `.text` suffix are ordinary text inputs that agents can safely inspect through the same bounded upload path as `.txt`, `.md`, and `.xml`. Rejecting them forces users to rename files solely to satisfy Kiro Crew, and the duplicated frontend/backend lists make a one-sided fix easy to ship.

## What changed

- Added `.xwiki` and `.text` to the authoritative server-side text-extension allowlist.
- Added both extensions to the browser attachment picker's accept hint.
- Added parameterized multipart-upload regressions proving UTF-8 and Unicode bytes are preserved unchanged.
- Added a cross-language parity test requiring the browser picker text/document set to equal the backend allowlists.
- Kept all binary magic-byte checks and unrelated-extension refusals unchanged.

## Tests

- `python3 -m pytest -q test/test_handlers_files_upload.py test/test_handlers_files_video_upload.py --override-ini='addopts=-q -n auto --dist loadgroup --max-worker-restart=2'` — 26 passed.
- `npm run build` — TypeScript and production Vite build passed.
- Diff-scoped black, subprocess-encoding, comment-history, and brand gates passed.
- Focused flake8 and `git diff --check` passed.

## Manual verification

The multipart endpoint tests submit real `.xwiki` and `.text` form parts containing ASCII and Unicode text, assert HTTP 200, and compare the saved bytes exactly with the input.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** No visual layout or styling changes. The existing native file picker now permits two additional plain-text suffixes, and a still image cannot demonstrate an operating-system file filter.

## Related Issues

Fixes #9993

## Pattern harvest

Rule candidate: test coupling. When a user-facing accept hint mirrors a server-side allowlist across languages, pin equality from one test that reads both sources rather than maintaining two unverified copies.

## Checklist

- [x] One focused Conventional Commits commit
- [x] Existing focused tests pass and regression coverage was added
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation assessed — no user-facing documentation enumerates these upload suffixes
- [x] No secrets, credentials, or internal references in the diff

---

Disclosure: this change was prepared with assistance from Kiro Crew. The submitting human is the author of record and reviewed the diff.