### PR TITLE
fix(service): strip group/world-write from managed venv so AppArmor attaches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@
 PY ?= python3
 VENV := .venv
 PIP := $(VENV)/bin/pip
+# Build the venv under a umask that masks group/other WRITE so bin/kirocrew is
+# born non-group-writable -- `kirocrew service install` refuses to attach its
+# AppArmor profile to a group/world-writable launcher (see cli.sh). Caller umask
+# OR 022: only ever ADDS write-mask bits, a stricter umask is preserved.
+TIGHT_UMASK := umask "$$(printf '%03o' "$$(( $$(umask) | 022 ))")"
 PYTEST := $(VENV)/bin/pytest
 
 all: test
@@ -62,8 +67,10 @@ backend:
 	    echo "         bash ensure-python.sh   # or: make backend PY=python3.12" >&2; \
 	    exit 1; \
 	  fi; \
-	  test -x $(VENV)/bin/python || "$$PY" -m venv $(VENV)
-	$(PIP) install --upgrade pip setuptools wheel
+	  if [ -d $(VENV) ] && [ -n "$$(find $(VENV) $(VENV)/bin -prune \( -perm -g+w -o -perm -o+w \) -print 2>/dev/null)" ]; then \
+	    echo "  → recreating $(VENV) (existing tree is group/world-writable)"; rm -rf $(VENV); fi; \
+	  test -x $(VENV)/bin/python || { $(TIGHT_UMASK) && "$$PY" -m venv $(VENV); }
+	$(TIGHT_UMASK) && $(PIP) install --upgrade pip setuptools wheel
 	# --prefer-binary: on hosts below the modern manylinux baseline (e.g. Amazon
 	# Linux 2, glibc 2.26) the newest release of a compiled dep may ship only a
 	# manylinux_2_28 wheel + an sdist. Without this flag pip picks the newest
@@ -71,10 +78,10 @@ backend:
 	# GCC / missing -dev headers). --prefer-binary makes pip take an older
 	# prebuilt wheel instead. No-op where the newest deps already have a usable
 	# wheel (macOS, AL2023).
-	KIROCREW_SKIP_FRONTEND=1 $(PIP) install --prefer-binary -e ".[dev]"
+	$(TIGHT_UMASK) && KIROCREW_SKIP_FRONTEND=1 $(PIP) install --prefer-binary -e ".[dev]"
 	# CI parity: also install the PEP 735 dev dependency-group (pins
 	# jsonschema so the config-validation guard tests actually run).
-	$(PIP) install --group dev
+	$(TIGHT_UMASK) && $(PIP) install --group dev
 	bash packaging/resign-macos-libs.sh $(VENV)/bin/python
 
 test: build

--- a/cli.sh
+++ b/cli.sh
@@ -566,9 +566,25 @@ GOT="$($SHA_CMD "$WHL" | awk '{print $1}')"
 [ "$GOT" = "$SHA" ] || err "SHA-256 mismatch (expected $SHA, got $GOT) — refusing to install"
 echo "Verified SHA-256."
 
+# Build under a umask that masks group/other WRITE, so bin/kirocrew and its
+# dirs are born non-group-writable -- whether pipx or the managed venv builds
+# them. `kirocrew service install` refuses to attach its AppArmor
+# unprivileged-userns profile to a launcher whose file -- or any ancestor dir
+# -- is group- or world-writable, since another local user could plant an
+# executable at that path and inherit the grant. venv/pip/pipx honour the
+# process umask, so a permissive umask (002, common on shared dev hosts) would
+# otherwise yield a 0775 tree and the profile install would refuse, recurring
+# on every re-install. Tightening at BIRTH (not with a post-build chmod) leaves
+# no window in which a same-group user could modify the tree before it is
+# hardened and blessed. We OR the caller's umask with 022 so we only ever ADD
+# the write-mask bits -- a stricter umask (e.g. 077) is preserved, never
+# loosened. Each branch restores it once its tree is built.
+_KC_PREV_UMASK="$(umask)"
+umask "$(printf '%03o' "$(( $(umask) | 022 ))")"
 if command -v pipx >/dev/null 2>&1; then
   echo "Installing with pipx ..."
   pipx install --force --python "$PY" "$WHL" >/dev/null
