### PR TITLE
fix(cron): render non-whole-hour intervals exactly, not floored to hours

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -981,8 +981,14 @@ def format_schedule(schedule: CronSchedule, tz_name: str = "") -> str:
         return _humanize_cron(schedule.cron_expr, tz_name)
     if schedule.kind == "every" and schedule.every_secs:
         secs = schedule.every_secs
-        if secs >= 3600:
+        # Exact, never truncated: a saved interval must read back as what was
+        # saved, or the list cannot tell a wrong job from a right one. Whole
+        # hours as hours, whole minutes above the hour as minutes, everything
+        # else in seconds (sub-hour intervals keep their seconds spelling).
+        if secs >= 3600 and secs % 3600 == 0:
             return f"every {secs // 3600}h"
+        if secs >= 3600 and secs % 60 == 0:
+            return f"every {secs // 60}m"
         return f"every {secs}s"
     if schedule.kind == "at" and schedule.at_ts:
         tz = ZoneInfo(tz_name) if tz_name else None

--- a/test/test_cron.py
+++ b/test/test_cron.py
@@ -1046,6 +1046,17 @@ class TestFormatSchedule:
         s = CronSchedule(kind="every", every_secs=7200)
         assert format_schedule(s) == "every 2h"
 
+    def test_every_non_whole_hours_is_not_truncated(self) -> None:
+        """A 90-minute job reads back as 90 minutes, not as the hour floor: the
+        list is how a user checks that a job was saved as asked, and a floored
+        interval looks like a job that was silently changed."""
+        from kiro_crew.cron import CronSchedule, format_schedule
+
+        assert format_schedule(CronSchedule(kind="every", every_secs=5400)) == "every 90m"
+        assert format_schedule(CronSchedule(kind="every", every_secs=3660)) == "every 61m"
+        # Not a whole minute either: seconds, still exact.
+        assert format_schedule(CronSchedule(kind="every", every_secs=3661)) == "every 3661s"
+
     def test_at_timestamp_today(self, monkeypatch, _utc_tz) -> None:
         from kiro_crew.cron import CronSchedule, format_schedule
 


### PR DESCRIPTION
## Summary

`format_schedule` floored any `every` interval ≥ 1 h to whole hours, so a 90-minute job (`--every 5400`) read back as `every 1h` in the create confirmation and in `cron list`. The list is how a user checks that a job was saved as asked, so a floored interval reads as a job that was silently changed.

Rendering is now exact:
- whole hours → `every 2h` (unchanged)
- whole minutes above the hour → `every 90m`
- anything else → exact seconds (`every 3661s`); sub-hour intervals keep their existing seconds spelling (`every 300s`), so nothing that currently renders correctly changes.

Fixes #10206.

## Testing

- New regression test: 5400 → `every 90m`, 3660 → `every 61m`, 3661 → `every 3661s`; fails on main.
- `test_cron*.py`, `test_cli_commands_coverage.py`, `test_autonudge_stop_auth.py`: 1902 passed (these pin the existing `every 300s` / `every 2h` spellings, which are unchanged).
- black (baseline-aware, `.github/black-baseline.txt` untouched), isort, flake8, mypy, comment-history and brand gates clean.

Two-file diff; no `.github/**` changes, so no fork workflow-change label is needed.
