### PR TITLE
fix: drain pending chunk buffer before steer so segments stay ordered

### DIFF
--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -48,6 +48,7 @@ import FlyingQuote from './FlyingQuote'
 import { revealComposer } from '../pages/chat/composerFocus'
 import { triggerRefresh, updateSlot } from '../store/dashboardSlice'
 import { performSlotSwitch } from '../lib/slotSwitch'
+import { drainPendingChunks } from '../lib/pendingChunkDrain'
 import { performAgentSlotSwitch } from '../lib/agentSwitch'
 import { api } from '../api/client'
 import { resolveAskAfterSend } from '../lib/resolveAskAfterSend'
@@ -881,6 +882,10 @@ export default function ChatPane({
     // channel itself is text-only, but the echo reconciles by merging meta
     // onto this bubble, so the index rides the row from here.
     const steerMeta = { sendId, ...(filePaths.length ? { files: filePaths } : {}) }
+    // Drain the per-frame chunk buffer first, same as ChatPage's steer(): a
+    // pre-steer chunk still pending in useWebSocket's buffer would otherwise
+    // flush BELOW this card (see lib/pendingChunkDrain.ts).
+    drainPendingChunks()
     dispatch(appendSlotMessage({
       slot: slotKey,
       message: { role: 'user', content: txt, cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true, ...steerMeta } },

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -10,6 +10,7 @@ import { dispatchMcNotification, TURN_DONE_KIND, APPROVAL_KIND, shouldChimeOnTur
 import { shouldNotifyOnChatComplete } from './chatCompleteNotify'
 import { emitThemeSound } from './themeSound'
 import { streamingFlushHoldMs } from '../lib/streamHold'
+import { registerPendingChunkDrain } from '../lib/pendingChunkDrain'
 import { VoicePcmPlayer, voiceBoundary, createVoiceRequestId } from '../lib/voicePlayback'
 import { reportVoiceFailure } from '../lib/voiceFailure'
 import {
@@ -807,6 +808,13 @@ export function useWebSocket() {
     }
   }, [dispatch, enqueueVoiceSynthesis, voiceProgressFor])
 
+  // Expose the synchronous flush to steer initiators (ChatPage / ChatPane):
+  // an optimistic steer card dispatched while a chunk is still in this
+  // buffer would land ABOVE text that belongs before it (see
+  // lib/pendingChunkDrain.ts). Identity-guarded unregister, so a StrictMode
+  // double-mount cannot strip the live registration.
+  useEffect(() => registerPendingChunkDrain(flushChunks), [flushChunks])
+
   const scheduleChunkFlush = useCallback(() => {
     if (chunkFlushScheduledRef.current) return
     chunkFlushScheduledRef.current = true
@@ -1560,6 +1568,11 @@ export function useWebSocket() {
             // target slot's transcript. Uses appendSlotMessage so the bubble
             // appears whether or not the slot is currently active (background
             // tabs). Persisted server-side — survives page reload.
+            // Drain the per-frame chunk buffer FIRST: a pre-steer chunk still
+            // pending here means the reducer's finalize-on-steer would find no
+            // streaming row to freeze, so that text would later flush BELOW
+            // this card and post-steer chunks would append to the same row.
+            flushChunks()
             // `sendId` (present when the initiating client minted one) rides
             // into the meta so the reconcile in appendSlotMessage can match the
             // optimistic bubble by id instead of by content (#6075).

--- a/website/src/lib/pendingChunkDrain.ts
+++ b/website/src/lib/pendingChunkDrain.ts
@@ -1,0 +1,32 @@
+/**
+ * Synchronous drain of useWebSocket's pending chunk buffer, reachable from
+ * outside the hook.
+ *
+ * WHY THIS EXISTS. Chat chunks are buffered in `useWebSocket` and flushed to
+ * Redux once per animation frame. A mid-turn steer dispatched inside that
+ * window (between buffer-in and flush-out) finds no streaming row in Redux, so
+ * finalize-on-steer has nothing to freeze: the pre-steer text later flushes
+ * BELOW the steer card and post-steer chunks concatenate onto the same
+ * streaming row. Every steer insertion site drains this buffer first, so the
+ * trailing streaming row exists and is finalized ABOVE the card, and the next
+ * chunk opens a fresh streaming row below it.
+ *
+ * Same module-singleton shape as lib/streamHold.ts: the hook registers its
+ * flush on mount, steer initiators call the drain without needing the hook
+ * instance. With no hook mounted the drain is a no-op -- there is no buffer.
+ */
+
+let drain: (() => void) | null = null
+
+/** Register the hook's synchronous flush. Returns the unregister function
+ *  (identity-guarded, so a stale unmount cannot drop a newer registration). */
+export function registerPendingChunkDrain(fn: () => void): () => void {
+  drain = fn
+  return () => { if (drain === fn) drain = null }
+}
+
+/** Flush any buffered streaming chunks to Redux now. Call BEFORE dispatching a
+ *  steer row, so finalize-on-steer sees the full pre-steer text. */
+export function drainPendingChunks(): void {
+  drain?.()
+}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -56,6 +56,7 @@ import { addTab as addDockTerminal } from '../hooks/useBottomTerminal'
 import { interceptSlashCommand, isInterceptedSlashCommand } from './chat/ChatInput'
 import { sseSlotTitle, triggerRefresh, updateSlot } from '../store/dashboardSlice'
 import { performSlotSwitch } from '../lib/slotSwitch'
+import { drainPendingChunks } from '../lib/pendingChunkDrain'
 import { performAgentSlotSwitch } from '../lib/agentSwitch'
 import { api } from '../api/client'
 import { resolveAskAfterSend } from '../lib/resolveAskAfterSend'
@@ -4787,6 +4788,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // races chat_done falls onto — so the bubble is resolvable by id identity
     // whichever path the server took (#6075).
     const steerSendId = mintSendId()
+    // Drain the per-frame chunk buffer first: a pre-steer chunk still pending
+    // in useWebSocket's buffer means appendMessage's finalize-on-steer finds
+    // no streaming row to freeze, so that text would flush BELOW this card
+    // and post-steer chunks would append to it (see lib/pendingChunkDrain.ts).
+    drainPendingChunks()
     dispatch(appendMessage({ role: 'user', content: llmTxt, cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true, sendId: steerSendId } }))
     steerMutation.mutate({ text: llmTxt, sendId: steerSendId, slot: activeSlot })
     // Staged session references are deliberately NOT part of steering: neither

--- a/website/src/test/useWebSocket.steerPendingChunk.test.ts
+++ b/website/src/test/useWebSocket.steerPendingChunk.test.ts
@@ -1,0 +1,184 @@
+/**
+ * A rapid steer must not merge pre- and post-steer output (#9977).
+ *
+ * Chat chunks are buffered in useWebSocket and flushed once per animation
+ * frame. A steer landing inside that window (chunk buffered, flush frame not
+ * yet run) used to find no streaming row in Redux, so finalize-on-steer froze
+ * nothing: the pre-steer text flushed BELOW the steer card and post-steer
+ * chunks appended to the same streaming row. These tests hand-drive the
+ * animation frames so the chunk is still PENDING IN THE BUFFER -- not already
+ * in Redux, which the existing finalize-on-steer reducer tests cover -- when
+ * the steer arrives, for both insertion sites: the `steer_push` WS handler
+ * (observing tab) and the optimistic dispatch via the drain seam (initiating
+ * tab, ChatPage/ChatPane).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { store as globalStore } from '../store'
+import { setActiveSlot, clearSlotState, appendMessage } from '../store/chatSlice'
+import { drainPendingChunks } from '../lib/pendingChunkDrain'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockReturnValue(new Promise(() => {})),  // never resolves
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+/** Deliberately the SINGLETON store: useWebSocket dispatches via useAppDispatch()
+ *  but reads state off the imported singleton, so a separate Provider store would
+ *  let reads and writes diverge. */
+function seedStore() {
+  globalStore.dispatch(clearSlotState())
+  globalStore.dispatch(setActiveSlot('slot-1'))
+  return globalStore
+}
+
+const chunk = (slot: string, content: string) => ({
+  type: 'chat_chunk',
+  data: { slot, content },
+})
+
+const steerPush = (slot: string, content: string) => ({
+  type: 'steer_push',
+  data: { slot, content },
+})
+
+/** The transcript reduced to (role, content) rows for order assertions. */
+const rows = () =>
+  globalStore.getState().chat.messages
+    .filter(m => m.role === 'assistant' || m.role === 'streaming' || (m.role === 'user' && m.meta?.steer))
+    .map(m => ({ role: m.role, content: m.content }))
+
+describe('useWebSocket: steer with a chunk still pending in the frame buffer (#9977)', () => {
+  let queryClient: QueryClient
+  let rafQueue: FrameRequestCallback[]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    rafQueue = []
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // Hand-driven frames: nothing flushes until runFrames() is called
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { rafQueue.push(cb); return rafQueue.length })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => { rafQueue[id - 1] = () => {} })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    globalStore.dispatch(clearSlotState())
+    globalStore.dispatch(setActiveSlot(null))
+  })
+
+  function runFrames() {
+    const pending = rafQueue
+    rafQueue = []
+    act(() => { pending.forEach(cb => cb(performance.now())) })
+  }
+
+  function mount() {
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store: globalStore },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    }
+    const hook = renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    return { hook, ws }
+  }
+
+  it('steer_push finalizes the pending pre-steer chunk ABOVE the card; post-steer opens a new row', () => {
+    const { ws } = mount()
+    seedStore()
+
+    // Pre-steer chunk arrives and is buffered -- the flush frame has NOT run.
+    act(() => { ws.simulateMessage(chunk('slot-1', 'pre-steer text')) })
+    expect(rows()).toEqual([])  // still in the buffer, not in Redux
+
+    // The steer echo lands inside the buffer window (observing-tab path).
+    act(() => { ws.simulateMessage(steerPush('slot-1', 'steer message')) })
+
+    // Post-steer output resumes; then the deferred frame finally runs.
+    act(() => { ws.simulateMessage(chunk('slot-1', 'post-steer text')) })
+    runFrames()
+
+    expect(rows()).toEqual([
+      { role: 'assistant', content: 'pre-steer text' },   // frozen above the card
+      { role: 'user', content: 'steer message' },
+      { role: 'streaming', content: 'post-steer text' },  // NEW row below the card
+    ])
+  })
+
+  it('the optimistic steer dispatch (initiating tab) drains the buffer via the seam first', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => { ws.simulateMessage(chunk('slot-1', 'pre-steer text')) })
+    expect(rows()).toEqual([])
+
+    // What ChatPage.steer() / ChatPane's steer path do: drain, then dispatch
+    // the optimistic card.
+    act(() => {
+      drainPendingChunks()
+      globalStore.dispatch(appendMessage({ role: 'user', content: 'steer message', cls: 'msg msg-u', ts: 't1', meta: { steer: true, optimistic: true, sendId: 'sid-1' } }))
+    })
+
+    act(() => { ws.simulateMessage(chunk('slot-1', 'post-steer text')) })
+    runFrames()
+
+    expect(rows()).toEqual([
+      { role: 'assistant', content: 'pre-steer text' },
+      { role: 'user', content: 'steer message' },
+      { role: 'streaming', content: 'post-steer text' },
+    ])
+  })
+
+  it('steer_push with an empty buffer still inserts normally', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => { ws.simulateMessage(steerPush('slot-1', 'steer message')) })
+    act(() => { ws.simulateMessage(chunk('slot-1', 'after')) })
+    runFrames()
+
+    expect(rows()).toEqual([
+      { role: 'user', content: 'steer message' },
+      { role: 'streaming', content: 'after' },
+    ])
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Steering a running turn right after assistant text arrived could merge the pre-steer and post-steer output. The pre-steer text rendered BELOW the steer card and the post-steer text was concatenated onto it in the same bubble -- a visible signature is a line-final marker like `[OPTIONS: ...]` followed directly by unrelated text. The transcript should show three ordered rows: the finalized pre-steer segment, the steer card, then a new post-steer segment.