+  umask "$_KC_PREV_UMASK"
   BIN="$(pipx environment --value PIPX_BIN_DIR 2>/dev/null || echo "$HOME/.local/bin")"
 else
   # The managed venv lives BESIDE the data home, never inside it. Nesting the
@@ -653,6 +669,9 @@ else
   if [ -n "$_VENV_BACKUP" ] && [ -d "$_VENV_BACKUP" ]; then
     rm -rf "$_VENV_BACKUP" 2>/dev/null || true
   fi
+  # Venv tree is fully built and born non-group-writable; restore the caller's
+  # umask so the launcher symlinks below follow it.
+  umask "$_KC_PREV_UMASK"
   # Keep the stable launch path (`${VENV}-current`) naming the tree that holds
   # the LAST-INSTALLED version. The gateway's shadow-venv updater
   # (kiro_crew/platform/wheel_engine.py) promotes this same symlink to a fresh

--- a/cloud-install.sh
+++ b/cloud-install.sh
@@ -177,6 +177,20 @@ fi
 step 4 "KiroCrew client"
 info "Installing the KiroCrew client (pip, editable)…"
 _venv="$REPO_ROOT/.venv"
+# Build the venv under a umask that masks group/other WRITE so bin/kirocrew
+# and its dirs are born non-group-writable -- `kirocrew service install`
+# refuses to attach its AppArmor profile to a group/world-writable launcher
+# (see the matching block in cli.sh for the full rationale). OR-ing with 022
+# only ADDS write-mask bits, so a stricter caller umask is preserved.
+_KC_PREV_UMASK="$(umask)"
+umask "$(printf '%03o' "$(( $(umask) | 022 ))")"
+# A reused venv keeps the perms it was born with: one built by an older installer
+# under a permissive umask still has a group/world-writable root or bin/, so the
+# AppArmor profile would keep refusing. Rebuild it under the tightened umask.
+if [ -d "$_venv" ] && [ -n "$(find "$_venv" "$_venv/bin" -prune \( -perm -g+w -o -perm -o+w \) -print 2>/dev/null)" ]; then
+    warn "Existing venv is group/world-writable — recreating it"
+    rm -rf "$_venv"
+fi
 # Same requires-python reuse rule as install.sh and setup.sh: an existing venv
 # built on a pre-3.12 interpreter cannot host the package, and the pip install
 # below would be refused outright, so rebuild instead of reusing.
@@ -193,6 +207,7 @@ if [ "$WITH_VOICE" -eq 1 ]; then
     info "Including voice extras (.[voice])"
 fi
 KIROCREW_SKIP_FRONTEND=1 "$_venv/bin/pip" install -e "$_pip_target" -q && ok "Kiro Crew client installed" || { warn "pip install failed"; exit 1; }
+umask "$_KC_PREV_UMASK"
 mkdir -p "$HOME/.local/bin"
 ln -sf "$_venv/bin/kirocrew" "$HOME/.local/bin/kirocrew"
 KC="$_venv/bin/kirocrew"

--- a/install.sh
+++ b/install.sh
@@ -470,6 +470,20 @@ fi
 # ── Python virtual environment & package ──
 info "Creating virtual environment…"
 _venv="$KIROCREW_APP_DIR/.venv"
+# Build the venv under a umask that masks group/other WRITE so bin/kirocrew
+# and its dirs are born non-group-writable -- `kirocrew service install`
+# refuses to attach its AppArmor profile to a group/world-writable launcher
+# (see the matching block in cli.sh for the full rationale). OR-ing with 022
+# only ADDS write-mask bits, so a stricter caller umask is preserved.
+_KC_PREV_UMASK="$(umask)"
+umask "$(printf '%03o' "$(( $(umask) | 022 ))")"
+# A reused venv keeps the perms it was born with: one built by an older installer
+# under a permissive umask still has a group/world-writable root or bin/, so the
+# AppArmor profile would keep refusing. Rebuild it under the tightened umask.
+if [ -d "$_venv" ] && [ -n "$(find "$_venv" "$_venv/bin" -prune \( -perm -g+w -o -perm -o+w \) -print 2>/dev/null)" ]; then
+    warn "Existing venv is group/world-writable — recreating it"
+    rm -rf "$_venv"
+fi
 # An existing venv is reusable only while its interpreter still satisfies the
 # package's requires-python. On an upgrade from a pre-3.12 install, reusing a
 # 3.10/3.11 venv makes the `pip install -e .` below refuse the package outright
