### PR TITLE
fix(knowledge): finalize sync_status on cancellation in ingest handlers

### DIFF
--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -992,6 +992,72 @@ def _set_sync_status(store, source_id: str, status: str) -> None:
     store.db.commit()
 
 
+def _finalize_sync_status_write(
+    store, source_id: str, status: str, from_statuses: tuple[str, ...] = ("syncing",)  # type: ignore[no-untyped-def]
+) -> bool:
+    """CAS a terminal state over a row still mid-sync, in one off-loop take.
+
+    Compare-and-set for the reason ``_finalize_job`` documents: the terminal
+    paths race. A shutdown cancel can be delivered to the coroutine after the
+    success write's worker already committed 'synced', and a blind second
+    write would stamp 'error' over the state the work actually reached. Only
+    a row still in one of *from_statuses* is moved, so the loser's write
+    lands on nothing. The upload path passes ('syncing', 'pending') because a
+    cancel can land before its best-effort 'syncing' stamp, while the freshly
+    inserted row still reads the INSERT default 'pending'.
+    """
+    marks = ", ".join("?" for _ in from_statuses)
+    cur = store.db.execute(
+        f"UPDATE sources SET sync_status = ? WHERE id = ? AND sync_status IN ({marks})",
+        (status, source_id, *from_statuses))
+    store.db.commit()
+    return cur.rowcount > 0
+
+
+async def _finalize_sync_status(
+    store, source_id: str, status: str, from_statuses: tuple[str, ...] = ("syncing",)  # type: ignore[no-untyped-def]
+) -> None:
+    """Write a terminal ``sync_status`` from a finalizer, and never raise.
+
+    Runs inside an ``except BaseException`` arm, so an exception escaping here
+    would mask the original one -- a failed DB write is logged and dropped
+    instead. A re-cancel can interrupt the ``await`` before the worker returns;
+    a worker already RUNNING completes, so a write in flight still lands (only
+    a re-cancel that arrives before the executor picks the item up can drop
+    it). Suppressing the re-cancel keeps the caller's original exception
+    current for its bare ``raise`` (the same shape as
+    ``_rebuild_embeddings_job``'s finalize).
+    """
+    try:
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.to_thread(
+                _finalize_sync_status_write, store, source_id, status, from_statuses)
+    except Exception:
+        logger.exception(
+            "Could not finalize sync_status=%r for source %s", status, source_id)
+
+
+async def _write_status_cancel_safe(store, source_id: str, status: str) -> None:  # type: ignore[no-untyped-def]
+    """Write *status* so that a cancel cannot strand the row at 'syncing'.
+
+    An exception raised INSIDE an ``except`` arm is not caught by its sibling
+    arms, so a cancel delivered during a status write made from one (the
+    budget-deferral 'pending' writes) would otherwise propagate with the row
+    still 'syncing'. The worker also outlives the cancel, so it is drained
+    first; whatever it landed, the CAS finalize then moves only a row still
+    'syncing' -- a landed write leaves it nothing to do -- and the cancel is
+    re-raised.
+    """
+    write = asyncio.ensure_future(asyncio.to_thread(_set_sync_status, store, source_id, status))
+    try:
+        await asyncio.shield(write)
+    except asyncio.CancelledError:
+        with contextlib.suppress(BaseException):
+            await write
+        await _finalize_sync_status(store, source_id, "error")
+        raise
+
+
 def _claim_sync(store, source_id: str) -> bool:
     """Move a source into 'syncing' and report whether THIS call won it.
 
@@ -1364,9 +1430,21 @@ async def _ingest_local_file_task(  # type: ignore[no-untyped-def]
     (``sync_source``) waits on it, so the orphan sweep cannot take an itemless
     row in a terminal status between that caller's read and the claim here.
     """
+    claim = asyncio.ensure_future(asyncio.to_thread(_claim_sync, store, source_id))
     try:
         try:
-            claimed = await asyncio.to_thread(_claim_sync, store, source_id)
+            claimed = await asyncio.shield(claim)
+        except asyncio.CancelledError:
+            # A cancel here does not stop the worker: the thread runs to
+            # completion and can still commit 'syncing' after this task is
+            # gone -- the same strand the work sites below close. Wait for the
+            # thread's answer and finalize only a claim THIS task won; a lost
+            # claim is a sibling sync's row. Everything is suppressed because
+            # a finalizer must never replace the cancellation.
+            with contextlib.suppress(BaseException):
+                if await claim:
+                    await _finalize_sync_status(store, source_id, "error")
+            raise
         except Exception:
             # Failing to TAKE the work is not the work failing. 'error' is terminal --
             # sync_all skips an errored row on every sweep -- so stamping it for a
