### PR TITLE
docs(skill): slow patrol before the ask, and say who really filters the batch

### DIFF
--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -188,7 +188,7 @@ Each cycle:
    the gap with a search-style command either — list commands exit 0 on empty
    results, so they cannot carry the verdict.
 
-   **A `human_approval` item is verified by asking, and the ask is fragile.** The evaluator answers `pending` for it forever, so put the decision to the user with `ask_question` — then `monitor_update` `interval_secs=1800`, or the largest interval the goal tolerates, until the answer arrives, and restore the interval once it does.
+   **A `human_approval` item is verified by asking, and the ask is fragile.** The evaluator answers `pending` for it forever, so slow patrol FIRST — `monitor_update` `interval_secs=1800`, or the largest interval the goal tolerates — and only then put the decision to the user with `ask_question`, which ends your turn. Restore the interval on the cycle that reads the answer.
 
    If the user says the card is gone, re-issue it. A report that the card vanished is not an answer.
 3. For items still running, `session_read_message` with the `since` cursor you
@@ -361,7 +361,7 @@ watches, and that cost grows with the loop's own history.
   auto-approved for exactly this, so the load never prompts — then repeat the
   call. `chat_folder_create` is on the same server; `monitor_start` is served by
   `kirocrew-core`, so its id is `kirocrew-core::monitor_start`.
-- **A question card can be displaced by your own later turns.** `ask_question` posts a card into the dashboard transcript, and every patrol turn you take while it is outstanding can push it out of the user's view. Slow patrol while a card is open, and treat "the card is gone" as a re-issue rather than an answer.
+- **A question card can be displaced by your own later turns.** `ask_question` posts a card into the dashboard transcript, and every patrol turn you take while it is outstanding can push it out of the user's view.
 - **A cron job may dispatch into the sessions it created**, so a fleet can be
   stood up and driven from a schedule instead of only from a live chat session.
   Session control is on by default: the agent config is the grant, so you do not

--- a/src/kiro_crew/builtin_skills/goal-ledger-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-ledger-conductor/SKILL.md
@@ -197,15 +197,14 @@ Each cycle:
 
    ```bash
    python3 <this skill's dir>/scripts/accept_eval.py <<'ACCEPT_BATCH'
-   <the accept_batch document, with every non-done item's entry removed>
+   <the accept_batch document, with every non-done and every placeholder entry removed>
    ACCEPT_BATCH
    ```
 
    **The filter is yours to apply, and it is not optional.** `accept_batch` is
-   composed from every open item whose acceptance is concrete, whatever its
-   status — it is the two-phase promotion seam, not a verdict gate. Each entry
-   carries that item's `status` beside its condition, and that field is the one
-   you filter on; the server does not filter by it. The evaluator
+   composed from every open item whose `acceptance` is not empty — whatever its
+   status, and whether or not the condition's own values are filled in yet. It is
+   the two-phase promotion seam, not a verdict gate. The evaluator
    answers a world-state question ("does this file exist", "are this PR's checks
    green"), and a worker that is still `progress` can have made that true early:
    a stub written before the real content, a PR that is green before the last
@@ -241,20 +240,20 @@ Each cycle:
    kind); never try to route around a refusal. `error` is a broken spec or
    environment — fix the spec or ask.
 
-   **Two-phase acceptance is a field now, not a manual omission.** A condition may
+   **Two-phase acceptance is a manual omission, not a server filter.** A condition may
    name a value that only exists after the item starts — a PR number for
    `pr_checks` is the common case. Store the condition with the value marked TBD
    at `create`, tell the child in its seed to report the number through
-   `work_report`'s `pr`, and `accept_batch` will leave that item OUT of the batch
-   until the stored `acceptance` is concrete — the item's `acceptance_concrete`
-   flag is what says whether its bar is real yet. **The worker's claimed `pr` is
+   `work_report`'s `pr`, and **drop that item from the batch yourself until you have
+   promoted the real value** — the server does not omit it, and a `pr` that is still
+   `TBD` is an `error` verdict, not `pending`. **The worker's claimed `pr` is
    never read as the bar.** Promote it yourself with `work_ledger_record`
    `action=accept` once you have looked at it, and verify on the next cycle. A
    worker that could fill in its own acceptance could point it at anybody's
    already-green pull request, which is exactly why the claim and the condition
    are separate fields.
 
-   **A `human_approval` item is verified by asking, and the ask is fragile.** The evaluator answers `pending` for it forever, so put the decision to the user with `ask_question` — then `monitor_update` `interval_secs=1800`, or the largest interval the goal tolerates, until the answer arrives, and restore the interval once it does.
+   **A `human_approval` item is verified by asking, and the ask is fragile.** The evaluator answers `pending` for it forever, so slow patrol FIRST — `monitor_update` `interval_secs=1800`, or the largest interval the goal tolerates — and only then put the decision to the user with `ask_question`, which ends your turn. Restore the interval on the cycle that reads the answer.
 
    If the user says the card is gone, re-issue it. A report that the card vanished is not an answer.
 4. `work_ledger_record` `action=close` with the item's `state` when an item is
@@ -398,7 +397,7 @@ what the composer renders:
   arm that instead and the quiet cycles stop costing a turn. Until then, size
   the interval for the report cadence you expect rather than for the latency you
   want.
-- **A question card can be displaced by your own later turns.** `ask_question` posts a card into the dashboard transcript, and every patrol turn you take while it is outstanding can push it out of the user's view. Slow patrol while a card is open, and treat "the card is gone" as a re-issue rather than an answer.
+- **A question card can be displaced by your own later turns.** `ask_question` posts a card into the dashboard transcript, and every patrol turn you take while it is outstanding can push it out of the user's view.
 - **The session and ledger tools may not be in your tool list yet.** With MCP
   Tool Search active their specs are deferred, so a first `session_create` fails
   with `A tool with the name 'session_create' does not exist`. That means


