### PR TITLE
fix(file-explorer): keep directory listing resilient to an unreadable entry

### DIFF
--- a/src/kiro_crew/apps/builtins/file_explorer/server.py
+++ b/src/kiro_crew/apps/builtins/file_explorer/server.py
@@ -444,11 +444,17 @@ def _kirocrew_safe_children(kirocrew_dir: Path) -> list[dict]:
     kirocrew_dir = _contain_in_allowed_roots(kirocrew_dir, operation="tree_list")
     out: list[dict] = []
     try:
-        children = sorted(kirocrew_dir.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower()))
+        children = sorted(kirocrew_dir.iterdir(), key=_entry_sort_key)
     except (OSError, PermissionError):
         return out
     for child in children:
-        if _is_safe_crew_subdir(child.name) and child.is_dir():
+        # An unreadable child must not drop the readable safe subdirs, so guard
+        # the per-entry is_dir() the same way the sort key does.
+        try:
+            is_dir = child.is_dir()
+        except OSError:
+            continue
+        if _is_safe_crew_subdir(child.name) and is_dir:
             out.append(_entry_meta(child))
     return out
 
@@ -471,13 +477,19 @@ def _sel_audit(operation: str, resources: str, outcome: str = "granted") -> None
 
 def _file_kind(p: Path) -> str:
     # Follow symlinks: a symlink to a dir/file should behave like its target
-    # so the UI navigates into it instead of trying to read it as a file.
-    if p.is_dir():
-        return "dir"
-    if p.is_file():
-        return "file"
-    if p.is_symlink():
-        return "symlink"  # broken/dangling symlink
+    # so the UI navigates into it instead of reading it as a file. A probe can
+    # raise on an unreadable entry (e.g. TCC-protected); report it as "missing"
+    # -- the same access-failure sentinel _entry_meta uses -- so one child
+    # doesn't abort the whole listing.
+    try:
+        if p.is_dir():
+            return "dir"
+        if p.is_file():
+            return "file"
+        if p.is_symlink():
+            return "symlink"  # broken/dangling symlink
+    except OSError:
+        return "missing"
     return "other"
 
 
@@ -514,6 +526,17 @@ def _entry_meta(p: Path) -> dict:
     return info
 
 
+def _entry_sort_key(p: Path) -> tuple[bool, str]:
+    # Dirs first, then case-insensitive name. is_dir() can raise on an
+    # unreadable entry; treat that as a non-dir so one bad sibling never
+    # aborts the sort.
+    try:
+        is_dir = p.is_dir()
+    except OSError:
+        is_dir = False
+    return (not is_dir, p.name.lower())
+
+
 def _list_dir(p: Path, depth: int = 1, ignore: bool = True) -> tuple[list[dict], bool]:
     """List directory contents up to ``depth`` levels (1 = immediate children).
     Returns (entries, truncated)."""
@@ -527,8 +550,12 @@ def _list_dir(p: Path, depth: int = 1, ignore: bool = True) -> tuple[list[dict],
     def walk(d: Path, rem: int) -> list[dict]:
         if count[0] >= MAX_TREE_ENTRIES:
             return []
+        # A failure opening the directory is a real directory-level error; a
+        # failure statting one child (e.g. a TCC-protected ~/.docker) must not.
+        # Keep the sort key from raising so one bad sibling doesn't collapse the
+        # whole listing.
         try:
-            entries = sorted(d.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower()))
+            entries = sorted(d.iterdir(), key=_entry_sort_key)
         except (OSError, PermissionError) as exc:
             return [{"name": d.name, "path": str(d), "type": "error", "error": str(exc)}]
         items: list[dict] = []