## Why it matters

The merged bubble misattributes output: text the agent produced before the steer reads as a response to it, and machine-parsed line-final markers (`[OPTIONS: ...]`) stop rendering because unrelated text lands on the same row. Any user who steers while the agent is streaming can hit it -- steering mid-stream is the feature's normal use. The backend persists the rows correctly, so the transcript silently fixes itself on reload, which makes the live corruption look random.

## What changed (motivation -> approach -> change)

Chat chunks are buffered in `useWebSocket` and flushed to Redux once per animation frame. A steer landing inside that window found no streaming row in Redux, so the `finalizeTrailingStreaming` freeze in the reducers had nothing to freeze; the buffered text later flushed below the already-inserted steer card, and post-steer chunks appended to that same streaming row.

The fix drains the pending buffer synchronously before every steer insertion. A new module seam, `website/src/lib/pendingChunkDrain.ts` (same singleton shape as `lib/streamHold.ts`), lets steer initiators reach the hook's flush: `useWebSocket` registers `flushChunks` on it, the `steer_push` WS handler calls `flushChunks()` directly before reconciling the echo (observing tab), and the optimistic steer dispatches in `ChatPage.steer()` and `ChatPane`'s steer path call `drainPendingChunks()` first (initiating tab). With the buffer drained, the existing finalize-on-steer logic freezes the pre-steer row above the card and the next chunk opens a fresh streaming row below it.

