### PR TITLE
fix(security): allow Atlassian MCP OAuth authorize endpoint through the exfil gate

### DIFF
--- a/src/kiro_crew/security/exfil.py
+++ b/src/kiro_crew/security/exfil.py
@@ -283,6 +283,14 @@ _OAUTH_AUTHORIZATION_ENDPOINTS: frozenset[tuple[str, str]] = frozenset(
         # MCP authorization server here too.
         ("access.stripe.com", "/mcp/oauth2/authorize"),
         ("gitlab.com", "/oauth/authorize"),
+        # Atlassian's MCP authorization server (host mcp.atlassian.com, distinct
+        # from the classic web-OAuth auth.atlassian.com/authorize above),
+        # advertised via RFC 8414 metadata reached by RFC 9728 discovery from
+        # the registry's mcp_url on mcp.atlassian.com and corroborated by an
+        # authorize URL kiro-cli actually minted. Without this pair the
+        # fail-closed banner blocks every attempt to connect the Atlassian
+        # remote MCP server.
+        ("mcp.atlassian.com", "/v1/authorize"),
         ("mcp.auth.mail.superhuman.com", "/oauth2/authorize"),
         ("mcp.linear.app", "/authorize"),
         # Miro's authorization_endpoint per its RFC 8414 metadata at

--- a/test/oauth_url_corpus.py
+++ b/test/oauth_url_corpus.py
@@ -169,6 +169,23 @@ LEGIT_OAUTH_URLS: list[tuple[str, str]] = [
         "&code_challenge_method=S256"
         "&state=" + ("Kp7mQ2xR" * 12),  # 96-char opaque state
     ),
+    # Atlassian remote MCP server — authorization endpoint (host
+    # mcp.atlassian.com, distinct from the classic auth.atlassian.com web-OAuth
+    # entry above) verified via RFC 8414 metadata reached by RFC 9728 discovery
+    # from the registry's mcp_url on mcp.atlassian.com. The state/PKCE
+    # values kiro-cli mints are high-entropy, which is what tripped the gate
+    # before the endpoint was added to the builtin set.
+    (
+        "atlassian-mcp",
+        "https://mcp.atlassian.com/v1/authorize"
+        "?client_id=atlassian_mcp_0123456789abcdef"
+        "&response_type=code"
+        "&redirect_uri=http%3A%2F%2F127.0.0.1%3A33418%2Fcallback"
+        "&scope=read%3Ajira-work+offline_access"
+        "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        "&code_challenge_method=S256"
+        "&state=" + ("Kp7mQ2xR" * 12),  # 96-char opaque state
+    ),
     # Miro remote MCP server — authorization endpoint verified via RFC 8414
     # metadata.
     (


### PR DESCRIPTION
## Problem / Motivation

Connecting the **Atlassian remote MCP server** (`https://mcp.atlassian.com/v1/mcp`) fails at the OAuth consent banner with:

> authentication failed: URL contained credential or exfiltration pattern (endpoint: mcp.atlassian.com/v1/authorize)

The exfil gate's builtin OAuth allowlist (`_OAUTH_AUTHORIZATION_ENDPOINTS` in `src/kiro_crew/security/exfil.py`) contains Atlassian's classic web-OAuth endpoint `("auth.atlassian.com", "/authorize")`, but Atlassian's **MCP authorization server** runs at a different host+path — `mcp.atlassian.com/v1/authorize` — which is not in the set.

## Why it matters

Atlassian is a first-class connector target, and this blocks it out of the box. The operator escape hatch (`oauth_endpoints.json`, #1341) unblocks it locally, but every user hits the opaque fail-closed banner first, and hand-editing a keystone file is not a reasonable default-connect experience. This is the same class of gap already fixed for Miro (#7578).

## What changed (motivation → approach → change)

- **Symptom:** the Atlassian MCP consent banner fails closed. Its front-channel `state`/PKCE query values are high-entropy, so `diagnose_oauth_url_credential` trips the base64/query-length heuristic.
- **Root cause:** `mcp.atlassian.com/v1/authorize` is absent from the builtin `_OAUTH_AUTHORIZATION_ENDPOINTS` frozenset, which exempts known MCP authorization servers from the credential/exfil heuristic. The comments in `exfil.py` already anticipate exactly this failure mode for missing MCP authorization servers.
- **Change:** add `("mcp.atlassian.com", "/v1/authorize")` to the builtin frozenset, alongside the other MCP-server entries (`mcp.miro.com`, `mcp.notion.com`, etc.). The endpoint is the provider's advertised `authorization_endpoint` via RFC 9728 protected-resource discovery from the registry `mcp_url` `https://mcp.atlassian.com/v1/mcp`, corroborated by the authorize URL kiro-cli actually minted. It matches the exact-match / HTTPS-only / no-explicit-port posture the set enforces.

## Tests

- Added a representative `atlassian-mcp` authorize URL (real kiro-cli PKCE/state shape) to the `LEGIT_OAUTH_URLS` corpus in `test/oauth_url_corpus.py`. The existing `TestLegitOAuthUrlCorpus` in `test/test_mcp_oauth_banner.py` parametrizes over the corpus, so this locks in both behaviors for the new endpoint:
  - `test_corpus_url_not_flagged_as_credential[atlassian-mcp]` — the authorize URL is no longer flagged.
  - `test_corpus_url_renders_banner[atlassian-mcp]` — the consent banner renders.

## Manual verification

N/A — unit coverage sufficient. The added corpus case exercises the exact URL shape that previously failed closed, through the same gate the banner uses. (Locally: `black`/`isort`/`flake8` clean on both files; `test_mcp_oauth_banner.py` + `test_display_time_redaction.py` = 176 passed.)

## Related Issues

Fixes #10072

Related: #8423 (platform-supplied trusted endpoints — general ask), #7578 (opaque error + undocumented allowlist fix; Miro was added there), #1341 (the operator escape hatch that shipped `oauth_endpoints.json`).

## Pattern harvest

Not generalizable: each provider's MCP authorization server host+path is data that must be enumerated in the builtin set as the Connections registry grows; there is no code pattern to lint for. The existing `exfil.py` comment already states the invariant ("Every entry added to the Connections registry needs its MCP authorization server here too"), which is the durable guard.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff

— beep boop written by cabbey's Krewe (version 0.6.0-insider.6 on cabbey-work-mbp, at direct user instruction)
