### PR TITLE
feat(ledger): write the ACP turn lifecycle to a session ledger

### DIFF
--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -24,6 +24,7 @@ agent loads only the one it needs.
 | [session-summary.md](session-summary.md) | Intent-level session summaries: the sidecar cache, extraction, and the turn-end pass. |
 | [session-work-ledger.md](session-work-ledger.md) | Per-session durable work state (goal, phase, tried, artifacts) on disk, its MCP tools, and monitor-loop snapshot injection. |
 | [ledger-core.md](ledger-core.md) | Append-only per-crew and per-session ledgers: the wire format, type ownership and guest namespacing, the torn-tail rule, and how the stream relates to `kiro_crew.events`. |
+| [session-ledger-emitter.md](session-ledger-emitter.md) | The flag-gated writer that turns the ACP turn lifecycle into an append-only per-session `ledger.jsonl`: which facts are recorded, from which call site, and which are deliberately not. |
 | [file-search.md](file-search.md) | The `@`-mention file/folder search: index, ranking, `kinds` filter, and the sensitive-path symmetry. |
 | [session-storage.md](session-storage.md) | What sessions cost on disk, and the user-initiated trash that reclaims it. |
 | [session-control.md](session-control.md) | One chat session opening, stopping, and reading another. |

--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -14,7 +14,7 @@ agent loads only the one it needs.
 |---|---|
 | [acp-client.md](acp-client.md) | The ACP JSON-RPC client that drives `kiro-cli`: transport, framing, timeouts, and the backend seam. |
 | [providers.md](providers.md) | The `LLMProvider` interface, the `AcpProvider` the factory selects, and how a backend id is chosen. |
-| [agent-host-contract.md](agent-host-contract.md) | What an agent backend must supply besides speaking ACP: agent layout, session store, identity, sandbox, MCP delivery, billing, permission engine, auxiliary runtimes — kiro-cli, KAS and Claude Code side by side, with the new-provider checklist. |
+| [agent-host-contract.md](agent-host-contract.md) | What an agent backend must supply besides speaking ACP: agent layout, session store, identity, sandbox, MCP delivery, billing, permission engine, auxiliary runtimes -- kiro-cli, KAS and Claude Code side by side, with the new-provider checklist. |
 | [claude-code-provider.md](claude-code-provider.md) | Claude Code as a selectable ACP harness: the live spawn path, the two binaries it needs on the machine, and the MCP gap a Claude session still carries. |
 | [harness-parity.md](harness-parity.md) | The invariants keeping the Kiro harness first-class while other harnesses are adapted, and the test pinning each. |
 | [harness-onboarding.md](harness-onboarding.md) | The sequence a new ACP harness walks to land: vocabulary, capability decisions, spawn path, handshake, install probe, selectability, and what a live harness additionally touches. |
@@ -23,6 +23,7 @@ agent loads only the one it needs.
 | [history.md](history.md) | Conversation persistence, JSONL rotation, and transcript search. |
 | [session-summary.md](session-summary.md) | Intent-level session summaries: the sidecar cache, extraction, and the turn-end pass. |
 | [session-work-ledger.md](session-work-ledger.md) | Per-session durable work state (goal, phase, tried, artifacts) on disk, its MCP tools, and monitor-loop snapshot injection. |
+| [ledger-core.md](ledger-core.md) | Append-only per-crew and per-session ledgers: the wire format, type ownership and guest namespacing, the torn-tail rule, and how the stream relates to `kiro_crew.events`. |
 | [file-search.md](file-search.md) | The `@`-mention file/folder search: index, ranking, `kinds` filter, and the sensitive-path symmetry. |
 | [session-storage.md](session-storage.md) | What sessions cost on disk, and the user-initiated trash that reclaims it. |
 | [session-control.md](session-control.md) | One chat session opening, stopping, and reading another. |

--- a/docs/system-specs/modules/ledger-core.md
+++ b/docs/system-specs/modules/ledger-core.md
@@ -1,0 +1,88 @@
+# Ledger Core
+
+Owners: `kiro_crew.ledger` (`schema.py`, `store.py`, `errors.py`)
+
+## 1. Purpose
+
+`kiro_crew.ledger` gives a crew or a session one durable, ordered, citable record of what happened. It is the storage layer only: it defines a file format, enforces who may write what into it, and reads it back. It carries no routes, no MCP tools, no dashboard surface and no migration.
+
+The problem it answers is that long-horizon work keeps its state in a context window, which harness-owned compaction summarizes lossily. Transcripts are not a substitute: rotation, compaction and consolidation rewrite the whole file, the grain is a message rather than an operation, and no field defines an order a consumer can fold on. An append-only file with a writer-assigned sequence inverts that -- the record is the authority, the context is a cache -- and lets one unit cite a segment of another's history instead of copying it.
+
+## 2. Relationship to `kiro_crew.events`
+
+These are two layers of one story, not two competing logs, and the split is deliberate.
+
+`kiro_crew.events` is a **global lifecycle stream**: one envelope (`v`, `kind`, `src`, `key`, `ts_ms`, `data`), day-sharded under `events/`, joined across domains by its `key`. Its own contract records that it carries no ordering field because ordering "needs a defined scope (per writer? per key? global?)" and would arrive "with the first emitter". `kiro_crew.ledger` is a **per-unit record**: one file per crew or session, where the scope question is already answered by the file itself, so `seq` is contiguous *within that file* and means something a global stream cannot give it.
+
+That per-file scope is what the ledger adds, and it is why the two are not merged. `seq`, `thread` (a grouping key naming an earlier seq in the SAME file) and `ref` (a pointer into another file) are all defined relative to a single unit's ledger. Putting them in the global stream would require either a per-key sequencer inside a day-sharded multi-domain file, or a `seq` whose scope varies by `kind` -- the ambiguity that stream deliberately refused.
+
+Which stream a future emitter writes:
+
+| Emitter records | Stream | Why |
+|---|---|---|
+| One unit's own history, needing order, threading or citation | `kiro_crew.ledger` | The ordering scope is the unit's file. |
+| A cross-domain lifecycle fact folded by correlation key | `kiro_crew.events` | No per-unit order is needed; the join axis is `key`. |
+
+No emitter double-writes. The two envelopes are field-compatible on purpose -- the ledger's `type` is the stream's `kind`, its `time` is `ts_ms`, both `domain/action`, both epoch milliseconds -- so a projection that wants one timeline folds both with a field rename and no semantic translation.
+
+## 3. Storage and identity
+
+```
+<data home>/crews/<store name>/ledger.jsonl
+<data home>/sessions/<store name>/ledger.jsonl
+.lock                                        # sibling, per ledger
+```
+
+`<store name>` is `session_ledger._store_name()` -- a readable fold plus a digest of the exact id -- and the raw id lives in the header. The id is deliberately not the directory name: a channel session key legitimately carries a colon (`slack:1712793600.123`), which POSIX accepts and Windows refuses, so the raw id as a filename turns a sanctioned id into an `OSError` on a supported platform. Identity is the digest, so `Foo` and `foo` get distinct directories on a case-insensitive filesystem. `store.ledger_dir()` refuses a separator or NUL in the raw id and requires the resolved path to stay below the root, so a folded name cannot traverse. `Ledger.open()` proves it reached the right unit by checking the id the header stores.
+
+A ledger is non-recursive inside its root. Every reader of the flat `sessions/<key>.jsonl` transcripts globs one level deep, so the two stores share the `sessions` root without shadowing each other -- and session ledgers inherit the sandbox's existing `sessions` deny. The `crews` root is its own entry in `security.paths._CREW_SECRET_LEAVES`: the write-side rules below bind callers who go through the library, so without that floor an agent's own file tools could forge an entry attributed to `src:"gateway"` or rewrite the history a conductor is designed to trust.
+
+## 4. Format
+
+Line 1 is the header; every later line is an entry.
+
+```json
+{"type":"crew","version":1,"id":"qa","name":"QA Crew","template":null,"createdAt":1789000000000}
+{"type":"crew:qa/report","seq":388,"time":1789000000000,"src":"crew:qa","thread":120,
+ "ref":{"unit":"session","id":"s-7f3a","from":40,"to":96},"data":{"item":"pr-4127","status":"done"}}
+```
+
+| Field | Meaning |
+|---|---|
+| `type` | `domain/action`, or a guest-namespaced `crew:<name>/<action>` / `app:<name>/<action>`. |
+| `seq` | Contiguous from 1 after the header. Writer-assigned. |
+| `time` | Epoch milliseconds. Writer-assigned. |
+| `src` | `gateway`, `acp`, `dashboard`, `patrol`, `session:<id>`, `crew:<name>` or `app:<name>`. |
+| `thread` | Optional. The seq of an earlier entry in this same file -- a grouping key, like a chat thread id. |
+| `ref` | Optional. `{unit, id, from, to?}`, a pointer to a segment of another (or the same) ledger. `to` absent means one line. |
+| `data` | A JSON object. |
+
+A session header also carries `owner`, `agent`, and the optional `task`, `pack`, `slot`, `thread` (`{crew, seq}`), `cwd` and `remote`.
+
+## 5. Rules
+
+Every refusal is a `LedgerError` carrying a stable `code`; the codes are API surface and are additive-only.
+
+**Ownership** answers whether a kind of unit has such events at all. `schema.TYPE_OWNERSHIP` maps kind to owned `type` domains -- crew: `member` `activity` `slot` `patrol` `message` `crew` `item` `memory`; session: `session` `turn` `step` `tool` `approval` `model` `compaction` `remote` -- and anything else is `event_type_not_owned`. It is prefix-based, so a new action under an owned domain needs no change.
+
+**Namespacing** answers whether an emitter may write it. A `crew:<name>` or `app:<name>` emitter is a guest: it may write only under its own prefix, and only into a crew ledger, else `namespace_violation`. A guest type is judged by this rule *instead of* ownership, which is why the registry needs no guest entries -- a guest's own name is its permission.
+
+The remaining bounds: `thread` must name an existing, parseable, earlier seq (`bad_thread`); `ref` must be well-formed and span at most `MAX_REF_SPAN` lines (`bad_ref`); a serialized entry must be at most `MAX_ENTRY_BYTES` (`entry_too_large`). Caps refuse rather than truncate, leaving the file byte-identical -- a clipped record the caller believes landed intact is a loss the caller cannot detect.
+
+## 6. Append-only guarantee and damage
+
+A line is never rewritten. Exactly one mutation exists: on `open`, trailing bytes that are not a complete line are dropped. Termination decides which those are, so the rule needs no heuristic. Every append writes `line + "\n"` and fsyncs, so unterminated bytes that fail to parse are a crash artifact and go; unterminated bytes that *do* parse lost only their newline, so the record stays and the next append re-supplies the separator. A terminated line that does not parse is damage inside history: reads skip it, the file keeps it. Two readers of the same bytes therefore always agree.
+
+`seq` is read back from a bounded window at the file's end inside the per-ledger lock rather than trusted from an in-process cache, so two writers cannot both claim one number and the read costs the same on a ten-line ledger or a million-line one. `store._anchor_exists()` reuses that same window, so proving a `thread` anchor is parseable is free for a recent anchor and falls back to a scan only for one older than the window.
+
+`resolve` requires an explicit `may_read` decision for a ref that leaves the unit; omitting it denies rather than allows, because the shortest call shape must not be the insecure one. A ref that stays inside the ledger the caller already holds needs no callback. `forbidden` is decided before existence, so a denied read and an absent unit are indistinguishable.
+
+## 7. Retention, and what it costs
+
+There is no rotation, and adding one later is a format change, not a config change: `seq` is contiguous from 1 within one file, and `page`/`iter_from` stream from the header. Truncating a prefix would break contiguity and orphan every `ref` and `thread` pointing into the removed span.
+
+That is acceptable while writers are low-frequency (a crew's members, items and patrols; a session's lifecycle). It is not acceptable for a high-frequency session emitter -- `turn`, `step`, `tool` -- and the retention story has to be settled before one lands. The two shapes that preserve the guarantees are a segment directory whose files each keep their absolute `seq` range, and a `firstSeq` in the header so a truncated prefix is declared rather than inferred. Neither is implemented.
+
+## 8. Scope
+
+No consumer exists in the tree. Read and write paths ship together deliberately: the format's guarantees -- contiguous seq under a lock, torn-tail repair, refusal before any byte is written -- are only demonstrable with both halves, and `test/test_ledger_core.py` exercises them against real files rather than against a mock.

