### PR TITLE
feat(acp): detect agent-spec @server refs that name nothing

### DIFF
--- a/docs/system-specs/modules/agent-host-contract.md
+++ b/docs/system-specs/modules/agent-host-contract.md
@@ -217,18 +217,23 @@ credentials occupy. An unknown provider defaults to *not* self-sandboxing.
 | Auto-approve bypass | `allowedTools` is the one path that never reaches `hooks.on_tool_call` (`apps/bridges.py`) | KAS `rules` array | see §7 | **none reaches the harness** — no `--agent`, no spec, no session MCP array, and not in `ACP_BACKENDS_SEED_LOCAL_SETTINGS`; `allowedTools` is consumed Crew-side by the gate only. Routing is `SESSION_CONFIG`, so `read-only` is applied through `session/set_config_option` before the first prompt and the session is refused otherwise. The residual that does NOT close: ACP v1 cannot require a prompt for a passive READ, so the sensitive-path block never sees this harness's reads, and §4's OS-boundary mask is the compensating control (`acp_backends.py`) |
 | Tool-name grammar | `@server/tool` split on `/`, so slash-bearing keys are slugged or expose zero tools (`mcp_utils.py`) | — | `mcp__server`; `fs_read`→`Read`, `execute_bash`→`Bash`; `use_aws` has no equivalent and is dropped (companion) | unexercised — no MCP server is ever injected, so no grammar is reached |
 
-**Detected rather than declared, for every provider alike:** `acp/mcp_ref_guard.py`
-compares the spec's `@server` tool refs against the FINAL `mcpServers` array at the
-one point it is composed, and logs one structured warning plus a row on the
-session's MCP report (`unresolved_refs`) when a ref names nothing the session
-receives — the §5 failure this bucket keeps describing, made visible instead of
-re-diagnosed. Satisfaction is per backend: kiro-cli reads the spec itself via
-`--agent`, so its refs resolve against the spec's own `mcpServers`, while a harness
-that reads no agent file is satisfied only by the wire array (a broker stub counts
-on either, since it arrives under the name it wraps). It never alters the array and
-never fails the session. `kirocrew doctor` runs the same function per selectable
-backend, and it reads the mirror seam — so a backend projecting outside
-`providers/mirrors/` (KAS) reads as unprojected there.
+**Detected rather than declared, on every provider `AcpClient` composes for:**
+`agent_sdk/mcp_refs.py` compares the spec's `@server` tool refs against the FINAL
+`mcpServers` array, and `acp/mcp_ref_guard.py` logs one structured warning plus a
+row on the session's MCP report (`unresolved_refs`) at the one point that array is
+composed, when a ref names nothing the session receives — the §5 failure this
+bucket keeps describing, made visible instead of re-diagnosed. Satisfaction is per
+backend: kiro-cli reads the spec itself via `--agent`, so its refs resolve against
+the spec's own `mcpServers`, while a harness that reads no agent file is satisfied
+only by the wire array (a broker stub counts on either, since it arrives under the
+name it wraps). It never alters the array and never fails the session, and it adds
+no `await` to any construction path — the snapshot rides in the `mkdir` hop
+`_spawn` already had (H13). `kirocrew doctor` runs the same resolver per selectable
+backend through `agent_sdk.drivers.acp.agent_spec_mcp_refs`, which reads the mirror
+seam — so a backend projecting outside `providers/mirrors/` (KAS) reads as
+unprojected there. KAS is also the one backend the RUNTIME detector does not reach:
+it composes its array on `AcpRuntime`, not at `AcpClient`'s call sites, so its refs
+are checked statically only.
 
 **A provider must declare:** its injection channel and precedence rule, its
 server shape, its env-expansion semantics, its loader strictness, which field (if

--- a/docs/system-specs/modules/agent-host-contract.md
+++ b/docs/system-specs/modules/agent-host-contract.md
@@ -217,6 +217,19 @@ credentials occupy. An unknown provider defaults to *not* self-sandboxing.
 | Auto-approve bypass | `allowedTools` is the one path that never reaches `hooks.on_tool_call` (`apps/bridges.py`) | KAS `rules` array | see §7 | **none reaches the harness** — no `--agent`, no spec, no session MCP array, and not in `ACP_BACKENDS_SEED_LOCAL_SETTINGS`; `allowedTools` is consumed Crew-side by the gate only. Routing is `SESSION_CONFIG`, so `read-only` is applied through `session/set_config_option` before the first prompt and the session is refused otherwise. The residual that does NOT close: ACP v1 cannot require a prompt for a passive READ, so the sensitive-path block never sees this harness's reads, and §4's OS-boundary mask is the compensating control (`acp_backends.py`) |
 | Tool-name grammar | `@server/tool` split on `/`, so slash-bearing keys are slugged or expose zero tools (`mcp_utils.py`) | — | `mcp__server`; `fs_read`→`Read`, `execute_bash`→`Bash`; `use_aws` has no equivalent and is dropped (companion) | unexercised — no MCP server is ever injected, so no grammar is reached |
 
+**Detected rather than declared, for every provider alike:** `acp/mcp_ref_guard.py`
+compares the spec's `@server` tool refs against the FINAL `mcpServers` array at the
+one point it is composed, and logs one structured warning plus a row on the
+session's MCP report (`unresolved_refs`) when a ref names nothing the session
+receives — the §5 failure this bucket keeps describing, made visible instead of
+re-diagnosed. Satisfaction is per backend: kiro-cli reads the spec itself via
+`--agent`, so its refs resolve against the spec's own `mcpServers`, while a harness
+that reads no agent file is satisfied only by the wire array (a broker stub counts
+on either, since it arrives under the name it wraps). It never alters the array and
+never fails the session. `kirocrew doctor` runs the same function per selectable
+backend, and it reads the mirror seam — so a backend projecting outside
+`providers/mirrors/` (KAS) reads as unprojected there.
+
 **A provider must declare:** its injection channel and precedence rule, its
 server shape, its env-expansion semantics, its loader strictness, which field (if
 any) bypasses the permission callback, and its tool-reference grammar.

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -3741,6 +3741,25 @@ class AcpClient:
             return servers
         return [e for e in servers if e.get("name") != entry["name"]] + [entry]
 
+    def _prepare_spawn_workspace(self) -> None:
+        """Create the session's work dir, then snapshot its spec for the detector.
+
+        Two blocking reads folded into ONE executor hop, and the fold is the
+        point: the mkdir was already awaited here, so carrying the snapshot with
+        it means the unresolved-ref detector adds no suspension point to any
+        backend's construction path -- kiro-cli's included, which is what
+        harness-parity H13 protects. Nothing is deferred or reordered: the mkdir
+        still runs first and still raises, because the spawn genuinely cannot
+        proceed without the directory.
+
+        The snapshot half is best-effort and comes SECOND for that reason. It
+        cannot fail the spawn (see :meth:`_read_mcp_ref_spec`), and it is skipped
+        outright when the mkdir raises -- a session with no work dir has no
+        diagnostic to report.
+        """
+        self._work_dir.mkdir(parents=True, exist_ok=True)
+        self._mcp_ref_spec = self._read_mcp_ref_spec()
+
     def _read_mcp_ref_spec(self) -> dict[str, Any] | None:
         """Snapshot this session's agent spec for the unresolved-ref guard.
 
@@ -3748,7 +3767,7 @@ class AcpClient:
         guard itself then only reads what this left behind.
 
         Best-effort by construction: every failure resolves to ``None``, which
-        makes the guard silent rather than making the spawn fail. That is not
+        makes the detector silent rather than making the spawn fail. That is not
         politeness, it is the H13 constraint spelled out -- this runs on EVERY
         backend's construction path including kiro-cli's, and a diagnostic that
         can fail a session is a worse defect than the one it detects.
@@ -5220,17 +5239,13 @@ class AcpClient:
         select it and this branch spawns it.
         """
         # Off-loop: mkdir is a blocking syscall and the parent dirs may live on
-        # slow storage; the loop must never wait on the kernel here.
-        await asyncio.to_thread(self._work_dir.mkdir, parents=True, exist_ok=True)
-
-        # Snapshot the agent spec for the unresolved-ref guard, here rather than in
-        # any one backend's branch: the guard runs for EVERY harness, because the
-        # defect it detects has already shipped on three of them. It is not adapter
-        # work and so is not the addition H13 forbids -- kiro-cli is the backend the
-        # guard reads most accurately, since its refs resolve against the spec it is
-        # handed. _read_mcp_ref_spec swallows every failure, so this adds no failure
-        # mode to any construction path; a None snapshot only silences the guard.
-        self._mcp_ref_spec = await asyncio.to_thread(self._read_mcp_ref_spec)
+        # slow storage; the loop must never wait on the kernel here. The
+        # unresolved-ref snapshot rides IN this hop rather than in one of its own:
+        # the detector runs for every harness (the defect it catches has shipped on
+        # three), and a second await would be a new suspension point on kiro-cli's
+        # construction path in service of a diagnostic -- so the count of awaits
+        # here is deliberately unchanged (harness-parity H13).
+        await asyncio.to_thread(self._prepare_spawn_workspace)
 
         # Kiro's internal macOS sandbox replaces (rather than nests inside)
         # Kiro Crew's Seatbelt profile. Refuse a delegated agent workspace that

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -74,9 +74,10 @@ from kiro_crew.acp.liveness import (
     _consume_future_exception,
     consult_offloaded,
 )
+from kiro_crew.acp.mcp_ref_guard import warn_unresolved_server_refs
 from kiro_crew.acp.mcp_session_report import McpSessionReport
 from kiro_crew.acp.prompt_blocks import build_prompt_blocks
-from kiro_crew.acp.session_mcp import session_mcp_deny_rules
+from kiro_crew.acp.session_mcp import agent_spec_snapshot, session_mcp_deny_rules
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
     ACP_BACKEND_CODEX,
@@ -3363,6 +3364,14 @@ class AcpClient:
         # (harness-parity H13). None = not resolved yet; cleared on reset so the
         # next spawn re-reads the spec. See _session_mcp_servers.
         self._session_mcp_cache: list[dict[str, Any]] | None = None
+        # This session's agent spec, snapshotted once per spawn for the
+        # unresolved-ref guard alone (see _guard_unresolved_mcp_refs). Held for
+        # the same reason as the array above and read at the same kind of site:
+        # the guard runs where the wire array is composed, which is shared with
+        # kiro-cli, so the read cannot happen there. None = not snapshotted (or
+        # unreadable), which makes the guard a no-op rather than a disk read on
+        # the loop. Cleared on reset so the next spawn re-reads the spec.
+        self._mcp_ref_spec: dict[str, Any] | None = None
         self._session_key = session_key
         # When set, this client emits a per-tool-call SEL audit from the ACP
         # dispatch loop. Used by app/worker-pool clients (e.g. code-review-sage,
@@ -3731,6 +3740,66 @@ class AcpClient:
             )
             return servers
         return [e for e in servers if e.get("name") != entry["name"]] + [entry]
+
+    def _read_mcp_ref_spec(self) -> dict[str, Any] | None:
+        """Snapshot this session's agent spec for the unresolved-ref guard.
+
+        Blocking (reads the spec), so the spawn path runs it off the loop; the
+        guard itself then only reads what this left behind.
+
+        Best-effort by construction: every failure resolves to ``None``, which
+        makes the guard silent rather than making the spawn fail. That is not
+        politeness, it is the H13 constraint spelled out -- this runs on EVERY
+        backend's construction path including kiro-cli's, and a diagnostic that
+        can fail a session is a worse defect than the one it detects.
+        """
+        try:
+            return agent_spec_snapshot(self._agent, work_dir=self._work_dir)
+        except Exception:
+            logger.debug("unresolved-ref guard: agent spec unreadable", exc_info=True)
+            return None
+
+    def _guard_unresolved_mcp_refs(self, wire_servers: Any) -> None:
+        """Warn when the spec's ``@server`` refs name nothing this session gets.
+
+        The one place the answer can be known: *wire_servers* is the FINAL array
+        -- spec projection plus the broker stubs -- so this is the last point
+        before ``session/new`` at which "the spec asked for it" and "the session
+        receives it" can be compared at all.
+
+        Called for every backend, not just the ones with a mirror. The defect it
+        detects has landed on three harnesses already
+        (``providers/mirrors/README.md``), so a check that only ran on the harness
+        someone had already thought about would be the same omission a fourth
+        time. kiro-cli is judged against the spec's own ``mcpServers`` instead of
+        the wire -- it loads them via ``--agent`` -- which the guard resolves from
+        the backend id.
+
+        Synchronous, in-memory and non-raising, in that order of importance: the
+        composition site is shared with kiro-cli, so this adds no scheduling point
+        and no failure mode to that backend's path (harness-parity H13). It also
+        changes NOTHING -- not the array, not the session's fate. A ref naming
+        nothing is a configuration fact, and the complaint about this defect class
+        was that it was invisible, not that it was tolerated.
+        """
+        spec = self._mcp_ref_spec
+        if spec is None:
+            # No snapshot: either the spawn path did not warm one (a client driven
+            # straight into session/new by a test) or the spec was unreadable.
+            # Reading it here would be the disk touch this site must not have.
+            return
+        try:
+            unresolved = warn_unresolved_server_refs(
+                spec,
+                wire_servers,
+                backend=self.backend,
+                agent=self._agent,
+                gateway_enabled=self._mcp_gateway_overlay is not None,
+            )
+            if unresolved:
+                self._mcp_report.record_unresolved_refs(unresolved)
+        except Exception:
+            logger.debug("unresolved-ref guard: evaluation failed", exc_info=True)
 
     def _session_mcp_servers(self) -> list[dict[str, Any]]:
         """MCP server array passed to this session's ``session/new`` / ``session/load``.
@@ -5154,6 +5223,15 @@ class AcpClient:
         # slow storage; the loop must never wait on the kernel here.
         await asyncio.to_thread(self._work_dir.mkdir, parents=True, exist_ok=True)
 
+        # Snapshot the agent spec for the unresolved-ref guard, here rather than in
+        # any one backend's branch: the guard runs for EVERY harness, because the
+        # defect it detects has already shipped on three of them. It is not adapter
+        # work and so is not the addition H13 forbids -- kiro-cli is the backend the
+        # guard reads most accurately, since its refs resolve against the spec it is
+        # handed. _read_mcp_ref_spec swallows every failure, so this adds no failure
+        # mode to any construction path; a None snapshot only silences the guard.
+        self._mcp_ref_spec = await asyncio.to_thread(self._read_mcp_ref_spec)
+
         # Kiro's internal macOS sandbox replaces (rather than nests inside)
         # Kiro Crew's Seatbelt profile. Refuse a delegated agent workspace that
         # can reach the protected named decoder snapshots; otherwise a same-UID
@@ -5979,6 +6057,9 @@ class AcpClient:
         # lets installing or toggling a server take effect on the next session, so
         # a replacement process must not inherit this one's snapshot.
         self._session_mcp_cache = None
+        # Same per-spawn freshness rule as the array above: an edited spec must be
+        # what the next session's guard judges, not this one's.
+        self._mcp_ref_spec = None
         # Save PIDs before clearing state — needed for untracking
         saved_pid = self._pid
         saved_child_pids = self._child_pids
@@ -6122,6 +6203,9 @@ class AcpClient:
         # on disk: the backend starts the spec's own servers too, so the frames
         # that come back are a superset of this list.
         self._begin_session_report(new_params.get("mcpServers"))
+        # AFTER begin_session_report, which clears the report: the guard writes a
+        # row on it, and writing before the clear would erase the finding.
+        self._guard_unresolved_mcp_refs(new_params.get("mcpServers"))
 
         self._last_substitution_model = None
         session_id = await self._send_request(METHOD_SESSION_NEW, new_params)
@@ -6261,6 +6345,9 @@ class AcpClient:
                     else:
                         load_params["_meta"] = {"_kiro.dev/session_file": session_file}
                     self._begin_session_report(load_params.get("mcpServers"))
+                    # A resumed session re-declares its whole MCP surface, so it can
+                    # be short of a referenced server exactly as a fresh one can.
+                    self._guard_unresolved_mcp_refs(load_params.get("mcpServers"))
                     load_id = await self._send_request(METHOD_SESSION_LOAD, load_params)
                     load_resp = await self._wait_for_response(
                         load_id,

--- a/src/kiro_crew/acp/mcp_ref_guard.py
+++ b/src/kiro_crew/acp/mcp_ref_guard.py
@@ -1,163 +1,83 @@
-"""Agent-spec ``@server`` tool refs that name nothing the session will have.
+"""The ACP layer's reporting half of the unresolved-``@server``-ref detector.
 
-One defect class has shipped three times, on three different harnesses, and each
-time it was diagnosed from scratch by someone who did not know it had happened
-before. `providers/mirrors/README.md` names the shape: a session comes up holding
-``tools: ["@kirocrew-core", ...]`` while nothing in its effective ``mcpServers``
-defines ``kirocrew-core`` -- refs naming nothing, every Crew tool silently absent,
-the harness otherwise working and no error anywhere. KAS hit it, then
-claude-agent-acp, then codex, which is in that state on a plain build today
-(``AcpClient._codex_session_mcp_servers`` returns ``[]``).
+The question itself -- which of a spec's ``@server`` refs name nothing a session
+receives -- is provider-neutral plain data and lives in
+:mod:`kiro_crew.agent_sdk.mcp_refs`, which is what lets ``kirocrew doctor`` ask it
+without importing this layer. What lives HERE is the part that is genuinely ACP's:
+turning that answer into one structured log line at the point where a session's
+wire array becomes final.
 
-A mirror is the FIX for one backend. This module is the DETECTOR for all of them,
-so the fourth occurrence cannot be silent: it compares what the spec asks for
-against what the session is actually about to be handed, and the answer is a log
-line plus a row on the session's MCP report.
-
-**It never changes the array and never fails the session.** A ref naming nothing
-is a configuration fact, not a reason to deny someone their session -- and the
-whole complaint about this defect class was that it was invisible, not that it was
-tolerated. Visible and survivable is the fix.
-
-**Who satisfies a ref depends on the backend, and there are exactly two answers.**
-kiro-cli is handed ``--agent`` and reads the spec itself, so for it a ref is
-satisfied by the spec's OWN ``mcpServers`` definition -- Crew passes that backend
-an empty array by design, and reading its refs against the wire would report every
-single one as unresolved. Every other harness reads no agent file, so the wire
-array is the whole MCP surface of the session and the only thing that can satisfy a
-ref. A session-injected broker stub satisfies a ref on either backend, because it
-arrives on the wire under the same name as the entry it wraps.
-
-**Two ref spellings are not server refs and must not be reported.** A bare tool
-name (``fs_read``, ``execute_bash``) carries no ``@`` and names a built-in.
-``@builtin`` carries one but addresses kiro's built-in namespace rather than a
-server (kiro's own configuration reference documents it beside ``@server``), so
-reporting it would put a permanent false warning on every spec that uses it.
-``*`` grants every server that IS defined; it defines none, so it neither
-satisfies nor produces a ref.
-
-Its answer is advisory, which decides one detail deliberately: the wire roster is
-read through :func:`~kiro_crew.acp.mcp_session_report.roster_names`, the same
-reader the session report renders from. Judging against a different reading of the
-same array is how the dashboard ends up warning that a server is missing while
-listing it as present two rows down.
+Kept as its own module rather than inlined at the call site so ``session/new`` and
+the ``session/load`` that resumes the same session cannot drift into wording the
+finding differently.
 """
 
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from typing import Any
 
