### PR TITLE
test(gui-user-test): scenario batch 1a -- five P0 shell flows

### DIFF
--- a/.github/workflows/gui-user-test.yml
+++ b/.github/workflows/gui-user-test.yml
@@ -31,7 +31,7 @@ name: GUI User Test
 # under test can be the PR's while the code holding credentials is not.
 #
 # COST GATES: per-scenario max_steps / max_seconds live in the scenario YAML;
-# the run-level USD budget is an input (default $3); a failed scenario is
+# the run-level USD budget is an input (default $5); a failed scenario is
 # retried once.
 
 on:
@@ -53,7 +53,7 @@ on:
       budget_usd:
         description: "Stop the run once estimated spend reaches this many USD"
         type: string
-        default: "3"
+        default: "5"
   schedule:
     - cron: "20 9 * * *" # 09:20 UTC, clear of the 06:00 nightly build and the 08:xx benchmarks
 
@@ -70,9 +70,10 @@ jobs:
   gui-user-test:
     name: GUI User Test
     runs-on: ubuntu-latest
-    # Boot (~4 min: npm ci + build) + up to three scenarios at ~2-4 min each
-    # with one retry apiece, plus model-latency tail.
-    timeout-minutes: 45
+    # Boot (~4 min: npm ci + build) + every shipped scenario at ~2-4 min each
+    # with one retry apiece, plus model-latency tail. The USD budget below is
+    # the real stop; this is the backstop for a hung target.
+    timeout-minutes: 90
     env:
       GUI_DISPLAY: ":99"
       GUI_SCREEN: "1600x1000x24"
@@ -155,8 +156,8 @@ jobs:
         run: |
           set -euo pipefail
           case "$EVENT" in
-            workflow_dispatch) tier="${IN_TIER:-smoke}"; model="${IN_MODEL:-us.anthropic.claude-sonnet-4-6}"; budget="${IN_BUDGET:-3}" ;;
-            *)                 tier="nightly"; model="us.anthropic.claude-sonnet-4-6"; budget="4" ;;
+            workflow_dispatch) tier="${IN_TIER:-smoke}"; model="${IN_MODEL:-us.anthropic.claude-sonnet-4-6}"; budget="${IN_BUDGET:-5}" ;;
+            *)                 tier="nightly"; model="us.anthropic.claude-sonnet-4-6"; budget="8" ;;
           esac
           scenario_args=""
           if [ -n "${IN_SCENARIO:-}" ] && [ "$EVENT" = "workflow_dispatch" ]; then

--- a/docs/build/gui-user-test.md
+++ b/docs/build/gui-user-test.md
@@ -207,10 +207,15 @@ owning server is not a virtual one.
 - A 1280x800 screenshot is about 1 365 input tokens (width x height / 750). With three
   screenshots kept, a step costs roughly 6-8k input and ~150 output tokens; a
   10-step scenario on a Sonnet-class model is about $0.25-0.40 and two to four
-  minutes. The nightly tier (three scenarios, one retry each in the worst case) is
-  about $1-2.50; the PR smoke pair about $0.60. The run stops at `--budget-usd`
-  (dispatch default $3, nightly $4, PR $2) and marks the remaining scenarios
-  `SKIPPED`.
+  minutes. Budget the nightly tier (every shipped scenario, one retry each in the
+  worst case) at about $0.50 per scenario and the smoke tier at about $0.35. The run
+  stops at `--budget-usd` (dispatch default $5 -- the smoke tier is seven scenarios,
+  about $2.50 with one retry apiece, so the default has to clear that; nightly $8)
+  and marks the remaining
+  scenarios `SKIPPED`; the job's 90-minute timeout is the backstop for a hung target,
+  not the budget. Keep the nightly bill under $10: when a new batch would push past
+  it, move the lowest-value scenarios to a cheaper cadence (a `weekly` tier is a
+  schema + workflow change) rather than raising the budget.
 - Pixel tests are stochastic. One retry absorbs a mis-click; a scenario that flips
   night to night is a scenario problem (vague step, timing) before it is a product
   problem. Read `steps.jsonl` and the numbered screenshots: they show exactly where

