### PR TITLE
fix(papyrus): align Tectonic output with served PDF path

### DIFF
--- a/docs/system-specs/modules/papyrus.md
+++ b/docs/system-specs/modules/papyrus.md
@@ -278,7 +278,10 @@ a refused name never reaches `gitops` or the compiler.
 5. Without a bibliography, re-run once if the log says "Rerun to get…" — how a
    table of contents or a `\ref` settles. Not retried when the pass **failed**: a
    failing pass that also asks to rerun is broken, not merely unsettled.
-6. `ok` requires exit 0 **and** a PDF on disk — `pdflatex` can exit 0 having
+6. Both compilers write output in the project root, including when the main
+   document is in a subdirectory. Tectonic receives `--outdir` explicitly so
+   compilation and the PDF-serving path resolve the same file.
+7. `ok` requires exit 0 **and** a PDF on disk — `pdflatex` can exit 0 having
    produced nothing usable.
 
 ### Log parsing

--- a/src/kiro_crew/apps/builtins/papyrus/backend/latex.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/latex.py
@@ -530,7 +530,7 @@ def _compiler_argv(compiler: str, tex: Path, project: Path) -> list[str]:
     never pass it.
     """
     if "tectonic" in os.path.basename(compiler):
-        return [compiler, "--keep-logs", "--", str(tex)]
+        return [compiler, "--keep-logs", "--outdir", str(project), "--", str(tex)]
     return [
         compiler,
         "-interaction=nonstopmode",

--- a/test/test_papyrus_latex.py
+++ b/test/test_papyrus_latex.py
@@ -450,6 +450,35 @@ class TestCompileProject:
         assert result.ok is True
         assert recorder.operations == ["compile"]
 
+    @pytest.mark.parametrize("existing_pdf", [False, True])
+    async def test_tectonic_nested_main_updates_the_served_pdf(
+        self, project: Path, existing_pdf: bool
+    ) -> None:
+        nested = project / "chapters" / "paper.tex"
+        nested.parent.mkdir()
+        nested.write_text(r"\documentclass{article}", encoding="utf-8")
+        served = project / "paper.pdf"
+        if existing_pdf:
+            served.write_bytes(b"%PDF-stale")
+
+        async def compile_output(argv, **kwargs):
+            # Tectonic's V1 CLI defaults to the input file's directory.
+            output_dir = (
+                Path(argv[argv.index("--outdir") + 1])
+                if "--outdir" in argv else Path(argv[-1]).parent
+            )
+            (output_dir / "paper.pdf").write_bytes(b"%PDF-current")
+            return 0, ""
+
+        with mock.patch.object(
+            latex, "find_compiler", mock.AsyncMock(return_value="/usr/local/bin/tectonic")
+        ), mock.patch.object(latex, "_run", compile_output):
+            result = await latex.compile_project(project, "chapters/paper.tex")
+
+        assert result.ok is True
+        assert store.pdf_path(project, "chapters/paper.tex") == served
+        assert served.read_bytes() == b"%PDF-current"
+
     async def test_a_missing_pdf_means_failure_even_on_exit_zero(self, project: Path) -> None:
         """pdflatex can exit 0 having produced nothing usable."""
         recorder = _RunRecorder(code=0)


### PR DESCRIPTION
## Problem / Motivation

Papyrus serves compiled PDFs from the project root. Tectonic's V1 CLI instead defaults output to the directory containing the input file, so a configured nested main document such as chapters/paper.tex can compile successfully while Papyrus reports no PDF. If a stale project-root PDF exists, the UI can continue serving the stale artifact.

## Why it matters

A nested TeX document can compile successfully while Papyrus cannot find the PDF it serves. If a stale project-root PDF already exists, users can continue receiving that stale artifact, so a successful compiler exit does not guarantee that the exposed PDF is the one just produced.

## What changed

- Pass the already-created project root as Tectonic's explicit --outdir.
- Add an applying compile regression for both missing and stale served PDFs.
- Document the shared compiler-output contract in the Papyrus system spec.

This uses the pinned Tectonic 0.17.0 interface; its V1 CLI supports --outdir and documents the default as the input file's directory.

## Tests

- All Papyrus tests: 544 passed, 35 platform skips.
- flake8 on the changed Python: passed.
- diff check: passed.
- Red-before: the nested-main regression failed without --outdir because output landed under chapters; it passes after the fix and replaces a stale served PDF.

Mypy could not run to completion on this host's Python 3.10 because current main contains unrelated Python-3.12 f-string syntax in aws_control/backend/backup.py.

## Collision check

No open PR touches latex.py or test_papyrus_latex.py. PR #9057 changes Tectonic binary-install containment in tectonic.py and does not overlap this compile-output behavior.

## Manual verification

N/A — the compiler subprocess contract and served-path consequence are deterministic in the unit test.

## Related Issues

None.

## Pattern harvest

Not generalizable: this is a Papyrus/Tectonic output-directory integration mismatch. The focused nested-main regression pins the served-PDF contract; a repository-wide static rule would not identify this compiler-specific behavior.

## Checklist

- [x] One Conventional Commit
- [x] Regression test added
- [x] System spec updated
- [x] No secrets or credentials

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. Do not invent CLA text. -->

Generated with Codex.