### PR TITLE
fix(governance): reject non-UTF-8 policy sources

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -589,6 +589,11 @@ document does, since a merely *large* finite value (`1e12`) passes the finitenes
 floats now (an int has no non-finite values), and the value is stored without a `float()`
 round-trip, which would have raised three lines later.
 
+A declared `distribution.source` must also be representable as strict UTF-8. JSON accepts a
+lone surrogate, but the cache-provenance digest encodes the source during boot; rejecting that
+input during composition keeps the failure inside the platform error contract instead of leaking
+a `UnicodeEncodeError` from the distribution engine.
+
 **A DECLARED source may not carry a credential.** `PolicyDistribution.from_dict` refuses
 userinfo (`https://user:pass@host/…`) and any query string in a `distribution.source` that
 comes from a *document*. This block is cached verbatim — the bytes have to be identical for

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -1797,6 +1797,15 @@ class PolicyDistribution:
                 raise PlatformCompositionError(
                     f"distribution.source is not a parseable URL: {exc}"
                 ) from exc
+            try:
+                source.encode("utf-8")
+            except UnicodeEncodeError as exc:
+                # JSON can represent an unpaired surrogate even though UTF-8 cannot. The
+                # cache identity hashes this text during boot, so reject it as configuration
+                # here instead of leaking a UnicodeEncodeError from the distribution engine.
+                raise PlatformCompositionError(
+                    "distribution.source is not valid UTF-8 text"
+                ) from exc
             # ``.port`` is a LAZILY parsed property, so the ``urlsplit`` guard above does not
             # cover it: it raises for a non-numeric or out-of-range port. A policy is
             # configuration, so that is a composition error naming the key, not a traceback.

--- a/test/test_governance_distribution.py
+++ b/test/test_governance_distribution.py
@@ -3213,6 +3213,16 @@ class TestMalformedInputIsRefusedNotCrashedOn:
             governance.PolicyDistribution.from_dict({"source": source})
         assert "distribution.source" in str(caught.value)
 
+    def test_a_declared_source_must_be_valid_utf8_text(self):
+        """A lone JSON surrogate must fail at composition, before cache provenance hashes it."""
+        policy = json.loads(r'{"source": "https://h/p\udc80"}')
+
+        with pytest.raises(
+            PlatformCompositionError,
+            match="distribution.source is not valid UTF-8 text",
+        ):
+            governance.PolicyDistribution.from_dict(policy)
+
     def test_the_sanitiser_survives_a_malformed_source(self):
         """This one matters most: a sanitiser that crashes on a malformed source takes the
         error REPORT down with it, so the operator sees a traceback about URL parsing instead


### PR DESCRIPTION
## Problem / Motivation

A JSON policy can contain a lone surrogate in `distribution.source`. URL parsing accepts it, but cache-provenance hashing later performs strict UTF-8 encoding and leaks `UnicodeEncodeError` during boot instead of the platform's composition error.

## Why it matters

An operator-controlled policy document can crash the central-policy boot path outside the platform error contract, preventing callers from reporting the configuration failure consistently.

## What changed (motivation → approach → change)

The source is consumed later as UTF-8 cache identity input, so validation belongs at the declaration boundary. `PolicyDistribution.from_dict` now checks strict UTF-8 representability immediately after URL parsing, raises the stable `PlatformCompositionError` message `distribution.source is not valid UTF-8 text`, and documents that contract.

## Tests

- Red before fix: focused regression failed with `DID NOT RAISE`.
- Green after fix: focused regression passed.
- `pytest test/test_governance_distribution.py -n 0 -q`: 376 passed, 32 platform skips.
- `flake8` on changed Python and test files: passed.
- `python scripts/docs_lint.py`: passed (310 Markdown files).
- `git diff --check`: passed.
- Repository-wide comment-history checker is environment-blocked: the Python 3.10 runner cannot parse the unrelated Python 3.12 nested f-string in `src/kiro_crew/apps/builtins/aws_control/backend/backup.py:1741`.

## Manual verification

Confirmed the test input is produced by `json.loads`, is accepted by `urlsplit`, and is rejected during `PolicyDistribution.from_dict` before `_source_digest` can encode it.

## Related Issues

Closes #9839

## Pattern harvest

Rule candidate: review-prompt
Pattern: Text accepted by a permissive parser must still be validated for the stricter encoding required by its downstream identity or persistence boundary.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — exact CLA wording remains the repository's OSPO placeholder.