### PR TITLE
perf(windows): stop re-applying the data-home ACL on every gateway boot

### DIFF
--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -4840,6 +4840,20 @@ def restrict_dir_to_owner(path: str | os.PathLike) -> None:
 
     Fail-loud like :func:`restrict_to_owner`: any failure raises ``OSError`` so
     callers reach their warn-and-continue handlers.
+
+    On Windows the DACL is applied only when the directory's own descriptor does
+    not already match, because that write is an O(descendants) propagation (see
+    :func:`_apply_owner_only_dacl`). RECORDED DECISION: two states leave the
+    directory itself correct while a descendant does not, and neither is
+    detectable without the walk this avoids -- a propagation interrupted part way
+    through, and a child moved in on the same NTFS volume, since a move preserves
+    the child's ACL rather than inheriting the destination's. Measured on a local
+    NTFS volume, the propagation DOES rewrite such a child's INHERITED entries, so
+    skipping the write also stops healing a moved-in child whose foreign grant was
+    inherited at its source; a grant written EXPLICITLY on the child survives the
+    propagation and was never healed by it. Repairing either is a non-goal here:
+    it would cost the propagation on every launch, and a repair path that can
+    afford it belongs with the caller that needs one.
     """
     if IS_POSIX:
         # Semgrep's insecure-file-permissions rule reads 0o700 as "widely
@@ -4872,6 +4886,14 @@ def _apply_owner_only_dacl(path: str | os.PathLike, *, inherit: bool) -> None:
     mandatory, and a caller on the loop does not park the gateway for a third of
     a second per secret written.
 
+    That 0.24 ms is PER OBJECT, and with ``inherit=True`` the write reaches more
+    than one: Windows propagates an inheritable ACE to every descendant, so on a
+    directory the call is O(descendants). Measured on a local NTFS volume: 86 ms
+    on a 337-object tree and **2.94 s on a 12358-object one**, linear at 0.238 ms
+    per object. Quote the per-object figure as the cost of a directory call and it
+    understates that by four orders of magnitude, which is what the probe below
+    exists to bound.
+
     Resolve the invoking user's SID BEFORE writing anything, and resolve it
     WITHOUT the possibility of a spawn: :func:`current_user_sid` reads the
     process's own access token and nothing else. There is deliberately no
@@ -4901,6 +4923,42 @@ def _apply_owner_only_dacl(path: str | os.PathLike, *, inherit: bool) -> None:
         )
     sids = (_OWNER_RIGHTS_SID,) if user_sid == _OWNER_RIGHTS_SID else (_OWNER_RIGHTS_SID, user_sid)
     try:
+        # Probe before writing. On a DIRECTORY the write carries inheritable ACEs,
+        # which makes Windows propagate them to every descendant, so the cost is
+        # O(descendants) -- measured 0.238 ms per object, i.e. 2.94 s on a
+        # 12358-object data home. Reading this object's own descriptor is O(1), so
+        # an unchanged DACL costs a constant check instead of a full re-propagation
+        # on every boot. `vector_memory.init()` applies this to the whole data home
+        # on every gateway start, so that saving is paid on every launch.
+        #
+        # TWO STATES THE PROBE CANNOT SEE, both of which leave the parent matching
+        # while a descendant does not:
+        #   1. A propagation interrupted part way (the process dies inside
+        #      SetNamedSecurityInfoW). The parent is committed, some children are
+        #      not, and the parent alone reads as correct from then on.
+        #   2. A child MOVED in on the same NTFS volume. A move preserves the
+        #      child's own ACL rather than inheriting the destination's. Measured:
+        #      the propagation DOES rewrite that child's INHERITED entries, so
+        #      skipping it also stops healing a moved-in child whose foreign grant
+        #      was inherited at its source (Everyone:(I)(R) -> replaced by the
+        #      parent's grants). A grant written EXPLICITLY on the child
+        #      (Everyone:(R)) survives the propagation and was never healed by it.
+        # RECORDED DECISION: neither is repaired here. Detecting either one needs
+        # the descendant walk this removes, and the alternative is an
+        # O(descendants) write on every launch. A caller that must repair a drifted
+        # subtree needs a maintenance path of its own; this is the boot path.
+        #
+        # The probe answers False on any doubt (read failure, NULL or unprotected
+        # DACL, unexpected ACE shape), so a wrong answer costs a redundant write
+        # rather than a skipped lockdown. It is wrapped anyway: the fallback must be
+        # "write", and a probe that somehow raises must not be able to turn a
+        # lockdown into an exception on a path that would otherwise be fixed.
+        try:
+            already_locked = windows_acl.owner_only_dacl_matches(path, inherit=inherit, sids=sids)
+        except Exception:
+            already_locked = False
+        if already_locked:
+            return
         windows_acl.apply_owner_only(path, inherit=inherit, sids=sids)
     except (windows_acl.AclWriteFailed, windows_acl.AclUnavailable) as exc:
         # Translated to OSError so both platforms raise the same type: every

--- a/src/kiro_crew/windows_acl.py
+++ b/src/kiro_crew/windows_acl.py
@@ -44,7 +44,7 @@ import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 # ``from ctypes import wintypes`` RAISES on Linux, so importing it unguarded
 # would make this module unimportable off Windows -- and with it every test of
@@ -98,6 +98,8 @@ __all__ = [
     "WELL_KNOWN_TRUSTED_SIDS",
     "Writer",
     "apply_owner_only",
+    "owner_only_dacl_matches",
+    "owner_only_dacl_matches_parsed",
     "describe",
     "volume_is_local",
 ]
@@ -259,6 +261,17 @@ def _install_prototypes(advapi32: _DLL, kernel32: _DLL) -> None:  # pragma: no c
     advapi32.GetNamedSecurityInfoW.restype = W.DWORD
     advapi32.GetAce.argtypes = [C.POINTER(_ACL), W.DWORD, C.POINTER(C.c_void_p)]
     advapi32.GetAce.restype = W.BOOL
+    # Read side of the PROTECTED bit. The SECURITY_INFORMATION flag that SETS it
+    # (_PROTECTED_DACL_SECURITY_INFORMATION) is not readable back; the state lives
+    # in the descriptor's control word, which only this call exposes. Needed so
+    # owner_only_dacl_matches can tell a protected DACL from an identical-looking
+    # inherited one.
+    advapi32.GetSecurityDescriptorControl.argtypes = [
+        C.c_void_p,
+        C.POINTER(W.WORD),
+        C.POINTER(W.DWORD),
+    ]
+    advapi32.GetSecurityDescriptorControl.restype = W.BOOL
     advapi32.ConvertSidToStringSidW.argtypes = [C.c_void_p, C.POINTER(W.LPWSTR)]
     advapi32.ConvertSidToStringSidW.restype = W.BOOL
     advapi32.LookupAccountSidW.argtypes = [
@@ -529,6 +542,10 @@ _DACL_SECURITY_INFORMATION = 0x00000004
 # would be MERGED with whatever the parent grants, which leaves exactly the
 # exposure the lockdown exists to close.
 _PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+# The same state as seen from the READ side: the control-word bit that
+# _PROTECTED_DACL_SECURITY_INFORMATION sets. Distinct value, same meaning, and the
+# only way to observe that inheritance is already stripped.
+_SE_DACL_PROTECTED = 0x1000
 
 
 class AclWriteFailed(RuntimeError):
@@ -539,6 +556,161 @@ class AclWriteFailed(RuntimeError):
     raises, so a failed lockdown reaches the same warn-or-refuse handler on both
     platforms rather than passing silently.
     """
