### PR TITLE
test(e2e): Navigate fork.spec on domcontentloaded, not networkidle

### DIFF
--- a/website/playwright/fork.spec.ts
+++ b/website/playwright/fork.spec.ts
@@ -17,7 +17,11 @@ test.describe('Fork Session E2E', { tag: '@needs-agent' }, () => {
     // Auth is handled by the 'setup' project (playwright.config.ts), which
     // exchanges PLAYWRIGHT_TOKEN for a cookie and persists it via storageState.
     // Tests just navigate straight to /chat with the cookie already attached.
-    await page.goto('/chat', { waitUntil: 'networkidle' })
+    // 'domcontentloaded', like every other spec: /chat holds a live connection
+    // to the gateway, so 'networkidle' (500 ms with no traffic) is never
+    // guaranteed to arrive inside goto's 10 s budget. Readiness is the
+    // composer becoming visible, asserted below.
+    await page.goto('/chat', { waitUntil: 'domcontentloaded' })
     // Dismiss first-run theme picker modal if present.
     const letsGo = page.getByRole('button', { name: /let's go/i })
     if (await letsGo.isVisible({ timeout: 2000 }).catch(() => false)) {


### PR DESCRIPTION
## Problem / Motivation

The `E2E (stub ACP backend, offline)` check fails intermittently with one spec: `playwright/fork.spec.ts:36:3 › Fork Session E2E › fork button appears on assistant message and creates new tab` dies in `beforeEach` with `page.goto: Timeout 10000ms exceeded` while `navigating to "http://localhost:<port>/chat", waiting until "networkidle"`, on all three attempts. It failed this way on `main` (run 34544308599), on the weekly prune PR #9973 (run 34533207421) and on an unrelated PR (#10010).

## Why it matters

A red E2E check blocks readiness on PRs whose diff never touched the dashboard. Bot PRs stall on it with nobody watching; human authors re-run the whole 9-minute job and hope. The failing test itself is fine; only its first line is.

## What changed (motivation → approach → change)

The spec opened `/chat` with `waitUntil: 'networkidle'`. `/chat` keeps a live connection to the gateway open, so the 500 ms of silence `networkidle` waits for is never guaranteed to arrive inside `page.goto`'s 10 s budget. When it does not, the test fails before it has done anything.

Every other spec in `website/playwright/`, including `chat.spec.ts` on the same page, navigates with `waitUntil: 'domcontentloaded'` and then waits for the composer to be visible. `fork.spec.ts` was the one outlier.

`fork.spec.ts` now navigates on `'domcontentloaded'` too. Its existing `expect(page.getByPlaceholder(/message/i)).toBeVisible({ timeout: 10000 })` already carries the readiness wait, so nothing else changes. A comment on the `goto` line says why.

## Tests

- `website/playwright/fork.spec.ts`: the `beforeEach` navigation waits on `domcontentloaded`. The test's own body is unchanged; the E2E job runs it on this PR.

## Manual verification

N/A — the E2E job on this PR is the verification: it runs the full Playwright set, this spec included, against the stub ACP backend. Locally the edited file type-checks with the repository's TypeScript (`tsc --noEmit` on the spec); the playwright directory is outside the app's `tsconfig`/eslint scope, so that is the only local check.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** test-only change under `website/playwright/`; no component, layout or string is touched and nothing renders differently.

## Related Issues

no linked issue: the flake was found on CI runs, not tracked as an issue.

## Pattern harvest

Rule candidate: lint
Pattern: `page.goto(..., { waitUntil: 'networkidle' })` in a Playwright spec against a page that holds a live connection; `domcontentloaded` plus an element wait is the idiom every other spec here uses.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
