### PR TITLE
fix(protocol): pair each bracket opener with its own closer in OPTIONS labels

### DIFF
--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -165,10 +165,50 @@ SUBAGENT_TIMEOUT_MAX = 86400
 #: :data:`_MARKER_LABEL_PAIR`, and via :data:`_MARKER_LABEL_CONTINUES`. Those two
 #: are what the disjointness argument is about (see :data:`_MARKER_BODY_LINE`),
 #: so the pair form -- which is where the deciding lookahead lives -- is the one
-#: NOT to skip. Both readmit all four codepoints at once, which is why adding
-#: these three introduces no ambiguity that ASCII ``]`` did not already have.
+#: NOT to skip.
+#:
+#: The two readmissions are asymmetric. Continuation readmits all four codepoints
+#: at once; the pair form readmits exactly ONE per branch, the partner of that
+#: branch's opener in :data:`_MARKER_OPENERS`. So this constant is not widenable on
+#: its own: a fifth closer with no opener beside it is admitted by continuation and
+#: by nothing else, which is a real shape but not the matched one. Widen the PAIR,
+#: and pin it in ``test_options_marker_lookalike_openers.py``. The two are zipped
+#: with ``strict=True``, so a length mismatch raises at import rather than dropping
+#: the surplus branch silently -- and unlike an ``assert`` that holds under ``-O``.
 MARKER_CLOSERS = "]\u3011\uff3d\u3015"
 _MARKER_CLOSE_CLASS = "[" + re.escape(MARKER_CLOSERS) + "]"
+
+#: The OPENERS those closers pair with, in the SAME ORDER -- ``[`` U+005B,
+#: ``\u3010`` U+3010, ``\uff3b`` U+FF3B, ``\u3014`` U+3014. The order is load-bearing, not
+#: cosmetic: :data:`_MARKER_LABEL_PAIR` zips the two strings to build one
+#: matched-pair branch per pair, so reordering either constant silently pairs
+#: ``\u3010`` with ``\uff3d`` and makes a mismatched bracket count as matched.
+#:
+#: Why an opener set exists at all: a closer is admitted back into a label when it
+#: is MATCHED by an opener earlier in the same label, so the rule needs to know
+#: which brackets can do the matching. A model that writes a label in CJK
+#: punctuation writes BOTH halves in it -- ``[OPTIONS: \u89c1\u3010\u88681\u3011\u8bf4\u660e | \u8df3\u8fc7]`` --
+#: and against ASCII ``[`` alone that ``\u3011`` has no opener the rule recognises: the
+#: body ends there, the anchor rejects the remainder, and the whole marker reaches
+#: the reader as literal text with no pills. Every opener the closer set accepts a
+#: lookalike of therefore belongs here.
+#:
+#: PRIVATE, unlike :data:`MARKER_CLOSERS`, which is public because
+#: ``messaging.renderer`` reads it to decide whether a tail could still be a marker
+#: in flight. Nothing outside this module and its tests needs the opener set:
+#: "matched" is a question only the grammar asks. Promote it when a caller exists.
+#:
+#: Spelled with escapes for the same reason as the closers: ``[`` and ``\uff3b``
+#: are hard to tell apart, so the pairing has to be readable to be checkable.
+_MARKER_OPENERS = "[\u3010\uff3b\u3014"
+#: Every bracket character the label body must not swallow into a pair interior
+#: or a run of ordinary text -- both classes at once, so a lookalike cannot hide
+#: inside either and escape the rule.
+_MARKER_BRACKETS = _MARKER_OPENERS + MARKER_CLOSERS
+#: The three NON-ASCII openers on their own. The bare-opener fallback needs them
+#: as a class without the ``(?!OPTIONS:)`` guard, which only ASCII ``[`` can
+#: begin a head with.
+_MARKER_LOOKALIKE_OPEN_CLASS = "[" + re.escape(_MARKER_OPENERS[1:]) + "]"
 
 #: Markdown WRAPPER characters tolerated around a complete marker line.
 #: A model sometimes wraps the whole marker in inline code or emphasis --
@@ -245,20 +285,28 @@ _MARKER_WRAP_CLASS = "[" + re.escape(MARKER_WRAPPERS) + "]"
 #: line". There is more than one way to be that closer, and all of them parsed
 #: on the old body:
 #:
-#:     [OPTIONS: Fix ]x logging | Skip]            unmatched -- no ``[`` at all
+#:     [OPTIONS: Fix ]x logging | Skip]            unmatched -- no opener at all
 #:     [OPTIONS: Fix list[dict[str, Any]] now | S] nesting deeper than one level
-#:     [OPTIONS: 【重要】修复 | 跳过】               a lookalike PAIR: ``【`` is not
-#:                                                 an opener, only ``[`` is
+#:     [OPTIONS: See [a【b] ref | Skip]             the pair interior holds a
+#:                                                 bracket of a DIFFERENT kind
+#:     [OPTIONS: 见【表1,表2】说明, 跳过]           a LOOKALIKE pair interior holds a
+#:                                                 separator the consumers'
+#:                                                 splitters cannot keep whole
 #:     [OPTIONS: Fix [multi\nline] now | Skip]     TRAILER only -- the pair
 #:                                                 interior excludes ``\n`` even
 #:                                                 under DOTALL
 #:
-#: All four fail toward a VISIBLE marker, not toward deleted prose, and that
+#: A well-formed lookalike pair is NOT on this list: ``[OPTIONS: 【重要】修复 |
+#: 跳过】`` parses, because :data:`_MARKER_OPENERS` carries a partner for every
+#: closer the set accepts.
+#:
+#: All five fail toward a VISIBLE marker, not toward deleted prose, and that
 #: asymmetry is what makes them affordable: the user sees the marker they were
 #: already seeing for the broken shapes, and nothing is removed from the
-#: message. Making them parse means matching brackets to arbitrary depth and
-#: over an opener set this grammar does not have, which a regex is the wrong
-#: tool for; the cost is bounded instead by the direction it fails in.
+#: message. Making the first two parse means matching brackets to arbitrary
+#: depth, which a regex is the wrong tool for; the last three are interior
+#: exclusions this grammar takes deliberately, each for a reason recorded at
+#: :data:`_MARKER_LABEL_PAIR`. The cost is bounded by the direction it fails in.
 #:
 #: A declined marker leaves the text intact only because every partial-cut gate
 #: downstream tests for a closer over :data:`MARKER_CLOSERS` rather than ASCII
@@ -272,10 +320,10 @@ _MARKER_WRAP_CLASS = "[" + re.escape(MARKER_WRAPPERS) + "]"
 #: apart. Resolving it means deciding which shape loses -- a separate call.
 _MARKER_LABEL_CONTINUES = rf"(?=[ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
 
-#: A closer MATCHED by a ``[`` earlier in the same label. One level deep, and its
-#: interior excludes ``[`` and EVERY closer (not just ASCII ``]``, so a lookalike
-#: cannot be swallowed into the interior and escape the rule), which makes its
-#: match from any given ``[`` unique. The trailing negative lookahead is what
+#: A closer MATCHED by its OWN opener earlier in the same label. One level deep,
+#: and its interior excludes every bracket in both classes -- so a lookalike cannot
+#: be swallowed into an interior and escape the rule -- which makes its match from
+#: any given opener unique. The trailing negative lookahead is what
 #: makes this disjoint from :data:`_MARKER_LABEL_CONTINUES` rather than an
 #: alternative spelling of it.
 #:
@@ -289,9 +337,55 @@ _MARKER_LABEL_CONTINUES = rf"(?=[ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
 #: restores "no bracket form may consume a ``[`` that begins a fresh
 #: ``[OPTIONS:``" as an absolute property of the body rather than one that holds
 #: only for sibling heads.