+
+
+def owner_only_dacl_matches_parsed(
+    *,
+    control: int,
+    aces: Sequence[tuple[int, int, int, str]],
+    inherit: bool,
+    sids: tuple[str, ...],
+) -> bool:
+    """Decide the match from ALREADY-PARSED descriptor values. Platform-independent.
+
+    Split out from the ``advapi32`` plumbing deliberately: every rule that decides
+    whether a DACL counts as "already owner-only" lives here, so each one is
+    exercised on every test shard rather than only on a Windows host. The caller
+    keeps the parts that genuinely need Win32 -- opening the descriptor, walking
+    the ACE array, turning a SID pointer into a string.
+
+    Each entry of *aces* is ``(ace_type, ace_flags, mask, sid_string)`` in ACL
+    order. *control* is the security descriptor's control word.
+
+    Every rule answers False, never raises: this is the conservative half of a
+    security check, so an unrecognised shape must read as "not yet applied".
+    """
+    if not sids:
+        return False
+    if not control & _SE_DACL_PROTECTED:
+        # Inheritance is not stripped, so applying
+        # PROTECTED_DACL_SECURITY_INFORMATION would still change something.
+        return False
+    if len(aces) != len(sids):
+        return False
+    expected_flags = (_OBJECT_INHERIT_ACE | _CONTAINER_INHERIT_ACE) if inherit else 0
+    for ace_type, ace_flags, mask, sid in aces:
+        if ace_type != ACCESS_ALLOWED_ACE_TYPE:
+            return False
+        if ace_flags != expected_flags:
+            return False
+        if mask != _FILE_ALL_ACCESS:
+            return False
+        if not sid:
+            return False
+    # Order-insensitive: the kernel may normalise ACE order, and the grant SET is
+    # what the policy is about. A duplicate would change the count, already checked.
+    return {sid for _t, _f, _m, sid in aces} == set(sids)
+
+
+def owner_only_dacl_matches(
+    path: str | os.PathLike,
+    *,
+    inherit: bool,
+    sids: tuple[str, ...],
+) -> bool:
+    """Is *path*'s DACL ALREADY exactly what :func:`apply_owner_only` would write?
+
+    Exists because the write is not free the way its cost looks. A single
+    ``SetNamedSecurityInfoW`` that carries inheritable grants makes Windows
+    propagate the ACE to every descendant object, so applying an owner-only DACL
+    to a directory costs O(descendants) -- measured at **0.238 ms per descendant**
+    on a local NTFS volume, i.e. 86 ms on a 337-object tree and **2.94 s on a
+    12358-object one**. A caller that re-applies an unchanged DACL on every boot
+    pays that in full for no change, and ``vector_memory.init()`` applies it to
+    the whole data home on every gateway start.
+
+    Reading the descriptor is O(1) -- it inspects THIS object only -- so probing
+    first turns an unconditional O(descendants) write into an O(1) check on every
+    boot after the first.
+
+    Conservative by construction: this returns ``True`` only when the descriptor
+    is an exact match, and ANY doubt answers ``False`` so the caller writes. A
+    read failure, a NULL DACL, an unprotected DACL, an unexpected ACE count, an
+    ACE that is not ``ACCESS_ALLOWED``, a mask that is not ``FILE_ALL_ACCESS``,
+    inheritance flags that differ, or a SID set that differs all mean "write".
+    The failure direction matters more than the speed: a wrong ``True`` silently
+    skips a security control, a wrong ``False`` only costs a redundant write.
+
+    SCOPE, stated plainly because it bounds the guarantee: this verifies the DACL
+    of *path* itself, not of its descendants -- verifying those is the
+    O(descendants) walk this avoids. A child created inside is still covered,
+    because Windows applies the parent's inheritable ACEs at creation time. Two
+    states therefore read as matching while a descendant does not: a propagation
+    interrupted part way through, and a child moved in on the same NTFS volume,
+    since a move preserves the child's ACL instead of inheriting the
+    destination's. Skipping the write also stops rewriting such a child's
+    INHERITED entries, which the propagation does do; an EXPLICIT grant on the
+    child survives it either way. Repairing either needs the walk, so it is a
+    non-goal for a caller on the boot path.
+    """
+    if not sids:
+        # apply_owner_only refuses this; never report a no-grant DACL as matching.
+        return False
+    try:
+        return _owner_only_dacl_matches(path, inherit=inherit, sids=sids)
+    except Exception:
+        # Includes the off-Windows / missing-advapi32 case: there is no descriptor
+        # to compare, so the answer must be "write", never "already correct".
+        return False
+
+
+def _owner_only_dacl_matches(
+    path: str | os.PathLike,
+    *,
+    inherit: bool,
+    sids: tuple[str, ...],
+) -> bool:
+    """Descriptor comparison for :func:`owner_only_dacl_matches`. May raise."""
+    advapi32, kernel32 = _load()
+
+    dacl = C.POINTER(_ACL)()
+    descriptor = C.c_void_p()
+    control = W.WORD()
+    revision = W.DWORD()
+    rc = advapi32.GetNamedSecurityInfoW(
+        os.fspath(path),
+        _SE_FILE_OBJECT,
+        _DACL_SECURITY_INFORMATION,
+        None,
+        None,
+        C.byref(dacl),
+        None,
+        C.byref(descriptor),
+    )
+    if rc != 0:
+        return False
+    try:
+        if not dacl:
+            # NULL DACL grants everyone full control -- the opposite of a match.
+            return False
+        if not advapi32.GetSecurityDescriptorControl(
+            descriptor, C.byref(control), C.byref(revision)
+        ):
+            return False
+        parsed: list[tuple[int, int, int, str]] = []
+        for index in range(int(dacl.contents.AceCount)):
+            ace_pointer = C.c_void_p()
+            if not advapi32.GetAce(dacl, index, C.byref(ace_pointer)):
+                return False
+            ace = C.cast(ace_pointer, C.POINTER(_ACCESS_ACE)).contents
+            base = ace_pointer.value
+            if base is None:  # pragma: no cover - GetAce contract
+                return False
+            sid_pointer = C.c_void_p(base + _ACCESS_ACE.SidStart.offset)
+            parsed.append(
+                (
+                    int(ace.Header.AceType),
+                    int(ace.Header.AceFlags),
+                    int(ace.Mask),
+                    _sid_to_string(advapi32, kernel32, sid_pointer),
+                )
+            )
+        return owner_only_dacl_matches_parsed(
+            control=int(control.value), aces=parsed, inherit=inherit, sids=sids
+        )
+    finally:
+        if descriptor:
+            kernel32.LocalFree(descriptor)
 
 
 def apply_owner_only(

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -4637,3 +4637,181 @@ class TestOpenLockFile:
             "lock files opened truncating before the acquire (GH-9248); "
             "use platform_compat.open_lock_file: " + ", ".join(offenders)
         )
