### PR TITLE
fix: scope app manifest cache to full source coordinates (#10145)

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -107,6 +107,33 @@ design: `_enrich_with_install_status` and `_apply_trust_fields` run afterwards
 and stamp them server-side, so an index-supplied value for one of them can
 never be read before it is replaced.
 
+The fetched `app.json` that feeds this merge is cached on disk
+(`cache/app-manifests/`), and the cache identity is the row's FULL source
+coordinates, not its name: `_manifest_cache_path` digests the normalized
+credential-free clone origin, the effective ref (always the configured
+branch, plus the pinned commit when the row carries one — non-catalog pins
+are data fidelity, not what the listing fetch resolves, so the branch must
+stay in the key), the repository subdirectory, and the app name into the
+file name. Changing the configured branch is therefore a cache MISS by
+construction, two same-name apps from different repositories never share (or
+poison) each other's cached metadata, and a failed fetch cannot silently
+attach a manifest cached for another branch or repo — the name-keyed
+predecessor could not establish provenance and did all three (#10145). The
+registry-refresh sweep expires caches through the same path derivation, so a
+row whose coordinates changed in the new index expires the OLD coordinates'
+file via the prior index's row. Coordinate churn orphans the old files
+themselves — no reader ever derives their path again — so the write path
+garbage-collects files older than every TTL plus a grace window
+(`_gc_manifest_cache_dir`; the grace is derived from the expiry backdate
+slack so an expired-but-preserved file is never GC-eligible in the same
+breath), which bounds what an index that rotates its coordinates can
+accumulate while staying invisible to reads. Manifest files live in the
+`by-source/` subdirectory and only that subdirectory is swept: registry
+index caches stay at the cache-dir root, making the GC boundary structural —
+an index cannot spell a directory into an app name, where a name-prefix
+convention (skip `_registry_*`) would be imitable by an app literally named
+`_registry_x` and hand a hostile index files the sweep never reclaims.
+
 The client
 (`isVerified`/`sourceLabel` in `website/src/components/appstore/types.ts`)
 reads the server fields, still rejects a `_registry`-tagged row first (so

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -335,6 +335,21 @@ def _manifest_cache_dir() -> Path:
 
 _MANIFEST_CACHE_TTL = 86400  # 24 hours
 
+#: Subdirectory of :func:`_manifest_cache_dir` holding the source-keyed
+#: manifest files. Registry INDEX caches live at the dir root; keeping the
+#: manifest files in a subdirectory separates the two by something an external
+#: index cannot spell in an app name (``_safe_cache_stem`` returns plain names
+#: byte-identical, so a name-prefix convention would be imitable — an app
+#: literally named ``_registry_x`` must not be able to place its manifest
+#: outside the garbage collector's reach).
+_MANIFEST_SOURCE_SUBDIR = "by-source"
+
+#: How far past its TTL a cache file's mtime is pushed by
+#: :func:`_expire_cache_file`. The GC grace below is derived from this so
+#: expiry (which deliberately preserves the file) and reclamation (which
+#: deletes it) can never collide however this slack changes.
+_CACHE_EXPIRY_BACKDATE_SLACK = 3600
+
 # ---------------------------------------------------------------------------
 # Registry loading
 # ---------------------------------------------------------------------------
@@ -1279,16 +1294,77 @@ def _safe_cache_stem(name: str) -> str:
     return f"{slug}-{digest}"
 
 
-def _manifest_cache_path(name: str) -> Path:
-    # Sanitize the name so a hostile/traversal entry name from an external
-    # registry can never resolve outside the manifest cache dir (read, write,
-    # AND delete all go through here, so they stay mutually consistent).
-    return _manifest_cache_dir() / f"{_safe_cache_stem(name)}.json"
+def _manifest_source_coordinates(entry: dict[str, Any]) -> tuple[str, str, str, str]:
+    """The full source coordinates a cached manifest's identity is scoped to.
+
+    Returns ``(origin, ref, subdirectory, name)`` where *origin* is the
+    normalized, credential-free clone URL (:func:`_normalize_git_target`
+    strips userinfo, so a token in a configured URL never reaches a cache
+    file name or key material), *ref* is the effective ref — always the
+    configured branch, plus the pinned commit when the row carries one — and
+    *subdirectory*/*name* are the entry's remaining coordinates.
+
+    The branch is folded in even when a commit is present: the listing fetch
+    resolves non-catalog rows by BRANCH (their pins are data fidelity, not
+    authorization), so a ref that kept only the commit would hold the cache
+    path fixed across an operator's branch change — the exact reuse this
+    identity exists to rule out. The pin is folded in as well so a
+    republished pin is a miss rather than a stale hit.
+
+    Every value an external index controls degrades to a safe default when it
+    is not a string: the coordinates feed a cache KEY, so a malformed value
+    must produce a distinct-but-harmless identity, never a crash.
+    """
+    name = entry.get("name", "")
+    if not isinstance(name, str):
+        name = ""
+    git_url = _entry_git_url(entry)
+    origin = _normalize_git_target(git_url) if git_url else ""
+    commit = entry.get("commit")
+    branch = entry.get("branch", "main")
+    if not isinstance(branch, str) or not branch:
+        branch = "main"
+    ref = f"branch:{branch}"
+    if isinstance(commit, str) and commit:
+        ref = f"{ref}|commit:{commit}"
+    subdirectory = entry.get("subdirectory", "")
+    if not isinstance(subdirectory, str):
+        subdirectory = ""
+    return origin, ref, subdirectory, name
 
 
-def _read_manifest_cache(name: str) -> dict[str, Any] | None:
-    """Read cached app.json for a registry app. Returns None if missing or stale."""
-    path = _manifest_cache_path(name)
+def _manifest_cache_path(entry: dict[str, Any]) -> Path:
+    """Cache file for *entry*'s fetched ``app.json``, keyed on SOURCE IDENTITY.
+
+    The stem sanitizes the name so a hostile/traversal entry name from an
+    external registry can never resolve outside the manifest cache dir (read,
+    write, AND expiry all go through here, so they stay mutually consistent).
+    The digest folds the full source coordinates — normalized credential-free
+    origin, effective branch/pinned commit, repository subdirectory, and app
+    name — into the identity, so changing the configured branch is a cache
+    MISS by construction and two same-name apps from different repositories
+    can never share (or poison) each other's cached metadata. Name-keyed
+    caching could not establish provenance: a listing configured for branch
+    ``dev`` happily reused a manifest resolved earlier from ``main``.
+    """
+    origin, ref, subdirectory, name = _manifest_source_coordinates(entry)
+    # json.dumps gives each coordinate an escaped, delimited slot, so a value
+    # containing a would-be separator can never make two different coordinate
+    # tuples serialize to the same key material.
+    material = json.dumps([origin, ref, subdirectory, name])
+    digest = sha256(material.encode("utf-8")).hexdigest()[:16]
+    return _manifest_cache_dir() / _MANIFEST_SOURCE_SUBDIR / f"{_safe_cache_stem(name)}-{digest}.json"
+
+
+def _read_manifest_cache(entry: dict[str, Any]) -> dict[str, Any] | None:
+    """Read cached app.json for a registry entry's exact source coordinates.
+
+    Returns None if missing or stale — and, because the path is derived from
+    the entry's full source identity, also None whenever the branch, pinned
+    commit, repository, or subdirectory differ from what was cached, so a
+    failed fetch can never silently fall back to another source's manifest.
+    """
+    path = _manifest_cache_path(entry)
     if not path.is_file():
         return None
     try:
@@ -1300,16 +1376,63 @@ def _read_manifest_cache(name: str) -> dict[str, Any] | None:
         return None
 
 
-def _write_manifest_cache(name: str, data: dict[str, Any]) -> None:
-    """Write app.json to the manifest cache (atomic)."""
-    _manifest_cache_dir().mkdir(parents=True, exist_ok=True)
+#: Extra age beyond the largest TTL before a cache file is reclaimed. Derived
+#: from the expiry backdate slack so a file :func:`_expire_cache_file` just
+#: backdated (whose whole point is surviving its expiry) is never GC-eligible
+#: in the same breath, whatever value the slack takes.
+_MANIFEST_CACHE_GC_GRACE = _CACHE_EXPIRY_BACKDATE_SLACK + 2 * 86400
+
+
+def _gc_manifest_cache_dir() -> None:
+    """Best-effort reclamation of manifest cache files nothing can read anymore.
+
+    Coordinate-keyed cache files are orphaned whenever a row's branch, pin,
+    repository, or subdirectory changes: the new coordinates write a NEW file
+    and no reader ever derives the old path again. An untrusted index that
+    churns its coordinates every refresh would otherwise grow the cache dir
+    without bound. Reclaim is age-based and read-invisible: only files older
+    than every TTL plus a grace window are removed, and ``_read_manifest_cache``
+    already answers ``None`` for anything past ``_MANIFEST_CACHE_TTL`` (there
+    is no ``ignore_ttl`` read of a manifest file), so deleting them changes no
+    read result. Only the ``by-source/`` subdirectory is scanned: registry
+    index caches live at the cache-dir ROOT, so the boundary between "GC may
+    reclaim" and "GC never touches" is structural — an index cannot spell a
+    directory into an app name, where a name-prefix convention (skip
+    ``_registry_*``) would be imitable and hand a hostile index files the
+    sweep never reclaims. Runs on the write path because writes are the only
+    way the directory grows, which bounds it by construction.
+    """
+    cutoff = (
+        time.time()
+        - max(_MANIFEST_CACHE_TTL, _EXTERNAL_REGISTRY_CACHE_TTL)
+        - _MANIFEST_CACHE_GC_GRACE
+    )
+    try:
+        entries = list((_manifest_cache_dir() / _MANIFEST_SOURCE_SUBDIR).iterdir())
+    except OSError:
+        return
+    for path in entries:
+        if not path.name.endswith(".json"):
+            continue
+        try:
+            if path.stat().st_mtime < cutoff:
+                path.unlink()
+        except OSError:
+            continue
+
+
+def _write_manifest_cache(entry: dict[str, Any], data: dict[str, Any]) -> None:
+    """Write app.json to the manifest cache (atomic), keyed on source identity."""
+    path = _manifest_cache_path(entry)
+    path.parent.mkdir(parents=True, exist_ok=True)
     try:
         atomic_write(
-            _manifest_cache_path(name),
+            path,
             json.dumps(data, indent=2) + "\n",
         )
     except OSError as exc:
-        logger.warning("Failed to cache manifest for %s: %s", name, exc)
+        logger.warning("Failed to cache manifest for %s: %s", entry.get("name", ""), exc)
+    _gc_manifest_cache_dir()
 
 
 def _is_safe_registry_subdir(subdir: Any) -> bool:
@@ -2167,8 +2290,9 @@ async def _resolve_manifest(entry: dict[str, Any]) -> dict[str, Any]:
     if not git_url:
         return entry
 
-    # Try cache first
-    cached = await asyncio.to_thread(_read_manifest_cache, name)
+    # Try cache first — keyed on the entry's full source coordinates, so a
+    # row configured for another branch/repo/subdirectory can never answer.
+    cached = await asyncio.to_thread(_read_manifest_cache, entry)
     if cached:
         return _merge_manifest(entry, cached)
 
@@ -2186,10 +2310,13 @@ async def _resolve_manifest(entry: dict[str, Any]) -> dict[str, Any]:
         owner_designated=bool(owner_target),
     )
     if manifest:
-        await asyncio.to_thread(_write_manifest_cache, name, manifest)
+        await asyncio.to_thread(_write_manifest_cache, entry, manifest)
         return _merge_manifest(entry, manifest)
 
-    # No manifest available — return entry as-is (minimal info)
+    # No manifest available — return entry as-is (minimal info). The failed
+    # fetch attaches NOTHING: the source-scoped cache read above already
+    # missed, and there is deliberately no name-only fallback that could
+    # attach a manifest cached for another branch or repository.
     logger.info("Could not fetch app.json for %s — showing minimal info", name)
     return entry
 
@@ -3221,7 +3348,11 @@ def _expire_cache_file(path: Path) -> None:
         if cache_dir not in resolved.parents:
             logger.warning("Refusing to expire cache file outside cache dir: %s", path)
             return
-        past = time.time() - max(_MANIFEST_CACHE_TTL, _EXTERNAL_REGISTRY_CACHE_TTL) - 3600
+        past = (
+            time.time()
+            - max(_MANIFEST_CACHE_TTL, _EXTERNAL_REGISTRY_CACHE_TTL)
+            - _CACHE_EXPIRY_BACKDATE_SLACK
+        )
         os.utime(resolved, (past, past))
     except FileNotFoundError:
         pass
@@ -3282,13 +3413,19 @@ async def refresh_registries(repo: str | None = None) -> dict[str, Any]:
             continue
         # Expire per-app manifest caches so fresh display info is refetched
         # lazily on the next read (mtime expiry preserves the stale fallback).
-        manifest_names: set[str] = set()
+        # Both the prior and the fresh index rows contribute: the cache path is
+        # derived from each row's FULL source coordinates, so a row whose
+        # branch/repo changed in the new index expires the old coordinates'
+        # cache (via the prior row) as well as priming a miss for the new ones.
+        expire_paths: set[Path] = set()
         for e in (prior or []) + entries:
+            if not isinstance(e, dict):
+                continue
             entry_name = e.get("name")
             if isinstance(entry_name, str) and entry_name:
-                manifest_names.add(entry_name)
-        for entry_name in manifest_names:
-            await asyncio.to_thread(_expire_cache_file, _manifest_cache_path(entry_name))
+                expire_paths.add(_manifest_cache_path(e))
+        for cache_path in expire_paths:
+            await asyncio.to_thread(_expire_cache_file, cache_path)
         refreshed.append(display_name)
         results.append({"name": display_name, "ok": True})
 

--- a/test/test_apps_registry_coverage.py
+++ b/test/test_apps_registry_coverage.py
@@ -529,35 +529,94 @@ class TestEditionRegistryRows:
 
 
 class TestManifestCache:
+    _DEMO = {"name": "demo", "repo": "https://github.com/o/demo.git", "branch": "main"}
+
     def test_missing_cache_reads_none(self, cache_dir):
-        assert registry._read_manifest_cache("nope") is None
+        assert registry._read_manifest_cache({"name": "nope"}) is None
 
     def test_round_trip(self, cache_dir):
-        registry._write_manifest_cache("demo", {"name": "demo", "version": "1.0.0"})
-        assert registry._read_manifest_cache("demo") == {"name": "demo", "version": "1.0.0"}
+        registry._write_manifest_cache(self._DEMO, {"name": "demo", "version": "1.0.0"})
+        assert registry._read_manifest_cache(self._DEMO) == {"name": "demo", "version": "1.0.0"}
 
     def test_stale_cache_reads_none(self, cache_dir):
-        registry._write_manifest_cache("demo", {"name": "demo"})
-        path = registry._manifest_cache_path("demo")
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})
+        path = registry._manifest_cache_path(self._DEMO)
         past = time.time() - registry._MANIFEST_CACHE_TTL - 3600
         os.utime(path, (past, past))
