### PR TITLE
fix(cron): open the store lock file without truncating it (#9266)

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -4809,19 +4809,20 @@ class CronService:
         self._guard_off_event_loop()
         self._dir.mkdir(parents=True, exist_ok=True)
         lock = self._dir / ".crons.lock"
-        fd = lock.open("w")
         deadline = time.monotonic() + timeout
-        try:
-            while not platform_compat.try_acquire_lock(fd.fileno(), exclusive=True):
+        # Non-truncating create-or-open (GH-9248): the old ``lock.open("w")``
+        # truncated before the acquire attempt, so on Windows a contending
+        # opener crashed with PermissionError at open() -- before the spin ever
+        # started. See platform_compat.open_lock_file / work_ledger._open_lock.
+        with platform_compat.open_lock_file(lock) as lock_fd:
+            while not platform_compat.try_acquire_lock(lock_fd, exclusive=True):
                 if time.monotonic() >= deadline:
                     raise CronStoreBusy(f"Could not acquire cron store lock within {timeout:g}s")
                 time.sleep(poll)
             try:
                 yield
             finally:
-                platform_compat.release_lock(fd.fileno())
-        finally:
-            fd.close()
+                platform_compat.release_lock(lock_fd)
 
     def _record_fingerprint(self) -> None:
         """Snapshot the store file's fingerprint as the last-loaded state.

--- a/test/test_cron_locking_regression.py
+++ b/test/test_cron_locking_regression.py
@@ -90,6 +90,32 @@ class TestFileLockNonBlocking:
         job = svc.add_job(name="j", message="m", every_secs=60)
         assert svc.get_job(job.id) is not None
 
+    def test_file_lock_open_does_not_truncate(self, tmp_path: Path) -> None:
+        """``_file_lock`` must open the lock file WITHOUT truncating it.
+
+        A truncating open (``"w"``) empties the lock file before the
+        ``try_acquire_lock`` spin ever runs. On Windows a truncating open of a
+        file whose first byte another holder has under ``msvcrt.locking``
+        raises a sharing violation (``PermissionError``) at ``open()`` time, so
+        a contending acquirer crashes instead of spinning until release; POSIX
+        ``flock`` tolerates it, hiding the defect on Linux. Seeding the file
+        and asserting the bytes survive a real acquire/release cycle fails on
+        EVERY platform if a truncating open comes back (same class as
+        ``work_ledger._open_lock``).
+
+        The seeded bytes are checked only AFTER release: ``msvcrt.locking`` is
+        a mandatory lock on byte 0, so reading the file while the lock is held
+        would itself raise ``PermissionError`` on Windows.
+        """
+        svc = CronService(base_dir=tmp_path)
+        svc._dir.mkdir(parents=True, exist_ok=True)
+        lock = svc._dir / ".crons.lock"
+        seed = b"seeded-lock-bytes"
+        lock.write_bytes(seed)
+        with svc._file_lock(timeout=1.0):
+            pass
+        assert lock.read_bytes() == seed, "lock file truncated at open()"
+
 
 # ── Bug 2: unlocked read paths racing the remove worker ──
 


### PR DESCRIPTION
## Summary

`CronService._file_lock` opened the cron store's `.crons.lock` sidecar with `lock.open("w")` and then spun on the non-blocking `platform_compat.try_acquire_lock`. `"w"` truncates at `open()` — before any acquire attempt. On Windows the acquire routes to `msvcrt.locking`, and a truncating open of a lock file whose first byte another holder has locked raises a sharing violation: the contending opener gets `PermissionError` at `open()` time, before the spin starts, instead of spinning until the holder releases. POSIX `flock` tolerates it, so the defect is invisible on Linux.

## Fix

Route the open through the existing GH-9248 helper `platform_compat.open_lock_file` (`O_RDWR | O_CREAT` in one syscall, never truncates, mode `0o644`) — the same shape already used by `session_pid.py`, `webhooks.py`, `mcp_tools/control.py` and the `aws_control` backends, and the same class as `work_ledger._open_lock` (#9237) and `_McpFileLock`. The `try_acquire_lock` spin, the `CronStoreBusy` deadline and the release path are unchanged. The shared-helper consolidation across remaining inline sites stays out of scope (#9267); no other lock site is touched.

## Test

`test/test_cron_locking_regression.py::TestFileLockNonBlocking::test_file_lock_open_does_not_truncate` seeds `.crons.lock` with bytes, drives a real acquire/release through `_file_lock`'s spin path, and asserts the seeded bytes survive after release. This fails on every platform (not just Windows) if a truncating open comes back. The survival check runs only after release, because `msvcrt.locking` is a mandatory lock on byte 0 and an in-context read would itself raise `PermissionError` on Windows.

## Pattern harvest

Rule candidate: extend the fleet-wide ratchet `test_no_lock_site_opens_truncating` — its acquire regex (`\b(file_lock|flock_exclusive|acquire_lock)\(`) misses `try_acquire_lock` sites, and its 2-line open/acquire window misses opens that sit a few lines above the acquire. Adding `try_acquire_lock` to the alternation and widening the window to ~5 lines would have caught this site (and any future revert) mechanically.

## Review

Two pre-push model-pinned review lanes: GPT lane PASS (0 findings), Opus lane PASS (0 blocking; its Medium finding — prefer the existing `open_lock_file` helper over a hand-rolled `touch()` + `open("r+")` — was adopted). The server-side GPT 5.6 lane's round-1 blocking finding (the in-context seed read would hit the mandatorily locked byte 0 on Windows) is fixed in this revision by asserting only after release.

Part of the #9248 sweep (umbrella stays open).

Closes #9266
