### PR TITLE
fix(claude): hold pooled broker stubs to the spec's tools allowlist

### DIFF
--- a/docs/system-specs/modules/claude-code-provider.md
+++ b/docs/system-specs/modules/claude-code-provider.md
@@ -171,14 +171,27 @@ and effort selection, the full `session/request_permission` flow) works. So
   difference from kiro-cli is stated for what it is: an administrator who omits
   `kirocrew-core` from the catalog has it dropped there and kept here (one
   host-owned server wider), while every third-party server goes the other way.
-- **A server the MCP gateway brokers yields to its stub.** The pooled broker
-  emits a stub under the SAME name as the agent-spec entry it rewrites, and the
-  caller appends those stubs to this array. Emitting both would put two elements
-  with one `name` in a single array: either the raw entry shadows the stub and
-  the session bypasses the broker, or both register and every pooled backend runs
+- **A server the MCP gateway brokers yields to its stub, and the MIRROR places
+  the stubs.** The pooled broker emits a stub under the SAME name as the
+  agent-spec entry it rewrites. Emitting both would put two elements with one
+  `name` in a single array: either the raw entry shadows the stub and the
+  session bypasses the broker, or both register and every pooled backend runs
   twice (#927). The client resolves `injection_server_names` for its overlay and
   passes the set down; an unreadable overlay degrades to "no stubs", never to a
-  session with no servers.
+  session with no servers. The stub ELEMENTS come down the same call
+  (`stub_elements`) and the mirror appends them itself -- the client's shared
+  append (`_pooled_mcp_servers`) is inert for every mirrored backend -- so two
+  of the rules that narrowed the translated half cover the stubs: a stub for a
+  server this agent's `tools` never references is not mounted (the gateway
+  overlay is written per agent from the GLOBAL settings file as well as the
+  agent's own spec, so it can carry exactly that stub), and a session whose
+  permission surface Crew does not own gets no stubs along with no array. The
+  registry filter is the stated residual: the rewriter has no registry
+  awareness, so a stub is not held to it here -- tracked separately, and
+  pre-existing on codex, whose stub filter reads the same two rules. A stub
+  for a spec-narrowed server stays mounted, unlike codex: the narrowing rides
+  `permissions.deny` in `settings.local.json`, which matches the stub because it
+  registers under the same server name.
 - **Crew's control plane is re-derived, not copied.** `kirocrew-core` and
   `kirocrew-cron` come from `agent.managed_mcp_spec_entry`, so a stale hand-edited
   command in the spec cannot cost a session the tools it needs to report back at

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -179,7 +179,7 @@ from kiro_crew.mcp_gateway.claim import schedule_claim
 from kiro_crew.mcp_gateway.session_servers import injection_server_names, pooled_session_servers
 from kiro_crew.metrics.tool_calls import note_tool_call_started, record_tool_call_finished
 from kiro_crew.platform.context import redact_log_via_context
-from kiro_crew.providers.mirrors import mirror_for
+from kiro_crew.providers.mirrors import MIRRORS, mirror_for
 from kiro_crew.providers.mirrors.codex import drop_unadvertised_transports
 from kiro_crew.resource_status import inject_xdist_auto_cap
 from kiro_crew.sandbox import (
@@ -3774,13 +3774,26 @@ class AcpClient:
         servers — nothing is written to the user's project or to
         ``~/.kiro/agents/``. Empty when the shared gateway is disabled.
 
-        Empty for codex as well, because its own projection already appended the
-        stubs it may have (``_resolve_session_mcp_servers``). A second unnarrowed
+        Empty for EVERY mirrored backend, with no per-backend branch: a mirror's
+        projection places the stubs itself (``_resolve_session_mcp_servers`` hands
+        them down as ``stub_elements``), so one withhold rule -- the spec's
+        ``tools`` allowlist, codex's restriction set, claude's permission-surface
+        precondition -- covers both halves of the array. A second unnarrowed
         append here would re-add, as an UNRESTRICTED broker stub, exactly the
-        servers that projection withheld — a stub carries the same name as the entry
-        it rewrites, so the withhold and the re-add are the same server.
+        servers that projection withheld: a stub carries the same name as the
+        entry it rewrites, so the withhold and the re-add are the same server.
+
+        The shared append remains for the mirror-less backends: kiro-cli reads
+        the spec itself via ``--agent``, so this array is the ONLY channel its
+        stubs can arrive on, and the injection outranking the spec entry is what
+        pools them there.
+
+        Membership in ``MIRRORS`` rather than ``mirror_for``, because this sits
+        on the shared session/new / session/load composition: ``mirror_for``
+        RAISES for a backend registered in neither map, and kiro's construction
+        path must not gain a failure mode in service of an adapter (H13).
         """
-        return [] if self._is_codex else self._pooled_broker_stubs()
+        return [] if self.backend in MIRRORS else self._pooled_broker_stubs()
 
     def _resolve_session_mcp_servers(self) -> list[dict[str, Any]]:
         """Translate the agent spec into this session's ``mcpServers`` array.

--- a/src/kiro_crew/providers/mirrors/README.md
+++ b/src/kiro_crew/providers/mirrors/README.md
@@ -72,8 +72,9 @@ register it in `registry.py`.
   wire params with nothing off-wire, so a mirror that has no such obligation
   implements only `session_params()`. A mirror that does (codex) overrides this
   and defines `session_params()` as its `.params`, so the two faces cannot drift.
-  Also the seam a mirror that must place the gateway's pooled stubs itself takes
-  them through (`stub_elements`).
+  Also the seam the gateway's pooled stubs come through (`stub_elements`): the
+  client's shared append is inert for every mirrored backend, so a mirror that
+  does not place them ships a backend the gateway cannot pool onto.
 - **`write_files()`** — the file face, for native config the harness loads itself.
   **Create-or-decline**: create the file, or leave the path entirely alone. Never
   read, merge into, rewrite or delete a file Crew did not author.

--- a/src/kiro_crew/providers/mirrors/base.py
+++ b/src/kiro_crew/providers/mirrors/base.py
@@ -182,10 +182,16 @@ class AgentConfigMirror(ABC):
 
         ``stub_elements`` may arrive in ``kwargs``: the shared MCP gateway's broker
         stubs for this session, which the client holds because it owns the overlay.
-        A mirror that must place them itself (so one withhold rule covers both halves
-        of the array) takes them; this default ignores them, and the client's shared
-        append then places them for that backend. Same blocking allowance and the
-        same wiring obligation as :meth:`session_params`.
+        A MIRRORED backend receives its stubs only through here -- the client's
+        shared append (``AcpClient._pooled_mcp_servers``) is inert for every
+        mirrored backend, precisely so an unnarrowed append cannot re-add what a
+        projection withheld -- so a mirror places them itself, under its own
+        withhold rules. This default ignores them, and that is the fail-CLOSED
+        direction: a new mirror that does not decide stub placement ships a
+        backend the gateway cannot pool onto, which is visible and harmless,
+        rather than one that mounts stubs no allowlist filtered.
+        Same blocking allowance and the same wiring obligation as
+        :meth:`session_params`.
         """
         return SessionProjection(params=self.session_params(agent, **kwargs))
 

--- a/src/kiro_crew/providers/mirrors/claude_code.py
+++ b/src/kiro_crew/providers/mirrors/claude_code.py
@@ -22,15 +22,16 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Collection
-from typing import Mapping
+from typing import Any, Mapping
 
-from kiro_crew.acp.session_mcp import session_mcp_servers
+from kiro_crew.acp.session_mcp import session_mcp_projection
 from kiro_crew.acp_backends import ACP_BACKEND_CLAUDE
 from kiro_crew.providers.mirrors.base import (
     AgentConfigMirror,
     Concern,
     Disposition,
     Ruling,
+    SessionProjection,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,20 +49,28 @@ class ClaudeCodeMirror(AgentConfigMirror):
             Concern.MCP_SERVERS: Ruling(
                 _D.DELIVERED,
                 "the session/new + session/load mcpServers array, translated by "
-                "acp.session_mcp.session_mcp_servers. The adapter reads no agent "
-                "file, so this array is the session's whole MCP surface. Delivered "
-                "ONLY when Crew authored settings.local.json: that file is this "
-                "backend's permission surface, and a tool Crew cannot gate must "
-                "not be handed to the session at all",
+                "acp.session_mcp.session_mcp_servers, with the shared gateway's "
+                "pooled broker stubs placed HERE beside the translation so one "
+                "withhold rule covers both halves of the array -- codex parity. "
+                "The adapter reads no agent file, so this array is the session's "
+                "whole MCP surface. Delivered ONLY when Crew authored "
+                "settings.local.json: that file is this backend's permission "
+                "surface, and a tool Crew cannot gate must not be handed to the "
+                "session at all -- stubs included, since a stub is the same "
+                "server under the same name",
             ),
             Concern.TOOL_ALLOWLIST: Ruling(
                 _D.TRANSLATED,
                 "`tools` is not sent; it is applied HERE as the allowlist deciding "
-                "which servers enter the array. A missing or non-list `tools` is an "
-                "empty allowlist, matching kiro-cli, which mounts a server only "
-                "when tools names it. Residual asymmetry: an `@server/tool` grant "
-                "narrows to one tool on kiro-cli but mounts the whole server here, "
-                "because the tool set is not knowable without connecting",
+                "which servers enter the array -- the translated half AND the "
+                "pooled broker stubs, from the same parse, because the gateway "
+                "overlay is written per agent from the global settings file too "
+                "and can carry a stub for a server this agent never references. A "
+                "missing or non-list `tools` is an empty allowlist, matching "
+                "kiro-cli, which mounts a server only when tools names it. "
+                "Residual asymmetry: an `@server/tool` grant narrows to one tool "
+                "on kiro-cli but mounts the whole server here, because the tool "
+                "set is not knowable without connecting",
             ),
             Concern.DENIED_TOOLS: Ruling(
                 _D.TRANSLATED,
@@ -163,21 +172,94 @@ class ClaudeCodeMirror(AgentConfigMirror):
         caller passes it.
 
         Blocking — it reads the agent spec. The caller warms this on the spawn path
-        and serves the shared ``session/new`` call site from that cache (H13).
+        and serves the shared ``session/new`` call site from that cache (H13). The
+        client calls :meth:`session_projection`; this method IS that projection's
+        ``params``, so the two faces cannot drift.
         """
+        stubs = kwargs.get("stub_elements") or ()
+        return self.session_projection(
+            agent,
+            stub_server_names=stub_server_names,
+            stub_elements=stubs if isinstance(stubs, (list, tuple)) else (),
+            permission_surface_owned=permission_surface_owned,
+            work_dir=work_dir,
+        ).params
+
+    def session_projection(
+        self,
+        agent: str | None,
+        *,
+        stub_server_names: Collection[str] = (),
+        stub_elements: Collection[Mapping[str, Any]] = (),
+        permission_surface_owned: bool = False,
+        work_dir: object = None,
+        **kwargs: object,
+    ) -> SessionProjection:
+        """The structured face: translation AND pooled stubs, one rule over both.
+
+        The shared gateway's broker stubs are placed HERE rather than by the
+        client's shared append, for the reason codex already placed its own: the
+        two withhold rules this mirror applies must cover BOTH halves of the
+        array, and an append the mirror never sees bypasses them.
+
+        * **The permission-surface precondition covers the stubs.** A stub is a
+          working server (``spawn_run``, ``cron_add``, every pooled backend), so
+          appending it after :meth:`session_params` withheld the translated half
+          would hand an ungoverned permission surface exactly the tools the
+          withhold exists to keep off it.
+        * **The spec's ``tools`` allowlist covers the stubs.** The gateway
+          overlay is written per agent from the GLOBAL settings file as well as
+          the agent's own spec, so it can carry a stub for a server this agent's
+          ``tools`` never references -- and a stub is that server, under the same
+          name. The translated half was filtered by that allowlist; the stubs
+          are held to the same one, from the same parse, or the unreferenced
+          server mounts anyway the moment the gateway pools it.
+
+        A stub for a server the spec narrows per tool stays MOUNTED here, unlike
+        codex: the narrowing rides ``permissions.deny`` in ``settings.local.json``
+        (``mcp__<server>__<tool>``), which matches the stub because the stub
+        registers under the same server name. Withholding it would drop a server
+        this backend can narrow correctly.
+
+        ``denied_tools`` stays empty: the deny channel is the settings file, not
+        a client-side refusal. ``kwargs`` may carry ``session_key`` /
+        ``channel_id``, which this backend ignores -- a claude MCP child inherits
+        the adapter's process env, so identity needs no element-level carry.
+
+        Same blocking allowance and the same wiring obligation as
+        :meth:`session_params` (H13).
+        """
+        del kwargs
         if not permission_surface_owned:
             logger.warning(
-                "session MCP: withholding the whole mcpServers array -- Crew does not own "
-                "this session's settings.local.json, so a permissions.allow entry there "
-                "could pre-approve a Crew tool and skip session/request_permission "
-                "entirely. This session runs without Crew's MCP tools; remove or rename "
-                "the project's own .claude/settings.local.json to restore them.",
+                "session MCP: withholding the whole mcpServers array, pooled broker stubs "
+                "included -- Crew does not own this session's settings.local.json, so a "
+                "permissions.allow entry there could pre-approve a Crew tool and skip "
+                "session/request_permission entirely. This session runs without Crew's MCP "
+                "tools; remove or rename the project's own .claude/settings.local.json to "
+                "restore them.",
             )
-            return {"mcpServers": []}
-        return {
-            "mcpServers": session_mcp_servers(
-                agent,
-                stub_server_names=stub_server_names,
-                work_dir=work_dir,  # type: ignore[arg-type]
-            )
-        }
+            return SessionProjection(params={"mcpServers": []})
+        projection = session_mcp_projection(
+            agent,
+            stub_server_names=stub_server_names,
+            work_dir=work_dir,  # type: ignore[arg-type]
+        )
+        out: list[dict[str, Any]] = list(projection.servers)
+        for stub in stub_elements:
+            if not isinstance(stub, Mapping):
+                continue
+            name = stub.get("name")
+            if not projection.allowlist.grants(str(name)):
+                # WARNING, not info: this is the one diagnostic for a pooled
+                # server an existing claude session stops receiving, and the
+                # default log level would swallow an info line.
+                logger.warning(
+                    "session MCP: not mounting pooled stub %r -- the agent spec's `tools` "
+                    "does not reference it, and the allowlist that filtered the translated "
+                    "half applies to a stub of the same name",
+                    name,
+                )
+                continue
+            out.append(dict(stub))
+        return SessionProjection(params={"mcpServers": out})

--- a/test/test_acp_session_mcp.py
+++ b/test/test_acp_session_mcp.py
@@ -632,12 +632,18 @@ class TestClientSeam:
             mcp_gateway_overlay=overlay,
         )
         original = _by_name(client._session_mcp_servers()).get("foo")
-        assert (original is not None) is private
+        # Present either way: privately as the spec's own entry, pooled as the
+        # broker stub the MIRROR appended (the spec's `tools` references foo, so
+        # the allowlist grants the stub).
+        assert original is not None
         if private:
             assert original["command"] == "/bin/foo"
             assert original["args"] == ["serve"]
             assert original["env"] == [{"name": "K", "value": "V"}]
-        assert bool(client._pooled_mcp_servers()) is (not private)
+        else:
+            assert original["command"] == "broker-stub"
+        # The shared append is inert for claude -- the mirror placed the stubs.
+        assert client._pooled_mcp_servers() == []
 
     def test_neither_gate_is_an_identity_check(self, tmp_path, agents_dir, monkeypatch):
         """Two gates decide the seam, and neither reads the harness's identity.
@@ -710,7 +716,7 @@ class TestClientSeam:
         def _never(*_a, **_kw):
             raise AssertionError("the kiro path must not translate a spec")
 
-        monkeypatch.setattr(claude_mirror, "session_mcp_servers", _never)
+        monkeypatch.setattr(claude_mirror, "session_mcp_projection", _never)
         monkeypatch.setattr(client_mod, "injection_server_names", _never)
         client = AcpClient(work_dir=tmp_path, agent="kirocrew")
         result = client._session_mcp_servers()
@@ -730,13 +736,13 @@ class TestClientSeam:
         """
         _write_spec(agents_dir, servers={"foo": {"command": "/bin/foo"}}, tools=["@foo"])
         calls: list[int] = []
-        real = session_mcp.session_mcp_servers
+        real = session_mcp.session_mcp_projection
 
         def _counted(*a, **kw):
             calls.append(1)
             return real(*a, **kw)
 
-        monkeypatch.setattr(claude_mirror, "session_mcp_servers", _counted)
+        monkeypatch.setattr(claude_mirror, "session_mcp_projection", _counted)
         client = self._seeded(tmp_path, agent="kirocrew", acp_backend=ACP_BACKEND_CLAUDE)
         assert "foo" in _by_name(client._session_mcp_servers())
         assert "foo" in _by_name(client._session_mcp_servers())
@@ -787,6 +793,141 @@ class TestClientSeam:
         first = client._session_mcp_servers()
         first.clear()
         assert "foo" in _by_name(client._session_mcp_servers())
+
+    def test_a_pooled_stub_the_spec_never_references_does_not_mount(self, tmp_path, agents_dir):
+        """The `tools` allowlist covers the pooled half of the array too.
+
+        The gateway rewriter writes each agent's overlay from the GLOBAL settings
+        file as well as the agent's own spec, so the overlay can carry a stub for
+        a server this agent's ``tools`` never references -- and a stub is that
+        server. Before the mirror placed the stubs, the shared append mounted it
+        anyway, so a claude session received a pooled server the same spec would
+        NOT mount on kiro-cli or codex. The unreferenced server is the widening
+        direction, and this is the parity this test pins.
+        """
+        _write_spec(agents_dir, servers={"direct": {"command": "/bin/direct"}}, tools=["@direct"])
+        client = self._seeded(tmp_path, agent="kirocrew", acp_backend=ACP_BACKEND_CLAUDE)
+        client._pooled_broker_stubs = lambda: [  # type: ignore[method-assign]
+            {"name": "unreferenced", "command": "/stub", "args": [], "env": [], "type": "stdio"},
+        ]
+        names = set(_by_name(client._session_mcp_servers()))
+        assert "direct" in names
+        assert "unreferenced" not in names
+        # And the shared append is inert for claude, so nothing re-adds it later.
+        assert client._pooled_mcp_servers() == []
+
+    def test_the_shared_append_still_pools_for_kiro(self, tmp_path):
+        """The mirror-less backend keeps the shared append.
+
+        kiro-cli reads the agent spec itself via ``--agent``, so the injected
+        array is the ONLY channel its broker stubs arrive on -- the injection
+        outranking the same-named spec entry is what pools them. Making the
+        append inert for every MIRRORED backend must not take kiro's away.
+        """
+        client = AcpClient(work_dir=tmp_path, agent="kirocrew")
+        stub = {"name": "pooled", "command": "/stub", "args": [], "env": [], "type": "stdio"}
+        client._pooled_broker_stubs = lambda: [dict(stub)]  # type: ignore[method-assign]
+        assert client._pooled_mcp_servers() == [stub]
+
+
+class TestPooledStubsOnTheClaudeMirror:
+    """The claude mirror places the pooled broker stubs itself (codex parity).
+
+    One withhold rule must cover both halves of the array: a stub carries the
+    SAME name as the agent-spec entry it rewrites, so a stub appended by the
+    client after the mirror's rules ran would re-add -- unfiltered -- exactly what
+    those rules withheld.
+    """
+
+    def test_the_mirror_places_the_pooled_stubs_itself(self, agents_dir):
+        _write_spec(agents_dir, servers={"granted": {"command": "/bin/g"}}, tools=["@granted"])
+        stubs = [{"name": "granted", "command": "/stub", "args": [], "env": [], "type": "stdio"}]
+        mirror = ClaudeCodeMirror()
+        projection = mirror.session_projection(
+            "kirocrew",
+            stub_server_names=("granted",),
+            stub_elements=stubs,
+            permission_surface_owned=True,
+        )
+        by_name = _by_name(projection.params["mcpServers"])
+        assert by_name["granted"]["command"] == "/stub"
+        # The wire face IS the projection's params, pinned so the two cannot drift.
+        assert (
+            mirror.session_params(
+                "kirocrew",
+                stub_server_names=("granted",),
+                stub_elements=stubs,
+                permission_surface_owned=True,
+            )
+            == projection.params
+        )
+
+    def test_a_pooled_stub_is_held_to_the_same_tools_allowlist(self, agents_dir):
+        """Same rule, same parse, as codex: `tools` gates the stubs too.
+
+        ``*`` still grants all, and a spec with no ``tools`` list grants nothing.
+        """
+        stubs = [
+            {"name": "granted", "command": "/stub", "args": [], "env": [], "type": "stdio"},
+            {"name": "unreferenced", "command": "/stub", "args": [], "env": [], "type": "stdio"},
+        ]
+        mirror = ClaudeCodeMirror()
+
+        def _names(tools):
+            _write_spec(agents_dir, servers={"granted": {"command": "/bin/g"}}, tools=tools)
+            projection = mirror.session_projection(
+                "kirocrew",
+                stub_server_names=("granted", "unreferenced"),
+                stub_elements=stubs,
+                permission_surface_owned=True,
+            )
+            return {e["name"] for e in projection.params["mcpServers"]}
+
+        assert "granted" in _names(["@granted"])
+        assert "unreferenced" not in _names(["@granted"])
+        assert {"granted", "unreferenced"} <= _names(["*"])
+        assert _names(None) & {"granted", "unreferenced"} == set()
+
+    def test_an_unowned_permission_surface_withholds_the_stubs_too(self, agents_dir):
+        """The fail-closed rule covers both halves of the array.
+
+        A stub is a WORKING server (``spawn_run``, ``cron_add``, every pooled
+        backend), so appending it after the translated half was withheld would
+        hand an ungoverned permission surface exactly the tools the withhold
+        exists to keep off it.
+        """
+        _write_spec(agents_dir, servers={"granted": {"command": "/bin/g"}}, tools=["@granted"])
+        stubs = [{"name": "granted", "command": "/stub", "args": [], "env": [], "type": "stdio"}]
+        projection = ClaudeCodeMirror().session_projection(
+            "kirocrew",
+            stub_server_names=("granted",),
+            stub_elements=stubs,
+            permission_surface_owned=False,
+        )
+        assert projection.params == {"mcpServers": []}
+
+    def test_a_narrowed_servers_stub_stays_mounted_unlike_codex(self, agents_dir):
+        """Claude honours `disabledTools` through `permissions.deny`, not withholding.
+
+        The deny rules in ``settings.local.json`` are keyed
+        ``mcp__<server>__<tool>`` and the stub registers under the same server
+        name, so the narrowing still applies to it. Withholding the stub, as
+        codex must (it has no deny channel), would drop a server this backend
+        can narrow correctly.
+        """
+        _write_spec(
+            agents_dir,
+            servers={"narrowed": {"command": "/bin/n", "disabledTools": ["dangerous"]}},
+            tools=["@narrowed"],
+        )
+        stubs = [{"name": "narrowed", "command": "/stub", "args": [], "env": [], "type": "stdio"}]
+        projection = ClaudeCodeMirror().session_projection(
+            "kirocrew",
+            stub_server_names=("narrowed",),
+            stub_elements=stubs,
+            permission_surface_owned=True,
+        )
+        assert "narrowed" in {e["name"] for e in projection.params["mcpServers"]}
 
 
 class TestLocalSettingsSeed:

--- a/test/test_member_memory_mcp_routing.py
+++ b/test/test_member_memory_mcp_routing.py
@@ -72,18 +72,27 @@ async def test_client_session_requests_do_not_restore_private_broker_routing(
         mcp_gateway_overlay=broker_overlay,
         mcp_gateway_socket=socket,
     )
+
     # Model the direct Claude projection after spawn; its resolver is exercised
     # separately below. Kiro reads its original agent spec without an injection.
-    client._session_mcp_cache = [{"name": "direct", "command": "local-mcp", "args": [], "env": []}]
+    # The claude mirror now places the pooled broker stubs INTO the projection
+    # (held to the spec's `tools` allowlist), so the post-spawn cache carries the
+    # stub for a non-private session; the shared _pooled_mcp_servers append is
+    # inert for mirrored backends and must not re-add it at the call site.
+    def _projected_cache() -> list:
+        cache = [{"name": "direct", "command": "local-mcp", "args": [], "env": []}]
+        if backend == ACP_BACKEND_CLAUDE and not private:
+            cache.append({"name": "builder", "command": "broker-stub", "args": [], "env": []})
+        return cache
+
+    client._session_mcp_cache = _projected_cache()
     claims = Mock()
     monkeypatch.setattr(client_mod, "schedule_claim", claims)
     if entry == "reset-and-rekey":
         client._reset_state()
         client.rekey("dashboard:next", channel_id="next-channel")
         client._agent = "another-agent"
-        client._session_mcp_cache = [
-            {"name": "direct", "command": "local-mcp", "args": [], "env": []}
-        ]
+        client._session_mcp_cache = _projected_cache()
         assert claims.call_args.args[0] == (None if private else str(socket))
 
     sent = []


### PR DESCRIPTION
## Problem / Motivation

On the claude backend, the shared MCP gateway's pooled broker stubs were appended to `session/new` by `AcpClient._pooled_mcp_servers` without being held to the agent spec's `tools` allowlist. The translated half of the array IS filtered by that allowlist, and the codex mirror holds its stubs to the same allowlist from the same parse (#9987). Claude was the one array backend where a pooled stub still bypassed it.

## Why it matters

The gateway rewriter writes each agent's overlay from the global settings file as well as the agent's own spec, so the overlay can carry a stub for a server this agent's `tools` never references -- and a stub is that server, under the same name. A claude session therefore mounted a pooled server the same spec would NOT mount on kiro-cli or codex. The unreferenced server is the widening direction: an `opt_in` grant deliberately left unreferenced, or a hand-narrowed spec, came alive the moment the gateway pooled it and the session ran on claude.

## What changed (motivation -> approach -> change)

Bring the claude mirror to parity with codex at the seam the base contract already defines:

- `ClaudeCodeMirror.session_projection` now places the pooled stubs itself: each stub is held to `projection.allowlist.grants(name)` from the SAME spec parse that filtered the translated half (`session_mcp_projection`), and the existing permission-surface withhold now covers both halves of the array -- a session whose `settings.local.json` Crew does not own gets no stubs along with no array. A dropped stub logs at WARNING, since this is the one diagnostic for a pooled server an existing session stops receiving. `session_params` is defined as `session_projection(...).params` so the two faces cannot drift (the codex shape).
- `AcpClient._pooled_mcp_servers` is now inert for every mirrored backend via `MIRRORS` membership (non-raising, so the shared session/new / session/load composition gains no failure mode -- H13), deleting the last per-backend branch at that seam. The mirror-less kiro-cli path keeps the shared append unchanged: the injected array is the only channel its stubs arrive on.
- A stub for a spec-narrowed server stays mounted, unlike codex: claude's `disabledTools` narrowing rides `permissions.deny` in `settings.local.json`, which matches the stub because it registers under the same server name.
- Spec and contract docs updated in the same commit: `docs/system-specs/modules/claude-code-provider.md` (stub bullet), `providers/mirrors/base.py` docstring and `providers/mirrors/README.md` (stub placement is the mirror's job; not placing means no pooling, the fail-closed direction).

This is a deliberate, user-visible behaviour change: a claude session that today receives a pooled server its spec never referenced stops receiving it. Per `docs/build/changelog.md`, the feature PR does not touch `CHANGELOG.md`; this paragraph is the release-notes source.

Two pre-review findings were dispositioned out of scope, both pre-existing and shared with codex on main: registry-mode withholding does not yet cover stubs on either mirror (the rewriter has no registry awareness; recorded as a local backlog item, and the spec bullet states the residual instead of overclaiming), and an edition that overrides `_claude_session_mcp_servers` with its own array now sources stubs from its own projection path, the same residual #9987 accepted at this seam.

## Tests

- New: a pooled stub the spec never references does not mount on claude (client seam), the shared append is inert for claude and still pools for kiro-cli, the mirror places stubs itself, stubs are held to the same `tools` allowlist (`@server` grant / `*` / no-`tools` spec), an unowned permission surface withholds the stubs too, and a narrowed server's stub stays mounted (claude/codex asymmetry).
- Updated: the private-claude projection test (the stub now arrives through the mirror), and the two tests that monkeypatch the mirror's translator import (`session_mcp_projection`).
- Local gates green: black check, subprocess-encoding, isort, flake8, mypy (full tree), docs-lint, `scripts/check_harness_parity.py` against origin/main, and the scoped suites `test_acp_session_mcp.py` + `test_codex_session_mcp.py` + `test_provider_mirrors.py` + `test_harness_parity.py` (204 passed, 2 pre-existing real-cli skips). `test_mcp_gateway_session_inject.py::test_real_kiro_cli_prefers_session_injected_server` fails identically on unmodified main in this environment (host kiro-cli e2e), verified by stash-and-rerun.

## Manual verification

Not applicable (no UI change); behaviour pinned by the unit suites above.

## Related Issues

Closes #10103

## Pattern harvest

Rule candidate: when a filtered projection and an unfiltered append compose one wire parameter, the append re-adds what the projection withheld under the same name -- hand the append's elements to the projection owner and make the shared append inert for every owner that exists, so one withhold rule covers both halves of the array.