@@ -524,6 +538,8 @@ else
     die "pip install failed. Check: $_venv/bin/pip --version"
 fi
 rm -f "$_pip_log"
+# Venv fully built and born non-group-writable; restore the caller's umask.
+umask "$_KC_PREV_UMASK"
 
 # Record install method so `kirocrew update` uses the right rebuild strategy
 echo "pip" > "$KIROCREW_APP_DIR/.install-method"

--- a/minimal_install.sh
+++ b/minimal_install.sh
@@ -93,6 +93,20 @@ echo ""
 
 # ── 2. Python venv + package install (pip) ──
 _venv="$REPO_DIR/.venv"
+# Build the venv under a umask that masks group/other WRITE so bin/kirocrew
+# and its dirs are born non-group-writable -- `kirocrew service install`
+# refuses to attach its AppArmor profile to a group/world-writable launcher
+# (see the matching block in cli.sh for the full rationale). OR-ing with 022
+# only ADDS write-mask bits, so a stricter caller umask is preserved.
+_KC_PREV_UMASK="$(umask)"
+umask "$(printf '%03o' "$(( $(umask) | 022 ))")"
+# A reused venv keeps the perms it was born with: one built by an older installer
+# under a permissive umask still has a group/world-writable root or bin/, so the
+# AppArmor profile would keep refusing. Rebuild it under the tightened umask.
+if [ -d "$_venv" ] && [ -n "$(find "$_venv" "$_venv/bin" -prune \( -perm -g+w -o -perm -o+w \) -print 2>/dev/null)" ]; then
+    echo "  ↳ existing venv is group/world-writable — recreating it"
+    rm -rf "$_venv"
+fi
 # Same requires-python reuse rule as the other installers: an existing venv built
 # on a pre-3.12 interpreter cannot host the package, and the `pip install -e .`
 # below would be refused outright with "Requires-Python >=3.12", so rebuild it.
@@ -123,6 +137,7 @@ fi
 "$_venv/bin/python" -c "import aiohttp" 2>/dev/null \
     || die "Install succeeded but aiohttp not importable — dependencies missing"
 echo "✓ Python package installed"
+umask "$_KC_PREV_UMASK"
 echo ""
 
 # ── 3. Agent backend (claude-agent-acp) ──

--- a/setup.sh
+++ b/setup.sh
@@ -200,6 +200,20 @@ fi
 
 # Backend: venv + pip install -e .
 _venv="$_kirocrew_dir/.venv"
+# Build the venv under a umask that masks group/other WRITE so bin/kirocrew
+# and its dirs are born non-group-writable -- `kirocrew service install`
+# refuses to attach its AppArmor profile to a group/world-writable launcher
+# (see the matching block in cli.sh for the full rationale). OR-ing with 022
+# only ADDS write-mask bits, so a stricter caller umask is preserved.
+_KC_PREV_UMASK="$(umask)"
+umask "$(printf '%03o' "$(( $(umask) | 022 ))")"
+# A reused venv keeps the perms it was born with: one built by an older installer
+# under a permissive umask still has a group/world-writable root or bin/, so the
+# AppArmor profile would keep refusing. Rebuild it under the tightened umask.
+if [ -d "$_venv" ] && [ -n "$(find "$_venv" "$_venv/bin" -prune \( -perm -g+w -o -perm -o+w \) -print 2>/dev/null)" ]; then
+    echo "→ Recreating virtual environment (existing one is group/world-writable)..."
+    rm -rf "$_venv"
+fi
 # Same requires-python reuse rule as install.sh: a pre-3.12 venv cannot host the
 # package, so rebuild rather than pip-install into it and hit a hard refusal.
 if [ ! -d "$_venv" ] || [ ! -x "$_venv/bin/python" ] \
@@ -212,6 +226,7 @@ if [ ! -d "$_venv" ] || [ ! -x "$_venv/bin/python" ] \
     fi
     "$_py" -m venv "$_venv" || {
         echo "  ❌ Failed to create venv"
+        umask "$_KC_PREV_UMASK"
         cd - > /dev/null 2>&1
         return 1 2>/dev/null || exit 1
     }
