### PR TITLE
fix(browser): send the abandoned-pick removal from committed state (#10007)

### DIFF
--- a/website/src/components/WebPreviewPanel.tsx
+++ b/website/src/components/WebPreviewPanel.tsx
@@ -84,10 +84,15 @@ interface AnnotateMirror {
   page: { url: string; title: string }
   /** The note editor: which pick, and the text being typed. */
   editing: { id: number; text: string } | null
+  /** Abandoned pick ids whose overlay-side removal is still owed. The poll
+   *  reducer records them (it holds the pre-update mirror); a drain effect
+   *  sends each 'remove' after commit -- a state updater runs at render time
+   *  and may run more than once, so it must never call the bridge itself. */
+  pendingDrops: number[]
 }
 const EMPTY_TARGETS: BrowserAnnotationTarget[] = []
 const EMPTY_ANNOTATE: AnnotateMirror = {
-  slot: '', live: false, picking: false, targets: EMPTY_TARGETS, notes: {}, retained: [], page: { url: '', title: '' }, editing: null,
+  slot: '', live: false, picking: false, targets: EMPTY_TARGETS, notes: {}, retained: [], page: { url: '', title: '' }, editing: null, pendingDrops: [],
 }
 /** One mirror per chat slot. Kept as a map (not "the current slot's mirror")
  *  so switching sessions and coming back finds the notes where they were. */
@@ -115,6 +120,9 @@ function loadAnnotateMirrors(): AnnotateMirrors {
         retained: Array.isArray(m.retained) ? m.retained : [],
         page: m.page && typeof m.page === 'object' ? { url: String(m.page.url ?? ''), title: String(m.page.title ?? '') } : { url: '', title: '' },
         editing: m.editing && typeof m.editing === 'object' && typeof m.editing.id === 'number' ? { id: m.editing.id, text: String(m.editing.text ?? '') } : null,
+        // Like `picking`: a live-session transient. A reloaded renderer polls
+        // the overlay fresh, so an unsent drop simply re-lists its pick.
+        pendingDrops: [],
       }
     }
     return out
@@ -154,6 +162,8 @@ function detachAll(prev: AnnotateMirror): AnnotateMirror {
     ],
     targets: EMPTY_TARGETS,
     notes: {},
+    // The page took the overlay with it: there is nothing left to remove from.
+    pendingDrops: [],
   }
 }
 function saveAnnotateMirrors(mirrors: AnnotateMirrors): void {
@@ -732,7 +742,6 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
       if (stopped) return
       if (isAnnotatePoll(res)) {
         pollFailures.current = 0
-        const dropped: { id: number | null } = { id: null }
         patchSlot(slot, prev => {
           // A live pick can never share an id with a retained note (the overlay
           // is started past the highest retained id); one that does is a
@@ -755,6 +764,7 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
             notes = Object.fromEntries(Object.entries(prev.notes).filter(([id]) => keep.has(Number(id))))
           }
           let editing = prev.editing
+          let pendingDrops = prev.pendingDrops
           const moveTo = res.picked !== undefined ? res.picked : res.edit
           if (moveTo !== undefined && (!editing || editing.id !== moveTo)) {
             // The editor moves to another pick. Whatever was typed for the one
@@ -768,7 +778,11 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
               retained = retained.map(a => (a.id === editing!.id ? { ...a, note: text } : a))
             }
             if (editing && !editing.text.trim() && !(notes[editing.id] ?? '').trim() && targets.some(t => t.id === editing!.id) && editing.id !== moveTo) {
-              dropped.id = editing.id
+              // Record the drop; never call the bridge from in here. This
+              // updater runs at render time and can run more than once for one
+              // logical update, so the send happens in the drain effect below,
+              // and the `includes` guard keeps a re-run from queueing it twice.
+              if (!pendingDrops.includes(editing.id)) pendingDrops = [...pendingDrops, editing.id]
               targets = targets.filter(t => t.id !== editing!.id)
             }
             editing = { id: moveTo, text: notes[moveTo] ?? '' }
@@ -777,9 +791,8 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
           const page = { url: res.url, title: res.title }
           if (sameTargets && notes === prev.notes && retained === prev.retained && editing === prev.editing && prev.picking === res.picking
             && prev.page.url === page.url && prev.page.title === page.title) return prev
-          return { ...prev, picking: res.picking, targets, notes, retained, editing, page }
+          return { ...prev, picking: res.picking, targets, notes, retained, editing, page, pendingDrops }
         })
-        if (dropped.id !== null) void callAnnotate('remove', { id: dropped.id })
         return
       }
       // The overlay is gone (navigation) or the view itself is (closed,