--- a/test/gui_user/scenarios/auth-sign-in-card-signed-out.yaml
+++ b/test/gui_user/scenarios/auth-sign-in-card-signed-out.yaml
@@ -1,0 +1,33 @@
+# Smoke: the Kiro sign-in card in its signed-out state. The card lives on
+# Developer > Agent Backend, under the backend switch (`KiroSignInCard` renders
+# there and nowhere else; Settings > Overview only carries a pointer link, and
+# only once KAS is the selected backend). It is offered whenever KAS is
+# selectable, which the baseline set makes true on the seeded target. The seeded
+# home holds no Kiro identity and the target has no network, so the card's status
+# probe answers "not signed in" deterministically and the card offers the provider
+# buttons. Completing a sign-in needs a real external identity and is out of
+# scope; this asserts that a user who cannot start a session can see WHY (no
+# identity) and WHERE to fix it (the card's buttons).
+name: auth-sign-in-card-signed-out
+tier: smoke
+feature: auth
+user_story: >-
+  As a Kiro Crew operator whose agents will not start, I want the dashboard to show me
+  whether Kiro Crew holds a Kiro identity and how to sign in, so that I can
+  fix the missing sign-in without reading logs.
+docs_url: docs/system-specs/modules/kas-auth.md
+summary: Open the Developer page's Agent Backend tab and read the signed-out Kiro sign-in card
+preconditions:
+  seed: rich
+  members: [nova-sky]
+  start_url: /developer
+steps:
+  - You are on the Developer page. It has a rail of tabs (Logs, System, Telemetry, Storage, ... , Agent Backend, Debug Tools, Archive). Click the tab labelled "Agent Backend" (it has a chip icon).
+  - Scroll down past the backend switch until you find a card titled "Kiro sign-in" (it has a key icon).
+  - Wait two seconds so the card can finish checking the sign-in status (a short "Checking sign-in…" line may show first).
+expectations:
+  - The "Kiro sign-in" card is visible and no longer says "Checking sign-in…".
+  - The card does not say "Signed in with"; instead it offers at least one sign-in button whose label starts with "Continue with" (for example "Continue with GitHub" or "Continue with AWS Builder ID").
+  - No error banner is shown on the card.
+max_steps: 10
+max_seconds: 240

--- a/test/gui_user/scenarios/chat-switch-seeded-sessions.yaml
+++ b/test/gui_user/scenarios/chat-switch-seeded-sessions.yaml
@@ -1,0 +1,28 @@
+# Smoke: the other half of the sessions surface that `sessions-new-chat` does
+# not cover -- returning to an existing conversation. The `rich` fixture seeds
+# four sessions with known titles and transcripts, so switching between two of
+# them and reading the right history back is a deterministic pixel check.
+name: chat-switch-seeded-sessions
+tier: smoke
+feature: chat
+user_story: >-
+  As a user with several conversations open, I want to click between them in
+  the sidebar and see each one's own history, so that I can run and return to
+  more than one piece of work at once.
+docs_url: docs/system-specs/modules/session.md
+summary: Switch between two seeded sessions from the sidebar and see each transcript
+preconditions:
+  seed: rich
+  members: [nova-sky]
+  start_url: /chat
+steps:
+  - You are on the chat page. In the left sidebar find the session titled "Fix empty-glob crash in list_sessions" (it sits inside a folder named "Demos"; expand the folder if its rows are hidden) and click it.
+  - Read the conversation that opens. It begins with a user message about the sessions tab failing to load when the sessions directory is empty.
+  - Now click the session titled "Welcome to KiroCrew" in the sidebar (it is pinned near the top).  # brand-ok: verbatim seeded session title from the rich fixture
+  - Wait a second for the transcript to switch.
+expectations:
+  - The conversation area shows the "Welcome to KiroCrew" transcript, which contains the question "Where does KiroCrew store my data?" and an answer mentioning config.json.  # brand-ok: verbatim seeded session title from the rich fixture
+  - The "Welcome to KiroCrew" row is highlighted as the current session in the sidebar, and "Fix empty-glob crash in list_sessions" is no longer highlighted.  # brand-ok: verbatim seeded session title from the rich fixture
+  - No message about the sessions directory being empty is visible in the conversation area any more.
+max_steps: 12
+max_seconds: 300