@@ -222,8 +237,10 @@ if KIROCREW_SKIP_FRONTEND=1 "$_venv/bin/pip" install -e "$_kirocrew_dir" -q; the
     echo "  ✅ Build succeeded"
     # Record install method for tooling that branches on it
     echo "pip" > "$_kirocrew_dir/.install-method"
+    umask "$_KC_PREV_UMASK"
 else
     echo "  ❌ pip install failed"
+    umask "$_KC_PREV_UMASK"
     cd - > /dev/null 2>&1
     return 1 2>/dev/null || exit 1
 fi

--- a/src/kiro_crew/platform/wheel_engine.py
+++ b/src/kiro_crew/platform/wheel_engine.py
@@ -641,8 +641,12 @@ def download_verified_wheel(payload: dict[str, str], dest_dir: Path) -> Path:
 
 
 def _run(argv: list[str], timeout: float, step: str, cwd: str | None = None) -> None:
+    # Every build child writes into the shadow tree, so all of them run under
+    # the owner-only build umask (see _BUILD_UMASK below).
     try:
-        proc = subprocess.run(argv, capture_output=True, timeout=timeout, cwd=cwd)
+        proc = subprocess.run(
+            argv, capture_output=True, timeout=timeout, cwd=cwd, umask=_BUILD_UMASK
+        )
     except subprocess.TimeoutExpired as exc:
         raise WheelUpdateError(f"{step} timed out after {timeout:.0f}s") from exc
     except OSError as exc:
@@ -652,6 +656,18 @@ def _run(argv: list[str], timeout: float, step: str, cwd: str | None = None) -> 
         raise WheelUpdateError(
             f"{step} exited {proc.returncode}" + (f": {detail[-2000:]}" if detail else "")
         )
+
+
+#: Owner-only umask for the venv/pip build children (POSIX; -1 = leave unchanged).
+#: ``kirocrew service install`` refuses to attach the AppArmor unprivileged-userns
+#: profile to a launcher that is group- or world-writable (service/apparmor.py), and
+#: ``python -m venv``/pip create ``bin/`` under the process umask — so a permissive
+#: umask (``002``, common on shared dev hosts) would otherwise birth the tree ``0775``
+#: and the profile install would refuse, recurring on every update. ``subprocess``
+#: applies ``umask`` in the child between fork and exec (thread-safe, unlike a
+#: ``preexec_fn`` in this threaded gateway), so bin/ and the launcher are born
+#: owner-only with no window and the profile attaches.
+_BUILD_UMASK = 0o077 if IS_POSIX else -1
 
 
 #: Ownership sentinel: written into a shadow directory the moment this engine
