### PR TITLE
fix(knowledge): offload artifact _get_state reads off the event loop

### DIFF
--- a/src/kiro_crew/knowledge/artifact_ingest.py
+++ b/src/kiro_crew/knowledge/artifact_ingest.py
@@ -372,7 +372,12 @@ async def ingest_artifact(
         # group rather than returning early and leaving obsolete chunks live.
         # Offloaded: remove_artifact -> delete_items_batch -> store._load_graph
         # is a graph rebuild inside a SQLite transaction, never loop-safe work.
-        prev_hash, old_item_ids = _get_state(kstore, source_id, slug)
+        # _get_state is a synchronous kstore.db read; run it off the loop too,
+        # or a contended knowledge DB busy-waits the whole loop (watchdog
+        # heartbeat included) for the connection's busy timeout.
+        prev_hash, old_item_ids = await asyncio.to_thread(
+            _get_state, kstore, source_id, slug
+        )
         if old_item_ids or prev_hash:
             await asyncio.to_thread(remove_artifact, kstore, source_id, slug)
         return None
@@ -383,7 +388,13 @@ async def ingest_artifact(
     title = _redact_for_ingest(art.name)
 
     content_hash = hashlib.sha256(text.encode()).hexdigest()
-    prev_hash, old_item_ids = _get_state(kstore, source_id, slug)
+    # Synchronous kstore.db read on the gateway loop: offload it so a contended
+    # knowledge DB cannot busy-wait the loop (watchdog heartbeat included) past
+    # the stall deadline. Mirrors the art_store.get / remove_artifact offloads
+    # in this same coroutine.
+    prev_hash, old_item_ids = await asyncio.to_thread(
+        _get_state, kstore, source_id, slug
+    )
     if prev_hash == content_hash and old_item_ids:
         # Unchanged since last ingest AND still holding its items -- cheap no-op
         # (per-slug short-circuit). A row with an empty group was left by a refused


### PR DESCRIPTION
## Problem / Motivation

`ingest_artifact()` (in `src/kiro_crew/knowledge/artifact_ingest.py`) is a coroutine that runs on the gateway event loop during the start-of-run reconcile pass. It already offloads its blocking neighbours — `art_store.get()` and `remove_artifact()` — via `asyncio.to_thread`, but the two `_get_state()` calls between them ran **synchronous SQLite** (`kstore.db.execute(...).fetchone()`) directly on the loop.

Observed symptom: after a nightly update the gateway boot-looped — it started, then was killed every ~40–60s. Crash dumps (`logs/crash-dumps/loopstall-*.txt`) show the main loop wedged with `_get_state → store.db → on_loop_db.check` on the stack and the watchdog firing `Timeout (0:00:25)!`. The in-tree `on_loop_db` guard emits the matching warning: *"connection taken ON the event loop without offloading; a contended query here blocks every task (including the watchdog heartbeat)…"*.

## Why it matters

An on-loop knowledge-DB read blocks **every** task — including the loop-stall watchdog heartbeat — for the connection's busy timeout. During the start-of-run reconcile on a slow or contended host this exceeds the 25s watchdog deadline, and the watchdog kills the gateway. The result is a gateway that cannot stay up (boot loop), i.e. total loss of service for the affected user until they roll back. Hosts most exposed: older/slower CPUs and installs with a large session/knowledge index.

Reproduced on an Intel i7-3632QM (Ivy Bridge, no AVX2 → keyword-search fallback) with an 83 MB `session_index.db`.

## What changed (motivation → approach → change)

- **Symptom:** gateway boot-loop, watchdog `Timeout (0:00:25)!`, `on_loop_db` warning naming `artifact_ingest`.
- **Root cause:** two `_get_state()` calls inside the `async def ingest_artifact` coroutine run synchronous SQLite on the event loop, unlike their already-offloaded neighbours in the same function.
- **Change:** wrap both reads in `await asyncio.to_thread(_get_state, ...)`, mirroring the existing `art_store.get` / `remove_artifact` offloads in the same coroutine. `_get_state` stays synchronous — it is also called from the sync `remove_artifact` path, which is already offloaded by *its* caller — so there is no signature or behaviour change, only where the read runs.

## Tests

`test/test_knowledge_artifact_ingest.py` — existing suite, **58 passed** on Python 3.12.12. It exercises both changed call sites: the unchanged-content short-circuit and the edit/replace/empty-drop paths that call `_get_state`. No behavioural change was expected or observed, so no new assertions were needed; the change is a work-placement (on-loop → worker-thread) fix that the existing coverage locks in.

## Manual verification

Applied the identical change to the affected live gateway: the boot loop stopped, the process stayed up past the previous ~25s kill window, and the dashboard served HTTP 200. Before the change the same host produced a fresh `loopstall-*.txt` on every startup; after, none.

## Related Issues

N/A — filed directly as a fix. Happy to open a tracking issue if maintainers prefer.

## Pattern harvest

Rule candidate: review-prompt / semgrep — "synchronous `*.db.execute(...)` (or other `KnowledgeStore.db` access) reached on a coroutine that runs on the gateway loop." This defect generalizes: the safe pattern is already established in this very function (neighbouring calls use `asyncio.to_thread`) and enforced at runtime by `on_loop_db`, but nothing catches it statically at review time. A lint/semgrep rule flagging on-loop `store.db` reads inside `async def` would stop the whole class rather than this one instance.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality (no new behaviour; existing tests pass)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