--- a/test/gui_user/scenarios/search-everywhere-open-schedule.yaml
+++ b/test/gui_user/scenarios/search-everywhere-open-schedule.yaml
@@ -1,0 +1,32 @@
+# Smoke: the one-box path to any page. The top bar carries a wide centre
+# trigger that opens the quick-search slot; on a fresh install the Command Bar
+# builtin owns that slot (it is enabled by default), so the trigger reads "Run a
+# command" and the surface lists commands, apps and settings without a network
+# request. Typing a page name and pressing Enter navigates. Ctrl+K (Cmd+K on
+# macOS) opens the same surface, but the harness key-chord allowlist in x11.py
+# does not admit it, so the scenario uses the visible trigger.
+name: search-everywhere-open-schedule
+tier: smoke
+feature: search
+user_story: >-
+  As a user, I want one search box that covers commands, apps, pages and
+  settings and takes me straight to what I typed, so that I can reach any part
+  of the dashboard without hunting through the sidebar.
+docs_url: docs/system-specs/modules/command-bar.md
+summary: Open the top-bar search trigger, type Schedule, press Enter and land on the Schedule page
+preconditions:
+  seed: rich
+  members: [nova-sky]
+  start_url: /chat
+steps:
+  - You are on the chat page. Look at the top bar. In its centre is a wide button that reads "Run a command" (or "⌘K — Search for anything…" if the plain search palette owns the slot -- either is fine). Click it once.
+  - A search box opens in the middle of the screen; its placeholder reads "Type a command…" (or "Search…" for the plain palette).
+  - Type exactly "Schedule" and wait a moment for the result list to filter.
+  - With a result named "Schedule" highlighted (press the Down arrow once if the first highlighted row is something else), press Enter.
+  - Wait a second for the page to change.
+expectations:
+  - The search box has closed.
+  - The main area now shows the Schedule page, with the heading "Schedule" and a List / Calendar / Executions switcher, and a table listing the job "daily rich fixture ping".
+  - The "Schedule" item is highlighted as active in the left rail.
+max_steps: 12
+max_seconds: 300

--- a/test/gui_user/scenarios/settings-search-jump-to-theme.yaml
+++ b/test/gui_user/scenarios/settings-search-jump-to-theme.yaml
@@ -1,0 +1,29 @@
+# Smoke: the Settings header search. It matches against the generated settings
+# registry entirely on the client; picking a result navigates to the owning
+# tab with the row scrolled into view and flashed for about two seconds. The
+# flash is too short to assert reliably from a screenshot, so the expectations
+# hold the landing (Display tab, Theme row on screen), not the ring.
+name: settings-search-jump-to-theme
+tier: smoke
+feature: settings
+user_story: >-
+  As a user who does not know which tab a setting lives on, I want to type its
+  name into the Settings search and pick the result, so that I land on the
+  right tab with the row in front of me.
+docs_url: docs/feature-map/README.md
+summary: Search "theme" in the Settings header and jump to the Theme row on the Display tab
+preconditions:
+  seed: rich
+  members: [nova-sky]
+  start_url: /settings
+steps:
+  - You are on the Settings page. Find the search box in the page header whose placeholder reads "Search settings…" and click into it.
+  - Type exactly "theme". A dropdown of matching settings appears under the box; each row shows a setting name and, beneath it, the tab it belongs to.
+  - Click the result named "Theme" (its subtitle names the Display tab).
+  - Wait a second for the page to move.
+expectations:
+  - The Display tab of Settings is showing (Display is highlighted in the settings navigation).
+  - A setting row labelled "Theme" with a dropdown control is visible on screen.
+  - The search dropdown has closed.
+max_steps: 12
+max_seconds: 300