@@ -741,14 +757,23 @@ def build_shadow_venv(wheel_path: Path, shadow_dir: Path, stable_link: Path | No
     # Claim ownership BEFORE any build step: the sentinel is what a future
     # retry's reuse guard keys on, so it must exist from the first moment a
     # partial tree can. `python -m venv` tolerates a non-empty directory.
+    #
+    # The root is created OWNER-ONLY (mode=0o700). It is mkdir'd here in the gateway
+    # process under that process's own umask, so a permissive umask (002) would
+    # otherwise leave it group-writable. mkdir(mode=0o700) passes any umask unchanged
+    # (umask only masks group/other bits, and 0o700 sets none), so the root is born
+    # owner-only. Owner-only is safe: the service runs the launcher as this same
+    # user, and no other account needs to traverse the tree.
     try:
-        shadow_dir.mkdir(parents=True, exist_ok=True)
+        shadow_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         (shadow_dir / _SHADOW_SENTINEL).write_text(
             "created by kiro_crew.platform.wheel_engine; removed after verification\n",
             encoding="utf-8",
         )
     except OSError as exc:
         raise WheelUpdateError(f"could not claim the shadow directory: {exc}") from exc
+    # _run applies the owner-only build umask (see _BUILD_UMASK), so bin/kirocrew
+    # and its dirs are born non-group-writable and the AppArmor profile can attach.
     _run(
         [sys.executable, "-m", "venv", str(shadow_dir)],
         _VENV_CREATE_TIMEOUT_SECS,
@@ -764,6 +789,7 @@ def build_shadow_venv(wheel_path: Path, shadow_dir: Path, stable_link: Path | No
             capture_output=True,
             timeout=_VENV_CREATE_TIMEOUT_SECS,
             cwd=str(shadow_dir),
+            umask=_BUILD_UMASK,
         )
     except (OSError, subprocess.SubprocessError):
         pass

--- a/test/test_wheel_engine.py
+++ b/test/test_wheel_engine.py
@@ -505,6 +505,63 @@ class TestBuildGuards2:
             wheel_engine.build_shadow_venv(tmp_path / "w.whl", target)
 
 
+class TestBuildUmask:
+    def test_build_runs_children_under_the_build_umask(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """venv creation, the pip refresh, and the wheel install all get the owner-only
+        build umask via subprocess's umask= (thread-safe, no preexec_fn), so bin/ is
+        born non-group-writable."""
+        seen: list[object] = []
+
+        def fake_subprocess_run(*a: object, **k: object):  # type: ignore[no-untyped-def]
+            seen.append(k.get("umask"))
+            return type("P", (), {"returncode": 0, "stdout": b"", "stderr": b""})()
+
+        monkeypatch.setattr(wheel_engine.subprocess, "run", fake_subprocess_run)
+        monkeypatch.setattr(wheel_engine, "_BUILD_UMASK", 0o077)
+
+        wheel_engine.build_shadow_venv(tmp_path / "w.whl", tmp_path / "crew-venv-1.0.0")
+
+        assert seen == [0o077, 0o077, 0o077]
+
+    def test_build_creates_owner_only_root(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The shadow root is born 0o700 -- not group-writable even under umask 002."""
+        monkeypatch.setattr(wheel_engine, "_run", lambda *a, **k: None)
+        monkeypatch.setattr(
+            wheel_engine.subprocess, "run", lambda *a, **k: type("P", (), {"returncode": 0})()
+        )
+        shadow = tmp_path / "crew-venv-1.0.0"
+        saved = os.umask(0o002)
+        try:
+            wheel_engine.build_shadow_venv(tmp_path / "w.whl", shadow)
+        finally:
+            os.umask(saved)
+        assert shadow.stat().st_mode & 0o077 == 0, oct(shadow.stat().st_mode)
+
+    def test_real_venv_dirs_born_non_group_writable_under_build_umask(self, tmp_path: Path) -> None:
+        """End-to-end: a real venv built with umask=0o077 under a umask-002 shell has
+        a non-group/world-writable root and bin/. Those are the components the AppArmor
+        profile walks (the launcher path + its ancestor dirs); venv's own activation
+        scripts are siblings the profile never inspects, so they are not asserted."""
+        target = tmp_path / "v"
+        saved = os.umask(0o002)
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "venv", str(target)],
+                check=True,
+                capture_output=True,
+                cwd=str(tmp_path),
+                umask=0o077,
+            )
+        finally:
+            os.umask(saved)
+        for path in (target, target / "bin"):
+            assert not path.stat().st_mode & 0o022, (path, oct(path.stat().st_mode))
+
+
 class TestManifestFetchOrchestration:
     def test_fetch_verified_manifest_wires_fetch_parse_verify(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -988,7 +1045,9 @@ class TestShadowBuildGuards:
         (tree / wheel_engine._SHADOW_SENTINEL).write_text("")
         calls: list[str] = []
         monkeypatch.setattr(
-            wheel_engine, "_run", lambda argv, timeout, step, cwd=None: calls.append(step)
+            wheel_engine,
+            "_run",
+            lambda argv, timeout, step, cwd=None: calls.append(step),
         )
         monkeypatch.setattr(
             wheel_engine.subprocess, "run", lambda *a, **k: type("P", (), {"returncode": 0})()


### PR DESCRIPTION
## Problem / Motivation

On a host with a permissive umask (`002`, common on shared/corporate dev boxes), `kirocrew service install` installs the service but does **not** attach the AppArmor sandbox profile, printing:

> AppArmor profile not installed: the file `~/.kiro/crew-venv/bin/kirocrew` is group- or world-writable (mode 0775) ... another local user could put their own executable at that path and inherit the unprivileged userns grant this profile carries.

The operator `chmod`s the launcher by hand, but the warning returns after every update.

## Why it matters

Without the profile, the Linux userns sandbox never comes up — the security posture the profile exists to provide is silently absent. The manual `chmod` is undone on the next update, so affected users hit this on a loop.

## What changed (motivation → approach → change)

The profile install is right to refuse a group/world-writable launcher: another local user could swap it and inherit the userns grant.

Root cause: `python -m venv` and pip create `bin/` under the **process umask**, so under umask `002` the venv is born `0775`. It recurs because every install and update builds or refills a venv — `cli.sh` rebuilds `crew-venv`, `wheel_engine.build_shadow_venv` builds a new `crew-venv-<version>` sibling, and the source installers (`install.sh`, `setup.sh`, `minimal_install.sh`, `cloud-install.sh`) and `make backend` each create the app's `.venv`.

Fix: build every venv non-group-writable **at birth**, so the launcher is attachable by construction and stays that way. Every shell installer and the `Makefile` run the venv + pip build under a write-masking umask (caller umask **OR** `022`, restored afterwards; `setup.sh` may be sourced, so it restores on every exit path). In `cli.sh` the guard covers both install branches, `pipx install` and the managed venv. `wheel_engine` creates the shadow root `0o700` and `_run` executes every venv / pip child with `subprocess`'s `umask=` set owner-only — applied in the child between fork and exec, so it is thread-safe in the long-lived gateway (a `preexec_fn` is not). OR-ing with `022` only adds write-mask bits, so a stricter caller umask (`077`) is preserved, never loosened. A source installer, and `make backend`, that finds an existing `.venv` whose root or `bin/` is already group/world-writable rebuilds it under the tightened umask instead of reusing it, so an install born loose by an older installer heals on the next run.

```mermaid
flowchart LR
  subgraph Before
    A1[venv/pip under umask 002]:::ctx --> B1[bin/kirocrew born 0775]:::removed --> C1[profile refused]:::removed
  end
  subgraph After
    A2[venv/pip under a write-masking umask]:::added --> B2[bin/kirocrew born 0755]:::added --> C2[profile attaches]:::ctx
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
```

🟩 added · 🟥 removed · 🟦 unchanged

*The launcher is born non-group-writable, so the profile attaches on install and stays attachable after every update — no recurring `chmod`.*

Scope: this PR fixes the trees the installers create. It does not change the mode of directories the user already owns above them. A `~/.kiro` that was itself born `0775` on such a host is refused by the same profile check once, naming that directory; one `chmod g-w ~/.kiro` settles it for good, because `~/.kiro` is created once and never rebuilt.

## Tests

- `test/test_wheel_engine.py::TestBuildUmask` — `build_shadow_venv` creates the root `0o700`, every build child (venv, pip refresh, wheel install) runs under the owner-only build umask via `subprocess`'s `umask=`, and a real `python -m venv` built with `umask=0o077` under a umask-`002` shell has no group/world-writable root or `bin/`.
- Full `test_wheel_engine.py` suite: 81 passed. `black`/`isort`/`flake8`/`mypy` clean. All five shell installers pass `bash -n` (`setup.sh`: `sh -n`); `make -n backend` expands the umask guard on every venv/pip line and the loose-venv rebuild check before it.

## Manual verification

On a umask-`002` shell, a fresh `python -m venv` + pip yields `bin/` at `0775`; the same build under the tightened umask yields `0755` (owner keeps write, group/other lose write), and `bin/python3`'s symlink target is untouched. The installer block, run under `sh` and `bash` from a umask-`002` shell against a pre-existing `0775` venv, detects it, rebuilds it, yields a `755` root and `bin/`, and restores the caller's umask (`0002`) afterwards. `validate_exec_path` then returns the resolved path instead of the group-writable refusal.

## Related Issues

no linked issue: reported directly by a user (AppArmor profile-not-installed on Ubuntu after install/update); this self-contained fix is not tracked by an issue.

## Pattern harvest

Rule candidate: review-prompt
Pattern: fix a permission defect at the moment of creation (tighten the umask before the writer runs) rather than with a post-hoc `chmod` or a runtime gate; the birth-time fix has no TOCTOU window and does not need to inspect or refuse the user's surrounding directories. Use `subprocess`'s `umask=` (not `preexec_fn`) to set a child umask from a threaded process.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

