### PR TITLE
fix(instances): center tunnel exit-error detail on classified line

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -539,7 +539,13 @@ what its own edit invalidated, and never reopens anything on the user's behalf.
 - **Untrusted ssh stderr.** A proxy banner is ANSI-stripped, credential- and
   exfiltration-redacted, and truncated before it is surfaced in status, and it is
   a secondary detail only: failure *classification* keys on real ssh signals, so
-  banner prose can never be read as an auth verdict.
+  banner prose can never be read as an auth verdict. When a classification phrase
+  matched, the fixed-width truncation window is centered on the matched phrase
+  rather than the head of the buffer -- on the phrase itself, not its line, since
+  the proxy controls the buffer and can make a single line arbitrarily long -- so
+  benign stderr written earlier (e.g. arbitrary `LocalCommand` output) cannot
+  consume the budget and truncate the classified reason out of the surfaced
+  detail.
 - **Trust root.** `<data-home>/run/` (the run-marker dir) is on the
   `is_sensitive_path` floor, so agent file tools can neither read nor write it.
   See §12 and [security.md](security.md).

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -236,6 +236,51 @@ _BENIGN_SSH_STDERR_MARKERS = (
 )
 
 
+# Classification phrases for _exit_error / _ssm_exit_error, matched against the
+# lowercased noise-stripped stderr. The first hit ALSO anchors the sanitized
+# detail window (see _sanitize_banner) so the classified phrase survives the cap
+# even when arbitrary benign stderr (e.g. LocalCommand output) precedes it.
+_SSH_AUTH_SIGNALS = (
+    "permission denied",
+    "publickey",
+    "authentication failed",
+    "certificate has expired",
+    "certificate expired",
+)
+_SSH_TRANSPORT_DROP_SIGNALS = (
+    "timed out during banner exchange",
+    "session ended unexpectedly",
+    "connection timed out",
+    "connection reset",
+    "closed by remote host",
+    "connection refused",
+)
+_SSH_BIND_SIGNALS = ("address already in use", "cannot listen to port")
+_SSM_CREDENTIAL_SIGNALS = (
+    "expired",
+    "unable to locate credentials",
+    "no credentials",
+    "credentials not found",
+)
+_SSM_DENIAL_SIGNALS = ("accessdenied", "not authorized", "unauthorizedoperation")
+_SSM_PLUGIN_SIGNALS = ("sessionmanagerplugin", "session-manager-plugin")
+_SSM_TARGET_SIGNALS = (
+    "targetnotconnected",
+    "not connected",
+    "invalidinstanceid",
+    "invalidinstanceinformation",
+)
+_SSM_BIND_SIGNALS = ("address already in use", "bind")
+
+
+def _first_hit(low: str, phrases: tuple[str, ...]) -> str | None:
+    """Return the first of *phrases* present in *low* (already lowercased)."""
+    for phrase in phrases:
+        if phrase in low:
+            return phrase
+    return None
+
+
 def _recover_backoff_secs(attempt: int, cap: float = _RECOVER_BACKOFF_MAX_SECS) -> float:
     """Exponential backoff before a self-heal rebuild, capped at *cap*. *attempt* is 1-based."""
     base = _RECOVER_BACKOFF_BASE_SECS * (2 ** max(0, attempt - 1))
@@ -258,15 +303,38 @@ def _strip_benign_ssh_noise(text: str) -> str:
 _ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
 
 
