### PR TITLE
fix(taskrunner): guard restart against a lost git worktree (#6676)

### DIFF
--- a/docs/system-specs/modules/taskrunner.md
+++ b/docs/system-specs/modules/taskrunner.md
@@ -567,7 +567,8 @@ Each task runs on an isolated git branch via `git_coord.py`:
 - **State summary**: `git log --oneline` + `git diff --stat` injected into step prompts
 - **Review diff**: `git diff HEAD~1` fed to independent review session
 - **Finalize**: worktree cleaned up on task completion
-- **Retry recovery**: a retry validates the saved worktree's path, repository,
+- **Resume recovery**: a retry — and a restart of a run that already had a
+  worktree — validates the saved worktree's path, repository,
   and branch before dispatching more steps. A lost worktree is recreated from
   its original repository and existing task branch only when a surviving Git
   pointer positively identifies the stale checkout; an arbitrary replacement
@@ -580,7 +581,18 @@ Each task runs on an isolated git branch via `git_coord.py`:
   that cannot be deleted is logged and left on disk beside the recreated
   worktree rather than failing the retry.
 
-Git init failure is non-fatal — task continues without git coordination.
+Git init failure on a run's first initialisation is non-fatal — the task
+continues without git coordination. A resumed run (retry or restart of a run
+that already had a worktree) whose worktree is lost and cannot be recreated
+fails closed instead of continuing without git isolation. This governs
+`fresh=True` restarts too: `fresh` resets task results, not git identity, so a
+fresh restart of a run that already owns a task branch resumes that branch
+under the same validate-or-fail-closed contract rather than minting a new
+worktree — recovery keeps every prior step commit reachable, and a run whose
+branch is truly gone fails closed; the escape is planning the task again from
+scratch. A restart is also refused while the previous run's background task is
+still finishing, because the terminal status is persisted before the old
+finalizer removes the worktree.
 
 ## Cycle Detection
 

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -896,6 +896,16 @@ class TaskRunner:
         restartable = {"planned", "paused", "cancelled", "failed"}
         if run.status not in restartable:
             raise ValueError(f"Run {task_id} is not in a startable state (status={run.status})")
+        # The status flips terminal BEFORE the prior run's finally-block
+        # finishes -- git finalize (which removes the worktree) runs after
+        # the terminal status is persisted. A restart accepted in that window
+        # validates a workspace the prior finalizer is about to delete, and
+        # then executes against a missing directory. The background task
+        # handle is the honest signal: refuse while it is still running.
+        # (Same guard as retry_from_task.)
+        prior = self._tasks.get(task_id)
+        if prior is not None and not prior.done():
+            raise ValueError("Cannot restart while the previous run is still finishing")
 
         # Optional per-run workspace override: only applied to a run that has NOT
         # begun yet (status "planned"). A resumed run (paused/cancelled/failed) keeps
@@ -935,15 +945,39 @@ class TaskRunner:
 
         async def _execute() -> None:
             watchdog_task: asyncio.Task | None = None  # type: ignore[type-arg]
+            # Pessimistic from entry for a run that already owns a worktree:
+            # the finally-block finalize() force-removes run.worktree_path,
+            # and until _ensure_resumable_workspace positively identifies
+            # that path as this run's own worktree, deleting it could destroy
+            # an unrelated directory. The flag is assigned before the first
+            # await, so no cancellation anywhere in this coroutine can reach
+            # the finally with an unvalidated workspace still marked safe.
+            # A planned first run starts False: its worktree is created by
+            # this invocation's init_workspace, so its identity is not in
+            # question.
+            workspace_lost = bool(run.branch_name)
             try:
                 run.status = "running"
                 run.started_at = run.last_task_time = time.time()
                 await self._workflow_rebind(run)
                 await self._apersist_runs()  # persist immediately so crash recovery works
-                try:
-                    await git_coord.init_workspace(run)
-                except Exception:
-                    logger.debug("Git init failed for plan execution", exc_info=True)
+                if run.branch_name:
+                    # A restart of a run that once had a worktree (paused /
+                    # cancelled / failed) resumes against it exactly like a
+                    # retry does, so it shares the retry path's guard: a lost
+                    # worktree is recovered or the run fails closed.
+                    #
+                    if not await self._ensure_resumable_workspace(run, "restart"):
+                        return
+                    workspace_lost = False
+                else:
+                    # First initialisation of a planned run: git is
+                    # best-effort and its failure is non-fatal (the run
+                    # continues without git coordination).
+                    try:
+                        await git_coord.init_workspace(run)
+                    except Exception:
+                        logger.debug("Git init failed for plan execution", exc_info=True)
                 save_progress(run)
                 task_list = "\n".join(f"  {t.index}. {t.title}" for t in run.tasks)
                 await self._notify(
@@ -980,7 +1014,7 @@ class TaskRunner:
                 run.finished_at = time.time()
                 save_progress(run)
                 await self._apersist_runs()
-                if run.branch_name:
+                if run.branch_name and not workspace_lost:
                     try:
                         await git_coord.finalize(run)
                     except Exception:
@@ -1686,6 +1720,36 @@ class TaskRunner:
         if t and not t.done():
             t.cancel()
 
+    async def _ensure_resumable_workspace(self, run: Project, verb: str) -> bool:
+        """Validate (and if possible recover) the worktree of a resumed run.
+
+        Directory-exists alone is not enough: ``git worktree remove``
+        deregisters and deletes in separate steps, so an interrupted
+        ``finalize()`` (or the worktree being removed out from under the run
+        some other way) can leave the directory present but not registered as
+        a git worktree -- resuming against it would silently dispatch every
+        remaining step against a non-git directory while still reporting them
+        completed. Returns True when the run may proceed. On unrecoverable
+        loss the run is failed closed (persisted and notified) and False is
+        returned; the caller must return without dispatching any steps.
+        """
+        if not run.branch_name or await git_coord.workspace_is_valid(run):
+            return True
+        if await git_coord.reinit_workspace_for_retry(run):
+            return True
+        run.status = "failed"
+        run.error = (
+            "Task Runner workspace worktree was lost and " f"could not be restored before {verb}"
+        )
+        run.finished_at = time.time()
+        await self._apersist_runs()
+        await self._notify(
+            f"\u274c {verb.capitalize()} failed",
+            "Workspace could not be restored",
+            run=run,
+        )
+        return False
+
     async def retry_from_task(self, task_id: str, from_task: int, agent: str = "") -> str:
         run = self._resolve_task(task_id)
         if not run:
@@ -1729,29 +1793,8 @@ class TaskRunner:
             watchdog_task: asyncio.Task | None = None  # type: ignore[type-arg]
             try:
                 await self._workflow_rebind(run)
-                if run.branch_name and not await git_coord.workspace_is_valid(run):
-                    # Directory-exists alone is not enough: `git worktree
-                    # remove` deregisters and deletes in separate steps, so
-                    # an interrupted finalize() (or the worktree being
-                    # removed out from under the run some other way) can
-                    # leave the directory present but not registered as a
-                    # git worktree -- resuming against it would silently
-                    # dispatch every remaining step against a non-git
-                    # directory while still reporting them completed.
-                    if not await git_coord.reinit_workspace_for_retry(run):
-                        run.status = "failed"
-                        run.error = (
-                            "Task Runner workspace worktree was lost and "
-                            "could not be restored before retry"
-                        )
-                        run.finished_at = time.time()
-                        await self._apersist_runs()
-                        await self._notify(
-                            "❌ Retry failed",
-                            "Workspace could not be restored",
-                            run=run,
-                        )
-                        return
+                if not await self._ensure_resumable_workspace(run, "retry"):
+                    return
                 await self._notify("\U0001f504 Retrying", f"From task {from_task}", run=run)
                 watchdog_task = asyncio.create_task(self._watchdog_loop(run))
                 await self._execute_tasks(run, history_key)

--- a/test/test_taskrunner_coverage.py
+++ b/test/test_taskrunner_coverage.py
@@ -762,6 +762,9 @@ class TestExecutePlan:
         with (
             patch.object(TaskRunner, "_execute_tasks", AsyncMock()) as exec_tasks,
             patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            # branch_name is set, so this run resumes through the workspace
+            # guard rather than the first-run init_workspace path.
+            patch.object(tr.git_coord, "workspace_is_valid", AsyncMock(return_value=True)),
             patch.object(tr.git_coord, "init_workspace", AsyncMock()) as init_ws,
             patch.object(tr.git_coord, "finalize", finalize),
         ):
@@ -769,7 +772,7 @@ class TestExecutePlan:
             assert safety_override().is_scope_active(scope) is True
             await runner._tasks[task_id]
         exec_tasks.assert_awaited_once()
-        init_ws.assert_awaited_once()
+        init_ws.assert_not_awaited()
         finalize.assert_awaited_once()
         consolidator.maybe_consolidate.assert_called_once_with("taskrunner:run:plan_trust")
         assert run.status == "completed"
@@ -777,6 +780,160 @@ class TestExecutePlan:
         assert task_id not in runner._tasks
         # trust never outlives the run
         assert safety_override().is_scope_active(scope) is False
+
+    @pytest.mark.asyncio
+    async def test_refuses_restart_while_previous_run_is_still_finishing(
+        self, tmp_path: Path
+    ) -> None:
+        """A run's status flips terminal before its finally-block (which
+        removes the worktree) completes. A restart accepted in that window
+        would validate a workspace the prior finalizer is about to delete,
+        so it is refused while the prior task handle is unfinished."""
+        import asyncio as _asyncio
+
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="failed")
+        release = _asyncio.Event()
+
+        async def _still_finalizing() -> None:
+            await release.wait()
+
+        runner._tasks["plan_1"] = _asyncio.create_task(_still_finalizing())
+        try:
+            with pytest.raises(ValueError, match="still finishing"):
+                await runner.execute_plan("plan_1")
+        finally:
+            release.set()
+            await runner._tasks["plan_1"]
+
+    @pytest.mark.asyncio
+    async def test_restart_fails_the_run_when_the_workspace_cannot_be_restored(
+        self, tmp_path: Path
+    ) -> None:
+        """A restarted run whose worktree was deregistered (directory present,
+        not a registered git repo) must not silently dispatch the remaining
+        steps against it. If recovery fails, the run is failed terminally
+        instead of continuing without git isolation."""
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="failed")
+        run.branch_name = "feat/x"
+        run.work_dir = str(tmp_path / "orphaned-worktree")
+        execute_tasks = AsyncMock()
+        with (
+            patch.object(TaskRunner, "_execute_tasks", execute_tasks),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "workspace_is_valid", AsyncMock(return_value=False)),
+            patch.object(tr.git_coord, "reinit_workspace_for_retry", AsyncMock(return_value=False)),
+            patch.object(tr.git_coord, "finalize", AsyncMock()) as finalize,
+        ):
+            task_id = await runner.execute_plan("plan_1")
+            await runner._tasks[task_id]
+        execute_tasks.assert_not_awaited()
+        assert run.status == "failed"
+        assert "workspace" in run.error.lower()
+        # The rejected path was never positively identified as the run's own
+        # worktree, so the finally-block must not force-remove it.
+        finalize.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_restart_validation_does_not_finalize(self, tmp_path: Path) -> None:
+        """A CancelledError raised while the workspace is still being
+        validated unwinds _execute before the guard's verdict lands. The
+        finally-block must treat that workspace as unvalidated and skip
+        finalize(), which would force-remove a path never positively
+        identified as this run's worktree."""
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="failed")
+        run.branch_name = "feat/x"
+        finalize = AsyncMock()
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(
+                tr.git_coord,
+                "workspace_is_valid",
+                AsyncMock(side_effect=asyncio.CancelledError()),
+            ),
+            patch.object(tr.git_coord, "finalize", finalize),
+        ):
+            task_id = await runner.execute_plan("plan_1")
+            await runner._tasks[task_id]
+        finalize.assert_not_awaited()
+        assert run.status == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_cancel_before_restart_validation_does_not_finalize(self, tmp_path: Path) -> None:
+        """A CancelledError raised before validation begins (during the
+        workflow rebind that precedes it) must also leave the workspace
+        marked unvalidated: the pessimistic flag is assigned before the
+        coroutine's first await, so no cancellation window exists."""
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="failed")
+        run.branch_name = "feat/x"
+        finalize = AsyncMock()
+        valid = AsyncMock()
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(
+                TaskRunner,
+                "_workflow_rebind",
+                AsyncMock(side_effect=asyncio.CancelledError()),
+            ),
+            patch.object(tr.git_coord, "workspace_is_valid", valid),
+            patch.object(tr.git_coord, "finalize", finalize),
+        ):
+            task_id = await runner.execute_plan("plan_1")
+            await runner._tasks[task_id]
+        valid.assert_not_awaited()
+        finalize.assert_not_awaited()
+        assert run.status == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_restart_skips_reinit_when_the_workspace_is_already_valid(
+        self, tmp_path: Path
+    ) -> None:
+        """The common restart case -- worktree still valid -- must not pay the
+        reinit cost or touch the workspace at all."""
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="failed")
+        run.branch_name = "feat/x"
+        reinit = AsyncMock()
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "workspace_is_valid", AsyncMock(return_value=True)),
+            patch.object(tr.git_coord, "reinit_workspace_for_retry", reinit),
+            patch.object(tr.git_coord, "finalize", AsyncMock()),
+        ):
+            task_id = await runner.execute_plan("plan_1")
+            await runner._tasks[task_id]
+        reinit.assert_not_awaited()
+        assert run.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_planned_run_keeps_the_first_run_init_path(self, tmp_path: Path) -> None:
+        """A planned run that never had a worktree (no branch_name) keeps the
+        original best-effort init_workspace call: the resume guard must not
+        run, and first-run git failure stays non-fatal."""
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="planned")
+        valid = AsyncMock()
+        reinit = AsyncMock()
+        init_ws = AsyncMock()
+        with (
+            patch.object(TaskRunner, "_execute_tasks", AsyncMock()),
+            patch.object(TaskRunner, "_watchdog_loop", AsyncMock()),
+            patch.object(tr.git_coord, "workspace_is_valid", valid),
+            patch.object(tr.git_coord, "reinit_workspace_for_retry", reinit),
+            patch.object(tr.git_coord, "init_workspace", init_ws),
+        ):
+            task_id = await runner.execute_plan("plan_1")
+            await runner._tasks[task_id]
+        valid.assert_not_awaited()
+        reinit.assert_not_awaited()
+        init_ws.assert_awaited_once()
+        assert run.status == "completed"
 
     @pytest.mark.asyncio
     async def test_git_init_failure_does_not_abort_run(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`execute_plan`'s `_execute` wrapped `git_coord.init_workspace(run)` in a bare `try/except Exception` that logged at debug level and continued. A restarted run (paused/cancelled/failed) whose worktree had already been removed by its own `finalize()` re-entered `init_workspace` against a dead worktree: `_is_git_repo` swallowed the `FileNotFoundError` (its documented "no git binary" case), `git_enabled` silently flipped to `False`, and every remaining step was dispatched against a non-git directory while still being reported completed. `retry_from_task` already guarded this exact shape with `workspace_is_valid` + `reinit_workspace_for_retry` (PR #3827); `execute_plan` was the unguarded sibling.

## Change

- New private coroutine `_ensure_resumable_workspace(run, verb)` holds the single spelling of the recovery predicate: workspace valid → proceed; recoverable → recover and proceed; otherwise fail the run closed (status `failed`, error `"Task Runner workspace worktree was lost and could not be restored before <verb>"`, persisted, operator notified with the same message class as the retry path).
- `_retry` delegates to the helper (behaviour unchanged).
- `_execute` branches on `run.branch_name`:
  - set (the run once had a worktree — a restart of paused/cancelled/failed): run the guard, and return before `save_progress` / `_execute_tasks` on unrecoverable loss;
  - unset (a `planned` run that never had a worktree): the existing best-effort `init_workspace` call and its non-fatal `try/except` are unchanged. First-run behaviour does not change.
- `execute_plan` now refuses a restart while the previous run's background task is still finishing (same guard and reason as `retry_from_task`): the terminal status is persisted before the old finalizer removes the worktree, so a restart accepted in that window validates a workspace about to be deleted.
- When workspace validation/recovery fails, `_execute`'s finally-block skips `git_coord.finalize(run)`: a rejected path was never positively identified as the run's own worktree, and finalize force-removes `run.worktree_path`, so finalizing there could delete an unrelated directory.

## Failure-semantics decision (per triage)

A run's **first** git initialisation stays non-fatal — the task runner must not require git of a folder the user never made a repo. A **resumed** run (retry OR restart) whose worktree is invalid and cannot be recreated fails closed, because both are resume-against-an-existing-worktree paths and continuing would silently drop per-step commit/revert/diff-review isolation. This governs `fresh=True` restarts too: `fresh` resets task results, not git identity, so a fresh restart of a run that owns a task branch resumes that branch under the same contract; the escape for a truly lost branch is planning the task again. `docs/system-specs/modules/taskrunner.md` is refined to state exactly this split.

## Tests

New tests in `test/test_taskrunner_coverage.py`, mirroring the retry-path set:
- restart with `branch_name` set, workspace invalid, reinit fails → run `failed`, "workspace" in error, `_execute_tasks` never awaited, `finalize` never awaited;
- restart with `branch_name` set and workspace valid → reinit not awaited, run completes;
- planned run with no `branch_name` → guard not consulted, `init_workspace` awaited once (first-run path locked in);
- restart refused with "still finishing" while the prior run's task handle is unfinished.

`test_happy_path_grants_then_revokes_trust` updated: it seeds `branch_name`, so under the new contract it resumes through the guard rather than `init_workspace`.

## Pattern harvest

Rule candidate: when sibling resume paths re-enter pre-existing on-disk state (retry vs restart, or any pair of "continue this run" entry points), a fail-closed validation guard added to one sibling must be mirrored to all of them in the same change, and the recovery predicate must live in exactly one shared helper — a guard with two spellings drifts, and the unguarded sibling silently keeps the original defect (this PR is that sibling for #3827).

## Verification

Local static gates green: isort, flake8, mypy (1414 files, no issues), diff-scoped black gate after commit. Test execution is left to CI per repo policy. Pre-push review subagents could not be spawned this run (host memory back-pressure refused the spawn); a contract-driven self-review against both reviewer charters was performed instead — it caught and fixed the stale trust-test assumption and verified `finalize()`/`save_progress` behaviour on the fail-closed path. The server-side GPT + Opus review lanes on this PR are the authoritative review gate. Round 1 addressed the GPT blocking finding (restart-while-finalizing race + unconditional finalize after failed validation) and the Design lane's fresh-restart concern (contract recorded in the module spec).

Closes #6676