+
+
+class TestOwnerOnlyDaclIsIdempotent:
+    """The lockdown must probe before writing, and must fail TOWARD writing.
+
+    Applying an owner-only DACL to a DIRECTORY carries inheritable ACEs, which
+    Windows propagates to every descendant, so the write is O(descendants) --
+    measured 0.238 ms per object, i.e. 2.94 s on a 12358-object data home, paid on
+    every gateway boot because ``vector_memory.init()`` locks down the whole home.
+    Reading this object's own descriptor is O(1), so an unchanged DACL should cost
+    a constant check.
+
+    These run on the POSIX matrix (the seam is the ``windows_acl`` call, which is
+    what the suite can observe off Windows), and they pin BOTH directions: the skip
+    must happen when it is safe, and must NOT happen when anything differs.
+    """
+
+    @staticmethod
+    def _capture(monkeypatch, *, matches, sid="S-1-5-21-1-2-3-1000"):
+        """Force the Windows branch; record probe questions and DACL writes."""
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_TOKEN_SID_CACHE", [])
+        monkeypatch.setattr(pc, "current_user_sid", lambda: sid)
+        probed: list[dict] = []
+        written: list[dict] = []
+
+        def fake_probe(path, *, inherit, sids, **_kw):
+            probed.append({"path": os.fspath(path), "inherit": inherit, "sids": tuple(sids)})
+            if isinstance(matches, Exception):
+                raise matches
+            return matches
+
+        def fake_apply(path, *, inherit, sids, **_kw):
+            written.append({"path": os.fspath(path), "inherit": inherit, "sids": tuple(sids)})
+
+        monkeypatch.setattr(pc.windows_acl, "owner_only_dacl_matches", fake_probe)
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", fake_apply)
+        return probed, written
+
+    def test_an_already_correct_dacl_is_not_rewritten(self, tmp_path, monkeypatch):
+        # The whole point: the O(descendants) propagation must not run when the
+        # descriptor already says what we would write.
+        probed, written = self._capture(monkeypatch, matches=True)
+        d = tmp_path / "home"
+        d.mkdir()
+        pc.restrict_dir_to_owner(d)
+        assert len(probed) == 1, probed
+        assert written == [], "an unchanged DACL must not be re-applied"
+
+    def test_a_mismatched_dacl_is_still_written(self, tmp_path, monkeypatch):
+        # Guards the failure mode that would make this change a security bug:
+        # the skip must never swallow a write that is actually needed.
+        probed, written = self._capture(monkeypatch, matches=False)
+        d = tmp_path / "home"
+        d.mkdir()
+        pc.restrict_dir_to_owner(d)
+        assert len(probed) == 1, probed
+        assert len(written) == 1, written
+        assert written[0]["inherit"] is True
+
+    def test_a_probe_that_raises_is_treated_as_a_mismatch(self, tmp_path, monkeypatch):
+        # Fail-safe direction: an unanswerable probe costs a redundant write,
+        # never a skipped lockdown.
+        probed, written = self._capture(monkeypatch, matches=OSError("descriptor unreadable"))
+        d = tmp_path / "home"
+        d.mkdir()
+        pc.restrict_dir_to_owner(d)
+        assert len(probed) == 1, probed
+        assert len(written) == 1, "a probe failure must fall back to writing"
+
+    def test_the_probe_is_asked_about_exactly_what_would_be_written(self, tmp_path, monkeypatch):
+        # If the probe were asked a different question than the write answers, a
+        # match could authorise skipping a DACL that does not exist yet.
+        probed, written = self._capture(monkeypatch, matches=False)
+        f = tmp_path / "secret.key"
+        f.write_bytes(b"s" * 32)
+        pc.restrict_to_owner(f)
+        assert len(probed) == 1 and len(written) == 1
+        assert probed[0] == written[0], (probed[0], written[0])
+        # File shape, so the grants must NOT be inheritable.
+        assert probed[0]["inherit"] is False
+        assert probed[0]["sids"] == ("S-1-3-4", "S-1-5-21-1-2-3-1000")
+
+
+class TestOwnerOnlyDaclMatchesIsConservative:
+    """``windows_acl.owner_only_dacl_matches`` must never answer True on doubt."""
+
+    # (ace_type, ace_flags, mask, sid) as the ctypes half parses them.
+    _PROTECTED = 0x1000
+    _ALLOWED = 0
+    _OI_CI = 0x01 | 0x02
+    _ALL = 0x001F01FF
+    _SIDS = ("S-1-3-4", "S-1-5-21-1-2-3-1000")
+
+    def _dir_aces(self):
+        return [(self._ALLOWED, self._OI_CI, self._ALL, s) for s in self._SIDS]
+
+    def _matches(self, **over):
+        kw = {
+            "control": self._PROTECTED,
+            "aces": self._dir_aces(),
+            "inherit": True,
+            "sids": self._SIDS,
+        }
+        kw.update(over)
+        return pc.windows_acl.owner_only_dacl_matches_parsed(**kw)
+
+    def test_the_exact_shipped_shape_matches(self):
+        # The positive case. Without this, every rule below could pass by always
+        # answering False and the probe would be a no-op that never skips.
+        assert self._matches() is True
+
+    def test_order_does_not_matter(self):
+        # The kernel may normalise ACE order; the grant SET is the policy.
+        assert self._matches(aces=list(reversed(self._dir_aces()))) is True
+
+    def test_an_unprotected_dacl_never_matches(self):
+        # Inheritance not stripped: applying PROTECTED would still change it.
+        assert self._matches(control=0) is False
+
+    def test_a_missing_grant_never_matches(self):
+        assert self._matches(aces=self._dir_aces()[:1]) is False
+
+    def test_an_extra_grant_never_matches(self):
+        extra = self._dir_aces() + [(self._ALLOWED, self._OI_CI, self._ALL, "S-1-1-0")]
+        assert self._matches(aces=extra) is False
+
+    def test_a_different_principal_never_matches(self):
+        aces = self._dir_aces()
+        aces[1] = (self._ALLOWED, self._OI_CI, self._ALL, "S-1-1-0")
+        assert self._matches(aces=aces) is False
+
+    def test_a_deny_ace_never_matches(self):
+        aces = self._dir_aces()
+        aces[0] = (1, self._OI_CI, self._ALL, self._SIDS[0])  # ACCESS_DENIED
+        assert self._matches(aces=aces) is False
+
+    def test_a_narrower_mask_never_matches(self):
+        aces = self._dir_aces()
+        aces[0] = (self._ALLOWED, self._OI_CI, 0x120089, self._SIDS[0])  # read-ish
+        assert self._matches(aces=aces) is False
+
+    def test_directory_shape_rejects_non_inheritable_grants(self):
+        # inherit=True wants (OI)(CI); a file-shaped ACE would leave children
+        # uncovered, so it must not read as already correct.
+        assert self._matches(aces=[(self._ALLOWED, 0, self._ALL, s) for s in self._SIDS]) is False
+
+    def test_file_shape_rejects_inheritable_grants(self):
+        # The mirror: inherit=False wants no inheritance flags.
+        assert self._matches(inherit=False) is False
+
+    def test_file_shape_matches_its_own_flags(self):
+        assert (
+            self._matches(
+                inherit=False, aces=[(self._ALLOWED, 0, self._ALL, s) for s in self._SIDS]
+            )
+            is True
+        )
+
+    def test_an_unresolvable_sid_never_matches(self):
+        aces = self._dir_aces()
+        aces[0] = (self._ALLOWED, self._OI_CI, self._ALL, "")
+        assert self._matches(aces=aces) is False
+
+    def test_no_grants_never_matches(self, tmp_path):
+        # apply_owner_only refuses an empty grant set, so "matches" is meaningless
+        # here; answering True would skip a lockdown that never happened.
+        assert self._matches(aces=[], sids=()) is False
+        assert pc.windows_acl.owner_only_dacl_matches(tmp_path, inherit=True, sids=()) is False
+
+    def test_an_unavailable_platform_api_never_matches(self, tmp_path):
+        # Off Windows there is no descriptor to compare. This is the case the whole
+        # POSIX matrix exercises, and it must read as "write", not "already correct".
+        assert (
+            pc.windows_acl.owner_only_dacl_matches(tmp_path, inherit=True, sids=("S-1-3-4",))
+            is False
+        )