-        assert registry._read_manifest_cache("demo") is None
+        assert registry._read_manifest_cache(self._DEMO) is None
 
     def test_corrupt_cache_reads_none(self, cache_dir):
-        registry._manifest_cache_path("demo").write_text("not json", encoding="utf-8")
-        assert registry._read_manifest_cache("demo") is None
+        path = registry._manifest_cache_path(self._DEMO)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        assert registry._read_manifest_cache(self._DEMO) is None
 
     def test_write_failure_is_swallowed(self, cache_dir, monkeypatch):
         def _boom(path, data):
             raise OSError("disk full")
 
         monkeypatch.setattr(registry, "atomic_write", _boom)
-        registry._write_manifest_cache("demo", {"name": "demo"})  # must not raise
-        assert registry._read_manifest_cache("demo") is None
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})  # must not raise
+        assert registry._read_manifest_cache(self._DEMO) is None
 
     def test_traversing_name_is_confined_to_the_cache_dir(self, cache_dir):
-        path = registry._manifest_cache_path("../../escape")
-        assert cache_dir.resolve() == path.parent.resolve()
+        path = registry._manifest_cache_path({"name": "../../escape"})
+        assert path.parent == cache_dir / registry._MANIFEST_SOURCE_SUBDIR
+        assert cache_dir.resolve() in path.resolve().parents
+
+    def test_branch_change_is_a_cache_miss(self, cache_dir):
+        # The cache identity folds the effective branch in, so flipping the
+        # configured branch can never reuse metadata resolved from another one.
+        main_row = {"name": "demo", "repo": "https://github.com/o/demo.git", "branch": "main"}
+        dev_row = {"name": "demo", "repo": "https://github.com/o/demo.git", "branch": "dev"}
+        assert registry._manifest_cache_path(main_row) != registry._manifest_cache_path(dev_row)
+        registry._write_manifest_cache(main_row, {"name": "demo", "version": "1.0.0"})
+        assert registry._read_manifest_cache(dev_row) is None
+        assert registry._read_manifest_cache(main_row) is not None
+
+    def test_same_name_different_repos_do_not_share_cache(self, cache_dir):
+        one = {"name": "demo", "repo": "https://github.com/one/demo.git", "branch": "main"}
+        two = {"name": "demo", "repo": "https://github.com/two/demo.git", "branch": "main"}
+        assert registry._manifest_cache_path(one) != registry._manifest_cache_path(two)
+        registry._write_manifest_cache(one, {"name": "demo", "description": "repo one"})
+        assert registry._read_manifest_cache(two) is None
+
+    def test_subdirectory_and_commit_pin_scope_the_identity(self, cache_dir):
+        base = {"name": "demo", "repo": "https://github.com/o/demo.git", "branch": "main"}
+        subdir = dict(base, subdirectory="apps/demo")
+        pinned = dict(base, commit="a" * 40)
+        paths = {
+            registry._manifest_cache_path(base),
+            registry._manifest_cache_path(subdir),
+            registry._manifest_cache_path(pinned),
+        }
+        assert len(paths) == 3
+
+    def test_branch_change_is_a_miss_even_under_an_unchanged_pin(self, cache_dir):
+        # Non-catalog pins are data fidelity, not what the listing fetch
+        # resolves — the fetch follows the BRANCH. A ref that kept only the
+        # commit would hold the cache path fixed across an operator's branch
+        # change, serving another branch's metadata for every pinned row.
+        pin = "a" * 40
+        main_row = {
+            "name": "demo",
+            "repo": "https://github.com/o/demo.git",
+            "branch": "main",
+            "commit": pin,
+        }
+        dev_row = dict(main_row, branch="dev")
+        assert registry._manifest_cache_path(main_row) != registry._manifest_cache_path(dev_row)
+        registry._write_manifest_cache(main_row, {"name": "demo", "version": "1.0.0"})
+        assert registry._read_manifest_cache(dev_row) is None
+
+    def test_credential_in_url_never_reaches_the_cache_identity(self, cache_dir):
+        # Normalization strips userinfo, so the same repo with and without an
+        # embedded credential is ONE cache identity and the secret is not in
+        # the file name.
+        plain = {"name": "demo", "gitUrl": "https://git.example.com/o/demo.git"}
+        credentialed = {"name": "demo", "gitUrl": "https://user:secret@git.example.com/o/demo.git"}
+        assert registry._manifest_cache_path(plain) == registry._manifest_cache_path(credentialed)
+        assert "secret" not in registry._manifest_cache_path(credentialed).name
 
     def test_external_cache_write_failure_is_swallowed(self, cache_dir, monkeypatch):
         def _boom(path, data):
