### PR TITLE
fix(deps): backport the electron js-yaml 4.3.2 pin to release/0.6.0

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -2403,9 +2403,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -24,7 +24,7 @@
   },
   "overrides": {
     "fast-uri": "3.1.7",
-    "js-yaml": "4.3.1"
+    "js-yaml": "4.3.2"
   },
   "build": {
     "appId": "com.amazon.kiro.crew",


### PR DESCRIPTION
Backport of #9671 (`89885ea0c`) onto `release/0.6.0`.

The bare `v0.6.0` stable tag failed in the Production Dependency Vulnerability Gate: `website/electron/package-lock.json` still holds js-yaml 4.3.1, which the newly published GHSA-2883-xcg3-v3hh (high) covers. Nothing published in that run, every build job was skipped.

Upstream shipped the fixed 4.3.2, so this bumps the existing `overrides` pin and regenerates the lockfile. Only the js-yaml entry changes, identical to the commit already on `main`.

After this merges, `v0.6.0-insider.7` is cut on the merge commit to produce a clean same-commit promotion record, then the `v0.6.0` tag moves onto that commit.

Test plan: the release pipeline's own vulnerability gate on the RC run. The local audit could not be exercised on the dev host because npm cannot authenticate to the registry there.