### PR TITLE
fix: match the expected profile ARN instead of taking the first listed (#10184)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
@@ -199,9 +199,12 @@ _MAX_BONUS_NAME_CHARS = 100
 # a few KB; 1 MB is comfortably above any real response.
 _MAX_RESP_BYTES = 1_000_000
 
-# Memoized account profile ARN (stable per account). Populated only from a
-# definitive ListAvailableProfiles 200 (the value may be None for individual
-# accounts); transient failures are never cached. See _list_profile_arn.
+# Memoized account profile ARN (stable per account). Keyed by
+# (token digest, expected-ARN digest) -- see _profile_cache_key -- so two probes
+# with the same token but different expected ARNs never serve each other's
+# answer. Populated only from a definitive ListAvailableProfiles 200 that
+# yielded an ARN; transient failures, empty lists, and anchored misses are
+# never cached. See _list_profile_arn.
 _PROFILE_ARN_CACHE: dict[str, str | None] = {}
 
 # Size cap for the two profile caches below. They are keyed by token digest and
@@ -577,22 +580,49 @@ def _read_capped(fp: object) -> str:
     return data.decode("utf-8", "replace")
 
 
-def _list_profile_arn(token: str, *, endpoint: str | None = None) -> str | None:
-    """Return the account's profile ARN, or None for non-enterprise accounts.
+def _profile_cache_key(token: str, expected_arn: str | None) -> str:
+    """Cache key for the profile caches: token digest + expected-ARN digest.
+
+    Keyed by BOTH so two probes with the same token but different expected
+    ARNs can never serve each other's answer — one memoized ARN per token
+    digest is what made a wrong first selection sticky for the process
+    lifetime. Never the raw token (control 5); the ARN is digested too so the
+    key shape stays uniform. A falsy anchor ("" or None) means "no question
+    asked" and maps to one shared key.
+    """
+    tok = hashlib.sha256(token.encode()).hexdigest()[:16]
+    anchor = hashlib.sha256((expected_arn or "").encode()).hexdigest()[:16]
+    return f"{tok}:{anchor}"
+
+
+def _list_profile_arn(
+    token: str, *, expected_arn: str | None = None, endpoint: str | None = None
+) -> str | None:
+    """Return the profile ARN this token should use, or None.
 
     Enterprise/IdC accounts (KIRO POWER etc.) must pass ``profileArn`` to
     GetUsageLimits or it returns 403 FEATURE_NOT_SUPPORTED.
 
-    The ARN is account-stable per token, so a found ARN is memoized in
-    ``_PROFILE_ARN_CACHE`` keyed by a token digest (never the token itself) to
-    save one RTS round-trip per refresh. Two things are deliberately NOT
-    cached: transient failures (network error, non-200), and a 200 with no
-    profiles — an empty list can be post-login propagation lag on an
-    enterprise account, so pinning arn=None would strand that account on the
-    text fallback until restart. Both are re-probed on the next refresh, and
-    each candidate token is probed for its own account (no cross-token reuse).
+    ``expected_arn`` is the question being asked: when supplied, the answer
+    is that ARN if it is present in THIS token's own ListAvailableProfiles
+    list, else None. Presence in the token's own list is what proves the
+    credential belongs to the signed-in account — position proves nothing,
+    because a token entitled to several profiles returns them in an order the
+    caller does not control. When no anchor is supplied (source-anchored
+    mode) the first entry carrying an ARN is the answer.
+
+    The answer is account-stable per (token, question), so a found ARN is
+    memoized in ``_PROFILE_ARN_CACHE`` keyed by :func:`_profile_cache_key`
+    (never the token itself) to save one RTS round-trip per refresh. Three
+    things are deliberately NOT cached: transient failures (network error,
+    non-200), a 200 with no profiles, and an anchored miss (expected ARN
+    absent from the list) — an empty or incomplete list can be post-login
+    propagation lag on an enterprise account, so pinning the miss would
+    strand that account on the text fallback until restart. All are re-probed
+    on the next refresh, and each candidate token is probed for its own
+    account (no cross-token reuse).
     """
-    key = hashlib.sha256(token.encode()).hexdigest()[:16]
+    key = _profile_cache_key(token, expected_arn)
     if key in _PROFILE_ARN_CACHE:
         return _PROFILE_ARN_CACHE[key]
     try:
@@ -616,15 +646,19 @@ def _list_profile_arn(token: str, *, endpoint: str | None = None) -> str | None:
         if not isinstance(p, dict):
             continue
         candidate = p.get("arn") or p.get("profileArn")
-        if candidate:
-            arn = candidate
-            # Human label for the signed-in account. Bounded like the plan name
-            # so a hostile/oversized value can't reach the cache/UI unbounded;
-            # only a non-empty string qualifies.
-            pname = p.get("profileName") or p.get("profileDisplayName")
-            if isinstance(pname, str) and pname:
-                name = pname[:100]
-            break
+        if not candidate:
+            continue
+        if expected_arn and candidate != expected_arn:
+            # Anchored mode: only the asked-about profile is an answer.
+            continue
+        arn = candidate
+        # Human label for the signed-in account. Bounded like the plan name
+        # so a hostile/oversized value can't reach the cache/UI unbounded;
+        # only a non-empty string qualifies.
+        pname = p.get("profileName") or p.get("profileDisplayName")
+        if isinstance(pname, str) and pname:
+            name = pname[:100]
+        break
     if arn is not None:
         _remember_profile(key, arn, name)
     return arn
@@ -648,14 +682,15 @@ def _remember_profile(key: str, arn: str, name: str | None) -> None:
     _PROFILE_NAME_CACHE[key] = name
 
 
-def _account_name(token: str) -> str | None:
+def _account_name(token: str, expected_arn: str | None = None) -> str | None:
     """Return the cached profile display name for ``token``, or None.
 
     Populated as a side effect of :func:`_list_profile_arn`; this getter never
     issues a request itself, so the ARN probe must have run first (it always
-    does in ``fetch_usage_limits``). Keyed by the same token digest (never the
-    token itself)."""
-    return _PROFILE_NAME_CACHE.get(hashlib.sha256(token.encode()).hexdigest()[:16])
+    does in ``fetch_usage_limits``), and ``expected_arn`` must be the same
+    anchor that probe was asked about. Keyed by :func:`_profile_cache_key`
+    (never the token itself)."""
+    return _PROFILE_NAME_CACHE.get(_profile_cache_key(token, expected_arn))
 
 
 def _bounded(value: object) -> float | None:
@@ -899,14 +934,18 @@ def fetch_usage_limits(expected_arn: str | None) -> dict | None:
                     "kiro-cli's own auth store"
                 )
                 continue