-from kiro_crew.acp.mcp_session_report import roster_names
-from kiro_crew.agent_sdk.backends import ACP_BACKEND_KIRO
+from kiro_crew.acp.mcp_session_report import NAME_CAP, sanitize_sink_text
+from kiro_crew.agent_sdk.mcp_refs import unresolved_server_refs
 
 logger = logging.getLogger(__name__)
 
-#: The ``tools`` entry that grants every DEFINED MCP server. It defines none, so
-#: it is neither a ref nor a satisfier here. Only the bare ``*``: this repo's own
-#: readers parse ``@*`` as a server LITERALLY named ``*`` (see
-#: ``connections.tool_aliases._parse_tool_refs`` and
-#: ``kas_permissions._mcp_pattern``), and a ref to a server named ``*`` resolves
-#: to nothing, which is the truth.
-_GRANT_ALL = "*"
-
-#: Marks an MCP server (or one of its tools) in a ``tools`` entry.
-_MCP_PREFIX = "@"
-
-#: ``@`` names that address a kiro namespace rather than an MCP server. kiro's
-#: configuration reference lists ``@builtin`` ("all built-in only") alongside
-#: ``@server`` and ``@server/tool``, so a spec written to that reference is
-#: correct and must not be warned about.
-RESERVED_TOOL_NAMESPACES = frozenset({"builtin"})
-
 #: Cap on how many refs one warning names. A spec is hand-editable and its
-#: ``tools`` list is unbounded; a log line and a dashboard payload are not.
+#: ``tools`` list is unbounded; a log line is not. The true count still rides
+#: along, so a truncated line never understates the problem.
 _REPORT_CAP = 32
 
+#: The characters a ref or an agent name may contribute to the LOG line, plus the
+#: two brackets a redaction tag needs to stay readable. Deliberately WITHOUT ``:``
+#: and ``/``: a URL needs both, so leaving them out means a ref cannot smuggle an
+#: endpoint into the record even if it somehow slipped the redactors.
+_LOG_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@._-[] "
 
-def parse_tools_refs(tools: Any) -> tuple[bool, list[str]]:
-    """Split a spec ``tools`` list into ``(grants_every_server, server names)``.
+#: Longest single ref or agent name the log line spells out. A server name is an
+#: identifier and short by convention; the cap stops one pathological name from
+#: dominating the record.
+_LOG_TOKEN_MAX = 96
 
-    The ONE reader of the ``tools`` ref vocabulary for MCP-server questions, so
-    ``session_mcp._tools_grant`` and this module cannot drift into disagreeing
-    about what an entry names. Names keep first-seen order and are de-duplicated,
-    which makes a derived warning stable across two sessions on one spec.
 
-    ``@server`` and ``@server/tool`` both name ``server``: whether the spec grants
-    a whole server or one of its tools, the server has to exist either way.
-    Entries that name no server -- a bare tool name, ``@`` alone, ``@/tool`` --
-    are skipped rather than reported, and ``@builtin`` is left IN: exclusions
-    belong to the caller asking the question, and a server genuinely called
-    ``builtin`` must still be mountable (see :func:`unresolved_server_refs`).
+def _log_safe(text: str) -> str:
+    """A ref or agent name rebuilt from :data:`_LOG_ALPHABET`, for the log line only.
 