@@ -552,8 +579,15 @@ def _list_dir(p: Path, depth: int = 1, ignore: bool = True) -> tuple[list[dict],
             count[0] += 1
             meta = _entry_meta(child)
             if rem > 1 and meta["type"] == "dir":
-                resolved_child = child.resolve()
-                if any(_is_within(resolved_child, root) for root in ALLOWED_ROOTS):
+                # resolve() can raise on an unreadable child; skip recursion
+                # for it rather than aborting the listing.
+                try:
+                    resolved_child = child.resolve()
+                except OSError:
+                    resolved_child = None
+                if resolved_child is not None and any(
+                    _is_within(resolved_child, root) for root in ALLOWED_ROOTS
+                ):
                     meta["children"] = walk(child, rem - 1)
             items.append(meta)
         return items
@@ -1223,7 +1257,7 @@ class FileExplorerHandler(BaseHTTPRequestHandler):
 
         results: list[dict] = []
         try:
-            children = sorted(parent.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower()))
+            children = sorted(parent.iterdir(), key=_entry_sort_key)
         except (OSError, PermissionError):
             return self._json(200, {"entries": []})
 
@@ -1242,7 +1276,12 @@ class FileExplorerHandler(BaseHTTPRequestHandler):
                 continue
             if plower and not name.lower().startswith(plower):
                 continue