-_MARKER_LABEL_PAIR = (
-    rf"\[(?!OPTIONS:)[^[{re.escape(MARKER_CLOSERS)}\n]*{_MARKER_CLOSE_CLASS}"
+#:
+#: ONE BRANCH PER BRACKET PAIR, matched POSITIONALLY against
+#: :data:`_MARKER_OPENERS`. A single branch spanning both classes -- any opener,
+#: then any closer -- would make ``【表1]`` a pair, and that is the greedy-body
+#: defect back through a side door: the label would end at a closer whose opener
+#: never appeared, so the body could again run past the marker's real terminator.
+#: The pairing is what keeps "matched" meaning matched.
+#:
+#: The interior excludes EVERY bracket, both classes, and that costs one shape:
+#: a pair whose interior holds a bracket of a DIFFERENT kind -- ``[OPTIONS: See
+#: [a【b] ref | Skip]`` -- has no pair parse, so with ordinary words after the
+#: closer the marker is declined. It is a real narrowing, pinned in
+#: ``test_options_marker_lookalike_openers.py`` beside the two older costs.
+#: The uniform exclusion is deliberate and is what the linearity argument reads:
+#: admitting ``【`` here would let the ASCII branch consume a character the
+#: ``【`` branch could also open on, so a span would have two parses. Trading a
+#: shape that fails toward a VISIBLE marker for an ambiguity in the body is the
+#: wrong way round -- the ambiguity is what the ReDoS profile rests on.
+#:
+#: The LOOKALIKE branches additionally exclude both SEPARATORS, ``|`` and ``,``, and
+#: that exclusion is about the CONSUMER rather than the grammar. Admitting a pair
+#: whole is only safe if what receives the capture can keep it whole, and the
+#: splitters cannot: the frontend's ``parseOptions`` picks its delimiter as
+#: ``labels.includes("|") ? "|" : ","`` and neither surface has any notion of
+#: nesting. So a lookalike pair carrying an internal separator --
+#: ``[OPTIONS: 见【表1,表2】说明, 跳过]``, an ordinary CJK phrase -- would be captured
+#: whole and then torn into ``['见【表1', '表2】说明', '跳过']``: three choices with
+#: unbalanced brackets, echoed back as the user's reply when tapped.
+#:
+#: The ASCII branch does NOT exclude them, and the asymmetry is deliberate rather
+#: than an oversight. Excluding ``,`` there declines ``[OPTIONS: Fix dict[str, Any]
+#: now | Skip]`` and ``[OPTIONS: Refactor arr[i, j] now | Skip]`` -- ordinary labels
+#: a model writes constantly, which parse today. The lookalike branches carry no
+#: such history: they are new, so nothing depends on them admitting a separator, and
+#: a separator inside one is only reachable through the corruption above. Each half
+#: is chosen against what it would break.
+#:
+#: This is a MITIGATION on the matched-pair path, not a guarantee. The continuation
+#: form admits a closer followed by a separator regardless of what preceded it, so
+#: ``[OPTIONS: 见【表1|表2】 | 跳过]`` still reaches the splitter and still splits into
+#: three -- exactly as it does today, on both surfaces. Removing that class needs a
+#: nesting-aware splitter, not a tighter interior; it is out of scope here and the
+#: cost table says so.
+_MARKER_LABEL_PAIR = "|".join(
+    rf"{re.escape(_open)}{'(?!OPTIONS:)' if _open == '[' else ''}"
+    rf"[^{re.escape(_MARKER_BRACKETS if _open == '[' else _MARKER_BRACKETS + '|,')}\n]*"
+    rf"{re.escape(_close)}"
     rf"(?![ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
+    for _open, _close in zip(_MARKER_OPENERS, MARKER_CLOSERS, strict=True)
 )
 
 #: Label body, spelled once per regex so LINE and TRAILER cannot drift. LINE
@@ -300,22 +394,25 @@ _MARKER_LABEL_PAIR = (
 #: :data:`_OPTIONS_TAIL_PREFIX_RE`, which is a prefix closure and has to stay
 #: looser -- see the reason there before "fixing" it to match.
 #:
-#: ReDoS: the four alternatives are mutually exclusive at every position. The
-#: two bracket forms both begin at ``[`` (and both refuse a fresh ``[OPTIONS:``)
-#: but cannot consume the same span -- the pair form's lookahead and the
-#: continuation form's are each other's negation -- an unmatched ``[`` is left to
-#: the bare-``[`` form, and the negated class excludes both ``[`` and every
-#: closer. So there is never more than one way to consume a character, and each
+#: ReDoS: the alternatives are mutually exclusive at every position. Each pair
+#: form begins at its OWN opener, so no two pair forms compete; a pair form and
+#: the continuation form cannot consume the same span, their lookaheads being
+#: each other's negation; an opener the pair forms reject is left to a
+#: bare-opener form; and the negated class excludes EVERY opener and EVERY closer,
+#: so it can never take a character a bracket form could have taken. That last
+#: exclusion is what the added openers made necessary -- leaving ``【`` in the
+#: catch-all would give it two parses and cost the disjointness the linearity
+#: rests on. So there is never more than one way to consume a character, and each
 #: lookahead is entered only at a bracket and bounded by the run it scans.
 _MARKER_BODY_LINE = (
-    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:)"
+    rf"(?:(?:{_MARKER_LABEL_PAIR})|\[(?!OPTIONS:)|{_MARKER_LOOKALIKE_OPEN_CLASS}"
     rf"|{_MARKER_CLOSE_CLASS}{_MARKER_LABEL_CONTINUES}"
-    rf"|[^[{re.escape(MARKER_CLOSERS)}\n])*"
+    rf"|[^{re.escape(_MARKER_BRACKETS)}\n])*"
 )
 _MARKER_BODY_TRAILER = (
-    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:)"
+    rf"(?:(?:{_MARKER_LABEL_PAIR})|\[(?!OPTIONS:)|{_MARKER_LOOKALIKE_OPEN_CLASS}"
     rf"|{_MARKER_CLOSE_CLASS}{_MARKER_LABEL_CONTINUES}"
-    rf"|[^[{re.escape(MARKER_CLOSERS)}])*"
+    rf"|[^{re.escape(_MARKER_BRACKETS)}])*"
 )
 
 # The ``labels`` group is NAMED because the ``lwrap`` conditional group

--- a/test/test_options_marker_label_closers.py
+++ b/test/test_options_marker_label_closers.py
@@ -176,11 +176,16 @@ class TestAcceptedCosts:
         assert match is not None
         assert match.group("labels") == " Fix list[dict[str, Any]] | Skip"
 
-    def test_a_lookalike_PAIR_is_a_cost_because_only_ascii_opens(self):
-        # ``MARKER_CLOSERS`` widened the CLOSER set; there is no matching OPENER
-        # set, so ``【`` is an ordinary character and the ``】`` after it reads as
-        # unmatched. Common in Chinese output, hence stated explicitly.
-        assert OPTIONS_RE_LINE.search("[OPTIONS: 【重要】修复 | 跳过】") is None
+    def test_a_lookalike_PAIR_is_matched_because_openers_are_paired_too(self):
+        # A closer counts as matched when its OWN opener precedes it, and
+        # ``MARKER_OPENERS`` carries a lookalike for every closer the set accepts.
+        # So a label written wholly in CJK punctuation parses like its ASCII
+        # equivalent. Asserted in this class because the rule under test here is
+        # what decides the outcome; the pairing itself is covered in full by
+        # ``test_options_marker_lookalike_openers.py``.
+        match = OPTIONS_RE_LINE.search("[OPTIONS: 【重要】修复 | 跳过】")
+        assert match is not None
+        assert match.group("labels") == " 【重要】修复 | 跳过"
 
     def test_a_pair_spanning_a_newline_is_a_trailer_only_cost(self):
         # The pair interior excludes ``\n`` on BOTH grammars, so under TRAILER