-            arn = _list_profile_arn(token, endpoint=endpoint)
+            arn = _list_profile_arn(token, expected_arn=expected_arn, endpoint=endpoint)
             if expected_arn and (not arn or arn != expected_arn):
-                # ARN-anchored mode: not provably the signed-in account. Skip
-                # WITHOUT calling GetUsageLimits. A null ``arn`` is rejected rather
-                # than compared, because None carries no identity — it is what a
-                # transient profile lookup returns AND what every profile-less
-                # account returns, so comparing it would match one account's
-                # leftover credential against a different one.
+                # ARN-anchored mode: the expected profile is genuinely absent
+                # from this token's own profile list (or the probe failed), so
+                # nothing proves the credential belongs to the signed-in
+                # account. Skip WITHOUT calling GetUsageLimits. The probe was
+                # asked about ``expected_arn`` and answers with that ARN or
+                # None; a null answer is rejected rather than compared, because
+                # None carries no identity — it is what a transient profile
+                # lookup returns AND what every profile-less account returns,
+                # so comparing it would match one account's leftover credential
+                # against a different one.
                 #
                 # ARNs are not secret, but they identify an account, so only the
                 # outcome is logged.
@@ -941,7 +980,7 @@ def fetch_usage_limits(expected_arn: str | None) -> dict | None:
                 # Tag the usage with WHO the plan belongs to (profile display
                 # name from the ListAvailableProfiles probe above). Absent for
                 # individual Builder ID accounts, which have no profile.
-                account = _account_name(token)
+                account = _account_name(token, expected_arn)
                 if account:
                     mapped["account"] = account
                 # Coupling metadata for the caller's identity check (private —

--- a/test/test_kiro_usage_api.py
+++ b/test/test_kiro_usage_api.py
@@ -1249,3 +1249,137 @@ class TestTokenStoreSensitivePath:
                 # The DB and its WAL/SHM/journal sidecars must all be sensitive.
                 assert is_sensitive_path(str(home / base / app / "data.sqlite3"))
                 assert is_sensitive_path(str(home / base / app / "data.sqlite3-wal"))