--- a/test/gui_user/scenarios/sidebar-folders-and-older-sessions.yaml
+++ b/test/gui_user/scenarios/sidebar-folders-and-older-sessions.yaml
@@ -1,0 +1,34 @@
+# Smoke: the list-shell sidebar read against the fixture built for it. `rich`
+# ships a pinned "Welcome to KiroCrew" session, a "Demos" folder holding two  (brand-ok: fixture title)
+# sessions, and a closed "Research: MCP transport trade-offs" session that the
+# slot cutoff has dropped from the live list but that the Older Sessions pane
+# still shows. The pane is closed by default, so opening it is the one action.
+name: sidebar-folders-and-older-sessions
+tier: smoke
+feature: sidebar
+user_story: >-
+  As a returning user, I want my sessions grouped in folders with pinned ones
+  on top and a pane for older, closed sessions, so that I can find past work
+  quickly without scrolling a flat list.
+docs_url: docs/feature-map/README.md
+summary: Read the pinned row and the Demos folder, then open Older Sessions and find the closed session
+preconditions:
+  seed: rich
+  members: [nova-sky]
+  start_url: /chat
+steps:
+  - You are on the chat page. Look at the left sidebar's session list without clicking anything yet. Note the pinned "Welcome to KiroCrew" row near the top and a folder row named "Demos".  # brand-ok: verbatim seeded session title from the rich fixture
+  - If the "Demos" folder is collapsed, click it once to expand it and read the two sessions inside.
+  - At the bottom of the sidebar find the "Older Sessions" row (it has a small clock icon) and click it to open the pane.
+  - Wait a second for the list of older sessions to load.
+expectations:
+  - >-
+    The "Demos" folder is expanded and lists exactly two sessions, "Fix empty-glob crash in
+    list_sessions" and "Triage: cron runs twice per tick".
+  - The pinned "Welcome to KiroCrew" row is listed above the folder, outside it.  # brand-ok: verbatim seeded session title from the rich fixture
+  - >-
+    The "Older Sessions" pane is open and lists a session titled "Research: MCP transport
+    trade-offs", which does not appear in the live list above.
+  - Nothing in the sidebar overflows horizontally or overlaps another row.
+max_steps: 12
+max_seconds: 300

--- a/test/gui_user/test_scenarios_and_report.py
+++ b/test/gui_user/test_scenarios_and_report.py
@@ -17,24 +17,38 @@ SCENARIOS_DIR = Path(__file__).parent / "scenarios"
 # --------------------------------------------------------------------------
 
 
+SHIPPED_SMOKE = {
+    "auth-sign-in-card-signed-out",
+    "chat-switch-seeded-sessions",
+    "search-everywhere-open-schedule",
+    "sessions-new-chat",
+    "settings-search-jump-to-theme",
+    "settings-theme-toggle",
+    "sidebar-folders-and-older-sessions",
+}
+SHIPPED = SHIPPED_SMOKE | {"members-dm-hello"}
+
+
 class TestShippedScenarios:
     def test_every_shipped_scenario_loads(self) -> None:
         loaded = scenarios.load_all(SCENARIOS_DIR)
-        assert {s.name for s in loaded} == {
-            "settings-theme-toggle",
-            "sessions-new-chat",
-            "members-dm-hello",
-        }
+        assert {s.name for s in loaded} == SHIPPED
 
-    def test_pr_smoke_tier_is_the_cheap_pair(self) -> None:
+    def test_smoke_tier_is_the_short_core_paths(self) -> None:
         smoke = scenarios.select(scenarios.load_all(SCENARIOS_DIR), tier="smoke")
