### PR TITLE
fix(mcp): preserve prior probe tools/capabilities on a failed re-probe

### DIFF
--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -439,20 +439,54 @@ def _cache_probe(server: McpServerInfo) -> None:
     built from the CURRENT config, so redacting only at serialization time
     would mask a rotated credential's NEW value while the cached error still
     carries the OLD one.
+
+    A failed probe (``server.status in {"error", "needs_auth"}``) still
+    overwrites ``status``/``error`` — a server that just failed to answer
+    IS currently failing, and ``mcp_gateway.shareability`` correctly reads a
+    fresh "error" as UNKNOWN via ``probe_ok``. What it must NOT overwrite is
+    the server's descriptive shape from its last successful handshake:
+    ``tools``, ``tool_annotations``, ``capabilities``, ``protocol_version``,
+    ``server_info``, and ``probed_at_wall``. Without this, a single transient
+    timeout on an otherwise-healthy server collapses its tool count to zero
+    for the probe that failed, discarding both lists together even though
+    each is only ever populated from that same successful handshake —
+    resetting one without the other would leave a caller reading tool
+    metadata that does not match the tools actually being reported. ``probed_at_wall`` travels with the preserved shape rather
+    than the failed probe's own timestamp, so an "as of" display next to
+    the preserved tools points to when they were actually observed, not to
+    the unrelated timeout that came later. A server that has never had a
+    successful probe has no prior shape to fall back to, so it gets the
+    failure's own (empty) shape — there is nothing stale to protect.
     """
     server.probed_at = time.time()
+    prior = _probe_cache.get(server.name)
+    probe_failed = server.status in ("error", "needs_auth")
+    if probe_failed and prior is not None:
+        tools = list(prior.tools)
+        tool_annotations = [dict(a) for a in prior.tool_annotations]
+        capabilities = dict(prior.capabilities) if isinstance(prior.capabilities, dict) else None
+        protocol_version = prior.protocol_version
+        server_info = dict(prior.server_info)
+        probed_at_wall = prior.probed_at_wall
+    else:
+        tools = list(server.tools)
+        tool_annotations = [dict(a) for a in server.tool_annotations]
+        capabilities = dict(server.capabilities) if isinstance(server.capabilities, dict) else None
+        protocol_version = server.protocol_version
+        server_info = dict(server.server_info)
+        probed_at_wall = server.probed_at
     _probe_cache[server.name] = _ProbeResult(
         status=server.status,
-        tools=list(server.tools),
+        tools=tools,
         error=redact_mcp_error(
             server.error, server.redaction_headers, server.resolved_header_values or ()
         ),
         probed_at=time.monotonic(),
-        capabilities=(dict(server.capabilities) if isinstance(server.capabilities, dict) else None),
-        protocol_version=server.protocol_version,
-        server_info=dict(server.server_info),
-        tool_annotations=[dict(a) for a in server.tool_annotations],
-        probed_at_wall=server.probed_at,
+        capabilities=capabilities,
+        protocol_version=protocol_version,
+        server_info=server_info,
+        tool_annotations=tool_annotations,
+        probed_at_wall=probed_at_wall,
         probe_mode=server.probe_mode,
         auth_challenge=server.auth_challenge,
         auth_grant_present=server.auth_grant_present,

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -1558,6 +1558,69 @@ class TestProbeCache:
         assert status == "error"
         assert error == "timeout"
 
+    def test_failed_probe_after_success_keeps_prior_tools(self) -> None:
+        """A transient failure must not collapse a healthy server's tool list.
+
+        `status`/`error` DO overwrite -- a fresh "error" should flip
+        `mcp_gateway.shareability`'s `probe_ok` to False, which is the
+        correct fail-closed behavior. What must survive is the server's last
+        known-good shape, so a single timeout doesn't render as "0 tools".
+        """
+        good = McpServerInfo(
+            name="flaky-srv",
+            command="x",
+            status="ok",
+            tools=["a", "b"],
+            tool_annotations=[{"readOnlyHint": True}, {}],
+            capabilities={"tools": {}},
+            protocol_version="2025-03-26",
+        )
+        _cache_probe(good)
+
+        failed = McpServerInfo(name="flaky-srv", command="x", status="error", error="timeout")
+        _cache_probe(failed)
+
+        status, tools, error, _at, _mode = _get_cached("flaky-srv")
+        assert status == "error"
+        assert error == "timeout"
+        assert tools == ["a", "b"]  # preserved, not collapsed to []
+
+        meta = probe_metadata("flaky-srv")
+        assert meta is not None
+        assert meta.tool_annotations == [{"readOnlyHint": True}, {}]
+        assert meta.capabilities == {"tools": {}}
+        assert meta.protocol_version == "2025-03-26"
+        # Both preserved together, never one alone -- a caller reading tool
+        # metadata after this must see the same handshake's tools and
+        # annotations, not a mix of stale and fresh.
+        assert meta.tools == good.tools
+        assert meta.tool_annotations == good.tool_annotations
+        # The preserved shape keeps its original observation time, not the
+        # failed probe's -- "as of" claims about the tool list must point to
+        # when it was actually seen, not to the timeout that came later.
+        assert meta.probed_at_wall == good.probed_at
+
+    def test_first_ever_probe_failing_has_no_prior_to_preserve(self) -> None:
+        """A server that has never succeeded gets the failure's own (empty)
+        shape -- there is nothing stale to protect it from."""
+        server = McpServerInfo(name="never-worked", command="x", status="error", error="refused")
+        _cache_probe(server)
+        status, tools, error, _at, _mode = _get_cached("never-worked")
+        assert status == "error"
+        assert error == "refused"
+        assert tools == []
+
+    def test_needs_auth_also_preserves_prior_shape(self) -> None:
+        """needs_auth is a probe-side failure too (no token to present), not
+        a success -- it must preserve prior tools the same way "error" does."""
+        good = McpServerInfo(name="oauth-srv", command="x", status="ok", tools=["x", "y"])
+        _cache_probe(good)
+        challenged = McpServerInfo(name="oauth-srv", command="x", status="needs_auth", error="")
+        _cache_probe(challenged)
+        status, tools, _error, _at, _mode = _get_cached("oauth-srv")
+        assert status == "needs_auth"
+        assert tools == ["x", "y"]
+
     def test_cache_preserves_declared_probe_mode(self) -> None:
         """The in-process fallback's "declared" mode survives the cache round trip."""
         server = McpServerInfo(


### PR DESCRIPTION
TLDR: a failed MCP probe was wiping the server's last-known tools/capabilities instead of just marking it failed. Fixes #10013.

## Problem / Motivation

A failed probe (`status in {"error", "needs_auth"}`) on an MCP server that had previously probed fine was overwriting `tools`, `tool_annotations`, `capabilities`, `protocol_version`, and `server_info` with the failed probe's empty values. One transient timeout on an otherwise healthy server collapsed its tool count to zero.

## Why it matters

`tools` and `tool_annotations` are both populated only from a successful handshake, so a single flaky probe wiping one without the other leaves a caller reading tool metadata that no longer corresponds to the tools actually being reported. Anyone relying on a server's cached tool list to survive a blip (network hiccup, a momentary auth token expiry) currently loses that list entirely until the next successful probe.

## What changed (motivation → approach → change)

Root cause: `_cache_probe()` in `mcp_discovery.py` unconditionally rebuilt every field of the cached `_ProbeResult` from the current `server.*` values, with no distinction between "this probe just failed" and "this probe just failed AND we have nothing better to fall back to."

Fix: on a failed probe, if a prior successful probe exists, keep its `tools`/`tool_annotations`/`capabilities`/`protocol_version`/`server_info` and only refresh `status`/`error`. A server with no prior successful probe has nothing to protect, so it still gets the failure's own (empty) shape. `mcp_gateway.shareability`'s fail-closed `probe_ok` check still reads a fresh `status`/`error` correctly either way, since those are never held back.

Caught a bug in my own first draft here: I computed the right local variables for the prior-shape case but the final `_ProbeResult(...)` construction still referenced `server.*` instead of them. The tests below caught it.

## Tests

- `test_failed_probe_after_success_keeps_prior_tools` — a probe that succeeds then fails keeps the earlier tools/capabilities/etc, only status/error move.
- `test_first_ever_probe_failing_has_no_prior_to_preserve` — a server with no prior successful probe gets the failure's own empty shape, nothing to fall back to.
- `test_needs_auth_also_preserves_prior_shape` — `needs_auth` is treated the same as `error` for this purpose.

210/210 pass in `test_mcp_discovery.py` (4 skipped, unrelated to this change). Clean isort/flake8/mypy on both changed files.

## Manual verification

N/A — unit coverage sufficient. This is a pure function over `_ProbeResult`/`McpServerInfo` state with no I/O or UI surface.

## Related Issues

Fixes #10013

## Pattern harvest

Not generalizable: a cache-refresh function conflating "the fresh value is authoritative" with "the fresh value is authoritative even when it's empty because the fetch failed" is a real class of bug, but this specific instance is one function with a known, enumerable field list, not a pattern I can turn into a lint rule without false positives on caches that legitimately should reset on error.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no public-facing doc describes this internal cache behavior
- [x] No secrets, credentials, or internal references in the diff