### PR DESCRIPTION
no linked issue: found by measurement while attributing a user-reported Windows gateway
cold-boot regression (tens of seconds on Windows, near-instant on macOS). This is the
second of the causes that investigation isolated; the first shipped separately as #9865.

## What

`vector_memory.init()` calls `make_owner_only_dir(self._db_path.parent)`, and with the
default `db_path` that parent **is the data home**. The code already says so:

> SCOPE: with the default `db_path` this directory IS the data home (`config_dir()`), so a
> memory init tightens the whole home. That is wider than this class and the only place in
> the tree that does it.

That reaches `windows_acl.apply_owner_only`: one `SetNamedSecurityInfoW` carrying
`(OI)(CI)` inheritable grants plus `SE_DACL_PROTECTED`. **Windows propagates an
inheritable ACE to every descendant object**, so that single call is O(descendants) across
the entire data home — and it is re-paid on every gateway start even when nothing changed.

This probes the existing descriptor first and skips the write when it already matches.

## The cost, measured

`restrict_dir_to_owner` called directly on a local NTFS volume, n=3 per target:

| descendants | median |
|---|---|
| 337 | 86.3 ms |
| 293 | 74.4 ms |
| **12358** (a real data home) | **2941.3 ms** |

Linear at **0.238 ms per descendant**. Confirmed independently by in-gateway stack
sampling at 25 ms: `apply_owner_only` held the stack for **110 consecutive ticks
(~2750 ms)** on a real home versus **3 ticks (~75 ms)** on a virgin one — essentially the
whole virgin-vs-real boot gap, under chain `vector_memory.py init <
platform_compat make_owner_only_dir < restrict_dir_to_owner < _apply_owner_only_dacl <
windows_acl.apply_owner_only`.

