### PR TITLE
fix: steer the host-decline cause before the shared reject (#8578)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -543,7 +543,6 @@ test/test_cse_2026_08_05_fixes.py
 test/test_cse_2026_08_07_fixes.py
 test/test_custom_embedding_model.py
 test/test_dashboard.py
-test/test_dashboard_approval.py
 test/test_dashboard_branding.py
 test/test_dashboard_config_gitlab_hosts.py
 test/test_dashboard_cron_approval.py

--- a/docs/system-specs/common/injected-messages.md
+++ b/docs/system-specs/common/injected-messages.md
@@ -239,7 +239,20 @@ unattended transcript line remains the only agent-facing explanation. The
 timeout card stays the sole user-visible surface — this steer paints no
 tool-blocked row.
 
-The recovery classification for the last two is **structural**: the queue entry
+**The other two host-originated approval auto-declines take the same path**,
+each with its own cause and the same no-ledger, no-row discipline as the
+timeout: `approval_no_budget` (the turn had no budget left to host the prompt
+— the agent is told the prompt was never shown, to state the permission it
+needs, and not to immediately reissue the identical call, since this turn
+cannot host an approval wait) and `approval_undeliverable` (the approval card
+could not be delivered to the operator's channel — the agent is told the call
+was never judged and to state the permission it needs). All three are steered
+once, at the shared reject branch, gated on the host-recorded provenance; a
+genuine user refusal records no cause, so kiro-cli's generic denial stays the
+true attribution there and no notice is sent.
+
+The recovery classification for the last two rows of the marker table above
+is **structural**: the queue entry
 carries `kind == "synthetic_recovery"` (`SYNTHETIC_RECOVERY_KIND`), set at insert
 time. Metadata survives every queue transformation (merge, prefixing, truncation)
 and cannot collide with a user pasting the transcript-visible recovery text back

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -137,7 +137,9 @@ from kiro_crew.dashboard.session_directive_apply import (
 from kiro_crew.dashboard.state import (
     CRON_NOTIFY_PREFIX,
     CRON_NOTIFY_RE,
+    DENY_CAUSE_APPROVAL_NO_BUDGET,
     DENY_CAUSE_APPROVAL_TIMEOUT,
+    DENY_CAUSE_APPROVAL_UNDELIVERABLE,
     DENY_CAUSE_BATCH_CASCADE,
     DENY_CAUSE_HOOK_ERROR,
     DENY_CAUSE_INVALID_NAME,
@@ -9685,14 +9687,17 @@ async def _run_chat(
                     continue
                 # Interactive approval — send to frontend, wait for decision
                 #
-                # WHO/WHAT declines this tool, when it is declined. Stays empty
-                # for an interactive user refusal; each host-side auto-decline
-                # below (Slack delivery failure, no turn budget, approval
-                # timeout) overwrites it with a short host-authored sentence.
-                # The batch setter at the bottom copies it onto
-                # ``slot._batch_rejected_cause`` so the cascade site can tell a
-                # person's refusal from an expired prompt.
+                # WHO/WHAT declines this tool, when it is declined. Both stay
+                # empty for an interactive user refusal; each host-side
+                # auto-decline below (Slack delivery failure, no turn budget,
+                # approval timeout) overwrites the cause with its DENY_CAUSE_*
+                # constant and the reason with a short host-authored sentence.
+                # The cause gates the provenance steer at the shared reject
+                # branch below, and the batch setter at the bottom copies the
+                # reason onto ``slot._batch_rejected_cause`` so the cascade
+                # site can tell a person's refusal from a host auto-decline.
                 _host_deny_cause = ""
+                _host_deny_reason = ""
                 perm_meta = {
                     "request_id": str(event.request_id),
                     "tool_call_id": event.tool_call_id or "",
@@ -9844,10 +9849,9 @@ async def _run_chat(
                             state.push_slots_update()
                             if not fut.done():
                                 fut.set_result("rejected")
-                                _host_deny_cause = (
-                                    "the approval prompt for an earlier tool in "
-                                    "this batch could not be delivered to Slack, "
-                                    "so the host declined it"
+                                _host_deny_cause = DENY_CAUSE_APPROVAL_UNDELIVERABLE
+                                _host_deny_reason = (
+                                    "the approval prompt could not be delivered to Slack"
                                 )
                     except Exception:
                         # Any failure before the future is resolved (ImportError,
@@ -9859,10 +9863,9 @@ async def _run_chat(
                         logger.warning("Error mirroring approval prompt to Slack", exc_info=True)
                         if not fut.done():
                             fut.set_result("rejected")
-                            _host_deny_cause = (
-                                "the approval prompt for an earlier tool in "
-                                "this batch could not be delivered to Slack, "
-                                "so the host declined it"
+                            _host_deny_cause = DENY_CAUSE_APPROVAL_UNDELIVERABLE
+                            _host_deny_reason = (
+                                "the approval prompt could not be delivered to Slack"
                             )
                 # Pre-seeded so the `finally` backstop below is total over EVERY
                 # exit from the await — including CancelledError, which slot
@@ -9906,10 +9909,8 @@ async def _run_chat(
                             event.title,
                         )
                         _approval_card = format_approval_no_budget_card()
-                        _host_deny_cause = (
-                            "the turn had no budget left to wait for approval of "
-                            "an earlier tool in this batch, so the host declined it"
-                        )
+                        _host_deny_cause = DENY_CAUSE_APPROVAL_NO_BUDGET
+                        _host_deny_reason = "the turn had no budget left to wait for approval"
                     else:
                         outcome = await asyncio.wait_for(fut, timeout=_approval_window)
                 except asyncio.TimeoutError:
@@ -9925,49 +9926,17 @@ async def _run_chat(
                         _approval_window,
                     )
                     _approval_card = format_approval_timeout_card(_approval_window)
-                    _host_deny_cause = (
-                        "the approval prompt for an earlier tool in this batch "
-                        f"went unanswered for {int(_approval_window)}s, so the "
-                        "host declined it"
+                    _host_deny_cause = DENY_CAUSE_APPROVAL_TIMEOUT
+                    _host_deny_reason = (
+                        "the approval prompt went unanswered for "
+                        f"{max(1, round(_approval_window))}s"
                     )
-                    # The AGENT's channel, sent for attended and unattended slots
-                    # alike: the rejection below reaches the model as kiro-cli's
-                    # generic "User denied tool execution", so without this it
-                    # concludes the human actively refused a call nobody judged.
-                    # Steered HERE, before the reject goes on the wire in the
-                    # rejected branch below — the still-unanswered permission
-                    # request is what proves the turn is in flight, so the notice
-                    # is queued instead of dropped (same ordering as the policy
-                    # deny paths). Best-effort like every _steer_policy_notice
-                    # call: a harness without steer keeps today's behaviour.
-                    # This notice covers the tool whose prompt expired; the
-                    # cascaded remainder of its batch is corrected separately by
-                    # the DENY_CAUSE_BATCH_CASCADE steer, keyed on
-                    # _host_deny_cause above.
-                    #
-                    # A THROWAWAY list, deliberately not _refusal_notices: this
-                    # path appends no _refusal_reasons entry (an expired prompt
-                    # is answered as an ordinary rejection, never by a recovery
-                    # continuation), and should_queue_refusal_recovery compares
-                    # the two lists by COUNT, not by pairing. Threading the turn
-                    # ledger here would let an unsettled timeout notice force a
-                    # duplicate recovery turn — or let a settled one mask a real
-                    # deny whose own steer failed, handing the model an
-                    # uncorrected "User denied tool execution".
-                    #
-                    # No slot/state either: the ⏱️ timeout card appended in the
-                    # finally below is already the human's explanation, so the
-                    # display row the policy paths add would paint the same
-                    # event twice.
-                    _timeout_notices: list[str] = []
-                    await _steer_policy_notice(
-                        client,
-                        _redact_display_text(event.title),
-                        f"the approval prompt expired after "
-                        f"{max(1, round(_approval_window))}s with no answer",
-                        _timeout_notices,
-                        cause=DENY_CAUSE_APPROVAL_TIMEOUT,
-                    )
+                    # The in-band correction for this expired prompt is
+                    # steered ONCE at the shared reject branch below, keyed on
+                    # _host_deny_cause — the same site that corrects the other
+                    # host auto-declines (no budget, Slack delivery failure).
+                    # Steering here as well would tell the model the same fact
+                    # twice in one turn.
                     if _unattended_wait:
                         # The card is for the human; this line is for the AGENT.
                         # A denial it cannot read makes it retry the same tool
@@ -10168,20 +10137,43 @@ async def _run_chat(
                         request_id=event.request_id,
                         metadata={"reason": _safety_reason or "interactive"},
                     )
+                    # Host-originated auto-declines (approval timeout, no
+                    # turn budget, Slack delivery failure) funnel into this
+                    # shared reject, where kiro-cli's "User denied tool
+                    # execution" is FALSE: nobody judged the call. Each arm
+                    # records its cause upstream where it is known; this one
+                    # steer, gated on that provenance, corrects the attribution
+                    # for whichever arm declined — BEFORE the rejection goes on
+                    # the wire, because the still-unanswered permission request
+                    # is what keeps the notice queued instead of dropped.
+                    #
+                    # A THROWAWAY list, deliberately not _refusal_notices: these
+                    # paths append no _refusal_reasons entry (a host
+                    # auto-decline is answered as an ordinary rejection, never
+                    # by a recovery continuation), and
+                    # should_queue_refusal_recovery compares the two lists by
+                    # COUNT, not by pairing. No slot/state either: the cards the
+                    # arms render are already the human's explanation, so the
+                    # display row the policy paths add would paint the same
+                    # event twice.
+                    if _host_deny_cause:
+                        await _steer_policy_notice(
+                            client,
+                            _safe_reject_title,
+                            _host_deny_reason,
+                            [],
+                            cause=_host_deny_cause,
+                        )
                     # deny-notice-exempt: interactive user denial. The person
                     # clicked Reject (or "reject once"), so kiro-cli's "User
                     # denied tool execution" is the true and correct attribution
                     # here — the sharpest case in the class, because steering a
                     # policy notice would tell the model a rule blocked a call
-                    # the user personally refused. Two host-side auto-declines
-                    # still funnel to this shared reject (no turn budget,
-                    # Slack-delivery failure) and DO carry the wrong
-                    # attribution, but the correction belongs at their own
-                    # decision points upstream where the cause is known, not at
-                    # this shared answer site where user and host causes are
-                    # indistinguishable. The approval timeout steers
-                    # DENY_CAUSE_APPROVAL_TIMEOUT at its own branch above, which
-                    # is exactly the shape the remaining two want.
+                    # the user personally refused. A genuine user refusal leaves
+                    # _host_deny_cause empty, so the provenance-gated steer
+                    # above never fires for it and this exemption stays true for
+                    # exactly the branch it covers; the host auto-declines are
+                    # that steer's job, not this marker's.
                     await client.reject_tool(event.request_id)
                     if _safety_reason:
                         _reject_label = f"🚫 {_safe_reject_title} (cancelled — {_safety_reason})"
@@ -10212,8 +10204,19 @@ async def _run_chat(
                     # auto-decline that did. The cascade site branches on it —
                     # a user's refusal keeps kiro-cli's "User denied tool
                     # execution" true for the remainder, a host cause makes it
-                    # false and worth an in-band correction.
-                    slot._batch_rejected_cause = _host_deny_cause
+                    # false and worth an in-band correction. A sentence (not the
+                    # DENY_CAUSE_* constant) because the cascade notice embeds
+                    # it verbatim as the reason the model reads — and it is
+                    # batch-framed here because that notice shows it under the
+                    # CASCADED member's title, where the bare reason would claim
+                    # the member's own prompt failed when it was never prompted.
+                    # The conditional is load-bearing: a user refusal must copy
+                    # "" so the cascade stays exempt, never a framed empty.
+                    slot._batch_rejected_cause = (
+                        f"the host declined an earlier tool of this batch ({_host_deny_reason})"
+                        if _host_deny_reason
+                        else ""
+                    )
                     # New denied batch, fresh notice budget for its cascade.
                     _batch_cascade_steered = False
                     logger.warning(

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2910,6 +2910,8 @@ DENY_CAUSE_INVALID_NAME = "invalid_name"
 DENY_CAUSE_HOOK_ERROR = "hook_error"
 DENY_CAUSE_BATCH_CASCADE = "batch_cascade"
 DENY_CAUSE_APPROVAL_TIMEOUT = "approval_timeout"
+DENY_CAUSE_APPROVAL_NO_BUDGET = "approval_no_budget"
+DENY_CAUSE_APPROVAL_UNDELIVERABLE = "approval_undeliverable"
 
 #: cause → (clause completing "The tool call you just made …", what to do next).
 _DENY_CAUSE_TEXT: dict[str, tuple[str, str]] = {
@@ -2947,6 +2949,22 @@ _DENY_CAUSE_TEXT: dict[str, tuple[str, str]] = {
         "it. Do not immediately reissue the same call: the person who did not "
         "answer is still away, and re-prompting re-arms the same wait for the "
         "same silence.",
+    ),
+    DENY_CAUSE_APPROVAL_NO_BUDGET: (
+        "was auto-declined because the turn had no budget left to host its approval prompt",
+        "the prompt was never shown, so the action itself was never judged — do "
+        "not abandon it or route around it on this evidence. State the "
+        "permission you need and why, then continue with what you can do "
+        "without it. Do not immediately reissue the same call: this turn cannot "
+        "host an approval wait, so the identical call would be declined the "
+        "same way.",
+    ),
+    DENY_CAUSE_APPROVAL_UNDELIVERABLE: (
+        "was auto-declined because its approval prompt could not be delivered "
+        "to the operator's channel",
+        "delivery failed, so the action itself was never judged — do not "
+        "abandon it or route around it on this evidence. State the permission "
+        "you need and why, then continue with what you can do without it.",
     ),
 }
 

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -240,7 +240,9 @@ def _context_builder(hook_result: ToolHookResult | None = None) -> MagicMock:
     # from the operator's real config: an exporter bound to the real
     # ~/.kiro/crew/metrics for the life of the worker. Built per call instead.
     cb = MagicMock()
-    cb.hooks.on_tool_call.return_value = hook_result if hook_result is not None else ToolHookResult.allow()
+    cb.hooks.on_tool_call.return_value = (
+        hook_result if hook_result is not None else ToolHookResult.allow()
+    )
     cb.build_message.return_value = ("hello", None)
     return cb
 
@@ -366,9 +368,7 @@ class TestApprovalModes:
         """The blocked pill must carry the deny reason, not just '(blocked)',
         so the user learns WHY (e.g. 'Blocked by security policy: git push')
         instead of seeing a silent/cryptic stop."""
-        cb = _context_builder(
-            ToolHookResult.deny("Blocked by security policy: git push")
-        )
+        cb = _context_builder(ToolHookResult.deny("Blocked by security policy: git push"))
         state, client = _make_state(tmp_path, context_builder=cb)
         slot = _make_slot()
         _set_stream(client, [_permission_event(), _complete_event()])
@@ -377,18 +377,15 @@ class TestApprovalModes:
             await _run_chat(state, slot, "hello")
 
         msgs = _tool_messages(slot)
-        assert any(
-            "security policy: git push" in m.get("content", "").lower()
-            for m in msgs
-        ), [m.get("content") for m in msgs]
+        assert any("security policy: git push" in m.get("content", "").lower() for m in msgs), [
+            m.get("content") for m in msgs
+        ]
 
     @pytest.mark.asyncio
     async def test_hook_deny_broadcasts_activity_event(self, tmp_path):
         """A host-gate deny must broadcast a visible activity_event (mirroring
         the auto-approve branch) so the block is not silent."""
-        cb = _context_builder(
-            ToolHookResult.deny("Blocked by security policy: git push")
-        )
+        cb = _context_builder(ToolHookResult.deny("Blocked by security policy: git push"))
         state, client = _make_state(tmp_path, context_builder=cb)
         slot = _make_slot()
         _set_stream(client, [_permission_event(), _complete_event()])
@@ -399,15 +396,14 @@ class TestApprovalModes:
         perm_activity = [
             c.args
             for c in state.broadcast_ws.call_args_list
-            if c.args and c.args[0] == "activity_event"
+            if c.args
+            and c.args[0] == "activity_event"
             and isinstance(c.args[1], dict)
             and c.args[1].get("kind") == "permission"
         ]
         assert perm_activity, state.broadcast_ws.call_args_list
         # The broadcast text should mention the block.
-        assert any(
-            "block" in a[1].get("text", "").lower() for a in perm_activity
-        ), perm_activity
+        assert any("block" in a[1].get("text", "").lower() for a in perm_activity), perm_activity
 
     @pytest.mark.asyncio
     async def test_hook_deny_never_registers_approval_future(self, tmp_path):
@@ -541,9 +537,7 @@ class TestApprovalModes:
         client.approve_tool.assert_not_called()
         # User-facing pill must reflect the block (NOT a hook_error).
         msgs = _tool_messages(slot)
-        assert any(
-            "hook blocked" in m.get("content", "").lower() for m in msgs
-        ), msgs
+        assert any("hook blocked" in m.get("content", "").lower() for m in msgs), msgs
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -602,9 +596,7 @@ class TestApprovalModes:
         client.reject_tool.assert_called_once()
         client.approve_tool.assert_not_called()
         msgs = _tool_messages(slot)
-        assert any(
-            "hook blocked" in m.get("content", "").lower() for m in msgs
-        ), (label, msgs)
+        assert any("hook blocked" in m.get("content", "").lower() for m in msgs), (label, msgs)
 
     @pytest.mark.asyncio
     async def test_auto_approve_allowed_when_pretooluse_hook_exits_zero(self, tmp_path):
@@ -833,9 +825,13 @@ class TestToolCallIdRedaction:
         state.broadcast_ws.assert_any_call(
             "tool_call",
             {
-                "slot": slot.key, "tool": evt.title, "kind": evt.tool_kind,
-                "auto": True, "tool_call_id": "tcid-clean",
-                "purpose": "test purpose", "input_preview": "",
+                "slot": slot.key,
+                "tool": evt.title,
+                "kind": evt.tool_kind,
+                "auto": True,
+                "tool_call_id": "tcid-clean",
+                "purpose": "test purpose",
+                "input_preview": "",
             },
         )
 
@@ -903,9 +899,7 @@ class TestDenialCascadeLifetime:
 
     @pytest.mark.parametrize("resume_kind", [EVENT_TEXT_CHUNK, EVENT_THINKING_CHUNK])
     @pytest.mark.asyncio
-    async def test_later_sequential_call_is_evaluated_independently(
-        self, tmp_path, resume_kind
-    ):
+    async def test_later_sequential_call_is_evaluated_independently(self, tmp_path, resume_kind):
         """Call N+1 gets its own prompt once the model resumed after N was denied."""
         state, client = _make_state(tmp_path, context_builder=_context_builder())
         slot = _make_slot()
@@ -1031,9 +1025,16 @@ class TestBatchCascadeAttribution:
         with _patch_stats():
             await _run_chat(state, slot, "hello")
 
+        client.reject_tool.assert_any_call("req-1")
         client.reject_tool.assert_any_call("req-2")
-        client.steer.assert_called_once()
-        notice = client.steer.call_args[0][0]
+        # The declined tool itself is corrected first — its own no-budget
+        # notice — then exactly ONE cascade notice covers the remainder.
+        assert client.steer.call_count == 2
+        no_budget_notice = client.steer.call_args_list[0][0][0]
+        assert "no budget left" in no_budget_notice
+        assert "every remaining call in its batch" not in no_budget_notice
+        assert "NOT a user action" in no_budget_notice
+        notice = client.steer.call_args_list[1][0][0]
         assert "every remaining call in its batch" in notice
         assert "no budget left" in notice
 
@@ -1224,9 +1225,7 @@ class TestDenyOnce:
         state._approval_futures["req-bg"] = state_fut
 
         with patch.object(state, "_log") as log:
-            assert (
-                state.resolve_approval("req-bg", False, rejected_once=True) is True
-            )
+            assert state.resolve_approval("req-bg", False, rejected_once=True) is True
         assert state_fut.result() is False
         assert log.warning.called
         assert "rejected_once" in repr(log.warning.call_args)
@@ -1331,9 +1330,7 @@ class TestBackgroundApprovalDenyFast:
 
         monkeypatch.setattr("kiro_crew.dashboard.state.asyncio.wait_for", _fake_wait_for)
 
-        result = await state.request_approval(
-            "req-bg", "heartbeat", "fs_write", is_background=True
-        )
+        result = await state.request_approval("req-bg", "heartbeat", "fs_write", is_background=True)
 
         assert result is False  # deny-fast on expiry
         assert captured["timeout"] == DashboardState._BACKGROUND_APPROVAL_TIMEOUT_SECS
@@ -1371,9 +1368,7 @@ class TestBackgroundApprovalDenyFast:
             state.resolve_approval("req-bg2", True)
 
         asyncio.get_event_loop().create_task(_approve_soon())
-        result = await state.request_approval(
-            "req-bg2", "cron", "fs_write", is_background=True
-        )
+        result = await state.request_approval("req-bg2", "cron", "fs_write", is_background=True)
         assert result is True
 
 
@@ -1382,11 +1377,14 @@ class TestStateMetaAndPermissions:
 
     def test_append_with_meta(self):
         slot = _make_slot()
-        slot.append("tool", "test", meta={"tool_call_id": "tc-1", "purpose": "testing"}, broadcast=False)
+        slot.append(
+            "tool", "test", meta={"tool_call_id": "tc-1", "purpose": "testing"}, broadcast=False
+        )
         assert slot.messages[-1]["meta"]["tool_call_id"] == "tc-1"
 
     def test_mark_permission_resolved(self):
         import json
+
         slot = _make_slot()
         cls_data = json.dumps({"request_id": "req-42"})
         slot.append("permission", "tool_x", cls_data, broadcast=False)
@@ -1420,9 +1418,7 @@ class TestRefusalRecovery:
     async def test_host_gate_deny_enqueues_recovery_continuation(self, tmp_path):
         """A host-gate deny records the reason and the finally-block dequeue
         re-dispatches it as an 'inject' continuation carrying that reason."""
-        cb = _context_builder(
-            ToolHookResult.deny("Blocked by security policy: git push")
-        )
+        cb = _context_builder(ToolHookResult.deny("Blocked by security policy: git push"))
         state, client = _make_state(tmp_path, context_builder=cb)
         slot = _make_slot()
 
@@ -1470,9 +1466,7 @@ class TestRefusalRecovery:
         left off" — so it answered the same question again, at full turn cost,
         once per blocked call.
         """
-        cb = _context_builder(
-            ToolHookResult.deny("Blocked by security policy: git push")
-        )
+        cb = _context_builder(ToolHookResult.deny("Blocked by security policy: git push"))
         state, client = _make_state(tmp_path, context_builder=cb)
         slot = _make_slot()
         client.context_usage_pct = MagicMock(return_value=0.0)
@@ -1528,9 +1522,7 @@ class TestRefusalRecovery:
         alone sent the resume instruction for this ordering, which is the same
         duplicate answer at full turn cost.
         """
-        cb = _context_builder(
-            ToolHookResult.deny("Blocked by security policy: git push")
-        )
+        cb = _context_builder(ToolHookResult.deny("Blocked by security policy: git push"))
         state, client = _make_state(tmp_path, context_builder=cb)
         slot = _make_slot()
         client.context_usage_pct = MagicMock(return_value=0.0)
@@ -1585,9 +1577,7 @@ class TestRefusalRecovery:
             if slot.task:
                 await slot.task
 
-        assert not any(
-            REFUSAL_RECOVERY_PREFIX in m.get("content", "") for m in slot.messages
-        )
+        assert not any(REFUSAL_RECOVERY_PREFIX in m.get("content", "") for m in slot.messages)
         assert not slot._queue
 
 
@@ -1658,11 +1648,11 @@ class TestBuildRefusalRecoveryPrompt:
         # The awareness variant drops the resume instruction, not the guidance:
         # "how to do this properly" is the awareness the user is owed.
         reason = "Blocked by security policy: cat ~/.aws/credentials"
-        assert build_refusal_recovery_prompt(
-            [("Running: cat creds", reason)], answered=True
-        ).count("How to do this properly:") == build_refusal_recovery_prompt(
-            [("Running: cat creds", reason)]
-        ).count("How to do this properly:")
+        assert build_refusal_recovery_prompt([("Running: cat creds", reason)], answered=True).count(
+            "How to do this properly:"
+        ) == build_refusal_recovery_prompt([("Running: cat creds", reason)]).count(
+            "How to do this properly:"
+        )
 
 
 class TestPendingProjectReset:
@@ -1801,9 +1791,7 @@ class TestInteractiveDenyDoesNotTriggerRecovery:
     async def test_hook_deny_still_populates_refusal_recovery(self, tmp_path):
         """Complementary check: a system-side hook deny DOES trigger recovery,
         confirming the hook-deny path (L1974) is unaffected by the fix."""
-        cb = _context_builder(
-            ToolHookResult.deny("Blocked by security policy: rm -rf /")
-        )
+        cb = _context_builder(ToolHookResult.deny("Blocked by security policy: rm -rf /"))
         state, client = _make_state(tmp_path, context_builder=cb)
         slot = _make_slot()
 
@@ -1921,9 +1909,7 @@ class TestPreToolUseHookBlockRecovery:
         )
 
     @pytest.mark.asyncio
-    async def test_blocked_row_and_audit_redact_the_model_authored_title(
-        self, tmp_path
-    ) -> None:
+    async def test_blocked_row_and_audit_redact_the_model_authored_title(self, tmp_path) -> None:
         """A credential the model put in the tool title must not reach either surface.
 
         ``event.title`` prefers the model's own ``description`` field
@@ -1950,9 +1936,7 @@ class TestPreToolUseHookBlockRecovery:
         with patch("kiro_crew.dashboard.chat_runner.sel") as mock_sel:
             audit = MagicMock()
             mock_sel.return_value = audit
-            await _drive_hook_blocked_turn(
-                state, client, slot, title=f"Deploy with {secret} now"
-            )
+            await _drive_hook_blocked_turn(state, client, slot, title=f"Deploy with {secret} now")
 
         rows = [m.get("content", "") for m in slot.messages]
         assert not any(secret in row for row in rows), rows
@@ -2182,9 +2166,7 @@ class TestDenyRowTitleRedaction:
             for call in audit.log_tool_invocation.call_args_list
             if call.kwargs.get("outcome") == "denied"
         ]
-        assert any(
-            (c.get("metadata") or {}).get("reason") == "trust_reads" for c in denied
-        ), denied
+        assert any((c.get("metadata") or {}).get("reason") == "trust_reads" for c in denied), denied
 
     @pytest.mark.asyncio
     async def test_trust_mode_invalid_name_redacts(self, tmp_path):
@@ -2308,8 +2290,7 @@ class TestApprovalAnswerersDoNotRaceTheStream:
             if fn.name == "_answer_approval":
                 continue  # the one place allowed to wait, and it polls
             touches = any(
-                isinstance(n, ast.Attribute) and n.attr == "_approval_futures"
-                for n in ast.walk(fn)
+                isinstance(n, ast.Attribute) and n.attr == "_approval_futures" for n in ast.walk(fn)
             )
             if not touches:
                 continue
@@ -2326,8 +2307,7 @@ class TestApprovalAnswerersDoNotRaceTheStream:
         offenders = [
             f"{fn.name} (line {fn.lineno})"
             for fn in self._functions()
-            if fn.name != "_answer_approval"
-            and self._calls(fn, attr="get", on="_approval_futures")
+            if fn.name != "_answer_approval" and self._calls(fn, attr="get", on="_approval_futures")
         ]
         assert not offenders, (
             "these functions look up an approval future themselves instead of "

--- a/test/test_dashboard_approval_window.py
+++ b/test/test_dashboard_approval_window.py
@@ -294,15 +294,52 @@ class TestTimeoutTellsTheAgentInBand:
             body.append(ln)
         return body
 
-    def test_the_branch_steers_the_timeout_cause(self) -> None:
+    @staticmethod
+    def _shared_steer_block() -> str:
+        """The provenance-gated steer at the shared reject branch.
+
+        The timeout arm records its cause and the correction is steered ONCE
+        where every host auto-decline funnels — immediately before the shared
+        ``reject_tool`` — so the block under ``if _host_deny_cause:`` is the
+        wiring these tests pin.
+        """
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner._run_chat)
+        gate = "if _host_deny_cause:"
+        assert gate in src, "the shared provenance-gated steer is gone"
+        block = src.split(gate, 1)[1]
+        end = block.index("await client.reject_tool(")
+        return block[:end]
+
+    def test_the_branch_records_the_timeout_cause(self) -> None:
         body = "\n".join(self._timeout_branch())
-        assert "_steer_policy_notice(" in body, (
-            "the approval-timeout branch sends no in-band notice; the agent is "
-            "left holding kiro-cli's generic 'User denied tool execution'"
+        assert "_host_deny_cause = DENY_CAUSE_APPROVAL_TIMEOUT" in body, (
+            "the approval-timeout branch no longer records its cause; the agent "
+            "is left holding kiro-cli's generic 'User denied tool execution'"
         )
-        assert "cause=DENY_CAUSE_APPROVAL_TIMEOUT" in body, (
-            "the notice must carry the timeout cause, not inherit the policy "
-            "wording — 'blocked by a safety policy' is false here"
+        assert (
+            "_host_deny_reason = (" in body
+        ), "the approval-timeout branch no longer records a reason sentence"
+        # The correction itself is folded into the shared reject branch — a
+        # second steer here would tell the model the same fact twice.
+        assert "_steer_policy_notice(" not in body, (
+            "the timeout arm steers its own notice again — the shared "
+            "provenance-gated steer now double-steers"
+        )
+
+    def test_the_shared_branch_steers_the_recorded_cause(self) -> None:
+        block = self._shared_steer_block()
+        assert "_steer_policy_notice(" in block
+        assert "cause=_host_deny_cause" in block, (
+            "the notice must carry the arm's recorded cause, not inherit the "
+            "policy wording — 'blocked by a safety policy' is false here"
+        )
+        # BOTH attended and unattended slots get the notice: the shared site
+        # must gate on provenance alone, never on attendedness.
+        assert "_unattended_wait" not in block, (
+            "the shared steer is gated on the unattended flag — an attended "
+            "slot's agent would never be corrected"
         )
 
     def test_the_notice_stays_out_of_the_turn_ledger(self) -> None:
@@ -318,37 +355,33 @@ class TestTimeoutTellsTheAgentInBand:
         # Scanned over CODE lines only: the comment above the call site names
         # _refusal_notices while explaining why it is NOT used, and a comment
         # must neither satisfy nor trip a wiring assertion.
-        code = "\n".join(ln for ln in self._timeout_branch() if not ln.lstrip().startswith("#"))
-        assert (
-            "_timeout_notices" in code
-        ), "expected a local throwaway notice list for the timeout steer"
+        code = "\n".join(
+            ln for ln in self._shared_steer_block().splitlines() if not ln.lstrip().startswith("#")
+        )
+        assert "[]," in code, "expected a throwaway notice list for the shared host-decline steer"
         assert "_refusal_notices" not in code, (
-            "the timeout steer must not participate in the recovery-fallback "
+            "the host-decline steer must not participate in the recovery-fallback "
             "accounting — it pairs with no _refusal_reasons entry"
         )
 
-    def test_the_steer_is_not_gated_on_the_unattended_flag(self) -> None:
+    def test_the_cause_is_not_gated_on_the_unattended_flag(self) -> None:
         """BOTH attended and unattended slots get the notice.
 
         The unattended transcript line stays unattended-only, but an attended
-        slot's AGENT is handed the exact same generic denial string — nesting
-        the steer under the flag would leave the attended case exactly as
-        broken as before this change.
+        slot's AGENT is handed the exact same generic denial string — recording
+        the cause under the flag would leave the attended case exactly as
+        broken as before this change. The shared steer is gated ONLY on the
+        recorded provenance, so the cause assignment is what must stay outside
+        the unattended gate.
         """
         body = self._timeout_branch()
         gate = next(i for i, ln in enumerate(body) if ln.strip() == "if _unattended_wait:")
-        gate_indent = len(body[gate]) - len(body[gate].lstrip())
-        call = next(i for i, ln in enumerate(body) if "_steer_policy_notice(" in ln)
-        owner = next(
-            i
-            for i in range(call, -1, -1)
-            if body[i].strip()
-            and not body[i].lstrip().startswith("#")
-            and (len(body[i]) - len(body[i].lstrip())) <= gate_indent
+        cause = next(
+            i for i, ln in enumerate(body) if "_host_deny_cause = DENY_CAUSE_APPROVAL_TIMEOUT" in ln
         )
-        assert (len(body[owner]) - len(body[owner].lstrip())) == gate_indent, (
-            "the in-band steer is nested inside a gate — an attended (or "
-            "unattended) slot's agent would never be corrected"
+        assert cause < gate, (
+            "the timeout cause is recorded inside (or after) the unattended "
+            "gate — an attended slot's agent would never be corrected"
         )
 
     def test_the_steer_is_bounded_so_reject_and_audit_cannot_be_skipped(self) -> None:
@@ -366,9 +399,11 @@ class TestTimeoutTellsTheAgentInBand:
         helper = inspect.getsource(chat_runner._steer_policy_notice)
         assert "asyncio.wait_for(" in helper, "the steer notice is awaited unbounded"
         assert "_STEER_NOTICE_BOUND_SECS" in helper
-        # The branch itself must NOT re-wrap the call: a second, per-site bound
-        # is exactly the duplication moving it into the helper removed.
-        code = "\n".join(ln for ln in self._timeout_branch() if not ln.lstrip().startswith("#"))
+        # The call site itself must NOT re-wrap the call: a second, per-site
+        # bound is exactly the duplication moving it into the helper removed.
+        code = "\n".join(
+            ln for ln in self._shared_steer_block().splitlines() if not ln.lstrip().startswith("#")
+        )
         assert "asyncio.wait_for(" not in code
 
     def test_the_reject_still_happens_after_the_steer(self) -> None:
@@ -382,7 +417,7 @@ class TestTimeoutTellsTheAgentInBand:
         from kiro_crew.dashboard import chat_runner
 
         src = inspect.getsource(chat_runner._run_chat)
-        steer = src.index("cause=DENY_CAUSE_APPROVAL_TIMEOUT")
+        steer = src.index("cause=_host_deny_cause")
         reject = src.index('slot.append("tool", _reject_label, "msg msg-tool")')
         assert steer < reject, "the steer must precede the rejection going on the wire"
         assert "await client.reject_tool(event.request_id)" in src[steer:reject]

--- a/test/test_refusal_inband_notice.py
+++ b/test/test_refusal_inband_notice.py
@@ -29,7 +29,9 @@ from kiro_crew.dashboard.chat_runner import (
 )
 from kiro_crew.dashboard.state import (
     _DENY_CAUSE_TEXT,
+    DENY_CAUSE_APPROVAL_NO_BUDGET,
     DENY_CAUSE_APPROVAL_TIMEOUT,
+    DENY_CAUSE_APPROVAL_UNDELIVERABLE,
     DENY_CAUSE_BATCH_CASCADE,
     DENY_CAUSE_HOOK_ERROR,
     DENY_CAUSE_INVALID_NAME,
@@ -422,6 +424,37 @@ class TestCauseSpecificWording:
         assert "do not immediately reissue" in out.lower()
         assert "budget" not in out.lower()
 
+    def test_approval_no_budget_says_never_shown_not_denied(self):
+        out = build_refusal_steer_notice(
+            "bash",
+            "the turn had no budget left to wait for approval",
+            cause=DENY_CAUSE_APPROVAL_NO_BUDGET,
+        )
+        assert "no budget left to host its approval prompt" in out
+        assert "never judged" in out
+        # The action was never judged, so neither a policy verdict nor the
+        # policy guidance may appear: both would send the model routing around
+        # a call nobody refused.
+        assert "safety policy" not in out
+        assert "allowed alternative" not in out
+        assert "state the permission you need" in out.lower()
+        # Unlike the timeout, the no-reissue advice here IS justified by the
+        # budget: the window is recomputed from what is left of THIS turn, so
+        # an immediately reissued identical call is declined the same way.
+        assert "do not immediately reissue" in out.lower()
+
+    def test_approval_undeliverable_says_delivery_failed_not_denied(self):
+        out = build_refusal_steer_notice(
+            "bash",
+            "the approval prompt could not be delivered to Slack",
+            cause=DENY_CAUSE_APPROVAL_UNDELIVERABLE,
+        )
+        assert "could not be delivered" in out
+        assert "never judged" in out
+        assert "safety policy" not in out
+        assert "allowed alternative" not in out
+        assert "state the permission you need" in out.lower()
+
     def test_policy_wording_is_unchanged_by_default(self):
         # Every pre-existing caller passes no cause; the policy text must be
         # byte-identical to what shipped, or the model's correction changes
@@ -437,10 +470,13 @@ class TestCauseSpecificWording:
         # The cascade's members were never individually judged, so the wording
         # must neither claim a policy verdict nor scope itself to one call: the
         # single notice stands in for every cascaded member of the batch.
+        # The reason below is the batch-framed copy the setter records: the
+        # notice shows it under the CASCADED member's title, so it must speak
+        # about the batch's originating tool, not the member it is shown under.
         out = build_refusal_steer_notice(
             "list_files",
-            "the approval prompt for an earlier tool in this batch went unanswered "
-            "for 600s, so the host declined it",
+            "the host declined an earlier tool of this batch "
+            "(the approval prompt went unanswered for 600s)",
             cause=DENY_CAUSE_BATCH_CASCADE,
         )
         assert "every remaining call in its batch" in out
@@ -760,30 +796,80 @@ class TestEveryHostDenyCallSiteIsWired:
             (
                 "slack delivery-failure (None branch)",
                 "Linked approval delivery to Slack failed; auto-rejecting tool %r",
-                1000,
+                1100,
+                "DENY_CAUSE_APPROVAL_UNDELIVERABLE",
             ),
             (
                 "slack delivery-failure (except arm)",
                 "Error mirroring approval prompt to Slack",
-                800,
+                900,
+                "DENY_CAUSE_APPROVAL_UNDELIVERABLE",
             ),
-            ("no-budget", "format_approval_no_budget_card()", 400),
-            ("approval timeout", "format_approval_timeout_card(_approval_window)", 400),
+            (
+                "no-budget",
+                "format_approval_no_budget_card()",
+                400,
+                "DENY_CAUSE_APPROVAL_NO_BUDGET",
+            ),
+            (
+                "approval timeout",
+                "format_approval_timeout_card(_approval_window)",
+                400,
+                "DENY_CAUSE_APPROVAL_TIMEOUT",
+            ),
         )
         missing = []
-        for arm, anchor, window in arm_anchors:
+        for arm, anchor, window, constant in arm_anchors:
             assert (
                 src.count(anchor) == 1
             ), f"the {arm} arm's source landmark is no longer unique -- guard is stale"
-            if "_host_deny_cause = (" not in src.split(anchor, 1)[1][:window]:
+            win = src.split(anchor, 1)[1][:window]
+            if f"_host_deny_cause = {constant}" not in win or "_host_deny_reason = " not in win:
                 missing.append(arm)
         assert not missing, (
-            f"these host auto-decline arms no longer record a cause: {missing} -- "
-            "their cascades are again indistinguishable from a user refusal"
+            f"these host auto-decline arms no longer record their cause constant "
+            f"and reason: {missing} -- their declines are again indistinguishable "
+            "from a user refusal"
         )
+        setter = "slot._batch_rejected_cause = ("
         assert (
-            "slot._batch_rejected_cause = _host_deny_cause" in src
+            setter in src and "_host_deny_reason" in src.split(setter, 1)[1][:300]
         ), "the batch setter no longer copies the decline's provenance onto the slot"
+        # The copy must stay BATCH-FRAMED: the cascade notice embeds it under
+        # the cascaded member's title, where the bare per-tool reason would
+        # claim that member's own prompt failed.
+        assert "earlier tool of this batch" in src.split(setter, 1)[1][:300], (
+            "the batch copy lost its batch framing — the cascade notice now "
+            "misattributes the originating decline to the cascaded member"
+        )
+
+    def test_shared_reject_branch_steers_the_host_cause(self):
+        # The three host auto-decline arms (no budget, Slack ts-None, Slack
+        # except) record their cause upstream and funnel into the interactive
+        # rejected branch; the correction is steered there ONCE, gated on the
+        # provenance, BEFORE the rejection is answered. Guarded at source
+        # level because the branch lives inside the turn coroutine, where the
+        # direct unit fixtures of this file cannot reach it.
+        src = self._src()
+        anchor = "# deny-notice-exempt: interactive user denial."
+        assert src.count(anchor) == 1, "the interactive exemption marker moved -- guard is stale"
+        before = src.split(anchor, 1)[0][-1400:]
+        gate = "if _host_deny_cause:"
+        assert gate in before, (
+            "the shared reject branch no longer gates a steer on the " "host-decline provenance"
+        )
+        gated = before.split(gate, 1)[1]
+        assert "_steer_policy_notice(" in gated, "the provenance gate no longer steers"
+        assert (
+            "cause=_host_deny_cause" in gated
+        ), "the shared steer no longer carries the arm's recorded cause"
+        assert (
+            "_host_deny_reason" in gated
+        ), "the shared steer no longer carries the arm's recorded reason"
+        after = src.split(anchor, 1)[1][:1200]
+        assert (
+            "await client.reject_tool(event.request_id)" in after
+        ), "the steer must precede the rejection going on the wire"
 
     def test_flag_and_provenance_clear_together(self):
         # A stale cause is never READ today (the flag gates the only reader and


### PR DESCRIPTION
## Summary

Three host-originated approval auto-decline paths in the dashboard chat runner handed the agent kiro-cli's generic `User denied tool execution` with no in-band explanation of the real cause:

1. the **no-budget** arm (`_approval_window <= 0` — the remaining turn budget cannot host a prompt),
2. the **Slack delivery** arm where `_slack_approval_ts is None` (card never posted),
3. the **Slack `except Exception`** arm.

The model therefore treated a budget or delivery failure as a human refusal: it neither re-requested the permission nor explained what it needed.

This mirrors the pattern [PR #8508](https://github.com/kirodotdev/KiroCrew/pull/8508) established for the timeout arm and the batch-cascade steer:

- **`src/kiro_crew/dashboard/state.py`** — two new entries in `_DENY_CAUSE_TEXT`: `DENY_CAUSE_APPROVAL_NO_BUDGET` (the prompt was never shown; state the permission needed; do not immediately reissue the identical call, this turn cannot host an approval wait) and `DENY_CAUSE_APPROVAL_UNDELIVERABLE` (the card never reached the operator's channel; never judged; state the permission needed). Wording follows the existing table shape and `docs/system-specs/common/injected-messages.md`.
- **`src/kiro_crew/dashboard/chat_runner.py`** — each of the three arms records its `DENY_CAUSE_*` constant (`_host_deny_cause`) plus a host-authored reason sentence (`_host_deny_reason`); ONE provenance-gated `_steer_policy_notice` at the shared `reject_tool` branch corrects the attribution before the rejection goes on the wire. The timeout arm's inline steer is folded into that shared call so nothing double-steers. Genuine user refusals record no cause, so the `deny-notice-exempt: interactive user denial` marker stays true for exactly the branch it covers. The batch setter copies a batch-framed sentence (`the host declined an earlier tool of this batch (<reason>)`) so the cascade notice, which renders the reason under the CASCADED member's title, never claims that member's own prompt failed.
- **Tests** — `TestEveryHostDenyCallSiteIsWired` now asserts each arm sets its cause constant + reason and that the shared branch steers (gated, before rejecting); `TestTimeoutTellsTheAgentInBand`'s pins were faithfully moved to the shared site (including a new pin that the timeout arm no longer steers inline, and that the shared site has no attendedness gate); table-driven wording tests for both new causes; the no-budget cascade test now expects the originating tool's own notice plus one cascade notice.
- **Docs** — the two new causes documented next to the `approval_timeout` paragraph in `docs/system-specs/common/injected-messages.md`.

Attribution only: Slack delivery itself, the cascade logic, and the approval-window arithmetic are untouched.

## Pre-push review

- Opus lane (pinned claude-opus-5, read-only, mirroring claude-review.yml + BASE AUTOSDE): **CONCERNS**, 0 blocking — all five findings fixed in this head (batch-framed cascade copy, `max(1, round())` window string, docs antecedent, unattended-flag pin restored at the steering site, string-concat nit).
- GPT lane: the pinned gpt-5.6-sol subagent harness mounts no file-read tools (confirmed twice), so per the task's fallback clause this round was a contract-driven self-review against the codex-review.yml charter: PASS. The server-side GPT 5.6 lane on this PR is the authoritative gate.

## Testing

- Local static gates green: isort, flake8, mypy (1414 files), black, diff-scoped black-baseline gate (one graduated entry pruned per the gate's instruction), diff-scoped brand-name gate.
- Test runs are delegated to CI per repository operating policy (no local test execution on this host).

Closes #8578
Closes #8977

## Pattern harvest

Rule candidate: source guard (already extended in this PR). The defect class — a `reject_tool` answer site handing the model kiro-cli's generic "User denied tool execution" for a decline no user made — is enumerable, and `test_refusal_inband_notice.py::TestEveryHostDenyCallSiteIsWired::test_every_reject_tool_site_is_steered_or_exempt` already closes that enumeration for `chat_runner.py` (every answer site must steer or carry a reasoned `deny-notice-exempt:` marker). This PR extends the companion per-arm guard so a host auto-decline arm cannot ship without recording its `DENY_CAUSE_*` constant and reason sentence, which is the residual gap #8578 fell through: the arms existed before the provenance contract did.
