### PR TITLE
fix(protocol): decide the marker terminator outside the pattern

### DIFF
--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -1,7 +1,10 @@
 """Shared constants used across cli and gateway modules."""
 
+from __future__ import annotations
+
 import os
 import re
+from collections.abc import Iterator
 
 # Positive-identity marker injected into the environment of every subprocess
 # tree KiroCrew spawns (the ACP provider, MCP probes, gateway pool backends).
@@ -296,76 +299,12 @@ _MARKER_LABEL_PAIR = (
     rf"(?![ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
 )
 
-#: A bare opener may not be the one whose partner closer ENDS the marker.
-#:
-#: The bare-``[`` alternative exists so a stray opener inside a label does not
-#: sink the whole marker: ``[OPTIONS: Fix [x logging | Skip]`` parses, and is
-#: tested. But nothing about it distinguishes that opener from the one in
-#: ``[OPTIONS: A | B then check arr[0]``, where the marker was never closed and
-#: the ``]`` of ``arr[0]`` is the only closer on the line. There the body ran on
-#: through the prose, that ``]`` became the terminator, and since every consumer
-#: removes the whole match, the line was deleted from the message and came back
-#: as the label ``B then check arr[0``.
-#:
-#: What separates the two is where the opener sits relative to the END, not the
-#: brackets themselves -- the two shapes are otherwise identical token for token,
-#: which is why no rule over bracket structure alone can tell them apart. So the
-#: bare form is refused exactly when nothing but ordinary text lies between it
-#: and a closer at the end anchor: that closer is then its partner rather than
-#: the marker's, and the marker is unterminated.
-#:
-#: Crossing ``|`` clears the gate, because that is the unambiguous option
-#: separator: the opener is inside a label and the list continues past it, which
-#: is what keeps the pinned stray-opener shape. Crossing another BRACKET clears it
-#: too, because some other bracket form owns that closer -- which is what keeps
-#: ``[OPTIONS: Fix arr[0] | Skip]`` (the continuation half admits that ``]``) and
-#: ``[OPTIONS: a[1] | b[2]]`` parsing.
-#:
-#: ``,`` does NOT clear it, and that asymmetry is the whole reason the scan can
-#: find the partner closer at all. A comma is only a FALLBACK separator -- the
-#: frontend's ``parseOptions`` reaches for it just when no ``|`` is present -- and
-#: inside brackets it is ordinary punctuation, which models write constantly:
-#: ``dict[str, Any]``, ``arr[i, j]``. A scan that stopped at it halted before the
-#: closer in ``[OPTIONS: A | B then inspect dict[str, int]`` and cleared the gate,
-#: leaving exactly the shape this exists to refuse.
-#:
-#: Spelled twice because the two bodies end differently and, more importantly,
-#: because they differ on NEWLINES. LINE stops at one; TRAILER spans them under
-#: DOTALL, so its scan has to as well -- otherwise a ``\n`` blinds the gate and
-#: ``[OPTIONS: A | B then check arr[0\nAnd that is all]`` walks straight through
-#: it. The scan must see as far as the body can reach, or it is not looking at the
-#: same terminator. Both carry the optional stray markdown-link tic and a wrapper
-#: run, so a marker wearing either still gates on the closer its tail consumes;
-#: both reuse the tail's own constants below rather than respelling them.
-#:
-#: WHAT THIS DOES NOT CLOSE. The gate clears when the scan meets another bracket,
-#: on the grounds that some other bracket form owns that closer. With NESTING at
-#: the end of the line that reasoning fails: in ``[OPTIONS: A | B then inspect
-#: list[dict[str, int]]`` the outer opener's partner IS the terminator, but the
-#: scan halts at the inner ``[`` and never reaches it. Encoding one level of
-#: nesting here only moves the boundary -- depth three defeats that, depth four
-#: the next one. The condition being reached for is "the terminating closer is not
-#: nested", which is bracket BALANCE, and balance is not a regular language at
-#: unbounded depth. Closing it means the check cannot live in this pattern at all;
-#: the residual is pinned at the depth where the gate stops reaching, in
-#: ``test_options_marker_terminator.py``.
-#:
-#: ReDoS: the lookahead is TEMPERED -- its scan stops at the first bracket or
-#: ``|``, so the runs scanned from different openers are disjoint and the total
-#: work stays linear. It adds no quantifier over a quantifier, which is the shape
-#: the frontend's ``.source`` pin forbids.
-_MARKER_TERMINATOR_SCAN_LINE = rf"[^[{re.escape(MARKER_CLOSERS)}|\n]*"
-_MARKER_TERMINATOR_SCAN_TRAILER = rf"[^[{re.escape(MARKER_CLOSERS)}|]*"
+#: The marker TAIL, spelled once so the patterns below and anything reasoning
+#: about where a marker ends agree by construction. ``_MARKER_STRAY_TIC`` is the
+#: tolerated markdown-link tic after the closer; ``_MARKER_WRAP_RUN`` is the
+#: conditional half of :data:`MARKER_WRAPPERS`.
 _MARKER_STRAY_TIC = r"(?:\([^\s()]*\))?"
 _MARKER_WRAP_RUN = rf"{_MARKER_WRAP_CLASS}{{0,3}}"
-_MARKER_BARE_OPENER_GATE_LINE = (
-    rf"(?!{_MARKER_TERMINATOR_SCAN_LINE}{_MARKER_CLOSE_CLASS}"
-    rf"{_MARKER_STRAY_TIC}{_MARKER_WRAP_RUN}[ \t]*$)"
-)
-_MARKER_BARE_OPENER_GATE_TRAILER = (
-    rf"(?!{_MARKER_TERMINATOR_SCAN_TRAILER}{_MARKER_CLOSE_CLASS}"
-    rf"{_MARKER_STRAY_TIC}{_MARKER_WRAP_RUN}\s*\Z)"
-)
 
 #: Label body, spelled once per regex so LINE and TRAILER cannot drift. LINE
 #: stops at a newline; TRAILER spans them (``DOTALL``, as the old ``.*`` did).
@@ -381,12 +320,12 @@ _MARKER_BARE_OPENER_GATE_TRAILER = (
 #: closer. So there is never more than one way to consume a character, and each
 #: lookahead is entered only at a bracket and bounded by the run it scans.
 _MARKER_BODY_LINE = (
-    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:){_MARKER_BARE_OPENER_GATE_LINE}"
+    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:)"
     rf"|{_MARKER_CLOSE_CLASS}{_MARKER_LABEL_CONTINUES}"
     rf"|[^[{re.escape(MARKER_CLOSERS)}\n])*"
 )
 _MARKER_BODY_TRAILER = (
-    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:){_MARKER_BARE_OPENER_GATE_TRAILER}"
+    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:)"
     rf"|{_MARKER_CLOSE_CLASS}{_MARKER_LABEL_CONTINUES}"
     rf"|[^[{re.escape(MARKER_CLOSERS)}])*"
 )