-        assert {s.name for s in smoke} == {"settings-theme-toggle", "sessions-new-chat"}
-        # The bill for a PR run is bounded by the smoke tier's own limits.
-        assert sum(s.max_steps for s in smoke) <= 30
+        assert {s.name for s in smoke} == SHIPPED_SMOKE
+        # A smoke scenario is a core path in a handful of actions; the tier's bill is
+        # bounded by the scenarios' own limits, which the nightly tier then inherits.
+        for s in smoke:
+            assert len(s.steps) <= 5, s.name
+            assert s.max_steps <= 14, s.name
+        assert sum(s.max_steps for s in smoke) <= 120
+        assert sum(s.max_seconds for s in smoke) <= 3000
 
     def test_nightly_includes_smoke(self) -> None:
         nightly = scenarios.select(scenarios.load_all(SCENARIOS_DIR), tier="nightly")
-        assert len(nightly) == 3
+        assert {s.name for s in nightly} == SHIPPED
+        assert SHIPPED_SMOKE < SHIPPED
 
     def test_explicit_name_selection(self) -> None:
         picked = scenarios.select(scenarios.load_all(SCENARIOS_DIR), names=["members-dm-hello"])
@@ -65,12 +79,15 @@ class TestShippedScenarios:
     def test_shipped_scenarios_group_by_feature(self) -> None:
         groups = scenarios.by_feature(scenarios.load_all(SCENARIOS_DIR))
         assert {slug: [s.name for s in g] for slug, g in groups.items()} == {
-            "chat": ["sessions-new-chat"],
+            "chat": ["chat-switch-seeded-sessions", "sessions-new-chat"],
+            "sidebar": ["sidebar-folders-and-older-sessions"],
+            "search": ["search-everywhere-open-schedule"],
             "members": ["members-dm-hello"],
-            "settings": ["settings-theme-toggle"],
+            "auth": ["auth-sign-in-card-signed-out"],
+            "settings": ["settings-search-jump-to-theme", "settings-theme-toggle"],
         }
         # FEATURES order, not alphabetical: chat is the product's primary surface.
-        assert list(groups) == ["chat", "members", "settings"]
+        assert list(groups) == ["chat", "sidebar", "search", "members", "auth", "settings"]
 
     def test_members_scenario_holds_across_the_crew_mode_retirement(self) -> None:
         """The Feature Previews card carries two titles across the Crew Mode retirement; the steps name both."""