+
+
+class TestExpectedArnSelection:
+    """The profile probe answers a question ("is the signed-in profile in this
+    token's list?"), never a position ("what is first?").
+
+    The failure mode being locked out: taking the FIRST entry carrying an
+    ARN means that, for a token entitled to two or more profiles, whether the
+    credit pill works depends on the order the upstream API happens to
+    return — the signed-in profile can be present in the list and never asked
+    about. A one-answer-per-token memo then makes that wrong selection sticky
+    for the process lifetime.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_arn_cache(self):
+        api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
+        yield
+        api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
+
+    ARN_A = "arn:aws:codewhisperer:us-east-1:1:profile/A"
+    ARN_B = "arn:aws:codewhisperer:us-east-1:2:profile/B"
+    USAGE = {"usageBreakdownList": [
+        {"resourceType": "CREDIT", "currentUsage": 1200.0, "usageLimit": 10000.0}]}
+
+    def _post_two_profiles(self, token, target, payload, **_kwargs):
+        # The signed-in profile (A) is SECOND — exactly the reporter's shape.
+        if target == api._TARGET_LIST_PROFILES:
+            return _resp(200, {"profiles": [
+                {"arn": self.ARN_B, "profileName": "Other Org"},
+                {"arn": self.ARN_A, "profileName": "My Org"}]})
+        return _resp(200, self.USAGE)
+
+    def test_expected_arn_second_in_list_is_matched(self):
+        # THE bug: a signed-in profile that is present but not first must still
+        # be found, and the pill must show real usage instead of degrading.
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
+             patch.object(api, "_post", side_effect=self._post_two_profiles):
+            out = api.fetch_usage_limits(expected_arn=self.ARN_A)
+        assert out is not None, "credential declined although the signed-in profile is listed"
+        assert out["_profile_arn"] == self.ARN_A
+        assert out["credits_used"] == 1200.0
+
+    def test_matched_profile_name_rides_along(self):
+        # The ``account`` label must be the MATCHED profile's name, not the
+        # first entry's — a wrong label attributes the credits to another org.
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
+             patch.object(api, "_post", side_effect=self._post_two_profiles):
+            out = api.fetch_usage_limits(expected_arn=self.ARN_A)
+        assert out is not None
+        assert out.get("account") == "My Org"
+
+    def test_expected_arn_absent_declines_the_credential(self):
+        # A multi-profile list WITHOUT the expected ARN proves nothing: the
+        # credential must be declined without spending a GetUsageLimits call —
+        # presence is the proof, and mere listing of OTHER profiles is not.
+        seen: list[str] = []
+
+        def recording(token, target, payload, **_kwargs):
+            seen.append(target)
+            if target == api._TARGET_LIST_PROFILES:
+                return _resp(200, {"profiles": [
+                    {"arn": self.ARN_B}, {"arn": "arn:other"}]})
+            return _resp(200, self.USAGE)
+
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
+             patch.object(api, "_post", side_effect=recording):
+            assert api.fetch_usage_limits(expected_arn=self.ARN_A) is None
+        assert api._TARGET_GET_USAGE not in seen
+
+    def test_single_profile_path_unchanged(self):
+        def fake_post(token, target, payload, **_kwargs):
+            if target == api._TARGET_LIST_PROFILES:
+                return _resp(200, {"profiles": [{"arn": self.ARN_A}]})
+            return _resp(200, self.USAGE)
+
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
+             patch.object(api, "_post", side_effect=fake_post):
+            out = api.fetch_usage_limits(expected_arn=self.ARN_A)
+        assert out is not None
+        assert out["_profile_arn"] == self.ARN_A
+
+    def test_no_expected_arn_keeps_first_with_arn(self):
+        # Source-anchored mode asks no question, so the first entry carrying an
+        # ARN is still the answer (the provenance check is the proof there).
+        with patch.object(api, "_post", side_effect=self._post_two_profiles):
+            assert api._list_profile_arn("tok") == self.ARN_B
+
+    def test_warm_cache_does_not_cross_expectations(self):
+        # Two probes with the same token and different expected ARNs must not
+        # return each other's answer: one memoized ARN per token digest made
+        # the wrong first selection sticky for the process lifetime.
+        with patch.object(api, "_candidate_tokens", return_value=[_cand("tok")]), \
+             patch.object(api, "_post", side_effect=self._post_two_profiles):
+            first = api.fetch_usage_limits(expected_arn=self.ARN_B)
+            second = api.fetch_usage_limits(expected_arn=self.ARN_A)
+        assert first is not None
+        assert first["_profile_arn"] == self.ARN_B
+        assert second is not None, "warm cache served the other expectation's answer"
+        assert second["_profile_arn"] == self.ARN_A
+
+    def test_name_cache_keyed_with_the_arn_it_belongs_to(self):
+        # The co-cached display name must follow the same composite key, so an
+        # account label can never be served for a different expectation.
+        with patch.object(api, "_post", side_effect=self._post_two_profiles):
+            assert api._list_profile_arn("tok", expected_arn=self.ARN_A) == self.ARN_A
+            assert api._list_profile_arn("tok", expected_arn=self.ARN_B) == self.ARN_B
+        assert api._account_name("tok", self.ARN_A) == "My Org"
+        assert api._account_name("tok", self.ARN_B) == "Other Org"
+
+    def test_anchored_miss_is_not_cached(self):
+        # An absent expected ARN may be post-login propagation lag; the next
+        # refresh must re-probe rather than serve a pinned miss.
+        with patch.object(api, "_post",
+                          return_value=_resp(200, {"profiles": [{"arn": self.ARN_B}]})):
+            assert api._list_profile_arn("tok", expected_arn=self.ARN_A) is None
+        with patch.object(api, "_post", side_effect=self._post_two_profiles) as mp:
+            assert api._list_profile_arn("tok", expected_arn=self.ARN_A) == self.ARN_A
+        assert mp.call_count == 1
+
+    def test_anchored_match_is_memoized(self):
+        # The composite key still saves the round-trip on the SAME question.
+        with patch.object(api, "_post", side_effect=self._post_two_profiles) as mp:
+            assert api._list_profile_arn("tok", expected_arn=self.ARN_A) == self.ARN_A
+            assert api._list_profile_arn("tok", expected_arn=self.ARN_A) == self.ARN_A
+        assert mp.call_count == 1
+
+    def test_empty_anchor_behaves_as_no_anchor_in_probe(self):
+        # A falsy anchor means "no question asked" — first-with-ARN, matching
+        # fetch_usage_limits' own truthiness convention for expected_arn.
+        with patch.object(api, "_post", side_effect=self._post_two_profiles):
+            assert api._list_profile_arn("tok", expected_arn="") == self.ARN_B


### PR DESCRIPTION
## Problem / Motivation

The dashboard credit pill goes unavailable for an account that has a plan, whenever the signed-in token can list more than one profile. The gateway log shows the usage API degrading to the text-scrape fallback with "no candidate credential proved it belongs to the signed-in profile" — while a direct GetUsageLimits call with the same token and the same active profile returns 200 with a full payload.

## Why it matters

Every multi-profile enterprise account is one upstream list reordering away from losing the real usage figure. Whether the pill works depends on the order ListAvailableProfiles happens to return, not on whether the signed-in profile is present. Single-profile tokens make "first" trivially correct, which is why the defect stayed hidden.

## What changed (motivation → approach → change)

The profile probe answered a position, not a question. `_list_profile_arn` returned the FIRST list entry carrying an ARN, and `fetch_usage_limits` then required that one value to equal the signed-in profile's ARN — so a token entitled to two profiles was declined whenever the signed-in profile came back second, without GetUsageLimits ever being asked.

The probe now takes the question with it. `_list_profile_arn` accepts `expected_arn` and answers with that ARN when it is present anywhere in the token's own list, else `None`; presence in the token's own list is the ownership proof the module's docstring requires, and position never was. With no anchor supplied (the source-anchored, provenance-proven path) the first entry carrying an ARN is still the answer, so single-profile and Builder ID accounts behave exactly as they did. A credential is declined only when the expected profile is genuinely absent from its list, and that absence is never cached — like the empty-list case, it can be post-login propagation lag.

The memo moves from one-ARN-per-token-digest to a `(token digest, expected-ARN digest)` key (`_profile_cache_key`), because the old key made a wrong first selection sticky for the process lifetime — a warm cache would have defeated the selection fix on its own. The co-cached display name follows the same key, `_remember_profile` still evicts both caches together under the `_PROFILE_CACHE_MAX` insertion-order cap, and no raw token or ARN ever appears in a key or a log line.

| case | Before | After |
|---|---|---|
| expected ARN is first in the token's list | 🟦 accepted | 🟦 accepted |
| expected ARN is second of two | 🟥 declined, pill unavailable | 🟩 accepted, real usage shown |
| expected ARN absent from the list | 🟦 declined | 🟦 declined |
| no expected ARN (source-anchored path) | 🟦 first-with-ARN | 🟦 first-with-ARN |
| same token probed for two different ARNs | 🟥 second probe served the first's cached answer | 🟩 each expectation answered independently |

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The probe now says whether the signed-in profile is in the token's list; which profile happens to be listed first no longer decides anything.*

## Tests

`TestExpectedArnSelection` (10 tests) locks in: the expected ARN being second of two is matched and the pill shows real usage (red before the fix); the matched profile's display name — not the first entry's — becomes the `account` label; an absent expected ARN declines the credential without spending a GetUsageLimits call; the single-profile and no-anchor paths are unchanged; two probes with the same token and different expected ARNs never serve each other's answer (red before the fix); an anchored miss is re-probed rather than pinned; an anchored match is still memoized; an empty-string anchor behaves as no anchor. Red-before proven mechanically with the prepare-pr `prove.py` harness (production hunks reverted, new tests fail).

## Manual verification

N/A — the RTS API interaction is fully mocked at `_post` and the selection/cache logic is pure; unit coverage exercises every branch the diff touches.

## Related Issues

Closes #10184

## Pattern harvest

Rule candidate: review-prompt
Pattern: probe returns first-matching element instead of being told which element the caller is asking about ("position, not answer"), plus a memo keyed narrower than the question it caches.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
