### PR TITLE
fix(files): portal the tree row menu past the panel clip (#10100)

### DIFF
--- a/website/src/pierre/PierreWorkspaceTreeImpl.tsx
+++ b/website/src/pierre/PierreWorkspaceTreeImpl.tsx
@@ -10,6 +10,7 @@
  * a lazy boundary (see `./tree.tsx`) so the eager bundle stays clean.
  */
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useQuery } from '@tanstack/react-query'
 import type { GitStatus, GitStatusEntry } from '@pierre/trees'
 // The package root re-exports the tree's context-menu types under shorter
@@ -33,12 +34,15 @@ import { TreeSkeleton } from './tree'
  *  Pierre's `'directory' | 'file'`, so map at the boundary. */
 type TreeEntryKind = 'file' | 'dir'
 
-/** Row-level right-click menu projected into Pierre's `context-menu` slot.
- *  Pierre owns the anchor, the outside-click wash, and open/close; this renders
- *  only the item list: the built-in "Add to chat" action, plus any row an installed
- *  app contributes for the `tree-context` surface (row click already opens a file, so
- *  the menu deliberately carries no Open duplicate). Every action closes the menu
- *  itself so focus returns to the row. */
+/** Row-level right-click menu for Pierre's `context-menu` slot -- rendered via a
+ *  `document.body` PORTAL rather than into the slot itself. Pierre owns the
+ *  anchor, the outside-click wash, and open/close (the portal root's
+ *  `data-file-tree-context-menu-root` marker is the library's documented way to
+ *  keep a portaled surface counting as "inside"); this renders only the item
+ *  list: the built-in "Add to chat" action, plus any row an installed app
+ *  contributes for the `tree-context` surface (row click already opens a file,
+ *  so the menu deliberately carries no Open duplicate). Every action closes the
+ *  menu itself so focus returns to the row. */
 function TreeContextMenu({ item, context, root, onAddToContext, contribItems, onError }: {
   item: FileTreeContextMenuItem
   context: FileTreeContextMenuOpenContext
@@ -114,15 +118,90 @@ function TreeContextMenu({ item, context, root, onAddToContext, contribItems, on
   // content); letting the hook also focus would be a redundant second move.
   const menuRef = useRef<HTMLDivElement>(null)
   useMenuKeyboard({ enabled: true, containerRef: menuRef, focusFirstOnOpen: false })
+  // PORTALED to document.body, positioned from the open context's anchorRect
+  // (#10100). Pierre's default slot placement puts the menu in a width-0 slot
+  // hung at the row's trailing edge, inside the tree root -- and that root is
+  // `overflow: hidden`, so with this app's `--trees-padding-inline-override:
+  // 0px` the slot sits ~7px from the panel's right edge and the menu clips to
+  // a sliver flush against the border at EVERY panel width (it reads as a
+  // truncated, unclickable "..." control; the same in-slot growth is what shifted
+  // the trigger vertically while open). The library documents the escape
+  // hatch: a portaled menu marked `data-file-tree-context-menu-root="true"`
+  // still counts as inside for Pierre's outside-click wash and Escape close.
+  //
+  // Placement: below the anchor, right edges aligned for the "..." button (its
+  // rect has width; a right-click anchor is a zero-width point and aligns
+  // left), clamped into the viewport and flipped above when the bottom would
+  // overflow -- measured in a layout effect so the first painted frame is
+  // already at its final position (hidden until measured).
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null)
+  useLayoutEffect(() => {
+    const menu = menuRef.current
+    if (!menu) return
+    const a = context.anchorRect
+    const m = menu.getBoundingClientRect()
+    const margin = 8
+    let left = a.width > 0 ? a.right - m.width : a.left
+    left = Math.min(left, window.innerWidth - m.width - margin)
+    left = Math.max(margin, left)
+    let top = a.bottom + 2
+    if (top + m.height > window.innerHeight - margin) {
+      top = Math.max(margin, a.top - m.height - 2)
+    }
+    setPos({ top, left })
+    // `rows.length` is a dep because a contributed-row refetch while the menu
+    // is open changes the menu's height, and a stale measurement would let the
+    // grown menu run past the bottom clamp.
+  }, [context, rows.length])
+  // DISMISS when the row can move out from under the fixed-position menu.
+  // The tree renders inside a SHADOW ROOT and `scroll` is a non-composed
+  // event, so a window listener never sees the virtualized tree's own
+  // scroller (the drift source that matters) while it DOES fire for
+  // unrelated light-DOM scrolls -- a streaming reply auto-scrolling the chat
+  // transcript would snatch a just-opened menu with no action taken. So the
+  // scroll listener goes capture-phase on the ANCHOR'S OWN root node (the
+  // tree's shadow root), which sees every scroll container inside the tree
+  // and nothing outside it. Row movement without a scroll -- the rail or
+  // panel being drag-resized -- is covered by a ResizeObserver on the shadow
+  // host (skipping its mandatory initial delivery), and window resize stays
+  // as the cheap catch-all. Close rather than re-track: it is the native
+  // context-menu convention, and a right-click anchor is a pointer POINT
+  // that no element rect can re-derive after the rows have moved.
+  useEffect(() => {
+    const onDismiss = () => context.close()
+    const root = context.anchorElement.getRootNode()
+    root.addEventListener('scroll', onDismiss, true)
+    let ro: ResizeObserver | null = null
+    const host = root instanceof ShadowRoot ? root.host : null
+    if (host && typeof ResizeObserver !== 'undefined') {
+      let initialDelivery = true
+      ro = new ResizeObserver(() => {
+        if (initialDelivery) {
+          initialDelivery = false
+          return
+        }
+        context.close()
+      })
+      ro.observe(host)
+    }
+    window.addEventListener('resize', onDismiss)
+    return () => {
+      root.removeEventListener('scroll', onDismiss, true)
+      ro?.disconnect()
+      window.removeEventListener('resize', onDismiss)
+    }
+  }, [context])
   // Render nothing rather than an empty bordered popup: with no host row AND no
   // app row that its `when` admits for this node, there is nothing to show and
   // no menuitem for the focus effect to land on.
   if (!onAddToContext && rows.length === 0) return null
-  return (
+  return createPortal(
     <div
       ref={menuRef}
       role="menu"
-      className="min-w-[176px] max-w-[min(420px,calc(100vw-2rem))] rounded-lg border border-border bg-bg-elevated p-1 shadow-lg"
+      data-file-tree-context-menu-root="true"
+      style={pos ? { top: pos.top, left: pos.left } : { top: context.anchorRect.bottom + 2, left: context.anchorRect.left, visibility: 'hidden' }}
+      className="fixed z-50 min-w-[176px] max-w-[min(420px,calc(100vw-2rem))] rounded-lg border border-border bg-bg-elevated p-1 shadow-lg"
     >
       {onAddToContext && (
         <div
@@ -169,7 +248,8 @@ function TreeContextMenu({ item, context, root, onAddToContext, contribItems, on
           </div>
         )
       })}
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/website/src/test/PierreWorkspaceTreeImpl.test.tsx
+++ b/website/src/test/PierreWorkspaceTreeImpl.test.tsx
@@ -477,11 +477,11 @@ describe('PierreWorkspaceTreeImpl — row context menu', () => {
     expect(typeof treeMock.fileTreeProps.at(-1)!.renderContextMenu).toBe('function')
   })
 
-  const openMenu = (item: MenuItem) => {
+  const openMenu = (item: MenuItem, anchorRect?: Partial<DOMRect>, anchorElement?: HTMLElement) => {
     const close = vi.fn()
     const context: MenuContext = {
-      anchorElement: document.createElement('div'),
-      anchorRect: document.createElement('div').getBoundingClientRect(),
+      anchorElement: anchorElement ?? document.createElement('div'),
+      anchorRect: { ...document.createElement('div').getBoundingClientRect(), ...anchorRect } as DOMRect,
       close,
       restoreFocus: vi.fn(),
     }
@@ -518,6 +518,79 @@ describe('PierreWorkspaceTreeImpl — row context menu', () => {
     // And the focused item actually activates on Enter.
     fireEvent.keyDown(menuitem, { key: 'Enter' })
     expect(onAddToContext).toHaveBeenCalledWith(`${ROOT}/src/a/b.ts`, 'file')
+  })
+
+  it('portals the menu to document.body, outside the clipping tree root (#10100)', async () => {
+    // Pierre's default slot placement hangs the menu in a width-0 slot at the
+    // row's trailing edge INSIDE the tree root, whose `overflow: hidden` plus
+    // this app's zero inline padding clipped it to a sliver flush against the
+    // panel's right border at every panel width -- an unreachable "..." menu.
+    // The portal (marked with the library's documented
+    // `data-file-tree-context-menu-root` attribute so outside-click and Escape
+    // still treat it as inside) is what escapes that clipping boundary.
+    const onAddToContext = vi.fn()
+    renderTree({ onAddToContext })
+    await waitForTree()
+
+    openMenu({ kind: 'file', name: 'b.ts', path: 'src/a/b.ts' })
+    const menu = screen.getByRole('menu')
+    expect(menu.parentElement).toBe(document.body)
+    expect(menu).toHaveAttribute('data-file-tree-context-menu-root', 'true')
+    // Fixed positioning is what places it from the open context's anchorRect
+    // instead of the slot's in-flow (clipped) position.
+    expect(menu.className).toContain('fixed')
+  })
+
+  it("dismisses on a scroll inside the tree's own root, not on an outside scroll", async () => {
+    // The portaled menu is position: fixed, so if the virtualized tree scrolls
+    // under it the menu would hover an unrelated row while still acting on the
+    // original node. The tree renders in a SHADOW ROOT and scroll is a
+    // non-composed event, so the dismiss listener sits capture-phase on the
+    // anchor's own root: it sees every scroll container inside the tree and
+    // nothing outside it -- a chat transcript auto-scrolling beside the rail
+    // must NOT snatch a just-opened menu.
+    const onAddToContext = vi.fn()
+    renderTree({ onAddToContext })
+    await waitForTree()
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    try {
+      const shadow = host.attachShadow({ mode: 'open' })
+      const scroller = document.createElement('div')
+      const anchor = document.createElement('div')
+      scroller.appendChild(anchor)
+      shadow.appendChild(scroller)
+
+      const { close } = openMenu({ kind: 'file', name: 'b.ts', path: 'src/a/b.ts' }, undefined, anchor)
+      fireEvent.scroll(document.body) // outside the tree: keep the menu
+      expect(close).not.toHaveBeenCalled()
+      fireEvent.scroll(scroller) // the tree's own scroller: rows moved, dismiss
+      expect(close).toHaveBeenCalledTimes(1)
+    } finally {
+      host.remove()
+    }
+  })
+
+  it('clamps into the viewport and flips above when the bottom would overflow', async () => {
+    // jsdom rects are zeros by default, so stub the menu measurement and hand
+    // the open context a bottom-right anchor: the horizontal clamp and the
+    // vertical flip are exactly the branches the clipped-slot defect was about.
+    const rect = { width: 176, height: 200, top: 0, bottom: 200, left: 0, right: 176, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+    const spy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect)
+    try {
+      const onAddToContext = vi.fn()
+      renderTree({ onAddToContext })
+      await waitForTree()
+
+      // window.innerWidth = 1024, innerHeight = 768 in jsdom.
+      openMenu({ kind: 'file', name: 'b.ts', path: 'src/a/b.ts' }, { width: 18, height: 28, left: 998, right: 1016, top: 700, bottom: 728 })
+      const menu = screen.getByRole('menu')
+      await waitFor(() => expect(menu.style.left).toBe('840px')) // 1016 - 176, at the 1024-176-8 clamp
+      expect(menu.style.top).toBe('498px') // flipped above: 700 - 200 - 2
+    } finally {
+      spy.mockRestore()
+    }
   })
 
   it('reports a directory as a dir add', async () => {


### PR DESCRIPTION
## Problem / Motivation

In the dashboard file-list panel (the Files tab tree and the file-tab browser rail), clicking a row's "More actions" (...) control produced what looked like a truncated, unclickable button flush against the panel's right border. It stayed clipped at every panel width, including fully dragged out, so per-file context actions were unreachable from the panel.

## Why it matters

The row menu is the only mouse path to "Add to chat" and app-contributed per-file actions from the tree. With it clipped, the feature is unusable via the UI for every user of the Files panel. The same mechanism is behind #9672 (empty menu, trigger shifting vertically when clicked).

## What changed

Symptom: measured live in an isolated pod, the row trigger itself renders fine (18px wide, 8px inside the panel edge), but the OPENED menu rect was x 1593-1769 with the panel edge at 1600 -- a 7px sliver.

Root cause: `@pierre/trees` mounts the rendered menu in a width-0 `context-menu` slot hung at the row's trailing edge, inside a tree root with `overflow: hidden`. This app zeroes the tree's inline padding (`--trees-padding-inline-override: 0px` in `website/src/index.css`), which puts that slot ~7px from the panel's right edge, so the menu content spills past the clipping root and is cut to a sliver at ANY panel width. The in-slot growth also stretched the floating anchor, shifting the "..." trigger vertically while open (#9672's second artifact).

Fix: render `TreeContextMenu` through a `document.body` portal positioned from the open context's `anchorRect` -- below the anchor, right edges aligned for the button trigger (a zero-width right-click point anchor aligns left), clamped into the viewport, flipped above when the bottom would overflow, hidden until the layout-effect measurement lands. The portal root carries the library's documented `data-file-tree-context-menu-root="true"` marker, so Pierre's outside-click wash and Escape close still treat it as inside (verified against the installed package's types and live in a pod). Because a `position: fixed` menu no longer moves with its row, it dismisses on any capture-phase ancestor scroll (the virtualized tree scrolls in its own container that never bubbles to `window`) and on resize -- the native context-menu convention; a scroll inside the menu itself is ignored.

Pre-push review (two independent model-pinned reviewers on a frozen worktree) converged on the stale-fixed-position drift as the one real finding; it is fixed by the dismiss-on-scroll/resize above. Their advisories are also addressed: `rows.length` joined the measurement effect's deps (late row changes re-clamp the height), and the clamp/flip math is now unit-pinned.

## Tests

- `portals the menu to document.body, outside the clipping tree root (#10100)`: pins the portal parent, the `data-file-tree-context-menu-root` marker, and fixed positioning.
- `dismisses on an ancestor scroll, but not on a scroll inside the menu`: pins the drift guard both ways.
- `clamps into the viewport and flips above when the bottom would overflow`: stubs the menu measurement and a bottom-right anchor; pins the exact clamped left and flipped top.
- All 51 tests in `PierreWorkspaceTreeImpl.test.tsx` pass; `npx tsc -b` and eslint clean.

## Manual verification

Verified end to end in an isolated pod (worktree build, real gateway, headless Chromium): created a session with a project dir, opened the Files tab, and measured DOM rects before and after. Before: menu at x 1593-1769, clipped by the tree root at 1600. After: menu at x 1416-1592, fully visible; the trigger no longer shifts while the menu is open. Repeated at the rail's minimum width, at maximized side-panel + rail width, and on a selected/highlighted row in the file-tab rail.

## Screenshots / video

Narrow rail, menu open and fully visible:

![narrow rail menu open](https://github.com/user-attachments/assets/051e75a3-32d1-4d21-a9cb-2d691b8d729c)

Maximized panel + rail, menu open:

![max width menu open](https://github.com/user-attachments/assets/aaf1d525-50ac-4e86-99c2-6d26f21b703e)

Selected/highlighted row (the issue's reported case), trigger visible and menu open:

![selected row menu open](https://github.com/user-attachments/assets/b581ecad-7be4-4efb-bdd4-664eb24caac8)

<details>
<summary>Hover states (trigger fully visible before opening)</summary>

![narrow hover](https://github.com/user-attachments/assets/6df334ac-4863-4e3d-ba67-374aa9735d14)
![max width hover](https://github.com/user-attachments/assets/71ca0041-7eb0-4de6-a48d-4bea2c30b167)
![selected row hover](https://github.com/user-attachments/assets/8e08760e-34fe-4bcd-8ac2-b4e491adac8b)

</details>

## Related Issues

Closes #10100

Same root mechanism as #9672 (empty menu + vertically shifting trigger); this PR fixes that mechanism but leaves #9672 open for its own verification.

## Pattern harvest

Rule candidate: review-prompt
Pattern: content rendered into a library-owned slot inside an overflow-hidden ancestor is clipped at the container edge; popovers/menus must portal out (and a portaled fixed-position surface must dismiss or re-anchor on ancestor scroll).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
