### PR TITLE
fix(apps): reject non-string cron execution selectors

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -105,6 +105,8 @@ installed against:
 | `cron_expr` | string | Cron expression (mutually exclusive with `every`) |
 | `message` | string | Prompt sent to the agent on each run |
 | `agent` | string | Agent to run (optional, uses default if omitted) |
+| `command` | string | Shell command to run instead of an agent job. A present non-string value is rejected rather than treated as absent. Mutually exclusive with `script` |
+| `script` | string | Script path to run instead of an agent job. A present non-string value is rejected rather than treated as absent. Mutually exclusive with `command` |
 | `timezone` | string | IANA zone name the schedule and `skip_dates` are evaluated in, e.g. `America/New_York`. Optional, but an empty value falls back to the gateway config's timezone and then to **UTC** — so `"cron_expr": "0 6 * * *"` without it fires at 06:00 UTC, the wrong calendar day for most users. An unknown zone is rejected at manifest validation. A per-**user** zone is not manifest data: pass `timezone=` to `ctx.cron.add_job` instead |
 | `skip_dates` | string[] | Calendar dates the job must not fire on, evaluated in `timezone`. Must be zero-padded `YYYY-MM-DD` — `2026-1-1` parses but never matches the padded fire-time rendering, so it is rejected at manifest validation rather than silently skipping nothing |
 | `enabled` | boolean | Default `true`. Must be a JSON boolean — any other type is rejected at manifest validation. When `false` the cron is registered **paused** (visible in the Schedule view, resumable) instead of firing on install/enable — for jobs that need user configuration first |

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -221,7 +221,9 @@ def _path_escapes_app_root(rel_path: str, app_root: Path | None) -> bool:
 _CRON_FIELD_JSON_TYPES = {
     "every": "a number of seconds",
     "agent_sequence": "an array of agent names",
+    "command": "a string command",
     "env": "an object of string keys to string values",
+    "script": "a string script path",
     "timezone": "a string IANA zone name",
     "skip_dates": "an array of YYYY-MM-DD strings",
 }
@@ -386,8 +388,8 @@ class CronEntry:
             cron_expr=_str_or_empty(data.get("cron_expr")),
             agent=_str_or_empty(data.get("agent")),
             message=_str_or_empty(data.get("message")),
-            command=_str_or_empty(data.get("command")),
-            script=_str_or_empty(data.get("script")),
+            command=_str_or_flagged("command", data.get("command")),
+            script=_str_or_flagged("script", data.get("script")),
             agent_sequence=[
                 str(a) for a in _list_or_empty("agent_sequence", data.get("agent_sequence"))
             ],

--- a/test/test_app_manifest.py
+++ b/test/test_app_manifest.py
@@ -284,6 +284,29 @@ class TestValidation:
             )
             assert m.validate() == []
             assert m.crons[0].enabled is expected
+
+    @pytest.mark.parametrize("selector", ["command", "script"])
+    def test_cron_execution_selector_non_string_is_rejected(self, selector):
+        m = AppManifest.from_dict(
+            _valid_manifest(
+                crons=[{"name": "j1", "every": 300, "message": "go", selector: 7}]
+            )
+        )
+
+        assert m.crons[0].command == ""
+        assert m.crons[0].script == ""
+        errors = m.validate()
+        assert any(selector in error and "wrong JSON type" in error for error in errors)
+
+    @pytest.mark.parametrize("selector", ["command", "script"])
+    def test_cron_null_execution_selector_remains_absent(self, selector):
+        m = AppManifest.from_dict(
+            _valid_manifest(
+                crons=[{"name": "j1", "every": 300, "message": "go", selector: None}]
+            )
+        )
+
+        assert not any(selector in error for error in m.validate())
         # Absent key: default enabled, no error.
         m = AppManifest.from_dict(
             _valid_manifest(crons=[{"name": "j1", "every": 300, "message": "go"}])


### PR DESCRIPTION
## Problem / Motivation

An app manifest cron with a present non-string command or script selector is currently coerced to an empty string. The manifest then validates and the scheduler sees neither execution selector, so the job falls through to the default-agent mode and runs its message instead of rejecting corrupted input.

## Why it matters

A malformed non-string cron `command` or `script` is currently accepted and coerced into absence. The scheduler can then silently run the job in default-agent mode instead of rejecting corrupted manifest input, changing execution semantics rather than merely emitting a validation warning.

## What changed

- Record present non-null non-string command and script values as cron type violations.
- Reuse manifest validation to reject them with an actionable expected-type error.
- Preserve the established null-means-absent convention.
- Document both execution-selector fields and their validation contract.

## Tests

- Red-before: both command=7 and script=7 parsed empty and produced no validation error (2 failures).
- Green-after: focused cron tests 9 passed; full test_app_manifest.py 227 passed.
- flake8, documentation lint, and diff check passed.

## Collision check

No open PR addresses cron selector typing or issue #9895. PR #9907 also edits apps/manifest.py, but only adds the unrelated append-only event-log contribution schema in distant sections; it does not touch CronEntry parsing or validation.

## Manual verification

N/A — manifest parsing and the admission error are deterministic unit-level contracts.

## Related Issues

Closes #9895.

## Pattern harvest

Rule candidate: manifest execution selectors that are present and non-null must be type-checked before any normalization that can turn them into absence. The focused cron tests pin both command and script.

## Checklist

- [x] One Conventional Commit
- [x] Deterministic regression coverage
- [x] Manifest reference updated
- [x] No secrets or credentials

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. Do not invent CLA text. -->

Generated with Codex.