### PR TITLE
fix(platform): route gateway stop kills through platform_compat

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import shutil
-import signal
 import subprocess
 import sys
 import time
@@ -492,8 +491,12 @@ def _stop(cli_port: int | None = None) -> None:
                 if platform_compat.pid_exists(pid):
                     denied.append(pid)
             continue
+        # POSIX: single-PID SIGTERM via the platform_compat helper. A tree kill
+        # has nothing extra to reach — the gateway's kiro-cli / MCP-server
+        # children are spawned start_new_session=True (their own process
+        # groups), so killpg of this group is just this process.
         try:
-            os.kill(pid, signal.SIGTERM)
+            platform_compat.kill_pid(pid, platform_compat.SIGTERM)
             sent.add(pid)
         except ProcessLookupError:
             pass

--- a/src/kiro_crew/dashboard/port_reclaim.py
+++ b/src/kiro_crew/dashboard/port_reclaim.py
@@ -51,7 +51,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import subprocess
 from collections.abc import Awaitable, Callable
 
@@ -191,8 +190,11 @@ async def _terminate_pids(
                 if platform_compat.pid_exists(pid):
                     return False
             return True
+        # POSIX: single-PID signal via the platform_compat helper. The gateway's
+        # kiro-cli / MCP-server children are spawned start_new_session=True
+        # (own process groups), so a tree kill would reach no more than this pid.
         try:
-            os.kill(pid, sig)
+            platform_compat.kill_pid(pid, sig)
         except ProcessLookupError:
             pass  # already gone — success for our purposes
         except PermissionError:

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -300,6 +300,60 @@ class TestStopOnWindows:
         assert "No permission" not in out
 
 
+class TestStopOnPosix:
+    """The POSIX branch delivers the kill through ``platform_compat.kill_pid``
+    (the platform-compat helper-per-call table), not a raw ``os.kill``.
+
+    A single-PID SIGTERM is the correct semantics here: the gateway's kiro-cli
+    / MCP-server children are spawned ``start_new_session=True`` on POSIX
+    (their own process groups), so the tree helper has nothing to add —
+    merely switching this branch to ``kill_process_tree`` would not reproduce
+    the Windows ``taskkill /T`` descendant-reaping behaviour.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _posix(self, monkeypatch):
+        monkeypatch.setattr(cli_server, "resolve_client_port", lambda p: 5476)
+        monkeypatch.setattr(cli_server.service_controller, "stop_service", lambda: False)
+        monkeypatch.setattr(platform_compat, "find_listening_pids", lambda port: [4242])
+        monkeypatch.setattr(cli_server, "_is_kirocrew_process", lambda pid: True)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        monkeypatch.setattr(cli_server, "_pid_exited", lambda pid: True)
+        monkeypatch.setattr("time.sleep", lambda s: None)
+
+    def test_kill_goes_through_platform_compat(self, monkeypatch, sel_rec, capsys) -> None:
+        seen: list[tuple[int, int]] = []
+        monkeypatch.setattr(platform_compat, "kill_pid", lambda pid, sig: seen.append((pid, sig)))
+        cli_server._stop(None)
+        out = capsys.readouterr().out
+        assert seen == [(4242, platform_compat.SIGTERM)]
+        assert "Sent SIGTERM to gateway (pid 4242)" in out
+        assert sel_rec.calls[-1]["outcome"] == "allowed"
+
+    def test_posix_already_gone_pid_is_not_reported_as_stopped(self, monkeypatch, capsys) -> None:
+        def gone(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(platform_compat, "kill_pid", gone)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._stop(None)
+        assert exc.value.code == 1
+        assert "process already exited" in capsys.readouterr().out
+
+    def test_posix_permission_error_asks_for_sudo_and_exits(
+        self, monkeypatch, sel_rec, capsys
+    ) -> None:
+        def denied(pid, sig):
+            raise PermissionError
+
+        monkeypatch.setattr(platform_compat, "kill_pid", denied)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._stop(None)
+        assert exc.value.code == 1
+        assert "No permission to stop pid 4242" in capsys.readouterr().out
+        assert sel_rec.calls[-1]["outcome"] == "denied"
+
+
 # --------------------------------------------------------------------------
 # _service_cmd / _sandbox_cmd
 # --------------------------------------------------------------------------

--- a/test/test_port_reclaim.py
+++ b/test/test_port_reclaim.py
@@ -238,11 +238,37 @@ async def test_probe_healthy_false_for_wedged_socket() -> None:
 
 
 @pytest.mark.asyncio
+async def test_terminate_posix_routes_through_kill_pid(monkeypatch) -> None:
+    """The POSIX branch delivers through ``platform_compat.kill_pid``, not a
+    raw ``os.kill`` (platform-compat.md helper-per-call table).
+
+    Single-PID semantics are the right shape here: the gateway's kiro-cli /
+    MCP-server children are spawned ``start_new_session=True`` on POSIX (own
+    process groups), so ``kill_process_tree`` (a ``killpg`` of the gateway's
+    group) has nothing extra to reach -- matching the ``kirocrew stop`` branch.
+    """
+    signals: list[tuple[int, int]] = []
+    import kiro_crew.cli_server as cli_server
+
+    monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
+    monkeypatch.setattr(
+        pr.platform_compat, "kill_pid", lambda pid, sig: signals.append((pid, sig))
+    )
+    monkeypatch.setattr(cli_server, "_pid_exited", lambda _pid: True)
+
+    ok = await pr._terminate_pids([1234], term_wait=0.1, kill_wait=0.1, poll=0.01)
+    assert ok is True
+    assert signals == [(1234, pr.platform_compat.SIGTERM)]
+
+
+@pytest.mark.asyncio
 async def test_terminate_returns_true_when_already_gone(monkeypatch) -> None:
     signals: list[tuple[int, int]] = []
     # Patch BOTH delivery primitives so the test is platform agnostic: POSIX
-    # _signal calls os.kill, Windows _signal calls kill_process_tree.
-    monkeypatch.setattr(pr.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+    # _signal calls kill_pid, Windows _signal calls kill_process_tree.
+    monkeypatch.setattr(
+        pr.platform_compat, "kill_pid", lambda pid, sig: signals.append((pid, sig))
+    )
     monkeypatch.setattr(
         pr.platform_compat, "kill_process_tree",
         lambda pid, sig: signals.append((pid, sig)),
@@ -274,7 +300,7 @@ async def test_terminate_escalates_to_sigkill(monkeypatch) -> None:
         if sig == pr.platform_compat.SIGKILL:
             state["alive"] = False
 
-    monkeypatch.setattr(pr.os, "kill", _kill)
+    monkeypatch.setattr(pr.platform_compat, "kill_pid", _kill)
     monkeypatch.setattr(pr.platform_compat, "kill_process_tree", _kill)
     monkeypatch.setattr(cli_server, "_pid_exited", _exited)
 
@@ -289,7 +315,7 @@ async def test_terminate_returns_false_on_permission_error(monkeypatch) -> None:
     def _kill(_pid: int, _sig: int) -> None:
         raise PermissionError("not allowed")
 
-    monkeypatch.setattr(pr.os, "kill", _kill)
+    monkeypatch.setattr(pr.platform_compat, "kill_pid", _kill)
     monkeypatch.setattr(pr.platform_compat, "kill_process_tree", _kill)
     ok = await pr._terminate_pids([1], term_wait=0.05, kill_wait=0.05, poll=0.01)
     assert ok is False

--- a/test/test_port_reclaim_cov80.py
+++ b/test/test_port_reclaim_cov80.py
@@ -8,7 +8,8 @@ default collaborators (the real identity check and the real terminator) that
 production actually uses.
 
 No test here shells out or signals a real process: ``subprocess.check_output``,
-``os.kill``, ``kill_process_tree`` and the liveness check are all patched.
+``platform_compat.kill_pid``, ``kill_process_tree`` and the liveness check are
+all patched.
 """
 
 from __future__ import annotations
@@ -104,7 +105,7 @@ async def test_posix_already_exited_process_counts_as_success(monkeypatch) -> No
         raise ProcessLookupError("no such process")
 
     monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
-    monkeypatch.setattr(pr.os, "kill", _kill)
+    monkeypatch.setattr(pr.platform_compat, "kill_pid", _kill)
     monkeypatch.setattr(cli_server, "_pid_exited", lambda _pid: True)
 
     assert await pr._terminate_pids([4242], term_wait=0.05, kill_wait=0.05, poll=0.01)
@@ -125,7 +126,7 @@ async def test_posix_denied_sigkill_reports_failure(monkeypatch) -> None:
             raise PermissionError("operation not permitted")
 
     monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
-    monkeypatch.setattr(pr.os, "kill", _kill)
+    monkeypatch.setattr(pr.platform_compat, "kill_pid", _kill)
     monkeypatch.setattr(cli_server, "_pid_exited", lambda _pid: False)
 
     ok = await pr._terminate_pids([4242], term_wait=0.02, kill_wait=0.02, poll=0.01)


### PR DESCRIPTION
## Problem / Motivation

The POSIX branches of two gateway-lifecycle call sites still signal the process with a raw `os.kill(...)`, while the Windows branch sitting next to each one deliberately routes the same operation through `platform_compat`:

- `kirocrew stop`, in `src/kiro_crew/cli_server.py` inside `_stop()`
- the dashboard port-reclaim, in `src/kiro_crew/dashboard/port_reclaim.py` inside `_terminate_pids()._signal()`

The Windows branch in both places documents why it uses `platform_compat.kill_process_tree` (a `taskkill /T` tree kill so the gateway's detached kiro-cli / MCP-server children are reaped too), then the POSIX branch drops the seam and calls `os.kill` directly. That is the exact inversion this repo's cross-platform rule exists to prevent.

The sanctioned shape is spelled out in `docs/system-specs/common/platform-compat.md` (the helper-per-call table): kill a process -> `kill_pid(pid, sig)`, kill a tree -> `kill_process_tree(pid, sig)`, liveness -> `pid_exists` / `pid_liveness`, with raw `os.kill` as the "don't" column. The workspace router (`AGENTS.md`) restates the same rule: route POSIX calls through `platform_compat`.

## Why it matters

The seam exists so signal delivery keeps one contract on every OS: `platform_compat.kill_pid` maps to `os.kill` on POSIX and to `taskkill /F` on Windows, raises the same exception shapes (`ProcessLookupError`, `PermissionError`, `OSError`), and gives a future platform fix one place to land. Two raw call sites beside guarded ones means the next person changing how the gateway is signalled (PID-reuse checks, group semantics, a macOS or ARM quirk) has to remember both spots and patch them separately, or one platform drifts from the other without any test noticing.

It is also a genuine portability hazard, not just a style point. Forcing the POSIX branch in a test on a Windows host makes the raw call raise `OSError: [WinError 87] The parameter is incorrect` where the routed call would behave, and the docs' table exists specifically because these differences are silent until someone runs that combination.

## What changed (motivation → approach → change)

Symptom: the POSIX stop path bypasses the platform seam every other signal path in the codebase uses. Root cause: both sites spend the seam on their Windows branch and then call the raw primitive on POSIX. Fix: route both POSIX branches through `platform_compat.kill_pid(...)`, the single-PID helper that matches the semantics they already have.

Two files carry the functional change, in each case one line plus the now-unused import going away:

- `src/kiro_crew/cli_server.py` — `os.kill(pid, signal.SIGTERM)` -> `platform_compat.kill_pid(pid, platform_compat.SIGTERM)`; drops the now-unused `import signal`
- `src/kiro_crew/dashboard/port_reclaim.py` — `os.kill(pid, sig)` -> `platform_compat.kill_pid(pid, sig)`; drops the now-unused `import os`

On POSIX `kill_pid` is a pass-through to `os.kill`, so the exception handling around both calls (`ProcessLookupError` -> already gone, `PermissionError` -> denied) behaves exactly as before. The change is a routing fix with identical runtime behaviour on POSIX.

One alternative considered and rejected: copying the Windows branch and calling `kill_process_tree` on POSIX too. On POSIX that helper is `killpg(os.getpgid(pid), sig)`, a process-group signal, while the gateway's kiro-cli and MCP-server children are spawned with `start_new_session=True` (their own process groups, see the ACP client spawn in `src/kiro_crew/acp/client.py`). A group kill of the gateway would therefore reach no more than the gateway itself. The Windows `taskkill /T` descendant walk has no POSIX equivalent here, so mirroring the call would add a semantic with no effect while changing the code's intent. The honest change is the single-PID helper.

## Tests

Written test-first. The new `TestStopOnPosix` class in `test/test_cli_server_more_coverage.py` and `test_terminate_posix_routes_through_kill_pid` in `test/test_port_reclaim.py` assert that the POSIX branch delivers the signal through `platform_compat.kill_pid`. On the old code they failed, and on this Windows test host they failed with `OSError: [WinError 87]` from the raw `os.kill` call, which both proved the routing was missing and demonstrated the portability hazard the change removes. After the fix they pass.

The existing platform-agnostic tests in `test/test_port_reclaim.py` and `test/test_port_reclaim_cov80.py` patched the raw `os.kill` for the POSIX branch; they now patch `platform_compat.kill_pid`, so no test can accidentally signal a real process.

- `test/test_cli_server_more_coverage.py`, `test/test_port_reclaim.py`, `test/test_port_reclaim_cov80.py` — 130 tests pass
- `flake8` on the touched files — clean; `isort` — clean
- `mypy src/kiro_crew/cli_server.py src/kiro_crew/dashboard/port_reclaim.py` — clean
- `scripts/check_black_formatting.py` — passed (the one non-baselined file touched is black-clean; the other two source files sit on the repo's known-unformatted baseline, so the diff stays as small as the change)
- `scripts/check_subprocess_encoding.py` — passed

## Manual verification

None needed for behaviour: on POSIX `kill_pid` delegates straight to `os.kill`, so `kirocrew stop` sends the same SIGTERM it always sent. A reviewer who wants to see the routing can run `kirocrew stop` on a Linux host and check the gateway pid exits and the port frees, or force the Windows branch in a unit test and watch `kill_pid` forward to `taskkill /F`. Both paths are already covered by the tests above.

## Screenshots / video

There is no UI or observable output change, so nothing to capture. Say the word if you would rather see concrete captures of the test run and I can attach them.

## Related Issues

No dedicated issue tracks these two call sites. The requirement they violate is documented in `docs/system-specs/common/platform-compat.md` (helper-per-call table) and the workspace router's cross-platform rule, so this PR brings the code in line with the documented contract rather than introducing a new pattern.

## Checklist

- [x] One logical change: route the two remaining raw stop-path kills through `platform_compat`
- [x] Tests written first, watched fail (including the WinError 87 proof), then pass; 130 targeted tests green
- [x] Backend gates clean: flake8, isort, mypy, black gate, subprocess-encoding gate
- [x] Documentation: none to update, the change makes the code match the existing helper table
- [x] No secrets, credentials, or internal references in the diff

## Pattern harvest

Rule candidate: semgrep
Pattern: a raw `os.kill(` / `os.killpg(` call anywhere in `src/kiro_crew/` outside the seam module itself (`platform_compat.py`). The repo route for every process signal is the `platform_compat` helper seam, and this PR deleted the last two raw kill sites in the gateway-stop and port-reclaim lifecycle. A rule scoped to `src/` with the seam file excluded would have flagged both sites; the repo already runs a Semgrep SAST lane it can slot into.