@@ -202,7 +207,12 @@ class TestAcceptedCosts:
         load-bearing, so the two are pinned together.
         """
         for text in (
-            "请选择：\n[OPTIONS: 【重要】修复 | 跳过】",
+            # A MISMATCHED lookalike pair: ``【`` pairs only with ``】``, so the
+            # ``〕`` here is unmatched and the marker is declined. A shape whose
+            # ONLY closers are lookalikes is what makes the gate's closer set
+            # load-bearing -- an ASCII-only gate reads this as in-flight and cuts
+            # it, which is the destructive outcome the class exists to rule out.
+            "请选择：\n[OPTIONS: 见【表1〕说明 | 跳过】",
             "Pick one:\n[OPTIONS: Fix ]x logging | Skip]",
             "Pick one:\n[OPTIONS: Fix list[dict[str, Any]] now | Skip]",
         ):

--- a/test/test_options_marker_lookalike_openers.py
+++ b/test/test_options_marker_lookalike_openers.py
@@ -1,0 +1,346 @@
+"""A lookalike bracket PAIR inside an ``[OPTIONS:]`` label parses.
+
+A closer is readmitted to a label when an opener earlier in the same label
+MATCHES it, so the rule needs an opener set to match against.
+:data:`MARKER_CLOSERS` accepts three lookalikes alongside ASCII ``]``, and a model
+writing a label in CJK punctuation writes both halves in it::
+
+    [OPTIONS: 见【表1】说明 | 跳过]
+
+Against ASCII ``[`` alone that ``】`` has no opener the rule recognises: the body
+ends there, the line anchor rejects the remainder, and the whole marker reaches
+the reader as literal text with no pills. :data:`_MARKER_OPENERS` supplies the
+missing half, so each closer the set accepts has an opener that can match it.
+
+THE PAIRING IS THE LOAD-BEARING PART. One branch accepting any opener followed by
+any closer would make ``【表1]`` a pair, and that is the greedy body this grammar
+exists to prevent, reached by a side door: the label would end at a closer whose
+opener never appeared, so the body could run past the marker's real terminator and
+delete the prose after it. Each opener therefore pairs ONLY with its positional
+partner in :data:`MARKER_CLOSERS`, and the mismatched shapes are asserted here as
+explicitly as the matched ones.
+
+Two claims are kept separate, as in ``test_options_marker_label_closers.py``,
+because only the second is what a user experiences: that the grammar does not
+MATCH, and that removing the match leaves the text UNCHANGED.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+from kiro_crew.constants import (
+    _MARKER_BRACKETS,
+    _MARKER_OPENERS,
+    MARKER_CLOSERS,
+    OPTIONS_RE_LINE,
+    OPTIONS_RE_TRAILER,
+)
+from kiro_crew.messaging.renderer import split_options_trailer
+
+#: Each opener with the closer it is supposed to pair with.
+PAIRS = list(zip(_MARKER_OPENERS, MARKER_CLOSERS, strict=True))
+
+
+class TestTheConstantsThemselves:
+    def test_openers_and_closers_are_the_same_length_and_order(self):
+        # The grammar zips them with ``strict=True``, so a length mismatch raises at
+        # import rather than dropping the surplus branch. Asserted here as well so
+        # the invariant is discoverable from the suite, not only from the zip call.
+        assert len(_MARKER_OPENERS) == len(MARKER_CLOSERS)
+        assert _MARKER_OPENERS[0] == "[" and MARKER_CLOSERS[0] == "]"
+
+    def test_brackets_is_both_classes(self):
+        # The negated class in the body is spelled over this, so a lookalike
+        # cannot hide inside a pair interior or an ordinary-text run.
+        assert set(_MARKER_BRACKETS) == set(_MARKER_OPENERS) | set(MARKER_CLOSERS)
+
+
+class TestAMatchedLookalikePairParses:
+    @pytest.mark.parametrize(("opener", "closer"), PAIRS)
+    def test_every_pair_is_matched_inside_a_label(self, opener: str, closer: str):
+        text = f"[OPTIONS: 见{opener}表1{closer}说明 | 跳过]"
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None, text
+        assert match.group("labels") == f" 见{opener}表1{closer}说明 | 跳过"
+
+    def test_the_reported_shape_parses_end_to_end(self):
+        # The issue's own example, through the consumer rather than the regex:
+        # the option list survives AND the leading prose is kept.
+        body, choices = split_options_trailer("请选择：\n[OPTIONS: 见【表1】说明 | 跳过]")
+        assert body == "请选择："
+        assert choices == ["见【表1】说明", "跳过"]
+
+    def test_a_lookalike_pair_AND_a_lookalike_closer_together(self):
+        # The marker's own terminator is a lookalike too, so the closer set and the
+        # opener set have to compose rather than each work only on its own.
+        match = OPTIONS_RE_LINE.search("[OPTIONS: 【重要】修复 | 跳过】")
+        assert match is not None
+        assert match.group("labels") == " 【重要】修复 | 跳过"
+
+    def test_the_pair_also_works_under_the_trailer_grammar(self):
+        match = OPTIONS_RE_TRAILER.search("请选择：\n\n[OPTIONS: 见〔表1〕说明 | 跳过]")
+        assert match is not None
+        assert match.group("labels") == " 见〔表1〕说明 | 跳过"
+
+    def test_a_pair_may_hold_anything_that_is_not_a_bracket_or_a_separator(self):
+        # Interior content is otherwise opaque: spaces, digits, CJK text and
+        # punctuation that no splitter looks at all pass through as label text.
+        # Asserted at the consumer, because the capture is not the claim.
+        match = OPTIONS_RE_LINE.search("[OPTIONS: 见【表 1：注释】说明 | 跳过]")
+        assert match is not None
+        assert match.group("labels") == " 见【表 1：注释】说明 | 跳过"
+        assert split_options_trailer("[OPTIONS: 见【表 1：注释】说明 | 跳过]") == (
+            "",
+            ["见【表 1：注释】说明", "跳过"],
+        )
+
+
+class TestAPairMayNotHoldASeparator:
+    """A LOOKALIKE pair interior refuses ``|`` and ``,``; the ASCII one does not.
+
+    Capturing a pair whole is only safe if what receives the capture can keep it
+    whole, and neither splitter has any notion of nesting. The frontend's
+    ``parseOptions`` picks its delimiter as ``labels.includes("|") ? "|" : ","``, so
+    a comma is load-bearing exactly when no pipe is present -- which is why testing
+    only the pipe shape, or only the backend, misses half of this.
+
+    A lookalike pair carrying an internal separator -- an ordinary CJK phrase like
+    ``【表1,表2】`` -- would be captured and then torn into three choices with
+    unbalanced brackets, echoed back as the user's reply when one is tapped.
+
+    The exclusion stops at the lookalike branches on purpose. Applying it to ASCII
+    too declines ``[OPTIONS: Fix dict[str, Any] now | Skip]``, which parses today;
+    the lookalike branches have no such history to protect. Both halves are pinned
+    here, because the asymmetry is the design and not an oversight.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "[OPTIONS: 见【表1|表2】说明 | 跳过]",
+            "[OPTIONS: 见［表1|表2］说明 | 跳过]",
+            # The comma shapes, with NO pipe anywhere -- the case the frontend's
+            # delimiter fallback makes reachable.
+            "[OPTIONS: 见【表1,表2】说明, 跳过]",
+            "[OPTIONS: 见〔表1,表2〕说明, 跳过]",
+            # ...and with a pipe present, so the rule does not depend on which
+            # delimiter the consumer happens to pick.
+            "[OPTIONS: 见【表1,表2】说明 | 跳过]",
+        ],
+    )
+    def test_a_lookalike_pair_holding_a_separator_is_declined(self, text: str):
+        assert OPTIONS_RE_LINE.search(text) is None, text
+        # The claim that matters is at the CONSUMER: no choices, text left intact.
+        assert split_options_trailer(text) == (text, []), text
+
+    @pytest.mark.parametrize(
+        ("text", "corrupt"),
+        [
+            ("[OPTIONS: 见【表1|表2】说明 | 跳过]", ["见【表1", "表2】说明", "跳过"]),
+            ("[OPTIONS: 见【表1,表2】说明, 跳过]", ["见【表1", "表2】说明", "跳过"]),
+        ],
+    )
+    def test_the_corruption_this_prevents_is_named_explicitly(self, text: str, corrupt: list):
+        # What a naive split produces, asserted as the thing that must NOT happen:
+        # three fragments, two of them with unbalanced brackets.
+        body, choices = split_options_trailer(text)
+        assert choices != corrupt
+        assert choices == []
+        assert body == text
+
+    @pytest.mark.parametrize(
+        ("text", "labels"),
+        [
+            ("[OPTIONS: Fix dict[str, Any] now | Skip]", " Fix dict[str, Any] now | Skip"),
+            ("[OPTIONS: Refactor arr[i, j] now | Skip]", " Refactor arr[i, j] now | Skip"),
+            ("[OPTIONS: Refactor arr[i, j] | Skip]", " Refactor arr[i, j] | Skip"),
+        ],
+    )
+    def test_the_ASCII_interior_still_admits_separators(self, text: str, labels: str):
+        """The asymmetry, pinned as the thing that keeps it.
+
+        Applying the exclusion to the ASCII branch too declines these -- labels a
+        model writes constantly, which parse today. The lookalike branches carry no
+        such history, so each half is chosen against what it would break.
+        """
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None, text
+        assert match.group("labels") == labels
+
+    def test_the_exclusion_is_a_MITIGATION_not_a_guarantee(self):
+        # The continuation form admits a closer followed by a separator regardless of
+        # what preceded it, so a bracket run holding ``|`` still reaches the splitter
+        # by that route and still splits into three. Pinned so the interior rule is
+        # not read as closing the whole class: removing it needs a nesting-aware
+        # splitter. Unchanged from the behaviour before this grammar existed.
+        text = "[OPTIONS: 见【表1|表2】 | 跳过]"
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None
+        assert split_options_trailer(text) == ("", ["见【表1", "表2】", "跳过"])
+
+
+class TestAMismatchedPairIsNotAPair:
+    """The half that keeps the body from running past its terminator.
+
+    Each of these has an opener and a closer but not a PAIR, so the closer is
+    unmatched -- and with ordinary words after it, the marker is declined rather
+    than run on to a later closer.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "[OPTIONS: 见【表1] 说明 | 跳过]",  # CJK opener, ASCII closer
+            "[OPTIONS: 见[表1】 说明 | 跳过]",  # ASCII opener, CJK closer
+            "[OPTIONS: 见【表1〕 说明 | 跳过】",  # two different lookalikes
+            "[OPTIONS: 见［表1〕 说明 | 跳过]",  # fullwidth opener, tortoise closer
+        ],
+    )
+    def test_a_crossed_pair_is_declined(self, text: str):
+        assert OPTIONS_RE_LINE.search(text) is None, text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "[OPTIONS: 见【表1] 说明 | 跳过]",
+            "[OPTIONS: 见[表1】 说明 | 跳过]",
+        ],
+    )
+    def test_declining_a_crossed_pair_does_not_delete_the_line(self, text: str):
+        # The claim that makes the cost affordable, asserted at the consumer.
+        assert OPTIONS_RE_LINE.sub("", text) == text
+        assert split_options_trailer(text, hide_partial=True) == (text, [])
+
+    def test_the_9284_shape_still_declines_with_lookalikes_in_play(self):
+        # The defect this whole line of work exists for, spelled in CJK: a closer
+        # that is neither matched nor continuing, with prose after it.
+        text = "见 [OPTIONS: 保留 | 丢弃] 然后看 arr[0]"
+        assert OPTIONS_RE_LINE.search(text) is None
+        assert OPTIONS_RE_LINE.sub("", text) == text
+
+    def test_a_pair_interior_may_not_swallow_another_bracket(self):
+        # The interior excludes EVERY bracket, so nesting is still one level deep
+        # and a lookalike cannot be hidden inside an interior to escape the rule.
+        assert OPTIONS_RE_LINE.search("[OPTIONS: 见【表【1】】说明 | 跳过]") is None
+
+
+class TestWhatMustNotHaveChanged:
+    def test_a_stray_lookalike_opener_is_ordinary_label_text(self):
+        # No partner closer, so no pair. The bare-opener branch consumes it and
+        # the label list is unaffected -- the mirror of a stray ASCII ``[``.
+        for opener in _MARKER_OPENERS[1:]:
+            text = f"[OPTIONS: Fix {opener} now | Skip]"
+            match = OPTIONS_RE_LINE.search(text)
+            assert match is not None, text
+            assert match.group("labels") == f" Fix {opener} now | Skip"
+
+    @pytest.mark.parametrize(
+        ("text", "labels"),
+        [
+            ("[OPTIONS: Read arr[0] now | Skip it]", " Read arr[0] now | Skip it"),
+            ("[OPTIONS: See [1] above | Skip]", " See [1] above | Skip"),
+            ("[OPTIONS: Alpha ] | Bravo ]]", " Alpha ] | Bravo ]"),
+            ("[OPTIONS: Alpha ], Bravo]", " Alpha ], Bravo"),
+            ("[OPTIONS: Yes | No]", " Yes | No"),
+            ("**[OPTIONS: Yes | No]**", " Yes | No"),
+        ],
+    )
+    def test_every_previously_supported_shape_still_parses(self, text: str, labels: str):
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None, text
+        assert match.group("labels") == labels
+
+    def test_a_nested_head_is_still_refused(self):
+        # Only ASCII ``[`` can begin a head, so only its branch carries the
+        # ``(?!OPTIONS:)`` guard -- but that is the branch a nested head opens on,
+        # so widening the opener set did not reopen this.
+        assert OPTIONS_RE_LINE.search("Note [OPTIONS: see [OPTIONS: x] below | Skip]") is None
+
+    def test_the_accepted_cost_table_is_exactly_these_four_rows(self):
+        # Asserted so the table cannot quietly grow or shrink. Rows 1-2 predate the
+        # opener set and need bracket matching to arbitrary depth, which a regex is
+        # the wrong tool for. Rows 3-4 are interior exclusions this grammar takes
+        # deliberately -- see TestAMixedBracketInterior and
+        # TestAPairMayNotHoldTheSeparator for why each is the right trade.
+        for text in (
+            "[OPTIONS: Fix ]x logging | Skip]",  # unmatched, no opener at all
+            "[OPTIONS: Fix list[dict[str, Any]] now | S]",  # deeper than one level
+            "[OPTIONS: See [a【b] ref | Skip]",  # interior holds another bracket kind
+            "[OPTIONS: 见【表1,表2】说明, 跳过]",  # interior holds a separator
+        ):
+            assert OPTIONS_RE_LINE.search(text) is None, text
+            # Every row fails toward a VISIBLE marker; that is what makes it a cost
+            # rather than a defect.
+            assert OPTIONS_RE_LINE.sub("", text) == text, text
+
+
+class TestAMixedBracketInterior:
+    """The one shape this opener set NARROWS rather than widens.
+
+    The pair interior excludes EVERY bracket, both classes. A pair whose interior
+    holds a bracket of a different kind therefore has no pair parse, and with
+    ordinary words after the closer the marker is declined -- where an interior that
+    excluded only ASCII ``[`` and the closers would have admitted it.
+
+    The exclusion is deliberate. Admitting ``【`` in the ASCII branch's interior
+    would let that branch consume a character the ``【`` branch could also open on,
+    so a span would have two parses -- and single-parse-per-span is exactly what the
+    linearity argument reads off the pattern. A shape that fails toward a VISIBLE
+    marker is the cheaper thing to give up than an ambiguity in the body.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "[OPTIONS: See [a【b] ref | Skip]",
+            "[OPTIONS: See [a［b] ref | Skip]",
+            "[OPTIONS: See [a〔b] ref | Skip]",
+            "[OPTIONS: 见【表[1】说明 | 跳过]",
+        ],
+    )
+    def test_a_mixed_bracket_interior_is_declined_and_nothing_is_deleted(self, text: str):
+        assert OPTIONS_RE_LINE.search(text) is None, text
+        assert OPTIONS_RE_LINE.sub("", text) == text, text
+
+    def test_the_same_interior_still_parses_when_the_list_CONTINUES(self):
+        # The cost is the tail, not the interior: with a separator after the closer
+        # the continuation half admits it and no pair parse is needed.
+        match = OPTIONS_RE_LINE.search("[OPTIONS: See [a【b] | Skip]")
+        assert match is not None
+        assert match.group("labels") == " See [a【b] | Skip"
+
+
+class TestLinearity:
+    """The disjointness argument, exercised rather than asserted in a comment.
+
+    Four pair branches now begin at four different openers, so the claim "at most
+    one alternative can consume a given character" is stronger than it was with
+    one. What could break it is the catch-all: if it still admitted ``【``, that
+    character would have two parses.
+    """
+
+    def test_the_catch_all_admits_no_bracket(self):
+        # Read off the compiled pattern, so it cannot drift from the comment.
+        assert f"[^{re.escape(_MARKER_BRACKETS)}\\n]" in OPTIONS_RE_LINE.pattern
+
+    @pytest.mark.parametrize("reps", [500, 2_000, 8_000])
+    def test_lookalike_heavy_adversarial_input_stays_linear(self, reps: int):
+        # An unterminated marker whose body is nothing but lookalike pairs: the
+        # shape that would blow up if the pair and catch-all branches overlapped.
+        src = "[OPTIONS:" + ("【a】 | " * reps)
+        started = time.perf_counter()
+        assert OPTIONS_RE_LINE.search(src) is None
+        assert OPTIONS_RE_TRAILER.search(src) is None
+        assert time.perf_counter() - started < 2.0
+
+    def test_a_long_mismatched_run_also_stays_linear(self):
+        # Mismatched brackets are the worst case for a pair form: every branch is
+        # attempted and every one fails.
+        src = "[OPTIONS:" + ("【a〕 | " * 4_000)
+        started = time.perf_counter()
+        assert OPTIONS_RE_LINE.search(src) is None
+        assert time.perf_counter() - started < 2.0

--- a/website/src/app-sdk/protocol/optionMarker.ts
+++ b/website/src/app-sdk/protocol/optionMarker.ts
@@ -38,11 +38,14 @@
 // and the turn silently loses its pills. Labels are unaffected, so accepting the
 // lookalike costs nothing. ReDoS profile is unchanged from the previous literal
 // `\]`: the class shares no character with the trailing `[ \t]*`, and the body
-// excludes it from its negated class and readmits all four codepoints in exactly
-// TWO tempered places (below) — as the matched-pair form's final atom, and via the
-// continuation lookahead. A widening of this class has to be re-audited against
-// both; the pair form is the one holding the deciding lookahead, so it is the one
-// not to skip.
+// excludes it from its negated class and readmits it in exactly TWO tempered
+// places (below) — as the matched-pair form's final atom, and via the continuation
+// lookahead. A widening of this class has to be re-audited against both; the pair
+// form is the one holding the deciding lookahead, so it is the one not to skip.
+// Note the asymmetry between those two: continuation readmits all four codepoints
+// at once, while the pair form readmits exactly ONE per branch — its own opener's
+// partner. So this class is not widenable alone; widen the PAIR, keeping the opener
+// and closer lists the same length and order.
 //
 // A CLOSER MUST BE MATCHED, OR CONTINUE THE LABEL LIST (#9284). A label may
 // legitimately carry a closer (`[OPTIONS: Alpha ] | Bravo ]]` is a supported,
@@ -75,12 +78,41 @@
 //
 //   [OPTIONS: Fix ]x logging | Skip]             unmatched — no `[` at all
 //   [OPTIONS: Fix list[dict[str, Any]] now | S]  nesting deeper than one level
-//   [OPTIONS: 【重要】修复 | 跳过】                 a lookalike PAIR — `【` is not an
-//                                                opener, only `[` is
+//   [OPTIONS: See [a【b] ref | Skip]              interior holds another bracket kind
+//   [OPTIONS: 见【表1,表2】说明, 跳过]            a LOOKALIKE pair interior holds a
+//                                                separator the splitters cannot keep
 //
-// All fail toward a VISIBLE marker, not toward deleted prose, and that asymmetry
-// is what makes them affordable. Making them parse means matching brackets to
-// arbitrary depth and over an opener set this grammar does not have. The
+// A well-formed lookalike PAIR is NOT among them: `[OPTIONS: 见【表1】说明 | 跳过]`
+// parses, because the pair branches below pair each opener positionally with its own
+// closer, so a label written wholly in CJK punctuation behaves like its ASCII
+// equivalent. The pairing is the load-bearing part — one branch accepting any
+// opener followed by any closer would make `【表1]` a pair and hand the body a way
+// past the marker's real terminator again.
+//
+// Rows 3-4 are interior exclusions, and each is deliberate. Row 3: admitting `【` in
+// the ASCII branch's interior would let it consume a character the `【` branch could
+// also open on, giving a span two parses — and single-parse-per-span is what the
+// linearity argument rests on. Row 4 is about the CONSUMER rather than the grammar:
+// `parseOptions` picks its delimiter as `labels.includes('|') ? '|' : ','` and has no
+// notion of nesting, so a lookalike pair carrying either separator would be torn into
+// fragments with unbalanced brackets, echoed back as the user's reply when tapped.
+//
+// Row 4 applies to the LOOKALIKE interiors only. The ASCII interior keeps admitting
+// both separators, because excluding `,` there declines `[OPTIONS: Fix dict[str, Any]
+// now | Skip]` and `[OPTIONS: Refactor arr[i, j] now | Skip]` — labels a model writes
+// constantly, which parse today. The lookalike branches carry no such history, and a
+// separator inside one is only reachable through the corruption above. Each half is
+// chosen against what it would break.
+//
+// And it is a MITIGATION, not a guarantee: the continuation form admits a closer
+// followed by a separator regardless of what preceded it, so
+// `[OPTIONS: 见【表1|表2】 | 跳过]` still reaches the splitter and still splits into
+// three — exactly as it does today. Removing that class needs a nesting-aware
+// splitter, not a tighter interior.
+//
+// All four rows fail toward a VISIBLE marker, not toward deleted prose, and that
+// asymmetry is what makes them affordable. Making rows 1-2 parse means matching
+// brackets to arbitrary depth, which a regex is the wrong tool for. The
 // separator-tail form (`…| Wait], details in CHANGELOG[1]`) is NOT reachable by
 // this rule and is unchanged: `], ` does continue the list, by the same rule that
 // makes `[OPTIONS: Alpha ], Bravo]` legal.
@@ -118,8 +150,31 @@
 // `String#matchAll` does NOT — it seeds its internal clone from `lastIndex`, so pass a fresh
 // `new RegExp(OPTION_MARKER_RE)` there. Never call `.exec`/`.test` on it: both leave the index
 // advanced, and the next reader silently scans from the wrong offset.
+// ONE REGEX LITERAL, with the body spelled twice (once per wrapper branch) and the
+// four matched-pair branches spelled out in each. It is long, and composing it from
+// named fragments would read far better \u2014 but every fragment would be a module-scope
+// STRING literal, and `eslint.i18n.strict.config.js` reports those as untranslated
+// user-visible copy. The exemption the gate offers is by shape in
+// `eslint.i18n.config.js`, and that config argues at length against widening a
+// shape for one file ("A path this narrow cannot exempt a future file"): a hole cut
+// for regex fragments is a hole real copy can sit in later. A regex literal
+// contains no string literal, so it needs no hole.
+//
+// What guards the duplication instead: `.source` is pinned character-for-character
+// by `AssistantMessage.test.tsx`, and that pin is BUILT from per-pair pieces, so the
+// two copies here cannot drift from each other or from the backend without the test
+// naming the difference. The four pair branches read, per pair:
+//
+//   <opener>[^<every bracket>\n]*<its own closer>(?![ \t]*[|,]|<any closer>)
+//
+// with `(?!OPTIONS?:)` on the ASCII branch alone, since only `[` can begin a head.
+//
+// Every lookalike is written as a `\uXXXX` ESCAPE, never as the character itself.
+// That is not stylistic: `\uff3d` U+FF3D and `]` U+005D are indistinguishable at a
+// glance in most fonts, so a literal class would be unreviewable and a wrong
+// codepoint would read as correct. The escapes make the pairing checkable.
 export const OPTION_MARKER_RE =
-  /(?:^[ \t]*[`*_]{1,3}\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}|\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?)[ \t]*$/gim
+  /(?:^[ \t]*[`*_]{1,3}\[OPTION(S)?:((?:(?:\[(?!OPTIONS?:)[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015\n]*\](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\u3010[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015|,\n]*\u3011(?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\uFF3B[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015|,\n]*\uFF3D(?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\u3014[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015|,\n]*\u3015(?![ \t]*[|,]|[\]\u3011\uFF3D\u3015]))|\[(?!OPTIONS?:)|[\u3010\uFF3B\u3014]|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}|\[OPTION(S)?:((?:(?:\[(?!OPTIONS?:)[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015\n]*\](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\u3010[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015|,\n]*\u3011(?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\uFF3B[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015|,\n]*\uFF3D(?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\u3014[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015|,\n]*\u3015(?![ \t]*[|,]|[\]\u3011\uFF3D\u3015]))|\[(?!OPTIONS?:)|[\u3010\uFF3B\u3014]|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^\[\u3010\uFF3B\u3014\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?)[ \t]*$/gim
 
 /** The closing brackets OPTION_MARKER_RE accepts — ASCII plus the CJK lookalikes.
  *  Module-private and used with matchAll only (to take the LAST closer in the

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -895,16 +895,39 @@ describe('parseOptions', () => {
     // The label body: tempered alternation, NOT a nested quantifier. Spelled with
     // `\uXXXX` escapes because that is how the SOURCE spells the closer class —
     // `.source` is the literal pattern text, so a literal `】` here would not match.
+    const O = '\\[\\u3010\\uFF3B\\u3014'
     const C = '\\]\\u3011\\uFF3D\\u3015'
+    const B = O + C
     const CONT = `[ \\t]*[|,]|[${C}]`
-    // Four alternatives, mutually exclusive at every position. The two bracket
-    // forms both begin at `[` but are each other's negation on what FOLLOWS the
-    // closer, so no span of input ever has two parses — that disjointness is what
-    // the linearity rests on, so it is pinned here character for character. BOTH
-    // bracket forms carry `(?!OPTIONS?:)`: that is what keeps a nested head out of
-    // a label, and dropping it from the pair form is a widening, not a tidy-up.
+    // One matched-pair branch PER BRACKET PAIR (#9375), each beginning at its own
+    // opener and ending at that opener's own closer — so no two pair branches can
+    // consume the same span, and a crossed `【…]` is not a pair. Only the ASCII
+    // branch carries `(?!OPTIONS?:)`, because only `[` can begin a nested head;
+    // dropping it there is a widening, not a tidy-up.
+    const pairs = [
+      ['\\[(?!OPTIONS?:)', '\\]'],
+      ['\\u3010', '\\u3011'],
+      ['\\uFF3B', '\\uFF3D'],
+      ['\\u3014', '\\u3015'],
+    ]
+      // The LOOKALIKE interiors refuse both separators on top of every bracket, and
+      // that is about the CONSUMER: `parseOptions` picks its delimiter as
+      // `labels.includes('|') ? '|' : ','` with no notion of nesting, so a pair
+      // carrying either is torn into fragments with unbalanced brackets. The ASCII
+      // interior does NOT refuse them, because excluding `,` there declines
+      // `[OPTIONS: Fix dict[str, Any] now | Skip]`, which parses today — so the
+      // asymmetry is pinned here character for character rather than left to drift.
+      .map(([open, close]) => {
+        const interior = open === '\\[(?!OPTIONS?:)' ? B : `${B}|,`
+        return `${open}[^${interior}\\n]*${close}(?!${CONT})`
+      })
+      .join('|')
+    // The catch-all excludes EVERY bracket, not just the closers: leaving `【` in it
+    // would give that character two parses and cost the disjointness the linearity
+    // rests on. It does NOT exclude the separators — only a lookalike pair interior
+    // does, and only because of the splitter. Pinned for both reasons.
     expect(src).toContain(
-      `(?:\\[(?!OPTIONS?:)[^[${C}\\n]*[${C}](?!${CONT})|\\[(?!OPTIONS?:)|[${C}](?=${CONT})|[^[${C}\\n])*`,
+      `(?:(?:${pairs})|\\[(?!OPTIONS?:)|[\\u3010\\uFF3B\\u3014]|[${C}](?=${CONT})|[^${B}\\n])*`,
     )
     // No `(x+)+` / `(x*)*` anywhere: that is the shape that backtracks
     // exponentially, and it is what the tempered body above replaced.

--- a/website/src/test/optionsMarkerLabelClosers.test.ts
+++ b/website/src/test/optionsMarkerLabelClosers.test.ts
@@ -116,13 +116,15 @@ describe('OPTION_MARKER_RE label closers must be matched or continue the list (#
     ])
   })
 
-  it('accepts a lookalike PAIR as a cost, because only ASCII `[` opens', () => {
-    // The closer set was widened to the CJK lookalikes; there is no matching
-    // OPENER set, so `【` is an ordinary character and the `】` after it reads as
-    // unmatched. Common in Chinese output, hence stated explicitly.
+  it('matches a lookalike PAIR, because openers are paired too', () => {
+    // A closer counts as matched when its OWN opener precedes it, and the opener
+    // class carries a lookalike for every closer the set accepts — so a label
+    // written wholly in CJK punctuation parses like its ASCII equivalent. Asserted
+    // here because the rule under test in this suite is what decides the outcome;
+    // the pairing itself is covered by `optionsMarkerLookalikeOpeners.test.ts`.
     const text = '[OPTIONS: 【重要】修复 | 跳过】'
-    expect(parseOptions(text).options).toEqual([])
-    expect(parseOptions(text).text).toBe(text)
+    expect(parseOptions(text).options).toEqual(['【重要】修复', '跳过'])
+    expect(parseOptions(text).text).toBe('')
   })
 
   it('never swallows a NESTED head into a label', () => {

--- a/website/src/test/optionsMarkerLookalikeOpeners.test.ts
+++ b/website/src/test/optionsMarkerLookalikeOpeners.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+
+import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+import { parseOptions } from '../app-sdk/protocol/options'
+
+/** Labels of the LAST marker, or null when the grammar declines the line. */
+function labelsOf(text: string): string | null {
+  const m = [...text.matchAll(new RegExp(OPTION_MARKER_RE))].pop()
+  return m ? (m[2] ?? m[4]) : null
+}
+
+/**
+ * #9375: a closer is readmitted to a label when an opener earlier in the label
+ * MATCHES it. "Matches" was decided against ASCII `[` alone, so a label written
+ * wholly in CJK punctuation had a `】` with no recognised opener -- the body ended
+ * there and the whole marker was declined, leaking as literal text. Each opener
+ * now pairs with its own closer.
+ *
+ * The pairing is the load-bearing half. A single branch taking any opener and any
+ * closer would make `【表1]` a pair, which is #9284's greedy body back through a
+ * side door: the label would end at a closer whose opener never appeared.
+ */
+describe('OPTION_MARKER_RE lookalike bracket pairs inside a label (#9375)', () => {
+  it.each([
+    ['CJK', '[OPTIONS: 见【表1】说明 | 跳过]', ' 见【表1】说明 | 跳过'],
+    ['fullwidth', '[OPTIONS: 见［表1］说明 | 跳过]', ' 见［表1］说明 | 跳过'],
+    ['tortoise-shell', '[OPTIONS: 见〔表1〕说明 | 跳过]', ' 见〔表1〕说明 | 跳过'],
+  ])('parses a %s pair inside a label', (_kind, text, want) => {
+    expect(labelsOf(text)).toBe(want)
+  })
+
+  it('parses a marker whose closer is a lookalike AND whose label carries a pair', () => {
+    expect(labelsOf('[OPTIONS: 【重要】修复 | 跳过】')).toBe(' 【重要】修复 | 跳过')
+  })
+
+  it('renders the CJK pair as real options, not as text', () => {
+    const { options, text } = parseOptions('请选择：\n[OPTIONS: 见【表1】说明 | 跳过]')
+    expect(options).toEqual(['见【表1】说明', '跳过'])
+    expect(text).toBe('请选择：')
+  })
+
+  it.each([
+    ['opener with the wrong closer', '[OPTIONS: 见【表1] 说明 | 跳过]'],
+    ['closer with the wrong opener', '[OPTIONS: 见[表1】 说明 | 跳过]'],
+  ])('declines a MISMATCHED pair (%s)', (_kind, text) => {
+    expect(labelsOf(text)).toBeNull()
+    // Declining must not delete: the whole line survives the strip.
+    expect(text.replace(OPTION_MARKER_RE, '')).toBe(text)
+  })
+
+  it('still declines #9284: a closer that is neither matched nor continuing', () => {
+    const text = '见 [OPTIONS: 保留 | 丢弃] 然后看 arr[0]'
+    expect(labelsOf(text)).toBeNull()
+    expect(text.replace(OPTION_MARKER_RE, '')).toBe(text)
+  })
+
+  it('treats a STRAY lookalike opener as ordinary label text', () => {
+    // No partner closer, so no pair -- the bare-opener branch consumes it and the
+    // label list is unaffected.
+    expect(labelsOf('[OPTIONS: Fix 【 now | Skip]')).toBe(' Fix 【 now | Skip')
+  })
+
+  it('keeps every pre-existing supported shape', () => {
+    expect(labelsOf('[OPTIONS: Read arr[0] now | Skip it]')).toBe(' Read arr[0] now | Skip it')
+    expect(labelsOf('[OPTIONS: See [1] above | Skip]')).toBe(' See [1] above | Skip')
+    expect(labelsOf('[OPTIONS: Alpha ] | Bravo ]]')).toBe(' Alpha ] | Bravo ]')
+    expect(labelsOf('[OPTIONS: Alpha ], Bravo]')).toBe(' Alpha ], Bravo')
+    expect(labelsOf('**[OPTIONS: Yes | No]**')).toBe(' Yes | No')
+  })
+
+  it('still refuses a NESTED head, which the pair guard is what preserves', () => {
+    // Only ASCII `[` can begin a head, so only its branch carries the guard --
+    // but that is the branch a nested `[OPTIONS:` would open on.
+    expect(labelsOf('Note [OPTIONS: see [OPTIONS: x] below | Skip]')).toBeNull()
+  })
+
+  it.each([
+    '[OPTIONS: See [a【b] ref | Skip]',
+    '[OPTIONS: See [a［b] ref | Skip]',
+    '[OPTIONS: 见【表[1】说明 | 跳过]',
+  ])('declines a pair whose INTERIOR holds another bracket kind: %s', (text) => {
+    // The cost the opener set pays for. The interior excludes EVERY bracket, so a
+    // pair holding a different kind has no pair parse. Admitting `【` in the ASCII
+    // branch's interior would let it consume a character the `【` branch could also
+    // open on, giving a span two parses — and single-parse-per-span is what the
+    // linearity argument reads off the pattern. Fails toward a VISIBLE marker.
+    expect(labelsOf(text)).toBeNull()
+    expect(text.replace(OPTION_MARKER_RE, '')).toBe(text)
+  })
+
+  it('parses that same interior when the list CONTINUES after the closer', () => {
+    // The cost is the tail, not the interior.
+    expect(labelsOf('[OPTIONS: See [a【b] | Skip]')).toBe(' See [a【b] | Skip')
+  })
+
+  it.each([
+    '[OPTIONS: 见【表1|表2】说明 | 跳过]',
+    '[OPTIONS: 见［表1|表2］说明 | 跳过]',
+    // The comma shapes with NO pipe anywhere. `parseOptions` picks its delimiter as
+    // `labels.includes('|') ? '|' : ','`, so the comma is load-bearing exactly when
+    // no pipe is present — the case a pipe-only test cannot reach.
+    '[OPTIONS: 见【表1,表2】说明, 跳过]',
+    '[OPTIONS: 见〔表1,表2〕说明, 跳过]',
+    // ...and with a pipe present too, so the rule does not depend on which
+    // delimiter the consumer happens to pick.
+    '[OPTIONS: 见【表1,表2】说明 | 跳过]',
+  ])('declines a LOOKALIKE pair whose interior holds a separator: %s', (text) => {
+    // About the CONSUMER, not the grammar: the splitter has no notion of nesting, so
+    // admitting a pair that carries a separator would tear it into fragments with
+    // unbalanced brackets — echoed back as the user's reply when tapped. Declining is
+    // affordable; corrupting is not.
+    expect(labelsOf(text)).toBeNull()
+    const { options, text: kept } = parseOptions(text)
+    expect(options).toEqual([])
+    expect(kept).toBe(text)
+  })
+
+  it.each([
+    ['[OPTIONS: Fix dict[str, Any] now | Skip]', ['Fix dict[str, Any] now', 'Skip']],
+    ['[OPTIONS: Refactor arr[i, j] now | Skip]', ['Refactor arr[i, j] now', 'Skip']],
+  ])('keeps the ASCII interior admitting separators: %s', (text, options) => {
+    // The asymmetry, pinned as the thing that keeps it. Applying the exclusion to the
+    // ASCII branch too declines these — labels a model writes constantly, which parse
+    // today. The lookalike branches carry no such history to protect.
+    expect(parseOptions(text as string).options).toEqual(options)
+  })
+
+  it('is a MITIGATION, not a guarantee — the continuation path is unchanged', () => {
+    // A closer followed by a separator is admitted by continuation regardless of what
+    // preceded it, so a bracket run holding `|` still reaches the splitter that way.
+    // Pinned so the interior rule is not read as closing the whole class; removing it
+    // needs a nesting-aware splitter. Same as the behaviour before this change.
+    expect(parseOptions('[OPTIONS: 见【表1|表2】 | 跳过]').options).toEqual([
+      '见【表1',
+      '表2】',
+      '跳过',
+    ])
+  })
+
+  it.each([
+    '[OPTIONS: 见【表1|表2】说明 | 跳过]',
+    '[OPTIONS: 见【表1,表2】说明, 跳过]',
+  ])('names the corruption it prevents, so the reason cannot be optimised away: %s', (text) => {
+    expect(parseOptions(text).options).not.toEqual(['见【表1', '表2】说明', '跳过'])
+  })
+
+  it('admits anything in a pair that is neither a bracket nor a separator', () => {
+    // The interior is otherwise opaque: spaces, digits and punctuation no splitter
+    // looks at pass through as ordinary label text.
+    expect(parseOptions('[OPTIONS: 见【表 1：注释】说明 | 跳过]').options).toEqual([
+      '见【表 1：注释】说明',
+      '跳过',
+    ])
+  })
+
+  it('does not backtrack catastrophically on lookalike-heavy adversarial input', () => {
+    const src = `[OPTIONS:${'【a】 | '.repeat(4000)}`
+    const started = Date.now()
+    expect(labelsOf(src)).toBeNull()
+    expect(Date.now() - started).toBeLessThan(1000)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

A closer is readmitted to an `[OPTIONS:]` label when an opener earlier in the same label **matches** it. "Matches" was decided against ASCII `[` alone, while `MARKER_CLOSERS` already accepted three lookalikes (`】` U+3011, `］` U+FF3D, `〕` U+3015). A model writing a label in CJK punctuation writes **both** halves in it:

```
[OPTIONS: 见【表1】说明 | 跳过]
```

That `】` had no opener the rule recognised, so the body ended there, the line anchor rejected the remainder, and the whole marker reached the reader as literal text with no pills.

## Why it matters

This is the affordable half of a cost that was accepted knowingly: the shape fails toward a **visible marker**, not toward deleted prose. So it is a rendering failure, not data loss — but it is a rendering failure that hits Chinese, Japanese and Korean output specifically, on the surface that decides whether a turn has buttons at all. It was row 3 of the four-row cost table in #9341, pinned by tests in both languages, and #9375 was filed to track paying it.

## What changed

`_MARKER_OPENERS = "[【［〔"` is zipped **positionally** with `MARKER_CLOSERS` to emit one matched-pair branch per pair. It is private, unlike its public twin: `MARKER_CLOSERS` is public because `messaging/renderer.py` reads it, and review counted zero consumers outside `constants.py` for the opener set, so symmetry alone was not a reason to export it.

### The pairing is the load-bearing part, not a detail

One branch accepting *any* opener followed by *any* closer would make `【表1]` a pair — and that is #9284's greedy body reached by a side door. The label would end at a closer whose opener never appeared, so the body could again run past the marker's real terminator and delete the prose after it. So the mismatched shapes are asserted as explicitly as the matched ones:

| input | outcome |
|---|---|
| `[OPTIONS: 见【表1】说明 \| 跳过]` | parses — `【` pairs with `】` |
| `[OPTIONS: 见【表1] 说明 \| 跳过]` | **declined** — CJK opener, ASCII closer |
| `[OPTIONS: 见[表1】 说明 \| 跳过]` | **declined** — ASCII opener, CJK closer |
| `[OPTIONS: 见【表1〕 说明 \| 跳过】` | **declined** — two different lookalikes |

### Two consequences that deserve review in their own right

**The catch-all class now excludes every bracket, not just the closers.** Leaving `【` in it would give that character two parses — the pair branch and the catch-all — costing the disjointness the linearity argument rests on. `TestLinearity` reads the exclusion off the compiled pattern so the claim cannot drift from the comment, and exercises the shape that would blow up if it did.

**`MARKER_CLOSERS` is no longer widenable on its own.** Continuation readmits all four codepoints at once; the pair form readmits exactly one per branch, its own opener's partner. A fifth closer with no opener beside it would be admitted by continuation and by nothing else — a real shape, but not the matched one. The two constants are zipped with `strict=True`, so a length mismatch raises at import. That replaced a hand-written `assert` after review pointed out the obvious: `strict=True` is the language guarantee for exactly this, and an `assert` is stripped by `python -O` while the zip is not.

### The frontend stays one regex literal, deliberately

Composing the pattern from named fragments reads far better and was the first attempt. But every fragment is a module-scope **string** literal, and `eslint.i18n.strict.config.js` reports those as untranslated user-visible copy — 11 findings, `[added-lines]` zero-tolerance. The exemption the gate offers is by shape in `eslint.i18n.config.js`, and that config argues at length against widening a shape for one file ("A path this narrow cannot exempt a future file"). A hole cut for regex fragments is one real copy could sit in later, so I did not cut it. A regex literal contains no string literal and needs no hole.

The duplication that costs is guarded instead: the `.source` pin in `AssistantMessage.test.tsx` is **built from per-pair pieces**, so the two copies of the body cannot drift from each other, or from the backend, without the test naming the difference. Every lookalike is written as a `\uXXXX` escape rather than the character itself — `]` and `］` are indistinguishable at a glance, so a literal class would be unreviewable and a wrong codepoint would read as correct.

### This NARROWS one shape, and that is a cost the table has to carry

Raised by review, and correct: the pair interior excludes **every** bracket, both classes, so a pair whose interior holds a bracket of a different kind loses its pair parse. On base the interior excluded only `[` and the closers, so `【` was ordinary interior content and these parsed:

```
[OPTIONS: See [a【b] ref | Skip]       base: parses     this branch: declined
[OPTIONS: See [a［b] ref | Skip]       base: parses     this branch: declined
[OPTIONS: 见【表[1】说明 | 跳过]         base: parses     this branch: declined
```

All three fail toward a **visible marker** — verified, `sub` leaves the text byte-identical — so it is the same affordable class as the other rows, and the same shape still parses when a separator follows the closer (`[OPTIONS: See [a【b] | Skip]`), because then continuation admits it. The cost is the tail, not the interior.

I kept the behaviour rather than admitting openers into the interior. Admitting `【` there would let the ASCII branch consume a character the `【` branch could also open on, so a span would have two parses — and single-parse-per-span is exactly what `TestLinearity` reads off the compiled pattern and what the ReDoS profile rests on. Trading a shape that degrades to visible text for an ambiguity in the body is the wrong way round.

My first draft of this description claimed the table "cannot quietly grow or shrink" while this PR grew it. That accounting error is fixed here and pinned in `TestAMixedBracketInterior`.

### The pair interior also refuses BOTH separators, and that is about the CONSUMER

Raised by review as blocking — twice, and correct both times. Admitting a pair whole is only safe if what receives the capture can keep it whole, and neither splitter has any notion of nesting. So a pair carrying an internal separator, which is an ordinary CJK phrase, was captured and then torn apart:

```
[OPTIONS: 见【表1,表2】说明, 跳过]
  base:    declines  (【 was not an opener, so this never parsed)
  round 1: ['见【表1', '表2】说明', '跳过']   ← three choices, two with unbalanced brackets
  now:     declines, text intact
```

The corruption was introduced by this PR — base declines that shape — so it was mine to fix, not a pre-existing condition.

**`|` alone was not enough.** `parseOptions` picks its delimiter as `labels.includes('|') ? '|' : ','` (`options.ts:38`), so a **comma** is load-bearing exactly when no pipe is present. The backend splitter has no such fallback, so a check against the backend plus a frontend shape that happened to contain a pipe reported commas as safe. They were not.

**But excluding `,` from every interior was too much, and review caught that too.** It declined `[OPTIONS: Fix dict[str, Any] now | Skip]` and `[OPTIONS: Refactor arr[i, j] now | Skip]` — labels a model writes constantly, which parse on `main`. So the exclusion is now **per branch**:

| interior | excludes | why |
|---|---|---|
| ASCII `[…]` | brackets only | `dict[str, Any]` and `arr[i, j]` parse today; nothing may regress |
| `【…】`, `［…］`, `〔…〕` | brackets + both separators | new in this PR, so no shape depends on them admitting a separator |

Each half is chosen against what it would break, and both are pinned.

**It is a mitigation, not a guarantee — and that matters for how the row reads.** The continuation form admits a closer followed by a separator regardless of what precedes it, so `[OPTIONS: 见【表1|表2】 | 跳过]` reaches the splitter and splits into three. Measured on `main` as well as here: **identical**. Closing that class needs a nesting-aware splitter, not a tighter interior, and it is out of scope; the continuation-path behaviour is pinned as unchanged so the interior rule is not read as more than it is.

**The mistakes worth naming, since all three were mine:** round 1 asserted what the *regex captured* and never asked what the consumer did with it — the lesson this grammar's own pattern harvest already carried from #9341. Round 2 verified the fix against *one* of two consumers. Round 3 then over-corrected and regressed ordinary ASCII labels. Every cost row is now asserted at the consumer on both surfaces, and the shapes that must keep parsing are pinned alongside the ones that must not.

### The remaining costs, and what is still out of scope

The cost table is now **four** rows, all asserted at the consumer on both surfaces so it cannot quietly change: an unmatched closer with no opener at all (`[OPTIONS: Fix ]x logging | Skip]`), nesting deeper than one level (`[OPTIONS: Fix list[dict[str, Any]] now | S]`), the mixed-bracket interior, and the separator in a lookalike interior above. The first two need bracket matching to arbitrary depth, which a regex is the wrong tool for; the last two are interior exclusions taken deliberately, each for a reason recorded beside the pair rule.

A comma *outside* a pair is unaffected — `[OPTIONS: 见【表1】说明, 跳过]` still parses to two clean choices. The separator-tail form (`…| Wait], details in CHANGELOG[1]`) is unchanged and still out of scope, for the reason #9341 gave: `], ` genuinely does continue the list.

### Two cost pins flipped rather than deleted

One per surface — `test_options_marker_label_closers.py` and `optionsMarkerLabelClosers.test.ts` — each kept in its original suite, now asserting the parse instead of the decline, because the rule under test there is what decides the outcome.

## Tests

- **New:** `test/test_options_marker_lookalike_openers.py` and `website/src/test/optionsMarkerLookalikeOpeners.test.ts`.
- **Backend:** 761 passed across the marker, option and renderer suites — `test_*option*`, `test_*marker*`, `test_*renderer*`, `test_slack*`, `test_whatsapp*`, `test_parse_options`.
- **Frontend:** 170 passed across the four marker suites including the `.source` pin.
- **Cross-surface agreement:** a differential over all 16 opener×closer combinations plus the pinned shape vocabulary — **70 shapes, zero disagreements** between `OPTIONS_RE_LINE` and `OPTION_MARKER_RE`. Both surfaces have to agree or a marker parses to buttons on one and to text on the other.
- **Linearity:** measured, not asserted in a comment. Lookalike-heavy adversarial input (`[OPTIONS:` + `【a】 | ` × N) stays linear — 0.5 ms at 2 KB, 1.7 ms at 8 KB, 4.1 ms at 20 KB — and a long *mismatched* run, the worst case for a pair form since every branch is attempted and every one fails, is pinned too.

## Manual verification

N/A, and the reason is the same as #9341's: the trigger is what the model happens to emit, not an input a user can type. Both surfaces are exercised at the parser level, which is the only code the marker passes through, and the end-to-end assertion goes through `split_options_trailer` / `parseOptions` rather than the regex alone.

## Related Issues

Fixes #9375

Follow-up to #9341 / #9284, which established the matched-or-continues rule and enumerated this as one of its four accepted costs.

**Overlaps #6823.** That PR carries `MARKER_OPENERS` with the same name and the same value, added for a different reason ("a citation `[1]` must not cancel an open marker head"). If it lands first this becomes a one-line dedupe; if this lands first, #6823's copy is redundant. #6823 also touches `constants.py` and `optionMarker.ts` and is currently labelled `merge conflict`, so a conflict there is expected either way and is not caused by this PR alone. Flagged rather than resolved, since that PR is its author's to sequence.

## Pattern harvest

Rule candidate: review-prompt

Pattern: when a grammar admits a delimiter **conditionally** on some earlier context, check that the test for "earlier context" ranges over the same alphabet as the delimiter set. Widening one side alone is silent: `MARKER_CLOSERS` grew three codepoints while "what can match a closer" stayed ASCII, so a whole script's worth of input fell through a rule that looked complete. The tell is a constant naming one half of a pair with no constant naming the other. Two general follow-ons: when you pair two ordered constants by `zip`, assert their lengths at import, because `zip` truncates silently and the only symptom is one shape quietly failing; and when a fix adds alternatives to a regex body, re-audit the catch-all class — an alternative that can also be consumed by the catch-all gives that character two parses and silently costs whatever linearity argument the body relied on.