### PR DESCRIPTION
## Problem / Motivation

Five defects in the two conductor skill bodies, all found by review on #9943 and on this PR's first head.

The `human_approval` procedure reads "put the decision to the user with `ask_question` — then `monitor_update` `interval_secs=1800`". `ask_question` ends the conductor's turn, so a conductor following that order never reaches the interval change: it posts the card, the turn ends, and patrol keeps firing every 300 s — the exact displacement the paragraph was added to prevent.

The ledger skill then says three untrue things about `accept_batch`. Two name fields it does not emit — a per-entry `status` and an `acceptance_concrete` flag — so a conductor told to "filter on that item's `status`" hunts for something no install has. The third is older and worse: two sentences claim the batch omits an item whose stored `pr` is still `TBD`. It does not. `accept_batch` keeps every non-terminal item with a non-empty `acceptance`, so the placeholder entry reaches `accept_eval.py` and comes back `error` ("pr_checks spec needs an integer pr") — indistinguishable, to a conductor reading the skill, from a genuinely malformed condition.

Smaller: the new known-limits bullet restated the patrol rule from three sections earlier, and the card-displacement mitigation is prose working around a dashboard defect with nothing tracking the root cause.

## Why it matters

The ordering defect makes the mitigation inert — a conductor does exactly what the skill says and the card still gets buried, which is how an hour went missing in the run that prompted #9943. The `TBD` claim is the one that silently misfires: two-phase acceptance is the normal path for `pr_checks`, so every conductor that trusts it meets an `error` verdict on an item that was merely early, on its first round.

## What changed (motivation → approach → change)

Both `goal-ledger-conductor/SKILL.md` and `goal-conductor/SKILL.md`:

- The `human_approval` rule moves the interval FIRST — `monitor_update` `interval_secs=1800`, or the largest interval the goal tolerates — and only then posts `ask_question`, naming that the call ends the turn. The interval is restored on the cycle that reads the answer. Ordering is the whole fix: the same two calls in the other order cannot both happen in one turn.
- The known-limits bullet keeps the displacement mechanism and drops its "slow patrol… re-issue rather than an answer" tail, which the patrol rule already carries.

`goal-ledger-conductor/SKILL.md` only:

- The batch is now described as what it is: composed from every open item whose `acceptance` is not empty, whatever its status and whether or not the condition's values are filled in yet.
- Two-phase acceptance is stated as the conductor's own omission rather than a server filter, with the consequence named — a `pr` still reading `TBD` is an `error` verdict, not `pending`. Its heading changes from "is a field now, not a manual omission" to "is a manual omission, not a server filter", because the former said the opposite of what the code does.
- The heredoc placeholder and the section heading follow the same correction, so the example and the rule agree.
- The two sentences naming per-entry `status` and `acceptance_concrete` are withdrawn. **The load-bearing rule is untouched** — the conductor still filters the batch to `done` items itself, and still promotes a claimed `pr` with `action=accept` rather than reading it as the bar.

Two root causes are tracked rather than papered over:

- #9997 — pin an unanswered `ask_question` card so it survives later turns. Its done-condition includes deleting the workaround prose this PR shrank, so the mitigation has an exit.
- #10033 — the same false `TBD` claim lives in the ledger-conductor prompt in `agent.py`. Left out of this PR deliberately: a prompt string is read before the skill, so the correction earns its own review rather than riding along on a docs change.

Rulings applied, by span: `094deb6bf199` and `e79227337a44` (gpt) fixed; `737e26e72c14`, `11a9ef7fd3c5`, `7da3077ff69d`, `3b50b82295b9` (first-principles) fixed, three by subtraction; `0cc84a637644` and `e89b429d8d2f` (watch) cleared by that subtraction; `e5fa3aea751e` (design) accepted and deferred to #9997.

## Tests

No new tests. The tests that pin these two bodies are the coverage, and every one of them runs against the edited text: `test/test_ledger_conductor_agent.py`, `test/test_conductor_agent.py`, `test/test_work_ledger.py`, `test/test_work_ledger_tools.py`, `test/test_conductor_ledger_entry.py`, `test/test_builtin_skill_packaging.py`, `test/test_builtin_skill_scope.py`, `test/test_builtin_skill_sync_safety.py`, `test/test_docs_lint_fact_checks.py` — 491 passed.

They are load-bearing here rather than incidental: `test_prompt_and_skill_filter_the_batch_to_done_items` asserts the surviving filter rule by normalized substring, and `test_the_shipped_conductor_skill_is_untouched_by_this_flow` asserts `goal-conductor` stays free of the ledger flow's vocabulary — which the edits to both files had to respect.

## Manual verification

N/A — unit coverage sufficient. The change is prose in two skill bodies with no runtime path. The gate floor that applies to it was run locally, each exit 0 with its `*_BASE_REF` exported to `git merge-base HEAD origin/main`: brand name, harness parity, feature map, builtin-skill scope, changelog history, focus cue, comment history, black formatting, testpaths coverage, loop-bound locks, and `scripts/docs-lint.sh`.

The full backend suite could not run locally: a concurrent run on this host held 31 of the 32 xdist workers. The diff is markdown-only and CI runs the full matrix.

## Related Issues

Follow-up to #9943. Root causes tracked in #9997 and #10033.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a skill sentence describes what a server does on the writer's behalf, and the server does not do it — check any "the batch/store/gate will leave X out" claim against the function that builds it, since the writer's own filter is then missing and the failure surfaces as an unexplained verdict.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
