### PR TITLE
fix(cron): bound run_script_sandboxed redaction input to a straddle window (#10071)

### DIFF
--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -59,7 +59,12 @@ from kiro_crew.sandbox import (
     wrap_argv,
 )
 from kiro_crew.secrets import SecretVault
-from kiro_crew.security import is_sensitive_path, redact
+from kiro_crew.security import (
+    _REDACTED_CREDENTIAL_TAG,
+    _STREAM_HOLDBACK_JWT_MAX,
+    is_sensitive_path,
+    redact,
+)
 from kiro_crew.sel import sel
 
 # Env vars stripped from EVERY cron subprocess (command and script), regardless
@@ -1502,6 +1507,158 @@ def _resolve_dial_port() -> int:
     return resolve_serving_port()
 
 
+# How far BEYOND its kept slice each diagnostic-site pattern redaction reads. A
+# credential straddling the slice boundary is only detectable while the bytes
+# on the far side are still present -- but redacting the WHOLE capture to get
+# them costs a multiple of an unbounded string (``proc.communicate`` caps
+# neither stream, and ``redact_credentials`` materialises its base64 runs), so
+# a script streaming gigabytes would OOM the gateway in redaction that survived
+# capture. Redacting a fixed window that overshoots the slice by the streaming
+# redactor's credential-holdback ceiling keeps the footprint constant. Two
+# credential classes are exempted from the margin because a fixed window
+# cannot cover them: granted vault values (shapeless, unbounded -- so
+# ``_scrub_grant_values`` runs over the whole capture BEFORE the window is
+# cut; exact-substring replacement carries none of the amplification this
+# window exists to bound) and severed credentials on the tail-keeping
+# window, where the cut removes the ANCHOR a pattern needs --
+# ``_safe_tail_redaction_window`` masks both severed shapes as classes
+# (label-paired open private-key blocks, and the severed line's leading
+# non-whitespace run) rather than per pattern.
+_REDACT_STRADDLE_MARGIN = _STREAM_HOLDBACK_JWT_MAX
+
+# How much of a failed script's stderr is reported, taken from the END.
+_MAX_SCRIPT_STDERR_TAIL = 500
+
+# How much of an unparsable script stdout is reported, taken from the START.
+_MAX_BAD_OUTPUT_HEAD = 200
+
+#: Private-key PEM block markers, with the SAME label class the batch
+#: redactor's PEM alternative anchors on (``[A-Z ]*PRIVATE KEY``). Only
+#: private-key blocks are tracked: they are the one secret PEM class the
+#: redactor masks, and they have no length ceiling, so they are the one class
+#: the straddle margin cannot cover on a tail-keeping window. The label is
+#: captured so an END can only close a block whose label it MATCHES -- a
+#: certificate footer (or any foreign END line) interleaved inside an open
+#: private-key block is body text, not a close.
+_PEM_KEY_MARKER_RE = re.compile(r"-----(BEGIN|END) ([A-Z ]*PRIVATE KEY)-----")
+
+#: Everything a complete private-key BEGIN marker could start with. Recognises
+#: the cut landing INSIDE a marker, where neither the prefix scan (marker
+#: incomplete before the cut) nor the window's own pattern pass (anchor
+#: destroyed) can see the block that just opened.
+_PEM_BEGIN_LITERAL = "-----BEGIN "
+_PEM_SEVERED_LABEL_RE = re.compile(r"[A-Z ]*-{0,4}\Z")
+
+
+def _may_end_inside_begin_marker(pre_cut_line: str) -> bool:
+    """True when ``pre_cut_line`` could end with a BEGIN marker cut mid-marker.
+
+    ``pre_cut_line`` is the severed line's content BEFORE the cut (bounded by
+    the caller). A marker severed by the cut leaves a nonempty PREFIX of
+    ``-----BEGIN <label>-----`` at the line's end -- possibly after arbitrary
+    inline prose (``Error: dumping -----BEG``), so the check is on the line's
+    SUFFIX, not its start. Two forms: the suffix is a proper prefix of the
+    ``-----BEGIN `` literal itself, or the literal is complete and everything
+    after it to the cut is label characters plus at most four closing dashes.
+    Either way the label (and whether it names a private key) is unknowable
+    from this side of the cut alone, so the caller fails closed. A trailing
+    dash of ordinary prose also matches the first form; that costs a
+    tag-only report for one rare line shape, the safe direction.
+    """
+    for k in range(1, len(_PEM_BEGIN_LITERAL)):
+        if pre_cut_line.endswith(_PEM_BEGIN_LITERAL[:k]):
+            return True
+    idx = pre_cut_line.rfind(_PEM_BEGIN_LITERAL)
+    if idx == -1:
+        return False
+    return (
+        _PEM_SEVERED_LABEL_RE.fullmatch(pre_cut_line[idx + len(_PEM_BEGIN_LITERAL) :]) is not None
+    )
+
+
+def _pem_open_label(text: str, pos: int, endpos: int, open_label: str | None = None) -> str | None:
+    """Walk PEM key markers in ``text[pos:endpos]``; return the open label.
+
+    Label-paired: an END closes only the block whose label it matches, so a
+    foreign END line (a certificate footer) inside an open key block is body
+    text. A BEGIN inside an open block cannot nest (PEM has no nesting): the
+    outer block stays open -- fail closed.
+    """
+    for m in _PEM_KEY_MARKER_RE.finditer(text, pos, endpos):
+        kind, label = m.group(1), m.group(2)
+        if open_label is None:
+            if kind == "BEGIN":
+                open_label = label
+        elif kind == "END" and label == open_label:
+            open_label = None
+    return open_label
+
+
+def _mask_from_open_block(window: str, label: str) -> str:
+    """Mask ``window`` through the labelled END line of an open PEM block."""
+    close = window.find(f"-----END {label}-----")
+    if close == -1:
+        return _REDACTED_CREDENTIAL_TAG
+    close_nl = window.find("\n", close)
+    kept_after = window[close_nl + 1 :] if close_nl != -1 else ""
+    return _REDACTED_CREDENTIAL_TAG + "\n" + kept_after
+
+
+def _safe_tail_redaction_window(text: str, keep: int) -> str:
+    """Return the pattern-redaction input for a TAIL-keeping ``keep`` slice.
+
+    The window is the last ``keep + _REDACT_STRADDLE_MARGIN`` chars of
+    ``text``. Cutting there can sever a credential's ANCHOR from the body the
+    pattern would mask, so fail-closed rules cover the shapes a severed
+    credential can take, without enumerating credential patterns:
+
+    - MULTI-LINE (private-key PEM, unbounded): walk the discarded prefix's
+      PEM markers (bounded ``finditer`` state machine, no copies) pairing
+      each END with its matching BEGIN label; when the window starts inside a
+      block that never closed, mask the retained bytes through that block's
+      OWN labelled END line -- or the whole window when it never closes. The
+      SEVERED LINE gets the same walk: a BEGIN marker sitting after the cut
+      on that line opens a block whose body follows it, so masking the line
+      alone would delete the anchor and hand the body to the pattern pass
+      unanchored -- the walk continues through the severed segment and an
+      open block at its end is masked through its END like any other.
+
+    - SINGLE-LINE (JWT, Bearer, token URL, base64 run): when the window
+      starts mid-line, a broken single-line credential can sit anywhere on
+      the severed line -- directly at the cut, after whitespace, or stranded
+      from an anchor word (``Bearer``) the cut left in the prefix -- so the
+      severed line's whole in-window remainder is masked as a unit. The cost
+      is one partial line of diagnostics that was already cut anyway. When
+      the cut lands inside a BEGIN marker itself -- with or without inline
+      prose before the marker on that line -- the block's label is split
+      across the cut and unknowable, so the whole window fails closed to the
+      tag.
+    """
+    start = len(text) - (keep + _REDACT_STRADDLE_MARGIN)
+    if start <= 0:
+        return text
+    window = text[start:]
+    open_label = _pem_open_label(text, 0, start)
+    if open_label is not None:
+        return _mask_from_open_block(window, open_label)
+    if text[start - 1] not in "\r\n":
+        line_start = text.rfind("\n", 0, start) + 1
+        pre_cut_line = text[max(line_start, start - 256) : start]
+        if _may_end_inside_begin_marker(pre_cut_line):
+            return _REDACTED_CREDENTIAL_TAG
+        line_end = window.find("\n")
+        if line_end == -1:
+            return _REDACTED_CREDENTIAL_TAG
+        severed_open = _pem_open_label(window, 0, line_end)
+        if severed_open is not None:
+            # A BEGIN marker after the cut on the severed line: its block's
+            # body follows in the remainder, and the line mask below would
+            # delete the anchor -- mask through the labelled END instead.
+            return _mask_from_open_block(window[line_end:], severed_open)
+        return _REDACTED_CREDENTIAL_TAG + window[line_end:]
+    return window
+
+
 def run_script_sandboxed(
     script_path: str,
     job_id: str,
@@ -1889,12 +2046,22 @@ def run_script_sandboxed(
             # budget, and so an all-whitespace stderr still falls through to the
             # exit-code fallback rather than reporting blank text.
             #
-            # Redact the WHOLE stream before bounding: slicing first would cut
-            # a credential that straddles the 500-char boundary in half, and
-            # ``redact`` cannot recognise the surviving fragment, so it would
-            # reach logs and the persisted ``last_error`` unmasked.
-            tail = redact(_scrub_grant_values(stderr.rstrip(), resolved_secret_env))
-            error_text = tail[-500:] if tail else f"exit {proc.returncode}"
+            # Redact BEFORE bounding: slicing first would cut a credential that
+            # straddles the 500-char boundary in half, and ``redact`` cannot
+            # recognise the surviving fragment, so it would reach logs and the
+            # persisted ``last_error`` unmasked. The two passes get DIFFERENT
+            # inputs, matching what each costs and needs. The grant scrub runs
+            # over the WHOLE capture: it is exact-substring replacement of
+            # values the parent already holds -- O(len) scans, no base64
+            # materialisation -- and a vault value has no shape, so a value
+            # straddling any window edge would stop matching ``value in text``
+            # and its fragment would leak with nothing downstream able to
+            # recognise it. Pattern ``redact`` is the memory amplifier, so ITS
+            # input is a TAIL window reaching ``_REDACT_STRADDLE_MARGIN`` back
+            # past the kept region (see ``_REDACT_STRADDLE_MARGIN``).
+            scrubbed = _scrub_grant_values(stderr.rstrip(), resolved_secret_env)
+            tail = redact(_safe_tail_redaction_window(scrubbed, _MAX_SCRIPT_STDERR_TAIL))
+            error_text = tail[-_MAX_SCRIPT_STDERR_TAIL:] if tail else f"exit {proc.returncode}"
             return {"status": "error", "error": error_text}
 
         try:
@@ -1915,12 +2082,19 @@ def run_script_sandboxed(
                         parsed[k] = _scrub_grant_values(v, resolved_secret_env)
             return parsed
         except (json.JSONDecodeError, IndexError):
+            # Redact BEFORE truncating: slicing first could cut a credential at
+            # the boundary, leaving its unredacted head in the diagnostic. Same
+            # split as the stderr tail above: the grant scrub reads the WHOLE
+            # capture (shapeless values, cheap exact replacement), pattern
+            # ``redact`` reads a HEAD window overshooting the kept region by
+            # ``_REDACT_STRADDLE_MARGIN``.
+            scrubbed_out = _scrub_grant_values(stdout, resolved_secret_env)
             return {
                 "status": "error",
-                # Redact the complete stdout BEFORE truncating: slicing first
-                # could cut a credential at the boundary, leaving its unredacted
-                # head in the diagnostic.
-                "error": f"Bad output: {redact(_scrub_grant_values(stdout, resolved_secret_env))[:200]}",
+                "error": (
+                    "Bad output: "
+                    f"{redact(scrubbed_out[: _MAX_BAD_OUTPUT_HEAD + _REDACT_STRADDLE_MARGIN])[:_MAX_BAD_OUTPUT_HEAD]}"
+                ),
             }
     except subprocess.TimeoutExpired:
         return {"status": "error", "error": f"Script timed out after {timeout}s"}

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -12,6 +12,9 @@ import pytest
 
 from kiro_crew import platform_compat as pc
 from kiro_crew.cron_script import (
+    _MAX_BAD_OUTPUT_HEAD,
+    _MAX_SCRIPT_STDERR_TAIL,
+    _REDACT_STRADDLE_MARGIN,
     Done,
     Report,
     ScriptContext,
@@ -1794,6 +1797,429 @@ class TestRunScriptSandboxedErrorPaths:
         # into the replacement marker, so its head survives the slice.
         assert "[REDACTED:" in result["error"]
         assert padding in result["error"]
+
+    def test_stderr_redaction_input_is_bounded_to_a_window(self, tmp_path, monkeypatch):
+        """The stderr-tail redaction must not copy an unbounded capture.
+
+        ``proc.communicate`` caps neither stream and ``redact_credentials``
+        materialises its base64 runs into a list beside the input, so redacting
+        the WHOLE stderr costs a multiple of an unbounded string: a script
+        streaming gigabytes and then failing would OOM the gateway in redaction
+        that survived capture. Redaction reads a TAIL window of the kept 500
+        chars plus ``_REDACT_STRADDLE_MARGIN``, which keeps the footprint fixed.
+
+        Asserted on redact's INPUT rather than on the output, because the output
+        cannot tell the two apart -- a credential far before the window is
+        truncated away whether or not it was ever scanned. A credential
+        straddling the -500 boundary proves the window overshoot still lets the
+        pattern see it whole.
+        """
+        from kiro_crew import cron_script
+
+        seen: list[int] = []
+        real_redact = cron_script.redact
+
+        def _spy(text: str) -> str:
+            seen.append(len(text))
+            return real_redact(text)
+
+        monkeypatch.setattr(cron_script, "redact", _spy)
+        fake_key = "AKIA" + "B" * 16  # matches the AWS access-key-id pattern
+        # The -500 cut lands ONE character into the key: slice-then-redact
+        # would leak the 19-char fragment, and a window that failed to reach
+        # back past the cut would leak it the same way.
+        # Newline-separated filler: the window then starts inside an ordinary
+        # short line, so only that line's severed remainder is masked and the
+        # straddling credential is still exercised against the pattern pass.
+        stderr_text = ("n" * 100 + "\n") * 200 + "W" * 300 + fake_key + "X" * 481
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert fake_key not in result["error"]
+        # The discriminator for the straddle: the fragment slice-then-redact
+        # (or an undershooting window) leaves behind.
+        assert fake_key[1:] not in result["error"]
+        assert "credential]" in result["error"]
+        assert seen, "redact was never called on the captured stderr"
+        assert max(seen) <= _MAX_SCRIPT_STDERR_TAIL + _REDACT_STRADDLE_MARGIN
+
+    def test_bad_output_redaction_input_is_bounded_to_a_window(
+        self, tmp_path, monkeypatch
+    ):
+        """The bad-stdout redaction must not copy an unbounded capture either.
+
+        Same denial-of-service shape as the stderr tail, on the ``Bad output``
+        diagnostic path: this cut keeps the HEAD, so its window reaches
+        ``_REDACT_STRADDLE_MARGIN`` PAST the first 200 chars instead of back
+        before them. A credential straddling the 200-char boundary proves the
+        overshoot still lets the pattern see it whole.
+        """
+        from kiro_crew import cron_script
+
+        seen: list[int] = []
+        real_redact = cron_script.redact
+
+        def _spy(text: str) -> str:
+            seen.append(len(text))
+            return real_redact(text)
+
+        monkeypatch.setattr(cron_script, "redact", _spy)
+        fake_key = "AKIA" + "B" * 16  # matches the AWS access-key-id pattern
+        # The 200-char head cut lands 10 chars into the key; the trailing run
+        # pushes the capture far past the window so the bound is discriminating.
+        stdout_text = "p" * 190 + fake_key + "e" * 30000
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = (stdout_text, "")
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert fake_key not in result["error"]
+        # The head of the replacement marker survives the slice, proving the
+        # straddling key was whole inside the window when redaction ran.
+        assert "[REDACTED:" in result["error"]
+        assert seen, "redact was never called on the captured stdout"
+        assert max(seen) <= _MAX_BAD_OUTPUT_HEAD + _REDACT_STRADDLE_MARGIN
+
+    def test_grant_value_longer_than_the_margin_is_still_scrubbed(self, tmp_path):
+        """The grant scrub must read the WHOLE capture, not the redact window.
+
+        A vault value has no shape, so ``_scrub_grant_values`` matches it only
+        whole (``value in text``): if the scrub ran on the bounded window, a
+        granted value LONGER than ``_REDACT_STRADDLE_MARGIN`` straddling the
+        window's far edge would lose its head, stop matching, and its tail --
+        which no pattern recognises either -- would reach the persisted
+        ``last_error`` verbatim. The scrub is exact-substring replacement, so
+        whole-capture input carries none of the memory amplification the
+        redact window exists to bound.
+        """
+        # Longer than the margin, and shaped like nothing redact recognises,
+        # so only the scrub stands between it and the diagnostic.
+        secret_value = "grantval-" * 700  # 6300 chars > _REDACT_STRADDLE_MARGIN
+        assert len(secret_value) > _REDACT_STRADDLE_MARGIN
+        # Ends 100 chars before the capture's end: it STARTS well before the
+        # stderr window's far edge (window = last 4596 chars), so a scrub that
+        # only saw the window would see a headless fragment and skip it, and
+        # the fragment's tail would sit inside the kept 500 chars.
+        stderr_text = "n" * 2000 + secret_value + "X" * 100
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script._read_script_body",
+            return_value=b"def run(ctx):\n    return None\n",
+        ), patch(
+            "kiro_crew.cron_script._secret_env_precheck",
+            return_value=({"TOKEN": secret_value}, None),
+        ), patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed(
+                "/f.py:run", "j1", "", secret_env={"TOKEN": "vault:t"},
+                secret_env_pin="pin",
+            )
+        assert result["status"] == "error"
+        # No recognisable run of the value survives -- neither the whole value
+        # nor the fragment a window-scoped scrub would have left in the tail.
+        assert "grantval-" * 20 not in result["error"]
+        assert "[redacted-grant-value]" in result["error"]
+
+    def test_pem_opened_before_the_tail_window_is_still_masked(self, tmp_path):
+        """A PEM block spanning the whole tail window must not leak body lines.
+
+        A PEM block has no length ceiling, so the straddle margin cannot cover
+        it: a block whose ``-----BEGIN `` line falls before the window start
+        loses the anchor the pattern needs, and its body lines inside the
+        window -- shaped like nothing else redact recognises -- would reach
+        the persisted ``last_error`` verbatim. ``_pem_safe_tail_window``
+        tracks open-block state across the discarded prefix and masks the
+        retained bytes through the END line.
+        """
+        label = "OPENSSH PRIVATE" + " KEY"
+        # Body lines deliberately lowercase-only: they trip neither the
+        # base64-run pass nor any anchored pattern, so ONLY the open-block
+        # tracking stands between them and the diagnostic.
+        body = ("keybodyline" * 5 + "\n") * 120  # ~6.7KB > 500 + margin
+        pem = f"-----BEGIN {label}-----\n{body}-----END {label}-----\n"
+        stderr_text = pem + "trailing diagnostic context"
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "keybodyline" not in result["error"]
+        assert "credential]" in result["error"]
+        # Post-block content survives: the mask reaches the END line, not the
+        # whole report.
+        assert "trailing diagnostic context" in result["error"]
+
+    def test_pem_that_never_closes_masks_the_whole_tail(self, tmp_path):
+        """An unterminated over-window PEM yields the tag, not body lines."""
+        label = "RSA PRIVATE" + " KEY"
+        body = ("keybodyline" * 5 + "\n") * 120
+        stderr_text = f"-----BEGIN {label}-----\n{body}"  # no END marker
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "keybodyline" not in result["error"]
+        assert "credential]" in result["error"]
+
+    def test_closed_pem_before_the_window_does_not_mask_the_tail(self, tmp_path):
+        """A block that CLOSED in the discarded prefix must not cost the tail.
+
+        The open-block test is last-BEGIN vs last-END order; a closed block
+        followed by ordinary diagnostics is the common case and must report
+        those diagnostics whole.
+        """
+        label = "EC PRIVATE" + " KEY"
+        pem = f"-----BEGIN {label}-----\nshortbody\n-----END {label}-----\n"
+        stderr_text = pem + ("n" * 80 + "\n") * 75 + "REAL_TERMINAL_DIAGNOSIS"
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "REAL_TERMINAL_DIAGNOSIS" in result["error"]
+
+    def test_foreign_end_marker_does_not_close_an_open_key_block(self, tmp_path):
+        """A certificate footer inside an open key block must not close it.
+
+        END markers pair by LABEL: ``-----END CERTIFICATE-----`` interleaved
+        inside an open ``RSA PRIVATE KEY`` block is body text. A tracker that
+        paired any BEGIN with any END would treat the key as closed and hand
+        its remaining body lines to the pattern pass anchor-less.
+        """
+        label = "RSA PRIVATE" + " KEY"
+        stderr_text = (
+            f"-----BEGIN {label}-----\n"
+            + ("keybodyline\n" * 30)
+            + "-----END CERTIFICATE-----\n"
+            + ("keybodyline" * 5 + "\n") * 120  # pushes the window inside the block
+            + f"-----END {label}-----\n"
+            + "trailing diagnostic context"
+        )
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "keybodyline" not in result["error"]
+        assert "trailing diagnostic context" in result["error"]
+
+    def test_severed_single_line_run_is_masked_not_reported(self, tmp_path):
+        """A single-line token severed by the window start leaks no suffix.
+
+        Every single-line credential shape is whitespace-free, so when the
+        window boundary lands mid-line the possible credential tail is the
+        window's leading non-whitespace run. All-same-letter content is the
+        discriminator: it trips no pattern (no mixed case, no digits, no
+        anchor), so only the severed-run rule stands between it and the
+        persisted ``last_error``.
+        """
+        stderr_text = "warmup line\n" + "Z" * 6000 + "\n" + ("post-token diagnostic\n" * 10)
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "Z" * 40 not in result["error"]
+        assert "credential]" in result["error"]
+        assert "post-token diagnostic" in result["error"]
+
+    def test_whitespace_after_the_cut_does_not_unmask_the_severed_line(self, tmp_path):
+        """A severed line is masked whole, wherever the credential sits on it.
+
+        The cut can land inside whitespace that PRECEDES the credential (an
+        indented value, a wrapped ``Authorization:`` header), so a rule that
+        masked only a leading non-whitespace run would see whitespace at the
+        window start, match nothing, and hand the raw token through. The
+        whole in-window remainder of the severed line is masked instead.
+        """
+        stderr_text = (
+            ("n" * 100 + "\n") * 2
+            + "authheader:"
+            + " " * 60
+            + "Z" * 4200
+            + "\n"
+            + ("post diagnostic\n" * 22)
+        )
+        # Geometry check: the cut lands INSIDE the whitespace run that
+        # precedes the token, the exact shape a leading-run rule misses.
+        window_span = 500 + _REDACT_STRADDLE_MARGIN
+        cut = len(stderr_text.rstrip()) - window_span
+        ws_start = stderr_text.index("authheader:") + len("authheader:")
+        assert ws_start <= cut < ws_start + 60
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "Z" * 40 not in result["error"]
+        assert "post diagnostic" in result["error"]
+
+    def test_begin_marker_straddling_the_cut_fails_closed(self, tmp_path):
+        """A BEGIN marker split by the cut must not leak the block body.
+
+        The prefix scan cannot see the marker (incomplete before the cut) and
+        the window's pattern pass cannot either (its anchor is destroyed), so
+        the label is unknowable from either side; the window fails closed to
+        the tag alone.
+        """
+        label = "RSA PRIVATE" + " KEY"
+        key_open = f"-----BEGIN {label}-----"
+        body = ("b" * 64 + "\n") * 68  # ~4.4KB: END stays inside the window
+        stderr_text = (
+            ("n" * 100 + "\n") * 50
+            + key_open
+            + "\n"
+            + body
+            + f"-----END {label}-----\n"
+            + ("c" * 11 + "\n") * 10
+        )
+        # Geometry check: the cut lands INSIDE the BEGIN marker line.
+        window_span = 500 + _REDACT_STRADDLE_MARGIN
+        cut = len(stderr_text.rstrip()) - window_span
+        marker_at = stderr_text.index(key_open)
+        assert marker_at <= cut < marker_at + len(key_open)
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "b" * 40 not in result["error"]
+        assert "credential]" in result["error"]
+
+    def test_begin_marker_after_the_cut_on_the_severed_line_keeps_its_block_masked(
+        self, tmp_path
+    ):
+        """Masking the severed line must not delete a BEGIN anchor it carries.
+
+        A key printed inline in an error string (``Error: ... -----BEGIN
+        ...``) puts the BEGIN marker AFTER the cut on the severed line. A rule
+        that masked the severed line as an opaque unit would delete the anchor
+        with the line while the key body survives in the remainder, unmatched
+        by the pattern pass. The marker walk continues through the severed
+        segment, so the block is masked through its labelled END like any
+        other open block.
+        """
+        label = "RSA PRIVATE" + " KEY"
+        key_open = f"-----BEGIN {label}-----"
+        body = ("b" * 64 + "\n") * 68
+        stderr_text = (
+            ("n" * 100 + "\n") * 44
+            + "Error: dumping key "
+            + key_open
+            + "\n"
+            + body
+            + f"-----END {label}-----\n"
+            + ("c" * 11 + "\n") * 9
+        )
+        # Geometry check: the cut lands inside the prose BEFORE the marker.
+        window_span = 500 + _REDACT_STRADDLE_MARGIN
+        cut = len(stderr_text.rstrip()) - window_span
+        assert stderr_text.index("Error:") <= cut < stderr_text.index(key_open)
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "b" * 40 not in result["error"]
+        assert "c" * 11 in result["error"]
+
+    def test_inline_prefixed_begin_marker_split_by_the_cut_fails_closed(self, tmp_path):
+        """Inline prose before a marker must not defeat the severed-BEGIN rule.
+
+        A key printed mid-sentence (``Error: dumping key -----BEGIN ...``)
+        with the cut landing INSIDE the marker leaves an inline prefix before
+        the partial marker on the pre-cut line, so a check that requires the
+        LINE to start with the marker never fires while the marker walk sees
+        no complete marker on either side. The rule inspects the pre-cut
+        line's SUFFIX instead, so this shape fails closed to the tag.
+        """
+        label = "RSA PRIVATE" + " KEY"
+        key_open = f"-----BEGIN {label}-----"
+        body = ("b" * 64 + "\n") * 68
+        stderr_text = (
+            ("n" * 100 + "\n") * 44
+            + "Error: dumping key "
+            + key_open
+            + "\n"
+            + body
+            + f"-----END {label}-----\n"
+            + ("c" * 11 + "\n") * 10
+        )
+        # Geometry check: the cut lands INSIDE the marker, after inline prose.
+        window_span = 500 + _REDACT_STRADDLE_MARGIN
+        cut = len(stderr_text.rstrip()) - window_span
+        marker_at = stderr_text.index(key_open)
+        assert marker_at < cut < marker_at + len(key_open)
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "b" * 40 not in result["error"]
+        assert "credential]" in result["error"]
 
 
 class TestMcpCronHandlerPaths:


### PR DESCRIPTION
## Problem / Motivation

Two sites in `run_script_sandboxed` (src/kiro_crew/cron_script.py) redact an unbounded captured stream before slicing it to a small fixed window: the failed-script stderr tail (`[-500:]`) and the bad-stdout diagnostic (`[:200]`). `proc.communicate` bounds neither stream -- popen_limited's RLIMIT and the cgroup MemoryMax bound the child's RSS, not the bytes it writes nor the parent's captured string -- and `redact_credentials` materialises its base64 runs into a list alongside the input and the result, so redacting a whole multi-GB capture costs a multiple of it.

## Why it matters

A script cron that streams gigabytes and then fails can exhaust gateway memory inside redaction that survived capture -- a recoverable denial-of-service shape (a restart clears it, the cron re-fires on its next tick). The equivalent pair of sites in `run_command_sandboxed` was addressed in the now-closed PR #9862; these two were deliberately left out of it and issue #10071 is the remaining record.

## What changed (motivation → approach → change)

Pattern redaction's INPUT is now a fixed window that overshoots its own kept slice by `_REDACT_STRADDLE_MARGIN` (= `_STREAM_HOLDBACK_JWT_MAX`, 4096 -- the same margin the closed PR #9862 derived), instead of the whole capture. Redact-before-slice is preserved in both cases, keeping the repo-wide invariant (`redact_and_truncate`'s docstring: a credential straddling the cut stops matching once the cut removes its delimiter):

- stderr site keeps the TAIL, so its window reaches the margin back before the last 500 chars;
- stdout site keeps the HEAD, so its window reaches the margin past the first 200 chars.

Two credential classes cannot be covered by a fixed margin, and each gets its own treatment instead of the window:

- Granted vault values are shapeless and unbounded, so `_scrub_grant_values` still reads the WHOLE capture, before the window is cut: a value longer than the margin straddling a window edge would stop matching `value in text`, and exact-substring replacement carries none of the amplification the window exists to bound (no base64 materialisation, O(len) scans). Driven by a pre-push review finding.
- A credential SEVERED by the tail window's start loses the anchor its pattern needs, so `_safe_tail_redaction_window` masks the two shapes a severed credential can take as CLASSES, with no per-pattern anchor list to drift: private-key PEM blocks (unbounded, multi-line) are tracked across the discarded prefix by a label-pairing marker walk -- an END closes only the block whose label it matches, so a certificate footer interleaved in an open key block is body text -- and masked through the block's own END line (whole window if it never closes); a single-line credential severed mid-line can sit anywhere on the severed line (after leading whitespace, or stranded from an anchor word the cut left behind), so the severed line's whole in-window remainder is masked, costing one already-cut partial line of diagnostics; and a BEGIN marker the cut lands INSIDE has an unknowable label, so that window fails closed to the tag alone. Driven by the GPT 5.6 review's blocking findings across three heads (anchor loss, label pairing, whitespace/severed-marker cuts). The head-keeping stdout window needs no equivalent: a credential straddling its FAR edge keeps its anchor inside the window, and the cut tail stays out of the report.

Behaviour for ordinary small captures is unchanged: the window is a no-op when the capture fits inside it, and a window starting at a line boundary is passed through untouched.

The pre-existing sibling site in `run_command_sandboxed` (`redact(stderr_out.rstrip())[-1000:]`) is deliberately NOT touched: it pre-dates this issue, belongs to the scope PR #9862 was closed over, and folding it in would widen this PR past the issue's record.

## Tests

- `test_stderr_redaction_input_is_bounded_to_a_window` / `test_bad_output_redaction_input_is_bounded_to_a_window`: spy on `redact`'s input length over a capture several times the window, credential straddling the kept-region boundary -- assert bounded input AND the straddling credential still masked whole. Mutation-verified red when the window slices are removed.
- `test_grant_value_longer_than_the_margin_is_still_scrubbed`: an over-margin vault value straddling the window edge stays fully scrubbed. Mutation-verified red against a window-scoped scrub.
- `test_pem_opened_before_the_tail_window_is_still_masked` / `test_pem_that_never_closes_masks_the_whole_tail`: an over-window PEM leaks no body line, post-block diagnostics survive; `test_closed_pem_before_the_window_does_not_mask_the_tail` pins the common closed-block case unmasked; `test_foreign_end_marker_does_not_close_an_open_key_block` pins label pairing (mutation-verified red against generic END pairing); `test_severed_single_line_run_is_masked_not_reported`, `test_whitespace_after_the_cut_does_not_unmask_the_severed_line` and `test_begin_marker_straddling_the_cut_fails_closed` pin the severed-line rules (each mutation-verified red against the weaker prior mechanism). The two PEM leak tests are mutation-verified red against the bare window.
- Existing redact-before-slice straddle tests and the empty-stderr `exit N` fallback tests pass unchanged.
- Local gates: black, isort, flake8 clean; mypy reds are pre-existing in transcribe.py; 22 scoped tests in the touched classes pass.

## Manual verification

Two independent pre-push review subagents ran against a frozen worktree at the first head: one confirmed window math, small-capture invariance and test quality; the other surfaced the grant-value window regression fixed by the whole-capture scrub. The GPT 5.6 lane's blocking finding on the first head (open-PEM anchor loss on the tail window) is fixed by `_pem_safe_tail_window` rather than overridden, since it was a real regression relative to main's whole-capture redaction.

## Related Issues

Closes #10071

## Pattern harvest

Rule candidate: when bounding a redactor's input to a window, exempt every credential class whose detection cannot survive the window -- shapeless exact-match values need the whole capture (cheap, no amplification), and unbounded anchor-at-start classes like PEM need open-state tracking across the discarded prefix; a single margin only covers classes with a length ceiling at or below it.