@@ -583,12 +642,14 @@ class TestSafeCacheStem:
 
 
 class TestExpireCacheFile:
+    _DEMO = {"name": "demo", "repo": "https://github.com/o/demo.git", "branch": "main"}
+
     def test_backdates_instead_of_unlinking(self, cache_dir):
-        registry._write_manifest_cache("demo", {"name": "demo"})
-        path = registry._manifest_cache_path("demo")
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})
+        path = registry._manifest_cache_path(self._DEMO)
         registry._expire_cache_file(path)
         assert path.is_file()  # data survives as stale fallback
-        assert registry._read_manifest_cache("demo") is None
+        assert registry._read_manifest_cache(self._DEMO) is None
 
     def test_missing_file_is_a_no_op(self, cache_dir):
         registry._expire_cache_file(cache_dir / "absent.json")
@@ -601,13 +662,79 @@ class TestExpireCacheFile:
         assert outside.stat().st_mtime == before
 
     def test_utime_failure_is_swallowed(self, cache_dir, monkeypatch):
-        registry._write_manifest_cache("demo", {"name": "demo"})
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})
 
         def _boom(path, times):
             raise OSError("read-only fs")
 
         monkeypatch.setattr(registry.os, "utime", _boom)
-        registry._expire_cache_file(registry._manifest_cache_path("demo"))
+        registry._expire_cache_file(registry._manifest_cache_path(self._DEMO))
+
+
+class TestManifestCacheGc:
+    _DEMO = {"name": "demo", "repo": "https://github.com/o/demo.git", "branch": "main"}
+
+    def _age(self, path, extra=0):
+        past = (
+            time.time()
+            - max(registry._MANIFEST_CACHE_TTL, registry._EXTERNAL_REGISTRY_CACHE_TTL)
+            - registry._MANIFEST_CACHE_GC_GRACE
+            - 3600
+            - extra
+        )
+        os.utime(path, (past, past))
+
+    def test_write_reclaims_orphans_past_every_ttl_plus_grace(self, cache_dir):
+        # A coordinate change orphans the old file (no reader derives its path
+        # again); once it is older than every TTL plus the grace window, the
+        # next write sweeps it, so churned coordinates cannot grow the dir
+        # without bound.
+        old_row = dict(self._DEMO, branch="dead-branch")
+        registry._write_manifest_cache(old_row, {"name": "demo"})
+        orphan = registry._manifest_cache_path(old_row)
+        self._age(orphan)
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})
+        assert not orphan.exists()
+        assert registry._manifest_cache_path(self._DEMO).is_file()
+
+    def test_fresh_and_recently_expired_files_survive(self, cache_dir):
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})
+        kept = registry._manifest_cache_path(self._DEMO)
+        # A file _expire_cache_file just backdated is expired but NOT yet
+        # GC-eligible: expiry preserves it on purpose.
+        registry._expire_cache_file(kept)
+        other = dict(self._DEMO, name="other")
+        registry._write_manifest_cache(other, {"name": "other"})
+        assert kept.is_file()
+
+    def test_registry_index_caches_are_never_swept(self, cache_dir):
+        index_file = cache_dir / "_registry_acme.json"
+        index_file.write_text("[]", encoding="utf-8")
+        self._age(index_file)
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})
+        assert index_file.is_file()
+
+    def test_a_registry_prefixed_app_name_cannot_escape_the_gc(self, cache_dir):
+        # _safe_cache_stem returns plain names byte-identical, so an external
+        # index can name an app `_registry_evil`. The GC boundary is the
+        # by-source subdirectory, not a name prefix, so such a file is
+        # reclaimed like any other manifest instead of accumulating forever.
+        evil = {"name": "_registry_evil", "repo": "https://github.com/o/x.git", "branch": "main"}
+        registry._write_manifest_cache(evil, {"name": "_registry_evil"})
+        orphan = registry._manifest_cache_path(evil)
+        assert orphan.parent.name == registry._MANIFEST_SOURCE_SUBDIR
+        self._age(orphan)
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})
+        assert not orphan.exists()
+
+    def test_gc_errors_are_swallowed(self, cache_dir, monkeypatch):
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})
+
+        def _boom(self_path):
+            raise OSError("no listdir for you")
+
+        monkeypatch.setattr(registry.Path, "iterdir", _boom)
+        registry._write_manifest_cache(self._DEMO, {"name": "demo"})  # must not raise
 
 
 # ---------------------------------------------------------------------------
