### PR TITLE
fix(dashboard): keep file browser listing on one unreadable entry

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -3669,6 +3669,17 @@ async def api_file_diff(request: web.Request) -> web.Response:
     return web.json_response(result)
 
 
+def _browse_entry_is_dir(entry) -> bool:
+    # DirEntry.is_dir(follow_symlinks=True) stats the target, so one
+    # unreadable child (a TCC-protected dir, a permission-denied entry)
+    # raises instead of answering. Treat that as a non-dir so one bad
+    # sibling never aborts the sort or the listing loop.
+    try:
+        return bool(entry.is_dir(follow_symlinks=True))
+    except OSError:
+        return False
+
+
 def _browse_dirs_sync(base: str, skip: set[str]) -> list[dict]:
     """Walk *base* one level deep and return its visible subdirectories.
 
@@ -3681,12 +3692,15 @@ def _browse_dirs_sync(base: str, skip: set[str]) -> list[dict]:
     dirs: list[dict] = []
     try:
         for entry in sorted(os.scandir(base), key=lambda e: e.name.lower()):
-            if entry.is_dir(follow_symlinks=True) and entry.name not in skip and not entry.name.startswith("."):
-                # Resolve symlinks before the sensitivity check — a symlink in
-                # a benign dir pointing at ~/.aws would otherwise pass through.
-                if is_sensitive_path(os.path.realpath(entry.path)):
-                    continue
-                dirs.append({"name": entry.name, "path": entry.path})
+            if not _browse_entry_is_dir(entry):
+                continue
+            if entry.name in skip or entry.name.startswith("."):
+                continue
+            # Resolve symlinks before the sensitivity check — a symlink in
+            # a benign dir pointing at ~/.aws would otherwise pass through.
+            if is_sensitive_path(os.path.realpath(entry.path)):
+                continue
+            dirs.append({"name": entry.name, "path": entry.path})
     except PermissionError:
         pass
     return dirs
@@ -3701,9 +3715,19 @@ def _browse_files_sync(base: str, skip: set[str]) -> tuple[list[dict], list[dict
     dirs: list[dict] = []
     files: list[dict] = []
     try:
-        # Sort: dirs before files, then alphabetical
-        for entry in sorted(os.scandir(base), key=lambda e: (not e.is_dir(follow_symlinks=True), e.name.lower())):
+        # Sort: dirs before files, then alphabetical. The key must not raise
+        # on an unreadable child: DirEntry.is_dir stats the target, so one
+        # bad sibling would abort sorted() and empty the whole listing.
+        for entry in sorted(os.scandir(base), key=lambda e: (not _browse_entry_is_dir(e), e.name.lower())):
             if entry.name.startswith("."):
+                continue
+            # An entry that cannot even be classified is skipped, not fatal:
+            # without this, one unreadable child aborts the loop and drops
+            # every entry after it.
+            try:
+                is_dir = entry.is_dir(follow_symlinks=True)
+                is_file = False if is_dir else entry.is_file(follow_symlinks=True)
+            except OSError:
                 continue
             # Resolve symlinks before the sensitivity check — a symlink in a
             # benign dir pointing at ~/.aws would otherwise pass through.
@@ -3716,10 +3740,10 @@ def _browse_files_sync(base: str, skip: set[str]) -> tuple[list[dict], list[dict
                 mtime = int(entry.stat(follow_symlinks=True).st_mtime)
             except OSError:
                 mtime = 0
-            if entry.is_dir(follow_symlinks=True):
+            if is_dir:
                 if entry.name not in skip:
                     dirs.append({"name": entry.name, "path": entry.path, "mtime": mtime})
-            elif entry.is_file(follow_symlinks=True):
+            elif is_file:
                 files.append({"name": entry.name, "path": entry.path, "mtime": mtime})
     except PermissionError:
         pass

--- a/test/test_browse_dirs.py
+++ b/test/test_browse_dirs.py
@@ -102,6 +102,35 @@ class TestBrowseDirs:
             restricted.chmod(0o755)
 
     @pytest.mark.asyncio
+    async def test_unreadable_sibling_does_not_collapse_listing(self, tmp_path, mock_sel):
+        """A child raising PermissionError on is_dir() (a TCC-protected dir,
+        a permission-denied entry) is skipped while healthy siblings still
+        list, instead of aborting the loop with a partial result."""
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "zebra").mkdir()
+
+        class _Entry:
+            def __init__(self, name):
+                self.name = name
+                self.path = str(tmp_path / name)
+
+            def is_dir(self, follow_symlinks: bool = True) -> bool:
+                if self.name == "docker":
+                    raise PermissionError(1, "Operation not permitted")
+                return True
+
+        entries = [_Entry("alpha"), _Entry("docker"), _Entry("zebra")]
+        with patch(
+            "kiro_crew.dashboard.handlers.files.os.scandir",
+            return_value=entries,
+        ):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(f"/api/browse-dirs?path={tmp_path}")
+                assert resp.status == 200
+                data = await resp.json()
+                assert [d["name"] for d in data["dirs"]] == ["alpha", "zebra"]
+
+    @pytest.mark.asyncio
     async def test_scan_does_not_run_on_the_event_loop(self, tmp_path, mock_sel):
         """The directory walk must execute off the loop thread.
 