@@ -1398,10 +1476,24 @@ async def _ingest_local_file_task(  # type: ignore[no-untyped-def]
         # keeps 'pending' off an upload, whose only copy is the unlinked temp file.
         # SyncScheduler.sync_source treats this exception the same way.
         logger.warning("Ingestion deferred by import budget for %s: %s", path, exc)
-        await asyncio.to_thread(_set_sync_status, store, source_id, "pending")
-    except Exception:
-        logger.exception("Background ingestion failed for %s", path)
-        await asyncio.to_thread(_set_sync_status, store, source_id, "error")
+        await _write_status_cancel_safe(store, source_id, "pending")
+    except BaseException as exc:
+        # CancelledError is a BaseException in 3.8+, so an ``except Exception``
+        # arm lets a shutdown cancel skip finalization and strand the row at
+        # 'syncing' -- every later sync then answers 409 with no recovery. A
+        # cancelled sync lands in 'error' like any other incomplete sync (no
+        # new status value: the settings UI and the watcher read this column),
+        # and the cancellation is re-raised so task semantics are preserved --
+        # shutdown drains ``_bg_tasks`` by cancelling them. The shape follows
+        # ``_rebuild_embeddings_job``, this file's precedent.
+        is_cancel = isinstance(exc, asyncio.CancelledError)
+        if is_cancel:
+            logger.debug("Background ingestion cancelled for %s", path)
+        else:
+            logger.exception("Background ingestion failed for %s", path)
+        await _finalize_sync_status(store, source_id, "error")
+        if is_cancel:
+            raise
 
 
 async def _hand_off_under_gate(  # type: ignore[no-untyped-def]
@@ -1521,9 +1613,21 @@ async def _background_agent_sync(  # type: ignore[no-untyped-def]
     the claim is atomic and the task owns both ends of the row's lifecycle.
     *claim_settled* is set once the claim is decided (see that task).
     """
+    claim = asyncio.ensure_future(asyncio.to_thread(_claim_sync, store, source_id))
     try:
         try:
-            claimed = await asyncio.to_thread(_claim_sync, store, source_id)
+            claimed = await asyncio.shield(claim)
+        except asyncio.CancelledError:
+            # A cancel here does not stop the worker: the thread runs to
+            # completion and can still commit 'syncing' after this task is
+            # gone -- the same strand the work sites below close. Wait for the
+            # thread's answer and finalize only a claim THIS task won; a lost
+            # claim is a sibling sync's row. Everything is suppressed because
+            # a finalizer must never replace the cancellation.
+            with contextlib.suppress(BaseException):
+                if await claim:
+                    await _finalize_sync_status(store, source_id, "error")
+            raise
         except Exception:
             # Failing to TAKE the work is not the work failing. 'error' is terminal --
             # sync_all skips an errored row on every sweep -- so stamping it for a
@@ -1559,10 +1663,18 @@ async def _background_agent_sync(  # type: ignore[no-untyped-def]
         logger.warning(
             "Agent sync deferred by import budget: source=%s url=%s: %s", source_id, url, exc
         )
-        await asyncio.to_thread(_set_sync_status, store, source_id, "pending")
-    except Exception:
-        logger.exception("Agent sync failed: source=%s url=%s", source_id, url)
-        await asyncio.to_thread(_set_sync_status, store, source_id, "error")
+        await _write_status_cancel_safe(store, source_id, "pending")
+    except BaseException as exc:
+        # ``except BaseException`` for the reason _ingest_local_file_task
+        # documents: a cancel must not strand the row at 'syncing'.
+        is_cancel = isinstance(exc, asyncio.CancelledError)
+        if is_cancel:
+            logger.debug("Agent sync cancelled: source=%s url=%s", source_id, url)
+        else:
+            logger.exception("Agent sync failed: source=%s url=%s", source_id, url)
+        await _finalize_sync_status(store, source_id, "error")
+        if is_cancel:
+            raise
 
 
 async def delete_source(request: web.Request) -> web.Response:
@@ -1842,7 +1954,11 @@ async def ingest_text(request: web.Request) -> web.Response:
             tmp.close()
             job_id = await pipeline.ingest_file(tmp.name, original_name=name,
                                                 namespace=namespace, source_id=source_id)
-            # Update source status
+            # Update source status. INVARIANT: the 'synced' write and the
+            # source.ingest_text audit ride in ONE worker take (_audited_write),
+            # with no await between them -- that is what makes the audit
+            # un-skippable by a cancellation. Do not split them or move one
+            # off-loop on its own.
             await _audited_write(
                 partial(_set_sync_status, store, source_id, "synced"),
                 event="source.ingest_text", fields={"source_id": source_id, "name": name})
@@ -1854,7 +1970,19 @@ async def ingest_text(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": str(exc), "code": "import_budget_exceeded"},
                 status=429)
-        except Exception:
+        except BaseException as exc:
+            # ``except BaseException`` so a cancel is seen and re-raised (task
+            # semantics), but this handler writes NO terminal status: it holds
+            # no claim, so a row reading 'syncing' here belongs to the sync
+            # task that requested this text, and that task's own finalizer
+            # clears it (a shutdown cancels every ``_bg_tasks`` member, this
+            # handler's caller included). Stamping 'error' from here would
+            # steal a live sibling claim and admit a concurrent replacement
+            # ingest. Non-cancel failures keep the existing 500 body.
+            is_cancel = isinstance(exc, asyncio.CancelledError)
+            if is_cancel:
+                logger.debug("Agent ingest_text cancelled for source %s", source_id)
+                raise
             logger.exception("Agent ingest_text failed for source %s", source_id)
             return web.json_response({"error": "internal server error"}, status=500)
         finally:
@@ -2085,8 +2213,20 @@ async def ingest_file(request: web.Request) -> web.Response:
                     # was already told 'processing'. ingest_file stamps the terminal
                     # status itself on both its paths (ingestion.py:1128 / 1144), so a
                     # skipped stamp costs a UI hint and heals on its own.
+                    stamp = asyncio.ensure_future(
+                        asyncio.to_thread(_set_sync_status, store, src_id, "syncing"))
                     try:
-                        await asyncio.to_thread(_set_sync_status, store, src_id, "syncing")
+                        await asyncio.shield(stamp)
+                    except asyncio.CancelledError:
+                        # The stamp's worker outlives a cancel and can commit
+                        # 'syncing' AFTER the outer arm's CAS finalize ran,
+                        # which would re-strand the row. Drain it, then
+                        # re-raise so the outer arm finalizes a stamp that has
+                        # actually landed -- the same shield-and-drain the
+                        # claim takes use.
+                        with contextlib.suppress(BaseException):
+                            await stamp
+                        raise
                     except Exception:
                         # The row id, not the filename: an upload's name is
                         # client-supplied and can carry a secret, and the row is what
@@ -2103,7 +2243,7 @@ async def ingest_file(request: web.Request) -> web.Response:
                         count_toward_import_budget=False,
                         import_budget_token=budget_token,
                     )
-            except Exception:
+            except BaseException as exc:
                 # No dedicated ImportChunkBudgetError branch here, and none is
                 # reachable from the front door: admission was reserved above, so
                 # an exhausted window answered 429 before this task existed and
@@ -2113,16 +2253,34 @@ async def ingest_file(request: web.Request) -> web.Response:
                 # unlinks, and an upload:// source has no re-fetchable URI, so
                 # unlike the local_file / agent-url paths there is nothing to
                 # retry from and 'pending' would promise one.
-                logger.exception("Background ingestion failed for %s", filename)
+                # ``except BaseException`` for the reason _ingest_local_file_task
+                # documents: a cancel must not strand the row at 'syncing'.
+                is_cancel = isinstance(exc, asyncio.CancelledError)
+                if is_cancel:
+                    logger.debug("Background ingestion cancelled for %s", src_id)
+                else:
+                    logger.exception("Background ingestion failed for %s", filename)
+                # ('syncing', 'pending'): a cancel can land before this path's
+                # best-effort 'syncing' stamp -- during the source re-read --
+                # while a freshly inserted row still reads the INSERT default
+                # 'pending'. A committed 'synced' is still never overwritten.
                 # The re-read above sits between reserving the admission and
                 # handing it to ingest_file, so a failure there leaves the
                 # reservation open and its placeholder stranded in the window
                 # for the process lifetime. Release is a no-op once ingest_file
                 # has taken the token (its own finally settles or releases it),
-                # so this is safe on every path through the try. First, before
-                # the status stamp: that write can itself raise on a contended
-                # lock and must not skip the reclaim.
+                # so this is safe on every path through the try -- the cancel
+                # path included. First, before the status write: that write
+                # must not skip the reclaim.
                 pipeline.release_import_budget(budget_token)
+                if is_cancel:
+                    await _finalize_sync_status(
+                        store, src_id, "error", from_statuses=("syncing", "pending"))
+                    raise
+                # Unconditional, NOT the CAS: this path's 'syncing' stamp is
+                # best-effort, so a failed stamp co-occurring with a failed
+                # ingest would leave the CAS nothing to move and the row
+                # holding a stale prior status over a deleted upload.
                 await asyncio.to_thread(_set_sync_status, store, src_id, "error")
             finally:
                 Path(tmp_path).unlink(missing_ok=True)

--- a/test/test_knowledge_handlers_off_loop.py
+++ b/test/test_knowledge_handlers_off_loop.py
@@ -43,7 +43,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 from aiohttp import web
-from aiohttp.test_utils import TestClient, TestServer
+from aiohttp.test_utils import TestClient, TestServer, make_mocked_request
 
 from kiro_crew._sqlite_compat import sqlite3
 from kiro_crew.dashboard.handlers import knowledge as kh
@@ -1034,3 +1034,387 @@ class TestOnlyTheFinalizeThatLandedIsAudited:
 def _props(store, source_id: str) -> dict:
     row = store.db.execute("SELECT properties FROM sources WHERE id = ?", (source_id,)).fetchone()
     return json.loads(row["properties"]) if row["properties"] else {}
+
+
+class TestCancellationFinalizesSyncStatus:
+    """A cancel must never strand a source at 'syncing'.
+
+    ``CancelledError`` is a ``BaseException`` (3.8+), so a finalizer guarded by
+    ``except Exception`` lets a shutdown cancel skip the terminal
+    ``sync_status`` write -- the row stays 'syncing' and every later sync
+    answers 409 forever. Each path must land the row in 'error' (the existing
+    terminal vocabulary; a cancelled sync presents like a failed one) and
+    RE-RAISE, because aiohttp shutdown drains ``_bg_tasks`` by cancelling them
+    and swallowing the cancel would break task semantics. The shape mirrors
+    ``_rebuild_embeddings_job``, the file's own precedent.
+    """
+
+    @staticmethod
+    async def _wait_until(predicate, timeout: float = 5.0) -> None:
+        for _ in range(int(timeout / 0.01)):
+            if predicate():
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError("condition never became true")
+
+    @pytest.mark.asyncio
+    async def test_cancelled_local_file_ingest_lands_in_error(self, store, tmp_path):
+        source_id = await asyncio.to_thread(_seed_source, store)
+        doc = tmp_path / "doc.md"
+        doc.write_text("# hi\n")
+        started = asyncio.Event()
+
+        async def _hang(*_a, **_k):
+            started.set()
+            await asyncio.Event().wait()
+
+        pipeline = MagicMock(ingest_file=AsyncMock(side_effect=_hang))
+        task = asyncio.ensure_future(
+            kh._ingest_local_file_task(pipeline, store, str(doc), source_id)
+        )
+        await asyncio.wait_for(started.wait(), 5.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "error"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_agent_sync_lands_in_error(self, store, monkeypatch):
+        source_id = await asyncio.to_thread(_seed_source, store)
+        started = asyncio.Event()
+
+        async def _hang_fetch(_url, _pool):
+            started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(kh, "fetch_url_content", _hang_fetch)
+        task = asyncio.ensure_future(
+            kh._background_agent_sync(
+                source_id, "https://example.com/x", "x", store, MagicMock(), MagicMock()
+            )
+        )
+        await asyncio.wait_for(started.wait(), 5.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "error"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_upload_ingest_lands_in_error(self, store, monkeypatch):
+        monkeypatch.setattr(kh, "_sel_log", lambda tool, **kw: None)
+        started = asyncio.Event()
+
+        async def _hang_ingest(_tmp_path, **_kw):
+            started.set()
+            await asyncio.Event().wait()
+
+        pipeline = MagicMock(
+            ingest_file=AsyncMock(side_effect=_hang_ingest),
+            reserve_import_budget=AsyncMock(return_value=None),
+            release_import_budget=MagicMock(),
+        )
+        app = _make_app(store, pipeline=pipeline)
+        async with TestClient(TestServer(app)) as client:
+            form = aiohttp.FormData()
+            form.add_field("file", b"# hello\n", filename="notes.md", content_type="text/markdown")
+            resp = await client.post("/api/knowledge/ingest", data=form)
+            assert resp.status == 200, await resp.text()
+            source_id = (await resp.json())["source_id"]
+            await asyncio.wait_for(started.wait(), 5.0)
+            task = next(t for t in app["_bg_tasks"] if not t.done())
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert await asyncio.to_thread(_sync_status, store, source_id) == "error"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_ingest_text_reraises_and_leaves_the_claim_alone(
+        self, store, monkeypatch
+    ):
+        """The handler variant: the cancel propagates (aiohttp owns it) but the
+        row is NOT finalized here -- a 'syncing' row belongs to the sync task
+        that requested this text, and that task's own finalizer clears it."""
+        source_id = await asyncio.to_thread(_seed_source, store)
+        await asyncio.to_thread(_set_status, store, source_id, "syncing")
+        pipeline = MagicMock(ingest_file=AsyncMock(side_effect=asyncio.CancelledError()))
+        app = _make_app(store, pipeline=pipeline)
+
+        async def _body(_request, max_bytes=None, **_kw):
+            return {"text": "hello"}, None
+
+        monkeypatch.setattr(kh, "read_bounded_json", _body)
+        req = make_mocked_request(
+            "POST",
+            f"/api/knowledge/sources/{source_id}/ingest-text",
+            match_info={"id": source_id},
+            app=app,
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await kh.ingest_text(req)
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "syncing"
+
+    @pytest.mark.asyncio
+    async def test_plain_ingest_text_failure_500s_without_touching_the_claim(self, store):
+        """Regression: widening to BaseException must not change the non-cancel
+        contract -- a plain failure still answers the existing 500 body, and
+        the sibling sync's 'syncing' claim is left for its owner to finalize."""
+        source_id = await asyncio.to_thread(_seed_source, store)
+        await asyncio.to_thread(_set_status, store, source_id, "syncing")
+        pipeline = MagicMock(ingest_file=AsyncMock(side_effect=RuntimeError("boom")))
+        app = _make_app(store, pipeline=pipeline)
+        app.router.add_post("/api/knowledge/sources/{id}/ingest-text", kh.ingest_text)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                f"/api/knowledge/sources/{source_id}/ingest-text", json={"text": "x"}
+            )
+            assert resp.status == 500
+            assert (await resp.json())["error"] == "internal server error"
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "syncing"
+
+    @pytest.mark.asyncio
+    async def test_plain_local_file_failure_still_lands_in_error(self, store, tmp_path):
+        """Regression: the background task's plain-Exception arm is unchanged."""
+        source_id = await asyncio.to_thread(_seed_source, store)
+        doc = tmp_path / "doc.md"
+        doc.write_text("# hi\n")
+        pipeline = MagicMock(ingest_file=AsyncMock(side_effect=RuntimeError("boom")))
+        await kh._ingest_local_file_task(pipeline, store, str(doc), source_id)
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "error"
+
+    @pytest.mark.asyncio
+    async def test_successful_ingest_text_still_writes_synced_and_audits(self, store, monkeypatch):
+        """The success invariant: 'synced' and the source.ingest_text audit ride
+        one worker take, so a normal run emits both."""
+        seen: list[str] = []
+        monkeypatch.setattr(kh, "_sel_log", lambda tool, **kw: seen.append(tool))
+        source_id = await asyncio.to_thread(_seed_source, store)
+        pipeline = MagicMock(ingest_file=AsyncMock(return_value="job-9"))
+        app = _make_app(store, pipeline=pipeline)
+        app.router.add_post("/api/knowledge/sources/{id}/ingest-text", kh.ingest_text)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                f"/api/knowledge/sources/{source_id}/ingest-text", json={"text": "hello"}
+            )
+            assert resp.status == 200
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "synced"
+        assert "source.ingest_text" in seen
+
+    @pytest.mark.asyncio
+    async def test_a_failed_finalize_write_does_not_mask_the_cancel(self, store, monkeypatch):
+        """A finalizer must never replace the original exception: a DB failure
+        inside the terminal write is logged and dropped, and the cancel still
+        propagates."""
+        source_id = await asyncio.to_thread(_seed_source, store)
+        started = asyncio.Event()
+
+        async def _hang_fetch(_url, _pool):
+            started.set()
+            await asyncio.Event().wait()
+
+        attempts: list[str] = []
+
+        def _boom_write(_store, _sid, status, _from_statuses=("syncing",)):
+            attempts.append(status)
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(kh, "fetch_url_content", _hang_fetch)
+        task = asyncio.ensure_future(
+            kh._background_agent_sync(
+                source_id, "https://example.com/x", "x", store, MagicMock(), MagicMock()
+            )
+        )
+        await asyncio.wait_for(started.wait(), 5.0)
+        monkeypatch.setattr(kh, "_finalize_sync_status_write", _boom_write)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert attempts == ["error"], "the terminal write was never attempted"
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_the_claim_take_still_finalizes(self, store, monkeypatch):
+        """A cancel delivered while the claim's worker is in flight does not
+        stop the thread: it commits 'syncing' after the task is gone. The
+        claim await must therefore finalize a claim it WON on the way out."""
+        source_id = await asyncio.to_thread(_seed_source, store)
+        entered = threading.Event()
+        release = threading.Event()
+        real_claim = kh._claim_sync
+
+        def _slow_claim(s, sid):
+            entered.set()
+            release.wait(5.0)
+            return real_claim(s, sid)
+
+        monkeypatch.setattr(kh, "_claim_sync", _slow_claim)
+        pipeline = MagicMock(ingest_file=AsyncMock())
+        task = asyncio.ensure_future(
+            kh._ingest_local_file_task(pipeline, store, "/tmp/x.md", source_id)
+        )
+        await asyncio.to_thread(entered.wait, 5.0)
+        task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        pipeline.ingest_file.assert_not_awaited()
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "error"
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_a_lost_claim_leaves_the_siblings_row_alone(
+        self, store, monkeypatch
+    ):
+        """A lost claim belongs to the sibling sync that holds it: the cancel
+        path must not stamp 'error' over a row another task is working on."""
+        source_id = await asyncio.to_thread(_seed_source, store)
+        await asyncio.to_thread(_set_status, store, source_id, "syncing")
+        entered = threading.Event()
+        release = threading.Event()
+        real_claim = kh._claim_sync
+
+        def _slow_claim(s, sid):
+            entered.set()
+            release.wait(5.0)
+            return real_claim(s, sid)  # loses: the row is already 'syncing'
+
+        monkeypatch.setattr(kh, "_claim_sync", _slow_claim)
+        pipeline = MagicMock(ingest_file=AsyncMock())
+        task = asyncio.ensure_future(
+            kh._ingest_local_file_task(pipeline, store, "/tmp/x.md", source_id)
+        )
+        await asyncio.to_thread(entered.wait, 5.0)
+        task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "syncing"
+
+    @pytest.mark.asyncio
+    async def test_finalize_is_compare_and_set_over_syncing(self, store):
+        """A late cancel finalize must not overwrite a committed 'synced': only
+        a row still mid-sync is moved (same rule as ``_finalize_job``)."""
+        source_id = await asyncio.to_thread(_seed_source, store)
+        await asyncio.to_thread(_set_status, store, source_id, "synced")
+        await kh._finalize_sync_status(store, source_id, "error")
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "synced"
+        await asyncio.to_thread(_set_status, store, source_id, "syncing")
+        await kh._finalize_sync_status(store, source_id, "error")
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "error"
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_the_upload_stamp_still_lands_in_error(self, store, monkeypatch):
+        """The stamp's worker outlives a cancel and can commit 'syncing' after
+        the cancel arm's CAS ran. The stamp is shielded and drained so the
+        finalize always sees the stamp's landed state."""
+        monkeypatch.setattr(kh, "_sel_log", lambda tool, **kw: None)
+        entered = threading.Event()
+        release = threading.Event()
+        real_stamp = kh._set_sync_status
+
+        def _slow_stamp(s, sid, status):
+            entered.set()
+            release.wait(5.0)
+            real_stamp(s, sid, status)
+
+        monkeypatch.setattr(kh, "_set_sync_status", _slow_stamp)
+        pipeline = MagicMock(
+            ingest_file=AsyncMock(),
+            reserve_import_budget=AsyncMock(return_value=None),
+            release_import_budget=MagicMock(),
+        )
+        app = _make_app(store, pipeline=pipeline)
+        async with TestClient(TestServer(app)) as client:
+            form = aiohttp.FormData()
+            form.add_field("file", b"# hello\n", filename="notes.md", content_type="text/markdown")
+            resp = await client.post("/api/knowledge/ingest", data=form)
+            assert resp.status == 200, await resp.text()
+            source_id = (await resp.json())["source_id"]
+            task = next(t for t in app["_bg_tasks"] if not t.done())
+            await asyncio.to_thread(entered.wait, 5.0)
+            task.cancel()
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert await asyncio.to_thread(_sync_status, store, source_id) == "error"
+            pipeline.ingest_file.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_stamp_plus_failed_ingest_still_lands_in_error(self, store, monkeypatch):
+        """The upload path's plain-failure write is unconditional: when the
+        best-effort 'syncing' stamp failed AND the ingest then fails, the CAS
+        would move nothing, so the arm must write 'error' outright."""
+        monkeypatch.setattr(kh, "_sel_log", lambda tool, **kw: None)
+        real_stamp = kh._set_sync_status
+
+        def _stamp(s, sid, status):
+            if status == "syncing":
+                raise sqlite3.OperationalError("database is locked")
+            real_stamp(s, sid, status)
+
+        monkeypatch.setattr(kh, "_set_sync_status", _stamp)
+        pipeline = MagicMock(
+            ingest_file=AsyncMock(side_effect=RuntimeError("parser exploded")),
+            reserve_import_budget=AsyncMock(return_value=None),
+            release_import_budget=MagicMock(),
+        )
+        app = _make_app(store, pipeline=pipeline)
+        async with TestClient(TestServer(app)) as client:
+            form = aiohttp.FormData()
+            form.add_field("file", b"# hello\n", filename="notes.md", content_type="text/markdown")
+            resp = await client.post("/api/knowledge/ingest", data=form)
+            assert resp.status == 200, await resp.text()
+            source_id = (await resp.json())["source_id"]
+            task = next(t for t in app["_bg_tasks"] if not t.done())
+            await task
+            assert await asyncio.to_thread(_sync_status, store, source_id) == "error"
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_the_pending_write_does_not_strand_syncing(
+        self, store, monkeypatch
+    ):
+        """A cancel inside the budget-deferral arm is not caught by the sibling
+        ``except BaseException`` arm, so the 'pending' write itself must be
+        cancel-safe: drained, finalized, re-raised -- never left 'syncing'."""
+        from kiro_crew.knowledge.ingestion import ImportChunkBudgetError
+
+        source_id = await asyncio.to_thread(_seed_source, store)
+        entered = threading.Event()
+        release = threading.Event()
+        real_stamp = kh._set_sync_status
+
+        def _slow_stamp(s, sid, status):
+            if status == "pending":
+                entered.set()
+                release.wait(5.0)
+            real_stamp(s, sid, status)
+
+        monkeypatch.setattr(kh, "_set_sync_status", _slow_stamp)
+        pipeline = MagicMock(
+            ingest_file=AsyncMock(side_effect=ImportChunkBudgetError(100, 3600.0, 100))
+        )
+        task = asyncio.ensure_future(
+            kh._ingest_local_file_task(pipeline, store, "/tmp/x.md", source_id)
+        )
+        await asyncio.to_thread(entered.wait, 5.0)
+        task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        status = await asyncio.to_thread(_sync_status, store, source_id)
+        assert status != "syncing", "the deferral arm re-stranded the row"
+        assert status == "pending", "the drained deferral write must land"
+
+    @pytest.mark.asyncio
+    async def test_the_upload_finalize_also_moves_a_pending_row(self, store):
+        """A cancel can land before the upload's 'syncing' stamp, while the
+        fresh row still reads the INSERT default 'pending' -- the widened CAS
+        moves it, and a committed 'synced' still survives."""
+        source_id = await asyncio.to_thread(_seed_source, store)
+        await asyncio.to_thread(_set_status, store, source_id, "pending")
+        await kh._finalize_sync_status(
+            store, source_id, "error", from_statuses=("syncing", "pending")
+        )
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "error"
+        await asyncio.to_thread(_set_status, store, source_id, "synced")
+        await kh._finalize_sync_status(
+            store, source_id, "error", from_statuses=("syncing", "pending")
+        )
+        assert await asyncio.to_thread(_sync_status, store, source_id) == "synced"


### PR DESCRIPTION
## Summary

Closes #9280.

`asyncio.CancelledError` is a `BaseException` since Python 3.8, so the terminal `sync_status` writes guarded by `except Exception:` in `src/kiro_crew/dashboard/handlers/knowledge.py` were skipped when a sync task was cancelled (gateway shutdown drains `_bg_tasks` by cancelling them). The source row then stayed `'syncing'` forever, and every later sync answered 409 "sync already in progress" with no recovery path — no sweeper heals a stale `'syncing'` sources row.

## What changed

One helper plus the four except-clauses; the change follows the file's own precedent (`_rebuild_embeddings_job`: `except BaseException`, finalize, re-raise on cancel).

- **`_finalize_sync_status` / `_finalize_sync_status_write`** — a never-raising finalizer that compare-and-sets a terminal state **over `'syncing'` only** (same rule as `_finalize_job`): a shutdown cancel delivered after the success write's worker already committed `'synced'` must not stamp `'error'` over the state the work actually reached. A failed DB write inside the finalizer is logged, never raised, so it cannot mask the original exception; a re-cancel during the write is suppressed so the caller's bare `raise` re-raises the cancellation.
- **`_ingest_local_file_task`, `_background_agent_sync`, `ingest_text`, upload `_bg_ingest`** — the terminal `except Exception:` arms are widened to `except BaseException as exc:`; cancellation finalizes the row to `'error'` and re-raises; non-cancel behavior is unchanged (`ingest_text` still answers the existing 500 body; the `ImportChunkBudgetError` arms still precede and keep their 429/`'pending'` semantics).
- **The claim takes are cancel-safe too** (review finding): `claimed = await asyncio.to_thread(_claim_sync, ...)` was itself an unguarded window — a cancel does not stop the worker thread, which can still commit `'syncing'` after the task is gone. Both background tasks now `asyncio.shield` the claim; on cancellation they await the thread's answer and finalize **only a claim this task won** (a lost claim is a sibling sync's row), then re-raise.
- A cancelled sync is recorded as **`'error'`**, not a new status value: the settings UI and the watcher read this column, and an incomplete sync already presents as `'error'` for the user to re-trigger.

## Finding 2 from the issue (audit-skip window)

On `main` that window does not exist: the `'synced'` write and the `source.ingest_text` SEL audit ride in ONE worker take (`_audited_write`) with no await between them, so a cancellation cannot separate them. It only existed in withdrawn PR #9272's offloaded form. This PR adds a code comment pinning that invariant so a future offload cannot reintroduce it, and closes the shared class gap (`ingest_text`'s missing terminal write on cancellation).

## `KeyboardInterrupt` / `SystemExit`

Followed the precedent exactly: every non-cancel `BaseException` is treated as a failure (row finalized, exception not re-raised in the background tasks), matching `_rebuild_embeddings_job`. Not widened or narrowed.

## Known narrow trade-off (documented, not fixed here)

In `_bg_ingest`, the `'syncing'` stamp is deliberately best-effort (a contended writer lock must not discard the upload's only copy). If that stamp fails **and** the ingest then also fails before `ingestion.py`'s own finalize runs, the CAS finalize is a no-op and the row keeps its prior status where the pre-fix code stamped `'error'`. A two-failure window that degrades to a stale UI hint only; keeping the CAS is what protects the far more reachable success-overwrite race.

## Tests

`test/test_knowledge_handlers_off_loop.py`, new class `TestCancellationFinalizesSyncStatus` (10 tests): cancel mid-ingest lands `'error'` and re-raises on all four paths; cancel during the claim take finalizes a won claim and leaves a sibling's row alone; the finalize is CAS (a committed `'synced'` is not overwritten); a failed finalize write does not mask the cancellation (and the write attempt is asserted); plain-`Exception` regressions (500 body + `'error'` row; background task unchanged); a normal `ingest_text` still writes `'synced'` and emits the SEL event.

## Review

Two pre-push model-pinned lanes per the pipeline contract. Opus lane: round 1 found 1 blocking (the claim-take window, fixed above) + 3 advisories (all fixed); round 2 verified every fix and returned PASS. GPT lane: its subagent environment exposed no file-reading tools in two attempts, so a contract-driven self-review against the codex-review.yml charter was run instead (documented fallback); no Critical/High findings. The server-side GPT 5.6 / Opus review bots on this PR are the authoritative gate.

## Pattern harvest

Rule candidate: a status write dispatched to a worker thread survives its coroutine's cancellation, so every cancel-path finalizer must shield-and-drain any in-flight status worker (claim takes and progress stamps alike) before writing its own terminal state -- otherwise the late worker re-strands the row the finalizer just cleaned.

## Rebase note

#9222 / #8985 / #8345 are open against the same file. This change is confined to the four except-clauses, the two claim takes, the upload path's shielded 'syncing' stamp, and one helper near `_set_sync_status`, so rebases across it should be trivial.

## Gates

Static gates green locally (flake8, isort, mypy, diff-scoped black/subprocess-encoding/sync-io gates, brand gate); pytest runs in CI per repo policy.

