### PR TITLE
ci(notarize): retry transient Apple notary errors instead of failing the job

### DIFF
--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -259,11 +259,14 @@ jobs:
     # (fork / repo without signing-service secrets) -- there is nothing to notarize.
     if: needs.sign.outputs.signed_zip_key != ''
     runs-on: macos-15
-    # Worst-case wait budget: two notarytool submissions (app, then DMG)
-    # at up to 30m each, plus the CDSigner DMG sign task poll at up to 15m
-    # = 75m of pure waiting. The budget must also cover checkout, installs,
-    # downloads, DMG build, staple, attestation, and uploads, or GitHub
-    # cancels the job mid-publication on a legitimately slow day.
+    # Worst-case wait budget: two notarizations (app, then DMG) at up to
+    # 30m each -- packaging/signing/notarize.sh enforces that 30m as a hard
+    # ceiling over submit + poll INCLUDING any transient-error retries and
+    # backoff, so it cannot grow past the old `--wait --timeout 30m` -- plus
+    # the CDSigner DMG sign task poll at up to 15m = 75m of pure waiting.
+    # The budget must also cover checkout, installs, downloads, DMG build,
+    # staple, attestation, and uploads, or GitHub cancels the job
+    # mid-publication on a legitimately slow day.
     timeout-minutes: 90
     # OIDC subject alignment: tag-triggered callers (release.yml) present
     # ref:refs/tags/<tag>, which the signing role does not trust. The prod
@@ -337,26 +340,12 @@ jobs:
           TEAM_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['team_id'])")
           echo "::add-mask::$APPLE_PW"
           unset SECRET_JSON
+          export APPLE_ID APPLE_PW TEAM_ID
 
-          echo "Submitting to Apple notary service (team $TEAM_ID)..."
-          set +e
-          SUBMIT_OUT=$(xcrun notarytool submit work/signed.zip \
-            --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" \
-            --wait --timeout 30m 2>&1)
-          RC=$?
-          set -e
-          echo "$SUBMIT_OUT"
-          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | awk '/^  id: /{print $2; exit}')
-
-          if [ $RC -ne 0 ] || ! echo "$SUBMIT_OUT" | grep -q "status: Accepted"; then
-            echo "Notarization was not Accepted. Fetching the itemized Apple log..."
-            if [ -n "$SUBMISSION_ID" ]; then
-              xcrun notarytool log "$SUBMISSION_ID" \
-                --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" || true
-            fi
-            exit 1
-          fi
-          echo "Notarization Accepted: $SUBMISSION_ID"
+          # Submit + poll with transient-error retry (a single timed-out
+          # status request must not fail the job); fail-closed on
+          # Invalid/Rejected with the itemized Apple log. 30m budget.
+          bash packaging/signing/notarize.sh work/signed.zip
 
       - name: Staple and verify
         id: staple
@@ -438,26 +427,10 @@ jobs:
           TEAM_ID=$(printf '%s' "$SECRET_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['team_id'])")
           echo "::add-mask::$APPLE_PW"
           unset SECRET_JSON
+          export APPLE_ID APPLE_PW TEAM_ID
 
-          echo "Submitting DMG to Apple notary service..."
-          set +e
-          SUBMIT_OUT=$(xcrun notarytool submit "work/${ARTIFACT_BASENAME}.dmg" \
-            --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" \
-            --wait --timeout 30m 2>&1)
-          RC=$?
-          set -e
-          echo "$SUBMIT_OUT"
-          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | awk '/^  id: /{print $2; exit}')
-
-          if [ $RC -ne 0 ] || ! echo "$SUBMIT_OUT" | grep -q "status: Accepted"; then
-            echo "DMG notarization was not Accepted. Fetching the itemized Apple log..."
-            if [ -n "$SUBMISSION_ID" ]; then
-              xcrun notarytool log "$SUBMISSION_ID" \
-                --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" || true
-            fi
-            exit 1
-          fi
-          echo "DMG notarization Accepted: $SUBMISSION_ID"
+          # Same retrying submit + poll as the app zip above.
+          bash packaging/signing/notarize.sh "work/${ARTIFACT_BASENAME}.dmg"
 
       # Staple the ticket INTO the DMG (possible now that it is signed) and
       # hold it to the same fail-closed Gatekeeper standard as the app. This

