### PR TITLE
fix(chat): soft-wrap prose-tagged code fences instead of scrolling (#9199)

### DIFF
--- a/website/src/components/CodeBlock.tsx
+++ b/website/src/components/CodeBlock.tsx
@@ -18,6 +18,19 @@ import { useLanguageGeneration } from '../i18n/useLanguageGeneration'
  *  measures via ResizeObserver. */
 const TALL_CODE_BLOCK_PX = 480
 
+/** Fence tags whose content is prose, not source code. A markdown paragraph is
+ *  one long source line, so rendering it under `white-space: pre` turns every
+ *  paragraph into a horizontal scrub — these tags soft-wrap instead. The set
+ *  stays small and explicit: an unknown or missing tag is code and KEEPS the
+ *  horizontal scroll (that is the reported requirement, not an oversight). */
+const PROSE_LANGS = new Set(['markdown', 'md', 'text', 'txt', 'plaintext', 'plain'])
+const isProseLang = (lang?: string) => !!lang && PROSE_LANGS.has(lang.toLowerCase())
+
+/** Module constant so the options reference is stable across renders — Pierre
+ *  diffs options/files by reference first (same pattern as CMD_CODE_OPTIONS in
+ *  ToolDetails.tsx; the `file` object below is memoized for the same reason). */
+const PROSE_CODE_OPTIONS = { overflow: 'wrap' } as const
+
 /** The copy button, plus any caller-supplied actions (e.g. the pencil edit
  *  button), as one reusable row -- shared between the header and the footer
  *  duplicate so the two stay visually identical without a copy-pasted JSX
@@ -65,6 +78,7 @@ export const CodeBlock = memo(function CodeBlock(
   }
   const [contentRef, contentHeight] = useMeasuredHeight<HTMLDivElement>()
   const isTall = contentHeight > TALL_CODE_BLOCK_PX
+  const prose = isProseLang(lang)
   // Stable file identity per (code, lang): Pierre diffs options/files by
   // reference first, so a fresh object every render would force re-renders.
   const file = useMemo(() => ({ name: `snippet.${lang || 'txt'}`, contents: code }), [code, lang])
@@ -93,11 +107,14 @@ export const CodeBlock = memo(function CodeBlock(
       </div>
       {/* tabIndex=0 + role/label: a horizontally-scrollable region must be keyboard
           focusable so keyboard-only users can scroll it (axe scrollable-region-focusable).
-          The region role is a labelled landmark, so the tabIndex here is intentional. */}
+          The region role is a labelled landmark, so the tabIndex here is intentional.
+          A prose block no longer scrolls horizontally, but it keeps the focus stop:
+          conditioning tabIndex on the tag would move keyboard behavior with content
+          type, and a focusable non-scrolling region is harmless. */}
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
       <div ref={contentRef} className="pierre-surface scroll-fade" tabIndex={0} role="region" aria-label={lang ? `${lang} code` : 'code'}>
         {complete && highlighted ? (
-          <PierreCode file={file} langHint={lang} />
+          <PierreCode file={file} langHint={lang} options={prose ? PROSE_CODE_OPTIONS : undefined} />
         ) : (
           /* `pierre-plain` is what makes the swap a restyle instead of a reflow.
              The utilities here LOSE to `.msg-content pre` (two selectors beat one
@@ -108,8 +125,11 @@ export const CodeBlock = memo(function CodeBlock(
              every code block 12px taller than the Pierre surface it stands in
              for, so a row with three of them dropped 36px the moment its chunks
              resolved, moving a reader scrolling above it. This stand-in is the
-             real code text -- a queued block is readable, never a bare bar. */
-          <pre className="pierre-plain overflow-x-auto px-3 py-2 m-0"><code className="text-[13px] font-mono leading-5">{code}</code></pre>
+             real code text -- a queued block is readable, never a bare bar.
+             Prose tags wrap here too (mirrors PlainFilePairFallback's wraps
+             branch), so the stand-in and the highlighted surface agree on line
+             count and the swap stays a restyle in the prose case as well. */
+          <pre className={`pierre-plain ${prose ? 'whitespace-pre-wrap break-words' : 'overflow-x-auto'} px-3 py-2 m-0`}><code className="text-[13px] font-mono leading-5">{code}</code></pre>
         )}
         {!complete && <div className="px-3 pb-2 text-muted text-[12px] italic animate-pulse">{i18nT('components.codeBlock.generating')}</div>}
       </div>