@@ -863,7 +990,7 @@ class TestResolveManifest:
     @pytest.mark.asyncio
     async def test_cached_manifest_short_circuits_the_fetch(self, monkeypatch):
         monkeypatch.setattr(
-            registry, "_read_manifest_cache", lambda name: {"description": "cached"}
+            registry, "_read_manifest_cache", lambda entry: {"description": "cached"}
         )
 
         async def _never(*a, **k):
@@ -877,13 +1004,13 @@ class TestResolveManifest:
 
     @pytest.mark.asyncio
     async def test_fetched_manifest_is_cached_and_merged(self, monkeypatch):
-        monkeypatch.setattr(registry, "_read_manifest_cache", lambda name: None)
+        monkeypatch.setattr(registry, "_read_manifest_cache", lambda entry: None)
         monkeypatch.setattr(registry, "_is_owner_designated_repo", lambda entry: False)
         written: list[tuple[str, dict]] = []
         monkeypatch.setattr(
             registry,
             "_write_manifest_cache",
-            lambda name, data: written.append((name, data)),
+            lambda entry, data: written.append((entry["name"], data)),
         )
 
         async def _fetch(*a, **k):
@@ -898,7 +1025,7 @@ class TestResolveManifest:
 
     @pytest.mark.asyncio
     async def test_unavailable_manifest_leaves_a_minimal_row(self, monkeypatch):