@@ -416,7 +433,7 @@ class TestReport:
         md = report.render_features(catalog, _summary(), run_url="https://x/run")
         assert md.startswith("# GUI user-test feature catalog\n")
         assert (
-            f"_3 of {len(scenarios.FEATURES)} features covered · 3 scenarios (2 smoke / 1 nightly)._"
+            f"_6 of {len(scenarios.FEATURES)} features covered · 8 scenarios (7 smoke / 1 nightly)._"
             in md
         )
         assert (
@@ -444,7 +461,7 @@ class TestReport:
     def test_features_catalog_without_a_run(self) -> None:
         md = report.render_features(scenarios.load_all(SCENARIOS_DIR))
         assert "_No run attached" in md
-        assert md.count("▫️ not run") == 3 and "✅" not in md and "❌" not in md
+        assert md.count("▫️ not run") == len(SHIPPED) and "✅" not in md and "❌" not in md
 
     def test_neutralize_defangs_fences_mentions_and_control_chars(self) -> None:
         raw = "ok\n```\n@maintainer see <img src=x onerror=1>\x07\r~~~\n" + "z" * 50


### PR DESCRIPTION
Closes #10179. Part of #9578; batch 1a of the backlog in #10040.

Based on `main` (#10040, which registered the `auth` slug this batch uses, has merged).

## Summary

Five smoke scenarios for the GUI user-test lane, each a P0 row of `test/gui_user/FEATURES.md`, written against the `rich` seed the lane boots (`GUI_SEED` default) with the one member `boot.sh` adds (`nova-sky`):

| Scenario | Feature | What the tester does | What the final screenshot must show |
|---|---|---|---|
| `chat-switch-seeded-sessions` | `chat` | Open "Fix empty-glob crash in list_sessions" inside the Demos folder, then "Welcome to KiroCrew" | The welcome transcript ("Where does KiroCrew store my data?"), the welcome row highlighted, the other transcript gone |
| `sidebar-folders-and-older-sessions` | `sidebar` | Read the pinned row and the Demos folder, open the "Older Sessions" pane | Demos lists exactly its two sessions; the closed "Research: MCP transport trade-offs" appears in Older Sessions only |
| `search-everywhere-open-schedule` | `search` | Click the top-bar search trigger ("Run a command"; Ctrl+K is not on the harness chord allowlist), type `Schedule`, Enter | Schedule page with its List / Calendar / Executions switcher and the seeded job; rail item active |
| `settings-search-jump-to-theme` | `settings` | Type `theme` into the "Search settings…" header box, pick "Theme" | Display tab showing, Theme row on screen, dropdown closed |
| `auth-sign-in-card-signed-out` | `auth` | Open Developer, click the "Agent Backend" tab, find the "Kiro sign-in" card (its only render site; Settings > Overview carries just a pointer link, and only once KAS is selected) | Card past "Checking sign-in…", no "Signed in with", at least one "Continue with …" button |

Every step names a control by its on-screen label as the current source renders it (`Type a command…` for the Command Bar that owns the quick-search slot by default, `Search settings…`, `Older Sessions`, `Kiro sign-in`, `Continue with GitHub`), and every expectation is a pixel fact. Two deliberate softenings: the settings-search flash lasts two seconds, so the scenario asserts the landing (tab + row) rather than the ring; the Command Bar placeholder is named with the plain-palette fallback in case the slot owner changes.

## Tests and limits

- `test_scenarios_and_report.py`: the shipped set is now `SHIPPED` / `SHIPPED_SMOKE` constants; the smoke test asserts each smoke scenario has ≤ 5 steps and `max_steps` ≤ 14 and bounds the tier's total `max_steps` / `max_seconds`; the grouping test lists the six covered features in registry order; the catalog line reads `6 of N features covered · 8 scenarios (7 smoke / 1 nightly)`.
- `gui-user-test.yml`: nightly `--budget-usd` 4 → 8, **dispatch default `budget_usd` 3 → 5** (the default smoke dispatch grows 2 → 7 scenarios, ≈ $2.50 with one retry apiece, so the old default would SKIP its tail) and job timeout 45 → 90 min, so neither tier `SKIP`s its own tail as batches land; the doc's cost section is now count-agnostic (≈ $0.50 per nightly scenario, ≈ $0.35 per smoke scenario, keep the night under $10 by demoting rather than raising).
- Tests written, not run locally (CI runs them); black / isort / flake8 clean; `scenarios.load_all` accepts all eight files; every `docs_url` resolves.

## Verification

The lane's Bedrock role trusts `main` only, so a branch dispatch of `gui-user-test.yml` fails at the credential step before any scenario runs (#9965 recorded the attempt). These scenarios verify on the first nightly after merge, or a maintainer `gh workflow run gui-user-test.yml -f tier=smoke -f scenario=<name>` on `main`. A scenario that fails there is a scenario problem first (vague step, timing) and gets fixed in a follow-up, per the lane's own doc.

Not in this batch: `apps-discover`, `schedule-cron-jobs`, `members-crew-members`, `chat-subagents` (batch 1b, stacked on this one); `knowledge-add-folder-source-and-scan`, which needs the tester to type the seeded home's absolute path and therefore a harness placeholder (`{{KIROCREW_HOME}}` in step text) before it can be written.

