### PR TITLE
feat(verbosity): a picture is payload; prepare-pr picks the picture's form

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -700,50 +700,57 @@ technically exact.
   before, or stops seeing. Not "improves robustness".
 - **Show it, when words alone are slow.** A five-year-old gets a moved flow from
   one picture before they finish the first sentence about it. When the change
-  moves steps, states, or who calls whom, add one Mermaid diagram. See *Draw it*
-  below.
+  has a shape, add one picture of the delta. See *Draw it* below.
 
 Rewrite check before every push of the body: read section 3 once, out loud. If
 any sentence needs a second read to find its point, rewrite that sentence. If the
 first sentence of any section is not the point, move the point up. If any sentence
 says what an earlier version did, delete it — the body has no earlier version.
 
-#### Draw it — the Age 5 diagram
+#### Draw it — the Age 5 picture
 
-The doctrine lives in the `explain-for` skill: *Draw it when the thing has a
-shape* says when a Mermaid fence beats prose, and *Colour it, and make every
-colour mean something* says how to colour it. Do not restate it here — follow it.
-What this section adds is only what a PR body needs on top: the trigger, the fixed
-diff palette, the legend, the placement, and the render check.
+A picture is part of the body, not decoration on it. Draw one when the change has
+a **shape** the reviewer would otherwise have to rebuild in their head from prose:
+steps that moved, a state that changed hands, a guard that now passes or blocks
+different inputs, a structure that gained or lost a field. Skip it for a one-line
+fix, a rename, a test-only change, or a doc edit. **One picture, at most**, and a
+picture that only restates section 3 is deleted, not kept.
 
-Draw one when the change alters **a sequence, a state machine, or who calls
-whom** — a step added, removed, reordered, or given a new owner. Skip it for a
-one-line fix, a rename, a test-only change, or a doc edit. **One diagram, at most.**
+You choose the form. Anything GitHub renders inside a ```` ```mermaid ```` fence is
+fair — flowchart, sequence, state, class, ER, timeline, or whatever fits the delta —
+and when the delta is a **matrix** (which inputs pass or fail, how each platform
+behaves), a markdown table is the picture: rows are the concrete cases, columns are
+Before and After, each cell is one coloured verdict. Do not force a matrix into
+boxes and arrows. The constraints below are the ones that make every PR read the
+same way at a glance; everything else is your call.
 
-- **Mermaid, in the body.** GitHub renders a ```` ```mermaid ```` fence in the PR
-  body directly. Nothing to commit, no SHA to re-pin, nothing for
-  `cleanup-temp-screenshots.yml` to prune, and a reviewer can fix a box label in
-  the text. A real rendered screen or a pixel before/after is not a diagram — that
-  is a screenshot; see *Screenshots* below, which owns the path and pinning rules.
-- **Show the delta, not the whole system.** Before → after side by side
-  (`flowchart LR` with two subgraphs), or one graph where the changed edge is the
-  only thing that stands out. Six to ten nodes is the ceiling.
-- **The diff palette is fixed.** Declare these four `classDef`s and tag every
-  node, so each PR reads the same way at a glance:
+- **Text, in the body.** A Mermaid fence or a markdown table renders in the PR body
+  directly. Nothing to commit, no SHA to re-pin, nothing for
+  `cleanup-temp-screenshots.yml` to prune, and a reviewer can fix a label in the
+  text. A real rendered screen or a pixel before/after is not a picture of the
+  delta — that is a screenshot; see *Screenshots* below, which owns the path and
+  pinning rules.
+- **Before → After, and only the delta.** Two states side by side (two subgraphs,
+  or two columns), or one graph where the changed edge is the only thing that
+  stands out. Six to ten nodes, or eight rows, is the ceiling.
+- **The diff palette is fixed.** In a Mermaid fence declare these four `classDef`s
+  and tag every node; in a table use the matching squares in each cell:
 