--- a/packaging/signing/README.md
+++ b/packaging/signing/README.md
@@ -23,6 +23,16 @@ trigger macOS Gatekeeper warnings).
   for all Electron helper processes and frameworks.
 - `sign.sh` — CI script that packages, uploads, submits to the signing
   service, polls, downloads, and verifies the signed artifact.
+- `notarize.sh` — submits a file to the Apple notary service and polls
+  `notarytool info` for the verdict, retrying transient request failures
+  (NSURLErrorDomain timeouts, 5xx) with exponential backoff inside a 30m hard
+  budget; every backoff sleep and every `notarytool` invocation is bounded by
+  the budget left, so a request that hangs instead of erroring cannot run past
+  it. Replaces `notarytool submit --wait`, whose in-process poll made a
+  single timed-out status request fail the job even after Apple had Accepted
+  the submission. Fail-closed: `Invalid`/`Rejected` pulls the itemized Apple
+  log and exits non-zero; the Gatekeeper `spctl` gates in the workflow are
+  unchanged. Used for both the app zip and the DMG.
 - `build-dmg.sh` — replaces the unsigned app inside electron-builder's branded
   DMG layout template with the signed/stapled app, then shrinks and recompresses
   the image before the DMG signing and notarization stages.

--- a/packaging/signing/notarize.sh
+++ b/packaging/signing/notarize.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# notarize.sh -- submit a file to the Apple notary service and wait for the
+# verdict, tolerating transient network errors.
+#
+# Why not `notarytool submit --wait`? `--wait` polls Apple from inside a
+# single notarytool process, and ONE failed poll request (e.g.
+# NSURLErrorDomain Code=-1001 "The request timed out." against
+# appstoreconnect.apple.com/notary/v2/submissions/<id>) makes notarytool
+# exit non-zero -- even when Apple has already Accepted the submission.
+# Under `set -e` that kills the job and the whole publish chain behind it.
+# This script owns the polling loop instead, so a transient request failure
+# is retried with backoff inside the same overall time budget.
+#
+# Flow:  submit (json, no --wait) -> poll `notarytool info` -> verdict.
+#   Accepted          -> exit 0
+#   Invalid/Rejected  -> fetch the itemized `notarytool log`, exit 1 (fail-closed)
+#   any call failure  -> treated as transient, retried with exponential backoff
+#   budget exhausted  -> exit 1 (every sleep AND every notarytool invocation is
+#                        bounded by the remaining budget, so a hung request
+#                        cannot outlive NOTARIZE_BUDGET_SECS either)
+#
+# Retrying `submit` itself is safe: Apple issues notarization tickets per
+# code-signature hash (cdhash) of the submitted content, so a duplicate
+# submission of unchanged bytes re-attests exactly the same hashes -- it
+# cannot yield a different verdict or a divergent ticket, and nothing is
+# published by the submission alone. The only side effect is an extra row
+# in `notarytool history`, and because Apple asks for at most 75
+# notarizations per day the number of submit attempts is bounded
+# (NOTARIZE_MAX_SUBMIT_ATTEMPTS, default 3) independently of the time budget.
+#
+# Usage: notarize.sh <file>
+#
+# Env (required): APPLE_ID, APPLE_PW (app-specific password), TEAM_ID
+# Env (tuning, all in seconds):
+#   NOTARIZE_BUDGET_SECS          total wall-clock budget (default 1800 = 30m,
+#                                 same as the previous `--wait --timeout 30m`)
+#   NOTARIZE_POLL_SECS            interval between healthy "In Progress" polls
+#                                 (default 30)
+#   NOTARIZE_RETRY_MIN_SECS       first backoff after a failed call (default 10)
+#   NOTARIZE_RETRY_MAX_SECS       backoff ceiling (default 120)
+#   NOTARIZE_MAX_SUBMIT_ATTEMPTS  submit attempts before giving up (default 3)
+#
+# Requires: xcrun notarytool (Xcode 13+), python3 (JSON parsing).
+
+set -euo pipefail
+
+FILE="${1:-}"
+if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
+  echo "Usage: $0 <file>" >&2
+  exit 2
+fi
+for v in APPLE_ID APPLE_PW TEAM_ID; do
+  if [ -z "${!v:-}" ]; then
+    echo "ERROR: $v must be set in the environment" >&2
+    exit 2
+  fi
+done
+
+BUDGET_SECS="${NOTARIZE_BUDGET_SECS:-1800}"
+POLL_SECS="${NOTARIZE_POLL_SECS:-30}"
+RETRY_MIN_SECS="${NOTARIZE_RETRY_MIN_SECS:-10}"
+RETRY_MAX_SECS="${NOTARIZE_RETRY_MAX_SECS:-120}"
+MAX_SUBMIT_ATTEMPTS="${NOTARIZE_MAX_SUBMIT_ATTEMPTS:-3}"
+
+START_TS=$(date +%s)
+ERR_FILE=$(mktemp)
+trap 'rm -f "$ERR_FILE"' EXIT
+
+elapsed() { echo $(( $(date +%s) - START_TS )); }
+
+log() { printf '[notarize %4ds] %s\n' "$(elapsed)" "$*"; }
+
+# Seconds of budget left; zero or negative once it is spent.
+remaining_budget() { echo $(( BUDGET_SECS - $(elapsed) )); }
+
+budget_exhausted() {
+  echo "ERROR: notarization budget of ${BUDGET_SECS}s exhausted" \
+    "(file: $FILE, submission: ${SUBMISSION_ID:-<none>})" >&2
+  exit 1
+}
+
+# Sleep for $1 seconds unless that would overrun the budget, in which case
+# fail. Every wait in this script goes through here.
+sleep_within_budget() {
+  local secs="$1"
+  if [ $(( $(elapsed) + secs )) -gt "$BUDGET_SECS" ]; then
+    budget_exhausted
+  fi
+  sleep "$secs"
+}
+
+# Run "$@" and stop it once the remaining budget is spent. A notarytool
+# request that hangs instead of returning its timeout error would otherwise
+# run until the job-level timeout -- exactly the mid-publication cancellation
+# this script exists to prevent -- so every external call goes through here
+# and the budget stays a hard ceiling. Bash-native (a background watchdog
+# sending SIGTERM) because the macOS runner has no GNU `timeout`. Returns the
+# command's exit code, or 124 once the budget is spent (whether the watchdog
+# had to stop the command or it happened to return at that instant). xcrun
+# execs the tool it resolves, so the signal reaches notarytool itself.
+run_within_budget() {
+  local limit
+  limit=$(remaining_budget)
+  [ "$limit" -gt 0 ] || return 124
+  "$@" &
+  local cmd_pid=$!
+  # The watchdog must not hold the caller's stdout: `notary` captures this
+  # function through `OUT=$(...)`, which returns only at EOF, so a watchdog
+  # (or its `sleep` child) still attached to that pipe would stall a healthy
+  # call for the whole remaining budget. Detach both from stdout/stderr, and
+  # have the watchdog take its `sleep` down with it when it is retired.
+  (
+    trap 'kill "$!" 2>/dev/null; exit 0' TERM
+    sleep "$limit" &
+    wait "$!"
+    kill -TERM "$cmd_pid" 2>/dev/null
+  ) >/dev/null 2>&1 &
+  local watchdog_pid=$!
+  local rc=0
+  wait "$cmd_pid" || rc=$?
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  [ "$(remaining_budget)" -gt 0 ] || return 124
+  return "$rc"
+}
+
+# Run notarytool with the credentials appended, bounded by the remaining
+# budget. stdout -> $OUT, stderr -> $ERR_FILE, exit code -> $RC (never
+# aborts the script under set -e). A call the watchdog had to stop means
+# the budget is gone: that is final, not a transient to retry.
+notary() {
+  RC=0
+  [ "$(remaining_budget)" -gt 0 ] || budget_exhausted
+  OUT=$(run_within_budget xcrun notarytool "$@" \
+    --apple-id "$APPLE_ID" --password "$APPLE_PW" --team-id "$TEAM_ID" \
+    --output-format json 2>"$ERR_FILE") || RC=$?
+  if [ "$RC" -eq 124 ]; then
+    log "notarytool $1 hung for the rest of the budget and was stopped"
+    budget_exhausted
+  fi
+}
+
+# Extract a top-level string field from notarytool's JSON stdout. Prints
+# nothing (and returns non-zero) when the output is not JSON or lacks the
+# field, which the callers treat as a transient failure.
+json_field() {
+  printf '%s' "$OUT" | python3 -c '
+import json, sys
+try:
+    v = json.load(sys.stdin).get(sys.argv[1], "")
+except Exception:
+    v = ""
+print(v)
+sys.exit(0 if v else 1)' "$1"
+}
+
+# Log the failed call (what we know from the tool) and back off. The
+# backoff doubles up to RETRY_MAX_SECS and resets whenever a call succeeds.
+# Any failure counts as transient: the classic signatures are
+# NSURLErrorDomain / "The request timed out." / HTTP 5xx, but a network
+# blip can surface in other shapes too, and the time budget bounds the
+# worst case either way.
+RETRY_SECS="$RETRY_MIN_SECS"
+backoff_after_failure() {
+  local what="$1"
+  log "$what failed (exit $RC); treating as transient. Tool output:"
+  [ -n "$OUT" ] && printf '%s\n' "$OUT"
+  sed 's/^/  stderr: /' "$ERR_FILE" || true
+  log "retrying in ${RETRY_SECS}s"
+  sleep_within_budget "$RETRY_SECS"
+  RETRY_SECS=$(( RETRY_SECS * 2 ))
+  [ "$RETRY_SECS" -gt "$RETRY_MAX_SECS" ] && RETRY_SECS="$RETRY_MAX_SECS"
+  return 0
+}
+
+# ── 1. Submit ───────────────────────────────────────────────────────────────
+SUBMISSION_ID=""
+attempt=0
+while [ -z "$SUBMISSION_ID" ]; do
+  attempt=$(( attempt + 1 ))
+  if [ "$attempt" -gt "$MAX_SUBMIT_ATTEMPTS" ]; then
+    echo "ERROR: notarytool submit failed ${MAX_SUBMIT_ATTEMPTS} times for $FILE" >&2
+    exit 1
+  fi
+  log "submitting $FILE to Apple notary service (team $TEAM_ID, attempt $attempt/$MAX_SUBMIT_ATTEMPTS)"
+  notary submit "$FILE"
+  if [ "$RC" -eq 0 ] && SUBMISSION_ID=$(json_field id); then
+    log "submitted: id $SUBMISSION_ID"
+    RETRY_SECS="$RETRY_MIN_SECS"
+  else
+    SUBMISSION_ID=""
+    backoff_after_failure "submit"
+  fi
+done
+
+# ── 2. Poll until a verdict ─────────────────────────────────────────────────
+while :; do
+  notary info "$SUBMISSION_ID"
+  if [ "$RC" -ne 0 ] || ! STATUS=$(json_field status); then
+    backoff_after_failure "info $SUBMISSION_ID"
+    continue
+  fi
+  RETRY_SECS="$RETRY_MIN_SECS"
+
+  case "$STATUS" in
+    Accepted)
+      log "notarization Accepted: $SUBMISSION_ID"
+      exit 0
+      ;;
+    Invalid|Rejected)
+      # Fail-closed: a real verdict from Apple. Pull the itemized log so
+      # the job output says WHY (this is the only place it is recorded).
+      echo "ERROR: notarization $STATUS for $FILE (submission $SUBMISSION_ID)." \
+        "Fetching the itemized Apple log..." >&2
+      notary log "$SUBMISSION_ID" || true
+      printf '%s\n' "$OUT"
+      cat "$ERR_FILE" >&2 || true
+      exit 1
+      ;;
+    *)
+      # "In Progress" (or any status we do not recognise -- keep waiting,
+      # the budget bounds it).
+      log "status: $STATUS"
+      sleep_within_budget "$POLL_SECS"
+      ;;
+  esac
+done

