### PR TITLE
fix(voice): downgrade missing Piper binary log

### DIFF
--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -917,7 +917,7 @@ async def _synthesize_piper(
     """
     bin_path = _resolve_piper_binary(piper_binary)
     if not bin_path:
-        logger.error("piper binary not found (configured=%r)", piper_binary)
+        logger.warning("piper binary not found (configured=%r)", piper_binary)
         return None
     model = os.path.expanduser(piper_model) if piper_model else ""
     if not model or not os.path.isfile(model):

--- a/test/test_voice_reply.py
+++ b/test/test_voice_reply.py
@@ -1386,9 +1386,18 @@ class TestSynthesizeSystem:
 
 class TestSynthesizePiper:
     @pytest.mark.asyncio
-    async def test_binary_not_found_returns_none(self) -> None:
-        with patch("kiro_crew.voice_reply._resolve_piper_binary", return_value=None):
+    async def test_binary_not_found_warns_and_returns_none(self, caplog) -> None:
+        with (
+            patch("kiro_crew.voice_reply._resolve_piper_binary", return_value=None),
+            caplog.at_level("DEBUG", logger="kiro_crew.voice_reply"),
+        ):
             assert await _synthesize_piper("hi") is None
+
+        records = [
+            record for record in caplog.records if "piper binary not found" in record.message
+        ]
+        assert len(records) == 1
+        assert records[0].levelname == "WARNING"
 
     @pytest.mark.asyncio
     async def test_model_missing_returns_none(self, tmp_path) -> None:


### PR DESCRIPTION
## Problem / Motivation

A missing local Piper binary is an expected optional-dependency state. `_synthesize_piper()` already handles it by returning `None`, but it logs the state at `ERROR`.

## Why it matters

The gateway error log reports a handled voice fallback as a service error. This creates noisy alerts even though the text reply still succeeds.

## What changed (motivation → approach → change)

The missing binary path already has a safe fallback contract: return `None` and let the caller continue without audio. This change keeps that behavior and lowers only the log severity from `ERROR` to `WARNING`.

The focused test now locks in both parts of the contract: synthesis returns `None`, and the event is emitted once at `WARNING`.

## Tests

- `test/test_voice_reply.py`: 191 passed.
- Manual mutation proof: restoring `logger.error(...)` makes `TestSynthesizePiper::test_binary_not_found_warns_and_returns_none` fail with `ERROR != WARNING`.
- Deterministic backend static gates passed: Black scope, isort, flake8, mypy, subprocess encoding, SDK boundary, async-I/O, lockdown, brand, harness parity, feature map, loop locks, built-in skill scope, test-path coverage, changelog, focus cue, docs lint, per-file coverage, vendor manifest, and CFN lint.
- Frontend cross-surface gates passed: build, TypeScript, ESLint, i18n, phantom classes, frontend tests, duplication, and bundle size.
- Full backend gate reached 94,579 passed; its 85 failures and 17 fixture errors are outside this two-file diff. Representative failures reproduce unchanged on pristine `origin/main` and come from this host's `/local/home` ownership and scratch-path safety topology.
- Electron tests reached 1,780 passed. The remaining 17 are local setup failures because the nested Electron dependency install is blocked by this host's npm authentication (`E401`); each failed case reports a missing package such as `electron-updater` or `electron-builder`.
- Local GPT and Opus CI-contract reviewer lanes both passed with no findings.

## Manual verification

N/A — the regression test directly captures the changed log record and the mutation proof shows it fails on the old severity.

## Related Issues

no linked issue: this was found by gateway log-signature triage rather than a tracked GitHub issue.

## Pattern harvest

Rule candidate: review-prompt
Pattern: A handled optional-dependency absence should not emit an `ERROR` when the established caller contract falls back safely.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