-  | class | fill / stroke | meaning |
-  |---|---|---|
-  | `added` | `#DCFCE7` / `#16A34A` | new after this PR |
-  | `changed` | `#FEF3C7` / `#D97706` | behaviour changed |
-  | `removed` | `#FEE2E2` / `#DC2626`, dashed | gone after this PR |
-  | `ctx` | `#E0F2FE` / `#0284C7` | untouched, shown for context |
+  | class | fill / stroke | cell | meaning |
+  |---|---|---|---|
+  | `added` | `#DCFCE7` / `#16A34A` | 🟩 | new after this PR |
+  | `changed` | `#FEF3C7` / `#D97706` | 🟨 | behaviour changed |
+  | `removed` | `#FEE2E2` / `#DC2626`, dashed | 🟥 | gone after this PR |
+  | `ctx` | `#E0F2FE` / `#0284C7` | 🟦 | untouched, shown for context |
 
   Colour the edges too: `linkStyle <n> stroke:#16A34A,stroke-width:2px` on the
   new path, `stroke:#DC2626,stroke-dasharray:4 3` on the removed one. Put one
-  legend line under the fence: `🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged`.
-- **Caption in the Age 5 register**, one sentence: who now calls whom, and what
-  the reader sees because of it.
+  legend line under the picture: `🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged`.
+- **Caption in the Age 5 register**, one sentence: what now happens that did not,
+  and what the reader sees because of it.
 - **Place it inside section 3**, right after the paragraph it illustrates.