@@ -395,7 +334,7 @@ _MARKER_BODY_TRAILER = (
 # necessarily precedes it, shifting positional numbering: consumers read
 # ``group("labels")`` (and iterate with ``finditer``, since ``findall`` on a
 # multi-group pattern yields tuples).
-OPTIONS_RE_LINE = re.compile(
+_RAW_OPTIONS_RE_LINE = re.compile(
     rf"(?:^[ \t]*(?P<lwrap>{_MARKER_WRAP_CLASS}{{1,3}}))?"
     rf"\[OPTIONS:(?P<labels>{_MARKER_BODY_LINE}){_MARKER_CLOSE_CLASS}"
     rf"{_MARKER_STRAY_TIC}(?(lwrap){_MARKER_WRAP_RUN})[ \t]*$",
@@ -412,12 +351,111 @@ OPTIONS_RE_LINE = re.compile(
 # ``re.MULTILINE`` is added ONLY so the optional leading-wrapper group can
 # anchor ``^`` at the marker's own line start; the pattern has no ``$`` and
 # ``\Z`` is unaffected by the flag, so nothing else changes.
-OPTIONS_RE_TRAILER = re.compile(
+_RAW_OPTIONS_RE_TRAILER = re.compile(
     rf"(?:^[ \t]*(?P<lwrap>{_MARKER_WRAP_CLASS}{{1,3}}))?"
     rf"\[OPTIONS:(?P<labels>{_MARKER_BODY_TRAILER}){_MARKER_CLOSE_CLASS}"
     rf"{_MARKER_STRAY_TIC}(?(lwrap){_MARKER_WRAP_RUN})\s*\Z",
     re.DOTALL | re.MULTILINE,
 )
+
+
+#: A marker's labels must have BALANCED brackets.
+#:
+#: The two patterns above find CANDIDATE markers; this decides which candidates are
+#: markers, and it is the whole reason the raw patterns are private. An unmatched
+#: opener in the labels means the closer the pattern consumed as the terminator is
+#: really that opener's partner -- so the marker was never closed and the candidate
+#: is refused.
+#:
+#: What it prevents: ``[OPTIONS: A | B then check arr[0]``, where the only closer on
+#: the line belongs to ``arr[0]``. The body runs on through the prose, that ``]``
+#: becomes the terminator, and since every consumer removes the whole match, the
+#: line leaves the message and comes back as the pill label ``B then check arr[0``.
+#:
+#: WHY THE PATTERN CANNOT DO IT. Balance is not a regular language at unbounded
+#: depth: a lookahead sees one nesting level, so ``list[dict[str, int]]`` defeats a
+#: one-level rule and ``a[b[c[d]]]`` a two-level one. Encoding depths is a
+#: treadmill, so the decision lives here and the patterns stay candidates.
+#:
+#: WHY THE RULE IS TOTAL -- no separator escape hatch. An earlier form accepted an
+#: unmatched opener when a ``|`` followed it, on the theory that the opener was then
+#: inside a label with the list continuing past it. That hatch was defeated three
+#: times, most recently by a ``|`` INSIDE the unmatched bracket
+#: (``[OPTIONS: A | B then inspect dict[str | int]``), and each time the shape it
+#: readmitted was structurally identical to the shape it was meant to protect. The
+#: hatch was the defect, not its spelling.
+#:
+#: THE COST, which is exactly one shape: ``[OPTIONS: Fix [x logging | Skip]`` -- a
+#: label carrying an unclosed ``[`` -- is refused. Admitting it means admitting
+#: ``[OPTIONS: A | B then check arr[0]`` too, since both hold one unmatched opener
+#: and a closer at the end anchor, and admitting the second deletes a line of prose.
+#: A dropped bracket renders the marker as visible text instead, which is the
+#: direction every cost in this grammar fails in.
+#:
+#: An unmatched CLOSER is ignored rather than counted negative: a label may
+#: legitimately carry one (``[OPTIONS: Alpha ] | Bravo ]]`` is a supported, tested
+#: shape), so it says nothing about the terminator.
+def _marker_labels_have_unmatched_opener(labels: str) -> bool:
+    """Whether *labels* leave an opener unclosed, so the terminator is not theirs."""
+    depth = 0
+    for char in labels:
+        if char == "[":
+            depth += 1
+        elif char in MARKER_CLOSERS and depth:
+            depth -= 1
+    return depth > 0
+
+
+class _MarkerMatcher:
+    """A candidate pattern plus the balance decision the pattern cannot make.
+
+    Deliberately shaped like the compiled pattern it replaced -- ``search``,
+    ``finditer``, ``sub`` and ``pattern`` are the only members anything used -- so
+    every call site reads the same and none of them can opt out of the check by
+    forgetting to call it. That is the point of the indirection: the raw patterns
+    are private, so there is no supported way to get an unchecked match.
+    """
+
+    __slots__ = ("_pattern",)
+
+    def __init__(self, pattern: re.Pattern[str]) -> None:
+        self._pattern = pattern
+
+    @property
+    def pattern(self) -> str:
+        """The candidate pattern's source, for the tests that pin its shape."""
+        return self._pattern.pattern
+
+    def finditer(self, text: str) -> Iterator[re.Match[str]]:
+        """Every candidate whose terminator is its own, in order."""
+        for match in self._pattern.finditer(text):
+            if not _marker_labels_have_unmatched_opener(match.group("labels")):
+                yield match
+
+    def search(self, text: str) -> re.Match[str] | None:
+        """The first accepted marker, or ``None``.
+
+        A refused candidate cannot hide an accepted one inside its span: the body
+        refuses a nested ``[OPTIONS:``, so no candidate ever contains another head.
+        """
+        return next(self.finditer(text), None)
+
+    def sub(self, repl: str, text: str) -> str:
+        """Remove every accepted marker, leaving refused candidates in the text."""
+        out: list[str] = []
+        cursor = 0
+        for match in self.finditer(text):
+            out.append(text[cursor : match.start()])
+            out.append(repl)
+            cursor = match.end()
+        out.append(text[cursor:])
+        return "".join(out)
+
+
+#: The marker matchers callers use. Same four members as the patterns they wrap,
+#: so the grammar and the balance decision can never be applied separately.
+OPTIONS_RE_LINE = _MarkerMatcher(_RAW_OPTIONS_RE_LINE)
+OPTIONS_RE_TRAILER = _MarkerMatcher(_RAW_OPTIONS_RE_TRAILER)
 
 # CONTROL-TAG HTML COMMENTS — canonical grammar (single source of truth).
 #

--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -265,11 +265,13 @@ _MARKER_WRAP_CLASS = "[" + re.escape(MARKER_WRAPPERS) + "]"
 #: ``]`` -- see the gate in ``messaging.renderer.split_options_trailer``, which
 #: this rule is what made load-bearing.
 #:
-#: NOT reachable by this rule, and deliberately unchanged: the separator-tail
-#: form (``Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]``). ``], ``
-#: DOES continue the list, by the very rule that makes ``[OPTIONS: Alpha ],
-#: Bravo]`` legal, so no guard applied at the internal closer can tell them
-#: apart. Resolving it means deciding which shape loses -- a separate call.
+#: NOT reachable by this rule: the separator-tail form (``Done. [OPTIONS: Merge |
+#: Wait], details in CHANGELOG[1]``). ``], `` DOES continue the list, by the very
+#: rule that makes ``[OPTIONS: Alpha ], Bravo]`` legal, so no guard applied at the
+#: INTERNAL closer can tell them apart. What decides that shape is the terminator
+#: gate on the bare opener (see :data:`_MARKER_BARE_OPENER_GATE_LINE`), which
+#: reaches it from the other end -- the ``[`` of ``CHANGELOG[1]`` is the opener
+#: whose partner would end the marker, so the line is declined and left whole.
 _MARKER_LABEL_CONTINUES = rf"(?=[ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
 
 #: A closer MATCHED by a ``[`` earlier in the same label. One level deep, and its
@@ -294,6 +296,77 @@ _MARKER_LABEL_PAIR = (
     rf"(?![ \t]*[|,]|{_MARKER_CLOSE_CLASS})"
 )
 
+#: A bare opener may not be the one whose partner closer ENDS the marker.
+#:
+#: The bare-``[`` alternative exists so a stray opener inside a label does not
+#: sink the whole marker: ``[OPTIONS: Fix [x logging | Skip]`` parses, and is
+#: tested. But nothing about it distinguishes that opener from the one in
+#: ``[OPTIONS: A | B then check arr[0]``, where the marker was never closed and
+#: the ``]`` of ``arr[0]`` is the only closer on the line. There the body ran on
+#: through the prose, that ``]`` became the terminator, and since every consumer
+#: removes the whole match, the line was deleted from the message and came back
+#: as the label ``B then check arr[0``.
+#:
+#: What separates the two is where the opener sits relative to the END, not the
+#: brackets themselves -- the two shapes are otherwise identical token for token,
+#: which is why no rule over bracket structure alone can tell them apart. So the
+#: bare form is refused exactly when nothing but ordinary text lies between it
+#: and a closer at the end anchor: that closer is then its partner rather than
+#: the marker's, and the marker is unterminated.
+#:
+#: Crossing ``|`` clears the gate, because that is the unambiguous option
+#: separator: the opener is inside a label and the list continues past it, which
+#: is what keeps the pinned stray-opener shape. Crossing another BRACKET clears it
+#: too, because some other bracket form owns that closer -- which is what keeps
+#: ``[OPTIONS: Fix arr[0] | Skip]`` (the continuation half admits that ``]``) and
+#: ``[OPTIONS: a[1] | b[2]]`` parsing.
+#:
+#: ``,`` does NOT clear it, and that asymmetry is the whole reason the scan can
+#: find the partner closer at all. A comma is only a FALLBACK separator -- the
+#: frontend's ``parseOptions`` reaches for it just when no ``|`` is present -- and
+#: inside brackets it is ordinary punctuation, which models write constantly:
+#: ``dict[str, Any]``, ``arr[i, j]``. A scan that stopped at it halted before the
+#: closer in ``[OPTIONS: A | B then inspect dict[str, int]`` and cleared the gate,
+#: leaving exactly the shape this exists to refuse.
+#:
+#: Spelled twice because the two bodies end differently and, more importantly,
+#: because they differ on NEWLINES. LINE stops at one; TRAILER spans them under
+#: DOTALL, so its scan has to as well -- otherwise a ``\n`` blinds the gate and
+#: ``[OPTIONS: A | B then check arr[0\nAnd that is all]`` walks straight through
+#: it. The scan must see as far as the body can reach, or it is not looking at the
+#: same terminator. Both carry the optional stray markdown-link tic and a wrapper
+#: run, so a marker wearing either still gates on the closer its tail consumes;
+#: both reuse the tail's own constants below rather than respelling them.
+#:
+#: WHAT THIS DOES NOT CLOSE. The gate clears when the scan meets another bracket,
+#: on the grounds that some other bracket form owns that closer. With NESTING at
+#: the end of the line that reasoning fails: in ``[OPTIONS: A | B then inspect
+#: list[dict[str, int]]`` the outer opener's partner IS the terminator, but the
+#: scan halts at the inner ``[`` and never reaches it. Encoding one level of
+#: nesting here only moves the boundary -- depth three defeats that, depth four
+#: the next one. The condition being reached for is "the terminating closer is not
+#: nested", which is bracket BALANCE, and balance is not a regular language at
+#: unbounded depth. Closing it means the check cannot live in this pattern at all;
+#: the residual is pinned at the depth where the gate stops reaching, in
+#: ``test_options_marker_terminator.py``.
+#:
+#: ReDoS: the lookahead is TEMPERED -- its scan stops at the first bracket or
+#: ``|``, so the runs scanned from different openers are disjoint and the total
+#: work stays linear. It adds no quantifier over a quantifier, which is the shape
+#: the frontend's ``.source`` pin forbids.
+_MARKER_TERMINATOR_SCAN_LINE = rf"[^[{re.escape(MARKER_CLOSERS)}|\n]*"
+_MARKER_TERMINATOR_SCAN_TRAILER = rf"[^[{re.escape(MARKER_CLOSERS)}|]*"
+_MARKER_STRAY_TIC = r"(?:\([^\s()]*\))?"
+_MARKER_WRAP_RUN = rf"{_MARKER_WRAP_CLASS}{{0,3}}"
+_MARKER_BARE_OPENER_GATE_LINE = (
+    rf"(?!{_MARKER_TERMINATOR_SCAN_LINE}{_MARKER_CLOSE_CLASS}"
+    rf"{_MARKER_STRAY_TIC}{_MARKER_WRAP_RUN}[ \t]*$)"
+)
+_MARKER_BARE_OPENER_GATE_TRAILER = (
+    rf"(?!{_MARKER_TERMINATOR_SCAN_TRAILER}{_MARKER_CLOSE_CLASS}"
+    rf"{_MARKER_STRAY_TIC}{_MARKER_WRAP_RUN}\s*\Z)"
+)
+
 #: Label body, spelled once per regex so LINE and TRAILER cannot drift. LINE
 #: stops at a newline; TRAILER spans them (``DOTALL``, as the old ``.*`` did).
 #: The one body-shaped pattern NOT derived from these is
@@ -308,12 +381,12 @@ _MARKER_LABEL_PAIR = (
 #: closer. So there is never more than one way to consume a character, and each
 #: lookahead is entered only at a bracket and bounded by the run it scans.
 _MARKER_BODY_LINE = (
-    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:)"
+    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:){_MARKER_BARE_OPENER_GATE_LINE}"
     rf"|{_MARKER_CLOSE_CLASS}{_MARKER_LABEL_CONTINUES}"
     rf"|[^[{re.escape(MARKER_CLOSERS)}\n])*"
 )
 _MARKER_BODY_TRAILER = (
-    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:)"
+    rf"(?:{_MARKER_LABEL_PAIR}|\[(?!OPTIONS:){_MARKER_BARE_OPENER_GATE_TRAILER}"
     rf"|{_MARKER_CLOSE_CLASS}{_MARKER_LABEL_CONTINUES}"
     rf"|[^[{re.escape(MARKER_CLOSERS)}])*"
 )
@@ -325,7 +398,7 @@ _MARKER_BODY_TRAILER = (
 OPTIONS_RE_LINE = re.compile(
     rf"(?:^[ \t]*(?P<lwrap>{_MARKER_WRAP_CLASS}{{1,3}}))?"
     rf"\[OPTIONS:(?P<labels>{_MARKER_BODY_LINE}){_MARKER_CLOSE_CLASS}"
-    rf"(?:\([^\s()]*\))?(?(lwrap){_MARKER_WRAP_CLASS}{{0,3}})[ \t]*$",
+    rf"{_MARKER_STRAY_TIC}(?(lwrap){_MARKER_WRAP_RUN})[ \t]*$",
     re.MULTILINE,
 )
 
@@ -342,7 +415,7 @@ OPTIONS_RE_LINE = re.compile(
 OPTIONS_RE_TRAILER = re.compile(
     rf"(?:^[ \t]*(?P<lwrap>{_MARKER_WRAP_CLASS}{{1,3}}))?"
     rf"\[OPTIONS:(?P<labels>{_MARKER_BODY_TRAILER}){_MARKER_CLOSE_CLASS}"
-    rf"(?:\([^\s()]*\))?(?(lwrap){_MARKER_WRAP_CLASS}{{0,3}})\s*\Z",
+    rf"{_MARKER_STRAY_TIC}(?(lwrap){_MARKER_WRAP_RUN})\s*\Z",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/test/test_options_marker_label_closers.py
+++ b/test/test_options_marker_label_closers.py
@@ -135,13 +135,23 @@ class TestACloserMustBeMatchedOrContinueTheList:
             assert match is not None, text
             assert match.group("labels").startswith(" Fix "), text
 
-    def test_an_unmatched_opener_in_a_label_still_parses(self):
-        # The pair alternative must not become a REQUIREMENT: a stray ``[`` with no
-        # closer of its own is still just a character in the label, as it was
-        # before this rule.
-        match = OPTIONS_RE_LINE.search("[OPTIONS: Fix [x logging | Skip]")
-        assert match is not None
-        assert match.group("labels") == " Fix [x logging | Skip"
+    def test_an_unmatched_opener_in_a_label_is_refused(self):
+        """The one shape the balanced-labels rule costs.
+
+        A stray ``[`` with no closer of its own cannot be treated as ordinary label
+        text, because that shape is indistinguishable from a marker the model never
+        closed: in ``[OPTIONS: A | B then check arr[0]`` the only closer belongs to
+        ``arr[0]``, and the body would run through the prose to reach it. Both hold
+        one unmatched opener and a closer at the end anchor, so accepting either
+        accepts both -- and accepting the second deletes a line of prose.
+
+        So the marker now renders as visible text. Nothing is removed, which is the
+        direction every cost in this grammar fails in, and the full argument lives at
+        :func:`kiro_crew.constants._marker_labels_have_unmatched_opener`.
+        """
+        text = "[OPTIONS: Fix [x logging | Skip]"
+        assert OPTIONS_RE_LINE.search(text) is None
+        assert OPTIONS_RE_LINE.sub("", text) == text
 
 
 class TestAcceptedCosts:

--- a/test/test_options_marker_label_closers.py
+++ b/test/test_options_marker_label_closers.py
@@ -228,17 +228,21 @@ class TestAcceptedCosts:
         # here, and neither does this one.
         assert OPTIONS_RE_LINE.search("Note [OPTIONS: see [OPTIONS: x] below | Skip]") is None
 
-    def test_the_separator_tail_form_is_out_of_scope_and_unchanged(self):
-        # NOT reachable by this rule, and pinned so it is not read as a regression
-        # introduced here: ``], `` DOES continue the label list, by the very rule
-        # that makes ``[OPTIONS: Alpha ], Bravo]`` legal, so no guard applied at the
-        # internal closer can tell the two apart. Resolving it means deciding which
-        # shape loses -- a separate call with its own cost. Behaviour here is
-        # byte-for-byte what origin/main does.
+    def test_the_separator_tail_form_is_declined_rather_than_truncated(self):
+        # Not reachable by the matched-or-continues rule: ``], `` DOES continue the
+        # label list, by the very rule that makes ``[OPTIONS: Alpha ], Bravo]``
+        # legal, so no guard applied at the INTERNAL closer can tell the two apart.
+        # The terminator gate reaches it from the other end -- the ``[`` of
+        # ``CHANGELOG[1]`` is the opener whose partner would end the marker, so the
+        # bare form is refused and the line stays whole.
+        #
+        # Declining is the affordable outcome: truncating deleted ``, details in
+        # CHANGELOG[1]`` from the message and handed it back as the pill label
+        # ``Wait], details in CHANGELOG[1``.
         text = "Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]"
-        match = OPTIONS_RE_LINE.search(text)
-        assert match is not None
-        assert OPTIONS_RE_LINE.sub("", text) == "Done. "
+        assert OPTIONS_RE_LINE.search(text) is None
+        assert OPTIONS_RE_LINE.sub("", text) == text
+        assert split_options_trailer(text) == (text, [])
 
 
 class TestTheWideningIsNotOverlyNarrow:

--- a/test/test_options_marker_terminator.py
+++ b/test/test_options_marker_terminator.py
@@ -1,60 +1,52 @@
-"""A bare opener may not be the one whose partner closer ENDS the marker.
+"""The terminating closer must not be an unmatched opener's PARTNER.
 
-The bare-``[`` alternative in the label body exists so a stray opener does not sink
-a whole marker -- ``[OPTIONS: Fix [x logging | Skip]`` parses, and is pinned in
-``test_options_marker_label_closers.py``. But that alternative also admitted the
-opener in a marker the model never closed::
+The label body admits a bare ``[`` on purpose, so a stray opener inside a label does
+not sink the marker -- ``[OPTIONS: Fix [x logging | Skip]`` parses, and is pinned in
+``test_options_marker_label_closers.py``. That same alternative admitted the opener
+in a marker the model never closed::
 
     [OPTIONS: A | B then check arr[0]
 
-Here the only closer on the line is the one belonging to ``arr[0]``. The body ran
-on through the prose, that ``]`` became the marker's terminator, and because every
-consumer removes the whole match -- ``parse_options`` replaces, ``slack.format`` and
-``messaging.renderer`` cut at ``match.start()``, and ``whatsapp.turn_renderer``
-PERSISTS the cut turn -- the line was deleted from the message and came back as the
-pill label ``B then check arr[0``.
+The only closer on that line belongs to ``arr[0]``. The body ran on through the
+prose, that ``]`` became the terminator, and because every consumer removes the
+whole match -- ``parse_options`` replaces, ``slack.format`` and ``messaging.renderer``
+cut at ``match.start()``, and ``whatsapp.turn_renderer`` PERSISTS the cut turn -- the
+line was deleted from the message and came back as the pill label
+``B then check arr[0``.
 
-WHY NO BRACKET RULE CAN SEPARATE THEM. Reduce both to their bracket/separator
-skeleton and they are the same string::
+WHY THE PATTERN CANNOT DECIDE IT. Reduce the shape that must be REFUSED and the one
+that must be ACCEPTED to their bracket structure and they are the same string::
 
     [OPTIONS: Fix | Skip [x logging]        ->  w|w[w]
     [OPTIONS: A | B then check arr[0]       ->  w|w[w]
 
-So the discriminator cannot be the brackets. It is WHERE the opener sits relative
-to the END: the bare form is refused exactly when nothing but ordinary text lies
-between it and a closer sitting at the end anchor, because that closer is then its
-own partner rather than the marker's, which means the marker is unterminated.
+So no rule over brackets alone separates them. And a lookahead inside the pattern
+can only see one nesting level: ``list[dict[str, int]]`` defeats a one-level rule and
+``a[b[c[d]]]`` defeats a two-level one. The condition wanted is "the terminator is
+not nested", which is bracket BALANCE -- not a regular language at unbounded depth.
 
-Crossing ``|`` clears the gate -- the opener is inside a label and the list
-continues past it, which is what keeps the pinned stray-opener shape. Crossing
-another BRACKET clears it too, because some other bracket form owns that closer,
-which is what keeps ``[OPTIONS: Fix arr[0] | Skip]`` (continuation admits the
-``]``) and ``[OPTIONS: a[1] | b[2]]``.
-
-``,`` does NOT clear it. A comma is only the fallback separator -- the frontend's
-``parseOptions`` reaches for it just when no ``|`` is present -- and inside brackets
-it is ordinary punctuation, so a scan that stopped there halted before the closer
-in ``[OPTIONS: A | B then inspect dict[str, int]`` and cleared the gate.
-
-The boundary this does NOT reach is nesting at the end of the line; see
-:class:`TestTheResidualThisGateCannotClose` for why no regex closes it.
+So the decision lives OUTSIDE the pattern, in
+:func:`kiro_crew.constants._marker_labels_have_unmatched_opener`, and the raw patterns are
+private so no caller can obtain an unchecked match. What callers get is
+:data:`OPTIONS_RE_LINE` / :data:`OPTIONS_RE_TRAILER`, which apply both.
 
 Two claims are asserted separately throughout, as elsewhere in this grammar's
-suites, because only the second is what a user experiences: that the pattern does
-not MATCH, and that the visible text is UNCHANGED.
+suites, because only the second is what a user experiences: that no marker is
+FOUND, and that the visible text is UNCHANGED.
 """
 
 from __future__ import annotations
 
-import re
 import time
 
 import pytest
 
 from kiro_crew.constants import (
+    _RAW_OPTIONS_RE_LINE,
     MARKER_CLOSERS,
     OPTIONS_RE_LINE,
     OPTIONS_RE_TRAILER,
+    _marker_labels_have_unmatched_opener,
 )
 from kiro_crew.messaging.renderer import split_options_trailer
 
@@ -71,129 +63,176 @@ def skeleton(text: str) -> str:
     return "".join(out)
 
 
-class TestAnUnterminatedMarkerNoLongerEatsItsLine:
+class TestAnUnterminatedMarkerDoesNotEatItsLine:
     @pytest.mark.parametrize(
         "text",
         [
             "[OPTIONS: A | B then check arr[0]",
             "[OPTIONS: Ship | Hold and read docs[4]",
             "[OPTIONS: Merge | Wait then diff src/app[3]",
-            # The wrapper and stray-tic forms reach the same terminator, so the gate
-            # has to account for both or the shape simply comes back wearing one.
-            "**[OPTIONS: A | B then check arr[0]**",
-            "[OPTIONS: A | B then check arr[0](OPTIONS)",
-            # A COMMA INSIDE the terminal bracket. The scan has to cross it to reach
-            # the partner closer: a comma is only the fallback separator, and inside
-            # brackets it is ordinary punctuation, so a scan that stopped there
-            # halted before the closer and cleared the gate.
+            # A comma INSIDE the terminal bracket: ordinary punctuation, not a label
+            # boundary, so it must not rescue the shape.
             "[OPTIONS: A | B then inspect dict[str, int]",
             "[OPTIONS: Ship | Hold then arr[i, j]",
+            # The wrapper and stray-tic forms reach the same terminator, so the check
+            # has to survive both or the shape returns wearing one.
+            "**[OPTIONS: A | B then check arr[0]**",
+            "[OPTIONS: A | B then check arr[0](OPTIONS)",
         ],
     )
-    def test_it_is_declined(self, text: str):
+    def test_it_is_refused(self, text: str):
         assert OPTIONS_RE_LINE.search(text) is None, text
 
     @pytest.mark.parametrize(
         "text",
         [
             "[OPTIONS: A | B then check arr[0]",
-            "[OPTIONS: Ship | Hold and read docs[4]",
+            "[OPTIONS: A | B then inspect dict[str, int]",
         ],
     )
     def test_and_therefore_deletes_nothing(self, text: str):
-        # The claim that matters. Asserted at the consumer, not only at the regex,
-        # because removing the match is what deleted the line.
+        # The claim that matters, asserted at the consumer: removing the match is
+        # what deleted the line.
         assert OPTIONS_RE_LINE.sub("", text) == text, text
         assert split_options_trailer(text) == (text, []), text
 
-    def test_the_trailer_grammar_declines_it_too(self):
+    def test_nesting_of_ANY_depth_is_refused(self):
+        """The part a lookahead in the pattern could never reach.
+
+        Each of these defeats a rule that looks one level deeper than the last, which
+        is why the check counts depth instead of matching a shape.
+        """
+        for depth in range(1, 7):
+            inner = "x"
+            for _ in range(depth):
+                inner = f"a[{inner}]"
+            text = f"[OPTIONS: A | B then see {inner}"[:-1]
+            assert OPTIONS_RE_LINE.search(text) is None, (depth, text)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "[OPTIONS: A | B then inspect list[dict[str, int]]",
+            "[OPTIONS: A | B then inspect a[b[c[d]]]",
+            "[OPTIONS: A | B see a[b[c[d[e]]]]",
+        ],
+    )
+    def test_the_reported_nested_shapes_are_refused_and_nothing_is_deleted(self, text: str):
+        assert OPTIONS_RE_LINE.search(text) is None, text
+        assert OPTIONS_RE_LINE.sub("", text) == text, text
+
+    def test_the_trailer_grammar_refuses_it_too(self):
         # The TRAILER body spans newlines under DOTALL, so its blast radius was a
-        # paragraph rather than a line. Its gate is anchored on ``\\s*\\Z``.
+        # paragraph rather than a line.
         text = "Here are your choices.\n\n[OPTIONS: A | B then check arr[0]"
         assert OPTIONS_RE_TRAILER.search(text) is None
         assert OPTIONS_RE_TRAILER.sub("", text) == text
 
-    def test_the_trailer_gate_sees_ACROSS_a_newline(self):
-        """The TRAILER scan must span newlines, because its body does.
-
-        A scan that stopped at ``\\n`` is blinded the moment the prose wraps: the
-        opener is on one line and its partner closer on the next, the gate finds no
-        closer before the newline and clears, and the body -- which spans newlines
-        under DOTALL -- runs on to that closer anyway. The scan has to see as far as
-        the body can reach or it is not looking at the same terminator.
-        """
+    def test_the_trailer_check_reaches_across_a_newline(self):
+        # A pattern-level scan that stopped at ``\\n`` was blinded the moment the
+        # prose wrapped. Counting depth over the captured labels has no such blind
+        # spot, because the labels already span the newlines the body crossed.
         text = "[OPTIONS: A | B then check arr[0\nAnd that is all]"
         assert OPTIONS_RE_TRAILER.search(text) is None
-        assert OPTIONS_RE_TRAILER.sub("", text) == text
         assert split_options_trailer(text) == (text, [])
 
-    def test_the_LINE_scan_stops_at_a_newline_because_its_body_does(self):
-        # The mirror of the above, so the asymmetry between the two scans is pinned
-        # rather than looking like an oversight: the LINE body cannot cross a newline,
-        # so neither should its scan, and the shape above is simply not a LINE match.
-        assert "|\\n]*" in OPTIONS_RE_LINE.pattern
-        assert "|\\n]*" not in OPTIONS_RE_TRAILER.pattern
-
-    def test_a_marker_with_no_closer_at_all_is_still_declined(self):
-        # The neighbouring shape, unchanged: with no closer anywhere the end anchor
-        # was never satisfiable, so this never matched and still does not.
+    def test_a_marker_with_no_closer_at_all_is_still_refused(self):
+        # Unchanged: with no closer anywhere the end anchor was never satisfiable.
         assert OPTIONS_RE_LINE.search("[OPTIONS: A | B then check arr") is None
 
+    def test_the_separator_tail_form_is_refused_rather_than_truncated(self):
+        # Documented in ``constants.py`` as unresolved, because ``], `` genuinely
+        # continues the list and no guard at the INTERNAL closer can tell it apart.
+        # Counting from the other end decides it: the ``[`` of ``CHANGELOG[1]`` is
+        # still open at the end of the labels and no ``|`` follows it.
+        text = "Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]"
+        assert OPTIONS_RE_LINE.search(text) is None
+        assert OPTIONS_RE_LINE.sub("", text) == text
+        assert split_options_trailer(text) == (text, [])
 
-class TestTheDiscriminatorIsNotBracketStructure:
-    """Pinned because it is the reason the gate is shaped the way it is.
 
-    If someone later replaces this with a bracket-balance rule, these assertions
-    are what say why that cannot work: the shape the grammar must ACCEPT and the
-    shape it must REFUSE have identical bracket structure.
+class TestTheDecisionCannotLiveInThePattern:
+    """Pinned because it is the reason for the indirection.
+
+    If someone later folds this back into the regex, these are the assertions that
+    say why it cannot work.
     """
 
-    def test_the_two_shapes_share_a_skeleton(self):
-        refused = "[OPTIONS: A | B then check arr[0]"
-        accepted = "[OPTIONS: Fix | Skip [x logging]"
-        assert skeleton(refused) == skeleton(accepted) == "w|w[w]"
+    def test_the_refused_and_accepted_shapes_share_a_skeleton(self):
+        assert skeleton("[OPTIONS: A | B then check arr[0]") == "w|w[w]"
+        assert skeleton("[OPTIONS: Fix | Skip [x logging]") == "w|w[w]"
 
-    def test_and_are_nonetheless_decided_differently(self):
-        # ...because the gate reads the run between the opener and the end anchor,
-        # not the bracket nesting. Both of these end in a closer at the anchor, and
-        # both hold one unmatched opener; only the CONTENT of that run differs.
-        assert OPTIONS_RE_LINE.search("[OPTIONS: A | B then check arr[0]") is None
-        # The accepted twin is the un-pinned tail of the stray-opener family; it is
-        # given up by the same rule, and that is the cost recorded below.
-        assert OPTIONS_RE_LINE.search("[OPTIONS: Fix | Skip [x logging]") is None
+    def test_a_separator_after_the_opener_cannot_save_it_either(self):
+        """Why the rule is TOTAL rather than carrying an escape hatch.
 
-    def test_the_pinned_stray_opener_shape_is_the_one_that_survives(self):
-        # A separator after the opener is what clears the gate, and it is exactly
-        # what distinguishes the supported shape: the opener is inside a label and
-        # the list continues past it.
-        match = OPTIONS_RE_LINE.search("[OPTIONS: Fix [x logging | Skip]")
-        assert match is not None
-        assert match.group("labels") == " Fix [x logging | Skip"
-        assert skeleton("[OPTIONS: Fix [x logging | Skip]") == "w[w|w]"
+        The hatch was "an unmatched opener is label text if a ``|`` follows it", and
+        it was defeated three times. The last one is the clearest: a ``|`` INSIDE the
+        unmatched bracket satisfies it, so ``dict[str | int]`` at the end of a line
+        readmitted the whole defect.
+
+        And it could not be narrowed, because the shape it protected and the shape it
+        readmitted differ only in where a ``|`` sits relative to an opener that has no
+        closer -- which is to say, not structurally at all.
+        """
+        for text in (
+            "[OPTIONS: Fix [x logging | Skip]",  # the hatch protected this
+            "[OPTIONS: A | B then inspect dict[str | int]",  # ...and readmitted this
+        ):
+            assert OPTIONS_RE_LINE.search(text) is None, text
+            assert OPTIONS_RE_LINE.sub("", text) == text, text
+
+    def test_the_raw_pattern_still_over_matches_which_is_why_it_is_private(self):
+        # The candidate pattern on its own accepts the shape; only the matcher
+        # refuses it. Asserted so that "just use the regex" is visibly not an option.
+        text = "[OPTIONS: A | B then check arr[0]"
+        assert _RAW_OPTIONS_RE_LINE.search(text) is not None
+        assert OPTIONS_RE_LINE.search(text) is None
+
+
+class TestTheBalanceRuleDirectly:
+    @pytest.mark.parametrize(
+        ("labels", "nested"),
+        [
+            (" A | B then check arr[0", True),
+            (" A | B then inspect list[dict[str, int]", True),
+            (" A | B then inspect dict[str | int", True),  # a `|` inside the bracket
+            (" Fix [x logging | Skip", True),  # a `|` after it changes nothing
+            (" Fix arr[0] | Skip", False),  # balanced
+            (" a[1] | b[2]", False),  # balanced
+            (" Alpha ] | Bravo ]", False),  # unmatched CLOSERS say nothing
+            (" Yes | No", False),  # no brackets
+            (" A | B then check arr", False),  # no opener
+            (" Merge | Wait], details in CHANGELOG[1", True),
+            (" 见【表1】说明 | 跳过", False),  # a lookalike closer closes nothing here
+        ],
+    )
+    def test_the_rule_in_isolation(self, labels: str, nested: bool):
+        assert _marker_labels_have_unmatched_opener(labels) is nested
 
 
 class TestWhatMustNotHaveChanged:
     @pytest.mark.parametrize(
         ("text", "labels"),
         [
-            # A closer admitted by CONTINUATION, whose opener therefore is not the
-            # terminator's partner. The gate must not reach these.
+            # A closer admitted by CONTINUATION, so its opener is closed by the time
+            # the labels end.
             ("[OPTIONS: Fix arr[0] | Skip]", " Fix arr[0] | Skip"),
             ("[OPTIONS: a[1] | b[2]]", " a[1] | b[2]"),
             ("[OPTIONS: Fix list[dict[str, Any]] | Skip]", " Fix list[dict[str, Any]] | Skip"),
-            # Matched pairs, which own their own closer.
+            # Matched pairs own their own closer.
             ("[OPTIONS: Fix [x] logging | Skip]", " Fix [x] logging | Skip"),
             ("[OPTIONS: Read arr[0] now | Skip it]", " Read arr[0] now | Skip it"),
             ("[OPTIONS: See [1] above | Skip]", " See [1] above | Skip"),
             ("[OPTIONS: Fix dict[str, Any] now | Skip]", " Fix dict[str, Any] now | Skip"),
-            # No opener at all, so no gate applies.
+            ("[OPTIONS: Refactor arr[i, j] now | Skip]", " Refactor arr[i, j] now | Skip"),
+            # No opener at all, so nothing to be unbalanced.
             ("[OPTIONS: Alpha ] | Bravo ]]", " Alpha ] | Bravo ]"),
             ("[OPTIONS: Alpha ], Bravo]", " Alpha ], Bravo"),
             ("[OPTIONS: Yes | No]", " Yes | No"),
             ("**[OPTIONS: Yes | No]**", " Yes | No"),
             ("[OPTIONS: A | B](OPTIONS)", " A | B"),
-            # Prose ending in a closer with no opener: the closer genuinely IS the
-            # marker's, so this parses, as it did before.
+            # Prose ending in a closer with no opener: that closer genuinely IS the
+            # marker's, so this parses as it did before.
             ("[OPTIONS: A | B then check arr]", " A | B then check arr"),
         ],
     )
@@ -211,17 +250,32 @@ class TestWhatMustNotHaveChanged:
             "Note [OPTIONS: see [OPTIONS: x] below | Skip]",
         ],
     )
-    def test_every_previously_declined_shape_still_declines(self, text: str):
+    def test_every_previously_refused_shape_still_is(self, text: str):
         assert OPTIONS_RE_LINE.search(text) is None, text
+
+    def test_sub_removes_an_accepted_marker_and_leaves_a_refused_one(self):
+        # ``sub`` is reimplemented on the matcher, so its two behaviours are pinned:
+        # it removes what it accepts and leaves what it refuses.
+        assert OPTIONS_RE_LINE.sub("", "Done.\n[OPTIONS: A | B]") == "Done.\n"
+        refused = "Done.\n[OPTIONS: A | B then arr[0]"
+        assert OPTIONS_RE_LINE.sub("", refused) == refused
+
+    def test_finditer_yields_every_accepted_marker_in_order(self):
+        text = "[OPTIONS: A | B]\n[OPTIONS: C | D]"
+        assert [m.group("labels") for m in OPTIONS_RE_LINE.finditer(text)] == [" A | B", " C | D"]
+
+    def test_a_refused_candidate_does_not_hide_a_later_accepted_one(self):
+        # The body refuses a nested ``[OPTIONS:``, so a candidate never contains
+        # another head -- which is what makes filtering candidates safe.
+        text = "[OPTIONS: A then arr[0]\n[OPTIONS: C | D]"
+        assert [m.group("labels") for m in OPTIONS_RE_LINE.finditer(text)] == [" C | D"]
 
 
 class TestTheCost:
-    """What the gate gives up, enumerated rather than summarised.
+    """A stray opener in the FINAL label, where no ``|`` follows to make it text.
 
-    One family: a stray opener in the FINAL label, where no separator follows to
-    clear the gate. It fails toward a VISIBLE marker rather than a deleted line,
-    which is what makes it affordable -- and it is the same direction every other
-    cost in this grammar fails in.
+    It fails toward a VISIBLE marker with nothing removed -- the direction every cost
+    in this grammar fails in -- and that is what makes it affordable.
     """
 
     @pytest.mark.parametrize(
@@ -229,77 +283,30 @@ class TestTheCost:
         [
             "[OPTIONS: Fix | Skip [x logging]",
             "[OPTIONS: Fix [x logging]",
-            # And the comma variant: only a COMMA follows the stray opener, which
-            # does not clear the gate, so this joins the same family. It is the price
-            # of seeing through ``dict[str, int]`` to its closer.
+            # Only a comma follows, and a comma is not enough.
             "[OPTIONS: Fix [x logging, Skip]",
         ],
     )
-    def test_a_stray_opener_in_the_final_label_is_given_up(self, text: str):
+    def test_it_is_given_up_without_deleting_anything(self, text: str):
         assert OPTIONS_RE_LINE.search(text) is None, text
-        # Affordable because nothing is removed.
         assert OPTIONS_RE_LINE.sub("", text) == text, text
         assert split_options_trailer(text) == (text, []), text
 
 
-class TestTheResidualThisGateCannotClose:
-    """NESTED terminal brackets still reach the terminator, and no regex can stop it.
-
-    The gate clears when the scan meets another bracket, on the grounds that some
-    other bracket form owns that closer. With nesting at the end of the line that
-    reasoning fails: in ``list[dict[str, int]]`` the OUTER opener's partner is the
-    final ``]``, which is the terminator, but the scan halts at the inner ``[`` and
-    never sees it.
-
-    Encoding one level of nesting into the scan only moves the boundary -- depth
-    three defeats that, depth four the next one, and so on. The condition the gate
-    is reaching for is "the terminating closer is not nested", which is bracket
-    BALANCE, and balance is not expressible as a regular expression at unbounded
-    depth. Closing it means the check cannot live in the pattern at all.
-
-    Pinned so the boundary is a named, measured residual rather than a surprise:
-    depth one is fixed, depth two and beyond behave as they do on main.
-    """
-
-    @pytest.mark.parametrize(
-        "text",
-        [
-            "[OPTIONS: A | B then inspect list[dict[str, int]]",
-            "[OPTIONS: A | B then inspect list[dict[x]]",
-            "[OPTIONS: A | B then inspect a[b[c[d]]]",
-        ],
-    )
-    def test_nested_terminal_brackets_still_match(self, text: str):
-        # NOT an assertion that this is desirable -- it is the residual, recorded at
-        # the depth where the gate stops reaching. If a future change closes it, this
-        # test should flip and the docstring above should go with it.
-        assert OPTIONS_RE_LINE.search(text) is not None, text
-
-    def test_depth_one_is_the_part_that_is_fixed(self):
-        # The boundary, either side of it, in one place.
-        assert OPTIONS_RE_LINE.search("[OPTIONS: A | B then inspect dict[str, int]") is None
-        assert (
-            OPTIONS_RE_LINE.search("[OPTIONS: A | B then inspect list[dict[str, int]]") is not None
-        )
-
-
-class TestLinearity:
-    def test_the_gate_scan_is_tempered(self):
-        # Read off the compiled pattern so the claim cannot drift from the comment:
-        # the scan stops at the first bracket or ``|``, which is what keeps the runs
-        # scanned from different openers disjoint and the total work linear.
-        assert f"[^[{re.escape(MARKER_CLOSERS)}|\\n]*" in OPTIONS_RE_LINE.pattern
-        assert f"[^[{re.escape(MARKER_CLOSERS)}|]*" in OPTIONS_RE_TRAILER.pattern
-
-    def test_it_adds_no_quantifier_over_a_quantifier(self):
-        # The shape that backtracks exponentially, and the one the frontend's
-        # ``.source`` pin also forbids.
-        assert re.search(r"\([^)]*[+*]\)[+*]", OPTIONS_RE_LINE.pattern) is None
+class TestCost:
+    def test_the_check_is_linear_in_the_label_length(self):
+        # One pass over the labels with a stack, so an adversarial run of openers is
+        # linear rather than quadratic. Pinned by timing because the stack depth is
+        # the only thing that grows.
+        labels = "a[" * 200_000
+        started = time.perf_counter()
+        assert _marker_labels_have_unmatched_opener(labels) is True
+        assert time.perf_counter() - started < 1.0
 
     @pytest.mark.parametrize("reps", [2_000, 10_000, 40_000])
-    def test_many_bare_openers_stay_linear(self, reps: int):
-        # The adversarial shape for this gate specifically: one lookahead entered
-        # per opener, on an unterminated marker so every one of them fails.
+    def test_matching_stays_linear(self, reps: int):
+        # The adversarial shape: an unterminated marker made of bare openers, so the
+        # pattern scans it all and the check walks it all.
         src = "[OPTIONS:" + ("a[b" * reps)
         started = time.perf_counter()
         assert OPTIONS_RE_LINE.search(src) is None

--- a/test/test_options_marker_terminator.py
+++ b/test/test_options_marker_terminator.py
@@ -1,0 +1,307 @@
+"""A bare opener may not be the one whose partner closer ENDS the marker.
+
+The bare-``[`` alternative in the label body exists so a stray opener does not sink
+a whole marker -- ``[OPTIONS: Fix [x logging | Skip]`` parses, and is pinned in
+``test_options_marker_label_closers.py``. But that alternative also admitted the
+opener in a marker the model never closed::
+
+    [OPTIONS: A | B then check arr[0]
+
+Here the only closer on the line is the one belonging to ``arr[0]``. The body ran
+on through the prose, that ``]`` became the marker's terminator, and because every
+consumer removes the whole match -- ``parse_options`` replaces, ``slack.format`` and
+``messaging.renderer`` cut at ``match.start()``, and ``whatsapp.turn_renderer``
+PERSISTS the cut turn -- the line was deleted from the message and came back as the
+pill label ``B then check arr[0``.
+
+WHY NO BRACKET RULE CAN SEPARATE THEM. Reduce both to their bracket/separator
+skeleton and they are the same string::
+
+    [OPTIONS: Fix | Skip [x logging]        ->  w|w[w]
+    [OPTIONS: A | B then check arr[0]       ->  w|w[w]
+
+So the discriminator cannot be the brackets. It is WHERE the opener sits relative
+to the END: the bare form is refused exactly when nothing but ordinary text lies
+between it and a closer sitting at the end anchor, because that closer is then its
+own partner rather than the marker's, which means the marker is unterminated.
+
+Crossing ``|`` clears the gate -- the opener is inside a label and the list
+continues past it, which is what keeps the pinned stray-opener shape. Crossing
+another BRACKET clears it too, because some other bracket form owns that closer,
+which is what keeps ``[OPTIONS: Fix arr[0] | Skip]`` (continuation admits the
+``]``) and ``[OPTIONS: a[1] | b[2]]``.
+
+``,`` does NOT clear it. A comma is only the fallback separator -- the frontend's
+``parseOptions`` reaches for it just when no ``|`` is present -- and inside brackets
+it is ordinary punctuation, so a scan that stopped there halted before the closer
+in ``[OPTIONS: A | B then inspect dict[str, int]`` and cleared the gate.
+
+The boundary this does NOT reach is nesting at the end of the line; see
+:class:`TestTheResidualThisGateCannotClose` for why no regex closes it.
+
+Two claims are asserted separately throughout, as elsewhere in this grammar's
+suites, because only the second is what a user experiences: that the pattern does
+not MATCH, and that the visible text is UNCHANGED.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+from kiro_crew.constants import (
+    MARKER_CLOSERS,
+    OPTIONS_RE_LINE,
+    OPTIONS_RE_TRAILER,
+)
+from kiro_crew.messaging.renderer import split_options_trailer
+
+
+def skeleton(text: str) -> str:
+    """Bracket/separator structure, with every other run collapsed to ``w``."""
+    body = text[len("[OPTIONS:") :] if text.startswith("[OPTIONS:") else text
+    out: list[str] = []
+    for ch in body:
+        if ch in "[]|," or ch in MARKER_CLOSERS:
+            out.append(ch)
+        elif not out or out[-1] != "w":
+            out.append("w")
+    return "".join(out)
+
+
+class TestAnUnterminatedMarkerNoLongerEatsItsLine:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "[OPTIONS: A | B then check arr[0]",
+            "[OPTIONS: Ship | Hold and read docs[4]",
+            "[OPTIONS: Merge | Wait then diff src/app[3]",
+            # The wrapper and stray-tic forms reach the same terminator, so the gate
+            # has to account for both or the shape simply comes back wearing one.
+            "**[OPTIONS: A | B then check arr[0]**",
+            "[OPTIONS: A | B then check arr[0](OPTIONS)",
+            # A COMMA INSIDE the terminal bracket. The scan has to cross it to reach
+            # the partner closer: a comma is only the fallback separator, and inside
+            # brackets it is ordinary punctuation, so a scan that stopped there
+            # halted before the closer and cleared the gate.
+            "[OPTIONS: A | B then inspect dict[str, int]",
+            "[OPTIONS: Ship | Hold then arr[i, j]",
+        ],
+    )
+    def test_it_is_declined(self, text: str):
+        assert OPTIONS_RE_LINE.search(text) is None, text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "[OPTIONS: A | B then check arr[0]",
+            "[OPTIONS: Ship | Hold and read docs[4]",
+        ],
+    )
+    def test_and_therefore_deletes_nothing(self, text: str):
+        # The claim that matters. Asserted at the consumer, not only at the regex,
+        # because removing the match is what deleted the line.
+        assert OPTIONS_RE_LINE.sub("", text) == text, text
+        assert split_options_trailer(text) == (text, []), text
+
+    def test_the_trailer_grammar_declines_it_too(self):
+        # The TRAILER body spans newlines under DOTALL, so its blast radius was a
+        # paragraph rather than a line. Its gate is anchored on ``\\s*\\Z``.
+        text = "Here are your choices.\n\n[OPTIONS: A | B then check arr[0]"
+        assert OPTIONS_RE_TRAILER.search(text) is None
+        assert OPTIONS_RE_TRAILER.sub("", text) == text
+
+    def test_the_trailer_gate_sees_ACROSS_a_newline(self):
+        """The TRAILER scan must span newlines, because its body does.
+
+        A scan that stopped at ``\\n`` is blinded the moment the prose wraps: the
+        opener is on one line and its partner closer on the next, the gate finds no
+        closer before the newline and clears, and the body -- which spans newlines
+        under DOTALL -- runs on to that closer anyway. The scan has to see as far as
+        the body can reach or it is not looking at the same terminator.
+        """
+        text = "[OPTIONS: A | B then check arr[0\nAnd that is all]"
+        assert OPTIONS_RE_TRAILER.search(text) is None
+        assert OPTIONS_RE_TRAILER.sub("", text) == text
+        assert split_options_trailer(text) == (text, [])
+
+    def test_the_LINE_scan_stops_at_a_newline_because_its_body_does(self):
+        # The mirror of the above, so the asymmetry between the two scans is pinned
+        # rather than looking like an oversight: the LINE body cannot cross a newline,
+        # so neither should its scan, and the shape above is simply not a LINE match.
+        assert "|\\n]*" in OPTIONS_RE_LINE.pattern
+        assert "|\\n]*" not in OPTIONS_RE_TRAILER.pattern
+
+    def test_a_marker_with_no_closer_at_all_is_still_declined(self):
+        # The neighbouring shape, unchanged: with no closer anywhere the end anchor
+        # was never satisfiable, so this never matched and still does not.
+        assert OPTIONS_RE_LINE.search("[OPTIONS: A | B then check arr") is None
+
+
+class TestTheDiscriminatorIsNotBracketStructure:
+    """Pinned because it is the reason the gate is shaped the way it is.
+
+    If someone later replaces this with a bracket-balance rule, these assertions
+    are what say why that cannot work: the shape the grammar must ACCEPT and the
+    shape it must REFUSE have identical bracket structure.
+    """
+
+    def test_the_two_shapes_share_a_skeleton(self):
+        refused = "[OPTIONS: A | B then check arr[0]"
+        accepted = "[OPTIONS: Fix | Skip [x logging]"
+        assert skeleton(refused) == skeleton(accepted) == "w|w[w]"
+
+    def test_and_are_nonetheless_decided_differently(self):
+        # ...because the gate reads the run between the opener and the end anchor,
+        # not the bracket nesting. Both of these end in a closer at the anchor, and
+        # both hold one unmatched opener; only the CONTENT of that run differs.
+        assert OPTIONS_RE_LINE.search("[OPTIONS: A | B then check arr[0]") is None
+        # The accepted twin is the un-pinned tail of the stray-opener family; it is
+        # given up by the same rule, and that is the cost recorded below.
+        assert OPTIONS_RE_LINE.search("[OPTIONS: Fix | Skip [x logging]") is None
+
+    def test_the_pinned_stray_opener_shape_is_the_one_that_survives(self):
+        # A separator after the opener is what clears the gate, and it is exactly
+        # what distinguishes the supported shape: the opener is inside a label and
+        # the list continues past it.
+        match = OPTIONS_RE_LINE.search("[OPTIONS: Fix [x logging | Skip]")
+        assert match is not None
+        assert match.group("labels") == " Fix [x logging | Skip"
+        assert skeleton("[OPTIONS: Fix [x logging | Skip]") == "w[w|w]"
+
+
+class TestWhatMustNotHaveChanged:
+    @pytest.mark.parametrize(
+        ("text", "labels"),
+        [
+            # A closer admitted by CONTINUATION, whose opener therefore is not the
+            # terminator's partner. The gate must not reach these.
+            ("[OPTIONS: Fix arr[0] | Skip]", " Fix arr[0] | Skip"),
+            ("[OPTIONS: a[1] | b[2]]", " a[1] | b[2]"),
+            ("[OPTIONS: Fix list[dict[str, Any]] | Skip]", " Fix list[dict[str, Any]] | Skip"),
+            # Matched pairs, which own their own closer.
+            ("[OPTIONS: Fix [x] logging | Skip]", " Fix [x] logging | Skip"),
+            ("[OPTIONS: Read arr[0] now | Skip it]", " Read arr[0] now | Skip it"),
+            ("[OPTIONS: See [1] above | Skip]", " See [1] above | Skip"),
+            ("[OPTIONS: Fix dict[str, Any] now | Skip]", " Fix dict[str, Any] now | Skip"),
+            # No opener at all, so no gate applies.
+            ("[OPTIONS: Alpha ] | Bravo ]]", " Alpha ] | Bravo ]"),
+            ("[OPTIONS: Alpha ], Bravo]", " Alpha ], Bravo"),
+            ("[OPTIONS: Yes | No]", " Yes | No"),
+            ("**[OPTIONS: Yes | No]**", " Yes | No"),
+            ("[OPTIONS: A | B](OPTIONS)", " A | B"),
+            # Prose ending in a closer with no opener: the closer genuinely IS the
+            # marker's, so this parses, as it did before.
+            ("[OPTIONS: A | B then check arr]", " A | B then check arr"),
+        ],
+    )
+    def test_every_supported_shape_still_parses(self, text: str, labels: str):
+        match = OPTIONS_RE_LINE.search(text)
+        assert match is not None, text
+        assert match.group("labels") == labels
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Use [OPTIONS: A | B] then check arr[0]",
+            "[OPTIONS: Fix ]x logging | Skip]",
+            "[OPTIONS: Fix list[dict[str, Any]] now | S]",
+            "Note [OPTIONS: see [OPTIONS: x] below | Skip]",
+        ],
+    )
+    def test_every_previously_declined_shape_still_declines(self, text: str):
+        assert OPTIONS_RE_LINE.search(text) is None, text
+
+
+class TestTheCost:
+    """What the gate gives up, enumerated rather than summarised.
+
+    One family: a stray opener in the FINAL label, where no separator follows to
+    clear the gate. It fails toward a VISIBLE marker rather than a deleted line,
+    which is what makes it affordable -- and it is the same direction every other
+    cost in this grammar fails in.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "[OPTIONS: Fix | Skip [x logging]",
+            "[OPTIONS: Fix [x logging]",
+            # And the comma variant: only a COMMA follows the stray opener, which
+            # does not clear the gate, so this joins the same family. It is the price
+            # of seeing through ``dict[str, int]`` to its closer.
+            "[OPTIONS: Fix [x logging, Skip]",
+        ],
+    )
+    def test_a_stray_opener_in_the_final_label_is_given_up(self, text: str):
+        assert OPTIONS_RE_LINE.search(text) is None, text
+        # Affordable because nothing is removed.
+        assert OPTIONS_RE_LINE.sub("", text) == text, text
+        assert split_options_trailer(text) == (text, []), text
+
+
+class TestTheResidualThisGateCannotClose:
+    """NESTED terminal brackets still reach the terminator, and no regex can stop it.
+
+    The gate clears when the scan meets another bracket, on the grounds that some
+    other bracket form owns that closer. With nesting at the end of the line that
+    reasoning fails: in ``list[dict[str, int]]`` the OUTER opener's partner is the
+    final ``]``, which is the terminator, but the scan halts at the inner ``[`` and
+    never sees it.
+
+    Encoding one level of nesting into the scan only moves the boundary -- depth
+    three defeats that, depth four the next one, and so on. The condition the gate
+    is reaching for is "the terminating closer is not nested", which is bracket
+    BALANCE, and balance is not expressible as a regular expression at unbounded
+    depth. Closing it means the check cannot live in the pattern at all.
+
+    Pinned so the boundary is a named, measured residual rather than a surprise:
+    depth one is fixed, depth two and beyond behave as they do on main.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "[OPTIONS: A | B then inspect list[dict[str, int]]",
+            "[OPTIONS: A | B then inspect list[dict[x]]",
+            "[OPTIONS: A | B then inspect a[b[c[d]]]",
+        ],
+    )
+    def test_nested_terminal_brackets_still_match(self, text: str):
+        # NOT an assertion that this is desirable -- it is the residual, recorded at
+        # the depth where the gate stops reaching. If a future change closes it, this
+        # test should flip and the docstring above should go with it.
+        assert OPTIONS_RE_LINE.search(text) is not None, text
+
+    def test_depth_one_is_the_part_that_is_fixed(self):
+        # The boundary, either side of it, in one place.
+        assert OPTIONS_RE_LINE.search("[OPTIONS: A | B then inspect dict[str, int]") is None
+        assert (
+            OPTIONS_RE_LINE.search("[OPTIONS: A | B then inspect list[dict[str, int]]") is not None
+        )
+
+
+class TestLinearity:
+    def test_the_gate_scan_is_tempered(self):
+        # Read off the compiled pattern so the claim cannot drift from the comment:
+        # the scan stops at the first bracket or ``|``, which is what keeps the runs
+        # scanned from different openers disjoint and the total work linear.
+        assert f"[^[{re.escape(MARKER_CLOSERS)}|\\n]*" in OPTIONS_RE_LINE.pattern
+        assert f"[^[{re.escape(MARKER_CLOSERS)}|]*" in OPTIONS_RE_TRAILER.pattern
+
+    def test_it_adds_no_quantifier_over_a_quantifier(self):
+        # The shape that backtracks exponentially, and the one the frontend's
+        # ``.source`` pin also forbids.
+        assert re.search(r"\([^)]*[+*]\)[+*]", OPTIONS_RE_LINE.pattern) is None
+
+    @pytest.mark.parametrize("reps", [2_000, 10_000, 40_000])
+    def test_many_bare_openers_stay_linear(self, reps: int):
+        # The adversarial shape for this gate specifically: one lookahead entered
+        # per opener, on an unterminated marker so every one of them fails.
+        src = "[OPTIONS:" + ("a[b" * reps)
+        started = time.perf_counter()
+        assert OPTIONS_RE_LINE.search(src) is None
+        assert OPTIONS_RE_TRAILER.search(src) is None
+        assert time.perf_counter() - started < 2.0

--- a/website/src/app-sdk/protocol/optionMarker.ts
+++ b/website/src/app-sdk/protocol/optionMarker.ts
@@ -82,8 +82,29 @@
 // is what makes them affordable. Making them parse means matching brackets to
 // arbitrary depth and over an opener set this grammar does not have. The
 // separator-tail form (`…| Wait], details in CHANGELOG[1]`) is NOT reachable by
-// this rule and is unchanged: `], ` does continue the list, by the same rule that
-// makes `[OPTIONS: Alpha ], Bravo]` legal.
+// this rule: `], ` does continue the list, by the same rule that makes
+// `[OPTIONS: Alpha ], Bravo]` legal. What decides it is the TERMINATOR GATE below,
+// reaching it from the other end — the `[` of `CHANGELOG[1]` is the opener whose
+// partner would end the marker, so the line is declined and left whole.
+//
+// A BARE OPENER MAY NOT BE THE ONE WHOSE PARTNER CLOSER ENDS THE MARKER. The bare
+// form exists so a stray opener does not sink a whole marker, but it also admitted
+// the opener in a marker the model never closed — `[OPTIONS: A | B then check
+// arr[0]`, where the only closer belongs to `arr[0]`. The body ran on through the
+// prose, that `]` became the terminator, and since the marker is removed by
+// `replace` the line left the message and came back as the pill label
+// `B then check arr[0`.
+//
+// No rule over bracket structure can separate the two: reduced to skeletons,
+// `[OPTIONS: Fix | Skip [x logging]` and `[OPTIONS: A | B then check arr[0]` are
+// the same string. The discriminator is where the opener sits relative to the END,
+// so the bare form is refused when nothing but ordinary text lies between it and a
+// closer at the end anchor. Crossing `|` clears it — the opener is inside a label
+// and the list continues past it, which is what keeps the pinned stray-opener
+// shape — and so does another bracket, because some other form owns that closer.
+// `,` does NOT clear it: a comma is only the fallback separator, and inside brackets
+// it is ordinary punctuation (`dict[str, Any]`), so a scan that stopped there would
+// halt before the closer and let the shape through.
 //
 // MARKDOWN WRAPPERS (#9110): a model sometimes wraps the whole marker line in
 // inline code or emphasis — `` `[OPTIONS: A | B]` `` or `**[OPTIONS: A | B]**`.
@@ -119,7 +140,7 @@
 // `new RegExp(OPTION_MARKER_RE)` there. Never call `.exec`/`.test` on it: both leave the index
 // advanced, and the next reader silently scans from the wrong offset.
 export const OPTION_MARKER_RE =
-  /(?:^[ \t]*[`*_]{1,3}\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}|\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?)[ \t]*$/gim
+  /(?:^[ \t]*[`*_]{1,3}\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)(?![^[\]\u3011\uFF3D\u3015|\n]*[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}[ \t]*$)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}|\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)(?![^[\]\u3011\uFF3D\u3015|\n]*[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}[ \t]*$)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?)[ \t]*$/gim
 
 /** The closing brackets OPTION_MARKER_RE accepts — ASCII plus the CJK lookalikes.
  *  Module-private and used with matchAll only (to take the LAST closer in the

--- a/website/src/app-sdk/protocol/optionMarker.ts
+++ b/website/src/app-sdk/protocol/optionMarker.ts
@@ -135,14 +135,101 @@
 // with the indent/trailing `[ \t]*`.
 // Mirrors the backend's MARKER_WRAPPERS + `(?(lwrap)...)` conditional
 // (constants.py).
-// `String#replace` is the only use that is safe on this shared const as-is: it resets `lastIndex`.
-// `String#matchAll` does NOT — it seeds its internal clone from `lastIndex`, so pass a fresh
-// `new RegExp(OPTION_MARKER_RE)` there. Never call `.exec`/`.test` on it: both leave the index
-// advanced, and the next reader silently scans from the wrong offset.
-export const OPTION_MARKER_RE =
-  /(?:^[ \t]*[`*_]{1,3}\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)(?![^[\]\u3011\uFF3D\u3015|\n]*[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}[ \t]*$)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}|\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)(?![^[\]\u3011\uFF3D\u3015|\n]*[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}[ \t]*$)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?)[ \t]*$/gim
+// MODULE-PRIVATE, and deliberately so: this pattern finds CANDIDATE markers, and a
+// candidate is not yet a marker. Whether its terminating closer is really its own
+// cannot be decided here — see `labelsHaveUnmatchedOpener` below — so handing the pattern
+// out would hand out a way to skip that decision. `findOptionMarkers`,
+// `findLastOptionMarker` and `stripOptionMarkers` are the API; they apply both halves
+// and clone the regex internally, which also retires the `lastIndex` hazard that used
+// to be every caller's problem.
+const OPTION_MARKER_RE =
+  /(?:^[ \t]*[`*_]{1,3}\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?[`*_]{0,3}|\[OPTION(S)?:((?:\[(?!OPTIONS?:)[^[\]\u3011\uFF3D\u3015\n]*[\]\u3011\uFF3D\u3015](?![ \t]*[|,]|[\]\u3011\uFF3D\u3015])|\[(?!OPTIONS?:)|[\]\u3011\uFF3D\u3015](?=[ \t]*[|,]|[\]\u3011\uFF3D\u3015])|[^[\]\u3011\uFF3D\u3015\n])*)[\]\u3011\uFF3D\u3015](?:\([^\s()]*\))?)[ \t]*$/gim
 
-/** The closing brackets OPTION_MARKER_RE accepts — ASCII plus the CJK lookalikes.
+/** The pattern's source text, for the tests that pin its shape.
+ *
+ *  A string, not a regex, on purpose: a shape pin needs the characters, and handing
+ *  back something callable would reopen the bypass the pattern's privacy closes. */
+export const OPTION_MARKER_PATTERN_SOURCE = OPTION_MARKER_RE.source
+
+/** Whether `labels` leave an opener unclosed, so the terminator is not theirs.
+ *
+ * The pattern finds candidates; this decides which candidates are markers, and it is
+ * the whole reason the pattern is private. An unmatched opener means the closer the
+ * pattern took as the terminator is really that opener's partner — so the marker was
+ * never closed.
+ *
+ * What it prevents: `[OPTIONS: A | B then check arr[0]`, where the only closer
+ * belongs to `arr[0]`. The body ran on through the prose, that `]` became the
+ * terminator, and since the marker is removed by `replace` the line left the message
+ * and came back as the pill label `B then check arr[0`.
+ *
+ * The pattern cannot do it: balance is not a regular language at unbounded depth, so
+ * a lookahead sees one nesting level and `list[dict[str, int]]` defeats a one-level
+ * rule, `a[b[c[d]]]` a two-level one.
+ *
+ * The rule is TOTAL — no separator escape hatch. An earlier form accepted an
+ * unmatched opener when a `|` followed it; that hatch was defeated three times, most
+ * recently by a `|` INSIDE the unmatched bracket (`dict[str | int]`), and each time
+ * the shape it readmitted was structurally identical to the one it was meant to
+ * protect. THE COST is exactly one shape: `[OPTIONS: Fix [x logging | Skip]`, a label
+ * carrying an unclosed `[`, no longer parses — it renders as visible text, which is
+ * the direction every cost in this grammar fails in.
+ *
+ * An unmatched CLOSER is ignored: a label may legitimately carry one
+ * (`[OPTIONS: Alpha ] | Bravo ]]` is supported and tested).
+ *
+ * Mirrors `_marker_labels_have_unmatched_opener` in `constants.py`. */
+export function labelsHaveUnmatchedOpener(labels: string): boolean {
+  let depth = 0
+  for (const ch of labels) {
+    if (ch === '[') depth++
+    else if (']】］〕'.includes(ch) && depth > 0) depth--
+  }
+  return depth > 0
+}
+
+/** The labels of a candidate match. Groups 1/2 belong to the wrapped branch, 3/4 to
+ *  the bare one, and exactly one pair is defined per match. */
+function labelsOf(match: RegExpMatchArray): string {
+  return (match[2] ?? match[4]) ?? ''
+}
+
+/** Every marker in `content` whose terminator is its own, in order.
+ *
+ * Clones the pattern per call, so the g-flag `lastIndex` hazard cannot reach a
+ * caller. A refused candidate cannot hide an accepted one inside its span: the body
+ * refuses a nested `[OPTION(S):`, so no candidate ever contains another head. */
+export function findOptionMarkers(content: string): RegExpMatchArray[] {
+  const out: RegExpMatchArray[] = []
+  for (const m of content.matchAll(new RegExp(OPTION_MARKER_RE))) {
+    if (!labelsHaveUnmatchedOpener(labelsOf(m))) out.push(m)
+  }
+  return out
+}
+
+/** The LAST accepted marker, which is the one whose options a turn offers. */
+export function findLastOptionMarker(content: string): RegExpMatchArray | null {
+  const all = findOptionMarkers(content)
+  return all.length > 0 ? all[all.length - 1] : null
+}
+
+/** `content` with every accepted marker removed, refused candidates left in place.
+ *
+ * Refused text staying visible is the point: a candidate this declines is prose the
+ * user should still see, and deleting it is the defect the check exists to prevent. */
+export function stripOptionMarkers(content: string): string {
+  const parts: string[] = []
+  let cursor = 0
+  for (const m of findOptionMarkers(content)) {
+    const start = m.index ?? 0
+    parts.push(content.slice(cursor, start))
+    cursor = start + m[0].length
+  }
+  parts.push(content.slice(cursor))
+  return parts.join('')
+}
+
+/** The closing brackets the marker pattern accepts — ASCII plus the CJK lookalikes.
  *  Module-private and used with matchAll only (to take the LAST closer in the
  *  probed body), so the g-flag `lastIndex` hazard never applies. */
 const CLOSER_RE = /[\]\u3011\uFF3D\u3015]/g

--- a/website/src/app-sdk/protocol/options.ts
+++ b/website/src/app-sdk/protocol/options.ts
@@ -3,7 +3,7 @@ import { isSystemNoticeKind } from '../../lib/systemNotice'
 import { isStopEvent } from '../../lib/stopEvent'
 import { isRetryNotice } from '../../lib/retryNotice'
 import { isNoteRow } from '../../lib/noteContract'
-import { OPTION_MARKER_RE } from './optionMarker'
+import { findLastOptionMarker, stripOptionMarkers } from './optionMarker'
 
 // A plan is recognised by BOTH its header and at least one stage line, so ordinary
 // prose that happens to mention a plan is not mistaken for one.
@@ -23,13 +23,14 @@ export interface ParsedOptions {
 }
 
 export function parseOptions(content: string): ParsedOptions {
-  let last: RegExpMatchArray | null = null
-  // `matchAll` seeds its internal clone from this regex's `lastIndex`, so a stray `.test()` or
-  // `.exec()` anywhere would make the scan start mid-string and miss the marker. Clone per call:
-  // the cost is one regex construction, the alternative is a silent parse failure.
-  for (const m of content.matchAll(new RegExp(OPTION_MARKER_RE))) last = m
+  // `findLastOptionMarker` applies BOTH halves of the grammar: the pattern that finds
+  // candidates, and the check that a candidate's terminating closer is its own rather
+  // than an unmatched opener's partner. The pattern is module-private precisely so
+  // this cannot be done by halves. It also clones the regex per call, so the g-flag
+  // `lastIndex` hazard is no longer a caller's problem to remember.
+  const last = findLastOptionMarker(content)
   if (!last || last.index === undefined) return { text: content, options: [], multi: true, isPlan: false }
-  // OPTION_MARKER_RE is a two-branch alternation (line-anchored-with-wrappers
+  // The marker pattern is a two-branch alternation (line-anchored-with-wrappers
   // vs mid-line): groups 1/2 belong to the first branch, 3/4 to the second, and
   // exactly one pair is defined per match. `??` (not `||`) so an empty label
   // string from the matched branch is kept rather than falling through.
@@ -38,11 +39,12 @@ export function parseOptions(content: string): ParsedOptions {
   const sep = labels.includes('|') ? '|' : ','
   const options = labels.split(sep).map(o => o.trim()).filter(Boolean)
   const isPlan = PLAN_HEADER_RE.test(content) && STAGE_RE.test(content)
-  // Strip ALL markers from the displayed text (not just the last) so a stray earlier
-  // marker can't leak as raw "[OPTION: …]" syntax to the user; options still come from
-  // the LAST marker (computed above). OPTION_MARKER_RE is global, so replace removes
-  // every occurrence while preserving the prose around them.
-  const text = content.replace(OPTION_MARKER_RE, '').trim()
+  // Strip ALL accepted markers from the displayed text (not just the last) so a stray
+  // earlier marker can't leak as raw "[OPTION: …]" syntax to the user; options still
+  // come from the LAST marker (computed above). A REFUSED candidate is deliberately
+  // left in place — it is prose the user should still see, and removing it is the
+  // defect the check exists to prevent.
+  const text = stripOptionMarkers(content).trim()
   return { text, options, multi, isPlan }
 }
 

--- a/website/src/pages/chat/TurnBlock.tsx
+++ b/website/src/pages/chat/TurnBlock.tsx
@@ -10,7 +10,7 @@ import { isWorkflowCompletionMessage } from './WorkflowCompletionCard'
 import { isSubagentCompletionMessage } from './subagentCompletion'
 import { isReasoningBurst } from './groupDisplayItems'
 import { isDiffToolMessage } from './toolDiff'
-import { OPTION_MARKER_RE } from '../../app-sdk/protocol/optionMarker'
+import { findOptionMarkers, stripOptionMarkers } from '../../app-sdk/protocol/optionMarker'
 import { hasKeepVisibleMarker } from '../../app-sdk/protocol/keepVisibleMarker'
 import { i18nT } from '../../i18n/t'
 
@@ -92,12 +92,11 @@ const isRenderable = (it: TurnItem) =>
  * hand-back would otherwise be buried in the collapse pane. Surfacing each one
  * inline fixes that.
  *
- * OPTION_MARKER_RE is g-flagged and optionsMarker.ts forbids .test()/.exec() on
- * it (the lastIndex hazard); probe it via .replace(), exactly like
- * substantiveLength() below.
+ * Asks the marker module rather than probing a regex: a candidate whose terminator
+ * belongs to an unmatched opener is NOT a marker, and only that module can tell.
  */
 function hasOptionsMarker(text: string): boolean {
-  return text.replace(OPTION_MARKER_RE, '') !== text
+  return findOptionMarkers(text).length > 0
 }
 const isHandBack = (it: TurnItem) =>
   it.kind === 'single' && isConclusion(it) && hasOptionsMarker(it.msg.content)
@@ -190,7 +189,7 @@ const EMPTY_ID_SET: ReadonlySet<string> = new Set()
 
 /** Strip OPTIONS/markdown formatting and return plain text content length */
 function substantiveLength(text: string): number {
-  return text.replace(OPTION_MARKER_RE, '').replace(/[#*_`>\-|]/g, '').trim().length
+  return stripOptionMarkers(text).replace(/[#*_`>\-|]/g, '').trim().length
 }
 
 /**

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -5,7 +5,7 @@ import { parseOptions } from '../app-sdk/protocol'
 // Imported from the defining module, not the `protocol` barrel, which deliberately
 // does not re-export a g-flagged regex. Only `.source` is read below — a string
 // copy — so the shared `lastIndex` this const's own docs warn about is untouched.
-import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+import { OPTION_MARKER_PATTERN_SOURCE } from '../app-sdk/protocol/optionMarker'
 
 // Mock MarkdownRenderer to avoid complex markdown parsing in tests
 vi.mock('../components/MarkdownRenderer', () => ({
@@ -891,32 +891,26 @@ describe('parseOptions', () => {
   // reaching for, deterministically and in microseconds. The behavioural half — an
   // adversarial input still parses to no options — is asserted directly below.
   it('does not catastrophically backtrack on adversarial `[OPTIONS:` input', () => {
-    const src = OPTION_MARKER_RE.source
+    const src = OPTION_MARKER_PATTERN_SOURCE
     // The label body: tempered alternation, NOT a nested quantifier. Spelled with
     // `\uXXXX` escapes because that is how the SOURCE spells the closer class —
     // `.source` is the literal pattern text, so a literal `】` here would not match.
     const C = '\\]\\u3011\\uFF3D\\u3015'
     const CONT = `[ \\t]*[|,]|[${C}]`
-    // The bare-opener form carries a TERMINATOR GATE: it is refused when nothing but
-    // ordinary text lies between it and a closer at the end anchor, because that
-    // closer is then its own partner rather than the marker's — the shape in which an
-    // unterminated `[OPTIONS:` consumed the rest of its line. The gate's scan is
-    // TEMPERED (it stops at the first bracket or separator), which keeps the runs
-    // scanned from different openers disjoint and the whole pattern linear.
-    // The scan crosses `,` and stops only at `|`, a bracket, or a newline. A comma is
-    // the FALLBACK separator and inside brackets is ordinary punctuation
-    // (`dict[str, Any]`), so a scan that stopped there halted before the closer and
-    // let `[OPTIONS: A | B then inspect dict[str, int]` through.
-    const TIC = '(?:\\([^\\s()]*\\))?'
-    const GATE = `(?![^[${C}|\\n]*[${C}]${TIC}[\`*_]{0,3}[ \\t]*$)`
     // Four alternatives, mutually exclusive at every position. The two bracket
     // forms both begin at `[` but are each other's negation on what FOLLOWS the
     // closer, so no span of input ever has two parses — that disjointness is what
     // the linearity rests on, so it is pinned here character for character. BOTH
     // bracket forms carry `(?!OPTIONS?:)`: that is what keeps a nested head out of
     // a label, and dropping it from the pair form is a widening, not a tidy-up.
+    //
+    // Note what is NOT here: whether a candidate's terminating closer is really its
+    // own. That is bracket balance, which no pattern decides at unbounded depth, so
+    // `labelsHaveUnmatchedOpener` decides it and the pattern is module-private to stop the
+    // two being applied separately. Pinning the pattern's shape is still worth it:
+    // this is the half that has to stay linear.
     expect(src).toContain(
-      `(?:\\[(?!OPTIONS?:)[^[${C}\\n]*[${C}](?!${CONT})|\\[(?!OPTIONS?:)${GATE}|[${C}](?=${CONT})|[^[${C}\\n])*`,
+      `(?:\\[(?!OPTIONS?:)[^[${C}\\n]*[${C}](?!${CONT})|\\[(?!OPTIONS?:)|[${C}](?=${CONT})|[^[${C}\\n])*`,
     )
     // No `(x+)+` / `(x*)*` anywhere: that is the shape that backtracks
     // exponentially, and it is what the tempered body above replaced.

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -897,6 +897,18 @@ describe('parseOptions', () => {
     // `.source` is the literal pattern text, so a literal `】` here would not match.
     const C = '\\]\\u3011\\uFF3D\\u3015'
     const CONT = `[ \\t]*[|,]|[${C}]`
+    // The bare-opener form carries a TERMINATOR GATE: it is refused when nothing but
+    // ordinary text lies between it and a closer at the end anchor, because that
+    // closer is then its own partner rather than the marker's — the shape in which an
+    // unterminated `[OPTIONS:` consumed the rest of its line. The gate's scan is
+    // TEMPERED (it stops at the first bracket or separator), which keeps the runs
+    // scanned from different openers disjoint and the whole pattern linear.
+    // The scan crosses `,` and stops only at `|`, a bracket, or a newline. A comma is
+    // the FALLBACK separator and inside brackets is ordinary punctuation
+    // (`dict[str, Any]`), so a scan that stopped there halted before the closer and
+    // let `[OPTIONS: A | B then inspect dict[str, int]` through.
+    const TIC = '(?:\\([^\\s()]*\\))?'
+    const GATE = `(?![^[${C}|\\n]*[${C}]${TIC}[\`*_]{0,3}[ \\t]*$)`
     // Four alternatives, mutually exclusive at every position. The two bracket
     // forms both begin at `[` but are each other's negation on what FOLLOWS the
     // closer, so no span of input ever has two parses — that disjointness is what
@@ -904,7 +916,7 @@ describe('parseOptions', () => {
     // bracket forms carry `(?!OPTIONS?:)`: that is what keeps a nested head out of
     // a label, and dropping it from the pair form is a widening, not a tidy-up.
     expect(src).toContain(
-      `(?:\\[(?!OPTIONS?:)[^[${C}\\n]*[${C}](?!${CONT})|\\[(?!OPTIONS?:)|[${C}](?=${CONT})|[^[${C}\\n])*`,
+      `(?:\\[(?!OPTIONS?:)[^[${C}\\n]*[${C}](?!${CONT})|\\[(?!OPTIONS?:)${GATE}|[${C}](?=${CONT})|[^[${C}\\n])*`,
     )
     // No `(x+)+` / `(x*)*` anywhere: that is the shape that backtracks
     // exponentially, and it is what the tempered body above replaced.

--- a/website/src/test/chatProtocolBoundary.test.ts
+++ b/website/src/test/chatProtocolBoundary.test.ts
@@ -123,19 +123,26 @@ describe('the protocol surface apps import', () => {
     expect(missing, 'vendor stub must re-export every value the app surface exports').toEqual([])
   })
 
-  it('parses correctly even after the shared regex has been left mid-string', async () => {
-    // The pattern is g-flagged, and `matchAll` seeds its internal clone from `lastIndex` — so a
-    // single `.test()` elsewhere would otherwise make the scan start past the marker and return no
-    // options, which renders the raw `[OPTIONS: …]` to the user with no buttons.
-    const { OPTION_MARKER_RE } = await import('../app-sdk/protocol/optionMarker')
+  it('exposes no shared regex whose lastIndex a caller could leave mid-string', async () => {
+    // The pattern is g-flagged, so a single `.test()` on a shared instance would make
+    // the next `matchAll` start past the marker and return no options — rendering a
+    // raw `[OPTIONS: …]` with no buttons. The module now keeps the pattern private and
+    // clones it per call, so the hazard has no reachable handle rather than being
+    // something every caller must remember. Asserted structurally: what leaks out is
+    // functions and a source STRING, nothing with a `lastIndex`.
+    const marker = await import('../app-sdk/protocol/optionMarker')
     const { parseOptions } = await import('../app-sdk/protocol')
 
-    OPTION_MARKER_RE.test('elsewhere [OPTIONS: X]')  // `$`-anchored: must end at the bracket
-    expect(OPTION_MARKER_RE.lastIndex).toBeGreaterThan(0)
+    const regexExports = Object.entries(marker).filter(([, v]) => v instanceof RegExp)
+    expect(regexExports.map(([k]) => k), 'no exported RegExp to corrupt').toEqual([])
+    expect(typeof marker.OPTION_MARKER_PATTERN_SOURCE).toBe('string')
 
-    const parsed = parseOptions('Pick one [OPTIONS: Alpha|Beta]')
-    expect(parsed.options).toEqual(['Alpha', 'Beta'])
-    expect(parsed.text).toBe('Pick one')
+    // And repeated parses stay stable, which is what the hazard used to break.
+    for (let i = 0; i < 3; i++) {
+      const parsed = parseOptions('Pick one [OPTIONS: Alpha|Beta]')
+      expect(parsed.options).toEqual(['Alpha', 'Beta'])
+      expect(parsed.text).toBe('Pick one')
+    }
   })
 
   it('keeps the mutable regex out of the app surface', () => {

--- a/website/src/test/optionsMarker.test.ts
+++ b/website/src/test/optionsMarker.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { stripPartialOptionMarker } from '../app-sdk/protocol'
 // The pattern is in-tree only — the barrel deliberately withholds it from the app surface.
-import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+import { stripOptionMarkers } from '../app-sdk/protocol/optionMarker'
 
 /** What the reader sees for a given stream prefix: the finished-marker strip
  *  (OPTION_MARKER_RE, what parseOptions does) followed by the partial-marker
  *  strip. Mirrors AssistantMessage's streaming pipeline. */
 const visible = (prefix: string) =>
-  stripPartialOptionMarker(prefix.replace(OPTION_MARKER_RE, '').trim())
+  stripPartialOptionMarker(stripOptionMarkers(prefix).trim())
 
 describe('stripPartialOptionMarker', () => {
   it('hides a marker whose closing bracket has not arrived yet', () => {

--- a/website/src/test/optionsMarkerLabelClosers.test.ts
+++ b/website/src/test/optionsMarkerLabelClosers.test.ts
@@ -136,14 +136,16 @@ describe('OPTION_MARKER_RE label closers must be matched or continue the list (#
     expect(parseOptions(text).text).toBe(text)
   })
 
-  it('leaves the separator-tail form out of scope and unchanged', () => {
-    // NOT reachable by this rule, pinned so it is not read as a regression here:
-    // `], ` DOES continue the label list, by the very rule that makes
-    // `[OPTIONS: Alpha ], Bravo]` legal, so no guard applied at the internal closer
-    // can tell them apart. Byte-for-byte what origin/main does.
-    expect(parseOptions('Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]').text).toBe(
-      'Done.',
-    )
+  it('declines the separator-tail form rather than truncating it', () => {
+    // Not reachable by THIS rule: `], ` DOES continue the label list, by the very
+    // rule that makes `[OPTIONS: Alpha ], Bravo]` legal, so no guard applied at the
+    // internal closer can tell them apart. The terminator gate reaches it from the
+    // other end — the `[` of `CHANGELOG[1]` is the opener whose partner would end
+    // the marker — so the line stays whole instead of losing its tail to a pill
+    // label reading `Wait], details in CHANGELOG[1`.
+    const text = 'Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]'
+    expect(parseOptions(text).options).toEqual([])
+    expect(parseOptions(text).text).toBe(text)
   })
 })
 

--- a/website/src/test/optionsMarkerLabelClosers.test.ts
+++ b/website/src/test/optionsMarkerLabelClosers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { parseOptions } from '../app-sdk/protocol'
 // The pattern is in-tree only — the barrel deliberately withholds it from the app surface.
-import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+import { stripOptionMarkers } from '../app-sdk/protocol/optionMarker'
 
 // #9284: a label may legitimately carry a closer (`[OPTIONS: Alpha ] | Bravo ]]` is
 // a supported, tested shape), so the body has to admit one — but admitting it
@@ -40,7 +40,7 @@ describe('OPTION_MARKER_RE label closers must be matched or continue the list (#
 
   it('and therefore deletes no prose', () => {
     for (const text of overreach) {
-      expect(text.replace(OPTION_MARKER_RE, ''), text).toBe(text)
+      expect(stripOptionMarkers(text), text).toBe(text)
     }
   })
 
@@ -78,11 +78,17 @@ describe('OPTION_MARKER_RE label closers must be matched or continue the list (#
     ])
   })
 
-  it('does not make the pair a REQUIREMENT — a stray opener still parses', () => {
-    expect(parseOptions('[OPTIONS: Fix [x logging | Skip]').options).toEqual([
-      'Fix [x logging',
-      'Skip',
-    ])
+  it('refuses a stray opener, which is the one shape balanced labels cost', () => {
+    // A stray `[` with no closer of its own used to be just a character in the label.
+    // It cannot be: the shape is indistinguishable from a marker the model never
+    // closed — in `[OPTIONS: A | B then check arr[0]` the only closer belongs to
+    // `arr[0]`, and the body would run through the prose to reach it. Both have one
+    // unmatched opener and a closer at the end anchor, so accepting either accepts
+    // both, and accepting the second deletes a line. The marker now renders as
+    // visible text; see `labelsHaveUnmatchedOpener` for the full argument.
+    const text = '[OPTIONS: Fix [x logging | Skip]'
+    expect(parseOptions(text).options).toEqual([])
+    expect(parseOptions(text).text).toBe(text)
   })
 
   // Every shape the union rule gives up, enumerated rather than summarised. They

--- a/website/src/test/optionsMarkerTerminator.test.ts
+++ b/website/src/test/optionsMarkerTerminator.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+
+import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+import { parseOptions } from '../app-sdk/protocol/options'
+
+/** Labels of the LAST marker, or null when the grammar declines the line. */
+function labelsOf(text: string): string | null {
+  const m = [...text.matchAll(new RegExp(OPTION_MARKER_RE))].pop()
+  return m ? (m[2] ?? m[4]) : null
+}
+
+/** Bracket/separator structure, every other run collapsed to `w`. */
+function skeleton(text: string): string {
+  const body = text.startsWith('[OPTIONS:') ? text.slice('[OPTIONS:'.length) : text
+  const out: string[] = []
+  for (const ch of body) {
+    if ('[]|,】］〕'.includes(ch)) out.push(ch)
+    else if (out.length === 0 || out[out.length - 1] !== 'w') out.push('w')
+  }
+  return out.join('')
+}
+
+/**
+ * A bare opener may not be the one whose partner closer ENDS the marker.
+ *
+ * The bare-`[` alternative exists so a stray opener does not sink a whole marker
+ * (`[OPTIONS: Fix [x logging | Skip]` parses, and is pinned). But it also admitted
+ * the opener in a marker the model never closed:
+ *
+ *   [OPTIONS: A | B then check arr[0]
+ *
+ * The only closer on that line belongs to `arr[0]`, so the body ran on through the
+ * prose, that `]` became the terminator, and since the marker is removed by
+ * `replace` the whole line vanished from the message and came back as the pill
+ * label `B then check arr[0`.
+ *
+ * No rule over bracket structure can separate the two: reduced to skeletons they
+ * are the same string. The discriminator is where the opener sits relative to the
+ * END — the bare form is refused when nothing but ordinary text lies between it and
+ * a closer at the end anchor. A separator clears the gate (the opener is inside a
+ * label), and so does another bracket (some other form owns that closer).
+ */
+describe('an unterminated [OPTIONS: no longer consumes its line', () => {
+  it.each([
+    '[OPTIONS: A | B then check arr[0]',
+    '[OPTIONS: Ship | Hold and read docs[4]',
+    '[OPTIONS: Merge | Wait then diff src/app[3]',
+    // The wrapper and stray-tic forms reach the same terminator, so the gate has to
+    // account for both or the shape returns wearing one.
+    '**[OPTIONS: A | B then check arr[0]**',
+    '[OPTIONS: A | B then check arr[0](OPTIONS)',
+    // A COMMA INSIDE the terminal bracket. The scan has to cross it to reach the
+    // partner closer — a comma is only the fallback separator and inside brackets is
+    // ordinary punctuation, so a scan that stopped there cleared the gate.
+    '[OPTIONS: A | B then inspect dict[str, int]',
+    '[OPTIONS: Ship | Hold then arr[i, j]',
+  ])('declines it and deletes nothing: %s', (text) => {
+    expect(labelsOf(text)).toBeNull()
+    const { options, text: kept } = parseOptions(text)
+    expect(options).toEqual([])
+    expect(kept).toBe(text)
+  })
+
+  it('names the corruption it prevents, so the reason cannot be optimised away', () => {
+    expect(parseOptions('[OPTIONS: A | B then check arr[0]').options).not.toEqual([
+      'A',
+      'B then check arr[0',
+    ])
+  })
+
+  it('still declines a marker with no closer anywhere', () => {
+    expect(labelsOf('[OPTIONS: A | B then check arr')).toBeNull()
+  })
+})
+
+describe('the discriminator is not bracket structure', () => {
+  it('the refused and accepted shapes share a skeleton', () => {
+    // Pinned as the reason the gate is shaped this way: if someone replaces it with
+    // a bracket-balance rule, this is what says that cannot work.
+    expect(skeleton('[OPTIONS: A | B then check arr[0]')).toBe('w|w[w]')
+    expect(skeleton('[OPTIONS: Fix | Skip [x logging]')).toBe('w|w[w]')
+  })
+
+  it('and the pinned stray-opener shape is the one a separator saves', () => {
+    expect(skeleton('[OPTIONS: Fix [x logging | Skip]')).toBe('w[w|w]')
+    expect(parseOptions('[OPTIONS: Fix [x logging | Skip]').options).toEqual([
+      'Fix [x logging',
+      'Skip',
+    ])
+  })
+})
+
+describe('the terminator gate leaves the rest of the grammar where it was', () => {
+  it.each([
+    // A closer admitted by CONTINUATION, so its opener is not the terminator's
+    // partner. The gate must not reach these.
+    ['[OPTIONS: Fix arr[0] | Skip]', ['Fix arr[0]', 'Skip']],
+    ['[OPTIONS: a[1] | b[2]]', ['a[1]', 'b[2]']],
+    ['[OPTIONS: Fix list[dict[str, Any]] | Skip]', ['Fix list[dict[str, Any]]', 'Skip']],
+    // Matched pairs own their own closer.
+    ['[OPTIONS: Fix [x] logging | Skip]', ['Fix [x] logging', 'Skip']],
+    ['[OPTIONS: Read arr[0] now | Skip it]', ['Read arr[0] now', 'Skip it']],
+    ['[OPTIONS: See [1] above | Skip]', ['See [1] above', 'Skip']],
+    ['[OPTIONS: Fix dict[str, Any] now | Skip]', ['Fix dict[str, Any] now', 'Skip']],
+    // No opener at all, so no gate applies.
+    ['[OPTIONS: Alpha ] | Bravo ]]', ['Alpha ]', 'Bravo ]']],
+    ['[OPTIONS: Yes | No]', ['Yes', 'No']],
+    ['**[OPTIONS: Yes | No]**', ['Yes', 'No']],
+    ['[OPTIONS: A | B](OPTIONS)', ['A', 'B']],
+    // Prose ending in a closer with no opener: that closer genuinely IS the
+    // marker's, so this parses as before.
+    ['[OPTIONS: A | B then check arr]', ['A', 'B then check arr']],
+  ])('still parses %s', (text, options) => {
+    expect(parseOptions(text as string).options).toEqual(options)
+  })
+
+  it.each([
+    'Use [OPTIONS: A | B] then check arr[0]',
+    '[OPTIONS: Fix ]x logging | Skip]',
+    '[OPTIONS: Fix list[dict[str, Any]] now | S]',
+    'Note [OPTIONS: see [OPTIONS: x] below | Skip]',
+  ])('still declines %s', (text) => {
+    expect(labelsOf(text)).toBeNull()
+  })
+})
+
+describe('what the gate gives up', () => {
+  it.each([
+    '[OPTIONS: Fix | Skip [x logging]',
+    '[OPTIONS: Fix [x logging]',
+    // The comma variant joins the same family: only a comma follows the stray
+    // opener, and a comma no longer clears the gate. That is the price of seeing
+    // through `dict[str, int]` to its closer.
+    '[OPTIONS: Fix [x logging, Skip]',
+  ])(
+    'a stray opener in the FINAL label, with nothing deleted: %s',
+    (text) => {
+      // The one family given up: no separator follows to clear the gate. It fails
+      // toward a VISIBLE marker, which is the direction every cost in this grammar
+      // fails in, and is what makes it affordable.
+      expect(labelsOf(text)).toBeNull()
+      expect(parseOptions(text).text).toBe(text)
+    },
+  )
+})
+
+describe('the gate stays linear', () => {
+  it('does not backtrack catastrophically on many failing openers', () => {
+    // The adversarial shape for this gate specifically: one lookahead entered per
+    // opener, on an unterminated marker so every one of them fails.
+    const src = `[OPTIONS:${'a[b'.repeat(20_000)}`
+    const started = Date.now()
+    expect(labelsOf(src)).toBeNull()
+    expect(Date.now() - started).toBeLessThan(1000)
+  })
+})

--- a/website/src/test/optionsMarkerTerminator.test.ts
+++ b/website/src/test/optionsMarkerTerminator.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+import {
+  findLastOptionMarker,
+  findOptionMarkers,
+  stripOptionMarkers,
+  labelsHaveUnmatchedOpener,
+} from '../app-sdk/protocol/optionMarker'
 import { parseOptions } from '../app-sdk/protocol/options'
 
-/** Labels of the LAST marker, or null when the grammar declines the line. */
+/** Labels of the LAST accepted marker, or null when none is accepted. */
 function labelsOf(text: string): string | null {
-  const m = [...text.matchAll(new RegExp(OPTION_MARKER_RE))].pop()
-  return m ? (m[2] ?? m[4]) : null
+  const m = findLastOptionMarker(text)
+  return m ? ((m[2] ?? m[4]) ?? '') : null
 }
 
 /** Bracket/separator structure, every other run collapsed to `w`. */
@@ -21,40 +26,40 @@ function skeleton(text: string): string {
 }
 
 /**
- * A bare opener may not be the one whose partner closer ENDS the marker.
+ * The terminating closer must not be an unmatched opener's PARTNER.
  *
- * The bare-`[` alternative exists so a stray opener does not sink a whole marker
- * (`[OPTIONS: Fix [x logging | Skip]` parses, and is pinned). But it also admitted
- * the opener in a marker the model never closed:
+ * The body admits a bare `[` on purpose, so a stray opener in a label does not sink
+ * the marker (`[OPTIONS: Fix [x logging | Skip]` parses, and is pinned). That same
+ * alternative admitted the opener in a marker the model never closed:
  *
  *   [OPTIONS: A | B then check arr[0]
  *
  * The only closer on that line belongs to `arr[0]`, so the body ran on through the
- * prose, that `]` became the terminator, and since the marker is removed by
- * `replace` the whole line vanished from the message and came back as the pill
- * label `B then check arr[0`.
+ * prose, that `]` became the terminator, and since the marker is removed by `replace`
+ * the line left the message and came back as the pill label `B then check arr[0`.
  *
- * No rule over bracket structure can separate the two: reduced to skeletons they
- * are the same string. The discriminator is where the opener sits relative to the
- * END — the bare form is refused when nothing but ordinary text lies between it and
- * a closer at the end anchor. A separator clears the gate (the opener is inside a
- * label), and so does another bracket (some other form owns that closer).
+ * The pattern cannot decide this. Reduced to their bracket structure the shape to
+ * REFUSE and the shape to ACCEPT are the same string, and a lookahead sees only one
+ * nesting level — `list[dict[str, int]]` defeats a one-level rule, `a[b[c[d]]]` a
+ * two-level one. The condition is bracket BALANCE, so `labelsHaveUnmatchedOpener` decides
+ * it and the pattern is module-private to stop the two being applied separately.
  */
-describe('an unterminated [OPTIONS: no longer consumes its line', () => {
+describe('an unterminated [OPTIONS: does not consume its line', () => {
   it.each([
     '[OPTIONS: A | B then check arr[0]',
     '[OPTIONS: Ship | Hold and read docs[4]',
     '[OPTIONS: Merge | Wait then diff src/app[3]',
-    // The wrapper and stray-tic forms reach the same terminator, so the gate has to
-    // account for both or the shape returns wearing one.
+    // The wrapper and stray-tic forms reach the same terminator.
     '**[OPTIONS: A | B then check arr[0]**',
     '[OPTIONS: A | B then check arr[0](OPTIONS)',
-    // A COMMA INSIDE the terminal bracket. The scan has to cross it to reach the
-    // partner closer — a comma is only the fallback separator and inside brackets is
-    // ordinary punctuation, so a scan that stopped there cleared the gate.
+    // A comma inside the terminal bracket is ordinary punctuation, not a boundary.
     '[OPTIONS: A | B then inspect dict[str, int]',
     '[OPTIONS: Ship | Hold then arr[i, j]',
-  ])('declines it and deletes nothing: %s', (text) => {
+    // NESTED terminal brackets, at the depths a pattern-level rule could not reach.
+    '[OPTIONS: A | B then inspect list[dict[str, int]]',
+    '[OPTIONS: A | B then inspect a[b[c[d]]]',
+    '[OPTIONS: A | B see a[b[c[d[e]]]]',
+  ])('refuses it and deletes nothing: %s', (text) => {
     expect(labelsOf(text)).toBeNull()
     const { options, text: kept } = parseOptions(text)
     expect(options).toEqual([])
@@ -68,32 +73,68 @@ describe('an unterminated [OPTIONS: no longer consumes its line', () => {
     ])
   })
 
-  it('still declines a marker with no closer anywhere', () => {
+  it('still refuses a marker with no closer anywhere', () => {
     expect(labelsOf('[OPTIONS: A | B then check arr')).toBeNull()
+  })
+
+  it('refuses the separator-tail form rather than truncating it', () => {
+    // `], ` genuinely continues the list, so no guard at the INTERNAL closer can tell
+    // this apart. Counting from the other end decides it.
+    const text = 'Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]'
+    expect(labelsOf(text)).toBeNull()
+    expect(parseOptions(text).text).toBe(text)
   })
 })
 
-describe('the discriminator is not bracket structure', () => {
+describe('the decision cannot live in the pattern', () => {
   it('the refused and accepted shapes share a skeleton', () => {
-    // Pinned as the reason the gate is shaped this way: if someone replaces it with
-    // a bracket-balance rule, this is what says that cannot work.
     expect(skeleton('[OPTIONS: A | B then check arr[0]')).toBe('w|w[w]')
     expect(skeleton('[OPTIONS: Fix | Skip [x logging]')).toBe('w|w[w]')
   })
 
-  it('and the pinned stray-opener shape is the one a separator saves', () => {
-    expect(skeleton('[OPTIONS: Fix [x logging | Skip]')).toBe('w[w|w]')
-    expect(parseOptions('[OPTIONS: Fix [x logging | Skip]').options).toEqual([
-      'Fix [x logging',
-      'Skip',
-    ])
+  it('and a `|` after the opener cannot save it either', () => {
+    // Why the rule is TOTAL rather than carrying an escape hatch. The hatch was "an
+    // unmatched opener is label text if a `|` follows it", and a `|` INSIDE the
+    // unmatched bracket satisfies that — so `dict[str | int]` at the end of a line
+    // readmitted the whole defect. The shape it protected and the shape it readmitted
+    // differ only in where a `|` sits relative to an opener that has no closer.
+    for (const text of [
+      '[OPTIONS: Fix [x logging | Skip]', // the hatch protected this
+      '[OPTIONS: A | B then inspect dict[str | int]', // ...and readmitted this
+    ]) {
+      expect(labelsOf(text), text).toBeNull()
+      expect(parseOptions(text).text, text).toBe(text)
+    }
   })
 })
 
-describe('the terminator gate leaves the rest of the grammar where it was', () => {
+describe('labelsHaveUnmatchedOpener, directly', () => {
   it.each([
-    // A closer admitted by CONTINUATION, so its opener is not the terminator's
-    // partner. The gate must not reach these.
+    [' A | B then check arr[0', true],
+    [' A | B then inspect list[dict[str, int]', true],
+    [' Merge | Wait], details in CHANGELOG[1', true],
+    [' A | B then inspect dict[str | int', true], // a `|` inside the bracket
+    [' Fix [x logging | Skip', true], // a `|` after it changes nothing
+    [' Fix arr[0] | Skip', false], // balanced
+    [' a[1] | b[2]', false], // balanced
+    [' Alpha ] | Bravo ]', false], // unmatched CLOSERS say nothing
+    [' Yes | No', false], // no brackets
+    [' A | B then check arr', false], // no opener
+    [' 见【表1】说明 | 跳过', false], // a lookalike closer closes nothing here
+  ])('%s -> %s', (labels, nested) => {
+    expect(labelsHaveUnmatchedOpener(labels as string)).toBe(nested)
+  })
+
+  it('mirrors the backend rule, which the cross-surface differential checks', () => {
+    // Both surfaces must agree or a marker becomes buttons on one and text on the
+    // other; the shared cases above are the ones the differential compares.
+    expect(labelsHaveUnmatchedOpener(' A | B then see a[b[c[d]]')).toBe(true)
+  })
+})
+
+describe('the check leaves the rest of the grammar where it was', () => {
+  it.each([
+    // A closer admitted by CONTINUATION, so its opener is closed by the labels' end.
     ['[OPTIONS: Fix arr[0] | Skip]', ['Fix arr[0]', 'Skip']],
     ['[OPTIONS: a[1] | b[2]]', ['a[1]', 'b[2]']],
     ['[OPTIONS: Fix list[dict[str, Any]] | Skip]', ['Fix list[dict[str, Any]]', 'Skip']],
@@ -102,13 +143,12 @@ describe('the terminator gate leaves the rest of the grammar where it was', () =
     ['[OPTIONS: Read arr[0] now | Skip it]', ['Read arr[0] now', 'Skip it']],
     ['[OPTIONS: See [1] above | Skip]', ['See [1] above', 'Skip']],
     ['[OPTIONS: Fix dict[str, Any] now | Skip]', ['Fix dict[str, Any] now', 'Skip']],
-    // No opener at all, so no gate applies.
+    // No opener at all, so nothing to be unbalanced.
     ['[OPTIONS: Alpha ] | Bravo ]]', ['Alpha ]', 'Bravo ]']],
     ['[OPTIONS: Yes | No]', ['Yes', 'No']],
     ['**[OPTIONS: Yes | No]**', ['Yes', 'No']],
     ['[OPTIONS: A | B](OPTIONS)', ['A', 'B']],
-    // Prose ending in a closer with no opener: that closer genuinely IS the
-    // marker's, so this parses as before.
+    // Prose ending in a closer with no opener: that closer genuinely IS the marker's.
     ['[OPTIONS: A | B then check arr]', ['A', 'B then check arr']],
   ])('still parses %s', (text, options) => {
     expect(parseOptions(text as string).options).toEqual(options)
@@ -119,38 +159,54 @@ describe('the terminator gate leaves the rest of the grammar where it was', () =
     '[OPTIONS: Fix ]x logging | Skip]',
     '[OPTIONS: Fix list[dict[str, Any]] now | S]',
     'Note [OPTIONS: see [OPTIONS: x] below | Skip]',
-  ])('still declines %s', (text) => {
+  ])('still refuses %s', (text) => {
     expect(labelsOf(text)).toBeNull()
+  })
+
+  it('strips accepted markers and leaves refused candidates in place', () => {
+    expect(stripOptionMarkers('Done.\n[OPTIONS: A | B]')).toBe('Done.\n')
+    const refused = 'Done.\n[OPTIONS: A | B then arr[0]'
+    expect(stripOptionMarkers(refused)).toBe(refused)
+  })
+
+  it('finds every accepted marker in order', () => {
+    const found = findOptionMarkers('[OPTIONS: A | B]\n[OPTIONS: C | D]')
+    expect(found.map((m) => (m[2] ?? m[4]) ?? '')).toEqual([' A | B', ' C | D'])
+  })
+
+  it('does not let a refused candidate hide a later accepted one', () => {
+    // The body refuses a nested `[OPTION(S):`, so a candidate never contains another
+    // head — which is what makes filtering candidates safe.
+    const found = findOptionMarkers('[OPTIONS: A then arr[0]\n[OPTIONS: C | D]')
+    expect(found.map((m) => (m[2] ?? m[4]) ?? '')).toEqual([' C | D'])
   })
 })
 
-describe('what the gate gives up', () => {
+describe('what the check gives up', () => {
   it.each([
     '[OPTIONS: Fix | Skip [x logging]',
     '[OPTIONS: Fix [x logging]',
-    // The comma variant joins the same family: only a comma follows the stray
-    // opener, and a comma no longer clears the gate. That is the price of seeing
-    // through `dict[str, int]` to its closer.
+    // Only a comma follows the stray opener, and a comma is not enough.
     '[OPTIONS: Fix [x logging, Skip]',
-  ])(
-    'a stray opener in the FINAL label, with nothing deleted: %s',
-    (text) => {
-      // The one family given up: no separator follows to clear the gate. It fails
-      // toward a VISIBLE marker, which is the direction every cost in this grammar
-      // fails in, and is what makes it affordable.
-      expect(labelsOf(text)).toBeNull()
-      expect(parseOptions(text).text).toBe(text)
-    },
-  )
+  ])('a stray opener in the FINAL label, with nothing deleted: %s', (text) => {
+    expect(labelsOf(text)).toBeNull()
+    expect(parseOptions(text).text).toBe(text)
+  })
 })
 
-describe('the gate stays linear', () => {
-  it('does not backtrack catastrophically on many failing openers', () => {
-    // The adversarial shape for this gate specifically: one lookahead entered per
-    // opener, on an unterminated marker so every one of them fails.
+describe('cost', () => {
+  it('stays linear on many failing openers', () => {
+    // The adversarial shape: an unterminated marker of bare openers, so the pattern
+    // scans it all and the check walks it all.
     const src = `[OPTIONS:${'a[b'.repeat(20_000)}`
     const started = Date.now()
     expect(labelsOf(src)).toBeNull()
+    expect(Date.now() - started).toBeLessThan(1000)
+  })
+
+  it('walks a long label run in one pass', () => {
+    const started = Date.now()
+    expect(labelsHaveUnmatchedOpener('a['.repeat(200_000))).toBe(true)
     expect(Date.now() - started).toBeLessThan(1000)
   })
 })

--- a/website/src/test/optionsMarkerWrapper.test.ts
+++ b/website/src/test/optionsMarkerWrapper.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { stripPartialOptionMarker } from '../app-sdk/protocol'
 // The pattern is in-tree only — the barrel deliberately withholds it from the app surface.
-import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+import { findLastOptionMarker, stripOptionMarkers } from '../app-sdk/protocol/optionMarker'
 
 /** What the reader sees for a given stream prefix: the finished-marker strip
  *  (OPTION_MARKER_RE, what parseOptions does) followed by the partial-marker
  *  strip. Mirrors AssistantMessage's streaming pipeline. */
 const visible = (prefix: string) =>
-  stripPartialOptionMarker(prefix.replace(OPTION_MARKER_RE, '').trim())
+  stripPartialOptionMarker(stripOptionMarkers(prefix).trim())
 
 // #9110: a model sometimes wraps the whole marker line in inline code or
 // emphasis — `` `[OPTIONS: A | B]` `` / `**[OPTIONS: A | B]**`. The wrapper
@@ -28,7 +28,7 @@ describe('OPTION_MARKER_RE with Markdown wrappers (#9110)', () => {
   it('parses the wrapped marker and keeps the labels clean', () => {
     for (const line of wrapped) {
       let last: RegExpMatchArray | null = null
-      for (const m of `Done.\n${line}`.matchAll(new RegExp(OPTION_MARKER_RE))) last = m
+      last = findLastOptionMarker(`Done.\n${line}`)
       expect(last, line).not.toBeNull()
       const labels = last![2].split('|').map(s => s.trim())
       expect(labels, line).toEqual(['Alpha', 'Beta'])
@@ -37,7 +37,7 @@ describe('OPTION_MARKER_RE with Markdown wrappers (#9110)', () => {
 
   it('strips the wrapper together with the marker', () => {
     for (const line of wrapped) {
-      expect(`Done.\n${line}`.replace(OPTION_MARKER_RE, '').trim(), line).toBe('Done.')
+      expect(stripOptionMarkers(`Done.\n${line}`).trim(), line).toBe('Done.')
     }
   })
 
@@ -57,7 +57,7 @@ describe('OPTION_MARKER_RE with Markdown wrappers (#9110)', () => {
       '[OPTIONS: Alpha | Beta]**', // trailing-only: nothing opened it, prose
     ]) {
       const text = `Done.\n${line}`
-      expect(text.replace(OPTION_MARKER_RE, ''), line).toBe(text)
+      expect(stripOptionMarkers(text), line).toBe(text)
     }
   })
 
@@ -66,28 +66,28 @@ describe('OPTION_MARKER_RE with Markdown wrappers (#9110)', () => {
     // the marker did not open that run, so nothing matches and the pair
     // survives intact.
     const text = '**Choose one\n[OPTIONS: Alpha | Beta]**'
-    expect(text.replace(OPTION_MARKER_RE, '')).toBe(text)
+    expect(stripOptionMarkers(text)).toBe(text)
   })
 
   it('never eats emphasis belonging to preceding prose', () => {
     // The leading wrapper is only legal at line start: here the `**` pair
     // closes real emphasis, and only the marker itself is stripped.
-    expect('**Choose one:** [OPTIONS: A | B]'.replace(OPTION_MARKER_RE, ''))
+    expect(stripOptionMarkers('**Choose one:** [OPTIONS: A | B]'))
       .toBe('**Choose one:** ')
   })
 
   it('still parses a mid-line BARE marker (the pre-widening grammar)', () => {
-    expect('Pick one [OPTIONS: A | B]'.replace(OPTION_MARKER_RE, '')).toBe('Pick one ')
+    expect(stripOptionMarkers('Pick one [OPTIONS: A | B]')).toBe('Pick one ')
   })
 
   it('branch group pairs: (1,2) anchored, (3,4) mid-line — exactly one defined', () => {
     let last: RegExpMatchArray | null = null
-    for (const m of '`[OPTION: Solo]`'.matchAll(new RegExp(OPTION_MARKER_RE))) last = m
+    last = findLastOptionMarker('`[OPTION: Solo]`')
     expect(last![1]).toBeUndefined() // singular [OPTION:], anchored branch
     expect(last![2].trim()).toBe('Solo')
     expect(last![4]).toBeUndefined()
     last = null
-    for (const m of 'Pick one [OPTIONS: Solo]'.matchAll(new RegExp(OPTION_MARKER_RE))) last = m
+    last = findLastOptionMarker('Pick one [OPTIONS: Solo]')
     expect(last![3]).toBe('S') // mid-line branch
     expect(last![4].trim()).toBe('Solo')
     expect(last![2]).toBeUndefined()

--- a/website/src/utils/searchableText.ts
+++ b/website/src/utils/searchableText.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage } from '../types'
-import { OPTION_MARKER_RE } from '../app-sdk/protocol/optionMarker'
+import { stripOptionMarkers } from '../app-sdk/protocol/optionMarker'
 import { stripKeepVisibleMarker } from '../app-sdk/protocol/keepVisibleMarker'
 
 // `<mcwidget>...</mcwidget>` bodies render as a sandboxed iframe (WidgetFrame).
@@ -24,7 +24,7 @@ export function searchableText(m: ChatMessage): string {
   if (m.role === 'assistant' || m.role === 'streaming') {
     // stripKeepVisibleMarker: the marker is an HTML comment the renderer never
     // shows (#7948), so a search hit inside it would be a phantom match.
-    return stripKeepVisibleMarker(m.content.replace(MCWIDGET_RE, '').replace(OPTION_MARKER_RE, '')).trimEnd()
+    return stripKeepVisibleMarker(stripOptionMarkers(m.content.replace(MCWIDGET_RE, ''))).trimEnd()
   }
   return m.content
 }


### PR DESCRIPTION
## Problem / Motivation

An `[OPTIONS:` head the model never closed consumed **the rest of its line** whenever the line held any later `]`:

```
[OPTIONS: A | B then check arr[0]
  labels  = ' A | B then check arr[0'
  visible = ''                          ← the whole line is gone
```

The only closer on that line belongs to `arr[0]`, so the body ran on through the prose and that `]` became the marker's terminator.

## Why it matters

Every consumer removes the whole match — `parse_options` replaces it, `slack/format.py` and `messaging/renderer.py` cut at `match.start()`, and `whatsapp/turn_renderer.py` **persists** the cut turn. So on the channels that cannot render buttons the prose is unrecoverable, and the user is shown pills reading `A` and `B then check arr[0`. A dropped closer is an ordinary model slip; its blast radius was the rest of the line, and a paragraph under the `DOTALL` trailer form.

## Why this is not a regex change

The body admits a bare `[` on purpose, so that a stray opener inside a label did not sink the marker — `[OPTIONS: Fix [x logging | Skip]` was pinned as parsing on both surfaces. But that shape and the defect are the same string once reduced to their bracket structure:

```
[OPTIONS: Fix | Skip [x logging]    ->  w|w[w]
[OPTIONS: A | B then check arr[0]   ->  w|w[w]
```

So no rule over brackets alone can accept one and refuse the other — which is why the allowance had to go, and it is the single accepted cost below. Separately, a lookahead inside the pattern sees only one nesting level: `list[dict[str, int]]` defeats a one-level rule, `a[b[c[d]]]` a two-level one. The condition wanted is "the terminating closer is not nested" — bracket **balance**, which is not a regular language at unbounded depth. Encoding depths is a treadmill.

I know that from having walked it: an earlier revision of this branch put the rule in the pattern and took three review rounds, each one a locally-correct patch that exposed the next reachable shape (a separator stopping the scan early, a newline blinding the trailer scan, then nesting). The commit history has the detail.

## What changed

**The decision left the pattern, and the rule is total.** A marker's labels must have **balanced brackets**: an unmatched opener means the closer the pattern took as the terminator is really that opener's partner, so the marker was never closed. No depth limit, no separator heuristic, no exceptions.

It got there the hard way. An earlier form carried an escape hatch — "an unmatched opener is label text if a `|` follows it" — and review defeated it three times: a separator stopping the scan early, a newline blinding the trailer scan, and finally a `|` **inside** the unmatched bracket (`dict[str | int]`) satisfying it. Each time, the shape the hatch readmitted was structurally identical to the shape it was meant to protect. The hatch was the defect, not its spelling.

One thing the rule deliberately ignores: an unmatched **closer**. A label may legitimately carry one — `[OPTIONS: Alpha ] | Bravo ]]` is supported and tested — so it says nothing about the terminator.

**And the check cannot be bypassed**, which is the other half of the fix. A check callers must remember to call is one a future caller forgets, and this module's own comments call the grammar a single source of truth precisely to stop that drift. So the compiled patterns are private now, and what callers get applies both halves:

| surface | public API | private |
|---|---|---|
| backend | `OPTIONS_RE_LINE` / `OPTIONS_RE_TRAILER` — matchers exposing `search`, `finditer`, `sub`, `pattern` | `_RAW_OPTIONS_RE_LINE` / `_RAW_OPTIONS_RE_TRAILER` |
| frontend | `findOptionMarkers`, `findLastOptionMarker`, `stripOptionMarkers`, `labelsHaveUnmatchedOpener`, `OPTION_MARKER_PATTERN_SOURCE` (a **string**) | the pattern is module-scoped |

Those four members are exactly what anything used, so all five backend call sites and 94 existing test references read unchanged and every one of them gains the check. On the frontend nothing callable leaks, so the two halves cannot be applied separately.

**Making the pattern private found two callers I had not enumerated** — `TurnBlock.tsx` and `searchableText.ts` — both using the raw regex, both of which would have kept the old behaviour silently. The typechecker found them, not review. That is the argument for the indirection, demonstrated.

### Two things fall out of it

**The `lastIndex` hazard is gone.** The frontend docs warned every caller that `matchAll` seeds its clone from a shared g-flagged regex's `lastIndex`, so one stray `.test()` anywhere would make a scan start past the marker. The functions clone internally, so there is no shared handle to corrupt; the test that used to poke `lastIndex` now asserts the stronger property that the module exports no `RegExp` at all.

**A shape the grammar documented as unresolved is resolved.** `constants.py` said of `Done. [OPTIONS: Merge | Wait], details in CHANGELOG[1]`:

> `], ` **DOES** continue the label list … so no guard applied at the internal closer can tell them apart. Resolving it means deciding which shape loses — a separate call.

True of a guard at the *internal* closer. Counting from the other end decides it: the `[` of `CHANGELOG[1]` is still open when the labels end and no `|` follows, so the line stays whole instead of losing its tail to a pill reading `Wait], details in CHANGELOG[1`. Its two pins are updated, one per surface.

## Accepted cost

Exactly one shape, measured across all 96 marker shapes in `main`'s suites: **a label carrying an unclosed `[`**.

```
[OPTIONS: Fix [x logging | Skip]     refused   ← was pinned as parsing
[OPTIONS: Fix | Skip [x logging]     refused
[OPTIONS: Fix [x logging]            refused
```

The first was a deliberate allowance — its test said the grammar "does not make the pair a REQUIREMENT" — taken when the alternative was unknown. The alternative turns out to be deleting a line of prose: `[OPTIONS: Fix [x logging | Skip]` and `[OPTIONS: A | B then check arr[0]` both hold one unmatched opener and a closer at the end anchor, so accepting either accepts both. Its two pins are rewritten, one per surface, carrying that argument.

All of them fail toward a **visible marker** with nothing removed — the direction every cost in this grammar fails in — and that is asserted at the consumer, not only at the pattern.

## Tests

- **New:** `test/test_options_marker_terminator.py` and `website/src/test/optionsMarkerTerminator.test.ts`, including the rule tested directly in isolation on both surfaces.
- **Differential, not inspection.** All **96** marker shapes appearing in `main`'s five marker suites, run on both the old and the new decision. The only behaviour changes are the separator-tail form and the one accepted cost below. That method is what caught the four pinned shapes an earlier pattern-level attempt would have broken.
- **Depth is exercised, not assumed:** nesting from depth 1 to 6 is refused in a loop, so a future change that reintroduces a depth-limited rule fails rather than regressing quietly.
- **Cross-surface:** 34 markers compared on labels **and** stripped text, plus 12 label runs on the rule itself — zero disagreements. Both surfaces must agree or a marker becomes buttons on one and prose on the other.
- **Backend:** 3804 passed across the marker, renderer, preview and channel suites (`slack`, `whatsapp`, `feishu`, `imessage`, `weixin`). **Frontend:** 27311 passed, whole suite.
- **Cost:** one pass with a depth counter. Pinned linear at 200k openers on both surfaces, and the pattern's own shape pin still forbids a quantifier over a quantifier.

## Manual verification

N/A, same reasoning as #9341: the trigger is what the model happens to emit, not something a user can type. Both surfaces are exercised at the parser level, which is the only code the marker passes through, and the end-to-end assertions go through `split_options_trailer` / `parseOptions` rather than the regex alone.

## One pre-existing divergence observed, not fixed here

For `[OPTIONS: Alpha ], Bravo]` the backend yields `['Alpha ], Bravo']` while the frontend yields `['Alpha ]', 'Bravo']`, because `parseOptions` picks its delimiter as `labels.includes('|') ? '|' : ','` and the backend splits on `|` only. Untouched by this diff and out of scope; flagged because it means the surfaces can disagree about how many options a comma-only marker has.

## Related Issues

Fixes #10058

- #9284 / #9341 — the matched-or-continues rule for internal closers. It fixed the adjacent shape (`Use [OPTIONS: A | B] then check arr[0]`) and could not reach this one; both remain pinned.
- #9375 — lookalike bracket pairs in labels, blocked on this. With the terminator decided outside the pattern, adding an opener set no longer makes this defect reachable for CJK input, so that issue becomes small and safe.
- #10032 — closed; it attempted the opener set on top of this defect and did not converge.

## Pattern harvest

Rule candidate: review-prompt

Pattern: when a grammar has a forgiving fallback — a bare opener, an optional delimiter, a lenient escape — check what that forgiveness does at the END of the input, where the terminator lives. A fallback that is harmless mid-input can let an unterminated construct swallow everything up to the next character satisfying the end anchor, and because parse-and-strip consumers remove the whole match, "mis-parsed" becomes "deleted".

Three general follow-ons, each earned here. **First:** before writing the rule, reduce the shape you must REFUSE and the shape you must ACCEPT to their structural skeletons; if the skeletons collide, no rule over that structure exists and you need a different discriminator — that check is cheap and it saved a fix that would have broken four pinned shapes. **Second:** if the discriminator needs unbounded counting (bracket balance, nesting depth, matching quotes), a regex cannot express it, and adding one more level is a treadmill — three review rounds here, each closing one depth. Move the decision out and keep the pattern as a candidate matcher. **Third:** when you move a check out of a pattern, make the unchecked form unreachable in the same change — private the raw pattern and hand out functions. Otherwise the check is advice, and the typechecker will show you the callers who were never going to take it.