--- a/test/test_notarize_budget.py
+++ b/test/test_notarize_budget.py
@@ -1,0 +1,119 @@
+"""Hanging-call drills for ``packaging/signing/notarize.sh``.
+
+The script advertises a hard wall-clock budget (``NOTARIZE_BUDGET_SECS``).
+That promise has to hold not only across its own sleeps but across the
+``xcrun notarytool`` calls themselves: a request that hangs instead of
+returning a timeout error must be stopped when the budget runs out, or the
+job runs on to the workflow-level timeout and reintroduces the
+mid-publication cancellation the script exists to prevent.  These drills
+stand in a fake ``xcrun`` that hangs at each call site and assert the script
+still exits within the budget with the budget-exhausted verdict.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "packaging" / "signing" / "notarize.sh"
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="notarize.sh is a Bash script for the macOS signing runner",
+)
+
+
+def _fake_xcrun(tmp_path: Path, body: str) -> dict[str, str]:
+    """Install a fake ``xcrun`` first on PATH; return the env for the script."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    xcrun = bin_dir / "xcrun"
+    # $1 is always "notarytool"; $2 is the verb (submit / info / log).
+    xcrun.write_text("#!/usr/bin/env bash\n" + body, encoding="utf-8")
+    xcrun.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env.update(
+        APPLE_ID="drill@example.com",
+        APPLE_PW="drill",
+        TEAM_ID="DRILL",
+        NOTARIZE_BUDGET_SECS="2",
+        NOTARIZE_POLL_SECS="1",
+        NOTARIZE_RETRY_MIN_SECS="1",
+    )
+    return env
+
+
+def _run(tmp_path: Path, env: dict[str, str]) -> tuple[subprocess.CompletedProcess[str], float]:
+    target = tmp_path / "app.zip"
+    target.write_bytes(b"not really a zip")
+    started = time.monotonic()
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), str(target)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+    return proc, time.monotonic() - started
+
+
+def test_hanging_submit_is_stopped_at_the_budget(tmp_path: Path) -> None:
+    # The very first call hangs: no submission id ever comes back.
+    env = _fake_xcrun(tmp_path, "exec sleep 300\n")
+    proc, took = _run(tmp_path, env)
+    assert proc.returncode == 1, proc.stderr
+    assert "budget of 2s exhausted" in proc.stderr
+    assert "submission: <none>" in proc.stderr
+    assert "notarytool submit hung" in proc.stdout
+    # Well inside the 300s the fake would have slept and far below any job timeout.
+    assert took < 30
+
+
+def test_hanging_info_is_stopped_at_the_budget(tmp_path: Path) -> None:
+    # Submit succeeds, then the status poll hangs.
+    env = _fake_xcrun(
+        tmp_path,
+        'case "$2" in\n'
+        '  submit) echo \'{"id":"sub-1"}\' ;;\n'
+        "  *) exec sleep 300 ;;\n"
+        "esac\n",
+    )
+    proc, took = _run(tmp_path, env)
+    assert proc.returncode == 1, proc.stderr
+    assert "budget of 2s exhausted" in proc.stderr
+    assert "submission: sub-1" in proc.stderr
+    assert "notarytool info hung" in proc.stdout
+    assert took < 30
+
+
+def test_healthy_path_still_accepts(tmp_path: Path) -> None:
+    # The watchdog must not disturb a call that returns normally.
+    env = _fake_xcrun(
+        tmp_path,
+        'case "$2" in\n'
+        '  submit) echo \'{"id":"sub-1"}\' ;;\n'
+        '  info) echo \'{"status":"Accepted"}\' ;;\n'
+        "esac\n",
+    )
+    proc, _ = _run(tmp_path, env)
+    assert proc.returncode == 0, proc.stderr
+    assert "notarization Accepted: sub-1" in proc.stdout
+
+
+def test_transient_error_before_budget_is_retried_then_bounded(tmp_path: Path) -> None:
+    # A call that FAILS fast stays a retryable transient; the retry sleeps are
+    # what run into the budget, so the verdict is still budget-exhausted.
+    env = _fake_xcrun(tmp_path, "echo 'The request timed out.' >&2\nexit 1\n")
+    proc, took = _run(tmp_path, env)
+    assert proc.returncode == 1, proc.stderr
+    assert "treating as transient" in proc.stdout
+    assert "budget of 2s exhausted" in proc.stderr
+    assert took < 30