-def _sanitize_banner(text: str) -> str:
+_BANNER_DETAIL_MAX_CHARS = 200
+
+
+def _sanitize_banner(text: str, *, anchor: str | None = None) -> str:
     """ANSI-strip + credential/exfil-redact untrusted ssh stderr before it is
-    surfaced in status/logs, capped at 200 chars. The banner is external,
-    proxy-controlled text, so it is a redacted secondary detail only — never a
-    classification signal."""
+    surfaced in status/logs, capped at ``_BANNER_DETAIL_MAX_CHARS``. The banner
+    is external, proxy-controlled text, so it is a redacted secondary detail
+    only -- never a classification signal.
+
+    When *anchor* names the lowercase classification phrase the exit-error
+    classifier matched, the fixed-width window is centered on the first
+    occurrence of that phrase instead of taken from the head, so benign stderr
+    written earlier (e.g. arbitrary ``LocalCommand`` output such as repeated
+    ``tput`` warnings under launchd/systemd where ``TERM`` is unset) cannot
+    consume the budget and truncate the classified reason out of the surfaced
+    detail. Centering on the phrase itself (never on its line, which the
+    proxy-controlled buffer can make arbitrarily long) keeps the phrase inside
+    the window unconditionally. Without an anchor, or when sanitization
+    removed the phrase, the head slice is unchanged.
+    """
     cleaned = _ANSI_CSI_RE.sub("", text)
     cleaned = redact_credentials(cleaned)[0]
     cleaned = redact_exfiltration_urls(cleaned)[0]
-    return cleaned[:200]
+    if len(cleaned) <= _BANNER_DETAIL_MAX_CHARS:
+        return cleaned
+    if anchor:
+        hit = cleaned.lower().find(anchor)
+        if hit >= 0:
+            start = hit + len(anchor) // 2 - _BANNER_DETAIL_MAX_CHARS // 2
+            start = max(0, min(start, len(cleaned) - _BANNER_DETAIL_MAX_CHARS))
+            return cleaned[start : start + _BANNER_DETAIL_MAX_CHARS]
+    return cleaned[:_BANNER_DETAIL_MAX_CHARS]
 
 
 class ProxyRequestError(Exception):
@@ -693,7 +761,9 @@ class _SshTunnel:
         (idle timeout, banner-exchange timeout, reset, refused) is reported as a
         transport drop — never as an auth verdict inferred from banner text. The
         raw banner is ANSI-stripped and credential-redacted before it is
-        surfaced as a secondary detail.
+        surfaced as a secondary detail, with the fixed-width detail window
+        centered on the matched classification phrase so preceding benign
+        noise (e.g. LocalCommand output) cannot truncate the real reason away.
 
         The SSM transport has an entirely different error vocabulary (IAM
         denials, a missing session-manager-plugin, an offline SSM agent), so it
@@ -709,33 +779,23 @@ class _SshTunnel:
         # failure (the loop symptom was this warning hiding "bind: ... in use").
         tail = _strip_benign_ssh_noise(self._stderr_buf)
         low = tail.lower()
-        detail = _sanitize_banner(tail)
         # Genuine ssh auth signals first, so a real auth failure is never masked
         # by a transport phrase that happens to co-occur in the same banner.
-        if (
-            "permission denied" in low
-            or "publickey" in low
-            or "authentication failed" in low
-            or "certificate has expired" in low
-            or "certificate expired" in low
-        ):
-            return f"ssh auth failed (check SSH access): {detail}"
+        hit = _first_hit(low, _SSH_AUTH_SIGNALS)
+        if hit is not None:
+            return f"ssh auth failed (check SSH access): {_sanitize_banner(tail, anchor=hit)}"
         # WSSH / transport session drops — not an auth problem. Worded neutrally
         # because this method is also used for the initial-connect failure path,
         # where no self-heal is armed yet (so it must not promise reconnection).
-        if (
-            "timed out during banner exchange" in low
-            or "session ended unexpectedly" in low
-            or "connection timed out" in low
-            or "connection reset" in low
-            or "closed by remote host" in low
-            or "connection refused" in low
-        ):
-            return f"ssh tunnel transport drop: {detail}"
-        if "address already in use" in low or "cannot listen to port" in low:
+        hit = _first_hit(low, _SSH_TRANSPORT_DROP_SIGNALS)
+        if hit is not None:
+            return f"ssh tunnel transport drop: {_sanitize_banner(tail, anchor=hit)}"
+        hit = _first_hit(low, _SSH_BIND_SIGNALS)
+        if hit is not None:
+            detail = _sanitize_banner(tail, anchor=hit)
             return f"ssh forward bind failed (local port already in use): {detail}"
         if tail:
-            return f"ssh exited {returncode}: {detail}"
+            return f"ssh exited {returncode}: {_sanitize_banner(tail)}"
         return f"ssh exited with code {returncode}"
 
     def _ssm_exit_error(self, returncode: int | None) -> str:
@@ -750,40 +810,37 @@ class _SshTunnel:
         """
         tail = self._stderr_buf.strip()
         low = tail.lower()
-        detail = _sanitize_banner(tail)
         # Credentials first: an expired/absent credential is the most common
         # cause and its message can also contain "not authorized"-adjacent text.
-        if (
-            "expired" in low
-            or "unable to locate credentials" in low
-            or "no credentials" in low
-            or "credentials not found" in low
-        ):
+        hit = _first_hit(low, _SSM_CREDENTIAL_SIGNALS)
+        if hit is not None:
             return (
                 "AWS credentials missing or expired (refresh them, e.g. "
-                f"`aws sso login --profile <name>`): {detail}"
+                f"`aws sso login --profile <name>`): {_sanitize_banner(tail, anchor=hit)}"
             )