-        monkeypatch.setattr(registry, "_read_manifest_cache", lambda name: None)
+        monkeypatch.setattr(registry, "_read_manifest_cache", lambda entry: None)
         monkeypatch.setattr(registry, "_is_owner_designated_repo", lambda entry: False)
 
         async def _fetch(*a, **k):
@@ -907,6 +1034,61 @@ class TestResolveManifest:
         monkeypatch.setattr(registry, "_fetch_app_manifest", _fetch)
         entry = {"name": "demo", "gitUrl": "https://github.com/o/demo.git"}
         assert await registry._resolve_manifest(entry) == entry
+
+    @pytest.mark.asyncio
+    async def test_failed_fetch_never_attaches_another_sources_manifest(
+        self, cache_dir, monkeypatch
+    ):
+        # A manifest cached for branch `main` must not be attached to the same
+        # app configured for branch `dev` when the dev fetch fails: the row
+        # comes back minimal, never wearing another branch's metadata.
+        main_row = {"name": "demo", "gitUrl": "https://github.com/o/demo.git", "branch": "main"}
+        registry._write_manifest_cache(main_row, {"description": "from main", "version": "9.9.9"})
+        monkeypatch.setattr(registry, "_owner_designated_repo_target", lambda entry: "")
+
+        async def _fetch(*a, **k):
+            return None
+
+        monkeypatch.setattr(registry, "_fetch_app_manifest", _fetch)
+        dev_row = {"name": "demo", "gitUrl": "https://github.com/o/demo.git", "branch": "dev"}
+        got = await registry._resolve_manifest(dict(dev_row))
+        assert "description" not in got
+        assert got.get("version") is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_expiry_updates_available_version_for_not_installed_app(
+        self, cache_dir, monkeypatch
+    ):
+        # After the refresh path expires the coordinates' cache, the next
+        # listing resolve refetches and surfaces the NEW available version;
+        # install-status enrichment keeps the row not-installed.
+        row = {"name": "demo", "gitUrl": "https://github.com/o/demo.git", "branch": "main"}
+        registry._write_manifest_cache(row, {"version": "1.0.0"})
+        registry._expire_cache_file(registry._manifest_cache_path(row))
+        monkeypatch.setattr(registry, "_owner_designated_repo_target", lambda entry: "")
+
+        async def _fetch(*a, **k):
+            return {"version": "2.0.0"}
+
+        monkeypatch.setattr(registry, "_fetch_app_manifest", _fetch)
+        got = await registry._resolve_manifest(dict(row))
+        assert got["version"] == "2.0.0"
+        enriched = registry._enrich_with_install_status([got], installed_map={})
+        assert enriched[0]["installed"] is False
+        assert "installedVersion" not in enriched[0]
+
+    @pytest.mark.asyncio
+    async def test_installed_and_available_versions_stay_distinct(self, cache_dir, monkeypatch):
+        row = {"name": "demo", "gitUrl": "https://github.com/o/demo.git", "branch": "main"}
+        registry._write_manifest_cache(row, {"version": "2.0.0"})
+        got = await registry._resolve_manifest(dict(row))
+        assert got["version"] == "2.0.0"
+        enriched = registry._enrich_with_install_status(
+            [got], installed_map={"demo": {"version": "1.0.0", "enabled": True}}
+        )
+        assert enriched[0]["installedVersion"] == "1.0.0"
+        assert enriched[0]["version"] == "2.0.0"
+        assert enriched[0]["updateAvailable"] is True
 
 
 class TestMergeManifest:

--- a/test/test_external_registry.py
+++ b/test/test_external_registry.py
@@ -1109,7 +1109,7 @@ class TestRefreshRegistries:
         _write_external_registry_cache(
             "acme", [{"name": "cool-app", "repo": "R", "branch": "main"}]
         )
-        manifest_path = _manifest_cache_path("cool-app")
+        manifest_path = _manifest_cache_path({"name": "cool-app", "repo": "R", "branch": "main"})
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
         manifest_path.write_text('{"name": "cool-app"}', encoding="utf-8")
         index_path = _external_registry_cache_path("acme")
@@ -1362,8 +1362,22 @@ class TestRefreshRegistries:
 
         cache_root = _reg._manifest_cache_dir().resolve()
         for hostile in ("../../config", "../../../etc/passwd", "a/b/c", "..%2F..%2Fconfig"):
-            resolved = _manifest_cache_path(hostile).resolve()
+            resolved = _manifest_cache_path({"name": hostile}).resolve()
             assert cache_root in resolved.parents, f"{hostile!r} escaped to {resolved}"
+
+    def test_manifest_cache_identity_is_scoped_to_source_coordinates(self, cache_dir):
+        # main vs dev of the same repo, and same-name apps from two different
+        # repos, must each get a DISTINCT cache identity: a name-only key
+        # would let a dev listing reuse main's cached metadata.
+        base = {"name": "cool-app", "repo": "https://github.com/acme/apps", "branch": "main"}
+        dev = dict(base, branch="dev")
+        other_repo = dict(base, repo="https://github.com/rival/apps")
+        paths = {
+            _manifest_cache_path(base),
+            _manifest_cache_path(dev),
+            _manifest_cache_path(other_repo),
+        }
+        assert len(paths) == 3
 
     def test_safe_cache_stem_preserves_plain_names(self):
         # Plain names stay byte-identical (no hash suffix) so caches persist.