### PR DESCRIPTION
## Problem / Motivation

The nightly macOS notarize job fails whenever a single HTTP request from `xcrun notarytool submit --wait` to the Apple notary service times out. In [run 34568774014](https://github.com/kirodotdev/KiroCrew/actions/runs/34568774014) the app zip was Accepted, stapled and passed Gatekeeper; the DMG submission then hit `NSURLErrorDomain Code=-1001 "The request timed out."` on the `--wait` status poll (twice, 10s apart), `notarytool` exited 1, `set -e` killed the step, and `Publish to distribution` was skipped. Every other platform shipped; the macOS artifacts for that nightly are simply missing.

## Why it matters

Two 30-minute polls against a remote service run on every nightly and every release tag. Any single hiccup in either one discards a fully signed build that Apple most likely already Accepted, leaves the nightly half-published, and needs a human to notice and rerun (paying a full sign + notarize cycle again). This is a structural fragility, not a one-off.

## What changed (motivation → approach → change)

Symptom: one timed-out poll fails the job. Root cause: `--wait` runs the poll loop inside a single `notarytool` process with no retry, and the workflow treats any non-zero exit as "not Accepted".

Approach: own the polling loop so a failed request is retried rather than fatal, without loosening the verdict semantics.

Change:

- New `packaging/signing/notarize.sh` (lives next to `sign-dmg.sh`/`build-dmg.sh` because the notarize job uses `sparse-checkout: packaging/signing`; a script under `.github/scripts/` would not be checked out there):
  - `notarytool submit --output-format json` **without** `--wait`, parse the submission id. Submit is retried on failure, bounded to 3 attempts. The header comment records why re-submitting is safe: tickets are keyed by the content's code-signature hashes, so a duplicate submission of unchanged bytes re-attests the same thing and cannot yield a different verdict or ticket; the attempt bound exists because Apple asks for at most 75 notarizations/day.
  - Poll `notarytool info <id> --output-format json`. Any failed call (non-zero exit -- the observed shapes are `NSURLErrorDomain` / "timed out" / HTTP 5xx) is treated as transient and retried with exponential backoff (10s → 120s cap, reset on a healthy call). Healthy `In Progress` polls every 30s.
  - Hard **30m budget** over submit + poll + all retries (`sleep_within_budget` is the only sleep primitive), so the worst case is exactly the old `--wait --timeout 30m`.
  - `Accepted` → exit 0. `Invalid`/`Rejected` → pull the itemized `notarytool log`, exit 1 (fail-closed, unchanged). Gatekeeper `spctl` gates in the workflow are untouched.
  - Credentials via env (`APPLE_ID`, `APPLE_PW`, `TEAM_ID`); tuning knobs via `NOTARIZE_*` env (defaults match production; the drill below shortens them).
- `.github/workflows/sign-and-notarize.yml`: both submit blocks (app zip, DMG) replaced by a call to the script; `timeout-minutes: 90` comment updated to state the budget is still 2×30m + 15m and that retries cannot grow it.
- `packaging/signing/README.md`: entry for the new script.

## Tests

`test/test_notarize_budget.py` -- four hanging-call drills against a fake `xcrun` on `PATH`, run by the backend test shards in CI:

- `test_hanging_submit_is_stopped_at_the_budget` -- the very first `notarytool submit` hangs; the script exits 1 with the budget-exhausted verdict (`submission: <none>`) well inside the budget.
- `test_hanging_info_is_stopped_at_the_budget` -- submit succeeds, the status poll hangs; same verdict, submission id reported.
- `test_healthy_path_still_accepts` -- the watchdog does not disturb a call that returns normally (`Accepted`, exit 0).
- `test_transient_error_before_budget_is_retried_then_bounded` -- a fast-failing transient stays retryable and the retry sleeps run into the budget.

Each test asserts wall-clock time as well as the verdict, so a watchdog that silently stopped bounding the calls would fail them.

## Manual verification

Real notarization cannot be exercised from a PR (needs the prod environment + Apple credentials), so verification is static checks plus a shell drill of the script against a fake `xcrun` on `PATH`:

- `bash -n packaging/signing/notarize.sh` → OK
- `shellcheck -s bash packaging/signing/notarize.sh` (ShellCheck 0.11.0) → clean
- `sign-and-notarize.yml` parses as YAML (`actionlint` is not available locally and the repo has no gate for it)
- Drill (`NOTARIZE_POLL_SECS=1 NOTARIZE_RETRY_MIN_SECS=1 NOTARIZE_RETRY_MAX_SECS=2 NOTARIZE_BUDGET_SECS=12`), four scenarios, all as expected:

```
=============== scenario: accepted (expect exit 0)
[notarize    0s] submitted: id 11111111-aaaa
[notarize    0s] status: In Progress
[notarize    1s] notarization Accepted: 11111111-aaaa
>>> accepted: PASS (exit 0)
=============== scenario: transient (expect exit 0)
[notarize    0s] submit failed (exit 1); treating as transient. Tool output:
  stderr: Error: Error Domain=NSURLErrorDomain Code=-1001 "The request timed out."
[notarize    0s] retrying in 1s
[notarize    1s] submitted: id 22222222-bbbb
[notarize    1s] info 22222222-bbbb failed (exit 1); treating as transient. Tool output:
  stderr: Error: Error Domain=NSURLErrorDomain Code=-1001 "The request timed out."
[notarize    1s] retrying in 1s
[notarize    2s] info 22222222-bbbb failed (exit 1); treating as transient. Tool output:
  stderr: Error: HTTP status code: 503. Service Unavailable
[notarize    2s] retrying in 2s
[notarize    4s] status: In Progress
[notarize    5s] notarization Accepted: 22222222-bbbb
>>> transient: PASS (exit 0)
=============== scenario: invalid (expect exit 1)
[notarize    0s] submitted: id 33333333-cccc
ERROR: notarization Invalid for .../fake.zip (submission 33333333-cccc). Fetching the itemized Apple log...
{"status":"Invalid","issues":[{"severity":"error","message":"The signature of the binary is invalid."}]}
>>> invalid: PASS (exit 1)
=============== scenario: budget (expect exit 1)
[notarize    0s] submitted: id 44444444-dddd
... 7 consecutive info timeouts, backoff 1s,2s,2s,... ...
ERROR: notarization budget of 12s exhausted (file: .../fake.zip, submission: 44444444-dddd)
>>> budget: PASS (exit 1)
```

Still required: watch the first real nightly after merge -- the `--output-format json` field names (`id`, `status`) are per the `notarytool` man page and Apple's docs, but this is their first use in this pipeline.

## UX concerns

None (CI-only).

## Related Issues

Fixes #10133

## Pattern harvest

Rule candidate: review-prompt
Pattern: "long-running remote poll delegated to a vendor CLI's `--wait` flag with no retry, under `set -e`" -- any CI step that waits on an external service through a single blocking tool invocation shares this failure class (one dropped request = whole job lost).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality (`test/test_notarize_budget.py`)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