+
+A moved step, as a flowchart:
 
 ```mermaid
 flowchart LR
@@ -765,8 +772,21 @@ flowchart LR
 
 *The cron now runs a script instead of spending an LLM turn; the PR still opens.*
 
+A guard whose boundary moved, as a matrix:
+
+| case | Before | After |
+|---|---|---|
+| `~/.aws/credentials` read by a script | 🟦 blocked | 🟦 blocked |
+| the word `credentials` inside a code comment | 🟥 blocked | 🟩 allowed |
+| `%USERPROFILE%\.aws\credentials` on Windows | 🟥 allowed | 🟩 blocked |
+
+🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged
+
+*Real credential reads stay blocked on every platform; a comment that merely
+names the file no longer trips the guard.*
+
 Check the render before pushing — `gh pr view <n> --web`. A fence that fails to
-parse shows as a red error box, which is worse than no diagram.
+parse shows as a red error box, which is worse than no picture.
 
 ### Screenshots
 

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -2312,6 +2312,16 @@ class ContextBuilder:
                 "list is illustrative, not exhaustive: whenever a format is "
                 "mandated elsewhere in your instructions, brevity never "
                 "overrides it.\n\n"
+                "A picture is payload, not prose. When the answer has a "
+                "shape — a flow, a before/after, a matrix of cases and "
+                "verdicts — prefer one picture with a one-sentence caption "
+                "over the sentences that would describe it, and do not "
+                "repeat in words what the picture already shows. Use the "
+                "richest form this surface renders: an inline widget when "
+                "your instructions carry an Inline Widgets section, else a "
+                "mermaid fence, else an image file, else a plain table. A "
+                "picture that only restates the text is cut like any other "
+                "explanation.\n\n"
                 "Preserve the user's language."
             )
         else:

--- a/test/test_verbosity_config.py
+++ b/test/test_verbosity_config.py
@@ -575,6 +575,33 @@ class TestAnswerOnlyBlock:
             assert "That single line is the whole warning" not in result
             assert "The defect here is silence about a one-way door" not in result
 
+    def test_a_picture_is_payload_and_the_surface_picks_its_form(self):
+        """Measured gap this closes: asked how a guard change stops false
+        positives across platforms, answer_only wrote the case matrix out as
+        sentences — one per row — and the reader rebuilt the table in their
+        head. The block classes a picture as payload, so the one-sentence
+        bound does not read as a ban on drawing, and it ranks the forms by
+        what the surface renders: the widget clause is keyed on the Inline
+        Widgets section being present in the prompt, which
+        ``_resolve_prompt_placeholders`` already withholds off-dashboard, so
+        a Slack-only session degrades to a mermaid fence or a table without a
+        second surface check here.
+        """
+        result = _resolve("{{VERBOSITY_BLOCK}}", "dashboard:x", verbosity="answer_only")
+        assert "A picture is payload, not prose" in result
+        assert "a matrix of cases and verdicts" in result
+        assert "when your instructions carry an Inline Widgets section" in result
+        assert "else a mermaid fence, else an image file, else a plain table" in result
+
+    def test_a_picture_that_restates_the_text_is_cut(self):
+        """The preference for pictures must not become a licence to draw a
+        box with the paragraph inside it — that is explanation in a frame,
+        and the same opt-in rule removes it.
+        """
+        result = _resolve("{{VERBOSITY_BLOCK}}", "dashboard:x", verbosity="answer_only")
+        assert "do not repeat in words what the picture already shows" in result
+        assert "A picture that only restates the text is cut" in result
+
     def test_a_destructive_command_carries_its_undo_path(self):
         """Measured gap this closes: asked how to delete every local branch
         merged into main, answer_only returned the bare command and conveyed


### PR DESCRIPTION
## Problem / Motivation

`answer_only` writes a case matrix out as sentences. Asked how a guard change stops false positives across platforms, it produced one sentence per case and the reader rebuilt the table in their head. The mode's one-sentence-per-thing bound reads as a ban on drawing, so no picture is offered even when the answer is a shape.

`prepare-pr`'s *Draw it* section allows one diagram form. It names three triggers (a sequence, a state machine, who calls whom), prescribes a `flowchart LR` before/after, and points into the `explain-for` skill for the rest. A change whose delta is a matrix of inputs and verdicts has no sanctioned picture at all.

## Why it matters

A reader on `answer_only` gets the least readable version of exactly the answers that most need a picture. A PR body written under `prepare-pr` describes a moved decision boundary in prose, and the reviewer traces it through the diff instead.

## What changed (motivation → approach → change)

A picture is payload, not prose. `answer_only` says so in one paragraph: when the answer has a shape (a flow, a before/after, a matrix of cases and verdicts), prefer one picture with a one-sentence caption, and do not repeat it in words. The form follows the surface: an inline widget when the prompt carries an Inline Widgets section, else a mermaid fence, else an image file, else a plain table. That widget clause is keyed on a section `_resolve_prompt_placeholders` already withholds off-dashboard, so a Slack-only session degrades without a second surface check. A picture that only restates the text is cut like any other explanation.

`prepare-pr` keeps the constraints that make every PR body read the same way at a glance and drops the rest. Kept: Before → After showing only the delta, the fixed four-colour palette, one picture at most, a one-sentence caption, placement in section 3, the render check. Dropped: the diagram-type whitelist and the pointer into `explain-for`. Any form GitHub renders in a mermaid fence is allowed, and a delta that is a matrix is drawn as a markdown table with the same palette as cell squares. The section carries one example of each.

| case | Before | After |
|---|---|---|
| a moved step in a flow | 🟦 flowchart before/after | 🟦 flowchart before/after |
| a guard whose boundary moved | 🟥 prose, no picture | 🟩 markdown matrix, palette in the cells |
| a state or sequence change | 🟥 must be a `flowchart LR` | 🟩 any Mermaid form GitHub renders |
| which diagram to draw | 🟥 read `explain-for` | 🟩 the writer's call, inside the constraints |

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The body still gets one picture in the same colours; the writer now picks its shape.*

## Tests

- `test_a_picture_is_payload_and_the_surface_picks_its_form` locks the payload sentence, the matrix trigger, the Inline Widgets key, and the fallback order.
- `test_a_picture_that_restates_the_text_is_cut` locks the guard against a box with the paragraph inside it.
- Existing `test_verbosity_config.py`, `test_explain_for_skill.py`, `test_agent_template_skills.py`, `test_builtin_skill_sync_safety.py`, `test_prepare_pr_ledger_contract.py` pass unchanged.

## Manual verification

N/A — the change is prompt and skill prose; the tests pin the strings and no runtime path changed.

## Related Issues

None.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