```mermaid
flowchart LR
  subgraph Before
    A1[chunk buffered]:::ctx --> B1[steer card inserted]:::changed --> C1[buffer flushes BELOW card]:::removed
  end
  subgraph After
    A2[chunk buffered]:::ctx --> B2[drain buffer + freeze row]:::added --> C2[steer card inserted]:::changed --> D2[new row below card]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 0,1 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 2,3,4 stroke:#16A34A,stroke-width:2px
```

Legend: green = added, yellow = changed, red = removed, blue = unchanged.

*Every steer insertion now drains the chunk buffer first, so pre-steer text is frozen above the card and post-steer text opens a new row.*

## Tests

`website/src/test/useWebSocket.steerPendingChunk.test.ts` hand-drives the animation frames so the chunk is still pending in the buffer -- not already in Redux, which the existing finalize-on-steer reducer tests cover -- when the steer arrives:

- `steer_push` with a pending chunk: pre-steer text is finalized above the card, post-steer text opens a new streaming row below it (observing tab).
- The optimistic dispatch via the drain seam produces the same ordering (initiating tab).
- `steer_push` with an empty buffer still inserts normally.

Both regression cases fail without the fix, with the exact merge symptom (pre-steer text below the card, concatenated with post-steer text).

## Manual verification

N/A -- the hook-level tests reproduce the exact race deterministically by controlling the animation-frame flush; there is no rendering change to inspect.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** stream-assembly ordering fix; no component, layout, or style changes -- identical pixels except that mis-ordered text no longer occurs.

## Related Issues

Fixes #9977

## Pattern harvest

Rule candidate: review-prompt
Pattern: a Redux-visible invariant enforced at dispatch time can be defeated by data still pending in a render-frame buffer; every synchronous insertion site must drain the buffer first.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