-        if "accessdenied" in low or "not authorized" in low or "unauthorizedoperation" in low:
+        hit = _first_hit(low, _SSM_DENIAL_SIGNALS)
+        if hit is not None:
+            detail = _sanitize_banner(tail, anchor=hit)
             return f"IAM denied ssm:StartSession for this target: {detail}"
-        if "sessionmanagerplugin" in low or "session-manager-plugin" in low:
+        hit = _first_hit(low, _SSM_PLUGIN_SIGNALS)
+        if hit is not None:
             return (
                 "session-manager-plugin is not installed locally (install the AWS "
-                f"Session Manager plugin, then reconnect): {detail}"
+                f"Session Manager plugin, then reconnect): {_sanitize_banner(tail, anchor=hit)}"
             )
-        if (
-            "targetnotconnected" in low
-            or "not connected" in low
-            or "invalidinstanceid" in low
-            or "invalidinstanceinformation" in low
-        ):
+        hit = _first_hit(low, _SSM_TARGET_SIGNALS)
+        if hit is not None:
             return (
                 "the SSM target is not a connected managed node (is the instance "
-                f"running with the SSM agent online and an instance profile?): {detail}"
+                f"running with the SSM agent online and an instance profile?): "
+                f"{_sanitize_banner(tail, anchor=hit)}"
             )
-        if "address already in use" in low or "bind" in low:
+        hit = _first_hit(low, _SSM_BIND_SIGNALS)
+        if hit is not None:
+            detail = _sanitize_banner(tail, anchor=hit)
             return f"SSM forward bind failed (local port already in use): {detail}"
         if tail:
-            return f"SSM session exited {returncode}: {detail}"
+            return f"SSM session exited {returncode}: {_sanitize_banner(tail)}"
         return f"SSM session exited with code {returncode}"
 
     async def _capture_stderr(self) -> None:

--- a/test/test_ssh_tunnel_manager_cov80.py
+++ b/test/test_ssh_tunnel_manager_cov80.py
@@ -31,6 +31,7 @@ import pytest
 from kiro_crew import platform_compat
 from kiro_crew.instances.ssh_tunnel_manager import (
     TunnelState,
+    _sanitize_banner,
     _SshTunnel,
     _TransportParams,
 )
@@ -434,3 +435,72 @@ class TestTransportParams:
             "aws_profile": "zibble",
             "aws_region": "us-west-2",
         }
+
+
+class TestExitErrorDetailWindow:
+    """The 200-char detail budget must not be spent on benign stderr written
+    BEFORE the classified failure line: under launchd/systemd with no ``TERM``,
+    arbitrary ``LocalCommand`` output (repeated ``tput`` warnings) precedes the
+    real diagnostic, so a head slice surfaces the cosmetic warning while the
+    classifier state is correct. The window must anchor on the matched
+    phrase."""
+
+    # 5 x 45 chars = 225 chars of benign noise, > the 183-char budget remainder.
+    _NOISE = "tput: No value for $TERM and no -T specified\n" * 5
+
+    def test_classified_reason_survives_leading_localcommand_noise(self) -> None:
+        tunnel = _tunnel()
+        tunnel._stderr_buf = self._NOISE + "client_loop: send disconnect: Connection reset by peer"
+        error = tunnel._exit_error(255)
+        assert error.startswith("ssh tunnel transport drop:")
+        assert "Connection reset by peer" in error
+
+    def test_unclassified_stderr_keeps_the_head_slice(self) -> None:
+        tunnel = _tunnel()
+        tunnel._stderr_buf = self._NOISE + "some entirely unclassified failure text"
+        error = tunnel._exit_error(255)
+        assert error.startswith("ssh exited 255: tput: No value for $TERM")
+        assert "unclassified failure" not in error
+
+    def test_ssm_detail_window_is_also_anchored(self) -> None:
+        tunnel = _tunnel(transport="ssm", ssm_target="i-0123456789abcdef0")
+        tunnel._stderr_buf = (
+            "z" * 250 + "\nAn error occurred (TargetNotConnected) when calling StartSession"
+        )
+        error = tunnel._ssm_exit_error(1)
+        assert "not a connected managed node" in error
+        assert "TargetNotConnected" in error
+
+
+class TestSanitizeBannerAnchor:
+    def test_short_text_is_returned_whole(self) -> None:
+        assert _sanitize_banner("short", anchor="connection reset") == "short"
+
+    def test_no_anchor_takes_the_head(self) -> None:
+        assert _sanitize_banner("a" * 300) == "a" * 200
+
+    def test_anchor_centers_the_window_on_the_matched_line(self) -> None:
+        text = "n" * 250 + "\nError: Connection reset by peer"
+        out = _sanitize_banner(text, anchor="connection reset")
+        assert "Connection reset by peer" in out
+        assert len(out) == 200
+
+    def test_a_long_single_line_still_keeps_the_phrase_in_the_window(self) -> None:
+        """The proxy controls the buffer, so LocalCommand output with no
+        trailing newline can merge onto ssh's diagnostic into one arbitrarily
+        long line; centering on the phrase (not its line) must still surface
+        the reason."""
+        text = "x" * 400 + "client_loop: send disconnect: Connection reset by peer"
+        out = _sanitize_banner(text, anchor="connection reset")
+        assert "Connection reset by peer" in out
+        assert len(out) == 200
+
+    def test_redaction_happens_before_the_window_is_taken(self) -> None:
+        token = "ghp_" + "a1B2" * 9
+        text = "m" * 250 + f"\ntoken {token} then Connection reset by peer"
+        out = _sanitize_banner(text, anchor="connection reset")
+        assert token not in out
+        assert "Connection reset by peer" in out
+
+    def test_a_missing_anchor_falls_back_to_the_head(self) -> None:
+        assert _sanitize_banner("b" * 300, anchor="connection refused") == "b" * 200