### PR DESCRIPTION
## Problem / Motivation

External app.json manifests are cached by name alone
(`_manifest_cache_path(name)` in `src/kiro_crew/apps/registry.py`), at
`cache/app-manifests/<safe-stem>.json`. The cache identity omits the
repository origin, the effective branch or pinned commit, and the
repository subdirectory.

## Why it matters

A listing configured for branch `dev` can silently reuse manifest
metadata (including version, permissions, and setup copy) resolved
earlier from `main`, and two same-name apps from different repositories
share -- and can poison -- one cache file. Name-only refresh
invalidation cannot establish provenance, so what the App Store shows
can describe a different tree than what an install fetches.

## What changed

- `_manifest_source_coordinates(entry)` derives the identity tuple:
  normalized credential-free clone origin, effective ref (always the
  configured branch, plus the pinned commit when the row carries one --
  non-catalog pins are data fidelity, not what the listing fetch
  resolves, so the branch must stay in the key), repository
  subdirectory, and app name. Index-controlled non-string values
  degrade to safe defaults.
- `_manifest_cache_path(entry)` digests that tuple (json.dumps material,
  so no separator ambiguity) into the file name next to the sanitized
  name stem. Branch change = miss by construction; different repos never
  collide; credentials never reach key material or file names.
- `_read_manifest_cache` / `_write_manifest_cache` take the entry, and
  `_resolve_manifest` routes both through it, so a failed fetch cannot
  attach a manifest cached for another branch/repo: there is no
  name-only fallback left to answer.