--- a/website/src/test/CodeBlock.proseWrap.test.tsx
+++ b/website/src/test/CodeBlock.proseWrap.test.tsx
@@ -1,0 +1,105 @@
+// Feature: prose-tagged fences soft-wrap; code fences keep horizontal scroll.
+//
+// A fenced block tagged with a prose language (markdown, md, text, txt,
+// plaintext, plain) is a paragraph, and a paragraph is one long source line —
+// rendering it under `white-space: pre` turns every paragraph into a
+// horizontal scrub (#9199). The fix lives entirely in CodeBlock's two render
+// branches:
+//
+// 1. The highlighted branch passes `options={{ overflow: 'wrap' }}` to
+//    PierreCode for prose tags and `undefined` otherwise, so Pierre's own
+//    default (`overflow: 'scroll'` from PIERRE_CODE_DEFAULTS) still governs
+//    real source code.
+// 2. The plain <pre> stand-in swaps `overflow-x-auto` for
+//    `whitespace-pre-wrap break-words` on prose tags, mirroring the wraps
+//    branch of PlainFilePairFallback, so the stand-in and the highlighted
+//    surface agree on line count and the swap stays a restyle.
+//
+// The reporter is explicit that source-code fences must KEEP scrolling, so the
+// inverse assertions (ts stays scroll) are as load-bearing as the wrap ones.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import { CodeBlock } from '../components/CodeBlock'
+import { __resetStagingForTests } from '../components/pierreStaging'
+
+// Pierre's real chunk never resolves under vitest, so the mount is stubbed
+// (same pattern as CodeBlock.staging.test.tsx). The stub records the options
+// each mount received, which is the whole contract under test for the
+// highlighted branch.
+const pierreCalls: Array<{ options?: { overflow?: string } }> = []
+vi.mock('../pierre', () => ({
+  PierreCode: ({ file, options }: { file: { contents: string }; options?: { overflow?: string } }) => {
+    pierreCalls.push({ options })
+    return <div data-testid="pierre-mounted">{file.contents}</div>
+  },
+}))
+
+const LONG_LINE = 'A markdown paragraph is normally one long source line that would force a horizontal scrollbar under white-space: pre.'
+
+/** The plain stand-in <pre> of the fallback branch (complete={false}). */
+function renderFallbackPre(lang?: string) {
+  const { container } = render(<CodeBlock code={LONG_LINE} lang={lang} complete={false} />)
+  const pre = container.querySelector('pre')
+  expect(pre).not.toBeNull()
+  return pre as HTMLPreElement
+}
+
+describe('CodeBlock: prose fences wrap, code fences keep horizontal scroll', () => {
+  beforeEach(() => {
+    __resetStagingForTests()
+    pierreCalls.length = 0
+  })
+
+  describe('fallback branch (plain <pre> stand-in)', () => {
+    it('a markdown fence soft-wraps instead of scrolling', () => {
+      const pre = renderFallbackPre('markdown')
+      expect(pre.className).toContain('whitespace-pre-wrap')
+      expect(pre.className).toContain('break-words')
+      expect(pre.className).not.toContain('overflow-x-auto')
+    })
+
+    it('a ts fence keeps the horizontal scroll', () => {
+      const pre = renderFallbackPre('ts')
+      expect(pre.className).toContain('overflow-x-auto')
+      expect(pre.className).not.toContain('whitespace-pre-wrap')
+    })
+
+    it('the prose tag match is case-insensitive', () => {
+      const pre = renderFallbackPre('Markdown')
+      expect(pre.className).toContain('whitespace-pre-wrap')
+      expect(pre.className).not.toContain('overflow-x-auto')
+    })
+
+    it('a missing tag stays code (scroll)', () => {
+      const pre = renderFallbackPre(undefined)
+      expect(pre.className).toContain('overflow-x-auto')
+      expect(pre.className).not.toContain('whitespace-pre-wrap')
+    })
+
+    it('the wrap swap keeps the stand-in geometry classes', () => {
+      // The stand-in must keep matching Pierre's metrics so the highlight
+      // swap stays a restyle, not a reflow — only the overflow class changes.
+      const pre = renderFallbackPre('markdown')
+      for (const cls of ['pierre-plain', 'px-3', 'py-2', 'm-0']) {
+        expect(pre.className).toContain(cls)
+      }
+    })
+  })
+
+  describe('highlighted branch (PierreCode options)', () => {
+    it('a markdown fence passes overflow wrap to Pierre', () => {
+      render(<CodeBlock code={LONG_LINE} lang="markdown" complete />)
+      expect(pierreCalls.length).toBeGreaterThan(0)
+      expect(pierreCalls.at(-1)?.options).toEqual({ overflow: 'wrap' })
+    })
+
+    it('a ts fence passes no options, keeping Pierre default scroll', () => {
+      render(<CodeBlock code={LONG_LINE} lang="ts" complete />)
+      expect(pierreCalls.length).toBeGreaterThan(0)
+      expect(pierreCalls.at(-1)?.options).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

A chat fence tagged with a prose language (` ```markdown `, ` ```md `, ` ```text `, ` ```txt `, ` ```plaintext `) renders exactly like source code: `white-space: pre` plus a horizontal scrollbar. A markdown paragraph is one long source line. So every paragraph becomes a single horizontal run, and the reader has to scrub sideways to read each sentence (#9199).

## Why it matters

Agents post markdown-tagged fences constantly — drafts, commit messages, doc excerpts. Each one is unreadable without horizontal scrubbing. Sibling surfaces (tool detail cards, diff cards) already wrap prose via the shared renderer's `overflow` option, so the chat code card is the one surface left behind.

## What changed (motivation → approach → change)

The card has two render branches and neither consulted the language tag. The highlighted branch passed no `options` to `PierreCode`, so it inherited `PIERRE_CODE_DEFAULTS.overflow = 'scroll'`. The plain `<pre>` stand-in carried `overflow-x-auto` with default `white-space: pre`.

`CodeBlock.tsx` now has a small module-level prose predicate: `PROSE_LANGS` (markdown, md, text, txt, plaintext, plain), matched case-insensitively. An unknown or missing tag stays code and keeps the scroll — the reporter is explicit that source-code fences must not change.

Both branches use it. The highlighted branch passes `PROSE_CODE_OPTIONS = { overflow: 'wrap' }` (module constant, so the reference is stable and Pierre does not re-render — same pattern as `CMD_CODE_OPTIONS` in `ToolDetails.tsx`). The stand-in swaps `overflow-x-auto` for `whitespace-pre-wrap break-words`, mirroring `PlainFilePairFallback`'s wraps branch, and keeps `pierre-plain px-3 py-2 m-0` so the highlight swap stays a restyle. No CSS geometry rules changed, no toggle, no setting, no new strings.

One pre-existing edge left alone on purpose: `PlainCodeFallback` (Pierre's own Suspense/warm fallback) is hard-coded non-wrap, so a prose block can briefly show unwrapped while the Pierre chunk loads. Every existing wrap surface (e.g. tool detail cards) has the same transient; changing it is out of scope here.

## Tests

`website/src/test/CodeBlock.proseWrap.test.tsx` (vitest):
- fallback `<pre>`: markdown wraps (`whitespace-pre-wrap break-words`, no `overflow-x-auto`); ts keeps the scroll; `Markdown` matches case-insensitively; a missing tag stays code; the geometry classes survive the swap.
- highlighted branch (mocked `PierreCode`, same pattern as `CodeBlock.staging.test.tsx`): markdown receives `options={ overflow: 'wrap' }`; ts receives `undefined`.

## Manual verification

Rendered the real component in a browser (Vite dev + Chromium) and measured: the markdown surface has no horizontal scroller (content wrapped, surface 216px tall), the ts surface keeps its scroller (`scrollWidth` 1614 vs `clientWidth` 663). Screenshots below are from that run, uploaded as attachments (not committed).

## Screenshots / video

Before — the markdown paragraph is one horizontal run:

![before: markdown fence forces horizontal scroll](https://github.com/user-attachments/assets/2885663e-2b96-4761-8ebb-b54565352efa)

After — markdown wraps; the ts fence below it still scrolls:

![after: markdown fence wraps, ts fence keeps scroll](https://github.com/user-attachments/assets/64f36c38-7793-4c96-b359-d5ea0d23993f)

## Related Issues

Fixes #9199

## Pattern harvest

Rule candidate: review-prompt
Pattern: a shared renderer option (Pierre `overflow`) adopted by sibling surfaces but not audited across all call sites — when one surface gains a rendering option, list the remaining call sites that still use the default and decide each one deliberately.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, rendering-default fix, no doc covers fence overflow
- [x] No secrets, credentials, or internal references in the diff