macOS is unaffected: the POSIX branch is a single `chmod(0o700)` on one directory, O(1).
That asymmetry is why this reads as a Windows-only problem.

## The fix, measured

Reading this object's own descriptor is O(1), so an unchanged DACL becomes a constant check:

| state | call 1 | calls 2–4 |
|---|---|---|
| DACL already ours | **0.2 ms** (was 2941 ms) | 0.2 ms |
| after `icacls /inheritance:e` cleared the protected bit | **2435.7 ms** — the write still happens | 0.1–0.3 ms |

So the lockdown still happens exactly once, and then costs nothing. The second row is the
one that matters for review: it proves the probe correctly detects a DACL that no longer
matches and does not skip it.

## Why this is safe

The probe is conservative by construction and **fails toward writing**. It answers `False`
on a read failure, a NULL DACL, an unprotected DACL, an unexpected ACE count, a
non-`ACCESS_ALLOWED` ACE, a mask that is not `FILE_ALL_ACCESS`, differing inheritance
flags, a differing SID set, an empty grant set, and off Windows where there is no
descriptor at all. The caller wraps the probe as well, so even one that somehow raises
falls back to writing rather than skipping the lockdown. **A wrong `False` costs the write
we were going to do anyway; only a wrong `True` could skip a security control.**

