### PR TITLE
fix(e2e): pin chat.spec new-chat locator to its stable accessible name (#10089)

### DIFF
--- a/website/playwright/chat.spec.ts
+++ b/website/playwright/chat.spec.ts
@@ -7,6 +7,13 @@ const SLOW = '[[SLOW]]'
 const SLOW_NOACK = '[[SLOW_NOACK]]'
 const SLOW_LATEACK = '[[SLOW_LATEACK]]'
 
+// The new-chat control's stable accessible name: the en.json value of
+// pages.chatSidebar.new_chat_session (ChatSidebar.tsx aria-label). A
+// whole-string exact match cannot collide with the per-turn minimap buttons,
+// whose accessible names are prompt-derived (e.g. "What is 2+2?"), or the
+// per-folder "New chat in <name>" buttons. fork.spec.ts uses the same locator.
+const NEW_CHAT_NAME = 'New chat session'
+
 // @needs-agent: these specs drive a live agent turn (send/stream/soft-stop),
 // so they require model/agent credentials the credential-less CI gateway
 // lacks. Tagged so the default gating run (grepInvert /@needs-agent/ in
@@ -74,25 +81,24 @@ test.describe('Chat Page E2E Tests', { tag: '@needs-agent' }, () => {
   })
 
   test('creates new chat slot', async ({ page }) => {
-    // Look for "New Chat" or "+" button
-    const newChatButton = page.getByRole('button', { name: /new chat|\+/i })
-    
-    if (await newChatButton.isVisible()) {
-      await newChatButton.click()
-      
-      // Should see empty message input (confirmed by waiting for it)
-      await expect(page.getByPlaceholder(/message/i)).toBeVisible()
-    }
+    const newChatButton = page.getByRole('button', { name: NEW_CHAT_NAME, exact: true })
+    // Assert rather than guard: an if(isVisible()) skip would report green
+    // without ever exercising new-chat creation, and toBeVisible() auto-waits
+    // where isVisible() races the sidebar paint.
+    await expect(newChatButton).toBeVisible()
+    await newChatButton.click()
+
+    // Should see empty message input (confirmed by waiting for it)
+    await expect(page.getByPlaceholder(/message/i)).toBeVisible()
   })
 
   test('switches between chat slots', async ({ page }) => {
-    // Create a second chat first
-    const newChatButton = page.getByRole('button', { name: /new chat|\+/i })
-    if (await newChatButton.isVisible()) {
-      await newChatButton.click()
-      // Wait for new slot to be created
-      await expect(page.getByPlaceholder(/message/i)).toBeVisible()
-    }
+    // Create a second chat first (same stable accessible name as above)
+    const newChatButton = page.getByRole('button', { name: NEW_CHAT_NAME, exact: true })
+    await expect(newChatButton).toBeVisible()
+    await newChatButton.click()
+    // Wait for new slot to be created
+    await expect(page.getByPlaceholder(/message/i)).toBeVisible()
     
     // Look for chat history/slots in sidebar
     const chatSlots = page.locator('[class*="slot"], [class*="session"]')


### PR DESCRIPTION
## Problem / Motivation

The offline-stub E2E suite fails deterministically on every main-based head in `website/playwright/chat.spec.ts` ("switches between chat slots") with a Playwright strict-mode violation. The new-chat locator `getByRole('button', { name: /new chat|\+/i })` resolves to two elements: the real new-chat button (aria-label "New chat session") and a TurnNavigationMinimap per-turn button whose accessible name is the user's prompt text. The seeded E2E prompt "What is 2+2?" contains a literal `+`, so the `\+` alternative matches it.

## Why it matters

The E2E check is a PR Readiness input, so every fork PR inherits this red check regardless of its own diff. Real E2E regressions in those PRs are masked by the pre-existing failure, and the gate reads as noise instead of signal.

## What changed (motivation → approach → change)

The locator matched on a pattern loose enough to collide with prompt-derived accessible names, which the minimap intentionally produces. Both call sites now pin the new-chat control by its stable whole-string accessible name: `getByRole('button', { name: NEW_CHAT_NAME, exact: true })`, where `NEW_CHAT_NAME` is a module-scope constant documenting its source (the `pages.chatSidebar.new_chat_session` en.json value, applied as the aria-label in ChatSidebar.tsx). This is the same locator `fork.spec.ts` already uses. The minimap component is untouched: prompt-derived names on turn buttons are intended behavior.

Both call sites also replace the `if (await newChatButton.isVisible())` guard with `await expect(newChatButton).toBeVisible()` followed by an unconditional click. The guard was the silent-failure twin of the loud bug being fixed: `isVisible()` does not auto-wait, so a paint race or a renamed label would skip the body and report green without ever exercising new-chat creation. The assertion auto-waits and fails loudly instead.

## Tests

This PR changes only tests. The two affected specs ("creates new chat slot", "switches between chat slots") now lock in: the new-chat button is present and uniquely locatable by its stable accessible name, clicking it produces a ready composer, and slot switching works across two slots.

## Manual verification

Ran `playwright/chat.spec.ts` against the stub-backend harness gateway (fake ACP backend, `PLAYWRIGHT_RUN_AGENT_SPECS=1`, built dashboard staged): the strict-mode violation is gone and both affected specs pass. The remaining failures in that local run are the agent-turn specs requiring unprivileged user namespaces, which the local host blocks and CI enables via sysctl; they are untouched by this diff.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** test-only change to a Playwright spec; no rendered UI differs.

## Related Issues

Fixes #10089

## Pattern harvest

Rule candidate: review-prompt
Pattern: Playwright locator built from a regex with a symbol alternative (`/new chat|\+/i`) collides with content-derived accessible names; prefer whole-string `exact: true` names, and prefer `expect(...).toBeVisible()` over non-waiting `isVisible()` guards that skip silently.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