--- a/docs/system-specs/modules/session-ledger-emitter.md
+++ b/docs/system-specs/modules/session-ledger-emitter.md
@@ -1,0 +1,80 @@
+# Session Ledger Emitter
+
+`session_ledger_emit.py` turns the gateway's ACP turn lifecycle into the append-only
+per-session ledger `kiro_crew.ledger` keeps for each ACP session id. It is a **writer
+only**: it owns which facts matter and where they are known, not storage or its layout.
+
+The emitter is gated behind `KIROCREW_SESSION_LEDGER=1` (`constants.env_flag_enabled`,
+read per call, truthy set `{1, true, yes, on}`) and defaults **OFF**, so this module is
+inert until a later change turns it on. With the flag off no ledger directory is created
+and no call reaches the storage library.
+
+## Identity
+
+The ledger key is the **ACP session id**, not the slot key. A slot outlives its ACP
+session: an agent switch, a model switch, or a project change calls
+`SessionLifecycle.reset`, which pops the live session and lets the next turn cold-start a
+fresh one. When that reset cleared the conversation the successor has a new id and a new
+ledger; when it did not, the next cold start resumes the same id via `session/load`, so
+`Ledger.exists` decides between create and open and a resumed session never truncates it.
+
+`owner` and `agent` are header fields, written once at create time. There is no turn id in
+the repo, so a turn is identified by its message boundary, `len(slot.messages)` at turn
+start, and is also a **thread**: `turn/started` anchors one and every later entry in that
+turn carries the anchor's `seq`, so `thread_page` answers what one turn did with no fold.
+
+## Emitted facts
+
+| Fact | Site | Data |
+|---|---|---|
+| `session/opened` | after `get_or_create`, on create or re-attach only | agent, slot key, model, cwd, `resumed` |
+| `turn/started` | turn-start block in `_run_chat`, beside `_turn_t0` | turn ordinal, actor, prompt depth |
+| `turn/completed` | the `EVENT_COMPLETE` arm, beside `_emit_turn_metric` | the four `TurnUsage` token counts, credits, `duration_ms`, `stop_reason`, model, provider |
+| `tool/called` | `EVENT_TOOL_CALL` | `tool_call_id`, trusted `tool_name`, `mcp_server_name`, kind |
+| `tool/completed` | `EVENT_TOOL_RESULT` when `tool_final` | same id, outcome, elapsed ms measured by the emitter |
+| `approval/requested`, `approval/decided` | `ApprovalCoordinator.request` / `resolve` | approval id, tool name, decision |
+| `model/selected` | the fallback swap in `_run_chat`, after the pick lock is released | model id, source |
+| `compaction/applied` | `_settle_compact_cooldown`, once the after-reading is confirmed | `pct_before`, `pct_after`, freed |
+| `session/closed` | `SessionLifecycle.reset` | the gateway's own `end_reason` |
+
+Actor is derived in `_run_chat` from the nudge self-wake flag and the cron and subagent
+message prefixes, the same signals the dispatch classifier uses; reading the queue
+entry's `kind` would be stronger and needs the drain to pass it down. `approval/*` is
+implemented and tested but not wired: the approval coordinator holds only a slot key.
+
+## What is deliberately not recorded
+
+No message bodies, no tool arguments, and no tool results. A tool call is identified by
+its `tool_call_id` inside `data`, not by `ref`: a `Ref` cites lines of another ledger, and
+an ACP frame is not a ledger unit. That id is the join key the transcript already uses.
+
+A tool's `name` and `server` carry ONLY the trusted `_meta.kiro` identity, so both are
+empty when the backend supplies none, and the call id still joins the entry to the
+transcript. Neither `title` nor `wire_title` is used as a fallback: for a shell tool those
+are model-authored, and a log whose record of what ran can be written by the model is
+worth less than one that admits it does not know.
+
+`compaction/applied` carries **percentages, not token counts**: that boundary measures
+`provider.context_usage_pct()`, never raw tokens. The session's STARTING model is not a
+`model/selected` entry: it resolves before the session id exists, so it rides on
+`session/opened`, while the model a turn served rides on `turn/completed`.
+
+A turn that dies before `EVENT_COMPLETE` writes no `turn/completed`. That is the intended
+encoding: in an append-only log a `turn/started` with no matching completion **is** the
+record of an aborted turn, and synthesizing one would assert an outcome nobody observed. A
+recovery re-entry writes its own pair rather than folding into the original turn, and
+`depth` tells them apart. Tombstones, projections, a reader, and any UI are out of scope.
+
+## Failure policy
+
+Every entry point is fail-soft and returns `None`. A storage error is caught, reported
+once per process at warning level, and demoted to debug afterwards so a broken ledger
+cannot flood the log. This matters at three sites: the approval decision resolves on the
+websocket handler task, so an exception there would break the click handler and hang the
+waiting turn; `_default_session_model` runs inside `asyncio.to_thread` behind a
+swallow-all `except`; and `_fallback_swap_for_turn` holds `slot._model_pick_lock`. The
+emitter is called from the callers of the last two, never inside them, and never holds a
+lock or awaits I/O on the gateway event loop.
+
+`kiro_crew.events` is not a second emitter to reconcile with: its only constructor today
+is the read-only `events/backfill.py` validator, and this module does not route through it.

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -13,7 +13,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from kiro_crew import mcp_apps_render, model_registry, session_directive
+from kiro_crew import (
+    mcp_apps_render,
+    model_registry,
+    session_directive,
+    session_ledger_emit,
+)
 from kiro_crew.acp.client import (
     AcpAuthRequired,
     AcpError,
@@ -7260,6 +7265,19 @@ async def _run_chat(
         # (the dashboard steer handler) can reach the running session's client
         # to inject a mid-turn steer. Cleared in the finally below.
         slot._acp_client = getattr(client, "client", None)
+        # Append-only session ledger (flag-gated, fail-soft). The id is read
+        # once here and reused at every emit site below, so a turn that never
+        # got a session id emits nothing rather than guessing one. ``owner`` is
+        # "default" because a crew-bound slot never reaches this local runner.
+        _ledger_sid = session_ledger_emit.session_id_of(client)
+        session_ledger_emit.on_session_opened(
+            _ledger_sid,
+            agent=slot.agent or "",
+            slot=slot.key,
+            model=slot.model or "",
+            cwd=slot.project or "",
+            resumed=bool(resumed),
+        )
         # This consumer implements the low-fidelity child downgrade (the
         # interactive card) — opt in so the handle-level fail-close gate
         # yields those events here instead of rejecting them itself.
@@ -8023,6 +8041,18 @@ async def _run_chat(
         _turn_cost_usd = 0.0
         _turn_model = ""
         _turn_msg_boundary = len(slot.messages)
+        session_ledger_emit.on_turn_started(
+            _ledger_sid,
+            _turn_msg_boundary,
+            "autonudge"
+            if _directive_self_wake
+            else "cron"
+            if message.startswith(CRON_NOTIFY_PREFIX)
+            else "subagent"
+            if message.startswith(SUBAGENT_COMPLETION_PREFIXES)
+            else "user",
+            depth=_prompt_depth,
+        )
 
         # Lease-dispatch race gate: this session's semaphore lease
         # was taken by get_or_create above, but the provider turn only opens on
@@ -8199,6 +8229,14 @@ async def _run_chat(
                 _turn_thought = True
             elif event.kind == EVENT_TOOL_CALL:
                 _turn_tool_calls += 1
+                session_ledger_emit.on_tool_called(
+                    _ledger_sid,
+                    _turn_msg_boundary,
+                    name=event.tool_name or "",
+                    server=event.mcp_server_name or "",
+                    kind=event.tool_kind or "",
+                    call_id=event.tool_call_id or "",
+                )
                 # Flush pre-tool text silently (no broadcast) so it persists,
                 # but keep the streaming message in place for correct tool ordering.
                 _flush_text_stream()
@@ -8522,6 +8560,19 @@ async def _run_chat(
                 # redacted form, so the comparison must use the redacted form
                 # too — see the `_tool_meta` docstring for the convention.
                 _tcid = _redact_tool_field(event.tool_call_id) if event.tool_call_id else ""
+                # Only the terminal frame: a tool result can arrive more than
+                # once for one call, and the ledger records one completion.
+                # ``tool_final`` IS the completed status; ``stop_reason`` on this
+                # event describes the turn, not the tool, so it is not used here.
+                if event.tool_final:
+                    session_ledger_emit.on_tool_completed(
+                        _ledger_sid,
+                        _turn_msg_boundary,
+                        name=event.tool_name or "",
+                        server=event.mcp_server_name or "",
+                        status="refused" if event.refusal else "completed",
+                        call_id=event.tool_call_id or "",
+                    )
                 # MCP Apps (flag-independent on this side): if gatewayd spooled a
                 # UI payload it injected an opaque marker into the result text.
                 # Load it, push an mcp_app_render event to this slot, and strip
@@ -10702,6 +10753,20 @@ async def _run_chat(
                 #      joins. Attributing the sample to the slot would file every
                 #      linked Slack or Telegram turn under ``dashboard`` — the
                 #      same blind spot in a new place.
+                session_ledger_emit.on_turn_completed(
+                    _ledger_sid,
+                    _turn_msg_boundary,
+                    input_tokens=event.usage.input_tokens,
+                    output_tokens=event.usage.output_tokens,
+                    cache_read_tokens=event.usage.cache_read_tokens,
+                    cache_write_tokens=event.usage.cache_creation_tokens,
+                    credits=_turn_credits,
+                    duration_ms=_turn_elapsed_ms,
+                    stop_reason=event.stop_reason,
+                    model=_turn_model or _record_model,
+                    provider=_provider_name,
+                    depth=_prompt_depth,
+                )
                 _emit_turn_metric(
                     event.usage.duration_ms,
                     event.stop_reason,
@@ -12451,6 +12516,14 @@ async def _run_chat(
             and not _should_suppress_requeue(slot)
             and (_fb_candidate := await _fallback_swap_for_turn(slot, client)) is not None
         ):
+            # Append-only session ledger (flag-gated, fail-soft). Emitted HERE,
+            # in the branch body, so it runs after _fallback_swap_for_turn has
+            # released slot._model_pick_lock rather than while it is held. This
+            # is the one model decision a transcript cannot answer afterwards:
+            # the user picked the primary and the turn ran somewhere else.
+            session_ledger_emit.on_model_selected(
+                _ledger_sid, _fb_candidate, "fallback"
+            )
             # ── Throttle-exhaustion model fallback (agent.fallback_model) ──
             # The same-model budget above is spent and the error is still
             # transient (throttle/capacity). _fallback_swap_for_turn already

--- a/src/kiro_crew/ledger/__init__.py
+++ b/src/kiro_crew/ledger/__init__.py
@@ -1,0 +1,111 @@
+"""Append-only ledgers for crews and sessions -- the storage layer, nothing else.
+
+The format, the rules and how this stream relates to ``kiro_crew.events`` are
+specified in ``docs/system-specs/modules/ledger-core.md``. Two units, one file
+each, the gateway the only writer::
+
+    from kiro_crew.ledger import Ledger
+
+    crew = Ledger.create("crew", "qa", name="QA Crew")
+    crew.append("member/joined", {"who": "s-7f3a"}, src="gateway")
+
+This package holds no dashboard, route, tool or migration code. It reads and
+writes its own files and imports only path, lock and containment primitives, so
+a consumer can be added without this layer learning about it.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.ledger.errors import (
+    CODE_ALREADY_EXISTS,
+    CODE_BAD_DATA,
+    CODE_BAD_HEADER,
+    CODE_BAD_HEADER_FIELD,
+    CODE_BAD_KIND,
+    CODE_BAD_REF,
+    CODE_BAD_SRC,
+    CODE_BAD_THREAD,
+    CODE_BAD_TYPE,
+    CODE_ENTRY_TOO_LARGE,
+    CODE_EVENT_TYPE_NOT_OWNED,
+    CODE_INVALID_ID,
+    CODE_NAMESPACE_VIOLATION,
+    CODE_NO_LEDGER,
+    LedgerError,
+)
+from kiro_crew.ledger.schema import (
+    FIXED_SOURCES,
+    KIND_CREW,
+    KIND_SESSION,
+    KINDS,
+    MAX_ENTRY_BYTES,
+    MAX_REF_SPAN,
+    SCHEMA_VERSION,
+    TYPE_OWNERSHIP,
+    CrewHeader,
+    Entry,
+    Header,
+    Ref,
+    SessionHeader,
+    SessionThread,
+)
+from kiro_crew.ledger.store import (
+    DEFAULT_PAGE_LIMIT,
+    LEDGER_FILE,
+    MAX_PAGE_LIMIT,
+    STATUS_FORBIDDEN,
+    STATUS_GONE,
+    STATUS_OK,
+    Ledger,
+    Page,
+    Resolution,
+    ledger_dir,
+    ledger_path,
+    ledger_root,
+    now_ms,
+)
+
+__all__ = [
+    "CODE_ALREADY_EXISTS",
+    "CODE_BAD_DATA",
+    "CODE_BAD_HEADER",
+    "CODE_BAD_HEADER_FIELD",
+    "CODE_BAD_KIND",
+    "CODE_BAD_REF",
+    "CODE_BAD_SRC",
+    "CODE_BAD_THREAD",
+    "CODE_BAD_TYPE",
+    "CODE_ENTRY_TOO_LARGE",
+    "CODE_EVENT_TYPE_NOT_OWNED",
+    "CODE_INVALID_ID",
+    "CODE_NAMESPACE_VIOLATION",
+    "CODE_NO_LEDGER",
+    "DEFAULT_PAGE_LIMIT",
+    "FIXED_SOURCES",
+    "KINDS",
+    "KIND_CREW",
+    "KIND_SESSION",
+    "LEDGER_FILE",
+    "MAX_ENTRY_BYTES",
+    "MAX_PAGE_LIMIT",
+    "MAX_REF_SPAN",
+    "SCHEMA_VERSION",
+    "STATUS_FORBIDDEN",
+    "STATUS_GONE",
+    "STATUS_OK",
+    "TYPE_OWNERSHIP",
+    "CrewHeader",
+    "Entry",
+    "Header",
+    "Ledger",
+    "LedgerError",
+    "Page",
+    "Ref",
+    "Resolution",
+    "SessionHeader",
+    "SessionThread",
+    "ledger_dir",
+    "ledger_path",
+    "ledger_root",
+    "now_ms",
+]

--- a/src/kiro_crew/ledger/errors.py
+++ b/src/kiro_crew/ledger/errors.py
@@ -1,0 +1,63 @@
+"""Refusals the append-only ledger raises, each carrying a stable ``code``.
+
+Every refusal is a :class:`LedgerError` with a machine-readable ``code``, the
+same contract :mod:`kiro_crew.work_ledger` uses: a caller (a route handler, a
+tool wrapper) branches on the code, and the human-readable message is free to
+change without breaking that caller.
+
+Codes are additive-only. A code string, once shipped, is never renamed or
+repurposed -- it is part of the API surface, not a log string.
+"""
+
+from __future__ import annotations
+
+#: The requested ledger kind is neither ``crew`` nor ``session``.
+CODE_BAD_KIND = "bad_kind"
+#: The unit id is empty, carries a path separator or a NUL, or resolves outside
+#: its own root.
+CODE_INVALID_ID = "invalid_id"
+#: ``create`` was asked for a ledger whose file is already there.
+CODE_ALREADY_EXISTS = "already_exists"
+#: ``open`` was asked for a ledger whose file is not there.
+CODE_NO_LEDGER = "no_ledger"
+#: Line 1 is missing, unparseable, or describes a different unit than the one
+#: asked for. A ledger without a readable header is not a ledger.
+CODE_BAD_HEADER = "bad_header"
+#: A header field is missing, of the wrong python type, or unknown.
+CODE_BAD_HEADER_FIELD = "bad_header_field"
+
+#: ``type`` is not spelled ``domain/action``.
+CODE_BAD_TYPE = "bad_type"
+#: ``src`` is not one of the fixed emitters nor a well-formed namespaced one.
+CODE_BAD_SRC = "bad_src"
+#: ``data`` is not a JSON object, or holds something not JSON-serializable.
+CODE_BAD_DATA = "bad_data"
+#: This ledger kind does not own that ``type`` prefix (rule 1).
+CODE_EVENT_TYPE_NOT_OWNED = "event_type_not_owned"
+#: A guest emitter wrote outside its own namespace, or wrote a guest type into
+#: a session ledger (rule 2).
+CODE_NAMESPACE_VIOLATION = "namespace_violation"
+#: ``thread`` does not name an existing, earlier seq in this same ledger.
+CODE_BAD_THREAD = "bad_thread"
+#: ``ref`` is malformed: bad unit, bad id, non-positive bounds, inverted
+#: bounds, or a span wider than the read cap.
+CODE_BAD_REF = "bad_ref"
+#: The serialized entry line is over the size ceiling.
+CODE_ENTRY_TOO_LARGE = "entry_too_large"
+
+
+class LedgerError(Exception):
+    """A refused ledger operation.
+
+    ``code`` is the stable identifier; ``field`` names the offending input when
+    one field is to blame, so a caller can point at it without parsing prose.
+    """
+
+    def __init__(self, message: str, *, code: str, field: str | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.field = field
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.message

--- a/src/kiro_crew/ledger/schema.py
+++ b/src/kiro_crew/ledger/schema.py
@@ -1,0 +1,706 @@
+"""Wire format for the append-only ledger: the header, the entry, the rules.
+
+One ledger is one file. Line 1 is a **header** describing the unit the file
+belongs to; every later line is an **entry**. Nothing is ever rewritten, so the
+format has to be readable by a consumer newer *or* older than the writer:
+
+- Unknown envelope keys are ignored rather than rejected, and an unparseable
+  interior line is skipped rather than failing the read (see
+  :mod:`kiro_crew.ledger.store`). ``version`` is the escape hatch for a future
+  incompatible break, not a per-change workflow.
+- The envelope is field-compatible with :mod:`kiro_crew.events.base`: this
+  module's ``type`` is that one's ``kind``, and this module's ``time`` is its
+  ``ts_ms``. Same ``domain/action`` naming, same epoch-millisecond clock, so a
+  later projection can fold both streams on one axis. What this format adds is
+  a writer-assigned ``seq`` (contiguous per file, which the lifecycle envelope
+  deliberately left unspecified), a ``thread`` grouping key, and a ``ref``
+  pointer into another file.
+
+Two rules decide whether an entry may be written at all, and they are separate
+because they answer different questions.
+
+**Ownership** (rule 1) answers *does this kind of unit have such events at
+all*: a session has turns and tool calls, a crew has members and patrols. It is
+a prefix registry, :data:`TYPE_OWNERSHIP`, so adding an action to an existing
+domain needs no change here.
+
+**Namespacing** (rule 2) answers *may this emitter write this*. A crew or an app
+writing into a crew ledger is a GUEST: it may write only under its own
+``crew:<name>/`` or ``app:<name>/`` prefix, and only into a crew ledger. The
+guest prefix is what makes the registry safe to keep short -- a guest never
+needs a registry entry, because its own name is its permission. Guest types are
+therefore checked by rule 2 *instead of* rule 1, not in addition to it.
+
+Caps refuse; they never truncate. An entry over :data:`MAX_ENTRY_BYTES`, or a
+``ref`` spanning more than :data:`MAX_REF_SPAN` lines, is refused whole. A
+silently clipped record the caller believes landed intact is a loss the caller
+cannot detect.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from kiro_crew.ledger.errors import (
+    CODE_BAD_DATA,
+    CODE_BAD_HEADER,
+    CODE_BAD_HEADER_FIELD,
+    CODE_BAD_KIND,
+    CODE_BAD_REF,
+    CODE_BAD_SRC,
+    CODE_BAD_TYPE,
+    CODE_ENTRY_TOO_LARGE,
+    CODE_EVENT_TYPE_NOT_OWNED,
+    CODE_INVALID_ID,
+    CODE_NAMESPACE_VIOLATION,
+    LedgerError,
+)
+
+#: Header schema version. Additive changes never bump it.
+SCHEMA_VERSION = 1
+
+KIND_CREW = "crew"
+KIND_SESSION = "session"
+
+#: The two units that own a ledger. A kind is also the ``unit`` a ref names.
+KINDS: frozenset[str] = frozenset({KIND_CREW, KIND_SESSION})
+
+#: Serialized-line ceiling. A line past this is refused, not clipped.
+MAX_ENTRY_BYTES = 64 * 1024
+
+#: Widest span a single ``ref`` may point at. A pointer is a citation, not a
+#: bulk export: an unbounded span would let one entry make its reader
+#: materialize a whole history.
+MAX_REF_SPAN = 500
+
+#: Which ``type`` domains each kind owns (rule 1). Prefix-based on purpose: a
+#: new action under an owned domain needs no change here.
+TYPE_OWNERSHIP: dict[str, frozenset[str]] = {
+    KIND_CREW: frozenset(
+        {"member", "activity", "slot", "patrol", "message", "crew", "item", "memory"}
+    ),
+    KIND_SESSION: frozenset(
+        {"session", "turn", "step", "tool", "approval", "model", "compaction", "remote"}
+    ),
+}
+
+#: Emitters that name a whole subsystem and carry no instance id.
+FIXED_SOURCES: frozenset[str] = frozenset({"gateway", "acp", "dashboard", "patrol"})
+
+#: Emitter prefixes that DO carry an instance id, spelled ``<prefix>:<name>``.
+SESSION_SOURCE_PREFIX = "session:"
+CREW_SOURCE_PREFIX = "crew:"
+APP_SOURCE_PREFIX = "app:"
+
+#: The two guest prefixes. A guest's own name is its write permission.
+GUEST_PREFIXES: tuple[str, ...] = (CREW_SOURCE_PREFIX, APP_SOURCE_PREFIX)
+
+# A name segment: a domain, an action, a crew name, an app name. No separator,
+# so it can never widen a type into another namespace or a path into another
+# directory.
+_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# A session id as it appears after ``session:``. Colons are allowed because a
+# channel session key legitimately carries one (``slack:1712793600.123``), so a
+# colon count cannot classify the tail.
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+
+# --------------------------------------------------------------------------- #
+# Ids
+# --------------------------------------------------------------------------- #
+
+
+def require_unit_id(unit_id: str, *, field: str = "id") -> str:
+    """*unit_id* unchanged, or raise ``invalid_id``.
+
+    A unit id names a DIRECTORY, so a separator or a NUL in it would let the
+    ledger escape its own root. The raw id is refused loudly rather than folded
+    to something safe: a fold would silently merge two units into one file, and
+    two units sharing a ledger is worse than a refused write. Containment is
+    re-checked symlink-safely when the path is built (``resolved_within``); this
+    is the cheap shape gate in front of it.
+    """
+    if not isinstance(unit_id, str) or not unit_id:
+        raise LedgerError("ledger id must be a non-empty string", code=CODE_INVALID_ID, field=field)
+    if "\0" in unit_id or "/" in unit_id or "\\" in unit_id:
+        raise LedgerError(
+            f"ledger id must not contain a path separator or NUL: {unit_id!r}",
+            code=CODE_INVALID_ID,
+            field=field,
+        )
+    if unit_id in {".", ".."}:
+        raise LedgerError(
+            f"ledger id must not be a relative path element: {unit_id!r}",
+            code=CODE_INVALID_ID,
+            field=field,
+        )
+    return unit_id
+
+
+def require_kind(kind: str, *, field: str = "kind") -> str:
+    """*kind* unchanged, or raise ``bad_kind``."""
+    if kind not in KINDS:
+        raise LedgerError(
+            f"unknown ledger kind {kind!r}; expected one of {sorted(KINDS)}",
+            code=CODE_BAD_KIND,
+            field=field,
+        )
+    return kind
+
+
+# --------------------------------------------------------------------------- #
+# type / src
+# --------------------------------------------------------------------------- #
+
+
+def split_type(entry_type: str) -> tuple[str, str]:
+    """``("domain", "action")`` for *entry_type*, or raise ``bad_type``.
+
+    Partitioned on the FIRST slash, which is what lets a guest domain keep its
+    colon: ``crew:qa/report`` splits to ``("crew:qa", "report")``. The action
+    may not itself contain a slash, so the namespace is exactly one level deep
+    and no action can smuggle a second domain behind it.
+    """
+    if not isinstance(entry_type, str) or not entry_type:
+        raise LedgerError("entry type must be a non-empty string", code=CODE_BAD_TYPE, field="type")
+    domain, sep, action = entry_type.partition("/")
+    if sep != "/" or not domain or not action:
+        raise LedgerError(
+            f"entry type must be spelled domain/action: {entry_type!r}",
+            code=CODE_BAD_TYPE,
+            field="type",
+        )
+    if not _SEGMENT_RE.match(action):
+        raise LedgerError(
+            f"entry type action is not a plain name: {entry_type!r}",
+            code=CODE_BAD_TYPE,
+            field="type",
+        )
+    guest = guest_prefix_of(domain)
+    tail = domain[len(guest) :] if guest else domain
+    if not _SEGMENT_RE.match(tail):
+        raise LedgerError(
+            f"entry type domain is not a plain name: {entry_type!r}",
+            code=CODE_BAD_TYPE,
+            field="type",
+        )
+    return domain, action
+
+
+def guest_prefix_of(value: str) -> str | None:
+    """The guest prefix *value* starts with (``crew:`` / ``app:``), else ``None``."""
+    for prefix in GUEST_PREFIXES:
+        if value.startswith(prefix):
+            return prefix
+    return None
+
+
+def require_src(src: str) -> str:
+    """*src* unchanged, or raise ``bad_src``."""
+    if not isinstance(src, str) or not src:
+        raise LedgerError("src must be a non-empty string", code=CODE_BAD_SRC, field="src")
+    if src in FIXED_SOURCES:
+        return src
+    if src.startswith(SESSION_SOURCE_PREFIX):
+        if _SESSION_ID_RE.match(src[len(SESSION_SOURCE_PREFIX) :]):
+            return src
+    else:
+        guest = guest_prefix_of(src)
+        if guest and _SEGMENT_RE.match(src[len(guest) :]):
+            return src
+    raise LedgerError(
+        f"src must be one of {sorted(FIXED_SOURCES)} or "
+        f"session:<id> / crew:<name> / app:<name>: {src!r}",
+        code=CODE_BAD_SRC,
+        field="src",
+    )
+
+
+def check_ownership(kind: str, entry_type: str, src: str) -> None:
+    """Enforce rules 1 and 2 for one (*kind*, *entry_type*, *src*) triple.
+
+    Order matters. Whether the TYPE is guest-namespaced is decided first,
+    because that answer selects which rule governs: a guest type is judged by
+    rule 2 alone (its own name is its permission) and never consulted against
+    the ownership registry, which is why the registry needs no guest entries.
+    """
+    domain, _action = split_type(entry_type)
+    require_src(src)
+    type_guest = guest_prefix_of(domain)
+    src_guest = guest_prefix_of(src)
+
+    if type_guest is not None:
+        if kind != KIND_CREW:
+            raise LedgerError(
+                f"a {kind} ledger does not accept the guest type {entry_type!r}; "
+                "guest namespaces are crew-ledger only",
+                code=CODE_NAMESPACE_VIOLATION,
+                field="type",
+            )
+        if domain != src:
+            raise LedgerError(
+                f"guest type {entry_type!r} must be written by src {domain!r}, not {src!r}",
+                code=CODE_NAMESPACE_VIOLATION,
+                field="type",
+            )
+        return
+
+    if src_guest is not None:
+        raise LedgerError(
+            f"guest src {src!r} may only write types under {src}/, not {entry_type!r}",
+            code=CODE_NAMESPACE_VIOLATION,
+            field="src",
+        )
+    if domain not in TYPE_OWNERSHIP[require_kind(kind)]:
+        raise LedgerError(
+            f"a {kind} ledger does not own the type {entry_type!r}; "
+            f"owned domains are {sorted(TYPE_OWNERSHIP[kind])}",
+            code=CODE_EVENT_TYPE_NOT_OWNED,
+            field="type",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# ref
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Ref:
+    """A pointer to a segment of another (or the same) ledger.
+
+    A ref is a CITATION, not a copy: the bytes stay in the ledger they were
+    written to, and a reader that may not read that unit gets ``forbidden``
+    rather than the contents. ``to_seq`` absent means the single line at
+    ``from_seq``.
+    """
+
+    unit: str
+    id: str
+    from_seq: int
+    to_seq: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.unit not in KINDS:
+            raise LedgerError(
+                f"ref unit must be one of {sorted(KINDS)}: {self.unit!r}",
+                code=CODE_BAD_REF,
+                field="unit",
+            )
+        try:
+            require_unit_id(self.id, field="ref.id")
+        except LedgerError as exc:
+            raise LedgerError(exc.message, code=CODE_BAD_REF, field="ref.id") from exc
+        if not _is_seq(self.from_seq):
+            raise LedgerError(
+                f"ref from must be a positive int: {self.from_seq!r}",
+                code=CODE_BAD_REF,
+                field="ref.from",
+            )
+        if self.to_seq is None:
+            return
+        if not _is_seq(self.to_seq) or self.to_seq < self.from_seq:
+            raise LedgerError(
+                f"ref to must be a positive int at or after from: {self.to_seq!r}",
+                code=CODE_BAD_REF,
+                field="ref.to",
+            )
+        if self.to_seq - self.from_seq + 1 > MAX_REF_SPAN:
+            raise LedgerError(
+                f"ref spans more than {MAX_REF_SPAN} lines; cite a narrower segment",
+                code=CODE_BAD_REF,
+                field="ref.to",
+            )
+
+    @property
+    def last_seq(self) -> int:
+        """The last seq the ref covers -- ``from_seq`` when ``to_seq`` is absent."""
+        return self.from_seq if self.to_seq is None else self.to_seq
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"unit": self.unit, "id": self.id, "from": self.from_seq}
+        if self.to_seq is not None:
+            out["to"] = self.to_seq
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> Ref:
+        """A :class:`Ref` from its wire form, or raise ``bad_ref``."""
+        if not isinstance(raw, dict):
+            raise LedgerError(f"ref must be an object: {raw!r}", code=CODE_BAD_REF, field="ref")
+        # Deliberately ``Any``: these come off the wire untyped, and
+        # ``__post_init__`` is the thing that rejects a wrong one -- the same
+        # check a direct constructor call goes through, so the two paths cannot
+        # disagree about what a valid ref is.
+        unit: Any = raw.get("unit")
+        unit_id: Any = raw.get("id")
+        from_seq: Any = raw.get("from")
+        to_seq: Any = raw.get("to")
+        return cls(unit=unit, id=unit_id, from_seq=from_seq, to_seq=to_seq)
+
+
+def _is_seq(value: Any) -> bool:
+    """Whether *value* is a usable seq: a positive int, and not a JSON ``true``."""
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 1
+
+
+# --------------------------------------------------------------------------- #
+# Entries
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Entry:
+    """One ledger line after the header. ``seq`` and ``time`` are writer-assigned."""
+
+    type: str
+    seq: int
+    time: int
+    src: str
+    data: dict[str, Any]
+    thread: int | None = None
+    ref: Ref | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "type": self.type,
+            "seq": self.seq,
+            "time": self.time,
+            "src": self.src,
+        }
+        if self.thread is not None:
+            out["thread"] = self.thread
+        if self.ref is not None:
+            out["ref"] = self.ref.to_dict()
+        out["data"] = self.data
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> Entry | None:
+        """An :class:`Entry` from a parsed line, or ``None`` when unusable.
+
+        Returns ``None`` instead of raising: this is the READ path, and a reader
+        of an append-only file must not be the thing that crashes because one
+        interior line is damaged. Unknown envelope keys are ignored, so a line
+        from a newer writer still reads.
+        """
+        if not isinstance(raw, dict):
+            return None
+        entry_type = raw.get("type")
+        # ``Any`` because ``_is_seq`` is what narrows these, and a static
+        # annotation here would only duplicate a check the reader must make
+        # against untrusted bytes anyway.
+        seq: Any = raw.get("seq")
+        stamp = raw.get("time")
+        src = raw.get("src")
+        data = raw.get("data")
+        if not isinstance(entry_type, str) or not entry_type:
+            return None
+        if not _is_seq(seq) or not isinstance(stamp, int) or isinstance(stamp, bool):
+            return None
+        if not isinstance(src, str) or not src or not isinstance(data, dict):
+            return None
+        thread = raw.get("thread")
+        if thread is not None and not _is_seq(thread):
+            return None
+        raw_ref = raw.get("ref")
+        ref: Ref | None = None
+        if raw_ref is not None:
+            try:
+                ref = Ref.from_dict(raw_ref)
+            except LedgerError:
+                return None
+        return cls(type=entry_type, seq=seq, time=stamp, src=src, data=data, thread=thread, ref=ref)
+
+
+def serialize(payload: dict[str, Any]) -> str:
+    """*payload* as one compact JSON line, or raise ``bad_data``.
+
+    ``ensure_ascii`` stays on so the file is byte-stable regardless of the
+    reader's locale, and the separators drop the whitespace ``json`` adds by
+    default -- a ledger line is machine-read, and the bytes are the budget the
+    size cap is spent from.
+    """
+    try:
+        return json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=False)
+    except (TypeError, ValueError) as exc:
+        raise LedgerError(
+            f"ledger payload is not JSON-serializable: {exc}", code=CODE_BAD_DATA, field="data"
+        ) from exc
+
+
+def require_entry_line(line: str) -> str:
+    """*line* unchanged, or raise ``entry_too_large``."""
+    size = len(line.encode("utf-8"))
+    if size > MAX_ENTRY_BYTES:
+        raise LedgerError(
+            f"entry is {size} bytes, over the {MAX_ENTRY_BYTES}-byte ceiling",
+            code=CODE_ENTRY_TOO_LARGE,
+            field="data",
+        )
+    return line
+
+
+def require_data(data: Any) -> dict[str, Any]:
+    """*data* unchanged, or raise ``bad_data``."""
+    if not isinstance(data, dict):
+        raise LedgerError(
+            f"entry data must be a JSON object, got {type(data).__name__}",
+            code=CODE_BAD_DATA,
+            field="data",
+        )
+    return data
+
+
+# --------------------------------------------------------------------------- #
+# Headers
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class SessionThread:
+    """Where a session hangs off its owning crew's ledger."""
+
+    crew: str
+    seq: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"crew": self.crew, "seq": self.seq}
+
+    @classmethod
+    def coerce(cls, raw: Any) -> SessionThread | None:
+        """A :class:`SessionThread` from itself, a dict, or ``None``."""
+        if raw is None or isinstance(raw, cls):
+            return raw
+        if isinstance(raw, dict) and isinstance(raw.get("crew"), str) and _is_seq(raw.get("seq")):
+            return cls(crew=raw["crew"], seq=raw["seq"])
+        raise LedgerError(
+            f"session thread must be null or {{crew, seq}}: {raw!r}",
+            code=CODE_BAD_HEADER_FIELD,
+            field="thread",
+        )
+
+
+@dataclass(frozen=True)
+class CrewHeader:
+    """Line 1 of a crew ledger."""
+
+    id: str
+    name: str
+    created_at: int
+    template: str | None = None
+    version: int = SCHEMA_VERSION
+
+    kind: str = KIND_CREW
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": KIND_CREW,
+            "version": self.version,
+            "id": self.id,
+            "name": self.name,
+            "template": self.template,
+            "createdAt": self.created_at,
+        }
+
+
+@dataclass(frozen=True)
+class SessionHeader:
+    """Line 1 of a session ledger."""
+
+    id: str
+    owner: str
+    agent: str
+    created_at: int
+    task: str | None = None
+    pack: str | None = None
+    slot: str | None = None
+    thread: SessionThread | None = None
+    cwd: str | None = None
+    remote: dict[str, Any] | None = None
+    version: int = SCHEMA_VERSION
+
+    kind: str = KIND_SESSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": KIND_SESSION,
+            "version": self.version,
+            "id": self.id,
+            "owner": self.owner,
+            "task": self.task,
+            "pack": self.pack,
+            "agent": self.agent,
+            "slot": self.slot,
+            "thread": None if self.thread is None else self.thread.to_dict(),
+            "cwd": self.cwd,
+            "remote": self.remote,
+            "createdAt": self.created_at,
+        }
+
+
+Header = CrewHeader | SessionHeader
+
+_REQUIRED_HEADER_FIELDS: dict[str, tuple[str, ...]] = {
+    KIND_CREW: ("name",),
+    KIND_SESSION: ("owner", "agent"),
+}
+
+_OPTIONAL_HEADER_FIELDS: dict[str, tuple[str, ...]] = {
+    KIND_CREW: ("template",),
+    KIND_SESSION: ("task", "pack", "slot", "thread", "cwd", "remote"),
+}
+
+_STR_HEADER_FIELDS = frozenset(
+    {"name", "template", "owner", "agent", "task", "pack", "slot", "cwd"}
+)
+
+
+def build_header(kind: str, unit_id: str, created_at: int, fields: dict[str, Any]) -> Header:
+    """The header for a new ledger, or raise ``bad_header_field``.
+
+    Unknown keys are refused rather than dropped. On the READ path an unknown
+    key is ignored (an older reader must tolerate a newer writer), but on the
+    WRITE path a caller that misspells a field would otherwise be told the
+    header was stored as asked while the value silently vanished.
+    """
+    require_kind(kind)
+    require_unit_id(unit_id)
+    allowed = set(_REQUIRED_HEADER_FIELDS[kind]) | set(_OPTIONAL_HEADER_FIELDS[kind])
+    unknown = sorted(set(fields) - allowed)
+    if unknown:
+        raise LedgerError(
+            f"unknown header field(s) for a {kind} ledger: {unknown}; allowed: {sorted(allowed)}",
+            code=CODE_BAD_HEADER_FIELD,
+            field=unknown[0],
+        )
+    missing = [name for name in _REQUIRED_HEADER_FIELDS[kind] if fields.get(name) is None]
+    if missing:
+        raise LedgerError(
+            f"missing required header field(s) for a {kind} ledger: {missing}",
+            code=CODE_BAD_HEADER_FIELD,
+            field=missing[0],
+        )
+    for name in sorted(set(fields) & _STR_HEADER_FIELDS):
+        value = fields[name]
+        if value is not None and not isinstance(value, str):
+            raise LedgerError(
+                f"header field {name!r} must be a string or null, got {type(value).__name__}",
+                code=CODE_BAD_HEADER_FIELD,
+                field=name,
+            )
+    if kind == KIND_CREW:
+        return CrewHeader(
+            id=unit_id,
+            name=fields["name"],
+            created_at=created_at,
+            template=fields.get("template"),
+        )
+    remote = fields.get("remote")
+    if remote is not None and not isinstance(remote, dict):
+        raise LedgerError(
+            f"header field 'remote' must be an object or null, got {type(remote).__name__}",
+            code=CODE_BAD_HEADER_FIELD,
+            field="remote",
+        )
+    return SessionHeader(
+        id=unit_id,
+        owner=fields["owner"],
+        agent=fields["agent"],
+        created_at=created_at,
+        task=fields.get("task"),
+        pack=fields.get("pack"),
+        slot=fields.get("slot"),
+        thread=SessionThread.coerce(fields.get("thread")),
+        cwd=fields.get("cwd"),
+        remote=remote,
+    )
+
+
+def parse_header(raw: Any, *, kind: str, unit_id: str) -> Header:
+    """A header from its wire form, or raise ``bad_header``.
+
+    The stored ``type`` and ``id`` must match what the caller asked to open. A
+    ledger whose header names a different unit is not this unit's ledger, and
+    reading it as if it were would attribute one unit's history to another.
+    """
+    if not isinstance(raw, dict):
+        raise LedgerError("ledger header is not an object", code=CODE_BAD_HEADER, field="type")
+    stored_kind = raw.get("type")
+    if stored_kind != kind:
+        raise LedgerError(
+            f"ledger header says type {stored_kind!r}, opened as {kind!r}",
+            code=CODE_BAD_HEADER,
+            field="type",
+        )
+    if raw.get("id") != unit_id:
+        raise LedgerError(
+            f"ledger header says id {raw.get('id')!r}, opened as {unit_id!r}",
+            code=CODE_BAD_HEADER,
+            field="id",
+        )
+    created_at = raw.get("createdAt")
+    if not isinstance(created_at, int) or isinstance(created_at, bool):
+        raise LedgerError(
+            f"ledger header createdAt must be epoch ms: {created_at!r}",
+            code=CODE_BAD_HEADER,
+            field="createdAt",
+        )
+    version = raw.get("version")
+    if not isinstance(version, int) or isinstance(version, bool):
+        raise LedgerError(
+            f"ledger header version must be an int: {version!r}",
+            code=CODE_BAD_HEADER,
+            field="version",
+        )
+    if kind == KIND_CREW:
+        name = raw.get("name")
+        if not isinstance(name, str):
+            raise LedgerError(
+                f"crew ledger header name must be a string: {name!r}",
+                code=CODE_BAD_HEADER,
+                field="name",
+            )
+        template = raw.get("template")
+        return CrewHeader(
+            id=unit_id,
+            name=name,
+            created_at=created_at,
+            template=template if isinstance(template, str) else None,
+            version=version,
+        )
+    agent = raw.get("agent")
+    owner = raw.get("owner")
+    if not isinstance(agent, str) or not isinstance(owner, str):
+        raise LedgerError(
+            f"session ledger header needs string owner and agent: {owner!r}, {agent!r}",
+            code=CODE_BAD_HEADER,
+            field="agent",
+        )
+    thread_raw = raw.get("thread")
+    try:
+        thread = SessionThread.coerce(thread_raw)
+    except LedgerError:
+        thread = None
+    remote = raw.get("remote")
+    return SessionHeader(
+        id=unit_id,
+        owner=owner,
+        agent=agent,
+        created_at=created_at,
+        task=_opt_str(raw.get("task")),
+        pack=_opt_str(raw.get("pack")),
+        slot=_opt_str(raw.get("slot")),
+        thread=thread,
+        cwd=_opt_str(raw.get("cwd")),
+        remote=remote if isinstance(remote, dict) else None,
+        version=version,
+    )
+
+
+def _opt_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None

--- a/src/kiro_crew/ledger/store.py
+++ b/src/kiro_crew/ledger/store.py
@@ -1,0 +1,733 @@
+"""The append-only ledger store: one file per unit, the gateway the only writer.
+
+Layout, resolved against the live data home on every call (never captured at
+import, so pod isolation and test isolation both keep working)::
+
+    <data home>/crews/<store name>/ledger.jsonl
+    <data home>/sessions/<store name>/ledger.jsonl
+
+``<store name>`` is the readable-plus-digest fold of the unit id that
+``session_ledger`` and ``work_ledger`` already use, and the raw id lives in the
+header (see :func:`ledger_dir` for why the id is not the directory name). Both
+files carry a ``.lock`` sibling in the same directory.
+
+A ledger is NON-RECURSIVE inside its root, which is what lets the session root
+be shared with the existing flat ``sessions/<key>.jsonl`` transcripts: every
+reader of those globs ``*.jsonl`` one level deep, so a ledger in a subdirectory
+is invisible to them and neither store can shadow the other. That reuse also
+puts session ledgers behind the sandbox's existing ``sessions`` deny; the
+``crews`` root carries its own entry on the sensitive-path floor, because a
+record a conductor is meant to trust as authority must not be forgeable by an
+agent's own file tools.
+
+Three properties are the whole design.
+
+**Append only.** A line, once written, is never rewritten. There is exactly ONE
+mutation: on ``open``, trailing bytes that are not a complete line are dropped.
+Everything else -- a damaged interior line, an unknown envelope key, a type from
+a newer writer -- is handled on the READ side by skipping or ignoring, never by
+repairing the file. So two readers of the same bytes always agree, and a reader
+is never the thing that changes history.
+
+**Torn is decided by termination, not by taste.** Every append writes
+``line + "\\n"`` and fsyncs, so a file that does not end in a newline was
+interrupted mid-write. Those trailing bytes are the crash artifact and are
+truncated -- unless they happen to parse whole, in which case only the newline
+was lost: the record is kept and the next append re-supplies the separator. A
+line that IS newline-terminated but does not parse is damage *inside* history,
+so it is skipped on read and left on disk. Nothing else can be torn, which is
+why this rule needs no heuristics.
+
+**Seq comes from the file, under the lock.** ``seq`` is read back from the tail
+inside the critical section on every append rather than trusted from the
+in-process cache, so two writers cannot both believe they own the same number.
+The read is a bounded window at the end of the file (``_TAIL_WINDOW``), not a
+scan, so it costs the same on a ledger with ten lines and one with a million.
+``.last_seq`` serves the cached value for callers that only want to look.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections import deque
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.config.paths import data_home
+from kiro_crew.ledger.errors import (
+    CODE_ALREADY_EXISTS,
+    CODE_BAD_HEADER,
+    CODE_BAD_THREAD,
+    CODE_INVALID_ID,
+    CODE_NO_LEDGER,
+    LedgerError,
+)
+from kiro_crew.ledger.schema import (
+    KIND_CREW,
+    KIND_SESSION,
+    Entry,
+    Header,
+    Ref,
+    build_header,
+    check_ownership,
+    parse_header,
+    require_data,
+    require_entry_line,
+    require_kind,
+    require_unit_id,
+    serialize,
+)
+from kiro_crew.platform_compat import file_lock
+from kiro_crew.session_ledger import _store_name, resolved_within
+
+logger = logging.getLogger(__name__)
+
+LEDGER_FILE = "ledger.jsonl"
+_LOCK_FILE = ".lock"
+
+#: Directory under the data home that holds each kind's units.
+_ROOT_DIR: dict[str, str] = {KIND_CREW: "crews", KIND_SESSION: "sessions"}
+
+#: How much of the file's end a tail read covers. One maximum-size entry plus
+#: slack, so the newest complete line is inside the window even when it is the
+#: largest line the format allows.
+_TAIL_WINDOW = 64 * 1024 + 8 * 1024
+
+#: Largest page a single read may materialize.
+MAX_PAGE_LIMIT = 500
+DEFAULT_PAGE_LIMIT = 50
+
+#: ``resolve`` outcomes.
+STATUS_OK = "ok"
+STATUS_FORBIDDEN = "forbidden"
+STATUS_GONE = "gone"
+
+
+def now_ms() -> int:
+    """Epoch milliseconds, the clock every ``time`` and ``createdAt`` uses."""
+    return int(time.time() * 1000)
+
+
+# --------------------------------------------------------------------------- #
+# Paths
+# --------------------------------------------------------------------------- #
+
+
+def ledger_root(kind: str) -> Path:
+    """Root directory holding every ledger of *kind*."""
+    return data_home() / _ROOT_DIR[require_kind(kind)]
+
+
+def ledger_dir(kind: str, unit_id: str) -> Path:
+    """The validated directory for one unit's ledger. Does not create it.
+
+    The directory is named with the readable-plus-digest fold
+    (``session_ledger._store_name``) rather than the raw id, and the raw id is
+    persisted in the header instead. Two reasons, and the second is the load
+    bearing one:
+
+    * A legitimate id is not always a legitimate FILENAME. A channel session key
+      carries a colon (``slack:1712793600.123``), which POSIX accepts and Windows
+      refuses, so the raw id as a directory name turns a sanctioned id into an
+      ``OSError`` on a supported platform.
+    * Identity is the DIGEST over the exact id, so ``Foo`` and ``foo`` get
+      distinct directories on a case-insensitive filesystem and two long ids
+      sharing a prefix cannot land in one file. The readable half is a
+      convenience for a human reading the directory listing and is capped for
+      filesystem name limits; it is not the identity, and the fold is not
+      reversible -- ``open`` proves it reached the right unit by checking the id
+      the header stores.
+
+    Containment is what makes the path safe regardless: the shape gate refuses a
+    separator or a NUL in the raw id, and ``resolved_within`` re-checks
+    symlink-safely that the resolved path stays under the root.
+    """
+    require_unit_id(unit_id)
+    resolved = resolved_within(ledger_root(kind), _store_name(unit_id))
+    if resolved is None:
+        raise LedgerError(
+            f"path traversal blocked for ledger id: {unit_id!r}",
+            code=CODE_INVALID_ID,
+            field="id",
+        )
+    return resolved
+
+
+def ledger_path(kind: str, unit_id: str) -> Path:
+    """The ledger file for one unit."""
+    return ledger_dir(kind, unit_id) / LEDGER_FILE
+
+
+def _lock_path(kind: str, unit_id: str) -> Path:
+    return ledger_dir(kind, unit_id) / _LOCK_FILE
+
+
+@contextmanager
+def _open_lock(path: Path) -> Iterator[None]:
+    """Hold the advisory lock on *path*, creating the lock file if absent.
+
+    ``"r+"`` -- writable but NOT truncating -- for the reason ``work_ledger``
+    documents: ``msvcrt.locking`` needs a writable handle, so ``"r"`` is out,
+    while ``"w"`` truncates, and on Windows a truncating open of a file another
+    process already holds locked raises a sharing violation instead of waiting.
+    That would make the second contender crash before it reached the lock,
+    defeating the serialization the lock exists for. ``file_lock`` itself fails
+    closed, which is why nothing here has a lock-less fallback.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(exist_ok=True)
+    with open(path, "r+") as handle:
+        with file_lock(handle.fileno(), exclusive=True):
+            yield
+
+
+# --------------------------------------------------------------------------- #
+# Tail scan
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class _Tail:
+    """What a bounded read of the file's end says about its state.
+
+    ``torn_offset`` and ``needs_newline`` are mutually exclusive: the trailing
+    unterminated bytes either parse (the newline was lost, keep the record) or
+    they do not (a crash artifact, drop it).
+
+    ``window`` is the bytes that were read, already stripped of any torn tail,
+    and ``at_start`` says whether they reach the beginning of the file. Both are
+    carried so a caller that needs a SECOND answer about the tail -- does this
+    seq exist -- can have it without a second read, and without this function
+    parsing the whole window for a caller that does not ask.
+    """
+
+    last_seq: int
+    torn_offset: int | None
+    needs_newline: bool
+    empty: bool
+    window: bytes = b""
+    at_start: bool = True
+
+
+def _parses_to_object(blob: bytes) -> dict[str, Any] | None:
+    """*blob* as a JSON object, or ``None``. Never raises."""
+    try:
+        parsed = json.loads(blob.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _seq_of(blob: bytes) -> int | None:
+    """The ``seq`` of the entry *blob* encodes, or ``None`` when it has none."""
+    parsed = _parses_to_object(blob)
+    if parsed is None:
+        return None
+    entry = Entry.from_dict(parsed)
+    return None if entry is None else entry.seq
+
+
+def _scan_tail(path: Path) -> _Tail:
+    """Read the end of *path* and report seq, torn bytes, and emptiness."""
+    size = path.stat().st_size
+    if size == 0:
+        return _Tail(last_seq=0, torn_offset=None, needs_newline=False, empty=True)
+    window = min(size, _TAIL_WINDOW)
+    with open(path, "rb") as handle:
+        handle.seek(size - window)
+        blob = handle.read(window)
+    at_start = window == size
+
+    torn_offset: int | None = None
+    needs_newline = False
+    if not blob.endswith(b"\n"):
+        cut = blob.rfind(b"\n")
+        trailing = blob[cut + 1 :]
+        if _parses_to_object(trailing) is not None:
+            needs_newline = True
+        else:
+            torn_offset = size - len(trailing)
+            blob = blob[: cut + 1]
+
+    segments = blob.split(b"\n")
+    if not at_start:
+        # The window may begin mid-line; that first fragment is not a record.
+        segments = segments[1:]
+    last_seq = 0
+    for segment in reversed(segments):
+        stripped = segment.strip()
+        if not stripped:
+            continue
+        seq = _seq_of(stripped)
+        if seq is not None:
+            last_seq = seq
+            break
+    if last_seq == 0 and not at_start:
+        # Every line in the window was the header-less kind or damaged; only a
+        # full scan can answer, and it is the rare path by construction.
+        last_seq = _full_scan_last_seq(path)
+    return _Tail(
+        last_seq=last_seq,
+        torn_offset=torn_offset,
+        needs_newline=needs_newline,
+        empty=False,
+        window=blob,
+        at_start=at_start,
+    )
+
+
+def _anchor_exists(path: Path, seq: int, tail: _Tail) -> bool:
+    """Whether *seq* names a PARSEABLE entry in *path*.
+
+    A thread pointing at a line no reader can parse is a pointer to nothing, so
+    the range check ``1 <= seq <= last_seq`` is not enough on its own: a damaged
+    interior line at exactly that seq is skipped by every reader, and the group
+    would hang off an anchor that never appears.
+
+    Bounded, in three steps, so proving this costs an ordinary append nothing:
+
+    1. The window is already in memory, so an anchor inside it is free. A thread
+       anchor is normally recent, which is exactly where that lands.
+    2. If the window reached the start of the file, its answer is complete -- the
+       whole file was examined.
+    3. Only an anchor OLDER than the window falls back to a scan, and that scan
+       stops AT the anchor instead of reading to the end.
+
+    An append that passes no ``thread`` never calls this, so the bounded-tail
+    cost of the ordinary write path is unchanged.
+    """
+    segments = tail.window.split(b"\n")
+    if not tail.at_start:
+        segments = segments[1:]
+    for segment in segments:
+        stripped = segment.strip()
+        if stripped and _seq_of(stripped) == seq:
+            return True
+    if tail.at_start:
+        return False
+    for entry in _iter_entries(path):
+        if entry.seq == seq:
+            return True
+        if entry.seq > seq:
+            return False
+    return False
+
+
+def _full_scan_last_seq(path: Path) -> int:
+    """The highest seq any parseable line carries. The fallback path only."""
+    highest = 0
+    for entry in _iter_entries(path):
+        if entry.seq > highest:
+            highest = entry.seq
+    return highest
+
+
+def _iter_entries(path: Path) -> Iterator[Entry]:
+    """Every parseable entry in *path*, oldest first, header excluded.
+
+    A malformed interior line is SKIPPED, not raised on: the log is append-only
+    and one damaged line must not hide the history in front of it. The file is
+    streamed line by line, so a large ledger costs one line of memory, not its
+    size.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace", newline="\n") as handle:
+            for index, line in enumerate(handle):
+                if index == 0:
+                    continue  # the header
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed = json.loads(stripped)
+                except ValueError:
+                    continue
+                entry = Entry.from_dict(parsed)
+                if entry is not None:
+                    yield entry
+    except FileNotFoundError:
+        return
+
+
+def _read_header_line(path: Path) -> str | None:
+    """Line 1 of *path*, or ``None`` when the file has none."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace", newline="\n") as handle:
+            for line in handle:
+                return line.strip()
+    except FileNotFoundError:
+        return None
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Read results
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Page:
+    """One page of entries, NEWEST first.
+
+    ``next_before`` is the cursor for the following page, or ``None`` when this
+    page reached the oldest entry. It is set only when an older entry actually
+    exists, so paging never hands back a phantom empty page at the end.
+    """
+
+    entries: tuple[Entry, ...]
+    next_before: int | None
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """The outcome of following a :class:`~kiro_crew.ledger.schema.Ref`."""
+
+    status: str
+    entries: tuple[Entry, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.status == STATUS_OK
+
+
+# --------------------------------------------------------------------------- #
+# The ledger
+# --------------------------------------------------------------------------- #
+
+
+class Ledger:
+    """One unit's append-only ledger.
+
+    Construct through :meth:`create` or :meth:`open`, never directly: both do
+    the file-level work (existence, header, torn-tail repair, seq recovery) that
+    the instance then assumes has happened.
+    """
+
+    __slots__ = ("_kind", "_id", "_path", "_header", "_last_seq", "_needs_newline")
+
+    def __init__(
+        self,
+        *,
+        kind: str,
+        unit_id: str,
+        path: Path,
+        header: Header,
+        last_seq: int,
+        needs_newline: bool,
+    ) -> None:
+        self._kind = kind
+        self._id = unit_id
+        self._path = path
+        self._header = header
+        self._last_seq = last_seq
+        self._needs_newline = needs_newline
+
+    # -- identity ----------------------------------------------------------- #
+
+    @property
+    def kind(self) -> str:
+        return self._kind
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def header(self) -> Header:
+        return self._header
+
+    @property
+    def last_seq(self) -> int:
+        """The newest seq this instance knows of. Authoritative only for its own
+        appends -- the file is re-read under the lock on every write."""
+        return self._last_seq
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return f"Ledger(kind={self._kind!r}, id={self._id!r}, last_seq={self._last_seq})"
+
+    # -- lifecycle ---------------------------------------------------------- #
+
+    @classmethod
+    def exists(cls, kind: str, unit_id: str) -> bool:
+        """Whether *unit_id*'s ledger file is there. Raises on an invalid id."""
+        return ledger_path(kind, unit_id).is_file()
+
+    @classmethod
+    def create(cls, kind: str, unit_id: str, **header_fields: Any) -> Ledger:
+        """Write a new ledger's header. Refuses if the file already exists.
+
+        Existence is checked twice, the second time under the lock: the first
+        check is the cheap answer for the ordinary caller, the second is what
+        makes "create refuses an existing ledger" true when two processes race,
+        rather than one of them appending a second header to a live file.
+        """
+        kind = require_kind(kind)
+        path = ledger_path(kind, unit_id)
+        if path.is_file():
+            raise LedgerError(
+                f"{kind} ledger {unit_id!r} already exists", code=CODE_ALREADY_EXISTS, field="id"
+            )
+        header = build_header(kind, unit_id, now_ms(), header_fields)
+        line = require_entry_line(serialize(header.to_dict()))
+        with _open_lock(_lock_path(kind, unit_id)):
+            if path.is_file():
+                raise LedgerError(
+                    f"{kind} ledger {unit_id!r} already exists",
+                    code=CODE_ALREADY_EXISTS,
+                    field="id",
+                )
+            _append_line(path, line, needs_newline=False)
+        return cls(
+            kind=kind,
+            unit_id=unit_id,
+            path=path,
+            header=header,
+            last_seq=0,
+            needs_newline=False,
+        )
+
+    @classmethod
+    def open(cls, kind: str, unit_id: str) -> Ledger:
+        """Open an existing ledger, repairing a torn tail if there is one."""
+        kind = require_kind(kind)
+        path = ledger_path(kind, unit_id)
+        if not path.is_file():
+            raise LedgerError(f"no {kind} ledger for {unit_id!r}", code=CODE_NO_LEDGER, field="id")
+        with _open_lock(_lock_path(kind, unit_id)):
+            tail = _scan_tail(path)
+            if tail.torn_offset is not None:
+                dropped = path.stat().st_size - tail.torn_offset
+                _truncate(path, tail.torn_offset)
+                logger.warning(
+                    "dropped %d torn trailing byte(s) from %s ledger %r",
+                    dropped,
+                    kind,
+                    unit_id,
+                )
+            raw = _read_header_line(path)
+        if not raw:
+            raise LedgerError(
+                f"{kind} ledger {unit_id!r} has no header line",
+                code=CODE_BAD_HEADER,
+                field="type",
+            )
+        try:
+            parsed = json.loads(raw)
+        except ValueError as exc:
+            raise LedgerError(
+                f"{kind} ledger {unit_id!r} header is not JSON: {exc}",
+                code=CODE_BAD_HEADER,
+                field="type",
+            ) from exc
+        header = parse_header(parsed, kind=kind, unit_id=unit_id)
+        return cls(
+            kind=kind,
+            unit_id=unit_id,
+            path=path,
+            header=header,
+            last_seq=tail.last_seq,
+            needs_newline=tail.needs_newline,
+        )
+
+    # -- write -------------------------------------------------------------- #
+
+    def append(
+        self,
+        type: str,
+        data: dict[str, Any],
+        *,
+        src: str,
+        thread: int | None = None,
+        ref: Ref | dict[str, Any] | None = None,
+    ) -> Entry:
+        """Append one entry and return it, with ``seq`` and ``time`` filled in.
+
+        Every refusal happens before any byte is written, so a rejected append
+        leaves the file identical. ``thread`` is checked against the seq read
+        back under the lock, which is also what assigns this entry's own seq.
+        """
+        require_data(data)
+        check_ownership(self._kind, type, src)
+        pointer = None if ref is None else (ref if isinstance(ref, Ref) else Ref.from_dict(ref))
+        if thread is not None and (
+            not isinstance(thread, int) or isinstance(thread, bool) or thread < 1
+        ):
+            raise LedgerError(
+                f"thread must be a positive seq in this ledger: {thread!r}",
+                code=CODE_BAD_THREAD,
+                field="thread",
+            )
+        with _open_lock(_lock_path(self._kind, self._id)):
+            tail = _scan_tail(self._path)
+            if tail.empty:
+                raise LedgerError(
+                    f"{self._kind} ledger {self._id!r} has no header line",
+                    code=CODE_BAD_HEADER,
+                    field="type",
+                )
+            if tail.torn_offset is not None:
+                _truncate(self._path, tail.torn_offset)
+            if thread is not None and (
+                thread > tail.last_seq or not _anchor_exists(self._path, thread, tail)
+            ):
+                raise LedgerError(
+                    f"thread {thread} names no parseable entry in this ledger "
+                    f"(newest seq is {tail.last_seq})",
+                    code=CODE_BAD_THREAD,
+                    field="thread",
+                )
+            entry = Entry(
+                type=type,
+                seq=tail.last_seq + 1,
+                time=now_ms(),
+                src=src,
+                data=data,
+                thread=thread,
+                ref=pointer,
+            )
+            line = require_entry_line(serialize(entry.to_dict()))
+            _append_line(self._path, line, needs_newline=tail.needs_newline)
+        self._last_seq = entry.seq
+        self._needs_newline = False
+        return entry
+
+    # -- read --------------------------------------------------------------- #
+
+    def iter_from(self, seq: int = 1) -> Iterator[Entry]:
+        """Every entry from *seq* onward, OLDEST first -- the shape a fold wants."""
+        for entry in _iter_entries(self._path):
+            if entry.seq >= seq:
+                yield entry
+
+    def get(self, seq: int) -> Entry | None:
+        """The entry at *seq*, or ``None``.
+
+        Stops as soon as the stream passes *seq*: entries are written in seq
+        order, so a miss costs the prefix, not the file.
+        """
+        for entry in _iter_entries(self._path):
+            if entry.seq == seq:
+                return entry
+            if entry.seq > seq:
+                return None
+        return None
+
+    def page(self, before: int | None = None, limit: int = DEFAULT_PAGE_LIMIT) -> Page:
+        """Up to *limit* entries older than *before*, NEWEST first.
+
+        ``before`` is exclusive, so feeding ``next_before`` straight back walks
+        the history without repeating or skipping a line.
+        """
+        return self._page(before, limit, keep=lambda _entry: True)
+
+    def thread_page(
+        self, anchor: int, before: int | None = None, limit: int = DEFAULT_PAGE_LIMIT
+    ) -> Page:
+        """One thread's entries, NEWEST first, the anchor last.
+
+        A thread is a GROUPING key, not a tree: members carry ``thread ==
+        anchor`` and the anchor carries its own seq. The anchor is included, so
+        the final page of a thread ends with the entry the group hangs off --
+        which is what makes a thread readable bottom-up without a second call.
+        """
+        return self._page(
+            before, limit, keep=lambda entry: entry.thread == anchor or entry.seq == anchor
+        )
+
+    def _page(self, before: int | None, limit: int, *, keep: Callable[[Entry], bool]) -> Page:
+        bound = max(1, min(int(limit), MAX_PAGE_LIMIT))
+        # One extra slot answers "is there an older entry" exactly, so the
+        # cursor is None precisely when the caller has seen everything.
+        window: deque[Entry] = deque(maxlen=bound + 1)
+        for entry in _iter_entries(self._path):
+            if before is not None and entry.seq >= before:
+                continue
+            if keep(entry):
+                window.append(entry)
+        newest_first = list(reversed(window))
+        has_more = len(newest_first) > bound
+        entries = tuple(newest_first[:bound])
+        return Page(entries=entries, next_before=entries[-1].seq if has_more and entries else None)
+
+    def resolve(
+        self,
+        ref: Ref | dict[str, Any],
+        *,
+        may_read: Callable[[str, str], bool] | None = None,
+    ) -> Resolution:
+        """Follow *ref* and return the segment it cites.
+
+        A ref that leaves this unit needs an access decision, and the ABSENCE of
+        one is a refusal, not a grant. Omitting ``may_read`` is the easiest call
+        shape there is, so letting it mean "allow" would make the default path
+        the insecure one and expose the first caller that forgets the argument.
+        A ref that stays inside THIS ledger needs no callback: the caller already
+        holds this unit open, so there is no boundary left to check.
+
+        ``forbidden`` is decided BEFORE existence. Answering "does that unit
+        exist" first would leak the existence of a unit the caller is not allowed
+        to read, which is the one thing an access check on a pointer is for --
+        so a denied read and an absent unit are deliberately indistinguishable.
+
+        ``gone`` is a normal outcome, not an error: the cited ledger may
+        legitimately have been deleted, and the citing entry stays honest about
+        having pointed at it.
+        """
+        pointer = ref if isinstance(ref, Ref) else Ref.from_dict(ref)
+        own = pointer.unit == self._kind and pointer.id == self._id
+        if not own and (may_read is None or not may_read(pointer.unit, pointer.id)):
+            return Resolution(status=STATUS_FORBIDDEN, entries=())
+        if own:
+            target: Ledger | None = self
+        else:
+            try:
+                target = Ledger.open(pointer.unit, pointer.id)
+            except LedgerError:
+                target = None
+        if target is None:
+            return Resolution(status=STATUS_GONE, entries=())
+        last = pointer.last_seq
+        found = tuple(entry for entry in target.iter_from(pointer.from_seq) if entry.seq <= last)
+        return Resolution(status=STATUS_OK, entries=found)
+
+
+# --------------------------------------------------------------------------- #
+# File primitives
+# --------------------------------------------------------------------------- #
+
+
+def _append_line(path: Path, line: str, *, needs_newline: bool) -> None:
+    """Append *line* plus its terminator, then fsync.
+
+    ``newline="\\n"`` is load-bearing, not cosmetic: without it Windows
+    translates the terminator to ``\\r\\n``, and the byte offsets the torn-tail
+    truncation computes stop matching what is on disk.
+
+    *needs_newline* re-supplies a separator the previous write lost -- the one
+    case where a record survived but its terminator did not. It PREPENDS rather
+    than rewriting that line, so the append-only rule holds.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    prefix = "\n" if needs_newline else ""
+    with open(path, "a", encoding="utf-8", newline="\n") as handle:
+        handle.write(f"{prefix}{line}\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _truncate(path: Path, offset: int) -> None:
+    """Drop everything at or after *offset* -- the one allowed mutation."""
+    with open(path, "r+b") as handle:
+        handle.truncate(offset)
+        handle.flush()
+        os.fsync(handle.fileno())

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -282,6 +282,13 @@ _CREW_HIDDEN_LEAVES: tuple[str, ...] = (
     # The conductor work ledger: a worker's full file toolset must not reach any
     # conductor's records except through the routes that check its binding.
     "work-ledger",
+    # Per-crew append-only ledgers. The design treats the ledger as the authority
+    # a conductor reads instead of re-deriving, so an in-sandbox process able to
+    # write here could forge an entry attributed to the gateway or rewrite the
+    # history it is reporting into. Nothing in-sandbox reads one: the store runs
+    # in the GATEWAY process, so HIDDEN rather than READONLY. Session ledgers need
+    # no entry, their root being the already-masked ``sessions`` leaf.
+    "crews",
     "cron-history",
     # The cron in-flight markers, masked rather than sealed read-only because
     # nothing in the sandbox reads one: they are written and cleared by the run

--- a/src/kiro_crew/security/paths.py
+++ b/src/kiro_crew/security/paths.py
@@ -337,6 +337,19 @@ _CREW_SECRET_LEAVES: list[str] = [
     # straight off disk, and a corrupted record reads as ABSENT to the store —
     # silent loss the conductor cannot see. No legitimate file-tool reader.
     "work-ledger",
+    # Per-crew append-only ledgers (ledger/store.py). Not credentials, but the
+    # design's whole premise is that the ledger is the AUTHORITY and the context
+    # window only a cache: a conductor reads a crew's history as fact instead of
+    # re-deriving it. An agent's auto-approved file tools reaching this subtree
+    # would let it forge an entry attributed to the gateway, or rewrite the
+    # history it is supposed to be reporting into, which is the one thing an
+    # append-only record exists to prevent. The write-side rules (type ownership,
+    # guest namespacing, seq under the lock) live in the library, so they bind
+    # only callers who go through it; this entry is what keeps a file tool from
+    # going around it. Session ledgers get the same protection from the sandbox's
+    # existing ``sessions`` deny, which their root reuses. The store opens these
+    # paths directly rather than through this gate, so nothing breaks.
+    "crews",
     # The optional Playwright extension token. It removes the browser-side approval
     # click for an attach, so a process that could read it could attach to the
     # operator's logged-in browser without them seeing a prompt. The gateway hands

--- a/src/kiro_crew/session_compaction.py
+++ b/src/kiro_crew/session_compaction.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
+from kiro_crew import session_ledger_emit
 from kiro_crew.metrics.events import CONTEXT_COMPACTIONS, emit_counter
 from kiro_crew.metrics.sessions import END_REASON_RECYCLED, record_session_ended
 
@@ -550,6 +551,13 @@ class CompactionCoordinator:
             )
             return False
         self.state.pending_verdict.pop(key, None)
+        # Append-only session ledger (flag-gated, fail-soft). Emitted only once
+        # the after-reading is confirmed, so a deferred verdict records nothing.
+        session_ledger_emit.on_compaction_applied(
+            session_ledger_emit.session_id_of(provider),
+            pct_before=pct_before,
+            pct_after=pct_after,
+        )
         return self._owner._judge_compact_effect(key, pct_before, pct_after)
 
     def _judge_compact_effect(self, key: str, pct_before: float, pct_after: float) -> bool:

--- a/src/kiro_crew/session_ledger_emit.py
+++ b/src/kiro_crew/session_ledger_emit.py
@@ -1,0 +1,514 @@
+"""Write the ACP turn lifecycle to an append-only per-session ledger.
+
+See ``docs/system-specs/modules/session-ledger-emitter.md`` for the contract this
+module implements. In short: each entry point is a one-line call at a site in the
+dashboard chat path where a lifecycle fact is already known, and every one of
+them is **fail-soft** -- a ledger error is reported once and then swallowed, so a
+broken ledger can never break a turn.
+
+The whole module is inert unless ``KIROCREW_SESSION_LEDGER`` is truthy. With the
+flag off nothing is created and every call returns immediately.
+
+A turn is a **thread**: ``on_turn_started`` anchors one, and every entry that
+belongs to that turn carries the anchor's ``seq`` as its ``thread``, so the
+storage layer's own grouping answers "what happened in this turn" without a fold.
+
+Three things are recorded differently from a naive reading of the lifecycle, all
+deliberate and all explained in the spec:
+
+* ``compaction/applied`` carries context-usage **percentages**, because the
+  compaction boundary never learns a raw token count.
+* A tool call and an approval are identified by an id inside ``data``, not by
+  ``ref``. A ``Ref`` is a citation of another ledger's lines, and a tool call id
+  names a frame on the ACP stream, which is not a ledger unit.
+* A turn that dies before its terminal event writes no ``turn/completed``, and a
+  recovery re-entry anchors its own thread carrying ``depth``. A started entry
+  with no completion is how an aborted turn is recorded.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import OrderedDict
+from typing import Any
+
+from kiro_crew.constants import env_flag_enabled
+
+logger = logging.getLogger(__name__)
+
+#: Turning this on is a separate change from landing the emitter.
+SESSION_LEDGER_ENV = "KIROCREW_SESSION_LEDGER"
+
+_KIND = "session"
+
+#: Facts read off the ACP stream vs. facts the gateway decided by itself.
+_SRC_ACP = "acp"
+_SRC_GATEWAY = "gateway"
+
+#: Used when a call site has no agent name, matching the repo's own default.
+_DEFAULT_AGENT = "kirocrew"
+
+#: Who caused a turn to run. ``_start_next_queued_turn`` already distinguishes
+#: these; anything unrecognised is recorded as ``other`` rather than guessed.
+ACTORS = frozenset({"user", "crew", "cron", "autonudge", "subagent", "other"})
+
+#: Bounded so a long-lived gateway cannot grow any map without limit.
+_MAX_OPEN_LEDGERS = 128
+_MAX_PENDING_TOOLS = 512
+
+_lock = threading.Lock()
+_open: "OrderedDict[str, Any]" = OrderedDict()
+_turn_anchor: "OrderedDict[str, int]" = OrderedDict()
+_tool_started: "OrderedDict[tuple[str, str], float]" = OrderedDict()
+_ledger_cls: Any = None
+_import_failed = False
+_warned = False
+
+
+def enabled() -> bool:
+    """True when the emitter should write. Read per call, never cached."""
+    return env_flag_enabled(SESSION_LEDGER_ENV)
+
+
+def reset_caches() -> None:
+    """Drop cached handles, anchors and timings. Tests and gateway restart."""
+    global _warned
+    with _lock:
+        _open.clear()
+        _turn_anchor.clear()
+        _tool_started.clear()
+        _warned = False
+
+
+def session_id_of(client: Any) -> str:
+    """The ACP session id behind a session handle, or ``""`` when it has none.
+
+    A provider exposes it as ``session_id`` and the inner client as
+    ``_session_id``; a turn that failed before ``session/new`` has neither, and
+    an empty id makes every call in this module a no-op.
+    """
+    for candidate in (client, getattr(client, "client", None)):
+        if candidate is None:
+            continue
+        for attr in ("session_id", "_session_id"):
+            value = getattr(candidate, attr, "")
+            if isinstance(value, str) and value:
+                return value
+    return ""
+
+
+def _report(what: str, exc: BaseException) -> None:
+    """Report a ledger failure once at warning level, then stay quiet."""
+    global _warned
+    with _lock:
+        first = not _warned
+        _warned = True
+    if first:
+        logger.warning(
+            "session ledger writes are failing (%s: %s%s); further failures "
+            "are logged at debug only",
+            what,
+            exc,
+            f", code={getattr(exc, 'code', '')}" if getattr(exc, "code", "") else "",
+        )
+    else:
+        logger.debug("session ledger %s failed", what, exc_info=True)
+
+
+def _ledger_class() -> Any:
+    """The storage class, or None when the library is unavailable."""
+    global _ledger_cls, _import_failed
+    if _ledger_cls is not None or _import_failed:
+        return _ledger_cls
+    try:
+        from kiro_crew.ledger import Ledger
+    except Exception as exc:  # pragma: no cover - the package ships beside this
+        _import_failed = True
+        _report("importing kiro_crew.ledger", exc)
+        return None
+    _ledger_cls = Ledger
+    return _ledger_cls
+
+
+def _bound(store: "OrderedDict[Any, Any]", limit: int) -> None:
+    while len(store) > limit:
+        store.popitem(last=False)
+
+
+def _remember(session_id: str, ledger: Any) -> None:
+    with _lock:
+        _open[session_id] = ledger
+        _open.move_to_end(session_id)
+        _bound(_open, _MAX_OPEN_LEDGERS)
+
+
+def _handle(session_id: str) -> Any:
+    """An open ledger for *session_id*, or None. Never creates one.
+
+    An event for a session whose ledger was never opened is dropped rather than
+    starting a ledger with no header.
+    """
+    if not session_id or not enabled():
+        return None
+    with _lock:
+        cached = _open.get(session_id)
+        if cached is not None:
+            _open.move_to_end(session_id)
+            return cached
+    cls = _ledger_class()
+    if cls is None:
+        return None
+    try:
+        if not cls.exists(_KIND, session_id):
+            return None
+        ledger = cls.open(_KIND, session_id)
+    except Exception as exc:
+        _report("opening a ledger", exc)
+        return None
+    _remember(session_id, ledger)
+    return ledger
+
+
+def _anchor(session_id: str) -> int | None:
+    with _lock:
+        return _turn_anchor.get(session_id)
+
+
+def _write(
+    session_id: str,
+    entry_type: str,
+    data: dict[str, Any],
+    *,
+    src: str = _SRC_ACP,
+    in_turn: bool = True,
+) -> Any:
+    """Append one entry, threaded under the current turn. None on any failure."""
+    ledger = _handle(session_id)
+    if ledger is None:
+        return None
+    try:
+        return ledger.append(
+            entry_type,
+            data,
+            src=src,
+            thread=_anchor(session_id) if in_turn else None,
+        )
+    except Exception as exc:
+        _report(f"appending {entry_type}", exc)
+        return None
+
+
+def on_session_opened(
+    session_id: str,
+    *,
+    agent: str = "",
+    slot: str = "",
+    model: str = "",
+    cwd: str = "",
+    owner: str = "default",
+    resumed: bool = False,
+) -> None:
+    """Create the ledger if this session has none, then echo its header.
+
+    Called once per turn, because the per-turn session claim is where the ACP
+    id becomes known -- but an entry is written only when there is something new
+    to say: the ledger was just created, or this claim RE-ATTACHED to an existing
+    conversation (a new gateway process taking over the same session id). A warm
+    reuse of a session already carrying a ledger adds nothing, so it is silent.
+
+    ``owner`` and ``agent`` are header fields, written once at create time and
+    never rewritten. A resumed session id reuses its existing ledger and
+    appends, so an agent or model switch that kept the conversation continues
+    one log rather than starting a second one. ``model`` is not a header field
+    in the storage schema, so it is carried on this entry instead.
+    """
+    if not session_id or not enabled():
+        return
+    cls = _ledger_class()
+    if cls is None:
+        return
+    created = False
+    try:
+        if cls.exists(_KIND, session_id):
+            ledger = cls.open(_KIND, session_id)
+        else:
+            ledger = cls.create(
+                _KIND,
+                session_id,
+                owner=owner or "default",
+                agent=agent or _DEFAULT_AGENT,
+                slot=slot or None,
+                cwd=cwd or None,
+            )
+            created = True
+    except Exception as exc:
+        _report("creating a ledger", exc)
+        return
+    _remember(session_id, ledger)
+    with _lock:
+        _turn_anchor.pop(session_id, None)
+    if not (created or resumed):
+        return
+    try:
+        ledger.append(
+            "session/opened",
+            {
+                "agent": agent or _DEFAULT_AGENT,
+                "slot": slot,
+                "model": model,
+                "cwd": cwd,
+                "owner": owner or "default",
+                "resumed": bool(resumed),
+            },
+            src=_SRC_GATEWAY,
+        )
+    except Exception as exc:
+        _report("appending session/opened", exc)
+
+
+def on_turn_started(
+    session_id: str,
+    turn: int,
+    actor: str = "user",
+    *,
+    depth: int = 0,
+) -> None:
+    """Anchor a turn's thread. ``turn`` is the message-boundary ordinal."""
+    if not session_id:
+        return
+    with _lock:
+        _turn_anchor.pop(session_id, None)
+    entry = _write(
+        session_id,
+        "turn/started",
+        {
+            "turn": int(turn),
+            "actor": actor if actor in ACTORS else "other",
+            "depth": int(depth),
+        },
+        src=_SRC_GATEWAY,
+        in_turn=False,
+    )
+    seq = getattr(entry, "seq", None)
+    if isinstance(seq, int):
+        with _lock:
+            _turn_anchor[session_id] = seq
+            _turn_anchor.move_to_end(session_id)
+            _bound(_turn_anchor, _MAX_OPEN_LEDGERS)
+
+
+def on_turn_completed(
+    session_id: str,
+    turn: int,
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    credits: float = 0.0,
+    duration_ms: int = 0,
+    stop_reason: str = "",
+    model: str = "",
+    provider: str = "",
+    depth: int = 0,
+) -> None:
+    """Record a turn's terminal event and what it cost."""
+    _write(
+        session_id,
+        "turn/completed",
+        {
+            "turn": int(turn),
+            "depth": int(depth),
+            "stop_reason": stop_reason,
+            "duration_ms": int(duration_ms),
+            "credits": float(credits),
+            "model": model,
+            "provider": provider,
+            "tokens": {
+                "input": int(input_tokens),
+                "output": int(output_tokens),
+                "cache_read": int(cache_read_tokens),
+                "cache_write": int(cache_write_tokens),
+            },
+        },
+    )
+    if session_id:
+        with _lock:
+            _turn_anchor.pop(session_id, None)
+
+
+def on_tool_called(
+    session_id: str,
+    turn: int,
+    *,
+    name: str,
+    server: str = "",
+    kind: str = "",
+    call_id: str = "",
+) -> None:
+    """Record a tool call by its id. Arguments are never recorded."""
+    if session_id and call_id and enabled():
+        with _lock:
+            _tool_started[(session_id, call_id)] = (time.monotonic(), name, server)
+            _bound(_tool_started, _MAX_PENDING_TOOLS)
+    _write(
+        session_id,
+        "tool/called",
+        {
+            "turn": int(turn),
+            "call_id": call_id,
+            "name": name,
+            "server": server,
+            "kind": kind,
+        },
+    )
+
+
+def on_tool_completed(
+    session_id: str,
+    turn: int,
+    *,
+    name: str = "",
+    server: str = "",
+    status: str = "",
+    call_id: str = "",
+) -> None:
+    """Record a tool call's terminal frame. Results are never recorded.
+
+    The terminal frame does not repeat the tool's identity -- only the call
+    frame carries the trusted name and server -- so both are remembered per
+    call id and filled in here rather than being recorded empty.
+    """
+    elapsed_ms = -1
+    if session_id and call_id:
+        with _lock:
+            started = _tool_started.pop((session_id, call_id), None)
+        if started is not None:
+            began, called_name, called_server = started
+            elapsed_ms = max(0, int((time.monotonic() - began) * 1000))
+            name = name or called_name
+            server = server or called_server
+    data: dict[str, Any] = {
+        "turn": int(turn),
+        "call_id": call_id,
+        "name": name,
+        "server": server,
+        "status": status,
+    }
+    if elapsed_ms >= 0:
+        data["elapsed_ms"] = elapsed_ms
+    _write(session_id, "tool/completed", data)
+
+
+def on_approval_requested(
+    session_id: str,
+    turn: int,
+    *,
+    approval_id: str,
+    tool: str = "",
+) -> None:
+    """Record that a tool call is waiting on a human."""
+    _write(
+        session_id,
+        "approval/requested",
+        {"turn": int(turn), "approval_id": approval_id, "tool": tool},
+        src=_SRC_GATEWAY,
+    )
+
+
+def on_approval_decided(
+    session_id: str,
+    turn: int,
+    *,
+    approval_id: str,
+    decision: str,
+) -> None:
+    """Record how an approval resolved, including a timeout.
+
+    This runs on the task that handled the click, not the task running the
+    turn, which is why it must never raise.
+    """
+    _write(
+        session_id,
+        "approval/decided",
+        {"turn": int(turn), "approval_id": approval_id, "decision": decision},
+        src=_SRC_GATEWAY,
+    )
+
+
+def on_model_selected(session_id: str, model: str, source: str = "") -> None:
+    """Record the model a session will serve and why it was chosen."""
+    _write(
+        session_id,
+        "model/selected",
+        {"model": model, "source": source},
+        src=_SRC_GATEWAY,
+    )
+
+
+def on_compaction_applied(
+    session_id: str,
+    *,
+    pct_before: float,
+    pct_after: float,
+) -> None:
+    """Record a compaction as context-usage percentages.
+
+    Compaction is session-scoped rather than per-turn, so no turn ordinal is
+    recorded; the entry threads under the live turn when one is open. The
+    compaction boundary measures ``provider.context_usage_pct()`` and never
+    learns a raw token count, so this records what the site knows.
+    """
+    _write(
+        session_id,
+        "compaction/applied",
+        {
+            "pct_before": round(float(pct_before), 4),
+            "pct_after": round(float(pct_after), 4),
+            "freed_pct": round(float(pct_before) - float(pct_after), 4),
+        },
+        src=_SRC_GATEWAY,
+    )
+
+
+def on_session_closed(session_id: str, reason: str) -> None:
+    """Record a session teardown and drop its cached state.
+
+    ``reason`` is the gateway's own ``end_reason`` (``reset``, ``shutdown``,
+    ``evicted``, ``destroyed`` and the rest), recorded verbatim rather than
+    remapped onto a second vocabulary.
+    """
+    _write(
+        session_id,
+        "session/closed",
+        {"reason": reason},
+        src=_SRC_GATEWAY,
+        in_turn=False,
+    )
+    if not session_id:
+        return
+    with _lock:
+        _open.pop(session_id, None)
+        _turn_anchor.pop(session_id, None)
+        for key in [k for k in _tool_started if k[0] == session_id]:
+            _tool_started.pop(key, None)
+
+
+__all__ = [
+    "ACTORS",
+    "SESSION_LEDGER_ENV",
+    "enabled",
+    "on_approval_decided",
+    "on_approval_requested",
+    "on_compaction_applied",
+    "on_model_selected",
+    "on_session_closed",
+    "on_session_opened",
+    "on_tool_called",
+    "on_tool_completed",
+    "on_turn_completed",
+    "on_turn_started",
+    "reset_caches",
+]

--- a/src/kiro_crew/session_lifecycle.py
+++ b/src/kiro_crew/session_lifecycle.py
@@ -20,6 +20,7 @@ from concurrent.futures import Executor
 from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol
 
+from kiro_crew import session_ledger_emit
 from kiro_crew.metrics.sessions import (
     END_REASON_DESTROYED,
     END_REASON_DISCARDED,
@@ -398,6 +399,13 @@ class SessionLifecycleService:
                 # own suspension point, so that ordering still holds; only the
                 # crumb unlink is deferred to a worker.
                 await record_session_ended(key, end_reason=END_REASON_RESET)
+                # Append-only session ledger (flag-gated, fail-soft). Reset is
+                # the teardown that ends a ledger's life, since the successor
+                # cold-starts a new ACP session id.
+                session_ledger_emit.on_session_closed(
+                    session_ledger_emit.session_id_of(session.provider),
+                    END_REASON_RESET,
+                )
         if clear_conversation and session is not None:
             # The registry lock, not an absence of suspension points, is what makes
             # this safe: the end record above awaits, but it awaits while this

--- a/test/test_ledger_core.py
+++ b/test/test_ledger_core.py
@@ -1,0 +1,927 @@
+"""Append-only ledger core -- one test per rule the format promises.
+
+Grouped the way the module is reasoned about: identity and lifecycle, the seq
+contract, the two namespace rules, the caps, the read shapes (fold, page,
+thread, ref) and finally damage tolerance. Every ``LedgerError`` code has a test
+that pins it, because the code strings are API surface a caller branches on, not
+log text.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+
+import pytest
+
+from kiro_crew import ledger as lg
+from kiro_crew.ledger import Ledger, LedgerError, Ref
+from kiro_crew.session_ledger import _store_name
+
+CREW = "qa"
+SESSION = "s-7f3a"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Every test writes into its own data home, never the live one."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    yield
+
+
+def _crew(unit_id: str = CREW, **fields) -> Ledger:
+    fields.setdefault("name", "QA Crew")
+    return Ledger.create(lg.KIND_CREW, unit_id, **fields)
+
+
+def _session(unit_id: str = SESSION, **fields) -> Ledger:
+    fields.setdefault("owner", CREW)
+    fields.setdefault("agent", "kirocrew")
+    return Ledger.create(lg.KIND_SESSION, unit_id, **fields)
+
+
+def _raises(code: str):
+    return pytest.raises(LedgerError)
+
+
+def _code(excinfo) -> str:
+    return excinfo.value.code
+
+
+# --- layout and lifecycle -------------------------------------------------
+
+
+def test_each_kind_lands_in_its_own_root_one_directory_deep():
+    crew, session = _crew(), _session()
+    assert crew.path == lg.ledger_root("crew") / _store_name(CREW) / "ledger.jsonl"
+    assert session.path == lg.ledger_root("session") / _store_name(SESSION) / "ledger.jsonl"
+    assert crew.path.parent.parent == lg.ledger_root("crew")
+
+
+def test_a_colon_bearing_channel_session_id_is_storable():
+    # The id is sanctioned by the schema and legal on POSIX, illegal as a
+    # Windows directory name. The fold is what keeps it storable everywhere.
+    sid = "slack:1712793600.123"
+    led = _session(sid, task="watch the thread")
+    assert ":" not in led.path.parent.name
+    reopened = Ledger.open(lg.KIND_SESSION, sid)
+    assert reopened.header.id == sid
+    assert reopened.header.task == "watch the thread"
+
+
+def test_ids_differing_only_in_case_never_share_a_ledger():
+    # Identity is the digest over the exact id, so a case-insensitive filesystem
+    # cannot fold two crews into one file.
+    lower, upper = _crew("qa"), _crew("QA")
+    assert lower.path != upper.path
+    lower.append("item/opened", {"which": "lower"}, src="gateway")
+    assert upper.last_seq == 0
+
+
+def test_the_raw_id_is_recoverable_from_the_header_not_the_directory_name():
+    led = _crew("qa-team")
+    assert led.path.parent.name != "qa-team"
+    assert Ledger.open(lg.KIND_CREW, "qa-team").header.id == "qa-team"
+
+
+def test_a_session_ledger_is_invisible_to_a_flat_transcript_glob():
+    # The session root is shared with the existing flat ``<key>.jsonl``
+    # transcripts, whose readers glob one level deep. A ledger nested a
+    # directory down must not appear to them, or the two stores shadow.
+    session = _session()
+    assert session.path.is_file()
+    assert list(lg.ledger_root("session").glob("*.jsonl")) == []
+
+
+def test_exists_is_false_before_create_and_true_after():
+    assert Ledger.exists(lg.KIND_CREW, CREW) is False
+    _crew()
+    assert Ledger.exists(lg.KIND_CREW, CREW) is True
+
+
+def test_create_refuses_an_existing_ledger():
+    _crew()
+    with _raises(lg.CODE_ALREADY_EXISTS) as exc:
+        _crew()
+    assert _code(exc) == lg.CODE_ALREADY_EXISTS
+
+
+def test_open_refuses_a_missing_ledger():
+    with _raises(lg.CODE_NO_LEDGER) as exc:
+        Ledger.open(lg.KIND_CREW, CREW)
+    assert _code(exc) == lg.CODE_NO_LEDGER
+
+
+def test_an_unknown_kind_is_refused_rather_than_rooted_somewhere():
+    with _raises(lg.CODE_BAD_KIND) as exc:
+        Ledger.create("swarm", CREW, name="x")
+    assert _code(exc) == lg.CODE_BAD_KIND
+
+
+@pytest.mark.parametrize("hostile", ["", "../escape", "a/b", "a\\b", "with\0nul", ".."])
+def test_a_path_hostile_id_is_refused_loudly_not_folded(hostile):
+    with _raises(lg.CODE_INVALID_ID) as exc:
+        _crew(hostile)
+    assert _code(exc) == lg.CODE_INVALID_ID
+
+
+# --- headers --------------------------------------------------------------
+
+
+def test_crew_header_round_trips_through_the_file():
+    created = _crew(name="QA Crew", template="reviewer").header
+    reopened = Ledger.open(lg.KIND_CREW, CREW).header
+    assert reopened == created
+    assert reopened.to_dict() == {
+        "type": "crew",
+        "version": 1,
+        "id": CREW,
+        "name": "QA Crew",
+        "template": "reviewer",
+        "createdAt": created.created_at,
+    }
+
+
+def test_session_header_round_trips_including_its_crew_thread_anchor():
+    created = _session(
+        task="port the gate",
+        pack="review",
+        slot="chat-7",
+        thread={"crew": CREW, "seq": 120},
+        cwd="/w/repo",
+        remote={"host": "pod-3"},
+    ).header
+    reopened = Ledger.open(lg.KIND_SESSION, SESSION).header
+    assert reopened == created
+    assert reopened.to_dict() == {
+        "type": "session",
+        "version": 1,
+        "id": SESSION,
+        "owner": CREW,
+        "task": "port the gate",
+        "pack": "review",
+        "agent": "kirocrew",
+        "slot": "chat-7",
+        "thread": {"crew": CREW, "seq": 120},
+        "cwd": "/w/repo",
+        "remote": {"host": "pod-3"},
+        "createdAt": created.created_at,
+    }
+
+
+def test_the_header_is_line_one_and_optional_fields_are_present_as_null():
+    _crew()
+    first = lg.ledger_path(lg.KIND_CREW, CREW).read_text(encoding="utf-8").splitlines()[0]
+    assert json.loads(first)["template"] is None
+
+
+def test_a_missing_required_header_field_is_refused():
+    with _raises(lg.CODE_BAD_HEADER_FIELD) as exc:
+        Ledger.create(lg.KIND_CREW, CREW)
+    assert _code(exc) == lg.CODE_BAD_HEADER_FIELD
+    assert exc.value.field == "name"
+
+
+def test_an_unknown_header_field_is_refused_rather_than_dropped():
+    # Silently dropping it would tell the caller the header stored what they
+    # asked for while the value vanished.
+    with _raises(lg.CODE_BAD_HEADER_FIELD) as exc:
+        _crew(nickname="qa")
+    assert _code(exc) == lg.CODE_BAD_HEADER_FIELD
+    assert exc.value.field == "nickname"
+
+
+def test_a_header_field_of_the_wrong_type_is_refused():
+    with _raises(lg.CODE_BAD_HEADER_FIELD) as exc:
+        _crew(name=7)
+    assert _code(exc) == lg.CODE_BAD_HEADER_FIELD
+
+
+def test_a_session_thread_anchor_of_the_wrong_shape_is_refused():
+    with _raises(lg.CODE_BAD_HEADER_FIELD) as exc:
+        _session(thread={"crew": CREW})
+    assert _code(exc) == lg.CODE_BAD_HEADER_FIELD
+
+
+def test_a_session_remote_that_is_not_an_object_is_refused():
+    with _raises(lg.CODE_BAD_HEADER_FIELD) as exc:
+        _session(remote="pod-3")
+    assert _code(exc) == lg.CODE_BAD_HEADER_FIELD
+
+
+def test_opening_a_ledger_whose_header_names_another_unit_is_refused():
+    _crew()
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    header = json.loads(lines[0])
+    header["id"] = "other"
+    path.write_text(json.dumps(header) + "\n", encoding="utf-8")
+    with _raises(lg.CODE_BAD_HEADER) as exc:
+        Ledger.open(lg.KIND_CREW, CREW)
+    assert _code(exc) == lg.CODE_BAD_HEADER
+
+
+def test_opening_a_ledger_whose_header_is_not_json_is_refused():
+    _crew()
+    lg.ledger_path(lg.KIND_CREW, CREW).write_text("not json\n", encoding="utf-8")
+    with _raises(lg.CODE_BAD_HEADER) as exc:
+        Ledger.open(lg.KIND_CREW, CREW)
+    assert _code(exc) == lg.CODE_BAD_HEADER
+
+
+def test_opening_an_empty_file_is_refused_as_a_missing_header():
+    _crew()
+    lg.ledger_path(lg.KIND_CREW, CREW).write_bytes(b"")
+    with _raises(lg.CODE_BAD_HEADER) as exc:
+        Ledger.open(lg.KIND_CREW, CREW)
+    assert _code(exc) == lg.CODE_BAD_HEADER
+
+
+def test_appending_to_a_ledger_whose_file_was_emptied_is_refused():
+    crew = _crew()
+    lg.ledger_path(lg.KIND_CREW, CREW).write_bytes(b"")
+    with _raises(lg.CODE_BAD_HEADER) as exc:
+        crew.append("item/opened", {}, src="gateway")
+    assert _code(exc) == lg.CODE_BAD_HEADER
+
+
+# --- seq ------------------------------------------------------------------
+
+
+def test_seq_starts_at_one_after_the_header_and_time_is_epoch_ms():
+    crew = _crew()
+    first = crew.append("item/opened", {"item": "pr-1"}, src="gateway")
+    assert (first.seq, crew.last_seq) == (1, 1)
+    assert first.time > 1_600_000_000_000
+
+
+def test_seq_stays_contiguous_across_a_reopen():
+    crew = _crew()
+    for index in range(3):
+        crew.append("item/opened", {"i": index}, src="gateway")
+    reopened = Ledger.open(lg.KIND_CREW, CREW)
+    assert reopened.last_seq == 3
+    assert reopened.append("item/opened", {"i": 3}, src="gateway").seq == 4
+    assert [entry.seq for entry in reopened.iter_from()] == [1, 2, 3, 4]
+
+
+def test_two_concurrent_writers_never_claim_the_same_seq():
+    # The point of reading seq back from the file INSIDE the lock rather than
+    # trusting the in-process cache.
+    _crew()
+    writers = [Ledger.open(lg.KIND_CREW, CREW) for _ in range(4)]
+    barrier = threading.Barrier(len(writers))
+
+    def run(handle: Ledger) -> None:
+        barrier.wait()
+        for index in range(5):
+            handle.append("activity/tick", {"i": index}, src="gateway")
+
+    threads = [threading.Thread(target=run, args=(handle,)) for handle in writers]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    seqs = [entry.seq for entry in Ledger.open(lg.KIND_CREW, CREW).iter_from()]
+    assert seqs == list(range(1, 21))
+
+
+def test_the_entry_envelope_is_exactly_the_documented_shape():
+    crew = _crew()
+    anchor = crew.append("item/opened", {"item": "pr-4127"}, src="gateway")
+    entry = crew.append(
+        "crew:qa/report",
+        {"item": "pr-4127", "status": "done"},
+        src="crew:qa",
+        thread=anchor.seq,
+        ref=Ref("session", SESSION, 40, 96),
+    )
+    assert entry.to_dict() == {
+        "type": "crew:qa/report",
+        "seq": 2,
+        "time": entry.time,
+        "src": "crew:qa",
+        "thread": 1,
+        "ref": {"unit": "session", "id": SESSION, "from": 40, "to": 96},
+        "data": {"item": "pr-4127", "status": "done"},
+    }
+    stored = lg.ledger_path(lg.KIND_CREW, CREW).read_text(encoding="utf-8").splitlines()[2]
+    assert json.loads(stored) == entry.to_dict()
+
+
+def test_the_optional_keys_are_absent_not_null_when_unused():
+    crew = _crew()
+    entry = crew.append("item/opened", {}, src="gateway")
+    stored = json.loads(
+        lg.ledger_path(lg.KIND_CREW, CREW).read_text(encoding="utf-8").splitlines()[1]
+    )
+    assert "thread" not in stored and "ref" not in stored
+    assert entry.thread is None and entry.ref is None
+
+
+# --- rule 1: ownership ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind,owned",
+    [
+        (lg.KIND_CREW, "member/joined"),
+        (lg.KIND_CREW, "patrol/swept"),
+        (lg.KIND_SESSION, "turn/start"),
+        (lg.KIND_SESSION, "compaction/ran"),
+    ],
+)
+def test_a_kind_accepts_the_domains_it_owns(kind, owned):
+    unit = _crew() if kind == lg.KIND_CREW else _session()
+    assert unit.append(owned, {}, src="gateway").type == owned
+
+
+@pytest.mark.parametrize(
+    "kind,foreign",
+    [(lg.KIND_CREW, "turn/start"), (lg.KIND_SESSION, "member/joined")],
+)
+def test_a_kind_refuses_a_domain_the_other_kind_owns(kind, foreign):
+    unit = _crew() if kind == lg.KIND_CREW else _session()
+    with _raises(lg.CODE_EVENT_TYPE_NOT_OWNED) as exc:
+        unit.append(foreign, {}, src="gateway")
+    assert _code(exc) == lg.CODE_EVENT_TYPE_NOT_OWNED
+
+
+def test_the_ownership_registry_is_the_documented_partition():
+    assert lg.TYPE_OWNERSHIP[lg.KIND_CREW] == {
+        "member",
+        "activity",
+        "slot",
+        "patrol",
+        "message",
+        "crew",
+        "item",
+        "memory",
+    }
+    assert lg.TYPE_OWNERSHIP[lg.KIND_SESSION] == {
+        "session",
+        "turn",
+        "step",
+        "tool",
+        "approval",
+        "model",
+        "compaction",
+        "remote",
+    }
+
+
+@pytest.mark.parametrize("bad", ["noslash", "/leading", "trailing/", "a/b/c", "-bad/x", "x/-bad"])
+def test_a_type_that_is_not_domain_slash_action_is_refused(bad):
+    crew = _crew()
+    with _raises(lg.CODE_BAD_TYPE) as exc:
+        crew.append(bad, {}, src="gateway")
+    assert _code(exc) == lg.CODE_BAD_TYPE
+
+
+@pytest.mark.parametrize("src", ["gateway", "acp", "dashboard", "patrol", "session:slack:1712.5"])
+def test_the_fixed_and_session_emitters_are_accepted(src):
+    assert _crew().append("activity/tick", {}, src=src).src == src
+
+
+@pytest.mark.parametrize("bad", ["", "Gate way", "session:", "crew:", "app:bad/name", "unknown"])
+def test_an_unrecognized_src_is_refused(bad):
+    crew = _crew()
+    with _raises(lg.CODE_BAD_SRC) as exc:
+        crew.append("activity/tick", {}, src=bad)
+    assert _code(exc) == lg.CODE_BAD_SRC
+
+
+# --- rule 2: guest namespaces ---------------------------------------------
+
+
+def test_a_guest_writes_under_its_own_prefix_on_a_crew_ledger():
+    crew = _crew()
+    assert crew.append("crew:qa/report", {}, src="crew:qa").type == "crew:qa/report"
+    assert crew.append("app:radar/scan", {}, src="app:radar").type == "app:radar/scan"
+
+
+def test_a_session_ledger_refuses_a_guest_type_outright():
+    session = _session()
+    with _raises(lg.CODE_NAMESPACE_VIOLATION) as exc:
+        session.append("crew:qa/report", {}, src="crew:qa")
+    assert _code(exc) == lg.CODE_NAMESPACE_VIOLATION
+
+
+def test_a_guest_may_not_write_another_guests_namespace():
+    crew = _crew()
+    with _raises(lg.CODE_NAMESPACE_VIOLATION) as exc:
+        crew.append("crew:other/report", {}, src="crew:qa")
+    assert _code(exc) == lg.CODE_NAMESPACE_VIOLATION
+
+
+def test_a_guest_may_not_write_an_owned_domain_either():
+    # Its own name is its whole permission; the registry is not also open to it.
+    crew = _crew()
+    with _raises(lg.CODE_NAMESPACE_VIOLATION) as exc:
+        crew.append("member/joined", {}, src="crew:qa")
+    assert _code(exc) == lg.CODE_NAMESPACE_VIOLATION
+    assert exc.value.field == "src"
+
+
+def test_a_non_guest_emitter_may_not_borrow_a_guest_namespace():
+    crew = _crew()
+    with _raises(lg.CODE_NAMESPACE_VIOLATION) as exc:
+        crew.append("crew:qa/report", {}, src="gateway")
+    assert _code(exc) == lg.CODE_NAMESPACE_VIOLATION
+
+
+# --- rule 3: thread, ref, size --------------------------------------------
+
+
+def test_thread_groups_entries_under_an_earlier_anchor():
+    crew = _crew()
+    anchor = crew.append("item/opened", {}, src="gateway")
+    child = crew.append("item/updated", {}, src="gateway", thread=anchor.seq)
+    assert child.thread == anchor.seq
+
+
+@pytest.mark.parametrize("bad", [0, -1, True, 99])
+def test_a_thread_that_names_no_earlier_entry_is_refused(bad):
+    crew = _crew()
+    crew.append("item/opened", {}, src="gateway")
+    with _raises(lg.CODE_BAD_THREAD) as exc:
+        crew.append("item/updated", {}, src="gateway", thread=bad)
+    assert _code(exc) == lg.CODE_BAD_THREAD
+
+
+def test_a_thread_may_not_name_the_entry_being_written():
+    crew = _crew()
+    with _raises(lg.CODE_BAD_THREAD) as exc:
+        crew.append("item/opened", {}, src="gateway", thread=1)
+    assert _code(exc) == lg.CODE_BAD_THREAD
+
+
+def test_a_thread_naming_a_seq_no_reader_can_parse_is_refused():
+    # In range but unreadable: a group hanging off this anchor would never show
+    # the anchor, so the pointer is to nothing.
+    crew = _crew()
+    for index in range(3):
+        crew.append("activity/tick", {"i": index}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines[2] = '{"type":"activity/tick","seq":'  # seq 2, terminated, unparseable
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    reopened = Ledger.open(lg.KIND_CREW, CREW)
+
+    with _raises(lg.CODE_BAD_THREAD) as exc:
+        reopened.append("activity/tick", {}, src="gateway", thread=2)
+    assert _code(exc) == lg.CODE_BAD_THREAD
+    # The intact anchors on either side still work.
+    assert reopened.append("activity/tick", {}, src="gateway", thread=1).thread == 1
+    assert reopened.append("activity/tick", {}, src="gateway", thread=3).thread == 3
+
+
+def test_an_anchor_older_than_the_tail_window_is_still_accepted():
+    # The in-window check cannot see it, so this is the bounded fallback.
+    crew = _crew()
+    anchor = crew.append("item/opened", {"n": "anchor"}, src="gateway")
+    for _ in range(3):
+        crew.append("item/updated", {"blob": "x" * 40_000}, src="gateway")
+    assert lg.ledger_path(lg.KIND_CREW, CREW).stat().st_size > 72 * 1024
+
+    child = crew.append("item/updated", {}, src="gateway", thread=anchor.seq)
+
+    assert child.thread == anchor.seq
+    assert crew.thread_page(anchor.seq).entries[-1].seq == anchor.seq
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"unit": "swarm", "id": "x", "from": 1},
+        {"unit": "crew", "id": "", "from": 1},
+        {"unit": "crew", "id": "a/b", "from": 1},
+        {"unit": "crew", "id": "x", "from": 0},
+        {"unit": "crew", "id": "x", "from": "1"},
+        {"unit": "crew", "id": "x", "from": 5, "to": 4},
+        {"unit": "crew", "id": "x", "from": 1, "to": 1 + lg.MAX_REF_SPAN},
+        "not-an-object",
+    ],
+)
+def test_a_malformed_ref_is_refused(raw):
+    crew = _crew()
+    with _raises(lg.CODE_BAD_REF) as exc:
+        crew.append("item/opened", {}, src="gateway", ref=raw)
+    assert _code(exc) == lg.CODE_BAD_REF
+
+
+def test_a_ref_without_to_cites_one_line():
+    assert Ref("crew", CREW, 7).last_seq == 7
+    assert Ref("crew", CREW, 7, 9).last_seq == 9
+
+
+def test_an_entry_over_the_size_ceiling_is_refused_whole():
+    crew = _crew()
+    crew.append("item/opened", {"note": "kept"}, src="gateway")
+    before = lg.ledger_path(lg.KIND_CREW, CREW).read_bytes()
+    with _raises(lg.CODE_ENTRY_TOO_LARGE) as exc:
+        crew.append("item/opened", {"blob": "x" * (lg.MAX_ENTRY_BYTES + 1)}, src="gateway")
+    assert _code(exc) == lg.CODE_ENTRY_TOO_LARGE
+    # Caps refuse; a refused append leaves the file byte-identical and does not
+    # burn the seq it would have used.
+    assert lg.ledger_path(lg.KIND_CREW, CREW).read_bytes() == before
+    assert crew.append("item/opened", {}, src="gateway").seq == 2
+
+
+def test_an_entry_just_under_the_ceiling_is_accepted():
+    crew = _crew()
+    room = lg.MAX_ENTRY_BYTES - 200
+    assert crew.append("item/opened", {"blob": "x" * room}, src="gateway").seq == 1
+
+
+@pytest.mark.parametrize("bad", [None, [], "text", 7])
+def test_data_that_is_not_a_json_object_is_refused(bad):
+    crew = _crew()
+    with _raises(lg.CODE_BAD_DATA) as exc:
+        crew.append("item/opened", bad, src="gateway")
+    assert _code(exc) == lg.CODE_BAD_DATA
+
+
+def test_data_that_cannot_be_serialized_is_refused():
+    crew = _crew()
+    with _raises(lg.CODE_BAD_DATA) as exc:
+        crew.append("item/opened", {"when": object()}, src="gateway")
+    assert _code(exc) == lg.CODE_BAD_DATA
+
+
+# --- reads: fold, get, page -----------------------------------------------
+
+
+def test_iter_from_is_oldest_first_and_starts_where_asked():
+    crew = _crew()
+    for index in range(5):
+        crew.append("activity/tick", {"i": index}, src="gateway")
+    assert [entry.seq for entry in crew.iter_from()] == [1, 2, 3, 4, 5]
+    assert [entry.seq for entry in crew.iter_from(4)] == [4, 5]
+
+
+def test_get_returns_the_entry_or_none():
+    crew = _crew()
+    crew.append("activity/tick", {"i": 0}, src="gateway")
+    assert crew.get(1).data == {"i": 0}
+    assert crew.get(2) is None
+    assert crew.get(0) is None
+
+
+def test_page_walks_the_whole_history_newest_first_with_no_phantom_page():
+    crew = _crew()
+    for index in range(7):  # odd count, so the last page is a partial one
+        crew.append("activity/tick", {"i": index}, src="gateway")
+    seen: list[int] = []
+    cursor: int | None = None
+    pages = 0
+    while True:
+        page = crew.page(before=cursor, limit=3)
+        seen.extend(entry.seq for entry in page.entries)
+        pages += 1
+        if page.next_before is None:
+            break
+        cursor = page.next_before
+    assert seen == [7, 6, 5, 4, 3, 2, 1]
+    assert pages == 3
+
+
+def test_a_page_that_lands_exactly_on_the_oldest_entry_ends_the_walk():
+    # 6 entries at limit 3 is the boundary a naive cursor turns into a fourth,
+    # empty page.
+    crew = _crew()
+    for index in range(6):
+        crew.append("activity/tick", {"i": index}, src="gateway")
+    first = crew.page(limit=3)
+    second = crew.page(before=first.next_before, limit=3)
+    assert [entry.seq for entry in second.entries] == [3, 2, 1]
+    assert second.next_before is None
+
+
+def test_page_limit_is_clamped_to_the_read_ceiling():
+    crew = _crew()
+    crew.append("activity/tick", {}, src="gateway")
+    assert len(crew.page(limit=10**6).entries) == 1
+    assert len(crew.page(limit=0).entries) == 1
+
+
+def test_page_of_an_empty_ledger_is_empty_with_no_cursor():
+    page = _crew().page()
+    assert page.entries == () and page.next_before is None
+
+
+def test_thread_page_returns_the_group_newest_first_with_the_anchor_last():
+    crew = _crew()
+    anchor = crew.append("item/opened", {"n": "anchor"}, src="gateway")
+    crew.append("activity/tick", {"n": "unrelated"}, src="gateway")
+    members = [
+        crew.append("item/updated", {"n": index}, src="gateway", thread=anchor.seq)
+        for index in range(3)
+    ]
+    page = crew.thread_page(anchor.seq)
+    assert [entry.seq for entry in page.entries] == [
+        members[2].seq,
+        members[1].seq,
+        members[0].seq,
+        anchor.seq,
+    ]
+    assert page.next_before is None
+
+
+def test_thread_page_pages_and_reaches_the_anchor_on_the_last_page():
+    crew = _crew()
+    anchor = crew.append("item/opened", {}, src="gateway")
+    for index in range(4):
+        crew.append("item/updated", {"i": index}, src="gateway", thread=anchor.seq)
+    first = crew.thread_page(anchor.seq, limit=2)
+    assert [entry.seq for entry in first.entries] == [5, 4]
+    second = crew.thread_page(anchor.seq, before=first.next_before, limit=2)
+    assert [entry.seq for entry in second.entries] == [3, 2]
+    third = crew.thread_page(anchor.seq, before=second.next_before, limit=2)
+    assert [entry.seq for entry in third.entries] == [anchor.seq]
+    assert third.next_before is None
+
+
+def test_thread_page_of_an_unknown_anchor_is_empty_rather_than_a_refusal():
+    crew = _crew()
+    crew.append("activity/tick", {}, src="gateway")
+    assert crew.thread_page(99).entries == ()
+
+
+# --- reads: resolve -------------------------------------------------------
+
+
+def _allow(unit: str, uid: str) -> bool:
+    return True
+
+
+def test_resolve_returns_the_cited_segment_of_another_ledger():
+    session = _session()
+    for index in range(5):
+        session.append("turn/start", {"i": index}, src="acp")
+    crew = _crew()
+    resolution = crew.resolve(Ref(lg.KIND_SESSION, SESSION, 2, 4), may_read=_allow)
+    assert resolution.status == lg.STATUS_OK and resolution.ok
+    assert [entry.seq for entry in resolution.entries] == [2, 3, 4]
+
+
+def test_a_cross_ledger_ref_without_an_access_check_is_refused_not_allowed():
+    # Omitting the callback is the shortest call shape there is, so it must not
+    # be the one that hands over another unit's entries.
+    session = _session()
+    session.append("turn/start", {"private": True}, src="acp")
+    resolution = _crew().resolve(Ref(lg.KIND_SESSION, SESSION, 1))
+    assert resolution.status == lg.STATUS_FORBIDDEN
+    assert resolution.entries == ()
+
+
+def test_resolve_without_to_returns_the_single_cited_line():
+    session = _session()
+    session.append("turn/start", {"i": 0}, src="acp")
+    session.append("turn/end", {"i": 1}, src="acp")
+    resolution = _crew().resolve({"unit": "session", "id": SESSION, "from": 2}, may_read=_allow)
+    assert [entry.type for entry in resolution.entries] == ["turn/end"]
+
+
+def test_resolve_follows_a_ref_into_the_citing_ledger_itself_with_no_callback():
+    # No boundary is crossed: the caller already holds this ledger open.
+    crew = _crew()
+    crew.append("item/opened", {"i": 0}, src="gateway")
+    resolution = crew.resolve(Ref(lg.KIND_CREW, CREW, 1))
+    assert resolution.ok and [entry.seq for entry in resolution.entries] == [1]
+
+
+def test_resolve_is_gone_when_the_cited_ledger_does_not_exist():
+    resolution = _crew().resolve(Ref(lg.KIND_SESSION, "s-missing", 1, 3), may_read=_allow)
+    assert resolution.status == lg.STATUS_GONE
+    assert resolution.entries == () and not resolution.ok
+
+
+def test_resolve_is_forbidden_and_says_nothing_about_existence():
+    session = _session()
+    session.append("turn/start", {}, src="acp")
+    crew = _crew()
+    denied = crew.resolve(Ref(lg.KIND_SESSION, SESSION, 1), may_read=lambda unit, uid: False)
+    absent = crew.resolve(Ref(lg.KIND_SESSION, "s-missing", 1), may_read=lambda unit, uid: False)
+    # Both answers are identical, so a caller that may not read a unit cannot
+    # use the status to learn whether it is there.
+    assert denied == absent
+    assert denied.status == lg.STATUS_FORBIDDEN and denied.entries == ()
+
+
+def test_resolve_passes_the_unit_and_id_to_the_access_check():
+    seen: list[tuple[str, str]] = []
+    _crew().resolve(
+        Ref(lg.KIND_SESSION, SESSION, 1),
+        may_read=lambda unit, uid: seen.append((unit, uid)) or True,
+    )
+    assert seen == [(lg.KIND_SESSION, SESSION)]
+
+
+# --- damage tolerance -----------------------------------------------------
+
+
+def test_a_torn_last_line_is_truncated_on_open():
+    crew = _crew()
+    crew.append("item/opened", {"kept": True}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    intact = path.read_bytes()
+    path.write_bytes(intact + b'{"type":"item/opened","seq":2,"tim')
+
+    reopened = Ledger.open(lg.KIND_CREW, CREW)
+
+    assert path.read_bytes() == intact  # the crash artifact is gone, history is not
+    assert reopened.last_seq == 1
+    assert reopened.append("item/opened", {}, src="gateway").seq == 2
+
+
+def test_a_complete_last_line_missing_only_its_newline_is_kept():
+    # Only the separator was lost, so the record is real; the next append
+    # re-supplies the newline instead of rewriting the line.
+    crew = _crew()
+    crew.append("item/opened", {"kept": True}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    path.write_bytes(path.read_bytes().rstrip(b"\n"))
+
+    reopened = Ledger.open(lg.KIND_CREW, CREW)
+
+    assert reopened.last_seq == 1
+    assert reopened.append("item/opened", {"next": True}, src="gateway").seq == 2
+    assert [entry.seq for entry in Ledger.open(lg.KIND_CREW, CREW).iter_from()] == [1, 2]
+
+
+def test_a_malformed_interior_line_is_skipped_on_read_and_left_on_disk():
+    crew = _crew()
+    for index in range(3):
+        crew.append("activity/tick", {"i": index}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines[2] = '{"type":"activity/tick","seq":'  # terminated, so NOT torn
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    reopened = Ledger.open(lg.KIND_CREW, CREW)
+
+    assert [entry.seq for entry in reopened.iter_from()] == [1, 3]
+    assert reopened.last_seq == 3
+    assert '{"type":"activity/tick","seq":' in path.read_text(encoding="utf-8")
+
+
+def test_a_blank_interior_line_is_skipped():
+    crew = _crew()
+    crew.append("activity/tick", {"i": 0}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    path.write_text(path.read_text(encoding="utf-8") + "\n\n", encoding="utf-8")
+    assert [entry.seq for entry in Ledger.open(lg.KIND_CREW, CREW).iter_from()] == [1]
+
+
+def test_an_interior_line_whose_envelope_is_wrong_is_skipped():
+    crew = _crew()
+    crew.append("activity/tick", {"i": 0}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + json.dumps({"type": "activity/tick", "seq": 2, "time": 1, "src": "gateway"})
+        + "\n"
+        + json.dumps({"type": "activity/tick", "seq": 3, "time": 1, "src": "g", "data": 4})
+        + "\n",
+        encoding="utf-8",
+    )
+    assert [entry.seq for entry in Ledger.open(lg.KIND_CREW, CREW).iter_from()] == [1]
+
+
+def test_seq_recovers_from_the_newest_valid_line_when_the_tail_is_damaged():
+    crew = _crew()
+    for index in range(3):
+        crew.append("activity/tick", {"i": index}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines[-1] = "{damaged"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # The newest PARSEABLE seq is 2, so the next entry is 3 -- the damaged
+    # line's number is not reused, because a reader cannot know it was 3.
+    assert Ledger.open(lg.KIND_CREW, CREW).append("activity/tick", {}, src="gateway").seq == 3
+
+
+def test_a_torn_tail_is_repaired_by_an_append_too_not_only_by_a_reopen():
+    # A long-lived writer holds its handle open across a crash somewhere else,
+    # so the repair cannot live only in ``open``.
+    crew = _crew()
+    crew.append("item/opened", {"kept": True}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    path.write_bytes(path.read_bytes() + b'{"type":"item/opened","seq":2,"tim')
+
+    assert crew.append("item/opened", {"next": True}, src="gateway").seq == 2
+    assert [entry.seq for entry in crew.iter_from()] == [1, 2]
+
+
+def test_an_interior_line_carrying_a_malformed_ref_is_skipped():
+    crew = _crew()
+    crew.append("item/opened", {"i": 0}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + json.dumps(
+            {
+                "type": "item/opened",
+                "seq": 2,
+                "time": 1,
+                "src": "gateway",
+                "ref": {"unit": "swarm", "id": "x", "from": 1},
+                "data": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert [entry.seq for entry in Ledger.open(lg.KIND_CREW, CREW).iter_from()] == [1]
+
+
+def test_a_stored_session_thread_anchor_that_is_damaged_reads_as_absent():
+    _session()
+    path = lg.ledger_path(lg.KIND_SESSION, SESSION)
+    header = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    header["thread"] = {"crew": CREW}
+    path.write_text(json.dumps(header) + "\n", encoding="utf-8")
+    assert Ledger.open(lg.KIND_SESSION, SESSION).header.thread is None
+
+
+@pytest.mark.parametrize("key,bad", [("createdAt", "yesterday"), ("version", "1"), ("name", 7)])
+def test_a_header_field_of_the_wrong_stored_type_refuses_the_open(key, bad):
+    _crew()
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    header = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    header[key] = bad
+    path.write_text(json.dumps(header) + "\n", encoding="utf-8")
+    with _raises(lg.CODE_BAD_HEADER) as exc:
+        Ledger.open(lg.KIND_CREW, CREW)
+    assert _code(exc) == lg.CODE_BAD_HEADER
+
+
+def test_a_session_header_missing_its_owner_refuses_the_open():
+    _session()
+    path = lg.ledger_path(lg.KIND_SESSION, SESSION)
+    header = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    del header["owner"]
+    path.write_text(json.dumps(header) + "\n", encoding="utf-8")
+    with _raises(lg.CODE_BAD_HEADER) as exc:
+        Ledger.open(lg.KIND_SESSION, SESSION)
+    assert _code(exc) == lg.CODE_BAD_HEADER
+
+
+def test_a_ledger_of_one_kind_cannot_be_opened_as_the_other():
+    # The two roots are separate, so this needs the file moved -- which is
+    # exactly what a mistaken restore or a hand-edit does.
+    _crew()
+    target = lg.ledger_dir(lg.KIND_SESSION, CREW)
+    target.mkdir(parents=True, exist_ok=True)
+    (target / lg.LEDGER_FILE).write_bytes(lg.ledger_path(lg.KIND_CREW, CREW).read_bytes())
+    with _raises(lg.CODE_BAD_HEADER) as exc:
+        Ledger.open(lg.KIND_SESSION, CREW)
+    assert _code(exc) == lg.CODE_BAD_HEADER
+
+
+# --- large files: the bounded tail read -----------------------------------
+
+
+def test_seq_comes_off_a_bounded_window_on_a_file_past_that_window():
+    # The window can begin mid-line, so its first fragment is not a record. If
+    # that fragment were trusted the seq would come from a partial line.
+    crew = _crew()
+    for _ in range(3):  # three ~40 KiB lines clear the ~72 KiB window
+        crew.append("item/opened", {"blob": "x" * 40_000}, src="gateway")
+    assert crew.append("item/opened", {}, src="gateway").seq == 4
+    assert Ledger.open(lg.KIND_CREW, CREW).last_seq == 4
+
+
+def test_seq_falls_back_to_a_full_scan_when_the_window_holds_nothing_valid():
+    crew = _crew()
+    crew.append("item/opened", {"i": 0}, src="gateway")
+    path = lg.ledger_path(lg.KIND_CREW, CREW)
+    # One terminated garbage line wider than the tail window, so the window
+    # sees only garbage and the real seq is behind it.
+    with open(path, "a", encoding="utf-8", newline="\n") as handle:
+        handle.write("{" + "z" * 80_000 + "\n")
+
+    reopened = Ledger.open(lg.KIND_CREW, CREW)
+
+    assert reopened.last_seq == 1
+    assert reopened.append("item/opened", {"i": 1}, src="gateway").seq == 2
+    assert [entry.seq for entry in reopened.iter_from()] == [1, 2]
+
+
+# --- containment ----------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_an_id_that_symlinks_out_of_its_root_is_refused():
+    # The shape gate cannot see this one: the id has no separator, the ESCAPE is
+    # in the filesystem. Containment is re-checked on the resolved path.
+    _crew()
+    root = lg.ledger_root(lg.KIND_CREW)
+    outside = root.parent / "outside"
+    outside.mkdir(parents=True, exist_ok=True)
+    (root / _store_name("escape")).symlink_to(outside, target_is_directory=True)
+    with _raises(lg.CODE_INVALID_ID) as exc:
+        _crew("escape")
+    assert _code(exc) == lg.CODE_INVALID_ID

--- a/test/test_session_ledger_emit.py
+++ b/test/test_session_ledger_emit.py
@@ -1,0 +1,459 @@
+"""Unit tests for the append-only session ledger emitter."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import session_ledger_emit as emit
+from kiro_crew.ledger import ledger_path, ledger_root
+
+SESSION = "acp-sess-0001"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Every test writes into its own data home, never the live one."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv(emit.SESSION_LEDGER_ENV, "1")
+    emit.reset_caches()
+    yield
+    emit.reset_caches()
+
+
+def _ledger_path(session_id: str = SESSION) -> Path:
+    """Ask the storage library where it puts things; never pin its layout."""
+    return ledger_path("session", session_id)
+
+
+def _store_root() -> Path:
+    return ledger_root("session")
+
+
+def _entries(session_id: str = SESSION) -> list[dict]:
+    """Every line, header first, exactly as the emitter left it."""
+    path = _ledger_path(session_id)
+    if not path.is_file():
+        return []
+    with path.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def _body(session_id: str = SESSION) -> list[dict]:
+    """The entries after the header line."""
+    return _entries(session_id)[1:]
+
+
+def _open_session() -> None:
+    emit.on_session_opened(
+        SESSION,
+        agent="kirocrew",
+        slot="chat-7",
+        model="claude-opus-5",
+        cwd="/home/dev/project",
+        owner="default",
+    )
+
+
+# --- creation and header ---------------------------------------------------
+
+
+def test_first_open_creates_the_ledger_file():
+    assert not _ledger_path().exists()
+    _open_session()
+    assert _ledger_path().is_file()
+
+
+def test_the_header_is_line_one_and_carries_owner_agent_slot_cwd():
+    _open_session()
+    header = _entries()[0]
+    assert header["type"] == "session"
+    assert header["id"] == SESSION
+    assert header["owner"] == "default"
+    assert header["agent"] == "kirocrew"
+    assert header["slot"] == "chat-7"
+    assert header["cwd"] == "/home/dev/project"
+    assert isinstance(header["createdAt"], int)
+
+
+def test_opened_entry_echoes_the_header_and_adds_the_model():
+    _open_session()
+    opened = [e for e in _body() if e["type"] == "session/opened"]
+    assert len(opened) == 1
+    entry = opened[0]
+    assert entry["src"] == "gateway"
+    assert isinstance(entry["time"], int)
+    data = entry["data"]
+    assert data["agent"] == "kirocrew"
+    assert data["slot"] == "chat-7"
+    assert data["cwd"] == "/home/dev/project"
+    assert data["owner"] == "default"
+    assert data["resumed"] is False
+    # The storage header has no model field, so the entry carries it.
+    assert data["model"] == "claude-opus-5"
+
+
+def test_an_agentless_call_site_still_produces_a_valid_header():
+    emit.on_session_opened(SESSION, slot="chat-1")
+    assert _entries()[0]["agent"] == "kirocrew"
+
+
+def test_reopening_appends_instead_of_truncating():
+    _open_session()
+    first = len(_entries())
+    emit.reset_caches()
+    emit.on_session_opened(SESSION, agent="kirocrew", slot="chat-7", resumed=True)
+    entries = _entries()
+    assert len(entries) == first + 1
+    assert entries[-1]["data"]["resumed"] is True
+    assert sum(1 for e in entries if e["type"] == "session") == 1
+
+
+def test_a_warm_reuse_of_the_same_session_adds_no_second_opened_entry():
+    """The claim runs every turn; only a create or a re-attach is worth an entry."""
+    _open_session()
+    _open_session()
+    _open_session()
+    assert sum(1 for e in _body() if e["type"] == "session/opened") == 1
+
+
+def test_a_warm_reuse_still_clears_the_stale_turn_anchor():
+    _open_session()
+    emit.on_turn_started(SESSION, 1, "user")
+    _open_session()
+    emit.on_tool_called(SESSION, 2, name="fs_read", call_id="tc-1")
+    assert "thread" not in _body()[-1]
+
+
+def test_owner_is_written_once_and_a_reopen_cannot_change_it():
+    emit.on_session_opened(SESSION, agent="kirocrew", owner="raymond")
+    emit.reset_caches()
+    emit.on_session_opened(SESSION, agent="kirocrew", owner="somebody-else")
+    assert _entries()[0]["owner"] == "raymond"
+
+
+# --- a whole turn ----------------------------------------------------------
+
+
+def test_one_full_turn_produces_contiguous_seq():
+    _open_session()
+    emit.on_turn_started(SESSION, 4, "user")
+    emit.on_tool_called(SESSION, 4, name="fs_read", call_id="tc-1")
+    emit.on_tool_completed(SESSION, 4, name="fs_read", status="completed", call_id="tc-1")
+    emit.on_turn_completed(
+        SESSION,
+        4,
+        input_tokens=1200,
+        output_tokens=340,
+        cache_read_tokens=9000,
+        cache_write_tokens=15,
+        credits=0.42,
+        duration_ms=8123,
+        stop_reason="end_turn",
+        model="claude-opus-5",
+        provider="kiro",
+    )
+    body = _body()
+    assert [e["seq"] for e in body] == list(range(1, len(body) + 1))
+    assert [e["type"] for e in body] == [
+        "session/opened",
+        "turn/started",
+        "tool/called",
+        "tool/completed",
+        "turn/completed",
+    ]
+
+
+def test_a_turn_is_a_thread_anchored_on_its_started_entry():
+    _open_session()
+    emit.on_turn_started(SESSION, 4, "user")
+    emit.on_tool_called(SESSION, 4, name="fs_read", call_id="tc-1")
+    emit.on_tool_completed(SESSION, 4, name="fs_read", status="completed", call_id="tc-1")
+    emit.on_turn_completed(SESSION, 4, stop_reason="end_turn")
+    by_type = {e["type"]: e for e in _body()}
+    anchor = by_type["turn/started"]["seq"]
+    assert "thread" not in by_type["turn/started"], "the anchor threads nothing"
+    for kind in ("tool/called", "tool/completed", "turn/completed"):
+        assert by_type[kind]["thread"] == anchor
+
+
+def test_entries_outside_a_turn_carry_no_thread():
+    _open_session()
+    emit.on_session_closed(SESSION, "reset")
+    for entry in _body():
+        assert "thread" not in entry
+
+
+def test_a_second_turn_anchors_its_own_thread():
+    _open_session()
+    emit.on_turn_started(SESSION, 1, "user")
+    emit.on_turn_completed(SESSION, 1, stop_reason="end_turn")
+    emit.on_turn_started(SESSION, 2, "user")
+    emit.on_tool_called(SESSION, 2, name="fs_read", call_id="tc-2")
+    starts = [e for e in _body() if e["type"] == "turn/started"]
+    tool = [e for e in _body() if e["type"] == "tool/called"][0]
+    assert tool["thread"] == starts[1]["seq"] != starts[0]["seq"]
+
+
+def test_turn_completed_carries_the_four_token_counts_and_cost():
+    _open_session()
+    emit.on_turn_started(SESSION, 1, "user")
+    emit.on_turn_completed(
+        SESSION,
+        1,
+        input_tokens=11,
+        output_tokens=22,
+        cache_read_tokens=33,
+        cache_write_tokens=44,
+        credits=1.5,
+        duration_ms=99,
+        stop_reason="end_turn",
+    )
+    data = _body()[-1]["data"]
+    assert data["tokens"] == {
+        "input": 11,
+        "output": 22,
+        "cache_read": 33,
+        "cache_write": 44,
+    }
+    assert data["credits"] == 1.5
+    assert data["duration_ms"] == 99
+    assert data["stop_reason"] == "end_turn"
+
+
+def test_an_aborted_turn_leaves_a_started_with_no_completion():
+    _open_session()
+    emit.on_turn_started(SESSION, 2, "cron")
+    types = [e["type"] for e in _body()]
+    assert types.count("turn/started") == 1
+    assert "turn/completed" not in types
+
+
+def test_a_recovery_reentry_is_its_own_turn_pair_marked_by_depth():
+    _open_session()
+    emit.on_turn_started(SESSION, 5, "user", depth=0)
+    emit.on_turn_completed(SESSION, 5, stop_reason="cancelled", depth=0)
+    emit.on_turn_started(SESSION, 5, "user", depth=1)
+    emit.on_turn_completed(SESSION, 5, stop_reason="end_turn", depth=1)
+    turns = [e for e in _body() if e["type"].startswith("turn/")]
+    assert [e["data"]["depth"] for e in turns] == [0, 0, 1, 1]
+
+
+def test_every_actor_the_dispatcher_distinguishes_is_recorded_verbatim():
+    _open_session()
+    for actor in ("user", "cron", "autonudge", "subagent", "crew"):
+        emit.on_turn_started(SESSION, 1, actor)
+    recorded = [e["data"]["actor"] for e in _body() if e["type"] == "turn/started"]
+    assert recorded == ["user", "cron", "autonudge", "subagent", "crew"]
+
+
+def test_an_unknown_actor_is_recorded_as_other_not_guessed():
+    _open_session()
+    emit.on_turn_started(SESSION, 1, "something-new")
+    assert _body()[-1]["data"]["actor"] == "other"
+
+
+# --- tools, approvals, model, compaction ----------------------------------
+
+
+def test_a_tool_call_is_identified_by_id_in_data_and_records_no_arguments():
+    _open_session()
+    emit.on_turn_started(SESSION, 3, "user")
+    emit.on_tool_called(
+        SESSION, 3, name="execute_bash", server="", kind="execute", call_id="tc-9"
+    )
+    entry = _body()[-1]
+    # ref is a citation of another ledger's lines, so a tool call id is data.
+    assert "ref" not in entry
+    assert entry["data"] == {
+        "turn": 3,
+        "call_id": "tc-9",
+        "name": "execute_bash",
+        "server": "",
+        "kind": "execute",
+    }
+
+
+def test_an_mcp_tool_records_its_server():
+    _open_session()
+    emit.on_tool_called(
+        SESSION, 1, name="InternalSearch", server="builder-mcp", call_id="tc-3"
+    )
+    assert _body()[-1]["data"]["server"] == "builder-mcp"
+
+
+def test_tool_completion_measures_elapsed_ms_from_its_call():
+    _open_session()
+    emit.on_tool_called(SESSION, 1, name="fs_read", call_id="tc-2")
+    emit.on_tool_completed(SESSION, 1, name="fs_read", status="completed", call_id="tc-2")
+    assert _body()[-1]["data"]["elapsed_ms"] >= 0
+
+
+def test_completion_inherits_the_identity_the_call_frame_carried():
+    """The terminal ACP frame repeats neither the tool name nor its server."""
+    _open_session()
+    emit.on_tool_called(
+        SESSION, 1, name="InternalSearch", server="builder-mcp", call_id="tc-4"
+    )
+    emit.on_tool_completed(SESSION, 1, status="completed", call_id="tc-4")
+    data = _body()[-1]["data"]
+    assert data["name"] == "InternalSearch"
+    assert data["server"] == "builder-mcp"
+
+
+def test_an_explicit_completion_name_is_not_overwritten_by_the_remembered_one():
+    _open_session()
+    emit.on_tool_called(SESSION, 1, name="old", server="old-srv", call_id="tc-5")
+    emit.on_tool_completed(
+        SESSION, 1, name="new", server="new-srv", status="completed", call_id="tc-5"
+    )
+    data = _body()[-1]["data"]
+    assert data["name"] == "new"
+    assert data["server"] == "new-srv"
+
+
+def test_tool_completion_without_a_matching_call_omits_elapsed_ms():
+    _open_session()
+    emit.on_tool_completed(SESSION, 1, name="fs_read", status="completed", call_id="unseen")
+    assert "elapsed_ms" not in _body()[-1]["data"]
+
+
+def test_approval_request_and_decision_share_the_approval_id():
+    _open_session()
+    emit.on_turn_started(SESSION, 2, "user")
+    emit.on_approval_requested(SESSION, 2, approval_id="ap-1", tool="execute_bash")
+    emit.on_approval_decided(SESSION, 2, approval_id="ap-1", decision="rejected_once")
+    request, decision = _body()[-2:]
+    assert request["data"]["approval_id"] == decision["data"]["approval_id"] == "ap-1"
+    assert request["data"]["tool"] == "execute_bash"
+    assert decision["data"]["decision"] == "rejected_once"
+
+
+def test_compaction_records_percentages_not_token_counts():
+    _open_session()
+    emit.on_compaction_applied(SESSION, pct_before=0.92, pct_after=0.31)
+    data = _body()[-1]["data"]
+    assert data["pct_before"] == 0.92
+    assert data["pct_after"] == 0.31
+    assert data["freed_pct"] == pytest.approx(0.61)
+    assert "before_tokens" not in data
+
+
+def test_model_selection_records_its_source():
+    _open_session()
+    emit.on_model_selected(SESSION, "claude-haiku-4.5", "fallback")
+    assert _body()[-1]["data"] == {
+        "model": "claude-haiku-4.5",
+        "source": "fallback",
+    }
+
+
+def test_close_records_the_gateway_reason_verbatim():
+    _open_session()
+    emit.on_session_closed(SESSION, "shutdown")
+    assert _body()[-1]["data"]["reason"] == "shutdown"
+
+
+# --- fail-soft ------------------------------------------------------------
+
+
+def test_a_refused_oversize_write_is_swallowed_and_warned_once(caplog):
+    _open_session()
+    before = len(_entries())
+    with caplog.at_level(logging.WARNING, logger=emit.logger.name):
+        emit.on_tool_called(SESSION, 1, name="x" * (70 * 1024), call_id="tc-big")
+        emit.on_tool_called(SESSION, 1, name="y" * (70 * 1024), call_id="tc-big2")
+    assert len(_entries()) == before, "a refused write must not land"
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, "the failure is warned once, not per call"
+
+
+def test_a_refused_write_does_not_break_the_next_good_write():
+    _open_session()
+    emit.on_tool_called(SESSION, 1, name="z" * (70 * 1024), call_id="tc-big")
+    emit.on_turn_completed(SESSION, 1, stop_reason="end_turn")
+    assert _body()[-1]["type"] == "turn/completed"
+
+
+def test_a_storage_layer_that_raises_never_breaks_a_caller(monkeypatch):
+    _open_session()
+
+    class Exploding:
+        def append(self, *args, **kwargs):
+            raise RuntimeError("disk is on fire")
+
+    monkeypatch.setitem(emit._open, SESSION, Exploding())
+    emit.on_turn_started(SESSION, 1, "user")
+    emit.on_tool_called(SESSION, 1, name="fs_read", call_id="tc-1")
+    emit.on_tool_completed(SESSION, 1, name="fs_read", status="completed", call_id="tc-1")
+    emit.on_approval_requested(SESSION, 1, approval_id="ap-1")
+    emit.on_approval_decided(SESSION, 1, approval_id="ap-1", decision="approved")
+    emit.on_model_selected(SESSION, "m", "config")
+    emit.on_compaction_applied(SESSION, pct_before=0.9, pct_after=0.2)
+    emit.on_turn_completed(SESSION, 1, stop_reason="end_turn")
+    emit.on_session_closed(SESSION, "reset")
+
+
+def test_a_failed_turn_start_leaves_later_entries_unthreaded(monkeypatch):
+    """An anchor is only claimed from an entry that actually landed."""
+    _open_session()
+    emit.on_tool_called(SESSION, 1, name="fs_read", call_id="tc-1")
+    assert "thread" not in _body()[-1]
+
+
+def test_events_for_a_session_with_no_ledger_create_nothing():
+    emit.on_turn_started("never-opened", 1, "user")
+    emit.on_tool_called("never-opened", 1, name="fs_read", call_id="tc-1")
+    assert not _ledger_path("never-opened").exists()
+
+
+def test_a_missing_session_id_is_a_no_op():
+    emit.on_session_opened("", agent="kirocrew")
+    emit.on_turn_started("", 1, "user")
+    emit.on_session_closed("", "reset")
+    assert not _store_root().exists()
+
+
+# --- the flag ------------------------------------------------------------
+
+
+def test_flag_off_writes_no_file_at_all(monkeypatch):
+    monkeypatch.setenv(emit.SESSION_LEDGER_ENV, "0")
+    assert emit.enabled() is False
+    _open_session()
+    emit.on_turn_started(SESSION, 1, "user")
+    emit.on_tool_called(SESSION, 1, name="fs_read", call_id="tc-1")
+    emit.on_turn_completed(SESSION, 1, stop_reason="end_turn")
+    emit.on_session_closed(SESSION, "reset")
+    assert not _store_root().exists()
+
+
+def test_flag_unset_writes_no_file_at_all(monkeypatch):
+    monkeypatch.delenv(emit.SESSION_LEDGER_ENV, raising=False)
+    assert emit.enabled() is False
+    _open_session()
+    assert not _store_root().exists()
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", " yes ", "on"])
+def test_the_flag_accepts_the_repo_truthy_spellings(monkeypatch, value):
+    monkeypatch.setenv(emit.SESSION_LEDGER_ENV, value)
+    assert emit.enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "2"])
+def test_the_flag_rejects_everything_else(monkeypatch, value):
+    monkeypatch.setenv(emit.SESSION_LEDGER_ENV, value)
+    assert emit.enabled() is False
+
+
+def test_the_flag_is_read_per_call_not_at_import(monkeypatch):
+    monkeypatch.setenv(emit.SESSION_LEDGER_ENV, "0")
+    _open_session()
+    assert not _store_root().exists()
+    monkeypatch.setenv(emit.SESSION_LEDGER_ENV, "1")
+    _open_session()
+    assert _ledger_path().is_file()


### PR DESCRIPTION
Stacked on #10091 (`feat/ledger-core`). GitHub cannot take a cross-fork base, so this PR
targets `main` and its diff therefore also contains #10091's storage layer
(`src/kiro_crew/ledger/**`, `test/test_ledger_core.py`). Review that one first; the files
belonging to THIS change are `session_ledger_emit.py`, its test, the three wired call
sites, and the spec. A fork-internal PR with the clean stacked diff is at
https://github.com/chenmingwei23/KiroCrew/pull/1.

## Problem / Motivation

A dashboard chat session keeps no record of what it did. The only durable trace is the
message transcript, which is message-grain and rewritten in place by rotation and
compaction. Tool calls, approvals, model swaps and compaction are never journaled, so a
turn interrupted mid-flight loses every operation it executed since the last message
boundary. #10091 supplies the storage; nothing writes to it yet.

## Why it matters

When a long session goes wrong the evidence is gone. A user asking why their session
stalled, which tool was running when it hung, whether the model swapped under them, or
where their credits went has nothing on disk to read. The three hand-rolled ledgers
already in the tree exist because this record was missing.

## What changed

One writer, `src/kiro_crew/session_ledger_emit.py`, turning lifecycle facts the gateway
already computes into entries in the per-session append-only ledger. Each call site is a
single call at a point where the fact is already in hand.

- **Identity is the ACP session id, not the slot key.** A slot outlives its ACP session,
  so the id is read once after `get_or_create` and reused at every emit site below. A
  turn that never got an id emits nothing rather than guessing one. `session/opened`
  fires on a create or a genuine re-attach, not once per turn.
- **A turn is a thread.** `turn/started` anchors it, and every later entry in the turn
  carries the anchor's `seq` as its `thread`, so `thread_page` answers what one turn did
  with no fold.
- **Nothing already stored elsewhere is copied.** A tool call is named by its
  `tool_call_id`, never by its arguments or results. It is not a `ref`, because a `Ref`
  cites another ledger's lines and an ACP frame is not a ledger unit.
- **Only the trusted tool identity is recorded.** `name` and `server` carry the
  `_meta.kiro` pair and nothing else, so both are EMPTY when the backend supplies none,
  and the call id still joins the entry to the transcript. Neither `title` nor
  `wire_title` is used as a fallback: for a shell tool those are model-authored, and a log
  whose record of what ran can be written by the model is worth less than one that admits
  it does not know.
- **Wired at:** `chat_runner.py` for `session/opened`, `turn/started`, `turn/completed`,
  `tool/called`, `tool/completed`, and `model/selected` on the throttle fallback swap
  (emitted in the branch body, after `_fallback_swap_for_turn` has released
  `slot._model_pick_lock`); `session_compaction.py` for `compaction/applied`, at the settle
  point both in-place compaction paths share; `session_lifecycle.py` for `session/closed`
  at reset. A session's STARTING model is not a `model/selected` entry: it resolves before
  the session id exists, so it rides on `session/opened`, and the model a turn actually
  served rides on `turn/completed`. The fallback swap is the one model decision a
  transcript cannot answer afterwards.

Three recordings follow from what the sites can actually supply, and the spec says so.
Compaction records context **percentages** because that boundary never learns a raw token
count. A turn that dies before its terminal event writes **no** completion, because in an
append-only log a started entry with no completion is the record of an aborted turn. A
recovery re-entry anchors its own thread carrying `depth` rather than overwriting the
first one.

Every entry point is fail-soft: a storage error is warned once, demoted to debug after
that, and never raised. That is load-bearing at three sites and the emitter is placed
accordingly. The approval decision resolves on the websocket handler task, so an
exception there would break the click handler and hang the waiting turn.
`_default_session_model` runs in a worker thread behind a swallow-all `except`, and
`_fallback_swap_for_turn` holds `slot._model_pick_lock`, so the emitter is called from
the callers of those two, never inside them.

**Flag-gated and default OFF.** The module is inert unless `KIROCREW_SESSION_LEDGER` is
truthy (`constants.env_flag_enabled`, read per call). With the flag off no directory is
created and no call reaches storage, so turning it on is a separate change.

Spec: `docs/system-specs/modules/session-ledger-emitter.md` (80 lines), indexed in the
module README.

## Tests

47 unit tests in `test/test_session_ledger_emit.py`, all passing:

```
PYTHONPATH=src python -m pytest test/test_session_ledger_emit.py -n 2 -p no:cacheprovider
47 passed
```

They cover create-on-first-open, the header fields, a reopen that appends rather than
truncates, an owner a reopen cannot change, a warm reuse adding no second
`session/opened`, one full turn producing contiguous `seq`, a turn as a thread anchored
on its started entry, the four token counts, an aborted turn, a recovery pair told apart
by `depth`, actor mapping including the unknown case, tool ids with measured
`elapsed_ms`, a completion inheriting the identity only the call frame carries, approvals
sharing an id, compaction percentages, fail-soft on a refused oversize write warned
exactly once, a storage layer that raises on every method, and the flag off and unset
producing no file at all. The storage layer's own 118 tests pass beside them (165 total). The tests resolve paths through the library's `ledger_path` / `ledger_root` rather than hardcoding its layout.

**Live check in an isolated pod** (`kirocrew pod up session-ledger-emitter --provision`,
flag on via a per-instance drop-in, torn down after; the live gateway was never touched).
Two chat messages on one slot produced this ledger, keyed by the ACP session id
`78dd13cb-ef71-435f-9522-74e8faabb725`. The run predates a later rebase onto #10091's
current revision, which changed the DIRECTORY NAME to the library's folded store name;
the entries below are unaffected, since this module never resolves the path itself.

```
header            {"type":"session","version":1,"id":"78dd13cb-...","owner":"default",
                   "agent":"kirocrew","slot":"chat-9","createdAt":1789117942204}
seq=1 session/opened  src=gateway           {"agent":"kirocrew","slot":"chat-9","resumed":false}
seq=2 turn/started    src=gateway           {"turn":1,"actor":"user","depth":0}
seq=3 turn/completed  src=acp    thread=2   {"turn":1,"stop_reason":"end_turn",
                                             "duration_ms":3104,"credits":0.3197,
                                             "tokens":{"input":0,"output":0}}
seq=4 turn/started    src=gateway           {"turn":4,"actor":"user","depth":0}
seq=5 tool/called     src=acp    thread=4   {"turn":4,"call_id":"toolu_01WdGce",
                                             "name":"glob","kind":"search"}
```

The second turn's client disconnected, so it has a `turn/started` and a `tool/called`
with no completions: the aborted-turn encoding above, observed rather than asserted. A
separate pod session recorded the completed tool path,
`tool/completed {"name":"read","status":"completed","elapsed_ms":9}`, threaded under its
turn.

The pod run found two defects unit tests had missed, both now fixed and pinned: the
terminal tool frame carries no name (the emitter remembers the call frame's identity and
fills it in), and the per-turn session claim was writing `session/opened` every turn.

## Deliberately out of scope

- **Approval wiring.** The emitter's `approval/*` functions are implemented and tested,
  but the dashboard resolves approvals in its OWN decision ladder inside the
  `EVENT_PERMISSION_REQUEST` branch of `_run_chat`, which has many exits (hook grants,
  auto-approve, several denials, and an interactive card that resolves on the websocket
  handler task). `llm_helpers._resolve_permission` does carry a purpose-built
  `on_decision` sink, but it serves `stream_and_collect`, not the dashboard turn, so it
  is not reachable from here. Wiring the request is one line; wiring only SOME decision
  exits would make the ledger claim an approval hung, so request and decision land
  together in a follow-up.
- **Teardown beyond reset.** Reset is the case that ends a ledger's life; the other nine
  `end_reason` values want the same resolver.
- **Actor hardening.** The actor is derived from the self-wake flag and the cron and
  subagent message prefixes. Reading the queue entry's `kind` would make it unforgeable
  and needs the dispatcher to pass it down.
- Tombstones, projections, a reader, and any UI.

One thing worth chasing separately: the backend reported credits but zero per-token
counts for these turns. The ledger records what the usage object carries.

---

Rebased onto #10091's current head `2895a1c05` (that branch was revised three times while
this was in flight). The only conflict was the spec-index table, where both changes add a
row; both are kept. The core's move renamed the ledger DIRECTORY to a folded store name,
which broke five path assertions in my tests -- they now ask `ledger_path` / `ledger_root`
instead of pinning the layout. Head sha `35c5d8ce5`.