-            is_dir = child.is_dir()
+            # Skip a child we cannot stat rather than dropping the whole
+            # completion list.
+            try:
+                is_dir = child.is_dir()
+            except OSError:
+                continue
             if kind == "dir" and not is_dir:
                 continue
             results.append(

--- a/test/test_file_explorer_app.py
+++ b/test/test_file_explorer_app.py
@@ -214,6 +214,50 @@ class TestListDir:
         names = {e["name"] for e in entries}
         assert "node_modules" in names
 
+    def test_one_unreadable_sibling_does_not_collapse_listing(self, tmp_tree):
+        """One child raising OSError/PermissionError during its stat must not
+        abort the whole listing: readable siblings still list and the
+        unreadable child degrades to a non-error node."""
+        real_is_dir = Path.is_dir
+
+        def boom(self, *args, **kwargs):
+            if self.name == "file.txt":
+                raise PermissionError(1, "Operation not permitted")
+            return real_is_dir(self, *args, **kwargs)
+
+        with patch.object(Path, "is_dir", boom):
+            entries, _ = server._list_dir(tmp_tree, depth=1, ignore=True)
+
+        # The listing did not collapse to a single error node.
+        error_nodes = [e for e in entries if e.get("type") == "error"]
+        assert not error_nodes, f"listing collapsed to error node(s): {entries!r}"
+        # Readable siblings are still present.
+        names = {e["name"] for e in entries}
+        assert "code.py" in names
+        assert "subdir" in names
+        # The unreadable child is still listed (its stat failure degrades to a
+        # "missing" node via _entry_meta rather than vanishing).
+        assert "file.txt" in names
+
+    def test_kirocrew_safe_children_survives_unreadable_sibling(self, tmp_tree):
+        """A single unreadable child must not empty the crew-home safe-subdir
+        list: the readable safe subdirs still return."""
+        crew = tmp_tree / ".kiro" / "crew"
+        (crew / "skills").mkdir(parents=True)
+        (crew / "workspace").mkdir()
+        real_is_dir = Path.is_dir
+
+        def boom(self, *args, **kwargs):
+            if self.name == "skills":
+                raise PermissionError(1, "Operation not permitted")
+            return real_is_dir(self, *args, **kwargs)
+
+        with patch.object(Path, "is_dir", boom):
+            out = server._kirocrew_safe_children(crew)
+
+        names = {e["name"] for e in out}
+        assert "workspace" in names  # readable safe subdir still listed
+
 
 class TestFileHelpers:
     def test_file_kind_file(self, tmp_tree):
@@ -501,6 +545,22 @@ class TestHTTPHandler:
         names = {e["name"] for e in responses[0][1]["entries"]}
         assert "file.txt" not in names  # kind=dir by default
         assert "subdir" in names
+
+    def test_complete_survives_unreadable_sibling(self, tmp_tree):
+        """One unreadable child must not empty the completion list: the
+        readable directories still complete."""
+        real_is_dir = Path.is_dir
+
+        def boom(self, *args, **kwargs):
+            if self.name == ".ssh":
+                raise PermissionError(1, "Operation not permitted")
+            return real_is_dir(self, *args, **kwargs)
+
+        with patch.object(Path, "is_dir", boom):
+            responses = self._make_request(f"/complete?path={tmp_tree}/&kind=dir")
+        assert responses[0][0] == 200
+        names = {e["name"] for e in responses[0][1]["entries"]}
+        assert "subdir" in names  # readable dir still completes
 
     def test_complete_bare_allowed_root_matches_trailing_slash(self, tmp_tree):
         """A bare allowed-root path (no trailing slash) must complete exactly


### PR DESCRIPTION
## Problem / Motivation

The Files app's directory listing collapses when a single child entry cannot be statted. On the home view, one unreadable sibling — most commonly a macOS TCC-protected `~/.docker` — makes the whole folder come back as a single placeholder node (or an empty list), hiding the user's real files. The same failure mode exists at three separate listing sites in `file_explorer/server.py`.

## Why it matters

The home directory is the Files app's default view, and `~/.docker` is present on any machine with Docker Desktop, so a single common unreadable entry makes the app look broken: the user sees one meaningless item (or nothing) instead of their files. It is a low-severity path (no crash, no data loss) but high visibility, since it hits the first thing most users open. The bug is not `~/.docker`-specific — any entry that raises `OSError`/`PermissionError` on `is_dir()`/`stat()`/`resolve()` (a broken symlink, a permission-denied dir, a flaky network volume) triggers it.

## What changed (motivation -> approach -> change)

- **Symptom:** listing a folder returns a single `{"type": "error"}` node (in `_list_dir`) or an empty list (in the crew-home and path-completion sites).
- **Root cause:** each of the three sites sorts entries with `sorted(dir.iterdir(), key=lambda x: (not x.is_dir(), ...))` inside a directory-level `try/except`. The sort key calls `is_dir()` (a stat) on every child, so one unreadable child raises and is caught by the directory-level handler — collapsing the entire listing. Two of the sites also call `child.is_dir()` again in their loop body, which can re-raise per child.
- **Change:**
  - Added a module-level `_entry_sort_key` helper: a dir-first, case-insensitive sort key that treats a failing `is_dir()` as a non-dir instead of raising.
  - Applied it at all three sort sites: `_kirocrew_safe_children`, `_list_dir.walk()`, and `_h_complete`. The `try/except` now guards only `iterdir()` (a genuine directory-open failure still yields the single error node / empty list, which is correct).
  - Guarded the per-child `is_dir()` calls in the two loop bodies (`_kirocrew_safe_children`, `_h_complete`) so one unreadable child is skipped, not fatal.
  - In `_list_dir`, `_file_kind()` reports an unreadable entry as `"missing"` (the same sentinel `_entry_meta` already uses for a failed `stat()`), and the recursion's `child.resolve()` is guarded so an unresolvable subdirectory is skipped for descent rather than aborting the walk.

  Readable siblings now list normally across all three sites; an unreadable entry degrades (to a `"missing"` node, or is simply skipped) instead of taking down the listing.

## Tests

- `test_one_unreadable_sibling_does_not_collapse_listing` — `_list_dir` keeps readable siblings when one child's `is_dir()` raises.
- `test_kirocrew_safe_children_survives_unreadable_sibling` — the crew-home safe-subdir list still returns readable subdirs past an unreadable one.
- `test_complete_survives_unreadable_sibling` — the `/api/complete` endpoint still completes readable dirs past an unreadable one.
- `pytest test/test_file_explorer_app.py`: 99 passed, 1 skipped (the skip is a pre-existing environment guard, unrelated to this change).
- `isort --check-only`, `flake8`, `mypy` all clean on the changed files.

## Manual verification

N/A — unit coverage sufficient. The change is backend-only and fully exercised by the three regression tests; the failure it fixes is a data-shape bug in the listing payload, not a rendering path.

## Related Issues

Related to #7252 (embedded Python lacking macOS TCC access is the OS-level reason an entry becomes unreadable). This PR is the independent app-layer resilience fix and does not depend on that packaging change.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a per-item operation that can raise (here `is_dir()`) placed inside a batch-level `try/except` meant for a coarser operation (here `iterdir()`), so one bad item fails the whole batch. The same spelling appeared at three sites in one file; the fix scopes the guard to the batch op and routes the per-item step through a non-raising helper. A review-prompt/semgrep rule could flag a `sorted(...)`/comprehension whose key or predicate does I/O when it sits inside an except meant for a coarser operation.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no docs affected
- [x] No secrets, credentials, or internal references in the diff