@@ -801,6 +814,40 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
       clearInterval(t)
     }
   }, [annotateOn, canAnnotate, callAnnotate, sessionKey, patchSlot])
+
+  // Send the overlay-side removal for each abandoned pick AFTER the commit.
+  // The poll reducer only records the id (it is the one place that holds the
+  // pre-update mirror), because a state updater runs at render time -- reading
+  // a closure it mutated right after the setState call sees the untouched
+  // value, which is exactly the bug this drains away. Exactly one 'remove'
+  // goes out per id: the in-flight set covers effect re-runs while a send is
+  // still pending, and the id leaves the queue as soon as its send settles.
+  // A refused removal is surfaced like every other failed overlay update; the
+  // overlay then still reports the pick, so the next poll re-lists it rather
+  // than leaving a marker on the page the panel has forgotten. `no_overlay` /
+  // `no_view` stay silent: the page took the overlay with it, and the poll's
+  // detachAll already owns that path.
+  const pendingDrops = mirror.pendingDrops
+  // Keyed by slot AND id: pick ids are small per-session integers, so two
+  // sessions can hold the same id at once, and a bare-id key would make one
+  // session's in-flight send swallow the other's.
+  const dropsInFlight = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    if (!pendingDrops.length) return
+    const slot = sessionKey || ''
+    for (const id of pendingDrops) {
+      const flightKey = `${slot}:${id}`
+      if (dropsInFlight.current.has(flightKey)) continue
+      dropsInFlight.current.add(flightKey)
+      void callAnnotate('remove', { id }).then(res => {
+        dropsInFlight.current.delete(flightKey)
+        patchSlot(slot, prev => (prev.pendingDrops.includes(id) ? { ...prev, pendingDrops: prev.pendingDrops.filter(d => d !== id) } : prev))
+        if (res && res.ok) return
+        if (res && !res.ok && (res.code === 'no_overlay' || res.code === 'no_view')) return
+        setAnnotateError(annotateFailureText(res) || i18nT('components.webPreviewPanel.annotate_update_failed'))
+      })
+    }
+  }, [pendingDrops, callAnnotate, patchSlot, sessionKey])
 
   // The pick happened in the page; the note is typed here. Focus the editor
   // as soon as it opens (the main process has already handed keyboard focus

--- a/website/src/test/WebPreviewPanel.test.tsx
+++ b/website/src/test/WebPreviewPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { screen, fireEvent, act, waitFor } from '@testing-library/react'
 
+import { StrictMode } from 'react'
 import { renderWithProviders } from './helpers'
 import WebPreviewPanel, { normalizeUrl, setSessionPreviewUrl, setSessionPreviewPending, isolatePreviewHost, isDashboardOrigin, withCacheBuster } from '../components/WebPreviewPanel'
 