### PR DESCRIPTION
## Problem / Motivation

When a remote-instance tunnel child exits, `_exit_error()` classifies the
failure correctly against the full stderr buffer, but the human-readable
detail it surfaces is `_sanitize_banner(tail)`, which returns the HEAD 200
chars of the buffer. Benign stderr written before the real diagnostic line --
notably arbitrary `LocalCommand` output such as repeated
`tput: No value for $TERM and no -T specified` lines under launchd/systemd
where `TERM` is unset -- consumes the budget and truncates the actual failure
reason mid-sentence.

## Why it matters

The classifier state is correct (`transport drop`) while the operator-facing
text and dashboard instance status point at an irrelevant cosmetic warning,
sending operators down the wrong diagnostic path.

## What changed (motivation -> approach -> change)

Issue option 2 (budget-aware detail), which generalizes over ANY preceding
noise instead of curating a marker list:

- The classification phrase groups in `_exit_error` / `_ssm_exit_error` are
  now module-level tuples shared by the classifier and the detail step; the
  first matched phrase anchors the fixed-width 200-char sanitization window
  in `_sanitize_banner` on the matched phrase (centered, clamped) instead of
  taking the head slice.
- The window centers on the phrase itself, not its line: the buffer is
  proxy-controlled, so a single line can be arbitrarily long and
  line-centering could push the phrase back out of the window (found by the
  pre-push review fleet).
- ANSI-strip and credential/exfiltration redaction still run BEFORE the
  window is taken, and the anchor is matched against the cleaned text; when
  no phrase matched (or sanitization removed it), the head slice is
  unchanged.
- Classifier behavior is unchanged: phrase sets and group order are identical
  to the old or-chains.
- The owning spec bullet in `docs/system-specs/modules/instances.md` is
  updated in the same commit.

## Tests

- New: classified reason survives >183 chars of leading LocalCommand noise
  (ssh transport-drop path); unclassified stderr keeps the head slice; the
  parallel `_ssm_exit_error` window is anchored too; a long single line
  (noise merged onto the diagnostic with no newline) still keeps the phrase
  in the window; a credential near the anchor is redacted before windowing;
  direct `_sanitize_banner` anchor/no-anchor/missing-anchor/short-text cases.
- Local gates: black, subprocess-encoding check, isort, flake8, mypy
  (1326 files clean), scoped pytest (test_ssh_tunnel_manager_cov80.py,
  test_tunnel_manager.py, test_instances.py: 415 passed).

## Manual verification

Not applicable: pure error-text windowing change, covered by the unit tests
above; no runtime wiring or UI changed.

## Screenshots / video

Not applicable (backend-only error-text change).

## Related Issues

Closes #10043

## Pattern harvest

Rule candidate: a fixed-width truncation of untrusted text must anchor its
window on the signal that justified surfacing the text (the matched
classification phrase), never on document structure (head or lines) that the
writer of the untrusted text controls.
