### PR TITLE
fix(browser): send the abandoned-pick remove after the state commit

### DIFF
--- a/website/src/components/WebPreviewPanel.tsx
+++ b/website/src/components/WebPreviewPanel.tsx
@@ -643,6 +643,18 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
   const clearTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   /** Consecutive poll failures that are NOT "the overlay is gone". */
   const pollFailures = useRef(0)
+  /**
+   * Picks the poll updater abandons (nothing typed, editor moved on) and the
+   * page has not been told to drop yet, keyed by the slot they belong to. The
+   * updater fills it; the effect below drains it after the commit. React runs
+   * a state updater lazily whenever the hook already has an update queued, so
+   * a decision made inside it is not readable on the line after setState --
+   * only after the render it produces. The slot travels with the id because
+   * that render can also be the one that switches sessions: a remove bound to
+   * the session current at drain time would reach the other slot's page, where
+   * the same marker number may be a live pick.
+   */
+  const abandonedPicks = useRef<Map<string, Set<number>>>(new Map())
   const noteInputRef = useRef<HTMLInputElement>(null)
 
   const callAnnotate = useCallback(async (op: BrowserAnnotateOp, args?: Record<string, unknown>) => {
@@ -662,6 +674,19 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
   const patchMirror = useCallback((fn: (prev: AnnotateMirror) => AnnotateMirror) => {
     patchSlot(sessionKey || '', fn)
   }, [patchSlot, sessionKey])
+
+  // Tell each slot's overlay to drop the picks the poll updater abandoned. This
+  // runs after the commit that removed them from the list, so list, count and
+  // page highlight agree, and it addresses the bridge by the recorded slot
+  // rather than through callAnnotate, which is bound to whichever session is
+  // current now. The Set dedupes the updater's second run under StrictMode.
+  useEffect(() => {
+    if (!abandonedPicks.current.size) return
+    const pending = [...abandonedPicks.current]
+    abandonedPicks.current.clear()
+    if (typeof annotateBridge !== 'function') return
+    for (const [slot, ids] of pending) for (const id of ids) void annotateBridge(slot, 'remove', { id })
+  }, [annotateMirrors, annotateBridge])
 
   // A session switch resets the per-turn transients: poll failure count and an
   // armed Clear -- a confirmation armed for one session's notes must never fire
@@ -732,7 +757,6 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
       if (stopped) return
       if (isAnnotatePoll(res)) {
         pollFailures.current = 0
-        const dropped: { id: number | null } = { id: null }
         patchSlot(slot, prev => {
           // A live pick can never share an id with a retained note (the overlay
           // is started past the highest retained id); one that does is a
@@ -768,7 +792,9 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
               retained = retained.map(a => (a.id === editing!.id ? { ...a, note: text } : a))
             }
             if (editing && !editing.text.trim() && !(notes[editing.id] ?? '').trim() && targets.some(t => t.id === editing!.id) && editing.id !== moveTo) {
-              dropped.id = editing.id
+              const ids = abandonedPicks.current.get(slot) ?? new Set<number>()
+              ids.add(editing.id)
+              abandonedPicks.current.set(slot, ids)
               targets = targets.filter(t => t.id !== editing!.id)
             }
             editing = { id: moveTo, text: notes[moveTo] ?? '' }
@@ -779,7 +805,6 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
             && prev.page.url === page.url && prev.page.title === page.title) return prev
           return { ...prev, picking: res.picking, targets, notes, retained, editing, page }
         })
-        if (dropped.id !== null) void callAnnotate('remove', { id: dropped.id })
         return
       }
       // The overlay is gone (navigation) or the view itself is (closed,


### PR DESCRIPTION
## Problem / Motivation

`Frontend Tests (3)` is red on `main`. The failing test is `src/test/WebPreviewPanel.test.tsx` — "a pick abandoned with nothing typed is dropped when the next element is picked". It fails on `main` itself and on the merge commit of #9810 that added it. Every PR rebased onto today's `main` inherits the red shard, and `Frontend Coverage Merge` fails behind it because that shard writes no coverage.

The test is right. In the Browser panel, when you pick an element, type nothing, and pick another one, the panel drops the first pick from its list. The page is supposed to get a `remove` call so its highlight goes away too. That call does not always go out. The page keeps a highlight for a pick the panel no longer shows.

## Why it matters

Two things. The user sees the panel and the page disagree: one note in the list, two highlights on the page. And `main` is red on a required check, so every open PR that rebases sees a failing frontend shard and a failing coverage merge for a bug it did not write.

## What changed (motivation → approach → change)

The poll tick in `website/src/components/WebPreviewPanel.tsx` decided inside its `setState` updater which pick was abandoned. It wrote that pick's id into a local variable and read it on the very next line to send `remove`. React only runs an updater right away when the hook has nothing queued. When something is queued, React runs the updater later, at render time. By then the next line has already run and read `null`. So `remove` is skipped exactly when other state changes are in flight, which is why the test passes on one machine and fails on another.

The updater now writes the abandoned id into a ref, `abandonedPicks`. A `useEffect` on the mirror state drains that ref after the commit and sends one `remove` per id. The decision still lives in one place, the effect only delivers it, and the effect runs after the render that took the pick out of the list — so the list, the count and the page highlight agree. The Set dedupes the second updater run React does under StrictMode.

## Tests

No new test. The existing `WebPreviewPanel.test.tsx` case "a pick abandoned with nothing typed is dropped when the next element is picked (list, count and draft agree)" is the pin: it asserts `annotate` is called with `('sess-1', 'remove', { id: 1 })` after the second pick. It fails on `main` and passes with this change, three runs out of three locally. The full website suite passed locally (2010 files, 31809 tests).

## Manual verification

N/A — the failing unit test reproduces the exact user path (pick, type nothing, pick again) and asserts the call the page needs.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the panel renders the same DOM before and after; the change only makes the `remove` IPC call reach the embedded page after the state commit, and that page's highlight is not a dashboard surface.

## Related Issues

no linked issue: found while babysitting #9553, whose CI inherited the red shard from `main`.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a decision made inside a React `setState` updater is read synchronously after the `setState` call (updaters may run at render time, so the read sees the initial value)

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