@@ -1010,6 +1011,80 @@ describe('WebPreviewPanel — native browser transport', () => {
     await waitFor(() => expect(annotate).toHaveBeenCalledWith('sess-1', 'remove', { id: 1 }))
     await waitFor(() => expect(screen.getByTestId('browser-annotations').querySelectorAll('li')).toHaveLength(1))
     expect(screen.getByTestId('browser-annotations')).toHaveTextContent('1 note')
+  })
+
+  it('the abandoned pick is removed even when another panel update is already queued (no reliance on an eager dispatch)', async () => {
+    // The removal decision is made inside a state updater, which React runs at
+    // render time. When the fiber already has an update queued, the dispatch
+    // takes no synchronous shortcut -- a closure mutated inside the updater is
+    // untouched when the next statement reads it. Feeding a pending preview URL
+    // from inside the poll reply queues exactly such an update in the same
+    // task, so this locks the removal to committed state, not to timing.
+    const { annotate, state } = installAnnotateBridge()
+    renderWithProviders(<WebPreviewPanel sessionKey="sess-1" active />)
+    fireEvent.click(await screen.findByTestId('browser-annotate'))
+    await screen.findByTestId('browser-annotations')
+    state.items = [TARGET]
+    state.picked = 1
+    await screen.findByTestId('browser-annotation-note-input')
+    const t2 = { ...TARGET, id: 2, n: 2, ref: 'e4', tag: 'input', role: 'combobox', name: 'Search', text: '' }
+    const impl = annotate.getMockImplementation()!
+    annotate.mockImplementation(async (p: string, op: string, args?: Record<string, unknown>) => {
+      if (op === 'poll') setSessionPreviewPending('sess-1', 'http://localhost:5173/')
+      return impl(p, op, args)
+    })
+    state.items = [TARGET, t2]
+    state.picked = 2
+    await waitFor(() => expect(annotate).toHaveBeenCalledWith('sess-1', 'remove', { id: 1 }))
+    await waitFor(() => expect(screen.getByTestId('browser-annotations').querySelectorAll('li')).toHaveLength(1))
+    // Exactly one removal per abandoned pick, across every later poll tick.
+    await new Promise(r => setTimeout(r, 400))
+    expect(annotate.mock.calls.filter(c => c[1] === 'remove').length).toBe(1)
+  })
+
+  it('an in-flight removal in one session never swallows the same pick id abandoned in another session', async () => {
+    // Pick ids are small per-session integers, so two sessions can hold the
+    // same id at once. Session 1's removal is held in flight forever; session
+    // 2 abandoning its own pick 1 must still get its removal sent.
+    const { annotate, state } = installAnnotateBridge()
+    const impl = annotate.getMockImplementation()!
+    annotate.mockImplementation(async (p: string, op: string, args?: Record<string, unknown>) => {
+      if (op === 'remove' && p === 'sess-1') return new Promise(() => { /* held in flight */ })
+      return impl(p, op, args)
+    })
+    const { rerender } = renderWithProviders(<WebPreviewPanel sessionKey="sess-1" active />)
+    fireEvent.click(await screen.findByTestId('browser-annotate'))
+    await screen.findByTestId('browser-annotations')
+    state.items = [TARGET]
+    state.picked = 1
+    await screen.findByTestId('browser-annotation-note-input')
+    const t2 = { ...TARGET, id: 2, n: 2, ref: 'e4', tag: 'input', role: 'combobox', name: 'Search', text: '' }
+    state.items = [TARGET, t2]
+    state.picked = 2
+    await waitFor(() => expect(annotate).toHaveBeenCalledWith('sess-1', 'remove', { id: 1 }))
+    // Session 2, while session 1's removal is still pending: same abandon flow.
+    rerender(<WebPreviewPanel sessionKey="sess-2" active />)
+    fireEvent.click(await screen.findByTestId('browser-annotate'))
+    state.picked = 1
+    await screen.findByTestId('browser-annotation-note-input')
+    state.picked = 2
+    await waitFor(() => expect(annotate).toHaveBeenCalledWith('sess-2', 'remove', { id: 1 }))
+  })
+
+  it('exactly one remove is sent per abandoned pick when the state updater runs twice (StrictMode)', async () => {
+    const { annotate, state } = installAnnotateBridge()
+    renderWithProviders(<StrictMode><WebPreviewPanel sessionKey="sess-1" active /></StrictMode>)
+    fireEvent.click(await screen.findByTestId('browser-annotate'))
+    await screen.findByTestId('browser-annotations')
+    state.items = [TARGET]
+    state.picked = 1
+    await screen.findByTestId('browser-annotation-note-input')
+    const t2 = { ...TARGET, id: 2, n: 2, ref: 'e4', tag: 'input', role: 'combobox', name: 'Search', text: '' }
+    state.items = [TARGET, t2]
+    state.picked = 2
+    await waitFor(() => expect(annotate).toHaveBeenCalledWith('sess-1', 'remove', { id: 1 }))
+    await new Promise(r => setTimeout(r, 400))
+    expect(annotate.mock.calls.filter(c => c[1] === 'remove').length).toBe(1)
   })
 
   it('a noted pick the page stops reporting is kept as detached rather than losing its note', async () => {


### PR DESCRIPTION
## Problem / Motivation

Frontend Tests shard 3 is red on `main`: `WebPreviewPanel.test.tsx › a pick abandoned with nothing typed is dropped when the next element is picked` expects the annotate bridge to receive `('sess-1', 'remove', { id: 1 })` when the note editor moves off an empty pick, and no `remove` is ever sent. The page keeps an overlay marker for a pick the panel has already forgotten.

## Why it matters

Every PR that runs the frontend suite can go red on this pre-existing defect (e.g. #9550's only test failure), so a human has to re-triage the same known red on unrelated work.

## What changed (motivation → approach → change)

The abandon decision was made inside the `patchSlot` state updater, which wrote the abandoned id into a closure that the very next statement read. A state updater runs at render time, so that read sees the untouched value and the `remove` is skipped. The test still passes on many machines because React's eager dispatch shortcut sometimes runs the updater synchronously — a timing accident, which is why CI reddened while local runs stayed green.

The reducer now records the abandoned id in a `pendingDrops` queue on the mirror, and a drain effect sends each `remove` after the commit. Exactly one `remove` goes out per id: the reducer guards with `includes` (a re-run of the updater cannot queue the id twice) and the effect keeps an in-flight set keyed by `${slot}:${id}` (a re-run of the effect cannot send it twice, and one session's in-flight removal never swallows another session's pending drop of the same small per-session pick id). A refused removal surfaces through the existing annotate error path, and the overlay still reports the pick, so the next poll re-lists it instead of leaving the page and the panel disagreeing. `no_overlay` / `no_view` stay silent: the page took the overlay with it, `detachAll` owns that path and clears the queue.

The queue is a live-session transient like `picking`: it is never resumed from sessionStorage, so a reloaded renderer just re-lists an unsent pick on its first poll. Poll cadence and the `sameTargets` short-circuit are untouched.

## Tests

- The pre-existing named test now passes on committed state rather than on dispatch timing (unchanged — its assertion was correct all along).
- `the abandoned pick is removed even when another panel update is already queued (no reliance on an eager dispatch)` — queues a real update on the panel fiber inside the same poll tick, which deterministically defeats React's eager shortcut. This test fails on the old code exactly the way CI's shard did, and locks the removal to committed state. It also asserts exactly ONE `remove` across later poll ticks.
- `exactly one remove is sent per abandoned pick when the state updater runs twice (StrictMode)` — renders under `StrictMode` so the updater double-invokes, and asserts a single `remove`.
- `an in-flight removal in one session never swallows the same pick id abandoned in another session` — holds session 1's removal in flight while session 2 abandons its own pick 1, and asserts session 2's removal is still sent. Fails when the in-flight set is keyed by the bare id.
- All 90 tests in `WebPreviewPanel.test.tsx` pass.

## Manual verification

N/A — the behaviour is fully exercised by the bridge-mock tests; no pixels change (see below).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** internal state/effect refactor of the annotate poll path; no rendered output changes, no new or altered UI element.

## Related Issues

Closes #10007

## Pattern harvest

Rule candidate: review-prompt
Pattern: closure mutated inside a React state updater and read synchronously after the setState call — works only when the eager dispatch shortcut fires, so it passes locally and fails on CI timing.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