`GetSecurityDescriptorControl` is newly bound because the protected state cannot be read
back from the `SECURITY_INFORMATION` flag that sets it — it lives in the descriptor's
control word, and without it a protected DACL is indistinguishable from an
identical-looking inherited one.

## What is given up — a real behavioural change

This verifies the DACL of the directory **itself**, not of its descendants; verifying those
is exactly the O(descendants) walk being removed. Future children stay covered, because
Windows applies the parent's inheritable ACEs at creation time. Two states therefore read as
matching while a descendant does not, and **neither is repaired here**:

1. **A propagation interrupted part way through** — the process dies inside
   `SetNamedSecurityInfoW`, so the parent is committed while some children are not, and the
   parent alone reads as correct from then on.
2. **A child moved in on the same NTFS volume** — a move preserves the child's own ACL
   rather than inheriting the destination's.

On (2), **measured** on a local NTFS volume rather than asserted, because the first draft of
this description got it wrong:

| foreign grant on the moved file | survives the move | repaired by re-propagating the parent |
|---|---|---|
| **inherited** at its source (`Everyone:(I)(R)`) | yes | **yes** — replaced by `OWNER RIGHTS:(I)(F)` + the invoking user |
| **explicit** on the file (`Everyone:(R)`) | yes | **no** — `Everyone:(R)` persists |