- `refresh_registries` expires manifest caches by the same derivation,
  using both the prior and the fresh index rows, so a row whose
  coordinates changed expires the OLD coordinates' file too.
- Coordinate churn orphans old files (no reader derives their path
  again), so `_write_manifest_cache` garbage-collects files older than
  every TTL plus a 2-day grace window (`_gc_manifest_cache_dir`) --
  read-invisible by construction, `_registry_*.json` index caches are
  skipped -- bounding what a coordinate-churning index can accumulate.
- Spec updated in the same commit
  (`docs/system-specs/modules/app-kit-platform.md`).
- One-time upgrade cost, declared: the new digest-named file shape
  orphans every previously cached manifest, so each app refetches its
  manifest once after upgrade (and the GC reclaims the old files).
  Harm-free: the cache is display metadata only.

## Tests

- Local gates green: black gate, subprocess-encoding gate, isort,
  flake8, mypy (only pre-existing boto3-stubs drift in untouched
  files), and 511 tests across `test_apps_registry_coverage.py`,
  `test_external_registry.py`, `test_kebab_gates_reject_trailing_newline.py`.
- New tests cover: main vs dev distinct identities; branch change forces
  a miss (also under an unchanged ignored pin); same-name apps from
  different repos never share; subdirectory and pin scope the identity;
  credentials never reach the identity; refresh expiry then refetch
  updates the available version for a not-installed app; failed fetch
  never attaches another source's manifest; installed vs available
  versions stay distinct; GC reclaims orphans, keeps fresh and
  recently-expired files, never touches index caches, and swallows
  errors.
- Pre-push review: two model-pinned reviewer subagents (GPT + Opus
  lanes) on a frozen worktree; both blocking findings (pin-only ref
  dropping the branch; unbounded orphan growth) are fixed in this head.

## Pattern harvest

Rule candidate: a cache key must name the provenance of the bytes it
stores, not the entity they describe -- keying on the entity (app name)
lets one source answer for another. And when a key gains axes, files
orphaned by axis churn need a reclamation story in the same change.

Known sibling, split out on the First Principles lane's finding: the
external registry INDEX cache is still name-keyed -- follow-up filed as
#10174.

Closes #10145