--- a/test/test_browse_files.py
+++ b/test/test_browse_files.py
@@ -219,6 +219,83 @@ class TestBrowseFiles:
                 assert entry["mtime"] == 0
 
     @pytest.mark.asyncio
+    async def test_unreadable_sibling_does_not_collapse_listing(self, tmp_path, mock_sel):
+        """A child raising PermissionError on is_dir() (a TCC-protected dir,
+        a permission-denied entry) is skipped while healthy siblings still
+        list. The sort key stats every child, so an unguarded key empties
+        the whole response instead of dropping one entry."""
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "readme.md").write_text("hello")
+
+        class _Entry:
+            def __init__(self, name, isdir):
+                self.name = name
+                self.path = str(tmp_path / name)
+                self._isdir = isdir
+
+            def is_dir(self, follow_symlinks: bool = True) -> bool:
+                if self.name == "docker":
+                    raise PermissionError(1, "Operation not permitted")
+                return self._isdir
+
+            def is_file(self, follow_symlinks: bool = True) -> bool:
+                if self.name == "docker":
+                    raise PermissionError(1, "Operation not permitted")
+                return not self._isdir
+
+            def stat(self, follow_symlinks: bool = True):
+                return os.stat(self.path)
+
+        entries = [_Entry("alpha", True), _Entry("docker", True), _Entry("readme.md", False)]
+        with patch(
+            "kiro_crew.dashboard.handlers.files.os.scandir",
+            return_value=entries,
+        ):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(f"/api/browse-files?path={tmp_path}")
+                assert resp.status == 200
+                data = await resp.json()
+                assert {d["name"] for d in data["dirs"]} == {"alpha"}
+                assert {f["name"] for f in data["files"]} == {"readme.md"}
+
+    @pytest.mark.asyncio
+    async def test_unclassifiable_sibling_is_skipped(self, tmp_path, mock_sel):
+        """A child whose is_dir() answers False but is_file() raises is
+        skipped rather than aborting the loop and dropping the healthy
+        file that sorts after it."""
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "readme.md").write_text("hello")
+
+        class _Entry:
+            def __init__(self, name, isdir):
+                self.name = name
+                self.path = str(tmp_path / name)
+                self._isdir = isdir
+
+            def is_dir(self, follow_symlinks: bool = True) -> bool:
+                return self._isdir
+
+            def is_file(self, follow_symlinks: bool = True) -> bool:
+                if self.name == "aardvark":
+                    raise PermissionError(1, "Operation not permitted")
+                return not self._isdir
+
+            def stat(self, follow_symlinks: bool = True):
+                return os.stat(self.path)
+
+        entries = [_Entry("alpha", True), _Entry("aardvark", False), _Entry("readme.md", False)]
+        with patch(
+            "kiro_crew.dashboard.handlers.files.os.scandir",
+            return_value=entries,
+        ):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(f"/api/browse-files?path={tmp_path}")
+                assert resp.status == 200
+                data = await resp.json()
+                assert {d["name"] for d in data["dirs"]} == {"alpha"}
+                assert {f["name"] for f in data["files"]} == {"readme.md"}
+
+    @pytest.mark.asyncio
     async def test_scan_does_not_run_on_the_event_loop(self, tmp_path, mock_sel):
         """The walk must execute off the loop thread — see the sibling dirs test."""
         (tmp_path / "alpha").mkdir()


### PR DESCRIPTION
## Problem / Motivation

Browsing a folder that holds one unreadable child (a TCC-protected dir like ~/.docker, a permission-denied entry) collapses the dashboard file browser. The sort key in _browse_files_sync stats every child, so one bad sibling aborts sorted() and the endpoint returns empty dirs and files. _browse_dirs_sync degrades less but still drops every entry past the bad one. The default browse root is home, so this hits the first folder most people open.

## Why it matters

Anyone opening their home folder in the dashboard gets an empty file browser if a single entry (Docker socket dir, root-owned mount, broken symlink farm) cannot be statted. That reads as data loss and makes the browser unusable until the offending entry is removed by hand.

## What changed (motivation → approach → change)

The scan treated one bad child as fatal for the whole listing. Instead of letting the exception propagate, entries that cannot be classified are now skipped individually: added a _browse_entry_is_dir helper that treats a failing is_dir() as a non-dir instead of raising, used it in the files sort key, and both listing loops now skip an unclassifiable entry instead of aborting. A genuinely unreadable folder itself still returns empty, as before.

## Tests

3 new tests fail on main with the exact collapse (empty files listing, truncated dirs listing) and pass with the fix. test_browse_files.py, test_browse_dirs.py, test_handlers_files_upload.py, test_handlers_files_video_upload.py: 50 passed. flake8 clean on touched files; mypy reports only a pre-existing cli.py note.

## Manual verification

N/A beyond automated coverage. The fix is endpoint-level (same listing shape, fewer aborts), exercised through the 50-test browse suite with real permission-denied fixtures.

## Screenshots / video

N/A. No visual change: the browser renders the same listing, it just no longer collapses to empty.

## Related Issues

None.

## Pattern harvest

Rule candidate: review-prompt. Listing/sort loops over untrusted filesystem entries must handle per-item errors instead of letting one bad entry abort the whole scan.

## Checklist

- [x] At most two commits with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