So the propagation *does* rewrite a moved-in child's **inherited** entries, and skipping it
stops healing that case — which is the common one, since a file created inside any directory
inherits that directory's ACEs. An **explicit** grant on the child survives the propagation
and was never healed by it. Earlier wording here claimed such a child was "never covered";
that was unverified and is corrected.

Recorded as a decision at the call site and in the public docstring rather than left to be
discovered. Detecting either state needs the descendant walk this removes, and the
alternative is paying an O(descendants) write on every launch. A caller that must repair a
drifted subtree needs a maintenance path of its own; this is the boot path. Note
`vector_memory` separately calls `_restrict_memory_files()` on the specific memory-bearing
files it owns, so those do not depend on propagation.

## Also in scope, declared

The probe lives in the shared `_apply_owner_only_dacl`, so the **file**-shaped
`restrict_to_owner` (`inherit=False`) skips its write on a match too. That is harm-free — a
file write is O(1), so it saves ~0.24 ms rather than seconds — but it is a behaviour change
on a second call path and is listed here rather than left implicit.

## Docstring correction

`_apply_owner_only_dacl` claimed "measured on a local NTFS volume, the subprocess cost
313 ms per call and this costs 0.24 ms". 0.24 ms is the **per-object** cost, stated as the
**per-call** cost; on a 12358-object home the same call is 2.94 s. That sentence is why
this path looked free. It now states the per-object scaling explicitly.

## Testing

Four pins on the POSIX matrix (the `windows_acl` call is the seam the suite can observe off
Windows) plus two on the predicate: an already-correct DACL is not rewritten, a mismatched
one still is, a raising probe still writes, the probe is asked about exactly the
path/inherit/sids the write would use, an empty grant set never matches, and an unavailable
platform API never matches.

**Verified the idempotence pin bites**: disabling the skip makes it fail on
`assert written == []` with its intended message, rather than passing silently. Restored
after. Full `test_platform_compat.py` (272 passed / 43 skipped) and
`test_vector_memory.py` + `test_windows_acl.py` (269 passed / 17 skipped) are green;
black / isort / flake8 clean at the repo-pinned versions, and none of the three files is in
`.github/black-baseline.txt`, so black is enforced on all of them.

## Pattern harvest

Rule candidate: on Windows, a single `SetNamedSecurityInfoW` that carries inheritable ACEs is O(descendants), not O(1), because the kernel propagates the ACE to every child. Any "apply an ACL to a directory" call is therefore a walk in disguise, and a per-object cost must never be quoted as a per-call cost in its docstring.

Rule candidate: an idempotence check placed in front of a security control must fail toward performing it. Enumerate every uncertain state — read failure, absent or malformed descriptor, unsupported platform — and answer "not yet applied" for all of them, so the only way to be wrong is to do redundant work.