-    Never raises. The spec is hand-editable JSON, so a non-list ``tools`` or a
-    non-string entry is ordinary input here, not an error.
+    **Two jobs, and the second is why a redactor alone was not enough.** The first
+    is hardening: dropping every character outside the alphabet means the record
+    cannot carry URL punctuation whatever the spec put in the name.
+
+    The second is that the result must not be a string DERIVED from the input.
+    ``py/clear-text-logging-sensitive-data`` follows the spec-derived dataflow into
+    this warning's sink, and it does not model
+    :func:`~kiro_crew.acp.mcp_session_report.sanitize_sink_text` as a barrier -- so
+    the query reports at high severity even though the redaction is right there.
+    Code scanning does not honour a per-line ``lgtm`` suppression, so the barrier
+    has to be one the analysis can see, and this repository's own answer to exactly
+    this problem is to return characters the module itself owns: see ``_locus``
+    and ``_metric_slug``
+    in ``apps/builtins/auto_improvement/spine/keeper.py`` ("append the ALPHABET's
+    own character object, not the input's"), and the constant tables in
+    ``name_grant``. That severs the flow in a way the analysis can verify, where a
+    check-then-pass-through cannot.
+
+    Runs AFTER the redactors, never instead of them: a credential-shaped name can
+    be pure alphanumerics (``AKIAIOSFODNN7EXAMPLE``), which this alphabet would
+    pass through untouched. Redaction is what removes the secret; this is what
+    removes the punctuation and the dataflow.
+
+    Two refs differing only in dropped characters log identically. Accepted: the
+    log line is a diagnostic pointer, and the session's MCP report carries the
+    sanitized names for a reader who needs to tell two apart.
     """
-    grant_all = False
-    names: list[str] = []
-    for item in tools if isinstance(tools, (list, tuple)) else ():
-        if not isinstance(item, str):
-            continue
-        if item == _GRANT_ALL:
-            grant_all = True
-            continue
-        if not item.startswith(_MCP_PREFIX):
-            continue
-        server = item[len(_MCP_PREFIX) :].partition("/")[0]
-        if server and server not in names:
-            names.append(server)
-    return grant_all, names
-
-
-def _spec_server_names(spec: Any) -> set[str]:
-    """Server names an agent spec DEFINES, whatever the projection later does."""
-    servers = spec.get("mcpServers") if isinstance(spec, Mapping) else None
-    if not isinstance(servers, Mapping):
-        return set()
-    return {str(name) for name in servers}
-
-
-def unresolved_server_refs(
-    spec: Any,
-    wire_servers: Any,
-    *,
-    backend: str,
-) -> list[str]:
-    """The spec's ``@server`` refs that no server this session gets can satisfy.
-
-    *spec* is the agent spec as read from disk (``tools``, ``mcpServers``, and
-    the per-entry ``disabledTools`` inside them); *wire_servers* is the FINAL
-    ``mcpServers`` array about to go out on ``session/new`` / ``session/load``,
-    spec projection and broker stubs together; *backend* is the id the session
-    runs on.
-
-    Returned in the ``@name`` spelling the spec used, sorted, so two readings of
-    one spec produce the same line. Empty is the healthy answer.
-
-    ``disabledTools`` deliberately changes nothing here, and saying so is the
-    point: it turns individual TOOLS off within a server that is still mounted,
-    so it can narrow what a satisfied ref delivers but can never be what makes a
-    ref name nothing. A server whose every tool is disabled is a separate
-    question this function does not claim to answer.
-
-    Never raises: a malformed spec or a wire array of an unexpected shape yields
-    no finding rather than an exception on a session-establishment path.
-    """
-    _grant_all, refs = parse_tools_refs(spec.get("tools") if isinstance(spec, Mapping) else None)
-    if not refs:
-        return []
-    satisfied = set(roster_names(wire_servers))
-    if backend == ACP_BACKEND_KIRO:
-        # kiro-cli resolves --agent and loads the spec's own servers, which is why
-        # Crew passes it an empty array. Judging its refs against the wire alone
-        # would report every ref on the healthiest install there is.
-        satisfied |= _spec_server_names(spec)
-    return sorted(
-        f"{_MCP_PREFIX}{name}"
-        for name in refs
-        if name not in satisfied and name not in RESERVED_TOOL_NAMESPACES
-    )
+    out: list[str] = []
+    for ch in text[: _LOG_TOKEN_MAX * 2]:
+        idx = _LOG_ALPHABET.find(ch)
+        if idx >= 0:
+            # The ALPHABET's own character object, not the input's.
+            out.append(_LOG_ALPHABET[idx])
+        if len(out) >= _LOG_TOKEN_MAX:
+            break
+    return "".join(out) or "?"
 
 
 def warn_unresolved_server_refs(
@@ -168,22 +88,44 @@ def warn_unresolved_server_refs(
     agent: str,
     gateway_enabled: bool,
 ) -> list[str]:
-    """Evaluate the guard and log ONE structured line when it finds something.
+    """Evaluate the detector and log ONE structured line when it finds something.
 
-    Returns the refs so a caller can also record them where a user will see them;
-    logging here rather than at the call site is what keeps the wording identical
-    across ``session/new`` and the ``session/load`` that resumes the same session.
+    Returns the refs -- SANITIZED -- so a caller can also record them where a user
+    will see them.
 
-    ``gateway_enabled`` rides along because it decides the remedy rather than the
+    **A ref is untrusted text, and this is the boundary where it becomes a sink
+    payload.** It is the substring of a ``tools`` entry after ``@``, so its content
+    is whatever an operator, a cloned repository's ``<project>/.kiro/agents/*.json``
+    or an installed app's registered spec put there -- and this warning fires in
+    NORMAL operation (codex today), not in some contrived case. So every ref is run
+    through the package's one sanitizer before it reaches any sink: credentials and
+    exfiltration URLs are redacted, control characters are dropped so a ref cannot
+    forge a second log line, and the length is bounded so one pathological name
+    cannot dominate the record. Sanitizing here rather than at each sink is what
+    makes the RETURN value safe as well, so the next consumer to log it inherits
+    the redaction instead of re-opening the hole. The LOG line then adds
+    :func:`_log_safe` on top -- a rebuild from this module's own alphabet, which
+    both drops URL punctuation and severs the dataflow a taint query follows.
+
+    ``gateway_enabled`` rides along because it decides the REMEDY rather than the
     finding: with the shared MCP gateway on, a wrapped server arrives as a broker
-    stub and the fix may be to route it, while with the gateway off the only
-    channel is the projection. Reading the log line without knowing which world it
+    stub and routing it may be the fix, while with the gateway off the only
+    channel is the projection. Reading the line without knowing which world it
     came from is what made this defect take three diagnoses.
     """
-    unresolved = unresolved_server_refs(spec, wire_servers, backend=backend)
+    raw = unresolved_server_refs(spec, wire_servers, backend=backend)
+    if not raw:
+        return []
+    unresolved = [safe for safe in (sanitize_sink_text(ref, NAME_CAP) for ref in raw) if safe]
     if not unresolved:
         return []
     shown = unresolved[:_REPORT_CAP]
+    # Redacted already (above); rebuilt here so the log line carries characters this
+    # module owns rather than a string derived from the spec. See :func:`_log_safe`.
+    listed = ", ".join(_log_safe(ref) for ref in shown)
+    if len(shown) < len(unresolved):
+        listed += f" (+{len(unresolved) - len(shown)} more)"
+    safe_agent = _log_safe(sanitize_sink_text(agent, NAME_CAP))
     logger.warning(
         "agent-spec tool refs name no MCP server this session receives: "
         "backend=%r agent=%r unresolved=%s mcp_gateway=%s. Those tools are absent "
@@ -192,9 +134,8 @@ def warn_unresolved_server_refs(
         "(src/kiro_crew/providers/mirrors/) to project the spec onto its "
         "session/new mcpServers array.",
         backend,
-        agent,
-        ", ".join(shown)
-        + (f" (+{len(unresolved) - len(shown)} more)" if len(shown) < len(unresolved) else ""),
+        safe_agent,
+        listed,
         "on" if gateway_enabled else "off",
     )
     return unresolved

--- a/src/kiro_crew/acp/mcp_ref_guard.py
+++ b/src/kiro_crew/acp/mcp_ref_guard.py
@@ -1,0 +1,200 @@
+"""Agent-spec ``@server`` tool refs that name nothing the session will have.
+
+One defect class has shipped three times, on three different harnesses, and each
+time it was diagnosed from scratch by someone who did not know it had happened
+before. `providers/mirrors/README.md` names the shape: a session comes up holding
+``tools: ["@kirocrew-core", ...]`` while nothing in its effective ``mcpServers``
+defines ``kirocrew-core`` -- refs naming nothing, every Crew tool silently absent,
+the harness otherwise working and no error anywhere. KAS hit it, then
+claude-agent-acp, then codex, which is in that state on a plain build today
+(``AcpClient._codex_session_mcp_servers`` returns ``[]``).
+
+A mirror is the FIX for one backend. This module is the DETECTOR for all of them,
+so the fourth occurrence cannot be silent: it compares what the spec asks for
+against what the session is actually about to be handed, and the answer is a log
+line plus a row on the session's MCP report.
+
+**It never changes the array and never fails the session.** A ref naming nothing
+is a configuration fact, not a reason to deny someone their session -- and the
+whole complaint about this defect class was that it was invisible, not that it was
+tolerated. Visible and survivable is the fix.
+
+**Who satisfies a ref depends on the backend, and there are exactly two answers.**
+kiro-cli is handed ``--agent`` and reads the spec itself, so for it a ref is
+satisfied by the spec's OWN ``mcpServers`` definition -- Crew passes that backend
+an empty array by design, and reading its refs against the wire would report every
+single one as unresolved. Every other harness reads no agent file, so the wire
+array is the whole MCP surface of the session and the only thing that can satisfy a
+ref. A session-injected broker stub satisfies a ref on either backend, because it
+arrives on the wire under the same name as the entry it wraps.
+
+**Two ref spellings are not server refs and must not be reported.** A bare tool
+name (``fs_read``, ``execute_bash``) carries no ``@`` and names a built-in.
+``@builtin`` carries one but addresses kiro's built-in namespace rather than a
+server (kiro's own configuration reference documents it beside ``@server``), so
+reporting it would put a permanent false warning on every spec that uses it.
+``*`` grants every server that IS defined; it defines none, so it neither
+satisfies nor produces a ref.
+
+Its answer is advisory, which decides one detail deliberately: the wire roster is
+read through :func:`~kiro_crew.acp.mcp_session_report.roster_names`, the same
+reader the session report renders from. Judging against a different reading of the
+same array is how the dashboard ends up warning that a server is missing while
+listing it as present two rows down.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from kiro_crew.acp.mcp_session_report import roster_names
+from kiro_crew.agent_sdk.backends import ACP_BACKEND_KIRO
+
+logger = logging.getLogger(__name__)
+
+#: The ``tools`` entry that grants every DEFINED MCP server. It defines none, so
+#: it is neither a ref nor a satisfier here. Only the bare ``*``: this repo's own
+#: readers parse ``@*`` as a server LITERALLY named ``*`` (see
+#: ``connections.tool_aliases._parse_tool_refs`` and
+#: ``kas_permissions._mcp_pattern``), and a ref to a server named ``*`` resolves
+#: to nothing, which is the truth.
+_GRANT_ALL = "*"
+
+#: Marks an MCP server (or one of its tools) in a ``tools`` entry.
+_MCP_PREFIX = "@"
+
+#: ``@`` names that address a kiro namespace rather than an MCP server. kiro's
+#: configuration reference lists ``@builtin`` ("all built-in only") alongside
+#: ``@server`` and ``@server/tool``, so a spec written to that reference is
+#: correct and must not be warned about.
+RESERVED_TOOL_NAMESPACES = frozenset({"builtin"})
+
+#: Cap on how many refs one warning names. A spec is hand-editable and its
+#: ``tools`` list is unbounded; a log line and a dashboard payload are not.
+_REPORT_CAP = 32
+
+
+def parse_tools_refs(tools: Any) -> tuple[bool, list[str]]:
+    """Split a spec ``tools`` list into ``(grants_every_server, server names)``.
+
+    The ONE reader of the ``tools`` ref vocabulary for MCP-server questions, so
+    ``session_mcp._tools_grant`` and this module cannot drift into disagreeing
+    about what an entry names. Names keep first-seen order and are de-duplicated,
+    which makes a derived warning stable across two sessions on one spec.
+
+    ``@server`` and ``@server/tool`` both name ``server``: whether the spec grants
+    a whole server or one of its tools, the server has to exist either way.
+    Entries that name no server -- a bare tool name, ``@`` alone, ``@/tool`` --
+    are skipped rather than reported, and ``@builtin`` is left IN: exclusions
+    belong to the caller asking the question, and a server genuinely called
+    ``builtin`` must still be mountable (see :func:`unresolved_server_refs`).
+
+    Never raises. The spec is hand-editable JSON, so a non-list ``tools`` or a
+    non-string entry is ordinary input here, not an error.
+    """
+    grant_all = False
+    names: list[str] = []
+    for item in tools if isinstance(tools, (list, tuple)) else ():
+        if not isinstance(item, str):
+            continue
+        if item == _GRANT_ALL:
+            grant_all = True
+            continue
+        if not item.startswith(_MCP_PREFIX):
+            continue
+        server = item[len(_MCP_PREFIX) :].partition("/")[0]
+        if server and server not in names:
+            names.append(server)
+    return grant_all, names
+
+
+def _spec_server_names(spec: Any) -> set[str]:
+    """Server names an agent spec DEFINES, whatever the projection later does."""
+    servers = spec.get("mcpServers") if isinstance(spec, Mapping) else None
+    if not isinstance(servers, Mapping):
+        return set()
+    return {str(name) for name in servers}
+
+
+def unresolved_server_refs(
+    spec: Any,
+    wire_servers: Any,
+    *,
+    backend: str,
+) -> list[str]:
+    """The spec's ``@server`` refs that no server this session gets can satisfy.
+
+    *spec* is the agent spec as read from disk (``tools``, ``mcpServers``, and
+    the per-entry ``disabledTools`` inside them); *wire_servers* is the FINAL
+    ``mcpServers`` array about to go out on ``session/new`` / ``session/load``,
+    spec projection and broker stubs together; *backend* is the id the session
+    runs on.
+
+    Returned in the ``@name`` spelling the spec used, sorted, so two readings of
+    one spec produce the same line. Empty is the healthy answer.
+
+    ``disabledTools`` deliberately changes nothing here, and saying so is the
+    point: it turns individual TOOLS off within a server that is still mounted,
+    so it can narrow what a satisfied ref delivers but can never be what makes a
+    ref name nothing. A server whose every tool is disabled is a separate
+    question this function does not claim to answer.
+
+    Never raises: a malformed spec or a wire array of an unexpected shape yields
+    no finding rather than an exception on a session-establishment path.
+    """
+    _grant_all, refs = parse_tools_refs(spec.get("tools") if isinstance(spec, Mapping) else None)
+    if not refs:
+        return []
+    satisfied = set(roster_names(wire_servers))
+    if backend == ACP_BACKEND_KIRO:
+        # kiro-cli resolves --agent and loads the spec's own servers, which is why
+        # Crew passes it an empty array. Judging its refs against the wire alone
+        # would report every ref on the healthiest install there is.
+        satisfied |= _spec_server_names(spec)
+    return sorted(
+        f"{_MCP_PREFIX}{name}"
+        for name in refs
+        if name not in satisfied and name not in RESERVED_TOOL_NAMESPACES
+    )
+
+
+def warn_unresolved_server_refs(
+    spec: Any,
+    wire_servers: Any,
+    *,
+    backend: str,
+    agent: str,
+    gateway_enabled: bool,
+) -> list[str]:
+    """Evaluate the guard and log ONE structured line when it finds something.
+
+    Returns the refs so a caller can also record them where a user will see them;
+    logging here rather than at the call site is what keeps the wording identical
+    across ``session/new`` and the ``session/load`` that resumes the same session.
+
+    ``gateway_enabled`` rides along because it decides the remedy rather than the
+    finding: with the shared MCP gateway on, a wrapped server arrives as a broker
+    stub and the fix may be to route it, while with the gateway off the only
+    channel is the projection. Reading the log line without knowing which world it
+    came from is what made this defect take three diagnoses.
+    """
+    unresolved = unresolved_server_refs(spec, wire_servers, backend=backend)
+    if not unresolved:
+        return []
+    shown = unresolved[:_REPORT_CAP]
+    logger.warning(
+        "agent-spec tool refs name no MCP server this session receives: "
+        "backend=%r agent=%r unresolved=%s mcp_gateway=%s. Those tools are absent "
+        "from the session with nothing else to say so -- the harness still works. "
+        "A backend that reads no agent file needs a mirror "
+        "(src/kiro_crew/providers/mirrors/) to project the spec onto its "
+        "session/new mcpServers array.",
+        backend,
+        agent,
+        ", ".join(shown)
+        + (f" (+{len(unresolved) - len(shown)} more)" if len(shown) < len(unresolved) else ""),
+        "on" if gateway_enabled else "off",
+    )
+    return unresolved

--- a/src/kiro_crew/acp/mcp_session_report.py
+++ b/src/kiro_crew/acp/mcp_session_report.py
@@ -60,6 +60,9 @@ from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 # nothing and its row reads "no report" for a server that did report. The bound
 # only has to stop a pathological name, so it sits well above any real one.
 _NAME_CAP = 128
+# Shared with the unresolved-ref guard, whose refs are config-derived in exactly
+# the same way and reach the same three sinks.
+NAME_CAP = _NAME_CAP
 # A failure text comes from the failing server's own startup and can carry a
 # connection string. It is redacted first; this bounds what survives.
 _ERROR_CAP = 240
@@ -85,13 +88,19 @@ _EVENT_ACTIONS = {
 }
 
 
-def _clean(text: str, cap: int) -> str:
+def sanitize_sink_text(text: str, cap: int) -> str:
     """Redact, collapse whitespace, drop control characters, then truncate.
 
     Order matters: redaction runs first so a credential cannot be split across
     the truncation boundary and survive, and the control strip runs after the
     whitespace collapse so a redaction marker cannot reintroduce a line break
     into a log line or a payload.
+
+    Public because it is the ONE cleaner for every config-derived string this
+    package pushes at a sink -- a server name, a startup failure, an unresolved
+    tool ref. :mod:`kiro_crew.acp.mcp_ref_guard` shares it rather than repeating
+    the order above: two sanitizers with the same job are two that can drift, and
+    the one that drifts is the one that stops redacting.
     """
     scrubbed, _ = redact_exfiltration_urls(text)
     scrubbed, _ = redact_credentials(scrubbed)
@@ -106,7 +115,7 @@ def server_name_of(msg: JsonRpcMessage) -> str:
     """
     params = msg.params if isinstance(msg.params, dict) else {}
     raw = params.get("serverName") or params.get("name") or ""
-    return _clean(str(raw), _NAME_CAP)
+    return sanitize_sink_text(str(raw), _NAME_CAP)
 
 
 def roster_names(servers: Any) -> tuple[str, ...]:
@@ -120,7 +129,7 @@ def roster_names(servers: Any) -> tuple[str, ...]:
     for entry in servers if isinstance(servers, list) else []:
         if not isinstance(entry, dict):
             continue
-        name = _clean(str(entry.get("name") or ""), _NAME_CAP)
+        name = sanitize_sink_text(str(entry.get("name") or ""), _NAME_CAP)
         if name and name not in out:
             out.append(name)
     return tuple(out[:_BUCKET_CAP])
@@ -193,7 +202,7 @@ class McpSessionReport:
         for raw in refs if isinstance(refs, (list, tuple)) else ():
             if not isinstance(raw, str):
                 continue
-            ref = _clean(raw, _NAME_CAP)
+            ref = sanitize_sink_text(raw, _NAME_CAP)
             if ref and ref not in seen:
                 seen.append(ref)
         self.unresolved_refs = tuple(seen[:_BUCKET_CAP])
@@ -231,7 +240,7 @@ class McpSessionReport:
         error = ""
         if action == _ACTION_INIT_FAILURE:
             params = msg.params if isinstance(msg.params, dict) else {}
-            error = _clean(str(params.get("error") or ""), _ERROR_CAP)
+            error = sanitize_sink_text(str(params.get("error") or ""), _ERROR_CAP)
         return self._record(action, name, error)
 
     def record_event(
@@ -264,10 +273,10 @@ class McpSessionReport:
             # call site so both ownership rules live together — the event path
             # missing the rule the frame path had is exactly the bug this closes.
             return False
-        name = _clean(str(server_name or ""), _NAME_CAP)
+        name = sanitize_sink_text(str(server_name or ""), _NAME_CAP)
         if not name:
             return False
-        return self._record(action, name, _clean(str(error or ""), _ERROR_CAP))
+        return self._record(action, name, sanitize_sink_text(str(error or ""), _ERROR_CAP))
 
     def _record(self, action: str, name: str, error: str = "") -> bool:
         """Move ``name`` into the bucket ``action`` implies, evicting the others."""

--- a/src/kiro_crew/acp/mcp_session_report.py
+++ b/src/kiro_crew/acp/mcp_session_report.py
@@ -138,6 +138,13 @@ class McpSessionReport:
     #: Empty means Kiro Crew injected none — NOT that the session has none, since
     #: the backend also starts the agent spec's own servers.
     configured: tuple[str, ...] = ()
+    #: Agent-spec ``@server`` refs that named no server this session receives, as
+    #: :mod:`kiro_crew.acp.mcp_ref_guard` found them. A DIFFERENT claim from every
+    #: bucket below, and the difference is what makes it worth a slot: those say
+    #: what a configured server reported, this says the spec asked for a server
+    #: nothing configured -- so there is no row for it to be missing FROM, which
+    #: is exactly why the defect was invisible three times.
+    unresolved_refs: tuple[str, ...] = ()
     _ready: list[str] = field(default_factory=list)
     _failed: list[str] = field(default_factory=list)
     _awaiting_auth: list[str] = field(default_factory=list)
@@ -161,11 +168,35 @@ class McpSessionReport:
         not at any one of them.
         """
         self.configured = roster_names(servers)
+        self.unresolved_refs = ()
         self._started = True
         self._ready.clear()
         self._failed.clear()
         self._awaiting_auth.clear()
         self._failures.clear()
+
+    def record_unresolved_refs(self, refs: Any) -> None:
+        """Record the spec refs that named no server this session receives.
+
+        Sanitized and capped on the same terms as a server name: a ref is
+        config-derived, so an installed app chooses the text, and it reaches a log
+        line, a JSON payload and a DOM node. Set rather than accumulated -- the
+        guard evaluates the whole spec against the whole wire array in one pass,
+        so a second call is a re-evaluation of the same question and replaces the
+        answer instead of appending to it.
+
+        Only strings are taken. The guard emits nothing else, and stringifying a
+        non-string would put a row reading ``None`` or ``7`` in front of a user as
+        though the spec had asked for a server by that name.
+        """
+        seen: list[str] = []
+        for raw in refs if isinstance(refs, (list, tuple)) else ():
+            if not isinstance(raw, str):
+                continue
+            ref = _clean(raw, _NAME_CAP)
+            if ref and ref not in seen:
+                seen.append(ref)
+        self.unresolved_refs = tuple(seen[:_BUCKET_CAP])
 
     def record_frame(self, msg: JsonRpcMessage, *, owned: bool) -> bool:
         """Fold one notification in. Returns True when the report changed.
@@ -296,7 +327,13 @@ class McpSessionReport:
     @property
     def empty(self) -> bool:
         """True when nothing has been recorded and no roster was sent."""
-        return not (self.configured or self._ready or self._failed or self._awaiting_auth)
+        return not (
+            self.configured
+            or self.unresolved_refs
+            or self._ready
+            or self._failed
+            or self._awaiting_auth
+        )
 
     def payload(self) -> dict[str, Any] | None:
         """The serialized report, or ``None`` when no session has begun.
@@ -318,6 +355,7 @@ class McpSessionReport:
             return None
         return {
             "configured": list(self.configured),
+            "unresolved_refs": list(self.unresolved_refs),
             "ready": list(self._ready),
             "failed": list(self._failed),
             "awaiting_auth": list(self._awaiting_auth),

--- a/src/kiro_crew/acp/session_mcp.py
+++ b/src/kiro_crew/acp/session_mcp.py
@@ -74,7 +74,6 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
-from kiro_crew.acp.mcp_ref_guard import parse_tools_refs
 from kiro_crew.agent import (
     _mcp_registry_mode,
     agent_spec_path,
@@ -82,6 +81,7 @@ from kiro_crew.agent import (
     managed_mcp_spec_entry,
 )
 from kiro_crew.agent_discovery import _read_agent_spec, project_agent_files, project_agent_name
+from kiro_crew.agent_sdk.mcp_refs import parse_tools_refs
 
 logger = logging.getLogger(__name__)
 
@@ -173,9 +173,9 @@ def _tools_grant(tools: list[Any], name: str) -> bool:
     grant uses, and what a narrowed-by-hand spec looks like) would come alive the
     moment the session happened to run on claude.
 
-    Reads the refs through :func:`~kiro_crew.acp.mcp_ref_guard.parse_tools_refs`
+    Reads the refs through :func:`~kiro_crew.agent_sdk.mcp_refs.parse_tools_refs`
     rather than scanning the list here, so this module and the unresolved-ref
-    guard cannot disagree about what an entry names -- a guard that read ``@srv``
+    detector cannot disagree about what an entry names -- a guard that read ``@srv``
     where this read nothing would report a ref as unresolved while the server
     mounted, and the reverse would mount a server the guard called absent. Only
     the bare ``*`` grants everything: ``@*`` is a server LITERALLY named ``*``
@@ -262,11 +262,13 @@ def agent_spec_snapshot(
 ) -> dict[str, Any] | None:
     """The spec for *agent* exactly as this module's own translation reads it.
 
-    Exported for :mod:`kiro_crew.acp.mcp_ref_guard`, which has to judge the spec's
-    ``tools`` refs against the array the session receives. Reading the file itself
-    there would give it a SECOND resolution order, and the guard would then be able
-    to report a ref as unresolved because it read a different spec than the one the
-    projection ran on -- see :func:`_agent_spec_for` for why the order (project
+    Exported for the unresolved-ref detector's two callers --
+    :mod:`kiro_crew.acp.mcp_ref_guard` at session establishment and
+    ``agent_sdk.drivers.acp.agent_spec_mcp_refs`` for ``kirocrew doctor`` -- which
+    have to judge the spec's ``tools`` refs against the array a session receives.
+    Reading the file themselves would give them a SECOND resolution order, and
+    either could then report a ref as unresolved because it read a different spec
+    than the one the projection ran on -- see :func:`_agent_spec_for` for why the order (project
     checkout nearest, then user level) is load-bearing rather than incidental.
 
     Blocking, and never raises: callers run it off the event loop and treat

--- a/src/kiro_crew/acp/session_mcp.py
+++ b/src/kiro_crew/acp/session_mcp.py
@@ -74,6 +74,7 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.acp.mcp_ref_guard import parse_tools_refs
 from kiro_crew.agent import (
     _mcp_registry_mode,
     agent_spec_path,
@@ -96,15 +97,6 @@ _CONTROL_PLANE_SERVERS = ("kirocrew-core", "kirocrew-cron")
 # kiro-cli's enterprise-governance discriminator, mirrored rather than imported
 # (``agent._MCP_REGISTRY_TYPE`` is private; a ratchet test pins the two equal).
 _KIRO_REGISTRY_TYPE = "registry"
-
-# ``tools`` entries that grant every MCP server rather than naming one. Only the
-# bare ``*`` -- kiro's configuration reference documents ``*``, ``@builtin``,
-# ``@server`` and ``@server/tool`` for ``tools`` and reserves globs for
-# ``allowedTools``, and this repo's own reader (``connections.tool_aliases``)
-# parses ``@*`` as a server LITERALLY named ``*``. Treating ``@*`` as grant-all
-# here would mount every declared server on this backend while kiro-cli mounted
-# none of them.
-_GRANT_ALL_TOOL_REFS = frozenset({"*"})
 
 
 def _acp_pairs(raw: Any) -> list[dict[str, str]]:
@@ -180,15 +172,21 @@ def _tools_grant(tools: list[Any], name: str) -> bool:
     entry the user deliberately left unreferenced (the shape every ``opt_in``
     grant uses, and what a narrowed-by-hand spec looks like) would come alive the
     moment the session happened to run on claude.
+
+    Reads the refs through :func:`~kiro_crew.acp.mcp_ref_guard.parse_tools_refs`
+    rather than scanning the list here, so this module and the unresolved-ref
+    guard cannot disagree about what an entry names -- a guard that read ``@srv``
+    where this read nothing would report a ref as unresolved while the server
+    mounted, and the reverse would mount a server the guard called absent. Only
+    the bare ``*`` grants everything: ``@*`` is a server LITERALLY named ``*``
+    there, matching this repo's other readers, so treating it as grant-all would
+    mount every declared server on this backend while kiro-cli mounted none.
+    ``@builtin`` is not special-cased -- a server actually called ``builtin`` is
+    mountable, and the namespace exclusion belongs to the guard asking whether a
+    ref resolves.
     """
-    ref = f"@{name}"
-    prefix = f"{ref}/"
-    for item in tools:
-        if not isinstance(item, str):
-            continue
-        if item in _GRANT_ALL_TOOL_REFS or item == ref or item.startswith(prefix):
-            return True
-    return False
+    grant_all, refs = parse_tools_refs(tools)
+    return grant_all or name in refs
 
 
 def _project_spec_path_for(agent: str, work_dir: str | Path | None) -> Path | None:
@@ -257,6 +255,24 @@ def _agent_spec_for(agent: str, work_dir: str | Path | None = None) -> dict[str,
         )
         return None
     return _read_agent_spec(path, operation="session_mcp_servers", source="unknown")
+
+
+def agent_spec_snapshot(
+    agent: str | None, *, work_dir: str | Path | None = None
+) -> dict[str, Any] | None:
+    """The spec for *agent* exactly as this module's own translation reads it.
+
+    Exported for :mod:`kiro_crew.acp.mcp_ref_guard`, which has to judge the spec's
+    ``tools`` refs against the array the session receives. Reading the file itself
+    there would give it a SECOND resolution order, and the guard would then be able
+    to report a ref as unresolved because it read a different spec than the one the
+    projection ran on -- see :func:`_agent_spec_for` for why the order (project
+    checkout nearest, then user level) is load-bearing rather than incidental.
+
+    Blocking, and never raises: callers run it off the event loop and treat
+    ``None`` as "nothing to say".
+    """
+    return _agent_spec_for(agent, work_dir) if agent else None
 
 
 def session_mcp_deny_rules(agent: str | None, *, work_dir: str | Path | None = None) -> list[str]:

--- a/src/kiro_crew/agent_sdk/drivers/acp.py
+++ b/src/kiro_crew/agent_sdk/drivers/acp.py
@@ -37,6 +37,7 @@ sandbox posture at their defining modules.
 from __future__ import annotations
 
 __all__ = [
+    "agent_spec_mcp_refs",
     "claude_adapter_cached_negative",
     "claude_adapter_install_command",
     "claude_components_resolve",
@@ -89,6 +90,66 @@ def derived_agent_permissions(allowed_tools: object, agent_filename: str) -> dic
 
     derived = allowed_tools_to_permissions(allowed_tools, agent_id=Path(agent_filename).stem)
     return derived if derived is not None else {"rules": []}
+
+
+def agent_spec_mcp_refs(agent: str) -> tuple[bool, list[tuple[str, list[str], bool]]]:
+    """Per selectable backend: which of *agent*'s ``@server`` refs resolve to nothing.
+
+    The static half of the runtime detector in
+    :mod:`kiro_crew.acp.mcp_ref_guard`, answering before a session exists rather
+    than during one. ``kirocrew doctor`` is the consumer, and it reaches it here
+    for the usual reason: the answer needs the agent spec AND each backend's spec
+    projection, both of which live below the boundary, so a consumer assembling it
+    itself would take three new ACP/providers edges the agent-sdk-boundary gate
+    refuses. The RESOLVER is provider-neutral and needs no delegation --
+    :mod:`kiro_crew.agent_sdk.mcp_refs` is importable directly.
+
+    Returns ``(spec_found, [(backend, unresolved refs, backend has a mirror)])``,
+    sorted by backend id. Plain data only, so no ACP type crosses the boundary,
+    and ``has_mirror`` is the one bit of provenance the caller cannot recover from
+    the refs alone: "no mirror registered" and "a mirror that dropped this ref"
+    are different problems with different remedies.
+
+    **It reads the mirror seam, and that bounds what it can claim.** The wire
+    array comes from ``providers.mirrors.mirror_for`` -- the same seam
+    ``AcpClient._resolve_session_mcp_servers`` composes from -- so a backend whose
+    projection lives OUTSIDE that folder (KAS today, per its own ``NO_MIRROR``
+    reason) reports refs here that its own projection may well carry.
+    ``has_mirror`` is what lets the caller say which case it is instead of
+    collapsing the two.
+
+    ``permission_surface_owned=True`` models the ordinary spawn: the claude mirror
+    withholds its whole array when Crew did not author the session's native
+    permission file, and that is a per-SESSION fact no static check can know.
+    Passing ``False`` would report every ref as unresolved on the one backend
+    whose projection actually works.
+
+    Blocking (reads the spec) and never raises: a backend whose projection cannot
+    be resolved is omitted rather than reported wrongly. Function-local imports
+    for the same boot-path reason as every other function here.
+    """
+    from kiro_crew.acp.session_mcp import agent_spec_snapshot
+    from kiro_crew.acp_backends import selectable_backend_values
+    from kiro_crew.agent_sdk.mcp_refs import unresolved_server_refs
+    from kiro_crew.providers.mirrors import NO_MIRROR, mirror_for
+
+    spec = agent_spec_snapshot(agent)
+    if not spec:
+        return False, []
+    rows: list[tuple[str, list[str], bool]] = []
+    for backend in selectable_backend_values():
+        try:
+            mirror = mirror_for(backend)
+            wire: list = []
+            if mirror is not None:
+                params = mirror.session_params(agent, permission_surface_owned=True)
+                raw = params.get("mcpServers")
+                wire = list(raw) if isinstance(raw, list) else []
+            unresolved = unresolved_server_refs(spec, wire, backend=backend)
+        except Exception:
+            continue
+        rows.append((backend, unresolved, backend not in NO_MIRROR))
+    return True, sorted(rows)
 
 
 def kiro_cli_resolves() -> bool:

--- a/src/kiro_crew/agent_sdk/mcp_refs.py
+++ b/src/kiro_crew/agent_sdk/mcp_refs.py
@@ -1,0 +1,193 @@
+"""Which of an agent spec's ``@server`` tool refs name nothing a session gets.
+
+One defect class has shipped three times, on three different harnesses, and each
+time it was diagnosed from scratch by someone who did not know it had happened
+before. ``providers/mirrors/README.md`` names the shape: a session comes up
+holding ``tools: ["@kirocrew-core", ...]`` while nothing in its effective
+``mcpServers`` defines ``kirocrew-core`` -- refs naming nothing, every Crew tool
+silently absent, the harness otherwise working and no error anywhere. KAS hit it,
+then claude-agent-acp, then codex, which is in that state on a plain build today.
+
+A mirror is the FIX for one backend. This is the DETECTOR, and it is worth being
+exact about its reach rather than claiming the tidier thing: the resolver is
+provider-neutral, but the runtime call site is ``AcpClient``'s ``session/new`` /
+``session/load`` composition, so it covers kiro-cli, claude and codex. **KAS runs
+on ``AcpRuntime``, which composes its array elsewhere and never reaches this
+detector** -- so a KAS session's refs are checked only by ``kirocrew doctor``, and
+wiring that second transport is a separate change. Saying "all of them" here would
+be the same kind of unexamined claim the mirrors folder exists to stop.
+
+**It lives in the SDK rather than in the ACP layer because the question is not an
+ACP question.** Given a spec, the server array a session is about to receive and
+a backend id, "which refs resolve to nothing" is answerable from plain data --
+which is what lets ``kirocrew doctor`` ask it without importing the backend at
+all (the agent-sdk-boundary gate refuses a consumer a new ACP edge). Nothing here
+imports :mod:`kiro_crew.acp`; the ACP layer's own logging wrapper
+(:mod:`kiro_crew.acp.mcp_ref_guard`) and the runtime call sites import THIS.
+
+**Who satisfies a ref depends on the backend, and there are exactly two
+answers.** kiro-cli is handed ``--agent`` and reads the spec itself, so for it a
+ref is satisfied by the spec's OWN ``mcpServers`` definition -- Crew passes that
+backend an empty array by design, and reading its refs against the wire would
+report every single one as unresolved on the healthiest install there is. Every
+other harness reads no agent file, so the wire array is the whole MCP surface of
+the session and the only thing that can satisfy a ref. A session-injected broker
+stub satisfies a ref on either backend, because it arrives on the wire under the
+same name as the entry it wraps.
+
+**Two ref spellings are not server refs and must not be reported.** A bare tool
+name (``fs_read``, ``execute_bash``) carries no ``@`` and names a built-in.
+``@builtin`` carries one but addresses kiro's built-in namespace rather than a
+server (kiro's own configuration reference documents it beside ``@server``), so
+reporting it would put a permanent false warning on every spec that uses it.
+``*`` grants every server that IS defined; it defines none, so it neither
+satisfies nor produces a ref.
+
+Nothing here raises. Both inputs are shapes a hand-editable JSON file and a wire
+payload can hold, and the callers are session-establishment paths where an
+exception would cost the session over a diagnostic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from kiro_crew.agent_sdk.backends import ACP_BACKEND_KIRO
+
+#: The ``tools`` entry that grants every DEFINED MCP server. It defines none, so
+#: it is neither a ref nor a satisfier here. Only the bare ``*``: this repo's own
+#: readers parse ``@*`` as a server LITERALLY named ``*`` (see
+#: ``connections.tool_aliases._parse_tool_refs`` and
+#: ``acp.kas_permissions._mcp_pattern``), and a ref to a server named ``*``
+#: resolves to nothing, which is the truth.
+_GRANT_ALL = "*"
+
+#: Marks an MCP server (or one of its tools) in a ``tools`` entry.
+_MCP_PREFIX = "@"
+
+#: ``@`` names that address a kiro namespace rather than an MCP server. kiro's
+#: configuration reference lists ``@builtin`` ("all built-in only") alongside
+#: ``@server`` and ``@server/tool``, so a spec written to that reference is
+#: correct and must not be warned about.
+RESERVED_TOOL_NAMESPACES = frozenset({"builtin"})
+
+
+def parse_tools_refs(tools: Any) -> tuple[bool, list[str]]:
+    """Split a spec ``tools`` list into ``(grants_every_server, server names)``.
+
+    The ONE reader of the ``tools`` ref vocabulary for MCP-server questions, so
+    ``acp.session_mcp._tools_grant`` and this module cannot drift into
+    disagreeing about what an entry names -- a detector reading ``@srv`` where
+    the projection read nothing reports a ref as unresolved while the server
+    mounts, and the reverse mounts a server the detector called absent. Both
+    directions are the same defect. Names keep first-seen order and are
+    de-duplicated, which makes a derived warning stable across two sessions on
+    one spec, and the pass is LINEAR in the number of entries -- a session waits
+    on this, and the spec it reads is only size-capped, not entry-capped.
+
+    ``@server`` and ``@server/tool`` both name ``server``: whether the spec
+    grants a whole server or one of its tools, the server has to exist either
+    way. Entries that name no server -- a bare tool name, ``@`` alone,
+    ``@/tool`` -- are skipped rather than reported, and ``@builtin`` is left IN:
+    exclusions belong to the caller asking the question, and a server genuinely
+    called ``builtin`` must still be mountable (see
+    :func:`unresolved_server_refs`).
+    """
+    grant_all = False
+    names: list[str] = []
+    # A SET decides membership; the list only preserves order. Testing ``in`` against
+    # the growing list instead would be a linear scan per entry, so a spec with N
+    # distinct refs would cost O(N**2) -- and this runs synchronously on the
+    # session-establishment path, off a file whose size cap (50 MB, ``hooks``)
+    # permits millions of entries. The two structures cannot disagree: nothing adds
+    # to one without the other.
+    seen: set[str] = set()
+    for item in tools if isinstance(tools, (list, tuple)) else ():
+        if not isinstance(item, str):
+            continue
+        if item == _GRANT_ALL:
+            grant_all = True
+            continue
+        if not item.startswith(_MCP_PREFIX):
+            continue
+        server = item[len(_MCP_PREFIX) :].partition("/")[0]
+        if server and server not in seen:
+            seen.add(server)
+            names.append(server)
+    return grant_all, names
+
+
+def wire_server_names(servers: Any) -> list[str]:
+    """Server names in a ``session/new`` / ``session/load`` ``mcpServers`` array.
+
+    Accepts the wire shape directly (a list of dicts with a ``name``) and
+    tolerates anything else by returning empty, so a caller can hand over
+    whatever it sent without pre-validating it.
+
+    Deliberately NOT
+    :func:`kiro_crew.acp.mcp_session_report.roster_names`, which reads the same
+    array for the dashboard: importing it would give this module an ACP edge and
+    cost ``kirocrew doctor`` its boundary-clean route to the resolver. The two
+    must still AGREE -- a detector warning that a server is missing while the
+    panel lists it two rows down is worse than no detector -- so their agreement
+    is pinned by a test instead of by a shared import. This one applies no cap:
+    the report bounds a payload that reaches a browser, while a name dropped
+    here would make a satisfied ref read as unresolved.
+    """
+    out: list[str] = []
+    # Set-backed membership, ordered output -- see :func:`parse_tools_refs` for why
+    # a linear ``in`` over the growing list is the wrong shape on a path a session
+    # waits on. Uncapped here (unlike the report's reader) because a name dropped at
+    # a cap would make a satisfied ref read as unresolved.
+    seen: set[str] = set()
+    for entry in servers if isinstance(servers, (list, tuple)) else ():
+        if not isinstance(entry, Mapping):
+            continue
+        name = entry.get("name")
+        if isinstance(name, str) and name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+def _spec_server_names(spec: Any) -> set[str]:
+    """Server names an agent spec DEFINES, whatever the projection later does."""
+    servers = spec.get("mcpServers") if isinstance(spec, Mapping) else None
+    if not isinstance(servers, Mapping):
+        return set()
+    return {str(name) for name in servers}
+
+
+def unresolved_server_refs(spec: Any, wire_servers: Any, *, backend: str) -> list[str]:
+    """The spec's ``@server`` refs that no server this session gets can satisfy.
+
+    *spec* is the agent spec as read from disk (``tools``, ``mcpServers``, and
+    the per-entry ``disabledTools`` inside them); *wire_servers* is the FINAL
+    ``mcpServers`` array about to go out on ``session/new`` / ``session/load``,
+    spec projection and broker stubs together; *backend* is the id the session
+    runs on.
+
+    Returned in the ``@name`` spelling the spec used, sorted, so two readings of
+    one spec produce the same line. Empty is the healthy answer.
+
+    ``disabledTools`` deliberately changes nothing here, and saying so is the
+    point: it turns individual TOOLS off within a server that is still mounted,
+    so it can narrow what a satisfied ref delivers but can never be what makes a
+    ref name nothing. A server whose every tool is disabled is a separate
+    question this function does not claim to answer.
+    """
+    _grant_all, refs = parse_tools_refs(spec.get("tools") if isinstance(spec, Mapping) else None)
+    if not refs:
+        return []
+    satisfied = set(wire_server_names(wire_servers))
+    if backend == ACP_BACKEND_KIRO:
+        # kiro-cli resolves --agent and loads the spec's own servers, which is why
+        # Crew passes it an empty array. Judging its refs against the wire alone
+        # would report every ref on the healthiest install there is.
+        satisfied |= _spec_server_names(spec)
+    return sorted(
+        f"{_MCP_PREFIX}{name}"
+        for name in refs
+        if name not in satisfied and name not in RESERVED_TOOL_NAMESPACES
+    )

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -1135,6 +1135,102 @@ def _doctor_claude_backend() -> None:
         print("  claude-acp:  ⚠️  could not check")
 
 
+#: The managed default agent, whose spec is the one a stock install runs.
+#: Mirrors ``agent._MAIN_AGENT_NAME``, which is private; the doctor row below
+#: reports on that spec because it is the one every default session resolves.
+_MAIN_AGENT_NAME = "kirocrew"
+
+
+def _doctor_unresolved_mcp_refs() -> None:
+    """One row per selectable harness: would the default spec's ``@server`` refs
+    resolve on it?
+
+    The static half of the runtime guard in
+    :mod:`kiro_crew.acp.mcp_ref_guard`, answering the same question before a
+    session rather than during one. The defect it names has shipped on three
+    harnesses (``providers/mirrors/README.md``): a session comes up with
+    ``tools: ["@kirocrew-core", ...]`` and nothing defining ``kirocrew-core``, so
+    every Crew tool is absent while the harness works and nothing anywhere is red.
+    A row here is the answer to "my agent has no tools on this backend" that
+    otherwise takes a diagnosis.
+
+    Reports only, and appends NO entry to ``issues``, on the terms
+    :func:`_doctor_strict_identity` sets: a harness the operator has not adopted
+    having no projection yet is a known state of the tree, not a broken install,
+    and failing doctor's exit code on it would make every stock host red for a
+    backend nobody selected.
+
+    **It reads the mirror seam, and that bounds what it can say.** The wire array
+    comes from ``providers.mirrors.mirror_for`` -- the same seam
+    ``AcpClient._resolve_session_mcp_servers`` composes from -- so a backend whose
+    projection lives OUTSIDE that folder (KAS today, per its own ``NO_MIRROR``
+    reason) shows refs here that its own projection may well carry. The row says
+    which case it is instead of collapsing the two, because "no mirror registered"
+    and "no channel for these tools" are the distinction the mirror registry
+    exists to keep apart.
+
+    kiro-cli resolves its refs against the spec it is handed, so a healthy install
+    prints a clean row there rather than every ref it declares -- the guard keys
+    that on the backend id, not on this function.
+    """
+    from kiro_crew.acp.mcp_ref_guard import unresolved_server_refs
+    from kiro_crew.acp.session_mcp import agent_spec_snapshot
+    from kiro_crew.acp_backends import POLICY_ID_BY_BACKEND, selectable_backend_values
+    from kiro_crew.providers.mirrors import NO_MIRROR, mirror_for
+
+    try:
+        spec = agent_spec_snapshot(_MAIN_AGENT_NAME)
+        backends = selectable_backend_values()
+    except Exception:
+        # Triage must survive an unreadable spec or registry; the rows are advisory.
+        return
+    if not spec:
+        print("  mcp tool refs: ⏹ no default agent spec on disk yet")
+        return
+
+    for backend in backends:
+        label = POLICY_ID_BY_BACKEND.get(backend, backend) or backend
+        try:
+            mirror = mirror_for(backend)
+            wire: list = []
+            if mirror is not None:
+                # ``permission_surface_owned=True`` models the ordinary spawn: the
+                # claude mirror withholds the whole array when Crew did not author
+                # the session's native permission file, and that is a per-SESSION
+                # fact no static check can know. Passing False would print every
+                # ref as unresolved on the backend whose projection actually works.
+                params = mirror.session_params(_MAIN_AGENT_NAME, permission_surface_owned=True)
+                raw = params.get("mcpServers")
+                wire = list(raw) if isinstance(raw, list) else []
+            unresolved = unresolved_server_refs(spec, wire, backend=backend)
+        except Exception:
+            continue
+        if not unresolved:
+            print(f"  mcp tool refs: ✅ {label} — every @server ref resolves")
+            continue
+        refs = ", ".join(unresolved)
+        if backend in NO_MIRROR:
+            print(f"  mcp tool refs: ⏹ {label} has no mirror; unprojected: {refs}")
+            _print_wrapped(
+                "Those refs name no server this backend would be handed, so the "
+                "tools behind them are absent from its sessions with nothing to "
+                "say so. The shared MCP gateway can still deliver a server it "
+                "wrapped as a broker stub, which this row does not model. "
+                "Whether the omission is a decision or an unwritten projection "
+                "is recorded per backend in providers/mirrors/registry.py "
+                "(NO_MIRROR); a backend that projects elsewhere reads as "
+                "unprojected here."
+            )
+            continue
+        print(f"  mcp tool refs: ⚠ {label} projects a spec that still misses: {refs}")
+        _print_wrapped(
+            "This backend HAS a mirror and its projection dropped these refs "
+            "anyway -- a registry-marked entry, an entry with no usable "
+            "transport, or a name the spec references but never defines. Compare "
+            "the agent spec's mcpServers against its tools list."
+        )
+
+
 def _doctor_agent_auth() -> None:
     """One sign-in row per selectable harness, projected from its declaration.
 
@@ -3217,6 +3313,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     _doctor_trust_root()
     _doctor_strict_identity(cfg)
     _doctor_mcp_gateway_daemon(issues)
+    _doctor_unresolved_mcp_refs()
 
     # ── Credentials (AWS / credential-vending MCP) ──
     # After identity, before the agent-facing sections: this is the answer to

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -1145,7 +1145,7 @@ def _doctor_unresolved_mcp_refs() -> None:
     """One row per selectable harness: would the default spec's ``@server`` refs
     resolve on it?
 
-    The static half of the runtime guard in
+    The static half of the runtime detector in
     :mod:`kiro_crew.acp.mcp_ref_guard`, answering the same question before a
     session rather than during one. The defect it names has shipped on three
     harnesses (``providers/mirrors/README.md``): a session comes up with
@@ -1160,57 +1160,43 @@ def _doctor_unresolved_mcp_refs() -> None:
     and failing doctor's exit code on it would make every stock host red for a
     backend nobody selected.
 
-    **It reads the mirror seam, and that bounds what it can say.** The wire array
-    comes from ``providers.mirrors.mirror_for`` -- the same seam
-    ``AcpClient._resolve_session_mcp_servers`` composes from -- so a backend whose
-    projection lives OUTSIDE that folder (KAS today, per its own ``NO_MIRROR``
-    reason) shows refs here that its own projection may well carry. The row says
-    which case it is instead of collapsing the two, because "no mirror registered"
-    and "no channel for these tools" are the distinction the mirror registry
-    exists to keep apart.
+    Asks ``agent_sdk`` rather than assembling the answer here. The refs need the
+    agent spec and each backend's spec projection, both of which live below the
+    boundary, so reaching them from this module would take three new ACP /
+    providers edges the agent-sdk-boundary gate refuses -- and correctly: which
+    file a harness reads its servers from is exactly the knowledge a consumer is
+    not supposed to hold. ``agent_spec_mcp_refs`` reads the mirror seam, so a
+    backend projecting outside ``providers/mirrors/`` (KAS) reads as unprojected;
+    ``has_mirror`` is what lets the row say which case it is.
 
     kiro-cli resolves its refs against the spec it is handed, so a healthy install
-    prints a clean row there rather than every ref it declares -- the guard keys
+    prints a clean row there rather than every ref it declares -- the resolver keys
     that on the backend id, not on this function.
     """
-    from kiro_crew.acp.mcp_ref_guard import unresolved_server_refs
-    from kiro_crew.acp.session_mcp import agent_spec_snapshot
-    from kiro_crew.acp_backends import POLICY_ID_BY_BACKEND, selectable_backend_values
-    from kiro_crew.providers.mirrors import NO_MIRROR, mirror_for
+    from kiro_crew.acp_backends import POLICY_ID_BY_BACKEND
+    from kiro_crew.agent_sdk.drivers.acp import agent_spec_mcp_refs
 
     try:
-        spec = agent_spec_snapshot(_MAIN_AGENT_NAME)
-        backends = selectable_backend_values()
+        spec_found, rows = agent_spec_mcp_refs(_MAIN_AGENT_NAME)
     except Exception:
         # Triage must survive an unreadable spec or registry; the rows are advisory.
         return
-    if not spec:
-        print("  mcp tool refs: ⏹ no default agent spec on disk yet")
+    if not spec_found:
+        print("  mcp tool refs: \u23f9 no default agent spec on disk yet")
         return
 
-    for backend in backends:
+    for backend, unresolved, has_mirror in rows:
         label = POLICY_ID_BY_BACKEND.get(backend, backend) or backend
-        try:
-            mirror = mirror_for(backend)
-            wire: list = []
-            if mirror is not None:
-                # ``permission_surface_owned=True`` models the ordinary spawn: the
-                # claude mirror withholds the whole array when Crew did not author
-                # the session's native permission file, and that is a per-SESSION
-                # fact no static check can know. Passing False would print every
-                # ref as unresolved on the backend whose projection actually works.
-                params = mirror.session_params(_MAIN_AGENT_NAME, permission_surface_owned=True)
-                raw = params.get("mcpServers")
-                wire = list(raw) if isinstance(raw, list) else []
-            unresolved = unresolved_server_refs(spec, wire, backend=backend)
-        except Exception:
-            continue
         if not unresolved:
-            print(f"  mcp tool refs: ✅ {label} — every @server ref resolves")
+            print(f"  mcp tool refs: \u2705 {label} \u2014 every @server ref resolves")
             continue
-        refs = ", ".join(unresolved)
-        if backend in NO_MIRROR:
-            print(f"  mcp tool refs: ⏹ {label} has no mirror; unprojected: {refs}")
+        # Read off a hand-editable spec a cloned repo or an installed app can
+        # author, so it can carry OSC/ANSI sequences that spoof the lines around
+        # it -- the same reason every other spec-derived value in this report is
+        # printed through _safe_display.
+        refs = ", ".join(_safe_display(ref) for ref in unresolved)
+        if not has_mirror:
+            print(f"  mcp tool refs: \u23f9 {label} has no mirror; unprojected: {refs}")
             _print_wrapped(
                 "Those refs name no server this backend would be handed, so the "
                 "tools behind them are absent from its sessions with nothing to "
@@ -1222,7 +1208,7 @@ def _doctor_unresolved_mcp_refs() -> None:
                 "unprojected here."
             )
             continue
-        print(f"  mcp tool refs: ⚠ {label} projects a spec that still misses: {refs}")
+        print(f"  mcp tool refs: \u26a0 {label} projects a spec that still misses: {refs}")
         _print_wrapped(
             "This backend HAS a mirror and its projection dropped these refs "
             "anyway -- a registry-marked entry, an entry with no usable "

--- a/src/kiro_crew/providers/mirrors/README.md
+++ b/src/kiro_crew/providers/mirrors/README.md
@@ -19,6 +19,27 @@ scratch, by someone who did not know the first had happened. Then a fourth backe
 Nothing in any of those files said "this is a projection of the agent spec, and
 every backend needs one." That sentence is what this folder is.
 
+## Runtime guard
+
+A mirror is the fix for one backend. `acp/mcp_ref_guard.py` is the detector for all
+of them, so a fourth occurrence cannot be silent. At the one point where the
+`session/new` / `session/load` `mcpServers` array is final — spec projection plus
+the gateway's broker stubs — it compares the spec's `@server` refs against what the
+session is actually about to receive, and logs ONE structured warning naming the
+backend, the agent, the unresolved refs and whether the shared gateway is on. It
+also records them on the session's MCP report (`unresolved_refs`), beside the
+buckets saying what a configured server reported — a different claim, because a
+server nothing configured has no row there to be missing from. `kirocrew doctor`
+evaluates the same function per selectable backend before a session exists.
+
+It never changes the array and never fails the session: a ref naming nothing is a
+configuration fact, and the complaint about this defect class was that it was
+invisible, not that it was tolerated. Two rules keep it from crying wolf — kiro-cli
+reads the spec itself via `--agent`, so its refs resolve against the spec's own
+`mcpServers` rather than the (deliberately empty) wire array; and `@builtin` and
+bare tool names are not server refs. Until codex has a mirror, the warning fires
+for every codex session that references a server, which is the guard being right.
+
 ## What a mirror must do
 
 Implement `AgentConfigMirror` (`base.py`) in a file named after the backend, and
@@ -72,6 +93,8 @@ Beside the mirror, not inside it, when it is substantial:
 - `acp/session_mcp.py` — Claude Code's spec-entry to array-element translation,
   the `tools` allowlist and the registry filter.
 - `acp/kas_permissions.py` — KAS's `allowedTools` to `permissions` mapping.
+- `acp/mcp_ref_guard.py` — the provider-agnostic unresolved-ref detector above, and
+  the one reader of the `tools` ref vocabulary that `session_mcp` mounts through.
 
 A mirror declares and routes; a helper translates.
 
@@ -82,4 +105,4 @@ A mirror declares and routes; a helper translates.
 | `claude` | `claude_code.py` | both faces; `hooks` is its one open `no-channel` |
 | `` (kiro-cli) | `NO_MIRROR` | reads the spec itself via `--agent`; only a small `cli.json` overlay, whose home is still an open decision |
 | `kas` | `NO_MIRROR`, pending | has the most complete projection of any backend, not yet moved here |
-| `codex` | `NO_MIRROR` | known but not selectable, so no session to configure yet |
+| `codex` | `NO_MIRROR` | selectable on a plain build and serving sessions today; the projection is unwritten, so the runtime guard above warns on every codex session whose spec references a server |

--- a/src/kiro_crew/providers/mirrors/README.md
+++ b/src/kiro_crew/providers/mirrors/README.md
@@ -21,16 +21,28 @@ every backend needs one." That sentence is what this folder is.
 
 ## Runtime guard
 
-A mirror is the fix for one backend. `acp/mcp_ref_guard.py` is the detector for all
-of them, so a fourth occurrence cannot be silent. At the one point where the
+A mirror is the fix for one backend. `agent_sdk/mcp_refs.py` is the detector, so a
+fourth occurrence cannot be silent. At the one point where the
 `session/new` / `session/load` `mcpServers` array is final — spec projection plus
-the gateway's broker stubs — it compares the spec's `@server` refs against what the
-session is actually about to receive, and logs ONE structured warning naming the
-backend, the agent, the unresolved refs and whether the shared gateway is on. It
-also records them on the session's MCP report (`unresolved_refs`), beside the
-buckets saying what a configured server reported — a different claim, because a
-server nothing configured has no row there to be missing from. `kirocrew doctor`
-evaluates the same function per selectable backend before a session exists.
+the gateway's broker stubs — `acp/mcp_ref_guard.py` compares the spec's `@server`
+refs against what the session is actually about to receive, and logs ONE structured
+warning naming the backend, the agent, the unresolved refs and whether the shared
+gateway is on. It also records them on the session's MCP report
+(`unresolved_refs`), beside the buckets saying what a configured server reported —
+a different claim, because a server nothing configured has no row there to be
+missing from.
+
+Its runtime reach is `AcpClient`'s composition — kiro-cli, claude, codex. **KAS
+composes its array on `AcpRuntime` and never reaches that call site**, so a KAS
+session's refs are checked only by `kirocrew doctor`; wiring the second transport is
+a separate change, and claiming "every backend" here would be the same unexamined
+claim this folder exists to stop.
+
+The resolver sits in the SDK rather than in the ACP layer because the question is
+not an ACP question: spec in, wire array in, backend id in, refs out. That is what
+lets `kirocrew doctor` evaluate the same function per selectable backend, before a
+session exists, without taking an ACP edge (`agent_spec_mcp_refs` in
+`agent_sdk/drivers/acp.py` supplies it the spec and each backend's projection).
 
 It never changes the array and never fails the session: a ref naming nothing is a
 configuration fact, and the complaint about this defect class was that it was
@@ -93,8 +105,10 @@ Beside the mirror, not inside it, when it is substantial:
 - `acp/session_mcp.py` — Claude Code's spec-entry to array-element translation,
   the `tools` allowlist and the registry filter.
 - `acp/kas_permissions.py` — KAS's `allowedTools` to `permissions` mapping.
-- `acp/mcp_ref_guard.py` — the provider-agnostic unresolved-ref detector above, and
-  the one reader of the `tools` ref vocabulary that `session_mcp` mounts through.
+- `agent_sdk/mcp_refs.py` — the provider-agnostic unresolved-ref resolver above,
+  and the one reader of the `tools` ref vocabulary that `session_mcp` mounts
+  through. `acp/mcp_ref_guard.py` is its one-line-of-log half, at the session
+  call sites.
 
 A mirror declares and routes; a helper translates.
 

--- a/test/test_acp_mcp_ref_guard.py
+++ b/test/test_acp_mcp_ref_guard.py
@@ -6,8 +6,13 @@ holding ``tools: ["@kirocrew-core", ...]`` while nothing in its effective
 with the harness otherwise working. These tests pin the two backend semantics
 (kiro-cli reads the spec itself, everyone else gets only the wire array), the ref
 spellings that are NOT server refs, and that the composition path in
-``acp/client.py`` actually reaches the guard on both ``session/new`` and
+``acp/client.py`` actually reaches the detector on both ``session/new`` and
 ``session/load``.
+
+The resolver itself is provider-neutral and lives in
+:mod:`kiro_crew.agent_sdk.mcp_refs`, which is what lets ``kirocrew doctor`` ask the
+same question without taking an ACP edge; ``acp/mcp_ref_guard`` is only the log
+line. Both are exercised from here, because they are one behaviour.
 """
 
 from __future__ import annotations
@@ -15,6 +20,7 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import time
 from typing import Any
 
 import pytest
@@ -23,13 +29,20 @@ from kiro_crew import agent as agent_mod
 from kiro_crew.acp import client as client_mod
 from kiro_crew.acp import mcp_ref_guard, session_mcp
 from kiro_crew.acp.client import AcpClient
-from kiro_crew.acp.mcp_ref_guard import (
+from kiro_crew.acp.mcp_ref_guard import warn_unresolved_server_refs
+from kiro_crew.acp.mcp_session_report import (
+    NAME_CAP,
+    McpSessionReport,
+    roster_names,
+    sanitize_sink_text,
+)
+from kiro_crew.acp.types import ACP_BACKEND_CLAUDE, ACP_BACKEND_CODEX, ACP_BACKEND_KIRO
+from kiro_crew.agent_sdk import mcp_refs as mcp_refs_mod
+from kiro_crew.agent_sdk.mcp_refs import (
     parse_tools_refs,
     unresolved_server_refs,
-    warn_unresolved_server_refs,
+    wire_server_names,
 )
-from kiro_crew.acp.mcp_session_report import McpSessionReport
-from kiro_crew.acp.types import ACP_BACKEND_CLAUDE, ACP_BACKEND_CODEX, ACP_BACKEND_KIRO
 
 _CORE = {"command": "/opt/kirocrew", "args": ["mcp-core"]}
 _CRON = {"command": "/opt/kirocrew", "args": ["mcp-cron"]}
@@ -73,6 +86,66 @@ class TestRefParsing:
 
     def test_non_string_entries_are_ignored(self):
         assert parse_tools_refs([None, 3, ["@srv"], "@real"]) == (False, ["real"])
+
+    def test_the_two_array_readers_agree(self):
+        """``wire_server_names`` and the report's ``roster_names`` read one array.
+
+        The SDK resolver may not import the ACP layer, so it carries its own
+        reader -- and a detector warning that a server is missing while the
+        dashboard panel lists it two rows down is worse than no detector. Their
+        agreement is therefore pinned here instead of by a shared import. The two
+        differ only where the report deliberately bounds a browser payload, which
+        no case below reaches.
+        """
+        for array in (
+            _wire("a", "b"),
+            _wire("a", "a"),
+            [],
+            [{"name": ""}, {"name": "ok"}],
+            [None, 3, {}, {"name": "late"}],
+            "not an array",
+        ):
+            assert wire_server_names(array) == list(roster_names(array)), array
+
+    def test_a_large_spec_is_parsed_in_linear_time(self):
+        """Both readers must not be quadratic: a session waits on them.
+
+        The spec is only SIZE-capped (50 MB, ``hooks.MAX_FILE_BYTES``), never
+        entry-capped, so the number of refs is operator-controlled and large. A
+        linear ``in`` over the growing result list would make N distinct refs cost
+        O(N**2) on the session-establishment path -- minutes for the input below,
+        long enough for a watchdog to kill the gateway mid-session.
+
+        The ceiling is deliberately loose. Linear finishes this in milliseconds, so
+        a wide margin still separates the two shapes by orders of magnitude and
+        cannot flake on a loaded host.
+        """
+        n = 60_000
+        tools = [f"@srv{i}" for i in range(n)]
+        wire = [{"name": f"srv{i}"} for i in range(n)]
+
+        start = time.monotonic()
+        grant_all, refs = parse_tools_refs(tools)
+        names = wire_server_names(wire)
+        elapsed = time.monotonic() - start
+
+        assert grant_all is False
+        assert len(refs) == n
+        assert len(names) == n
+        assert elapsed < 5.0, f"parsing {n} refs took {elapsed:.1f}s -- shape is not linear"
+
+    def test_dedup_is_set_backed_while_output_stays_ordered(self):
+        """The property the timing test measures, stated directly.
+
+        Order is contractual (a stable warning across two sessions on one spec) and
+        so is the dedup, so the two structures have to coexist -- and nothing may
+        add to one without the other.
+        """
+        assert parse_tools_refs(["@b", "@a", "@b", "@a", "@c"]) == (False, ["b", "a", "c"])
+        assert wire_server_names([{"name": "b"}, {"name": "a"}, {"name": "b"}]) == ["b", "a"]
+        source = inspect.getsource(mcp_refs_mod.parse_tools_refs)
+        assert "seen: set[str] = set()" in source
+        assert "server not in seen" in source
 
     def test_session_mcp_mounts_through_this_parser(self):
         """The mounting decision and the guard read one vocabulary.
@@ -251,6 +324,164 @@ class TestTheWarning:
             )
         assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
 
+    def test_a_credential_shaped_ref_is_redacted_before_it_is_logged(self, caplog):
+        """A ref is untrusted text, and this warning fires in normal operation.
+
+        The ref is whatever follows ``@`` in a ``tools`` entry, authored by an
+        operator, a cloned repository's project spec, or an installed app. The log
+        ring fans out to the dashboard, so a credential-shaped ref would appear
+        there verbatim. Redaction is not optional on a sink like that.
+        """
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        spec = {"tools": [f"@{secret}"], "mcpServers": {}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            found = warn_unresolved_server_refs(
+                spec, [], backend=ACP_BACKEND_CODEX, agent="kirocrew", gateway_enabled=False
+            )
+        assert secret not in caplog.text
+        # The RETURN value is sanitized too, so the next consumer to log or render
+        # it inherits the redaction instead of re-opening the hole.
+        assert all(secret not in ref for ref in found)
+
+    def test_a_ref_cannot_forge_a_second_log_line(self, caplog):
+        spec = {"tools": ["@srv\nWARNING  everything is fine"], "mcpServers": {}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            found = warn_unresolved_server_refs(
+                spec, [], backend=ACP_BACKEND_CODEX, agent="a", gateway_enabled=False
+            )
+        assert "\n" not in found[0]
+        assert len(caplog.records) == 1
+
+    def test_the_agent_name_is_redacted_on_the_same_line(self, caplog):
+        """The agent name reaches the same sink and is config-derived too.
+
+        Asserted as REDACTION rather than as control-character stripping, because
+        the format spells it ``%r`` -- which already escapes a newline, so a forged
+        second line was never the exposure there. Redaction is the half ``%r``
+        cannot do: it would print a secret-shaped name in full, just quoted.
+        """
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        spec = {"tools": ["@ghost"], "mcpServers": {}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            warn_unresolved_server_refs(
+                spec, [], backend=ACP_BACKEND_CODEX, agent=secret, gateway_enabled=False
+            )
+        assert len(caplog.records) == 1
+        assert secret not in caplog.records[0].getMessage()
+
+    def test_a_ref_is_length_bounded_in_the_line(self, caplog):
+        spec = {"tools": ["@" + "x" * 5000], "mcpServers": {}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            found = warn_unresolved_server_refs(
+                spec, [], backend=ACP_BACKEND_CODEX, agent="a", gateway_enabled=False
+            )
+        assert len(found[0]) <= NAME_CAP
+
+    def test_the_logged_text_is_rebuilt_from_the_modules_own_alphabet(self):
+        """The log line must not carry a string DERIVED from the spec.
+
+        ``py/clear-text-logging-sensitive-data`` follows the spec-derived dataflow
+        into this sink and does not model the sanitizer as a barrier, and code
+        scanning does not honour a per-line ``lgtm`` suppression either. This
+        repository's own answer is to return characters the module owns --
+        ``keeper._locus`` / ``_metric_slug``, ``name_grant``'s constant tables --
+        which is what ``_log_safe`` does. Pinned as the property, not as a comment:
+        every character out is one this module holds.
+        """
+        out = mcp_ref_guard._log_safe("@srv-1.x_Y")
+        assert out == "@srv-1.x_Y"
+        assert all(ch in mcp_ref_guard._LOG_ALPHABET for ch in out)
+
+    def test_url_punctuation_never_reaches_the_log_line(self, caplog):
+        """``:`` is outside the alphabet, so an endpoint cannot ride along.
+
+        Two independent cuts, and both are worth pinning because either alone would
+        look sufficient. ``parse_tools_refs`` keeps only the text before the first
+        ``/``, so the path half of a URL never becomes a ref at all; the alphabet
+        then drops the ``:`` that a host:port needs. Hardening on top of the
+        redactors, not instead of them.
+        """
+        spec = {
+            "tools": ["@host.example:8080", "@sneaky/../../etc/passwd"],
+            "mcpServers": {},
+        }
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            found = warn_unresolved_server_refs(
+                spec, [], backend=ACP_BACKEND_CODEX, agent="a", gateway_enabled=False
+            )
+        # The parser already cut at the first slash, so no path segment is a ref.
+        assert found == ["@host.example:8080", "@sneaky"]
+        line = caplog.records[0].getMessage()
+        assert "host.example8080" in line  # still identifiable
+        assert ":8080" not in line
+        assert "passwd" not in line
+
+    def test_the_rebuild_runs_after_the_redactors_not_instead_of_them(self, caplog):
+        """Order is the load-bearing part: the alphabet alone would leak a key.
+
+        ``AKIAIOSFODNN7EXAMPLE`` is pure alphanumerics, so a rebuild would pass it
+        through verbatim. Redaction is what removes the secret; the rebuild removes
+        the punctuation and the dataflow.
+        """
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        assert mcp_ref_guard._log_safe(secret) == secret  # the alphabet alone: no help
+        spec = {"tools": [f"@{secret}"], "mcpServers": {}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            warn_unresolved_server_refs(
+                spec, [], backend=ACP_BACKEND_CODEX, agent="a", gateway_enabled=False
+            )
+        assert secret not in caplog.records[0].getMessage()
+
+    def test_the_agent_name_is_rebuilt_too_not_only_redacted(self, caplog):
+        # It reaches the same sink through the same dataflow, so it needs both
+        # halves; redaction alone would leave the punctuation and the taint edge.
+        spec = {"tools": ["@ghost"], "mcpServers": {}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            warn_unresolved_server_refs(
+                spec,
+                [],
+                backend=ACP_BACKEND_CODEX,
+                agent="crew:9100/x",
+                gateway_enabled=False,
+            )
+        line = caplog.records[0].getMessage()
+        assert "crew9100" in line
+        assert ":9100" not in line and "/x" not in line
+
+    def test_the_rebuild_returns_the_alphabets_own_characters(self):
+        """The taint-severance property, which no output assertion can reach.
+
+        ``_LOG_ALPHABET[idx]`` and ``ch`` are equal strings, so swapping them
+        changes nothing observable -- and everything about whether a taint query
+        sees the result as derived from the input. The property therefore lives in
+        the source shape, which is exactly what the analyser reads, so that is
+        where it is pinned. Same reason ``keeper._locus`` spells out "append the
+        ALPHABET's own character object, not the input's" in a comment.
+        """
+        body = inspect.getsource(mcp_ref_guard._log_safe)
+        assert "out.append(_LOG_ALPHABET[idx])" in body
+        assert "out.append(ch)" not in body
+
+    def test_an_all_dropped_name_still_prints_something(self):
+        # A row reading nothing would look like a bug in the report rather than a
+        # name made entirely of characters the log will not carry.
+        assert mcp_ref_guard._log_safe("::://") == "?"
+
+    def test_a_logged_token_is_length_bounded(self):
+        assert len(mcp_ref_guard._log_safe("x" * 10_000)) == mcp_ref_guard._LOG_TOKEN_MAX
+
+    def test_one_sanitizer_serves_the_log_line_and_the_report(self):
+        """The guard shares the report's cleaner rather than repeating its order.
+
+        Two sanitizers with the same job are two that can drift, and the one that
+        drifts is the one that stops redacting -- which is the same
+        two-readers-of-one-thing failure this whole PR is about, in miniature.
+        """
+        assert mcp_ref_guard.sanitize_sink_text is sanitize_sink_text
+        source = inspect.getsource(mcp_ref_guard)
+        assert "redact_credentials" not in source
+        assert "isprintable" not in source
+
     def test_the_line_is_bounded_but_the_count_is_not_lost(self, caplog):
         many = [f"@srv{i:03d}" for i in range(mcp_ref_guard._REPORT_CAP + 5)]
         spec = {"tools": many, "mcpServers": {}}
@@ -260,6 +491,29 @@ class TestTheWarning:
             )
         assert len(found) == len(many)
         assert "(+5 more)" in caplog.records[-1].getMessage()
+
+
+class TestTheDocumentedReach:
+    """The module must not claim a reach it does not have.
+
+    The resolver is provider-neutral, but the RUNTIME call site is ``AcpClient``'s
+    composition. KAS runs on ``AcpRuntime``, which composes its array elsewhere, so
+    a KAS session never reaches the detector -- and an over-broad claim in the one
+    module written to stop unexamined claims about backend coverage would be the
+    same defect it exists to catch.
+    """
+
+    def test_the_module_names_kas_as_out_of_runtime_reach(self):
+        doc = mcp_refs_mod.__doc__ or ""
+        assert "AcpRuntime" in doc
+        assert "KAS" in doc
+
+    def test_the_runtime_call_site_really_is_acpclient_only(self):
+        from kiro_crew.acp import runtime as runtime_mod
+
+        # If a future change wires the detector into the runtime too, this fails and
+        # the docstring above has to be corrected with it.
+        assert "mcp_ref_guard" not in inspect.getsource(runtime_mod)
 
 
 class TestTheReportSlot:
@@ -494,3 +748,74 @@ class TestTheCallSitesAreWired:
             # Same argument, so the guard judges the array that actually went out
             # rather than a stale or differently-composed one.
             assert guard.split("_guard_unresolved_mcp_refs(", 1)[1] == roster
+
+
+class TestTheSpawnHopCarriesTheSnapshot:
+    """The warm rides in the hop ``_spawn`` already had, and adds no await.
+
+    The reviewer finding that produced this shape was specific: an added
+    ``await asyncio.to_thread`` on the Kiro construction path is a new suspension
+    point in service of a diagnostic (harness-parity H13). Folding the snapshot
+    into the pre-existing ``mkdir`` hop answers it by making the added await not
+    exist -- which is only true while nothing re-adds one, hence the structural
+    pin below.
+    """
+
+    def test_the_hop_creates_the_dir_and_warms_the_snapshot(self, tmp_path, monkeypatch):
+        work = tmp_path / "nested" / "work"
+        client = AcpClient(work_dir=work, agent="kirocrew", acp_backend=ACP_BACKEND_CODEX)
+        monkeypatch.setattr(
+            client_mod, "agent_spec_snapshot", lambda _a, **_k: {"tools": ["@ghost"]}
+        )
+        client._mcp_ref_spec = None
+
+        client._prepare_spawn_workspace()
+
+        assert work.is_dir()
+        assert client._mcp_ref_spec == {"tools": ["@ghost"]}
+
+    def test_the_mkdir_still_raises_and_the_snapshot_never_does(self, tmp_path, monkeypatch):
+        """Two halves, two failure contracts, and the order is what separates them.
+
+        The spawn genuinely cannot proceed without the work dir, so that half must
+        still raise. The diagnostic must never cost a session, so its half is
+        swallowed -- and it runs SECOND, so a failed mkdir skips it rather than
+        reporting on a session that has no workspace.
+        """
+        blocker = tmp_path / "blocked"
+        blocker.write_text("not a directory", encoding="utf-8")
+        client = AcpClient(
+            work_dir=blocker / "work", agent="kirocrew", acp_backend=ACP_BACKEND_CODEX
+        )
+        with pytest.raises(OSError):
+            client._prepare_spawn_workspace()
+        assert client._mcp_ref_spec is None
+
+        # The other direction: a spec that cannot be read leaves the dir made.
+        def _boom(*_a, **_k):
+            raise OSError("spec unreadable")
+
+        ok = AcpClient(work_dir=tmp_path / "ok", agent="kirocrew", acp_backend=ACP_BACKEND_CODEX)
+        monkeypatch.setattr(client_mod, "agent_spec_snapshot", _boom)
+        ok._prepare_spawn_workspace()
+        assert (tmp_path / "ok").is_dir()
+        assert ok._mcp_ref_spec is None
+
+    def test_the_detector_adds_no_await_to_the_construction_path(self):
+        """The snapshot is never awaited on its own -- only inside the mkdir hop.
+
+        Pinned as the absence of a separate hop rather than as a total await count,
+        so an unrelated await added to ``_spawn`` later cannot fail this for the
+        wrong reason. What must stay true is narrow: the detector's read reaches
+        the executor ONLY as a passenger of the hop ``_spawn`` already had, which
+        is what keeps it off kiro-cli's suspension-point budget (H13).
+        """
+        spawn = inspect.getsource(AcpClient._spawn)
+        assert "await asyncio.to_thread(self._prepare_spawn_workspace)" in spawn
+        assert "_read_mcp_ref_spec" not in spawn
+        assert "_mcp_ref_spec" not in spawn
+
+        # ...and the fold itself is not split back apart: one hop, both halves.
+        hop = inspect.getsource(AcpClient._prepare_spawn_workspace)
+        assert "self._work_dir.mkdir(" in hop
+        assert "self._mcp_ref_spec = self._read_mcp_ref_spec()" in hop

--- a/test/test_acp_mcp_ref_guard.py
+++ b/test/test_acp_mcp_ref_guard.py
@@ -1,0 +1,496 @@
+"""The unresolved-``@server``-ref guard (:mod:`kiro_crew.acp.mcp_ref_guard`).
+
+The defect this guards against has shipped on three harnesses: a session comes up
+holding ``tools: ["@kirocrew-core", ...]`` while nothing in its effective
+``mcpServers`` defines ``kirocrew-core``, so every Crew tool is silently absent
+with the harness otherwise working. These tests pin the two backend semantics
+(kiro-cli reads the spec itself, everyone else gets only the wire array), the ref
+spellings that are NOT server refs, and that the composition path in
+``acp/client.py`` actually reaches the guard on both ``session/new`` and
+``session/load``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from typing import Any
+
+import pytest
+
+from kiro_crew import agent as agent_mod
+from kiro_crew.acp import client as client_mod
+from kiro_crew.acp import mcp_ref_guard, session_mcp
+from kiro_crew.acp.client import AcpClient
+from kiro_crew.acp.mcp_ref_guard import (
+    parse_tools_refs,
+    unresolved_server_refs,
+    warn_unresolved_server_refs,
+)
+from kiro_crew.acp.mcp_session_report import McpSessionReport
+from kiro_crew.acp.types import ACP_BACKEND_CLAUDE, ACP_BACKEND_CODEX, ACP_BACKEND_KIRO
+
+_CORE = {"command": "/opt/kirocrew", "args": ["mcp-core"]}
+_CRON = {"command": "/opt/kirocrew", "args": ["mcp-cron"]}
+
+
+def _wire(*names: str) -> list[dict[str, Any]]:
+    """A ``session/new`` ``mcpServers`` array carrying exactly *names*."""
+    return [{"name": n, "command": "/bin/x", "args": [], "env": [], "type": "stdio"} for n in names]
+
+
+class TestRefParsing:
+    """The one reader of the ``tools`` ref vocabulary, shared with session_mcp."""
+
+    def test_both_ref_forms_name_the_same_server(self):
+        # A whole-server ref and a per-tool ref both require the server to exist.
+        assert parse_tools_refs(["@srv", "@other/tool"]) == (False, ["srv", "other"])
+
+    def test_a_bare_tool_name_is_not_a_server_ref(self):
+        assert parse_tools_refs(["fs_read", "execute_bash", "tool_search"]) == (False, [])
+
+    def test_the_bare_star_is_grant_all_and_names_no_server(self):
+        assert parse_tools_refs(["*"]) == (True, [])
+
+    def test_at_star_is_a_server_literally_named_star(self):
+        # Matching connections.tool_aliases and kas_permissions: reading `@*` as
+        # grant-all here would mount every declared server on a backend where
+        # kiro-cli mounted none.
+        assert parse_tools_refs(["@*"]) == (False, ["*"])
+
+    @pytest.mark.parametrize("ref", ["@", "@/tool", ""])
+    def test_a_ref_naming_no_server_is_skipped(self, ref):
+        assert parse_tools_refs([ref]) == (False, [])
+
+    def test_duplicates_collapse_in_first_seen_order(self):
+        assert parse_tools_refs(["@b", "@a/x", "@b/y", "@a"]) == (False, ["b", "a"])
+
+    @pytest.mark.parametrize("tools", [None, "@srv", 7, {"@srv": True}])
+    def test_a_non_list_tools_does_not_raise(self, tools):
+        # The spec is hand-editable JSON, so this is ordinary input, not an error.
+        assert parse_tools_refs(tools) == (False, [])
+
+    def test_non_string_entries_are_ignored(self):
+        assert parse_tools_refs([None, 3, ["@srv"], "@real"]) == (False, ["real"])
+
+    def test_session_mcp_mounts_through_this_parser(self):
+        """The mounting decision and the guard read one vocabulary.
+
+        A guard that read ``@srv`` where the projection read nothing would report a
+        ref as unresolved while the server mounted; the reverse would mount a
+        server the guard called absent. Both directions are the same defect, so the
+        two must not have separate parsers.
+        """
+        assert session_mcp._tools_grant(["@srv/tool"], "srv") is True
+        assert session_mcp._tools_grant(["*"], "anything") is True
+        assert session_mcp._tools_grant(["@*"], "srv") is False
+        assert session_mcp._tools_grant(["fs_read"], "srv") is False
+
+
+class TestResolution:
+    def test_a_wire_served_ref_resolves(self):
+        spec = {"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": _CORE}}
+        assert (
+            unresolved_server_refs(spec, _wire("kirocrew-core"), backend=ACP_BACKEND_CLAUDE) == []
+        )
+
+    def test_codex_today_reports_every_ref(self):
+        """The live state of a plain public build, which is why the guard exists.
+
+        ``_codex_session_mcp_servers`` returns ``[]``, so with the shared gateway
+        off a codex session receives nothing at all -- while its spec declares and
+        references Crew's whole control plane.
+        """
+        spec = {
+            "tools": ["@kirocrew-core", "@kirocrew-cron", "fs_read"],
+            "mcpServers": {"kirocrew-core": _CORE, "kirocrew-cron": _CRON},
+        }
+        assert unresolved_server_refs(spec, [], backend=ACP_BACKEND_CODEX) == [
+            "@kirocrew-core",
+            "@kirocrew-cron",
+        ]
+
+    def test_kiro_resolves_its_refs_against_the_spec_not_the_wire(self):
+        """kiro-cli is handed ``--agent`` and loads the spec itself.
+
+        Crew passes it an EMPTY array by design, so judging its refs against the
+        wire would report every ref on the healthiest install there is -- the
+        guard's own false-positive failure mode, and the one that would get it
+        deleted rather than fixed.
+        """
+        spec = {"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": _CORE}}
+        assert unresolved_server_refs(spec, [], backend=ACP_BACKEND_KIRO) == []
+        # ...and the same spec on a backend that reads no agent file does report it.
+        assert unresolved_server_refs(spec, [], backend=ACP_BACKEND_CLAUDE) == ["@kirocrew-core"]
+
+    def test_kiro_still_reports_a_ref_the_spec_never_defines(self):
+        # The spec being the satisfier does not make every ref satisfied: a typo'd
+        # or removed server name names nothing on kiro-cli either.
+        spec = {"tools": ["@typo-core"], "mcpServers": {"kirocrew-core": _CORE}}
+        assert unresolved_server_refs(spec, [], backend=ACP_BACKEND_KIRO) == ["@typo-core"]
+
+    def test_a_broker_stub_satisfies_a_ref(self):
+        """A pooled server arrives on the wire under the name it wraps.
+
+        The projection yields the raw entry to its stub (two elements with one name
+        would either shadow the broker or start it twice), so the stub is the ONLY
+        thing carrying that name -- and it must count.
+        """
+        spec = {"tools": ["@pooled"], "mcpServers": {"pooled": {"command": "/bin/raw"}}}
+        assert unresolved_server_refs(spec, _wire("pooled"), backend=ACP_BACKEND_CLAUDE) == []
+
+    def test_a_spec_server_the_projection_dropped_is_reported(self):
+        """Declared, referenced, and still absent from the session.
+
+        A registry-marked entry, or one with neither ``command`` nor ``url``, is
+        dropped by the translation -- so the spec's own ``mcpServers`` proves
+        nothing about what the session receives on a backend that reads no spec.
+        """
+        spec = {
+            "tools": ["@marked", "@ok"],
+            "mcpServers": {
+                "marked": {"type": "registry", "command": "/bin/placeholder"},
+                "ok": {"command": "/bin/ok"},
+            },
+        }
+        assert unresolved_server_refs(spec, _wire("ok"), backend=ACP_BACKEND_CLAUDE) == ["@marked"]
+
+    def test_builtin_namespace_is_never_reported(self):
+        """``@builtin`` addresses kiro's built-in tools, not a server.
+
+        kiro's own configuration reference documents it beside ``@server``, so a
+        spec written to that reference is correct -- reporting it would put a
+        permanent false warning on every such spec.
+        """
+        spec = {"tools": ["@builtin", "fs_read"], "mcpServers": {}}
+        assert unresolved_server_refs(spec, [], backend=ACP_BACKEND_CLAUDE) == []
+
+    def test_a_server_actually_called_builtin_is_still_mountable(self):
+        # The exclusion belongs to the guard, not to the parser: session_mcp must
+        # still mount a server whose real name is `builtin`.
+        assert session_mcp._tools_grant(["@builtin"], "builtin") is True
+
+    def test_grant_all_does_not_satisfy_a_ref_naming_nothing(self):
+        # `*` grants every DEFINED server; it defines none, so a ref beside it to
+        # something undefined still names nothing.
+        spec = {"tools": ["*", "@ghost"], "mcpServers": {}}
+        assert unresolved_server_refs(spec, [], backend=ACP_BACKEND_CLAUDE) == ["@ghost"]
+
+    def test_a_spec_with_no_refs_is_silent(self):
+        assert unresolved_server_refs({"tools": ["fs_read"]}, [], backend=ACP_BACKEND_CODEX) == []
+
+    def test_disabled_tools_never_make_a_ref_unresolved(self):
+        # It narrows what a MOUNTED server delivers; the server is still there.
+        spec = {
+            "tools": ["@srv"],
+            "mcpServers": {"srv": {"command": "/bin/srv", "disabledTools": ["dangerous"]}},
+        }
+        assert unresolved_server_refs(spec, _wire("srv"), backend=ACP_BACKEND_CLAUDE) == []
+
+    @pytest.mark.parametrize("spec", [None, "not a spec", 7, []])
+    def test_a_malformed_spec_yields_no_finding(self, spec):
+        # This runs on a session-establishment path; raising there would cost the
+        # session over a diagnostic.
+        assert unresolved_server_refs(spec, [], backend=ACP_BACKEND_CLAUDE) == []
+
+    @pytest.mark.parametrize("wire", [None, "servers", {"name": "x"}, [None, 3, {}]])
+    def test_a_malformed_wire_array_yields_a_finding_not_an_exception(self, wire):
+        spec = {"tools": ["@srv"], "mcpServers": {"srv": {"command": "/bin/srv"}}}
+        assert unresolved_server_refs(spec, wire, backend=ACP_BACKEND_CLAUDE) == ["@srv"]
+
+    def test_the_answer_is_sorted(self):
+        spec = {"tools": ["@zeta", "@alpha", "@mid"], "mcpServers": {}}
+        assert unresolved_server_refs(spec, [], backend=ACP_BACKEND_CLAUDE) == [
+            "@alpha",
+            "@mid",
+            "@zeta",
+        ]
+
+
+class TestTheWarning:
+    def test_one_line_naming_backend_agent_refs_and_gateway(self, caplog):
+        spec = {"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": _CORE}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            found = warn_unresolved_server_refs(
+                spec,
+                [],
+                backend=ACP_BACKEND_CODEX,
+                agent="kirocrew",
+                gateway_enabled=False,
+            )
+        assert found == ["@kirocrew-core"]
+        records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(records) == 1
+        text = records[0].getMessage()
+        assert "codex" in text
+        assert "kirocrew" in text
+        assert "@kirocrew-core" in text
+        assert "mcp_gateway=off" in text
+
+    def test_the_gateway_state_rides_along_because_it_decides_the_remedy(self, caplog):
+        spec = {"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": _CORE}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            warn_unresolved_server_refs(
+                spec, [], backend=ACP_BACKEND_CODEX, agent="a", gateway_enabled=True
+            )
+        assert "mcp_gateway=on" in caplog.records[-1].getMessage()
+
+    def test_a_healthy_spec_logs_nothing(self, caplog):
+        spec = {"tools": ["@srv"], "mcpServers": {"srv": {"command": "/bin/srv"}}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            assert (
+                warn_unresolved_server_refs(
+                    spec,
+                    _wire("srv"),
+                    backend=ACP_BACKEND_CLAUDE,
+                    agent="a",
+                    gateway_enabled=False,
+                )
+                == []
+            )
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    def test_the_line_is_bounded_but_the_count_is_not_lost(self, caplog):
+        many = [f"@srv{i:03d}" for i in range(mcp_ref_guard._REPORT_CAP + 5)]
+        spec = {"tools": many, "mcpServers": {}}
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            found = warn_unresolved_server_refs(
+                spec, [], backend=ACP_BACKEND_CODEX, agent="a", gateway_enabled=False
+            )
+        assert len(found) == len(many)
+        assert "(+5 more)" in caplog.records[-1].getMessage()
+
+
+class TestTheReportSlot:
+    def test_refs_reach_the_payload(self):
+        r = McpSessionReport()
+        r.begin_session(_wire("srv"))
+        r.record_unresolved_refs(["@ghost"])
+        payload = r.payload()
+        assert payload is not None
+        assert payload["unresolved_refs"] == ["@ghost"]
+
+    def test_a_new_session_attempt_clears_them(self):
+        # Same cross-attempt leak `begin_session` closes for every other bucket: a
+        # failed session/load's finding must not be published as the replacement
+        # session's own.
+        r = McpSessionReport()
+        r.record_unresolved_refs(["@ghost"])
+        r.begin_session(_wire("srv"))
+        payload = r.payload()
+        assert payload is not None
+        assert payload["unresolved_refs"] == []
+
+    def test_a_second_evaluation_replaces_rather_than_appends(self):
+        r = McpSessionReport()
+        r.record_unresolved_refs(["@a", "@b"])
+        r.record_unresolved_refs(["@b"])
+        assert r.unresolved_refs == ("@b",)
+
+    def test_refs_are_sanitized_and_deduplicated(self):
+        r = McpSessionReport()
+        r.record_unresolved_refs(["@a\nb", "@a b", "@x", "@x", 7, None, ""])
+        # The newline collapses to a space, so the first two are one ref: a name
+        # reaching a log line must not be able to forge a second line. The
+        # non-strings are dropped rather than stringified -- a row reading `None`
+        # would read as a server the spec asked for.
+        assert r.unresolved_refs == ("@a b", "@x")
+
+    @pytest.mark.parametrize("refs", [None, "@srv", 7])
+    def test_a_non_list_records_nothing(self, refs):
+        r = McpSessionReport()
+        r.record_unresolved_refs(refs)
+        assert r.unresolved_refs == ()
+
+
+class TestTheCompositionPath:
+    """The guard is reached where the wire array is actually built."""
+
+    @pytest.fixture
+    def agents_dir(self, tmp_path, monkeypatch):
+        d = tmp_path / "agents"
+        d.mkdir()
+        monkeypatch.setattr(agent_mod, "KIRO_AGENTS_DIR", d)
+        monkeypatch.setattr(session_mcp, "ensure_agent_materialized", lambda _a: True)
+        monkeypatch.setattr(
+            session_mcp,
+            "managed_mcp_spec_entry",
+            lambda name: {"kirocrew-core": dict(_CORE), "kirocrew-cron": dict(_CRON)}.get(name),
+        )
+        monkeypatch.setattr(session_mcp, "_mcp_registry_mode", lambda: False)
+        return d
+
+    def _spec(self, agents_dir, *, servers: dict, tools: list) -> None:
+        (agents_dir / "kirocrew.json").write_text(
+            json.dumps({"name": "kirocrew", "mcpServers": servers, "tools": tools}),
+            encoding="utf-8",
+        )
+
+    def _client(self, tmp_path, agents_dir, backend: str) -> AcpClient:
+        """A client whose spawn-path warms have run, as ``_spawn`` does.
+
+        Both are deliberately off-loop in production: the composition site is
+        shared with kiro-cli and must stay a synchronous in-memory read
+        (harness-parity H13), so a test that skips the warm exercises the
+        guard's silent path rather than its finding.
+        """
+        client = AcpClient(work_dir=tmp_path, agent="kirocrew", acp_backend=backend)
+        client._write_claude_local_settings()
+        client._mcp_ref_spec = client._read_mcp_ref_spec()
+        return client
+
+    def _compose(self, client: AcpClient) -> list[dict[str, Any]]:
+        """The array the session/new call site builds, then the guard over it."""
+        wire = [
+            *(client._claude_session_mcp_servers() if client._is_claude else []),
+            *(client._codex_session_mcp_servers() if client._is_codex else []),
+        ]
+        client._begin_session_report(wire)
+        client._guard_unresolved_mcp_refs(wire)
+        return wire
+
+    def test_a_codex_session_today_records_the_finding(self, tmp_path, agents_dir, caplog):
+        self._spec(
+            agents_dir,
+            servers={"kirocrew-core": dict(_CORE)},
+            tools=["@kirocrew-core", "@kirocrew-cron"],
+        )
+        client = self._client(tmp_path, agents_dir, ACP_BACKEND_CODEX)
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            assert self._compose(client) == []
+        assert client.mcp_session_report().unresolved_refs == ("@kirocrew-core", "@kirocrew-cron")
+        assert "@kirocrew-core" in caplog.text
+
+    def test_a_claude_session_whose_mirror_projects_the_server_is_silent(
+        self, tmp_path, agents_dir, caplog
+    ):
+        self._spec(
+            agents_dir,
+            servers={"kirocrew-core": dict(_CORE)},
+            tools=["@kirocrew-core", "@kirocrew-cron"],
+        )
+        client = self._client(tmp_path, agents_dir, ACP_BACKEND_CLAUDE)
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            names = {e["name"] for e in self._compose(client)}
+        assert {"kirocrew-core", "kirocrew-cron"} <= names
+        assert client.mcp_session_report().unresolved_refs == ()
+        assert "name no MCP server" not in caplog.text
+
+    def test_a_kiro_session_is_silent_on_its_empty_array(self, tmp_path, agents_dir, caplog):
+        # kiro-cli receives no array by design and loads the spec via --agent, so
+        # the guard must read its refs against the spec.
+        self._spec(agents_dir, servers={"kirocrew-core": dict(_CORE)}, tools=["@kirocrew-core"])
+        client = self._client(tmp_path, agents_dir, ACP_BACKEND_KIRO)
+        with caplog.at_level(logging.WARNING, logger=mcp_ref_guard.__name__):
+            assert self._compose(client) == []
+        assert client.mcp_session_report().unresolved_refs == ()
+
+    def test_the_guard_reads_no_disk_at_the_shared_call_site(
+        self, tmp_path, agents_dir, monkeypatch
+    ):
+        """H13: the composition site is a pure in-memory read for every backend.
+
+        A cold snapshot silences the guard rather than resolving inline, because
+        nothing about the session depends on the answer -- unlike the MCP array
+        itself, which does and therefore may.
+        """
+        self._spec(agents_dir, servers={}, tools=["@ghost"])
+        client = AcpClient(work_dir=tmp_path, agent="kirocrew", acp_backend=ACP_BACKEND_CODEX)
+
+        def _boom(*_a, **_k):
+            raise AssertionError("the guard read the agent spec at the call site")
+
+        monkeypatch.setattr(client_mod, "agent_spec_snapshot", _boom)
+        client._begin_session_report([])
+        client._guard_unresolved_mcp_refs([])
+        assert client.mcp_session_report().unresolved_refs == ()
+
+    def test_a_reset_drops_the_snapshot_so_an_edited_spec_is_reread(self, tmp_path, agents_dir):
+        self._spec(agents_dir, servers={}, tools=["@ghost"])
+        client = self._client(tmp_path, agents_dir, ACP_BACKEND_CODEX)
+        assert client._mcp_ref_spec is not None
+        client._reset_state()
+        assert client._mcp_ref_spec is None
+
+    def test_the_guard_never_raises_out_of_the_call_site(self, tmp_path, agents_dir, monkeypatch):
+        # It runs on a session-establishment path shared with kiro-cli, so a
+        # failure here must cost a log line and nothing else.
+        self._spec(agents_dir, servers={}, tools=["@ghost"])
+        client = self._client(tmp_path, agents_dir, ACP_BACKEND_CODEX)
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("guard exploded")
+
+        monkeypatch.setattr(client_mod, "warn_unresolved_server_refs", _boom)
+        client._begin_session_report([])
+        client._guard_unresolved_mcp_refs([])  # must not raise
+
+    def test_a_spec_that_cannot_be_read_leaves_no_snapshot(self, tmp_path, agents_dir, monkeypatch):
+        client = AcpClient(work_dir=tmp_path, agent="kirocrew", acp_backend=ACP_BACKEND_CODEX)
+
+        def _boom(*_a, **_k):
+            raise OSError("spec unreadable")
+
+        monkeypatch.setattr(client_mod, "agent_spec_snapshot", _boom)
+        assert client._read_mcp_ref_spec() is None
+
+
+class TestTheCallSitesAreWired:
+    """The guard is reached from the real composition path, not only from a test.
+
+    ``TestTheCompositionPath`` above reproduces the array the call site builds, so
+    it proves the GUARD is right while proving nothing about whether anything calls
+    it. These two do that half: one drives ``session/new`` for real, and one holds
+    every roster hand-off in the client to the pairing, which is the only way to
+    cover the ``session/load`` twin without standing up a resume.
+    """
+
+    @pytest.mark.asyncio
+    async def test_session_new_reaches_the_guard(self, tmp_path, monkeypatch):
+        client = AcpClient(work_dir=tmp_path, agent="kirocrew", acp_backend=ACP_BACKEND_CODEX)
+        client._mcp_ref_spec = {"tools": ["@kirocrew-core"], "mcpServers": {}}
+
+        async def _work_dir():
+            return str(tmp_path)
+
+        async def _send(_method, _params):
+            return 1
+
+        async def _wait(_rid, **_kw):
+            return {"sessionId": "s-1"}
+
+        monkeypatch.setattr(client, "_session_work_dir", _work_dir)
+        monkeypatch.setattr(client, "_send_request", _send)
+        monkeypatch.setattr(client, "_wait_for_response", _wait)
+
+        resp = await client._new_session_following_substitution()
+
+        assert resp["sessionId"] == "s-1"
+        assert client.mcp_session_report().unresolved_refs == ("@kirocrew-core",)
+
+    def test_every_roster_handoff_is_paired_with_the_guard(self):
+        """Both call sites, held to the pairing by structure.
+
+        ``_begin_session_report`` marks the point at which the wire array is final,
+        which is exactly where the guard can be evaluated -- so a new
+        session-establishment path that hands over a roster and forgets the guard is
+        the omission this pins. It also pins the ORDER: the report clear runs first,
+        and a guard that ran before it would have its row erased.
+        """
+        lines = inspect.getsource(client_mod).splitlines()
+        handoffs = [i for i, ln in enumerate(lines) if "self._begin_session_report(" in ln]
+        assert len(handoffs) == 2, "a session-establishment path was added or removed"
+        for i in handoffs:
+            roster = lines[i].split("_begin_session_report(", 1)[1]
+            # The next statement, skipping the comments that explain the pairing.
+            j = i + 1
+            while j < len(lines) and (not lines[j].strip() or lines[j].lstrip().startswith("#")):
+                j += 1
+            guard = lines[j]
+            assert (
+                "self._guard_unresolved_mcp_refs(" in guard
+            ), f"line {i} hands over a final roster and never reaches the guard: {guard!r}"
+            # Same argument, so the guard judges the array that actually went out
+            # rather than a stale or differently-composed one.
+            assert guard.split("_guard_unresolved_mcp_refs(", 1)[1] == roster

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -378,6 +378,143 @@ class TestTrustRoot:
         assert "⚠" not in out
 
 
+class TestUnresolvedMcpRefs:
+    """`kirocrew doctor` answers "why does my agent have no tools here?" statically.
+
+    The runtime guard in ``acp/mcp_ref_guard`` reports the same thing from inside a
+    session; this row reports it before one, per selectable harness. Advisory by
+    design -- a harness with no projection yet is a known state of the tree, not a
+    broken install, so it must never move doctor's exit code.
+    """
+
+    def _wire(self, *names: str) -> list:
+        return [{"name": n, "command": "/bin/x", "args": [], "env": [], "type": "stdio"} for n in names]
+
+    def _arrange(self, monkeypatch, *, spec, backends, projections, no_mirror=("codex",)):
+        """Point the check's three lookups at fixtures.
+
+        The check imports them inside the function (doctor keeps its import graph
+        lazy), so the patches land on the source modules.
+        """
+        from kiro_crew import acp_backends, providers
+        from kiro_crew.acp import session_mcp
+
+        # The PACKAGE module, not registry: ``providers/mirrors/__init__`` re-exports
+        # both names, so that is the binding the check's own import reads.
+        mirrors = providers.mirrors
+
+        monkeypatch.setattr(session_mcp, "agent_spec_snapshot", lambda _a: spec)
+        monkeypatch.setattr(acp_backends, "selectable_backend_values", lambda: backends)
+
+        class _Mirror:
+            def __init__(self, servers):
+                self._servers = servers
+
+            def session_params(self, _agent, **_kw):
+                return {"mcpServers": self._servers}
+
+        def _mirror_for(backend):
+            projected = projections.get(backend)
+            return None if projected is None else _Mirror(projected)
+
+        monkeypatch.setattr(mirrors, "mirror_for", _mirror_for)
+        monkeypatch.setattr(mirrors, "NO_MIRROR", {b: "declared" for b in no_mirror})
+
+    def test_a_backend_with_no_projection_names_the_unprojected_refs(self, monkeypatch, capsys):
+        self._arrange(
+            monkeypatch,
+            spec={"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": {"command": "/x"}}},
+            backends=["codex"],
+            projections={"codex": None},
+        )
+        cli_doctor._doctor_unresolved_mcp_refs()
+        out = capsys.readouterr().out
+        assert "codex has no mirror" in out
+        assert "@kirocrew-core" in out
+
+    def test_a_healthy_projection_prints_a_clean_row(self, monkeypatch, capsys):
+        self._arrange(
+            monkeypatch,
+            spec={"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": {"command": "/x"}}},
+            backends=["claude"],
+            projections={"claude": self._wire("kirocrew-core")},
+            no_mirror=(),
+        )
+        cli_doctor._doctor_unresolved_mcp_refs()
+        out = capsys.readouterr().out
+        assert "✅ claude" in out
+        assert "@kirocrew-core" not in out
+
+    def test_kiro_reads_its_refs_against_the_spec_not_the_empty_array(self, monkeypatch, capsys):
+        """Crew passes kiro-cli no array on purpose; it loads the spec via --agent.
+
+        Judging it against the wire would make the healthiest install in the tree
+        print every ref it declares -- the false positive that would get this row
+        deleted rather than fixed.
+        """
+        self._arrange(
+            monkeypatch,
+            spec={"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": {"command": "/x"}}},
+            backends=[""],
+            projections={"": None},
+            no_mirror=("",),
+        )
+        cli_doctor._doctor_unresolved_mcp_refs()
+        out = capsys.readouterr().out
+        assert "✅ kiro" in out
+
+    def test_a_mirrored_backend_that_still_drops_a_ref_is_the_louder_row(self, monkeypatch, capsys):
+        # A mirror exists and its projection lost the server anyway, which is a
+        # different problem from having no projection at all.
+        self._arrange(
+            monkeypatch,
+            spec={"tools": ["@marked"], "mcpServers": {"marked": {"type": "registry"}}},
+            backends=["claude"],
+            projections={"claude": []},
+            no_mirror=(),
+        )
+        cli_doctor._doctor_unresolved_mcp_refs()
+        out = capsys.readouterr().out
+        assert "⚠ claude" in out
+        assert "@marked" in out
+
+    def test_no_spec_on_disk_is_informational(self, monkeypatch, capsys):
+        self._arrange(monkeypatch, spec=None, backends=["codex"], projections={})
+        cli_doctor._doctor_unresolved_mcp_refs()
+        assert "no default agent spec" in capsys.readouterr().out
+
+    def test_the_row_never_moves_doctors_exit_code(self):
+        """It takes no ``issues`` list, so it structurally cannot append one.
+
+        Same rule as ``_doctor_strict_identity``: making every stock host red for a
+        backend nobody selected is how a useful note becomes one people disable.
+        """
+        import inspect
+
+        assert list(inspect.signature(cli_doctor._doctor_unresolved_mcp_refs).parameters) == []
+
+    def test_the_row_is_reached_from_the_report_itself(self):
+        """The check runs, rather than merely existing for its own tests to call.
+
+        Every other test here invokes it directly, so all of them stay green on a
+        build where nothing in ``_doctor`` calls it at all -- which is the same
+        shape of omission the guard exists to detect, one layer up.
+        """
+        import inspect
+
+        assert "_doctor_unresolved_mcp_refs()" in inspect.getsource(cli_doctor._doctor)
+
+    def test_an_unreadable_registry_does_not_break_triage(self, monkeypatch, capsys):
+        from kiro_crew.acp import session_mcp
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("spec unreadable")
+
+        monkeypatch.setattr(session_mcp, "agent_spec_snapshot", _boom)
+        cli_doctor._doctor_unresolved_mcp_refs()  # must not raise
+        assert capsys.readouterr().out == ""
+
+
 class TestSwapTotalProbe:
     """``SwapTotal`` parsed from /proc/meminfo → KiB, or None when unreadable."""
 

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -381,107 +381,80 @@ class TestTrustRoot:
 class TestUnresolvedMcpRefs:
     """`kirocrew doctor` answers "why does my agent have no tools here?" statically.
 
-    The runtime guard in ``acp/mcp_ref_guard`` reports the same thing from inside a
-    session; this row reports it before one, per selectable harness. Advisory by
+    The runtime detector in ``acp/mcp_ref_guard`` reports the same thing from inside
+    a session; this row reports it before one, per selectable harness. Advisory by
     design -- a harness with no projection yet is a known state of the tree, not a
     broken install, so it must never move doctor's exit code.
     """
 
-    def _wire(self, *names: str) -> list:
-        return [{"name": n, "command": "/bin/x", "args": [], "env": [], "type": "stdio"} for n in names]
+    def _arrange(self, monkeypatch, rows, *, spec_found=True):
+        """Fixture the SDK delegation the row asks.
 
-    def _arrange(self, monkeypatch, *, spec, backends, projections, no_mirror=("codex",)):
-        """Point the check's three lookups at fixtures.
-
-        The check imports them inside the function (doctor keeps its import graph
-        lazy), so the patches land on the source modules.
+        Patched at ``agent_sdk.drivers.acp``, its defining module, because the row
+        imports it inside the function (doctor keeps its import graph lazy). That
+        the row asks ONE boundary-clean question rather than assembling the answer
+        from the spec, the backend registry and the mirror seam is the reason this
+        fixture is a single return value -- and is what keeps `cli_doctor` off the
+        agent-sdk-boundary baseline.
         """
-        from kiro_crew import acp_backends, providers
-        from kiro_crew.acp import session_mcp
+        from kiro_crew.agent_sdk.drivers import acp as acp_driver
 
-        # The PACKAGE module, not registry: ``providers/mirrors/__init__`` re-exports
-        # both names, so that is the binding the check's own import reads.
-        mirrors = providers.mirrors
-
-        monkeypatch.setattr(session_mcp, "agent_spec_snapshot", lambda _a: spec)
-        monkeypatch.setattr(acp_backends, "selectable_backend_values", lambda: backends)
-
-        class _Mirror:
-            def __init__(self, servers):
-                self._servers = servers
-
-            def session_params(self, _agent, **_kw):
-                return {"mcpServers": self._servers}
-
-        def _mirror_for(backend):
-            projected = projections.get(backend)
-            return None if projected is None else _Mirror(projected)
-
-        monkeypatch.setattr(mirrors, "mirror_for", _mirror_for)
-        monkeypatch.setattr(mirrors, "NO_MIRROR", {b: "declared" for b in no_mirror})
+        monkeypatch.setattr(
+            acp_driver, "agent_spec_mcp_refs", lambda _agent: (spec_found, rows)
+        )
 
     def test_a_backend_with_no_projection_names_the_unprojected_refs(self, monkeypatch, capsys):
-        self._arrange(
-            monkeypatch,
-            spec={"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": {"command": "/x"}}},
-            backends=["codex"],
-            projections={"codex": None},
-        )
+        self._arrange(monkeypatch, [("codex", ["@kirocrew-core"], False)])
         cli_doctor._doctor_unresolved_mcp_refs()
         out = capsys.readouterr().out
         assert "codex has no mirror" in out
         assert "@kirocrew-core" in out
 
     def test_a_healthy_projection_prints_a_clean_row(self, monkeypatch, capsys):
-        self._arrange(
-            monkeypatch,
-            spec={"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": {"command": "/x"}}},
-            backends=["claude"],
-            projections={"claude": self._wire("kirocrew-core")},
-            no_mirror=(),
-        )
+        self._arrange(monkeypatch, [("claude", [], True)])
         cli_doctor._doctor_unresolved_mcp_refs()
         out = capsys.readouterr().out
-        assert "✅ claude" in out
-        assert "@kirocrew-core" not in out
+        assert out.strip() == "mcp tool refs: \u2705 claude \u2014 every @server ref resolves"
+        # The whole row, so a clean backend cannot also print a remedy paragraph.
+        assert "no mirror" not in out and "still misses" not in out
 
-    def test_kiro_reads_its_refs_against_the_spec_not_the_empty_array(self, monkeypatch, capsys):
-        """Crew passes kiro-cli no array on purpose; it loads the spec via --agent.
+    def test_kiro_is_labelled_by_its_policy_id_not_the_empty_string(self, monkeypatch, capsys):
+        """The kiro backend is spelled ``""``, which would print as a blank row.
 
-        Judging it against the wire would make the healthiest install in the tree
-        print every ref it declares -- the false positive that would get this row
-        deleted rather than fixed.
+        Same translation ``_doctor_agent_auth`` applies: the policy id is the
+        readable name for the one backend whose identifier is empty.
         """
-        self._arrange(
-            monkeypatch,
-            spec={"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": {"command": "/x"}}},
-            backends=[""],
-            projections={"": None},
-            no_mirror=("",),
-        )
+        self._arrange(monkeypatch, [("", [], True)])
         cli_doctor._doctor_unresolved_mcp_refs()
-        out = capsys.readouterr().out
-        assert "✅ kiro" in out
+        assert "\u2705 kiro" in capsys.readouterr().out
 
     def test_a_mirrored_backend_that_still_drops_a_ref_is_the_louder_row(self, monkeypatch, capsys):
         # A mirror exists and its projection lost the server anyway, which is a
         # different problem from having no projection at all.
-        self._arrange(
-            monkeypatch,
-            spec={"tools": ["@marked"], "mcpServers": {"marked": {"type": "registry"}}},
-            backends=["claude"],
-            projections={"claude": []},
-            no_mirror=(),
-        )
+        self._arrange(monkeypatch, [("claude", ["@marked"], True)])
         cli_doctor._doctor_unresolved_mcp_refs()
         out = capsys.readouterr().out
-        assert "⚠ claude" in out
+        assert "\u26a0 claude" in out
         assert "@marked" in out
+        assert "has no mirror" not in out
 
     def test_no_spec_on_disk_is_informational(self, monkeypatch, capsys):
-        self._arrange(monkeypatch, spec=None, backends=["codex"], projections={})
+        self._arrange(monkeypatch, [], spec_found=False)
         cli_doctor._doctor_unresolved_mcp_refs()
         assert "no default agent spec" in capsys.readouterr().out
+
+    def test_a_ref_carrying_terminal_controls_is_rendered_inert(self, monkeypatch, capsys):
+        """Spec-derived text printed to a terminal goes through ``_safe_display``.
+
+        A cloned repository ships its own ``<project>/.kiro/agents/*.json`` and an
+        installed app registers a user-level spec, so a ref can carry OSC/ANSI
+        sequences that spoof the diagnostic lines around it.
+        """
+        self._arrange(monkeypatch, [("codex", ["@srv\x1b]0;pwned\x07"], False)])
+        cli_doctor._doctor_unresolved_mcp_refs()
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "srv" in out
 
     def test_the_row_never_moves_doctors_exit_code(self):
         """It takes no ``issues`` list, so it structurally cannot append one.
@@ -498,19 +471,54 @@ class TestUnresolvedMcpRefs:
 
         Every other test here invokes it directly, so all of them stay green on a
         build where nothing in ``_doctor`` calls it at all -- which is the same
-        shape of omission the guard exists to detect, one layer up.
+        shape of omission the detector exists to catch, one layer up.
         """
         import inspect
 
         assert "_doctor_unresolved_mcp_refs()" in inspect.getsource(cli_doctor._doctor)
 
-    def test_an_unreadable_registry_does_not_break_triage(self, monkeypatch, capsys):
+    def test_the_sdk_probe_models_an_owned_permission_surface(self, monkeypatch):
+        """The delegation must pass ``permission_surface_owned=True``.
+
+        The claude mirror withholds its WHOLE array when Crew did not author the
+        session's native permission file — a per-session fact no static check can
+        know. Passing False would make doctor report every ref as unresolved on the
+        one backend whose projection actually works, which is the false positive
+        that would get this row disabled.
+        """
+        from kiro_crew import acp_backends, providers
         from kiro_crew.acp import session_mcp
+        from kiro_crew.agent_sdk.drivers import acp as acp_driver
+
+        seen: dict = {}
+
+        class _Mirror:
+            def session_params(self, _agent, **kw):
+                seen.update(kw)
+                return {"mcpServers": [{"name": "kirocrew-core"}]}
+
+        monkeypatch.setattr(
+            session_mcp,
+            "agent_spec_snapshot",
+            lambda _a: {"tools": ["@kirocrew-core"], "mcpServers": {"kirocrew-core": {}}},
+        )
+        monkeypatch.setattr(acp_backends, "selectable_backend_values", lambda: ["claude"])
+        # The PACKAGE module: the driver imports both names from ``providers.mirrors``.
+        monkeypatch.setattr(providers.mirrors, "mirror_for", lambda _b: _Mirror())
+
+        found, rows = acp_driver.agent_spec_mcp_refs("kirocrew")
+
+        assert found is True
+        assert seen.get("permission_surface_owned") is True
+        assert rows == [("claude", [], True)]
+
+    def test_an_unreadable_registry_does_not_break_triage(self, monkeypatch, capsys):
+        from kiro_crew.agent_sdk.drivers import acp as acp_driver
 
         def _boom(*_a, **_k):
             raise RuntimeError("spec unreadable")
 
-        monkeypatch.setattr(session_mcp, "agent_spec_snapshot", _boom)
+        monkeypatch.setattr(acp_driver, "agent_spec_mcp_refs", _boom)
         cli_doctor._doctor_unresolved_mcp_refs()  # must not raise
         assert capsys.readouterr().out == ""
 

--- a/test/test_mcp_session_report.py
+++ b/test/test_mcp_session_report.py
@@ -65,6 +65,7 @@ class TestBuckets:
         assert r.record_frame(_ready("github-mcp"), owned=True) is True
         assert r.payload() == {
             "configured": [],
+            "unresolved_refs": [],
             "ready": ["github-mcp"],
             "failed": [],
             "awaiting_auth": [],
@@ -95,6 +96,7 @@ class TestBuckets:
         assert r.record_frame(_ready("builder-mcp"), owned=True) is True
         assert r.payload() == {
             "configured": [],
+            "unresolved_refs": [],
             "ready": ["builder-mcp"],
             "failed": [],
             "awaiting_auth": [],

--- a/test/test_mcp_session_report_wiring.py
+++ b/test/test_mcp_session_report_wiring.py
@@ -104,6 +104,7 @@ class TestAcpClientCapture:
             == second
             == {
                 "configured": [],
+                "unresolved_refs": [],
                 "ready": ["a"],
                 "failed": [],
                 "awaiting_auth": [],

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -796,6 +796,15 @@ export interface TodoList {
 export interface McpSessionReport {
   /** Server names Kiro Crew put on the wire for this session. */
   configured: string[]
+  /**
+   * Agent-spec `@server` tool refs that named no server this session receives.
+   *
+   * A different claim from every bucket below: those say what a *configured*
+   * server reported, this says the spec asked for one that was never
+   * configured — so it has no row here to be missing from. Optional because a
+   * gateway from before the guard shipped sends no such key.
+   */
+  unresolved_refs?: string[]
   /** Reported initialized. */
   ready: string[]
   /** Reported a startup failure. */


### PR DESCRIPTION
## Problem / Motivation

The same defect has shipped **three times, on three harnesses**, and each time it was diagnosed from scratch by someone who did not know the previous one had happened. `src/kiro_crew/providers/mirrors/README.md` names the shape: a session comes up holding `tools: ["@kirocrew-core", ...]` while nothing in its effective `mcpServers` defines `kirocrew-core` — refs naming nothing, every Crew tool silently absent, the harness otherwise working and no error anywhere.

KAS hit it, then claude-agent-acp, then codex — and **codex is in exactly that state on a plain public build today**: `AcpClient._codex_session_mcp_servers()` returns `[]`, so with the shared MCP gateway off a codex session receives nothing at all while its spec declares and references Crew's whole control plane.

## Why it matters

Nothing detects the class. A mirror is the fix for one backend; a mirror that has not been written yet produces a session that looks completely healthy — prompts stream, permissions gate, the harness works — with every Crew tool missing. The user's only symptom is "the agent says it cannot do that", which is indistinguishable from a hundred other things. That is what made it cost three separate diagnoses, and nothing in the tree stops a fourth.

## What changed (motivation → approach → change)

**Goal:** make this class impossible to be silent, provider-agnostically, without changing what any session receives.

**Approach.** There is exactly one point where the question is answerable: where the `session/new` / `session/load` `mcpServers` array is final — spec projection plus the gateway's broker stubs. Before it, "the session receives it" is unknown; after it, the array is on the wire. So the detector is a pure function evaluated there.

Two rules keep it from crying wolf, and each was the failure mode that would get it deleted rather than fixed:

- **kiro-cli is judged against the spec, not the wire.** It is handed `--agent` and loads the spec itself, which is why Crew passes it an empty array by design — reading its refs against the wire would report every ref on the healthiest install in the tree.
- **`@builtin` and bare tool names are not server refs.** kiro's own configuration reference documents `@builtin` beside `@server`, so a spec written to that reference is correct.

A broker stub satisfies a ref on either backend, because it arrives on the wire under the name it wraps.

**Where it lives, and why that is not incidental.** The resolver is in `src/kiro_crew/agent_sdk/mcp_refs.py` and imports no ACP module at all. "Given a spec, a server array and a backend id, which refs resolve to nothing" is provider-neutral plain data, and putting it in the SDK is what lets `kirocrew doctor` ask the same question without holding backend knowledge — which the agent-sdk-boundary gate refuses a consumer, correctly: *which file a harness reads its servers from* is exactly what a consumer must not know. `acp/mcp_ref_guard.py` keeps only the ACP-shaped half (the log line at the session call sites).

**What was built:**

1. **`agent_sdk/mcp_refs.py`** — `parse_tools_refs`, `wire_server_names`, `unresolved_server_refs`, `RESERVED_TOOL_NAMESPACES`.
2. **`acp/mcp_ref_guard.py`** — one structured warning naming the backend, agent, unresolved refs and whether the shared gateway is on. The gateway state rides along because it decides the *remedy*, not the finding: reading the line without knowing which world it came from is what made this take three diagnoses.
3. **Wired at both composition sites** in `acp/client.py`, immediately after `_begin_session_report` (which clears the report — a guard running before it would have its row erased). Synchronous, in-memory and non-raising over a snapshot the spawn path warms. **It adds no `await` to any construction path:** the snapshot rides inside the `mkdir` hop `_spawn` already had (`_prepare_spawn_workspace`), so kiro-cli's suspension-point budget is unchanged (harness-parity **H13**). `mkdir` still runs first and still raises; the snapshot half runs second and swallows everything. A cold snapshot silences the detector rather than reading disk at the shared site — nothing about the session depends on the answer, unlike the MCP array itself, which does and therefore may.
4. **`unresolved_refs` on `McpSessionReport`** (payload + optional TS field). Its own slot rather than folded into a bucket: the buckets say what a *configured* server reported, this says the spec asked for one that was never configured — so there is no row for it to be missing from, which is precisely why the defect was invisible.
5. **A `kirocrew doctor` row** per selectable backend, asking one boundary-clean delegation (`agent_sdk.drivers.acp.agent_spec_mcp_refs`). Informational, and it takes no `issues` list at all, on the terms `_doctor_strict_identity` sets — a harness with no projection yet is a known state of the tree, not a broken install, and failing doctor's exit code on it would make every stock host red for a backend nobody selected.
6. **`session_mcp._tools_grant` now mounts through the shared parser.** One reader of the `tools` ref vocabulary, because disagreement in either direction is the same defect: a detector reading `@srv` where the projection read nothing reports a ref as unresolved while the server mounts, and the reverse mounts a server the detector called absent. Behaviour is unchanged — the existing 71 `test_acp_session_mcp.py` tests pass untouched, including `test_at_wildcard_is_not_a_grant_all`.
7. **Docs** — a `## Runtime guard` section in `providers/mirrors/README.md` (plus the codex row and the translation-logic list), and a paragraph in `docs/system-specs/modules/agent-host-contract.md` §5.

**It changes nothing about a session.** Not the array, not the session's fate. A ref naming nothing is a configuration fact, and the complaint about this defect class was that it was invisible, not that it was tolerated.

### Review round 1

Both reds were the same shape — the detector was in the wrong layer — and commit 2 is that correction rather than two patches:

- **`check_agent_sdk_boundary` refused `cli_doctor.py` three new ACP/providers edges.** Fixed by moving the resolver into `agent_sdk` and giving doctor a single driver delegation, so `cli_doctor.py` stays off the boundary baseline. The SDK resolver carries its own wire-array reader instead of importing `mcp_session_report.roster_names`; their agreement is pinned by a test, because a detector warning that a server is missing while the panel lists it two rows down would be worse than none.
- **GPT 5.6 blocked the added `await asyncio.to_thread(self._read_mcp_ref_spec)`** as an H13 violation — a new suspension point on kiro-cli's construction path in service of a diagnostic. Not overridden: **the await is gone.** Folding the snapshot into the pre-existing `mkdir` hop makes the finding's mechanism factually absent rather than argued, and it shrinks the diff's footprint on the shared path.

### Review round 2

- **GPT 5.6 blocked the unresolved refs reaching the log ring unredacted**, and it was right — my own diff was already sanitizing them on the way to the browser (the report slot) and not on the way to the log. A ref is the substring of a `tools` entry after `@`, so it is whatever the spec's author put there, and this warning fires in *normal* operation. Fixed by sharing one cleaner rather than adding a second: `mcp_session_report._clean` becomes the public `sanitize_sink_text`, and the guard runs every ref and the agent name through it before logging **and in its return value**, so the next consumer to log the result inherits the redaction. `kirocrew doctor` prints refs through `_safe_display`, the same treatment every other spec-derived value in that report gets. Two sanitizers with the same job are two that can drift — which is this PR's own subject in miniature.

### Review round 3

- **CodeQL raised two new high-severity `py/clear-text-logging-sensitive-data` alerts** on the two interpolated values. The redaction from round 2 is there; CodeQL does not model `sanitize_sink_text` as a barrier, so it follows the spec-derived dataflow into the sink. A per-line `lgtm[...]` suppression was tried first and **did not clear it** — the alerts came back on the marked lines, so those comments are no longer honoured. Fixed the way this repository already answers exactly this problem: the log line spells its two values through `_log_safe`, a rebuild from the module's own alphabet (`keeper._locus` / `_metric_slug`, `name_grant`'s constant tables — "append the ALPHABET's own character object, not the input's"). It runs **after** the redactors, never instead: a credential-shaped name is pure alphanumerics, so the alphabet alone would pass one through. It also leaves out `:` and `/`, so a ref cannot spell an endpoint into the record at all — hardening, not just gate-appeasement.
- **GPT's non-blocking finding that "the DETECTOR for all of them" is false was correct.** KAS composes its array on `AcpRuntime` and never reaches this call site, so the runtime half covers kiro-cli, claude and codex only, and a KAS session's refs are checked by `kirocrew doctor` alone. Narrowed in the module docstring and in both docs, and pinned — including a test that fails if someone wires the runtime without correcting the claim.
- **GPT re-raised H13 twice more, against the spec read itself** ("keep the shared hop mkdir-only"). Overridden, on a rationale verified against the code rather than the pre-drafted one: the read resolves through `session_mcp._agent_spec_for`, whose first statement is `ensure_agent_materialized(agent)` — **the exact call the kiro branch of `_spawn` already awaits at `client.py:5411`**. So on the Kiro path it adds no storage dependency that path does not already have, and cannot be the difference between kiro-cli starting and not. It is also unconditional, argument-free and non-raising, so it adds none of the three things H13 names. And the suggested fix would itself breach H13: skipping the snapshot for Kiro requires a *conditional* on the Kiro construction path.

### Review round 5

- **The Comment History Gate** flagged two "no longer" phrases in a docstring and a test docstring. Rewritten in the present tense; comments state current behavior and the history lives in git.

### Review round 6

- **GPT flagged `parse_tools_refs` as quadratic, and it was right.** `server not in names` is a linear scan of the growing result list, so N distinct refs cost O(N²) on the session-establishment path — and the spec is only *size*-capped (50 MB, `hooks.MAX_FILE_BYTES`), never entry-capped, so N is operator-controlled. Both readers now dedupe through a set while an ordered list carries the output; order stays contractual (a stable warning across two sessions on one spec) and the pass is linear. Pinned two ways: a 60k-ref timing test with a wide margin (linear finishes in milliseconds, quadratic in minutes) and a direct assertion of the set-plus-ordered-list shape.

## Tests

`test/test_acp_mcp_ref_guard.py` + `TestUnresolvedMcpRefs` in `test/test_cli_doctor.py`:

- **Ref parsing** — both ref forms name the same server; bare tool names are not refs; bare `*` is grant-all and defines nothing; `@*` is a server *literally named* `*` (matching `connections.tool_aliases` and `kas_permissions`); `@`, `@/tool` and non-list/non-string `tools` are ordinary input, not errors. Plus: the SDK's wire reader and the report's `roster_names` agree on every array shape short of the report's browser-payload cap.
- **Resolution** — kiro resolves against the spec and NOT the wire (and the same spec on claude does report the ref); kiro still reports a ref the spec never defines; a stub-satisfied ref; a spec server the projection dropped (registry marker) is reported; `@builtin` is never reported while a server actually *called* `builtin` stays mountable; `*` beside an undefined ref does not swallow it; `disabledTools` never makes a ref unresolved; malformed spec and malformed wire array yield a finding or nothing, never an exception.
- **The warning** — exactly one line carrying backend, agent, refs and `mcp_gateway=on|off`; silent on a healthy spec; bounded output that still reports the true count.
- **The report slot** — refs reach the payload; a new session attempt clears them (the same cross-attempt leak `begin_session` closes for every other bucket); re-evaluation replaces rather than appends; sanitized, deduplicated, non-strings dropped.
- **The composition path** — a codex-shaped session today records the finding and logs it; a claude session whose mirror projects the server is silent; a kiro session is silent on its empty array; no disk is read at the shared call site; a reset drops the snapshot; the detector never raises out of the call site.
- **The call sites are wired** — `session/new` is driven for real (mocked request/response) and asserted to reach the detector, and a structural pin holds *every* roster hand-off in the client to the pairing, same argument, no `await` between them. That second one covers the `session/load` twin without standing up a resume.
- **The spawn hop** — it creates the dir *and* warms the snapshot; `mkdir` still raises while the snapshot half never does; and the H13 property is pinned as the *absence* of a separate hop (`_read_mcp_ref_spec` is never awaited in `_spawn`, and the fold is not split apart), so an unrelated await added later cannot fail it for the wrong reason.
- **Doctor** — unprojected backend names the refs; a healthy projection prints the clean row and no remedy paragraph; kiro is labelled by its policy id rather than printing a blank; a mirrored backend that still drops a ref is the louder row; no spec on disk is informational; the row is reached from `_doctor` itself; the SDK probe passes `permission_surface_owned=True`; an unreadable registry does not break triage; and the signature structurally cannot append to `issues`.

- **Redaction and the log rebuild** — a credential-shaped ref is redacted before it is logged and in the returned list; a ref cannot forge a second log line; a ref is length-bounded; a credential-shaped agent name is redacted (asserted as redaction, not control-stripping, because the format spells it `%r`, which already escapes a newline); the guard shares the report's sanitizer rather than re-implementing its order; and a ref carrying OSC/ANSI sequences is rendered inert in the doctor row. Plus the rebuild: the logged text is drawn from the module's alphabet, URL punctuation never reaches the line (two independent cuts — the parser stops at the first `/`, the alphabet drops `:`), the rebuild runs *after* the redactors and applies to the agent name too, an all-dropped name still prints `?`, a token is length-bounded, and the rebuild returns the alphabet's own characters — pinned on the source, because that property is invisible to any output assertion and the source is what the analyser reads.
- **Complexity** — both readers stay linear on a 60k-ref spec, and the set-backed dedup with ordered output is asserted directly rather than only measured.

**Revert-verify:** 32 mutations, **32 caught** — including the three gaps the review rounds exposed, where a test had been reproducing the wiring instead of asserting it.

## Manual verification

N/A — the paths are unit-covered end to end, including the real `session/new` composition. Verifying the codex warning against a live codex-acp session would need that adapter installed and would only re-observe what `test_a_codex_session_today_records_the_finding` already pins.

## Related Issues

Documented, not filed: `src/kiro_crew/providers/mirrors/README.md` "Why this folder exists".

## Known gaps

- **The warning WILL fire for codex until the codex mirror lands, and that is correct behaviour.** Nothing is projected onto a codex session today, so a spec referencing `@kirocrew-core` genuinely names a server the session does not receive. The codex mirror is a separate work item and is deliberately not implemented here.
- **No UI yet.** `unresolved_refs` is on the payload and in the TS type so the panel *can* render it; adding the row and its i18n strings is a follow-up, not folded into a detector PR.
- **The doctor row reads the mirror seam**, so a backend whose projection lives outside `providers/mirrors/` — KAS, per its own `NO_MIRROR` reason — reads as unprojected there. The row says which case it is rather than collapsing the two (`has_mirror`), and the docstring names the limit. The runtime detector is unaffected: KAS runs on `AcpRuntime`, not this composition path.
- **KAS is not covered at runtime.** It composes its `mcpServers` array on `AcpRuntime`, not at `AcpClient`'s call sites, so only `kirocrew doctor` checks its refs. Wiring the second transport means modelling KAS's own projection (`acp/kas_agents.py`, not the mirror seam), which is a separate change — doing it by guess would produce false warnings on the backend with the most complete projection in the tree.
- **`@server/tool` granularity.** A ref to one tool on a server requires the server, which is what the detector checks; whether that *tool* exists is not knowable without connecting, and the detector does not claim it.
- **At runtime the detector needs a snapshot**, so a client driven straight into `session/new` without the spawn path (a test, or a future caller) is silent rather than reading disk at the shared site. Deliberate, and `kirocrew doctor` covers the static case.

## Checklist

- [x] Two commits, Conventional Commits titles
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`providers/mirrors/README.md`, `agent-host-contract.md` §5)
- [x] No secrets, credentials, or internal references in the diff
